### PR TITLE
Background image support behind the terminal

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -55,6 +55,11 @@ unfocused_split_opacity: f32,
 split_divider_color: ?Config.Color,
 focus_follows_mouse: bool,
 
+// Background image
+background_image: ?[]const u8,
+background_opacity: f32,
+background_image_mode: Config.BackgroundImageMode,
+
 // Remote access config
 remote_enabled: bool,
 remote_server_url: ?[]const u8,
@@ -111,6 +116,8 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
     errdefer freeOptStr(allocator, remote_device_name);
     const remote_client_ptr = startRemoteClient(allocator, cfg.@"remote-enabled", remote_server_url, remote_device_name);
     errdefer if (remote_client_ptr) |client| client.destroy();
+    const background_image = try dupeOptStr(allocator, cfg.@"background-image");
+    errdefer freeOptStr(allocator, background_image);
 
     var app = App{
         .allocator = allocator,
@@ -136,6 +143,9 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .unfocused_split_opacity = cfg.@"unfocused-split-opacity",
         .split_divider_color = cfg.@"split-divider-color",
         .focus_follows_mouse = cfg.@"focus-follows-mouse",
+        .background_image = background_image,
+        .background_opacity = cfg.@"background-opacity",
+        .background_image_mode = cfg.@"background-image-mode",
         .remote_enabled = cfg.@"remote-enabled",
         .remote_server_url = remote_server_url,
         .remote_server_fingerprint = remote_server_fingerprint,
@@ -257,6 +267,9 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.unfocused_split_opacity = cfg.@"unfocused-split-opacity";
     self.split_divider_color = cfg.@"split-divider-color";
     self.focus_follows_mouse = cfg.@"focus-follows-mouse";
+    self.replaceOptStr(&self.background_image, cfg.@"background-image");
+    self.background_opacity = cfg.@"background-opacity";
+    self.background_image_mode = cfg.@"background-image-mode";
     self.remote_enabled = cfg.@"remote-enabled";
     self.replaceOptStr(&self.remote_server_url, cfg.@"remote-server-url");
     self.replaceOptStr(&self.remote_server_fingerprint, cfg.@"remote-server-fingerprint");
@@ -468,6 +481,7 @@ pub fn deinit(self: *App) void {
     freeOptStr(self.allocator, self.remote_server_url);
     freeOptStr(self.allocator, self.remote_server_fingerprint);
     freeOptStr(self.allocator, self.remote_device_name);
+    freeOptStr(self.allocator, self.background_image);
 
     self.windows.deinit(self.allocator);
     self.window_threads.deinit(self.allocator);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -28,6 +28,7 @@ pub const split_layout = @import("appwindow/split_layout.zig");
 pub const wsl_paths = @import("apprt/wsl_paths.zig");
 pub const window_state = @import("apprt/window_state.zig");
 pub const fbo = @import("renderer/fbo.zig");
+pub const background_image = @import("renderer/background_image.zig");
 pub const file_explorer = @import("file_explorer.zig");
 pub const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig");
 pub const markdown_preview_panel = @import("markdown_preview_panel.zig");
@@ -95,6 +96,9 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     g_shader_path = app.shader_path;
     g_start_maximize = app.maximize;
     g_start_fullscreen = app.fullscreen;
+    g_background_image_path = app.background_image;
+    background_image.g_mode = app.background_image_mode;
+    gl_init.g_bg_opacity = app.background_opacity;
     tab.g_forced_title = app.title;
 
     // Get initial CWD for this window (if any) - copy into thread-local buffer
@@ -150,6 +154,7 @@ threadlocal var g_initial_cwd_len: usize = 0;
 threadlocal var g_requested_font: []const u8 = "";
 threadlocal var g_requested_weight: directwrite.DWRITE_FONT_WEIGHT = .NORMAL;
 threadlocal var g_shader_path: ?[]const u8 = null;
+threadlocal var g_background_image_path: ?[]const u8 = null;
 threadlocal var g_start_maximize: bool = false;
 threadlocal var g_start_fullscreen: bool = false;
 threadlocal var g_remote_layout_last_ms: i64 = 0;
@@ -185,6 +190,21 @@ pub const MAX_TABS = tab.MAX_TABS;
 // ============================================================================
 // Tab/split operation wrappers — delegate to tab module, handle UI side effects
 // ============================================================================
+
+fn optStringsEqual(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return std.mem.eql(u8, a.?, b.?);
+}
+
+/// Clear the framebuffer with the theme background color, then draw the
+/// background image (if any) over the cleared color. The current viewport
+/// must already cover (0,0)..(fb_w,fb_h).
+fn clearWithBackground(fb_w: c_int, fb_h: c_int) void {
+    gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
+    gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+    background_image.drawFullscreen(@floatFromInt(fb_w), @floatFromInt(fb_h));
+}
 
 pub fn activeTab() ?*TabState {
     return tab.activeTab();
@@ -529,8 +549,7 @@ fn onWin32Resize(width: i32, height: i32) void {
 
                 gl.Viewport.?(0, 0, fb_width, fb_height);
                 gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-                gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-                gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+                clearWithBackground(fb_width, fb_height);
 
                 const pad = surface.getPadding();
                 const pad_top = @as(f32, @floatFromInt(pad.top)) + titlebar_offset;
@@ -546,8 +565,7 @@ fn onWin32Resize(width: i32, height: i32) void {
             // Multiple splits: render each surface in its own viewport
             gl.Viewport.?(0, 0, fb_width, fb_height);
             gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-            gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-            gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+            clearWithBackground(fb_width, fb_height);
 
             titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
             titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -594,8 +612,7 @@ fn onWin32Resize(width: i32, height: i32) void {
     } else {
         gl.Viewport.?(0, 0, fb_width, fb_height);
         gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-        gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-        gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+        clearWithBackground(fb_width, fb_height);
         titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, explorer_w);
@@ -653,6 +670,22 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     overlays.g_unfocused_split_opacity = cfg.@"unfocused-split-opacity";
     g_focus_follows_mouse = cfg.@"focus-follows-mouse";
     overlays.g_split_divider_color = cfg.@"split-divider-color";
+
+    // --- Background image ---
+    {
+        const new_path = cfg.@"background-image";
+        const path_changed = !optStringsEqual(g_background_image_path, new_path);
+        const mode_changed = background_image.g_mode != cfg.@"background-image-mode";
+        background_image.g_mode = cfg.@"background-image-mode";
+        gl_init.g_bg_opacity = cfg.@"background-opacity";
+        if (path_changed) {
+            // App owns the duped string; read it back (already replaced by updateConfig above).
+            g_background_image_path = if (g_app) |a| a.background_image else new_path;
+            background_image.load(g_background_image_path);
+        } else if (mode_changed) {
+            background_image.refreshWrapMode();
+        }
+    }
 
     // Sync cursor style to all tabs' terminals (rendering reads from terminal state)
     for (0..tab.g_tab_count) |ti| {
@@ -1359,7 +1392,9 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
     // Initialize custom post-processing shader if requested
     post_process.init(allocator, shader_path);
+    background_image.load(g_background_image_path);
     defer {
+        background_image.deinit();
         post_process.deinit();
         gl_init.deinitInstancedResources();
     }
@@ -1615,8 +1650,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
                     gl.Viewport.?(0, 0, fb_width, fb_height);
                     gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-                    gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-                    gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+                    clearWithBackground(fb_width, fb_height);
 
                     // Use surface's computed padding (includes titlebar offset from content_y)
                     const pad = surface.getPadding();
@@ -1635,8 +1669,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
                 // Multiple splits: render with scissor/viewport per surface
                 gl.Viewport.?(0, 0, fb_width, fb_height);
                 gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-                gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-                gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+                clearWithBackground(fb_width, fb_height);
 
                 titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
                 titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -1703,8 +1736,7 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
         } else if (!post_process.g_post_enabled) {
             gl.Viewport.?(0, 0, fb_width, fb_height);
             gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
-            gl.ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-            gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+            clearWithBackground(fb_width, fb_height);
             titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
             titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
             markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, explorer_w);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -96,7 +96,6 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     g_shader_path = app.shader_path;
     g_start_maximize = app.maximize;
     g_start_fullscreen = app.fullscreen;
-    g_background_image_path = app.background_image;
     background_image.g_mode = app.background_image_mode;
     gl_init.g_bg_opacity = app.background_opacity;
     tab.g_forced_title = app.title;
@@ -154,7 +153,6 @@ threadlocal var g_initial_cwd_len: usize = 0;
 threadlocal var g_requested_font: []const u8 = "";
 threadlocal var g_requested_weight: directwrite.DWRITE_FONT_WEIGHT = .NORMAL;
 threadlocal var g_shader_path: ?[]const u8 = null;
-threadlocal var g_background_image_path: ?[]const u8 = null;
 threadlocal var g_start_maximize: bool = false;
 threadlocal var g_start_fullscreen: bool = false;
 threadlocal var g_remote_layout_last_ms: i64 = 0;
@@ -190,12 +188,6 @@ pub const MAX_TABS = tab.MAX_TABS;
 // ============================================================================
 // Tab/split operation wrappers — delegate to tab module, handle UI side effects
 // ============================================================================
-
-fn optStringsEqual(a: ?[]const u8, b: ?[]const u8) bool {
-    if (a == null and b == null) return true;
-    if (a == null or b == null) return false;
-    return std.mem.eql(u8, a.?, b.?);
-}
 
 /// Clear the framebuffer with the theme background color, then draw the
 /// background image (if any) over the cleared color. The current viewport
@@ -673,15 +665,11 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
 
     // --- Background image ---
     {
-        const new_path = cfg.@"background-image";
-        const path_changed = !optStringsEqual(g_background_image_path, new_path);
         const mode_changed = background_image.g_mode != cfg.@"background-image-mode";
         background_image.g_mode = cfg.@"background-image-mode";
         gl_init.g_bg_opacity = cfg.@"background-opacity";
-        if (path_changed) {
-            // App owns the duped string; read it back (already replaced by updateConfig above).
-            g_background_image_path = if (g_app) |a| a.background_image else new_path;
-            background_image.load(g_background_image_path);
+        if (!background_image.isLoaded(cfg.@"background-image")) {
+            background_image.load(allocator, cfg.@"background-image");
         } else if (mode_changed) {
             background_image.refreshWrapMode();
         }
@@ -1392,7 +1380,17 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
     // Initialize custom post-processing shader if requested
     post_process.init(allocator, shader_path);
-    background_image.load(g_background_image_path);
+    if (g_app) |app| {
+        // Dupe the path under app.mutex so a concurrent updateConfig from
+        // another window cannot free it out from under us.
+        app.mutex.lock();
+        const initial_path: ?[]u8 = if (app.background_image) |p| (allocator.dupe(u8, p) catch null) else null;
+        app.mutex.unlock();
+        if (initial_path) |p| {
+            defer allocator.free(p);
+            background_image.load(allocator, p);
+        }
+    }
     defer {
         background_image.deinit();
         post_process.deinit();

--- a/src/config.zig
+++ b/src/config.zig
@@ -133,6 +133,25 @@ pub const CursorStyle = enum {
 };
 
 // ============================================================================
+// Background Image
+// ============================================================================
+
+pub const BackgroundImageMode = enum {
+    fill, // cover the window, may crop
+    fit, // scale to fit, may letterbox
+    center, // 1:1, centered, may be cropped or surrounded by clear color
+    tile, // repeat at native size
+
+    pub fn parse(s: []const u8) ?BackgroundImageMode {
+        if (std.mem.eql(u8, s, "fill")) return .fill;
+        if (std.mem.eql(u8, s, "fit")) return .fit;
+        if (std.mem.eql(u8, s, "center")) return .center;
+        if (std.mem.eql(u8, s, "tile")) return .tile;
+        return null;
+    }
+};
+
+// ============================================================================
 // Font Weight
 // ============================================================================
 
@@ -295,6 +314,24 @@ foreground: ?Color = null,
 /// Palette color overrides. Indexed 0-15 for the 16 ANSI colors.
 /// Use syntax: palette = N=#RRGGBB (e.g., palette = 0=#000000)
 palette_overrides: [16]?Color = .{null} ** 16,
+
+// ============================================================================
+// Background Image
+// ============================================================================
+
+/// Path to an image file (PNG/JPG/BMP/GIF/...) to draw behind the terminal.
+/// When set, the theme background color and per-cell background colors are
+/// rendered with `background-opacity` so the image shows through.
+@"background-image": ?[]const u8 = null,
+
+/// Opacity applied to the theme background and per-cell background colors
+/// (0.0 = fully transparent, 1.0 = fully opaque). Lower values reveal more of
+/// the background image. Has no visible effect when `background-image` is unset.
+@"background-opacity": f32 = 1.0,
+
+/// How the background image is sized relative to the window.
+/// Values: fill (default, cover), fit (letterbox), center, tile.
+@"background-image-mode": BackgroundImageMode = .fill,
 
 // ============================================================================
 // Window Options
@@ -627,6 +664,24 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         } else {
             log.warn("invalid palette syntax, expected N=COLOR: {s}", .{value});
         }
+    } else if (std.mem.eql(u8, key, "background-image")) {
+        if (value.len == 0) {
+            self.@"background-image" = null;
+        } else {
+            self.@"background-image" = self.dupeString(allocator, value) orelse return;
+        }
+    } else if (std.mem.eql(u8, key, "background-opacity")) {
+        if (std.fmt.parseFloat(f32, value)) |opacity| {
+            self.@"background-opacity" = @max(0.0, @min(1.0, opacity));
+        } else |_| {
+            log.warn("invalid background-opacity: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "background-image-mode")) {
+        if (BackgroundImageMode.parse(value)) |m| {
+            self.@"background-image-mode" = m;
+        } else {
+            log.warn("invalid background-image-mode (expected fill|fit|center|tile): {s}", .{value});
+        }
     } else if (std.mem.eql(u8, key, "title")) {
         self.title = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "maximize")) {
@@ -863,6 +918,9 @@ pub fn printHelp() void {
         \\  --selection-background <color>  Selection background color
         \\  --selection-foreground <color>  Selection text color
         \\  --palette <N=color>          Set ANSI color N (0-15), e.g. --palette 1=#ff0000
+        \\  --background-image <path>    Image file to render behind the terminal
+        \\  --background-opacity <0..1>  Opacity of theme/cell backgrounds (default: 1.0)
+        \\  --background-image-mode <m>  fill | fit | center | tile (default: fill)
         \\
         \\Window Options:
         \\  --title <text>               Force window title (programs cannot override)
@@ -1113,6 +1171,11 @@ const default_config_template =
     \\# selection-foreground = #f3f4f5
     \\# palette = 0=#191e2a
     \\# palette = 1=#ff3333
+    \\
+    \\# Background image (PNG/JPG/BMP/GIF). Lower background-opacity to reveal it.
+    \\# background-image = C:\Users\me\wallpapers\dunes.jpg
+    \\# background-opacity = 0.7
+    \\# background-image-mode = fill   # fill | fit | center | tile
     \\
     \\# Custom post-processing shader (GLSL)
     \\# custom-shader =

--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -1,0 +1,206 @@
+//! Background image rendering.
+//!
+//! Loads an image (PNG/JPG/BMP/GIF/...) via stb_image and uploads it as a GL
+//! texture. Drawn fullscreen between the framebuffer clear and the cell pass,
+//! so per-cell backgrounds drawn with `background-opacity < 1.0` reveal it.
+
+const std = @import("std");
+const Config = @import("../config.zig");
+const AppWindow = @import("../AppWindow.zig");
+const gl_init = AppWindow.gl_init;
+
+const c = @cImport({
+    @cInclude("glad/gl.h");
+    @cInclude("stb_image.h");
+});
+
+pub const Mode = Config.BackgroundImageMode;
+
+pub threadlocal var g_enabled: bool = false;
+pub threadlocal var g_mode: Mode = .fill;
+
+threadlocal var g_texture: c.GLuint = 0;
+threadlocal var g_width: c_int = 0;
+threadlocal var g_height: c_int = 0;
+
+/// Load an image from `path` and upload it as a GL texture. Replaces any
+/// previously loaded image. Call with `null` to disable. Safe to call again
+/// for hot-reload.
+pub fn load(path: ?[]const u8) void {
+    const gl = AppWindow.gl;
+
+    // Reset existing state
+    if (g_texture != 0) {
+        gl.DeleteTextures.?(1, &g_texture);
+        g_texture = 0;
+    }
+    g_enabled = false;
+    g_width = 0;
+    g_height = 0;
+
+    const p = path orelse return;
+    if (p.len == 0) return;
+
+    var path_buf: [std.fs.max_path_bytes + 1]u8 = undefined;
+    if (p.len >= path_buf.len) {
+        std.debug.print("background-image path too long\n", .{});
+        return;
+    }
+    @memcpy(path_buf[0..p.len], p);
+    path_buf[p.len] = 0;
+
+    var w: c_int = 0;
+    var h: c_int = 0;
+    var n: c_int = 0;
+    const data = c.stbi_load(&path_buf[0], &w, &h, &n, 4);
+    if (data == null or w <= 0 or h <= 0) {
+        std.debug.print("background-image: failed to load '{s}'\n", .{p});
+        return;
+    }
+    defer c.stbi_image_free(data);
+
+    gl.GenTextures.?(1, &g_texture);
+    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
+    const wrap: c.GLint = if (g_mode == .tile) c.GL_REPEAT else c.GL_CLAMP_TO_EDGE;
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrap);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrap);
+    gl.PixelStorei.?(c.GL_UNPACK_ALIGNMENT, 1);
+    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RGBA8, w, h, 0, c.GL_RGBA, c.GL_UNSIGNED_BYTE, data);
+
+    g_width = w;
+    g_height = h;
+    g_enabled = true;
+    std.debug.print("background-image loaded: {s} ({}x{})\n", .{ p, w, h });
+}
+
+/// Update the wrap mode after `g_mode` changes (without reloading the image).
+pub fn refreshWrapMode() void {
+    if (g_texture == 0) return;
+    const gl = AppWindow.gl;
+    const wrap: c.GLint = if (g_mode == .tile) c.GL_REPEAT else c.GL_CLAMP_TO_EDGE;
+    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrap);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrap);
+}
+
+pub fn deinit() void {
+    if (g_texture == 0) return;
+    const gl = AppWindow.gl;
+    gl.DeleteTextures.?(1, &g_texture);
+    g_texture = 0;
+    g_enabled = false;
+}
+
+/// Compute UVs for a fullscreen quad given the chosen mode.
+/// For fill/fit/center we keep the quad covering the whole framebuffer and
+/// adjust UVs so the image aspect is preserved. For tile we set UVs > 1 and
+/// rely on GL_REPEAT wrap.
+fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) struct { u0: f32, v0: f32, u1: f32, v1: f32 } {
+    if (g_width <= 0 or g_height <= 0) return .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1 };
+    const iw: f32 = @floatFromInt(g_width);
+    const ih: f32 = @floatFromInt(g_height);
+
+    switch (mode) {
+        .fill => {
+            // Cover: the image is scaled so the smaller axis fills the
+            // framebuffer; the larger axis is cropped via UVs (< 1 range).
+            const win_aspect = fb_w / fb_h;
+            const img_aspect = iw / ih;
+            if (img_aspect > win_aspect) {
+                // image is wider than the window — crop sides
+                const visible = win_aspect / img_aspect;
+                const offset = (1.0 - visible) * 0.5;
+                return .{ .u0 = offset, .v0 = 0, .u1 = 1.0 - offset, .v1 = 1 };
+            } else {
+                // image is taller — crop top/bottom
+                const visible = img_aspect / win_aspect;
+                const offset = (1.0 - visible) * 0.5;
+                return .{ .u0 = 0, .v0 = offset, .u1 = 1, .v1 = 1.0 - offset };
+            }
+        },
+        .fit => {
+            // Letterbox: scale so the larger axis fills, the smaller is
+            // padded with extra UV space (sampled outside [0,1]). With
+            // CLAMP_TO_EDGE the padding shows the edge pixels — usually fine
+            // for landscape wallpapers but acceptable as a v1.
+            const win_aspect = fb_w / fb_h;
+            const img_aspect = iw / ih;
+            if (img_aspect > win_aspect) {
+                const extra = img_aspect / win_aspect;
+                const offset = (1.0 - extra) * 0.5;
+                return .{ .u0 = 0, .v0 = offset, .u1 = 1, .v1 = 1.0 - offset };
+            } else {
+                const extra = win_aspect / img_aspect;
+                const offset = (1.0 - extra) * 0.5;
+                return .{ .u0 = offset, .v0 = 0, .u1 = 1.0 - offset, .v1 = 1 };
+            }
+        },
+        .center => {
+            // 1:1 pixel scale, centered. UV range is window/image so a
+            // center crop or surround happens naturally. Outside [0,1] the
+            // CLAMP_TO_EDGE wrap shows the edge row — close enough.
+            const u_range = fb_w / iw;
+            const v_range = fb_h / ih;
+            const u0 = (1.0 - u_range) * 0.5;
+            const v0 = (1.0 - v_range) * 0.5;
+            return .{ .u0 = u0, .v0 = v0, .u1 = u0 + u_range, .v1 = v0 + v_range };
+        },
+        .tile => {
+            // Repeat the image at native size. UVs equal window / image.
+            const u_range = fb_w / iw;
+            const v_range = fb_h / ih;
+            return .{ .u0 = 0, .v0 = 0, .u1 = u_range, .v1 = v_range };
+        },
+    }
+}
+
+/// Draw the loaded image filling the current viewport. The caller must have
+/// already set the viewport and projection. No-op when no image is loaded.
+/// Note: `viewport_height` is the height in pixels of the current viewport
+/// (used to flip Y in the projection matrix used by the simple shader).
+pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
+    if (!g_enabled or g_texture == 0) return;
+    const gl = AppWindow.gl;
+    if (gl_init.simple_color_shader == 0) return;
+
+    const uv = computeUv(viewport_width, viewport_height, g_mode);
+
+    // The simple_color_shader uses gl_init.shader_program's vertex layout
+    // (vec4: xy=pos, zw=texcoord) and gl_init.setProjection's projection
+    // matrix. We bind the simple_color_shader and set its uniforms.
+    gl.UseProgram.?(gl_init.simple_color_shader);
+    gl_init.setProjectionForProgram(gl_init.simple_color_shader, viewport_height);
+    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
+    gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "text"), 0);
+
+    // Two triangles covering the whole viewport in pixel coords.
+    // setProjectionForProgram maps [0..w] x [0..h] to NDC.
+    const x0: f32 = 0;
+    const y0: f32 = 0;
+    const x1: f32 = viewport_width;
+    const y1: f32 = viewport_height;
+    const vertices = [6][4]f32{
+        .{ x0, y1, uv.u0, uv.v0 }, // top-left
+        .{ x0, y0, uv.u0, uv.v1 }, // bottom-left
+        .{ x1, y0, uv.u1, uv.v1 }, // bottom-right
+        .{ x0, y1, uv.u0, uv.v0 },
+        .{ x1, y0, uv.u1, uv.v1 },
+        .{ x1, y1, uv.u1, uv.v0 }, // top-right
+    };
+
+    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
+    gl.BindVertexArray.?(gl_init.vao);
+    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
+    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
+    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
+
+    // The image is opaque RGBA; we want to write it directly without blending
+    // against whatever ClearColor wrote. Disable blending for this single draw.
+    gl.Disable.?(c.GL_BLEND);
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    gl.Enable.?(c.GL_BLEND);
+    gl_init.g_draw_call_count += 1;
+}

--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -244,8 +244,8 @@ pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
     // `g_bg_opacity`. Without this, default-bg cells (which emit no per-cell
     // bg quad) would show the image at 100% regardless of opacity. With it,
     // default cells end up as `(1-opacity)*image + opacity*theme_bg`, which
-    // is what users actually expect from "background-opacity = 0.85".
-    if (gl_init.g_bg_opacity < 1.0 and gl_init.overlay_shader != 0) {
+    // matches the documented intent. Skip only at opacity == 0 (no-op).
+    if (gl_init.g_bg_opacity > 0.0 and gl_init.overlay_shader != 0) {
         const theme = AppWindow.g_theme.background;
         gl.UseProgram.?(gl_init.overlay_shader);
         gl_init.setProjectionForProgram(gl_init.overlay_shader, viewport_height);

--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -239,4 +239,25 @@ pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
     gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
     gl.Enable.?(c.GL_BLEND);
     gl_init.g_draw_call_count += 1;
+
+    // Tint pass: blend the theme background color over the image at
+    // `g_bg_opacity`. Without this, default-bg cells (which emit no per-cell
+    // bg quad) would show the image at 100% regardless of opacity. With it,
+    // default cells end up as `(1-opacity)*image + opacity*theme_bg`, which
+    // is what users actually expect from "background-opacity = 0.85".
+    if (gl_init.g_bg_opacity < 1.0 and gl_init.overlay_shader != 0) {
+        const theme = AppWindow.g_theme.background;
+        gl.UseProgram.?(gl_init.overlay_shader);
+        gl_init.setProjectionForProgram(gl_init.overlay_shader, viewport_height);
+        gl.Uniform4f.?(
+            gl.GetUniformLocation.?(gl_init.overlay_shader, "overlayColor"),
+            theme[0],
+            theme[1],
+            theme[2],
+            gl_init.g_bg_opacity,
+        );
+        // Reuse the same fullscreen vertices (overlay shader ignores texcoords).
+        gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+        gl_init.g_draw_call_count += 1;
+    }
 }

--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -22,11 +22,35 @@ pub threadlocal var g_mode: Mode = .fill;
 threadlocal var g_texture: c.GLuint = 0;
 threadlocal var g_width: c_int = 0;
 threadlocal var g_height: c_int = 0;
+/// Owned copy of the currently-loaded image path. The module owns this slice
+/// (allocated via `g_path_allocator`) so callers cannot pass in stale aliases
+/// from sources whose lifetime is independent of the loaded texture.
+threadlocal var g_loaded_path: ?[]u8 = null;
+threadlocal var g_path_allocator: ?std.mem.Allocator = null;
+
+/// Whether the currently loaded path matches `path`. Returns true for the
+/// "no image" case as well (both null/empty).
+pub fn isLoaded(path: ?[]const u8) bool {
+    const want = if (path) |p| (if (p.len == 0) null else p) else null;
+    if (want == null and g_loaded_path == null) return true;
+    if (want == null or g_loaded_path == null) return false;
+    return std.mem.eql(u8, g_loaded_path.?, want.?);
+}
+
+fn freeLoadedPath() void {
+    if (g_loaded_path) |buf| {
+        if (g_path_allocator) |alloc| alloc.free(buf);
+    }
+    g_loaded_path = null;
+}
 
 /// Load an image from `path` and upload it as a GL texture. Replaces any
-/// previously loaded image. Call with `null` to disable. Safe to call again
-/// for hot-reload.
-pub fn load(path: ?[]const u8) void {
+/// previously loaded image. Call with `null` (or empty) to disable. Safe to
+/// call repeatedly for hot-reload — duplicate loads of the same path are a
+/// no-op.
+pub fn load(allocator: std.mem.Allocator, path: ?[]const u8) void {
+    if (isLoaded(path)) return;
+
     const gl = AppWindow.gl;
 
     // Reset existing state
@@ -37,6 +61,7 @@ pub fn load(path: ?[]const u8) void {
     g_enabled = false;
     g_width = 0;
     g_height = 0;
+    freeLoadedPath();
 
     const p = path orelse return;
     if (p.len == 0) return;
@@ -72,6 +97,13 @@ pub fn load(path: ?[]const u8) void {
     g_width = w;
     g_height = h;
     g_enabled = true;
+
+    // Take an owned copy only after the texture is fully usable. If the dupe
+    // fails, leave g_loaded_path null so the next call retries the load.
+    if (allocator.dupe(u8, p)) |owned| {
+        g_loaded_path = owned;
+        g_path_allocator = allocator;
+    } else |_| {}
     std.debug.print("background-image loaded: {s} ({}x{})\n", .{ p, w, h });
 }
 
@@ -86,19 +118,23 @@ pub fn refreshWrapMode() void {
 }
 
 pub fn deinit() void {
-    if (g_texture == 0) return;
-    const gl = AppWindow.gl;
-    gl.DeleteTextures.?(1, &g_texture);
-    g_texture = 0;
+    if (g_texture != 0) {
+        const gl = AppWindow.gl;
+        gl.DeleteTextures.?(1, &g_texture);
+        g_texture = 0;
+    }
     g_enabled = false;
+    freeLoadedPath();
 }
 
 /// Compute UVs for a fullscreen quad given the chosen mode.
 /// For fill/fit/center we keep the quad covering the whole framebuffer and
 /// adjust UVs so the image aspect is preserved. For tile we set UVs > 1 and
 /// rely on GL_REPEAT wrap.
-fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) struct { u0: f32, v0: f32, u1: f32, v1: f32 } {
-    if (g_width <= 0 or g_height <= 0) return .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1 };
+const Uv = struct { u_min: f32, v_min: f32, u_max: f32, v_max: f32 };
+
+fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) Uv {
+    if (g_width <= 0 or g_height <= 0) return .{ .u_min = 0, .v_min = 0, .u_max = 1, .v_max = 1 };
     const iw: f32 = @floatFromInt(g_width);
     const ih: f32 = @floatFromInt(g_height);
 
@@ -112,12 +148,12 @@ fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) struct { u0: f32, v0: f32, u1: f3
                 // image is wider than the window — crop sides
                 const visible = win_aspect / img_aspect;
                 const offset = (1.0 - visible) * 0.5;
-                return .{ .u0 = offset, .v0 = 0, .u1 = 1.0 - offset, .v1 = 1 };
+                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
             } else {
                 // image is taller — crop top/bottom
                 const visible = img_aspect / win_aspect;
                 const offset = (1.0 - visible) * 0.5;
-                return .{ .u0 = 0, .v0 = offset, .u1 = 1, .v1 = 1.0 - offset };
+                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
             }
         },
         .fit => {
@@ -130,11 +166,11 @@ fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) struct { u0: f32, v0: f32, u1: f3
             if (img_aspect > win_aspect) {
                 const extra = img_aspect / win_aspect;
                 const offset = (1.0 - extra) * 0.5;
-                return .{ .u0 = 0, .v0 = offset, .u1 = 1, .v1 = 1.0 - offset };
+                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
             } else {
                 const extra = win_aspect / img_aspect;
                 const offset = (1.0 - extra) * 0.5;
-                return .{ .u0 = offset, .v0 = 0, .u1 = 1.0 - offset, .v1 = 1 };
+                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
             }
         },
         .center => {
@@ -143,15 +179,15 @@ fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) struct { u0: f32, v0: f32, u1: f3
             // CLAMP_TO_EDGE wrap shows the edge row — close enough.
             const u_range = fb_w / iw;
             const v_range = fb_h / ih;
-            const u0 = (1.0 - u_range) * 0.5;
-            const v0 = (1.0 - v_range) * 0.5;
-            return .{ .u0 = u0, .v0 = v0, .u1 = u0 + u_range, .v1 = v0 + v_range };
+            const u_off = (1.0 - u_range) * 0.5;
+            const v_off = (1.0 - v_range) * 0.5;
+            return .{ .u_min = u_off, .v_min = v_off, .u_max = u_off + u_range, .v_max = v_off + v_range };
         },
         .tile => {
             // Repeat the image at native size. UVs equal window / image.
             const u_range = fb_w / iw;
             const v_range = fb_h / ih;
-            return .{ .u0 = 0, .v0 = 0, .u1 = u_range, .v1 = v_range };
+            return .{ .u_min = 0, .v_min = 0, .u_max = u_range, .v_max = v_range };
         },
     }
 }
@@ -177,17 +213,17 @@ pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
 
     // Two triangles covering the whole viewport in pixel coords.
     // setProjectionForProgram maps [0..w] x [0..h] to NDC.
-    const x0: f32 = 0;
-    const y0: f32 = 0;
-    const x1: f32 = viewport_width;
-    const y1: f32 = viewport_height;
+    const x_lo: f32 = 0;
+    const y_lo: f32 = 0;
+    const x_hi: f32 = viewport_width;
+    const y_hi: f32 = viewport_height;
     const vertices = [6][4]f32{
-        .{ x0, y1, uv.u0, uv.v0 }, // top-left
-        .{ x0, y0, uv.u0, uv.v1 }, // bottom-left
-        .{ x1, y0, uv.u1, uv.v1 }, // bottom-right
-        .{ x0, y1, uv.u0, uv.v0 },
-        .{ x1, y0, uv.u1, uv.v1 },
-        .{ x1, y1, uv.u1, uv.v0 }, // top-right
+        .{ x_lo, y_hi, uv.u_min, uv.v_min }, // top-left
+        .{ x_lo, y_lo, uv.u_min, uv.v_max }, // bottom-left
+        .{ x_hi, y_lo, uv.u_max, uv.v_max }, // bottom-right
+        .{ x_lo, y_hi, uv.u_min, uv.v_min },
+        .{ x_hi, y_lo, uv.u_max, uv.v_max },
+        .{ x_hi, y_hi, uv.u_max, uv.v_min }, // top-right
     };
 
     gl.ActiveTexture.?(c.GL_TEXTURE0);

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -407,7 +407,12 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
         gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "cellSize"), font.cell_width, font.cell_height);
         gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "gridOffset"), offset_x, offset_y);
         gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "windowHeight"), window_height);
-        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "uBgOpacity"), gl_init.g_bg_opacity);
+        // Only thin out cell backgrounds when a wallpaper is actually loaded —
+        // otherwise lowering background-opacity would make selections / colored
+        // cells translucent over an opaque theme bg, which is just a darkening
+        // effect with no useful visual.
+        const bg_opacity: f32 = if (AppWindow.background_image.g_enabled) gl_init.g_bg_opacity else 1.0;
+        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "uBgOpacity"), bg_opacity);
         gl_init.setProjectionForProgram(gl_init.bg_shader, window_height);
 
         gl.BindVertexArray.?(gl_init.bg_vao);

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -407,6 +407,7 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
         gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "cellSize"), font.cell_width, font.cell_height);
         gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "gridOffset"), offset_x, offset_y);
         gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "windowHeight"), window_height);
+        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "uBgOpacity"), gl_init.g_bg_opacity);
         gl_init.setProjectionForProgram(gl_init.bg_shader, window_height);
 
         gl.BindVertexArray.?(gl_init.bg_vao);

--- a/src/renderer/gl_init.zig
+++ b/src/renderer/gl_init.zig
@@ -40,6 +40,10 @@ threadlocal var solid_texture: c.GLuint = 0;
 // Draw call counter (reset each frame)
 pub threadlocal var g_draw_call_count: u32 = 0;
 
+// Opacity for cell background quads (0..1). Set from config
+// `background-opacity`; lower values reveal the background image underneath.
+pub threadlocal var g_bg_opacity: f32 = 1.0;
+
 // ============================================================================
 // Shader sources
 // ============================================================================
@@ -92,9 +96,13 @@ const bg_vertex_source: [*c]const u8 =
 const bg_fragment_source: [*c]const u8 =
     \\#version 330 core
     \\flat in vec3 vColor;
+    \\uniform float uBgOpacity;
     \\out vec4 fragColor;
     \\void main() {
-    \\    fragColor = vec4(vColor, 1.0);
+    \\    // The pipeline blend func is (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA),
+    \\    // so an alpha of uBgOpacity correctly reveals the framebuffer (the
+    \\    // background image) underneath proportionally to (1 - uBgOpacity).
+    \\    fragColor = vec4(vColor, uBgOpacity);
     \\}
 ;
 

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -14,6 +14,7 @@ const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
 const gl_init = AppWindow.gl_init;
 const cell_renderer = AppWindow.cell_renderer;
+const background_image = AppWindow.background_image;
 const Renderer = @import("Renderer.zig");
 
 const c = @cImport({
@@ -262,6 +263,7 @@ pub fn renderFrameWithPostFromCells(rend: *const Renderer, width: c_int, height:
     gl_init.setProjection(@floatFromInt(width), @floatFromInt(height));
     gl.ClearColor.?(AppWindow.g_theme.background[0], AppWindow.g_theme.background[1], AppWindow.g_theme.background[2], 1.0);
     gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+    background_image.drawFullscreen(@floatFromInt(width), @floatFromInt(height));
     cell_renderer.drawCells(rend, @floatFromInt(height), padding, padding);
 
     // 2. Apply post-processing shader to screen


### PR DESCRIPTION
## Summary
- Three new config keys: \`background-image\` (path), \`background-opacity\` (0..1), \`background-image-mode\` (fill/fit/center/tile).
- Image decoded via vendored stb_image, uploaded once as a GL texture, drawn fullscreen at every \`glClear\` site (including the post-process FBO so custom shaders distort the wallpaper too).
- Cell background shader takes a new \`uBgOpacity\` uniform so theme/cell bg quads become semi-transparent and let the image show through proportionally to \`1 - opacity\`.
- Hot-reload swaps the texture and refreshes wrap mode without restarting; \`load(null)\` cleanly disables.

## Design choices (per discussion)
- **B tier** of three options considered — adds the opacity uniform so the whole terminal becomes a translucent overlay (vs. the minimal \"image only under default-bg cells\" tier).
- **Image inside the post-process FBO** — wallpaper is affected by glitchy/CRT shaders alongside the terminal content (visual cohesion).
- **Whole-window single image across splits** — wallpaper is drawn once at full FB size; per-split viewports only render terminal content over it.

## Test plan
- [ ] \`zig build\` passes (could not run locally — Linux host has no zig)
- [ ] No image configured: terminal looks identical to current behavior
- [ ] \`background-image = some.jpg\` + \`background-opacity = 0.7\` shows the image through theme/cell backgrounds
- [ ] \`background-image-mode\` of fill / fit / center / tile each behave as documented
- [ ] Modes can be switched via Ctrl+, hot-reload without restart
- [ ] Multi-split layout shows one wallpaper across the whole window
- [ ] Custom post-process shader (\`--custom-shader\`) distorts wallpaper alongside cells
- [ ] PNG, JPG, BMP all decode correctly via stb_image

🤖 Generated with [Claude Code](https://claude.com/claude-code)