### PR TITLE
Add SSH keepalive to defeat NAT idle drops

### DIFF
--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -194,10 +194,12 @@ fn splitSshCommand(
     const conn = surface.ssh_connection orelse return null;
 
     var command_buf: [512]u8 = undefined;
+    // Keep this in sync with overlays.connectSshProfile — see comment there
+    // for why ServerAlive* is mandatory for split-inherited SSH sessions too.
     const auth_flags = if (conn.password_auth)
-        "-o StrictHostKeyChecking=accept-new -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no "
+        "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no "
     else
-        "-o StrictHostKeyChecking=accept-new ";
+        "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 ";
     const command = if (conn.port().len > 0)
         std.fmt.bufPrint(&command_buf, "cmd.exe /k ssh.exe -tt {s}-p {s} {s}@{s}", .{ auth_flags, conn.port(), conn.user(), conn.host() }) catch return null
     else

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1054,10 +1054,13 @@ fn connectSshProfile(idx: usize) void {
     if (port.len > 0 and !isPortTokenSafe(port)) return;
 
     var command_buf: [512]u8 = undefined;
+    // ServerAlive* sends an encrypted keepalive every 60s and gives up after 3
+    // misses (~3 min). Defeats NAT/firewall idle drops that hang interactive
+    // sessions (e.g. Codex over SSH) after ~10 min of silence.
     const auth_flags = if (password.len > 0)
-        "-o StrictHostKeyChecking=accept-new -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no "
+        "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no "
     else
-        "-o StrictHostKeyChecking=accept-new ";
+        "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 ";
     const command = if (port.len > 0)
         std.fmt.bufPrint(&command_buf, "cmd.exe /k ssh.exe -tt {s}-p {s} {s}@{s}", .{ auth_flags, port, user, ip }) catch return
     else


### PR DESCRIPTION
## Summary

- Adds `-o ServerAliveInterval=60 -o ServerAliveCountMax=3` to both interactive `ssh.exe -tt` launches: `connectSshProfile` in `src/renderer/overlays.zig` (initial connect from the session launcher) and `splitSshCommand` in `src/appwindow/tab.zig` (split-inherited sessions).
- Fixes the reported hang where, after ~10 min of inactivity, NAT/firewall idle timeouts silently drop the TCP connection. ssh keeps waiting on a dead socket and the next keystroke — including Codex's remote access — hangs indefinitely.
- With keepalive: ssh sends an encrypted probe every 60s and gives up after ~3 min of unanswered probes, so the user gets a clean disconnect instead of a stuck pane.

## Why these values

- `ServerAliveInterval=60` is well below typical NAT/firewall idle timeouts (5–10 min) and matches common defaults in production tooling.
- `ServerAliveCountMax=3` ≈ 3 min before giving up — fast enough to surface real network failures, tolerant of brief blips.

## Notes

- The two call sites duplicate the auth-flag string by design (matching the existing pattern); `tab.zig` has a comment pointing at `overlays.zig` so future edits stay in sync.
- Helper SSH/SCP calls in `src/scp.zig` are intentionally untouched — they're short-lived and don't have the idle-hang failure mode.
- I do not have a Zig toolchain in this environment, so the change has not been built locally; it is a pure string-literal edit and should compile cleanly.

## Test plan

- [ ] Build on Windows (`zig build`).
- [ ] Connect to an SSH host through the session launcher, leave idle for >10 min behind a NAT, return and type — connection should still respond.
- [ ] Open a split that inherits an SSH connection, repeat idle test.
- [ ] Kill the network mid-session — ssh should exit on its own within ~3 min instead of hanging forever.