### PR TITLE
[codex] embed WebView2 browser panel

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -81,6 +81,9 @@ jobs:
         run: |
           $portableExe = "zig-out\dist\portable\phantty.exe"
           $portableVersion = "zig-out\dist\portable\version.txt"
+          $portableWebView2Exe = "zig-out\dist\portable-webview2\phantty.exe"
+          $portableWebView2Version = "zig-out\dist\portable-webview2\version.txt"
+          $portableWebView2Loader = "zig-out\dist\portable-webview2\WebView2Loader.dll"
 
           if (!(Test-Path $portableExe)) {
             throw "Portable executable not found: $portableExe"
@@ -90,23 +93,47 @@ jobs:
             throw "Portable version file not found: $portableVersion"
           }
 
+          if (!(Test-Path $portableWebView2Exe)) {
+            throw "Portable WebView2 executable not found: $portableWebView2Exe"
+          }
+
+          if (!(Test-Path $portableWebView2Version)) {
+            throw "Portable WebView2 version file not found: $portableWebView2Version"
+          }
+
+          if (!(Test-Path $portableWebView2Loader)) {
+            throw "Portable WebView2 loader not found: $portableWebView2Loader"
+          }
+
       - name: Create release assets
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}"
           $portableAsset = "phantty-windows-portable-$tag.zip"
+          $portableWebView2Asset = "phantty-windows-portable-webview2-$tag.zip"
 
           if (Test-Path $portableAsset) {
             Remove-Item $portableAsset -Force
           }
+          if (Test-Path $portableWebView2Asset) {
+            Remove-Item $portableWebView2Asset -Force
+          }
 
           Compress-Archive -Path zig-out\dist\portable\* -DestinationPath $portableAsset -Force
+          Compress-Archive -Path zig-out\dist\portable-webview2\* -DestinationPath $portableWebView2Asset -Force
 
       - name: Upload portable artifact
         uses: actions/upload-artifact@v4
         with:
           name: phantty-windows-portable-${{ github.ref_name }}
           path: phantty-windows-portable-${{ github.ref_name }}.zip
+          if-no-files-found: error
+
+      - name: Upload portable WebView2 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: phantty-windows-portable-webview2-${{ github.ref_name }}
+          path: phantty-windows-portable-webview2-${{ github.ref_name }}.zip
           if-no-files-found: error
 
       - name: Publish GitHub release
@@ -116,19 +143,24 @@ jobs:
         run: |
           $tag = "${{ github.ref_name }}"
           $portableAsset = "phantty-windows-portable-$tag.zip"
+          $portableWebView2Asset = "phantty-windows-portable-webview2-$tag.zip"
 
           if (!(Test-Path $portableAsset)) {
             throw "Portable release asset not found: $portableAsset"
           }
+          if (!(Test-Path $portableWebView2Asset)) {
+            throw "Portable WebView2 release asset not found: $portableWebView2Asset"
+          }
 
           gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
           if ($LASTEXITCODE -eq 0) {
-            gh release upload $tag $portableAsset --repo $env:GITHUB_REPOSITORY --clobber
+            gh release upload $tag $portableAsset $portableWebView2Asset --repo $env:GITHUB_REPOSITORY --clobber
           } else {
             $assetNotes = @(
               "Windows assets included in this release:",
               "",
-              "- Portable: zip archive containing phantty.exe",
+              "- Portable: lightweight zip archive containing phantty.exe",
+              "- Portable WebView2: zip archive containing phantty.exe and WebView2Loader.dll for the embedded browser",
               "",
               "The unsigned IExpress setup executable is not published because Windows Defender can quarantine it as a false positive. Use the portable zip for now."
             ) -join "`n"
@@ -145,7 +177,7 @@ jobs:
               $notes = $assetNotes
             }
 
-            gh release create $tag $portableAsset `
+            gh release create $tag $portableAsset $portableWebView2Asset `
               --repo $env:GITHUB_REPOSITORY `
               --verify-tag `
               --generate-notes `

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ URL in terminal output opens it in the same right-side WebView2 panel. In SSH
 profile sessions, loopback URLs such as `http://127.0.0.1:4232` and
 `http://localhost:43455` are opened through an automatic local SSH tunnel;
 non-loopback URLs such as `https://10.10.x.x` or public websites open directly.
+Drag the browser panel's left edge to resize it.
 
 The preview panel can be resized by dragging its left edge and scrolled with the
 mouse wheel. `Ctrl+Shift+W` closes the preview panel before closing a split.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ Explorer to open the right-side preview panel. Markdown previews render
 headings, lists, blockquotes, code blocks, inline code, links, and horizontal
 rules. Text files are shown as plain text.
 
+Open the command center with `Ctrl+Shift+P` and run `Toggle Browser` to open
+the embedded WebView2 browser panel. The first implementation opens
+`http://localhost:3000` in a native child WebView2 window docked to the right
+side of the terminal.
+
 The preview panel can be resized by dragging its left edge and scrolled with the
 mouse wheel. `Ctrl+Shift+W` closes the preview panel before closing a split.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ URL in terminal output opens it in the same right-side WebView2 panel. In SSH
 profile sessions, loopback URLs such as `http://127.0.0.1:4232` and
 `http://localhost:43455` are opened through an automatic local SSH tunnel;
 non-loopback URLs such as `https://10.10.x.x` or public websites open directly.
-Drag the browser panel's left edge to resize it.
+Click the browser panel's URL bar to type a new address; press `Enter` to
+navigate. Drag the browser panel's left edge to resize it.
 
 The preview panel can be resized by dragging its left edge and scrolled with the
 mouse wheel. `Ctrl+Shift+W` closes the preview panel before closing a split.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ development should use PowerShell and direct `zig` commands.
 
 ## Packaging
 
-Phantty now supports two Windows distribution formats:
+Phantty supports two portable Windows packages plus the local installer build:
 
-- `phantty.exe` — portable build, run directly without installation
+- `portable` — lightweight portable build, run directly without installation
+- `portable-webview2` — portable build with `WebView2Loader.dll` for the embedded browser
 - `phantty-setup.exe` — installer build, installs to the current user's profile and creates a Start menu shortcut
 
-Build both artifacts with:
+Build the artifacts with:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\packaging\windows\package.ps1
@@ -50,6 +51,8 @@ This produces:
 
 ```text
 zig-out\dist\portable\phantty.exe
+zig-out\dist\portable-webview2\phantty.exe
+zig-out\dist\portable-webview2\WebView2Loader.dll
 zig-out\dist\installer\phantty-setup.exe
 ```
 
@@ -65,10 +68,11 @@ publishes Windows release assets whenever a tag matching `vX.Y.Z` is pushed.
 Each tagged release uploads:
 
 - `phantty-windows-portable-vX.Y.Z.zip`
+- `phantty-windows-portable-webview2-vX.Y.Z.zip`
 
 The unsigned IExpress installer is not published for now because Windows
 Defender can quarantine it as a false positive. Use the portable zip release
-asset.
+asset, or the `portable-webview2` zip when using the embedded browser panel.
 
 Release notes are checked in under `release-notes/vX.Y.Z.md` when a release
 needs curated notes. If a matching file is present, the workflow prepends it to

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ headings, lists, blockquotes, code blocks, inline code, links, and horizontal
 rules. Text files are shown as plain text.
 
 Open the command center with `Ctrl+Shift+P` and run `Toggle Browser` to open
-the embedded WebView2 browser panel. The first implementation opens
-`http://localhost:3000` in a native child WebView2 window docked to the right
-side of the terminal.
+the embedded WebView2 browser panel. `Ctrl`-clicking an `http://` or `https://`
+URL in terminal output opens it in the same right-side WebView2 panel. In SSH
+profile sessions, loopback URLs such as `http://127.0.0.1:4232` and
+`http://localhost:43455` are opened through an automatic local SSH tunnel;
+non-loopback URLs such as `https://10.10.x.x` or public websites open directly.
 
 The preview panel can be resized by dragging its left edge and scrolled with the
 mouse wheel. `Ctrl+Shift+W` closes the preview panel before closing a split.

--- a/build.zig
+++ b/build.zig
@@ -51,6 +51,7 @@ pub fn build(b: *std.Build) void {
     exe_mod.linkSystemLibrary("shell32", .{});
     exe_mod.linkSystemLibrary("imm32", .{});
     exe_mod.linkSystemLibrary("winhttp", .{});
+    exe_mod.linkSystemLibrary("ole32", .{});
 
     // Add FreeType dependency (shared between main and harfbuzz)
     const freetype_dep = b.lazyDependency("freetype", .{
@@ -110,6 +111,10 @@ pub fn build(b: *std.Build) void {
     exe_mod.addIncludePath(b.path("vendor/glad/include"));
     exe_mod.addCSourceFile(.{
         .file = b.path("vendor/glad/src/gl.c"),
+        .flags = &.{},
+    });
+    exe_mod.addCSourceFile(.{
+        .file = b.path("src/webview2_bridge.c"),
         .flags = &.{},
     });
 

--- a/packaging/windows/Install-Phantty.ps1
+++ b/packaging/windows/Install-Phantty.ps1
@@ -40,6 +40,7 @@ $appName = 'Phantty'
 $publisher = 'Phantty'
 $exeName = 'phantty.exe'
 $sourceExe = Join-Path $PSScriptRoot $exeName
+$sourceWebView2Loader = Join-Path $PSScriptRoot 'WebView2Loader.dll'
 
 if (-not (Test-Path $sourceExe)) {
     throw "Missing payload: $sourceExe"
@@ -47,10 +48,14 @@ if (-not (Test-Path $sourceExe)) {
 
 $resolvedInstallDir = [System.IO.Path]::GetFullPath($InstallDir)
 $installedExe = Join-Path $resolvedInstallDir $exeName
+$installedWebView2Loader = Join-Path $resolvedInstallDir 'WebView2Loader.dll'
 $version = Get-PhanttyVersion
 
 New-Item -ItemType Directory -Path $resolvedInstallDir -Force | Out-Null
 Copy-Item -Path $sourceExe -Destination $installedExe -Force
+if (Test-Path $sourceWebView2Loader) {
+    Copy-Item -Path $sourceWebView2Loader -Destination $installedWebView2Loader -Force
+}
 Set-Content -Path (Join-Path $resolvedInstallDir 'version.txt') -Value $version -Encoding ASCII
 
 $startMenuDir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Phantty'

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -1,8 +1,10 @@
 param(
     [string]$Version,
     [string]$OutputDir = '.\zig-out\dist',
+    [string]$WebView2Version = '1.0.3912.50',
     [switch]$SkipBuild,
-    [switch]$SkipInstaller
+    [switch]$SkipInstaller,
+    [switch]$SkipWebView2Bundle
 )
 
 Set-StrictMode -Version Latest
@@ -29,6 +31,67 @@ function Get-ReleaseVersion {
     return (Get-Date -Format 'yyyy.MM.dd')
 }
 
+function Get-WebView2Loader {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    $loaderRelativePath = 'build\native\x64\WebView2Loader.dll'
+    $nugetLoader = Join-Path $env:USERPROFILE ".nuget\packages\microsoft.web.webview2\$Version\$loaderRelativePath"
+    if (Test-Path $nugetLoader) {
+        return $nugetLoader
+    }
+
+    $cacheRoot = Join-Path $RepoRoot '.zig-cache\webview2'
+    $packageDir = Join-Path $cacheRoot "Microsoft.Web.WebView2.$Version"
+    $cachedLoader = Join-Path $packageDir $loaderRelativePath
+    if (Test-Path $cachedLoader) {
+        return $cachedLoader
+    }
+
+    New-Item -ItemType Directory -Path $cacheRoot -Force | Out-Null
+    $nupkgPath = Join-Path $cacheRoot "Microsoft.Web.WebView2.$Version.nupkg"
+    $zipPath = Join-Path $cacheRoot "Microsoft.Web.WebView2.$Version.zip"
+    $packageUrl = "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/$Version"
+
+    if (-not (Test-Path $nupkgPath)) {
+        Write-Host "Downloading Microsoft.Web.WebView2 $Version"
+        Invoke-WebRequest -Uri $packageUrl -OutFile $nupkgPath
+    }
+
+    Remove-Item -Path $packageDir -Recurse -Force -ErrorAction SilentlyContinue
+    Copy-Item -Path $nupkgPath -Destination $zipPath -Force
+    try {
+        Expand-Archive -LiteralPath $zipPath -DestinationPath $packageDir -Force
+    } finally {
+        Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-Path $cachedLoader)) {
+        throw "WebView2Loader.dll was not found in Microsoft.Web.WebView2 $Version."
+    }
+
+    return $cachedLoader
+}
+
+function Copy-PortablePayload {
+    param(
+        [Parameter(Mandatory = $true)][string]$BinaryPath,
+        [Parameter(Mandatory = $true)][string]$TargetDir,
+        [Parameter(Mandatory = $true)][string]$ReleaseVersion,
+        [string]$WebView2LoaderPath
+    )
+
+    New-Item -ItemType Directory -Path $TargetDir -Force | Out-Null
+    Copy-Item -Path $BinaryPath -Destination (Join-Path $TargetDir 'phantty.exe') -Force
+    Set-Content -Path (Join-Path $TargetDir 'version.txt') -Value $ReleaseVersion -Encoding ASCII
+
+    if (-not [string]::IsNullOrWhiteSpace($WebView2LoaderPath)) {
+        Copy-Item -Path $WebView2LoaderPath -Destination (Join-Path $TargetDir 'WebView2Loader.dll') -Force
+    }
+}
+
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
 $resolvedOutputDir = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDir))
 $releaseVersion = Get-ReleaseVersion -ExplicitVersion $Version
@@ -51,20 +114,30 @@ if (-not (Test-Path $binaryPath)) {
 }
 
 $portableDir = Join-Path $resolvedOutputDir 'portable'
+$portableWebView2Dir = Join-Path $resolvedOutputDir 'portable-webview2'
 $installerDir = Join-Path $resolvedOutputDir 'installer'
 $stagingDir = Join-Path $installerDir 'staging'
 $setupExe = Join-Path $installerDir 'phantty-setup.exe'
 $versionFile = Join-Path $stagingDir 'version.txt'
 $sedFile = Join-Path $installerDir 'phantty-installer.sed'
+$webView2LoaderPath = $null
 
-Remove-Item -Path $portableDir, $installerDir -Recurse -Force -ErrorAction SilentlyContinue
-New-Item -ItemType Directory -Path $portableDir -Force | Out-Null
+if (-not $SkipWebView2Bundle) {
+    $webView2LoaderPath = Get-WebView2Loader -RepoRoot $repoRoot -Version $WebView2Version
+}
 
-Copy-Item -Path $binaryPath -Destination (Join-Path $portableDir 'phantty.exe') -Force
-Set-Content -Path (Join-Path $portableDir 'version.txt') -Value $releaseVersion -Encoding ASCII
+Remove-Item -Path $portableDir, $portableWebView2Dir, $installerDir -Recurse -Force -ErrorAction SilentlyContinue
+
+Copy-PortablePayload -BinaryPath $binaryPath -TargetDir $portableDir -ReleaseVersion $releaseVersion
+if ($webView2LoaderPath) {
+    Copy-PortablePayload -BinaryPath $binaryPath -TargetDir $portableWebView2Dir -ReleaseVersion $releaseVersion -WebView2LoaderPath $webView2LoaderPath
+}
 
 if ($SkipInstaller) {
     Write-Host "Portable build: $(Join-Path $portableDir 'phantty.exe')"
+    if ($webView2LoaderPath) {
+        Write-Host "Portable WebView2 build: $(Join-Path $portableWebView2Dir 'phantty.exe')"
+    }
     Write-Host 'Installer build skipped. Unsigned IExpress installers are prone to Windows Defender false positives.'
     exit 0
 }
@@ -74,7 +147,27 @@ New-Item -ItemType Directory -Path $installerDir, $stagingDir -Force | Out-Null
 Copy-Item -Path $binaryPath -Destination (Join-Path $stagingDir 'phantty.exe') -Force
 Copy-Item -Path (Join-Path $PSScriptRoot 'Install-Phantty.ps1') -Destination (Join-Path $stagingDir 'Install-Phantty.ps1') -Force
 Copy-Item -Path (Join-Path $PSScriptRoot 'install.cmd') -Destination (Join-Path $stagingDir 'install.cmd') -Force
+if ($webView2LoaderPath) {
+    Copy-Item -Path $webView2LoaderPath -Destination (Join-Path $stagingDir 'WebView2Loader.dll') -Force
+}
 Set-Content -Path $versionFile -Value $releaseVersion -Encoding ASCII
+
+$sedFiles = @(
+    'FILE0=phantty.exe',
+    'FILE1=Install-Phantty.ps1',
+    'FILE2=install.cmd',
+    'FILE3=version.txt'
+)
+$sedSourceFiles = @(
+    '%FILE0%=',
+    '%FILE1%=',
+    '%FILE2%=',
+    '%FILE3%='
+)
+if ($webView2LoaderPath) {
+    $sedFiles += 'FILE4=WebView2Loader.dll'
+    $sedSourceFiles += '%FILE4%='
+}
 
 $sedBody = @"
 [Version]
@@ -105,17 +198,11 @@ FriendlyName=Phantty Setup
 AppLaunched=cmd.exe /c install.cmd
 AdminQuietInstCmd=cmd.exe /c install.cmd /quiet
 UserQuietInstCmd=cmd.exe /c install.cmd /quiet
-FILE0=phantty.exe
-FILE1=Install-Phantty.ps1
-FILE2=install.cmd
-FILE3=version.txt
+$($sedFiles -join "`r`n")
 [SourceFiles]
 SourceFiles0=$stagingDir\
 [SourceFiles0]
-%FILE0%=
-%FILE1%=
-%FILE2%=
-%FILE3%=
+$($sedSourceFiles -join "`r`n")
 "@
 
 Set-Content -Path $sedFile -Value $sedBody -Encoding ASCII
@@ -131,4 +218,7 @@ try {
 }
 
 Write-Host "Portable build: $(Join-Path $portableDir 'phantty.exe')"
+if ($webView2LoaderPath) {
+    Write-Host "Portable WebView2 build: $(Join-Path $portableWebView2Dir 'phantty.exe')"
+}
 Write-Host "Installer build: $setupExe"

--- a/src/App.zig
+++ b/src/App.zig
@@ -353,14 +353,15 @@ pub fn requestNewWindow(self: *App, parent_hwnd: ?win32_backend.HWND, cwd: ?[]co
 
 /// Thread entry point for spawned windows.
 fn windowThreadMain(app: *App) void {
-    // Initialize COM for this thread (required for DirectWrite)
+    // Initialize COM as STA for this UI thread. WebView2 requires STA, and
+    // DirectWrite is fine with the same apartment choice.
     const ole32 = std.os.windows.kernel32.GetModuleHandleW(std.unicode.utf8ToUtf16LeStringLiteral("ole32.dll"));
     var co_initialized = false;
     if (ole32) |h| {
         const CoInit = std.os.windows.kernel32.GetProcAddress(h, "CoInitializeEx");
         if (CoInit) |f| {
             const coInitFn: *const fn (?*anyopaque, u32) callconv(.winapi) i32 = @ptrCast(f);
-            const hr = coInitFn(null, 0x0); // COINIT_MULTITHREADED
+            const hr = coInitFn(null, 0x2); // COINIT_APARTMENTTHREADED
             co_initialized = (hr >= 0);
         }
     }

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -230,6 +230,8 @@ fn clearUiStateOnTabChange() void {
     input.g_explorer_resize_dragging = false;
     input.g_markdown_preview_resize_hover = false;
     input.g_markdown_preview_resize_dragging = false;
+    input.g_browser_resize_hover = false;
+    input.g_browser_resize_dragging = false;
     input.g_divider_dragging = false;
     input.g_divider_drag_handle = null;
     input.g_divider_drag_layout = null;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -232,6 +232,7 @@ fn clearUiStateOnTabChange() void {
     input.g_markdown_preview_resize_dragging = false;
     input.g_browser_resize_hover = false;
     input.g_browser_resize_dragging = false;
+    browser_panel.blurUrlBar();
     input.g_divider_dragging = false;
     input.g_divider_drag_handle = null;
     input.g_divider_drag_layout = null;
@@ -601,6 +602,7 @@ fn onWin32Resize(width: i32, height: i32) void {
         file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     }
 
+    overlays.renderBrowserUrlBar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderSessionLauncher(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -1711,6 +1713,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
         gl.Viewport.?(0, 0, fb_width, fb_height);
         gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+        overlays.renderBrowserUrlBar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderStartupShortcutsOverlay(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -32,6 +32,7 @@ pub const file_explorer = @import("file_explorer.zig");
 pub const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig");
 pub const markdown_preview_panel = @import("markdown_preview_panel.zig");
 pub const markdown_preview_renderer = @import("renderer/markdown_preview_renderer.zig");
+pub const browser_panel = @import("browser_panel.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -131,6 +132,7 @@ pub fn deinit(self: *AppWindow) void {
     }
     tab.g_tab_count = 0;
     tab.g_remote_client = null;
+    browser_panel.deinit();
 }
 
 // ============================================================================
@@ -195,6 +197,14 @@ pub fn activeSurface() ?*Surface {
 pub fn currentTitlebarHeight() f32 {
     if (g_window) |w| return @floatFromInt(w.titlebar_height);
     return titlebar.titlebarHeight();
+}
+
+pub fn rightPanelsWidth() f32 {
+    return file_explorer.width() + markdown_preview_panel.width() + browser_panel.width();
+}
+
+pub fn browserPanelRightOffset() f32 {
+    return file_explorer.width() + markdown_preview_panel.width();
 }
 
 fn syncWindowTitlebarHeight(win: *win32_backend.Window) f32 {
@@ -459,8 +469,7 @@ fn onWin32Resize(width: i32, height: i32) void {
     const tb = currentTitlebarHeight();
     const sidebar_w = titlebar.sidebarWidth();
     const explorer_w = file_explorer.width();
-    const preview_w = markdown_preview_panel.width();
-    const right_panels_w = explorer_w + preview_w;
+    const right_panels_w = rightPanelsWidth();
     const avail_w = @as(f32, @floatFromInt(width)) - sidebar_w - right_panels_w - padding_left - padding_right;
     const avail_h = @as(f32, @floatFromInt(height)) - (render_padding * 2 + tb) - padding_top - padding_bottom;
     if (avail_w <= 0 or avail_h <= 0) return;
@@ -487,6 +496,9 @@ fn onWin32Resize(width: i32, height: i32) void {
     const fb_width: c_int = width;
     const fb_height: c_int = height;
     const titlebar_offset: f32 = tb;
+    if (g_window) |w| {
+        browser_panel.sync(w.hwnd, width, height, titlebar_offset, browserPanelRightOffset());
+    }
 
     // Snapshot + rebuild + draw (split-aware, mirrors main loop)
     if (activeTab()) |active_tab| {
@@ -600,7 +612,7 @@ fn resizeWindowToGrid() void {
     const tb = currentTitlebarHeight();
     const content_w: f32 = font.cell_width * @as(f32, @floatFromInt(term_cols));
     const content_h: f32 = font.cell_height * @as(f32, @floatFromInt(term_rows));
-    const win_w: i32 = @intFromFloat(content_w + titlebar.sidebarWidth() + file_explorer.width() + markdown_preview_panel.width() + padding * 2);
+    const win_w: i32 = @intFromFloat(content_w + titlebar.sidebarWidth() + rightPanelsWidth() + padding * 2);
     const win_h: i32 = @intFromFloat(content_h + padding + (padding + tb));
     if (g_window) |w| w.setSize(win_w, win_h);
 }
@@ -1549,9 +1561,9 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
         const titlebar_offset = syncWindowTitlebarHeight(win);
         const sidebar_w = titlebar.sidebarWidth();
         const explorer_w = file_explorer.width();
-        const preview_w = markdown_preview_panel.width();
-        const right_panels_w = explorer_w + preview_w;
+        const right_panels_w = rightPanelsWidth();
         const top_padding: f32 = padding + titlebar_offset;
+        browser_panel.sync(win.hwnd, fb_width, fb_height, titlebar_offset, browserPanelRightOffset());
 
         if (activeTab()) |active_tab| {
             // Compute split layout for the active tab
@@ -1723,6 +1735,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
     // Clean up file explorer async state (join background thread, free job)
     file_explorer.deinit();
+    browser_panel.deinit();
 
     // Tab cleanup is handled by AppWindow.deinit()
 }

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -69,7 +69,7 @@ pub fn hitTestDivider(x: i32, y: i32) ?DividerHit {
     const win = AppWindow.g_window orelse return null;
     const fb = win.getFramebufferSize();
     const sidebar_w = AppWindow.titlebar.sidebarWidth();
-    const right_panels_w = AppWindow.file_explorer.width() + AppWindow.markdown_preview_panel.width();
+    const right_panels_w = AppWindow.rightPanelsWidth();
     const content_x: f32 = sidebar_w + @as(f32, @floatFromInt(DEFAULT_PADDING));
     const content_y = AppWindow.currentTitlebarHeight();
     const content_w: f32 = @as(f32, @floatFromInt(fb.width)) - sidebar_w - right_panels_w - @as(f32, @floatFromInt(2 * DEFAULT_PADDING));

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -157,11 +157,17 @@ pub fn openForSurface(allocator: std.mem.Allocator, parent: ?win32.HWND, url: []
     defer if (tunneled_url) |owned| allocator.free(owned);
 
     if (sshLoopbackUrl(surface, target)) |request| {
-        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host), request.parsed.host) orelse return false;
+        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host), browser_url.remoteTunnelHost(request.parsed.host)) orelse return false;
         tunneled_url = browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port) orelse return false;
         target = tunneled_url.?;
     } else {
         stopTunnel();
+        if (browser_url.parseHttpUrl(target)) |parsed| {
+            if (browser_url.isUnspecifiedHost(parsed.host)) {
+                tunneled_url = browser_url.buildLocalTunnelUrl(allocator, parsed, parsed.port) orelse return false;
+                target = tunneled_url.?;
+            }
+        }
     }
 
     open(parent, target);

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -1,0 +1,173 @@
+//! State and WebView2 interop for the right-side browser panel.
+
+const std = @import("std");
+const win32 = @import("apprt/win32.zig");
+
+pub const DEFAULT_WIDTH: f32 = 720;
+pub const MIN_WIDTH: f32 = 360;
+pub const MAX_WIDTH: f32 = 1280;
+pub const MIN_CONTENT_WIDTH: f32 = 320;
+pub const DEFAULT_URL = "http://localhost:3000";
+
+const MAX_URL_BYTES = 2048;
+const BrowserHandle = opaque {};
+
+extern fn phantty_webview2_create(
+    parent: win32.HWND,
+    left: c_int,
+    top: c_int,
+    right: c_int,
+    bottom: c_int,
+    initial_url: [*:0]const u16,
+) callconv(.c) ?*BrowserHandle;
+extern fn phantty_webview2_set_bounds(browser: *BrowserHandle, left: c_int, top: c_int, right: c_int, bottom: c_int) callconv(.c) void;
+extern fn phantty_webview2_set_visible(browser: *BrowserHandle, visible: c_int) callconv(.c) void;
+extern fn phantty_webview2_focus(browser: *BrowserHandle) callconv(.c) void;
+extern fn phantty_webview2_navigate(browser: *BrowserHandle, url: [*:0]const u16) callconv(.c) void;
+extern fn phantty_webview2_is_ready(browser: *BrowserHandle) callconv(.c) c_int;
+extern fn phantty_webview2_last_error(browser: *BrowserHandle) callconv(.c) win32.HRESULT;
+extern fn phantty_webview2_destroy(browser: *BrowserHandle) callconv(.c) void;
+
+const Bounds = struct {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+};
+
+pub threadlocal var g_visible: bool = false;
+pub threadlocal var g_width: f32 = DEFAULT_WIDTH;
+pub threadlocal var g_last_error: win32.HRESULT = 0;
+threadlocal var g_browser: ?*BrowserHandle = null;
+threadlocal var g_url_buf: [MAX_URL_BYTES]u8 = undefined;
+threadlocal var g_url_len: usize = 0;
+
+pub fn width() f32 {
+    return if (g_visible) g_width else 0;
+}
+
+pub fn open(parent: ?win32.HWND, url: []const u8) void {
+    setUrl(url);
+    g_visible = true;
+
+    if (g_browser) |browser| {
+        navigateCurrentUrl(browser);
+        phantty_webview2_set_visible(browser, 1);
+        focus();
+        return;
+    }
+
+    _ = parent;
+}
+
+pub fn toggle(parent: ?win32.HWND) void {
+    if (g_visible) {
+        close();
+    } else {
+        open(parent, DEFAULT_URL);
+    }
+}
+
+pub fn close() void {
+    g_visible = false;
+    if (g_browser) |browser| {
+        phantty_webview2_set_visible(browser, 0);
+    }
+}
+
+pub fn focus() void {
+    if (g_browser) |browser| {
+        phantty_webview2_focus(browser);
+    }
+}
+
+pub fn isReady() bool {
+    const browser = g_browser orelse return false;
+    return phantty_webview2_is_ready(browser) != 0;
+}
+
+pub fn lastError() win32.HRESULT {
+    if (g_browser) |browser| {
+        g_last_error = phantty_webview2_last_error(browser);
+    }
+    return g_last_error;
+}
+
+pub fn sync(parent: win32.HWND, window_width: i32, window_height: i32, titlebar_height: f32, right_offset: f32) void {
+    if (window_width <= 0 or window_height <= 0) return;
+
+    if (!g_visible) {
+        if (g_browser) |browser| phantty_webview2_set_visible(browser, 0);
+        return;
+    }
+
+    const bounds = panelBounds(window_width, window_height, titlebar_height, right_offset);
+    if (bounds.right <= bounds.left or bounds.bottom <= bounds.top) return;
+
+    if (g_browser == null) {
+        var wide_buf: [MAX_URL_BYTES]u16 = undefined;
+        const wide_url = urlToWide(currentUrl(), &wide_buf) orelse return;
+        g_browser = phantty_webview2_create(parent, bounds.left, bounds.top, bounds.right, bounds.bottom, wide_url);
+        if (g_browser) |browser| {
+            g_last_error = phantty_webview2_last_error(browser);
+        }
+    }
+
+    if (g_browser) |browser| {
+        phantty_webview2_set_bounds(browser, bounds.left, bounds.top, bounds.right, bounds.bottom);
+        phantty_webview2_set_visible(browser, 1);
+        g_last_error = phantty_webview2_last_error(browser);
+    }
+}
+
+pub fn deinit() void {
+    if (g_browser) |browser| {
+        phantty_webview2_destroy(browser);
+        g_browser = null;
+    }
+    g_visible = false;
+}
+
+fn setUrl(url: []const u8) void {
+    const n = @min(url.len, g_url_buf.len - 1);
+    @memcpy(g_url_buf[0..n], url[0..n]);
+    g_url_len = n;
+}
+
+fn currentUrl() []const u8 {
+    if (g_url_len == 0) return DEFAULT_URL;
+    return g_url_buf[0..g_url_len];
+}
+
+fn navigateCurrentUrl(browser: *BrowserHandle) void {
+    var wide_buf: [MAX_URL_BYTES]u16 = undefined;
+    const wide_url = urlToWide(currentUrl(), &wide_buf) orelse return;
+    phantty_webview2_navigate(browser, wide_url);
+    g_last_error = phantty_webview2_last_error(browser);
+}
+
+fn urlToWide(url: []const u8, out: *[MAX_URL_BYTES]u16) ?[*:0]const u16 {
+    if (url.len >= out.len) return null;
+    @memset(out, 0);
+    const len = std.unicode.utf8ToUtf16Le(out[0 .. out.len - 1], url) catch return null;
+    out[len] = 0;
+    return out[0..len :0].ptr;
+}
+
+fn panelBounds(window_width: i32, window_height: i32, titlebar_height: f32, right_offset: f32) Bounds {
+    const win_w: f32 = @floatFromInt(window_width);
+    const win_h: f32 = @floatFromInt(window_height);
+    const max_width = @max(MIN_WIDTH, @min(MAX_WIDTH, win_w - right_offset - MIN_CONTENT_WIDTH));
+    const panel_w = @max(MIN_WIDTH, @min(g_width, max_width));
+    const right = @max(0, win_w - right_offset);
+    const left = @max(0, right - panel_w);
+    const top = @max(0, titlebar_height);
+    const bottom = @max(top, win_h);
+
+    return .{
+        .left = @intFromFloat(@round(left)),
+        .top = @intFromFloat(@round(top)),
+        .right = @intFromFloat(@round(right)),
+        .bottom = @intFromFloat(@round(bottom)),
+    };
+}

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -10,6 +10,8 @@ pub const MIN_WIDTH: f32 = 360;
 pub const MAX_WIDTH: f32 = 1280;
 pub const MIN_CONTENT_WIDTH: f32 = 320;
 pub const RESIZE_HIT_WIDTH: f32 = 12;
+pub const URL_BAR_HEIGHT: f32 = 42;
+pub const URL_BAR_MARGIN: f32 = 8;
 pub const DEFAULT_URL = "http://localhost:3000";
 
 const MAX_URL_BYTES = 2048;
@@ -36,20 +38,34 @@ extern fn phantty_webview2_is_ready(browser: *BrowserHandle) callconv(.c) c_int;
 extern fn phantty_webview2_last_error(browser: *BrowserHandle) callconv(.c) win32.HRESULT;
 extern fn phantty_webview2_destroy(browser: *BrowserHandle) callconv(.c) void;
 
-const Bounds = struct {
+pub const Bounds = struct {
     left: i32,
     top: i32,
     right: i32,
     bottom: i32,
 };
 
-fn contentBounds(bounds: Bounds) ?Bounds {
+pub fn urlBarBounds(bounds: Bounds) ?Bounds {
     const grip: i32 = @intFromFloat(@round(RESIZE_HIT_WIDTH));
     const left = @min(bounds.right, bounds.left + grip);
-    if (bounds.right <= left or bounds.bottom <= bounds.top) return null;
+    const bottom = @min(bounds.bottom, bounds.top + @as(i32, @intFromFloat(@round(URL_BAR_HEIGHT))));
+    if (bounds.right <= left or bottom <= bounds.top) return null;
     return .{
         .left = left,
         .top = bounds.top,
+        .right = bounds.right,
+        .bottom = bottom,
+    };
+}
+
+pub fn contentBounds(bounds: Bounds) ?Bounds {
+    const grip: i32 = @intFromFloat(@round(RESIZE_HIT_WIDTH));
+    const left = @min(bounds.right, bounds.left + grip);
+    const top = @min(bounds.bottom, bounds.top + @as(i32, @intFromFloat(@round(URL_BAR_HEIGHT))));
+    if (bounds.right <= left or bounds.bottom <= top) return null;
+    return .{
+        .left = left,
+        .top = top,
         .right = bounds.right,
         .bottom = bounds.bottom,
     };
@@ -61,6 +77,10 @@ pub threadlocal var g_last_error: win32.HRESULT = 0;
 threadlocal var g_browser: ?*BrowserHandle = null;
 threadlocal var g_url_buf: [MAX_URL_BYTES]u8 = undefined;
 threadlocal var g_url_len: usize = 0;
+threadlocal var g_url_bar_focused: bool = false;
+threadlocal var g_url_edit_buf: [MAX_URL_BYTES]u8 = undefined;
+threadlocal var g_url_edit_len: usize = 0;
+threadlocal var g_url_edit_select_all: bool = false;
 threadlocal var g_tunnel: ?SshTunnel = null;
 
 const SshTunnel = struct {
@@ -192,6 +212,8 @@ pub fn toggleForSurface(allocator: std.mem.Allocator, parent: ?win32.HWND, surfa
 
 pub fn close() void {
     g_visible = false;
+    g_url_bar_focused = false;
+    g_url_edit_select_all = false;
     stopTunnel();
     if (g_browser) |browser| {
         phantty_webview2_set_visible(browser, 0);
@@ -224,7 +246,7 @@ pub fn sync(parent: win32.HWND, window_width: i32, window_height: i32, titlebar_
         return;
     }
 
-    const bounds = panelBounds(window_width, window_height, titlebar_height, right_offset);
+    const bounds = boundsForWindow(window_width, window_height, titlebar_height, right_offset);
     if (bounds.right <= bounds.left or bounds.bottom <= bounds.top) return;
 
     const webview_bounds = contentBounds(bounds) orelse return;
@@ -252,6 +274,8 @@ pub fn deinit() void {
     }
     stopTunnel();
     g_visible = false;
+    g_url_bar_focused = false;
+    g_url_edit_select_all = false;
 }
 
 fn setUrl(url: []const u8) void {
@@ -260,9 +284,88 @@ fn setUrl(url: []const u8) void {
     g_url_len = n;
 }
 
-fn currentUrl() []const u8 {
+pub fn currentUrl() []const u8 {
     if (g_url_len == 0) return DEFAULT_URL;
     return g_url_buf[0..g_url_len];
+}
+
+pub fn urlBarFocused() bool {
+    return g_url_bar_focused;
+}
+
+pub fn urlBarText() []const u8 {
+    if (g_url_bar_focused) return g_url_edit_buf[0..g_url_edit_len];
+    return currentUrl();
+}
+
+pub fn urlBarSelectAll() bool {
+    return g_url_bar_focused and g_url_edit_select_all and g_url_edit_len > 0;
+}
+
+pub fn focusUrlBar() void {
+    g_url_bar_focused = true;
+    g_url_edit_len = copyBounded(g_url_edit_buf[0 .. g_url_edit_buf.len - 1], currentUrl());
+    g_url_edit_select_all = g_url_edit_len > 0;
+}
+
+pub fn blurUrlBar() void {
+    g_url_bar_focused = false;
+    g_url_edit_select_all = false;
+}
+
+pub fn insertUrlBarChar(codepoint: u21) void {
+    if (!g_url_bar_focused) return;
+    if (codepoint <= 0x20 or codepoint == 0x7F or codepoint > 0x7E) return;
+    replaceSelectedUrlBeforeEdit();
+    if (g_url_edit_len >= g_url_edit_buf.len - 1) return;
+    g_url_edit_buf[g_url_edit_len] = @intCast(codepoint);
+    g_url_edit_len += 1;
+}
+
+pub fn appendUrlBarText(text: []const u8) void {
+    for (text) |ch| {
+        if (ch <= 0x20 or ch == 0x7F) continue;
+        replaceSelectedUrlBeforeEdit();
+        if (g_url_edit_len >= g_url_edit_buf.len - 1) return;
+        g_url_edit_buf[g_url_edit_len] = ch;
+        g_url_edit_len += 1;
+    }
+}
+
+pub fn backspaceUrlBar() void {
+    if (!g_url_bar_focused or g_url_edit_len == 0) return;
+    if (g_url_edit_select_all) {
+        g_url_edit_len = 0;
+        g_url_edit_select_all = false;
+        return;
+    }
+    g_url_edit_len -= 1;
+}
+
+pub fn clearUrlBar() void {
+    if (!g_url_bar_focused) return;
+    g_url_edit_len = 0;
+    g_url_edit_select_all = false;
+}
+
+pub fn submitUrlBar(allocator: std.mem.Allocator, parent: ?win32.HWND, surface: ?*const Surface) bool {
+    const target = normalizeUrlInput(allocator, g_url_edit_buf[0..g_url_edit_len]) orelse return false;
+    defer allocator.free(target);
+
+    if (!openForSurface(allocator, parent, target, surface)) return false;
+    g_url_bar_focused = false;
+    return true;
+}
+
+pub fn selectAllUrlBar() void {
+    if (!g_url_bar_focused) return;
+    g_url_edit_select_all = g_url_edit_len > 0;
+}
+
+fn replaceSelectedUrlBeforeEdit() void {
+    if (!g_url_edit_select_all) return;
+    g_url_edit_len = 0;
+    g_url_edit_select_all = false;
 }
 
 fn navigateCurrentUrl(browser: *BrowserHandle) void {
@@ -280,7 +383,7 @@ fn urlToWide(url: []const u8, out: *[MAX_URL_BYTES]u16) ?[*:0]const u16 {
     return out[0..len :0].ptr;
 }
 
-fn panelBounds(window_width: i32, window_height: i32, titlebar_height: f32, right_offset: f32) Bounds {
+pub fn boundsForWindow(window_width: i32, window_height: i32, titlebar_height: f32, right_offset: f32) Bounds {
     const win_w: f32 = @floatFromInt(window_width);
     const win_h: f32 = @floatFromInt(window_height);
     const max_width = @max(MIN_WIDTH, @min(MAX_WIDTH, win_w - right_offset - MIN_CONTENT_WIDTH));
@@ -296,6 +399,28 @@ fn panelBounds(window_width: i32, window_height: i32, titlebar_height: f32, righ
         .right = @intFromFloat(@round(right)),
         .bottom = @intFromFloat(@round(bottom)),
     };
+}
+
+fn normalizeUrlInput(allocator: std.mem.Allocator, input: []const u8) ?[]u8 {
+    const trimmed = std.mem.trim(u8, input, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    if (std.mem.indexOf(u8, trimmed, "://") != null) return allocator.dupe(u8, trimmed) catch null;
+
+    const scheme = if (defaultsToHttp(trimmed)) "http" else "https";
+    return std.fmt.allocPrint(allocator, "{s}://{s}", .{ scheme, trimmed }) catch null;
+}
+
+fn defaultsToHttp(input: []const u8) bool {
+    return startsWithIgnoreCase(input, "localhost") or
+        startsWithIgnoreCase(input, "127.") or
+        startsWithIgnoreCase(input, "0.0.0.0") or
+        startsWithIgnoreCase(input, "[::1]") or
+        std.mem.indexOfScalar(u8, input, ':') != null;
+}
+
+fn startsWithIgnoreCase(text: []const u8, prefix: []const u8) bool {
+    if (text.len < prefix.len) return false;
+    return std.ascii.eqlIgnoreCase(text[0..prefix.len], prefix);
 }
 
 const SshLoopbackUrl = struct {

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -9,6 +9,7 @@ pub const DEFAULT_WIDTH: f32 = 720;
 pub const MIN_WIDTH: f32 = 360;
 pub const MAX_WIDTH: f32 = 1280;
 pub const MIN_CONTENT_WIDTH: f32 = 320;
+pub const RESIZE_HIT_WIDTH: f32 = 12;
 pub const DEFAULT_URL = "http://localhost:3000";
 
 const MAX_URL_BYTES = 2048;
@@ -39,6 +40,18 @@ const Bounds = struct {
     right: i32,
     bottom: i32,
 };
+
+fn contentBounds(bounds: Bounds) ?Bounds {
+    const grip: i32 = @intFromFloat(@round(RESIZE_HIT_WIDTH));
+    const left = @min(bounds.right, bounds.left + grip);
+    if (bounds.right <= left or bounds.bottom <= bounds.top) return null;
+    return .{
+        .left = left,
+        .top = bounds.top,
+        .right = bounds.right,
+        .bottom = bounds.bottom,
+    };
+}
 
 pub threadlocal var g_visible: bool = false;
 pub threadlocal var g_width: f32 = DEFAULT_WIDTH;
@@ -101,6 +114,17 @@ const SshTunnel = struct {
 
 pub fn width() f32 {
     return if (g_visible) g_width else 0;
+}
+
+pub fn maxWidthForWindow(window_width: f32) f32 {
+    return @max(MIN_WIDTH, @min(MAX_WIDTH, window_width - MIN_CONTENT_WIDTH));
+}
+
+pub fn setWidth(w: f32, window_width: f32) bool {
+    const next = @max(MIN_WIDTH, @min(maxWidthForWindow(window_width), w));
+    if (next == g_width) return false;
+    g_width = next;
+    return true;
 }
 
 pub fn open(parent: ?win32.HWND, url: []const u8) void {
@@ -187,17 +211,19 @@ pub fn sync(parent: win32.HWND, window_width: i32, window_height: i32, titlebar_
     const bounds = panelBounds(window_width, window_height, titlebar_height, right_offset);
     if (bounds.right <= bounds.left or bounds.bottom <= bounds.top) return;
 
+    const webview_bounds = contentBounds(bounds) orelse return;
+
     if (g_browser == null) {
         var wide_buf: [MAX_URL_BYTES]u16 = undefined;
         const wide_url = urlToWide(currentUrl(), &wide_buf) orelse return;
-        g_browser = phantty_webview2_create(parent, bounds.left, bounds.top, bounds.right, bounds.bottom, wide_url);
+        g_browser = phantty_webview2_create(parent, webview_bounds.left, webview_bounds.top, webview_bounds.right, webview_bounds.bottom, wide_url);
         if (g_browser) |browser| {
             g_last_error = phantty_webview2_last_error(browser);
         }
     }
 
     if (g_browser) |browser| {
-        phantty_webview2_set_bounds(browser, bounds.left, bounds.top, bounds.right, bounds.bottom);
+        phantty_webview2_set_bounds(browser, webview_bounds.left, webview_bounds.top, webview_bounds.right, webview_bounds.bottom);
         phantty_webview2_set_visible(browser, 1);
         g_last_error = phantty_webview2_last_error(browser);
     }

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -2,6 +2,8 @@
 
 const std = @import("std");
 const win32 = @import("apprt/win32.zig");
+const Surface = @import("Surface.zig");
+const browser_url = @import("browser_url.zig");
 
 pub const DEFAULT_WIDTH: f32 = 720;
 pub const MIN_WIDTH: f32 = 360;
@@ -10,6 +12,9 @@ pub const MIN_CONTENT_WIDTH: f32 = 320;
 pub const DEFAULT_URL = "http://localhost:3000";
 
 const MAX_URL_BYTES = 2048;
+const MAX_SSH_DEST_BYTES = 280;
+const MAX_TUNNEL_SPEC_BYTES = 96;
+const MAX_LOCAL_HOST_BYTES = 32;
 const BrowserHandle = opaque {};
 
 extern fn phantty_webview2_create(
@@ -41,6 +46,58 @@ pub threadlocal var g_last_error: win32.HRESULT = 0;
 threadlocal var g_browser: ?*BrowserHandle = null;
 threadlocal var g_url_buf: [MAX_URL_BYTES]u8 = undefined;
 threadlocal var g_url_len: usize = 0;
+threadlocal var g_tunnel: ?SshTunnel = null;
+
+const SshTunnel = struct {
+    child: std.process.Child,
+    local_port: u16,
+    remote_port: u16,
+    local_host_buf: [MAX_LOCAL_HOST_BYTES]u8 = undefined,
+    local_host_len: usize = 0,
+    user_buf: [128]u8 = undefined,
+    user_len: usize = 0,
+    host_buf: [128]u8 = undefined,
+    host_len: usize = 0,
+    ssh_port_buf: [16]u8 = undefined,
+    ssh_port_len: usize = 0,
+
+    fn init(child: std.process.Child, conn: *const Surface.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8) SshTunnel {
+        var tunnel: SshTunnel = .{
+            .child = child,
+            .local_port = local_port,
+            .remote_port = remote_port,
+        };
+        tunnel.local_host_len = copyBounded(tunnel.local_host_buf[0..], local_host);
+        tunnel.user_len = copyBounded(tunnel.user_buf[0..], conn.user());
+        tunnel.host_len = copyBounded(tunnel.host_buf[0..], conn.host());
+        tunnel.ssh_port_len = copyBounded(tunnel.ssh_port_buf[0..], conn.port());
+        return tunnel;
+    }
+
+    fn matches(self: *const SshTunnel, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8) bool {
+        return self.remote_port == remote_port and
+            std.mem.eql(u8, self.localHost(), local_host) and
+            std.mem.eql(u8, self.user(), conn.user()) and
+            std.mem.eql(u8, self.host(), conn.host()) and
+            std.mem.eql(u8, self.sshPort(), conn.port());
+    }
+
+    fn localHost(self: *const SshTunnel) []const u8 {
+        return self.local_host_buf[0..self.local_host_len];
+    }
+
+    fn user(self: *const SshTunnel) []const u8 {
+        return self.user_buf[0..self.user_len];
+    }
+
+    fn host(self: *const SshTunnel) []const u8 {
+        return self.host_buf[0..self.host_len];
+    }
+
+    fn sshPort(self: *const SshTunnel) []const u8 {
+        return self.ssh_port_buf[0..self.ssh_port_len];
+    }
+};
 
 pub fn width() f32 {
     return if (g_visible) g_width else 0;
@@ -60,6 +117,23 @@ pub fn open(parent: ?win32.HWND, url: []const u8) void {
     _ = parent;
 }
 
+pub fn openForSurface(allocator: std.mem.Allocator, parent: ?win32.HWND, url: []const u8, surface: ?*const Surface) bool {
+    var target = url;
+    var tunneled_url: ?[]u8 = null;
+    defer if (tunneled_url) |owned| allocator.free(owned);
+
+    if (sshLoopbackUrl(surface, target)) |request| {
+        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host)) orelse return false;
+        tunneled_url = browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port) orelse return false;
+        target = tunneled_url.?;
+    } else {
+        stopTunnel();
+    }
+
+    open(parent, target);
+    return true;
+}
+
 pub fn toggle(parent: ?win32.HWND) void {
     if (g_visible) {
         close();
@@ -68,8 +142,17 @@ pub fn toggle(parent: ?win32.HWND) void {
     }
 }
 
+pub fn toggleForSurface(allocator: std.mem.Allocator, parent: ?win32.HWND, surface: ?*const Surface) bool {
+    if (g_visible) {
+        close();
+        return true;
+    }
+    return openForSurface(allocator, parent, DEFAULT_URL, surface);
+}
+
 pub fn close() void {
     g_visible = false;
+    stopTunnel();
     if (g_browser) |browser| {
         phantty_webview2_set_visible(browser, 0);
     }
@@ -125,6 +208,7 @@ pub fn deinit() void {
         phantty_webview2_destroy(browser);
         g_browser = null;
     }
+    stopTunnel();
     g_visible = false;
 }
 
@@ -170,4 +254,162 @@ fn panelBounds(window_width: i32, window_height: i32, titlebar_height: f32, righ
         .right = @intFromFloat(@round(right)),
         .bottom = @intFromFloat(@round(bottom)),
     };
+}
+
+const SshLoopbackUrl = struct {
+    conn: Surface.SshConnection,
+    parsed: browser_url.HttpUrl,
+};
+
+fn sshLoopbackUrl(surface: ?*const Surface, url: []const u8) ?SshLoopbackUrl {
+    const s = surface orelse return null;
+    if (s.launch_kind != .ssh) return null;
+    const conn = s.ssh_connection orelse return null;
+    const parsed = browser_url.parseHttpUrl(url) orelse return null;
+    if (!browser_url.isLoopbackHost(parsed.host)) return null;
+    return .{ .conn = conn, .parsed = parsed };
+}
+
+fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8) ?u16 {
+    if (g_tunnel) |*tunnel| {
+        if (tunnel.matches(conn, remote_port, local_host)) return tunnel.local_port;
+    }
+
+    stopTunnel();
+
+    const local_port = reserveLocalPort() orelse return null;
+    var local_spec_buf: [MAX_TUNNEL_SPEC_BYTES]u8 = undefined;
+    const local_spec = std.fmt.bufPrint(
+        &local_spec_buf,
+        "{s}:{d}:127.0.0.1:{d}",
+        .{ local_host, local_port, remote_port },
+    ) catch return null;
+
+    var dest_buf: [MAX_SSH_DEST_BYTES]u8 = undefined;
+    const dest = sshDestination(&dest_buf, conn) orelse return null;
+
+    var askpass_path: ?[]u8 = null;
+    defer if (askpass_path) |path| allocator.free(path);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = ensureAskPassScript(allocator) orelse return null;
+        env_map = std.process.getEnvMap(allocator) catch return null;
+        if (env_map) |*map| {
+            map.put("SSH_ASKPASS", askpass_path.?) catch return null;
+            map.put("SSH_ASKPASS_REQUIRE", "force") catch return null;
+            map.put("DISPLAY", "phantty") catch return null;
+            map.put("PHANTTY_SSH_PASSWORD", conn.password()) catch return null;
+        }
+    }
+
+    var argv_buf: [48][]const u8 = undefined;
+    var argc: usize = 0;
+    argv_buf[argc] = "ssh.exe";
+    argc += 1;
+    argv_buf[argc] = "-N";
+    argc += 1;
+    argv_buf[argc] = "-T";
+    argc += 1;
+    argv_buf[argc] = "-L";
+    argc += 1;
+    argv_buf[argc] = local_spec;
+    argc += 1;
+
+    appendSshOption(&argv_buf, &argc, "ExitOnForwardFailure=yes");
+    appendSshOption(&argv_buf, &argc, "StrictHostKeyChecking=accept-new");
+    appendSshOption(&argv_buf, &argc, "ConnectTimeout=8");
+    appendSshOption(&argv_buf, &argc, "ServerAliveInterval=60");
+    appendSshOption(&argv_buf, &argc, "ServerAliveCountMax=3");
+    if (conn.password_auth) {
+        appendSshOption(&argv_buf, &argc, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        appendSshOption(&argv_buf, &argc, "NumberOfPasswordPrompts=1");
+    } else {
+        appendSshOption(&argv_buf, &argc, "BatchMode=yes");
+    }
+    if (conn.port().len > 0) {
+        argv_buf[argc] = "-p";
+        argc += 1;
+        argv_buf[argc] = conn.port();
+        argc += 1;
+    }
+    argv_buf[argc] = dest;
+    argc += 1;
+
+    // Keep this helper independent. Windows OpenSSH ControlMaster options are
+    // intentionally not used here; they break on Windows socket semantics.
+    var child = std.process.Child.init(argv_buf[0..argc], allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Inherit;
+    if (env_map) |*map| child.env_map = map;
+    child.spawn() catch |err| {
+        std.debug.print("SSH browser tunnel spawn failed: {}\n", .{err});
+        return null;
+    };
+
+    g_tunnel = SshTunnel.init(child, conn, remote_port, local_port, local_host);
+    std.debug.print("SSH browser tunnel: {s}:{d} -> remote 127.0.0.1:{d}\n", .{ local_host, local_port, remote_port });
+    return local_port;
+}
+
+fn stopTunnel() void {
+    if (g_tunnel) |*tunnel| {
+        _ = tunnel.child.kill() catch {};
+        g_tunnel = null;
+    }
+}
+
+fn reserveLocalPort() ?u16 {
+    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return null;
+    var server = address.listen(.{}) catch return null;
+    const port = server.listen_address.getPort();
+    server.deinit();
+    return if (port == 0) null else port;
+}
+
+fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const Surface.SshConnection) ?[]const u8 {
+    const user = conn.user();
+    const host = conn.host();
+    const len = user.len + 1 + host.len;
+    if (len > buf.len) return null;
+    @memcpy(buf[0..user.len], user);
+    buf[user.len] = '@';
+    @memcpy(buf[user.len + 1 ..][0..host.len], host);
+    return buf[0..len];
+}
+
+fn appendSshOption(argv_buf: *[48][]const u8, argc: *usize, option: []const u8) void {
+    argv_buf[argc.*] = "-o";
+    argc.* += 1;
+    argv_buf[argc.*] = option;
+    argc.* += 1;
+}
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+
+fn askPassScriptPath(allocator: std.mem.Allocator) ?[]u8 {
+    const temp = std.process.getEnvVarOwned(allocator, "TEMP") catch
+        std.process.getEnvVarOwned(allocator, "TMP") catch return null;
+    defer allocator.free(temp);
+    return std.fmt.allocPrint(allocator, "{s}\\phantty-ssh-askpass.cmd", .{temp}) catch null;
+}
+
+fn ensureAskPassScript(allocator: std.mem.Allocator) ?[]u8 {
+    const path = askPassScriptPath(allocator) orelse return null;
+    errdefer allocator.free(path);
+
+    const file = std.fs.createFileAbsolute(path, .{ .truncate = true }) catch return null;
+    defer file.close();
+
+    file.writeAll(
+        "@echo off\r\n" ++
+            "powershell.exe -NoLogo -NoProfile -Command \"[Console]::Out.Write($env:PHANTTY_SSH_PASSWORD)\"\r\n",
+    ) catch return null;
+    return path;
 }

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -16,6 +16,8 @@ const MAX_URL_BYTES = 2048;
 const MAX_SSH_DEST_BYTES = 280;
 const MAX_TUNNEL_SPEC_BYTES = 96;
 const MAX_LOCAL_HOST_BYTES = 32;
+const TUNNEL_READY_TIMEOUT_MS = 8000;
+const TUNNEL_READY_POLL_NS = 50 * std.time.ns_per_ms;
 const BrowserHandle = opaque {};
 
 extern fn phantty_webview2_create(
@@ -376,15 +378,62 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnect
     };
 
     g_tunnel = SshTunnel.init(child, conn, remote_port, local_port, local_host);
+    if (!waitForTunnelReady(allocator, local_host, local_port)) {
+        std.debug.print("SSH browser tunnel did not become ready on {s}:{d}\n", .{ local_host, local_port });
+        stopTunnel();
+        return null;
+    }
+
     std.debug.print("SSH browser tunnel: {s}:{d} -> remote 127.0.0.1:{d}\n", .{ local_host, local_port, remote_port });
     return local_port;
 }
 
 fn stopTunnel() void {
     if (g_tunnel) |*tunnel| {
-        _ = tunnel.child.kill() catch {};
+        if (childHasExited(&tunnel.child)) {
+            _ = tunnel.child.wait() catch {};
+        } else {
+            _ = tunnel.child.kill() catch {};
+        }
         g_tunnel = null;
     }
+}
+
+fn waitForTunnelReady(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
+    const deadline = std.time.milliTimestamp() + TUNNEL_READY_TIMEOUT_MS;
+    while (std.time.milliTimestamp() < deadline) {
+        if (canConnectToLocalPort(allocator, local_host, local_port)) return true;
+        if (g_tunnel) |*tunnel| {
+            if (childHasExited(&tunnel.child)) return false;
+        } else {
+            return false;
+        }
+        std.Thread.sleep(TUNNEL_READY_POLL_NS);
+    }
+    return false;
+}
+
+fn canConnectToLocalPort(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
+    if (std.mem.eql(u8, local_host, "127.0.0.1") or std.mem.eql(u8, local_host, "localhost")) {
+        const address = std.net.Address.parseIp4("127.0.0.1", local_port) catch return false;
+        var stream = std.net.tcpConnectToAddress(address) catch {
+            if (!std.mem.eql(u8, local_host, "localhost")) return false;
+            return canConnectToLocalHostName(allocator, local_host, local_port);
+        };
+        stream.close();
+        return true;
+    }
+    return canConnectToLocalHostName(allocator, local_host, local_port);
+}
+
+fn canConnectToLocalHostName(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
+    var stream = std.net.tcpConnectToHost(allocator, local_host, local_port) catch return false;
+    stream.close();
+    return true;
+}
+
+fn childHasExited(child: *const std.process.Child) bool {
+    return win32.WaitForSingleObject(child.id, 0) == win32.WAIT_OBJECT_0;
 }
 
 fn reserveLocalPort() ?u16 {

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -69,6 +69,8 @@ const SshTunnel = struct {
     remote_port: u16,
     local_host_buf: [MAX_LOCAL_HOST_BYTES]u8 = undefined,
     local_host_len: usize = 0,
+    remote_host_buf: [MAX_LOCAL_HOST_BYTES]u8 = undefined,
+    remote_host_len: usize = 0,
     user_buf: [128]u8 = undefined,
     user_len: usize = 0,
     host_buf: [128]u8 = undefined,
@@ -76,22 +78,24 @@ const SshTunnel = struct {
     ssh_port_buf: [16]u8 = undefined,
     ssh_port_len: usize = 0,
 
-    fn init(child: std.process.Child, conn: *const Surface.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8) SshTunnel {
+    fn init(child: std.process.Child, conn: *const Surface.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) SshTunnel {
         var tunnel: SshTunnel = .{
             .child = child,
             .local_port = local_port,
             .remote_port = remote_port,
         };
         tunnel.local_host_len = copyBounded(tunnel.local_host_buf[0..], local_host);
+        tunnel.remote_host_len = copyBounded(tunnel.remote_host_buf[0..], remote_host);
         tunnel.user_len = copyBounded(tunnel.user_buf[0..], conn.user());
         tunnel.host_len = copyBounded(tunnel.host_buf[0..], conn.host());
         tunnel.ssh_port_len = copyBounded(tunnel.ssh_port_buf[0..], conn.port());
         return tunnel;
     }
 
-    fn matches(self: *const SshTunnel, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8) bool {
+    fn matches(self: *const SshTunnel, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) bool {
         return self.remote_port == remote_port and
             std.mem.eql(u8, self.localHost(), local_host) and
+            std.mem.eql(u8, self.remoteHost(), remote_host) and
             std.mem.eql(u8, self.user(), conn.user()) and
             std.mem.eql(u8, self.host(), conn.host()) and
             std.mem.eql(u8, self.sshPort(), conn.port());
@@ -99,6 +103,10 @@ const SshTunnel = struct {
 
     fn localHost(self: *const SshTunnel) []const u8 {
         return self.local_host_buf[0..self.local_host_len];
+    }
+
+    fn remoteHost(self: *const SshTunnel) []const u8 {
+        return self.remote_host_buf[0..self.remote_host_len];
     }
 
     fn user(self: *const SshTunnel) []const u8 {
@@ -149,7 +157,7 @@ pub fn openForSurface(allocator: std.mem.Allocator, parent: ?win32.HWND, url: []
     defer if (tunneled_url) |owned| allocator.free(owned);
 
     if (sshLoopbackUrl(surface, target)) |request| {
-        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host)) orelse return false;
+        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host), request.parsed.host) orelse return false;
         tunneled_url = browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port) orelse return false;
         target = tunneled_url.?;
     } else {
@@ -298,9 +306,14 @@ fn sshLoopbackUrl(surface: ?*const Surface, url: []const u8) ?SshLoopbackUrl {
     return .{ .conn = conn, .parsed = parsed };
 }
 
-fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8) ?u16 {
+fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) ?u16 {
     if (g_tunnel) |*tunnel| {
-        if (tunnel.matches(conn, remote_port, local_host)) return tunnel.local_port;
+        if (tunnel.matches(conn, remote_port, local_host, remote_host) and
+            !childHasExited(&tunnel.child) and
+            canConnectToLocalPort(allocator, tunnel.localHost(), tunnel.local_port))
+        {
+            return tunnel.local_port;
+        }
     }
 
     stopTunnel();
@@ -309,8 +322,8 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnect
     var local_spec_buf: [MAX_TUNNEL_SPEC_BYTES]u8 = undefined;
     const local_spec = std.fmt.bufPrint(
         &local_spec_buf,
-        "{s}:{d}:127.0.0.1:{d}",
-        .{ local_host, local_port, remote_port },
+        "{s}:{d}:{s}:{d}",
+        .{ local_host, local_port, remote_host, remote_port },
     ) catch return null;
 
     var dest_buf: [MAX_SSH_DEST_BYTES]u8 = undefined;
@@ -377,14 +390,14 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnect
         return null;
     };
 
-    g_tunnel = SshTunnel.init(child, conn, remote_port, local_port, local_host);
+    g_tunnel = SshTunnel.init(child, conn, remote_port, local_port, local_host, remote_host);
     if (!waitForTunnelReady(allocator, local_host, local_port)) {
         std.debug.print("SSH browser tunnel did not become ready on {s}:{d}\n", .{ local_host, local_port });
         stopTunnel();
         return null;
     }
 
-    std.debug.print("SSH browser tunnel: {s}:{d} -> remote 127.0.0.1:{d}\n", .{ local_host, local_port, remote_port });
+    std.debug.print("SSH browser tunnel: {s}:{d} -> remote {s}:{d}\n", .{ local_host, local_port, remote_host, remote_port });
     return local_port;
 }
 

--- a/src/browser_url.zig
+++ b/src/browser_url.zig
@@ -50,11 +50,21 @@ pub fn parseHttpUrl(url: []const u8) ?HttpUrl {
 
 pub fn isLoopbackHost(host: []const u8) bool {
     return std.ascii.eqlIgnoreCase(host, "localhost") or
-        std.mem.eql(u8, host, "127.0.0.1");
+        std.mem.eql(u8, host, "127.0.0.1") or
+        std.mem.eql(u8, host, "0.0.0.0");
 }
 
 pub fn localTunnelHost(host: []const u8) []const u8 {
     return if (std.ascii.eqlIgnoreCase(host, "localhost")) "localhost" else "127.0.0.1";
+}
+
+pub fn remoteTunnelHost(host: []const u8) []const u8 {
+    if (std.ascii.eqlIgnoreCase(host, "localhost")) return "localhost";
+    return "127.0.0.1";
+}
+
+pub fn isUnspecifiedHost(host: []const u8) bool {
+    return std.mem.eql(u8, host, "0.0.0.0");
 }
 
 pub fn buildLocalTunnelUrl(allocator: std.mem.Allocator, parsed: HttpUrl, local_port: u16) ?[]u8 {
@@ -95,6 +105,14 @@ test "non-loopback host remains direct" {
     try std.testing.expectEqualStrings("10.10.1.20", parsed.host);
     try std.testing.expectEqual(@as(u16, 8443), parsed.port);
     try std.testing.expect(!isLoopbackHost(parsed.host));
+}
+
+test "0.0.0.0 maps to loopback tunnel targets" {
+    const parsed = parseHttpUrl("http://0.0.0.0:1234") orelse unreachable;
+    try std.testing.expectEqualStrings("0.0.0.0", parsed.host);
+    try std.testing.expect(isLoopbackHost(parsed.host));
+    try std.testing.expectEqualStrings("127.0.0.1", localTunnelHost(parsed.host));
+    try std.testing.expectEqualStrings("127.0.0.1", remoteTunnelHost(parsed.host));
 }
 
 test "build local tunnel URL preserves suffix" {

--- a/src/browser_url.zig
+++ b/src/browser_url.zig
@@ -1,0 +1,105 @@
+//! URL helpers for the embedded browser panel.
+
+const std = @import("std");
+
+pub const HttpUrl = struct {
+    scheme: []const u8,
+    host: []const u8,
+    port: u16,
+    suffix: []const u8,
+};
+
+pub fn parseHttpUrl(url: []const u8) ?HttpUrl {
+    const scheme_end = std.mem.indexOf(u8, url, "://") orelse return null;
+    const scheme = url[0..scheme_end];
+    const is_http = std.ascii.eqlIgnoreCase(scheme, "http");
+    const is_https = std.ascii.eqlIgnoreCase(scheme, "https");
+    if (!is_http and !is_https) return null;
+
+    const authority_start = scheme_end + 3;
+    const authority_end = std.mem.indexOfAnyPos(u8, url, authority_start, "/?#") orelse url.len;
+    const authority = url[authority_start..authority_end];
+    if (authority.len == 0) return null;
+    if (std.mem.indexOfScalar(u8, authority, '@') != null) return null;
+
+    var host = authority;
+    var port: ?u16 = null;
+    if (authority[0] == '[') {
+        const close = std.mem.indexOfScalar(u8, authority, ']') orelse return null;
+        host = authority[1..close];
+        if (close + 1 < authority.len) {
+            if (authority[close + 1] != ':') return null;
+            port = std.fmt.parseInt(u16, authority[close + 2 ..], 10) catch return null;
+        }
+    } else if (std.mem.lastIndexOfScalar(u8, authority, ':')) |colon| {
+        const maybe_port = authority[colon + 1 ..];
+        if (maybe_port.len > 0 and allDigits(maybe_port)) {
+            host = authority[0..colon];
+            port = std.fmt.parseInt(u16, maybe_port, 10) catch return null;
+        }
+    }
+    if (host.len == 0) return null;
+
+    return .{
+        .scheme = scheme,
+        .host = host,
+        .port = port orelse if (is_https) 443 else 80,
+        .suffix = url[authority_end..],
+    };
+}
+
+pub fn isLoopbackHost(host: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(host, "localhost") or
+        std.mem.eql(u8, host, "127.0.0.1");
+}
+
+pub fn localTunnelHost(host: []const u8) []const u8 {
+    return if (std.ascii.eqlIgnoreCase(host, "localhost")) "localhost" else "127.0.0.1";
+}
+
+pub fn buildLocalTunnelUrl(allocator: std.mem.Allocator, parsed: HttpUrl, local_port: u16) ?[]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}://{s}:{d}{s}",
+        .{ parsed.scheme, localTunnelHost(parsed.host), local_port, parsed.suffix },
+    ) catch null;
+}
+
+fn allDigits(text: []const u8) bool {
+    for (text) |ch| {
+        if (ch < '0' or ch > '9') return false;
+    }
+    return text.len > 0;
+}
+
+test "parse localhost URL with explicit port" {
+    const parsed = parseHttpUrl("http://localhost:43455/path?q=1#frag") orelse unreachable;
+    try std.testing.expectEqualStrings("http", parsed.scheme);
+    try std.testing.expectEqualStrings("localhost", parsed.host);
+    try std.testing.expectEqual(@as(u16, 43455), parsed.port);
+    try std.testing.expectEqualStrings("/path?q=1#frag", parsed.suffix);
+    try std.testing.expect(isLoopbackHost(parsed.host));
+}
+
+test "parse 127 URL with default https port" {
+    const parsed = parseHttpUrl("https://127.0.0.1") orelse unreachable;
+    try std.testing.expectEqualStrings("https", parsed.scheme);
+    try std.testing.expectEqualStrings("127.0.0.1", parsed.host);
+    try std.testing.expectEqual(@as(u16, 443), parsed.port);
+    try std.testing.expectEqualStrings("", parsed.suffix);
+    try std.testing.expect(isLoopbackHost(parsed.host));
+}
+
+test "non-loopback host remains direct" {
+    const parsed = parseHttpUrl("https://10.10.1.20:8443") orelse unreachable;
+    try std.testing.expectEqualStrings("10.10.1.20", parsed.host);
+    try std.testing.expectEqual(@as(u16, 8443), parsed.port);
+    try std.testing.expect(!isLoopbackHost(parsed.host));
+}
+
+test "build local tunnel URL preserves suffix" {
+    const parsed = parseHttpUrl("http://127.0.0.1:4232/app?q=1") orelse unreachable;
+    const target = buildLocalTunnelUrl(std.testing.allocator, parsed, 55001) orelse unreachable;
+    defer std.testing.allocator.free(target);
+    try std.testing.expectEqualStrings("http://127.0.0.1:55001/app?q=1", target);
+}

--- a/src/input.zig
+++ b/src/input.zig
@@ -529,8 +529,14 @@ pub fn copyRemoteSessionKeyToClipboard() bool {
 /// Row 0 on screen corresponds to absolute row `viewportOffset()`.
 pub fn viewportOffset() usize {
     const surface = AppWindow.activeSurface() orelse return 0;
-    return surface.terminal.screens.active.pages.scrollbar().offset;
+    return viewportOffsetForSurface(surface);
 }
+
+pub const ScrollbarState = struct {
+    total: usize,
+    offset: usize,
+    len: usize,
+};
 
 /// Convert mouse position to terminal cell coordinates.
 pub fn mouseToCell(xpos: f64, ypos: f64) CellPos {
@@ -555,7 +561,26 @@ fn splitRectForSurface(surface: *Surface) ?split_layout.SplitRect {
 }
 
 pub fn viewportOffsetForSurface(surface: *Surface) usize {
-    return surface.terminal.screens.active.pages.scrollbar().offset;
+    return scrollbarForSurface(surface).offset;
+}
+
+pub fn scrollbarForSurface(surface: *Surface) ScrollbarState {
+    var pages = &surface.terminal.screens.active.pages;
+    const rows: usize = @intCast(pages.rows);
+    if (pages.total_rows <= rows) {
+        return .{
+            .total = rows,
+            .offset = 0,
+            .len = rows,
+        };
+    }
+
+    const sb = pages.scrollbar();
+    return .{
+        .total = sb.total,
+        .offset = sb.offset,
+        .len = sb.len,
+    };
 }
 
 /// Convert a window mouse position to a cell in the clicked split surface.
@@ -1568,7 +1593,9 @@ fn openUrlAtCell(surface: *Surface, cell_pos: CellPos) bool {
     const token = extractUrlRangeAtCell(allocator, surface, cell_pos) orelse return false;
     defer token.deinit(allocator);
     setUrlUnderline(surface, viewportOffsetForSurface(surface) + token.row, token.start_col, token.end_col);
-    return openUrl(surface, token.text);
+    const opened = openUrl(surface, token.text);
+    if (opened) clearUrlUnderline();
+    return opened;
 }
 
 fn updateUrlUnderlineAtMouse(xpos: f64, ypos: f64) void {
@@ -2630,7 +2657,7 @@ pub fn copySelectionToClipboard() void {
     // Lock while reading terminal cells
     surface.render_state.mutex.lock();
     const screen = surface.terminal.screens.active;
-    const vp_off = surface.terminal.screens.active.pages.scrollbar().offset;
+    const vp_off = viewportOffsetForSurface(surface);
     var row: usize = start_row;
     while (row <= end_row) : (row += 1) {
         // Convert absolute row to viewport-relative for getCell

--- a/src/input.zig
+++ b/src/input.zig
@@ -367,6 +367,8 @@ pub threadlocal var g_explorer_resize_hover: bool = false; // Mouse is over the 
 pub threadlocal var g_explorer_resize_dragging: bool = false; // Currently dragging the file explorer edge
 pub threadlocal var g_markdown_preview_resize_hover: bool = false; // Mouse is over the preview resize edge
 pub threadlocal var g_markdown_preview_resize_dragging: bool = false; // Currently dragging the preview edge
+pub threadlocal var g_browser_resize_hover: bool = false; // Mouse is over the WebView2 browser edge
+pub threadlocal var g_browser_resize_dragging: bool = false; // Currently dragging the browser edge
 
 // Internal state (moved from win32_input struct)
 threadlocal var plus_btn_pressed: bool = false;
@@ -1040,6 +1042,28 @@ fn hitTestBrowserPanel(xpos: f64, ypos: f64) bool {
     const browser_w: f64 = @floatCast(browser_panel.width());
     const panel_x: f64 = @as(f64, @floatFromInt(win.width)) - right_offset - browser_w;
     return xpos >= panel_x and xpos < panel_x + browser_w;
+}
+
+fn hitTestBrowserResizeHandle(xpos: f64, ypos: f64) bool {
+    if (!browser_panel.g_visible) return false;
+    if (ypos < titlebarHeight()) return false;
+    const win = AppWindow.g_window orelse return false;
+    const right_offset: f64 = @floatCast(AppWindow.browserPanelRightOffset());
+    const browser_w: f64 = @floatCast(browser_panel.width());
+    const panel_x: f64 = @as(f64, @floatFromInt(win.width)) - right_offset - browser_w;
+    const half_hit: f64 = @as(f64, @floatCast(browser_panel.RESIZE_HIT_WIDTH)) / 2;
+    return xpos >= panel_x - half_hit and xpos <= panel_x + half_hit;
+}
+
+fn applyBrowserWidthFromMouse(xpos: f64) void {
+    const win = AppWindow.g_window orelse return;
+    const right_edge = @as(f64, @floatFromInt(win.width)) - @as(f64, @floatCast(AppWindow.browserPanelRightOffset()));
+    const new_width = right_edge - xpos;
+    const available_width: f32 = @as(f32, @floatFromInt(win.width)) - AppWindow.browserPanelRightOffset();
+    if (!browser_panel.setWidth(@floatCast(new_width), available_width)) return;
+    syncGridFromWindowSize(win.width, win.height);
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
 }
 
 fn hitTestMarkdownPreviewResizeHandle(xpos: f64, ypos: f64) bool {
@@ -1913,6 +1937,12 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_SIZEWE));
                 return;
             }
+            if (hitTestBrowserResizeHandle(xpos, ypos)) {
+                g_browser_resize_dragging = true;
+                g_browser_resize_hover = true;
+                _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_SIZEWE));
+                return;
+            }
 
             if (tab.g_sidebar_visible and xpos < @as(f64, @floatCast(titlebar.sidebarWidth()))) {
                 handleSidebarPress(xpos, ypos);
@@ -2040,6 +2070,13 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 g_markdown_preview_resize_dragging = false;
                 g_markdown_preview_resize_hover = hitTestMarkdownPreviewResizeHandle(xpos, ypos);
                 const cursor_id = if (g_markdown_preview_resize_hover) win32_backend.IDC_SIZEWE else win32_backend.IDC_ARROW;
+                _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, cursor_id));
+                return;
+            }
+            if (g_browser_resize_dragging) {
+                g_browser_resize_dragging = false;
+                g_browser_resize_hover = hitTestBrowserResizeHandle(xpos, ypos);
+                const cursor_id = if (g_browser_resize_hover) win32_backend.IDC_SIZEWE else win32_backend.IDC_ARROW;
                 _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, cursor_id));
                 return;
             }
@@ -2229,6 +2266,11 @@ fn handleMouseMove(ev: win32_backend.MouseMoveEvent) void {
         _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_SIZEWE));
         return;
     }
+    if (g_browser_resize_dragging) {
+        applyBrowserWidthFromMouse(xpos);
+        _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_SIZEWE));
+        return;
+    }
 
     // Handle divider dragging
     if (g_divider_dragging) {
@@ -2306,6 +2348,15 @@ fn handleMouseMove(ev: win32_backend.MouseMoveEvent) void {
         } else if (g_markdown_preview_resize_hover) {
             _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_ARROW));
             g_markdown_preview_resize_hover = false;
+        }
+        const over_browser_resize = hitTestBrowserResizeHandle(xpos, ypos);
+        if (over_browser_resize) {
+            _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_SIZEWE));
+            g_browser_resize_hover = true;
+            return;
+        } else if (g_browser_resize_hover) {
+            _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_ARROW));
+            g_browser_resize_hover = false;
         }
     }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -407,6 +407,17 @@ fn syncGridFromWindowSize(width: i32, height: i32) void {
     }
 }
 
+fn markBrowserUrlBarDirty() void {
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+}
+
+fn blurBrowserUrlBarIfFocused() void {
+    if (!browser_panel.urlBarFocused()) return;
+    browser_panel.blurUrlBar();
+    markBrowserUrlBarDirty();
+}
+
 pub fn toggleSidebar() void {
     tab.g_sidebar_visible = !tab.g_sidebar_visible;
     if (AppWindow.g_window) |win| {
@@ -697,6 +708,13 @@ fn handleChar(ev: win32_backend.CharEvent) void {
         if (!ev.ctrl and !ev.alt) overlays.commandPaletteInsertChar(ev.codepoint);
         return;
     }
+    if (browser_panel.urlBarFocused()) {
+        if (!ev.ctrl and !ev.alt) {
+            browser_panel.insertUrlBarChar(ev.codepoint);
+            markBrowserUrlBarDirty();
+        }
+        return;
+    }
     // File explorer inline editing
     if (file_explorer.g_focused and file_explorer.g_visible and file_explorer.g_op_mode != .none and file_explorer.g_op_mode != .confirm_delete) {
         if (!ev.ctrl and !ev.alt) file_explorer.inputChar(ev.codepoint);
@@ -843,6 +861,10 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
         tab.handleRenameKey(ev);
         return;
     }
+    if (browser_panel.urlBarFocused()) {
+        handleBrowserUrlBarKey(ev);
+        return;
+    }
     // Ctrl+Shift+C = copy
     if (ev.ctrl and ev.shift and ev.vk == 0x43) { // 'C'
         copySelectionToClipboard();
@@ -986,6 +1008,40 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
     }
 }
 
+fn handleBrowserUrlBarKey(ev: win32_backend.KeyEvent) void {
+    if (ev.ctrl and !ev.shift and !ev.alt and ev.vk == 0x41) { // Ctrl+A
+        browser_panel.selectAllUrlBar();
+        markBrowserUrlBarDirty();
+        return;
+    }
+    if (ev.ctrl and !ev.shift and !ev.alt and ev.vk == 0x56) { // Ctrl+V
+        if (pasteClipboardIntoBrowserUrlBar()) markBrowserUrlBarDirty();
+        return;
+    }
+
+    switch (ev.vk) {
+        win32_backend.VK_ESCAPE => {
+            browser_panel.blurUrlBar();
+            markBrowserUrlBarDirty();
+        },
+        win32_backend.VK_RETURN => {
+            const allocator = AppWindow.g_allocator orelse return;
+            const parent = if (AppWindow.g_window) |win| win.hwnd else null;
+            _ = browser_panel.submitUrlBar(allocator, parent, AppWindow.activeSurface());
+            markBrowserUrlBarDirty();
+        },
+        win32_backend.VK_BACK => {
+            browser_panel.backspaceUrlBar();
+            markBrowserUrlBarDirty();
+        },
+        win32_backend.VK_DELETE => {
+            browser_panel.clearUrlBar();
+            markBrowserUrlBarDirty();
+        },
+        else => {},
+    }
+}
+
 fn hitTestSidebarTab(xpos: f64, ypos: f64) ?usize {
     if (!tab.g_sidebar_visible) return null;
     if (xpos < 0 or xpos >= @as(f64, @floatCast(titlebar.sidebarWidth()))) return null;
@@ -1059,14 +1115,32 @@ fn hitTestMarkdownPreviewPanel(xpos: f64, ypos: f64) bool {
     return xpos >= panel_x and xpos < panel_x + preview_w;
 }
 
+fn browserPanelBounds() ?browser_panel.Bounds {
+    if (!browser_panel.g_visible) return null;
+    const win = AppWindow.g_window orelse return null;
+    return browser_panel.boundsForWindow(
+        win.width,
+        win.height,
+        @floatCast(titlebarHeight()),
+        AppWindow.browserPanelRightOffset(),
+    );
+}
+
 fn hitTestBrowserPanel(xpos: f64, ypos: f64) bool {
-    if (!browser_panel.g_visible) return false;
-    if (ypos < titlebarHeight()) return false;
-    const win = AppWindow.g_window orelse return false;
-    const right_offset: f64 = @floatCast(AppWindow.browserPanelRightOffset());
-    const browser_w: f64 = @floatCast(browser_panel.width());
-    const panel_x: f64 = @as(f64, @floatFromInt(win.width)) - right_offset - browser_w;
-    return xpos >= panel_x and xpos < panel_x + browser_w;
+    const bounds = browserPanelBounds() orelse return false;
+    return xpos >= @as(f64, @floatFromInt(bounds.left)) and
+        xpos < @as(f64, @floatFromInt(bounds.right)) and
+        ypos >= @as(f64, @floatFromInt(bounds.top)) and
+        ypos < @as(f64, @floatFromInt(bounds.bottom));
+}
+
+fn hitTestBrowserUrlBar(xpos: f64, ypos: f64) bool {
+    const bounds = browserPanelBounds() orelse return false;
+    const url_bar = browser_panel.urlBarBounds(bounds) orelse return false;
+    return xpos >= @as(f64, @floatFromInt(url_bar.left)) and
+        xpos < @as(f64, @floatFromInt(url_bar.right)) and
+        ypos >= @as(f64, @floatFromInt(url_bar.top)) and
+        ypos < @as(f64, @floatFromInt(url_bar.bottom));
 }
 
 fn hitTestBrowserResizeHandle(xpos: f64, ypos: f64) bool {
@@ -1949,9 +2023,12 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
 
             // Check if click is in the titlebar (tab bar area)
             if (ypos < titlebar_h) {
+                blurBrowserUrlBarIfFocused();
                 handleTopbarPress(xpos);
                 return;
             }
+            const over_browser_url_bar = hitTestBrowserUrlBar(xpos, ypos);
+            if (!over_browser_url_bar) blurBrowserUrlBarIfFocused();
             if (hitTestSidebarResizeHandle(xpos, ypos)) {
                 g_sidebar_resize_dragging = true;
                 g_sidebar_resize_hover = true;
@@ -1971,6 +2048,14 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 return;
             }
 
+            if (over_browser_url_bar) {
+                file_explorer.g_focused = false;
+                if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+                browser_panel.focusUrlBar();
+                markBrowserUrlBarDirty();
+                return;
+            }
+
             if (tab.g_sidebar_visible and xpos < @as(f64, @floatCast(titlebar.sidebarWidth()))) {
                 handleSidebarPress(xpos, ypos);
                 return;
@@ -1979,6 +2064,8 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
             if (hitTestBrowserPanel(xpos, ypos)) {
                 file_explorer.g_focused = false;
                 if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+                browser_panel.blurUrlBar();
+                markBrowserUrlBarDirty();
                 browser_panel.focus();
                 return;
             }
@@ -2741,6 +2828,32 @@ pub fn pasteFromClipboard() void {
         }
         return;
     }
+}
+
+fn pasteClipboardIntoBrowserUrlBar() bool {
+    const win = AppWindow.g_window orelse return false;
+    const allocator = AppWindow.g_allocator orelse return false;
+
+    if (win32_backend.OpenClipboard(win.hwnd) == 0) return false;
+    defer {
+        _ = win32_backend.CloseClipboard();
+    }
+
+    if (win32_backend.GetClipboardData(CF_UNICODETEXT)) |hmem| {
+        const text = readClipboardUnicodeText(allocator, hmem) orelse return false;
+        defer allocator.free(text);
+        browser_panel.appendUrlBarText(text);
+        return text.len > 0;
+    }
+
+    if (win32_backend.GetClipboardData(CF_TEXT)) |hmem| {
+        const text = readClipboardAnsiText(allocator, hmem) orelse return false;
+        defer allocator.free(text);
+        browser_panel.appendUrlBarText(text);
+        return text.len > 0;
+    }
+
+    return false;
 }
 
 pub fn pasteImageFromClipboard() void {

--- a/src/input.zig
+++ b/src/input.zig
@@ -16,6 +16,7 @@ const file_explorer = AppWindow.file_explorer;
 const file_backend = @import("file_backend.zig");
 const markdown_preview = @import("markdown_preview.zig");
 const markdown_preview_panel = AppWindow.markdown_preview_panel;
+const browser_panel = AppWindow.browser_panel;
 const scp = @import("scp.zig");
 const win32_backend = @import("apprt/win32.zig");
 const Config = @import("config.zig");
@@ -381,7 +382,7 @@ fn syncGridFromWindowSize(width: i32, height: i32) void {
     const render_padding: f32 = 10;
     const tb_offset: f32 = @floatCast(titlebarHeight());
     const sidebar_w = titlebar.sidebarWidth();
-    const right_panels_w = file_explorer.width() + markdown_preview_panel.width();
+    const right_panels_w = AppWindow.rightPanelsWidth();
     const explicit_left: f32 = @floatFromInt(split_layout.DEFAULT_PADDING);
     const explicit_right: f32 = @as(f32, @floatFromInt(split_layout.DEFAULT_PADDING)) + overlays.SCROLLBAR_WIDTH;
     const explicit_top: f32 = @floatFromInt(split_layout.DEFAULT_PADDING);
@@ -457,6 +458,34 @@ pub fn toggleFileExplorer() void {
     }
     AppWindow.g_force_rebuild = true;
     AppWindow.g_cells_valid = false;
+}
+
+pub fn toggleBrowserPanel() void {
+    const parent = if (AppWindow.g_window) |win| win.hwnd else null;
+    browser_panel.toggle(parent);
+    if (AppWindow.g_window) |win| {
+        syncGridFromWindowSize(win.width, win.height);
+    }
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+}
+
+pub fn closePanelOrTab() void {
+    if (markdown_preview_panel.g_visible) {
+        markdown_preview_panel.close();
+        if (AppWindow.g_window) |win| syncGridFromWindowSize(win.width, win.height);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
+    if (browser_panel.g_visible) {
+        browser_panel.close();
+        if (AppWindow.g_window) |win| syncGridFromWindowSize(win.width, win.height);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
+    AppWindow.closeFocusedSplit();
 }
 
 pub fn adjustFontSize(delta: i32) void {
@@ -758,14 +787,7 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
     // Ctrl+Shift+W = close focused panel/tab/window
     if (ev.ctrl and ev.shift and ev.vk == 0x57) { // 'W'
         if (tab.g_tab_rename_active) tab.commitTabRename();
-        if (markdown_preview_panel.g_visible) {
-            markdown_preview_panel.close();
-            if (AppWindow.g_window) |win| syncGridFromWindowSize(win.width, win.height);
-            AppWindow.g_force_rebuild = true;
-            AppWindow.g_cells_valid = false;
-            return;
-        }
-        AppWindow.closeFocusedSplit();
+        closePanelOrTab();
         return;
     }
     // Alt+Enter = maximize / restore window
@@ -1006,6 +1028,16 @@ fn hitTestMarkdownPreviewPanel(xpos: f64, ypos: f64) bool {
     const preview_w: f64 = @floatCast(markdown_preview_panel.width());
     const panel_x: f64 = @as(f64, @floatFromInt(win.width)) - explorer_w - preview_w;
     return xpos >= panel_x and xpos < panel_x + preview_w;
+}
+
+fn hitTestBrowserPanel(xpos: f64, ypos: f64) bool {
+    if (!browser_panel.g_visible) return false;
+    if (ypos < titlebarHeight()) return false;
+    const win = AppWindow.g_window orelse return false;
+    const right_offset: f64 = @floatCast(AppWindow.browserPanelRightOffset());
+    const browser_w: f64 = @floatCast(browser_panel.width());
+    const panel_x: f64 = @as(f64, @floatFromInt(win.width)) - right_offset - browser_w;
+    return xpos >= panel_x and xpos < panel_x + browser_w;
 }
 
 fn hitTestMarkdownPreviewResizeHandle(xpos: f64, ypos: f64) bool {
@@ -1523,7 +1555,7 @@ fn updateUrlUnderlineAtMouse(xpos: f64, ypos: f64) void {
         clearUrlUnderline();
         return;
     }
-    if (ypos < titlebarHeight() or hitTestFileExplorer(xpos, ypos) or hitTestMarkdownPreviewPanel(xpos, ypos)) {
+    if (ypos < titlebarHeight() or hitTestFileExplorer(xpos, ypos) or hitTestMarkdownPreviewPanel(xpos, ypos) or hitTestBrowserPanel(xpos, ypos)) {
         clearUrlUnderline();
         return;
     }
@@ -1890,6 +1922,13 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 return;
             }
 
+            if (hitTestBrowserPanel(xpos, ypos)) {
+                file_explorer.g_focused = false;
+                if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+                browser_panel.focus();
+                return;
+            }
+
             // File explorer right sidebar click
             if (hitTestFileExplorer(xpos, ypos)) {
                 handleFileExplorerPress(xpos, ypos, ev.ctrl, ev.shift, ev.alt);
@@ -2208,7 +2247,7 @@ fn handleMouseMove(ev: win32_backend.MouseMoveEvent) void {
             const win = AppWindow.g_window orelse return;
             const fb = win.getFramebufferSize();
             const sidebar_w = titlebar.sidebarWidth();
-            const right_panels_w = file_explorer.width() + markdown_preview_panel.width();
+            const right_panels_w = AppWindow.rightPanelsWidth();
             const content_x: f32 = sidebar_w + @as(f32, @floatFromInt(split_layout.DEFAULT_PADDING));
             const content_y: f32 = @floatCast(titlebarHeight());
             const content_w: f32 = @as(f32, @floatFromInt(fb.width)) - sidebar_w - right_panels_w - @as(f32, @floatFromInt(2 * split_layout.DEFAULT_PADDING));
@@ -2271,6 +2310,11 @@ fn handleMouseMove(ev: win32_backend.MouseMoveEvent) void {
             _ = win32_backend.SetCursor(win32_backend.LoadCursor(null, win32_backend.IDC_ARROW));
             g_markdown_preview_resize_hover = false;
         }
+    }
+
+    if (hitTestBrowserPanel(xpos, ypos)) {
+        clearUrlUnderline();
+        return;
     }
 
     // Focus follows mouse: check if mouse is over a different split
@@ -2421,6 +2465,7 @@ fn appendAlternateScrollKeys(surface: *Surface, ev: win32_backend.MouseWheelEven
 fn handleMouseWheel(ev: win32_backend.MouseWheelEvent) void {
     overlays.startupShortcutsDismiss();
     if (tab.g_sidebar_visible and ev.xpos >= 0 and ev.xpos < @as(i32, @intFromFloat(titlebar.sidebarWidth()))) return;
+    if (hitTestBrowserPanel(@floatFromInt(ev.xpos), @floatFromInt(ev.ypos))) return;
     if (markdown_preview_panel.g_visible) {
         const win = AppWindow.g_window orelse return;
         const panel_x = @as(i32, @intFromFloat(@as(f32, @floatFromInt(win.width)) - file_explorer.width() - markdown_preview_panel.width()));

--- a/src/input.zig
+++ b/src/input.zig
@@ -461,8 +461,10 @@ pub fn toggleFileExplorer() void {
 }
 
 pub fn toggleBrowserPanel() void {
+    const allocator = AppWindow.g_allocator orelse return;
     const parent = if (AppWindow.g_window) |win| win.hwnd else null;
-    browser_panel.toggle(parent);
+    const surface = AppWindow.activeSurface();
+    if (!browser_panel.toggleForSurface(allocator, parent, surface)) return;
     if (AppWindow.g_window) |win| {
         syncGridFromWindowSize(win.width, win.height);
     }
@@ -1519,7 +1521,7 @@ fn extractPreviewPathAtCell(allocator: std.mem.Allocator, surface: *Surface, cel
     return token;
 }
 
-fn openUrl(url: []const u8) bool {
+fn openUrl(surface: *Surface, url: []const u8) bool {
     const allocator = AppWindow.g_allocator orelse return false;
     const target = if (std.mem.startsWith(u8, url, "www."))
         std.fmt.allocPrint(allocator, "https://{s}", .{url}) catch return false
@@ -1527,19 +1529,14 @@ fn openUrl(url: []const u8) bool {
         allocator.dupe(u8, url) catch return false;
     defer allocator.free(target);
 
-    const target_w = std.unicode.utf8ToUtf16LeAllocZ(allocator, target) catch return false;
-    defer allocator.free(target_w);
-
     const hwnd = if (AppWindow.g_window) |win| win.hwnd else null;
-    const result = win32_backend.ShellExecuteW(
-        hwnd,
-        std.unicode.utf8ToUtf16LeStringLiteral("open"),
-        target_w.ptr,
-        null,
-        null,
-        win32_backend.SW_SHOW,
-    );
-    return result > 32;
+    if (!browser_panel.openForSurface(allocator, hwnd, target, surface)) return false;
+    if (AppWindow.g_window) |win| {
+        syncGridFromWindowSize(win.width, win.height);
+    }
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+    return true;
 }
 
 fn openUrlAtCell(surface: *Surface, cell_pos: CellPos) bool {
@@ -1547,7 +1544,7 @@ fn openUrlAtCell(surface: *Surface, cell_pos: CellPos) bool {
     const token = extractUrlRangeAtCell(allocator, surface, cell_pos) orelse return false;
     defer token.deinit(allocator);
     setUrlUnderline(surface, viewportOffsetForSurface(surface) + token.row, token.start_col, token.end_col);
-    return openUrl(token.text);
+    return openUrl(surface, token.text);
 }
 
 fn updateUrlUnderlineAtMouse(xpos: f64, ypos: f64) void {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1947,7 +1947,7 @@ pub const ScrollbarGeometry = struct {
 /// Compute scrollbar geometry for a specific surface.
 /// Returns null if there's no scrollback (nothing to scroll).
 pub fn scrollbarGeometryForSurface(surface: *Surface, view_height: f32, top_padding: f32) ?ScrollbarGeometry {
-    const sb = surface.terminal.screens.active.pages.scrollbar();
+    const sb = AppWindow.input.scrollbarForSurface(surface);
     if (sb.total <= sb.len) return null; // No scrollback, no scrollbar
 
     // Track spans the terminal content area (below top padding, all the way to bottom)
@@ -2074,7 +2074,7 @@ pub fn scrollbarThumbHitTest(ypos: f64, window_height: f32, top_padding: f32) bo
 /// Handle scrollbar drag: convert pixel y to scroll position.
 pub fn scrollbarDrag(ypos: f64, window_height: f32, top_padding: f32) void {
     const surface = AppWindow.activeSurface() orelse return;
-    const sb = surface.terminal.screens.active.pages.scrollbar();
+    const sb = AppWindow.input.scrollbarForSurface(surface);
     if (sb.total <= sb.len) return;
 
     const padding: f32 = 10;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -10,6 +10,7 @@ const font = AppWindow.font;
 const tab = AppWindow.tab;
 const gl_init = AppWindow.gl_init;
 const split_layout = AppWindow.split_layout;
+const browser_panel = AppWindow.browser_panel;
 const Surface = @import("../Surface.zig");
 const SplitTree = @import("../split_tree.zig");
 const Config = @import("../config.zig");
@@ -581,6 +582,69 @@ fn renderTitlebarTextStrongLimited(text: []const u8, x_start: f32, y: f32, color
     const y_aligned = @round(y);
     renderTitlebarTextLimited(text, x, y_aligned, color, max_w);
     renderTitlebarTextLimited(text, x + 1, y_aligned, color, max_w - 1);
+}
+
+pub fn renderBrowserUrlBar(window_width: f32, window_height: f32, top_offset: f32) void {
+    if (!browser_panel.g_visible) return;
+
+    const bounds = browser_panel.boundsForWindow(
+        @intFromFloat(@round(window_width)),
+        @intFromFloat(@round(window_height)),
+        top_offset,
+        AppWindow.browserPanelRightOffset(),
+    );
+    const url_bar = browser_panel.urlBarBounds(bounds) orelse return;
+
+    const gl = &AppWindow.gl;
+    gl.Enable.?(c.GL_BLEND);
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    gl.UseProgram.?(gl_init.shader_program);
+    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    gl.BindVertexArray.?(gl_init.vao);
+
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const panel_bg = mixColor(bg, fg, 0.055);
+    const field_bg = mixColor(bg, fg, 0.12);
+    const field_border = if (browser_panel.urlBarFocused()) accent else mixColor(bg, fg, 0.28);
+    const text_color = mixColor(bg, fg, 0.88);
+    const placeholder_color = mixColor(bg, fg, 0.48);
+
+    const panel_x: f32 = @floatFromInt(bounds.left);
+    const panel_w: f32 = @floatFromInt(bounds.right - bounds.left);
+    const bar_top: f32 = @floatFromInt(url_bar.top);
+    const bar_bottom: f32 = @floatFromInt(url_bar.bottom);
+    const bar_h = @max(1.0, bar_bottom - bar_top);
+    const bar_y = @round(window_height - bar_bottom);
+    gl_init.renderQuadAlpha(panel_x, bar_y, panel_w, bar_h, panel_bg, 0.98);
+
+    const margin = browser_panel.URL_BAR_MARGIN;
+    const input_x = @round(@as(f32, @floatFromInt(url_bar.left)) + margin);
+    const input_w = @max(1.0, @as(f32, @floatFromInt(url_bar.right - url_bar.left)) - margin * 2);
+    const input_h = @max(24.0, bar_h - margin * 2);
+    const input_y = @round(bar_y + margin);
+    renderRoundedQuadAlpha(input_x - 1, input_y - 1, input_w + 2, input_h + 2, 6, field_border, if (browser_panel.urlBarFocused()) 0.70 else 0.34);
+    renderRoundedQuadAlpha(input_x, input_y, input_w, input_h, 5, field_bg, 0.96);
+
+    const text = browser_panel.urlBarText();
+    const shown_text = if (text.len == 0) "Enter URL" else text;
+    const shown_color = if (text.len == 0) placeholder_color else text_color;
+    const text_x = input_x + 10;
+    const text_y = @round(input_y + (input_h - font.g_titlebar_cell_height) / 2);
+    const text_max_w = @max(1.0, input_w - 22);
+    if (browser_panel.urlBarSelectAll()) {
+        const selection_w = @min(text_max_w, measureTitlebarText(shown_text) + 6);
+        renderRoundedQuadAlpha(text_x - 3, input_y + 5, selection_w, @max(8.0, input_h - 10), 3, mixColor(bg, accent, 0.58), 0.64);
+    }
+    const text_end = titlebar.renderTextLimited(shown_text, text_x, text_y, shown_color, text_max_w);
+
+    if (browser_panel.urlBarFocused() and !browser_panel.urlBarSelectAll()) {
+        const cursor_x = @min(input_x + input_w - 10, @max(text_x, text_end + 1));
+        gl_init.renderQuadAlpha(cursor_x, input_y + 6, 1.5, @max(8.0, input_h - 12), accent, 0.90);
+    }
+
+    gl_init.renderQuadAlpha(panel_x, bar_y, panel_w, 1, mixColor(bg, fg, 0.18), 0.55);
 }
 
 /// Render the command center overlay.

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -173,6 +173,7 @@ const CommandAction = enum {
     close_split_or_tab,
     toggle_sidebar,
     toggle_file_explorer,
+    toggle_browser_panel,
     show_shortcuts,
     open_config,
     font_size_decrease,
@@ -199,7 +200,8 @@ const COMMAND_ENTRIES = [_]CommandEntry{
     .{ .title = "Equalize Panels", .detail = "Reset split sizes in the current tab", .shortcut = "Ctrl+Shift+Z", .action = .equalize_splits },
     .{ .title = "Close Panel / Tab", .detail = "Close the focused panel, tab, or window", .shortcut = "Ctrl+Shift+W", .action = .close_split_or_tab },
     .{ .title = "Toggle Sidebar", .detail = "Show or hide the tab sidebar", .shortcut = "Ctrl+Shift+B", .action = .toggle_sidebar },
-    .{ .title = "Toggle File Explorer", .detail = "Show or hide the right-side file browser", .shortcut = "Ctrl+Shift+E", .action = .toggle_file_explorer },
+    .{ .title = "Toggle File Explorer", .detail = "Show or hide the right-side file explorer", .shortcut = "Ctrl+Shift+E", .action = .toggle_file_explorer },
+    .{ .title = "Toggle Browser", .detail = "Show or hide the right-side WebView2 browser", .shortcut = "", .action = .toggle_browser_panel },
     .{ .title = "Keyboard Shortcuts", .detail = "Show the shortcut reference overlay", .shortcut = "Ctrl+Shift+P", .action = .show_shortcuts },
     .{ .title = "Open Config", .detail = "Open the Phantty config file", .shortcut = "Ctrl+,", .action = .open_config },
     .{ .title = "Decrease Font Size", .detail = "Make terminal text smaller", .shortcut = "Ctrl+-", .action = .font_size_decrease },
@@ -330,9 +332,10 @@ fn executeCommand(action: CommandAction) void {
         .focus_previous => AppWindow.gotoSplit(.previous_wrapped),
         .focus_next => AppWindow.gotoSplit(.next_wrapped),
         .equalize_splits => AppWindow.equalizeSplits(),
-        .close_split_or_tab => AppWindow.closeFocusedSplit(),
+        .close_split_or_tab => AppWindow.input.closePanelOrTab(),
         .toggle_sidebar => AppWindow.input.toggleSidebar(),
         .toggle_file_explorer => AppWindow.input.toggleFileExplorer(),
+        .toggle_browser_panel => AppWindow.input.toggleBrowserPanel(),
         .show_shortcuts => startupShortcutsShow(),
         .open_config => if (AppWindow.g_allocator) |alloc| Config.openConfigInEditor(alloc),
         .font_size_decrease => AppWindow.input.adjustFontSize(-1),
@@ -373,8 +376,15 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 fn commandEntryMatches(entry: CommandEntry) bool {
     const filter = commandPaletteFilter();
     if (filter.len == 0) return true;
-    return containsIgnoreCase(entry.title, filter) or
-        containsIgnoreCase(entry.detail, filter) or
+    return commandEntryTitleMatches(entry, filter) or commandEntrySecondaryMatches(entry, filter);
+}
+
+fn commandEntryTitleMatches(entry: CommandEntry, filter: []const u8) bool {
+    return containsIgnoreCase(entry.title, filter);
+}
+
+fn commandEntrySecondaryMatches(entry: CommandEntry, filter: []const u8) bool {
+    return containsIgnoreCase(entry.detail, filter) or
         containsIgnoreCase(entry.shortcut, filter);
 }
 
@@ -393,7 +403,14 @@ fn rebuildPaletteScratch() void {
     }
 
     for (COMMAND_ENTRIES, 0..) |entry, idx| {
-        if (!commandEntryMatches(entry)) continue;
+        if (!commandEntryTitleMatches(entry, filter)) continue;
+        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
+        g_palette_scratch_len += 1;
+    }
+    for (COMMAND_ENTRIES, 0..) |entry, idx| {
+        if (commandEntryTitleMatches(entry, filter)) continue;
+        if (!commandEntrySecondaryMatches(entry, filter)) continue;
         if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
         g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
         g_palette_scratch_len += 1;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -201,7 +201,7 @@ const COMMAND_ENTRIES = [_]CommandEntry{
     .{ .title = "Close Panel / Tab", .detail = "Close the focused panel, tab, or window", .shortcut = "Ctrl+Shift+W", .action = .close_split_or_tab },
     .{ .title = "Toggle Sidebar", .detail = "Show or hide the tab sidebar", .shortcut = "Ctrl+Shift+B", .action = .toggle_sidebar },
     .{ .title = "Toggle File Explorer", .detail = "Show or hide the right-side file explorer", .shortcut = "Ctrl+Shift+E", .action = .toggle_file_explorer },
-    .{ .title = "Toggle Browser", .detail = "Show or hide the right-side WebView2 browser", .shortcut = "", .action = .toggle_browser_panel },
+    .{ .title = "Toggle Browser", .detail = "Show WebView2 browser for local or SSH URLs", .shortcut = "", .action = .toggle_browser_panel },
     .{ .title = "Keyboard Shortcuts", .detail = "Show the shortcut reference overlay", .shortcut = "Ctrl+Shift+P", .action = .show_shortcuts },
     .{ .title = "Open Config", .detail = "Open the Phantty config file", .shortcut = "Ctrl+,", .action = .open_config },
     .{ .title = "Decrease Font Size", .detail = "Make terminal text smaller", .shortcut = "Ctrl+-", .action = .font_size_decrease },

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -3,6 +3,7 @@
 
 comptime {
     _ = @import("scp.zig");
+    _ = @import("browser_url.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("markdown_preview.zig");

--- a/src/webview2_bridge.c
+++ b/src/webview2_bridge.c
@@ -1,0 +1,602 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <objbase.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+
+typedef struct ICoreWebView2 ICoreWebView2;
+typedef struct ICoreWebView2Controller ICoreWebView2Controller;
+typedef struct ICoreWebView2Environment ICoreWebView2Environment;
+typedef struct ICoreWebView2AcceleratorKeyPressedEventArgs ICoreWebView2AcceleratorKeyPressedEventArgs;
+typedef struct ICoreWebView2AcceleratorKeyPressedEventHandler ICoreWebView2AcceleratorKeyPressedEventHandler;
+typedef struct ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler;
+typedef struct ICoreWebView2CreateCoreWebView2ControllerCompletedHandler ICoreWebView2CreateCoreWebView2ControllerCompletedHandler;
+
+typedef HRESULT (WINAPI *CreateCoreWebView2EnvironmentWithOptionsFn)(
+    LPCWSTR browserExecutableFolder,
+    LPCWSTR userDataFolder,
+    void *environmentOptions,
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *environmentCreatedHandler);
+
+typedef struct ICoreWebView2EnvironmentVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2Environment *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2Environment *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2Environment *This);
+    HRESULT (STDMETHODCALLTYPE *CreateCoreWebView2Controller)(
+        ICoreWebView2Environment *This,
+        HWND parentWindow,
+        ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *handler);
+} ICoreWebView2EnvironmentVtbl;
+
+struct ICoreWebView2Environment {
+    const ICoreWebView2EnvironmentVtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2ControllerVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2Controller *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2Controller *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2Controller *This);
+    HRESULT (STDMETHODCALLTYPE *get_IsVisible)(ICoreWebView2Controller *This, BOOL *isVisible);
+    HRESULT (STDMETHODCALLTYPE *put_IsVisible)(ICoreWebView2Controller *This, BOOL isVisible);
+    HRESULT (STDMETHODCALLTYPE *get_Bounds)(ICoreWebView2Controller *This, RECT *bounds);
+    HRESULT (STDMETHODCALLTYPE *put_Bounds)(ICoreWebView2Controller *This, RECT bounds);
+    HRESULT (STDMETHODCALLTYPE *get_ZoomFactor)(ICoreWebView2Controller *This, double *zoomFactor);
+    HRESULT (STDMETHODCALLTYPE *put_ZoomFactor)(ICoreWebView2Controller *This, double zoomFactor);
+    HRESULT (STDMETHODCALLTYPE *add_ZoomFactorChanged)(ICoreWebView2Controller *This, void *eventHandler, void *token);
+    HRESULT (STDMETHODCALLTYPE *remove_ZoomFactorChanged)(ICoreWebView2Controller *This, int64_t token);
+    HRESULT (STDMETHODCALLTYPE *SetBoundsAndZoomFactor)(ICoreWebView2Controller *This, RECT bounds, double zoomFactor);
+    HRESULT (STDMETHODCALLTYPE *MoveFocus)(ICoreWebView2Controller *This, int reason);
+    HRESULT (STDMETHODCALLTYPE *add_MoveFocusRequested)(ICoreWebView2Controller *This, void *eventHandler, void *token);
+    HRESULT (STDMETHODCALLTYPE *remove_MoveFocusRequested)(ICoreWebView2Controller *This, int64_t token);
+    HRESULT (STDMETHODCALLTYPE *add_GotFocus)(ICoreWebView2Controller *This, void *eventHandler, void *token);
+    HRESULT (STDMETHODCALLTYPE *remove_GotFocus)(ICoreWebView2Controller *This, int64_t token);
+    HRESULT (STDMETHODCALLTYPE *add_LostFocus)(ICoreWebView2Controller *This, void *eventHandler, void *token);
+    HRESULT (STDMETHODCALLTYPE *remove_LostFocus)(ICoreWebView2Controller *This, int64_t token);
+    HRESULT (STDMETHODCALLTYPE *add_AcceleratorKeyPressed)(
+        ICoreWebView2Controller *This,
+        ICoreWebView2AcceleratorKeyPressedEventHandler *eventHandler,
+        void *token);
+    HRESULT (STDMETHODCALLTYPE *remove_AcceleratorKeyPressed)(ICoreWebView2Controller *This, int64_t token);
+    HRESULT (STDMETHODCALLTYPE *get_ParentWindow)(ICoreWebView2Controller *This, HWND *parentWindow);
+    HRESULT (STDMETHODCALLTYPE *put_ParentWindow)(ICoreWebView2Controller *This, HWND parentWindow);
+    HRESULT (STDMETHODCALLTYPE *NotifyParentWindowPositionChanged)(ICoreWebView2Controller *This);
+    HRESULT (STDMETHODCALLTYPE *Close)(ICoreWebView2Controller *This);
+    HRESULT (STDMETHODCALLTYPE *get_CoreWebView2)(ICoreWebView2Controller *This, ICoreWebView2 **coreWebView2);
+} ICoreWebView2ControllerVtbl;
+
+struct ICoreWebView2Controller {
+    const ICoreWebView2ControllerVtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2Vtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2 *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2 *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2 *This);
+    HRESULT (STDMETHODCALLTYPE *get_Settings)(ICoreWebView2 *This, void **settings);
+    HRESULT (STDMETHODCALLTYPE *get_Source)(ICoreWebView2 *This, LPWSTR *uri);
+    HRESULT (STDMETHODCALLTYPE *Navigate)(ICoreWebView2 *This, LPCWSTR uri);
+    HRESULT (STDMETHODCALLTYPE *NavigateToString)(ICoreWebView2 *This, LPCWSTR htmlContent);
+} ICoreWebView2Vtbl;
+
+struct ICoreWebView2 {
+    const ICoreWebView2Vtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2AcceleratorKeyPressedEventArgsVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2AcceleratorKeyPressedEventArgs *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2AcceleratorKeyPressedEventArgs *This);
+    HRESULT (STDMETHODCALLTYPE *get_KeyEventKind)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, int *keyEventKind);
+    HRESULT (STDMETHODCALLTYPE *get_VirtualKey)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, UINT *virtualKey);
+    HRESULT (STDMETHODCALLTYPE *get_KeyEventLParam)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, INT *lParam);
+    HRESULT (STDMETHODCALLTYPE *get_PhysicalKeyStatus)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, void *physicalKeyStatus);
+    HRESULT (STDMETHODCALLTYPE *get_Handled)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, BOOL *handled);
+    HRESULT (STDMETHODCALLTYPE *put_Handled)(ICoreWebView2AcceleratorKeyPressedEventArgs *This, BOOL handled);
+} ICoreWebView2AcceleratorKeyPressedEventArgsVtbl;
+
+struct ICoreWebView2AcceleratorKeyPressedEventArgs {
+    const ICoreWebView2AcceleratorKeyPressedEventArgsVtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2AcceleratorKeyPressedEventHandler *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2AcceleratorKeyPressedEventHandler *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2AcceleratorKeyPressedEventHandler *This);
+    HRESULT (STDMETHODCALLTYPE *Invoke)(
+        ICoreWebView2AcceleratorKeyPressedEventHandler *This,
+        ICoreWebView2Controller *sender,
+        ICoreWebView2AcceleratorKeyPressedEventArgs *args);
+} ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl;
+
+struct ICoreWebView2AcceleratorKeyPressedEventHandler {
+    const ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This);
+    HRESULT (STDMETHODCALLTYPE *Invoke)(
+        ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This,
+        HRESULT errorCode,
+        ICoreWebView2Environment *result);
+} ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl;
+
+struct ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler {
+    const ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl *lpVtbl;
+};
+
+typedef struct ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl {
+    HRESULT (STDMETHODCALLTYPE *QueryInterface)(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This, REFIID riid, void **ppvObject);
+    ULONG (STDMETHODCALLTYPE *AddRef)(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This);
+    ULONG (STDMETHODCALLTYPE *Release)(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This);
+    HRESULT (STDMETHODCALLTYPE *Invoke)(
+        ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This,
+        HRESULT errorCode,
+        ICoreWebView2Controller *result);
+} ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl;
+
+struct ICoreWebView2CreateCoreWebView2ControllerCompletedHandler {
+    const ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl *lpVtbl;
+};
+
+typedef struct PhanttyWebView2Browser PhanttyWebView2Browser;
+
+typedef struct EnvCompletedHandler {
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler iface;
+    LONG refs;
+    PhanttyWebView2Browser *browser;
+} EnvCompletedHandler;
+
+typedef struct ControllerCompletedHandler {
+    ICoreWebView2CreateCoreWebView2ControllerCompletedHandler iface;
+    LONG refs;
+    PhanttyWebView2Browser *browser;
+} ControllerCompletedHandler;
+
+typedef struct AcceleratorKeyPressedHandler {
+    ICoreWebView2AcceleratorKeyPressedEventHandler iface;
+    LONG refs;
+    PhanttyWebView2Browser *browser;
+} AcceleratorKeyPressedHandler;
+
+typedef struct EventRegistrationToken {
+    int64_t value;
+} EventRegistrationToken;
+
+struct PhanttyWebView2Browser {
+    HWND parent;
+    RECT bounds;
+    BOOL visible;
+    BOOL com_initialized;
+    HRESULT last_error;
+    HMODULE loader;
+    ICoreWebView2Environment *environment;
+    ICoreWebView2Controller *controller;
+    ICoreWebView2 *webview;
+    EnvCompletedHandler env_handler;
+    ControllerCompletedHandler controller_handler;
+    AcceleratorKeyPressedHandler accelerator_handler;
+    EventRegistrationToken accelerator_token;
+    BOOL accelerator_registered;
+    WCHAR pending_url[2048];
+};
+
+static void copy_url(WCHAR *dst, size_t dst_len, const WCHAR *src) {
+    if (!dst || dst_len == 0) return;
+    dst[0] = 0;
+    if (!src) return;
+    wcsncpy(dst, src, dst_len - 1);
+    dst[dst_len - 1] = 0;
+}
+
+static HRESULT handler_qi(void *This, void **ppvObject) {
+    if (!ppvObject) return E_POINTER;
+    *ppvObject = This;
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE env_QueryInterface(
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This,
+    REFIID riid,
+    void **ppvObject) {
+    (void)riid;
+    return handler_qi(This, ppvObject);
+}
+
+static ULONG STDMETHODCALLTYPE env_AddRef(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This) {
+    EnvCompletedHandler *handler = (EnvCompletedHandler *)This;
+    return (ULONG)InterlockedIncrement(&handler->refs);
+}
+
+static ULONG STDMETHODCALLTYPE env_Release(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This) {
+    EnvCompletedHandler *handler = (EnvCompletedHandler *)This;
+    LONG refs = InterlockedDecrement(&handler->refs);
+    return refs < 0 ? 0 : (ULONG)refs;
+}
+
+static HRESULT STDMETHODCALLTYPE controller_QueryInterface(
+    ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This,
+    REFIID riid,
+    void **ppvObject) {
+    (void)riid;
+    return handler_qi(This, ppvObject);
+}
+
+static ULONG STDMETHODCALLTYPE controller_AddRef(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This) {
+    ControllerCompletedHandler *handler = (ControllerCompletedHandler *)This;
+    return (ULONG)InterlockedIncrement(&handler->refs);
+}
+
+static ULONG STDMETHODCALLTYPE controller_Release(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This) {
+    ControllerCompletedHandler *handler = (ControllerCompletedHandler *)This;
+    LONG refs = InterlockedDecrement(&handler->refs);
+    return refs < 0 ? 0 : (ULONG)refs;
+}
+
+static HRESULT STDMETHODCALLTYPE accelerator_QueryInterface(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This,
+    REFIID riid,
+    void **ppvObject) {
+    (void)riid;
+    return handler_qi(This, ppvObject);
+}
+
+static ULONG STDMETHODCALLTYPE accelerator_AddRef(ICoreWebView2AcceleratorKeyPressedEventHandler *This) {
+    AcceleratorKeyPressedHandler *handler = (AcceleratorKeyPressedHandler *)This;
+    return (ULONG)InterlockedIncrement(&handler->refs);
+}
+
+static ULONG STDMETHODCALLTYPE accelerator_Release(ICoreWebView2AcceleratorKeyPressedEventHandler *This) {
+    AcceleratorKeyPressedHandler *handler = (AcceleratorKeyPressedHandler *)This;
+    LONG refs = InterlockedDecrement(&handler->refs);
+    return refs < 0 ? 0 : (ULONG)refs;
+}
+
+static BOOL key_down(int vk) {
+    return (GetKeyState(vk) & 0x8000) != 0;
+}
+
+static BOOL should_forward_host_shortcut(UINT virtual_key, BOOL ctrl, BOOL shift, BOOL alt) {
+    if (ctrl && shift && !alt) {
+        switch (virtual_key) {
+            case 'B':
+            case 'E':
+            case 'N':
+            case 'O':
+            case 'P':
+            case 'T':
+            case 'W':
+            case 'Z':
+            case VK_OEM_4: // [
+            case VK_OEM_6: // ]
+                return TRUE;
+            default:
+                return FALSE;
+        }
+    }
+
+    if (alt && !ctrl && !shift) {
+        switch (virtual_key) {
+            case VK_RETURN:
+            case VK_LEFT:
+            case VK_RIGHT:
+            case VK_UP:
+            case VK_DOWN:
+                return TRUE;
+            default:
+                return FALSE;
+        }
+    }
+
+    return FALSE;
+}
+
+static HRESULT STDMETHODCALLTYPE accelerator_Invoke(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This,
+    ICoreWebView2Controller *sender,
+    ICoreWebView2AcceleratorKeyPressedEventArgs *args);
+
+static HRESULT STDMETHODCALLTYPE env_Invoke(
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This,
+    HRESULT errorCode,
+    ICoreWebView2Environment *result);
+
+static HRESULT STDMETHODCALLTYPE controller_Invoke(
+    ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This,
+    HRESULT errorCode,
+    ICoreWebView2Controller *result);
+
+static const ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandlerVtbl env_vtbl = {
+    env_QueryInterface,
+    env_AddRef,
+    env_Release,
+    env_Invoke,
+};
+
+static const ICoreWebView2CreateCoreWebView2ControllerCompletedHandlerVtbl controller_vtbl = {
+    controller_QueryInterface,
+    controller_AddRef,
+    controller_Release,
+    controller_Invoke,
+};
+
+static const ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl accelerator_vtbl = {
+    accelerator_QueryInterface,
+    accelerator_AddRef,
+    accelerator_Release,
+    accelerator_Invoke,
+};
+
+static HMODULE try_load_from_nuget(void) {
+    WCHAR user_profile[MAX_PATH];
+    DWORD profile_len = GetEnvironmentVariableW(L"USERPROFILE", user_profile, MAX_PATH);
+    if (profile_len == 0 || profile_len >= MAX_PATH) return NULL;
+
+    WCHAR base[MAX_PATH];
+    if (wsprintfW(base, L"%s\\.nuget\\packages\\microsoft.web.webview2", user_profile) <= 0) {
+        return NULL;
+    }
+
+    WCHAR pattern[MAX_PATH];
+    if (wsprintfW(pattern, L"%s\\*", base) <= 0) return NULL;
+
+    WIN32_FIND_DATAW data;
+    HANDLE find = FindFirstFileW(pattern, &data);
+    if (find == INVALID_HANDLE_VALUE) return NULL;
+
+    HMODULE result = NULL;
+    do {
+        if (!(data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) continue;
+        if (wcscmp(data.cFileName, L".") == 0 || wcscmp(data.cFileName, L"..") == 0) continue;
+
+        WCHAR candidate[MAX_PATH];
+        if (wsprintfW(candidate, L"%s\\%s\\build\\native\\x64\\WebView2Loader.dll", base, data.cFileName) <= 0) {
+            continue;
+        }
+        result = LoadLibraryW(candidate);
+        if (result) break;
+    } while (FindNextFileW(find, &data));
+
+    FindClose(find);
+    return result;
+}
+
+static HMODULE load_loader(void) {
+    HMODULE loader = LoadLibraryW(L"WebView2Loader.dll");
+    if (loader) return loader;
+    return try_load_from_nuget();
+}
+
+static void build_user_data_folder(WCHAR *buf, size_t len) {
+    if (!buf || len == 0) return;
+    buf[0] = 0;
+
+    WCHAR local_app_data[MAX_PATH];
+    DWORD n = GetEnvironmentVariableW(L"LOCALAPPDATA", local_app_data, MAX_PATH);
+    if (n == 0 || n >= MAX_PATH) return;
+
+    WCHAR root[MAX_PATH];
+    if (wsprintfW(root, L"%s\\phantty", local_app_data) <= 0) return;
+    CreateDirectoryW(root, NULL);
+    wsprintfW(buf, L"%s\\webview2", root);
+    CreateDirectoryW(buf, NULL);
+}
+
+static void browser_apply_bounds(PhanttyWebView2Browser *browser) {
+    if (!browser || !browser->controller) return;
+    browser->controller->lpVtbl->put_Bounds(browser->controller, browser->bounds);
+    browser->controller->lpVtbl->put_IsVisible(browser->controller, browser->visible);
+    browser->controller->lpVtbl->NotifyParentWindowPositionChanged(browser->controller);
+}
+
+static HRESULT STDMETHODCALLTYPE accelerator_Invoke(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This,
+    ICoreWebView2Controller *sender,
+    ICoreWebView2AcceleratorKeyPressedEventArgs *args) {
+    (void)sender;
+    AcceleratorKeyPressedHandler *handler = (AcceleratorKeyPressedHandler *)This;
+    PhanttyWebView2Browser *browser = handler->browser;
+    if (!browser || !browser->parent || !args) return S_OK;
+
+    int key_kind = 0;
+    UINT virtual_key = 0;
+    INT key_lparam = 0;
+    if (FAILED(args->lpVtbl->get_KeyEventKind(args, &key_kind))) return S_OK;
+    if (key_kind != 0 && key_kind != 2) return S_OK; // KEY_DOWN or SYSTEM_KEY_DOWN
+    if (FAILED(args->lpVtbl->get_VirtualKey(args, &virtual_key))) return S_OK;
+    (void)args->lpVtbl->get_KeyEventLParam(args, &key_lparam);
+
+    BOOL ctrl = key_down(VK_CONTROL);
+    BOOL shift = key_down(VK_SHIFT);
+    BOOL alt = key_down(VK_MENU);
+    if (!should_forward_host_shortcut(virtual_key, ctrl, shift, alt)) return S_OK;
+
+    args->lpVtbl->put_Handled(args, TRUE);
+    SetFocus(browser->parent);
+    const UINT msg = alt ? WM_SYSKEYDOWN : WM_KEYDOWN;
+    SendMessageW(browser->parent, msg, (WPARAM)virtual_key, (LPARAM)key_lparam);
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE controller_Invoke(
+    ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This,
+    HRESULT errorCode,
+    ICoreWebView2Controller *result) {
+    ControllerCompletedHandler *handler = (ControllerCompletedHandler *)This;
+    PhanttyWebView2Browser *browser = handler->browser;
+    if (!browser) return E_FAIL;
+    browser->last_error = errorCode;
+    if (FAILED(errorCode) || !result) return S_OK;
+
+    browser->controller = result;
+    browser->controller->lpVtbl->AddRef(browser->controller);
+    browser_apply_bounds(browser);
+    browser->last_error = browser->controller->lpVtbl->add_AcceleratorKeyPressed(
+        browser->controller,
+        &browser->accelerator_handler.iface,
+        &browser->accelerator_token);
+    browser->accelerator_registered = SUCCEEDED(browser->last_error);
+
+    ICoreWebView2 *webview = NULL;
+    HRESULT hr = browser->controller->lpVtbl->get_CoreWebView2(browser->controller, &webview);
+    browser->last_error = hr;
+    if (SUCCEEDED(hr) && webview) {
+        browser->webview = webview;
+        if (browser->pending_url[0] != 0) {
+            browser->last_error = browser->webview->lpVtbl->Navigate(browser->webview, browser->pending_url);
+        }
+    }
+    return S_OK;
+}
+
+static HRESULT STDMETHODCALLTYPE env_Invoke(
+    ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This,
+    HRESULT errorCode,
+    ICoreWebView2Environment *result) {
+    EnvCompletedHandler *handler = (EnvCompletedHandler *)This;
+    PhanttyWebView2Browser *browser = handler->browser;
+    if (!browser) return E_FAIL;
+    browser->last_error = errorCode;
+    if (FAILED(errorCode) || !result) return S_OK;
+
+    browser->environment = result;
+    browser->environment->lpVtbl->AddRef(browser->environment);
+    browser->last_error = browser->environment->lpVtbl->CreateCoreWebView2Controller(
+        browser->environment,
+        browser->parent,
+        &browser->controller_handler.iface);
+    return S_OK;
+}
+
+PhanttyWebView2Browser *phantty_webview2_create(
+    HWND parent,
+    int left,
+    int top,
+    int right,
+    int bottom,
+    const WCHAR *initial_url) {
+    HRESULT co_hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+
+    PhanttyWebView2Browser *browser = (PhanttyWebView2Browser *)calloc(1, sizeof(PhanttyWebView2Browser));
+    if (!browser) {
+        if (SUCCEEDED(co_hr)) CoUninitialize();
+        return NULL;
+    }
+
+    browser->parent = parent;
+    browser->bounds.left = left;
+    browser->bounds.top = top;
+    browser->bounds.right = right;
+    browser->bounds.bottom = bottom;
+    browser->visible = TRUE;
+    browser->com_initialized = SUCCEEDED(co_hr);
+    browser->last_error = co_hr;
+    copy_url(browser->pending_url, sizeof(browser->pending_url) / sizeof(browser->pending_url[0]), initial_url);
+
+    if (FAILED(co_hr)) {
+        return browser;
+    }
+
+    browser->env_handler.iface.lpVtbl = &env_vtbl;
+    browser->env_handler.refs = 1;
+    browser->env_handler.browser = browser;
+    browser->controller_handler.iface.lpVtbl = &controller_vtbl;
+    browser->controller_handler.refs = 1;
+    browser->controller_handler.browser = browser;
+    browser->accelerator_handler.iface.lpVtbl = &accelerator_vtbl;
+    browser->accelerator_handler.refs = 1;
+    browser->accelerator_handler.browser = browser;
+
+    browser->loader = load_loader();
+    if (!browser->loader) {
+        browser->last_error = HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
+        return browser;
+    }
+
+    CreateCoreWebView2EnvironmentWithOptionsFn create_environment =
+        (CreateCoreWebView2EnvironmentWithOptionsFn)GetProcAddress(browser->loader, "CreateCoreWebView2EnvironmentWithOptions");
+    if (!create_environment) {
+        browser->last_error = HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
+        return browser;
+    }
+
+    WCHAR user_data[MAX_PATH];
+    build_user_data_folder(user_data, sizeof(user_data) / sizeof(user_data[0]));
+    browser->last_error = create_environment(
+        NULL,
+        user_data[0] ? user_data : NULL,
+        NULL,
+        &browser->env_handler.iface);
+    return browser;
+}
+
+void phantty_webview2_set_bounds(PhanttyWebView2Browser *browser, int left, int top, int right, int bottom) {
+    if (!browser) return;
+    browser->bounds.left = left;
+    browser->bounds.top = top;
+    browser->bounds.right = right;
+    browser->bounds.bottom = bottom;
+    browser_apply_bounds(browser);
+}
+
+void phantty_webview2_set_visible(PhanttyWebView2Browser *browser, int visible) {
+    if (!browser) return;
+    browser->visible = visible ? TRUE : FALSE;
+    browser_apply_bounds(browser);
+}
+
+void phantty_webview2_focus(PhanttyWebView2Browser *browser) {
+    if (!browser || !browser->controller) return;
+    browser->controller->lpVtbl->MoveFocus(browser->controller, 0);
+}
+
+void phantty_webview2_navigate(PhanttyWebView2Browser *browser, const WCHAR *url) {
+    if (!browser) return;
+    copy_url(browser->pending_url, sizeof(browser->pending_url) / sizeof(browser->pending_url[0]), url);
+    if (browser->webview && browser->pending_url[0] != 0) {
+        browser->last_error = browser->webview->lpVtbl->Navigate(browser->webview, browser->pending_url);
+    }
+}
+
+int phantty_webview2_is_ready(PhanttyWebView2Browser *browser) {
+    return browser && browser->controller && browser->webview;
+}
+
+HRESULT phantty_webview2_last_error(PhanttyWebView2Browser *browser) {
+    return browser ? browser->last_error : E_POINTER;
+}
+
+void phantty_webview2_destroy(PhanttyWebView2Browser *browser) {
+    if (!browser) return;
+    if (browser->controller) {
+        if (browser->accelerator_registered) {
+            browser->controller->lpVtbl->remove_AcceleratorKeyPressed(browser->controller, browser->accelerator_token.value);
+            browser->accelerator_registered = FALSE;
+        }
+        browser->controller->lpVtbl->Close(browser->controller);
+    }
+    if (browser->webview) {
+        browser->webview->lpVtbl->Release(browser->webview);
+        browser->webview = NULL;
+    }
+    if (browser->controller) {
+        browser->controller->lpVtbl->Release(browser->controller);
+        browser->controller = NULL;
+    }
+    if (browser->environment) {
+        browser->environment->lpVtbl->Release(browser->environment);
+        browser->environment = NULL;
+    }
+    if (browser->loader) {
+        FreeLibrary(browser->loader);
+        browser->loader = NULL;
+    }
+    if (browser->com_initialized) {
+        CoUninitialize();
+        browser->com_initialized = FALSE;
+    }
+    free(browser);
+}

--- a/src/webview2_bridge.c
+++ b/src/webview2_bridge.c
@@ -167,9 +167,11 @@ typedef struct EventRegistrationToken {
 } EventRegistrationToken;
 
 struct PhanttyWebView2Browser {
+    LONG refs;
     HWND parent;
     RECT bounds;
     BOOL visible;
+    BOOL closing;
     BOOL com_initialized;
     HRESULT last_error;
     HMODULE loader;
@@ -179,10 +181,18 @@ struct PhanttyWebView2Browser {
     EnvCompletedHandler env_handler;
     ControllerCompletedHandler controller_handler;
     AcceleratorKeyPressedHandler accelerator_handler;
+    BOOL env_async_pending;
+    BOOL controller_async_pending;
     EventRegistrationToken accelerator_token;
     BOOL accelerator_registered;
     WCHAR pending_url[2048];
 };
+
+static void browser_release(PhanttyWebView2Browser *browser);
+
+static void browser_add_ref(PhanttyWebView2Browser *browser) {
+    if (browser) InterlockedIncrement(&browser->refs);
+}
 
 static void copy_url(WCHAR *dst, size_t dst_len, const WCHAR *src) {
     if (!dst || dst_len == 0) return;
@@ -191,6 +201,10 @@ static void copy_url(WCHAR *dst, size_t dst_len, const WCHAR *src) {
     wcsncpy(dst, src, dst_len - 1);
     dst[dst_len - 1] = 0;
 }
+
+static ULONG STDMETHODCALLTYPE env_AddRef(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This);
+static ULONG STDMETHODCALLTYPE controller_AddRef(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This);
+static ULONG STDMETHODCALLTYPE accelerator_AddRef(ICoreWebView2AcceleratorKeyPressedEventHandler *This);
 
 static HRESULT handler_qi(void *This, void **ppvObject) {
     if (!ppvObject) return E_POINTER;
@@ -203,7 +217,9 @@ static HRESULT STDMETHODCALLTYPE env_QueryInterface(
     REFIID riid,
     void **ppvObject) {
     (void)riid;
-    return handler_qi(This, ppvObject);
+    HRESULT hr = handler_qi(This, ppvObject);
+    if (SUCCEEDED(hr)) env_AddRef(This);
+    return hr;
 }
 
 static ULONG STDMETHODCALLTYPE env_AddRef(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This) {
@@ -214,6 +230,11 @@ static ULONG STDMETHODCALLTYPE env_AddRef(ICoreWebView2CreateCoreWebView2Environ
 static ULONG STDMETHODCALLTYPE env_Release(ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler *This) {
     EnvCompletedHandler *handler = (EnvCompletedHandler *)This;
     LONG refs = InterlockedDecrement(&handler->refs);
+    PhanttyWebView2Browser *browser = handler->browser;
+    if (refs == 1 && browser && browser->env_async_pending) {
+        browser->env_async_pending = FALSE;
+        browser_release(browser);
+    }
     return refs < 0 ? 0 : (ULONG)refs;
 }
 
@@ -222,7 +243,9 @@ static HRESULT STDMETHODCALLTYPE controller_QueryInterface(
     REFIID riid,
     void **ppvObject) {
     (void)riid;
-    return handler_qi(This, ppvObject);
+    HRESULT hr = handler_qi(This, ppvObject);
+    if (SUCCEEDED(hr)) controller_AddRef(This);
+    return hr;
 }
 
 static ULONG STDMETHODCALLTYPE controller_AddRef(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This) {
@@ -233,6 +256,11 @@ static ULONG STDMETHODCALLTYPE controller_AddRef(ICoreWebView2CreateCoreWebView2
 static ULONG STDMETHODCALLTYPE controller_Release(ICoreWebView2CreateCoreWebView2ControllerCompletedHandler *This) {
     ControllerCompletedHandler *handler = (ControllerCompletedHandler *)This;
     LONG refs = InterlockedDecrement(&handler->refs);
+    PhanttyWebView2Browser *browser = handler->browser;
+    if (refs == 1 && browser && browser->controller_async_pending) {
+        browser->controller_async_pending = FALSE;
+        browser_release(browser);
+    }
     return refs < 0 ? 0 : (ULONG)refs;
 }
 
@@ -241,7 +269,9 @@ static HRESULT STDMETHODCALLTYPE accelerator_QueryInterface(
     REFIID riid,
     void **ppvObject) {
     (void)riid;
-    return handler_qi(This, ppvObject);
+    HRESULT hr = handler_qi(This, ppvObject);
+    if (SUCCEEDED(hr)) accelerator_AddRef(This);
+    return hr;
 }
 
 static ULONG STDMETHODCALLTYPE accelerator_AddRef(ICoreWebView2AcceleratorKeyPressedEventHandler *This) {
@@ -386,10 +416,49 @@ static void build_user_data_folder(WCHAR *buf, size_t len) {
 }
 
 static void browser_apply_bounds(PhanttyWebView2Browser *browser) {
-    if (!browser || !browser->controller) return;
+    if (!browser || browser->closing || !browser->controller) return;
     browser->controller->lpVtbl->put_Bounds(browser->controller, browser->bounds);
     browser->controller->lpVtbl->put_IsVisible(browser->controller, browser->visible);
     browser->controller->lpVtbl->NotifyParentWindowPositionChanged(browser->controller);
+}
+
+static void browser_release_webview_resources(PhanttyWebView2Browser *browser) {
+    if (!browser) return;
+    if (browser->controller) {
+        if (browser->accelerator_registered) {
+            browser->controller->lpVtbl->remove_AcceleratorKeyPressed(browser->controller, browser->accelerator_token.value);
+            browser->accelerator_registered = FALSE;
+        }
+        browser->controller->lpVtbl->Close(browser->controller);
+    }
+    if (browser->webview) {
+        browser->webview->lpVtbl->Release(browser->webview);
+        browser->webview = NULL;
+    }
+    if (browser->controller) {
+        browser->controller->lpVtbl->Release(browser->controller);
+        browser->controller = NULL;
+    }
+    if (browser->environment) {
+        browser->environment->lpVtbl->Release(browser->environment);
+        browser->environment = NULL;
+    }
+}
+
+static void browser_release(PhanttyWebView2Browser *browser) {
+    if (!browser) return;
+    if (InterlockedDecrement(&browser->refs) != 0) return;
+
+    browser_release_webview_resources(browser);
+    if (browser->loader) {
+        FreeLibrary(browser->loader);
+        browser->loader = NULL;
+    }
+    if (browser->com_initialized) {
+        CoUninitialize();
+        browser->com_initialized = FALSE;
+    }
+    free(browser);
 }
 
 static HRESULT STDMETHODCALLTYPE accelerator_Invoke(
@@ -399,7 +468,7 @@ static HRESULT STDMETHODCALLTYPE accelerator_Invoke(
     (void)sender;
     AcceleratorKeyPressedHandler *handler = (AcceleratorKeyPressedHandler *)This;
     PhanttyWebView2Browser *browser = handler->browser;
-    if (!browser || !browser->parent || !args) return S_OK;
+    if (!browser || browser->closing || !browser->parent || !args) return S_OK;
 
     int key_kind = 0;
     UINT virtual_key = 0;
@@ -429,6 +498,10 @@ static HRESULT STDMETHODCALLTYPE controller_Invoke(
     PhanttyWebView2Browser *browser = handler->browser;
     if (!browser) return E_FAIL;
     browser->last_error = errorCode;
+    if (browser->closing) {
+        if (result) result->lpVtbl->Close(result);
+        return S_OK;
+    }
     if (FAILED(errorCode) || !result) return S_OK;
 
     browser->controller = result;
@@ -460,14 +533,20 @@ static HRESULT STDMETHODCALLTYPE env_Invoke(
     PhanttyWebView2Browser *browser = handler->browser;
     if (!browser) return E_FAIL;
     browser->last_error = errorCode;
-    if (FAILED(errorCode) || !result) return S_OK;
+    if (browser->closing || FAILED(errorCode) || !result) return S_OK;
 
     browser->environment = result;
     browser->environment->lpVtbl->AddRef(browser->environment);
+    browser_add_ref(browser);
+    browser->controller_async_pending = TRUE;
     browser->last_error = browser->environment->lpVtbl->CreateCoreWebView2Controller(
         browser->environment,
         browser->parent,
         &browser->controller_handler.iface);
+    if (FAILED(browser->last_error) && browser->controller_async_pending) {
+        browser->controller_async_pending = FALSE;
+        browser_release(browser);
+    }
     return S_OK;
 }
 
@@ -486,6 +565,7 @@ PhanttyWebView2Browser *phantty_webview2_create(
         return NULL;
     }
 
+    browser->refs = 1;
     browser->parent = parent;
     browser->bounds.left = left;
     browser->bounds.top = top;
@@ -525,16 +605,22 @@ PhanttyWebView2Browser *phantty_webview2_create(
 
     WCHAR user_data[MAX_PATH];
     build_user_data_folder(user_data, sizeof(user_data) / sizeof(user_data[0]));
+    browser_add_ref(browser);
+    browser->env_async_pending = TRUE;
     browser->last_error = create_environment(
         NULL,
         user_data[0] ? user_data : NULL,
         NULL,
         &browser->env_handler.iface);
+    if (FAILED(browser->last_error) && browser->env_async_pending) {
+        browser->env_async_pending = FALSE;
+        browser_release(browser);
+    }
     return browser;
 }
 
 void phantty_webview2_set_bounds(PhanttyWebView2Browser *browser, int left, int top, int right, int bottom) {
-    if (!browser) return;
+    if (!browser || browser->closing) return;
     browser->bounds.left = left;
     browser->bounds.top = top;
     browser->bounds.right = right;
@@ -543,18 +629,18 @@ void phantty_webview2_set_bounds(PhanttyWebView2Browser *browser, int left, int 
 }
 
 void phantty_webview2_set_visible(PhanttyWebView2Browser *browser, int visible) {
-    if (!browser) return;
+    if (!browser || browser->closing) return;
     browser->visible = visible ? TRUE : FALSE;
     browser_apply_bounds(browser);
 }
 
 void phantty_webview2_focus(PhanttyWebView2Browser *browser) {
-    if (!browser || !browser->controller) return;
+    if (!browser || browser->closing || !browser->controller) return;
     browser->controller->lpVtbl->MoveFocus(browser->controller, 0);
 }
 
 void phantty_webview2_navigate(PhanttyWebView2Browser *browser, const WCHAR *url) {
-    if (!browser) return;
+    if (!browser || browser->closing) return;
     copy_url(browser->pending_url, sizeof(browser->pending_url) / sizeof(browser->pending_url[0]), url);
     if (browser->webview && browser->pending_url[0] != 0) {
         browser->last_error = browser->webview->lpVtbl->Navigate(browser->webview, browser->pending_url);
@@ -562,7 +648,7 @@ void phantty_webview2_navigate(PhanttyWebView2Browser *browser, const WCHAR *url
 }
 
 int phantty_webview2_is_ready(PhanttyWebView2Browser *browser) {
-    return browser && browser->controller && browser->webview;
+    return browser && !browser->closing && browser->controller && browser->webview;
 }
 
 HRESULT phantty_webview2_last_error(PhanttyWebView2Browser *browser) {
@@ -571,32 +657,7 @@ HRESULT phantty_webview2_last_error(PhanttyWebView2Browser *browser) {
 
 void phantty_webview2_destroy(PhanttyWebView2Browser *browser) {
     if (!browser) return;
-    if (browser->controller) {
-        if (browser->accelerator_registered) {
-            browser->controller->lpVtbl->remove_AcceleratorKeyPressed(browser->controller, browser->accelerator_token.value);
-            browser->accelerator_registered = FALSE;
-        }
-        browser->controller->lpVtbl->Close(browser->controller);
-    }
-    if (browser->webview) {
-        browser->webview->lpVtbl->Release(browser->webview);
-        browser->webview = NULL;
-    }
-    if (browser->controller) {
-        browser->controller->lpVtbl->Release(browser->controller);
-        browser->controller = NULL;
-    }
-    if (browser->environment) {
-        browser->environment->lpVtbl->Release(browser->environment);
-        browser->environment = NULL;
-    }
-    if (browser->loader) {
-        FreeLibrary(browser->loader);
-        browser->loader = NULL;
-    }
-    if (browser->com_initialized) {
-        CoUninitialize();
-        browser->com_initialized = FALSE;
-    }
-    free(browser);
+    browser->closing = TRUE;
+    browser_release_webview_resources(browser);
+    browser_release(browser);
 }


### PR DESCRIPTION
## Summary

This adds a first embedded WebView2 browser panel for Phantty on Windows. The panel is opened from the command center via `Toggle Browser` and docks to the right side of the terminal.

## Details

- Adds a small C WebView2 bridge that creates the environment/controller, embeds the browser as a child HWND, tracks bounds/visibility, and forwards Phantty host shortcuts from WebView2 focus back to the main window.
- Adds Zig-side browser panel state and layout synchronization alongside the existing file explorer and Markdown preview panels.
- Updates the command center matching so title matches are prioritized and `browser` no longer resolves to File Explorer.
- Documents the command-center entry in the README and links the new C bridge into the Zig build.

## Validation

- `zig build`
- `git diff --check`
- Windows path and symlink checks from `AGENTS.md`
- Manual/automation smoke test with WSL `python3 -m http.server 3000`, confirming WebView2 loads the WSL-served page titled `Phantty WSL WebView2 Test`
- Verified `Toggle Browser` opens, hides, and reopens the panel, including from WebView2 focus through accelerator forwarding