### PR TITLE
Native Windows scrollbar experiment and AI Chat tool folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ A Windows terminal written in Zig, powered by [libghostty-vt](https://github.com
 > [!NOTE]
 > Phantty is **Windows-only**. On macOS and Linux, use [Ghostty](https://ghostty.org/) instead.
 
+## TODO
+
+- **Native Windows UI components** — test a Win32 native scrollbar for terminal surfaces first via `native-scrollbar = true`. If the native scrollbar integrates cleanly with scrollback, split layouts, DPI scaling, dark mode, and input focus, continue evaluating other native Windows components to reduce custom-drawn UI where platform controls behave better.
+
 ## Building
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A Windows terminal written in Zig, powered by [libghostty-vt](https://github.com
 
 ## TODO
 
-- **Native Windows UI components** — test a Win32 native scrollbar for terminal surfaces first via `native-scrollbar = true`. If the native scrollbar integrates cleanly with scrollback, split layouts, DPI scaling, dark mode, and input focus, continue evaluating other native Windows components to reduce custom-drawn UI where platform controls behave better.
+- **Native Windows UI components** — Win32 native scrollbar is enabled by default for terminal surfaces; use `native-scrollbar = false` only to compare against the legacy virtual scrollbar. If the native scrollbar integrates cleanly with scrollback, split layouts, DPI scaling, dark mode, and input focus, continue evaluating other native Windows components to reduce custom-drawn UI where platform controls behave better.
 
 ## Building
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -28,6 +28,7 @@ shell_cmd_len: usize,
 
 // Config values (read-only after init)
 scrollback_limit: u32,
+native_scrollbar: bool,
 font_family: []const u8,
 font_family_cjk: ?[]const u8,
 font_family_fallback: ?[]const u8,
@@ -138,6 +139,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .shell_cmd_buf = undefined,
         .shell_cmd_len = 0,
         .scrollback_limit = cfg.@"scrollback-limit",
+        .native_scrollbar = cfg.@"native-scrollbar",
         .font_family = font_family,
         .font_family_cjk = font_family_cjk,
         .font_family_fallback = font_family_fallback,
@@ -274,6 +276,7 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     defer self.mutex.unlock();
 
     self.scrollback_limit = cfg.@"scrollback-limit";
+    self.native_scrollbar = cfg.@"native-scrollbar";
     self.replaceStr(&self.font_family, cfg.@"font-family");
     self.replaceOptStr(&self.font_family_cjk, cfg.@"font-family-cjk");
     self.replaceOptStr(&self.font_family_fallback, cfg.@"font-family-fallback");

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -80,6 +80,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     overlays.g_debug_fps = app.debug_fps;
     overlays.g_debug_draw_calls = app.debug_draw_calls;
     g_debug_memory = app.debug_memory;
+    g_native_scrollbar = app.native_scrollbar;
 
     // Split config
     overlays.g_unfocused_split_opacity = app.unfocused_split_opacity;
@@ -198,6 +199,7 @@ threadlocal var g_start_maximize: bool = false;
 threadlocal var g_start_fullscreen: bool = false;
 threadlocal var g_debug_memory: bool = false;
 threadlocal var g_debug_memory_last_ms: i64 = 0;
+pub threadlocal var g_native_scrollbar: bool = false;
 threadlocal var g_remote_layout_last_ms: i64 = 0;
 threadlocal var g_remote_ai_sinks: [tab.MAX_TABS]RemoteAiInputSink = undefined;
 
@@ -340,6 +342,48 @@ fn syncWindowTitlebarHeight(win: *win32_backend.Window) f32 {
     const next: i32 = @intFromFloat(titlebar.titlebarHeight());
     win.titlebar_height = next;
     return @floatFromInt(next);
+}
+
+fn syncNativeScrollbarForFrame(
+    win: *win32_backend.Window,
+    active_tab: *TabState,
+    split_count: usize,
+    content_x: i32,
+    content_y: i32,
+    content_w: i32,
+    content_h: i32,
+) bool {
+    if (!g_native_scrollbar or active_tab.kind != .terminal or split_count != 1) {
+        win.hideNativeScrollbar();
+        return false;
+    }
+
+    const surface = activeSurface() orelse {
+        win.hideNativeScrollbar();
+        return false;
+    };
+
+    const sb = input.scrollbarForSurface(surface);
+    if (sb.total <= sb.len) {
+        win.hideNativeScrollbar();
+        return false;
+    }
+
+    const bar_w = @min(win.nativeScrollbarWidth(), @max(0, content_w));
+    if (bar_w <= 0 or content_h <= 0) {
+        win.hideNativeScrollbar();
+        return false;
+    }
+
+    return win.syncNativeScrollbar(
+        content_x + content_w - bar_w,
+        content_y,
+        bar_w,
+        content_h,
+        sb.total,
+        sb.len,
+        sb.offset,
+    );
 }
 
 pub fn activeSelection() *Selection {
@@ -693,6 +737,10 @@ fn onWin32Resize(width: i32, height: i32) void {
         const content_w: i32 = @intFromFloat(@as(f32, @floatFromInt(width)) - left_panels_w - right_panels_w - render_padding * 2);
         const content_h: i32 = @intFromFloat(@as(f32, @floatFromInt(height)) - (render_padding + tb) - render_padding);
         const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
+        const native_scrollbar_visible = if (g_window) |w|
+            syncNativeScrollbarForFrame(w, active_tab, split_count, content_x, content_y, content_w, content_h)
+        else
+            false;
         if (g_allocator) |alloc| syncRemoteLayout(alloc);
 
         if (split_count <= 1) {
@@ -722,7 +770,7 @@ fn onWin32Resize(width: i32, height: i32) void {
                 markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
                 file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
                 cell_renderer.drawCells(rend, @floatFromInt(fb_height), left_panels_w + @as(f32, @floatFromInt(pad.left)), pad_top);
-                overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
+                if (!native_scrollbar_visible) overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
                 overlays.renderResizeOverlayWithOffset(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
             }
         } else {
@@ -839,6 +887,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     overlays.g_debug_fps = cfg.@"phantty-debug-fps";
     overlays.g_debug_draw_calls = cfg.@"phantty-debug-draw-calls";
     g_debug_memory = cfg.@"phantty-debug-memory";
+    g_native_scrollbar = cfg.@"native-scrollbar";
 
     // --- Split config ---
     overlays.g_unfocused_split_opacity = cfg.@"unfocused-split-opacity";
@@ -2500,6 +2549,7 @@ fn runMainLoop(self: *AppWindow) !void {
             const content_w: i32 = @intFromFloat(@as(f32, @floatFromInt(fb_width)) - left_panels_w - right_panels_w - padding * 2);
             const content_h: i32 = @intFromFloat(@as(f32, @floatFromInt(fb_height)) - top_padding - padding);
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
+            const native_scrollbar_visible = syncNativeScrollbarForFrame(win, active_tab, split_count, content_x, content_y, content_w, content_h);
             syncRemoteLayout(allocator);
             syncImeCaretPosition(win, split_count);
 
@@ -2551,7 +2601,7 @@ fn runMainLoop(self: *AppWindow) !void {
                     markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
                     file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
                     cell_renderer.drawCells(rend, @floatFromInt(fb_height), left_panels_w + @as(f32, @floatFromInt(pad.left)), pad_top);
-                    overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
+                    if (!native_scrollbar_visible) overlays.renderScrollbar(@floatFromInt(fb_width), @floatFromInt(fb_height), pad_top);
 
                     // Render resize overlay centered in content area (offset for titlebar)
                     overlays.renderResizeOverlayWithOffset(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -2625,6 +2675,7 @@ fn runMainLoop(self: *AppWindow) !void {
                 }
             }
         } else if (!post_process.g_post_enabled) {
+            win.hideNativeScrollbar();
             gl.Viewport.?(0, 0, fb_width, fb_height);
             gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
             clearWithBackground(fb_width, fb_height);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -20,6 +20,7 @@ const remote = @import("remote_client.zig");
 const remote_snapshot = @import("remote_snapshot.zig");
 const memory_debug = @import("memory_debug.zig");
 const agent_detector = @import("agent_detector.zig");
+const native_scrollbar = @import("native_scrollbar.zig");
 pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
@@ -344,14 +345,35 @@ fn syncWindowTitlebarHeight(win: *win32_backend.Window) f32 {
     return @floatFromInt(next);
 }
 
+pub fn scrollbarWidthForLayout(active_tab: *const TabState) i32 {
+    if (g_native_scrollbar and active_tab.kind == .terminal and !active_tab.tree.isSplit()) {
+        if (g_window) |win| return win.nativeScrollbarWidth();
+    }
+    return @intFromFloat(overlays.SCROLLBAR_WIDTH);
+}
+
+pub fn scrollbarRightPaddingForLayout(active_tab: *const TabState) u32 {
+    return native_scrollbar.rightPadding(scrollbarWidthForLayout(active_tab), @intCast(DEFAULT_PADDING));
+}
+
+fn scrollbarRightPaddingForActiveTab() u32 {
+    const active_tab = activeTab() orelse return native_scrollbar.rightPadding(@intFromFloat(overlays.SCROLLBAR_WIDTH), @intCast(DEFAULT_PADDING));
+    return scrollbarRightPaddingForLayout(active_tab);
+}
+
+fn splitRectForSurface(surface: *Surface) ?SplitRect {
+    for (0..split_layout.g_split_rect_count) |i| {
+        const rect = split_layout.g_split_rects[i];
+        if (!split_layout.cachedRectIsLive(rect)) continue;
+        if (rect.surface == surface) return rect;
+    }
+    return null;
+}
+
 fn syncNativeScrollbarForFrame(
     win: *win32_backend.Window,
     active_tab: *TabState,
     split_count: usize,
-    content_x: i32,
-    content_y: i32,
-    content_w: i32,
-    content_h: i32,
 ) bool {
     if (!g_native_scrollbar or active_tab.kind != .terminal or split_count != 1) {
         win.hideNativeScrollbar();
@@ -363,23 +385,27 @@ fn syncNativeScrollbarForFrame(
         return false;
     };
 
+    const rect = splitRectForSurface(surface) orelse {
+        win.hideNativeScrollbar();
+        return false;
+    };
+
     const sb = input.scrollbarForSurface(surface);
     if (sb.total <= sb.len) {
         win.hideNativeScrollbar();
         return false;
     }
 
-    const bar_w = @min(win.nativeScrollbarWidth(), @max(0, content_w));
-    if (bar_w <= 0 or content_h <= 0) {
+    const track = native_scrollbar.trackRect(rect.x, rect.y, rect.width, rect.height, win.nativeScrollbarWidth()) orelse {
         win.hideNativeScrollbar();
         return false;
-    }
+    };
 
     return win.syncNativeScrollbar(
-        content_x + content_w - bar_w,
-        content_y,
-        bar_w,
-        content_h,
+        track.x,
+        track.y,
+        track.width,
+        track.height,
         sb.total,
         sb.len,
         sb.offset,
@@ -691,7 +717,7 @@ fn onWin32Resize(width: i32, height: i32) void {
     // Height: render-loop subtracts (render_padding+TB) top and render_padding
     //         bottom, then setScreenSize subtracts explicit T+B on top of that.
     const padding_left: f32 = @floatFromInt(DEFAULT_PADDING);
-    const padding_right: f32 = @as(f32, @floatFromInt(DEFAULT_PADDING)) + overlays.SCROLLBAR_WIDTH;
+    const padding_right: f32 = @floatFromInt(scrollbarRightPaddingForActiveTab());
     const padding_top: f32 = @floatFromInt(DEFAULT_PADDING);
     const padding_bottom: f32 = @floatFromInt(DEFAULT_PADDING);
     const render_padding: f32 = 10;
@@ -738,7 +764,7 @@ fn onWin32Resize(width: i32, height: i32) void {
         const content_h: i32 = @intFromFloat(@as(f32, @floatFromInt(height)) - (render_padding + tb) - render_padding);
         const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
         const native_scrollbar_visible = if (g_window) |w|
-            syncNativeScrollbarForFrame(w, active_tab, split_count, content_x, content_y, content_w, content_h)
+            syncNativeScrollbarForFrame(w, active_tab, split_count)
         else
             false;
         if (g_allocator) |alloc| syncRemoteLayout(alloc);
@@ -2339,7 +2365,7 @@ fn runMainLoop(self: *AppWindow) !void {
     //   avail_h = (fb_height - 54) - 10 - 10 = fb_height - 74
     const titlebar_height = currentTitlebarHeight();
     const explicit_left: f32 = @floatFromInt(DEFAULT_PADDING);
-    const explicit_right: f32 = @as(f32, @floatFromInt(DEFAULT_PADDING)) + overlays.SCROLLBAR_WIDTH;
+    const explicit_right: f32 = @floatFromInt(scrollbarRightPaddingForActiveTab());
     const explicit_top: f32 = @floatFromInt(DEFAULT_PADDING);
     const explicit_bottom: f32 = @floatFromInt(DEFAULT_PADDING);
     const render_padding: f32 = 10;
@@ -2549,7 +2575,7 @@ fn runMainLoop(self: *AppWindow) !void {
             const content_w: i32 = @intFromFloat(@as(f32, @floatFromInt(fb_width)) - left_panels_w - right_panels_w - padding * 2);
             const content_h: i32 = @intFromFloat(@as(f32, @floatFromInt(fb_height)) - top_padding - padding);
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
-            const native_scrollbar_visible = syncNativeScrollbarForFrame(win, active_tab, split_count, content_x, content_y, content_w, content_h);
+            const native_scrollbar_visible = syncNativeScrollbarForFrame(win, active_tab, split_count);
             syncRemoteLayout(allocator);
             syncImeCaretPosition(win, split_count);
 

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -49,6 +49,8 @@ pub const Message = struct {
     reasoning: ?[]u8 = null,
     content_collapsed: bool = false,
     content_auto_expand: bool = false,
+    tool_grouped: bool = false,
+    tool_group_collapsed: bool = false,
     reasoning_collapsed: bool = true,
     reasoning_auto_expand: bool = false,
 };
@@ -604,6 +606,15 @@ pub const Session = struct {
         msg.content_auto_expand = false;
     }
 
+    pub fn toggleToolGroupCollapsed(self: *Session, message_index: usize) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (message_index >= self.messages.items.len) return;
+        var msg = &self.messages.items[message_index];
+        if (msg.role != .tool or !msg.tool_grouped) return;
+        msg.tool_group_collapsed = !msg.tool_group_collapsed;
+    }
+
     pub fn toggleReasoningCollapsed(self: *Session, message_index: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -783,15 +794,45 @@ pub const Session = struct {
     }
 
     fn collapseAutoExpandedDetailsLocked(self: *Session) void {
-        for (self.messages.items) |*msg| {
-            if (msg.role == .tool and msg.content_auto_expand) {
-                msg.content_collapsed = true;
-                msg.content_auto_expand = false;
+        var i: usize = 0;
+        while (i < self.messages.items.len) {
+            if (self.messages.items[i].role != .tool) {
+                var msg = &self.messages.items[i];
+                if (msg.reasoning_auto_expand) {
+                    msg.reasoning_collapsed = true;
+                    msg.reasoning_auto_expand = false;
+                }
+                i += 1;
+                continue;
             }
-            if (msg.reasoning_auto_expand) {
-                msg.reasoning_collapsed = true;
-                msg.reasoning_auto_expand = false;
+
+            const group_start = i;
+            var group_end = i;
+            var has_auto_tool = false;
+            while (group_end < self.messages.items.len and self.messages.items[group_end].role == .tool) : (group_end += 1) {
+                var msg = &self.messages.items[group_end];
+                if (msg.content_auto_expand) {
+                    msg.content_collapsed = true;
+                    msg.content_auto_expand = false;
+                    has_auto_tool = true;
+                }
+                if (msg.reasoning_auto_expand) {
+                    msg.reasoning_collapsed = true;
+                    msg.reasoning_auto_expand = false;
+                }
             }
+
+            if (has_auto_tool) {
+                var j = group_start;
+                while (j < group_end) : (j += 1) {
+                    self.messages.items[j].tool_grouped = false;
+                    self.messages.items[j].tool_group_collapsed = false;
+                }
+                self.messages.items[group_start].tool_grouped = true;
+                self.messages.items[group_start].tool_group_collapsed = true;
+            }
+
+            i = group_end;
         }
     }
 
@@ -2939,4 +2980,51 @@ test "ai chat collapse helper only closes auto-expanded details" {
     try std.testing.expect(session.messages.items[1].reasoning_collapsed);
     try std.testing.expect(!session.messages.items[1].reasoning_auto_expand);
     try std.testing.expect(!session.messages.items[2].content_collapsed);
+}
+
+test "ai chat collapse helper creates a collapsed tool group" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| {
+            allocator.free(msg.content);
+            if (msg.reasoning) |reasoning| allocator.free(reasoning);
+        }
+        session.messages.deinit(allocator);
+    }
+
+    try session.messages.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "running terminal_list {}"),
+        .content_collapsed = false,
+        .content_auto_expand = true,
+    });
+    try session.messages.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "running terminal_snapshot {\"surface_id\":\"1\"}"),
+        .content_collapsed = false,
+        .content_auto_expand = true,
+    });
+    try session.messages.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "done"),
+    });
+
+    session.mutex.lock();
+    session.collapseAutoExpandedDetailsLocked();
+    session.mutex.unlock();
+
+    try std.testing.expect(session.messages.items[0].tool_grouped);
+    try std.testing.expect(session.messages.items[0].tool_group_collapsed);
+    try std.testing.expect(session.messages.items[0].content_collapsed);
+    try std.testing.expect(!session.messages.items[0].content_auto_expand);
+    try std.testing.expect(!session.messages.items[1].tool_grouped);
+    try std.testing.expect(!session.messages.items[1].tool_group_collapsed);
+    try std.testing.expect(session.messages.items[1].content_collapsed);
+    try std.testing.expect(!session.messages.items[1].content_auto_expand);
+
+    session.toggleToolGroupCollapsed(0);
+    try std.testing.expect(!session.messages.items[0].tool_group_collapsed);
+    session.toggleToolGroupCollapsed(1);
+    try std.testing.expect(!session.messages.items[0].tool_group_collapsed);
 }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -136,6 +136,16 @@ pub const NCCALCSIZE_PARAMS = extern struct {
     lppos: *WINDOWPOS,
 };
 
+pub const SCROLLINFO = extern struct {
+    cbSize: UINT = @sizeOf(SCROLLINFO),
+    fMask: UINT = 0,
+    nMin: INT = 0,
+    nMax: INT = 0,
+    nPage: UINT = 0,
+    nPos: INT = 0,
+    nTrackPos: INT = 0,
+};
+
 pub const WNDPROC = *const fn (HWND, UINT, WPARAM, LPARAM) callconv(.winapi) LRESULT;
 
 // ============================================================================
@@ -144,7 +154,9 @@ pub const WNDPROC = *const fn (HWND, UINT, WPARAM, LPARAM) callconv(.winapi) LRE
 
 // Window styles
 pub const WS_OVERLAPPEDWINDOW: DWORD = 0x00CF0000;
+pub const WS_CHILD: DWORD = 0x40000000;
 pub const WS_VISIBLE: DWORD = 0x10000000;
+pub const WS_CLIPCHILDREN: DWORD = 0x02000000;
 
 // Extended window styles
 pub const WS_EX_APPWINDOW: DWORD = 0x00040000;
@@ -158,6 +170,7 @@ pub const CS_DBLCLKS: UINT = 0x0008;
 // ShowWindow commands
 pub const SW_MINIMIZE: INT = 6;
 pub const SW_SHOW: INT = 5;
+pub const SW_HIDE: INT = 0;
 pub const SW_RESTORE: INT = 9;
 pub const SW_MAXIMIZE: INT = 3;
 
@@ -199,6 +212,7 @@ pub const WM_NCMBUTTONUP: UINT = 0x00A9;
 pub const WM_RBUTTONDOWN: UINT = 0x0204;
 pub const WM_RBUTTONUP: UINT = 0x0205;
 pub const WM_MOUSEWHEEL: UINT = 0x020A;
+pub const WM_VSCROLL: UINT = 0x0115;
 pub const WM_SETFOCUS: UINT = 0x0007;
 pub const WM_KILLFOCUS: UINT = 0x0008;
 pub const WM_DPICHANGED: UINT = 0x02E0;
@@ -305,6 +319,24 @@ pub const VK_F11: WPARAM = 0x7A;
 // GetKeyState
 pub const KEY_PRESSED: i16 = @bitCast(@as(u16, 0x8000));
 
+// Native scrollbar control
+pub const SBS_VERT: DWORD = 0x0001;
+pub const SB_CTL: INT = 2;
+pub const SB_LINEUP: UINT = 0;
+pub const SB_LINEDOWN: UINT = 1;
+pub const SB_PAGEUP: UINT = 2;
+pub const SB_PAGEDOWN: UINT = 3;
+pub const SB_THUMBPOSITION: UINT = 4;
+pub const SB_THUMBTRACK: UINT = 5;
+pub const SB_TOP: UINT = 6;
+pub const SB_BOTTOM: UINT = 7;
+pub const SB_ENDSCROLL: UINT = 8;
+const SIF_RANGE: UINT = 0x0001;
+const SIF_PAGE: UINT = 0x0002;
+const SIF_POS: UINT = 0x0004;
+const SIF_TRACKPOS: UINT = 0x0010;
+const SIF_ALL: UINT = SIF_RANGE | SIF_PAGE | SIF_POS | SIF_TRACKPOS;
+
 // ============================================================================
 // Win32 API imports
 // ============================================================================
@@ -357,6 +389,9 @@ extern "user32" fn SetWindowTextW(hWnd: HWND, lpString: [*:0]const WCHAR) callco
 extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: usize) callconv(.winapi) ?HCURSOR;
 pub extern "user32" fn GetWindowRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
 pub extern "user32" fn SetWindowPos(hWnd: HWND, hWndInsertAfter: ?HWND, X: INT, Y: INT, cx: INT, cy: INT, uFlags: UINT) callconv(.winapi) BOOL;
+extern "user32" fn SetFocus(hWnd: HWND) callconv(.winapi) ?HWND;
+extern "user32" fn SetScrollInfo(hWnd: HWND, nBar: INT, lpsi: *const SCROLLINFO, redraw: BOOL) callconv(.winapi) INT;
+extern "user32" fn GetScrollInfo(hWnd: HWND, nBar: INT, lpsi: *SCROLLINFO) callconv(.winapi) BOOL;
 extern "user32" fn SetCapture(hWnd: HWND) callconv(.winapi) ?HWND;
 extern "user32" fn ReleaseCapture() callconv(.winapi) BOOL;
 extern "user32" fn MessageBeep(uType: UINT) callconv(.winapi) BOOL;
@@ -654,6 +689,7 @@ extern "kernel32" fn GetProcAddress(hModule: HINSTANCE, lpProcName: [*:0]const u
 
 // System metrics
 pub extern "user32" fn GetSystemMetrics(nIndex: INT) callconv(.winapi) INT;
+pub const SM_CXVSCROLL: INT = 2;
 pub const SM_CXSIZEFRAME: INT = 32;
 pub const SM_CYSIZEFRAME: INT = 33;
 pub const SM_CXPADDEDBORDER: INT = 92;
@@ -747,6 +783,12 @@ pub const MouseWheelEvent = struct {
     alt: bool = false,
 };
 
+/// Native scrollbar notifications from a child Win32 SCROLLBAR control.
+pub const NativeScrollbarEvent = struct {
+    code: UINT,
+    pos: i32 = 0,
+};
+
 // Fixed-size ring buffers for events (avoids allocation in WndProc)
 fn RingBuffer(comptime T: type, comptime N: usize) type {
     return struct {
@@ -834,7 +876,12 @@ pub const Window = struct {
     mouse_button_events: RingBuffer(MouseButtonEvent, 32) = .{},
     mouse_move_events: RingBuffer(MouseMoveEvent, 64) = .{},
     mouse_wheel_events: RingBuffer(MouseWheelEvent, 16) = .{},
+    native_scrollbar_events: RingBuffer(NativeScrollbarEvent, 16) = .{},
     size_changed: bool = false, // set by WM_SIZE, cleared after processing
+
+    /// Optional child Win32 scrollbar used for the native scrollbar experiment.
+    native_scrollbar_hwnd: ?HWND = null,
+    native_scrollbar_visible: bool = false,
 
     /// Optional callback invoked from WM_SIZE so the application can
     /// do a GL clear+swap during the Win32 modal resize loop. Without
@@ -864,6 +911,7 @@ pub const Window = struct {
         self.mouse_button_events.clear();
         self.mouse_move_events.clear();
         self.mouse_wheel_events.clear();
+        self.native_scrollbar_events.clear();
         self.hovered_button = .none;
         self.pressed_button = .none;
         self.mouse_x = -1;
@@ -991,7 +1039,7 @@ pub const Window = struct {
             WS_EX_APPWINDOW,
             real_class,
             title,
-            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE | WS_CLIPCHILDREN,
             if (x) |xv| xv else CW_USEDEFAULT,
             if (y) |yv| yv else CW_USEDEFAULT,
             physical_width,
@@ -1145,6 +1193,10 @@ pub const Window = struct {
     }
 
     pub fn deinit(self: *Window) void {
+        if (self.native_scrollbar_hwnd) |scrollbar_hwnd| {
+            _ = DestroyWindow(scrollbar_hwnd);
+            self.native_scrollbar_hwnd = null;
+        }
         _ = wglMakeCurrent(self.hdc, null);
         _ = wglDeleteContext(self.hglrc);
         _ = DestroyWindow(self.hwnd);
@@ -1162,6 +1214,88 @@ pub const Window = struct {
             .width = rect.right - rect.left,
             .height = rect.bottom - rect.top,
         };
+    }
+
+    pub fn nativeScrollbarWidth(_: *const Window) i32 {
+        return @max(12, GetSystemMetrics(SM_CXVSCROLL));
+    }
+
+    pub fn hideNativeScrollbar(self: *Window) void {
+        if (self.native_scrollbar_hwnd) |scrollbar_hwnd| {
+            _ = ShowWindow(scrollbar_hwnd, SW_HIDE);
+        }
+        self.native_scrollbar_visible = false;
+    }
+
+    pub fn syncNativeScrollbar(
+        self: *Window,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        total: usize,
+        len: usize,
+        offset: usize,
+    ) bool {
+        if (width <= 0 or height <= 0 or total <= len) {
+            self.hideNativeScrollbar();
+            return false;
+        }
+
+        const scrollbar_hwnd = self.ensureNativeScrollbar() orelse return false;
+
+        _ = SetWindowPos(
+            scrollbar_hwnd,
+            null,
+            x,
+            y,
+            width,
+            height,
+            SWP_NOZORDER | SWP_NOACTIVATE,
+        );
+
+        const max_int_usize: usize = @intCast(std.math.maxInt(INT));
+        const total_i = @min(total, max_int_usize);
+        const len_i = @min(len, total_i);
+        const max_offset = if (total_i > len_i) total_i - len_i else 0;
+        const offset_i = @min(offset, max_offset);
+
+        var info = SCROLLINFO{
+            .fMask = SIF_ALL,
+            .nMin = 0,
+            .nMax = @intCast(total_i - 1),
+            .nPage = @intCast(@max(@as(usize, 1), len_i)),
+            .nPos = @intCast(offset_i),
+        };
+        _ = SetScrollInfo(scrollbar_hwnd, SB_CTL, &info, 1);
+
+        if (!self.native_scrollbar_visible) {
+            _ = ShowWindow(scrollbar_hwnd, SW_SHOW);
+            self.native_scrollbar_visible = true;
+        }
+        return true;
+    }
+
+    fn ensureNativeScrollbar(self: *Window) ?HWND {
+        if (self.native_scrollbar_hwnd) |scrollbar_hwnd| return scrollbar_hwnd;
+
+        const scrollbar_hwnd = CreateWindowExW(
+            0,
+            std.unicode.utf8ToUtf16LeStringLiteral("SCROLLBAR"),
+            std.unicode.utf8ToUtf16LeStringLiteral(""),
+            WS_CHILD | SBS_VERT,
+            0,
+            0,
+            1,
+            1,
+            self.hwnd,
+            null,
+            GetModuleHandleW(null),
+            null,
+        ) orelse return null;
+
+        self.native_scrollbar_hwnd = scrollbar_hwnd;
+        return scrollbar_hwnd;
     }
 
     /// Process all pending window messages. Returns false if WM_QUIT received.
@@ -1299,6 +1433,21 @@ fn pushMouseButtonEvent(w: *Window, button: MouseButton, action: MouseButtonActi
         .shift = mods.shift,
         .alt = mods.alt,
     });
+}
+
+fn hwndFromLParam(lParam: LPARAM) ?HWND {
+    if (lParam == 0) return null;
+    return @ptrFromInt(@as(usize, @bitCast(lParam)));
+}
+
+fn nativeScrollbarPosition(w: *Window, code: UINT) i32 {
+    const scrollbar_hwnd = w.native_scrollbar_hwnd orelse return 0;
+    var info = SCROLLINFO{ .fMask = SIF_TRACKPOS | SIF_POS };
+    if (GetScrollInfo(scrollbar_hwnd, SB_CTL, &info) == 0) return 0;
+    return switch (code) {
+        SB_THUMBTRACK, SB_THUMBPOSITION => info.nTrackPos,
+        else => info.nPos,
+    };
 }
 
 fn filteredImeSetContextLParam(lParam: LPARAM) LPARAM {
@@ -1559,6 +1708,22 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         WM_DROPFILES => {
             handleDropFiles(wParam, w);
             return 0;
+        },
+        WM_VSCROLL => {
+            if (w.native_scrollbar_hwnd) |scrollbar_hwnd| {
+                if (hwndFromLParam(lParam)) |event_hwnd| {
+                    if (event_hwnd == scrollbar_hwnd) {
+                        const code: UINT = @intCast(wParam & 0xFFFF);
+                        w.native_scrollbar_events.push(.{
+                            .code = code,
+                            .pos = nativeScrollbarPosition(w, code),
+                        });
+                        _ = SetFocus(w.hwnd);
+                        return 0;
+                    }
+                }
+            }
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
         },
 
         // WM_NCCALCSIZE is handled before the switch (to work during CreateWindowExW)

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -378,6 +378,7 @@ extern "user32" fn ReleaseDC(hWnd: ?HWND, hDC: HDC) callconv(.winapi) INT;
 pub extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
 pub extern "user32" fn GetDpiForWindow(hWnd: HWND) callconv(.winapi) UINT;
 extern "user32" fn GetDpiForSystem() callconv(.winapi) UINT;
+extern "user32" fn GetSystemMetricsForDpi(nIndex: INT, dpi: UINT) callconv(.winapi) INT;
 extern "user32" fn SetProcessDpiAwarenessContext(value: DPI_AWARENESS_CONTEXT) callconv(.winapi) BOOL;
 extern "user32" fn SetProcessDPIAware() callconv(.winapi) BOOL;
 pub extern "user32" fn SendMessageW(hWnd: HWND, Msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
@@ -1216,8 +1217,13 @@ pub const Window = struct {
         };
     }
 
-    pub fn nativeScrollbarWidth(_: *const Window) i32 {
-        return @max(12, GetSystemMetrics(SM_CXVSCROLL));
+    pub fn nativeScrollbarWidth(self: *const Window) i32 {
+        const dpi = if (self.dpi == 0) @as(u32, 96) else self.dpi;
+        const width_for_dpi = GetSystemMetricsForDpi(SM_CXVSCROLL, dpi);
+        if (width_for_dpi > 0) return width_for_dpi;
+
+        const system_width = @max(12, GetSystemMetrics(SM_CXVSCROLL));
+        return @max(12, scaleFrom96(system_width, dpi));
     }
 
     pub fn hideNativeScrollbar(self: *Window) void {

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -221,12 +221,11 @@ pub fn computeSplitLayout(
         // The surface computes grid size and balanced padding internally.
         // Right padding must account for scrollbar width plus gap.
         const surface = entry.surface;
-        const scrollbar_padding: u32 = @intFromFloat(overlays.SCROLLBAR_WIDTH + DEFAULT_PADDING);
         const explicit_padding = renderer.size.Padding{
             .top = DEFAULT_PADDING,
             .bottom = DEFAULT_PADDING,
             .left = DEFAULT_PADDING,
-            .right = scrollbar_padding,
+            .right = AppWindow.scrollbarRightPaddingForLayout(active_tab),
         };
 
         const resized = surface.setScreenSizeWithPolicy(

--- a/src/config.zig
+++ b/src/config.zig
@@ -236,6 +236,9 @@ theme: ?[]const u8 = null,
 /// Scrollback buffer limit in bytes.
 @"scrollback-limit": u32 = 10_000_000,
 
+/// Experimental Win32 native scrollbar for single-surface terminal windows.
+@"native-scrollbar": bool = false,
+
 /// Enable agent tools for AI Chat profiles by default.
 @"ai-agent-enabled": bool = false,
 
@@ -580,6 +583,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             log.warn("invalid scrollback-limit: {s}", .{value});
             return;
         };
+    } else if (std.mem.eql(u8, key, "native-scrollbar")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"native-scrollbar" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"native-scrollbar" = false;
+        } else {
+            log.warn("invalid native-scrollbar: {s}", .{value});
+        }
     } else if (std.mem.eql(u8, key, "ai-agent-enabled")) {
         if (std.mem.eql(u8, value, "true")) {
             self.@"ai-agent-enabled" = true;
@@ -976,6 +987,7 @@ pub fn printHelp() void {
         \\  --window-height <rows>       Initial height in cells (default: 0=auto, min: 4)
         \\  --window-width <cols>        Initial width in cells (default: 0=auto, min: 10)
         \\  --scrollback-limit <bytes>   Scrollback buffer size (default: 10000000)
+        \\  --native-scrollbar <bool>    Experimental Win32 native scrollbar (default: false)
         \\  --ai-agent-enabled <bool>    Enable AI Chat agent tools by default
         \\  --ai-agent-permission <mode> Agent tool permission: confirm | full
         \\  --ai-agent-command-timeout-ms <ms> Agent command timeout budget
@@ -1279,6 +1291,7 @@ const default_config_template =
     \\
     \\# Scrollback buffer size in bytes (default: 10MB)
     \\# scrollback-limit = 10000000
+    \\# native-scrollbar = false         # experimental single-surface Win32 scrollbar
     \\
     \\# AI Chat agent tools (disabled by default)
     \\# ai-agent-enabled = false
@@ -1352,6 +1365,22 @@ test "config: restore-tabs-on-startup parses true/false" {
     // Invalid value leaves the previous state untouched (still false).
     cfg.applyKeyValue(allocator, "restore-tabs-on-startup", "maybe", ".");
     try std.testing.expectEqual(false, cfg.@"restore-tabs-on-startup");
+}
+
+test "config: native-scrollbar parses true/false" {
+    const allocator = std.testing.allocator;
+    var cfg: Config = .{};
+
+    try std.testing.expectEqual(false, cfg.@"native-scrollbar");
+
+    cfg.applyKeyValue(allocator, "native-scrollbar", "true", ".");
+    try std.testing.expectEqual(true, cfg.@"native-scrollbar");
+
+    cfg.applyKeyValue(allocator, "native-scrollbar", "false", ".");
+    try std.testing.expectEqual(false, cfg.@"native-scrollbar");
+
+    cfg.applyKeyValue(allocator, "native-scrollbar", "maybe", ".");
+    try std.testing.expectEqual(false, cfg.@"native-scrollbar");
 }
 
 test "config: ai agent options parse" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -237,7 +237,7 @@ theme: ?[]const u8 = null,
 @"scrollback-limit": u32 = 10_000_000,
 
 /// Experimental Win32 native scrollbar for single-surface terminal windows.
-@"native-scrollbar": bool = false,
+@"native-scrollbar": bool = true,
 
 /// Enable agent tools for AI Chat profiles by default.
 @"ai-agent-enabled": bool = false,
@@ -987,7 +987,7 @@ pub fn printHelp() void {
         \\  --window-height <rows>       Initial height in cells (default: 0=auto, min: 4)
         \\  --window-width <cols>        Initial width in cells (default: 0=auto, min: 10)
         \\  --scrollback-limit <bytes>   Scrollback buffer size (default: 10000000)
-        \\  --native-scrollbar <bool>    Experimental Win32 native scrollbar (default: false)
+        \\  --native-scrollbar <bool>    Experimental Win32 native scrollbar (default: true)
         \\  --ai-agent-enabled <bool>    Enable AI Chat agent tools by default
         \\  --ai-agent-permission <mode> Agent tool permission: confirm | full
         \\  --ai-agent-command-timeout-ms <ms> Agent command timeout budget
@@ -1291,7 +1291,7 @@ const default_config_template =
     \\
     \\# Scrollback buffer size in bytes (default: 10MB)
     \\# scrollback-limit = 10000000
-    \\# native-scrollbar = false         # experimental single-surface Win32 scrollbar
+    \\# native-scrollbar = true          # experimental single-surface Win32 scrollbar
     \\
     \\# AI Chat agent tools (disabled by default)
     \\# ai-agent-enabled = false
@@ -1371,7 +1371,7 @@ test "config: native-scrollbar parses true/false" {
     const allocator = std.testing.allocator;
     var cfg: Config = .{};
 
-    try std.testing.expectEqual(false, cfg.@"native-scrollbar");
+    try std.testing.expectEqual(true, cfg.@"native-scrollbar");
 
     cfg.applyKeyValue(allocator, "native-scrollbar", "true", ".");
     try std.testing.expectEqual(true, cfg.@"native-scrollbar");

--- a/src/input.zig
+++ b/src/input.zig
@@ -16,6 +16,7 @@ const file_explorer = AppWindow.file_explorer;
 const file_backend = @import("file_backend.zig");
 const markdown_preview = @import("markdown_preview.zig");
 const markdown_preview_panel = AppWindow.markdown_preview_panel;
+const native_scrollbar = @import("native_scrollbar.zig");
 const preview_token = @import("preview_token.zig");
 const browser_panel = AppWindow.browser_panel;
 const scp = @import("scp.zig");
@@ -717,6 +718,7 @@ pub fn processEvents(win: *win32_backend.Window) void {
     processMouseButtonEvents(win);
     processMouseMoveEvents(win);
     processMouseWheelEvents(win);
+    processNativeScrollbarEvents(win);
     processSizeChange(win);
 }
 
@@ -763,6 +765,12 @@ fn processMouseMoveEvents(win: *win32_backend.Window) void {
 fn processMouseWheelEvents(win: *win32_backend.Window) void {
     while (win.mouse_wheel_events.pop()) |ev| {
         handleMouseWheel(ev);
+    }
+}
+
+fn processNativeScrollbarEvents(win: *win32_backend.Window) void {
+    while (win.native_scrollbar_events.pop()) |ev| {
+        handleNativeScrollbar(ev);
     }
 }
 
@@ -2389,6 +2397,11 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
                 )) |target| {
                     switch (target) {
                         .copy_message => |message_index| copyAiChatMessageToClipboard(chat, message_index),
+                        .toggle_tool_group => |message_index| {
+                            chat.toggleToolGroupCollapsed(message_index);
+                            AppWindow.g_force_rebuild = true;
+                            AppWindow.g_cells_valid = false;
+                        },
                         .toggle_tool => |message_index| {
                             chat.toggleToolMessageCollapsed(message_index);
                             AppWindow.g_force_rebuild = true;
@@ -2953,6 +2966,46 @@ fn appendAlternateScrollKeys(surface: *Surface, ev: win32_backend.MouseWheelEven
         if (!appendBytes(out, len, seq)) return false;
     }
     return true;
+}
+
+fn nativeScrollbarCommand(code: win32_backend.UINT) ?native_scrollbar.Command {
+    return switch (code) {
+        win32_backend.SB_LINEUP => .line_up,
+        win32_backend.SB_LINEDOWN => .line_down,
+        win32_backend.SB_PAGEUP => .page_up,
+        win32_backend.SB_PAGEDOWN => .page_down,
+        win32_backend.SB_THUMBPOSITION, win32_backend.SB_THUMBTRACK => .thumb,
+        win32_backend.SB_TOP => .top,
+        win32_backend.SB_BOTTOM => .bottom,
+        win32_backend.SB_ENDSCROLL => .end_scroll,
+        else => null,
+    };
+}
+
+fn handleNativeScrollbar(ev: win32_backend.NativeScrollbarEvent) void {
+    if (!AppWindow.g_native_scrollbar) return;
+    if (!AppWindow.isActiveTabTerminal()) return;
+
+    const command = nativeScrollbarCommand(ev.code) orelse return;
+    const surface = AppWindow.activeSurface() orelse return;
+    const sb = scrollbarForSurface(surface);
+    const state = native_scrollbar.State{
+        .total = sb.total,
+        .len = sb.len,
+        .offset = sb.offset,
+    };
+    const target = native_scrollbar.targetOffset(state, command, ev.pos) orelse return;
+    const delta = native_scrollbar.deltaToTarget(state, target);
+    if (delta == 0) return;
+
+    surface.render_state.mutex.lock();
+    surface.terminal.scrollViewport(.{ .delta = delta });
+    surface.render_state.mutex.unlock();
+
+    surface.scrollbar_opacity = 1.0;
+    surface.scrollbar_show_time = std.time.milliTimestamp();
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
 }
 
 fn handleMouseWheel(ev: win32_backend.MouseWheelEvent) void {

--- a/src/native_scrollbar.zig
+++ b/src/native_scrollbar.zig
@@ -1,0 +1,69 @@
+const std = @import("std");
+
+pub const State = struct {
+    total: usize,
+    len: usize,
+    offset: usize,
+};
+
+pub const Command = enum {
+    line_up,
+    line_down,
+    page_up,
+    page_down,
+    thumb,
+    top,
+    bottom,
+    end_scroll,
+};
+
+pub fn maxOffset(state: State) usize {
+    if (state.total <= state.len) return 0;
+    return state.total - state.len;
+}
+
+pub fn clampedOffset(state: State, offset: usize) usize {
+    return @min(offset, maxOffset(state));
+}
+
+pub fn targetOffset(state: State, command: Command, thumb_pos: ?i32) ?usize {
+    const max_offset = maxOffset(state);
+    if (max_offset == 0) return null;
+    const current = @min(state.offset, max_offset);
+
+    return switch (command) {
+        .line_up => if (current == 0) 0 else current - 1,
+        .line_down => @min(current + 1, max_offset),
+        .page_up => if (current <= state.len) 0 else current - state.len,
+        .page_down => @min(current + state.len, max_offset),
+        .thumb => blk: {
+            const pos = thumb_pos orelse return null;
+            if (pos <= 0) break :blk 0;
+            break :blk @min(@as(usize, @intCast(pos)), max_offset);
+        },
+        .top => 0,
+        .bottom => max_offset,
+        .end_scroll => null,
+    };
+}
+
+pub fn deltaToTarget(state: State, target: usize) isize {
+    const current: i64 = @intCast(clampedOffset(state, state.offset));
+    const wanted: i64 = @intCast(clampedOffset(state, target));
+    return @intCast(wanted - current);
+}
+
+test "native scrollbar commands clamp to scrollback range" {
+    const state = State{ .total = 200, .len = 40, .offset = 30 };
+
+    try std.testing.expectEqual(@as(?usize, 70), targetOffset(state, .page_down, null));
+    try std.testing.expectEqual(@as(?usize, 0), targetOffset(state, .thumb, -20));
+    try std.testing.expectEqual(@as(?usize, 160), targetOffset(state, .thumb, 240));
+}
+
+test "native scrollbar delta is relative to current viewport offset" {
+    const state = State{ .total = 200, .len = 40, .offset = 30 };
+
+    try std.testing.expectEqual(@as(isize, -30), deltaToTarget(state, 0));
+    try std.testing.expectEqual(@as(isize, 130), deltaToTarget(state, 160));
+}

--- a/src/native_scrollbar.zig
+++ b/src/native_scrollbar.zig
@@ -6,6 +6,13 @@ pub const State = struct {
     offset: usize,
 };
 
+pub const Rect = struct {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+};
+
 pub const Command = enum {
     line_up,
     line_down,
@@ -53,6 +60,24 @@ pub fn deltaToTarget(state: State, target: usize) isize {
     return @intCast(wanted - current);
 }
 
+pub fn rightPadding(scrollbar_width: i32, default_padding: i32) u32 {
+    const width = @max(0, scrollbar_width);
+    const padding = @max(0, default_padding);
+    return @intCast(width + padding);
+}
+
+pub fn trackRect(view_x: i32, view_y: i32, view_width: i32, view_height: i32, scrollbar_width: i32) ?Rect {
+    if (view_width <= 0 or view_height <= 0 or scrollbar_width <= 0) return null;
+
+    const width = @min(scrollbar_width, view_width);
+    return .{
+        .x = view_x + view_width - width,
+        .y = view_y,
+        .width = width,
+        .height = view_height,
+    };
+}
+
 test "native scrollbar commands clamp to scrollback range" {
     const state = State{ .total = 200, .len = 40, .offset = 30 };
 
@@ -66,4 +91,18 @@ test "native scrollbar delta is relative to current viewport offset" {
 
     try std.testing.expectEqual(@as(isize, -30), deltaToTarget(state, 0));
     try std.testing.expectEqual(@as(isize, 130), deltaToTarget(state, 160));
+}
+
+test "native scrollbar reserves padding from native control width" {
+    try std.testing.expectEqual(@as(u32, 27), rightPadding(17, 10));
+    try std.testing.expectEqual(@as(u32, 10), rightPadding(0, 10));
+}
+
+test "native scrollbar track sits on viewport right edge" {
+    const rect = trackRect(20, 40, 800, 600, 17).?;
+
+    try std.testing.expectEqual(@as(i32, 803), rect.x);
+    try std.testing.expectEqual(@as(i32, 40), rect.y);
+    try std.testing.expectEqual(@as(i32, 17), rect.width);
+    try std.testing.expectEqual(@as(i32, 600), rect.height);
 }

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -31,12 +31,14 @@ const DETAIL_PAD_X: f32 = 14;
 const DETAIL_PAD_Y: f32 = 10;
 const DETAIL_ARROW_W: f32 = 12;
 const DETAIL_RULE_W: f32 = 3;
+const TOOL_GROUP_ITEM_GAP: f32 = 8;
 const TABLE_MAX_COLS: usize = 8;
 const TABLE_CELL_PAD_X: f32 = 10;
 const TABLE_MIN_COL_W: f32 = 56;
 
 pub const HitTarget = union(enum) {
     copy_message: usize,
+    toggle_tool_group: usize,
     toggle_tool: usize,
     toggle_reasoning: usize,
 };
@@ -135,12 +137,23 @@ pub fn render(
     const viewport_bottom_top_px = window_height - transcript_bottom;
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    var measure_index: usize = 0;
+    while (measure_index < session.messages.items.len) {
+        const msg = session.messages.items[measure_index];
+        if (isToolGroupStart(session.messages.items, measure_index)) {
+            const group_end = toolGroupEnd(session.messages.items, measure_index);
+            content_h += toolGroupBlockHeight(session.messages.items, measure_index, group_end, content_w);
+            content_h += BUBBLE_GAP;
+            measure_index = group_end;
+            continue;
+        }
+
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
         }
         content_h += BUBBLE_GAP;
+        measure_index += 1;
     }
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
@@ -158,7 +171,20 @@ pub fn render(
     const transcript_selected = session.transcript_select_all;
     var cursor_top = transcript_top + gravity_offset - session.scroll_px;
 
-    for (session.messages.items, 0..) |msg, message_index| {
+    var message_index: usize = 0;
+    while (message_index < session.messages.items.len) {
+        const msg = session.messages.items[message_index];
+        if (isToolGroupStart(session.messages.items, message_index)) {
+            const group_end = toolGroupEnd(session.messages.items, message_index);
+            const group_h = toolGroupBlockHeight(session.messages.items, message_index, group_end, content_w);
+            if (sectionVisible(cursor_top, group_h, transcript_top, viewport_bottom_top_px)) {
+                renderToolGroup(session.messages.items, message_index, group_end, content_x, cursor_top, content_w, group_h, window_height, transcript_selected);
+            }
+            cursor_top += group_h + BUBBLE_GAP;
+            message_index = group_end;
+            continue;
+        }
+
         const block_h = messageBlockHeight(msg, content_w);
         if (msg.role == .tool) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
@@ -179,8 +205,8 @@ pub fn render(
             }
         }
 
-        _ = message_index;
         cursor_top += BUBBLE_GAP;
+        message_index += 1;
     }
 
     gl.Disable.?(c.GL_SCISSOR_TEST);
@@ -217,12 +243,23 @@ pub fn interactionHitTest(
     const content_x = x + LINE_PAD_X;
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    var measure_index: usize = 0;
+    while (measure_index < session.messages.items.len) {
+        const msg = session.messages.items[measure_index];
+        if (isToolGroupStart(session.messages.items, measure_index)) {
+            const group_end = toolGroupEnd(session.messages.items, measure_index);
+            content_h += toolGroupBlockHeight(session.messages.items, measure_index, group_end, content_w);
+            content_h += BUBBLE_GAP;
+            measure_index = group_end;
+            continue;
+        }
+
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
         }
         content_h += BUBBLE_GAP;
+        measure_index += 1;
     }
 
     const scroll_px = @min(session.scroll_px, @max(0.0, content_h - transcript_h));
@@ -231,7 +268,36 @@ pub fn interactionHitTest(
     const py: f32 = @floatCast(ypos);
     var cursor_top = transcript_top + gravity_offset - scroll_px;
 
-    for (session.messages.items, 0..) |msg, message_index| {
+    var message_index: usize = 0;
+    while (message_index < session.messages.items.len) {
+        const msg = session.messages.items[message_index];
+        if (isToolGroupStart(session.messages.items, message_index)) {
+            const group_end = toolGroupEnd(session.messages.items, message_index);
+            const group_h = toolGroupBlockHeight(session.messages.items, message_index, group_end, content_w);
+            if (sectionVisible(cursor_top, group_h, transcript_top, viewport_bottom_top_px)) {
+                const header_rect = detailHeaderRect(content_x, cursor_top, content_w);
+                if (pointInRect(px, py, header_rect)) return .{ .toggle_tool_group = message_index };
+
+                if (!msg.tool_group_collapsed) {
+                    var child_top = cursor_top + detailHeaderHeight() + TOOL_GROUP_ITEM_GAP;
+                    var child_index = message_index;
+                    while (child_index < group_end) : (child_index += 1) {
+                        const child_h = toolCardHeight(session.messages.items[child_index], content_w);
+                        if (sectionVisible(child_top, child_h, transcript_top, viewport_bottom_top_px)) {
+                            const copy_rect = detailCopyButtonRect(content_x, child_top, content_w);
+                            if (pointInRect(px, py, copy_rect)) return .{ .copy_message = child_index };
+                            const child_header_rect = detailHeaderRect(content_x, child_top, content_w);
+                            if (pointInRect(px, py, child_header_rect)) return .{ .toggle_tool = child_index };
+                        }
+                        child_top += child_h + TOOL_GROUP_ITEM_GAP;
+                    }
+                }
+            }
+            cursor_top += group_h + BUBBLE_GAP;
+            message_index = group_end;
+            continue;
+        }
+
         const block_h = messageBlockHeight(msg, content_w);
         if (msg.role == .tool) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
@@ -257,6 +323,7 @@ pub fn interactionHitTest(
             }
         }
         cursor_top += BUBBLE_GAP;
+        message_index += 1;
     }
 
     return null;
@@ -333,6 +400,29 @@ fn reasoningCardHeight(msg: ai_chat.Message, max_w: f32) f32 {
     else
         plainContentHeight(reasoning, @max(1.0, max_w - DETAIL_PAD_X * 2), reasoningLineHeight()) + DETAIL_PAD_Y * 2;
     return detailHeaderHeight() + body_h;
+}
+
+fn isToolGroupStart(messages: []const ai_chat.Message, index: usize) bool {
+    if (index >= messages.len) return false;
+    return messages[index].role == .tool and messages[index].tool_grouped;
+}
+
+fn toolGroupEnd(messages: []const ai_chat.Message, start: usize) usize {
+    var end = start;
+    while (end < messages.len and messages[end].role == .tool) : (end += 1) {}
+    return end;
+}
+
+fn toolGroupBlockHeight(messages: []const ai_chat.Message, start: usize, end: usize, max_w: f32) f32 {
+    if (start >= end) return 0;
+    var h = detailHeaderHeight();
+    if (messages[start].tool_group_collapsed) return h;
+
+    var i = start;
+    while (i < end) : (i += 1) {
+        h += TOOL_GROUP_ITEM_GAP + toolCardHeight(messages[i], max_w);
+    }
+    return h;
 }
 
 fn plainContentHeight(text: []const u8, max_w: f32, line_h: f32) f32 {
@@ -413,6 +503,78 @@ fn renderMessageBubble(
         _ = renderMarkdownContent(text, body_x, body_top, body_w, window_height, window_height, palette);
     } else {
         _ = renderWrappedText(text, body_x, body_top, body_w, lineHeight(), fg, window_height, window_height);
+    }
+}
+
+fn renderToolGroup(
+    messages: []const ai_chat.Message,
+    start: usize,
+    end: usize,
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+    window_height: f32,
+    selected: bool,
+) void {
+    if (start >= end) return;
+    const collapsed = messages[start].tool_group_collapsed;
+    renderToolGroupHeader(messages[start..end], collapsed, x, top_px, w, h, window_height, selected);
+    if (collapsed) return;
+
+    var child_top = top_px + detailHeaderHeight() + TOOL_GROUP_ITEM_GAP;
+    var i = start;
+    while (i < end) : (i += 1) {
+        const child_h = toolCardHeight(messages[i], w);
+        renderToolCard(messages[i], x, child_top, w, child_h, window_height, selected);
+        child_top += child_h + TOOL_GROUP_ITEM_GAP;
+    }
+}
+
+fn renderToolGroupHeader(
+    messages: []const ai_chat.Message,
+    collapsed: bool,
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+    window_height: f32,
+    selected: bool,
+) void {
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const header_h = detailHeaderHeight();
+    const y = window_height - top_px - h;
+    const header_y = y + h - header_h;
+    const card_bg = if (selected) mixColor(bg, accent, 0.20) else mixColor(bg, fg, 0.045);
+    const header_bg = if (selected) mixColor(bg, accent, 0.27) else mixColor(bg, fg, 0.085);
+
+    gl_init.renderQuadAlpha(x, y, w, h, card_bg, 0.92);
+    gl_init.renderQuadAlpha(x, header_y, w, header_h, header_bg, 0.98);
+    gl_init.renderQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.78 else 0.50);
+    gl_init.renderQuadAlpha(x, y + h - 1, w, 1, mixColor(bg, fg, 0.20), 0.62);
+
+    const arrow_x = x + DETAIL_PAD_X;
+    const text_y = header_y + @round((header_h - font.g_titlebar_cell_height) / 2);
+    _ = titlebar.renderTextLimited(if (collapsed) ">" else "v", arrow_x, text_y, mixColor(fg, accent, 0.16), DETAIL_ARROW_W);
+
+    var text_x = arrow_x + DETAIL_ARROW_W + 6;
+    const title_end = titlebar.renderTextLimited("Tool calls", text_x, text_y, mixColor(fg, accent, 0.18), w * 0.26);
+    text_x = title_end + 10;
+
+    var count_buf: [32]u8 = undefined;
+    const item_word = if (messages.len == 1) "item" else "items";
+    const count_text = std.fmt.bufPrint(&count_buf, "{} {s}", .{ messages.len, item_word }) catch "items";
+    const count_end = titlebar.renderTextLimited(count_text, text_x, text_y, mixColor(fg, accent, 0.32), w * 0.18);
+    text_x = count_end + 10;
+
+    if (collapsed and messages.len > 0 and text_x + 12 < x + w - DETAIL_PAD_X) {
+        const meta = toolSectionMeta(messages[0].content);
+        const preview = if (meta.name.len > 0) meta.name else meta.preview;
+        if (preview.len > 0) {
+            _ = titlebar.renderTextLimited(preview, text_x, text_y, mixColor(bg, fg, 0.58), @max(24.0, x + w - DETAIL_PAD_X - text_x));
+        }
     }
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3027,11 +3027,11 @@ pub fn renderScrollbarForSurface(surface: *Surface, view_width: f32, view_height
     const fg = AppWindow.g_theme.foreground;
 
     const track_color = mixColor(bg, fg, 0.18);
-    const track_alpha = fade * 0.20;
+    const track_alpha = scrollbar_model.trackAlpha(fade);
     gl_init.renderQuadAlpha(bar_x, geo.track_y, bar_w, geo.track_h, track_color, track_alpha);
 
     const thumb_color = mixColor(bg, fg, 0.46);
-    const thumb_alpha = fade * 0.62;
+    const thumb_alpha = scrollbar_model.thumbAlpha(fade);
     gl_init.renderQuadAlpha(bar_x, geo.thumb_y, bar_w, geo.thumb_h, thumb_color, thumb_alpha);
 }
 

--- a/src/scrollbar_model.zig
+++ b/src/scrollbar_model.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 
 pub const IDLE_OPACITY: f32 = 0.72;
+pub const TRACK_ALPHA_SCALE: f32 = 0.34;
+pub const THUMB_ALPHA_SCALE: f32 = 0.90;
 
 pub fn effectiveOpacity(stored_opacity: f32, has_scrollback: bool) f32 {
     if (!has_scrollback) return 0;
@@ -17,9 +19,30 @@ pub fn canInteract(has_scrollback: bool) bool {
     return has_scrollback;
 }
 
+pub fn trackAlpha(effective_opacity: f32) f32 {
+    return clamp01(effective_opacity) * TRACK_ALPHA_SCALE;
+}
+
+pub fn thumbAlpha(effective_opacity: f32) f32 {
+    return clamp01(effective_opacity) * THUMB_ALPHA_SCALE;
+}
+
+fn clamp01(value: f32) f32 {
+    if (value < 0) return 0;
+    if (value > 1) return 1;
+    return value;
+}
+
 test "scrollbar remains visible and interactive at idle when scrollback exists" {
     try std.testing.expect(effectiveOpacity(0, true) > 0.01);
     try std.testing.expect(canInteract(true));
+}
+
+test "scrollbar thumb keeps enough contrast at idle" {
+    const idle_fade = effectiveOpacity(0, true);
+    try std.testing.expect(thumbAlpha(idle_fade) >= 0.64);
+    try std.testing.expect(trackAlpha(idle_fade) >= 0.22);
+    try std.testing.expect(thumbAlpha(1.0) >= 0.90);
 }
 
 test "scrollbar hides and ignores input without scrollback" {

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -16,6 +16,7 @@ comptime {
     _ = @import("file_explorer.zig");
     _ = @import("input_shortcuts.zig");
     _ = @import("markdown_preview.zig");
+    _ = @import("native_scrollbar.zig");
     _ = @import("preview_token.zig");
     _ = @import("remote_client.zig");
     _ = @import("remote_snapshot.zig");


### PR DESCRIPTION
## Summary

- add completed AI Chat tool-call grouping so consecutive tool messages collapse as a single section
- increase virtual scrollbar contrast for the existing custom overlay path
- add an experimental Win32 native scrollbar path behind `native-scrollbar = true`
- document the native Windows UI component goal in README TODO

## Validation

- `zig build test`
- `zig build`
- `git diff --check`
- Manual Windows testing reported by user: native scrollbar works without obvious issues
