### PR TITLE
Add draggable scrollbar to AI Chat transcript

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -873,6 +873,7 @@ pub const Session = struct {
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     scroll_px: f32 = 0,
+    scrollbar_show_time: i64 = 0,
     approval_mutex: std.Thread.Mutex = .{},
     approval_cond: std.Thread.Condition = .{},
     approval_pending: bool = false,
@@ -1699,6 +1700,14 @@ pub const Session = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         self.scroll_px = @max(0.0, self.scroll_px + delta_px);
+        self.scrollbar_show_time = std.time.milliTimestamp();
+    }
+
+    pub fn scrollToPx(self: *Session, px: f32) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.scroll_px = @max(0.0, px);
+        self.scrollbar_show_time = std.time.milliTimestamp();
     }
 
     pub fn inputScrollRow(self: *Session) usize {

--- a/src/ai_chat_scrollbar_model.zig
+++ b/src/ai_chat_scrollbar_model.zig
@@ -1,0 +1,140 @@
+//! Pure geometry / drag / fade math for the AI Chat transcript scrollbar.
+//!
+//! No GL or platform imports so it can be unit-tested in test_main.zig
+//! (mirrors src/scrollbar_model.zig, which the terminal scrollbar extracted
+//! for the same reason — src/renderer/ai_chat_renderer.zig @cImports OpenGL
+//! and is not part of the test build).
+
+const std = @import("std");
+
+pub const WIDTH: f32 = 12; // Track/thumb width in px
+pub const MIN_THUMB: f32 = 20; // Minimum thumb height in px
+pub const HIT_PAD: f32 = 4; // Extra hit area on each side of the track
+pub const FADE_DELAY_MS: i64 = 800; // Fully visible before fading
+pub const FADE_DURATION_MS: i64 = 400; // Fade-out animation length
+
+/// Resolved scrollbar geometry. All `*_px` values use top-left origin.
+pub const Geometry = struct {
+    track_x: f32,
+    track_top_px: f32,
+    track_h: f32,
+    thumb_top_px: f32,
+    thumb_h: f32,
+    max_scroll: f32,
+};
+
+/// Compute geometry for the transcript scrollbar.
+/// `x`/`w` are the transcript panel's left edge and width; `transcript_top`
+/// is the top of the transcript area (top-left px); `transcript_h` the visible
+/// height; `content_h` the total content height; `scroll_px` the current scroll.
+/// Returns null when the content fits (no overflow → no scrollbar).
+pub fn geometry(x: f32, w: f32, transcript_top: f32, transcript_h: f32, content_h: f32, scroll_px: f32) ?Geometry {
+    if (transcript_h <= 0 or content_h <= transcript_h) return null;
+    const max_scroll = content_h - transcript_h;
+    const track_x = @round(x + w - WIDTH);
+    const track_top_px = @round(transcript_top);
+    const track_h = @round(@max(1.0, transcript_h));
+    const visible_ratio = transcript_h / content_h;
+    const thumb_h = @round(@min(track_h, @max(MIN_THUMB, track_h * visible_ratio)));
+    const frac = std.math.clamp(scroll_px / max_scroll, 0.0, 1.0);
+    const thumb_top_px = @round(track_top_px + frac * (track_h - thumb_h));
+    return .{
+        .track_x = track_x,
+        .track_top_px = track_top_px,
+        .track_h = track_h,
+        .thumb_top_px = thumb_top_px,
+        .thumb_h = thumb_h,
+        .max_scroll = max_scroll,
+    };
+}
+
+/// True when a point (top-left px) is over the track (including HIT_PAD).
+pub fn hitTrack(geo: Geometry, px: f32, py: f32) bool {
+    return px >= geo.track_x - HIT_PAD and px <= geo.track_x + WIDTH + HIT_PAD and
+        py >= geo.track_top_px and py <= geo.track_top_px + geo.track_h;
+}
+
+/// Drag offset within the thumb for a press at `py`. If the press is on the
+/// thumb, returns `py - thumb_top_px`; if on the bare track, centers the thumb.
+pub fn thumbDragOffset(geo: Geometry, py: f32) f32 {
+    if (py >= geo.thumb_top_px and py <= geo.thumb_top_px + geo.thumb_h) return py - geo.thumb_top_px;
+    return geo.thumb_h / 2.0;
+}
+
+/// Map a pointer y (top-left px) plus drag offset to a target scroll_px.
+pub fn scrollPxAt(geo: Geometry, py: f32, drag_offset: f32) f32 {
+    const usable = @max(1.0, geo.track_h - geo.thumb_h);
+    const frac = std.math.clamp((py - geo.track_top_px - drag_offset) / usable, 0.0, 1.0);
+    return frac * geo.max_scroll;
+}
+
+/// Fade opacity for the scrollbar. `held` is true while hovering or dragging.
+/// `show_time` is the last time the bar was shown (ms); 0 means never shown.
+pub fn fadeOpacity(show_time: i64, now: i64, held: bool) f32 {
+    if (held) return 1.0;
+    if (show_time <= 0) return 0;
+    const elapsed = now - show_time;
+    if (elapsed < FADE_DELAY_MS) return 1.0;
+    const fade_elapsed = elapsed - FADE_DELAY_MS;
+    if (fade_elapsed >= FADE_DURATION_MS) return 0;
+    return 1.0 - @as(f32, @floatFromInt(fade_elapsed)) / @as(f32, @floatFromInt(FADE_DURATION_MS));
+}
+
+test "geometry returns null when content fits" {
+    try std.testing.expect(geometry(0, 400, 100, 200, 150, 0) == null);
+    try std.testing.expect(geometry(0, 400, 100, 200, 200, 0) == null);
+}
+
+test "geometry thumb is proportional and clamps to MIN_THUMB" {
+    const geo = geometry(0, 400, 100, 200, 400, 0).?;
+    try std.testing.expectEqual(@as(f32, 388), geo.track_x); // round(0+400-12)
+    try std.testing.expectEqual(@as(f32, 200), geo.track_h);
+    try std.testing.expectEqual(@as(f32, 100), geo.thumb_h); // 200 * (200/400)
+    try std.testing.expectEqual(@as(f32, 200), geo.max_scroll);
+
+    // Tiny visible ratio with a tall track still floors at MIN_THUMB.
+    const small = geometry(0, 400, 100, 200, 100_000, 0).?;
+    try std.testing.expectEqual(@as(f32, MIN_THUMB), small.thumb_h);
+}
+
+test "geometry thumb position tracks scroll_px" {
+    const top = geometry(0, 400, 100, 200, 400, 0).?;
+    try std.testing.expectEqual(@as(f32, 100), top.thumb_top_px); // at track top
+
+    const bottom = geometry(0, 400, 100, 200, 400, 200).?;
+    try std.testing.expectEqual(@as(f32, 200), bottom.thumb_top_px); // track_top + (track_h - thumb_h)
+
+    const mid = geometry(0, 400, 100, 200, 400, 100).?;
+    try std.testing.expectEqual(@as(f32, 150), mid.thumb_top_px);
+}
+
+test "hitTrack respects width, pad, and vertical bounds" {
+    const geo = geometry(0, 400, 100, 200, 400, 0).?; // track_x=388, track 100..300
+    try std.testing.expect(hitTrack(geo, 390, 150));
+    try std.testing.expect(hitTrack(geo, 385, 150)); // within HIT_PAD on the left
+    try std.testing.expect(!hitTrack(geo, 350, 150)); // too far left
+    try std.testing.expect(!hitTrack(geo, 405, 150)); // too far right (track_x=388, WIDTH=12, HIT_PAD=4 → right bound 404)
+    try std.testing.expect(!hitTrack(geo, 390, 90)); // above track
+    try std.testing.expect(!hitTrack(geo, 390, 320)); // below track
+}
+
+test "thumbDragOffset uses press position on thumb, centers on bare track" {
+    const geo = geometry(0, 400, 100, 200, 400, 0).?; // thumb 100..200, thumb_h=100
+    try std.testing.expectEqual(@as(f32, 20), thumbDragOffset(geo, 120));
+    try std.testing.expectEqual(@as(f32, 50), thumbDragOffset(geo, 250)); // thumb_h/2
+}
+
+test "scrollPxAt round-trips track extremes" {
+    const geo = geometry(0, 400, 100, 200, 400, 0).?; // usable = 100, max_scroll=200
+    try std.testing.expectEqual(@as(f32, 0), scrollPxAt(geo, 100, 0)); // drag to top
+    try std.testing.expectEqual(@as(f32, 200), scrollPxAt(geo, 200, 0)); // drag to bottom
+    try std.testing.expectEqual(@as(f32, 100), scrollPxAt(geo, 150, 0)); // middle
+}
+
+test "fadeOpacity: held, never-shown, full, mid-fade, gone" {
+    try std.testing.expectEqual(@as(f32, 1.0), fadeOpacity(0, 5000, true)); // held overrides
+    try std.testing.expectEqual(@as(f32, 0), fadeOpacity(0, 5000, false)); // never shown
+    try std.testing.expectEqual(@as(f32, 1.0), fadeOpacity(1000, 1500, false)); // within delay
+    try std.testing.expectEqual(@as(f32, 0.5), fadeOpacity(1000, 2000, false)); // halfway through fade
+    try std.testing.expectEqual(@as(f32, 0), fadeOpacity(1000, 3000, false)); // fully faded
+}

--- a/src/input.zig
+++ b/src/input.zig
@@ -206,6 +206,9 @@ threadlocal var g_scrollbar_drag_top_pad: f32 = 0;
 threadlocal var g_ai_input_scroll_dragging: bool = false;
 threadlocal var g_ai_input_scroll_chat: ?*AppWindow.ai_chat.Session = null;
 threadlocal var g_ai_input_scroll_drag_offset: f32 = 0;
+threadlocal var g_ai_transcript_scroll_dragging: bool = false;
+threadlocal var g_ai_transcript_scroll_chat: ?*AppWindow.ai_chat.Session = null;
+threadlocal var g_ai_transcript_scroll_drag_offset: f32 = 0;
 threadlocal var g_ai_transcript_selecting: bool = false;
 threadlocal var g_ai_transcript_select_chat: ?*AppWindow.ai_chat.Session = null;
 threadlocal var g_ai_transcript_select_auto_copy: bool = false;
@@ -324,6 +327,10 @@ pub fn cancelTransientMouseState(win: anytype) void {
     g_scrollbar_drag_surface = null;
     g_ai_input_scroll_dragging = false;
     g_ai_input_scroll_chat = null;
+    g_ai_transcript_scroll_dragging = false;
+    g_ai_transcript_scroll_chat = null;
+    AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = false;
+    AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = false;
     g_ai_transcript_selecting = false;
     g_ai_transcript_select_chat = null;
     g_ai_transcript_select_auto_copy = false;
@@ -2546,6 +2553,25 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     toggleAiAgentPermission();
                     return;
                 }
+                if (AppWindow.ai_chat_renderer.transcriptScrollbarHitTest(
+                    chat,
+                    xpos,
+                    ypos,
+                    @floatFromInt(fb.width),
+                    @floatFromInt(fb.height),
+                    @floatCast(titlebarHeight()),
+                    AppWindow.leftPanelsWidth(),
+                    AppWindow.rightPanelsWidthForWindow(fb.width),
+                )) |drag_offset| {
+                    g_ai_transcript_scroll_dragging = true;
+                    g_ai_transcript_scroll_chat = chat;
+                    g_ai_transcript_scroll_drag_offset = drag_offset;
+                    AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = true;
+                    applyAiTranscriptScrollbarDrag(chat, ypos);
+                    AppWindow.g_force_rebuild = true;
+                    AppWindow.g_cells_valid = false;
+                    return;
+                }
                 if (!ev.ctrl and !ev.alt) {
                     if (AppWindow.ai_chat_renderer.transcriptTextHitTest(
                         chat,
@@ -2707,6 +2733,9 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             g_scrollbar_drag_surface = null;
             g_ai_input_scroll_dragging = false;
             g_ai_input_scroll_chat = null;
+            g_ai_transcript_scroll_dragging = false;
+            g_ai_transcript_scroll_chat = null;
+            AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = false;
             if (g_ai_transcript_selecting) {
                 if (g_ai_transcript_select_chat) |chat| {
                     if (chat.finishTranscriptSelection() and g_ai_transcript_select_auto_copy) copyAiChatToClipboard(chat);
@@ -2927,6 +2956,25 @@ fn applyAiInputScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) void {
     }
 }
 
+fn applyAiTranscriptScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) void {
+    const win = AppWindow.g_window orelse return;
+    const size = clientSize(win);
+    if (AppWindow.ai_chat_renderer.transcriptScrollbarScrollPxAt(
+        chat,
+        ypos,
+        @floatFromInt(size.width),
+        @floatFromInt(size.height),
+        @floatCast(titlebarHeight()),
+        AppWindow.leftPanelsWidth(),
+        AppWindow.rightPanelsWidthForWindow(size.width),
+        g_ai_transcript_scroll_drag_offset,
+    )) |px| {
+        chat.scrollToPx(px);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+    }
+}
+
 fn updateAiTranscriptSelectionDrag(chat: *AppWindow.ai_chat.Session, xpos: f64, ypos: f64) void {
     const win = AppWindow.g_window orelse return;
     const fb = window_backend.framebufferSize(win);
@@ -2973,6 +3021,10 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
         if (g_ai_input_scroll_chat) |chat| applyAiInputScrollbarDrag(chat, ypos);
         return;
     }
+    if (g_ai_transcript_scroll_dragging) {
+        if (g_ai_transcript_scroll_chat) |chat| applyAiTranscriptScrollbarDrag(chat, ypos);
+        return;
+    }
     if (g_ai_transcript_selecting) {
         if (g_ai_transcript_select_chat) |chat| updateAiTranscriptSelectionDrag(chat, xpos, ypos);
         platform_cursor.set(.ibeam);
@@ -2990,6 +3042,28 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
         return;
     }
 
+    if (AppWindow.g_window) |hover_win| {
+        if (AppWindow.activeAiChat()) |chat| {
+            const hover_fb = window_backend.framebufferSize(hover_win);
+            const over = AppWindow.ai_chat_renderer.transcriptScrollbarHitTest(
+                chat,
+                xpos,
+                ypos,
+                @floatFromInt(hover_fb.width),
+                @floatFromInt(hover_fb.height),
+                @floatCast(titlebarHeight()),
+                AppWindow.leftPanelsWidth(),
+                AppWindow.rightPanelsWidthForWindow(hover_fb.width),
+            ) != null;
+            if (over != AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover) {
+                AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = over;
+                AppWindow.g_force_rebuild = true;
+            }
+        } else if (AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover) {
+            AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = false;
+            AppWindow.g_force_rebuild = true;
+        }
+    }
     if (updateSidebarTabDrag(xpos, ypos)) return;
 
     // Handle divider dragging

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -4,6 +4,13 @@ const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
 const ai_chat = @import("../ai_chat.zig");
 const composer_layout = @import("../ai_chat_composer_layout.zig");
+const scrollbar_model = @import("../ai_chat_scrollbar_model.zig");
+
+// Transcript scrollbar interaction state (one mouse). Set by input.zig,
+// read by the fade computation in renderTranscriptScrollbar.
+pub threadlocal var g_transcript_scrollbar_hover: bool = false;
+pub threadlocal var g_transcript_scrollbar_dragging: bool = false;
+
 const font = AppWindow.font;
 const gl_init = AppWindow.gl_init;
 const titlebar = AppWindow.titlebar;
@@ -316,6 +323,8 @@ pub fn render(
 
     gl.Disable.?(c.GL_SCISSOR_TEST);
 
+    renderTranscriptScrollbar(session, x, w, transcript_top, transcript_h, content_h, window_height);
+
     if (approval) |view| {
         renderApprovalCard(view, x + LINE_PAD_X, input_h + APPROVAL_GAP, w - LINE_PAD_X * 2, APPROVAL_H);
     }
@@ -613,6 +622,101 @@ pub fn inputScrollbarDragRowAt(
     };
 }
 
+const TranscriptLayout = struct {
+    x: f32,
+    w: f32,
+    transcript_top: f32,
+    transcript_h: f32,
+    content_h: f32,
+};
+
+fn transcriptLayoutLocked(
+    session: *ai_chat.Session,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+) ?TranscriptLayout {
+    const x = @round(left_panels_w);
+    const w = @round(@max(1.0, window_width - left_panels_w - right_panels_w));
+    if (w <= 1) return null;
+
+    const approval = session.approvalView();
+    const approval_h: f32 = if (approval != null) APPROVAL_H + APPROVAL_GAP else 0;
+    const input_h = inputLayout(x, w, session.input()).input_h;
+    const transcript_top = titlebar_offset + HEADER_H + 18;
+    const transcript_bottom = input_h + approval_h + 18;
+    const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
+    const content_w = w - LINE_PAD_X * 2;
+
+    var content_h: f32 = 0;
+    for (session.messages.items) |msg| {
+        content_h += messageBlockHeight(msg, content_w);
+        if (msg.reasoning) |reasoning| {
+            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
+        }
+        if (msg.usage_footer) |footer| {
+            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
+        }
+        content_h += BUBBLE_GAP;
+    }
+
+    return .{
+        .x = x,
+        .w = w,
+        .transcript_top = transcript_top,
+        .transcript_h = transcript_h,
+        .content_h = content_h,
+    };
+}
+
+/// Returns the drag offset within the thumb if (xpos, ypos) is over the
+/// transcript scrollbar track, else null.
+pub fn transcriptScrollbarHitTest(
+    session: *ai_chat.Session,
+    xpos: f64,
+    ypos: f64,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+) ?f32 {
+    session.mutex.lock();
+    const layout = transcriptLayoutLocked(session, window_width, window_height, titlebar_offset, left_panels_w, right_panels_w);
+    const scroll_px = session.scroll_px;
+    session.mutex.unlock();
+
+    const l = layout orelse return null;
+    const geo = scrollbar_model.geometry(l.x, l.w, l.transcript_top, l.transcript_h, l.content_h, scroll_px) orelse return null;
+    const px: f32 = @floatCast(xpos);
+    const py: f32 = @floatCast(ypos);
+    if (!scrollbar_model.hitTrack(geo, px, py)) return null;
+    return scrollbar_model.thumbDragOffset(geo, py);
+}
+
+/// Maps a pointer y to a target scroll_px for the transcript scrollbar.
+pub fn transcriptScrollbarScrollPxAt(
+    session: *ai_chat.Session,
+    ypos: f64,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+    drag_offset: f32,
+) ?f32 {
+    session.mutex.lock();
+    const layout = transcriptLayoutLocked(session, window_width, window_height, titlebar_offset, left_panels_w, right_panels_w);
+    const scroll_px = session.scroll_px;
+    session.mutex.unlock();
+
+    const l = layout orelse return null;
+    const geo = scrollbar_model.geometry(l.x, l.w, l.transcript_top, l.transcript_h, l.content_h, scroll_px) orelse return null;
+    return scrollbar_model.scrollPxAt(geo, @floatCast(ypos), drag_offset);
+}
+
 fn messageBlockHeight(msg: ai_chat.Message, max_w: f32) f32 {
     return switch (msg.role) {
         .tool => toolCardHeight(msg, max_w),
@@ -855,6 +959,30 @@ fn renderInputScrollbar(layout: InputLayout, total_rows: usize, visible_rows_raw
 
     gl_init.renderQuadAlpha(geo.track_x, track_y, INPUT_SCROLLBAR_W, geo.track_h, mixColor(bg, fg, 0.24), 0.35);
     gl_init.renderQuadAlpha(geo.track_x, @round(thumb_y), INPUT_SCROLLBAR_W, geo.thumb_h, mixColor(fg, accent, 0.18), 0.72);
+}
+
+fn renderTranscriptScrollbar(
+    session: *ai_chat.Session,
+    x: f32,
+    w: f32,
+    transcript_top: f32,
+    transcript_h: f32,
+    content_h: f32,
+    window_height: f32,
+) void {
+    const geo = scrollbar_model.geometry(x, w, transcript_top, transcript_h, content_h, session.scroll_px) orelse return;
+
+    const held = g_transcript_scrollbar_hover or g_transcript_scrollbar_dragging;
+    const opacity = scrollbar_model.fadeOpacity(session.scrollbar_show_time, std.time.milliTimestamp(), held);
+    if (opacity <= 0.01) return;
+
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const track_y = window_height - geo.track_top_px - geo.track_h;
+    const thumb_y = window_height - geo.thumb_top_px - geo.thumb_h;
+
+    gl_init.renderQuadAlpha(geo.track_x, track_y, scrollbar_model.WIDTH, geo.track_h, mixColor(bg, fg, 0.18), opacity * 0.20);
+    gl_init.renderQuadAlpha(geo.track_x, thumb_y, scrollbar_model.WIDTH, geo.thumb_h, mixColor(bg, fg, 0.46), opacity * 0.62);
 }
 
 fn inputScrollbarGeometry(layout: InputLayout, window_height: f32, total_rows: usize, visible_rows_raw: usize, first_row_raw: usize) ?InputScrollbarGeometry {

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -660,6 +660,7 @@ comptime {
     _ = @import("session_persist.zig");
     _ = @import("skill_registry.zig");
     _ = @import("scrollbar_model.zig");
+    _ = @import("ai_chat_scrollbar_model.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("startup_tabs.zig");
     _ = @import("system_browser.zig");


### PR DESCRIPTION
## Summary
Adds a right-edge scrollbar to the AI Chat transcript, matching the terminal scrollbar's behavior: appears on scroll, fades after ~0.8s, stays visible while hovered or dragged, and is draggable to scroll. The transcript already scrolled via `Session.scroll_px`; this adds the visible/draggable affordance.

- **`src/ai_chat_scrollbar_model.zig`** (new): pure, std-only geometry/hit-test/drag/fade math (`geometry`, `hitTrack`, `thumbDragOffset`, `scrollPxAt`, `fadeOpacity`) with unit tests. Mirrors the terminal's `scrollbar_model.zig` so it's testable (the GL renderer is excluded from the test build).
- **`src/ai_chat.zig`**: `Session.scrollbar_show_time` field; `scrollBy` stamps it; new `scrollToPx` for drag.
- **`src/renderer/ai_chat_renderer.zig`**: draws the scrollbar (`renderTranscriptScrollbar`), exposes `transcriptScrollbarHitTest` / `transcriptScrollbarScrollPxAt`, plus hover/drag flags.
- **`src/input.zig`**: mouse-down hit-test, drag, and hover wiring, mirroring the existing input-scrollbar pattern.

Design + plan: `docs/superpowers/specs/2026-05-25-chat-transcript-scrollbar-design.md`, `docs/superpowers/plans/2026-05-25-chat-transcript-scrollbar.md`.

## Test Plan
`zig build` and `zig build test` pass (the new pure-model tests run natively). Manual verification on Windows still pending:
- [ ] Long conversation: wheel-scroll shows the bar (thumb ∝ visible fraction, tracks scroll), then it fades after ~0.8s
- [ ] Dragging the thumb scrolls the transcript; thumb stays under the cursor (no jump on press)
- [ ] Hover holds the bar visible; it resumes fading on pointer-leave
- [ ] Short conversation that fits: no scrollbar, and the right edge still allows text selection
- [ ] If the bar appears but doesn't fade, set `g_force_rebuild` at the end of `renderTranscriptScrollbar` while visible (noted in the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)