### PR TITLE
[codex] change split focus shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ __pycache__/
 .codex
 .playwright-mcp/
 .superpowers/
+.worktrees/
 
 # Node/Cloudflare remote console artifacts
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 # Local agent / MCP tooling artifacts
 .codex
 .playwright-mcp/
+.superpowers/
 
 # Node/Cloudflare remote console artifacts
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ This is the gold standard, we want to be as close to their implementation as pos
 
 Use the github cli gh to browse https://github.com/ghostty-org/ghostty and always add descriptions on how ghostty does things. 
 
+Exception: work under `remote/` is Phantty's own web remote console and relay implementation. Ghostty does not have an equivalent feature, so `remote/` planning and implementation **does not need to compare against or reference Ghostty**. For `remote/`, follow the existing `remote/` architecture, browser platform constraints, and the user-approved design/plan for that feature.
+
 ## Build Commands
 
 ```powershell
@@ -146,39 +148,62 @@ Rules of thumb:
 ## Project Structure
 
 ```
-src/
-├── main.zig            # Entry point, GLFW window, OpenGL rendering, input handling, main loop
-├── config.zig          # Config loading (file + CLI), theme resolution, key=value parser
-├── config_watcher.zig  # Hot-reload via ReadDirectoryChangesW (watches config directory)
-├── pty.zig             # Windows ConPTY pseudo-terminal
-├── directwrite.zig     # DirectWrite FFI for Windows font discovery
-├── themes.zig          # Embedded theme data (453 Ghostty-compatible themes)
-├── renderer.zig        # Renderer module entry point / re-exports
-├── renderer/
-│   ├── Renderer.zig    # Per-surface renderer implementation
-│   ├── State.zig       # Shared renderer state
-│   ├── cell_renderer.zig
-│   ├── fbo.zig
-│   ├── gl_init.zig
-│   └── post_process.zig
-└── font/
-    ├── embedded.zig    # Embedded fallback font (Cozette bitmap font)
-    ├── sprite.zig      # Sprite font for box drawing, block elements, braille, powerline
-    └── sprite/
-        ├── canvas.zig          # 2D canvas for sprite rasterization
-        └── draw/
-            ├── common.zig      # Shared sprite drawing utilities
-            ├── box.zig         # Box drawing characters (U+2500–U+257F)
-            └── braille.zig     # Braille patterns (U+2800–U+28FF)
+src/                         # Windows desktop terminal application
+├── main.zig                 # Entry point, GLFW window, OpenGL setup, main loop
+├── App.zig                  # Application-level state, config reload, remote client lifecycle
+├── AppWindow.zig            # Window-level tabs, splits, rendering and input routing
+├── Surface.zig              # Per-terminal surface state and PTY integration
+├── input.zig                # Keyboard/mouse shortcuts and command dispatch
+├── config.zig               # Config loading (file + CLI), theme resolution, key=value parser
+├── config_watcher.zig       # Hot-reload via ReadDirectoryChangesW
+├── pty.zig                  # Windows ConPTY pseudo-terminal
+├── remote_client.zig        # Outbound Phantty Remote relay client
+├── file_explorer.zig        # Local/SSH file explorer state and operations
+├── browser_panel.zig        # Embedded browser panel and SSH tunnel handling
+├── directwrite.zig          # DirectWrite FFI for Windows font discovery
+├── themes.zig              # Embedded Ghostty-compatible themes
+├── appwindow/               # Tab and split-tree helpers for AppWindow
+├── apprt/                   # Win32/windowing support code
+├── font/                    # Font manager, atlas, embedded fallback, sprite glyphs
+├── renderer/                # OpenGL renderer, cell renderer, overlays, titlebar, panels
+└── termio/                  # PTY read/write threads and terminal IO mailbox
 
-debug/                  # Test scripts (run inside phantty terminal)
-pkg/                    # Vendored build dependencies (freetype, zlib, libpng, opengl)
-vendor/                 # Vendored source code
+remote/                      # Phantty-specific web remote console and relay
+├── src/client/              # Browser app: xterm surfaces, layout, virtual keyboard, styles
+│   ├── views/               # Login and remote console views
+│   └── styles/              # Base, console, responsive, token, and virtual keyboard CSS
+├── src/server/              # Node.js relay server for Docker/local hosting
+├── src/worker.ts            # Cloudflare Worker + Durable Object relay
+├── index.html               # Vite browser entry
+├── package.json             # Remote build/dev/typecheck scripts
+├── Dockerfile               # Container build for the Node relay
+├── docker-compose.yml       # Local/VPS Docker deployment helper
+├── nginx.conf.example       # Reverse proxy example for Docker deployment
+└── wrangler.toml.example    # Cloudflare deployment template
+
+docs/                        # Static website and generated/project documentation
+├── index.html
+├── zh.html
+├── style.css
+├── assets/
+└── superpowers/             # Approved design specs and implementation plans
+
+plans/                       # Project planning notes and historical implementation plans
+release-notes/               # Versioned release notes
+debug/                       # Test/debug scripts, including Windows UI automation
+packaging/windows/           # Windows installer and packaging scripts
+assets/                      # Application icon and source art
+shaders/                     # GLSL shader files
+tools/                       # Terminal helper scripts such as imgcat/pdfcat
+pkg/                         # Vendored build dependencies (freetype, zlib, libpng, opengl, etc.)
+vendor/                      # Vendored source code
 ```
 
 ## Ghostty Reference
 
-Phantty intentionally follows Ghostty's design and behavior. When implementing or modifying features, **cross-reference the Ghostty source** at https://github.com/ghostty-org/ghostty.
+Phantty intentionally follows Ghostty's design and behavior for terminal emulator functionality. When implementing or modifying features in the main Zig terminal app, **cross-reference the Ghostty source** at https://github.com/ghostty-org/ghostty.
+
+This Ghostty reference requirement does **not** apply to `remote/`. The `remote/` directory contains Phantty-specific web remote console and relay code; develop it from the existing remote codebase, web/mobile UX requirements, and local plans rather than trying to match Ghostty.
 
 Key mapping of Phantty files to Ghostty counterparts:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Default chords are implemented in [`src/input.zig`](src/input.zig). Some keys ar
 | Right-click a selection | Copy selection |
 | **Ctrl+V** | Paste text |
 | **Ctrl+Shift+V** | Paste clipboard image |
-| **Alt** + arrow keys | Move focus to adjacent panel (spatial) |
+| **Ctrl+Shift** + arrow keys | Move focus to adjacent panel (spatial) |
 | **Ctrl+Shift+[** | Focus previous panel (cycle) |
 | **Ctrl+Shift+]** | Focus next panel (cycle) |
 | **Ctrl+Shift+Z** | Equalize split sizes |

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,7 +207,7 @@ remote-device-name     = Workstation</code></pre>
           <div><span class="label">Equalize splits</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Z</kbd></span></div>
           <div><span class="label">Close panel / tab / window</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>W</kbd></span></div>
           <div><span class="label">Maximize / restore window</span><span class="keys"><kbd>Alt</kbd><kbd>Enter</kbd></span></div>
-          <div><span class="label">Move focus by direction</span><span class="keys"><kbd>Alt</kbd><kbd>←</kbd><kbd>↑</kbd><kbd>↓</kbd><kbd>→</kbd></span></div>
+          <div><span class="label">Move focus by direction</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>←</kbd><kbd>↑</kbd><kbd>↓</kbd><kbd>→</kbd></span></div>
           <div><span class="label">Previous panel</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>[</kbd></span></div>
           <div><span class="label">Next panel</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>]</kbd></span></div>
           <div><span class="label">Previous tab</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Tab</kbd></span></div>

--- a/docs/superpowers/plans/2026-05-09-remote-mobile-console.md
+++ b/docs/superpowers/plans/2026-05-09-remote-mobile-console.md
@@ -1,0 +1,1058 @@
+# Remote Mobile Console Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the approved iPhone/mobile remote console layout with a terminal-first viewport, reliable selected-surface input, and a compact terminal utility keyboard.
+
+**Architecture:** Keep all behavior in `remote/src/client`; do not change the relay protocol, server routes, or Zig remote client. Add small testable helper modules for mobile layout decisions and input sequences, then wire them into `surfaces.ts`, `vkbd.ts`, and `views/console.ts`. Use CSS media queries for the mobile shell while keeping desktop layout behavior intact.
+
+**Tech Stack:** TypeScript, Vite, xterm.js, `@xterm/addon-fit`, Node test runner through `tsx`, CSS media queries, existing WebSocket relay client.
+
+---
+
+## Scope Notes
+
+The approved spec is `docs/superpowers/specs/2026-05-09-remote-mobile-console-design.md`.
+
+`AGENTS.md` now states that `remote/` does not need Ghostty comparison. This plan follows the existing `remote/` architecture and browser/mobile constraints.
+
+## File Structure
+
+- Create `remote/src/client/mobile_layout.ts`: pure layout decisions plus the browser media-query helper.
+- Create `remote/src/client/input_sequences.ts`: pure terminal key/text sequence helpers used by the virtual keyboard.
+- Create `remote/src/client/mobile_text_input.ts`: hidden mobile text input bridge for iOS/native keyboard text entry.
+- Create `remote/test/client/mobile_layout.test.ts`: Node test coverage for mobile fit decisions.
+- Create `remote/test/client/input_sequences.test.ts`: Node test coverage for terminal key sequence helpers.
+- Modify `remote/package.json`: add a client test script.
+- Modify `remote/src/client/main.ts`: register the text input sender.
+- Modify `remote/src/client/views/console.ts`: render and bind the hidden text input, bind viewport refits, keep drawer/keyboard state source of truth.
+- Modify `remote/src/client/surfaces.ts`: use viewport fitting on mobile, keep remote-grid geometry on desktop, focus the text bridge on mobile terminal taps.
+- Modify `remote/src/client/vkbd.ts`: use shared sequence helpers and route Type through the text bridge.
+- Modify `remote/src/client/styles/responsive.css`: implement the terminal-first mobile shell and selected-surface chrome.
+- Modify `remote/src/client/styles/vkbd.css`: make the utility keyboard compact and touch-stable.
+
+## Tasks
+
+### Task 1: Add Mobile Layout Helper And Test Script
+
+**Files:**
+- Modify: `remote/package.json`
+- Create: `remote/src/client/mobile_layout.ts`
+- Create: `remote/test/client/mobile_layout.test.ts`
+
+- [ ] **Step 1: Add the failing mobile layout test and test script**
+
+In `remote/package.json`, add this script after `preview`:
+
+```json
+"test:client": "node --import tsx --test test/client/*.test.ts",
+```
+
+The `scripts` section should include:
+
+```json
+"preview": "vite preview --host 127.0.0.1",
+"test:client": "node --import tsx --test test/client/*.test.ts",
+"deploy": "npm run build && wrangler deploy",
+```
+
+Create `remote/test/client/mobile_layout.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MOBILE_REMOTE_MEDIA_QUERY,
+  fitModeForSurface,
+  shouldUseViewportFit,
+} from "../../src/client/mobile_layout";
+
+test("mobile media query matches the responsive CSS breakpoint", () => {
+  assert.equal(
+    MOBILE_REMOTE_MEDIA_QUERY,
+    "(max-width: 860px), (pointer: coarse) and (max-width: 1024px)",
+  );
+});
+
+test("fitModeForSurface uses viewport fitting on mobile", () => {
+  assert.equal(fitModeForSurface(true), "viewport");
+});
+
+test("fitModeForSurface preserves remote-grid sizing on desktop", () => {
+  assert.equal(fitModeForSurface(false), "remote-grid");
+});
+
+test("shouldUseViewportFit is true only for mobile surfaces", () => {
+  assert.equal(shouldUseViewportFit(true), true);
+  assert.equal(shouldUseViewportFit(false), false);
+});
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+```
+
+Expected: FAIL with an import error for `../../src/client/mobile_layout`.
+
+- [ ] **Step 3: Add the mobile layout helper**
+
+Create `remote/src/client/mobile_layout.ts`:
+
+```ts
+export const MOBILE_REMOTE_MEDIA_QUERY =
+  "(max-width: 860px), (pointer: coarse) and (max-width: 1024px)";
+
+export type SurfaceFitMode = "remote-grid" | "viewport";
+
+export function fitModeForSurface(isMobile: boolean): SurfaceFitMode {
+  return isMobile ? "viewport" : "remote-grid";
+}
+
+export function shouldUseViewportFit(isMobile: boolean): boolean {
+  return fitModeForSurface(isMobile) === "viewport";
+}
+
+export function isMobileRemoteShell(win: Pick<Window, "matchMedia"> = window): boolean {
+  return win.matchMedia(MOBILE_REMOTE_MEDIA_QUERY).matches;
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+```
+
+Expected: PASS with 4 passing subtests.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add remote/package.json remote/src/client/mobile_layout.ts remote/test/client/mobile_layout.test.ts
+git commit -m "test remote mobile layout helpers"
+```
+
+### Task 2: Fit The Selected Surface To The Mobile Viewport
+
+**Files:**
+- Modify: `remote/src/client/surfaces.ts`
+- Modify: `remote/src/client/views/console.ts`
+- Test: `remote/test/client/mobile_layout.test.ts`
+
+- [ ] **Step 1: Add a test for mobile viewport fitting behavior**
+
+Append to `remote/test/client/mobile_layout.test.ts`:
+
+```ts
+test("mobile viewport fitting ignores remote grid dimensions", () => {
+  assert.equal(shouldUseViewportFit(true), true);
+});
+
+test("desktop rendering keeps remote grid dimensions", () => {
+  assert.equal(shouldUseViewportFit(false), false);
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+```
+
+Expected: PASS. The test documents the behavior before wiring it into xterm fitting.
+
+- [ ] **Step 3: Update `surfaces.ts` imports**
+
+In `remote/src/client/surfaces.ts`, add:
+
+```ts
+import { isMobileRemoteShell, shouldUseViewportFit } from "./mobile_layout";
+```
+
+- [ ] **Step 4: Replace duplicated fit logic with `fitOrResize`**
+
+In `remote/src/client/surfaces.ts`, add this helper above `scheduleFit`:
+
+```ts
+function fitOrResize(view: SurfaceView): void {
+  const useViewportFit = shouldUseViewportFit(isMobileRemoteShell());
+  if (!useViewportFit && view.remoteCols && view.remoteRows) {
+    if (view.term.cols !== view.remoteCols || view.term.rows !== view.remoteRows) {
+      view.term.resize(view.remoteCols, view.remoteRows);
+    }
+    return;
+  }
+
+  view.fit.fit();
+}
+```
+
+Then replace the body of the `try` block inside `scheduleFit` with:
+
+```ts
+fitOrResize(view);
+view.term.refresh(0, Math.max(0, view.term.rows - 1));
+```
+
+Then replace the fit/resize `try` block inside `applyInitialSnapshot` with:
+
+```ts
+try {
+  fitOrResize(view);
+} catch {
+  // xterm can briefly report zero-sized panels while layout is settling.
+}
+```
+
+- [ ] **Step 5: Bind viewport refits in `console.ts`**
+
+In `remote/src/client/views/console.ts`, add this module-level flag near the imports:
+
+```ts
+let viewportRefitBound = false;
+```
+
+Add this function near `bindMobileChrome`:
+
+```ts
+function bindViewportRefit(): void {
+  if (viewportRefitBound) return;
+  viewportRefitBound = true;
+
+  const refit = (): void => {
+    refitAllSurfaces();
+  };
+
+  window.addEventListener("resize", refit, { passive: true });
+  window.visualViewport?.addEventListener("resize", refit);
+  window.visualViewport?.addEventListener("scroll", refit);
+}
+```
+
+Call it in `renderConsole` after `bindMobileChrome();`:
+
+```ts
+bindMobileChrome();
+bindViewportRefit();
+bindVirtualKeyboard(() => setKbdVisible(false));
+```
+
+Update `setKbdVisible` so fitting runs after the grid row changes:
+
+```ts
+function setKbdVisible(visible: boolean): void {
+  state.kbdVisible = visible;
+  saveKbdVisible(visible);
+  const shell = document.querySelector<HTMLElement>(".console-shell");
+  if (shell) shell.dataset.kbdVisible = String(visible);
+  requestAnimationFrame(() => refitAllSurfaces());
+}
+```
+
+- [ ] **Step 6: Verify Task 2**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+npm run typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add remote/src/client/surfaces.ts remote/src/client/views/console.ts remote/test/client/mobile_layout.test.ts
+git commit -m "fit remote surfaces to mobile viewport"
+```
+
+### Task 3: Extract Terminal Input Sequence Helpers
+
+**Files:**
+- Create: `remote/src/client/input_sequences.ts`
+- Create: `remote/test/client/input_sequences.test.ts`
+- Modify: `remote/src/client/vkbd.ts`
+
+- [ ] **Step 1: Add the failing input sequence tests**
+
+Create `remote/test/client/input_sequences.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyStickyMods,
+  ctrlLetter,
+  keyToSequence,
+} from "../../src/client/input_sequences";
+
+test("keyToSequence returns terminal escape sequences for special keys", () => {
+  assert.equal(keyToSequence("esc"), "\x1b");
+  assert.equal(keyToSequence("tab"), "\t");
+  assert.equal(keyToSequence("up"), "\x1b[A");
+  assert.equal(keyToSequence("down"), "\x1b[B");
+  assert.equal(keyToSequence("right"), "\x1b[C");
+  assert.equal(keyToSequence("left"), "\x1b[D");
+  assert.equal(keyToSequence("bksp"), "\x7f");
+  assert.equal(keyToSequence("enter"), "\r");
+  assert.equal(keyToSequence("unknown"), null);
+});
+
+test("ctrlLetter maps letters to C0 control characters", () => {
+  assert.equal(ctrlLetter("a"), "\x01");
+  assert.equal(ctrlLetter("c"), "\x03");
+  assert.equal(ctrlLetter("z"), "\x1a");
+  assert.equal(ctrlLetter("1"), null);
+});
+
+test("applyStickyMods applies ctrl and alt to single characters", () => {
+  assert.equal(applyStickyMods("c", { ctrl: true, alt: false }), "\x03");
+  assert.equal(applyStickyMods("x", { ctrl: false, alt: true }), "\x1bx");
+  assert.equal(applyStickyMods("/", { ctrl: true, alt: false }), "/");
+  assert.equal(applyStickyMods("long", { ctrl: true, alt: true }), "long");
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+```
+
+Expected: FAIL with an import error for `../../src/client/input_sequences`.
+
+- [ ] **Step 3: Add `input_sequences.ts`**
+
+Create `remote/src/client/input_sequences.ts`:
+
+```ts
+export type StickyMods = { ctrl: boolean; alt: boolean };
+
+export function ctrlLetter(letter: string): string | null {
+  const lower = letter.toLowerCase();
+  if (lower.length !== 1 || lower < "a" || lower > "z") return null;
+  return String.fromCharCode(lower.charCodeAt(0) - 96);
+}
+
+export function applyStickyMods(text: string, mods: StickyMods): string {
+  if (mods.ctrl && text.length === 1) {
+    return ctrlLetter(text) ?? text;
+  }
+  if (mods.alt && text.length === 1) {
+    return `\x1b${text}`;
+  }
+  return text;
+}
+
+export function keyToSequence(key: string): string | null {
+  switch (key) {
+    case "esc":
+      return "\x1b";
+    case "tab":
+      return "\t";
+    case "up":
+      return "\x1b[A";
+    case "down":
+      return "\x1b[B";
+    case "right":
+      return "\x1b[C";
+    case "left":
+      return "\x1b[D";
+    case "bksp":
+      return "\x7f";
+    case "enter":
+      return "\r";
+    default:
+      return null;
+  }
+}
+```
+
+- [ ] **Step 4: Refactor `vkbd.ts` to use the helper**
+
+In `remote/src/client/vkbd.ts`, add:
+
+```ts
+import { applyStickyMods, ctrlLetter, keyToSequence } from "./input_sequences";
+```
+
+Replace the `vkCtrl` block with:
+
+```ts
+if (button.dataset.vkCtrl) {
+  const seq = ctrlLetter(button.dataset.vkCtrl);
+  if (seq) sender(surfaceId, seq);
+  clearStickyMods();
+  return;
+}
+```
+
+Replace the `vkText` block with:
+
+```ts
+if (button.dataset.vkText !== undefined) {
+  const text = applyStickyMods(button.dataset.vkText, kbdMods);
+  sender(surfaceId, text);
+  clearStickyMods();
+  return;
+}
+```
+
+Remove the local `keyToSequence` function from `vkbd.ts`.
+
+- [ ] **Step 5: Verify Task 3**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+npm run typecheck
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add remote/src/client/input_sequences.ts remote/test/client/input_sequences.test.ts remote/src/client/vkbd.ts
+git commit -m "share remote terminal input sequences"
+```
+
+### Task 4: Add The Mobile Text Input Bridge
+
+**Files:**
+- Create: `remote/src/client/mobile_text_input.ts`
+- Modify: `remote/src/client/main.ts`
+- Modify: `remote/src/client/views/console.ts`
+- Modify: `remote/src/client/surfaces.ts`
+- Modify: `remote/src/client/vkbd.ts`
+- Modify: `remote/src/client/styles/vkbd.css`
+
+- [ ] **Step 1: Create the mobile text input bridge**
+
+Create `remote/src/client/mobile_text_input.ts`:
+
+```ts
+import { activeSurfaceIdForInput } from "./state";
+
+type Sender = (surfaceId: string, data: string) => void;
+
+let sender: Sender = () => {
+  // no-op until transport registers
+};
+
+let inputEl: HTMLTextAreaElement | null = null;
+
+export function setMobileTextInputSender(send: Sender): void {
+  sender = send;
+}
+
+export function renderMobileTextInputMarkup(): string {
+  return `
+    <textarea
+      id="mobile-text-input"
+      class="mobile-text-input"
+      aria-label="Terminal text input"
+      autocomplete="off"
+      autocapitalize="off"
+      autocorrect="off"
+      spellcheck="false"
+      rows="1"
+    ></textarea>
+  `;
+}
+
+export function bindMobileTextInput(): void {
+  inputEl = document.querySelector<HTMLTextAreaElement>("#mobile-text-input");
+  if (!inputEl) return;
+
+  inputEl.addEventListener("beforeinput", (event) => {
+    const inputEvent = event as InputEvent;
+    if (inputEvent.inputType === "insertLineBreak") {
+      event.preventDefault();
+      dispatchText("\r");
+      clearInputValue();
+      return;
+    }
+    if (inputEvent.inputType === "deleteContentBackward") {
+      event.preventDefault();
+      dispatchText("\x7f");
+      clearInputValue();
+    }
+  });
+
+  inputEl.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      dispatchText("\r");
+      clearInputValue();
+      return;
+    }
+    if (event.key === "Backspace" && !inputEl?.value) {
+      event.preventDefault();
+      dispatchText("\x7f");
+    }
+  });
+
+  inputEl.addEventListener("input", () => {
+    if (!inputEl?.value) return;
+    dispatchText(inputEl.value);
+    clearInputValue();
+  });
+
+  inputEl.addEventListener("compositionend", () => {
+    if (!inputEl?.value) return;
+    dispatchText(inputEl.value);
+    clearInputValue();
+  });
+}
+
+export function focusMobileTextInput(): boolean {
+  const input = inputEl ?? document.querySelector<HTMLTextAreaElement>("#mobile-text-input");
+  if (!input) return false;
+  inputEl = input;
+  input.focus({ preventScroll: true });
+  return document.activeElement === input;
+}
+
+function dispatchText(text: string): void {
+  const surfaceId = activeSurfaceIdForInput();
+  if (!surfaceId || !text) return;
+  sender(surfaceId, text);
+}
+
+function clearInputValue(): void {
+  if (inputEl) inputEl.value = "";
+}
+```
+
+- [ ] **Step 2: Register the bridge sender in `main.ts`**
+
+In `remote/src/client/main.ts`, add:
+
+```ts
+import { setMobileTextInputSender } from "./mobile_text_input";
+```
+
+Then add this next to the existing sender setup:
+
+```ts
+setMobileTextInputSender(sendInputBytes);
+```
+
+- [ ] **Step 3: Render and bind the bridge in `console.ts`**
+
+In `remote/src/client/views/console.ts`, add:
+
+```ts
+import { bindMobileTextInput, renderMobileTextInputMarkup } from "../mobile_text_input";
+```
+
+Render it after the virtual keyboard:
+
+```ts
+${renderVirtualKeyboardMarkup()}
+${renderMobileTextInputMarkup()}
+```
+
+Call the binder after `bindVirtualKeyboard(...)`:
+
+```ts
+bindVirtualKeyboard(() => setKbdVisible(false));
+bindMobileTextInput();
+```
+
+- [ ] **Step 4: Route terminal taps and Type through the bridge**
+
+In `remote/src/client/surfaces.ts`, add:
+
+```ts
+import { focusMobileTextInput } from "./mobile_text_input";
+```
+
+Replace the terminal click handler body with:
+
+```ts
+panel.addEventListener("click", () => {
+  selectThis();
+  if (!focusMobileTextInput()) ensureSurfaceView(surfaceId).term.focus();
+});
+```
+
+Replace `focusAndFitSelectedSurface` with:
+
+```ts
+export function focusAndFitSelectedSurface(): void {
+  const id = state.selectedSurfaceId;
+  if (!id) return;
+  const view = state.surfaceViews.get(id);
+  if (!view) return;
+  if (!focusMobileTextInput()) view.term.focus();
+  scheduleFit(view);
+}
+```
+
+In `remote/src/client/vkbd.ts`, add:
+
+```ts
+import { focusMobileTextInput } from "./mobile_text_input";
+```
+
+Replace the Type key block with:
+
+```ts
+if (button.dataset.vkKey === "type") {
+  if (!focusMobileTextInput()) state.surfaceViews.get(surfaceId)?.term.focus();
+  return;
+}
+```
+
+- [ ] **Step 5: Style the hidden mobile text input**
+
+Append to `remote/src/client/styles/vkbd.css`:
+
+```css
+.mobile-text-input {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 1px;
+  height: 1px;
+  min-width: 1px;
+  min-height: 1px;
+  padding: 0;
+  border: 0;
+  opacity: 0.01;
+  color: transparent;
+  background: transparent;
+  caret-color: transparent;
+  resize: none;
+  pointer-events: none;
+  z-index: -1;
+}
+```
+
+- [ ] **Step 6: Verify Task 4**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+npm run typecheck
+npm run build
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add remote/src/client/mobile_text_input.ts remote/src/client/main.ts remote/src/client/views/console.ts remote/src/client/surfaces.ts remote/src/client/vkbd.ts remote/src/client/styles/vkbd.css
+git commit -m "add remote mobile text input bridge"
+```
+
+### Task 5: Apply The Terminal-First Mobile CSS
+
+**Files:**
+- Modify: `remote/src/client/styles/responsive.css`
+- Modify: `remote/src/client/styles/vkbd.css`
+
+- [ ] **Step 1: Replace the phone/tablet mobile block**
+
+In `remote/src/client/styles/responsive.css`, replace the first mobile block from:
+
+```css
+/* ─── Phone / tablet portrait ────────────────────────────────── */
+
+@media (max-width: 860px), (pointer: coarse) and (max-width: 1024px) {
+```
+
+through the closing brace immediately before:
+
+```css
+/* ─── Foldable: dual-fold horizontal crease (top/bottom) ─────── */
+```
+
+with:
+
+```css
+/* ─── Phone / tablet portrait ────────────────────────────────── */
+
+@media (max-width: 860px), (pointer: coarse) and (max-width: 1024px) {
+  html,
+  body,
+  #app {
+    overflow: hidden;
+  }
+
+  .console-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr);
+    height: 100dvh;
+  }
+
+  .sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 80;
+    animation: fade-in 200ms ease both;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(340px, 86vw);
+    z-index: 90;
+    transform: translateX(-102%);
+    transition: transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+    border-right: 1px solid var(--line);
+    border-bottom: 0;
+    box-shadow: var(--shadow-drawer);
+  }
+
+  .console-shell[data-drawer-open="true"] .sidebar {
+    transform: translateX(0);
+  }
+
+  .sidebar-head .icon-button {
+    display: grid;
+  }
+
+  .workspace {
+    grid-column: 1;
+    grid-row: 1;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .mobile-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 52px;
+    padding: 6px max(12px, var(--safe-right)) 6px max(12px, var(--safe-left));
+    padding-top: max(6px, var(--safe-top));
+    border-bottom: 1px solid var(--line);
+    background: var(--surface-overlay-strong);
+    backdrop-filter: blur(20px);
+  }
+
+  .mobile-bar-title {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-weight: 800;
+    font-size: 14px;
+  }
+
+  .terminal-toolbar {
+    display: none;
+  }
+
+  .terminal-panel {
+    grid-row: 3;
+    grid-template-rows: minmax(0, 1fr);
+    min-height: 0;
+    padding: 6px;
+    padding-right: max(6px, var(--safe-right));
+    padding-left: max(6px, var(--safe-left));
+  }
+
+  .panels-stage {
+    min-height: 0;
+    height: 100%;
+    border-radius: 14px;
+  }
+
+  .surface-strip {
+    grid-row: 2;
+    display: flex;
+    min-height: 42px;
+    gap: 6px;
+    padding: 6px max(10px, var(--safe-right)) 6px max(10px, var(--safe-left));
+    overflow-x: auto;
+    scrollbar-width: none;
+    border-bottom: 1px solid var(--line);
+    background: var(--surface-overlay);
+  }
+
+  .surface-strip::-webkit-scrollbar {
+    display: none;
+  }
+
+  .surface-strip:empty {
+    display: none;
+  }
+
+  .surface-chip {
+    flex: 0 0 auto;
+    max-width: 62vw;
+    min-height: 30px;
+    padding: 7px 11px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--surface-overlay);
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+  }
+
+  .surface-chip.active {
+    color: var(--accent);
+    border-color: var(--selected-ring);
+    background: var(--accent-soft);
+  }
+
+  .panels-stage[data-mobile-mode="single"] .remote-panel {
+    inset: 0 !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    min-width: 0;
+    min-height: 0;
+    display: none;
+    padding: 4px;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .remote-panel.selected {
+    display: grid;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .remote-panel::before {
+    inset: 3px;
+    border-radius: 12px;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .panel-header {
+    min-height: 28px;
+    padding: 6px 10px;
+    border-radius: 10px 10px 0 0;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .panel-header small {
+    display: none;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .terminal-mount {
+    padding: 4px;
+    border-radius: 0 0 10px 10px;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .terminal-mount::after {
+    display: none;
+  }
+
+  .panels-stage[data-mobile-mode="single"] .terminal-host {
+    touch-action: manipulation;
+  }
+
+  .console-shell[data-kbd-visible="true"] {
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+
+  .console-shell[data-kbd-visible="true"] .vkbd {
+    display: block;
+    grid-row: 2;
+  }
+
+  .console-shell[data-kbd-visible="true"] .panels-stage[data-mobile-mode="single"] .panel-header {
+    display: none;
+  }
+
+  .console-shell[data-kbd-visible="true"] .panels-stage[data-mobile-mode="single"] .terminal-mount {
+    border-radius: 10px;
+  }
+}
+```
+
+- [ ] **Step 2: Compact the virtual keyboard on mobile**
+
+Append to `remote/src/client/styles/vkbd.css`:
+
+```css
+@media (max-width: 860px), (pointer: coarse) and (max-width: 1024px) {
+  .vkbd {
+    padding: 8px max(8px, var(--safe-right)) max(8px, var(--safe-bottom)) max(8px, var(--safe-left));
+  }
+
+  .vkbd-rows {
+    gap: 5px;
+  }
+
+  .vkbd-row {
+    gap: 4px;
+  }
+
+  .vkbd-key {
+    height: 38px;
+    min-width: 0;
+    border-radius: 9px;
+    padding: 0 4px;
+    font-size: 13px;
+  }
+
+  .vkbd-key.vkbd-wide {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+  }
+}
+```
+
+- [ ] **Step 3: Verify Task 5**
+
+Run:
+
+```bash
+cd remote
+npm run typecheck
+npm run build
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add remote/src/client/styles/responsive.css remote/src/client/styles/vkbd.css
+git commit -m "polish remote mobile console layout"
+```
+
+### Task 6: Mobile Smoke Verification And Windows Path Check
+
+**Files:**
+- No code files required unless verification reveals a concrete defect.
+
+- [ ] **Step 1: Run all remote checks**
+
+Run:
+
+```bash
+cd remote
+npm run test:client
+npm run typecheck
+npm run build
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Start the local remote server for visual verification**
+
+Run:
+
+```bash
+cd remote
+npm run build:server
+ADMIN_USERNAME=admin ADMIN_PASSWORD_HASH=sha256:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8 SESSION_SIGNING_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef REMOTE_COOKIE_SECURE=false HOST=127.0.0.1 PORT=8787 npm run start:server
+```
+
+Expected: server prints `listening on http://127.0.0.1:8787`.
+
+- [ ] **Step 3: Use Playwright at iPhone 14 size**
+
+In Playwright, set viewport to `390 x 844`, navigate to `http://127.0.0.1:8787/`, login with `admin` / `password`, connect to session key `iphone`, then inject a mock Phantty websocket layout with two surfaces:
+
+```js
+const ws = new WebSocket("ws://127.0.0.1:8787/ws/phantty?session=iphone");
+const snapshot = [
+  "Phantty remote mock on iPhone 14",
+  "",
+  "$ git status --short",
+  " M remote/src/client/styles/responsive.css",
+  "$ npm run build",
+  "vite building...",
+  "",
+  "The selected terminal should own the mobile viewport.",
+].join("\r\n");
+ws.addEventListener("open", () => {
+  ws.send(JSON.stringify({
+    type: "layout",
+    activeTab: 0,
+    tabs: [{
+      index: 0,
+      title: "dev server",
+      focusedSurfaceId: "surf-a",
+      surfaces: [
+        { id: "surf-a", title: "PowerShell", focused: true, cols: 120, rows: 34, cursorX: 0, cursorY: 8, x: 0, y: 0, w: 0.55, h: 1, snapshot },
+        { id: "surf-b", title: "logs", focused: false, cols: 80, rows: 34, cursorX: 0, cursorY: 2, x: 0.55, y: 0, w: 0.45, h: 1, snapshot: "log stream\r\ninfo remote connected" },
+      ],
+    }],
+  }));
+});
+```
+
+Expected visual result:
+
+- Top bar, surface strip, terminal stage, and bottom utility keyboard match the approved four-part layout.
+- With keyboard visible, panel header is hidden and terminal area remains readable.
+- With keyboard hidden, selected terminal gets extra height.
+- Tapping `logs` switches selected surface.
+- Tapping `Type` focuses the hidden text input/native keyboard path without stealing selected surface state.
+
+- [ ] **Step 4: Run the Windows path checks because this plan adds files**
+
+From PowerShell, run the Windows path and symlink checks from `AGENTS.md`.
+
+Expected:
+
+```text
+windows_name_violations=0
+casefold_collisions=0
+```
+
+And:
+
+```powershell
+git ls-files -s | Select-String '^120000'
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit verification-only fixes if any were needed**
+
+If Step 3 or Step 4 required code changes, commit those exact fixes:
+
+```bash
+git add remote/src/client remote/test/client remote/package.json remote/package-lock.json
+git commit -m "fix remote mobile verification issues"
+```
+
+If no changes were required, do not create an empty commit.
+
+## Plan Self-Review
+
+- Spec coverage: layout, input, navigation, state flow, fitting, and verification requirements are covered by Tasks 1-6.
+- No relay/server/Zig protocol changes are included.
+- Desktop behavior is preserved by keeping remote-grid sizing outside the mobile media query path.
+- New files use Windows-safe lowercase names and no symlinks.

--- a/docs/superpowers/specs/2026-05-09-remote-mobile-console-design.md
+++ b/docs/superpowers/specs/2026-05-09-remote-mobile-console-design.md
@@ -1,0 +1,144 @@
+# Remote Mobile Console Design
+
+## Context
+
+Phantty Remote already mirrors tabs and split surfaces into the browser and routes browser input back to the selected surface. The desktop web console is usable, but the iPhone 14 viewport is too cramped: the mobile header, surface chips, panel header, terminal frame, and fixed virtual keyboard compete with the terminal itself.
+
+The approved direction is a mobile-first, terminal-first layout using the visual wireframe reviewed during brainstorming:
+
+1. Compact top bar for menu, current tab title, connection status, and keyboard toggle.
+2. Horizontal surface switcher directly below the top bar.
+3. Selected terminal surface as the primary content.
+4. Bottom utility keyboard for terminal-specific keys.
+
+The implementation should stay within `remote/src/client` and must not change the relay protocol, server routes, or Zig remote client behavior.
+
+## Ghostty Comparison
+
+Ghostty does not implement a web remote console, so there is no one-to-one source file to copy. The relevant Ghostty model is its separation of app, surface, renderer, and input concerns.
+
+Using `gh` against `ghostty-org/ghostty`:
+
+- `src/App.zig` keeps a `focused_surface` and routes app key handling separately from surface-scoped key handling. The mobile Remote UI should follow that model by keeping one selected browser surface for input and not broadcasting mobile controls across all panels.
+- `src/apprt/surface.zig` defines surface messages such as `present_surface`, clipboard read/write, and mouse shape changes. Remote mobile controls should remain browser-side presentation/input helpers and should not be treated as terminal emulation state.
+- `src/renderer/OpenGL.zig` derives render surface size from the current viewport and presents a render target. The browser should similarly fit xterm to the actual selected terminal viewport after chrome/keyboard changes, not to the whole page.
+
+## Goals
+
+- Make the iPhone 14 portrait experience feel like a terminal first, not a dashboard squeezed onto a phone.
+- Preserve the existing Remote session model: saved session key, drawer menu, tabs, surfaces, WebSocket reconnect, and xterm rendering.
+- Make touch targets reliable for thumb use.
+- Keep normal command typing and terminal utility keys easy to access.
+- Ensure selected-surface input remains explicit and predictable.
+
+## Non-Goals
+
+- No changes to the relay server, Worker, Docker server, or WebSocket message schema.
+- No changes to Phantty's Zig remote client.
+- No new authentication or pairing flow.
+- No desktop redesign beyond avoiding regressions from shared CSS.
+- No terminal emulator reimplementation; xterm remains the browser terminal renderer.
+
+## Recommended Approach
+
+Use a full mobile shell redesign scoped to the existing client modules.
+
+Other options considered:
+
+- Only reduce chrome and padding. This would improve visible terminal space but leave typing and control placement awkward.
+- Only improve the virtual keyboard. This would help command entry but leave navigation and viewport pressure unresolved.
+- Full mobile shell redesign. This solves the layout, switching, and input ergonomics together while still avoiding protocol or server changes.
+
+The recommended approach is the third option because the current pain is systemic: space, input, and controls all affect each other on iPhone.
+
+## Layout Design
+
+On mobile, `.console-shell` remains a single-column grid with the workspace above the virtual keyboard when the keyboard is visible.
+
+The workspace is:
+
+1. `.mobile-bar`: fixed-height compact bar with drawer button, tab title, status pip, and keyboard toggle.
+2. `.surface-strip`: horizontal scroll list of surfaces for the current tab. It appears only when more than one surface exists.
+3. `.terminal-panel`: full remaining height, containing `.panels-stage`.
+
+The selected surface fills the panels stage in mobile single-surface mode. Non-selected surfaces remain mounted only as needed for state, but are hidden visually.
+
+The mobile selected panel should reduce decorative chrome:
+
+- Keep enough selected-surface affordance to show focus.
+- Remove or compress the panel title/header on narrow screens.
+- Remove the "outside terminal grid" label on mobile.
+- Reduce terminal frame padding.
+- Preserve xterm background, foreground, cursor, and selection theme.
+
+## Input Design
+
+The bottom utility keyboard remains available because terminal users need Esc, Tab, Ctrl, Alt, arrows, Enter, Backspace, and common shell symbols.
+
+Improve the input model by making the "Type" action explicit:
+
+- Tapping the terminal or Type focuses the selected xterm instance.
+- Tapping utility keys should not steal terminal focus.
+- Ctrl and Alt stay sticky for one following text/special key, then clear.
+- Direct control shortcuts such as `^C`, `^D`, `^L`, `^R`, and `^Z` remain one-tap actions.
+
+If iOS still fails to show the native keyboard reliably through xterm focus, add a hidden mobile text input bridge in the client. The bridge should forward inserted text to the selected surface through the existing `sendInputBytes` path, while utility keys continue to use `vkbd.ts`.
+
+## Navigation Design
+
+The drawer remains the place for session connection, tab list, relay notices, theme toggle, and logout.
+
+The main mobile workspace should not require opening the drawer for common operation:
+
+- Current tab title is visible in the top bar.
+- Connection state is visible as a status pip.
+- Surface switching is available in the strip.
+- Keyboard visibility is one tap.
+
+Remote tabs stay in the drawer for now. If tab switching becomes a repeated mobile task, a later change can add a compact tab switcher to the top bar, but that is out of scope for this pass.
+
+## State And Data Flow
+
+Existing data flow remains:
+
+1. `transport.ts` receives layout/output/notice messages.
+2. `layout.ts` normalizes relay layout messages.
+3. `state.ts` stores selected tab, selected surface, drawer state, keyboard state, and surface views.
+4. `views/console.ts` renders shell chrome, drawer, surface strip, and virtual keyboard visibility.
+5. `surfaces.ts` owns xterm instances, selected surface rendering, focus, fit, and output writes.
+6. `vkbd.ts` sends terminal input sequences through the existing virtual keyboard sender.
+
+The redesign should avoid introducing a second source of truth for selected surface or keyboard visibility.
+
+## Error Handling
+
+- If no layout exists, keep the current empty state.
+- If a selected surface disappears, preserve current fallback behavior: choose the focused surface or first surface in the active tab.
+- If xterm fit fails during transient zero-size layout states, keep the existing guarded behavior.
+- If the hidden text input bridge is added and unsupported on a browser, fall back to xterm focus plus utility keyboard.
+
+## Testing
+
+Automated checks:
+
+- `npm run build` in `remote`.
+- `npm run typecheck` in `remote`.
+- Playwright mobile viewport check at iPhone 14 size, with a mocked Phantty WebSocket layout containing at least two surfaces.
+
+Manual checks:
+
+- iPhone 14 portrait: terminal occupies the majority of available height and selected surface is readable.
+- iPhone 14 with utility keyboard visible and hidden.
+- Surface switching by thumb.
+- Drawer open/close and connect form still work.
+- Type/focus path sends ordinary text to the selected surface.
+- Utility keys send expected terminal sequences.
+
+## Acceptance Criteria
+
+- On a 390 x 844 viewport, the approved four-part mobile structure is visible and stable.
+- The selected terminal surface fills the available terminal area without desktop-oriented decorative labels.
+- The bottom utility keyboard does not overlap terminal content.
+- Surface switching and keyboard toggling do not break xterm fitting.
+- Browser input continues to route only to the selected surface.
+- Desktop layout remains visually equivalent to the current console.

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -207,7 +207,7 @@ remote-device-name     = Workstation</code></pre>
           <div><span class="label">均分分屏尺寸</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Z</kbd></span></div>
           <div><span class="label">关闭面板 / 标签 / 窗口</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>W</kbd></span></div>
           <div><span class="label">最大化 / 还原窗口</span><span class="keys"><kbd>Alt</kbd><kbd>Enter</kbd></span></div>
-          <div><span class="label">按方位移动焦点</span><span class="keys"><kbd>Alt</kbd><kbd>←</kbd><kbd>↑</kbd><kbd>↓</kbd><kbd>→</kbd></span></div>
+          <div><span class="label">按方位移动焦点</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>←</kbd><kbd>↑</kbd><kbd>↓</kbd><kbd>→</kbd></span></div>
           <div><span class="label">上一个面板</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>[</kbd></span></div>
           <div><span class="label">下一个面板</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>]</kbd></span></div>
           <div><span class="label">上一个标签</span><span class="keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>Tab</kbd></span></div>

--- a/src/input.zig
+++ b/src/input.zig
@@ -18,6 +18,7 @@ const markdown_preview = @import("markdown_preview.zig");
 const markdown_preview_panel = AppWindow.markdown_preview_panel;
 const browser_panel = AppWindow.browser_panel;
 const scp = @import("scp.zig");
+const input_shortcuts = @import("input_shortcuts.zig");
 const win32_backend = @import("apprt/win32.zig");
 const Config = @import("config.zig");
 const Surface = @import("Surface.zig");
@@ -891,19 +892,10 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
         return;
     }
     // Ctrl+Shift+T and Ctrl+Shift+N are handled above (before rename guard)
-    // Alt+Arrows = goto split (spatial navigation)
-    if (ev.alt and !ev.ctrl and !ev.shift) {
-        const dir: ?SplitTree.Spatial.Direction = switch (ev.vk) {
-            win32_backend.VK_LEFT => .left,
-            win32_backend.VK_RIGHT => .right,
-            win32_backend.VK_UP => .up,
-            win32_backend.VK_DOWN => .down,
-            else => null,
-        };
-        if (dir) |d| {
-            AppWindow.gotoSplit(.{ .spatial = d });
-            return;
-        }
+    // Ctrl+Shift+Arrows = goto split (spatial navigation)
+    if (input_shortcuts.spatialFocusDirection(ev)) |dir| {
+        AppWindow.gotoSplit(.{ .spatial = dir });
+        return;
     }
     // Ctrl+Shift+[ = goto previous split
     if (ev.ctrl and ev.shift and ev.vk == win32_backend.VK_OEM_4) { // '['

--- a/src/input_shortcuts.zig
+++ b/src/input_shortcuts.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+
+const SplitTree = @import("split_tree.zig");
+const win32_backend = @import("apprt/win32.zig");
+
+pub fn spatialFocusDirection(ev: win32_backend.KeyEvent) ?SplitTree.Spatial.Direction {
+    if (!ev.ctrl or !ev.shift or ev.alt) return null;
+
+    return switch (ev.vk) {
+        win32_backend.VK_LEFT => .left,
+        win32_backend.VK_RIGHT => .right,
+        win32_backend.VK_UP => .up,
+        win32_backend.VK_DOWN => .down,
+        else => null,
+    };
+}
+
+test "spatial focus uses Ctrl+Shift+Arrow and not Alt+Arrow" {
+    try std.testing.expectEqual(
+        @as(?SplitTree.Spatial.Direction, .up),
+        spatialFocusDirection(.{ .vk = win32_backend.VK_UP, .ctrl = true, .shift = true, .alt = false }),
+    );
+    try std.testing.expectEqual(
+        @as(?SplitTree.Spatial.Direction, .down),
+        spatialFocusDirection(.{ .vk = win32_backend.VK_DOWN, .ctrl = true, .shift = true, .alt = false }),
+    );
+    try std.testing.expectEqual(
+        @as(?SplitTree.Spatial.Direction, .left),
+        spatialFocusDirection(.{ .vk = win32_backend.VK_LEFT, .ctrl = true, .shift = true, .alt = false }),
+    );
+    try std.testing.expectEqual(
+        @as(?SplitTree.Spatial.Direction, .right),
+        spatialFocusDirection(.{ .vk = win32_backend.VK_RIGHT, .ctrl = true, .shift = true, .alt = false }),
+    );
+    try std.testing.expectEqual(
+        @as(?SplitTree.Spatial.Direction, null),
+        spatialFocusDirection(.{ .vk = win32_backend.VK_UP, .ctrl = false, .shift = false, .alt = true }),
+    );
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -122,7 +122,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+Shift+E", .action = "File explorer" },
     .{ .keys = "Ctrl-click .md/.txt", .action = "Preview file" },
     .{ .keys = "Ctrl+Shift+[ / ]", .action = "Previous / next panel" },
-    .{ .keys = "Alt+Arrows", .action = "Focus panel" },
+    .{ .keys = "Ctrl+Shift+Arrows", .action = "Focus panel" },
     .{ .keys = "Ctrl+Shift+Z", .action = "Equalize panels" },
     .{ .keys = "Ctrl+Shift+W", .action = "Close panel / tab" },
     .{ .keys = "Ctrl+Shift+C / Ctrl+V", .action = "Copy / paste text" },

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -7,6 +7,7 @@ comptime {
     _ = @import("browser_url.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
+    _ = @import("input_shortcuts.zig");
     _ = @import("markdown_preview.zig");
     _ = @import("remote_client.zig");
 }


### PR DESCRIPTION
## Summary
- replace spatial split focus from Alt+Arrow to Ctrl+Shift+Arrow
- add a small shortcut mapping regression test
- update README and startup shortcut overlay text

## Validation
- zig build test
- zig build
- Windows path/name check: 0 violations, 0 collisions
- symlink check: no tracked symlinks