### PR TITLE
[codex] add optional WebView2 browser pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,20 @@ A Windows terminal written in Zig, powered by [libghostty-vt](https://github.com
 
 ```powershell
 zig build                         # Debug build for development
+zig build -Dwebview2=true         # Debug build with optional WebView2 browser panes
+zig build -Dwebview2=true -Dwebview2-loader=C:\path\to\WebView2Loader.dll
 zig build -Doptimize=ReleaseFast  # ReleaseFast build for distribution
 Remove-Item -Recurse -Force .\zig-out, .\.zig-cache -ErrorAction SilentlyContinue
 ```
 
 The `Makefile` may still exist as a convenience wrapper, but normal Windows
 development should use PowerShell and direct `zig` commands.
+
+The WebView2 build is opt-in. It requires `WebView2Loader.dll` to be available
+next to `phantty.exe` or on `PATH`, and a Microsoft Edge WebView2 Runtime
+installed on the machine. Pass `-Dwebview2-loader=...` to copy the loader DLL
+into `zig-out\bin` during the build. The default `zig build` remains the
+no-WebView2 terminal build.
 
 ## Packaging
 
@@ -102,6 +110,7 @@ Default chords are implemented in [`src/input.zig`](src/input.zig). Some keys ar
 | **Ctrl+Shift+B** | Toggle tab sidebar |
 | **Ctrl+Shift+O** | Split to the right |
 | **Ctrl+Shift+E** | Toggle file explorer sidebar |
+| **Ctrl+Shift+Click** on a URL | Open URL in a right-side browser pane (WebView2 build only) |
 | **Ctrl+Shift+W** | Close focused panel, tab, or window |
 | **Ctrl+Enter** | Maximize or restore window |
 | **Ctrl++** / **Ctrl+-** | Increase / decrease font size |

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,11 @@ pub fn build(b: *std.Build) void {
         },
     });
     const optimize = b.standardOptimizeOption(.{});
+    const enable_webview2 = b.option(bool, "webview2", "Enable the optional WebView2 browser pane") orelse false;
+    const webview2_loader_path = b.option([]const u8, "webview2-loader", "Path to WebView2Loader.dll to copy next to phantty.exe");
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "webview2", enable_webview2);
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -17,6 +22,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
+    exe_mod.addOptions("build_options", build_options);
 
     // Add ghostty-vt dependency with SIMD disabled for cross-compilation
     if (b.lazyDependency("ghostty", .{
@@ -50,6 +56,7 @@ pub fn build(b: *std.Build) void {
     exe_mod.linkSystemLibrary("comdlg32", .{});
     exe_mod.linkSystemLibrary("shell32", .{});
     exe_mod.linkSystemLibrary("imm32", .{});
+    exe_mod.linkSystemLibrary("ole32", .{});
 
     // Add FreeType dependency (shared between main and harfbuzz)
     const freetype_dep = b.lazyDependency("freetype", .{
@@ -131,6 +138,12 @@ pub fn build(b: *std.Build) void {
     exe.subsystem = if (optimize == .Debug) .Console else .Windows;
 
     b.installArtifact(exe);
+    if (enable_webview2) {
+        if (webview2_loader_path) |path| {
+            const install_loader = b.addInstallBinFile(.{ .cwd_relative = path }, "WebView2Loader.dll");
+            b.getInstallStep().dependOn(&install_loader.step);
+        }
+    }
 
     // Unit tests (zig build test)
     const test_mod = b.createModule(.{
@@ -138,6 +151,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    test_mod.addOptions("build_options", build_options);
 
     if (b.lazyDependency("ghostty", .{
         .target = target,

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -29,6 +29,7 @@ pub const window_state = @import("apprt/window_state.zig");
 pub const fbo = @import("renderer/fbo.zig");
 pub const file_explorer = @import("file_explorer.zig");
 pub const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig");
+pub const webview2 = @import("webview2.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -126,6 +127,7 @@ pub fn deinit(self: *AppWindow) void {
         }
     }
     tab.g_tab_count = 0;
+    webview2.deinitProcessGlobals();
 }
 
 // ============================================================================
@@ -202,7 +204,8 @@ pub fn activeSelection() *Selection {
 }
 
 pub fn isActiveTabTerminal() bool {
-    return tab.isActiveTabTerminal();
+    const surface = activeSurface() orelse return false;
+    return surface.kind == .terminal;
 }
 
 /// Clear UI state after tab creation or switch.
@@ -317,6 +320,86 @@ pub fn splitFocusedReturningSurface(direction: SplitTree.Split.Direction) ?*Surf
         g_cells_valid = false;
     }
     return surface;
+}
+
+pub fn splitBrowserReturningSurface(direction: SplitTree.Split.Direction, url: []const u8, tunnel: ?webview2.Tunnel) ?*Surface {
+    const allocator = g_allocator orelse return null;
+    const win = g_window orelse return null;
+    const active = activeSurface() orelse return null;
+
+    const pad = active.getPadding();
+    const screen_w = active.size.screen.width;
+    const screen_h = active.size.screen.height;
+    const pad_w = pad.left + pad.right;
+    const pad_h = pad.top + pad.bottom;
+    const split_w: u32 = switch (direction) {
+        .left, .right => @max(1, screen_w / 2),
+        .up, .down => screen_w,
+    };
+    const split_h: u32 = switch (direction) {
+        .left, .right => screen_h,
+        .up, .down => @max(1, screen_h / 2),
+    };
+    const avail_w = @as(i32, @intCast(split_w)) - @as(i32, @intCast(pad_w));
+    const avail_h = @as(i32, @intCast(split_h)) - @as(i32, @intCast(pad_h));
+    const cols: u16 = if (avail_w > 0) @intFromFloat(@max(1, @as(f32, @floatFromInt(avail_w)) / font.cell_width)) else 20;
+    const rows: u16 = if (avail_h > 0) @intFromFloat(@max(1, @as(f32, @floatFromInt(avail_h)) / font.cell_height)) else 5;
+    const initial_bounds = initialBrowserBounds(active, direction);
+
+    const surface = Surface.initBrowser(
+        allocator,
+        cols,
+        rows,
+        win.hwnd,
+        url,
+        initial_bounds,
+        tunnel,
+        tab.g_scrollback_limit,
+        g_cursor_style,
+        g_cursor_blink,
+    ) catch |err| {
+        std.debug.print("Failed to create browser surface: {}\n", .{err});
+        return null;
+    };
+
+    if (tab.splitFocusedWithSurface(allocator, direction, font.cell_width, font.cell_height, surface)) |inserted| {
+        overlays.g_resize_active = false;
+        g_force_rebuild = true;
+        g_cells_valid = false;
+        return inserted;
+    }
+
+    surface.deinit(allocator);
+    return null;
+}
+
+fn initialBrowserBounds(active: *Surface, direction: SplitTree.Split.Direction) win32_backend.RECT {
+    var base_x: i32 = 0;
+    var base_y: i32 = 0;
+    var base_w: i32 = @intCast(active.size.screen.width);
+    var base_h: i32 = @intCast(active.size.screen.height);
+
+    for (0..split_layout.g_split_rect_count) |i| {
+        const rect = split_layout.g_split_rects[i];
+        if (rect.surface == active) {
+            base_x = rect.x;
+            base_y = rect.y;
+            base_w = rect.width;
+            base_h = rect.height;
+            break;
+        }
+    }
+
+    const half_div = @divTrunc(tab.SPLIT_DIVIDER_WIDTH, 2);
+    const half_w = @max(1, @divTrunc(base_w, 2) - half_div);
+    const half_h = @max(1, @divTrunc(base_h, 2) - half_div);
+
+    return switch (direction) {
+        .right => .{ .left = base_x + base_w - half_w, .top = base_y, .right = base_x + base_w, .bottom = base_y + base_h },
+        .left => .{ .left = base_x, .top = base_y, .right = base_x + half_w, .bottom = base_y + base_h },
+        .down => .{ .left = base_x, .top = base_y + base_h - half_h, .right = base_x + base_w, .bottom = base_y + base_h },
+        .up => .{ .left = base_x, .top = base_y, .right = base_x + base_w, .bottom = base_y + half_h },
+    };
 }
 
 pub fn closeFocusedSplit() void {
@@ -927,6 +1010,30 @@ fn renderImePreedit(win: *win32_backend.Window, fb_width: i32, fb_height: i32) v
     gl.BindTexture.?(c.GL_TEXTURE_2D, 0);
 }
 
+fn browserPanesBlockedByOverlay() bool {
+    return overlays.commandPaletteVisible() or
+        overlays.sessionLauncherVisible() or
+        overlays.settingsPageVisible() or
+        overlays.startupShortcutsVisible();
+}
+
+fn hideAllBrowserPanes() void {
+    if (!webview2.enabled) return;
+    // Temporarily no-op: WebView2 panes are currently applied once from the
+    // async controller callback. Touching pane pointers from the render loop
+    // exposed a lifetime hazard while the controller is initializing.
+}
+
+fn syncBrowserPaneLayout(split_count: usize) void {
+    _ = split_count;
+    if (!webview2.enabled) return;
+    // WebView2 callbacks are asynchronous. Avoid touching BrowserPane pointers
+    // from the hot render loop; the pane applies its initial bounds once the
+    // controller becomes ready. Dynamic resize can be reintroduced after the
+    // pane lifetime model is made fully event-driven.
+    _ = browserPanesBlockedByOverlay();
+}
+
 /// Handle a bell notification from the terminal.
 /// Rate-limited to once per 100ms (matching Ghostty).
 fn handleBell(surface: *Surface, win: *win32_backend.Window, is_active_tab: bool) void {
@@ -1355,10 +1462,11 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
             const content_h: i32 = @intFromFloat(@as(f32, @floatFromInt(fb_height)) - top_padding - padding);
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
             syncImeCaretPosition(win, split_count);
+            syncBrowserPaneLayout(split_count);
 
             // Debug: print split count on first few frames
             // GL rendering
-            if (post_process.g_post_enabled) {
+            if (post_process.g_post_enabled and (if (activeSurface()) |surface| surface.kind == .terminal else false)) {
                 // Post-processing path: only render focused surface for now
                 if (activeSurface()) |surface| {
                     var needs_rebuild: bool = false;
@@ -1378,34 +1486,45 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
                 // Single surface (no splits): use original simple rendering path
                 // The surface padding is set by computeSplitLayout, so we use it here
                 if (activeSurface()) |surface| {
-                    const rend = &surface.surface_renderer;
-                    var needs_rebuild: bool = false;
-                    {
-                        surface.render_state.mutex.lock();
-                        defer surface.render_state.mutex.unlock();
-                        updateCursorBlinkForRenderer(rend);
-                        cell_renderer.g_current_render_surface = surface;
-                        rend.is_focused = true; // Single surface is always focused
-                        needs_rebuild = cell_renderer.updateTerminalCells(rend, &surface.terminal);
+                    if (surface.kind == .browser) {
+                        gl.Viewport.?(0, 0, fb_width, fb_height);
+                        gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+                        gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
+                        gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+                        titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        overlays.renderResizeOverlayWithOffset(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                    } else {
+                        const rend = &surface.surface_renderer;
+                        var needs_rebuild: bool = false;
+                        {
+                            surface.render_state.mutex.lock();
+                            defer surface.render_state.mutex.unlock();
+                            updateCursorBlinkForRenderer(rend);
+                            cell_renderer.g_current_render_surface = surface;
+                            rend.is_focused = true; // Single surface is always focused
+                            needs_rebuild = cell_renderer.updateTerminalCells(rend, &surface.terminal);
+                        }
+                        if (needs_rebuild) cell_renderer.rebuildCells(rend);
+
+                        gl.Viewport.?(0, 0, fb_width, fb_height);
+                        gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+                        gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
+                        gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+
+                        // Use surface's computed padding (includes titlebar offset from content_y)
+                        const pad = surface.getPadding();
+                        const pad_top = @as(f32, @floatFromInt(pad.top)) + titlebar_offset;
+                        titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+                        cell_renderer.drawCells(rend, @floatFromInt(fb_height), sidebar_w + @as(f32, @floatFromInt(pad.left)), pad_top);
+                        overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
+
+                        // Render resize overlay centered in content area (offset for titlebar)
+                        overlays.renderResizeOverlayWithOffset(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
                     }
-                    if (needs_rebuild) cell_renderer.rebuildCells(rend);
-
-                    gl.Viewport.?(0, 0, fb_width, fb_height);
-                    gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-                    gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-                    gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
-
-                    // Use surface's computed padding (includes titlebar offset from content_y)
-                    const pad = surface.getPadding();
-                    const pad_top = @as(f32, @floatFromInt(pad.top)) + titlebar_offset;
-                    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
-                    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
-                    file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
-                    cell_renderer.drawCells(rend, @floatFromInt(fb_height), sidebar_w + @as(f32, @floatFromInt(pad.left)), pad_top);
-                    overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
-
-                    // Render resize overlay centered in content area (offset for titlebar)
-                    overlays.renderResizeOverlayWithOffset(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
                 }
             } else {
                 // Multiple splits: render with scissor/viewport per surface
@@ -1423,6 +1542,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
                     for (0..split_count) |i| {
                         const rect = split_layout.g_split_rects[i];
                         const is_focused = (rect.handle == active_tab.focused);
+                        if (rect.surface.kind == .browser) continue;
                         const rend = &rect.surface.surface_renderer;
 
                         // Set viewport to this split's region
@@ -1476,6 +1596,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
                 }
             }
         } else if (!post_process.g_post_enabled) {
+            hideAllBrowserPanes();
             gl.Viewport.?(0, 0, fb_width, fb_height);
             gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
             gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -18,6 +18,7 @@ const termio = @import("termio.zig");
 const Config = @import("config.zig");
 const Renderer = @import("renderer/Renderer.zig");
 const RendererThread = @import("RendererThread.zig");
+const webview2 = @import("webview2.zig");
 
 const windows = std.os.windows;
 
@@ -46,6 +47,11 @@ pub const LaunchKind = enum {
     windows,
     wsl,
     ssh,
+};
+
+pub const SurfaceKind = enum {
+    terminal,
+    browser,
 };
 
 pub const SshConnection = struct {
@@ -145,6 +151,7 @@ fn detectLaunchKind(command: []const u16) LaunchKind {
 // ============================================================================
 
 allocator: std.mem.Allocator,
+kind: SurfaceKind,
 terminal: ghostty_vt.Terminal,
 pty: Pty,
 command: Command,
@@ -152,6 +159,7 @@ selection: Selection,
 render_state: renderer.State,
 launch_kind: LaunchKind,
 ssh_connection: ?SshConnection,
+browser: ?*webview2.BrowserPane,
 
 /// Size information for this surface (screen size, cell size, padding).
 /// Used by the renderer to position content correctly.
@@ -333,10 +341,12 @@ pub fn init(
 
     // Init remaining fields
     surface.allocator = allocator;
+    surface.kind = .terminal;
     surface.selection = .{};
     surface.render_state = renderer.State.init(&surface.terminal);
     surface.launch_kind = detectLaunchKind(shell_cmd);
     surface.ssh_connection = null;
+    surface.browser = null;
     surface.dirty = std.atomic.Value(bool).init(true);
     surface.exited = std.atomic.Value(bool).init(false);
 
@@ -445,9 +455,109 @@ pub fn init(
     return surface;
 }
 
+/// Initialize a browser surface hosted by WebView2.
+/// Browser surfaces live in the split tree like terminal surfaces, but they do
+/// not own a PTY or IO threads.
+pub fn initBrowser(
+    allocator: std.mem.Allocator,
+    cols: u16,
+    rows: u16,
+    parent_hwnd: win32.HWND,
+    url: []const u8,
+    initial_bounds: win32.RECT,
+    tunnel: ?webview2.Tunnel,
+    scrollback_limit: u32,
+    cursor_style: Config.CursorStyle,
+    cursor_blink: bool,
+) !*Surface {
+    if (!webview2.enabled) return error.WebView2Disabled;
+
+    const surface = try allocator.create(Surface);
+    errdefer allocator.destroy(surface);
+
+    surface.terminal = try ghostty_vt.Terminal.init(allocator, .{
+        .cols = cols,
+        .rows = rows,
+        .max_scrollback = scrollback_limit,
+        .default_modes = .{ .grapheme_cluster = true },
+        .kitty_image_storage_limit = 50 * 1024 * 1024,
+        .kitty_image_loading_limits = .all,
+    });
+    errdefer surface.terminal.deinit(allocator);
+
+    surface.terminal.screens.active.cursor.cursor_style = switch (cursor_style) {
+        .bar => .bar,
+        .block => .block,
+        .underline => .underline,
+        .block_hollow => .block_hollow,
+    };
+    surface.terminal.modes.set(.cursor_blinking, cursor_blink);
+
+    surface.allocator = allocator;
+    surface.kind = .browser;
+    surface.pty = Pty.invalid(.{ .ws_col = cols, .ws_row = rows });
+    surface.command = .{};
+    surface.selection = .{};
+    surface.render_state = renderer.State.init(&surface.terminal);
+    surface.launch_kind = .windows;
+    surface.ssh_connection = null;
+    surface.browser = try webview2.BrowserPane.init(allocator, parent_hwnd, url, initial_bounds, tunnel);
+    errdefer if (surface.browser) |browser| browser.deinit();
+    surface.dirty = std.atomic.Value(bool).init(true);
+    surface.exited = std.atomic.Value(bool).init(false);
+    surface.mailbox = try termio.Mailbox.init();
+    errdefer surface.mailbox.deinit();
+    surface.io_thread_state = null;
+    surface.io_writer_thread = null;
+    surface.io_reader_thread = null;
+    surface.size.grid.cols = cols;
+    surface.size.grid.rows = rows;
+    surface.surface_renderer = Renderer.init(surface);
+    surface.renderer_thread = RendererThread.init(&surface.surface_renderer, surface);
+
+    surface.window_title_len = 0;
+    surface.title_override_len = 0;
+    surface.setTitleOverride(url);
+    surface.osc_state = .ground;
+    surface.osc_is_title = false;
+    surface.osc_num = 0;
+    surface.osc_buf_len = 0;
+    surface.osc7_title_len = 0;
+    surface.got_osc7_this_batch = false;
+    surface.cwd_path_len = 0;
+    surface.initial_cwd_path_len = 0;
+
+    surface.bell_pending = std.atomic.Value(bool).init(false);
+    surface.last_bell_time = 0;
+    surface.bell_opacity = 0;
+    surface.bell_indicator = false;
+    surface.bell_indicator_time = 0;
+    surface.scrollbar_opacity = 0;
+    surface.scrollbar_show_time = 0;
+    surface.resize_overlay_active = false;
+    surface.resize_overlay_last_cols = cols;
+    surface.resize_overlay_last_rows = rows;
+    surface.ref_count = 1;
+
+    return surface;
+}
+
 /// Deinitialize and free a Surface.
 /// Stops the IO thread first, then cleans up PTY and terminal.
 pub fn deinit(self: *Surface, allocator: std.mem.Allocator) void {
+    if (self.kind == .browser) {
+        if (self.browser) |browser| {
+            webview2.deinitPaneIfLive(browser);
+            self.browser = null;
+        }
+        self.renderer_thread.stop();
+        self.surface_renderer.deinit();
+        self.mailbox.deinit();
+        self.terminal.deinit(allocator);
+        allocator.destroy(self);
+        return;
+    }
+
     // 1. Stop the renderer thread first (it accesses terminal state)
     self.renderer_thread.stop();
     self.surface_renderer.deinit();
@@ -578,6 +688,8 @@ pub fn setScreenSize(
     const changed = (self.size.grid.cols != new_cols or self.size.grid.rows != new_rows);
     self.size.grid.cols = new_cols;
     self.size.grid.rows = new_rows;
+    if (self.kind == .browser) return false;
+
     self.terminal.width_px = @intFromFloat(@as(f32, @floatFromInt(new_cols)) * cell_width);
     self.terminal.height_px = @intFromFloat(@as(f32, @floatFromInt(new_rows)) * cell_height);
 
@@ -592,6 +704,7 @@ pub fn setScreenSize(
 
 /// Send a message to the IO writer thread via the mailbox.
 pub fn queueIo(self: *Surface, msg: termio.Message) void {
+    if (self.kind != .terminal) return;
     self.mailbox.send(msg);
     self.mailbox.notify();
 }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -645,8 +645,10 @@ pub const FLASHW_TIMERNOFG: DWORD = 12; // Flash until window comes to foregroun
 pub const MB_OK: UINT = 0x00000000; // Default system sound
 
 // kernel32 for GetModuleHandle and GetProcAddress
-extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const WCHAR) callconv(.winapi) ?HINSTANCE;
-extern "kernel32" fn GetProcAddress(hModule: HINSTANCE, lpProcName: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
+pub extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const WCHAR) callconv(.winapi) ?HINSTANCE;
+pub extern "kernel32" fn LoadLibraryW(lpLibFileName: [*:0]const WCHAR) callconv(.winapi) ?HINSTANCE;
+pub extern "kernel32" fn FreeLibrary(hLibModule: HINSTANCE) callconv(.winapi) BOOL;
+pub extern "kernel32" fn GetProcAddress(hModule: HINSTANCE, lpProcName: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
 
 // System metrics
 pub extern "user32" fn GetSystemMetrics(nIndex: INT) callconv(.winapi) INT;

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -440,6 +440,73 @@ pub fn splitFocusedReturningSurface(
     return new_surface;
 }
 
+/// Insert an already-created surface next to the focused surface.
+/// Used for non-terminal panes such as the optional browser surface.
+pub fn splitFocusedWithSurface(
+    allocator: std.mem.Allocator,
+    direction: SplitTree.Split.Direction,
+    cell_w: f32,
+    cell_h: f32,
+    new_surface: *Surface,
+) ?*Surface {
+    const t = activeTab() orelse return null;
+    const focused_surface = t.focusedSurface() orelse return null;
+
+    const screen_w = focused_surface.size.screen.width;
+    const screen_h = focused_surface.size.screen.height;
+    const pad = focused_surface.getPadding();
+    const pad_w = pad.left + pad.right;
+    const pad_h = pad.top + pad.bottom;
+
+    const half_div = @divTrunc(SPLIT_DIVIDER_WIDTH, 2);
+    const new_screen_w: u32 = switch (direction) {
+        .left, .right => @max(1, (screen_w / 2) -| half_div),
+        .up, .down => screen_w,
+    };
+    const new_screen_h: u32 = switch (direction) {
+        .left, .right => screen_h,
+        .up, .down => @max(1, (screen_h / 2) -| half_div),
+    };
+
+    const avail_w = @as(i32, @intCast(new_screen_w)) - @as(i32, @intCast(pad_w));
+    const avail_h = @as(i32, @intCast(new_screen_h)) - @as(i32, @intCast(pad_h));
+    new_surface.size.grid.cols = if (avail_w > 0) @intFromFloat(@max(1, @as(f32, @floatFromInt(avail_w)) / cell_w)) else 10;
+    new_surface.size.grid.rows = if (avail_h > 0) @intFromFloat(@max(1, @as(f32, @floatFromInt(avail_h)) / cell_h)) else 5;
+    new_surface.size.screen.width = new_screen_w;
+    new_surface.size.screen.height = new_screen_h;
+    new_surface.size.cell.width = cell_w;
+    new_surface.size.cell.height = cell_h;
+    new_surface.size.padding = pad;
+
+    var insert_tree = SplitTree.init(allocator, new_surface) catch {
+        std.debug.print("Failed to create SplitTree for inserted surface\n", .{});
+        return null;
+    };
+    new_surface.unref(allocator);
+    defer insert_tree.deinit();
+
+    const new_tree = t.tree.split(
+        allocator,
+        t.focused,
+        direction,
+        0.5,
+        &insert_tree,
+    ) catch {
+        std.debug.print("Failed to split tree for inserted surface\n", .{});
+        return null;
+    };
+
+    const new_handle: SplitTree.Node.Handle = @enumFromInt(t.tree.nodes.len);
+
+    var old_tree = t.tree;
+    t.tree = new_tree;
+    old_tree.deinit();
+    t.focused = new_handle;
+
+    std.debug.print("Surface inserted as split, handle: {}, tree nodes: {}\n", .{ @intFromEnum(new_handle), t.tree.nodes.len });
+    return new_surface;
+}
+
 /// Result of closing the focused split.
 pub const CloseResult = enum {
     /// A split was removed from the tree. Caller should set rebuild flags.

--- a/src/input.zig
+++ b/src/input.zig
@@ -17,6 +17,7 @@ const win32_backend = @import("apprt/win32.zig");
 const Config = @import("config.zig");
 const Surface = @import("Surface.zig");
 const SplitTree = @import("split_tree.zig");
+const webview2 = @import("webview2.zig");
 const windows = @import("std").os.windows;
 const Selection = Surface.Selection;
 const CellPos = struct { col: usize, row: usize };
@@ -92,6 +93,7 @@ fn mutatePasteData(data: []u8, bracketed: bool) void {
 
 /// Write data to the PTY's input pipe (us -> child stdin).
 fn writeToPty(surface: *Surface, data: []const u8) void {
+    if (surface.kind != .terminal) return;
     var bytes_written: windows.DWORD = 0;
     _ = windows.kernel32.WriteFile(
         surface.pty.in_pipe,
@@ -1362,6 +1364,77 @@ fn openUrlAtCell(surface: *Surface, cell_pos: CellPos) bool {
     return openUrl(url);
 }
 
+const BrowserTarget = struct {
+    url: []u8,
+    tunnel: ?webview2.Tunnel = null,
+
+    fn deinit(self: *BrowserTarget, allocator: std.mem.Allocator) void {
+        if (self.tunnel) |*tunnel| tunnel.deinit();
+        allocator.free(self.url);
+        self.tunnel = null;
+    }
+};
+
+fn normalizeUrlForBrowser(allocator: std.mem.Allocator, url: []const u8) ?[]u8 {
+    if (std.mem.startsWith(u8, url, "www.")) {
+        return std.fmt.allocPrint(allocator, "https://{s}", .{url}) catch null;
+    }
+    return allocator.dupe(u8, url) catch null;
+}
+
+fn browserTargetForSurface(allocator: std.mem.Allocator, surface: *const Surface, url: []const u8) ?BrowserTarget {
+    var normalized = normalizeUrlForBrowser(allocator, url) orelse return null;
+    errdefer allocator.free(normalized);
+
+    if (surface.launch_kind == .ssh and webview2.isLocalhostUrl(normalized)) {
+        const conn = surface.ssh_connection orelse return .{ .url = normalized };
+        const remote_port = webview2.defaultPortForUrl(normalized) orelse return .{ .url = normalized };
+        const tunnel = webview2.startSshTunnel(allocator, .{
+            .user = conn.user(),
+            .host = conn.host(),
+            .port = conn.port(),
+            .password = conn.password(),
+            .password_auth = conn.password_auth,
+        }, remote_port) orelse {
+            std.debug.print("Browser pane SSH tunnel failed for {s}\n", .{normalized});
+            return null;
+        };
+
+        const local_url = webview2.makeLocalhostUrl(allocator, normalized, tunnel.local_port) orelse {
+            var t = tunnel;
+            t.deinit();
+            return null;
+        };
+        allocator.free(normalized);
+        normalized = local_url;
+        return .{ .url = normalized, .tunnel = tunnel };
+    }
+
+    return .{ .url = normalized };
+}
+
+fn openBrowserPaneUrl(surface: *Surface, url: []const u8) bool {
+    if (!webview2.enabled) {
+        std.debug.print("Browser pane support is disabled; build with -Dwebview2=true\n", .{});
+        return false;
+    }
+
+    const allocator = AppWindow.g_allocator orelse return false;
+    var target = browserTargetForSurface(allocator, surface, url) orelse return false;
+    defer target.deinit(allocator);
+
+    const tunnel = target.tunnel;
+    target.tunnel = null;
+    return AppWindow.splitBrowserReturningSurface(.right, target.url, tunnel) != null;
+}
+
+fn openBrowserPaneAtCell(surface: *Surface, cell_pos: CellPos) bool {
+    const allocator = AppWindow.g_allocator orelse return false;
+    const url = extractUrlAtCell(allocator, surface, cell_pos) orelse return false;
+    defer allocator.free(url);
+    return openBrowserPaneUrl(surface, url);
+}
+
 fn appendShellQuoted(list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, text: []const u8) !void {
     try list.append(allocator, '\'');
     for (text) |ch| {
@@ -1600,7 +1673,12 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 }
             }
 
+            if (clicked_surface.kind != .terminal) return;
+
             const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
+            if (ev.ctrl and ev.shift and !ev.alt) {
+                if (openBrowserPaneAtCell(clicked_surface, cell_pos)) return;
+            }
             if (ev.ctrl and !ev.shift and !ev.alt) {
                 if (openUrlAtCell(clicked_surface, cell_pos)) return;
                 if (openPreviewPanelForCell(clicked_surface, cell_pos)) return;
@@ -2222,6 +2300,30 @@ pub fn pasteFromClipboard() void {
     clipboard_open = false;
 
     _ = pasteSavedClipboardImage(surface, allocator, image_path);
+}
+
+pub fn openClipboardUrlInBrowserPane() void {
+    const surface = AppWindow.activeSurface() orelse return;
+    if (surface.kind != .terminal) return;
+    const win = AppWindow.g_window orelse return;
+    const allocator = AppWindow.g_allocator orelse return;
+
+    if (win32_backend.OpenClipboard(win.hwnd) == 0) return;
+    defer _ = win32_backend.CloseClipboard();
+
+    var text: ?[]u8 = null;
+    if (win32_backend.GetClipboardData(CF_UNICODETEXT)) |hmem| {
+        text = readClipboardUnicodeText(allocator, hmem);
+    } else if (win32_backend.GetClipboardData(CF_TEXT)) |hmem| {
+        text = readClipboardAnsiText(allocator, hmem);
+    }
+
+    const owned = text orelse return;
+    defer allocator.free(owned);
+
+    const trimmed = std.mem.trim(u8, owned, " \t\r\n");
+    if (!looksLikeUrl(trimmed)) return;
+    _ = openBrowserPaneUrl(surface, trimmed);
 }
 
 pub fn pasteImageFromClipboard() void {

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -22,6 +22,17 @@ const WindowsPty = struct {
     pseudo_console: win32.HPCON,
     size: winsize,
 
+    pub fn invalid(size: winsize) Pty {
+        return .{
+            .out_pipe = INVALID_HANDLE_VALUE,
+            .in_pipe = INVALID_HANDLE_VALUE,
+            .out_pipe_pty = INVALID_HANDLE_VALUE,
+            .in_pipe_pty = INVALID_HANDLE_VALUE,
+            .pseudo_console = INVALID_HANDLE_VALUE,
+            .size = size,
+        };
+    }
+
     pub fn open(size: winsize) !Pty {
         var self: Pty = undefined;
         self.size = size;
@@ -66,11 +77,11 @@ const WindowsPty = struct {
     }
 
     pub fn deinit(self: *Pty) void {
-        win32.ClosePseudoConsole(self.pseudo_console);
+        if (self.pseudo_console != INVALID_HANDLE_VALUE) win32.ClosePseudoConsole(self.pseudo_console);
         if (self.out_pipe != INVALID_HANDLE_VALUE) windows.CloseHandle(self.out_pipe);
         if (self.in_pipe != INVALID_HANDLE_VALUE) windows.CloseHandle(self.in_pipe);
-        windows.CloseHandle(self.out_pipe_pty);
-        windows.CloseHandle(self.in_pipe_pty);
+        if (self.out_pipe_pty != INVALID_HANDLE_VALUE) windows.CloseHandle(self.out_pipe_pty);
+        if (self.in_pipe_pty != INVALID_HANDLE_VALUE) windows.CloseHandle(self.in_pipe_pty);
     }
 
     pub fn getSize(self: *const Pty) winsize {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -98,6 +98,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+Shift+B", .action = "Toggle sidebar" },
     .{ .keys = "Ctrl+Shift+O", .action = "Split right" },
     .{ .keys = "Ctrl+Shift+E", .action = "File explorer" },
+    .{ .keys = "Ctrl+Shift+Click", .action = "Browser pane" },
     .{ .keys = "Ctrl+Shift+[ / ]", .action = "Previous / next panel" },
     .{ .keys = "Alt+Arrows", .action = "Focus panel" },
     .{ .keys = "Ctrl+Shift+Z", .action = "Equalize panels" },
@@ -125,6 +126,10 @@ pub fn startupShortcutsToggle() void {
     if (g_startup_shortcuts_visible) {
         g_startup_shortcuts_started_at = std.time.milliTimestamp();
     }
+}
+
+pub fn startupShortcutsVisible() bool {
+    return g_startup_shortcuts_visible;
 }
 
 // ============================================================================
@@ -156,6 +161,7 @@ const CommandAction = enum {
     close_split_or_tab,
     toggle_sidebar,
     toggle_file_explorer,
+    open_clipboard_url_browser,
     show_shortcuts,
     open_config,
     font_size_decrease,
@@ -182,6 +188,7 @@ const COMMAND_ENTRIES = [_]CommandEntry{
     .{ .title = "Close Panel / Tab", .detail = "Close the focused panel, tab, or window", .shortcut = "Ctrl+Shift+W", .action = .close_split_or_tab },
     .{ .title = "Toggle Sidebar", .detail = "Show or hide the tab sidebar", .shortcut = "Ctrl+Shift+B", .action = .toggle_sidebar },
     .{ .title = "Toggle File Explorer", .detail = "Show or hide the right-side file browser", .shortcut = "Ctrl+Shift+E", .action = .toggle_file_explorer },
+    .{ .title = "Open Clipboard URL in Browser Pane", .detail = "Open a copied URL beside the terminal", .shortcut = "", .action = .open_clipboard_url_browser },
     .{ .title = "Keyboard Shortcuts", .detail = "Show the shortcut reference overlay", .shortcut = "Ctrl+Shift+P", .action = .show_shortcuts },
     .{ .title = "Open Config", .detail = "Open the Phantty config file", .shortcut = "Ctrl+,", .action = .open_config },
     .{ .title = "Decrease Font Size", .detail = "Make terminal text smaller", .shortcut = "Ctrl+-", .action = .font_size_decrease },
@@ -314,6 +321,7 @@ fn executeCommand(action: CommandAction) void {
         .close_split_or_tab => AppWindow.closeFocusedSplit(),
         .toggle_sidebar => AppWindow.input.toggleSidebar(),
         .toggle_file_explorer => AppWindow.input.toggleFileExplorer(),
+        .open_clipboard_url_browser => AppWindow.input.openClipboardUrlInBrowserPane(),
         .show_shortcuts => startupShortcutsShow(),
         .open_config => if (AppWindow.g_allocator) |alloc| Config.openConfigInEditor(alloc),
         .font_size_decrease => AppWindow.input.adjustFontSize(-1),

--- a/src/webview2.zig
+++ b/src/webview2.zig
@@ -1,0 +1,731 @@
+//! Optional WebView2 browser pane support.
+//!
+//! The default build keeps this disabled. When compiled with
+//! `zig build -Dwebview2=true`, this module dynamically loads
+//! WebView2Loader.dll at runtime and hosts WebView2 inside Phantty's HWND.
+
+const std = @import("std");
+const build_options = @import("build_options");
+const win32 = @import("apprt/win32.zig");
+
+pub const enabled = build_options.webview2;
+
+const windows = std.os.windows;
+const HRESULT = i32;
+const ULONG = u32;
+const BOOL = win32.BOOL;
+const HWND = win32.HWND;
+const RECT = win32.RECT;
+const GUID = win32.GUID;
+
+const S_OK: HRESULT = 0;
+const S_FALSE: HRESULT = 1;
+const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
+const E_FAIL: HRESULT = @bitCast(@as(u32, 0x80004005));
+const COINIT_APARTMENTTHREADED: u32 = 0x2;
+const RPC_E_CHANGED_MODE: HRESULT = @bitCast(@as(u32, 0x80010106));
+const invalid_com_ptr = std.math.maxInt(usize);
+const min_valid_ptr = 0x10000;
+const max_live_panes = 256;
+
+extern "ole32" fn CoInitializeEx(pvReserved: ?*anyopaque, dwCoInit: u32) callconv(.winapi) HRESULT;
+extern "ole32" fn CoUninitialize() callconv(.winapi) void;
+
+const IUnknownIID = GUID{ .Data1 = 0x00000000, .Data2 = 0x0000, .Data3 = 0x0000, .Data4 = .{ 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 } };
+const EnvHandlerIID = GUID{ .Data1 = 0x4e8a3389, .Data2 = 0xc9d8, .Data3 = 0x4bd2, .Data4 = .{ 0xb6, 0xb5, 0x12, 0x4f, 0xee, 0x6c, 0xc1, 0x4d } };
+const ControllerHandlerIID = GUID{ .Data1 = 0x6c4819f3, .Data2 = 0xc9b7, .Data3 = 0x4260, .Data4 = .{ 0x81, 0x27, 0xc9, 0xf5, 0xbd, 0xe7, 0xf6, 0x8c } };
+
+fn succeeded(hr: HRESULT) bool {
+    return hr >= 0;
+}
+
+fn guidEql(a: *const GUID, b: *const GUID) bool {
+    return a.Data1 == b.Data1 and
+        a.Data2 == b.Data2 and
+        a.Data3 == b.Data3 and
+        std.mem.eql(u8, a.Data4[0..], b.Data4[0..]);
+}
+
+fn validComPtr(ptr: anytype) bool {
+    const value = @intFromPtr(ptr);
+    return value >= min_valid_ptr and value != invalid_com_ptr;
+}
+
+fn validFnPtr(ptr: anytype) bool {
+    const value = @intFromPtr(ptr);
+    return value >= min_valid_ptr and value != invalid_com_ptr;
+}
+
+const ICoreWebView2 = extern struct {
+    lpVtbl: *const Vtbl,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*ICoreWebView2, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ICoreWebView2) callconv(.winapi) ULONG,
+        Release: *const fn (*ICoreWebView2) callconv(.winapi) ULONG,
+        get_Settings: *const fn (*ICoreWebView2, *?*anyopaque) callconv(.winapi) HRESULT,
+        get_Source: *const fn (*ICoreWebView2, *?[*:0]u16) callconv(.winapi) HRESULT,
+        Navigate: *const fn (*ICoreWebView2, [*:0]const u16) callconv(.winapi) HRESULT,
+        NavigateToString: *const fn (*ICoreWebView2, [*:0]const u16) callconv(.winapi) HRESULT,
+    };
+};
+
+const ICoreWebView2Controller = extern struct {
+    lpVtbl: *const Vtbl,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*ICoreWebView2Controller, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ICoreWebView2Controller) callconv(.winapi) ULONG,
+        Release: *const fn (*ICoreWebView2Controller) callconv(.winapi) ULONG,
+        get_IsVisible: *const fn (*ICoreWebView2Controller, *BOOL) callconv(.winapi) HRESULT,
+        put_IsVisible: *const fn (*ICoreWebView2Controller, BOOL) callconv(.winapi) HRESULT,
+        get_Bounds: *const fn (*ICoreWebView2Controller, *RECT) callconv(.winapi) HRESULT,
+        put_Bounds: *const fn (*ICoreWebView2Controller, RECT) callconv(.winapi) HRESULT,
+        get_ZoomFactor: *const fn (*ICoreWebView2Controller, *f64) callconv(.winapi) HRESULT,
+        put_ZoomFactor: *const fn (*ICoreWebView2Controller, f64) callconv(.winapi) HRESULT,
+        add_ZoomFactorChanged: *const fn (*ICoreWebView2Controller, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_ZoomFactorChanged: *const fn (*ICoreWebView2Controller, i64) callconv(.winapi) HRESULT,
+        SetBoundsAndZoomFactor: *const fn (*ICoreWebView2Controller, RECT, f64) callconv(.winapi) HRESULT,
+        MoveFocus: *const fn (*ICoreWebView2Controller, i32) callconv(.winapi) HRESULT,
+        add_MoveFocusRequested: *const fn (*ICoreWebView2Controller, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_MoveFocusRequested: *const fn (*ICoreWebView2Controller, i64) callconv(.winapi) HRESULT,
+        add_GotFocus: *const fn (*ICoreWebView2Controller, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_GotFocus: *const fn (*ICoreWebView2Controller, i64) callconv(.winapi) HRESULT,
+        add_LostFocus: *const fn (*ICoreWebView2Controller, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_LostFocus: *const fn (*ICoreWebView2Controller, i64) callconv(.winapi) HRESULT,
+        add_AcceleratorKeyPressed: *const fn (*ICoreWebView2Controller, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_AcceleratorKeyPressed: *const fn (*ICoreWebView2Controller, i64) callconv(.winapi) HRESULT,
+        get_ParentWindow: *const fn (*ICoreWebView2Controller, *HWND) callconv(.winapi) HRESULT,
+        put_ParentWindow: *const fn (*ICoreWebView2Controller, HWND) callconv(.winapi) HRESULT,
+        NotifyParentWindowPositionChanged: *const fn (*ICoreWebView2Controller) callconv(.winapi) HRESULT,
+        Close: *const fn (*ICoreWebView2Controller) callconv(.winapi) HRESULT,
+        get_CoreWebView2: *const fn (*ICoreWebView2Controller, *?*ICoreWebView2) callconv(.winapi) HRESULT,
+    };
+};
+
+const ICoreWebView2Environment = extern struct {
+    lpVtbl: *const Vtbl,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*ICoreWebView2Environment, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ICoreWebView2Environment) callconv(.winapi) ULONG,
+        Release: *const fn (*ICoreWebView2Environment) callconv(.winapi) ULONG,
+        CreateCoreWebView2Controller: *const fn (*ICoreWebView2Environment, HWND, *ControllerCompletedHandler) callconv(.winapi) HRESULT,
+        CreateWebResourceResponse: *const fn (*ICoreWebView2Environment, ?*anyopaque, i32, [*:0]const u16, [*:0]const u16, *?*anyopaque) callconv(.winapi) HRESULT,
+        get_BrowserVersionString: *const fn (*ICoreWebView2Environment, *?[*:0]u16) callconv(.winapi) HRESULT,
+        add_NewBrowserVersionAvailable: *const fn (*ICoreWebView2Environment, ?*anyopaque, *i64) callconv(.winapi) HRESULT,
+        remove_NewBrowserVersionAvailable: *const fn (*ICoreWebView2Environment, i64) callconv(.winapi) HRESULT,
+    };
+};
+
+const EnvCompletedHandler = extern struct {
+    lpVtbl: *const Vtbl,
+    ref_count: ULONG,
+    pane: *BrowserPane,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*EnvCompletedHandler, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*EnvCompletedHandler) callconv(.winapi) ULONG,
+        Release: *const fn (*EnvCompletedHandler) callconv(.winapi) ULONG,
+        Invoke: *const fn (*EnvCompletedHandler, HRESULT, ?*ICoreWebView2Environment) callconv(.winapi) HRESULT,
+    };
+};
+
+const ControllerCompletedHandler = extern struct {
+    lpVtbl: *const Vtbl,
+    ref_count: ULONG,
+    pane: *BrowserPane,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*ControllerCompletedHandler, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*ControllerCompletedHandler) callconv(.winapi) ULONG,
+        Release: *const fn (*ControllerCompletedHandler) callconv(.winapi) ULONG,
+        Invoke: *const fn (*ControllerCompletedHandler, HRESULT, ?*ICoreWebView2Controller) callconv(.winapi) HRESULT,
+    };
+};
+
+const EnvCompletedVtbl = EnvCompletedHandler.Vtbl{
+    .QueryInterface = envQueryInterface,
+    .AddRef = envAddRef,
+    .Release = envRelease,
+    .Invoke = envInvoke,
+};
+
+const ControllerCompletedVtbl = ControllerCompletedHandler.Vtbl{
+    .QueryInterface = controllerQueryInterface,
+    .AddRef = controllerAddRef,
+    .Release = controllerRelease,
+    .Invoke = controllerInvoke,
+};
+
+pub const SshTarget = struct {
+    user: []const u8,
+    host: []const u8,
+    port: []const u8,
+    password: []const u8,
+    password_auth: bool,
+};
+
+pub const Tunnel = struct {
+    child: std.process.Child,
+    local_port: u16,
+
+    pub fn deinit(self: *Tunnel) void {
+        _ = self.child.kill() catch {};
+    }
+};
+
+pub const BrowserPane = struct {
+    allocator: std.mem.Allocator,
+    parent_hwnd: HWND,
+    url: [:0]u16,
+    url_utf8: []u8,
+    pending_bounds: RECT,
+    environment: ?*ICoreWebView2Environment = null,
+    controller: ?*ICoreWebView2Controller = null,
+    webview: ?*ICoreWebView2 = null,
+    env_handler: EnvCompletedHandler,
+    controller_handler: ControllerCompletedHandler,
+    tunnel: ?Tunnel,
+    desired_visible: bool = false,
+    ready: bool = false,
+    failed: bool = false,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        parent_hwnd: HWND,
+        url_utf8: []const u8,
+        initial_bounds: RECT,
+        tunnel: ?Tunnel,
+    ) !*BrowserPane {
+        if (!enabled) return error.WebView2Disabled;
+
+        const pane = try allocator.create(BrowserPane);
+
+        const url_w = std.unicode.utf8ToUtf16LeAllocZ(allocator, url_utf8) catch |err| {
+            allocator.destroy(pane);
+            return err;
+        };
+
+        const url_copy = allocator.dupe(u8, url_utf8) catch |err| {
+            allocator.free(url_w);
+            allocator.destroy(pane);
+            return err;
+        };
+
+        pane.* = .{
+            .allocator = allocator,
+            .parent_hwnd = parent_hwnd,
+            .url = url_w,
+            .url_utf8 = url_copy,
+            .pending_bounds = initial_bounds,
+            .env_handler = .{ .lpVtbl = &EnvCompletedVtbl, .ref_count = 1, .pane = pane },
+            .controller_handler = .{ .lpVtbl = &ControllerCompletedVtbl, .ref_count = 1, .pane = pane },
+            .tunnel = tunnel,
+            .desired_visible = true,
+        };
+        registerPane(pane);
+
+        pane.start() catch |err| {
+            pane.deinit();
+            return err;
+        };
+
+        return pane;
+    }
+
+    pub fn deinit(self: *BrowserPane) void {
+        unregisterPane(self);
+        // Be deliberately conservative while the pane lifetime is hosted inside
+        // the split tree: corrupted or asynchronously released COM pointers have
+        // shown up as 0xffffffffffffffff during close. Leaking the controller is
+        // preferable to crashing the terminal; process teardown releases it.
+        self.webview = null;
+        self.controller = null;
+        self.environment = null;
+        if (self.tunnel) |*tunnel| {
+            tunnel.deinit();
+            self.tunnel = null;
+        }
+        self.allocator.free(self.url_utf8);
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
+    }
+
+    pub fn setBounds(self: *BrowserPane, bounds: RECT) void {
+        self.pending_bounds = bounds;
+        if (self.usableController()) |controller| {
+            if (!validFnPtr(controller.lpVtbl.put_Bounds) or !validFnPtr(controller.lpVtbl.NotifyParentWindowPositionChanged)) {
+                self.failed = true;
+                std.debug.print("WebView2 controller vtable has invalid bounds function pointers\n", .{});
+                return;
+            }
+            _ = controller.lpVtbl.put_Bounds(controller, bounds);
+            _ = controller.lpVtbl.NotifyParentWindowPositionChanged(controller);
+        }
+    }
+
+    pub fn setVisible(self: *BrowserPane, visible: bool) void {
+        self.desired_visible = visible;
+        if (self.usableController()) |controller| {
+            if (!validFnPtr(controller.lpVtbl.put_IsVisible)) {
+                self.failed = true;
+                std.debug.print("WebView2 controller vtable has invalid visibility function pointer\n", .{});
+                return;
+            }
+            _ = controller.lpVtbl.put_IsVisible(controller, if (visible) 1 else 0);
+        }
+    }
+
+    fn usableController(self: *BrowserPane) ?*ICoreWebView2Controller {
+        if (!self.ready or self.failed) return null;
+        const controller = self.controller orelse return null;
+        if (!validComPtr(controller)) return null;
+        if (!validComPtr(controller.lpVtbl)) {
+            self.failed = true;
+            std.debug.print("WebView2 controller has an invalid vtable pointer\n", .{});
+            return null;
+        }
+        return controller;
+    }
+
+    fn start(self: *BrowserPane) !void {
+        const init_hr = CoInitializeEx(null, COINIT_APARTMENTTHREADED);
+        if (!succeeded(init_hr) and init_hr != RPC_E_CHANGED_MODE) {
+            return error.ComInitFailed;
+        }
+        if (init_hr == S_OK or init_hr == S_FALSE) {
+            g_com_initialized = true;
+        }
+
+        const loader = loadLoader() orelse return error.WebView2LoaderMissing;
+        const proc = win32.GetProcAddress(loader, "CreateCoreWebView2EnvironmentWithOptions") orelse return error.WebView2EntryPointMissing;
+        const create_env: CreateEnvironmentFn = @ptrCast(proc);
+
+        const user_data = webviewUserDataFolder(self.allocator) catch null;
+        defer if (user_data) |folder| self.allocator.free(folder);
+
+        const hr = create_env(
+            null,
+            if (user_data) |folder| folder.ptr else null,
+            null,
+            &self.env_handler,
+        );
+        if (!succeeded(hr)) return error.CreateEnvironmentFailed;
+        std.debug.print("WebView2 environment creation requested for {s}\n", .{self.url_utf8});
+    }
+};
+
+const CreateEnvironmentFn = *const fn (
+    browser_executable_folder: ?[*:0]const u16,
+    user_data_folder: ?[*:0]const u16,
+    environment_options: ?*anyopaque,
+    environment_created_handler: *EnvCompletedHandler,
+) callconv(.winapi) HRESULT;
+
+var g_loader: ?win32.HINSTANCE = null;
+var g_com_initialized: bool = false;
+var g_live_panes: [max_live_panes]?*BrowserPane = .{null} ** max_live_panes;
+
+fn registerPane(pane: *BrowserPane) void {
+    for (&g_live_panes) |*slot| {
+        if (slot.* == null) {
+            slot.* = pane;
+            return;
+        }
+    }
+    std.debug.print("WebView2 pane registry is full\n", .{});
+}
+
+fn unregisterPane(pane: *BrowserPane) void {
+    for (&g_live_panes) |*slot| {
+        if (slot.* == pane) {
+            slot.* = null;
+            return;
+        }
+    }
+}
+
+fn isLivePane(pane: *BrowserPane) bool {
+    if (!validComPtr(pane)) return false;
+    for (&g_live_panes) |slot| {
+        if (slot == pane) return true;
+    }
+    return false;
+}
+
+pub fn setPaneVisible(pane: *BrowserPane, visible: bool) void {
+    if (!isLivePane(pane)) return;
+    pane.setVisible(visible);
+}
+
+pub fn setPaneBounds(pane: *BrowserPane, bounds: RECT) void {
+    if (!isLivePane(pane)) return;
+    pane.setBounds(bounds);
+}
+
+pub fn deinitPaneIfLive(pane: *BrowserPane) void {
+    if (!isLivePane(pane)) return;
+    pane.deinit();
+}
+
+fn loadLoader() ?win32.HINSTANCE {
+    if (g_loader) |loader| return loader;
+    const loader = win32.LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("WebView2Loader.dll")) orelse return null;
+    g_loader = loader;
+    return loader;
+}
+
+fn webviewUserDataFolder(allocator: std.mem.Allocator) ![:0]u16 {
+    const local = std.process.getEnvVarOwned(allocator, "LOCALAPPDATA") catch
+        try std.process.getEnvVarOwned(allocator, "APPDATA");
+    defer allocator.free(local);
+
+    const path = try std.fs.path.join(allocator, &.{ local, "phantty", "webview2" });
+    defer allocator.free(path);
+    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => {},
+    };
+    return try std.unicode.utf8ToUtf16LeAllocZ(allocator, path);
+}
+
+fn envQueryInterface(self: *EnvCompletedHandler, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+    if (guidEql(riid, &IUnknownIID) or guidEql(riid, &EnvHandlerIID)) {
+        out.* = @ptrCast(self);
+        _ = envAddRef(self);
+        return S_OK;
+    }
+    out.* = null;
+    return E_NOINTERFACE;
+}
+
+fn envAddRef(self: *EnvCompletedHandler) callconv(.winapi) ULONG {
+    self.ref_count += 1;
+    return self.ref_count;
+}
+
+fn envRelease(self: *EnvCompletedHandler) callconv(.winapi) ULONG {
+    if (self.ref_count > 0) self.ref_count -= 1;
+    return self.ref_count;
+}
+
+fn envInvoke(self: *EnvCompletedHandler, error_code: HRESULT, environment: ?*ICoreWebView2Environment) callconv(.winapi) HRESULT {
+    const pane = self.pane;
+    if (!succeeded(error_code) or environment == null) {
+        pane.failed = true;
+        std.debug.print("WebView2 environment creation failed: 0x{x}\n", .{@as(u32, @bitCast(error_code))});
+        return S_OK;
+    }
+
+    pane.environment = environment;
+    std.debug.print("WebView2 environment ready for {s}\n", .{pane.url_utf8});
+    const hr = environment.?.lpVtbl.CreateCoreWebView2Controller(environment.?, pane.parent_hwnd, &pane.controller_handler);
+    if (!succeeded(hr)) {
+        pane.failed = true;
+        std.debug.print("WebView2 controller creation failed: 0x{x}\n", .{@as(u32, @bitCast(hr))});
+    }
+    return S_OK;
+}
+
+fn controllerQueryInterface(self: *ControllerCompletedHandler, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+    if (guidEql(riid, &IUnknownIID) or guidEql(riid, &ControllerHandlerIID)) {
+        out.* = @ptrCast(self);
+        _ = controllerAddRef(self);
+        return S_OK;
+    }
+    out.* = null;
+    return E_NOINTERFACE;
+}
+
+fn controllerAddRef(self: *ControllerCompletedHandler) callconv(.winapi) ULONG {
+    self.ref_count += 1;
+    return self.ref_count;
+}
+
+fn controllerRelease(self: *ControllerCompletedHandler) callconv(.winapi) ULONG {
+    if (self.ref_count > 0) self.ref_count -= 1;
+    return self.ref_count;
+}
+
+fn controllerInvoke(self: *ControllerCompletedHandler, error_code: HRESULT, controller: ?*ICoreWebView2Controller) callconv(.winapi) HRESULT {
+    const pane = self.pane;
+    if (!succeeded(error_code) or controller == null) {
+        pane.failed = true;
+        std.debug.print("WebView2 controller callback failed: 0x{x}\n", .{@as(u32, @bitCast(error_code))});
+        return S_OK;
+    }
+
+    const controller_ptr = controller.?;
+    if (!validComPtr(controller_ptr)) {
+        pane.failed = true;
+        std.debug.print("WebView2 controller callback returned an invalid pointer\n", .{});
+        return S_OK;
+    }
+    if (!validComPtr(controller_ptr.lpVtbl) or !validFnPtr(controller_ptr.lpVtbl.get_CoreWebView2)) {
+        pane.failed = true;
+        std.debug.print("WebView2 controller callback returned an invalid vtable\n", .{});
+        return S_OK;
+    }
+
+    var webview: ?*ICoreWebView2 = null;
+    const hr = controller_ptr.lpVtbl.get_CoreWebView2(controller_ptr, &webview);
+    if (!succeeded(hr) or webview == null) {
+        pane.failed = true;
+        std.debug.print("WebView2 get_CoreWebView2 failed: 0x{x}\n", .{@as(u32, @bitCast(hr))});
+        if (validFnPtr(controller_ptr.lpVtbl.Close)) {
+            _ = controller_ptr.lpVtbl.Close(controller_ptr);
+        }
+        if (validFnPtr(controller_ptr.lpVtbl.Release)) {
+            _ = controller_ptr.lpVtbl.Release(controller_ptr);
+        }
+        return S_OK;
+    }
+    if (!validComPtr(webview.?) or !validComPtr(webview.?.lpVtbl) or !validFnPtr(webview.?.lpVtbl.Navigate)) {
+        pane.failed = true;
+        std.debug.print("WebView2 core callback returned an invalid vtable\n", .{});
+        if (validFnPtr(controller_ptr.lpVtbl.Close)) {
+            _ = controller_ptr.lpVtbl.Close(controller_ptr);
+        }
+        if (validFnPtr(controller_ptr.lpVtbl.Release)) {
+            _ = controller_ptr.lpVtbl.Release(controller_ptr);
+        }
+        return S_OK;
+    }
+
+    pane.controller = controller_ptr;
+    pane.webview = webview.?;
+    pane.ready = true;
+    std.debug.print(
+        "WebView2 controller ready for {s}, bounds=({},{})->({},{})\n",
+        .{ pane.url_utf8, pane.pending_bounds.left, pane.pending_bounds.top, pane.pending_bounds.right, pane.pending_bounds.bottom },
+    );
+    if (validFnPtr(controller_ptr.lpVtbl.put_Bounds)) {
+        _ = controller_ptr.lpVtbl.put_Bounds(controller_ptr, pane.pending_bounds);
+    }
+    if (validFnPtr(controller_ptr.lpVtbl.put_IsVisible)) {
+        _ = controller_ptr.lpVtbl.put_IsVisible(controller_ptr, if (pane.desired_visible) 1 else 0);
+    }
+    const nav_hr = webview.?.lpVtbl.Navigate(webview.?, pane.url.ptr);
+    if (!succeeded(nav_hr)) {
+        pane.failed = true;
+        std.debug.print("WebView2 Navigate failed for {s}: 0x{x}\n", .{ pane.url_utf8, @as(u32, @bitCast(nav_hr)) });
+    } else {
+        std.debug.print("WebView2 Navigate requested for {s}\n", .{pane.url_utf8});
+    }
+    return S_OK;
+}
+
+pub fn deinitProcessGlobals() void {
+    if (g_com_initialized) {
+        CoUninitialize();
+        g_com_initialized = false;
+    }
+    if (g_loader) |loader| {
+        _ = win32.FreeLibrary(loader);
+        g_loader = null;
+    }
+}
+
+pub fn startSshTunnel(allocator: std.mem.Allocator, target: SshTarget, remote_port: u16) ?Tunnel {
+    if (!enabled) return null;
+
+    const local_port = reserveLocalPort() orelse remote_port;
+    const forward = std.fmt.allocPrint(allocator, "127.0.0.1:{d}:127.0.0.1:{d}", .{ local_port, remote_port }) catch return null;
+    defer allocator.free(forward);
+
+    const dest = std.fmt.allocPrint(allocator, "{s}@{s}", .{ target.user, target.host }) catch return null;
+    defer allocator.free(dest);
+
+    var askpass_path: ?[]u8 = null;
+    defer if (askpass_path) |path| allocator.free(path);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (target.password_auth) {
+        askpass_path = ensureAskPassScript(allocator) orelse return null;
+        env_map = std.process.getEnvMap(allocator) catch return null;
+        if (env_map) |*map| {
+            map.put("SSH_ASKPASS", askpass_path.?) catch return null;
+            map.put("SSH_ASKPASS_REQUIRE", "force") catch return null;
+            map.put("DISPLAY", "phantty") catch return null;
+            map.put("PHANTTY_SSH_PASSWORD", target.password) catch return null;
+        }
+    }
+
+    var argv: [32][]const u8 = undefined;
+    var argc: usize = 0;
+    argv[argc] = "ssh.exe";
+    argc += 1;
+    argv[argc] = "-N";
+    argc += 1;
+    argv[argc] = "-L";
+    argc += 1;
+    argv[argc] = forward;
+    argc += 1;
+    argc = appendSshOptions(&argv, argc, target);
+    argv[argc] = dest;
+    argc += 1;
+
+    var child = std.process.Child.init(argv[0..argc], allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Inherit;
+    if (env_map) |*map| child.env_map = map;
+
+    child.spawn() catch |err| {
+        std.debug.print("SSH tunnel spawn failed: {}\n", .{err});
+        return null;
+    };
+
+    waitForLocalPort(allocator, local_port, 2500);
+    return .{ .child = child, .local_port = local_port };
+}
+
+fn appendSshOptions(argv: *[32][]const u8, start_argc: usize, target: SshTarget) usize {
+    var argc = start_argc;
+    argv[argc] = "-o";
+    argc += 1;
+    argv[argc] = "StrictHostKeyChecking=accept-new";
+    argc += 1;
+    argv[argc] = "-o";
+    argc += 1;
+    argv[argc] = "ExitOnForwardFailure=yes";
+    argc += 1;
+    if (target.password_auth) {
+        argv[argc] = "-o";
+        argc += 1;
+        argv[argc] = "PreferredAuthentications=publickey,password,keyboard-interactive";
+        argc += 1;
+        argv[argc] = "-o";
+        argc += 1;
+        argv[argc] = "NumberOfPasswordPrompts=1";
+        argc += 1;
+    } else {
+        argv[argc] = "-o";
+        argc += 1;
+        argv[argc] = "BatchMode=yes";
+        argc += 1;
+    }
+    if (target.port.len > 0) {
+        argv[argc] = "-p";
+        argc += 1;
+        argv[argc] = target.port;
+        argc += 1;
+    }
+    return argc;
+}
+
+fn reserveLocalPort() ?u16 {
+    const addr = std.net.Address.parseIp4("127.0.0.1", 0) catch return null;
+    var server = std.net.Address.listen(addr, .{}) catch return null;
+    const port = server.listen_address.getPort();
+    server.deinit();
+    return port;
+}
+
+fn waitForLocalPort(allocator: std.mem.Allocator, port: u16, timeout_ms: i64) void {
+    const started = std.time.milliTimestamp();
+    while (std.time.milliTimestamp() - started < timeout_ms) {
+        if (std.net.tcpConnectToHost(allocator, "127.0.0.1", port)) |stream| {
+            stream.close();
+            return;
+        } else |_| {}
+        std.Thread.sleep(100 * std.time.ns_per_ms);
+    }
+}
+
+fn ensureAskPassScript(allocator: std.mem.Allocator) ?[]u8 {
+    const temp = std.process.getEnvVarOwned(allocator, "TEMP") catch
+        std.process.getEnvVarOwned(allocator, "TMP") catch return null;
+    defer allocator.free(temp);
+
+    const path = std.fmt.allocPrint(allocator, "{s}\\phantty-ssh-askpass.cmd", .{temp}) catch return null;
+    errdefer allocator.free(path);
+
+    const file = std.fs.createFileAbsolute(path, .{ .truncate = true }) catch return null;
+    defer file.close();
+
+    file.writeAll(
+        "@echo off\r\n" ++
+            "powershell.exe -NoLogo -NoProfile -Command \"[Console]::Out.Write($env:PHANTTY_SSH_PASSWORD)\"\r\n",
+    ) catch return null;
+    return path;
+}
+
+pub fn makeLocalhostUrl(
+    allocator: std.mem.Allocator,
+    original_url: []const u8,
+    local_port: u16,
+) ?[]u8 {
+    const parsed = parseUrl(original_url) orelse return null;
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}://127.0.0.1:{d}{s}",
+        .{ parsed.scheme, local_port, parsed.path_and_query },
+    ) catch null;
+}
+
+pub const ParsedUrl = struct {
+    scheme: []const u8,
+    host: []const u8,
+    port: ?u16,
+    path_and_query: []const u8,
+};
+
+pub fn parseUrl(url: []const u8) ?ParsedUrl {
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse return null;
+    const scheme = url[0..scheme_end];
+    if (!std.mem.eql(u8, scheme, "http") and !std.mem.eql(u8, scheme, "https")) return null;
+
+    const authority_start = scheme_end + 3;
+    var authority_end = authority_start;
+    while (authority_end < url.len and url[authority_end] != '/' and url[authority_end] != '?' and url[authority_end] != '#') {
+        authority_end += 1;
+    }
+    const authority = url[authority_start..authority_end];
+    if (authority.len == 0) return null;
+
+    const path_and_query = if (authority_end < url.len) url[authority_end..] else "/";
+
+    var host = authority;
+    var port: ?u16 = null;
+    if (std.mem.lastIndexOfScalar(u8, authority, ':')) |colon| {
+        const port_text = authority[colon + 1 ..];
+        if (port_text.len > 0) {
+            port = std.fmt.parseInt(u16, port_text, 10) catch null;
+            if (port != null) host = authority[0..colon];
+        }
+    }
+
+    return .{
+        .scheme = scheme,
+        .host = host,
+        .port = port,
+        .path_and_query = path_and_query,
+    };
+}
+
+pub fn isLocalhostUrl(url: []const u8) bool {
+    const parsed = parseUrl(url) orelse return false;
+    return std.ascii.eqlIgnoreCase(parsed.host, "localhost") or
+        std.mem.eql(u8, parsed.host, "127.0.0.1") or
+        std.mem.eql(u8, parsed.host, "::1") or
+        std.mem.eql(u8, parsed.host, "[::1]");
+}
+
+pub fn defaultPortForUrl(url: []const u8) ?u16 {
+    const parsed = parseUrl(url) orelse return null;
+    if (parsed.port) |port| return port;
+    if (std.mem.eql(u8, parsed.scheme, "http")) return 80;
+    if (std.mem.eql(u8, parsed.scheme, "https")) return 443;
+    return null;
+}
+
+test "parse localhost url" {
+    const parsed = parseUrl("http://127.0.0.1:1234/path?q=1").?;
+    try std.testing.expectEqualStrings("http", parsed.scheme);
+    try std.testing.expectEqualStrings("127.0.0.1", parsed.host);
+    try std.testing.expectEqual(@as(?u16, 1234), parsed.port);
+    try std.testing.expectEqualStrings("/path?q=1", parsed.path_and_query);
+}


### PR DESCRIPTION
## Summary

This draft PR keeps the experimental WebView2 browser pane work off `main` while we continue iterating on it.

It adds an opt-in `-Dwebview2=true` build path, a dynamically loaded WebView2 host module, browser split surfaces, and `Ctrl+Shift+Click` URL handling. For SSH sessions, localhost URLs are routed through an OpenSSH local forward so remote `127.0.0.1:<port>` apps can be viewed from Phantty.

## Current State

This is intentionally not ready for merge. The browser pane can be created and closed without the earlier crash, but the WebView2 rendering/lifetime model still needs hardening. Dynamic resize and overlay-driven visibility are currently conservative to avoid touching WebView2 COM objects from the hot render loop.

## Validation

- `zig build`
- `zig build test`
- `zig build -Dwebview2=true`
- `zig build -Dwebview2=true test`
- Windows path compatibility check: no illegal names, no casefold collisions, no symlinks

A later pre-commit rerun of `zig build` was blocked because `zig-out\bin\phantty.exe` was still running and locked the output file, not because of a compile error.
