### PR TITLE
Start SSH file transfers asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To confirm the running desktop version, open the command center with `Ctrl+Shift
 | **Ctrl+Shift+O**                                                               | Split to the right                                                                 |
 | **Ctrl+Shift+Alt+E**                                                           | Toggle file explorer sidebar                                                       |
 | Ctrl-click `.md` / `.txt` in terminal output, or double-click in File Explorer | Preview local, WSL, or SSH Markdown/text in the right preview panel                |
+| Ctrl+Shift-click file path in SSH terminal output                              | Download the SSH remote file to `%USERPROFILE%\Downloads`                         |
 | **Ctrl+Shift+W**                                                               | Close focused panel, tab, or window; press again to confirm closing the last panel |
 | **Alt+Enter**                                                                  | Maximize or restore window                                                         |
 | **Ctrl++** / **Ctrl+-**                                                        | Increase / decrease font size                                                      |

--- a/docs/file-explorer.md
+++ b/docs/file-explorer.md
@@ -12,6 +12,10 @@ a supported text file in the File Explorer, to open the right-side preview panel
 Markdown previews render headings, lists, blockquotes, code blocks, inline code,
 links, and horizontal rules. Text files are shown as plain text.
 
+In SSH profile sessions, hold `Ctrl+Shift` over a file path in terminal output
+to underline it, then click to download that remote file to
+`%USERPROFILE%\Downloads`. Downloads run in the background.
+
 Open the command center with `Ctrl+Shift+P` and run `Toggle Browser` to open
 the embedded WebView2 browser panel when WebView2 support is available.
 `Ctrl`-clicking an `http://` or `https://` URL in terminal output opens it in

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -735,6 +735,9 @@ pub const MouseButtonEvent = struct {
 pub const MouseMoveEvent = struct {
     x: i32,
     y: i32,
+    ctrl: bool = false,
+    shift: bool = false,
+    alt: bool = false,
 };
 
 /// Mouse wheel events
@@ -1835,9 +1838,16 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         WM_MOUSEMOVE => {
             const x: i32 = @as(i16, @bitCast(@as(u16, @intCast(lParam & 0xFFFF))));
             const y: i32 = @as(i16, @bitCast(@as(u16, @intCast((lParam >> 16) & 0xFFFF))));
+            const mods = getModifiers();
             w.mouse_x = x;
             w.mouse_y = y;
-            w.mouse_move_events.push(.{ .x = x, .y = y });
+            w.mouse_move_events.push(.{
+                .x = x,
+                .y = y,
+                .ctrl = mods.ctrl,
+                .shift = mods.shift,
+                .alt = mods.alt,
+            });
             return 0;
         },
         WM_MOUSEWHEEL => {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1295,6 +1295,21 @@ fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []c
     return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
 
+pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const Surface.SshConnection) bool {
+    return downloadRemoteFileToPathWithTransfer(remote_path, local_path, display_name, conn, scp.transfer);
+}
+
+fn downloadRemoteFileToPathWithTransfer(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const Surface.SshConnection, transfer_fn: TransferFn) bool {
+    if (conn.user_len + conn.host_len + remote_path.len + 2 > 512) {
+        setTransferStatus(.failed, "Path too long");
+        return false;
+    }
+
+    var spec_buf: [512]u8 = undefined;
+    const src = scp.remoteSpec(&spec_buf, conn, remote_path);
+    return startTransferJob(.download, conn, src, local_path, display_name, transfer_fn);
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -1357,6 +1372,22 @@ test "file_explorer: upload helper starts transfer with explicit remote spec" {
     try std.testing.expect(uploadLocalFileToRemoteSpecWithTransfer("local.txt", "user@host:/tmp", "local.txt", &conn, transferOkForTest));
     try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
     try std.testing.expectEqualStrings("local.txt", g_transfer_msg[0..g_transfer_msg_len]);
+    try std.testing.expect(g_transfer_job != null);
+}
+
+test "file_explorer: download helper starts transfer with explicit remote path" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var conn: Surface.SshConnection = .{};
+    conn.user_buf[0] = 'u';
+    conn.user_len = 1;
+    conn.host_buf[0] = 'h';
+    conn.host_len = 1;
+
+    try std.testing.expect(downloadRemoteFileToPathWithTransfer("/tmp/file.txt", "C:\\Users\\me\\Downloads\\file.txt", "file.txt", &conn, transferOkForTest));
+    try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
+    try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
     try std.testing.expect(g_transfer_job != null);
 }
 

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -122,10 +122,18 @@ threadlocal var g_async_context_id: u64 = 1;
 
 const TransferKind = enum { upload, download };
 const TransferFn = *const fn (std.mem.Allocator, *const Surface.SshConnection, []const u8, []const u8) scp.TransferResult;
+pub const TransferSuccessCallback = *const fn (?*anyopaque) void;
+pub const TransferDestroyCallback = *const fn (?*anyopaque) void;
 const TRANSFER_PATH_MAX: usize = 1024;
 const TRANSFER_DISPLAY_MAX: usize = 128;
 
-const TransferJob = struct {
+pub const TransferCompletion = struct {
+    context: ?*anyopaque = null,
+    on_success: ?TransferSuccessCallback = null,
+    on_destroy: ?TransferDestroyCallback = null,
+};
+
+const TransferRequest = struct {
     kind: TransferKind,
     conn: Surface.SshConnection,
     context_id: u64,
@@ -135,13 +143,19 @@ const TransferJob = struct {
     dst_len: usize = 0,
     display_buf: [TRANSFER_DISPLAY_MAX]u8 = undefined,
     display_len: usize = 0,
-    result: scp.TransferResult = .failed,
     transfer_fn: TransferFn,
+    completion: TransferCompletion = .{},
+};
+
+const TransferJob = struct {
+    request: TransferRequest,
+    result: scp.TransferResult = .failed,
     done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     thread: ?std.Thread = null,
 };
 
 threadlocal var g_transfer_job: ?*TransferJob = null;
+threadlocal var g_transfer_queue: std.ArrayListUnmanaged(TransferRequest) = .empty;
 
 pub const FlatEntry = struct {
     name_buf: [256]u8 = undefined,
@@ -858,22 +872,17 @@ fn destroyAsyncJob(job: *AsyncListJob) void {
 }
 
 fn startTransferJob(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
-    if (g_transfer_job != null) {
-        setTransferStatus(.failed, "Transfer busy");
-        return false;
-    }
+    return startTransferJobWithCompletion(kind, conn, src, dst, display, transfer_fn, .{});
+}
+
+fn startTransferJobWithCompletion(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn, completion: TransferCompletion) bool {
     if (src.len > TRANSFER_PATH_MAX or dst.len > TRANSFER_PATH_MAX) {
+        destroyTransferCompletion(completion);
         setTransferStatus(.failed, "Path too long");
         return false;
     }
 
-    const allocator = std.heap.page_allocator;
-    const job = allocator.create(TransferJob) catch {
-        setTransferStatus(.failed, "Transfer start failed");
-        return false;
-    };
-
-    job.* = .{
+    var request = TransferRequest{
         .kind = kind,
         .conn = conn.*,
         .context_id = g_async_context_id,
@@ -881,29 +890,58 @@ fn startTransferJob(kind: TransferKind, conn: *const Surface.SshConnection, src:
         .dst_len = dst.len,
         .display_len = @min(display.len, TRANSFER_DISPLAY_MAX),
         .transfer_fn = transfer_fn,
+        .completion = completion,
     };
-    @memcpy(job.src_buf[0..src.len], src);
-    @memcpy(job.dst_buf[0..dst.len], dst);
-    @memcpy(job.display_buf[0..job.display_len], display[0..job.display_len]);
+    @memcpy(request.src_buf[0..src.len], src);
+    @memcpy(request.dst_buf[0..dst.len], dst);
+    @memcpy(request.display_buf[0..request.display_len], display[0..request.display_len]);
+
+    return startTransferRequest(request);
+}
+
+fn startTransferRequest(request: TransferRequest) bool {
+    if (g_transfer_job != null) {
+        g_transfer_queue.append(std.heap.page_allocator, request) catch {
+            destroyTransferRequest(request);
+            setTransferStatus(.failed, "Transfer queue full");
+            return false;
+        };
+        return true;
+    }
+    return startTransferRequestNow(request);
+}
+
+fn startTransferRequestNow(request: TransferRequest) bool {
+    const allocator = std.heap.page_allocator;
+    const job = allocator.create(TransferJob) catch {
+        destroyTransferRequest(request);
+        setTransferStatus(.failed, "Transfer start failed");
+        return false;
+    };
+
+    job.* = .{
+        .request = request,
+    };
 
     const thread = std.Thread.spawn(.{}, transferThread, .{job}) catch {
         allocator.destroy(job);
+        destroyTransferRequest(request);
         setTransferStatus(.failed, "Transfer start failed");
         return false;
     };
     job.thread = thread;
     g_transfer_job = job;
-    setTransferStatus(.in_progress, job.display_buf[0..job.display_len]);
+    setTransferStatus(.in_progress, job.request.display_buf[0..job.request.display_len]);
     return true;
 }
 
 fn transferThread(job: *TransferJob) void {
     const allocator = std.heap.page_allocator;
-    job.result = job.transfer_fn(
+    job.result = job.request.transfer_fn(
         allocator,
-        &job.conn,
-        job.src_buf[0..job.src_len],
-        job.dst_buf[0..job.dst_len],
+        &job.request.conn,
+        job.request.src_buf[0..job.request.src_len],
+        job.request.dst_buf[0..job.request.dst_len],
     );
     job.done.store(true, .release);
 }
@@ -915,12 +953,14 @@ fn tickTransferJob() void {
     if (job.thread) |thread| thread.join();
     g_transfer_job = null;
     defer destroyTransferJob(job);
+    defer maybeStartNextTransfer();
 
-    const display = job.display_buf[0..job.display_len];
+    const display = job.request.display_buf[0..job.request.display_len];
     switch (job.result) {
         .ok => {
             setTransferStatus(.success, display);
-            if (job.kind == .upload and job.context_id == g_async_context_id and g_mode == .remote and g_has_ssh_conn) {
+            if (job.request.completion.on_success) |callback| callback(job.request.completion.context);
+            if (job.request.kind == .upload and job.request.context_id == g_async_context_id and g_mode == .remote and g_has_ssh_conn) {
                 rescanRemote();
             }
         },
@@ -928,7 +968,23 @@ fn tickTransferJob() void {
     }
 }
 
+fn maybeStartNextTransfer() void {
+    while (g_transfer_job == null and g_transfer_queue.items.len > 0) {
+        const next = g_transfer_queue.orderedRemove(0);
+        if (startTransferRequestNow(next)) return;
+    }
+}
+
+fn destroyTransferRequest(request: TransferRequest) void {
+    destroyTransferCompletion(request.completion);
+}
+
+fn destroyTransferCompletion(completion: TransferCompletion) void {
+    if (completion.on_destroy) |callback| callback(completion.context);
+}
+
 fn destroyTransferJob(job: *TransferJob) void {
+    destroyTransferRequest(job.request);
     std.heap.page_allocator.destroy(job);
 }
 
@@ -940,12 +996,18 @@ fn tickTransferJobForTest() void {
     tickTransferJob();
 }
 
+fn transferQueueLenForTest() usize {
+    return g_transfer_queue.items.len;
+}
+
 fn resetTransferStateForTest() void {
     if (g_transfer_job) |job| {
         if (job.thread) |thread| thread.join();
         destroyTransferJob(job);
         g_transfer_job = null;
     }
+    for (g_transfer_queue.items) |request| destroyTransferRequest(request);
+    g_transfer_queue.clearRetainingCapacity();
     g_transfer_status = .idle;
     g_transfer_msg_len = 0;
 }
@@ -958,6 +1020,8 @@ pub fn deinit() void {
         destroyTransferJob(job);
         g_transfer_job = null;
     }
+    for (g_transfer_queue.items) |request| destroyTransferRequest(request);
+    g_transfer_queue.clearAndFree(std.heap.page_allocator);
     if (g_async_job) |job| {
         // Wait for the background thread to finish
         if (job.thread) |thread| thread.join();
@@ -1295,6 +1359,27 @@ fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []c
     return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
 
+fn uploadLocalFileToRemoteSpecWithTransferAndCallback(
+    local_path: []const u8,
+    dst_spec: []const u8,
+    display_name: []const u8,
+    conn: *const Surface.SshConnection,
+    transfer_fn: TransferFn,
+    callback: TransferSuccessCallback,
+) bool {
+    return startTransferJobWithCompletion(.upload, conn, local_path, dst_spec, display_name, transfer_fn, .{ .on_success = callback });
+}
+
+pub fn uploadLocalFileToRemoteSpecWithCompletion(
+    local_path: []const u8,
+    dst_spec: []const u8,
+    display_name: []const u8,
+    conn: *const Surface.SshConnection,
+    completion: TransferCompletion,
+) bool {
+    return startTransferJobWithCompletion(.upload, conn, local_path, dst_spec, display_name, scp.transfer, completion);
+}
+
 pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const Surface.SshConnection) bool {
     return downloadRemoteFileToPathWithTransfer(remote_path, local_path, display_name, conn, scp.transfer);
 }
@@ -1322,6 +1407,20 @@ test "setTransferStatus stores message" {
 
 fn transferOkForTest(_: std.mem.Allocator, _: *const Surface.SshConnection, _: []const u8, _: []const u8) scp.TransferResult {
     return .ok;
+}
+
+threadlocal var g_transfer_success_callback_count_for_test: usize = 0;
+
+fn transferSuccessCallbackForTest(_: ?*anyopaque) void {
+    g_transfer_success_callback_count_for_test += 1;
+}
+
+fn tickTransfersUntilIdleForTest() void {
+    var attempts: usize = 0;
+    while ((g_transfer_job != null or transferQueueLenForTest() > 0) and attempts < 200) : (attempts += 1) {
+        tickTransferJobForTest();
+        if (g_transfer_job != null) std.Thread.sleep(std.time.ns_per_ms);
+    }
 }
 
 test "file_explorer: transfer job starts without completing on input thread" {
@@ -1353,15 +1452,43 @@ test "file_explorer: completed transfer job updates status on tick" {
     try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
 }
 
-test "file_explorer: second transfer is rejected while one is active" {
+test "file_explorer: second transfer is queued while one is active" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
     var conn: Surface.SshConnection = .{};
     try std.testing.expect(startTransferJobForTest(.download, &conn, "remote-a", "local-a", "a.txt", transferOkForTest));
-    try std.testing.expect(!startTransferJobForTest(.upload, &conn, "local-b", "remote-b", "b.txt", transferOkForTest));
-    try std.testing.expectEqual(TransferStatus.failed, g_transfer_status);
-    try std.testing.expectEqualStrings("Transfer busy", g_transfer_msg[0..g_transfer_msg_len]);
+    try std.testing.expect(startTransferJobForTest(.upload, &conn, "local-b", "remote-b", "b.txt", transferOkForTest));
+    try std.testing.expectEqual(@as(usize, 1), transferQueueLenForTest());
+
+    tickTransfersUntilIdleForTest();
+
+    try std.testing.expectEqual(@as(?*TransferJob, null), g_transfer_job);
+    try std.testing.expectEqual(@as(usize, 0), transferQueueLenForTest());
+    try std.testing.expectEqual(TransferStatus.success, g_transfer_status);
+    try std.testing.expectEqualStrings("b.txt", g_transfer_msg[0..g_transfer_msg_len]);
+}
+
+test "file_explorer: transfer success callback is deferred until upload succeeds" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+    g_transfer_success_callback_count_for_test = 0;
+
+    var conn: Surface.SshConnection = .{};
+    try std.testing.expect(uploadLocalFileToRemoteSpecWithTransferAndCallback(
+        "local.txt",
+        "user@host:/tmp",
+        "local.txt",
+        &conn,
+        transferOkForTest,
+        transferSuccessCallbackForTest,
+    ));
+
+    try std.testing.expectEqual(@as(usize, 0), g_transfer_success_callback_count_for_test);
+
+    tickTransfersUntilIdleForTest();
+
+    try std.testing.expectEqual(@as(usize, 1), g_transfer_success_callback_count_for_test);
 }
 
 test "file_explorer: upload helper starts transfer with explicit remote spec" {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -120,6 +120,29 @@ threadlocal var g_async_job: ?*AsyncListJob = null;
 threadlocal var g_pending_async_list: ?PendingAsyncList = null;
 threadlocal var g_async_context_id: u64 = 1;
 
+const TransferKind = enum { upload, download };
+const TransferFn = *const fn (std.mem.Allocator, *const Surface.SshConnection, []const u8, []const u8) scp.TransferResult;
+const TRANSFER_PATH_MAX: usize = 1024;
+const TRANSFER_DISPLAY_MAX: usize = 128;
+
+const TransferJob = struct {
+    kind: TransferKind,
+    conn: Surface.SshConnection,
+    context_id: u64,
+    src_buf: [TRANSFER_PATH_MAX]u8 = undefined,
+    src_len: usize = 0,
+    dst_buf: [TRANSFER_PATH_MAX]u8 = undefined,
+    dst_len: usize = 0,
+    display_buf: [TRANSFER_DISPLAY_MAX]u8 = undefined,
+    display_len: usize = 0,
+    result: scp.TransferResult = .failed,
+    transfer_fn: TransferFn,
+    done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    thread: ?std.Thread = null,
+};
+
+threadlocal var g_transfer_job: ?*TransferJob = null;
+
 pub const FlatEntry = struct {
     name_buf: [256]u8 = undefined,
     name_len: u8 = 0,
@@ -459,6 +482,8 @@ pub fn setRoot(path: []const u8) void {
 }
 
 pub fn tickAsync() void {
+    tickTransferJob();
+
     const job = g_async_job orelse return;
     if (!job.done.load(.acquire)) return;
 
@@ -832,9 +857,107 @@ fn destroyAsyncJob(job: *AsyncListJob) void {
     allocator.destroy(job);
 }
 
+fn startTransferJob(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
+    if (g_transfer_job != null) {
+        setTransferStatus(.failed, "Transfer busy");
+        return false;
+    }
+    if (src.len > TRANSFER_PATH_MAX or dst.len > TRANSFER_PATH_MAX) {
+        setTransferStatus(.failed, "Path too long");
+        return false;
+    }
+
+    const allocator = std.heap.page_allocator;
+    const job = allocator.create(TransferJob) catch {
+        setTransferStatus(.failed, "Transfer start failed");
+        return false;
+    };
+
+    job.* = .{
+        .kind = kind,
+        .conn = conn.*,
+        .context_id = g_async_context_id,
+        .src_len = src.len,
+        .dst_len = dst.len,
+        .display_len = @min(display.len, TRANSFER_DISPLAY_MAX),
+        .transfer_fn = transfer_fn,
+    };
+    @memcpy(job.src_buf[0..src.len], src);
+    @memcpy(job.dst_buf[0..dst.len], dst);
+    @memcpy(job.display_buf[0..job.display_len], display[0..job.display_len]);
+
+    const thread = std.Thread.spawn(.{}, transferThread, .{job}) catch {
+        allocator.destroy(job);
+        setTransferStatus(.failed, "Transfer start failed");
+        return false;
+    };
+    job.thread = thread;
+    g_transfer_job = job;
+    setTransferStatus(.in_progress, job.display_buf[0..job.display_len]);
+    return true;
+}
+
+fn transferThread(job: *TransferJob) void {
+    const allocator = std.heap.page_allocator;
+    job.result = job.transfer_fn(
+        allocator,
+        &job.conn,
+        job.src_buf[0..job.src_len],
+        job.dst_buf[0..job.dst_len],
+    );
+    job.done.store(true, .release);
+}
+
+fn tickTransferJob() void {
+    const job = g_transfer_job orelse return;
+    if (!job.done.load(.acquire)) return;
+
+    if (job.thread) |thread| thread.join();
+    g_transfer_job = null;
+    defer destroyTransferJob(job);
+
+    const display = job.display_buf[0..job.display_len];
+    switch (job.result) {
+        .ok => {
+            setTransferStatus(.success, display);
+            if (job.kind == .upload and job.context_id == g_async_context_id and g_mode == .remote and g_has_ssh_conn) {
+                rescanRemote();
+            }
+        },
+        else => setTransferStatus(.failed, display),
+    }
+}
+
+fn destroyTransferJob(job: *TransferJob) void {
+    std.heap.page_allocator.destroy(job);
+}
+
+fn startTransferJobForTest(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
+    return startTransferJob(kind, conn, src, dst, display, transfer_fn);
+}
+
+fn tickTransferJobForTest() void {
+    tickTransferJob();
+}
+
+fn resetTransferStateForTest() void {
+    if (g_transfer_job) |job| {
+        if (job.thread) |thread| thread.join();
+        destroyTransferJob(job);
+        g_transfer_job = null;
+    }
+    g_transfer_status = .idle;
+    g_transfer_msg_len = 0;
+}
+
 /// Clean up any in-flight async job. Call on window close to avoid leaking
 /// the job allocation and its thread.
 pub fn deinit() void {
+    if (g_transfer_job) |job| {
+        if (job.thread) |thread| thread.join();
+        destroyTransferJob(job);
+        g_transfer_job = null;
+    }
     if (g_async_job) |job| {
         // Wait for the background thread to finish
         if (job.thread) |thread| thread.join();
@@ -1132,10 +1255,6 @@ pub fn downloadSelected(local_dir: []const u8) void {
 
     const remote_path = entry.path_buf[0..entry.path_len];
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
     // Build remote spec: user@host:path
     var spec_buf: [512]u8 = undefined;
     const src = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_path);
@@ -1145,22 +1264,12 @@ pub fn downloadSelected(local_dir: []const u8) void {
     const name = entry.name_buf[0..entry.name_len];
     const dst = std.fmt.bufPrint(&dst_buf, "{s}\\{s}", .{ local_dir, name }) catch return;
 
-    setTransferStatus(.in_progress, name);
-
-    const result = scp.transfer(allocator, &g_ssh_conn, src, dst);
-    switch (result) {
-        .ok => setTransferStatus(.success, name),
-        else => setTransferStatus(.failed, name),
-    }
+    _ = startTransferJob(.download, &g_ssh_conn, src, dst, name, scp.transfer);
 }
 
 /// Upload a local file to the current remote directory.
 pub fn uploadFile(local_path: []const u8) void {
     if (g_mode != .remote or !g_has_ssh_conn) return;
-
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
 
     // Destination: current remote dir
     const remote_dir = g_root_path[0..g_root_path_len];
@@ -1175,16 +1284,15 @@ pub fn uploadFile(local_path: []const u8) void {
     }
     const filename = local_path[name_start..];
 
-    setTransferStatus(.in_progress, filename);
+    _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, filename, scp.transfer);
+}
 
-    const result = scp.transfer(allocator, &g_ssh_conn, local_path, dst);
-    switch (result) {
-        .ok => {
-            setTransferStatus(.success, filename);
-            rescanRemote();
-        },
-        else => setTransferStatus(.failed, filename),
-    }
+pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const Surface.SshConnection) bool {
+    return uploadLocalFileToRemoteSpecWithTransfer(local_path, dst_spec, display_name, conn, scp.transfer);
+}
+
+fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const Surface.SshConnection, transfer_fn: TransferFn) bool {
+    return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
 
 // ============================================================================
@@ -1195,6 +1303,61 @@ test "setTransferStatus stores message" {
     setTransferStatus(.success, "test_file.txt");
     try std.testing.expectEqual(TransferStatus.success, g_transfer_status);
     try std.testing.expectEqualStrings("test_file.txt", g_transfer_msg[0..g_transfer_msg_len]);
+}
+
+fn transferOkForTest(_: std.mem.Allocator, _: *const Surface.SshConnection, _: []const u8, _: []const u8) scp.TransferResult {
+    return .ok;
+}
+
+test "file_explorer: transfer job starts without completing on input thread" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var conn: Surface.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferOkForTest));
+    try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
+    try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
+    try std.testing.expect(g_transfer_job != null);
+}
+
+test "file_explorer: completed transfer job updates status on tick" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var conn: Surface.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferOkForTest));
+
+    var attempts: usize = 0;
+    while (g_transfer_job != null and attempts < 100) : (attempts += 1) {
+        tickTransferJobForTest();
+        if (g_transfer_job != null) std.Thread.sleep(std.time.ns_per_ms);
+    }
+
+    try std.testing.expectEqual(@as(?*TransferJob, null), g_transfer_job);
+    try std.testing.expectEqual(TransferStatus.success, g_transfer_status);
+    try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
+}
+
+test "file_explorer: second transfer is rejected while one is active" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var conn: Surface.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote-a", "local-a", "a.txt", transferOkForTest));
+    try std.testing.expect(!startTransferJobForTest(.upload, &conn, "local-b", "remote-b", "b.txt", transferOkForTest));
+    try std.testing.expectEqual(TransferStatus.failed, g_transfer_status);
+    try std.testing.expectEqualStrings("Transfer busy", g_transfer_msg[0..g_transfer_msg_len]);
+}
+
+test "file_explorer: upload helper starts transfer with explicit remote spec" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var conn: Surface.SshConnection = .{};
+    try std.testing.expect(uploadLocalFileToRemoteSpecWithTransfer("local.txt", "user@host:/tmp", "local.txt", &conn, transferOkForTest));
+    try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
+    try std.testing.expectEqualStrings("local.txt", g_transfer_msg[0..g_transfer_msg_len]);
+    try std.testing.expect(g_transfer_job != null);
 }
 
 test "buildChildPathInto avoids duplicate separators" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -56,6 +56,7 @@ const basenameForPreview = preview_source.basenameForPreview;
 const buildPreviewCommand = preview_source.buildPreviewCommand;
 
 const LayoutResizeUrgency = enum { coalesced, immediate };
+const TerminalPathClickAction = enum { pass_through, open_url_or_preview, download_ssh_file };
 
 fn panelToggleResizeUrgency() LayoutResizeUrgency {
     return .coalesced;
@@ -63,6 +64,31 @@ fn panelToggleResizeUrgency() LayoutResizeUrgency {
 
 test "panel toggles request coalesced layout resize" {
     try std.testing.expectEqual(LayoutResizeUrgency.coalesced, panelToggleResizeUrgency());
+}
+
+fn terminalPathClickAction(launch_kind: Surface.LaunchKind, has_ssh_conn: bool, ctrl: bool, shift: bool, alt: bool) TerminalPathClickAction {
+    if (ctrl and shift and !alt and launch_kind == .ssh and has_ssh_conn) return .download_ssh_file;
+    if (ctrl and !shift and !alt) return .open_url_or_preview;
+    return .pass_through;
+}
+
+test "terminal path click action maps ctrl shift ssh to download" {
+    try std.testing.expectEqual(
+        TerminalPathClickAction.download_ssh_file,
+        terminalPathClickAction(.ssh, true, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.pass_through,
+        terminalPathClickAction(.ssh, false, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.pass_through,
+        terminalPathClickAction(.wsl, false, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.open_url_or_preview,
+        terminalPathClickAction(.ssh, true, true, false, false),
+    );
 }
 
 // Selection + divider drag state (moved from AppWindow.zig)
@@ -1826,9 +1852,14 @@ pub fn isUrlUnderlineCell(surface: *Surface, col: usize, row: usize) bool {
 }
 
 fn extractPreviewPathAtCell(allocator: std.mem.Allocator, surface: *Surface, cell_pos: CellPos) ?[]u8 {
-    const token = extractTokenAtCell(allocator, surface, cell_pos) orelse return null;
-    if (!looksLikePreviewPath(token)) {
-        allocator.free(token);
+    const token = extractPreviewPathRangeAtCell(allocator, surface, cell_pos) orelse return null;
+    return token.text;
+}
+
+fn extractPreviewPathRangeAtCell(allocator: std.mem.Allocator, surface: *Surface, cell_pos: CellPos) ?TokenAtCell {
+    const token = extractTokenRangeAtCell(allocator, surface, cell_pos) orelse return null;
+    if (!looksLikePreviewPath(token.text)) {
+        token.deinit(allocator);
         return null;
     }
     return token;
@@ -1867,7 +1898,7 @@ fn openUrlAtCell(surface: *Surface, cell_pos: CellPos) bool {
     return opened;
 }
 
-fn updateUrlUnderlineAtMouse(xpos: f64, ypos: f64) void {
+fn updateInteractiveUnderlineAtMouse(xpos: f64, ypos: f64, ctrl: bool, shift: bool, alt: bool) void {
     if (g_selecting or overlays.scrollbar.g_scrollbar_dragging or g_divider_dragging) {
         clearUrlUnderline();
         return;
@@ -1887,9 +1918,17 @@ fn updateUrlUnderlineAtMouse(xpos: f64, ypos: f64) void {
     };
     const allocator = AppWindow.g_allocator orelse return;
     const cell_pos = mouseToSurfaceCell(surface, xpos, ypos);
-    const token = extractUrlRangeAtCell(allocator, surface, cell_pos) orelse {
-        clearUrlUnderline();
-        return;
+
+    const action = terminalPathClickAction(surface.launch_kind, surface.ssh_connection != null, ctrl, shift, alt);
+    const token = switch (action) {
+        .download_ssh_file => extractPreviewPathRangeAtCell(allocator, surface, cell_pos) orelse {
+            clearUrlUnderline();
+            return;
+        },
+        else => extractUrlRangeAtCell(allocator, surface, cell_pos) orelse {
+            clearUrlUnderline();
+            return;
+        },
     };
     defer token.deinit(allocator);
 
@@ -1961,6 +2000,40 @@ fn openPreviewPanelForCell(surface: *Surface, cell_pos: CellPos) bool {
 
     const preview_surface = AppWindow.splitFocusedReturningSurface(.right) orelse return false;
     writeTextToSurfacePty(preview_surface, command);
+    return true;
+}
+
+fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
+    if (surface.launch_kind != .ssh) return false;
+    const conn = surface.ssh_connection orelse return false;
+    const allocator = AppWindow.g_allocator orelse return false;
+
+    const path = extractPreviewPathAtCell(allocator, surface, cell_pos) orelse return false;
+    defer allocator.free(path);
+
+    const resolved_path = resolveTerminalPreviewPath(allocator, surface, path) catch {
+        file_explorer.setTransferStatus(.failed, "Download failed");
+        return true;
+    };
+    defer allocator.free(resolved_path);
+
+    const name = basenameForPreview(resolved_path);
+    if (name.len == 0) return false;
+
+    var dl_buf: [260]u8 = undefined;
+    const dl_path = getDownloadsFolder(&dl_buf);
+    if (dl_path.len == 0) {
+        file_explorer.setTransferStatus(.failed, "Download folder missing");
+        return true;
+    }
+
+    var dst_buf: [512]u8 = undefined;
+    const dst = std.fmt.bufPrint(&dst_buf, "{s}\\{s}", .{ dl_path, name }) catch {
+        file_explorer.setTransferStatus(.failed, "Path too long");
+        return true;
+    };
+
+    _ = file_explorer.downloadRemoteFileToPath(resolved_path, dst, name, &conn);
     return true;
 }
 
@@ -2332,9 +2405,15 @@ fn handleMouseButton(ev: win32_backend.MouseButtonEvent) void {
             }
 
             const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
-            if (ev.ctrl and !ev.shift and !ev.alt) {
-                if (openUrlAtCell(clicked_surface, cell_pos)) return;
-                if (openPreviewPanelForCell(clicked_surface, cell_pos)) return;
+            switch (terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, ev.ctrl, ev.shift, ev.alt)) {
+                .download_ssh_file => {
+                    if (downloadTerminalFileAtCell(clicked_surface, cell_pos)) return;
+                },
+                .open_url_or_preview => {
+                    if (openUrlAtCell(clicked_surface, cell_pos)) return;
+                    if (openPreviewPanelForCell(clicked_surface, cell_pos)) return;
+                },
+                .pass_through => {},
             }
 
             clearUrlUnderline();
@@ -2719,7 +2798,7 @@ fn handleMouseMove(ev: win32_backend.MouseMoveEvent) void {
     if (AppWindow.g_focus_follows_mouse) {
         updateFocusFromMouse(@intFromFloat(xpos), @intFromFloat(ypos));
     }
-    updateUrlUnderlineAtMouse(xpos, ypos);
+    updateInteractiveUnderlineAtMouse(xpos, ypos, ev.ctrl, ev.shift, ev.alt);
 
     // Update scrollbar hover state
     const win = AppWindow.g_window orelse return;

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -452,9 +452,8 @@ fn handleSshTerminalFileDrop(local_path: []const u8) bool {
     var spec_buf: [512]u8 = undefined;
     const destination = scp.remoteSpec(&spec_buf, &conn, remote_dir);
     std.debug.print("SSH file drop upload: {s} -> {s}\n", .{ local_path, destination });
-    const result = scp.transfer(allocator, &conn, local_path, destination);
-    if (result != .ok) {
-        std.debug.print("SSH file drop upload failed\n", .{});
+    if (!file_explorer.uploadLocalFileToRemoteSpec(local_path, destination, filename, &conn)) {
+        std.debug.print("SSH file drop upload failed to start\n", .{});
         return true;
     }
 

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -403,6 +403,41 @@ fn pasteSavedClipboardImage(surface: *Surface, allocator: std.mem.Allocator, ima
     return true;
 }
 
+const DeferredSshDropPaste = struct {
+    allocator: std.mem.Allocator,
+    surface_allocator: std.mem.Allocator,
+    surface: *Surface,
+    text: []u8,
+};
+
+fn deferredSshDropPasteSuccess(ctx: ?*anyopaque) void {
+    const pending: *DeferredSshDropPaste = @ptrCast(@alignCast(ctx orelse return));
+    writePasteToPty(pending.surface, pending.allocator, pending.text);
+}
+
+fn deferredSshDropPasteDestroy(ctx: ?*anyopaque) void {
+    const pending: *DeferredSshDropPaste = @ptrCast(@alignCast(ctx orelse return));
+    pending.surface.unref(pending.surface_allocator);
+    pending.allocator.free(pending.text);
+    pending.allocator.destroy(pending);
+}
+
+fn createDeferredSshDropPaste(surface: *Surface, text: []const u8) ?*DeferredSshDropPaste {
+    const allocator = std.heap.page_allocator;
+    const pending = allocator.create(DeferredSshDropPaste) catch return null;
+    const owned_text = allocator.dupe(u8, text) catch {
+        allocator.destroy(pending);
+        return null;
+    };
+    pending.* = .{
+        .allocator = allocator,
+        .surface_allocator = surface.allocator,
+        .surface = surface.ref(),
+        .text = owned_text,
+    };
+    return pending;
+}
+
 pub fn handleFileDrop(local_path: []const u8, x: i32, _: i32) bool {
     if (handleFileExplorerDrop(local_path, x)) return true;
     return handleSshTerminalFileDrop(local_path);
@@ -452,14 +487,20 @@ fn handleSshTerminalFileDrop(local_path: []const u8) bool {
     var spec_buf: [512]u8 = undefined;
     const destination = scp.remoteSpec(&spec_buf, &conn, remote_dir);
     std.debug.print("SSH file drop upload: {s} -> {s}\n", .{ local_path, destination });
-    if (!file_explorer.uploadLocalFileToRemoteSpec(local_path, destination, filename, &conn)) {
+
+    const pasted = shellSingleQuoteForPaste(allocator, remote_path) orelse return true;
+    defer allocator.free(pasted);
+
+    const pending_paste = createDeferredSshDropPaste(surface, pasted) orelse return true;
+    if (!file_explorer.uploadLocalFileToRemoteSpecWithCompletion(local_path, destination, filename, &conn, .{
+        .context = pending_paste,
+        .on_success = deferredSshDropPasteSuccess,
+        .on_destroy = deferredSshDropPasteDestroy,
+    })) {
         std.debug.print("SSH file drop upload failed to start\n", .{});
         return true;
     }
 
-    const pasted = shellSingleQuoteForPaste(allocator, remote_path) orelse return true;
-    defer allocator.free(pasted);
-    writePasteToPty(surface, allocator, pasted);
     return true;
 }
 

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -28,6 +28,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+Shift+O", .action = "Split right" },
     .{ .keys = "Ctrl+Shift+Alt+E", .action = "File explorer" },
     .{ .keys = "Ctrl/double-click text", .action = "Preview file" },
+    .{ .keys = "Ctrl+Shift-click SSH file", .action = "Download file" },
     .{ .keys = "Ctrl+Shift+[ / ]", .action = "Previous / next panel" },
     .{ .keys = "Alt+Arrows", .action = "Focus panel" },
     .{ .keys = "Ctrl+Shift+Z", .action = "Equalize panels" },


### PR DESCRIPTION
## Summary
- run SSH file explorer uploads/downloads as background transfer jobs
- add Ctrl+Shift-click SSH terminal path downloads
- preserve terminal drop semantics by queueing transfers and pasting dropped paths only after upload success

## Verification
- zig build test
- zig build