### PR TITLE
feat: add AI Chat native HTTP and streaming UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-<h1>
-  <p align="center">
-    <img src="assets/phantty.png" alt="Phantty logo" width="128">
-    <br>Phantty
-  </p>
-</h1>
+
+
+  
+Phantty
 
 A Windows terminal written in Zig, powered by [libghostty-vt](https://github.com/ghostty-org/ghostty) for terminal emulation.
 
 > [!NOTE]
 > This repository is a fork of [arya-s/phantty](https://github.com/arya-s/phantty),
 > with additional features layered on top: an embedded WebView2 browser panel,
-> a file explorer with Markdown/text preview, an opt-in remote-access client,
+> a file explorer with Markdown/text preview, AI Chat sessions,
+> an opt-in remote-access client,
 > Kitty Graphics image protocol support, and a configurable background image.
 
 ## Features
@@ -24,13 +23,13 @@ A Windows terminal written in Zig, powered by [libghostty-vt](https://github.com
 - **Splits and tabs** — vertical/horizontal splits, tab strip, focus-follows-mouse, equalize sizes
 - **File Explorer and previews** — browse local, WSL, and SSH files; preview Markdown/text without leaving the terminal
 - **Embedded browser panel** — open `http://` / `https://` URLs in a side WebView2 panel; SSH sessions tunnel loopback URLs automatically
+- **AI Chat sessions** — launch an OpenAI-compatible chat tab from saved profiles; DeepSeek is the default provider/model
 - **Kitty Graphics protocol** — display inline images and PDFs from remote shells via `imgcat.py` / `pdfcat.py`
 - **Custom post-processing shaders** — Ghostty-compatible GLSL post-processing (CRT, glitch, etc.); the wallpaper is rendered inside the same FBO so effects apply uniformly
 - **Opt-in remote access** — share a session key over a Cloudflare-hosted relay (disabled by default)
 
 > [!NOTE]
 > Phantty is **Windows-only**. On macOS and Linux, use [Ghostty](https://ghostty.org/) instead.
-
 
 ## Building
 
@@ -115,32 +114,34 @@ Options:
 
 ## Keyboard shortcuts
 
-Default chords are implemented in [`src/input.zig`](src/input.zig). Some keys are handled first when a modal overlay is open (command center, session launcher, settings, and similar).
+Default chords are implemented in `[src/input.zig](src/input.zig)`. Some keys are handled first when a modal overlay is open (command center, session launcher, settings, and similar).
 
-| Shortcut | Action |
-|----------|--------|
-| **Ctrl+Shift+P** | Open command center |
-| **Ctrl+Shift+T** | New session (session launcher) |
-| **Ctrl+Shift+N** | New window |
-| **Ctrl+Shift+B** | Toggle tab sidebar |
-| **Ctrl+Shift+O** | Split to the right |
-| **Ctrl+Shift+E** | Toggle file explorer sidebar |
-| Ctrl-click `.md` / `.txt` in terminal output, or double-click in File Explorer | Preview local, WSL, or SSH Markdown/text in the right preview panel |
-| **Ctrl+Shift+W** | Close focused panel, tab, or window; press again to confirm closing the last panel |
-| **Alt+Enter** | Maximize or restore window |
-| **Ctrl++** / **Ctrl+-** | Increase / decrease font size |
-| **Ctrl+Shift+C** | Copy selection |
-| Right-click a selection | Copy selection |
-| **Ctrl+V** | Paste text |
-| **Ctrl+Shift+V** | Paste clipboard image |
-| **Alt** + arrow keys | Move focus to adjacent panel (spatial) |
-| **Ctrl+Shift+[** | Focus previous panel (cycle) |
-| **Ctrl+Shift+]** | Focus next panel (cycle) |
-| **Ctrl+Shift+Z** | Equalize split sizes |
-| **Ctrl+Tab** | Next tab |
-| **Ctrl+Shift+Tab** | Previous tab |
-| **Alt+1**–**9** | Switch to tab 1–9 (when that tab exists) |
-| **Ctrl+,** | Open config file in the default editor |
+
+| Shortcut                                                                       | Action                                                                             |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| **Ctrl+Shift+P**                                                               | Open command center                                                                |
+| **Ctrl+Shift+T**                                                               | New session (session launcher)                                                     |
+| **Ctrl+Shift+N**                                                               | New window                                                                         |
+| **Ctrl+Shift+B**                                                               | Toggle tab sidebar                                                                 |
+| **Ctrl+Shift+O**                                                               | Split to the right                                                                 |
+| **Ctrl+Shift+E**                                                               | Toggle file explorer sidebar                                                       |
+| Ctrl-click `.md` / `.txt` in terminal output, or double-click in File Explorer | Preview local, WSL, or SSH Markdown/text in the right preview panel                |
+| **Ctrl+Shift+W**                                                               | Close focused panel, tab, or window; press again to confirm closing the last panel |
+| **Alt+Enter**                                                                  | Maximize or restore window                                                         |
+| **Ctrl++** / **Ctrl+-**                                                        | Increase / decrease font size                                                      |
+| **Ctrl+Shift+C**                                                               | Copy selection                                                                     |
+| Right-click a selection                                                        | Copy selection                                                                     |
+| **Ctrl+V**                                                                     | Paste text                                                                         |
+| **Ctrl+Shift+V**                                                               | Paste clipboard image                                                              |
+| **Alt** + arrow keys                                                           | Move focus to adjacent panel (spatial)                                             |
+| **Ctrl+Shift+[**                                                               | Focus previous panel (cycle)                                                       |
+| **Ctrl+Shift+]**                                                               | Focus next panel (cycle)                                                           |
+| **Ctrl+Shift+Z**                                                               | Equalize split sizes                                                               |
+| **Ctrl+Tab**                                                                   | Next tab                                                                           |
+| **Ctrl+Shift+Tab**                                                             | Previous tab                                                                       |
+| **Alt+1**–**9**                                                                | Switch to tab 1–9 (when that tab exists)                                           |
+| **Ctrl+,**                                                                     | Open config file in the default editor                                             |
+
 
 ## File Explorer and Markdown Preview
 
@@ -176,6 +177,27 @@ the built-in SSH launcher are supported. Manually typing `ssh user@host` inside
 a local shell is still treated as that local shell and cannot use remote file
 preview yet.
 
+## AI Chat Sessions
+
+Open the session launcher with `Ctrl+Shift+T`, choose `AI Chat`, then create or
+select a saved AI profile. AI profiles are managed in the launcher the same way
+SSH profiles are: profile data is stored under `%APPDATA%\phantty\ai_profiles`,
+with fields hex encoded on disk.
+
+The first AI Chat implementation targets OpenAI-compatible chat completions.
+The built-in defaults are:
+
+- Base URL: `https://api.deepseek.com`
+- Model: `deepseek-v4-pro`
+- System prompt: `You are a helpful assistant.`
+- Request mode: DeepSeek thinking enabled, `reasoning_effort = high`, non-streaming
+
+If an AI profile does not include an API key and its base URL points at
+DeepSeek, Phantty also checks `DEEPSEEK_API_KEY` in the process environment.
+Responses with `reasoning_content` are shown as a muted reasoning block above
+the assistant reply. This follows DeepSeek's
+[thinking mode guide](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode).
+
 ## Background Image
 
 Set `background-image` in the config (or pass `--background-image`) to render a
@@ -184,25 +206,29 @@ wallpaper behind the terminal. PNG, JPG, BMP, GIF, and TGA are supported.
 `background-opacity` controls how strongly the theme background tints the
 wallpaper:
 
-| Value | Effect |
-|------:|--------|
+
+| Value           | Effect                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------ |
 | `1.0` (default) | Theme background is fully opaque — image is hidden, terminal looks the same as without one |
-| `0.85` | Faint watermark (image shows through ~15%) |
-| `0.5` | Equal blend |
-| `0.15` | Image dominates with a light theme tint |
-| `0.0` | Theme tint is skipped — image at full strength |
+| `0.85`          | Faint watermark (image shows through ~15%)                                                 |
+| `0.5`           | Equal blend                                                                                |
+| `0.15`          | Image dominates with a light theme tint                                                    |
+| `0.0`           | Theme tint is skipped — image at full strength                                             |
+
 
 The opacity also applies to per-cell backgrounds (selections, ANSI-colored
 backgrounds), so the wallpaper shows through them at the same ratio.
 
 `background-image-mode` selects how the image is sized to the window:
 
-| Mode | Behavior |
-|------|----------|
-| `fill` (default) | Cover the window, cropping the longer axis |
-| `fit` | Letterbox so the whole image is visible (edges may stretch) |
-| `center` | 1:1 pixel scale, centered |
-| `tile` | Repeat at native size with `GL_REPEAT` |
+
+| Mode             | Behavior                                                    |
+| ---------------- | ----------------------------------------------------------- |
+| `fill` (default) | Cover the window, cropping the longer axis                  |
+| `fit`            | Letterbox so the whole image is visible (edges may stretch) |
+| `center`         | 1:1 pixel scale, centered                                   |
+| `tile`           | Repeat at native size with `GL_REPEAT`                      |
+
 
 The wallpaper is drawn inside the post-process framebuffer, so a custom shader
 set with `--custom-shader` distorts it together with the terminal content.
@@ -274,27 +300,29 @@ remote-device-name = Workstation
 
 ### Available keys
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `font-family` | *(none)* | Font family name (falls back to embedded font if unset) |
-| `font-style` | `regular` | Font weight: `thin`, `extra-light`, `light`, `regular`, `medium`, `semi-bold`, `bold`, `extra-bold`, `black` |
-| `font-size` | `12` | Font size in points |
-| `cursor-style` | `block` | Cursor shape: `block`, `bar`, `underline`, `block_hollow` |
-| `cursor-style-blink` | `true` | Enable cursor blinking |
-| `theme` | *(none)* | Theme name or absolute path (453 Ghostty themes built-in) |
-| `custom-shader` | *(none)* | Path to a GLSL post-processing shader |
-| `background-image` | *(none)* | Path to an image (PNG/JPG/BMP/GIF/TGA) rendered behind the terminal |
-| `background-opacity` | `1.0` | Opacity of the theme tint over the wallpaper (0.0 = image only, 1.0 = image hidden) |
-| `background-image-mode` | `fill` | Image scaling: `fill`, `fit`, `center`, or `tile` |
-| `window-height` | `0` (auto) | Initial height in cells (min: 4, 0 = auto 80×24) |
-| `window-width` | `0` (auto) | Initial width in cells (min: 10, 0 = auto 80×24) |
-| `scrollback-limit` | `10000000` | Scrollback buffer limit in bytes |
-| `restore-tabs-on-startup` | `false` | Persist tab/split layout to `%APPDATA%\phantty\session.json` on close and rebuild it on next launch. SSH passwords are never persisted; reconnects re-prompt. CLI overrides (`--cwd`) take precedence and skip restore. |
-| `config-file` | *(none)* | Include another config file (prefix with `?` to make optional) |
-| `remote-enabled` | `false` | Start the shared outbound RemoteClient for this Phantty instance |
-| `remote-server-url` | *(none)* | Cloudflare relay URL, for example `https://remote.example.com` |
-| `remote-server-fingerprint` | *(none)* | Expected relay fingerprint for server identity pinning |
-| `remote-device-name` | *(none)* | Friendly device name sent with the Phantty WebSocket pairing |
+
+| Key                         | Default    | Description                                                                                                                                                                                                             |
+| --------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `font-family`               | *(none)*   | Font family name (falls back to embedded font if unset)                                                                                                                                                                 |
+| `font-style`                | `regular`  | Font weight: `thin`, `extra-light`, `light`, `regular`, `medium`, `semi-bold`, `bold`, `extra-bold`, `black`                                                                                                            |
+| `font-size`                 | `12`       | Font size in points                                                                                                                                                                                                     |
+| `cursor-style`              | `block`    | Cursor shape: `block`, `bar`, `underline`, `block_hollow`                                                                                                                                                               |
+| `cursor-style-blink`        | `true`     | Enable cursor blinking                                                                                                                                                                                                  |
+| `theme`                     | *(none)*   | Theme name or absolute path (453 Ghostty themes built-in)                                                                                                                                                               |
+| `custom-shader`             | *(none)*   | Path to a GLSL post-processing shader                                                                                                                                                                                   |
+| `background-image`          | *(none)*   | Path to an image (PNG/JPG/BMP/GIF/TGA) rendered behind the terminal                                                                                                                                                     |
+| `background-opacity`        | `1.0`      | Opacity of the theme tint over the wallpaper (0.0 = image only, 1.0 = image hidden)                                                                                                                                     |
+| `background-image-mode`     | `fill`     | Image scaling: `fill`, `fit`, `center`, or `tile`                                                                                                                                                                       |
+| `window-height`             | `0` (auto) | Initial height in cells (min: 4, 0 = auto 80×24)                                                                                                                                                                        |
+| `window-width`              | `0` (auto) | Initial width in cells (min: 10, 0 = auto 80×24)                                                                                                                                                                        |
+| `scrollback-limit`          | `10000000` | Scrollback buffer limit in bytes                                                                                                                                                                                        |
+| `restore-tabs-on-startup`   | `false`    | Persist tab/split layout to `%APPDATA%\phantty\session.json` on close and rebuild it on next launch. SSH passwords are never persisted; reconnects re-prompt. CLI overrides (`--cwd`) take precedence and skip restore. |
+| `config-file`               | *(none)*   | Include another config file (prefix with `?` to make optional)                                                                                                                                                          |
+| `remote-enabled`            | `false`    | Start the shared outbound RemoteClient for this Phantty instance                                                                                                                                                        |
+| `remote-server-url`         | *(none)*   | Cloudflare relay URL, for example `https://remote.example.com`                                                                                                                                                          |
+| `remote-server-fingerprint` | *(none)*   | Expected relay fingerprint for server identity pinning                                                                                                                                                                  |
+| `remote-device-name`        | *(none)*   | Friendly device name sent with the Phantty WebSocket pairing                                                                                                                                                            |
+
 
 When `remote-enabled = true`, Phantty creates one RemoteClient for the running
 instance. All tabs and splits publish PTY output through that shared client, and
@@ -305,11 +333,11 @@ session key, or use `Copy Remote Key` from the command center.
 ## Credits
 
 - Original project: [arya-s/phantty](https://github.com/arya-s/phantty) — the
-  Zig + libghostty-vt foundation and the Windows terminal core.
+Zig + libghostty-vt foundation and the Windows terminal core.
 - Terminal emulation: [ghostty-org/ghostty](https://github.com/ghostty-org/ghostty)
-  via `libghostty-vt`.
+via `libghostty-vt`.
 - Image decoding: [stb_image](https://github.com/nothings/stb) (vendored
-  through the ghostty dependency).
+through the ghostty dependency).
 
 ## License
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -16,6 +16,7 @@ const win32_backend = @import("apprt/win32.zig");
 const App = @import("App.zig");
 const Renderer = @import("renderer/Renderer.zig");
 const remote = @import("remote_client.zig");
+pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
 pub const cell_renderer = @import("renderer/cell_renderer.zig");
@@ -34,6 +35,7 @@ pub const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig"
 pub const markdown_preview_panel = @import("markdown_preview_panel.zig");
 pub const markdown_preview_renderer = @import("renderer/markdown_preview_renderer.zig");
 pub const browser_panel = @import("browser_panel.zig");
+pub const ai_chat_renderer = @import("renderer/ai_chat_renderer.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -224,12 +226,36 @@ fn clearWithBackground(fb_w: c_int, fb_h: c_int) void {
     background_image.drawFullscreen(@floatFromInt(fb_w), @floatFromInt(fb_h));
 }
 
+fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
+    gl.Viewport.?(0, 0, fb_width, fb_height);
+    gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    clearWithBackground(fb_width, fb_height);
+    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
+    file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    if (activeAiChat()) |session| {
+        ai_chat_renderer.render(
+            session,
+            @floatFromInt(fb_width),
+            @floatFromInt(fb_height),
+            titlebar_offset,
+            left_panels_w,
+            right_panels_w,
+        );
+    }
+}
+
 pub fn activeTab() ?*TabState {
     return tab.activeTab();
 }
 
 pub fn activeSurface() ?*Surface {
     return tab.activeSurface();
+}
+
+pub fn activeAiChat() ?*ai_chat.Session {
+    return tab.activeAiChat();
 }
 
 pub fn currentTitlebarHeight() f32 {
@@ -358,6 +384,19 @@ pub fn spawnTabWithCommandUtf8ReturningSurface(command: []const u8) ?*Surface {
     return activeSurface();
 }
 
+pub fn spawnAiChatTab(
+    name: []const u8,
+    base_url: []const u8,
+    api_key: []const u8,
+    model: []const u8,
+    system_prompt: []const u8,
+) bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.spawnAiChatTab(allocator, name, base_url, api_key, model, system_prompt)) return false;
+    clearUiStateOnTabChange();
+    return true;
+}
+
 pub fn closeTab(idx: usize) void {
     const allocator = g_allocator orelse return;
     tab.closeTab(idx, allocator);
@@ -369,6 +408,7 @@ pub fn closeTab(idx: usize) void {
 
 pub fn closeFocusedSplitWouldCloseWindow() bool {
     const active_tab = activeTab() orelse return false;
+    if (active_tab.kind == .ai_chat) return tab.g_tab_count <= 1;
     return tab.g_tab_count <= 1 and !active_tab.tree.isSplit();
 }
 
@@ -597,8 +637,10 @@ fn onWin32Resize(width: i32, height: i32) void {
         if (g_allocator) |alloc| syncRemoteLayout(alloc);
 
         if (split_count <= 1) {
-            // Single surface: simple render path
-            if (activeSurface()) |surface| {
+            if (active_tab.kind == .ai_chat) {
+                renderAiChatFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (activeSurface()) |surface| {
+                // Single surface: simple render path
                 const rend = &surface.surface_renderer;
                 var needs_rebuild: bool = false;
                 {
@@ -1156,6 +1198,11 @@ fn syncImeCaretPosition(win: *win32_backend.Window, split_count: usize) void {
     // composition started, doesn't drift onto another line as the cursor moves.
     if (win.ime_composing) return;
 
+    if (activeAiChat()) |session| {
+        syncAiChatImeCaret(win, session);
+        return;
+    }
+
     const surface = activeSurface() orelse return;
 
     var cursor_x: usize = 0;
@@ -1203,6 +1250,26 @@ fn syncImeCaretPosition(win: *win32_backend.Window, split_count: usize) void {
         @intFromFloat(@round(x)),
         @intFromFloat(@round(y)),
         @intFromFloat(@max(1.0, @round(cell_h))),
+    );
+}
+
+fn syncAiChatImeCaret(win: *win32_backend.Window, session: *ai_chat.Session) void {
+    const wh: f32 = @floatFromInt(win.height);
+    const ww: f32 = @floatFromInt(win.width);
+    const left_panels_w = titlebar.sidebarWidth();
+    const panel_w = @max(1.0, ww - left_panels_w);
+    const field_x = left_panels_w + ai_chat_renderer.LINE_PAD_X + 12;
+    const field_w = panel_w - ai_chat_renderer.LINE_PAD_X * 2 - 24;
+    session.mutex.lock();
+    const input_text = session.input();
+    const cursor_x = ai_chat_renderer.inputCursorX(input_text, field_x, field_w);
+    session.mutex.unlock();
+    const cursor_y = wh - ai_chat_renderer.INPUT_H + 16 + 14;
+    const h = ai_chat_renderer.INPUT_H - 32 - 28;
+    win.setImeCaret(
+        @intFromFloat(@round(cursor_x)),
+        @intFromFloat(@round(cursor_y)),
+        @intFromFloat(@max(1.0, @round(h))),
     );
 }
 
@@ -1718,7 +1785,9 @@ fn runMainLoop(allocator: std.mem.Allocator) !void {
 
             // Debug: print split count on first few frames
             // GL rendering
-            if (post_process.g_post_enabled) {
+            if (active_tab.kind == .ai_chat) {
+                renderAiChatFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (post_process.g_post_enabled) {
                 // Post-processing path: only render focused surface for now
                 if (activeSurface()) |surface| {
                     var needs_rebuild: bool = false;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -390,9 +390,12 @@ pub fn spawnAiChatTab(
     api_key: []const u8,
     model: []const u8,
     system_prompt: []const u8,
+    thinking: []const u8,
+    reasoning_effort: []const u8,
+    stream_val: []const u8,
 ) bool {
     const allocator = g_allocator orelse return false;
-    if (!tab.spawnAiChatTab(allocator, name, base_url, api_key, model, system_prompt)) return false;
+    if (!tab.spawnAiChatTab(allocator, name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val)) return false;
     clearUiStateOnTabChange();
     return true;
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1,0 +1,596 @@
+//! AI Chat session state and OpenAI-compatible API bridge.
+//!
+//! This is intentionally kept outside Surface/PTY/VT paths: Ghostty keeps
+//! terminal surfaces focused on terminal emulation, and Phantty's AI Chat is a
+//! Phantty-specific session kind rendered by the window chrome.
+
+const std = @import("std");
+const win32_backend = @import("apprt/win32.zig");
+
+pub const DEFAULT_NAME = "DeepSeek";
+pub const DEFAULT_BASE_URL = "https://api.deepseek.com";
+pub const DEFAULT_MODEL = "deepseek-v4-pro";
+pub const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
+
+pub const Role = enum {
+    user,
+    assistant,
+
+    pub fn label(self: Role) []const u8 {
+        return switch (self) {
+            .user => "You",
+            .assistant => "AI",
+        };
+    }
+
+    pub fn apiName(self: Role) []const u8 {
+        return switch (self) {
+            .user => "user",
+            .assistant => "assistant",
+        };
+    }
+};
+
+pub const Message = struct {
+    role: Role,
+    content: []u8,
+    reasoning: ?[]u8 = null,
+};
+
+const RequestMessage = struct {
+    role: Role,
+    content: []u8,
+};
+
+const ChatRequest = struct {
+    allocator: std.mem.Allocator,
+    session: *Session,
+    base_url: []u8,
+    api_key: []u8,
+    model: []u8,
+    system_prompt: []u8,
+    messages: []RequestMessage,
+
+    fn deinit(self: *ChatRequest) void {
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.api_key);
+        self.allocator.free(self.model);
+        self.allocator.free(self.system_prompt);
+        for (self.messages) |msg| self.allocator.free(msg.content);
+        self.allocator.free(self.messages);
+        self.allocator.destroy(self);
+    }
+};
+
+const ApiResult = struct {
+    content: []u8,
+    reasoning: ?[]u8 = null,
+
+    fn deinit(self: ApiResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.content);
+        if (self.reasoning) |reasoning| allocator.free(reasoning);
+    }
+};
+
+pub const Session = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    messages: std.ArrayListUnmanaged(Message) = .empty,
+    input_buf: [8192]u8 = undefined,
+    input_len: usize = 0,
+    status_buf: [512]u8 = undefined,
+    status_len: usize = 0,
+    title_buf: [128]u8 = undefined,
+    title_len: usize = 0,
+    base_url_buf: [256]u8 = undefined,
+    base_url_len: usize = 0,
+    api_key_buf: [512]u8 = undefined,
+    api_key_len: usize = 0,
+    model_buf: [128]u8 = undefined,
+    model_len: usize = 0,
+    system_prompt_buf: [512]u8 = undefined,
+    system_prompt_len: usize = 0,
+    request_inflight: bool = false,
+    request_thread: ?std.Thread = null,
+    closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    scroll_px: f32 = 0,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        base_url: []const u8,
+        api_key: []const u8,
+        model_name: []const u8,
+        system_prompt: []const u8,
+    ) !*Session {
+        const session = try allocator.create(Session);
+        session.* = .{
+            .allocator = allocator,
+        };
+        session.copyTitle(if (name.len > 0) name else DEFAULT_NAME);
+        session.copyBaseUrl(if (base_url.len > 0) base_url else DEFAULT_BASE_URL);
+        session.copyModel(if (model_name.len > 0) model_name else DEFAULT_MODEL);
+        session.copySystemPrompt(if (system_prompt.len > 0) system_prompt else DEFAULT_SYSTEM_PROMPT);
+        session.copyApiKey(api_key);
+        if (session.api_key_len == 0 and isDeepSeekBaseUrl(session.baseUrl())) {
+            if (std.process.getEnvVarOwned(allocator, "DEEPSEEK_API_KEY")) |env_key| {
+                defer allocator.free(env_key);
+                session.copyApiKey(env_key);
+            } else |_| {}
+        }
+        session.setStatus("Ready");
+        return session;
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.closing.store(true, .release);
+        if (self.request_thread) |thread| {
+            thread.join();
+            self.request_thread = null;
+        }
+        for (self.messages.items) |msg| {
+            self.allocator.free(msg.content);
+            if (msg.reasoning) |reasoning| self.allocator.free(reasoning);
+        }
+        self.messages.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
+
+    pub fn title(self: *const Session) []const u8 {
+        return self.title_buf[0..self.title_len];
+    }
+
+    pub fn baseUrl(self: *const Session) []const u8 {
+        return self.base_url_buf[0..self.base_url_len];
+    }
+
+    pub fn model(self: *const Session) []const u8 {
+        return self.model_buf[0..self.model_len];
+    }
+
+    pub fn systemPrompt(self: *const Session) []const u8 {
+        return self.system_prompt_buf[0..self.system_prompt_len];
+    }
+
+    pub fn apiKey(self: *const Session) []const u8 {
+        return self.api_key_buf[0..self.api_key_len];
+    }
+
+    pub fn input(self: *const Session) []const u8 {
+        return self.input_buf[0..self.input_len];
+    }
+
+    pub fn status(self: *const Session) []const u8 {
+        return self.status_buf[0..self.status_len];
+    }
+
+    pub fn setTitle(self: *Session, title_text: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.copyTitle(title_text);
+    }
+
+    pub fn handleChar(self: *Session, codepoint: u21) void {
+        if (codepoint < 0x20 or codepoint == 0x7f) return;
+        var buf: [4]u8 = undefined;
+        const len = std.unicode.utf8Encode(codepoint, &buf) catch return;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.input_len + len > self.input_buf.len) return;
+        @memcpy(self.input_buf[self.input_len..][0..len], buf[0..len]);
+        self.input_len += len;
+    }
+
+    pub fn appendInputText(self: *Session, text: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const len = @min(text.len, self.input_buf.len - self.input_len);
+        if (len == 0) return;
+        @memcpy(self.input_buf[self.input_len..][0..len], text[0..len]);
+        self.input_len += len;
+    }
+
+    pub fn handleKey(self: *Session, ev: win32_backend.KeyEvent) void {
+        if (ev.ctrl and !ev.alt and ev.vk == 0x55) {
+            self.mutex.lock();
+            self.input_len = 0;
+            self.mutex.unlock();
+            return;
+        }
+        if (ev.ctrl and !ev.alt and ev.vk == 0x4C) {
+            self.clearMessages();
+            return;
+        }
+
+        switch (ev.vk) {
+            win32_backend.VK_BACK => self.backspaceInput(),
+            win32_backend.VK_RETURN => {
+                if (ev.shift) {
+                    self.appendInputText("\n");
+                } else {
+                    self.submit();
+                }
+            },
+            else => {},
+        }
+    }
+
+    pub fn submit(self: *Session) void {
+        self.mutex.lock();
+        if (self.request_thread) |thread| {
+            if (self.request_inflight) {
+                self.mutex.unlock();
+                return;
+            }
+            self.request_thread = null;
+            self.mutex.unlock();
+            thread.join();
+            self.mutex.lock();
+        }
+
+        const prompt_raw = std.mem.trim(u8, self.input(), " \t\r\n");
+        if (prompt_raw.len == 0) {
+            self.mutex.unlock();
+            return;
+        }
+        if (self.api_key_len == 0) {
+            self.setStatusLocked("Missing API key. Edit the AI Chat profile or set DEEPSEEK_API_KEY.");
+            self.mutex.unlock();
+            return;
+        }
+
+        const prompt = self.allocator.dupe(u8, prompt_raw) catch {
+            self.setStatusLocked("Out of memory");
+            self.mutex.unlock();
+            return;
+        };
+        self.messages.append(self.allocator, .{ .role = .user, .content = prompt }) catch {
+            self.allocator.free(prompt);
+            self.setStatusLocked("Out of memory");
+            self.mutex.unlock();
+            return;
+        };
+        self.input_len = 0;
+        self.scroll_px = 1_000_000;
+
+        const request = self.buildRequestLocked() catch {
+            self.setStatusLocked("Could not prepare request");
+            self.mutex.unlock();
+            return;
+        };
+
+        self.request_inflight = true;
+        self.setStatusLocked("Thinking...");
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, requestThreadMain, .{request}) catch {
+            request.deinit();
+            self.mutex.lock();
+            self.request_inflight = false;
+            self.setStatusLocked("Failed to start request thread");
+            self.mutex.unlock();
+            return;
+        };
+
+        self.mutex.lock();
+        self.request_thread = thread;
+        self.mutex.unlock();
+    }
+
+    fn clearMessages(self: *Session) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.request_inflight) return;
+        for (self.messages.items) |msg| {
+            self.allocator.free(msg.content);
+            if (msg.reasoning) |reasoning| self.allocator.free(reasoning);
+        }
+        self.messages.clearRetainingCapacity();
+        self.scroll_px = 0;
+        self.setStatusLocked("Cleared");
+    }
+
+    pub fn scrollBy(self: *Session, delta_px: f32) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.scroll_px = @max(0.0, self.scroll_px + delta_px);
+    }
+
+    fn backspaceInput(self: *Session) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.input_len == 0) return;
+        self.input_len -= 1;
+        while (self.input_len > 0 and (self.input_buf[self.input_len] & 0xC0) == 0x80) {
+            self.input_len -= 1;
+        }
+    }
+
+    fn buildRequestLocked(self: *Session) !*ChatRequest {
+        const req = try self.allocator.create(ChatRequest);
+        errdefer self.allocator.destroy(req);
+
+        const messages = try self.allocator.alloc(RequestMessage, self.messages.items.len);
+        errdefer self.allocator.free(messages);
+
+        var written: usize = 0;
+        errdefer {
+            for (messages[0..written]) |msg| self.allocator.free(msg.content);
+        }
+
+        for (self.messages.items, 0..) |msg, i| {
+            messages[i] = .{
+                .role = msg.role,
+                .content = try self.allocator.dupe(u8, msg.content),
+            };
+            written += 1;
+        }
+
+        req.* = .{
+            .allocator = self.allocator,
+            .session = self,
+            .base_url = try self.allocator.dupe(u8, self.baseUrl()),
+            .api_key = try self.allocator.dupe(u8, self.apiKey()),
+            .model = try self.allocator.dupe(u8, self.model()),
+            .system_prompt = try self.allocator.dupe(u8, self.systemPrompt()),
+            .messages = messages,
+        };
+        return req;
+    }
+
+    fn copyTitle(self: *Session, value: []const u8) void {
+        self.title_len = @min(value.len, self.title_buf.len);
+        @memcpy(self.title_buf[0..self.title_len], value[0..self.title_len]);
+    }
+
+    fn copyBaseUrl(self: *Session, value: []const u8) void {
+        self.base_url_len = @min(value.len, self.base_url_buf.len);
+        @memcpy(self.base_url_buf[0..self.base_url_len], value[0..self.base_url_len]);
+    }
+
+    fn copyApiKey(self: *Session, value: []const u8) void {
+        self.api_key_len = @min(value.len, self.api_key_buf.len);
+        @memcpy(self.api_key_buf[0..self.api_key_len], value[0..self.api_key_len]);
+    }
+
+    fn copyModel(self: *Session, value: []const u8) void {
+        self.model_len = @min(value.len, self.model_buf.len);
+        @memcpy(self.model_buf[0..self.model_len], value[0..self.model_len]);
+    }
+
+    fn copySystemPrompt(self: *Session, value: []const u8) void {
+        self.system_prompt_len = @min(value.len, self.system_prompt_buf.len);
+        @memcpy(self.system_prompt_buf[0..self.system_prompt_len], value[0..self.system_prompt_len]);
+    }
+
+    fn setStatus(self: *Session, value: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.setStatusLocked(value);
+    }
+
+    fn setStatusLocked(self: *Session, value: []const u8) void {
+        self.status_len = @min(value.len, self.status_buf.len);
+        @memcpy(self.status_buf[0..self.status_len], value[0..self.status_len]);
+    }
+};
+
+fn requestThreadMain(request: *ChatRequest) void {
+    const allocator = request.allocator;
+    defer request.deinit();
+
+    const result = runChatRequest(request) catch |err| blk: {
+        const text = std.fmt.allocPrint(allocator, "AI request failed: {}", .{err}) catch return;
+        break :blk ApiResult{ .content = text };
+    };
+    defer result.deinit(allocator);
+
+    const session = request.session;
+    if (session.closing.load(.acquire)) return;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return;
+
+    const content = allocator.dupe(u8, result.content) catch {
+        session.request_inflight = false;
+        session.setStatusLocked("Out of memory");
+        return;
+    };
+    var reasoning_copy: ?[]u8 = null;
+    if (result.reasoning) |reasoning| {
+        reasoning_copy = allocator.dupe(u8, reasoning) catch null;
+    }
+    session.messages.append(allocator, .{
+        .role = .assistant,
+        .content = content,
+        .reasoning = reasoning_copy,
+    }) catch {
+        allocator.free(content);
+        if (reasoning_copy) |r| allocator.free(r);
+        session.request_inflight = false;
+        session.setStatusLocked("Out of memory");
+        return;
+    };
+    session.request_inflight = false;
+    session.scroll_px = 1_000_000;
+    session.setStatusLocked("Ready");
+}
+
+fn runChatRequest(request: *const ChatRequest) !ApiResult {
+    const allocator = request.allocator;
+    const endpoint = try chatEndpoint(allocator, request.base_url);
+    defer allocator.free(endpoint);
+
+    const body = try buildRequestJson(allocator, request);
+    defer allocator.free(body);
+
+    const bearer = try std.fmt.allocPrint(allocator, "Bearer {s}", .{request.api_key});
+    defer allocator.free(bearer);
+
+    var client: std.http.Client = .{
+        .allocator = allocator,
+        .write_buffer_size = 16384,
+    };
+    defer client.deinit();
+
+    var resp_buf: std.Io.Writer.Allocating = .init(allocator);
+    defer resp_buf.deinit();
+
+    const result = client.fetch(.{
+        .location = .{ .url = endpoint },
+        .method = .POST,
+        .payload = body,
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .authorization = .{ .override = bearer },
+        },
+        .response_writer = &resp_buf.writer,
+    }) catch return error.RequestFailed;
+
+    var resp_list = resp_buf.toArrayList();
+    defer resp_list.deinit(allocator);
+
+    if (result.status != .ok) {
+        const trimmed = std.mem.trim(u8, resp_list.items, " \t\r\n");
+        if (trimmed.len > 0) return ApiResult{ .content = try allocator.dupe(u8, trimmed) };
+        return ApiResult{ .content = try std.fmt.allocPrint(allocator, "HTTP {d}", .{@intFromEnum(result.status)}) };
+    }
+
+    return parseApiResponse(allocator, resp_list.items);
+}
+
+fn chatEndpoint(allocator: std.mem.Allocator, base_url_raw: []const u8) ![]u8 {
+    const trimmed = std.mem.trim(u8, base_url_raw, " \t\r\n");
+    if (trimmed.len == 0) return error.MissingBaseUrl;
+    if (std.mem.endsWith(u8, trimmed, "/chat/completions")) {
+        return allocator.dupe(u8, trimmed);
+    }
+    var end = trimmed.len;
+    while (end > 0 and trimmed[end - 1] == '/') end -= 1;
+    return std.fmt.allocPrint(allocator, "{s}/chat/completions", .{trimmed[0..end]});
+}
+
+fn buildRequestJson(allocator: std.mem.Allocator, request: *const ChatRequest) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"model\":");
+    try appendJsonString(allocator, &out, request.model);
+    try out.appendSlice(allocator, ",\"messages\":[");
+    if (request.system_prompt.len > 0) {
+        try out.appendSlice(allocator, "{\"role\":\"system\",\"content\":");
+        try appendJsonString(allocator, &out, request.system_prompt);
+        try out.append(allocator, '}');
+        if (request.messages.len > 0) try out.append(allocator, ',');
+    }
+    for (request.messages, 0..) |msg, i| {
+        if (i > 0) try out.append(allocator, ',');
+        try out.appendSlice(allocator, "{\"role\":");
+        try appendJsonString(allocator, &out, msg.role.apiName());
+        try out.appendSlice(allocator, ",\"content\":");
+        try appendJsonString(allocator, &out, msg.content);
+        try out.append(allocator, '}');
+    }
+    try out.appendSlice(allocator, "],\"thinking\":{\"type\":\"enabled\"},\"reasoning_effort\":\"high\",\"stream\":false}");
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn parseApiResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch {
+        const trimmed = std.mem.trim(u8, body, " \t\r\n");
+        if (trimmed.len == 0) return error.EmptyResponse;
+        return ApiResult{ .content = try allocator.dupe(u8, trimmed) };
+    };
+    defer parsed.deinit();
+
+    const root = parsed.value;
+    if (root != .object) return error.InvalidResponse;
+    const obj = root.object;
+
+    if (obj.get("error")) |err_value| {
+        if (err_value == .object) {
+            if (err_value.object.get("message")) |message_value| {
+                if (message_value == .string) {
+                    return ApiResult{ .content = try allocator.dupe(u8, message_value.string) };
+                }
+            }
+        }
+        return ApiResult{ .content = try allocator.dupe(u8, "API returned an error") };
+    }
+
+    const choices_value = obj.get("choices") orelse return error.MissingChoices;
+    if (choices_value != .array or choices_value.array.items.len == 0) return error.MissingChoices;
+    const choice = choices_value.array.items[0];
+    if (choice != .object) return error.InvalidChoice;
+    const message_value = choice.object.get("message") orelse return error.MissingMessage;
+    if (message_value != .object) return error.MissingMessage;
+
+    const content = if (message_value.object.get("content")) |content_value|
+        if (content_value == .string) content_value.string else ""
+    else
+        "";
+    const reasoning = if (message_value.object.get("reasoning_content")) |reasoning_value|
+        if (reasoning_value == .string and reasoning_value.string.len > 0) reasoning_value.string else null
+    else
+        null;
+
+    return .{
+        .content = try allocator.dupe(u8, content),
+        .reasoning = if (reasoning) |r| try allocator.dupe(u8, r) else null,
+    };
+}
+
+fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: []const u8) !void {
+    const hex = "0123456789abcdef";
+    try out.append(allocator, '"');
+    for (value) |ch| {
+        switch (ch) {
+            '"' => try out.appendSlice(allocator, "\\\""),
+            '\\' => try out.appendSlice(allocator, "\\\\"),
+            '\n' => try out.appendSlice(allocator, "\\n"),
+            '\r' => try out.appendSlice(allocator, "\\r"),
+            '\t' => try out.appendSlice(allocator, "\\t"),
+            else => if (ch < 0x20) {
+                try out.appendSlice(allocator, "\\u00");
+                try out.append(allocator, hex[ch >> 4]);
+                try out.append(allocator, hex[ch & 0x0f]);
+            } else try out.append(allocator, ch),
+        }
+    }
+    try out.append(allocator, '"');
+}
+
+fn isDeepSeekBaseUrl(base_url: []const u8) bool {
+    return std.ascii.indexOfIgnoreCase(base_url, "deepseek.com") != null;
+}
+
+test "ai chat endpoint normalization" {
+    const allocator = std.testing.allocator;
+    const endpoint = try chatEndpoint(allocator, "https://api.deepseek.com/");
+    defer allocator.free(endpoint);
+    try std.testing.expectEqualStrings("https://api.deepseek.com/chat/completions", endpoint);
+}
+
+test "ai chat request json includes deepseek thinking mode" {
+    const allocator = std.testing.allocator;
+    var messages = [_]RequestMessage{.{
+        .role = .user,
+        .content = @constCast("Hello"),
+    }};
+    const request = ChatRequest{
+        .allocator = allocator,
+        .session = undefined,
+        .base_url = @constCast("https://api.deepseek.com"),
+        .api_key = @constCast("key"),
+        .model = @constCast(DEFAULT_MODEL),
+        .system_prompt = @constCast(DEFAULT_SYSTEM_PROMPT),
+        .messages = messages[0..],
+    };
+    const json = try buildRequestJson(allocator, &request);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"thinking\":{\"type\":\"enabled\"}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"reasoning_effort\":\"high\"") != null);
+}

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -11,6 +11,9 @@ pub const DEFAULT_NAME = "DeepSeek";
 pub const DEFAULT_BASE_URL = "https://api.deepseek.com";
 pub const DEFAULT_MODEL = "deepseek-v4-pro";
 pub const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
+pub const DEFAULT_THINKING = "enabled";
+pub const DEFAULT_REASONING_EFFORT = "high";
+pub const DEFAULT_STREAM = "false";
 
 pub const Role = enum {
     user,
@@ -50,12 +53,16 @@ const ChatRequest = struct {
     model: []u8,
     system_prompt: []u8,
     messages: []RequestMessage,
+    thinking_enabled: bool,
+    reasoning_effort: []u8,
+    stream: bool,
 
     fn deinit(self: *ChatRequest) void {
         self.allocator.free(self.base_url);
         self.allocator.free(self.api_key);
         self.allocator.free(self.model);
         self.allocator.free(self.system_prompt);
+        self.allocator.free(self.reasoning_effort);
         for (self.messages) |msg| self.allocator.free(msg.content);
         self.allocator.free(self.messages);
         self.allocator.destroy(self);
@@ -90,10 +97,18 @@ pub const Session = struct {
     model_len: usize = 0,
     system_prompt_buf: [512]u8 = undefined,
     system_prompt_len: usize = 0,
+    thinking_enabled: bool = true,
+    reasoning_effort_buf: [16]u8 = undefined,
+    reasoning_effort_len: usize = 0,
+    stream: bool = false,
     request_inflight: bool = false,
     request_thread: ?std.Thread = null,
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     scroll_px: f32 = 0,
+
+    pub fn reasoningEffort(self: *const Session) []const u8 {
+        return self.reasoning_effort_buf[0..self.reasoning_effort_len];
+    }
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -102,6 +117,9 @@ pub const Session = struct {
         api_key: []const u8,
         model_name: []const u8,
         system_prompt: []const u8,
+        thinking: []const u8,
+        reasoning_effort: []const u8,
+        stream_val: []const u8,
     ) !*Session {
         const session = try allocator.create(Session);
         session.* = .{
@@ -111,6 +129,9 @@ pub const Session = struct {
         session.copyBaseUrl(if (base_url.len > 0) base_url else DEFAULT_BASE_URL);
         session.copyModel(if (model_name.len > 0) model_name else DEFAULT_MODEL);
         session.copySystemPrompt(if (system_prompt.len > 0) system_prompt else DEFAULT_SYSTEM_PROMPT);
+        session.thinking_enabled = !std.mem.eql(u8, thinking, "disabled");
+        session.copyReasoningEffort(if (reasoning_effort.len > 0) reasoning_effort else DEFAULT_REASONING_EFFORT);
+        session.stream = std.mem.eql(u8, stream_val, "true");
         session.copyApiKey(api_key);
         if (session.api_key_len == 0 and isDeepSeekBaseUrl(session.baseUrl())) {
             if (std.process.getEnvVarOwned(allocator, "DEEPSEEK_API_KEY")) |env_key| {
@@ -335,6 +356,9 @@ pub const Session = struct {
             .model = try self.allocator.dupe(u8, self.model()),
             .system_prompt = try self.allocator.dupe(u8, self.systemPrompt()),
             .messages = messages,
+            .thinking_enabled = self.thinking_enabled,
+            .reasoning_effort = try self.allocator.dupe(u8, self.reasoningEffort()),
+            .stream = self.stream,
         };
         return req;
     }
@@ -362,6 +386,11 @@ pub const Session = struct {
     fn copySystemPrompt(self: *Session, value: []const u8) void {
         self.system_prompt_len = @min(value.len, self.system_prompt_buf.len);
         @memcpy(self.system_prompt_buf[0..self.system_prompt_len], value[0..self.system_prompt_len]);
+    }
+
+    fn copyReasoningEffort(self: *Session, value: []const u8) void {
+        self.reasoning_effort_len = @min(value.len, self.reasoning_effort_buf.len);
+        @memcpy(self.reasoning_effort_buf[0..self.reasoning_effort_len], value[0..self.reasoning_effort_len]);
     }
 
     fn setStatus(self: *Session, value: []const u8) void {
@@ -493,7 +522,13 @@ fn buildRequestJson(allocator: std.mem.Allocator, request: *const ChatRequest) !
         try appendJsonString(allocator, &out, msg.content);
         try out.append(allocator, '}');
     }
-    try out.appendSlice(allocator, "],\"thinking\":{\"type\":\"enabled\"},\"reasoning_effort\":\"high\",\"stream\":false}");
+    try out.appendSlice(allocator, "],\"thinking\":{\"type\":");
+    try appendJsonString(allocator, &out, if (request.thinking_enabled) "enabled" else "disabled");
+    try out.appendSlice(allocator, "},\"reasoning_effort\":");
+    try appendJsonString(allocator, &out, if (request.reasoning_effort.len > 0) request.reasoning_effort else "high");
+    try out.appendSlice(allocator, ",\"stream\":");
+    try out.appendSlice(allocator, if (request.stream) "true" else "false");
+    try out.append(allocator, '}');
 
     return out.toOwnedSlice(allocator);
 }
@@ -588,6 +623,9 @@ test "ai chat request json includes deepseek thinking mode" {
         .model = @constCast(DEFAULT_MODEL),
         .system_prompt = @constCast(DEFAULT_SYSTEM_PROMPT),
         .messages = messages[0..],
+        .thinking_enabled = true,
+        .reasoning_effort = @constCast("high"),
+        .stream = false,
     };
     const json = try buildRequestJson(allocator, &request);
     defer allocator.free(json);

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -409,13 +409,26 @@ fn requestThreadMain(request: *ChatRequest) void {
     const allocator = request.allocator;
     defer request.deinit();
 
+    if (request.stream) {
+        runChatRequestStreaming(request) catch |err| {
+            const text = std.fmt.allocPrint(allocator, "AI stream failed: {}", .{err}) catch return;
+            defer allocator.free(text);
+            appendAssistantResult(request.session, .{ .content = text });
+        };
+        return;
+    }
+
     const result = runChatRequest(request) catch |err| blk: {
         const text = std.fmt.allocPrint(allocator, "AI request failed: {}", .{err}) catch return;
         break :blk ApiResult{ .content = text };
     };
     defer result.deinit(allocator);
 
-    const session = request.session;
+    appendAssistantResult(request.session, result);
+}
+
+fn appendAssistantResult(session: *Session, result: ApiResult) void {
+    const allocator = session.allocator;
     if (session.closing.load(.acquire)) return;
 
     session.mutex.lock();
@@ -445,6 +458,84 @@ fn requestThreadMain(request: *ChatRequest) void {
     session.request_inflight = false;
     session.scroll_px = 1_000_000;
     session.setStatusLocked("Ready");
+}
+
+fn beginAssistantStream(session: *Session) !usize {
+    const allocator = session.allocator;
+    if (session.closing.load(.acquire)) return error.Closing;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return error.Closing;
+
+    const content = try allocator.dupe(u8, "");
+    errdefer allocator.free(content);
+    try session.messages.append(allocator, .{
+        .role = .assistant,
+        .content = content,
+        .reasoning = null,
+    });
+    session.scroll_px = 1_000_000;
+    session.setStatusLocked("Streaming...");
+    return session.messages.items.len - 1;
+}
+
+fn appendAssistantStreamDelta(session: *Session, message_idx: usize, content_delta: []const u8, reasoning_delta: []const u8) !void {
+    if (content_delta.len == 0 and reasoning_delta.len == 0) return;
+    const allocator = session.allocator;
+    if (session.closing.load(.acquire)) return;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return;
+    if (message_idx >= session.messages.items.len) return error.StreamMessageMissing;
+
+    var msg = &session.messages.items[message_idx];
+    if (content_delta.len > 0) {
+        const old_len = msg.content.len;
+        msg.content = try allocator.realloc(msg.content, old_len + content_delta.len);
+        @memcpy(msg.content[old_len..], content_delta);
+    }
+    if (reasoning_delta.len > 0) {
+        if (msg.reasoning) |old_reasoning| {
+            const old_len = old_reasoning.len;
+            const resized = try allocator.realloc(old_reasoning, old_len + reasoning_delta.len);
+            @memcpy(resized[old_len..], reasoning_delta);
+            msg.reasoning = resized;
+        } else {
+            msg.reasoning = try allocator.dupe(u8, reasoning_delta);
+        }
+    }
+    session.scroll_px = 1_000_000;
+    session.setStatusLocked("Streaming...");
+}
+
+fn finishAssistantStream(session: *Session, message_idx: usize) void {
+    if (session.closing.load(.acquire)) return;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return;
+    if (message_idx < session.messages.items.len) {
+        const msg = &session.messages.items[message_idx];
+        if (msg.content.len == 0 and msg.reasoning == null) {
+            msg.content = session.allocator.realloc(msg.content, "No response".len) catch msg.content;
+            if (msg.content.len == "No response".len) @memcpy(msg.content, "No response");
+        }
+    }
+    session.request_inflight = false;
+    session.scroll_px = 1_000_000;
+    session.setStatusLocked("Ready");
+}
+
+fn failAssistantStream(session: *Session, message_idx: ?usize, text: []const u8) void {
+    if (message_idx) |idx| {
+        appendAssistantStreamDelta(session, idx, text, "") catch {};
+        finishAssistantStream(session, idx);
+        return;
+    }
+
+    appendAssistantResult(session, .{ .content = @constCast(text) });
 }
 
 fn runChatRequest(request: *const ChatRequest) !ApiResult {
@@ -487,7 +578,76 @@ fn runChatRequest(request: *const ChatRequest) !ApiResult {
         return ApiResult{ .content = try std.fmt.allocPrint(allocator, "HTTP {d}", .{@intFromEnum(result.status)}) };
     }
 
-    return parseApiResponse(allocator, resp_list.items);
+    return if (request.stream)
+        parseApiStreamResponse(allocator, resp_list.items)
+    else
+        parseApiResponse(allocator, resp_list.items);
+}
+
+fn runChatRequestStreaming(request: *const ChatRequest) !void {
+    const allocator = request.allocator;
+    const endpoint = try chatEndpoint(allocator, request.base_url);
+    defer allocator.free(endpoint);
+
+    const body = try buildRequestJson(allocator, request);
+    defer allocator.free(body);
+
+    const bearer = try std.fmt.allocPrint(allocator, "Bearer {s}", .{request.api_key});
+    defer allocator.free(bearer);
+
+    var client: std.http.Client = .{
+        .allocator = allocator,
+        .write_buffer_size = 16384,
+    };
+    defer client.deinit();
+
+    const uri = try std.Uri.parse(endpoint);
+    var req = try client.request(.POST, uri, .{
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .authorization = .{ .override = bearer },
+        },
+        .keep_alive = false,
+    });
+    defer req.deinit();
+
+    try req.sendBodyComplete(body);
+
+    var redirect_buffer: [8 * 1024]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buffer);
+    var transfer_buffer: [16 * 1024]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+
+    if (response.head.status != .ok) {
+        var err_buf: std.Io.Writer.Allocating = .init(allocator);
+        defer err_buf.deinit();
+        _ = reader.streamRemaining(&err_buf.writer) catch {};
+        var err_list = err_buf.toArrayList();
+        defer err_list.deinit(allocator);
+        const trimmed = std.mem.trim(u8, err_list.items, " \t\r\n");
+        if (trimmed.len > 0) {
+            failAssistantStream(request.session, null, trimmed);
+        } else {
+            const msg = try std.fmt.allocPrint(allocator, "HTTP {d}", .{@intFromEnum(response.head.status)});
+            defer allocator.free(msg);
+            failAssistantStream(request.session, null, msg);
+        }
+        return;
+    }
+
+    const message_idx = try beginAssistantStream(request.session);
+    while (true) {
+        if (request.session.closing.load(.acquire)) return;
+        const line = reader.takeDelimiter('\n') catch |err| {
+            const msg = std.fmt.allocPrint(allocator, "Stream read failed: {}", .{err}) catch return err;
+            defer allocator.free(msg);
+            failAssistantStream(request.session, message_idx, msg);
+            return;
+        } orelse break;
+
+        if (try applyApiStreamLineToSession(allocator, request.session, message_idx, line)) break;
+    }
+    finishAssistantStream(request.session, message_idx);
 }
 
 fn chatEndpoint(allocator: std.mem.Allocator, base_url_raw: []const u8) ![]u8 {
@@ -578,6 +738,122 @@ fn parseApiResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
     };
 }
 
+fn parseApiStreamResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer content.deinit(allocator);
+    var reasoning: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer reasoning.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trim(u8, line_raw, " \t\r");
+        if (!std.mem.startsWith(u8, line, "data:")) continue;
+
+        const data = std.mem.trim(u8, line["data:".len..], " \t");
+        if (data.len == 0) continue;
+        if (std.mem.eql(u8, data, "[DONE]")) break;
+
+        var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch continue;
+        defer parsed.deinit();
+
+        const root = parsed.value;
+        if (root != .object) continue;
+        const obj = root.object;
+
+        if (obj.get("error")) |err_value| {
+            if (err_value == .object) {
+                if (err_value.object.get("message")) |message_value| {
+                    if (message_value == .string) {
+                        return ApiResult{ .content = try allocator.dupe(u8, message_value.string) };
+                    }
+                }
+            }
+            return ApiResult{ .content = try allocator.dupe(u8, "API returned an error") };
+        }
+
+        const choices_value = obj.get("choices") orelse continue;
+        if (choices_value != .array or choices_value.array.items.len == 0) continue;
+        const choice = choices_value.array.items[0];
+        if (choice != .object) continue;
+        const delta_value = choice.object.get("delta") orelse continue;
+        if (delta_value != .object) continue;
+
+        if (delta_value.object.get("content")) |content_value| {
+            if (content_value == .string and content_value.string.len > 0) {
+                try content.appendSlice(allocator, content_value.string);
+            }
+        }
+        if (delta_value.object.get("reasoning_content")) |reasoning_value| {
+            if (reasoning_value == .string and reasoning_value.string.len > 0) {
+                try reasoning.appendSlice(allocator, reasoning_value.string);
+            }
+        }
+    }
+
+    if (content.items.len == 0 and reasoning.items.len == 0) {
+        const trimmed = std.mem.trim(u8, body, " \t\r\n");
+        if (trimmed.len == 0) return error.EmptyResponse;
+        return ApiResult{ .content = try allocator.dupe(u8, trimmed) };
+    }
+
+    return .{
+        .content = try content.toOwnedSlice(allocator),
+        .reasoning = if (reasoning.items.len > 0) try reasoning.toOwnedSlice(allocator) else null,
+    };
+}
+
+fn applyApiStreamLineToSession(
+    allocator: std.mem.Allocator,
+    session: *Session,
+    message_idx: usize,
+    line_raw: []const u8,
+) !bool {
+    const line = std.mem.trim(u8, line_raw, " \t\r");
+    if (!std.mem.startsWith(u8, line, "data:")) return false;
+
+    const data = std.mem.trim(u8, line["data:".len..], " \t");
+    if (data.len == 0) return false;
+    if (std.mem.eql(u8, data, "[DONE]")) return true;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch return false;
+    defer parsed.deinit();
+
+    const root = parsed.value;
+    if (root != .object) return false;
+    const obj = root.object;
+
+    if (obj.get("error")) |err_value| {
+        if (err_value == .object) {
+            if (err_value.object.get("message")) |message_value| {
+                if (message_value == .string) {
+                    try appendAssistantStreamDelta(session, message_idx, message_value.string, "");
+                    return true;
+                }
+            }
+        }
+        try appendAssistantStreamDelta(session, message_idx, "API returned an error", "");
+        return true;
+    }
+
+    const choices_value = obj.get("choices") orelse return false;
+    if (choices_value != .array or choices_value.array.items.len == 0) return false;
+    const choice = choices_value.array.items[0];
+    if (choice != .object) return false;
+    const delta_value = choice.object.get("delta") orelse return false;
+    if (delta_value != .object) return false;
+
+    const content_delta = if (delta_value.object.get("content")) |content_value|
+        if (content_value == .string) content_value.string else ""
+    else
+        "";
+    const reasoning_delta = if (delta_value.object.get("reasoning_content")) |reasoning_value|
+        if (reasoning_value == .string) reasoning_value.string else ""
+    else
+        "";
+    try appendAssistantStreamDelta(session, message_idx, content_delta, reasoning_delta);
+    return false;
+}
+
 fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: []const u8) !void {
     const hex = "0123456789abcdef";
     try out.append(allocator, '"');
@@ -631,4 +907,20 @@ test "ai chat request json includes deepseek thinking mode" {
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"thinking\":{\"type\":\"enabled\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"reasoning_effort\":\"high\"") != null);
+}
+
+test "ai chat stream response aggregates content and reasoning chunks" {
+    const allocator = std.testing.allocator;
+    const body =
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"Think\"}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"ing\",\"content\":null}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"content\":\"!\"}}]}\n\n" ++
+        "data: [DONE]\n\n";
+
+    const result = try parseApiStreamResponse(allocator, body);
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings("Hello!", result.content);
+    try std.testing.expect(result.reasoning != null);
+    try std.testing.expectEqualStrings("Thinking", result.reasoning.?);
 }

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -11,6 +11,7 @@ const SplitTree = @import("../split_tree.zig");
 const win32_backend = @import("../apprt/win32.zig");
 const remote_client = @import("../remote_client.zig");
 const session_persist = @import("../session_persist.zig");
+const ai_chat = @import("../ai_chat.zig");
 
 const CursorStyle = Config.CursorStyle;
 const Selection = Surface.Selection;
@@ -33,11 +34,19 @@ pub const TAB_CLOSE_FADE_SPEED: f32 = 6.0;
 // ============================================================================
 
 pub const TabState = struct {
+    kind: Kind = .terminal,
     tree: SplitTree,
     focused: SplitTree.Node.Handle = .root,
+    ai_chat_session: ?*ai_chat.Session = null,
+
+    pub const Kind = enum {
+        terminal,
+        ai_chat,
+    };
 
     /// Get the focused surface in this tab, or null if tree is empty
     pub fn focusedSurface(self: *const TabState) ?*Surface {
+        if (self.kind != .terminal) return null;
         if (self.tree.isEmpty()) return null;
         if (self.focused.idx() >= self.tree.nodes.len) return null;
         return switch (self.tree.nodes[self.focused.idx()]) {
@@ -51,13 +60,26 @@ pub const TabState = struct {
         if (g_forced_title) |forced| {
             return forced;
         }
+        if (self.kind == .ai_chat) {
+            const chat = self.ai_chat_session orelse return "AI Chat";
+            const chat_title = chat.title();
+            return if (chat_title.len > 0) chat_title else "AI Chat";
+        }
         const surface = self.focusedSurface() orelse return "phantty";
         return surface.getTitle();
     }
 
     pub fn deinit(self: *TabState, allocator: std.mem.Allocator) void {
         _ = allocator;
-        self.tree.deinit();
+        switch (self.kind) {
+            .terminal => self.tree.deinit(),
+            .ai_chat => {
+                if (self.ai_chat_session) |session| {
+                    session.deinit();
+                    self.ai_chat_session = null;
+                }
+            },
+        }
     }
 };
 
@@ -130,6 +152,13 @@ pub fn activeSurface() ?*Surface {
     if (g_tab_count == 0) return null;
     const t = g_tabs[g_active_tab] orelse return null;
     return t.focusedSurface();
+}
+
+pub fn activeAiChat() ?*ai_chat.Session {
+    if (g_tab_count == 0) return null;
+    const t = g_tabs[g_active_tab] orelse return null;
+    if (t.kind != .ai_chat) return null;
+    return t.ai_chat_session;
 }
 
 fn splitSpawnCommand(
@@ -214,6 +243,12 @@ fn splitSshCommand(
 pub fn activeSelection() *Selection {
     if (g_tab_count > 0) {
         if (g_tabs[g_active_tab]) |t| {
+            if (t.kind != .terminal) {
+                const S = struct {
+                    var dummy: Selection = .{};
+                };
+                return &S.dummy;
+            }
             if (t.focusedSurface()) |surface| {
                 return &surface.selection;
             }
@@ -227,7 +262,8 @@ pub fn activeSelection() *Selection {
 
 pub fn isActiveTabTerminal() bool {
     if (g_tab_count == 0) return false;
-    return g_tabs[g_active_tab] != null;
+    const t = g_tabs[g_active_tab] orelse return false;
+    return t.kind == .terminal;
 }
 
 // ============================================================================
@@ -272,14 +308,55 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
         tree_mut.deinit();
         return false;
     };
+    t.kind = .terminal;
     t.tree = tree;
     t.focused = .root;
+    t.ai_chat_session = null;
 
     g_tabs[g_tab_count] = t;
     g_active_tab = g_tab_count;
     g_tab_count += 1;
 
     std.debug.print("New tab spawned (count={}), active: {}\n", .{ g_tab_count, g_active_tab });
+    return true;
+}
+
+pub fn spawnAiChatTab(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    base_url: []const u8,
+    api_key: []const u8,
+    model: []const u8,
+    system_prompt: []const u8,
+) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+
+    const session = ai_chat.Session.init(
+        allocator,
+        name,
+        base_url,
+        api_key,
+        model,
+        system_prompt,
+    ) catch {
+        std.debug.print("Failed to create AI Chat session\n", .{});
+        return false;
+    };
+
+    const t = allocator.create(TabState) catch {
+        session.deinit();
+        return false;
+    };
+    t.kind = .ai_chat;
+    t.tree = .empty;
+    t.focused = .root;
+    t.ai_chat_session = session;
+
+    g_tabs[g_tab_count] = t;
+    g_active_tab = g_tab_count;
+    g_tab_count += 1;
+
+    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, g_active_tab });
     return true;
 }
 
@@ -320,6 +397,7 @@ pub fn switchTab(idx: usize) void {
     g_active_tab = idx;
     // Clear bell indicator and force rebuild for surfaces in this tab
     if (g_tabs[idx]) |t| {
+        if (t.kind != .terminal) return;
         var it = t.tree.iterator();
         while (it.next()) |entry| {
             entry.surface.bell_indicator = false;
@@ -359,6 +437,7 @@ pub fn splitFocusedReturningSurface(
     cwd: ?[*:0]const u16,
 ) ?*Surface {
     const t = activeTab() orelse return null;
+    if (t.kind != .terminal) return null;
     const focused_surface = t.focusedSurface() orelse return null;
     const split_command = splitSpawnCommand(allocator, focused_surface);
     defer if (split_command) |command| allocator.free(command);
@@ -494,6 +573,11 @@ pub const CloseResult = enum {
 /// Close the focused split. Returns what happened so the caller can handle side effects.
 pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
     const t = activeTab() orelse return .no_op;
+    if (t.kind == .ai_chat) {
+        if (g_tab_count <= 1) return .close_window;
+        closeTab(g_active_tab, allocator);
+        return .closed_tab;
+    }
 
     if (!t.tree.isSplit()) {
         if (g_tab_count <= 1) {
@@ -547,6 +631,7 @@ pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
 /// Navigate to a split in the given direction. Returns true if focus changed.
 pub fn gotoSplit(allocator: std.mem.Allocator, direction: SplitTree.Goto) bool {
     const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
     const new_focus = t.tree.goto(allocator, t.focused, direction) catch return false;
     if (new_focus) |handle| {
         t.focused = handle;
@@ -558,6 +643,7 @@ pub fn gotoSplit(allocator: std.mem.Allocator, direction: SplitTree.Goto) bool {
 /// Equalize all split ratios. Returns true if equalization was performed.
 pub fn equalizeSplits(allocator: std.mem.Allocator) bool {
     const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
 
     var it = t.tree.iterator();
     while (it.next()) |entry| {
@@ -599,8 +685,13 @@ pub fn commitTabRename() void {
             const changed = g_tab_rename_len != g_tab_rename_orig_len or
                 !std.mem.eql(u8, g_tab_rename_buf[0..g_tab_rename_len], g_tab_rename_orig_buf[0..g_tab_rename_orig_len]);
             if (changed) {
-                if (t.focusedSurface()) |surface| {
-                    surface.setTitleOverride(g_tab_rename_buf[0..g_tab_rename_len]);
+                switch (t.kind) {
+                    .terminal => if (t.focusedSurface()) |surface| {
+                        surface.setTitleOverride(g_tab_rename_buf[0..g_tab_rename_len]);
+                    },
+                    .ai_chat => if (t.ai_chat_session) |session| {
+                        session.setTitle(g_tab_rename_buf[0..g_tab_rename_len]);
+                    },
                 }
             }
         }
@@ -752,6 +843,7 @@ pub fn handleRenameChar(codepoint: u21) void {
 /// is the caller's responsibility to free (via Session.deinit pattern, or
 /// shared across all tabs in a session).
 pub fn snapshotTab(arena: std.mem.Allocator, t: *const TabState) !session_persist.TabSnap {
+    if (t.kind != .terminal) return error.NotTerminalTab;
     if (t.tree.isEmpty()) return error.EmptyTree;
 
     // 1. Build NodeSnap tree.
@@ -981,10 +1073,12 @@ pub fn restoreTab(
         tree.deinit();
         return false;
     };
+    t.kind = .terminal;
     t.tree = tree;
 
     // Resolve focused_leaf from pre-order index back to a Handle.
     t.focused = handleOfNthLeaf(&t.tree, snap.focused_leaf) orelse .root;
+    t.ai_chat_session = null;
 
     g_tabs[g_tab_count] = t;
     g_active_tab = g_tab_count;

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -328,6 +328,9 @@ pub fn spawnAiChatTab(
     api_key: []const u8,
     model: []const u8,
     system_prompt: []const u8,
+    thinking: []const u8,
+    reasoning_effort: []const u8,
+    stream_val: []const u8,
 ) bool {
     if (g_tab_count >= MAX_TABS) return false;
 
@@ -338,6 +341,9 @@ pub fn spawnAiChatTab(
         api_key,
         model,
         system_prompt,
+        thinking,
+        reasoning_effort,
+        stream_val,
     ) catch {
         std.debug.print("Failed to create AI Chat session\n", .{});
         return false;

--- a/src/input.zig
+++ b/src/input.zig
@@ -808,6 +808,15 @@ fn handleChar(ev: win32_backend.CharEvent) void {
         tab.handleRenameChar(ev.codepoint);
         return;
     }
+    if (AppWindow.activeAiChat()) |chat| {
+        if (!ev.ctrl and !ev.alt) {
+            AppWindow.resetCursorBlink();
+            chat.handleChar(ev.codepoint);
+            AppWindow.g_force_rebuild = true;
+            AppWindow.g_cells_valid = false;
+        }
+        return;
+    }
     if (!AppWindow.isActiveTabTerminal()) return;
     // Skip chars when Alt is held without Ctrl — those are part of Alt+key
     // combos (e.g. Shift+Alt+4) and shouldn't produce text input.
@@ -838,6 +847,13 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
     const is_close_shortcut = ev.ctrl and ev.shift and ev.vk == 0x57;
     if (!is_close_shortcut and !isModifierKey(ev.vk)) g_close_shortcut_confirm_until_ms = 0;
     if (overlays.sessionLauncherVisible()) {
+        if (ev.ctrl and !ev.shift and !ev.alt and ev.vk == 0x56) { // Ctrl+V
+            if (pasteClipboardIntoSessionLauncher()) {
+                AppWindow.g_force_rebuild = true;
+                AppWindow.g_cells_valid = false;
+            }
+            return;
+        }
         overlays.sessionLauncherHandleKey(ev);
         return;
     }
@@ -961,7 +977,11 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
     }
     // Ctrl+V = paste text
     if (ev.ctrl and !ev.shift and !ev.alt and ev.vk == 0x56) { // 'V'
-        pasteFromClipboard();
+        if (AppWindow.activeAiChat()) |chat| {
+            pasteFromClipboardIntoAiChat(chat);
+        } else {
+            pasteFromClipboard();
+        }
         return;
     }
     // Ctrl+Shift+V = paste image
@@ -1013,6 +1033,16 @@ fn handleKey(ev: win32_backend.KeyEvent) void {
         return;
     }
     // Alt+Enter handled above as maximize/restore.
+
+    if (AppWindow.activeAiChat()) |chat| {
+        if (isAiChatKey(ev)) {
+            AppWindow.resetCursorBlink();
+            chat.handleKey(ev);
+            AppWindow.g_force_rebuild = true;
+            AppWindow.g_cells_valid = false;
+            return;
+        }
+    }
 
     // Don't send input to PTY if active tab isn't the terminal
     if (!AppWindow.isActiveTabTerminal()) return;
@@ -1095,6 +1125,12 @@ fn isModifierKey(vk: win32_backend.WPARAM) bool {
         vk == win32_backend.VK_RCONTROL or
         vk == win32_backend.VK_LMENU or
         vk == win32_backend.VK_RMENU;
+}
+
+fn isAiChatKey(ev: win32_backend.KeyEvent) bool {
+    if (ev.vk == win32_backend.VK_RETURN or ev.vk == win32_backend.VK_BACK) return true;
+    if (ev.ctrl and !ev.alt and (ev.vk == 0x55 or ev.vk == 0x4C)) return true; // Ctrl+U / Ctrl+L
+    return false;
 }
 
 fn handleBrowserUrlBarKey(ev: win32_backend.KeyEvent) void {
@@ -2858,6 +2894,17 @@ fn handleMouseWheel(ev: win32_backend.MouseWheelEvent) void {
             return;
         }
     }
+    if (AppWindow.activeAiChat()) |chat| {
+        const win = AppWindow.g_window orelse return;
+        const left = @as(i32, @intFromFloat(AppWindow.leftPanelsWidth()));
+        const right = win.width - @as(i32, @intFromFloat(AppWindow.rightPanelsWidthForWindow(win.width)));
+        if (ev.xpos >= left and ev.xpos < right) {
+            const delta: f32 = -@as(f32, @floatFromInt(ev.delta)) * 72.0 / 120.0;
+            chat.scrollBy(delta);
+            AppWindow.g_force_rebuild = true;
+            return;
+        }
+    }
     // Scroll the surface under the mouse cursor (like Ghostty), not the focused surface.
     // Fall back to focused surface if mouse is not over any split.
     const surface = split_layout.surfaceAtPoint(ev.xpos, ev.ypos) orelse AppWindow.activeSurface() orelse return;
@@ -3073,6 +3120,58 @@ fn pasteClipboardIntoBrowserUrlBar() bool {
     }
 
     return false;
+}
+
+fn pasteClipboardIntoSessionLauncher() bool {
+    const win = AppWindow.g_window orelse return false;
+    const allocator = AppWindow.g_allocator orelse return false;
+
+    if (win32_backend.OpenClipboard(win.hwnd) == 0) return false;
+    defer {
+        _ = win32_backend.CloseClipboard();
+    }
+
+    if (win32_backend.GetClipboardData(CF_UNICODETEXT)) |hmem| {
+        const text = readClipboardUnicodeText(allocator, hmem) orelse return false;
+        defer allocator.free(text);
+        return overlays.sessionLauncherPasteText(text);
+    }
+
+    if (win32_backend.GetClipboardData(CF_TEXT)) |hmem| {
+        const text = readClipboardAnsiText(allocator, hmem) orelse return false;
+        defer allocator.free(text);
+        return overlays.sessionLauncherPasteText(text);
+    }
+
+    return false;
+}
+
+fn pasteFromClipboardIntoAiChat(chat: *AppWindow.ai_chat.Session) void {
+    const win = AppWindow.g_window orelse return;
+    const allocator = AppWindow.g_allocator orelse return;
+
+    if (win32_backend.OpenClipboard(win.hwnd) == 0) return;
+    defer {
+        _ = win32_backend.CloseClipboard();
+    }
+
+    if (win32_backend.GetClipboardData(CF_UNICODETEXT)) |hmem| {
+        const text = readClipboardUnicodeText(allocator, hmem) orelse return;
+        defer allocator.free(text);
+        chat.appendInputText(text);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
+
+    if (win32_backend.GetClipboardData(CF_TEXT)) |hmem| {
+        const text = readClipboardAnsiText(allocator, hmem) orelse return;
+        defer allocator.free(text);
+        chat.appendInputText(text);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
 }
 
 pub fn pasteImageFromClipboard() void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -92,8 +92,8 @@ pub fn render(
     const transcript_top = top + HEADER_H + 18;
     const transcript_bottom = INPUT_H + 18;
     const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
-    const content_w = @min(920.0, w - LINE_PAD_X * 2);
-    const content_x = x + @round((w - content_w) / 2);
+    const content_w = w - LINE_PAD_X * 2;
+    const content_x = x + LINE_PAD_X;
 
     var content_h: f32 = 0;
     for (session.messages.items) |msg| {
@@ -114,7 +114,8 @@ pub fn render(
         scissor_h,
     );
 
-    var cursor_top = transcript_top - session.scroll_px;
+    const gravity_offset = @max(0.0, transcript_h - content_h);
+    var cursor_top = transcript_top + gravity_offset - session.scroll_px;
     for (session.messages.items) |msg| {
         const bubble_h = messageHeight(msg.content, content_w);
         const visible = cursor_top + bubble_h >= transcript_top and cursor_top <= window_height - transcript_bottom;
@@ -149,7 +150,7 @@ fn renderMessageBubble(role: ai_chat.Role, text: []const u8, x: f32, top_px: f32
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
     const is_user = role == .user;
-    const bubble_w = @min(w, if (is_user) w * 0.78 else w * 0.88);
+    const bubble_w = @min(w, if (is_user) w * 0.82 else w);
     const bubble_x = if (is_user) x + w - bubble_w else x;
     const bubble_y = window_height - top_px - h;
     const bubble_bg = if (is_user) mixColor(bg, accent, 0.20) else mixColor(bg, fg, 0.07);

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -1,0 +1,309 @@
+//! Native renderer for AI Chat sessions.
+
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const ai_chat = @import("../ai_chat.zig");
+const font = AppWindow.font;
+const gl_init = AppWindow.gl_init;
+const titlebar = AppWindow.titlebar;
+
+const c = @cImport({
+    @cInclude("glad/gl.h");
+});
+
+pub const LINE_PAD_X: f32 = 18;
+const HEADER_H: f32 = 54;
+pub const INPUT_H: f32 = 92;
+const BUBBLE_PAD_X: f32 = 14;
+const BUBBLE_PAD_Y: f32 = 10;
+const BUBBLE_GAP: f32 = 12;
+const REASONING_PAD_Y: f32 = 6;
+const REASONING_LEFT: f32 = 22;
+const REASONING_RIGHT: f32 = 12;
+const REASONING_LINE_SCALE: f32 = 0.95;
+
+pub fn render(
+    session: *ai_chat.Session,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+) void {
+    const gl = &AppWindow.gl;
+    gl.Enable.?(c.GL_BLEND);
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    gl.UseProgram.?(gl_init.shader_program);
+    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    gl.BindVertexArray.?(gl_init.vao);
+
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const muted = mixColor(bg, fg, 0.62);
+    const panel = mixColor(bg, fg, 0.045);
+    const line = mixColor(bg, fg, 0.18);
+
+    const x = @round(left_panels_w);
+    const w = @round(@max(1.0, window_width - left_panels_w - right_panels_w));
+    const top = @round(titlebar_offset);
+    const bottom: f32 = 0;
+    const h = @round(@max(1.0, window_height - top));
+    if (w <= 1 or h <= 1) return;
+
+    gl_init.renderQuad(x, bottom, w, h, bg);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+
+    const header_y = window_height - top - HEADER_H;
+    gl_init.renderQuadAlpha(x, header_y, w, HEADER_H, panel, 0.95);
+    gl_init.renderQuadAlpha(x, header_y, w, 1, line, 0.8);
+    _ = titlebar.renderTextLimited(session.title(), x + LINE_PAD_X, header_y + 10, mixColor(fg, accent, 0.12), w * 0.45);
+
+    var meta_buf: [256]u8 = undefined;
+    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}", .{ session.model(), session.status() }) catch session.status();
+    const meta_w = measureText(meta);
+    _ = titlebar.renderTextLimited(meta, x + w - LINE_PAD_X - @min(meta_w, w * 0.42), header_y + 10, muted, w * 0.42);
+
+    const input_y: f32 = 0;
+    gl_init.renderQuadAlpha(x, input_y, w, INPUT_H, panel, 0.98);
+    gl_init.renderQuadAlpha(x, input_y + INPUT_H - 1, w, 1, line, 0.8);
+
+    const field_x = x + LINE_PAD_X;
+    const field_y = input_y + 16;
+    const field_w = w - LINE_PAD_X * 2;
+    const field_h = INPUT_H - 32;
+    const field_bg = mixColor(bg, fg, 0.075);
+    gl_init.renderQuadAlpha(field_x, field_y, field_w, field_h, field_bg, 0.95);
+    gl_init.renderQuadAlpha(field_x, field_y, field_w, 1, mixColor(bg, accent, 0.38), 0.6);
+
+    const input_text = session.input();
+    if (input_text.len == 0) {
+        _ = titlebar.renderTextLimited("Ask AI Chat", field_x + 12, field_y + (field_h - font.g_titlebar_cell_height) / 2, mixColor(bg, fg, 0.42), field_w - 24);
+    } else {
+        _ = renderWrappedText(input_text, field_x + 12, window_height - field_y - field_h + 10, field_w - 24, lineHeight(), fg, window_height, window_height);
+    }
+    if (!session.request_inflight and AppWindow.g_cursor_blink_visible) {
+        const cursor_x = inputCursorX(input_text, field_x + 12, field_w - 24);
+        gl_init.renderQuad(cursor_x, field_y + 14, 1, field_h - 28, accent);
+    }
+
+    const transcript_top = top + HEADER_H + 18;
+    const transcript_bottom = INPUT_H + 18;
+    const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
+    const content_w = @min(920.0, w - LINE_PAD_X * 2);
+    const content_x = x + @round((w - content_w) / 2);
+
+    var content_h: f32 = 0;
+    for (session.messages.items) |msg| {
+        content_h += messageHeight(msg.content, content_w);
+        if (msg.reasoning) |reasoning| content_h += reasoningHeight(reasoning, content_w);
+        content_h += BUBBLE_GAP;
+    }
+    const max_scroll = @max(0.0, content_h - transcript_h);
+    session.scroll_px = @min(session.scroll_px, max_scroll);
+
+    const scissor_y: c.GLint = @intFromFloat(@round(INPUT_H + 18));
+    const scissor_h: c.GLsizei = @intFromFloat(@round(transcript_h));
+    gl.Enable.?(c.GL_SCISSOR_TEST);
+    gl.Scissor.?(
+        @intFromFloat(@round(x)),
+        scissor_y,
+        @intFromFloat(@round(w)),
+        scissor_h,
+    );
+
+    var cursor_top = transcript_top - session.scroll_px;
+    for (session.messages.items) |msg| {
+        const bubble_h = messageHeight(msg.content, content_w);
+        const visible = cursor_top + bubble_h >= transcript_top and cursor_top <= window_height - transcript_bottom;
+        if (visible) {
+            renderMessageBubble(
+                msg.role,
+                msg.content,
+                content_x,
+                cursor_top,
+                content_w,
+                bubble_h,
+                window_height,
+            );
+        }
+        cursor_top += bubble_h;
+        if (msg.reasoning) |reasoning| {
+            const r_h = reasoningHeight(reasoning, content_w);
+            const reasoning_visible = cursor_top + r_h >= transcript_top and cursor_top <= window_height - transcript_bottom;
+            if (reasoning_visible and reasoning.len > 0) {
+                renderReasoning(reasoning, content_x, cursor_top, content_w, r_h, window_height);
+            }
+            cursor_top += r_h;
+        }
+        cursor_top += BUBBLE_GAP;
+    }
+
+    gl.Disable.?(c.GL_SCISSOR_TEST);
+}
+
+fn renderMessageBubble(role: ai_chat.Role, text: []const u8, x: f32, top_px: f32, w: f32, h: f32, window_height: f32) void {
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const is_user = role == .user;
+    const bubble_w = @min(w, if (is_user) w * 0.78 else w * 0.88);
+    const bubble_x = if (is_user) x + w - bubble_w else x;
+    const bubble_y = window_height - top_px - h;
+    const bubble_bg = if (is_user) mixColor(bg, accent, 0.20) else mixColor(bg, fg, 0.07);
+    gl_init.renderQuadAlpha(bubble_x, bubble_y, bubble_w, h, bubble_bg, 0.92);
+    gl_init.renderQuadAlpha(bubble_x, bubble_y + h - 1, bubble_w, 1, if (is_user) accent else mixColor(bg, fg, 0.18), 0.55);
+
+    const label_color = if (is_user) mixColor(fg, accent, 0.18) else mixColor(fg, accent, 0.05);
+    _ = titlebar.renderTextLimited(role.label(), bubble_x + BUBBLE_PAD_X, bubble_y + h - BUBBLE_PAD_Y - font.g_titlebar_cell_height, label_color, bubble_w - BUBBLE_PAD_X * 2);
+    _ = renderWrappedText(
+        text,
+        bubble_x + BUBBLE_PAD_X,
+        top_px + BUBBLE_PAD_Y + lineHeight(),
+        bubble_w - BUBBLE_PAD_X * 2,
+        lineHeight(),
+        fg,
+        window_height,
+        window_height,
+    );
+}
+
+fn renderReasoning(text: []const u8, x: f32, top_px: f32, w: f32, h: f32, window_height: f32) void {
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const y = window_height - top_px - h;
+    gl_init.renderQuadAlpha(x, y, w, h, mixColor(bg, fg, 0.04), 0.85);
+    gl_init.renderQuadAlpha(x + 8, y, 3, h, accent, 0.32);
+    _ = renderWrappedText(text, x + REASONING_LEFT, top_px + REASONING_PAD_Y, w - REASONING_LEFT - REASONING_RIGHT, lineHeight() * REASONING_LINE_SCALE, mixColor(bg, fg, 0.58), window_height, window_height);
+}
+
+fn messageHeight(text: []const u8, max_w: f32) f32 {
+    const wrapped = countWrappedLines(text, max_w - BUBBLE_PAD_X * 2);
+    return BUBBLE_PAD_Y * 2 + lineHeight() + @as(f32, @floatFromInt(@max(1, wrapped))) * lineHeight();
+}
+
+fn reasoningHeight(text: []const u8, max_w: f32) f32 {
+    const text_w = max_w - REASONING_LEFT - REASONING_RIGHT;
+    const lines = countWrappedLines(text, text_w);
+    const lh = lineHeight() * REASONING_LINE_SCALE;
+    return REASONING_PAD_Y * 2 + @as(f32, @floatFromInt(@max(1, lines))) * lh;
+}
+
+fn countWrappedLines(text: []const u8, max_w: f32) usize {
+    if (text.len == 0) return 1;
+    var lines: usize = 1;
+    var width: f32 = 0;
+    var i: usize = 0;
+    while (i < text.len) {
+        if (text[i] == '\n') {
+            lines += 1;
+            width = 0;
+            i += 1;
+            continue;
+        }
+        const item = nextCodepoint(text, i);
+        if (width > 0 and width + item.advance > max_w) {
+            lines += 1;
+            width = 0;
+        }
+        width += item.advance;
+        i += item.len;
+    }
+    return lines;
+}
+
+fn renderWrappedText(
+    text: []const u8,
+    x: f32,
+    top_px: f32,
+    max_w: f32,
+    line_h: f32,
+    color: [3]f32,
+    window_height: f32,
+    clip_bottom_top_px: f32,
+) f32 {
+    var line_start: usize = 0;
+    var line_width: f32 = 0;
+    var i: usize = 0;
+    var current_top = top_px;
+    while (i < text.len) {
+        if (text[i] == '\n') {
+            renderTextLine(text[line_start..i], x, current_top, max_w, color, window_height, clip_bottom_top_px);
+            current_top += line_h;
+            i += 1;
+            line_start = i;
+            line_width = 0;
+            continue;
+        }
+        const item = nextCodepoint(text, i);
+        if (line_width > 0 and line_width + item.advance > max_w) {
+            renderTextLine(text[line_start..i], x, current_top, max_w, color, window_height, clip_bottom_top_px);
+            current_top += line_h;
+            line_start = i;
+            line_width = 0;
+            continue;
+        }
+        line_width += item.advance;
+        i += item.len;
+    }
+    renderTextLine(text[line_start..i], x, current_top, max_w, color, window_height, clip_bottom_top_px);
+    return current_top + line_h;
+}
+
+fn renderTextLine(text: []const u8, x: f32, top_px: f32, max_w: f32, color: [3]f32, window_height: f32, clip_bottom_top_px: f32) void {
+    if (top_px + lineHeight() < 0 or top_px > clip_bottom_top_px) return;
+    const y = window_height - top_px - font.g_titlebar_cell_height;
+    _ = titlebar.renderTextLimited(text, x, y, color, max_w);
+}
+
+const CodepointItem = struct {
+    len: usize,
+    advance: f32,
+};
+
+fn nextCodepoint(text: []const u8, i: usize) CodepointItem {
+    const first = text[i];
+    const len = std.unicode.utf8ByteSequenceLength(first) catch 1;
+    if (i + len > text.len) return .{ .len = 1, .advance = titlebar.titlebarGlyphAdvance('?') };
+    const cp = std.unicode.utf8Decode(text[i .. i + len]) catch @as(u21, '?');
+    return .{ .len = len, .advance = titlebar.titlebarGlyphAdvance(@intCast(cp)) };
+}
+
+pub fn inputCursorX(text: []const u8, x: f32, max_w: f32) f32 {
+    var width: f32 = 0;
+    var i: usize = 0;
+    while (i < text.len) {
+        const item = nextCodepoint(text, i);
+        if (width + item.advance > max_w) break;
+        width += item.advance;
+        i += item.len;
+    }
+    return x + width + 2;
+}
+
+fn measureText(text: []const u8) f32 {
+    var width: f32 = 0;
+    var i: usize = 0;
+    while (i < text.len) {
+        const item = nextCodepoint(text, i);
+        width += item.advance;
+        i += item.len;
+    }
+    return width;
+}
+
+fn lineHeight() f32 {
+    return @round(@max(23.0, font.g_titlebar_cell_height + 8.0));
+}
+
+fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const clamped = @max(0.0, @min(1.0, t));
+    return .{
+        a[0] + (b[0] - a[0]) * clamped,
+        a[1] + (b[1] - a[1]) * clamped,
+        a[2] + (b[2] - a[2]) * clamped,
+    };
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -218,7 +218,7 @@ const CommandEntry = struct {
 };
 
 const COMMAND_ENTRIES = [_]CommandEntry{
-    .{ .title = "New Session", .detail = "Choose PowerShell, SSH, or WSL", .shortcut = "Ctrl+Shift+T", .action = .new_tab },
+    .{ .title = "New Session", .detail = "Choose PowerShell, SSH, WSL, or AI Chat", .shortcut = "Ctrl+Shift+T", .action = .new_tab },
     .{ .title = "Split Right", .detail = "Create a panel to the right", .shortcut = "Ctrl+Shift+O", .action = .split_right },
     .{ .title = "Split Down", .detail = "Create a panel below", .shortcut = "", .action = .split_down },
     .{ .title = "Split Left", .detail = "Create a panel to the left", .shortcut = "", .action = .split_left },
@@ -860,7 +860,11 @@ const SSH_FIELD_COUNT = 5;
 const SSH_FIELD_MAX = 128;
 const SSH_PROFILE_MAX = 16;
 const SSH_PROFILE_NONE = std.math.maxInt(usize);
-const SESSION_LAUNCHER_ROW_COUNT = 3;
+const AI_FIELD_COUNT = 5;
+const AI_FIELD_MAX = 512;
+const AI_PROFILE_MAX = 16;
+const AI_PROFILE_NONE = std.math.maxInt(usize);
+const SESSION_LAUNCHER_ROW_COUNT = 4;
 
 const SshField = enum(usize) {
     name = 0,
@@ -870,16 +874,31 @@ const SshField = enum(usize) {
     port = 4,
 };
 
+const AiField = enum(usize) {
+    name = 0,
+    base_url = 1,
+    api_key = 2,
+    model = 3,
+    system_prompt = 4,
+};
+
 const SessionAction = enum {
     powershell,
     ssh,
     wsl,
+    ai_chat,
     connect_selected,
     new_ssh,
     edit_selected,
     delete_selected,
+    connect_ai_selected,
+    new_ai,
+    edit_ai_selected,
+    delete_ai_selected,
     connect,
     save,
+    connect_ai,
+    save_ai,
     cancel,
 };
 
@@ -889,9 +908,20 @@ const SshListMode = enum {
     delete_select,
 };
 
+const AiListMode = enum {
+    manage,
+    edit_select,
+    delete_select,
+};
+
 const SshProfile = struct {
     fields: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined,
     lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT,
+};
+
+const AiProfile = struct {
+    fields: [AI_FIELD_COUNT][AI_FIELD_MAX]u8 = undefined,
+    lens: [AI_FIELD_COUNT]usize = .{0} ** AI_FIELD_COUNT,
 };
 
 const SessionLayout = struct {
@@ -908,6 +938,8 @@ pub threadlocal var g_session_launcher_visible: bool = false;
 threadlocal var g_session_launcher_selected: usize = 0;
 threadlocal var g_ssh_list_visible: bool = false;
 threadlocal var g_ssh_form_visible: bool = false;
+threadlocal var g_ai_list_visible: bool = false;
+threadlocal var g_ai_form_visible: bool = false;
 threadlocal var g_ssh_focus: usize = @intFromEnum(SshField.name);
 threadlocal var g_ssh_bufs: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined;
 threadlocal var g_ssh_lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT;
@@ -917,13 +949,22 @@ threadlocal var g_ssh_profiles_loaded: bool = false;
 threadlocal var g_ssh_list_selected: usize = 0;
 threadlocal var g_ssh_list_mode: SshListMode = .manage;
 threadlocal var g_ssh_edit_index: usize = SSH_PROFILE_NONE;
+threadlocal var g_ai_focus: usize = @intFromEnum(AiField.name);
+threadlocal var g_ai_bufs: [AI_FIELD_COUNT][AI_FIELD_MAX]u8 = undefined;
+threadlocal var g_ai_lens: [AI_FIELD_COUNT]usize = .{0} ** AI_FIELD_COUNT;
+threadlocal var g_ai_profiles: [AI_PROFILE_MAX]AiProfile = undefined;
+threadlocal var g_ai_profile_count: usize = 0;
+threadlocal var g_ai_profiles_loaded: bool = false;
+threadlocal var g_ai_list_selected: usize = 0;
+threadlocal var g_ai_list_mode: AiListMode = .manage;
+threadlocal var g_ai_edit_index: usize = AI_PROFILE_NONE;
 threadlocal var g_pending_ssh_password: [SSH_FIELD_MAX + 1]u8 = undefined;
 threadlocal var g_pending_ssh_password_len: usize = 0;
 threadlocal var g_pending_ssh_password_due_ms: i64 = 0;
 threadlocal var g_pending_ssh_surface: ?*Surface = null;
 
 pub fn sessionLauncherVisible() bool {
-    return g_session_launcher_visible or g_ssh_list_visible or g_ssh_form_visible;
+    return g_session_launcher_visible or g_ssh_list_visible or g_ssh_form_visible or g_ai_list_visible or g_ai_form_visible;
 }
 
 pub fn sessionLauncherOpen() void {
@@ -931,7 +972,10 @@ pub fn sessionLauncherOpen() void {
     g_session_launcher_selected = 0;
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;
+    g_ai_list_visible = false;
+    g_ai_form_visible = false;
     g_ssh_list_mode = .manage;
+    g_ai_list_mode = .manage;
     g_command_palette_visible = false;
     g_settings_visible = false;
     g_startup_shortcuts_visible = false;
@@ -941,17 +985,41 @@ pub fn sessionLauncherClose() void {
     g_session_launcher_visible = false;
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;
+    g_ai_list_visible = false;
+    g_ai_form_visible = false;
     g_ssh_list_mode = .manage;
+    g_ai_list_mode = .manage;
 }
 
 pub fn sessionLauncherInsertChar(codepoint: u21) void {
-    if (!g_ssh_form_visible) return;
-    if (g_ssh_focus >= SSH_FIELD_COUNT) return;
-    if (codepoint < 0x20 or codepoint == 0x7f or codepoint > 0x7f) return;
-    const field = g_ssh_focus;
-    if (g_ssh_lens[field] >= SSH_FIELD_MAX) return;
-    g_ssh_bufs[field][g_ssh_lens[field]] = @intCast(codepoint);
-    g_ssh_lens[field] += 1;
+    if (codepoint < 0x20 or codepoint == 0x7f) return;
+    if (g_ssh_form_visible) {
+        if (codepoint > 0x7f) return;
+        if (g_ssh_focus >= SSH_FIELD_COUNT) return;
+        const field = g_ssh_focus;
+        if (g_ssh_lens[field] >= SSH_FIELD_MAX) return;
+        g_ssh_bufs[field][g_ssh_lens[field]] = @intCast(codepoint);
+        g_ssh_lens[field] += 1;
+        return;
+    }
+    if (g_ai_form_visible) {
+        if (g_ai_focus >= AI_FIELD_COUNT) return;
+        appendAiFormCodepoint(g_ai_focus, codepoint);
+    }
+}
+
+pub fn sessionLauncherPasteText(text: []const u8) bool {
+    if (g_ai_form_visible) {
+        if (g_ai_focus >= AI_FIELD_COUNT) return false;
+        appendAiFormText(g_ai_focus, text);
+        return true;
+    }
+    if (g_ssh_form_visible) {
+        if (g_ssh_focus >= SSH_FIELD_COUNT) return false;
+        appendSshFormText(g_ssh_focus, text);
+        return true;
+    }
+    return false;
 }
 
 pub fn sessionLauncherHandleKey(ev: win32_backend.KeyEvent) void {
@@ -960,9 +1028,13 @@ pub fn sessionLauncherHandleKey(ev: win32_backend.KeyEvent) void {
         return;
     }
 
-    if (!g_ssh_form_visible) {
+    if (!g_ssh_form_visible and !g_ai_form_visible) {
         if (g_ssh_list_visible) {
             handleSshListKey(ev);
+            return;
+        }
+        if (g_ai_list_visible) {
+            handleAiListKey(ev);
             return;
         }
         switch (ev.vk) {
@@ -981,6 +1053,23 @@ pub fn sessionLauncherHandleKey(ev: win32_backend.KeyEvent) void {
                 g_session_launcher_selected = 2;
                 runSessionLauncherRow(g_session_launcher_selected);
             },
+            0x41 => {
+                g_session_launcher_selected = 3;
+                runSessionLauncherRow(g_session_launcher_selected);
+            },
+            else => {},
+        }
+        return;
+    }
+
+    if (g_ai_form_visible) {
+        switch (ev.vk) {
+            win32_backend.VK_TAB, win32_backend.VK_DOWN => g_ai_focus = (g_ai_focus + 1) % (AI_FIELD_COUNT + 3),
+            win32_backend.VK_UP => g_ai_focus = if (g_ai_focus == 0) AI_FIELD_COUNT + 2 else g_ai_focus - 1,
+            win32_backend.VK_BACK => {
+                if (g_ai_focus < AI_FIELD_COUNT) backspaceAiFormField(g_ai_focus);
+            },
+            win32_backend.VK_RETURN => runAiFormFocusAction(),
             else => {},
         }
         return;
@@ -1011,12 +1100,19 @@ pub fn sessionLauncherExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_
         .powershell => openPowerShellSession(),
         .ssh => openSshList(),
         .wsl => openWslSession(),
+        .ai_chat => openAiList(),
         .connect_selected => runSshListRow(g_ssh_list_selected),
         .new_ssh => openSshFormNew(),
         .edit_selected => openSshEditPicker(),
         .delete_selected => openSshDeletePicker(),
+        .connect_ai_selected => runAiListRow(g_ai_list_selected),
+        .new_ai => openAiFormNew(),
+        .edit_ai_selected => openAiEditPicker(),
+        .delete_ai_selected => openAiDeletePicker(),
         .connect => connectSshFromForm(),
         .save => saveSshFormOnly(),
+        .connect_ai => connectAiFromForm(),
+        .save_ai => saveAiFormOnly(),
         .cancel => sessionLauncherClose(),
     }
     return true;
@@ -1037,6 +1133,7 @@ fn runSessionLauncherRow(row: usize) void {
         0 => openPowerShellSession(),
         1 => openSshList(),
         2 => openWslSession(),
+        3 => openAiList(),
         else => {},
     }
 }
@@ -1305,6 +1402,335 @@ pub fn tickSessionLauncher() void {
     g_pending_ssh_surface = null;
 }
 
+fn openAiList() void {
+    loadAiProfiles();
+    g_session_launcher_visible = false;
+    g_ssh_list_visible = false;
+    g_ssh_form_visible = false;
+    g_ai_list_visible = true;
+    g_ai_form_visible = false;
+    g_ai_list_mode = .manage;
+    g_ai_list_selected = @min(g_ai_list_selected, aiListRowCount() - 1);
+}
+
+fn openAiEditPicker() void {
+    openAiProfilePicker(.edit_select);
+}
+
+fn openAiDeletePicker() void {
+    openAiProfilePicker(.delete_select);
+}
+
+fn openAiProfilePicker(mode: AiListMode) void {
+    if (g_ai_profile_count == 0) return;
+    g_session_launcher_visible = false;
+    g_ssh_list_visible = false;
+    g_ssh_form_visible = false;
+    g_ai_list_visible = true;
+    g_ai_form_visible = false;
+    g_ai_list_mode = mode;
+    g_ai_list_selected = if (g_ai_list_selected < g_ai_profile_count) g_ai_list_selected else 0;
+}
+
+fn openAiFormNew() void {
+    clearAiForm();
+    g_ai_edit_index = AI_PROFILE_NONE;
+    openAiForm();
+}
+
+fn openAiFormEdit(index: usize) void {
+    if (index >= g_ai_profile_count) return;
+    clearAiForm();
+    for (0..AI_FIELD_COUNT) |i| {
+        g_ai_lens[i] = @min(g_ai_profiles[index].lens[i], AI_FIELD_MAX);
+        @memcpy(g_ai_bufs[i][0..g_ai_lens[i]], g_ai_profiles[index].fields[i][0..g_ai_lens[i]]);
+    }
+    g_ai_edit_index = index;
+    openAiForm();
+}
+
+fn openAiForm() void {
+    g_ssh_list_visible = false;
+    g_ssh_form_visible = false;
+    g_ai_list_visible = false;
+    g_session_launcher_visible = false;
+    g_ai_form_visible = true;
+    g_ai_focus = @intFromEnum(AiField.name);
+}
+
+fn setAiDefault(field: AiField, value: []const u8) void {
+    const idx: usize = @intFromEnum(field);
+    const len = @min(value.len, AI_FIELD_MAX);
+    @memcpy(g_ai_bufs[idx][0..len], value[0..len]);
+    g_ai_lens[idx] = len;
+}
+
+fn clearAiForm() void {
+    g_ai_lens = .{0} ** AI_FIELD_COUNT;
+    setAiDefault(.name, AppWindow.ai_chat.DEFAULT_NAME);
+    setAiDefault(.base_url, AppWindow.ai_chat.DEFAULT_BASE_URL);
+    setAiDefault(.model, AppWindow.ai_chat.DEFAULT_MODEL);
+    setAiDefault(.system_prompt, AppWindow.ai_chat.DEFAULT_SYSTEM_PROMPT);
+}
+
+fn appendAiFormCodepoint(field: usize, codepoint: u21) void {
+    if (field >= AI_FIELD_COUNT) return;
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(codepoint, &buf) catch return;
+    if (g_ai_lens[field] + len > AI_FIELD_MAX) return;
+    @memcpy(g_ai_bufs[field][g_ai_lens[field]..][0..len], buf[0..len]);
+    g_ai_lens[field] += len;
+}
+
+fn appendAiFormText(field: usize, text: []const u8) void {
+    if (field >= AI_FIELD_COUNT) return;
+    var i: usize = 0;
+    while (i < text.len) {
+        const len = std.unicode.utf8ByteSequenceLength(text[i]) catch {
+            i += 1;
+            continue;
+        };
+        if (i + len > text.len) break;
+        const codepoint = std.unicode.utf8Decode(text[i .. i + len]) catch {
+            i += 1;
+            continue;
+        };
+        if (codepoint >= 0x20 and codepoint != 0x7f) {
+            appendAiFormCodepoint(field, codepoint);
+        }
+        i += len;
+    }
+}
+
+fn appendSshFormText(field: usize, text: []const u8) void {
+    if (field >= SSH_FIELD_COUNT) return;
+    for (text) |ch| {
+        if (ch < 0x20 or ch >= 0x7f) continue;
+        if (g_ssh_lens[field] >= SSH_FIELD_MAX) return;
+        g_ssh_bufs[field][g_ssh_lens[field]] = ch;
+        g_ssh_lens[field] += 1;
+    }
+}
+
+fn backspaceAiFormField(field: usize) void {
+    if (field >= AI_FIELD_COUNT or g_ai_lens[field] == 0) return;
+    g_ai_lens[field] -= 1;
+    while (g_ai_lens[field] > 0 and (g_ai_bufs[field][g_ai_lens[field]] & 0xC0) == 0x80) {
+        g_ai_lens[field] -= 1;
+    }
+}
+
+fn handleAiListKey(ev: win32_backend.KeyEvent) void {
+    const row_count = aiListRowCount();
+    switch (ev.vk) {
+        win32_backend.VK_DOWN, win32_backend.VK_TAB => g_ai_list_selected = (g_ai_list_selected + 1) % row_count,
+        win32_backend.VK_UP => g_ai_list_selected = if (g_ai_list_selected == 0) row_count - 1 else g_ai_list_selected - 1,
+        win32_backend.VK_RETURN => runAiListRow(g_ai_list_selected),
+        else => {},
+    }
+}
+
+fn aiListRowCount() usize {
+    return switch (g_ai_list_mode) {
+        .manage => g_ai_profile_count + 4,
+        .edit_select, .delete_select => g_ai_profile_count + 1,
+    };
+}
+
+fn aiField(field: AiField) []const u8 {
+    const idx: usize = @intFromEnum(field);
+    return g_ai_bufs[idx][0..g_ai_lens[idx]];
+}
+
+fn aiProfileField(profile: *const AiProfile, field: AiField) []const u8 {
+    const idx: usize = @intFromEnum(field);
+    return profile.fields[idx][0..profile.lens[idx]];
+}
+
+fn runAiListRow(row: usize) void {
+    switch (g_ai_list_mode) {
+        .manage => {
+            if (row < g_ai_profile_count) {
+                connectAiProfile(row);
+                return;
+            }
+            const action_row = row - g_ai_profile_count;
+            switch (action_row) {
+                0 => openAiFormNew(),
+                1 => openAiEditPicker(),
+                2 => openAiDeletePicker(),
+                else => sessionLauncherClose(),
+            }
+        },
+        .edit_select => {
+            if (row < g_ai_profile_count) {
+                openAiFormEdit(row);
+            } else {
+                openAiList();
+            }
+        },
+        .delete_select => {
+            if (row < g_ai_profile_count) {
+                deleteAiProfile(row);
+                openAiList();
+            } else {
+                openAiList();
+            }
+        },
+    }
+}
+
+fn deleteAiProfile(idx: usize) void {
+    if (g_ai_profile_count == 0) return;
+    if (idx >= g_ai_profile_count) return;
+    var i = idx;
+    while (i + 1 < g_ai_profile_count) : (i += 1) {
+        g_ai_profiles[i] = g_ai_profiles[i + 1];
+    }
+    g_ai_profile_count -= 1;
+    g_ai_list_selected = @min(g_ai_list_selected, aiListRowCount() - 1);
+    if (AppWindow.g_allocator) |allocator| saveAiProfiles(allocator);
+}
+
+fn connectAiFromForm() void {
+    const idx = saveAiFormProfile() orelse return;
+    connectAiProfile(idx);
+}
+
+fn saveAiFormOnly() void {
+    _ = saveAiFormProfile() orelse return;
+    openAiList();
+}
+
+fn runAiFormFocusAction() void {
+    if (g_ai_focus < AI_FIELD_COUNT) {
+        g_ai_focus = (g_ai_focus + 1) % (AI_FIELD_COUNT + 3);
+        return;
+    }
+    switch (g_ai_focus - AI_FIELD_COUNT) {
+        0 => connectAiFromForm(),
+        1 => saveAiFormOnly(),
+        else => openAiList(),
+    }
+}
+
+fn saveAiFormProfile() ?usize {
+    const allocator = AppWindow.g_allocator orelse return null;
+    const base_url = aiField(.base_url);
+    const model = aiField(.model);
+    if (base_url.len == 0 or model.len == 0) return null;
+    if (!isHttpUrlish(base_url)) return null;
+
+    const idx = if (g_ai_edit_index != AI_PROFILE_NONE)
+        g_ai_edit_index
+    else blk: {
+        if (g_ai_profile_count >= AI_PROFILE_MAX) return null;
+        const next = g_ai_profile_count;
+        g_ai_profile_count += 1;
+        break :blk next;
+    };
+
+    for (0..AI_FIELD_COUNT) |i| {
+        g_ai_profiles[idx].lens[i] = g_ai_lens[i];
+        @memcpy(g_ai_profiles[idx].fields[i][0..g_ai_lens[i]], g_ai_bufs[i][0..g_ai_lens[i]]);
+    }
+    if (g_ai_profiles[idx].lens[@intFromEnum(AiField.name)] == 0) {
+        const len = @min(model.len, AI_FIELD_MAX);
+        @memcpy(g_ai_profiles[idx].fields[@intFromEnum(AiField.name)][0..len], model[0..len]);
+        g_ai_profiles[idx].lens[@intFromEnum(AiField.name)] = len;
+    }
+
+    saveAiProfiles(allocator);
+    g_ai_edit_index = idx;
+    return idx;
+}
+
+fn connectAiProfile(idx: usize) void {
+    if (idx >= g_ai_profile_count) return;
+    const profile = &g_ai_profiles[idx];
+    const name = aiProfileField(profile, .name);
+    const base_url = aiProfileField(profile, .base_url);
+    const api_key = aiProfileField(profile, .api_key);
+    const model = aiProfileField(profile, .model);
+    const system_prompt = aiProfileField(profile, .system_prompt);
+    if (base_url.len == 0 or model.len == 0) return;
+    if (!isHttpUrlish(base_url)) return;
+
+    sessionLauncherClose();
+    _ = AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt);
+}
+
+fn isHttpUrlish(value: []const u8) bool {
+    return std.mem.startsWith(u8, value, "https://") or std.mem.startsWith(u8, value, "http://");
+}
+
+fn aiProfilesPath(allocator: std.mem.Allocator) ![]u8 {
+    if (std.process.getEnvVarOwned(allocator, "APPDATA")) |appdata| {
+        defer allocator.free(appdata);
+        return std.fs.path.join(allocator, &.{ appdata, "phantty", "ai_profiles" });
+    } else |_| {}
+    return std.fs.path.join(allocator, &.{ ".", "ai_profiles" });
+}
+
+fn loadAiProfiles() void {
+    if (g_ai_profiles_loaded) return;
+    g_ai_profiles_loaded = true;
+    g_ai_profile_count = 0;
+    const allocator = AppWindow.g_allocator orelse return;
+    const path = aiProfilesPath(allocator) catch return;
+    defer allocator.free(path);
+    const content = std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch return;
+    defer allocator.free(content);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        if (g_ai_profile_count >= AI_PROFILE_MAX) break;
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        var profile = AiProfile{};
+        var parts = std.mem.splitScalar(u8, line, '\t');
+        var field_idx: usize = 0;
+        var ok = true;
+        while (field_idx < AI_FIELD_COUNT) : (field_idx += 1) {
+            const part = parts.next() orelse {
+                ok = false;
+                break;
+            };
+            const decoded = decodeHexFieldToSlice(part, profile.fields[field_idx][0..]) orelse {
+                ok = false;
+                break;
+            };
+            profile.lens[field_idx] = decoded;
+        }
+        if (!ok) continue;
+        g_ai_profiles[g_ai_profile_count] = profile;
+        g_ai_profile_count += 1;
+    }
+}
+
+fn saveAiProfiles(allocator: std.mem.Allocator) void {
+    const path = aiProfilesPath(allocator) catch return;
+    defer allocator.free(path);
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.cwd().makePath(dir) catch return;
+    }
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    out.appendSlice(allocator, "# Phantty AI Chat profiles. Fields are hex encoded: name, base_url, api_key, model, system_prompt.\n") catch return;
+    for (g_ai_profiles[0..g_ai_profile_count]) |profile| {
+        for (0..AI_FIELD_COUNT) |i| {
+            if (i > 0) out.append(allocator, '\t') catch return;
+            appendHexField(allocator, &out, profile.fields[i][0..profile.lens[i]]) catch return;
+        }
+        out.append(allocator, '\n') catch return;
+    }
+
+    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return;
+    defer file.close();
+    file.writeAll(out.items) catch {};
+}
+
 fn sshProfilesPath(allocator: std.mem.Allocator) ![]u8 {
     if (std.process.getEnvVarOwned(allocator, "APPDATA")) |appdata| {
         defer allocator.free(appdata);
@@ -1381,8 +1807,12 @@ fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)
 }
 
 fn decodeHexField(value: []const u8, out: *[SSH_FIELD_MAX]u8) ?usize {
+    return decodeHexFieldToSlice(value, out[0..]);
+}
+
+fn decodeHexFieldToSlice(value: []const u8, out: []u8) ?usize {
     if (value.len % 2 != 0) return null;
-    const len = @min(value.len / 2, SSH_FIELD_MAX);
+    const len = @min(value.len / 2, out.len);
     var i: usize = 0;
     while (i < len) : (i += 1) {
         const hi = hexValue(value[i * 2]) orelse return null;
@@ -1405,6 +1835,14 @@ fn sessionTwoColumnWidth(left: []const u8, right: []const u8) f32 {
 }
 
 fn sessionLauncherTitle() []const u8 {
+    if (g_ai_form_visible) return "AI Chat";
+    if (g_ai_list_visible) {
+        return switch (g_ai_list_mode) {
+            .manage => "AI Chats",
+            .edit_select => "Edit AI Chat",
+            .delete_select => "Delete AI Chat",
+        };
+    }
     if (g_ssh_form_visible) return "SSH Server";
     if (g_ssh_list_visible) {
         return switch (g_ssh_list_mode) {
@@ -1417,6 +1855,14 @@ fn sessionLauncherTitle() []const u8 {
 }
 
 fn sessionLauncherHint() []const u8 {
+    if (g_ai_form_visible) return "Tab changes field, Enter connects";
+    if (g_ai_list_visible) {
+        return switch (g_ai_list_mode) {
+            .manage => "Enter opens, New/Edit/Delete manage",
+            .edit_select => "Choose a profile to edit",
+            .delete_select => "Choose a profile to delete",
+        };
+    }
     if (g_ssh_form_visible) return "Tab changes field, Enter connects";
     if (g_ssh_list_visible) {
         return switch (g_ssh_list_mode) {
@@ -1433,6 +1879,18 @@ fn sessionDesiredBoxWidth() f32 {
     const hint = sessionLauncherHint();
     var desired = @max(measureTitlebarText(title), measureTitlebarText(hint)) + 48.0;
 
+    if (g_ai_form_visible) {
+        desired = @max(desired, sessionTwoColumnWidth("Profile name", aiField(.name)));
+        desired = @max(desired, sessionTwoColumnWidth("Base URL", aiField(.base_url)));
+        desired = @max(desired, sessionTwoColumnWidth("API key", aiField(.api_key)));
+        desired = @max(desired, sessionTwoColumnWidth("Model", aiField(.model)));
+        desired = @max(desired, sessionTwoColumnWidth("System prompt", aiField(.system_prompt)));
+        desired = @max(desired, sessionTwoColumnWidth("Save & Open", "chat"));
+        desired = @max(desired, sessionTwoColumnWidth("Save", "profile"));
+        desired = @max(desired, sessionTwoColumnWidth("Cancel", "Esc"));
+        return desired;
+    }
+
     if (g_ssh_form_visible) {
         desired = @max(desired, sessionTwoColumnWidth("Server name", sshField(.name)));
         desired = @max(desired, sessionTwoColumnWidth("IP / host", sshField(.ip)));
@@ -1442,6 +1900,33 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("Save & Connect", "ssh.exe"));
         desired = @max(desired, sessionTwoColumnWidth("Save", "profile"));
         desired = @max(desired, sessionTwoColumnWidth("Cancel", "Esc"));
+        return desired;
+    }
+
+    if (g_ai_list_visible) {
+        var row: usize = 0;
+        while (row < g_ai_profile_count) : (row += 1) {
+            var detail_buf: [AI_FIELD_MAX]u8 = undefined;
+            const profile = &g_ai_profiles[row];
+            const model = aiProfileField(profile, .model);
+            const base_url = aiProfileField(profile, .base_url);
+            const detail = if (model.len > 0)
+                model
+            else
+                std.fmt.bufPrint(&detail_buf, "{s}", .{base_url}) catch "";
+            desired = @max(desired, sessionTwoColumnWidth(aiProfileField(profile, .name), detail));
+        }
+        switch (g_ai_list_mode) {
+            .manage => {
+                desired = @max(desired, sessionTwoColumnWidth("New AI Chat", "add"));
+                desired = @max(desired, sessionTwoColumnWidth("Edit AI Chat", if (g_ai_profile_count > 0) "choose" else "no profile"));
+                desired = @max(desired, sessionTwoColumnWidth("Delete AI Chat", if (g_ai_profile_count > 0) "choose" else "no profile"));
+                desired = @max(desired, sessionTwoColumnWidth("Cancel", "Esc"));
+            },
+            .edit_select, .delete_select => {
+                desired = @max(desired, sessionTwoColumnWidth("Back", "manage"));
+            },
+        }
         return desired;
     }
 
@@ -1476,18 +1961,28 @@ fn sessionDesiredBoxWidth() f32 {
     desired = @max(desired, sessionTwoColumnWidth("PowerShell", "new terminal"));
     desired = @max(desired, sessionTwoColumnWidth("SSH", "connect server"));
     desired = @max(desired, sessionTwoColumnWidth("WSL", "wsl.exe ~"));
+    desired = @max(desired, sessionTwoColumnWidth("AI Chat", "DeepSeek"));
     return desired;
 }
 
 fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) SessionLayout {
     const content_height = @max(1, window_height - top_offset);
-    const min_box_w: f32 = if (g_ssh_form_visible or g_ssh_list_visible) 460 else 360;
+    const min_box_w: f32 = if (g_ssh_form_visible or g_ssh_list_visible or g_ai_form_visible or g_ai_list_visible) 460 else 360;
     const max_box_w = @max(260.0, @min(760.0, window_width - 48.0));
     const box_w: f32 = @round(@min(@max(min_box_w, sessionDesiredBoxWidth()), max_box_w));
     const row_h = overlayRowHeight(38);
     const header_h = @round(18 + overlayLineHeight() * 2 + 12);
     const bottom_pad = @round(@max(20.0, overlayTextHeight() * 0.55));
-    const row_count: usize = if (g_ssh_form_visible) SSH_FIELD_COUNT + 3 else if (g_ssh_list_visible) sshListRowCount() else SESSION_LAUNCHER_ROW_COUNT;
+    const row_count: usize = if (g_ai_form_visible)
+        AI_FIELD_COUNT + 3
+    else if (g_ai_list_visible)
+        aiListRowCount()
+    else if (g_ssh_form_visible)
+        SSH_FIELD_COUNT + 3
+    else if (g_ssh_list_visible)
+        sshListRowCount()
+    else
+        SESSION_LAUNCHER_ROW_COUNT;
     const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(row_count)) + bottom_pad);
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
@@ -1523,13 +2018,41 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
         };
     }
 
-    if (!g_ssh_form_visible) {
+    if (g_ai_list_visible) {
+        if (row >= aiListRowCount()) return null;
+        g_ai_list_selected = row;
+        if (row < g_ai_profile_count) return .connect_ai_selected;
+        if (g_ai_list_mode != .manage) return .connect_ai_selected;
+        return switch (row - g_ai_profile_count) {
+            0 => .new_ai,
+            1 => .edit_ai_selected,
+            2 => .delete_ai_selected,
+            else => .cancel,
+        };
+    }
+
+    if (!g_ssh_form_visible and !g_ai_form_visible) {
         if (row >= SESSION_LAUNCHER_ROW_COUNT) return null;
         g_session_launcher_selected = row;
         return switch (row) {
             0 => .powershell,
             1 => .ssh,
             2 => .wsl,
+            3 => .ai_chat,
+            else => null,
+        };
+    }
+
+    if (g_ai_form_visible) {
+        if (row < AI_FIELD_COUNT) {
+            g_ai_focus = row;
+            return null;
+        }
+        g_ai_focus = row;
+        return switch (row) {
+            AI_FIELD_COUNT => .connect_ai,
+            AI_FIELD_COUNT + 1 => .save_ai,
+            AI_FIELD_COUNT + 2 => .cancel,
             else => null,
         };
     }
@@ -1576,13 +2099,21 @@ fn renderSessionRow(layout: SessionLayout, window_height: f32, row: usize, left:
 }
 
 fn renderSessionField(layout: SessionLayout, window_height: f32, row: usize, label: []const u8, value: []const u8, masked: bool) void {
-    var display_buf: [SSH_FIELD_MAX]u8 = undefined;
+    renderSessionFieldValue(layout, window_height, row, label, value, masked, g_ssh_focus == row);
+}
+
+fn renderAiSessionField(layout: SessionLayout, window_height: f32, row: usize, label: []const u8, value: []const u8, masked: bool) void {
+    renderSessionFieldValue(layout, window_height, row, label, value, masked, g_ai_focus == row);
+}
+
+fn renderSessionFieldValue(layout: SessionLayout, window_height: f32, row: usize, label: []const u8, value: []const u8, masked: bool, selected: bool) void {
+    var display_buf: [AI_FIELD_MAX]u8 = undefined;
     const display = if (masked) blk: {
         const len = @min(value.len, display_buf.len);
         @memset(display_buf[0..len], '*');
         break :blk display_buf[0..len];
     } else value;
-    renderSessionRow(layout, window_height, row, label, display, g_ssh_focus == row);
+    renderSessionRow(layout, window_height, row, label, display, selected);
 }
 
 fn renderSshProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const SshProfile, selected: bool) void {
@@ -1595,6 +2126,14 @@ fn renderSshProfileRow(layout: SessionLayout, window_height: f32, row: usize, pr
     else
         std.fmt.bufPrint(&target_buf, "{s}@{s}", .{ user, host }) catch "";
     renderSessionRow(layout, window_height, row, profileField(profile, .name), target, selected);
+}
+
+fn renderAiProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const AiProfile, selected: bool) void {
+    const name = aiProfileField(profile, .name);
+    const model = aiProfileField(profile, .model);
+    const base_url = aiProfileField(profile, .base_url);
+    const detail = if (model.len > 0) model else base_url;
+    renderSessionRow(layout, window_height, row, name, detail, selected);
 }
 
 pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: f32) void {
@@ -1628,7 +2167,28 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     renderTitlebarTextStrong(title, layout.box_x + 24, title_y, title_color);
     renderTitlebarTextStrongLimited(hint, layout.box_x + 24, hint_y, muted_color, layout.box_w - 48);
 
-    if (!g_ssh_form_visible) {
+    if (!g_ssh_form_visible and !g_ai_form_visible) {
+        if (g_ai_list_visible) {
+            var row: usize = 0;
+            while (row < g_ai_profile_count) : (row += 1) {
+                renderAiProfileRow(layout, window_height, row, &g_ai_profiles[row], g_ai_list_selected == row);
+            }
+            switch (g_ai_list_mode) {
+                .manage => {
+                    renderSessionRow(layout, window_height, row, "New AI Chat", "add", g_ai_list_selected == row);
+                    row += 1;
+                    renderSessionRow(layout, window_height, row, "Edit AI Chat", if (g_ai_profile_count > 0) "choose" else "no profile", g_ai_list_selected == row);
+                    row += 1;
+                    renderSessionRow(layout, window_height, row, "Delete AI Chat", if (g_ai_profile_count > 0) "choose" else "no profile", g_ai_list_selected == row);
+                    row += 1;
+                    renderSessionRow(layout, window_height, row, "Cancel", "Esc", g_ai_list_selected == row);
+                },
+                .edit_select, .delete_select => {
+                    renderSessionRow(layout, window_height, row, "Back", "manage", g_ai_list_selected == row);
+                },
+            }
+            return;
+        }
         if (g_ssh_list_visible) {
             var row: usize = 0;
             while (row < g_ssh_profile_count) : (row += 1) {
@@ -1653,6 +2213,19 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderSessionRow(layout, window_height, 0, "PowerShell", "new terminal", g_session_launcher_selected == 0);
         renderSessionRow(layout, window_height, 1, "SSH", "connect server", g_session_launcher_selected == 1);
         renderSessionRow(layout, window_height, 2, "WSL", "wsl.exe ~", g_session_launcher_selected == 2);
+        renderSessionRow(layout, window_height, 3, "AI Chat", "DeepSeek", g_session_launcher_selected == 3);
+        return;
+    }
+
+    if (g_ai_form_visible) {
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.name), "Profile name", aiField(.name), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.base_url), "Base URL", aiField(.base_url), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.api_key), "API key", aiField(.api_key), true);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.model), "Model", aiField(.model), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.system_prompt), "System prompt", aiField(.system_prompt), false);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save & Open", "chat", g_ai_focus == AI_FIELD_COUNT);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save", "profile", g_ai_focus == AI_FIELD_COUNT + 1);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Cancel", "Esc", g_ai_focus == AI_FIELD_COUNT + 2);
         return;
     }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -860,7 +860,7 @@ const SSH_FIELD_COUNT = 5;
 const SSH_FIELD_MAX = 128;
 const SSH_PROFILE_MAX = 16;
 const SSH_PROFILE_NONE = std.math.maxInt(usize);
-const AI_FIELD_COUNT = 5;
+const AI_FIELD_COUNT = 8;
 const AI_FIELD_MAX = 512;
 const AI_PROFILE_MAX = 16;
 const AI_PROFILE_NONE = std.math.maxInt(usize);
@@ -880,6 +880,9 @@ const AiField = enum(usize) {
     api_key = 2,
     model = 3,
     system_prompt = 4,
+    thinking = 5,
+    reasoning_effort = 6,
+    stream = 7,
 };
 
 const SessionAction = enum {
@@ -1465,12 +1468,22 @@ fn setAiDefault(field: AiField, value: []const u8) void {
     g_ai_lens[idx] = len;
 }
 
+fn setProfileDefault(profile: *AiProfile, field: AiField, value: []const u8) void {
+    const idx: usize = @intFromEnum(field);
+    const len = @min(value.len, AI_FIELD_MAX);
+    @memcpy(profile.fields[idx][0..len], value[0..len]);
+    profile.lens[idx] = len;
+}
+
 fn clearAiForm() void {
     g_ai_lens = .{0} ** AI_FIELD_COUNT;
     setAiDefault(.name, AppWindow.ai_chat.DEFAULT_NAME);
     setAiDefault(.base_url, AppWindow.ai_chat.DEFAULT_BASE_URL);
     setAiDefault(.model, AppWindow.ai_chat.DEFAULT_MODEL);
     setAiDefault(.system_prompt, AppWindow.ai_chat.DEFAULT_SYSTEM_PROMPT);
+    setAiDefault(.thinking, AppWindow.ai_chat.DEFAULT_THINKING);
+    setAiDefault(.reasoning_effort, AppWindow.ai_chat.DEFAULT_REASONING_EFFORT);
+    setAiDefault(.stream, AppWindow.ai_chat.DEFAULT_STREAM);
 }
 
 fn appendAiFormCodepoint(field: usize, codepoint: u21) void {
@@ -1653,11 +1666,14 @@ fn connectAiProfile(idx: usize) void {
     const api_key = aiProfileField(profile, .api_key);
     const model = aiProfileField(profile, .model);
     const system_prompt = aiProfileField(profile, .system_prompt);
+    const thinking = aiProfileField(profile, .thinking);
+    const reasoning_effort = aiProfileField(profile, .reasoning_effort);
+    const stream_val = aiProfileField(profile, .stream);
     if (base_url.len == 0 or model.len == 0) return;
     if (!isHttpUrlish(base_url)) return;
 
     sessionLauncherClose();
-    _ = AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt);
+    _ = AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val);
 }
 
 fn isHttpUrlish(value: []const u8) bool {
@@ -1692,17 +1708,17 @@ fn loadAiProfiles() void {
         var field_idx: usize = 0;
         var ok = true;
         while (field_idx < AI_FIELD_COUNT) : (field_idx += 1) {
-            const part = parts.next() orelse {
-                ok = false;
-                break;
-            };
+            const part = parts.next() orelse break;
             const decoded = decodeHexFieldToSlice(part, profile.fields[field_idx][0..]) orelse {
                 ok = false;
                 break;
             };
             profile.lens[field_idx] = decoded;
         }
-        if (!ok) continue;
+        if (!ok or field_idx < 5) continue;
+        if (profile.lens[@intFromEnum(AiField.thinking)] == 0) setProfileDefault(&profile, .thinking, AppWindow.ai_chat.DEFAULT_THINKING);
+        if (profile.lens[@intFromEnum(AiField.reasoning_effort)] == 0) setProfileDefault(&profile, .reasoning_effort, AppWindow.ai_chat.DEFAULT_REASONING_EFFORT);
+        if (profile.lens[@intFromEnum(AiField.stream)] == 0) setProfileDefault(&profile, .stream, AppWindow.ai_chat.DEFAULT_STREAM);
         g_ai_profiles[g_ai_profile_count] = profile;
         g_ai_profile_count += 1;
     }
@@ -1717,7 +1733,7 @@ fn saveAiProfiles(allocator: std.mem.Allocator) void {
 
     var out: std.ArrayListUnmanaged(u8) = .empty;
     defer out.deinit(allocator);
-    out.appendSlice(allocator, "# Phantty AI Chat profiles. Fields are hex encoded: name, base_url, api_key, model, system_prompt.\n") catch return;
+    out.appendSlice(allocator, "# Phantty AI Chat profiles. Fields are hex encoded: name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream.\n") catch return;
     for (g_ai_profiles[0..g_ai_profile_count]) |profile| {
         for (0..AI_FIELD_COUNT) |i| {
             if (i > 0) out.append(allocator, '\t') catch return;
@@ -1884,7 +1900,10 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("Base URL", aiField(.base_url)));
         desired = @max(desired, sessionTwoColumnWidth("API key", aiField(.api_key)));
         desired = @max(desired, sessionTwoColumnWidth("Model", aiField(.model)));
-        desired = @max(desired, sessionTwoColumnWidth("System prompt", aiField(.system_prompt)));
+        desired = @max(desired, sessionTwoColumnWidth("System", aiField(.system_prompt)));
+        desired = @max(desired, sessionTwoColumnWidth("Thinking", aiField(.thinking)));
+        desired = @max(desired, sessionTwoColumnWidth("Effort", aiField(.reasoning_effort)));
+        desired = @max(desired, sessionTwoColumnWidth("Stream", aiField(.stream)));
         desired = @max(desired, sessionTwoColumnWidth("Save & Open", "chat"));
         desired = @max(desired, sessionTwoColumnWidth("Save", "profile"));
         desired = @max(desired, sessionTwoColumnWidth("Cancel", "Esc"));
@@ -2222,7 +2241,10 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.base_url), "Base URL", aiField(.base_url), false);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.api_key), "API key", aiField(.api_key), true);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.model), "Model", aiField(.model), false);
-        renderAiSessionField(layout, window_height, @intFromEnum(AiField.system_prompt), "System prompt", aiField(.system_prompt), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.system_prompt), "System", aiField(.system_prompt), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.thinking), "Thinking", aiField(.thinking), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.reasoning_effort), "Effort", aiField(.reasoning_effort), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.stream), "Stream", aiField(.stream), false);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save & Open", "chat", g_ai_focus == AI_FIELD_COUNT);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save", "profile", g_ai_focus == AI_FIELD_COUNT + 1);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Cancel", "Esc", g_ai_focus == AI_FIELD_COUNT + 2);

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -2,6 +2,7 @@
 //! Run with: zig build test
 
 comptime {
+    _ = @import("ai_chat.zig");
     _ = @import("scp.zig");
     _ = @import("browser_panel.zig");
     _ = @import("browser_url.zig");


### PR DESCRIPTION
## Summary
- Add an AI Chat tab/profile flow with OpenAI-compatible DeepSeek defaults.
- Replace curl.exe transport with Zig std.http.Client and support configurable thinking, reasoning_effort, and stream options.
- Improve AI Chat rendering, IME positioning, and stream responses into the UI incrementally.

## Test plan
- zig build test
- zig build compiled, but install can fail if an existing phantty.exe is running and locks zig-out/bin/phantty.exe.

Made with [Cursor](https://cursor.com)