### PR TITLE
[codex] Add mouse multi-click selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 # Local agent / MCP tooling artifacts
 .codex
 .playwright-mcp/
+.superpowers/
 
 # Node/Cloudflare remote console artifacts
 node_modules/

--- a/docs/superpowers/specs/2026-05-09-remote-mobile-console-design.md
+++ b/docs/superpowers/specs/2026-05-09-remote-mobile-console-design.md
@@ -1,0 +1,144 @@
+# Remote Mobile Console Design
+
+## Context
+
+Phantty Remote already mirrors tabs and split surfaces into the browser and routes browser input back to the selected surface. The desktop web console is usable, but the iPhone 14 viewport is too cramped: the mobile header, surface chips, panel header, terminal frame, and fixed virtual keyboard compete with the terminal itself.
+
+The approved direction is a mobile-first, terminal-first layout using the visual wireframe reviewed during brainstorming:
+
+1. Compact top bar for menu, current tab title, connection status, and keyboard toggle.
+2. Horizontal surface switcher directly below the top bar.
+3. Selected terminal surface as the primary content.
+4. Bottom utility keyboard for terminal-specific keys.
+
+The implementation should stay within `remote/src/client` and must not change the relay protocol, server routes, or Zig remote client behavior.
+
+## Ghostty Comparison
+
+Ghostty does not implement a web remote console, so there is no one-to-one source file to copy. The relevant Ghostty model is its separation of app, surface, renderer, and input concerns.
+
+Using `gh` against `ghostty-org/ghostty`:
+
+- `src/App.zig` keeps a `focused_surface` and routes app key handling separately from surface-scoped key handling. The mobile Remote UI should follow that model by keeping one selected browser surface for input and not broadcasting mobile controls across all panels.
+- `src/apprt/surface.zig` defines surface messages such as `present_surface`, clipboard read/write, and mouse shape changes. Remote mobile controls should remain browser-side presentation/input helpers and should not be treated as terminal emulation state.
+- `src/renderer/OpenGL.zig` derives render surface size from the current viewport and presents a render target. The browser should similarly fit xterm to the actual selected terminal viewport after chrome/keyboard changes, not to the whole page.
+
+## Goals
+
+- Make the iPhone 14 portrait experience feel like a terminal first, not a dashboard squeezed onto a phone.
+- Preserve the existing Remote session model: saved session key, drawer menu, tabs, surfaces, WebSocket reconnect, and xterm rendering.
+- Make touch targets reliable for thumb use.
+- Keep normal command typing and terminal utility keys easy to access.
+- Ensure selected-surface input remains explicit and predictable.
+
+## Non-Goals
+
+- No changes to the relay server, Worker, Docker server, or WebSocket message schema.
+- No changes to Phantty's Zig remote client.
+- No new authentication or pairing flow.
+- No desktop redesign beyond avoiding regressions from shared CSS.
+- No terminal emulator reimplementation; xterm remains the browser terminal renderer.
+
+## Recommended Approach
+
+Use a full mobile shell redesign scoped to the existing client modules.
+
+Other options considered:
+
+- Only reduce chrome and padding. This would improve visible terminal space but leave typing and control placement awkward.
+- Only improve the virtual keyboard. This would help command entry but leave navigation and viewport pressure unresolved.
+- Full mobile shell redesign. This solves the layout, switching, and input ergonomics together while still avoiding protocol or server changes.
+
+The recommended approach is the third option because the current pain is systemic: space, input, and controls all affect each other on iPhone.
+
+## Layout Design
+
+On mobile, `.console-shell` remains a single-column grid with the workspace above the virtual keyboard when the keyboard is visible.
+
+The workspace is:
+
+1. `.mobile-bar`: fixed-height compact bar with drawer button, tab title, status pip, and keyboard toggle.
+2. `.surface-strip`: horizontal scroll list of surfaces for the current tab. It appears only when more than one surface exists.
+3. `.terminal-panel`: full remaining height, containing `.panels-stage`.
+
+The selected surface fills the panels stage in mobile single-surface mode. Non-selected surfaces remain mounted only as needed for state, but are hidden visually.
+
+The mobile selected panel should reduce decorative chrome:
+
+- Keep enough selected-surface affordance to show focus.
+- Remove or compress the panel title/header on narrow screens.
+- Remove the "outside terminal grid" label on mobile.
+- Reduce terminal frame padding.
+- Preserve xterm background, foreground, cursor, and selection theme.
+
+## Input Design
+
+The bottom utility keyboard remains available because terminal users need Esc, Tab, Ctrl, Alt, arrows, Enter, Backspace, and common shell symbols.
+
+Improve the input model by making the "Type" action explicit:
+
+- Tapping the terminal or Type focuses the selected xterm instance.
+- Tapping utility keys should not steal terminal focus.
+- Ctrl and Alt stay sticky for one following text/special key, then clear.
+- Direct control shortcuts such as `^C`, `^D`, `^L`, `^R`, and `^Z` remain one-tap actions.
+
+If iOS still fails to show the native keyboard reliably through xterm focus, add a hidden mobile text input bridge in the client. The bridge should forward inserted text to the selected surface through the existing `sendInputBytes` path, while utility keys continue to use `vkbd.ts`.
+
+## Navigation Design
+
+The drawer remains the place for session connection, tab list, relay notices, theme toggle, and logout.
+
+The main mobile workspace should not require opening the drawer for common operation:
+
+- Current tab title is visible in the top bar.
+- Connection state is visible as a status pip.
+- Surface switching is available in the strip.
+- Keyboard visibility is one tap.
+
+Remote tabs stay in the drawer for now. If tab switching becomes a repeated mobile task, a later change can add a compact tab switcher to the top bar, but that is out of scope for this pass.
+
+## State And Data Flow
+
+Existing data flow remains:
+
+1. `transport.ts` receives layout/output/notice messages.
+2. `layout.ts` normalizes relay layout messages.
+3. `state.ts` stores selected tab, selected surface, drawer state, keyboard state, and surface views.
+4. `views/console.ts` renders shell chrome, drawer, surface strip, and virtual keyboard visibility.
+5. `surfaces.ts` owns xterm instances, selected surface rendering, focus, fit, and output writes.
+6. `vkbd.ts` sends terminal input sequences through the existing virtual keyboard sender.
+
+The redesign should avoid introducing a second source of truth for selected surface or keyboard visibility.
+
+## Error Handling
+
+- If no layout exists, keep the current empty state.
+- If a selected surface disappears, preserve current fallback behavior: choose the focused surface or first surface in the active tab.
+- If xterm fit fails during transient zero-size layout states, keep the existing guarded behavior.
+- If the hidden text input bridge is added and unsupported on a browser, fall back to xterm focus plus utility keyboard.
+
+## Testing
+
+Automated checks:
+
+- `npm run build` in `remote`.
+- `npm run typecheck` in `remote`.
+- Playwright mobile viewport check at iPhone 14 size, with a mocked Phantty WebSocket layout containing at least two surfaces.
+
+Manual checks:
+
+- iPhone 14 portrait: terminal occupies the majority of available height and selected surface is readable.
+- iPhone 14 with utility keyboard visible and hidden.
+- Surface switching by thumb.
+- Drawer open/close and connect form still work.
+- Type/focus path sends ordinary text to the selected surface.
+- Utility keys send expected terminal sequences.
+
+## Acceptance Criteria
+
+- On a 390 x 844 viewport, the approved four-part mobile structure is visible and stable.
+- The selected terminal surface fills the available terminal area without desktop-oriented decorative labels.
+- The bottom utility keyboard does not overlap terminal content.
+- Surface switching and keyboard toggling do not break xterm fitting.
+- Browser input continues to route only to the selected surface.
+- Desktop layout remains visually equivalent to the current console.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1757,7 +1757,9 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
                 pushMouseButtonEvent(w, .left, .double_click, x, y);
                 return 0;
             }
-            return DefWindowProcW(hwnd, msg, wParam, lParam);
+            pushMouseButtonEvent(w, .left, .press, x, y);
+            _ = SetCapture(hwnd);
+            return 0;
         },
         WM_LBUTTONUP => {
             const x: i32 = @as(i16, @bitCast(@as(u16, @intCast(lParam & 0xFFFF))));

--- a/src/input.zig
+++ b/src/input.zig
@@ -22,6 +22,7 @@ const win32_backend = @import("apprt/win32.zig");
 const Config = @import("config.zig");
 const Surface = @import("Surface.zig");
 const SplitTree = @import("split_tree.zig");
+const selection_unit = @import("selection_unit.zig");
 const Selection = Surface.Selection;
 const CellPos = struct { col: usize, row: usize };
 
@@ -330,6 +331,12 @@ fn pasteSavedClipboardImage(surface: *Surface, allocator: std.mem.Allocator, ima
 pub threadlocal var g_selecting: bool = false; // True while mouse button is held
 pub threadlocal var g_click_x: f64 = 0; // X position of initial click (for threshold calculation)
 pub threadlocal var g_click_y: f64 = 0; // Y position of initial click
+threadlocal var g_left_click_count: u8 = 0;
+threadlocal var g_left_click_time_ms: i64 = 0;
+threadlocal var g_left_click_x: f64 = 0;
+threadlocal var g_left_click_y: f64 = 0;
+const MULTI_CLICK_INTERVAL_MS: i64 = 500;
+const MAX_SELECTION_COLS: usize = 4096;
 
 const UrlUnderline = struct {
     surface: ?*Surface = null,
@@ -1462,6 +1469,115 @@ fn viewportCellCodepoint(surface: *Surface, col: usize, row: usize) u21 {
     return @intCast(cell_data.cell.codepoint());
 }
 
+fn markSelectionChanged() void {
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+}
+
+fn nextLeftClickCount(xpos: f64, ypos: f64) u8 {
+    const now = std.time.milliTimestamp();
+    const max_distance: f64 = @floatCast(@max(font.cell_width, font.cell_height));
+    const dx = xpos - g_left_click_x;
+    const dy = ypos - g_left_click_y;
+    const distance = @sqrt(dx * dx + dy * dy);
+    const within_interval = g_left_click_count > 0 and now - g_left_click_time_ms <= MULTI_CLICK_INTERVAL_MS;
+    const within_distance = g_left_click_count > 0 and distance <= max_distance;
+
+    if (!within_interval or !within_distance) g_left_click_count = 0;
+
+    g_left_click_count += 1;
+    if (g_left_click_count > 4) g_left_click_count = 1;
+    g_left_click_time_ms = now;
+    g_left_click_x = xpos;
+    g_left_click_y = ypos;
+    return g_left_click_count;
+}
+
+fn readViewportRowLocked(surface: *Surface, row: usize, buf: *[MAX_SELECTION_COLS]u21) []const u21 {
+    const cols = @min(@as(usize, @intCast(surface.size.grid.cols)), buf.len);
+    if (row >= @as(usize, @intCast(surface.size.grid.rows))) return buf[0..0];
+    for (0..cols) |col| {
+        buf[col] = viewportCellCodepoint(surface, col, row);
+    }
+    return buf[0..cols];
+}
+
+fn viewportRowIsBlankLocked(surface: *Surface, row: usize, buf: *[MAX_SELECTION_COLS]u21) bool {
+    return selection_unit.rowIsBlank(readViewportRowLocked(surface, row, buf));
+}
+
+fn activateSelection(surface: *Surface, start_col: usize, start_row: usize, end_col: usize, end_row: usize) void {
+    surface.selection.start_col = start_col;
+    surface.selection.start_row = start_row;
+    surface.selection.end_col = end_col;
+    surface.selection.end_row = end_row;
+    surface.selection.active = true;
+    markSelectionChanged();
+}
+
+fn clearSelectionAtCell(surface: *Surface, cell_pos: CellPos) void {
+    const abs_row = viewportOffsetForSurface(surface) + cell_pos.row;
+    surface.selection.start_col = cell_pos.col;
+    surface.selection.start_row = abs_row;
+    surface.selection.end_col = cell_pos.col;
+    surface.selection.end_row = abs_row;
+    surface.selection.active = false;
+    markSelectionChanged();
+}
+
+fn selectWordAtCell(surface: *Surface, cell_pos: CellPos) bool {
+    var row_buf: [MAX_SELECTION_COLS]u21 = undefined;
+
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+
+    const row = readViewportRowLocked(surface, cell_pos.row, &row_buf);
+    if (cell_pos.col >= row.len) return false;
+    const range = selection_unit.wordRange(row, cell_pos.col) orelse return false;
+    const abs_row = viewportOffsetForSurfaceLocked(surface) + cell_pos.row;
+    activateSelection(surface, range.start, abs_row, range.end, abs_row);
+    return true;
+}
+
+fn selectSentenceAtCell(surface: *Surface, cell_pos: CellPos) bool {
+    var row_buf: [MAX_SELECTION_COLS]u21 = undefined;
+
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+
+    const row = readViewportRowLocked(surface, cell_pos.row, &row_buf);
+    if (cell_pos.col >= row.len) return false;
+    const range = selection_unit.sentenceRange(row, cell_pos.col) orelse return false;
+    const abs_row = viewportOffsetForSurfaceLocked(surface) + cell_pos.row;
+    activateSelection(surface, range.start, abs_row, range.end, abs_row);
+    return true;
+}
+
+fn selectParagraphAtCell(surface: *Surface, cell_pos: CellPos) bool {
+    var row_buf: [MAX_SELECTION_COLS]u21 = undefined;
+
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+
+    const rows = @as(usize, @intCast(surface.size.grid.rows));
+    if (cell_pos.row >= rows or viewportRowIsBlankLocked(surface, cell_pos.row, &row_buf)) return false;
+
+    var start_row = cell_pos.row;
+    while (start_row > 0 and !viewportRowIsBlankLocked(surface, start_row - 1, &row_buf)) : (start_row -= 1) {}
+
+    var end_row = cell_pos.row;
+    while (end_row + 1 < rows and !viewportRowIsBlankLocked(surface, end_row + 1, &row_buf)) : (end_row += 1) {}
+
+    const start_cols = readViewportRowLocked(surface, start_row, &row_buf);
+    const start_col = selection_unit.firstNonBlankCol(start_cols) orelse 0;
+    const end_cols = readViewportRowLocked(surface, end_row, &row_buf);
+    const end_col = selection_unit.lastNonBlankCol(end_cols) orelse 0;
+    const vp_off = viewportOffsetForSurfaceLocked(surface);
+
+    activateSelection(surface, start_col, vp_off + start_row, end_col, vp_off + end_row);
+    return true;
+}
+
 fn isPreviewTokenDelimiter(cp: u21) bool {
     if (cp == 0 or cp <= 0x20) return true;
     return switch (cp) {
@@ -2164,15 +2280,33 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
 
             clearUrlUnderline();
             const abs_row = viewportOffsetForSurface(clicked_surface) + cell_pos.row;
-            // Start selection on the clicked surface
-            clicked_surface.selection.start_col = cell_pos.col;
-            clicked_surface.selection.start_row = abs_row;
-            clicked_surface.selection.end_col = cell_pos.col;
-            clicked_surface.selection.end_row = abs_row;
-            clicked_surface.selection.active = false;
-            g_selecting = true;
-            g_click_x = xpos;
-            g_click_y = ypos;
+            switch (nextLeftClickCount(xpos, ypos)) {
+                1 => {
+                    // Start selection on the clicked surface.
+                    clicked_surface.selection.start_col = cell_pos.col;
+                    clicked_surface.selection.start_row = abs_row;
+                    clicked_surface.selection.end_col = cell_pos.col;
+                    clicked_surface.selection.end_row = abs_row;
+                    clicked_surface.selection.active = false;
+                    g_selecting = true;
+                    g_click_x = xpos;
+                    g_click_y = ypos;
+                    markSelectionChanged();
+                },
+                2 => {
+                    g_selecting = false;
+                    if (!selectWordAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+                },
+                3 => {
+                    g_selecting = false;
+                    if (!selectSentenceAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+                },
+                4 => {
+                    g_selecting = false;
+                    if (!selectParagraphAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+                },
+                else => unreachable,
+            }
         } else {
             // Mouse up
             overlays.g_scrollbar_dragging = false;

--- a/src/selection_unit.zig
+++ b/src/selection_unit.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+
+pub const ColRange = struct {
+    start: usize,
+    end: usize,
+};
+
+pub const RowRange = struct {
+    start_row: usize,
+    end_row: usize,
+    start_col: usize,
+    end_col: usize,
+};
+
+pub fn wordRange(row: []const u21, col: usize) ?ColRange {
+    if (col >= row.len or !isWordCodepoint(row[col])) return null;
+
+    var start = col;
+    while (start > 0 and isWordCodepoint(row[start - 1])) : (start -= 1) {}
+
+    var end = col;
+    while (end + 1 < row.len and isWordCodepoint(row[end + 1])) : (end += 1) {}
+
+    return .{ .start = start, .end = end };
+}
+
+pub fn sentenceRange(row: []const u21, col: usize) ?ColRange {
+    if (col >= row.len) return null;
+    const first = firstNonBlankCol(row) orelse return null;
+    const last = lastNonBlankCol(row) orelse return null;
+    if (col < first or col > last) return null;
+
+    var start: usize = 0;
+    var cursor = col;
+    while (cursor > 0) {
+        cursor -= 1;
+        if (isSentenceTerminator(row[cursor])) {
+            start = cursor + 1;
+            while (start <= last and isSentenceCloser(row[start])) : (start += 1) {}
+            break;
+        }
+    }
+    while (start <= last and isBlankCodepoint(row[start])) : (start += 1) {}
+
+    var end = last;
+    cursor = col;
+    while (cursor <= last) : (cursor += 1) {
+        if (isSentenceTerminator(row[cursor])) {
+            end = cursor;
+            while (end + 1 <= last and isSentenceCloser(row[end + 1])) : (end += 1) {}
+            break;
+        }
+    }
+    while (end > start and isBlankCodepoint(row[end])) : (end -= 1) {}
+
+    if (start > end) return null;
+    return .{ .start = start, .end = end };
+}
+
+pub fn paragraphRange(rows: []const []const u21, row: usize) ?RowRange {
+    if (row >= rows.len or rowIsBlank(rows[row])) return null;
+
+    var start_row = row;
+    while (start_row > 0 and !rowIsBlank(rows[start_row - 1])) : (start_row -= 1) {}
+
+    var end_row = row;
+    while (end_row + 1 < rows.len and !rowIsBlank(rows[end_row + 1])) : (end_row += 1) {}
+
+    return .{
+        .start_row = start_row,
+        .end_row = end_row,
+        .start_col = firstNonBlankCol(rows[start_row]) orelse 0,
+        .end_col = lastNonBlankCol(rows[end_row]) orelse 0,
+    };
+}
+
+pub fn firstNonBlankCol(row: []const u21) ?usize {
+    for (row, 0..) |cp, i| {
+        if (!isBlankCodepoint(cp)) return i;
+    }
+    return null;
+}
+
+pub fn lastNonBlankCol(row: []const u21) ?usize {
+    var i = row.len;
+    while (i > 0) {
+        i -= 1;
+        if (!isBlankCodepoint(row[i])) return i;
+    }
+    return null;
+}
+
+pub fn rowIsBlank(row: []const u21) bool {
+    return firstNonBlankCol(row) == null;
+}
+
+pub fn isWordCodepoint(cp: u21) bool {
+    if (cp >= '0' and cp <= '9') return true;
+    if (cp >= 'A' and cp <= 'Z') return true;
+    if (cp >= 'a' and cp <= 'z') return true;
+    if (cp == '_') return true;
+    return cp > 0x7f and !isBlankCodepoint(cp);
+}
+
+fn isBlankCodepoint(cp: u21) bool {
+    return cp == 0 or cp <= 0x20;
+}
+
+fn isSentenceTerminator(cp: u21) bool {
+    return cp == '.' or cp == '!' or cp == '?';
+}
+
+fn isSentenceCloser(cp: u21) bool {
+    return switch (cp) {
+        '"', '\'', ')', ']', '}' => true,
+        else => false,
+    };
+}
+
+test "selection unit: word range selects an alphanumeric token" {
+    const row = comptime toCodepoints("alpha beta_42.");
+    try std.testing.expectEqual(ColRange{ .start = 6, .end = 12 }, wordRange(&row, 8).?);
+}
+
+test "selection unit: sentence range trims surrounding whitespace and includes terminator" {
+    const row = comptime toCodepoints("  first sentence. second one!  ");
+    try std.testing.expectEqual(ColRange{ .start = 18, .end = 28 }, sentenceRange(&row, 23).?);
+}
+
+test "selection unit: paragraph range selects contiguous nonblank rows" {
+    const row0 = comptime toCodepoints("");
+    const row1 = comptime toCodepoints("  first line");
+    const row2 = comptime toCodepoints("second line  ");
+    const row3 = comptime toCodepoints("   ");
+    const rows = [_][]const u21{ &row0, &row1, &row2, &row3 };
+    try std.testing.expectEqual(RowRange{
+        .start_row = 1,
+        .end_row = 2,
+        .start_col = 2,
+        .end_col = 10,
+    }, paragraphRange(&rows, 2).?);
+}
+
+fn toCodepoints(comptime text: []const u8) [text.len]u21 {
+    var out: [text.len]u21 = undefined;
+    for (text, 0..) |ch, i| out[i] = ch;
+    return out;
+}

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -9,4 +9,5 @@ comptime {
     _ = @import("file_explorer.zig");
     _ = @import("markdown_preview.zig");
     _ = @import("remote_client.zig");
+    _ = @import("selection_unit.zig");
 }


### PR DESCRIPTION
## Summary
- add terminal mouse multi-click tracking for word, sentence, and paragraph selection
- route terminal double-click events into the normal left-click path while preserving titlebar/sidebar double-click behavior
- add unit tests for word, sentence, and paragraph boundary detection

## Ghostty reference
Ghostty keeps a left-click counter with interval and distance checks in src/Surface.zig, selecting words on double-click and lines on triple-click. Phantty follows the same counter shape and extends the behavior to the requested four-click paragraph selection.

## Validation
- zig build test
- zig build
- Windows path and symlink checks