### PR TITLE
Add AI Chat agent tools

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Phantty — A Windows terminal, powered by Ghostty</title>
-  <meta name="description" content="Phantty is a fast, modern Windows-only terminal emulator written in Zig and powered by libghostty-vt. Splits, tabs, themes, background images, embedded browser, and more.">
+  <meta name="description" content="Phantty is a fast, modern Windows-only terminal emulator written in Zig and powered by libghostty-vt. Splits, tabs, AI agent tools, themes, embedded browser, and more.">
   <meta property="og:title" content="Phantty — A Windows terminal, powered by Ghostty">
   <meta property="og:description" content="A fast, modern Windows-only terminal emulator written in Zig, powered by libghostty-vt.">
   <meta property="og:image" content="assets/phantty.png">
@@ -83,7 +83,7 @@ nothing to commit, working tree clean
     <section id="features" class="section">
       <div class="container">
         <h2>Built for daily Windows work</h2>
-        <p class="section-lead">Phantty layers practical features on top of Ghostty's terminal core — splits, tabs, an embedded browser, a file explorer, themes, background images, and an opt-in remote-access client.</p>
+        <p class="section-lead">Phantty layers practical features on top of Ghostty's terminal core — splits, tabs, AI agent tools, an embedded browser, a file explorer, themes, background images, and an opt-in remote-access client.</p>
         <div class="feature-grid">
           <div class="feature">
             <h3>Ghostty's emulation</h3>
@@ -96,6 +96,10 @@ nothing to commit, working tree clean
           <div class="feature">
             <h3>Splits &amp; tabs</h3>
             <p>Vertical/horizontal splits, tab strip, focus-follows-mouse, equalize sizes, spatial focus movement.</p>
+          </div>
+          <div class="feature">
+            <h3>AI agent tabs</h3>
+            <p>Chat tabs can act as local agents: read terminal snapshots, run PowerShell, and type into opened SSH sessions with an approval card.</p>
           </div>
           <div class="feature">
             <h3>453 themes built-in</h3>
@@ -188,7 +192,12 @@ background-image-mode  = fill
 # Opt-in remote access (disabled by default)
 remote-enabled         = false
 remote-server-url      = https://remote.example.com
-remote-device-name     = Workstation</code></pre>
+remote-device-name     = Workstation
+
+# AI Chat agent tools
+ai-agent-enabled       = true
+ai-agent-permission    = confirm   # confirm | full
+ai-agent-output-limit  = 16384</code></pre>
         <p class="section-foot">Run <code>phantty.exe --help</code> for the full flag list, or <code>phantty.exe --show-config-path</code> to print the resolved config path.</p>
       </div>
     </section>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Phantty — 由 Ghostty 驱动的 Windows 终端</title>
-  <meta name="description" content="Phantty 是一款用 Zig 编写、由 libghostty-vt 驱动的现代 Windows 终端模拟器。支持分屏、标签、主题、背景图、内嵌浏览器等。">
+  <meta name="description" content="Phantty 是一款用 Zig 编写、由 libghostty-vt 驱动的现代 Windows 终端模拟器。支持分屏、标签、AI Agent 工具、主题、背景图、内嵌浏览器等。">
   <meta property="og:title" content="Phantty — 由 Ghostty 驱动的 Windows 终端">
   <meta property="og:description" content="一款用 Zig 编写、由 libghostty-vt 驱动的现代 Windows 终端模拟器。">
   <meta property="og:image" content="assets/phantty.png">
@@ -83,7 +83,7 @@
     <section id="features" class="section">
       <div class="container">
         <h2>为日常 Windows 工作而生</h2>
-        <p class="section-lead">Phantty 在 Ghostty 的终端核心之上叠加了实用功能：分屏、标签、内嵌浏览器、文件浏览器、主题、背景图，以及可选的远程访问客户端。</p>
+        <p class="section-lead">Phantty 在 Ghostty 的终端核心之上叠加了实用功能：分屏、标签、AI Agent 工具、内嵌浏览器、文件浏览器、主题、背景图，以及可选的远程访问客户端。</p>
         <div class="feature-grid">
           <div class="feature">
             <h3>Ghostty 模拟内核</h3>
@@ -96,6 +96,10 @@
           <div class="feature">
             <h3>分屏与标签</h3>
             <p>横竖分屏、标签栏、焦点跟随鼠标、均分尺寸、空间方向焦点切换。</p>
+          </div>
+          <div class="feature">
+            <h3>AI Agent 标签</h3>
+            <p>AI Chat 可以变成桌面 Agent：读取终端快照、运行本地 PowerShell，并在确认后向已打开的 SSH 会话输入命令。</p>
           </div>
           <div class="feature">
             <h3>内置 453 款主题</h3>
@@ -188,7 +192,12 @@ background-image-mode  = fill
 # 可选的远程访问（默认关闭）
 remote-enabled         = false
 remote-server-url      = https://remote.example.com
-remote-device-name     = Workstation</code></pre>
+remote-device-name     = Workstation
+
+# AI Chat Agent 工具
+ai-agent-enabled       = true
+ai-agent-permission    = confirm   # confirm | full
+ai-agent-output-limit  = 16384</code></pre>
         <p class="section-foot">运行 <code>phantty.exe --help</code> 查看完整参数列表，或 <code>phantty.exe --show-config-path</code> 打印解析后的配置路径。</p>
       </div>
     </section>

--- a/src/App.zig
+++ b/src/App.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const Config = @import("config.zig");
 const AppWindow = @import("AppWindow.zig");
+const ai_chat = @import("ai_chat.zig");
 const directwrite = @import("directwrite.zig");
 const win32_backend = @import("apprt/win32.zig");
 const remote = @import("remote_client.zig");
@@ -66,6 +67,12 @@ remote_server_url: ?[]const u8,
 remote_server_fingerprint: ?[]const u8,
 remote_device_name: ?[]const u8,
 remote_client: ?*remote.Client,
+
+// AI agent config
+ai_agent_enabled: bool,
+ai_agent_permission: ai_chat.AgentPermission,
+ai_agent_command_timeout_ms: u32,
+ai_agent_output_limit: u32,
 
 // Session persistence
 restore_tabs_on_startup: bool,
@@ -154,6 +161,10 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .remote_server_fingerprint = remote_server_fingerprint,
         .remote_device_name = remote_device_name,
         .remote_client = remote_client_ptr,
+        .ai_agent_enabled = cfg.@"ai-agent-enabled",
+        .ai_agent_permission = cfg.@"ai-agent-permission",
+        .ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
+        .ai_agent_output_limit = cfg.@"ai-agent-output-limit",
         .restore_tabs_on_startup = cfg.@"restore-tabs-on-startup",
         .windows = .empty,
         .mutex = .{},
@@ -279,6 +290,10 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.replaceOptStr(&self.remote_server_fingerprint, cfg.@"remote-server-fingerprint");
     self.replaceOptStr(&self.remote_device_name, cfg.@"remote-device-name");
     self.replaceOptStr(&self.title, cfg.title);
+    self.ai_agent_enabled = cfg.@"ai-agent-enabled";
+    self.ai_agent_permission = cfg.@"ai-agent-permission";
+    self.ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms";
+    self.ai_agent_output_limit = cfg.@"ai-agent-output-limit";
     self.restore_tabs_on_startup = cfg.@"restore-tabs-on-startup";
 }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -83,6 +83,18 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
 
     tab.g_scrollback_limit = app.scrollback_limit;
     tab.g_remote_client = app.remote_client;
+    ai_chat.configureAgent(.{
+        .enabled = app.ai_agent_enabled,
+        .permission = app.ai_agent_permission,
+        .command_timeout_ms = app.ai_agent_command_timeout_ms,
+        .output_limit = app.ai_agent_output_limit,
+    });
+    ai_chat.setToolHost(.{
+        .ctx = @ptrCast(app),
+        .collectSnapshot = collectAgentToolSnapshot,
+        .surfaceSnapshot = agentSurfaceSnapshot,
+        .writeSurface = agentWriteSurface,
+    });
 
     // Copy shell command from App
     @memcpy(tab.g_shell_cmd_buf[0..app.shell_cmd_len], app.shell_cmd_buf[0..app.shell_cmd_len]);
@@ -393,9 +405,10 @@ pub fn spawnAiChatTab(
     thinking: []const u8,
     reasoning_effort: []const u8,
     stream_val: []const u8,
+    agent_val: []const u8,
 ) bool {
     const allocator = g_allocator orelse return false;
-    if (!tab.spawnAiChatTab(allocator, name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val)) return false;
+    if (!tab.spawnAiChatTab(allocator, name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val, agent_val)) return false;
     clearUiStateOnTabChange();
     return true;
 }
@@ -765,6 +778,12 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     if (g_app) |app| {
         app.updateConfig(cfg);
     }
+    ai_chat.configureAgent(.{
+        .enabled = cfg.@"ai-agent-enabled",
+        .permission = cfg.@"ai-agent-permission",
+        .command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
+        .output_limit = cfg.@"ai-agent-output-limit",
+    });
 
     if (g_window == null) return;
     const ft_lib = font.g_ft_lib orelse return;
@@ -1005,6 +1024,52 @@ fn buildRemoteSurfaceSnapshot(allocator: std.mem.Allocator, surface: *Surface) !
     }
 
     return out.toOwnedSlice(allocator);
+}
+
+fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!ai_chat.ToolSnapshot {
+    _ = ctx;
+    var surfaces: std.ArrayListUnmanaged(ai_chat.ToolSurface) = .empty;
+    errdefer {
+        for (surfaces.items) |surface| surface.deinit(allocator);
+        surfaces.deinit(allocator);
+    }
+
+    for (0..tab.g_tab_count) |tab_index| {
+        const tab_state = tab.g_tabs[tab_index] orelse continue;
+        if (tab_state.kind != .terminal) continue;
+        var it = tab_state.tree.iterator();
+        while (it.next()) |entry| {
+            const surface = entry.surface;
+            try surfaces.append(allocator, .{
+                .id = try allocator.dupe(u8, surface.remote_id[0..]),
+                .title = try allocator.dupe(u8, surface.getTitle()),
+                .cwd = try allocator.dupe(u8, surface.getCwd() orelse surface.getInitialCwd() orelse ""),
+                .snapshot = buildRemoteSurfaceSnapshot(allocator, surface) catch try allocator.dupe(u8, ""),
+                .tab_index = tab_index,
+                .focused = tab_index == tab.g_active_tab and entry.handle == tab_state.focused,
+                .is_ssh = surface.launch_kind == .ssh and surface.ssh_connection != null,
+                .ptr = @ptrCast(surface),
+            });
+        }
+    }
+
+    return .{
+        .surfaces = try surfaces.toOwnedSlice(allocator),
+        .active_tab = tab.g_active_tab,
+    };
+}
+
+fn agentSurfaceSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator, surface_ptr: *anyopaque) anyerror![]u8 {
+    _ = ctx;
+    const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
+    return buildRemoteSurfaceSnapshot(allocator, surface);
+}
+
+fn agentWriteSurface(ctx: *anyopaque, surface_ptr: *anyopaque, data: []const u8) bool {
+    _ = ctx;
+    const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
+    surface.queuePtyWrite(data);
+    return true;
 }
 
 fn uiFontSize(term_font_size: u32) u32 {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -14,15 +14,22 @@ pub const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
 pub const DEFAULT_THINKING = "enabled";
 pub const DEFAULT_REASONING_EFFORT = "high";
 pub const DEFAULT_STREAM = "false";
+pub const DEFAULT_AGENT = "false";
+
+const MAX_AGENT_ITERATIONS = 12;
+const DEFAULT_AGENT_TIMEOUT_MS: u32 = 60_000;
+const DEFAULT_AGENT_OUTPUT_LIMIT: u32 = 16 * 1024;
 
 pub const Role = enum {
     user,
     assistant,
+    tool,
 
     pub fn label(self: Role) []const u8 {
         return switch (self) {
             .user => "You",
             .assistant => "AI",
+            .tool => "Tool",
         };
     }
 
@@ -30,6 +37,7 @@ pub const Role = enum {
         return switch (self) {
             .user => "user",
             .assistant => "assistant",
+            .tool => "tool",
         };
     }
 };
@@ -43,6 +51,89 @@ pub const Message = struct {
 const RequestMessage = struct {
     role: Role,
     content: []u8,
+    tool_call_id: ?[]u8 = null,
+    tool_calls: ?[]ToolCall = null,
+
+    fn deinit(self: RequestMessage, allocator: std.mem.Allocator) void {
+        allocator.free(self.content);
+        if (self.tool_call_id) |id| allocator.free(id);
+        if (self.tool_calls) |calls| {
+            for (calls) |call| call.deinit(allocator);
+            allocator.free(calls);
+        }
+    }
+};
+
+const ToolCall = struct {
+    id: []u8,
+    name: []u8,
+    arguments: []u8,
+
+    fn deinit(self: ToolCall, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.name);
+        allocator.free(self.arguments);
+    }
+};
+
+pub const AgentPermission = enum {
+    confirm,
+    full,
+
+    pub fn parse(value: []const u8) ?AgentPermission {
+        if (std.mem.eql(u8, value, "confirm")) return .confirm;
+        if (std.mem.eql(u8, value, "full") or std.mem.eql(u8, value, "full-permission")) return .full;
+        return null;
+    }
+
+    pub fn name(self: AgentPermission) []const u8 {
+        return switch (self) {
+            .confirm => "confirm",
+            .full => "full",
+        };
+    }
+};
+
+pub const AgentSettings = struct {
+    enabled: bool = false,
+    permission: AgentPermission = .confirm,
+    command_timeout_ms: u32 = DEFAULT_AGENT_TIMEOUT_MS,
+    output_limit: u32 = DEFAULT_AGENT_OUTPUT_LIMIT,
+};
+
+pub const ToolSurface = struct {
+    id: []u8,
+    title: []u8,
+    cwd: []u8,
+    snapshot: []u8,
+    tab_index: usize,
+    focused: bool,
+    is_ssh: bool,
+    ptr: *anyopaque,
+
+    pub fn deinit(self: ToolSurface, allocator: std.mem.Allocator) void {
+        allocator.free(self.id);
+        allocator.free(self.title);
+        allocator.free(self.cwd);
+        allocator.free(self.snapshot);
+    }
+};
+
+pub const ToolSnapshot = struct {
+    surfaces: []ToolSurface,
+    active_tab: usize,
+
+    pub fn deinit(self: ToolSnapshot, allocator: std.mem.Allocator) void {
+        for (self.surfaces) |surface| surface.deinit(allocator);
+        allocator.free(self.surfaces);
+    }
+};
+
+pub const ToolHost = struct {
+    ctx: *anyopaque,
+    collectSnapshot: *const fn (*anyopaque, std.mem.Allocator) anyerror!ToolSnapshot,
+    surfaceSnapshot: *const fn (*anyopaque, std.mem.Allocator, *anyopaque) anyerror![]u8,
+    writeSurface: *const fn (*anyopaque, *anyopaque, []const u8) bool,
 };
 
 const ChatRequest = struct {
@@ -56,6 +147,9 @@ const ChatRequest = struct {
     thinking_enabled: bool,
     reasoning_effort: []u8,
     stream: bool,
+    agent_enabled: bool,
+    tool_host: ?ToolHost,
+    tool_snapshot: ?ToolSnapshot,
 
     fn deinit(self: *ChatRequest) void {
         self.allocator.free(self.base_url);
@@ -63,8 +157,9 @@ const ChatRequest = struct {
         self.allocator.free(self.model);
         self.allocator.free(self.system_prompt);
         self.allocator.free(self.reasoning_effort);
-        for (self.messages) |msg| self.allocator.free(msg.content);
+        for (self.messages) |msg| msg.deinit(self.allocator);
         self.allocator.free(self.messages);
+        if (self.tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
         self.allocator.destroy(self);
     }
 };
@@ -72,12 +167,45 @@ const ChatRequest = struct {
 const ApiResult = struct {
     content: []u8,
     reasoning: ?[]u8 = null,
+    tool_calls: ?[]ToolCall = null,
 
     fn deinit(self: ApiResult, allocator: std.mem.Allocator) void {
         allocator.free(self.content);
         if (self.reasoning) |reasoning| allocator.free(reasoning);
+        if (self.tool_calls) |calls| {
+            for (calls) |call| call.deinit(allocator);
+            allocator.free(calls);
+        }
     }
 };
+
+var g_agent_mutex: std.Thread.Mutex = .{};
+var g_agent_settings: AgentSettings = .{};
+var g_tool_host: ?ToolHost = null;
+
+pub fn configureAgent(settings: AgentSettings) void {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    g_agent_settings = settings;
+}
+
+pub fn setToolHost(host: ?ToolHost) void {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    g_tool_host = host;
+}
+
+fn currentAgentSettings() AgentSettings {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    return g_agent_settings;
+}
+
+fn currentToolHost() ?ToolHost {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    return g_tool_host;
+}
 
 pub const Session = struct {
     allocator: std.mem.Allocator,
@@ -101,6 +229,7 @@ pub const Session = struct {
     reasoning_effort_buf: [16]u8 = undefined,
     reasoning_effort_len: usize = 0,
     stream: bool = false,
+    agent_enabled: bool = false,
     request_inflight: bool = false,
     request_thread: ?std.Thread = null,
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -120,6 +249,7 @@ pub const Session = struct {
         thinking: []const u8,
         reasoning_effort: []const u8,
         stream_val: []const u8,
+        agent_val: []const u8,
     ) !*Session {
         const session = try allocator.create(Session);
         session.* = .{
@@ -132,6 +262,7 @@ pub const Session = struct {
         session.thinking_enabled = !std.mem.eql(u8, thinking, "disabled");
         session.copyReasoningEffort(if (reasoning_effort.len > 0) reasoning_effort else DEFAULT_REASONING_EFFORT);
         session.stream = std.mem.eql(u8, stream_val, "true");
+        session.agent_enabled = std.mem.eql(u8, agent_val, "true") or std.mem.eql(u8, agent_val, "enabled");
         session.copyApiKey(api_key);
         if (session.api_key_len == 0 and isDeepSeekBaseUrl(session.baseUrl())) {
             if (std.process.getEnvVarOwned(allocator, "DEEPSEEK_API_KEY")) |env_key| {
@@ -332,21 +463,36 @@ pub const Session = struct {
         const req = try self.allocator.create(ChatRequest);
         errdefer self.allocator.destroy(req);
 
-        const messages = try self.allocator.alloc(RequestMessage, self.messages.items.len);
+        var visible_count: usize = 0;
+        for (self.messages.items) |msg| {
+            if (msg.role != .tool) visible_count += 1;
+        }
+
+        const messages = try self.allocator.alloc(RequestMessage, visible_count);
         errdefer self.allocator.free(messages);
 
         var written: usize = 0;
         errdefer {
-            for (messages[0..written]) |msg| self.allocator.free(msg.content);
+            for (messages[0..written]) |msg| msg.deinit(self.allocator);
         }
 
-        for (self.messages.items, 0..) |msg, i| {
-            messages[i] = .{
+        for (self.messages.items) |msg| {
+            if (msg.role == .tool) continue;
+            messages[written] = .{
                 .role = msg.role,
                 .content = try self.allocator.dupe(u8, msg.content),
             };
             written += 1;
         }
+
+        const settings = currentAgentSettings();
+        const agent_enabled = self.agent_enabled or settings.enabled;
+        const tool_host = if (agent_enabled) currentToolHost() else null;
+        var tool_snapshot: ?ToolSnapshot = null;
+        if (tool_host) |host| {
+            tool_snapshot = host.collectSnapshot(host.ctx, self.allocator) catch null;
+        }
+        errdefer if (tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
 
         req.* = .{
             .allocator = self.allocator,
@@ -358,7 +504,10 @@ pub const Session = struct {
             .messages = messages,
             .thinking_enabled = self.thinking_enabled,
             .reasoning_effort = try self.allocator.dupe(u8, self.reasoningEffort()),
-            .stream = self.stream,
+            .stream = self.stream and !agent_enabled,
+            .agent_enabled = agent_enabled,
+            .tool_host = tool_host,
+            .tool_snapshot = tool_snapshot,
         };
         return req;
     }
@@ -409,6 +558,16 @@ fn requestThreadMain(request: *ChatRequest) void {
     const allocator = request.allocator;
     defer request.deinit();
 
+    if (request.agent_enabled) {
+        const result = runAgentRequest(request) catch |err| blk: {
+            const text = std.fmt.allocPrint(allocator, "Agent request failed: {}", .{err}) catch return;
+            break :blk ApiResult{ .content = text };
+        };
+        defer result.deinit(allocator);
+        appendAssistantResult(request.session, result);
+        return;
+    }
+
     if (request.stream) {
         runChatRequestStreaming(request) catch |err| {
             const text = std.fmt.allocPrint(allocator, "AI stream failed: {}", .{err}) catch return;
@@ -425,6 +584,81 @@ fn requestThreadMain(request: *ChatRequest) void {
     defer result.deinit(allocator);
 
     appendAssistantResult(request.session, result);
+}
+
+fn runAgentRequest(request: *const ChatRequest) !ApiResult {
+    var transcript: std.ArrayListUnmanaged(RequestMessage) = .empty;
+    defer {
+        for (transcript.items) |msg| msg.deinit(request.allocator);
+        transcript.deinit(request.allocator);
+    }
+
+    for (request.messages) |msg| {
+        try transcript.append(request.allocator, try cloneRequestMessage(request.allocator, msg));
+    }
+
+    for (0..MAX_AGENT_ITERATIONS) |_| {
+        if (request.session.closing.load(.acquire)) return error.Closing;
+        const result = try runChatRequestForMessages(request, transcript.items, true);
+        if (result.tool_calls == null or result.tool_calls.?.len == 0) return result;
+
+        if (result.content.len > 0) {
+            appendProgressMessage(request.session, result.content) catch {};
+        }
+
+        try transcript.append(request.allocator, try assistantToolCallMessage(request.allocator, result.content, result.tool_calls.?));
+        for (result.tool_calls.?) |call| {
+            const progress = try std.fmt.allocPrint(request.allocator, "running {s} {s}", .{ call.name, call.arguments });
+            defer request.allocator.free(progress);
+            appendProgressMessage(request.session, progress) catch {};
+
+            const tool_result = try executeToolCall(request, call);
+            defer request.allocator.free(tool_result);
+            try transcript.append(request.allocator, .{
+                .role = .tool,
+                .content = try request.allocator.dupe(u8, tool_result),
+                .tool_call_id = try request.allocator.dupe(u8, call.id),
+            });
+        }
+        result.deinit(request.allocator);
+    }
+
+    return ApiResult{ .content = try request.allocator.dupe(u8, "Agent stopped after reaching the max tool-iteration limit.") };
+}
+
+fn cloneRequestMessage(allocator: std.mem.Allocator, msg: RequestMessage) !RequestMessage {
+    return .{
+        .role = msg.role,
+        .content = try allocator.dupe(u8, msg.content),
+        .tool_call_id = if (msg.tool_call_id) |id| try allocator.dupe(u8, id) else null,
+        .tool_calls = if (msg.tool_calls) |calls| try cloneToolCalls(allocator, calls) else null,
+    };
+}
+
+fn cloneToolCalls(allocator: std.mem.Allocator, calls: []const ToolCall) ![]ToolCall {
+    const out = try allocator.alloc(ToolCall, calls.len);
+    errdefer allocator.free(out);
+    var written: usize = 0;
+    errdefer {
+        for (out[0..written]) |call| call.deinit(allocator);
+    }
+    for (calls, 0..) |call, i| {
+        out[i] = .{
+            .id = try allocator.dupe(u8, call.id),
+            .name = try allocator.dupe(u8, call.name),
+            .arguments = try allocator.dupe(u8, call.arguments),
+        };
+        written += 1;
+    }
+    return out;
+}
+
+fn assistantToolCallMessage(allocator: std.mem.Allocator, content: []const u8, calls: []const ToolCall) !RequestMessage {
+    return .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, content),
+        .tool_calls = try cloneToolCalls(allocator, calls),
+    };
 }
 
 fn appendAssistantResult(session: *Session, result: ApiResult) void {
@@ -458,6 +692,24 @@ fn appendAssistantResult(session: *Session, result: ApiResult) void {
     session.request_inflight = false;
     session.scroll_px = 1_000_000;
     session.setStatusLocked("Ready");
+}
+
+fn appendProgressMessage(session: *Session, text: []const u8) !void {
+    if (session.closing.load(.acquire)) return error.Closing;
+    const allocator = session.allocator;
+    const content = try allocator.dupe(u8, text);
+    errdefer allocator.free(content);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return error.Closing;
+    try session.messages.append(allocator, .{
+        .role = .tool,
+        .content = content,
+        .reasoning = null,
+    });
+    session.scroll_px = 1_000_000;
+    session.setStatusLocked("Running tools...");
 }
 
 fn beginAssistantStream(session: *Session) !usize {
@@ -539,11 +791,15 @@ fn failAssistantStream(session: *Session, message_idx: ?usize, text: []const u8)
 }
 
 fn runChatRequest(request: *const ChatRequest) !ApiResult {
+    return runChatRequestForMessages(request, request.messages, request.agent_enabled);
+}
+
+fn runChatRequestForMessages(request: *const ChatRequest, messages: []const RequestMessage, include_tools: bool) !ApiResult {
     const allocator = request.allocator;
     const endpoint = try chatEndpoint(allocator, request.base_url);
     defer allocator.free(endpoint);
 
-    const body = try buildRequestJson(allocator, request);
+    const body = try buildRequestJsonForMessages(allocator, request, messages, include_tools);
     defer allocator.free(body);
 
     const bearer = try std.fmt.allocPrint(allocator, "Bearer {s}", .{request.api_key});
@@ -662,6 +918,15 @@ fn chatEndpoint(allocator: std.mem.Allocator, base_url_raw: []const u8) ![]u8 {
 }
 
 fn buildRequestJson(allocator: std.mem.Allocator, request: *const ChatRequest) ![]u8 {
+    return buildRequestJsonForMessages(allocator, request, request.messages, request.agent_enabled);
+}
+
+fn buildRequestJsonForMessages(
+    allocator: std.mem.Allocator,
+    request: *const ChatRequest,
+    messages: []const RequestMessage,
+    include_tools: bool,
+) ![]u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
 
@@ -672,14 +937,34 @@ fn buildRequestJson(allocator: std.mem.Allocator, request: *const ChatRequest) !
         try out.appendSlice(allocator, "{\"role\":\"system\",\"content\":");
         try appendJsonString(allocator, &out, request.system_prompt);
         try out.append(allocator, '}');
-        if (request.messages.len > 0) try out.append(allocator, ',');
+        if (messages.len > 0) try out.append(allocator, ',');
     }
-    for (request.messages, 0..) |msg, i| {
+    for (messages, 0..) |msg, i| {
         if (i > 0) try out.append(allocator, ',');
         try out.appendSlice(allocator, "{\"role\":");
         try appendJsonString(allocator, &out, msg.role.apiName());
         try out.appendSlice(allocator, ",\"content\":");
         try appendJsonString(allocator, &out, msg.content);
+        if (msg.role == .tool) {
+            if (msg.tool_call_id) |id| {
+                try out.appendSlice(allocator, ",\"tool_call_id\":");
+                try appendJsonString(allocator, &out, id);
+            }
+        }
+        if (msg.tool_calls) |calls| {
+            try out.appendSlice(allocator, ",\"tool_calls\":[");
+            for (calls, 0..) |call, call_i| {
+                if (call_i > 0) try out.append(allocator, ',');
+                try out.appendSlice(allocator, "{\"id\":");
+                try appendJsonString(allocator, &out, call.id);
+                try out.appendSlice(allocator, ",\"type\":\"function\",\"function\":{\"name\":");
+                try appendJsonString(allocator, &out, call.name);
+                try out.appendSlice(allocator, ",\"arguments\":");
+                try appendJsonString(allocator, &out, call.arguments);
+                try out.appendSlice(allocator, "}}");
+            }
+            try out.append(allocator, ']');
+        }
         try out.append(allocator, '}');
     }
     try out.appendSlice(allocator, "],\"thinking\":{\"type\":");
@@ -688,9 +973,261 @@ fn buildRequestJson(allocator: std.mem.Allocator, request: *const ChatRequest) !
     try appendJsonString(allocator, &out, if (request.reasoning_effort.len > 0) request.reasoning_effort else "high");
     try out.appendSlice(allocator, ",\"stream\":");
     try out.appendSlice(allocator, if (request.stream) "true" else "false");
+    if (include_tools) {
+        try appendToolSchemas(allocator, &out);
+    }
     try out.append(allocator, '}');
 
     return out.toOwnedSlice(allocator);
+}
+
+fn appendToolSchemas(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+    try out.appendSlice(allocator, ",\"tools\":[");
+    try out.appendSlice(allocator, toolSchema("terminal_list", "List Phantty terminal surfaces visible to the agent.", "{}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, toolSchema("terminal_snapshot", "Read a bounded text snapshot from one terminal surface or all surfaces.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Optional surface id from terminal_list.\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, toolSchema("powershell_exec", "Run a local PowerShell command on Windows and return stdout, stderr, and exit status.", "{\"command\":{\"type\":\"string\"},\"cwd\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, toolSchema("ssh_session_exec", "Type a command into an already-open SSH terminal surface and observe the resulting terminal snapshot.", "{\"surface_id\":{\"type\":\"string\"},\"command\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}"));
+    try out.append(allocator, ']');
+}
+
+fn toolSchema(comptime name: []const u8, comptime description: []const u8, comptime properties: []const u8) []const u8 {
+    return "{\"type\":\"function\",\"function\":{\"name\":\"" ++ name ++ "\",\"description\":\"" ++ description ++ "\",\"parameters\":{\"type\":\"object\",\"properties\":" ++ properties ++ ",\"additionalProperties\":false}}}";
+}
+
+fn executeToolCall(request: *const ChatRequest, call: ToolCall) ![]u8 {
+    if (std.mem.eql(u8, call.name, "terminal_list")) {
+        return terminalListTool(request);
+    }
+    if (std.mem.eql(u8, call.name, "terminal_snapshot")) {
+        const args = parseArgs(request.allocator, call.arguments);
+        defer if (args) |parsed| parsed.deinit();
+        const surface_id = if (args) |parsed| jsonStringArg(parsed.value, "surface_id") else null;
+        return terminalSnapshotTool(request, surface_id);
+    }
+    if (std.mem.eql(u8, call.name, "powershell_exec")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const command = jsonStringArg(args.value, "command") orelse return request.allocator.dupe(u8, "Missing command");
+        const cwd = jsonStringArg(args.value, "cwd");
+        return powershellExecTool(request, command, cwd);
+    }
+    if (std.mem.eql(u8, call.name, "ssh_session_exec")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const surface_id = jsonStringArg(args.value, "surface_id") orelse return request.allocator.dupe(u8, "Missing surface_id");
+        const command = jsonStringArg(args.value, "command") orelse return request.allocator.dupe(u8, "Missing command");
+        const timeout_ms = jsonIntArg(args.value, "timeout_ms") orelse currentAgentSettings().command_timeout_ms;
+        return sshSessionExecTool(request, surface_id, command, timeout_ms);
+    }
+    return std.fmt.allocPrint(request.allocator, "Unknown tool: {s}", .{call.name});
+}
+
+fn parseArgs(allocator: std.mem.Allocator, text: []const u8) ?std.json.Parsed(std.json.Value) {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    const body = if (trimmed.len == 0) "{}" else trimmed;
+    return std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch null;
+}
+
+fn jsonStringArg(root: std.json.Value, name: []const u8) ?[]const u8 {
+    if (root != .object) return null;
+    const value = root.object.get(name) orelse return null;
+    if (value != .string or value.string.len == 0) return null;
+    return value.string;
+}
+
+fn jsonIntArg(root: std.json.Value, name: []const u8) ?u32 {
+    if (root != .object) return null;
+    const value = root.object.get(name) orelse return null;
+    return switch (value) {
+        .integer => |v| if (v > 0 and v <= std.math.maxInt(u32)) @intCast(v) else null,
+        .float => |v| if (v > 0 and v <= @as(f64, @floatFromInt(std.math.maxInt(u32)))) @intFromFloat(v) else null,
+        else => null,
+    };
+}
+
+fn terminalListTool(request: *const ChatRequest) ![]u8 {
+    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(request.allocator);
+    try out.print(request.allocator, "active_tab={d}\n", .{snapshot.active_tab});
+    for (snapshot.surfaces) |surface| {
+        try out.print(request.allocator, "- id={s} tab={d} focused={} kind={s} title=\"{s}\" cwd=\"{s}\"\n", .{
+            surface.id,
+            surface.tab_index,
+            surface.focused,
+            if (surface.is_ssh) "ssh" else "terminal",
+            surface.title,
+            surface.cwd,
+        });
+    }
+    return truncateOwned(request.allocator, try out.toOwnedSlice(request.allocator));
+}
+
+fn terminalSnapshotTool(request: *const ChatRequest, surface_id: ?[]const u8) ![]u8 {
+    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(request.allocator);
+
+    for (snapshot.surfaces) |surface| {
+        if (surface_id) |id| {
+            if (!std.mem.eql(u8, surface.id, id)) continue;
+        }
+        try out.print(request.allocator, "surface={s} title=\"{s}\" kind={s} focused={}\n", .{
+            surface.id,
+            surface.title,
+            if (surface.is_ssh) "ssh" else "terminal",
+            surface.focused,
+        });
+        try out.appendSlice(request.allocator, surface.snapshot);
+        try out.appendSlice(request.allocator, "\n---\n");
+    }
+    if (out.items.len == 0) try out.appendSlice(request.allocator, "No matching terminal surface.");
+    return truncateOwned(request.allocator, try out.toOwnedSlice(request.allocator));
+}
+
+fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]const u8) ![]u8 {
+    const settings = currentAgentSettings();
+    if (settings.permission != .full) {
+        return deniedResult(request.allocator, command, "local PowerShell execution requires ai-agent-permission = full");
+    }
+    const warning = if (isDangerousCommand(command)) "warning: command matched a dangerous-command pattern; full-permission allowed it.\n" else "";
+    const result = runShellCommand(request.allocator, command, cwd, settings.output_limit) catch |err| {
+        return std.fmt.allocPrint(request.allocator, "{s}PowerShell failed: {}", .{ warning, err });
+    };
+    defer request.allocator.free(result.stdout);
+    defer request.allocator.free(result.stderr);
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(request.allocator);
+    try out.appendSlice(request.allocator, warning);
+    try out.print(request.allocator, "exit_code={d}\nstdout:\n{s}\nstderr:\n{s}", .{ result.exit_code, result.stdout, result.stderr });
+    return truncateOwned(request.allocator, try out.toOwnedSlice(request.allocator));
+}
+
+const ShellResult = struct {
+    exit_code: i32,
+    stdout: []u8,
+    stderr: []u8,
+};
+
+fn runShellCommand(allocator: std.mem.Allocator, command: []const u8, cwd: ?[]const u8, output_limit: u32) !ShellResult {
+    const pwsh_argv = [_][]const u8{ "pwsh.exe", "-NoProfile", "-Command", command };
+    if (runArgv(allocator, pwsh_argv[0..], cwd, output_limit)) |result| return result else |_| {}
+    const powershell_argv = [_][]const u8{ "powershell.exe", "-NoProfile", "-Command", command };
+    if (runArgv(allocator, powershell_argv[0..], cwd, output_limit)) |result| return result else |_| {}
+    const cmd_argv = [_][]const u8{ "cmd.exe", "/C", command };
+    return runArgv(allocator, cmd_argv[0..], cwd, output_limit);
+}
+
+fn runArgv(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, output_limit: u32) !ShellResult {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .cwd = cwd,
+        .max_output_bytes = output_limit,
+    });
+    const exit_code: i32 = switch (result.term) {
+        .Exited => |code| @intCast(code),
+        .Signal => |sig| -@as(i32, @intCast(sig)),
+        .Stopped => |sig| -@as(i32, @intCast(sig)),
+        .Unknown => |code| @intCast(code),
+    };
+    return .{ .exit_code = exit_code, .stdout = result.stdout, .stderr = result.stderr };
+}
+
+fn sshSessionExecTool(request: *const ChatRequest, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
+    const settings = currentAgentSettings();
+    if (settings.permission != .full) {
+        return deniedResult(request.allocator, command, "SSH PTY injection requires ai-agent-permission = full");
+    }
+    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    const host = request.tool_host orelse return request.allocator.dupe(u8, "No terminal tool host is available.");
+    const surface = findSurface(snapshot, surface_id) orelse return request.allocator.dupe(u8, "No matching terminal surface.");
+    if (!surface.is_ssh) return request.allocator.dupe(u8, "Target surface is not an opened SSH session.");
+
+    const nonce = std.time.milliTimestamp();
+    const wrapped = try std.fmt.allocPrint(
+        request.allocator,
+        "printf '\\n__PHANTTY_AGENT_START_{d}__\\n'; {{ {s}; }} 2>&1; __phantty_agent_status=$?; printf '\\n__PHANTTY_AGENT_END_{d}__:%s\\n' \"$__phantty_agent_status\"\r",
+        .{ nonce, command, nonce },
+    );
+    defer request.allocator.free(wrapped);
+
+    if (!host.writeSurface(host.ctx, surface.ptr, wrapped)) {
+        return request.allocator.dupe(u8, "Failed to write to SSH terminal surface.");
+    }
+
+    const start_marker = try std.fmt.allocPrint(request.allocator, "__PHANTTY_AGENT_START_{d}__", .{nonce});
+    defer request.allocator.free(start_marker);
+    const end_marker = try std.fmt.allocPrint(request.allocator, "__PHANTTY_AGENT_END_{d}__", .{nonce});
+    defer request.allocator.free(end_marker);
+
+    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(@max(timeout_ms, 1000)));
+    var last: ?[]u8 = null;
+    defer if (last) |text| request.allocator.free(text);
+
+    while (std.time.milliTimestamp() < deadline) {
+        if (last) |old| request.allocator.free(old);
+        last = host.surfaceSnapshot(host.ctx, request.allocator, surface.ptr) catch null;
+        if (last) |text| {
+            if (std.mem.indexOf(u8, text, end_marker) != null) {
+                return extractSshCommandResult(request.allocator, text, start_marker, end_marker);
+            }
+        }
+        std.Thread.sleep(100 * std.time.ns_per_ms);
+    }
+
+    if (last) |text| {
+        return std.fmt.allocPrint(request.allocator, "Timed out waiting for SSH command sentinel.\nLatest snapshot:\n{s}", .{text});
+    }
+    return request.allocator.dupe(u8, "Timed out waiting for SSH command sentinel.");
+}
+
+fn findSurface(snapshot: ToolSnapshot, surface_id: []const u8) ?ToolSurface {
+    for (snapshot.surfaces) |surface| {
+        if (std.mem.eql(u8, surface.id, surface_id)) return surface;
+    }
+    return null;
+}
+
+fn extractSshCommandResult(allocator: std.mem.Allocator, text: []const u8, start_marker: []const u8, end_marker: []const u8) ![]u8 {
+    const start = std.mem.indexOf(u8, text, start_marker) orelse return allocator.dupe(u8, text);
+    const body_start = start + start_marker.len;
+    const end = std.mem.indexOfPos(u8, text, body_start, end_marker) orelse return allocator.dupe(u8, text[body_start..]);
+    return allocator.dupe(u8, std.mem.trim(u8, text[body_start..end], " \t\r\n"));
+}
+
+fn deniedResult(allocator: std.mem.Allocator, command: []const u8, reason: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "DENIED by operator (reason: {s})\ncommand: {s}", .{ reason, command });
+}
+
+fn truncateOwned(allocator: std.mem.Allocator, text: []u8) ![]u8 {
+    const limit = currentAgentSettings().output_limit;
+    if (text.len <= limit) return text;
+    const truncated = try std.fmt.allocPrint(allocator, "{s}\n...[truncated to {d} bytes]", .{ text[0..limit], limit });
+    allocator.free(text);
+    return truncated;
+}
+
+fn isDangerousCommand(command: []const u8) bool {
+    const needles = [_][]const u8{
+        "rm -rf",
+        "Remove-Item -Recurse -Force",
+        "format ",
+        "mkfs",
+        "shutdown",
+        "Stop-Computer",
+        "Restart-Computer",
+        "git push --force",
+        ":(){",
+        "del /s",
+    };
+    for (needles) |needle| {
+        if (std.ascii.indexOfIgnoreCase(command, needle) != null) return true;
+    }
+    return false;
 }
 
 fn parseApiResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
@@ -731,11 +1268,52 @@ fn parseApiResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
         if (reasoning_value == .string and reasoning_value.string.len > 0) reasoning_value.string else null
     else
         null;
+    const tool_calls = try parseToolCalls(allocator, message_value);
 
     return .{
         .content = try allocator.dupe(u8, content),
         .reasoning = if (reasoning) |r| try allocator.dupe(u8, r) else null,
+        .tool_calls = tool_calls,
     };
+}
+
+fn parseToolCalls(allocator: std.mem.Allocator, message_value: std.json.Value) !?[]ToolCall {
+    const calls_value = message_value.object.get("tool_calls") orelse return null;
+    if (calls_value != .array or calls_value.array.items.len == 0) return null;
+
+    const calls = try allocator.alloc(ToolCall, calls_value.array.items.len);
+    errdefer allocator.free(calls);
+    var written: usize = 0;
+    errdefer {
+        for (calls[0..written]) |call| call.deinit(allocator);
+    }
+
+    for (calls_value.array.items) |item| {
+        if (item != .object) continue;
+        const call_obj = item.object;
+        const id_value = call_obj.get("id") orelse continue;
+        const function_value = call_obj.get("function") orelse continue;
+        if (id_value != .string or function_value != .object) continue;
+        const name_value = function_value.object.get("name") orelse continue;
+        const args_value = function_value.object.get("arguments") orelse continue;
+        if (name_value != .string) continue;
+        const args = switch (args_value) {
+            .string => args_value.string,
+            else => "",
+        };
+        calls[written] = .{
+            .id = try allocator.dupe(u8, id_value.string),
+            .name = try allocator.dupe(u8, name_value.string),
+            .arguments = try allocator.dupe(u8, args),
+        };
+        written += 1;
+    }
+
+    if (written == 0) {
+        allocator.free(calls);
+        return null;
+    }
+    return try allocator.realloc(calls, written);
 }
 
 fn parseApiStreamResponse(allocator: std.mem.Allocator, body: []const u8) !ApiResult {
@@ -902,11 +1480,62 @@ test "ai chat request json includes deepseek thinking mode" {
         .thinking_enabled = true,
         .reasoning_effort = @constCast("high"),
         .stream = false,
+        .agent_enabled = false,
+        .tool_host = null,
+        .tool_snapshot = null,
     };
     const json = try buildRequestJson(allocator, &request);
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"thinking\":{\"type\":\"enabled\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"reasoning_effort\":\"high\"") != null);
+}
+
+test "ai chat agent request json includes tool schemas" {
+    const allocator = std.testing.allocator;
+    var messages = [_]RequestMessage{.{
+        .role = .user,
+        .content = @constCast("List terminals"),
+    }};
+    const request = ChatRequest{
+        .allocator = allocator,
+        .session = undefined,
+        .base_url = @constCast("https://api.deepseek.com"),
+        .api_key = @constCast("key"),
+        .model = @constCast(DEFAULT_MODEL),
+        .system_prompt = @constCast(DEFAULT_SYSTEM_PROMPT),
+        .messages = messages[0..],
+        .thinking_enabled = true,
+        .reasoning_effort = @constCast("high"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+    };
+    const json = try buildRequestJson(allocator, &request);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"tools\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_list\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"ssh_session_exec\"") != null);
+}
+
+test "ai chat parses OpenAI tool calls" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"terminal_list","arguments":"{}"}}]}}]}
+    ;
+    const result = try parseApiResponse(allocator, body);
+    defer result.deinit(allocator);
+    try std.testing.expect(result.tool_calls != null);
+    try std.testing.expectEqual(@as(usize, 1), result.tool_calls.?.len);
+    try std.testing.expectEqualStrings("call_1", result.tool_calls.?[0].id);
+    try std.testing.expectEqualStrings("terminal_list", result.tool_calls.?[0].name);
+    try std.testing.expectEqualStrings("{}", result.tool_calls.?[0].arguments);
+}
+
+test "ai chat detects dangerous shell commands" {
+    try std.testing.expect(isDangerousCommand("rm -rf /tmp/demo"));
+    try std.testing.expect(isDangerousCommand("git push --force origin main"));
+    try std.testing.expect(!isDangerousCommand("Get-ComputerInfo | Select-Object OsName"));
 }
 
 test "ai chat stream response aggregates content and reasoning chunks" {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -51,11 +51,13 @@ pub const Message = struct {
 const RequestMessage = struct {
     role: Role,
     content: []u8,
+    reasoning: ?[]u8 = null,
     tool_call_id: ?[]u8 = null,
     tool_calls: ?[]ToolCall = null,
 
     fn deinit(self: RequestMessage, allocator: std.mem.Allocator) void {
         allocator.free(self.content);
+        if (self.reasoning) |reasoning| allocator.free(reasoning);
         if (self.tool_call_id) |id| allocator.free(id);
         if (self.tool_calls) |calls| {
             for (calls) |call| call.deinit(allocator);
@@ -179,6 +181,12 @@ const ApiResult = struct {
     }
 };
 
+pub const ApprovalView = struct {
+    tool: []const u8,
+    command: []const u8,
+    reason: []const u8,
+};
+
 var g_agent_mutex: std.Thread.Mutex = .{};
 var g_agent_settings: AgentSettings = .{};
 var g_tool_host: ?ToolHost = null;
@@ -234,6 +242,17 @@ pub const Session = struct {
     request_thread: ?std.Thread = null,
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     scroll_px: f32 = 0,
+    approval_mutex: std.Thread.Mutex = .{},
+    approval_cond: std.Thread.Condition = .{},
+    approval_pending: bool = false,
+    approval_resolved: bool = false,
+    approval_allowed: bool = false,
+    approval_tool_buf: [64]u8 = undefined,
+    approval_tool_len: usize = 0,
+    approval_command_buf: [1024]u8 = undefined,
+    approval_command_len: usize = 0,
+    approval_reason_buf: [256]u8 = undefined,
+    approval_reason_len: usize = 0,
 
     pub fn reasoningEffort(self: *const Session) []const u8 {
         return self.reasoning_effort_buf[0..self.reasoning_effort_len];
@@ -276,6 +295,7 @@ pub const Session = struct {
 
     pub fn deinit(self: *Session) void {
         self.closing.store(true, .release);
+        self.approval_cond.broadcast();
         if (self.request_thread) |thread| {
             thread.join();
             self.request_thread = null;
@@ -323,6 +343,12 @@ pub const Session = struct {
     }
 
     pub fn handleChar(self: *Session, codepoint: u21) void {
+        if (codepoint == 'y' or codepoint == 'Y') {
+            if (self.resolveApproval(true)) return;
+        }
+        if (codepoint == 'n' or codepoint == 'N') {
+            if (self.resolveApproval(false)) return;
+        }
         if (codepoint < 0x20 or codepoint == 0x7f) return;
         var buf: [4]u8 = undefined;
         const len = std.unicode.utf8Encode(codepoint, &buf) catch return;
@@ -344,6 +370,8 @@ pub const Session = struct {
     }
 
     pub fn handleKey(self: *Session, ev: win32_backend.KeyEvent) void {
+        if (self.handleApprovalKey(ev)) return;
+
         if (ev.ctrl and !ev.alt and ev.vk == 0x55) {
             self.mutex.lock();
             self.input_len = 0;
@@ -366,6 +394,67 @@ pub const Session = struct {
             },
             else => {},
         }
+    }
+
+    pub fn approvalView(self: *Session) ?ApprovalView {
+        self.approval_mutex.lock();
+        defer self.approval_mutex.unlock();
+        if (!self.approval_pending or self.approval_resolved) return null;
+        return .{
+            .tool = self.approval_tool_buf[0..self.approval_tool_len],
+            .command = self.approval_command_buf[0..self.approval_command_len],
+            .reason = self.approval_reason_buf[0..self.approval_reason_len],
+        };
+    }
+
+    fn handleApprovalKey(self: *Session, ev: win32_backend.KeyEvent) bool {
+        const approve = ev.vk == win32_backend.VK_RETURN or ev.vk == 0x59; // Y
+        const reject = ev.vk == win32_backend.VK_ESCAPE or ev.vk == 0x4E; // N
+        if (!approve and !reject) return false;
+        return self.resolveApproval(approve);
+    }
+
+    fn resolveApproval(self: *Session, approve: bool) bool {
+        self.approval_mutex.lock();
+        defer self.approval_mutex.unlock();
+        if (!self.approval_pending or self.approval_resolved) return false;
+        self.approval_allowed = approve;
+        self.approval_resolved = true;
+        self.approval_pending = false;
+        self.approval_cond.signal();
+        return true;
+    }
+
+    fn requestApproval(self: *Session, tool: []const u8, command: []const u8, reason: []const u8) bool {
+        self.approval_mutex.lock();
+        self.copyApprovalLocked(tool, command, reason);
+        self.approval_pending = true;
+        self.approval_resolved = false;
+        self.approval_allowed = false;
+        self.approval_mutex.unlock();
+
+        appendProgressMessage(self, "Approval required: press Enter/Y to run, Esc/N to deny.") catch {};
+        self.setStatus("Approval needed");
+
+        self.approval_mutex.lock();
+        defer self.approval_mutex.unlock();
+        while (!self.approval_resolved and !self.closing.load(.acquire)) {
+            self.approval_cond.wait(&self.approval_mutex);
+        }
+        const allowed = self.approval_resolved and self.approval_allowed and !self.closing.load(.acquire);
+        self.approval_pending = false;
+        self.approval_resolved = false;
+        self.approval_allowed = false;
+        return allowed;
+    }
+
+    fn copyApprovalLocked(self: *Session, tool: []const u8, command: []const u8, reason: []const u8) void {
+        self.approval_tool_len = @min(tool.len, self.approval_tool_buf.len);
+        @memcpy(self.approval_tool_buf[0..self.approval_tool_len], tool[0..self.approval_tool_len]);
+        self.approval_command_len = @min(command.len, self.approval_command_buf.len);
+        @memcpy(self.approval_command_buf[0..self.approval_command_len], command[0..self.approval_command_len]);
+        self.approval_reason_len = @min(reason.len, self.approval_reason_buf.len);
+        @memcpy(self.approval_reason_buf[0..self.approval_reason_len], reason[0..self.approval_reason_len]);
     }
 
     pub fn submit(self: *Session) void {
@@ -481,6 +570,7 @@ pub const Session = struct {
             messages[written] = .{
                 .role = msg.role,
                 .content = try self.allocator.dupe(u8, msg.content),
+                .reasoning = if (msg.reasoning) |reasoning| try self.allocator.dupe(u8, reasoning) else null,
             };
             written += 1;
         }
@@ -606,7 +696,7 @@ fn runAgentRequest(request: *const ChatRequest) !ApiResult {
             appendProgressMessage(request.session, result.content) catch {};
         }
 
-        try transcript.append(request.allocator, try assistantToolCallMessage(request.allocator, result.content, result.tool_calls.?));
+        try transcript.append(request.allocator, try assistantToolCallMessage(request.allocator, result.content, result.reasoning, result.tool_calls.?));
         for (result.tool_calls.?) |call| {
             const progress = try std.fmt.allocPrint(request.allocator, "running {s} {s}", .{ call.name, call.arguments });
             defer request.allocator.free(progress);
@@ -630,6 +720,7 @@ fn cloneRequestMessage(allocator: std.mem.Allocator, msg: RequestMessage) !Reque
     return .{
         .role = msg.role,
         .content = try allocator.dupe(u8, msg.content),
+        .reasoning = if (msg.reasoning) |reasoning| try allocator.dupe(u8, reasoning) else null,
         .tool_call_id = if (msg.tool_call_id) |id| try allocator.dupe(u8, id) else null,
         .tool_calls = if (msg.tool_calls) |calls| try cloneToolCalls(allocator, calls) else null,
     };
@@ -653,10 +744,11 @@ fn cloneToolCalls(allocator: std.mem.Allocator, calls: []const ToolCall) ![]Tool
     return out;
 }
 
-fn assistantToolCallMessage(allocator: std.mem.Allocator, content: []const u8, calls: []const ToolCall) !RequestMessage {
+fn assistantToolCallMessage(allocator: std.mem.Allocator, content: []const u8, reasoning: ?[]const u8, calls: []const ToolCall) !RequestMessage {
     return .{
         .role = .assistant,
         .content = try allocator.dupe(u8, content),
+        .reasoning = if (reasoning) |text| try allocator.dupe(u8, text) else null,
         .tool_calls = try cloneToolCalls(allocator, calls),
     };
 }
@@ -965,6 +1057,14 @@ fn buildRequestJsonForMessages(
             }
             try out.append(allocator, ']');
         }
+        if (msg.role == .assistant) {
+            if (msg.reasoning) |reasoning| {
+                if (reasoning.len > 0) {
+                    try out.appendSlice(allocator, ",\"reasoning_content\":");
+                    try appendJsonString(allocator, &out, reasoning);
+                }
+            }
+        }
         try out.append(allocator, '}');
     }
     try out.appendSlice(allocator, "],\"thinking\":{\"type\":");
@@ -1092,7 +1192,9 @@ fn terminalSnapshotTool(request: *const ChatRequest, surface_id: ?[]const u8) ![
 fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]const u8) ![]u8 {
     const settings = currentAgentSettings();
     if (settings.permission != .full) {
-        return deniedResult(request.allocator, command, "local PowerShell execution requires ai-agent-permission = full");
+        if (!request.session.requestApproval("powershell_exec", command, "Run local PowerShell command")) {
+            return deniedResult(request.allocator, command, "operator rejected local PowerShell command");
+        }
     }
     const warning = if (isDangerousCommand(command)) "warning: command matched a dangerous-command pattern; full-permission allowed it.\n" else "";
     const result = runShellCommand(request.allocator, command, cwd, settings.output_limit) catch |err| {
@@ -1141,7 +1243,9 @@ fn runArgv(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const
 fn sshSessionExecTool(request: *const ChatRequest, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
     const settings = currentAgentSettings();
     if (settings.permission != .full) {
-        return deniedResult(request.allocator, command, "SSH PTY injection requires ai-agent-permission = full");
+        if (!request.session.requestApproval("ssh_session_exec", command, "Type command into opened SSH terminal")) {
+            return deniedResult(request.allocator, command, "operator rejected SSH PTY command");
+        }
     }
     const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
     const host = request.tool_host orelse return request.allocator.dupe(u8, "No terminal tool host is available.");
@@ -1518,6 +1622,33 @@ test "ai chat agent request json includes tool schemas" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\"tool_choice\":\"auto\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_list\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"ssh_session_exec\"") != null);
+}
+
+test "ai chat request json replays assistant reasoning content" {
+    const allocator = std.testing.allocator;
+    var messages = [_]RequestMessage{.{
+        .role = .assistant,
+        .content = @constCast("I will inspect the system."),
+        .reasoning = @constCast("Need system info before answering."),
+    }};
+    const request = ChatRequest{
+        .allocator = allocator,
+        .session = undefined,
+        .base_url = @constCast("https://api.deepseek.com"),
+        .api_key = @constCast("key"),
+        .model = @constCast(DEFAULT_MODEL),
+        .system_prompt = @constCast(DEFAULT_SYSTEM_PROMPT),
+        .messages = messages[0..],
+        .thinking_enabled = true,
+        .reasoning_effort = @constCast("high"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+    };
+    const json = try buildRequestJson(allocator, &request);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"reasoning_content\":\"Need system info before answering.\"") != null);
 }
 
 test "ai chat parses OpenAI tool calls" {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -215,6 +215,10 @@ fn currentToolHost() ?ToolHost {
     return g_tool_host;
 }
 
+pub fn agentPermission() AgentPermission {
+    return currentAgentSettings().permission;
+}
+
 pub const Session = struct {
     allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -433,7 +433,6 @@ pub const Session = struct {
         self.approval_allowed = false;
         self.approval_mutex.unlock();
 
-        appendProgressMessage(self, "Approval required: press Enter/Y to run, Esc/N to deny.") catch {};
         self.setStatus("Approval needed");
 
         self.approval_mutex.lock();
@@ -1540,7 +1539,9 @@ fn applyApiStreamLineToSession(
 fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: []const u8) !void {
     const hex = "0123456789abcdef";
     try out.append(allocator, '"');
-    for (value) |ch| {
+    var i: usize = 0;
+    while (i < value.len) {
+        const ch = value[i];
         switch (ch) {
             '"' => try out.appendSlice(allocator, "\\\""),
             '\\' => try out.appendSlice(allocator, "\\\\"),
@@ -1551,8 +1552,30 @@ fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u
                 try out.appendSlice(allocator, "\\u00");
                 try out.append(allocator, hex[ch >> 4]);
                 try out.append(allocator, hex[ch & 0x0f]);
-            } else try out.append(allocator, ch),
+            } else if (ch < 0x80) {
+                try out.append(allocator, ch);
+            } else {
+                const len = std.unicode.utf8ByteSequenceLength(ch) catch {
+                    try out.appendSlice(allocator, "\\ufffd");
+                    i += 1;
+                    continue;
+                };
+                if (i + len > value.len) {
+                    try out.appendSlice(allocator, "\\ufffd");
+                    i += 1;
+                    continue;
+                }
+                _ = std.unicode.utf8Decode(value[i .. i + len]) catch {
+                    try out.appendSlice(allocator, "\\ufffd");
+                    i += 1;
+                    continue;
+                };
+                try out.appendSlice(allocator, value[i .. i + len]);
+                i += len;
+                continue;
+            },
         }
+        i += 1;
     }
     try out.append(allocator, '"');
 }
@@ -1649,6 +1672,16 @@ test "ai chat request json replays assistant reasoning content" {
     const json = try buildRequestJson(allocator, &request);
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"reasoning_content\":\"Need system info before answering.\"") != null);
+}
+
+test "ai chat request json replaces invalid utf8 bytes" {
+    const allocator = std.testing.allocator;
+    const bad = [_]u8{ 'o', 'k', ' ', 0xff, ' ', 0xc3 };
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+
+    try appendJsonString(allocator, &out, bad[0..]);
+    try std.testing.expectEqualStrings("\"ok \\ufffd \\ufffd\"", out.items);
 }
 
 test "ai chat parses OpenAI tool calls" {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -14,7 +14,7 @@ pub const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
 pub const DEFAULT_THINKING = "enabled";
 pub const DEFAULT_REASONING_EFFORT = "high";
 pub const DEFAULT_STREAM = "false";
-pub const DEFAULT_AGENT = "false";
+pub const DEFAULT_AGENT = "true";
 
 const MAX_AGENT_ITERATIONS = 12;
 const DEFAULT_AGENT_TIMEOUT_MS: u32 = 60_000;
@@ -991,6 +991,7 @@ fn appendToolSchemas(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(
     try out.append(allocator, ',');
     try out.appendSlice(allocator, toolSchema("ssh_session_exec", "Type a command into an already-open SSH terminal surface and observe the resulting terminal snapshot.", "{\"surface_id\":{\"type\":\"string\"},\"command\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}"));
     try out.append(allocator, ']');
+    try out.appendSlice(allocator, ",\"tool_choice\":\"auto\"");
 }
 
 fn toolSchema(comptime name: []const u8, comptime description: []const u8, comptime properties: []const u8) []const u8 {
@@ -1514,6 +1515,7 @@ test "ai chat agent request json includes tool schemas" {
     const json = try buildRequestJson(allocator, &request);
     defer allocator.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"tools\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"tool_choice\":\"auto\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_list\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"ssh_session_exec\"") != null);
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -581,11 +581,6 @@ pub const Session = struct {
         const settings = currentAgentSettings();
         const agent_enabled = self.agent_enabled or settings.enabled;
         const tool_host = if (agent_enabled) currentToolHost() else null;
-        var tool_snapshot: ?ToolSnapshot = null;
-        if (tool_host) |host| {
-            tool_snapshot = host.collectSnapshot(host.ctx, self.allocator) catch null;
-        }
-        errdefer if (tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
 
         req.* = .{
             .allocator = self.allocator,
@@ -600,7 +595,7 @@ pub const Session = struct {
             .stream = self.stream and !agent_enabled,
             .agent_enabled = agent_enabled,
             .tool_host = tool_host,
-            .tool_snapshot = tool_snapshot,
+            .tool_snapshot = null,
         };
         return req;
     }
@@ -1116,7 +1111,8 @@ fn executeToolCall(request: *const ChatRequest, call: ToolCall) ![]u8 {
         defer args.deinit();
         const command = jsonStringArg(args.value, "command") orelse return request.allocator.dupe(u8, "Missing command");
         const cwd = jsonStringArg(args.value, "cwd");
-        return powershellExecTool(request, command, cwd);
+        const timeout_ms = jsonIntArg(args.value, "timeout_ms") orelse currentAgentSettings().command_timeout_ms;
+        return powershellExecTool(request, command, cwd, timeout_ms);
     }
     if (std.mem.eql(u8, call.name, "ssh_session_exec")) {
         const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
@@ -1153,7 +1149,8 @@ fn jsonIntArg(root: std.json.Value, name: []const u8) ?u32 {
 }
 
 fn terminalListTool(request: *const ChatRequest) ![]u8 {
-    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    const snapshot = collectToolSnapshot(request) catch return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    defer snapshot.deinit(request.allocator);
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(request.allocator);
     try out.print(request.allocator, "active_tab={d}\n", .{snapshot.active_tab});
@@ -1171,7 +1168,8 @@ fn terminalListTool(request: *const ChatRequest) ![]u8 {
 }
 
 fn terminalSnapshotTool(request: *const ChatRequest, surface_id: ?[]const u8) ![]u8 {
-    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    const snapshot = collectToolSnapshot(request) catch return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    defer snapshot.deinit(request.allocator);
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(request.allocator);
 
@@ -1192,7 +1190,12 @@ fn terminalSnapshotTool(request: *const ChatRequest, surface_id: ?[]const u8) ![
     return truncateOwned(request.allocator, try out.toOwnedSlice(request.allocator));
 }
 
-fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]const u8) ![]u8 {
+fn collectToolSnapshot(request: *const ChatRequest) !ToolSnapshot {
+    const host = request.tool_host orelse return error.NoTerminalSnapshotHost;
+    return host.collectSnapshot(host.ctx, request.allocator);
+}
+
+fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8 {
     const settings = currentAgentSettings();
     if (settings.permission != .full) {
         if (!request.session.requestApproval("powershell_exec", command, "Run local PowerShell command")) {
@@ -1200,7 +1203,7 @@ fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]
         }
     }
     const warning = if (isDangerousCommand(command)) "warning: command matched a dangerous-command pattern; full-permission allowed it.\n" else "";
-    const result = runShellCommand(request.allocator, command, cwd, settings.output_limit) catch |err| {
+    const result = runShellCommand(request.allocator, command, cwd, settings.output_limit, timeout_ms) catch |err| {
         return std.fmt.allocPrint(request.allocator, "{s}PowerShell failed: {}", .{ warning, err });
     };
     defer request.allocator.free(result.stdout);
@@ -1208,6 +1211,7 @@ fn powershellExecTool(request: *const ChatRequest, command: []const u8, cwd: ?[]
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(request.allocator);
     try out.appendSlice(request.allocator, warning);
+    if (result.timed_out) try out.appendSlice(request.allocator, "timed_out=true\n");
     try out.print(request.allocator, "exit_code={d}\nstdout:\n{s}\nstderr:\n{s}", .{ result.exit_code, result.stdout, result.stderr });
     return truncateOwned(request.allocator, try out.toOwnedSlice(request.allocator));
 }
@@ -1216,31 +1220,121 @@ const ShellResult = struct {
     exit_code: i32,
     stdout: []u8,
     stderr: []u8,
+    timed_out: bool = false,
 };
 
-fn runShellCommand(allocator: std.mem.Allocator, command: []const u8, cwd: ?[]const u8, output_limit: u32) !ShellResult {
+fn runShellCommand(allocator: std.mem.Allocator, command: []const u8, cwd: ?[]const u8, output_limit: u32, timeout_ms: u32) !ShellResult {
     const pwsh_argv = [_][]const u8{ "pwsh.exe", "-NoProfile", "-Command", command };
-    if (runArgv(allocator, pwsh_argv[0..], cwd, output_limit)) |result| return result else |_| {}
+    if (runArgv(allocator, pwsh_argv[0..], cwd, output_limit, timeout_ms)) |result| return result else |_| {}
     const powershell_argv = [_][]const u8{ "powershell.exe", "-NoProfile", "-Command", command };
-    if (runArgv(allocator, powershell_argv[0..], cwd, output_limit)) |result| return result else |_| {}
+    if (runArgv(allocator, powershell_argv[0..], cwd, output_limit, timeout_ms)) |result| return result else |_| {}
     const cmd_argv = [_][]const u8{ "cmd.exe", "/C", command };
-    return runArgv(allocator, cmd_argv[0..], cwd, output_limit);
+    return runArgv(allocator, cmd_argv[0..], cwd, output_limit, timeout_ms);
 }
 
-fn runArgv(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, output_limit: u32) !ShellResult {
-    const result = try std.process.Child.run(.{
+const CaptureOutput = struct {
+    allocator: std.mem.Allocator,
+    file: std.fs.File,
+    max_bytes: usize,
+    data: []u8 = &.{},
+    truncated: bool = false,
+    failed: bool = false,
+
+    fn deinit(self: *CaptureOutput) void {
+        self.allocator.free(self.data);
+        self.data = &.{};
+    }
+};
+
+fn runArgv(allocator: std.mem.Allocator, argv: []const []const u8, cwd: ?[]const u8, output_limit: u32, timeout_ms: u32) !ShellResult {
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.cwd = cwd;
+    try child.spawn();
+
+    var stdout_capture = CaptureOutput{
         .allocator = allocator,
-        .argv = argv,
-        .cwd = cwd,
-        .max_output_bytes = output_limit,
-    });
-    const exit_code: i32 = switch (result.term) {
-        .Exited => |code| @intCast(code),
-        .Signal => |sig| -@as(i32, @intCast(sig)),
-        .Stopped => |sig| -@as(i32, @intCast(sig)),
-        .Unknown => |code| @intCast(code),
+        .file = child.stdout.?,
+        .max_bytes = output_limit,
     };
-    return .{ .exit_code = exit_code, .stdout = result.stdout, .stderr = result.stderr };
+    errdefer stdout_capture.deinit();
+    var stderr_capture = CaptureOutput{
+        .allocator = allocator,
+        .file = child.stderr.?,
+        .max_bytes = output_limit,
+    };
+    errdefer stderr_capture.deinit();
+
+    const stdout_thread = try std.Thread.spawn(.{}, captureOutputThread, .{&stdout_capture});
+    const stderr_thread = try std.Thread.spawn(.{}, captureOutputThread, .{&stderr_capture});
+
+    const wait_ms = @max(timeout_ms, 1);
+    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(wait_ms));
+    var timed_out = false;
+    while (true) {
+        const rc = win32_backend.WaitForSingleObject(child.id, 25);
+        if (rc == win32_backend.WAIT_OBJECT_0) break;
+        if (std.time.milliTimestamp() >= deadline) {
+            timed_out = true;
+            _ = child.kill() catch {};
+            break;
+        }
+    }
+
+    stdout_thread.join();
+    stderr_thread.join();
+
+    const exit_code: i32 = if (timed_out) 124 else blk: {
+        const term = try child.wait();
+        break :blk switch (term) {
+            .Exited => |code| @intCast(code),
+            .Signal => |sig| -@as(i32, @intCast(sig)),
+            .Stopped => |sig| -@as(i32, @intCast(sig)),
+            .Unknown => |code| @intCast(code),
+        };
+    };
+    return .{
+        .exit_code = exit_code,
+        .stdout = stdout_capture.data,
+        .stderr = stderr_capture.data,
+        .timed_out = timed_out,
+    };
+}
+
+fn captureOutputThread(capture: *CaptureOutput) void {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer {
+        if (capture.failed) out.deinit(capture.allocator);
+    }
+
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = capture.file.read(&buf) catch {
+            break;
+        };
+        if (n == 0) break;
+        if (out.items.len < capture.max_bytes) {
+            const remaining = capture.max_bytes - out.items.len;
+            const take = @min(remaining, n);
+            out.appendSlice(capture.allocator, buf[0..take]) catch {
+                capture.failed = true;
+                return;
+            };
+            if (take < n) capture.truncated = true;
+        } else {
+            capture.truncated = true;
+        }
+    }
+
+    if (capture.truncated) {
+        out.appendSlice(capture.allocator, "\n...[truncated]\n") catch {};
+    }
+    capture.data = out.toOwnedSlice(capture.allocator) catch blk: {
+        capture.failed = true;
+        break :blk &.{};
+    };
 }
 
 fn sshSessionExecTool(request: *const ChatRequest, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
@@ -1250,7 +1344,8 @@ fn sshSessionExecTool(request: *const ChatRequest, surface_id: []const u8, comma
             return deniedResult(request.allocator, command, "operator rejected SSH PTY command");
         }
     }
-    const snapshot = request.tool_snapshot orelse return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    const snapshot = collectToolSnapshot(request) catch return request.allocator.dupe(u8, "No terminal snapshot host is available.");
+    defer snapshot.deinit(request.allocator);
     const host = request.tool_host orelse return request.allocator.dupe(u8, "No terminal tool host is available.");
     const surface = findSurface(snapshot, surface_id) orelse return request.allocator.dupe(u8, "No matching terminal surface.");
     if (!surface.is_ssh) return request.allocator.dupe(u8, "Target surface is not an opened SSH session.");

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -331,6 +331,7 @@ pub fn spawnAiChatTab(
     thinking: []const u8,
     reasoning_effort: []const u8,
     stream_val: []const u8,
+    agent_val: []const u8,
 ) bool {
     if (g_tab_count >= MAX_TABS) return false;
 
@@ -344,6 +345,7 @@ pub fn spawnAiChatTab(
         thinking,
         reasoning_effort,
         stream_val,
+        agent_val,
     ) catch {
         std.debug.print("Failed to create AI Chat session\n", .{});
         return false;

--- a/src/config.zig
+++ b/src/config.zig
@@ -17,6 +17,7 @@
 const Config = @This();
 
 const std = @import("std");
+const ai_chat = @import("ai_chat.zig");
 const directwrite = @import("directwrite.zig");
 const themes = @import("themes.zig");
 
@@ -234,6 +235,18 @@ theme: ?[]const u8 = null,
 
 /// Scrollback buffer limit in bytes.
 @"scrollback-limit": u32 = 10_000_000,
+
+/// Enable agent tools for AI Chat profiles by default.
+@"ai-agent-enabled": bool = false,
+
+/// Agent command permission mode: confirm (deny until approved UI exists) or full.
+@"ai-agent-permission": ai_chat.AgentPermission = .confirm,
+
+/// Timeout budget for agent shell/SSH commands.
+@"ai-agent-command-timeout-ms": u32 = 60_000,
+
+/// Maximum bytes returned from a single tool result.
+@"ai-agent-output-limit": u32 = 16 * 1024,
 
 /// The shell to run in the terminal. Accepted values:
 ///   - "cmd" — run Command Prompt (cmd.exe, default)
@@ -560,6 +573,30 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
     } else if (std.mem.eql(u8, key, "scrollback-limit")) {
         self.@"scrollback-limit" = std.fmt.parseInt(u32, value, 10) catch {
             log.warn("invalid scrollback-limit: {s}", .{value});
+            return;
+        };
+    } else if (std.mem.eql(u8, key, "ai-agent-enabled")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"ai-agent-enabled" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"ai-agent-enabled" = false;
+        } else {
+            log.warn("invalid ai-agent-enabled: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "ai-agent-permission")) {
+        if (ai_chat.AgentPermission.parse(value)) |permission| {
+            self.@"ai-agent-permission" = permission;
+        } else {
+            log.warn("invalid ai-agent-permission: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "ai-agent-command-timeout-ms")) {
+        self.@"ai-agent-command-timeout-ms" = std.fmt.parseInt(u32, value, 10) catch {
+            log.warn("invalid ai-agent-command-timeout-ms: {s}", .{value});
+            return;
+        };
+    } else if (std.mem.eql(u8, key, "ai-agent-output-limit")) {
+        self.@"ai-agent-output-limit" = std.fmt.parseInt(u32, value, 10) catch {
+            log.warn("invalid ai-agent-output-limit: {s}", .{value});
             return;
         };
     } else if (std.mem.eql(u8, key, "shell")) {
@@ -921,6 +958,10 @@ pub fn printHelp() void {
         \\  --window-height <rows>       Initial height in cells (default: 0=auto, min: 4)
         \\  --window-width <cols>        Initial width in cells (default: 0=auto, min: 10)
         \\  --scrollback-limit <bytes>   Scrollback buffer size (default: 10000000)
+        \\  --ai-agent-enabled <bool>    Enable AI Chat agent tools by default
+        \\  --ai-agent-permission <mode> Agent tool permission: confirm | full
+        \\  --ai-agent-command-timeout-ms <ms> Agent command timeout budget
+        \\  --ai-agent-output-limit <bytes> Max bytes returned by each tool
         \\  --config-file <path>         Load additional config file (prefix ? for optional)
         \\  --remote-enabled <bool>      Enable opt-in remote access foundation
         \\  --remote-server-url <url>    Cloudflare relay URL
@@ -1217,6 +1258,12 @@ const default_config_template =
     \\# Scrollback buffer size in bytes (default: 10MB)
     \\# scrollback-limit = 10000000
     \\
+    \\# AI Chat agent tools (disabled by default)
+    \\# ai-agent-enabled = false
+    \\# ai-agent-permission = confirm   # confirm | full
+    \\# ai-agent-command-timeout-ms = 60000
+    \\# ai-agent-output-limit = 16384
+    \\
     \\# Debug
     \\# phantty-debug-fps = false
     \\# phantty-debug-draw-calls = false
@@ -1282,4 +1329,22 @@ test "config: restore-tabs-on-startup parses true/false" {
     // Invalid value leaves the previous state untouched (still false).
     cfg.applyKeyValue(allocator, "restore-tabs-on-startup", "maybe", ".");
     try std.testing.expectEqual(false, cfg.@"restore-tabs-on-startup");
+}
+
+test "config: ai agent options parse" {
+    const allocator = std.testing.allocator;
+    var cfg: Config = .{};
+
+    try std.testing.expectEqual(false, cfg.@"ai-agent-enabled");
+    try std.testing.expectEqual(ai_chat.AgentPermission.confirm, cfg.@"ai-agent-permission");
+
+    cfg.applyKeyValue(allocator, "ai-agent-enabled", "true", ".");
+    cfg.applyKeyValue(allocator, "ai-agent-permission", "full", ".");
+    cfg.applyKeyValue(allocator, "ai-agent-command-timeout-ms", "120000", ".");
+    cfg.applyKeyValue(allocator, "ai-agent-output-limit", "4096", ".");
+
+    try std.testing.expectEqual(true, cfg.@"ai-agent-enabled");
+    try std.testing.expectEqual(ai_chat.AgentPermission.full, cfg.@"ai-agent-permission");
+    try std.testing.expectEqual(@as(u32, 120000), cfg.@"ai-agent-command-timeout-ms");
+    try std.testing.expectEqual(@as(u32, 4096), cfg.@"ai-agent-output-limit");
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -1128,7 +1128,7 @@ fn isModifierKey(vk: win32_backend.WPARAM) bool {
 }
 
 fn isAiChatKey(ev: win32_backend.KeyEvent) bool {
-    if (ev.vk == win32_backend.VK_RETURN or ev.vk == win32_backend.VK_BACK) return true;
+    if (ev.vk == win32_backend.VK_RETURN or ev.vk == win32_backend.VK_BACK or ev.vk == win32_backend.VK_ESCAPE) return true;
     if (ev.ctrl and !ev.alt and (ev.vk == 0x55 or ev.vk == 0x4C)) return true; // Ctrl+U / Ctrl+L
     return false;
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -2311,6 +2311,23 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
             file_explorer.g_focused = false;
             if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
 
+            if (AppWindow.activeAiChat() != null) {
+                const win = AppWindow.g_window orelse return;
+                const fb = win.getFramebufferSize();
+                if (AppWindow.ai_chat_renderer.permissionChipHitTest(
+                    xpos,
+                    ypos,
+                    @floatFromInt(fb.width),
+                    @floatCast(titlebarHeight()),
+                    AppWindow.leftPanelsWidth(),
+                    AppWindow.rightPanelsWidthForWindow(fb.width),
+                )) {
+                    toggleAiAgentPermission();
+                    return;
+                }
+                return;
+            }
+
             // Click in terminal content area: update split focus
             updateFocusFromMouse(@intFromFloat(xpos), @intFromFloat(ypos));
 
@@ -3172,6 +3189,21 @@ fn pasteFromClipboardIntoAiChat(chat: *AppWindow.ai_chat.Session) void {
         AppWindow.g_cells_valid = false;
         return;
     }
+}
+
+fn toggleAiAgentPermission() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    var cfg = Config.load(allocator) catch Config{};
+    defer cfg.deinit(allocator);
+
+    const next = switch (cfg.@"ai-agent-permission") {
+        .confirm => "full",
+        .full => "confirm",
+    };
+    Config.setConfigValue(allocator, "ai-agent-permission", next) catch return;
+    AppWindow.reloadConfigImmediate(allocator);
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
 }
 
 pub fn pasteImageFromClipboard() void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -62,7 +62,8 @@ pub fn render(
     _ = titlebar.renderTextLimited(session.title(), x + LINE_PAD_X, header_y + 10, mixColor(fg, accent, 0.12), w * 0.45);
 
     var meta_buf: [256]u8 = undefined;
-    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}", .{ session.model(), session.status() }) catch session.status();
+    const mode = if (session.agent_enabled) "Agent" else "Chat";
+    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}  {s}", .{ session.model(), mode, session.status() }) catch session.status();
     const meta_w = measureText(meta);
     _ = titlebar.renderTextLimited(meta, x + w - LINE_PAD_X - @min(meta_w, w * 0.42), header_y + 10, muted, w * 0.42);
 
@@ -80,7 +81,8 @@ pub fn render(
 
     const input_text = session.input();
     if (input_text.len == 0) {
-        _ = titlebar.renderTextLimited("Ask AI Chat", field_x + 12, field_y + (field_h - font.g_titlebar_cell_height) / 2, mixColor(bg, fg, 0.42), field_w - 24);
+        const placeholder = if (session.agent_enabled) "Ask Agent" else "Ask AI Chat";
+        _ = titlebar.renderTextLimited(placeholder, field_x + 12, field_y + (field_h - font.g_titlebar_cell_height) / 2, mixColor(bg, fg, 0.42), field_w - 24);
     } else {
         _ = renderWrappedText(input_text, field_x + 12, window_height - field_y - field_h + 10, field_w - 24, lineHeight(), fg, window_height, window_height);
     }

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -17,6 +17,7 @@ pub const INPUT_H: f32 = 92;
 const BUBBLE_PAD_X: f32 = 14;
 const BUBBLE_PAD_Y: f32 = 10;
 const BUBBLE_GAP: f32 = 12;
+const APPROVAL_H: f32 = 92;
 const REASONING_PAD_Y: f32 = 6;
 const REASONING_LEFT: f32 = 22;
 const REASONING_RIGHT: f32 = 12;
@@ -91,8 +92,14 @@ pub fn render(
         gl_init.renderQuad(cursor_x, field_y + 14, 1, field_h - 28, accent);
     }
 
+    const approval = session.approvalView();
+    const approval_h: f32 = if (approval != null) APPROVAL_H else 0;
+    if (approval) |view| {
+        renderApprovalCard(view, x + LINE_PAD_X, INPUT_H + 10, w - LINE_PAD_X * 2, APPROVAL_H, window_height);
+    }
+
     const transcript_top = top + HEADER_H + 18;
-    const transcript_bottom = INPUT_H + 18;
+    const transcript_bottom = INPUT_H + approval_h + 18;
     const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
     const content_w = w - LINE_PAD_X * 2;
     const content_x = x + LINE_PAD_X;
@@ -145,6 +152,25 @@ pub fn render(
     }
 
     gl.Disable.?(c.GL_SCISSOR_TEST);
+}
+
+fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32, window_height: f32) void {
+    _ = window_height;
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const danger = [3]f32{ 0.95, 0.26, 0.30 };
+    gl_init.renderQuadAlpha(x, y, w, h, mixColor(bg, accent, 0.10), 0.98);
+    gl_init.renderQuadAlpha(x, y + h - 2, w, 2, accent, 0.85);
+    gl_init.renderQuadAlpha(x, y, 3, h, danger, 0.9);
+
+    var title_buf: [256]u8 = undefined;
+    const title = std.fmt.bufPrint(&title_buf, "Approve {s}?  Enter/Y approve, Esc/N deny", .{view.tool}) catch "Approve tool?  Enter/Y approve, Esc/N deny";
+    _ = titlebar.renderTextLimited(title, x + 14, y + h - 26, mixColor(fg, accent, 0.18), w - 28);
+    if (view.reason.len > 0) {
+        _ = titlebar.renderTextLimited(view.reason, x + 14, y + h - 50, mixColor(bg, fg, 0.72), w - 28);
+    }
+    _ = titlebar.renderTextLimited(view.command, x + 14, y + 14, fg, w - 28);
 }
 
 fn renderMessageBubble(role: ai_chat.Role, text: []const u8, x: f32, top_px: f32, w: f32, h: f32, window_height: f32) void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -17,7 +17,8 @@ pub const INPUT_H: f32 = 92;
 const BUBBLE_PAD_X: f32 = 14;
 const BUBBLE_PAD_Y: f32 = 10;
 const BUBBLE_GAP: f32 = 12;
-const APPROVAL_H: f32 = 92;
+const APPROVAL_H: f32 = 128;
+const APPROVAL_GAP: f32 = 12;
 const REASONING_PAD_Y: f32 = 6;
 const REASONING_LEFT: f32 = 22;
 const REASONING_RIGHT: f32 = 12;
@@ -93,10 +94,7 @@ pub fn render(
     }
 
     const approval = session.approvalView();
-    const approval_h: f32 = if (approval != null) APPROVAL_H else 0;
-    if (approval) |view| {
-        renderApprovalCard(view, x + LINE_PAD_X, INPUT_H + 10, w - LINE_PAD_X * 2, APPROVAL_H, window_height);
-    }
+    const approval_h: f32 = if (approval != null) APPROVAL_H + APPROVAL_GAP else 0;
 
     const transcript_top = top + HEADER_H + 18;
     const transcript_bottom = INPUT_H + approval_h + 18;
@@ -113,7 +111,7 @@ pub fn render(
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
 
-    const scissor_y: c.GLint = @intFromFloat(@round(INPUT_H + 18));
+    const scissor_y: c.GLint = @intFromFloat(@round(transcript_bottom));
     const scissor_h: c.GLsizei = @intFromFloat(@round(transcript_h));
     gl.Enable.?(c.GL_SCISSOR_TEST);
     gl.Scissor.?(
@@ -152,25 +150,32 @@ pub fn render(
     }
 
     gl.Disable.?(c.GL_SCISSOR_TEST);
+
+    if (approval) |view| {
+        renderApprovalCard(view, x + LINE_PAD_X, INPUT_H + APPROVAL_GAP, w - LINE_PAD_X * 2, APPROVAL_H);
+    }
 }
 
-fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32, window_height: f32) void {
-    _ = window_height;
+fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32) void {
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
-    const danger = [3]f32{ 0.95, 0.26, 0.30 };
-    gl_init.renderQuadAlpha(x, y, w, h, mixColor(bg, accent, 0.10), 0.98);
-    gl_init.renderQuadAlpha(x, y + h - 2, w, 2, accent, 0.85);
-    gl_init.renderQuadAlpha(x, y, 3, h, danger, 0.9);
+    const card_bg = mixColor(bg, accent, 0.08);
+    gl_init.renderQuadAlpha(x, y, w, h, card_bg, 0.98);
+    gl_init.renderQuadAlpha(x, y + h - 1, w, 1, accent, 0.65);
+    gl_init.renderQuadAlpha(x, y, w, 1, mixColor(bg, fg, 0.18), 0.8);
+    gl_init.renderQuadAlpha(x, y, 4, h, accent, 0.85);
 
     var title_buf: [256]u8 = undefined;
-    const title = std.fmt.bufPrint(&title_buf, "Approve {s}?  Enter/Y approve, Esc/N deny", .{view.tool}) catch "Approve tool?  Enter/Y approve, Esc/N deny";
-    _ = titlebar.renderTextLimited(title, x + 14, y + h - 26, mixColor(fg, accent, 0.18), w - 28);
+    const title = std.fmt.bufPrint(&title_buf, "Approve {s}?", .{view.tool}) catch "Approve tool?";
+    _ = titlebar.renderTextLimited(title, x + 16, y + h - 26, mixColor(fg, accent, 0.20), w - 32);
+    _ = titlebar.renderTextLimited("Enter/Y to run, Esc/N to deny", x + 16, y + h - 50, mixColor(bg, fg, 0.62), w - 32);
     if (view.reason.len > 0) {
-        _ = titlebar.renderTextLimited(view.reason, x + 14, y + h - 50, mixColor(bg, fg, 0.72), w - 28);
+        _ = titlebar.renderTextLimited(view.reason, x + 16, y + h - 74, mixColor(bg, fg, 0.70), w - 32);
     }
-    _ = titlebar.renderTextLimited(view.command, x + 14, y + 14, fg, w - 28);
+    const command_bg = mixColor(bg, fg, 0.065);
+    gl_init.renderQuadAlpha(x + 12, y + 10, w - 24, 34, command_bg, 0.95);
+    _ = titlebar.renderTextLimited(view.command, x + 20, y + 18, fg, w - 40);
 }
 
 fn renderMessageBubble(role: ai_chat.Role, text: []const u8, x: f32, top_px: f32, w: f32, h: f32, window_height: f32) void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -14,6 +14,9 @@ const c = @cImport({
 pub const LINE_PAD_X: f32 = 18;
 const HEADER_H: f32 = 54;
 pub const INPUT_H: f32 = 92;
+const PERMISSION_CHIP_W: f32 = 112;
+const PERMISSION_CHIP_H: f32 = 24;
+const STATUS_SLOT_W: f32 = 92;
 const BUBBLE_PAD_X: f32 = 14;
 const BUBBLE_PAD_Y: f32 = 10;
 const BUBBLE_GAP: f32 = 12;
@@ -65,9 +68,23 @@ pub fn render(
 
     var meta_buf: [256]u8 = undefined;
     const mode = if (session.agent_enabled) "Agent" else "Chat";
-    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}  {s}", .{ session.model(), mode, session.status() }) catch session.status();
+    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}", .{ session.model(), mode }) catch session.model();
     const meta_w = measureText(meta);
-    _ = titlebar.renderTextLimited(meta, x + w - LINE_PAD_X - @min(meta_w, w * 0.42), header_y + 10, muted, w * 0.42);
+    const permission = ai_chat.agentPermission();
+    const chip_x = permissionChipX(x, w);
+    const meta_right = chip_x - 10;
+    const meta_limit = @max(80.0, meta_right - (x + LINE_PAD_X + w * 0.28));
+    _ = titlebar.renderTextLimited(meta, meta_right - @min(meta_w, meta_limit), header_y + 10, muted, meta_limit);
+
+    var perm_buf: [48]u8 = undefined;
+    const perm_text = std.fmt.bufPrint(&perm_buf, "perm: {s}", .{permission.name()}) catch permission.name();
+    const perm_color = if (permission == .full) mixColor(fg, accent, 0.25) else mixColor(bg, fg, 0.66);
+    _ = titlebar.renderTextLimited(perm_text, chip_x, header_y + 10, perm_color, PERMISSION_CHIP_W);
+    gl_init.renderQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 10, 1, accent, if (permission == .full) 0.38 else 0.16);
+
+    const status_w = measureText(session.status());
+    const status_limit = STATUS_SLOT_W;
+    _ = titlebar.renderTextLimited(session.status(), x + w - LINE_PAD_X - @min(status_w, status_limit), header_y + 10, muted, status_limit);
 
     const input_y: f32 = 0;
     gl_init.renderQuadAlpha(x, input_y, w, INPUT_H, panel, 0.98);
@@ -154,6 +171,28 @@ pub fn render(
     if (approval) |view| {
         renderApprovalCard(view, x + LINE_PAD_X, INPUT_H + APPROVAL_GAP, w - LINE_PAD_X * 2, APPROVAL_H);
     }
+}
+
+pub fn permissionChipHitTest(
+    xpos: f64,
+    ypos: f64,
+    window_width: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+) bool {
+    const x = @round(left_panels_w);
+    const w = @round(@max(1.0, window_width - left_panels_w - right_panels_w));
+    const chip_x = permissionChipX(x, w);
+    const chip_top = titlebar_offset + 12;
+    const px: f32 = @floatCast(xpos);
+    const py: f32 = @floatCast(ypos);
+    return px >= chip_x and px <= chip_x + PERMISSION_CHIP_W and
+        py >= chip_top and py <= chip_top + PERMISSION_CHIP_H;
+}
+
+fn permissionChipX(x: f32, w: f32) f32 {
+    return x + w - LINE_PAD_X - STATUS_SLOT_W - PERMISSION_CHIP_W;
 }
 
 fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32) void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -14,9 +14,10 @@ const c = @cImport({
 pub const LINE_PAD_X: f32 = 18;
 const HEADER_H: f32 = 54;
 pub const INPUT_H: f32 = 92;
-const PERMISSION_CHIP_W: f32 = 112;
+const PERMISSION_CHIP_W: f32 = 104;
 const PERMISSION_CHIP_H: f32 = 24;
-const STATUS_SLOT_W: f32 = 92;
+const STATUS_SLOT_W: f32 = 120;
+const MODE_SLOT_W: f32 = 112;
 const BUBBLE_PAD_X: f32 = 14;
 const BUBBLE_PAD_Y: f32 = 10;
 const BUBBLE_GAP: f32 = 12;
@@ -64,23 +65,18 @@ pub fn render(
     const header_y = window_height - top - HEADER_H;
     gl_init.renderQuadAlpha(x, header_y, w, HEADER_H, panel, 0.95);
     gl_init.renderQuadAlpha(x, header_y, w, 1, line, 0.8);
-    _ = titlebar.renderTextLimited(session.title(), x + LINE_PAD_X, header_y + 10, mixColor(fg, accent, 0.12), w * 0.45);
+    _ = titlebar.renderTextLimited(session.model(), x + LINE_PAD_X, header_y + 10, mixColor(fg, accent, 0.12), w * 0.48);
 
-    var meta_buf: [256]u8 = undefined;
-    const mode = if (session.agent_enabled) "Agent" else "Chat";
-    const meta = std.fmt.bufPrint(&meta_buf, "{s}  {s}", .{ session.model(), mode }) catch session.model();
-    const meta_w = measureText(meta);
     const permission = ai_chat.agentPermission();
     const chip_x = permissionChipX(x, w);
-    const meta_right = chip_x - 10;
-    const meta_limit = @max(80.0, meta_right - (x + LINE_PAD_X + w * 0.28));
-    _ = titlebar.renderTextLimited(meta, meta_right - @min(meta_w, meta_limit), header_y + 10, muted, meta_limit);
+    const mode_text = if (session.agent_enabled) "Agent" else "Chat";
+    const mode_x = chip_x - MODE_SLOT_W - 8;
+    _ = titlebar.renderTextLimited(mode_text, mode_x, header_y + 10, mixColor(fg, accent, 0.18), MODE_SLOT_W);
 
-    var perm_buf: [48]u8 = undefined;
-    const perm_text = std.fmt.bufPrint(&perm_buf, "perm: {s}", .{permission.name()}) catch permission.name();
+    const perm_text = permissionDisplayName(permission);
     const perm_color = if (permission == .full) mixColor(fg, accent, 0.25) else mixColor(bg, fg, 0.66);
     _ = titlebar.renderTextLimited(perm_text, chip_x, header_y + 10, perm_color, PERMISSION_CHIP_W);
-    gl_init.renderQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 10, 1, accent, if (permission == .full) 0.38 else 0.16);
+    gl_init.renderQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, if (permission == .full) 0.38 else 0.16);
 
     const status_w = measureText(session.status());
     const status_limit = STATUS_SLOT_W;
@@ -192,7 +188,14 @@ pub fn permissionChipHitTest(
 }
 
 fn permissionChipX(x: f32, w: f32) f32 {
-    return x + w - LINE_PAD_X - STATUS_SLOT_W - PERMISSION_CHIP_W;
+    return x + w - LINE_PAD_X - STATUS_SLOT_W - 12 - PERMISSION_CHIP_W;
+}
+
+fn permissionDisplayName(permission: ai_chat.AgentPermission) []const u8 {
+    return switch (permission) {
+        .confirm => "Ask",
+        .full => "Full",
+    };
 }
 
 fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32) void {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -860,7 +860,7 @@ const SSH_FIELD_COUNT = 5;
 const SSH_FIELD_MAX = 128;
 const SSH_PROFILE_MAX = 16;
 const SSH_PROFILE_NONE = std.math.maxInt(usize);
-const AI_FIELD_COUNT = 8;
+const AI_FIELD_COUNT = 9;
 const AI_FIELD_MAX = 512;
 const AI_PROFILE_MAX = 16;
 const AI_PROFILE_NONE = std.math.maxInt(usize);
@@ -883,6 +883,7 @@ const AiField = enum(usize) {
     thinking = 5,
     reasoning_effort = 6,
     stream = 7,
+    agent = 8,
 };
 
 const SessionAction = enum {
@@ -1484,6 +1485,7 @@ fn clearAiForm() void {
     setAiDefault(.thinking, AppWindow.ai_chat.DEFAULT_THINKING);
     setAiDefault(.reasoning_effort, AppWindow.ai_chat.DEFAULT_REASONING_EFFORT);
     setAiDefault(.stream, AppWindow.ai_chat.DEFAULT_STREAM);
+    setAiDefault(.agent, AppWindow.ai_chat.DEFAULT_AGENT);
 }
 
 fn appendAiFormCodepoint(field: usize, codepoint: u21) void {
@@ -1669,11 +1671,12 @@ fn connectAiProfile(idx: usize) void {
     const thinking = aiProfileField(profile, .thinking);
     const reasoning_effort = aiProfileField(profile, .reasoning_effort);
     const stream_val = aiProfileField(profile, .stream);
+    const agent_val = aiProfileField(profile, .agent);
     if (base_url.len == 0 or model.len == 0) return;
     if (!isHttpUrlish(base_url)) return;
 
     sessionLauncherClose();
-    _ = AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val);
+    _ = AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val, agent_val);
 }
 
 fn isHttpUrlish(value: []const u8) bool {
@@ -1719,6 +1722,7 @@ fn loadAiProfiles() void {
         if (profile.lens[@intFromEnum(AiField.thinking)] == 0) setProfileDefault(&profile, .thinking, AppWindow.ai_chat.DEFAULT_THINKING);
         if (profile.lens[@intFromEnum(AiField.reasoning_effort)] == 0) setProfileDefault(&profile, .reasoning_effort, AppWindow.ai_chat.DEFAULT_REASONING_EFFORT);
         if (profile.lens[@intFromEnum(AiField.stream)] == 0) setProfileDefault(&profile, .stream, AppWindow.ai_chat.DEFAULT_STREAM);
+        if (profile.lens[@intFromEnum(AiField.agent)] == 0) setProfileDefault(&profile, .agent, AppWindow.ai_chat.DEFAULT_AGENT);
         g_ai_profiles[g_ai_profile_count] = profile;
         g_ai_profile_count += 1;
     }
@@ -1733,7 +1737,7 @@ fn saveAiProfiles(allocator: std.mem.Allocator) void {
 
     var out: std.ArrayListUnmanaged(u8) = .empty;
     defer out.deinit(allocator);
-    out.appendSlice(allocator, "# Phantty AI Chat profiles. Fields are hex encoded: name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream.\n") catch return;
+    out.appendSlice(allocator, "# Phantty AI Chat profiles. Fields are hex encoded: name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream, agent.\n") catch return;
     for (g_ai_profiles[0..g_ai_profile_count]) |profile| {
         for (0..AI_FIELD_COUNT) |i| {
             if (i > 0) out.append(allocator, '\t') catch return;
@@ -2245,6 +2249,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.thinking), "Thinking", aiField(.thinking), false);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.reasoning_effort), "Effort", aiField(.reasoning_effort), false);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.stream), "Stream", aiField(.stream), false);
+        renderAiSessionField(layout, window_height, @intFromEnum(AiField.agent), "Agent", aiField(.agent), false);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save & Open", "chat", g_ai_focus == AI_FIELD_COUNT);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save", "profile", g_ai_focus == AI_FIELD_COUNT + 1);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Cancel", "Esc", g_ai_focus == AI_FIELD_COUNT + 2);

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1984,7 +1984,7 @@ fn sessionDesiredBoxWidth() f32 {
     desired = @max(desired, sessionTwoColumnWidth("PowerShell", "new terminal"));
     desired = @max(desired, sessionTwoColumnWidth("SSH", "connect server"));
     desired = @max(desired, sessionTwoColumnWidth("WSL", "wsl.exe ~"));
-    desired = @max(desired, sessionTwoColumnWidth("AI Chat", "DeepSeek"));
+    desired = @max(desired, sessionTwoColumnWidth("AI", defaultAiModeLabel()));
     return desired;
 }
 
@@ -2153,10 +2153,23 @@ fn renderSshProfileRow(layout: SessionLayout, window_height: f32, row: usize, pr
 
 fn renderAiProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const AiProfile, selected: bool) void {
     const name = aiProfileField(profile, .name);
-    const model = aiProfileField(profile, .model);
-    const base_url = aiProfileField(profile, .base_url);
-    const detail = if (model.len > 0) model else base_url;
+    const detail = aiProfileModeLabel(profile);
     renderSessionRow(layout, window_height, row, name, detail, selected);
+}
+
+fn aiModeText(value: []const u8) []const u8 {
+    if (std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "enabled")) return "Agent";
+    return "Chat";
+}
+
+fn aiProfileModeLabel(profile: *const AiProfile) []const u8 {
+    return aiModeText(aiProfileField(profile, .agent));
+}
+
+fn defaultAiModeLabel() []const u8 {
+    loadAiProfiles();
+    if (g_ai_profile_count > 0) return aiProfileModeLabel(&g_ai_profiles[0]);
+    return aiModeText(AppWindow.ai_chat.DEFAULT_AGENT);
 }
 
 pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: f32) void {
@@ -2236,7 +2249,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderSessionRow(layout, window_height, 0, "PowerShell", "new terminal", g_session_launcher_selected == 0);
         renderSessionRow(layout, window_height, 1, "SSH", "connect server", g_session_launcher_selected == 1);
         renderSessionRow(layout, window_height, 2, "WSL", "wsl.exe ~", g_session_launcher_selected == 2);
-        renderSessionRow(layout, window_height, 3, "AI Chat", "DeepSeek", g_session_launcher_selected == 3);
+        renderSessionRow(layout, window_height, 3, "AI", defaultAiModeLabel(), g_session_launcher_selected == 3);
         return;
     }
 


### PR DESCRIPTION
## Summary
- Turns AI Chat into an agent-capable tab with OpenAI-compatible tool calls, terminal snapshots, PowerShell execution, and opened-SSH PTY dispatch.
- Adds agent permission handling, approval UI, mode labels, and safer request JSON handling for reasoning content and invalid UTF-8.
- Documents AI agent tools on the English and Chinese website pages.

## Test plan
- [x] zig build test
- [x] zig build
