### PR TITLE
feat(weixin): WeChat direct-connect (embedded ilink) scheme

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .phantty,
-    .version = "0.29.0",
+    .version = "0.30.0",
     .fingerprint = 0xdb7ae949ae4818ac,
     .minimum_zig_version = "0.15.2",
 

--- a/docs/superpowers/plans/2026-05-25-weixin-direct-ilink.md
+++ b/docs/superpowers/plans/2026-05-25-weixin-direct-ilink.md
@@ -1,0 +1,1871 @@
+# WeChat Direct (Embedded ilink) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Embed the WeChat ilink protocol client directly inside the Phantty desktop process so WeChat can drive the local terminal/AI without the Cloudflare Worker relay, as a path mutually exclusive with `remote-enabled`.
+
+**Architecture:** Two layers. A **cross-platform pure layer** (`src/weixin/`: ilink transport over `std.http.Client`, JSON codec, command routing, owner binding, AI-reply progress diffing, state persistence) that compiles and unit-tests on any OS. A **Windows-bound integration layer** (a `LocalControl` view factored out of `App`/`remote_client`/`AppWindow`, the poller thread/controller, a QR login panel, config wiring) that runs where the GUI runs. Routing logic is ported faithfully from the existing TypeScript bridge in `remote/src/server/bridge/weixin/`, whose tests in `remote/test/server/weixin_*.test.ts` are the behavioral source of truth.
+
+**Tech Stack:** Zig 0.15.2, `std.http.Client` (bundled TLS), `std.json`. Build: `zig build`. Pure-module tests: `zig test src/weixin/<file>.zig`. Full test binary registration via `src/test_main.zig`.
+
+---
+
+## Reference: ilink wire protocol (from `remote/src/server/bridge/weixin/`)
+
+- Base URL: `https://ilinkai.weixin.qq.com`; `bot_type = "3"`; `channel_version = "1.0.2"`.
+- `GET /ilink/bot/get_bot_qrcode?bot_type=3` → `{ ret, qrcode?, qrcode_img_content?, message? }`
+- `GET /ilink/bot/get_qrcode_status?qrcode=<urlenc>` (header `iLink-App-ClientVersion: 1`) → `{ ret, status?: "wait"|"scaned"|"confirmed"|"expired", bot_token?, baseurl?, ilink_bot_id?, ilink_user_id?, message? }` (note the API spells it `scaned`).
+- `POST /ilink/bot/getupdates` body `{ get_updates_buf, base_info:{channel_version} }` → `{ ret, msgs?[], get_updates_buf?, longpolling_timeout_ms?, errcode?, message? }`. `errcode == -14` ⇒ session expired.
+- `POST /ilink/bot/sendmessage` body `{ msg:{ to_user_id, client_id, message_type:2, message_state:2, context_token, item_list:[{type:1,text_item:{text}}] }, base_info }` → `{ ret?, errcode?, message? }`.
+- Headers on every request: `content-type: application/json`, `AuthorizationType: ilink_bot_token`, `X-WECHAT-UIN: <base64 of a random uint string>`, and `Authorization: Bearer <bot_token>` when a token is present.
+- Inbound `WeixinMessage`: `{ from_user_id?, to_user_id?, client_id?, message_type?, message_state?, context_token?, group_id?, item_list?: [{ type?, text_item?:{text?}, voice_item?:{text?} }] }`.
+
+---
+
+## File Structure
+
+**Cross-platform pure layer (new, under `src/weixin/`):**
+- `types.zig` — in-memory structs: `Message`, `MessageItem`, `GetUpdatesResult`, `QrCode`, `QrStatus`, `Settings`, `Binding`. No I/O.
+- `ilink_codec.zig` — build request JSON bodies/URLs; parse response JSON into `types`. Pure, `std.json`.
+- `ilink_client.zig` — `std.http.Client` wrapper implementing the `ClientApi` interface (`getBotQrcode`, `getQrcodeStatus`, `getUpdates`, `sendText`). Compiles cross-platform; network paths are compile-only on the Linux host.
+- `binding.zig` — `shouldHandle`, `extractText`, owner auto-bind decision. Pure.
+- `agent.zig` — command parsing + routing into a `Control` interface (`/ai /term /keys /stop /ping /status /help` + default→AI). Pure given a `Control`.
+- `reply_progress.zig` — AI transcript section parsing + baseline diffing + checkpoint progress text. Pure.
+- `poller.zig` — `processUpdates` (pure, testable with fakes) + `Poller` thread loop (generation/staleness, sync-buf, errcode −14). Loop uses injected `ClientApi`/scheduler.
+- `state_store.zig` — load/save `{ bot_token, owner_user_id, base_url, sync_buf }` to a `0600` JSON file under the app state dir. Uses `std.fs`; testable with a tmp dir.
+- `control.zig` — the `Control` interface (vtable) consumed by `agent.zig`/`poller.zig`, plus `Surface` and `OpenResult` types. A test fake lives in tests.
+
+**Windows-bound integration layer (modify existing):**
+- `src/config.zig` — add `weixin-direct-*` keys, parsing, and usage text.
+- `src/weixin/controller.zig` (new) — owns the poller thread, builds the live `Control` from `App`, lifecycle (`startLogin`, `start`, `stop`, `unbind`).
+- `src/App.zig` — construct/destroy the controller; mutual-exclusion guard with `remote-enabled`; expose accessors the controller needs.
+- `src/AppWindow.zig` — implement `findAiChatSurface` / `latestAiChatTranscript` / `onLayout` over the existing tab-indexed AI surface plumbing (`remoteAiSurfaceId`, `registerRemoteAiInputSink`, the `thread_message` marshalling).
+- `src/weixin/qr_panel.zig` (new) — decode + render the login QR via `image_decoder.zig`, show status, auto-close on `confirmed`.
+- `src/test_main.zig` — register the new pure modules in the test binary.
+
+---
+
+## Phase 0 — Config & state foundation (cross-platform)
+
+### Task 1: Add `weixin-direct-*` config keys
+
+**Files:**
+- Modify: `src/config.zig` (struct fields near line 311 after `remote-session-key`; `applyKeyValue` near line 760; usage text near line 1169)
+
+- [ ] **Step 1: Add the struct fields**
+
+In `src/config.zig`, immediately after the `@"remote-session-key"` field (around line 311), add:
+
+```zig
+/// Enables the embedded WeChat ilink direct path. Mutually exclusive with
+/// remote-enabled; if both are true, remote wins and this is disabled.
+@"weixin-direct-enabled": bool = false,
+
+/// Override for the ilink API base URL. Defaults to the public endpoint.
+@"weixin-base-url": ?[]const u8 = null,
+
+/// Max time (ms) to keep streaming AI-reply progress to WeChat. Clamped to
+/// [5000, 180000]. Matches the TS bridge default.
+@"weixin-reply-timeout-ms": u32 = 120000,
+
+/// When set, only this ilink user_id may control the terminal/AI. When empty,
+/// the first 1:1 sender after login is auto-bound as owner.
+@"weixin-allowed-user": ?[]const u8 = null,
+```
+
+- [ ] **Step 2: Add parsing in `applyKeyValue`**
+
+After the `remote-session-key` branch (around line 760), add:
+
+```zig
+} else if (std.mem.eql(u8, key, "weixin-direct-enabled")) {
+    if (std.mem.eql(u8, value, "true")) {
+        self.@"weixin-direct-enabled" = true;
+    } else if (std.mem.eql(u8, value, "false")) {
+        self.@"weixin-direct-enabled" = false;
+    } else {
+        log.warn("invalid weixin-direct-enabled: {s}", .{value});
+    }
+} else if (std.mem.eql(u8, key, "weixin-base-url")) {
+    self.@"weixin-base-url" = self.dupeString(allocator, value) orelse return;
+} else if (std.mem.eql(u8, key, "weixin-reply-timeout-ms")) {
+    self.@"weixin-reply-timeout-ms" = std.fmt.parseInt(u32, value, 10) catch {
+        log.warn("invalid weixin-reply-timeout-ms: {s}", .{value});
+        return;
+    };
+} else if (std.mem.eql(u8, key, "weixin-allowed-user")) {
+    self.@"weixin-allowed-user" = self.dupeString(allocator, value) orelse return;
+```
+
+- [ ] **Step 3: Add usage text**
+
+After the `--remote-server-fingerprint` usage line (around line 1169), add:
+
+```zig
+\\  --weixin-direct-enabled <bool> Enable embedded WeChat ilink direct path
+\\  --weixin-base-url <url>      Override ilink API base URL
+\\  --weixin-reply-timeout-ms <n> AI-reply streaming window in ms
+\\  --weixin-allowed-user <id>   Restrict control to one ilink user_id
+```
+
+- [ ] **Step 4: Compile**
+
+Run: `zig build`
+Expected: builds with no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.zig
+git commit -m "feat(weixin): add weixin-direct config keys"
+```
+
+### Task 2: Define `src/weixin/types.zig`
+
+**Files:**
+- Create: `src/weixin/types.zig`
+
+- [ ] **Step 1: Write the types (no test needed — plain structs)**
+
+```zig
+//! In-memory representations of ilink protocol values. No I/O lives here;
+//! `ilink_codec.zig` converts wire JSON to/from these.
+
+pub const MessageItem = struct {
+    type: i64 = 0,
+    /// text from a text_item (type 1)
+    text: []const u8 = "",
+    /// transcribed text from a voice_item (type 3)
+    voice_text: []const u8 = "",
+};
+
+pub const Message = struct {
+    from_user_id: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+    group_id: []const u8 = "",
+    item_list: []const MessageItem = &.{},
+};
+
+pub const GetUpdatesResult = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    longpolling_timeout_ms: i64 = 0,
+    get_updates_buf: []const u8 = "",
+    msgs: []const Message = &.{},
+};
+
+pub const QrCode = struct {
+    ret: i64 = 0,
+    qrcode: []const u8 = "",
+    /// base64 PNG content, when the API returns an inline image
+    qrcode_img_content: []const u8 = "",
+};
+
+pub const QrStatusKind = enum { wait, scaned, confirmed, expired, unknown };
+
+pub const QrStatus = struct {
+    ret: i64 = 0,
+    status: QrStatusKind = .unknown,
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    bot_id: []const u8 = "",
+    user_id: []const u8 = "",
+};
+
+pub const Settings = struct {
+    enabled: bool = false,
+    reply_timeout_ms: u32 = 120000,
+    /// empty ⇒ auto-bind first sender
+    allowed_user: []const u8 = "",
+};
+
+pub const Binding = struct {
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    owner_user_id: []const u8 = "",
+    bot_id: []const u8 = "",
+    sync_buf: []const u8 = "",
+};
+```
+
+- [ ] **Step 2: Compile-check the file**
+
+Run: `zig test src/weixin/types.zig`
+Expected: `All 0 tests passed.` (no tests, but it must compile).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/weixin/types.zig
+git commit -m "feat(weixin): add ilink in-memory types"
+```
+
+### Task 3: `src/weixin/state_store.zig` — persist token/owner/sync-buf
+
+**Files:**
+- Create: `src/weixin/state_store.zig`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/weixin/state_store.zig`:
+
+```zig
+test "round-trips binding through a file" {
+    const tmp_path = "zig-cache-tmp-weixin-state.json";
+    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+
+    try save(std.testing.allocator, tmp_path, .{
+        .bot_token = "tok-123",
+        .base_url = "https://example.test",
+        .owner_user_id = "user-9",
+        .bot_id = "bot-1",
+        .sync_buf = "BUF==",
+    });
+
+    var loaded = try load(std.testing.allocator, tmp_path);
+    defer loaded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("tok-123", loaded.binding.bot_token);
+    try std.testing.expectEqualStrings("user-9", loaded.binding.owner_user_id);
+    try std.testing.expectEqualStrings("BUF==", loaded.binding.sync_buf);
+}
+
+test "load returns empty binding when file is absent" {
+    var loaded = try load(std.testing.allocator, "definitely-not-here-weixin.json");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), loaded.binding.bot_token.len);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `zig test src/weixin/state_store.zig`
+Expected: FAIL — `save`/`load`/`Loaded` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/weixin/state_store.zig`:
+
+```zig
+//! Persists the WeChat direct binding to a 0600 JSON file. Secrets never go in
+//! config; they live here in the app state dir.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Loaded = struct {
+    arena: std.heap.ArenaAllocator,
+    binding: types.Binding,
+
+    pub fn deinit(self: *Loaded, _: std.mem.Allocator) void {
+        self.arena.deinit();
+    }
+};
+
+const Wire = struct {
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    owner_user_id: []const u8 = "",
+    bot_id: []const u8 = "",
+    sync_buf: []const u8 = "",
+};
+
+pub fn save(allocator: std.mem.Allocator, path: []const u8, binding: types.Binding) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.cwd().makePath(dir) catch {};
+    }
+    const wire = Wire{
+        .bot_token = binding.bot_token,
+        .base_url = binding.base_url,
+        .owner_user_id = binding.owner_user_id,
+        .bot_id = binding.bot_id,
+        .sync_buf = binding.sync_buf,
+    };
+    const json = try std.json.stringifyAlloc(allocator, wire, .{});
+    defer allocator.free(json);
+
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    try file.writeAll(json);
+}
+
+pub fn load(allocator: std.mem.Allocator, path: []const u8) !Loaded {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const data = std.fs.cwd().readFileAlloc(arena.allocator(), path, 1 << 20) catch |err| switch (err) {
+        error.FileNotFound => return .{ .arena = arena, .binding = .{} },
+        else => return err,
+    };
+
+    const parsed = std.json.parseFromSliceLeaky(Wire, arena.allocator(), data, .{
+        .ignore_unknown_fields = true,
+    }) catch return .{ .arena = arena, .binding = .{} };
+
+    return .{ .arena = arena, .binding = .{
+        .bot_token = parsed.bot_token,
+        .base_url = parsed.base_url,
+        .owner_user_id = parsed.owner_user_id,
+        .bot_id = parsed.bot_id,
+        .sync_buf = parsed.sync_buf,
+    } };
+}
+```
+
+> Note (Zig 0.15.2): if `std.json.stringifyAlloc` / `parseFromSliceLeaky` signatures differ in this toolchain, adjust to the available `std.json` API and re-run; the test asserts behavior, not the exact call.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `zig test src/weixin/state_store.zig`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/state_store.zig
+git commit -m "feat(weixin): add binding state store"
+```
+
+---
+
+## Phase 1 — Pure routing logic (cross-platform, TDD)
+
+### Task 4: `src/weixin/binding.zig` — message filtering + text extraction
+
+Ports `shouldHandleWeixinMessage` and `extractWeixinText` from `poller.ts:40-57`. Reference tests: `remote/test/server/weixin_poller.test.ts`.
+
+**Files:**
+- Create: `src/weixin/binding.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/weixin/binding.zig`:
+
+```zig
+const t = std.testing;
+
+test "rejects group, empty sender, bot echo, and stranger" {
+    try t.expect(!shouldHandle("", "", .{ .from_user_id = "u1", .group_id = "g1" }).ok);
+    try t.expect(!shouldHandle("", "", .{ .from_user_id = "" }).ok);
+    try t.expect(!shouldHandle("", "bot", .{ .from_user_id = "bot" }).ok);
+    try t.expect(!shouldHandle("owner", "", .{ .from_user_id = "stranger" }).ok);
+}
+
+test "accepts the owner and an unbound first sender" {
+    try t.expect(shouldHandle("owner", "", .{ .from_user_id = "owner" }).ok);
+    try t.expect(shouldHandle("", "", .{ .from_user_id = "anybody" }).ok);
+}
+
+test "extractText prefers text item then voice transcript" {
+    try t.expectEqualStrings("hi", extractText(.{ .item_list = &.{
+        .{ .type = 1, .text = "  hi  " },
+    } }));
+    try t.expectEqualStrings("said", extractText(.{ .item_list = &.{
+        .{ .type = 3, .voice_text = "said" },
+    } }));
+    try t.expectEqualStrings("", extractText(.{ .item_list = &.{} }));
+}
+
+test "ownerForBind returns first sender only when unbound and allowed empty" {
+    try t.expectEqualStrings("u1", ownerForBind("", "", "u1").?);
+    try t.expect(ownerForBind("existing", "", "u1") == null);
+    try t.expect(ownerForBind("", "allowed-only", "u1") == null);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig test src/weixin/binding.zig`
+Expected: FAIL — `shouldHandle`/`extractText`/`ownerForBind` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/weixin/binding.zig`:
+
+```zig
+//! Owner binding + inbound message filtering. Ported from poller.ts.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Decision = struct { ok: bool, reason: []const u8 };
+
+fn trim(s: []const u8) []const u8 {
+    return std.mem.trim(u8, s, " \t\r\n");
+}
+
+/// Mirror of shouldHandleWeixinMessage. `owner` is the bound owner ("" if
+/// unbound); `account_id` is the bot's own id ("" if unknown).
+pub fn shouldHandle(owner: []const u8, account_id: []const u8, msg: types.Message) Decision {
+    const from = trim(msg.from_user_id);
+    const to = trim(msg.to_user_id);
+    if (trim(msg.group_id).len != 0) return .{ .ok = false, .reason = "group_message" };
+    if (from.len == 0) return .{ .ok = false, .reason = "missing_sender" };
+    if (account_id.len != 0 and std.mem.eql(u8, from, account_id)) return .{ .ok = false, .reason = "bot_echo" };
+    if (owner.len != 0 and !std.mem.eql(u8, from, owner)) return .{ .ok = false, .reason = "unexpected_sender" };
+    if (account_id.len != 0 and to.len != 0 and !std.mem.eql(u8, to, account_id)) return .{ .ok = false, .reason = "unexpected_recipient" };
+    return .{ .ok = true, .reason = "" };
+}
+
+/// Mirror of extractWeixinText: text item (type 1), else voice transcript (type 3).
+pub fn extractText(msg: types.Message) []const u8 {
+    for (msg.item_list) |item| {
+        if (item.type == 1) {
+            const text = trim(item.text);
+            if (text.len != 0) return text;
+        }
+        if (item.type == 3) {
+            const text = trim(item.voice_text);
+            if (text.len != 0) return text;
+        }
+    }
+    return "";
+}
+
+/// Returns the user_id to persist as owner, or null if no auto-bind should
+/// happen (already bound, or an explicit allowed_user is configured).
+pub fn ownerForBind(current_owner: []const u8, allowed_user: []const u8, sender: []const u8) ?[]const u8 {
+    if (trim(current_owner).len != 0) return null;
+    if (trim(allowed_user).len != 0) return null;
+    const s = trim(sender);
+    return if (s.len == 0) null else s;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `zig test src/weixin/binding.zig`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/binding.zig
+git commit -m "feat(weixin): port message filtering and owner binding"
+```
+
+### Task 5: `src/weixin/control.zig` — the Control interface
+
+Defines the boundary `agent.zig`/`poller.zig` call into. The real implementation is built by `controller.zig` from `App`; tests use a fake.
+
+**Files:**
+- Create: `src/weixin/control.zig`
+
+- [ ] **Step 1: Write the interface (compile-checked, no logic test)**
+
+```zig
+//! Boundary between WeChat routing and the live Phantty surfaces. The real
+//! vtable is supplied by controller.zig; tests supply a fake.
+const std = @import("std");
+
+pub const Surface = struct { id: [16]u8, title: []const u8 };
+
+pub const OpenResult = enum { opened, no_profile, failed, offline, timeout };
+
+pub const Control = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        is_connected: *const fn (ctx: *anyopaque) bool,
+        find_ai_surface: *const fn (ctx: *anyopaque) ?Surface,
+        find_terminal_surface: *const fn (ctx: *anyopaque) ?Surface,
+        open_ai_agent: *const fn (ctx: *anyopaque, timeout_ms: u32) OpenResult,
+        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool,
+        latest_transcript: *const fn (ctx: *anyopaque) []const u8,
+    };
+
+    pub fn isConnected(self: Control) bool {
+        return self.vtable.is_connected(self.ctx);
+    }
+    pub fn findAiSurface(self: Control) ?Surface {
+        return self.vtable.find_ai_surface(self.ctx);
+    }
+    pub fn findTerminalSurface(self: Control) ?Surface {
+        return self.vtable.find_terminal_surface(self.ctx);
+    }
+    pub fn openAiAgent(self: Control, timeout_ms: u32) OpenResult {
+        return self.vtable.open_ai_agent(self.ctx, timeout_ms);
+    }
+    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8) bool {
+        return self.vtable.send_input(self.ctx, surface_id, bytes);
+    }
+    pub fn latestTranscript(self: Control) []const u8 {
+        return self.vtable.latest_transcript(self.ctx);
+    }
+};
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `zig test src/weixin/control.zig`
+Expected: `All 0 tests passed.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/weixin/control.zig
+git commit -m "feat(weixin): add Control interface"
+```
+
+### Task 6: `src/weixin/agent.zig` — command routing
+
+Ports `routeWeixinText` from `agent.ts`, dropping `/sessions` and `/use` (single local app). Reference: `remote/test/server/weixin_agent.test.ts`.
+
+**Files:**
+- Create: `src/weixin/agent.zig`
+
+- [ ] **Step 1: Write the failing tests (parsing + routing via a fake Control)**
+
+Append to `src/weixin/agent.zig`:
+
+```zig
+const t = std.testing;
+
+const FakeControl = struct {
+    connected: bool = true,
+    has_ai: bool = true,
+    last_input: []const u8 = "",
+    last_surface: [16]u8 = [_]u8{0} ** 16,
+
+    fn is_connected(ctx: *anyopaque) bool {
+        return cast(ctx).connected;
+    }
+    fn find_ai_surface(ctx: *anyopaque) ?control.Surface {
+        return if (cast(ctx).has_ai) .{ .id = aiId(), .title = "AI Chat" } else null;
+    }
+    fn find_terminal_surface(_: *anyopaque) ?control.Surface {
+        return .{ .id = termId(), .title = "zsh" };
+    }
+    fn open_ai_agent(_: *anyopaque, _: u32) control.OpenResult {
+        return .opened;
+    }
+    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
+        const self = cast(ctx);
+        if (!self.connected) return false;
+        self.last_surface = surface_id;
+        self.last_input = bytes;
+        return true;
+    }
+    fn latest_transcript(_: *anyopaque) []const u8 {
+        return "";
+    }
+    fn cast(ctx: *anyopaque) *FakeControl {
+        return @ptrCast(@alignCast(ctx));
+    }
+    fn aiId() [16]u8 {
+        return "aichat0000000000".*;
+    }
+    fn termId() [16]u8 {
+        return "term000000000000".*;
+    }
+    fn control_iface(self: *FakeControl) control.Control {
+        return .{ .ctx = self, .vtable = &.{
+            .is_connected = is_connected,
+            .find_ai_surface = find_ai_surface,
+            .find_terminal_surface = find_terminal_surface,
+            .open_ai_agent = open_ai_agent,
+            .send_input = send_input,
+            .latest_transcript = latest_transcript,
+        } };
+    }
+};
+
+test "ping returns pong without touching surfaces" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "ping", &out);
+    try t.expectEqualStrings("pong", out.text.items);
+    try t.expect(!out.expect_ai_progress);
+}
+
+test "default text goes to the AI surface with a carriage return" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "hello world", &out);
+    try t.expectEqualStrings("hello world\r", fake.last_input);
+    try t.expectEqualSlices(u8, &FakeControl.aiId(), &fake.last_surface);
+    try t.expect(out.expect_ai_progress);
+}
+
+test "/term sends to terminal with enter, /keys without" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/term ls", &out);
+    try t.expectEqualStrings("ls\r", fake.last_input);
+
+    var out2 = Reply.init(t.allocator);
+    defer out2.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/keys abc", &out2);
+    try t.expectEqualStrings("abc", fake.last_input);
+}
+
+test "offline control yields an offline message and no progress" {
+    var fake = FakeControl{ .connected = false };
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "do a thing", &out);
+    try t.expect(!out.expect_ai_progress);
+    try t.expect(std.mem.indexOf(u8, out.text.items, "离线") != null);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig test src/weixin/agent.zig`
+Expected: FAIL — `route`/`Reply`/`defaultSettings` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/weixin/agent.zig`:
+
+```zig
+//! WeChat command routing into the local Phantty surfaces. Port of agent.ts,
+//! minus /sessions and /use (one local app).
+const std = @import("std");
+const control = @import("control.zig");
+const types = @import("types.zig");
+
+const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。";
+const ESC = "\x1b";
+const AI_OPEN_TIMEOUT_MS: u32 = 2000;
+
+pub const Reply = struct {
+    text: std.ArrayList(u8),
+    /// true ⇒ caller should start AI-reply progress streaming.
+    expect_ai_progress: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator) Reply {
+        return .{ .text = std.ArrayList(u8).init(allocator) };
+    }
+    pub fn deinit(self: *Reply) void {
+        self.text.deinit();
+    }
+    fn set(self: *Reply, s: []const u8) !void {
+        self.text.clearRetainingCapacity();
+        try self.text.appendSlice(s);
+    }
+};
+
+pub fn defaultSettings() types.Settings {
+    return .{};
+}
+
+/// Returns the command token (lowercased, including leading '/') and the
+/// remaining argument. Normalizes a full-width '／' to '/'.
+fn splitCommand(text: []const u8) struct { cmd: []const u8, arg: []const u8 } {
+    var normalized = text;
+    // full-width slash U+FF0F is the 3 bytes EF BC 8F
+    if (std.mem.startsWith(u8, text, "\u{FF0F}")) {
+        // treat as '/': fall through using a synthesized view is awkward in Zig;
+        // handle by checking the rest below. For simplicity, only ASCII '/'
+        // starts a command here; tests use ASCII.
+        normalized = text;
+    }
+    if (normalized.len == 0 or normalized[0] != '/') return .{ .cmd = "", .arg = normalized };
+    const sp = std.mem.indexOfScalar(u8, normalized, ' ') orelse normalized.len;
+    return .{ .cmd = normalized[0..sp], .arg = std.mem.trim(u8, normalized[sp..], " \t\r\n") };
+}
+
+fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+fn isPing(text: []const u8) bool {
+    const n = std.mem.trim(u8, text, " \t\r\n");
+    return eqIgnoreCase(n, "ping") or eqIgnoreCase(n, "/ping");
+}
+
+pub fn route(
+    allocator: std.mem.Allocator,
+    ctrl: control.Control,
+    settings: types.Settings,
+    raw_text: []const u8,
+    out: *Reply,
+) !void {
+    _ = allocator;
+    _ = settings;
+    const text = std.mem.trim(u8, raw_text, " \t\r\n");
+    if (text.len == 0) return;
+    if (isPing(text)) return out.set("pong");
+
+    const parts = splitCommand(text);
+    const cmd = parts.cmd;
+
+    if (eqIgnoreCase(cmd, "/help")) return out.set(helpText());
+    if (eqIgnoreCase(cmd, "/status")) return out.set(statusText(ctrl));
+    if (cmd.len != 0 and !eqIgnoreCase(cmd, "/term") and !eqIgnoreCase(cmd, "/keys") and
+        !eqIgnoreCase(cmd, "/ai") and !eqIgnoreCase(cmd, "/stop"))
+    {
+        return out.set("未知命令。\n\n" ++ helpTextConst);
+    }
+    if (cmd.len != 0 and !eqIgnoreCase(cmd, "/stop") and parts.arg.len == 0) {
+        return out.set(usageText(cmd));
+    }
+
+    if (!ctrl.isConnected()) return out.set("Phantty 当前离线，无法处理。");
+
+    if (eqIgnoreCase(cmd, "/stop")) return stopAi(ctrl, out);
+    if (eqIgnoreCase(cmd, "/term")) return sendTerminal(ctrl, parts.arg, true, out);
+    if (eqIgnoreCase(cmd, "/keys")) return sendTerminal(ctrl, parts.arg, false, out);
+    if (eqIgnoreCase(cmd, "/ai")) return sendAi(ctrl, parts.arg, out);
+    return sendAi(ctrl, text, out);
+}
+
+fn sendAi(ctrl: control.Control, text: []const u8, out: *Reply) !void {
+    const ai = ctrl.findAiSurface() orelse blk: {
+        switch (ctrl.openAiAgent(AI_OPEN_TIMEOUT_MS)) {
+            .no_profile => return out.set("Phantty 尚未配置 AI Chat profile。"),
+            .failed => return out.set("Phantty 无法打开 AI Agent。"),
+            .offline => return out.set("Phantty 当前离线，无法打开 AI Agent。"),
+            .timeout => return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。"),
+            .opened => {},
+        }
+        break :blk ctrl.findAiSurface() orelse return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。");
+    };
+
+    var buf = std.ArrayList(u8).init(out.text.allocator);
+    defer buf.deinit();
+    try buf.appendSlice(text);
+    try buf.append('\r');
+    if (!ctrl.sendInput(ai.id, buf.items)) return out.set("Phantty 当前离线，无法发送给 AI Agent。");
+    try out.set(AI_ACK);
+    out.expect_ai_progress = true;
+}
+
+fn stopAi(ctrl: control.Control, out: *Reply) !void {
+    const ai = ctrl.findAiSurface() orelse return out.set("当前没有 AI Agent 可停止。");
+    if (!ctrl.sendInput(ai.id, ESC)) return out.set("Phantty 当前离线，无法停止 AI Agent。");
+    return out.set("已发送停止指令。");
+}
+
+fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Reply) !void {
+    const term = ctrl.findTerminalSurface() orelse return out.set("当前没有可写终端 surface。");
+    var buf = std.ArrayList(u8).init(out.text.allocator);
+    defer buf.deinit();
+    try buf.appendSlice(text);
+    if (enter) try buf.append('\r');
+    if (!ctrl.sendInput(term.id, buf.items)) return out.set("Phantty 当前离线，无法发送到终端。");
+    return out.set("已发送到终端。");
+}
+
+const helpTextConst =
+    "Phantty 微信直连命令：\n" ++
+    "/ping 验证连接\n/status 查看状态\n/ai <内容> 发送给 AI Agent\n" ++
+    "/stop 停止当前 AI 处理\n/term <命令> 发送到终端并回车\n/keys <文本> 发送原始文本\n" ++
+    "普通文本默认发送给 AI Agent。";
+
+fn helpText() []const u8 {
+    return helpTextConst;
+}
+
+fn statusText(ctrl: control.Control) []const u8 {
+    return if (ctrl.isConnected()) "微信直连：在线" else "微信直连：离线";
+}
+
+fn usageText(cmd: []const u8) []const u8 {
+    if (eqIgnoreCase(cmd, "/term")) return "用法：/term <命令>";
+    if (eqIgnoreCase(cmd, "/keys")) return "用法：/keys <文本>";
+    if (eqIgnoreCase(cmd, "/ai")) return "用法：/ai <内容>";
+    return helpTextConst;
+}
+```
+
+> Note: full-width `／` normalization is stubbed to ASCII for v1 (the TS bridge supports it; add byte-prefix handling later if needed). Tests use ASCII `/`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `zig test src/weixin/agent.zig`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/agent.zig
+git commit -m "feat(weixin): port command routing to local surfaces"
+```
+
+### Task 7: `src/weixin/reply_progress.zig` — AI transcript diffing
+
+Ports `aiReplyProgress` + `parseAiSections` + helpers from `poller.ts:293-413`. Pure string processing. Reference: the transcript cases in `remote/test/server/weixin_poller.test.ts`.
+
+**Files:**
+- Create: `src/weixin/reply_progress.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/weixin/reply_progress.zig`:
+
+```zig
+const t = std.testing;
+
+test "done when a new assistant message exists and status is idle" {
+    const baseline = "You:\nhi\n";
+    const current = "You:\nhi\nAI:\nthere\nStatus:\nidle\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expectEqualStrings("there", p.text);
+}
+
+test "not done while tools are running" {
+    const baseline = "You:\nhi\n";
+    const current = "You:\nhi\nStatus:\nrunning tools\n";
+    const p = progress(baseline, current);
+    try t.expect(!p.done);
+    try t.expect(p.text.len != 0);
+}
+
+test "empty when nothing new" {
+    const p = progress("You:\nhi\n", "You:\nhi\n");
+    try t.expect(!p.done);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig test src/weixin/reply_progress.zig`
+Expected: FAIL — `progress` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/weixin/reply_progress.zig`. This is a faithful port of `aiReplyProgress`; section parsing splits on lines that are exactly a label followed by `:`.
+
+```zig
+//! AI-reply progress detection by diffing the rendered AI chat transcript
+//! against a baseline. Port of poller.ts aiReplyProgress + parseAiSections.
+const std = @import("std");
+
+pub const Progress = struct { done: bool = false, text: []const u8 = "" };
+
+const Role = enum { metadata, user, assistant, tool, reasoning };
+const Section = struct { role: Role, label: []const u8, content: []const u8 };
+
+/// Compares baseline vs current transcript. `text` borrows from `current`.
+pub fn progress(baseline: []const u8, current: []const u8) Progress {
+    var base_buf: [256]Section = undefined;
+    var cur_buf: [256]Section = undefined;
+    const base_sections = parseSections(baseline, &base_buf);
+    const cur_sections = parseSections(current, &cur_buf);
+
+    const base_msgs = filterMessages(base_sections, base_buf[base_sections.len..]);
+    const cur_msgs = filterMessages(cur_sections, cur_buf[cur_sections.len..]);
+    const new_msgs = afterBaseline(base_msgs, cur_msgs);
+    const status = latestStatus(cur_sections);
+
+    // last assistant message among the new ones with non-empty content
+    var last_assistant: ?[]const u8 = null;
+    for (new_msgs) |m| {
+        if (m.role == .assistant and trim(m.content).len != 0) last_assistant = trim(m.content);
+    }
+
+    if (last_assistant) |content| {
+        if (!isActiveStatus(status)) return .{ .done = true, .text = content };
+    }
+    if (containsIgnoreCase(status, "running tools") or hasRole(new_msgs, .tool)) {
+        return .{ .done = false, .text = "还在处理中，工具调用仍在执行。" };
+    }
+    if (new_msgs.len != 0 or last_assistant != null) {
+        return .{ .done = false, .text = "还在处理中，等待 AI 回复。" };
+    }
+    return .{ .done = false, .text = "" };
+}
+
+fn trim(s: []const u8) []const u8 {
+    return std.mem.trim(u8, s, " \t\r\n");
+}
+
+fn parseSections(transcript: []const u8, buf: []Section) []Section {
+    var count: usize = 0;
+    var it = std.mem.splitScalar(u8, transcript, '\n');
+    var current_role: ?Role = null;
+    var current_label: []const u8 = "";
+    var content_start: usize = 0;
+    var content_end: usize = 0;
+    var have_content = false;
+
+    // We index into transcript; track offsets to slice content out.
+    var line_start: usize = 0;
+    while (it.next()) |line| {
+        const line_len = line.len;
+        const trimmed = trim(line);
+        if (asLabel(trimmed)) |role| {
+            if (current_role) |role_val| {
+                if (count < buf.len) {
+                    buf[count] = .{ .role = role_val, .label = current_label, .content = if (have_content) transcript[content_start..content_end] else "" };
+                    count += 1;
+                }
+            }
+            current_role = role;
+            current_label = trimmed[0 .. trimmed.len - 1]; // strip trailing ':'
+            have_content = false;
+            content_start = line_start + line_len + 1;
+            content_end = content_start;
+        } else if (current_role != null) {
+            content_end = line_start + line_len;
+            have_content = true;
+        }
+        line_start += line_len + 1;
+    }
+    if (current_role) |role_val| {
+        if (count < buf.len) {
+            buf[count] = .{ .role = role_val, .label = current_label, .content = if (have_content) transcript[content_start..content_end] else "" };
+            count += 1;
+        }
+    }
+    return buf[0..count];
+}
+
+/// A label line is exactly one of the known labels followed by ':'.
+fn asLabel(line: []const u8) ?Role {
+    if (line.len < 2 or line[line.len - 1] != ':') return null;
+    const name = line[0 .. line.len - 1];
+    if (eq(name, "You") or eq(name, "User")) return .user;
+    if (eq(name, "AI") or eq(name, "Assistant")) return .assistant;
+    if (eq(name, "Tool")) return .tool;
+    if (eq(name, "Reasoning")) return .reasoning;
+    if (eq(name, "Model") or eq(name, "Status")) return .metadata;
+    return null;
+}
+
+fn filterMessages(sections: []const Section, out: []Section) []Section {
+    var n: usize = 0;
+    for (sections) |s| {
+        if (s.role == .user or s.role == .assistant or s.role == .tool) {
+            out[n] = s;
+            n += 1;
+        }
+    }
+    return out[0..n];
+}
+
+fn afterBaseline(baseline: []const Section, current: []const Section) []const Section {
+    if (baseline.len == 0) return current;
+    if (current.len == 0) return current[0..0];
+    const max_overlap = @min(baseline.len, current.len);
+    var overlap = max_overlap;
+    while (overlap > 0) : (overlap -= 1) {
+        const base_start = baseline.len - overlap;
+        var matched = true;
+        var i: usize = 0;
+        while (i < overlap) : (i += 1) {
+            if (baseline[base_start + i].role != current[i].role or
+                !std.mem.eql(u8, baseline[base_start + i].content, current[i].content))
+            {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return current[overlap..];
+    }
+    return current;
+}
+
+fn latestStatus(sections: []const Section) []const u8 {
+    var i: usize = sections.len;
+    while (i > 0) : (i -= 1) {
+        if (eq(sections[i - 1].label, "Status")) return trim(sections[i - 1].content);
+    }
+    return "";
+}
+
+fn isActiveStatus(status: []const u8) bool {
+    return containsIgnoreCase(status, "running tools") or containsIgnoreCase(status, "thinking") or
+        containsIgnoreCase(status, "streaming") or containsIgnoreCase(status, "stopping");
+}
+
+fn hasRole(msgs: []const Section, role: Role) bool {
+    for (msgs) |m| if (m.role == role) return true;
+    return false;
+}
+
+fn eq(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, a, b);
+}
+
+fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[i .. i + needle.len], needle)) return true;
+    }
+    return false;
+}
+```
+
+> Note: section parsing here borrows content slices from the input transcript and uses fixed-size stack buffers (256 sections). If a transcript exceeds that, older sections are dropped — acceptable for progress detection. Verify the three tests pass; adjust slice-offset arithmetic if the toolchain's `splitScalar` accounting differs.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `zig test src/weixin/reply_progress.zig`
+Expected: PASS (3 tests). If offset math is off, fix until green before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/reply_progress.zig
+git commit -m "feat(weixin): port AI-reply progress diffing"
+```
+
+---
+
+## Phase 2 — ilink transport (cross-platform compile; logic via fakes)
+
+### Task 8: `src/weixin/ilink_codec.zig` — request/response JSON
+
+**Files:**
+- Create: `src/weixin/ilink_codec.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/weixin/ilink_codec.zig`:
+
+```zig
+const t = std.testing;
+
+test "builds a getupdates body with the channel version" {
+    const body = try buildGetUpdatesBody(t.allocator, "BUF==");
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"get_updates_buf\":\"BUF==\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
+}
+
+test "parses a getupdates response into typed messages" {
+    const json =
+        \\{"ret":0,"longpolling_timeout_ms":1500,"get_updates_buf":"NEXT",
+        \\"msgs":[{"from_user_id":"u1","context_token":"ctx",
+        \\"item_list":[{"type":1,"text_item":{"text":"hi"}}]}]}
+    ;
+    var parsed = try parseGetUpdates(t.allocator, json);
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 1500), parsed.value.longpolling_timeout_ms);
+    try t.expectEqualStrings("NEXT", parsed.value.get_updates_buf);
+    try t.expectEqual(@as(usize, 1), parsed.value.msgs.len);
+    try t.expectEqualStrings("u1", parsed.value.msgs[0].from_user_id);
+    try t.expectEqualStrings("hi", parsed.value.msgs[0].item_list[0].text);
+}
+
+test "maps qrcode status strings to the enum" {
+    try t.expectEqual(types.QrStatusKind.scaned, statusKindFromString("scaned"));
+    try t.expectEqual(types.QrStatusKind.confirmed, statusKindFromString("confirmed"));
+    try t.expectEqual(types.QrStatusKind.unknown, statusKindFromString("nonsense"));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig test src/weixin/ilink_codec.zig`
+Expected: FAIL — symbols undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/weixin/ilink_codec.zig`. Parsing uses `std.json` into wire structs, then maps into `types`. The `Parsed*` wrappers own an arena so callers free with `deinit`.
+
+```zig
+//! ilink JSON request builders and response parsers. Pure (std.json).
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const CHANNEL_VERSION = "1.0.2";
+pub const BOT_TYPE = "3";
+pub const DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com";
+
+pub fn buildGetUpdatesBody(allocator: std.mem.Allocator, buf: []const u8) ![]u8 {
+    const Body = struct {
+        get_updates_buf: []const u8,
+        base_info: struct { channel_version: []const u8 },
+    };
+    return std.json.stringifyAlloc(allocator, Body{
+        .get_updates_buf = buf,
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildSendTextBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    text: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+) ![]u8 {
+    const Body = struct {
+        msg: struct {
+            to_user_id: []const u8,
+            client_id: []const u8,
+            message_type: i64 = 2,
+            message_state: i64 = 2,
+            context_token: []const u8,
+            item_list: []const struct {
+                type: i64 = 1,
+                text_item: struct { text: []const u8 },
+            },
+        },
+        base_info: struct { channel_version: []const u8 },
+    };
+    const items = [_]@TypeOf(@as(Body, undefined).msg.item_list[0]){
+        .{ .text_item = .{ .text = text } },
+    };
+    return std.json.stringifyAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn statusKindFromString(s: []const u8) types.QrStatusKind {
+    if (std.mem.eql(u8, s, "wait")) return .wait;
+    if (std.mem.eql(u8, s, "scaned")) return .scaned;
+    if (std.mem.eql(u8, s, "confirmed")) return .confirmed;
+    if (std.mem.eql(u8, s, "expired")) return .expired;
+    return .unknown;
+}
+
+// --- response parsing ---
+
+pub fn ParsedGetUpdates(comptime T: type) type {
+    return struct {
+        arena: *std.heap.ArenaAllocator,
+        value: T,
+        pub fn deinit(self: *@This()) void {
+            const child = self.arena.child_allocator;
+            self.arena.deinit();
+            child.destroy(self.arena);
+        }
+    };
+}
+
+const WireItem = struct {
+    type: i64 = 0,
+    text_item: ?struct { text: []const u8 = "" } = null,
+    voice_item: ?struct { text: []const u8 = "" } = null,
+};
+const WireMsg = struct {
+    from_user_id: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+    group_id: []const u8 = "",
+    item_list: []const WireItem = &.{},
+};
+const WireUpdates = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    longpolling_timeout_ms: i64 = 0,
+    get_updates_buf: []const u8 = "",
+    msgs: []const WireMsg = &.{},
+};
+
+pub fn parseGetUpdates(allocator: std.mem.Allocator, json: []const u8) !ParsedGetUpdates(types.GetUpdatesResult) {
+    const arena = try allocator.create(std.heap.ArenaAllocator);
+    arena.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer {
+        arena.deinit();
+        allocator.destroy(arena);
+    }
+    const a = arena.allocator();
+    const wire = try std.json.parseFromSliceLeaky(WireUpdates, a, json, .{ .ignore_unknown_fields = true });
+
+    const msgs = try a.alloc(types.Message, wire.msgs.len);
+    for (wire.msgs, 0..) |wm, mi| {
+        const items = try a.alloc(types.MessageItem, wm.item_list.len);
+        for (wm.item_list, 0..) |wi, ii| {
+            items[ii] = .{
+                .type = wi.type,
+                .text = if (wi.text_item) |x| x.text else "",
+                .voice_text = if (wi.voice_item) |x| x.text else "",
+            };
+        }
+        msgs[mi] = .{
+            .from_user_id = wm.from_user_id,
+            .to_user_id = wm.to_user_id,
+            .context_token = wm.context_token,
+            .group_id = wm.group_id,
+            .item_list = items,
+        };
+    }
+    return .{ .arena = arena, .value = .{
+        .ret = wire.ret,
+        .errcode = wire.errcode,
+        .longpolling_timeout_ms = wire.longpolling_timeout_ms,
+        .get_updates_buf = wire.get_updates_buf,
+        .msgs = msgs,
+    } };
+}
+```
+
+> Note: `std.json` API names in Zig 0.15.2 may differ slightly (`stringifyAlloc` vs `Stringify`). If so, adapt the calls; the tests pin behavior. The anonymous-struct trick in `buildSendTextBody` for `item_list` element type may need extracting to a named struct if the compiler rejects `@TypeOf(... .item_list[0])` — extract a `const SendItem = struct {...}` and reuse it.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `zig test src/weixin/ilink_codec.zig`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/ilink_codec.zig
+git commit -m "feat(weixin): add ilink JSON codec"
+```
+
+### Task 9: `src/weixin/ilink_client.zig` — HTTP over `std.http.Client`
+
+Compiles cross-platform; the network methods can't be unit-tested on the Linux host (compile-only, per the project's test note). Define a `ClientApi` interface so the poller stays testable with fakes.
+
+**Files:**
+- Create: `src/weixin/ilink_client.zig`
+
+- [ ] **Step 1: Write the implementation (no network test on this host)**
+
+```zig
+//! ilink HTTP client over std.http.Client. Network calls are compile-only on
+//! the Linux dev host; logic that consumes this goes through ClientApi.
+const std = @import("std");
+const codec = @import("ilink_codec.zig");
+const types = @import("types.zig");
+
+pub const ClientApi = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+    pub const VTable = struct {
+        get_updates: *const fn (ctx: *anyopaque, buf: []const u8, out_arena: std.mem.Allocator) anyerror!types.GetUpdatesResult,
+        send_text: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+    };
+    pub fn getUpdates(self: ClientApi, buf: []const u8, out_arena: std.mem.Allocator) !types.GetUpdatesResult {
+        return self.vtable.get_updates(self.ctx, buf, out_arena);
+    }
+    pub fn sendText(self: ClientApi, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        return self.vtable.send_text(self.ctx, to_user_id, text, context_token);
+    }
+};
+
+pub const Client = struct {
+    allocator: std.mem.Allocator,
+    http: std.http.Client,
+    base_url: []const u8,
+    token: []const u8,
+    rng: std.Random.DefaultPrng,
+
+    pub fn init(allocator: std.mem.Allocator, base_url: []const u8, token: []const u8) Client {
+        return .{
+            .allocator = allocator,
+            .http = .{ .allocator = allocator },
+            .base_url = base_url,
+            .token = token,
+            .rng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp())),
+        };
+    }
+    pub fn deinit(self: *Client) void {
+        self.http.deinit();
+    }
+
+    fn headers(self: *Client, uin_buf: []u8) std.http.Client.Request.Headers {
+        // X-WECHAT-UIN: base64 of a random uint string. Compute into uin_buf.
+        _ = uin_buf;
+        _ = self;
+        // Implementation detail filled during compile iteration; see Step 2.
+        return .{};
+    }
+
+    /// GET /ilink/bot/get_bot_qrcode?bot_type=3
+    pub fn getBotQrcode(self: *Client, arena: std.mem.Allocator) !types.QrCode {
+        return self.getJson(types.QrCode, arena, "/ilink/bot/get_bot_qrcode?bot_type=" ++ codec.BOT_TYPE, qrCodeFromJson);
+    }
+
+    /// GET /ilink/bot/get_qrcode_status?qrcode=...
+    pub fn getQrcodeStatus(self: *Client, arena: std.mem.Allocator, qrcode: []const u8) !types.QrStatus {
+        const path = try std.fmt.allocPrint(arena, "/ilink/bot/get_qrcode_status?qrcode={s}", .{qrcode});
+        return self.getJson(types.QrStatus, arena, path, qrStatusFromJson);
+    }
+
+    /// POST /ilink/bot/getupdates  (≈35s long-poll)
+    pub fn getUpdates(self: *Client, arena: std.mem.Allocator, buf: []const u8) !types.GetUpdatesResult {
+        const body = try codec.buildGetUpdatesBody(arena, buf);
+        const resp = try self.postRaw(arena, "/ilink/bot/getupdates", body);
+        var parsed = try codec.parseGetUpdates(arena, resp);
+        return parsed.value; // arena owns it; freed when arena resets
+    }
+
+    /// POST /ilink/bot/sendmessage
+    pub fn sendText(self: *Client, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        var arena_state = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        const client_id = try std.fmt.allocPrint(arena, "phantty-weixin-{d}-{d}", .{
+            std.time.milliTimestamp(), self.rng.random().int(u32),
+        });
+        const body = try codec.buildSendTextBody(arena, to_user_id, text, context_token, client_id);
+        _ = try self.postRaw(arena, "/ilink/bot/sendmessage", body);
+    }
+
+    // --- the std.http plumbing below is filled in during compile iteration ---
+    fn getJson(self: *Client, comptime T: type, arena: std.mem.Allocator, path: []const u8, comptime mapFn: anytype) !T {
+        const raw = try self.fetch(arena, .GET, path, null);
+        return mapFn(arena, raw);
+    }
+    fn postRaw(self: *Client, arena: std.mem.Allocator, path: []const u8, body: []const u8) ![]u8 {
+        return self.fetch(arena, .POST, path, body);
+    }
+    fn fetch(self: *Client, arena: std.mem.Allocator, method: std.http.Method, path: []const u8, body: ?[]const u8) ![]u8 {
+        const url = try std.fmt.allocPrint(arena, "{s}{s}", .{ self.base_url, path });
+        var buf = std.ArrayList(u8).init(arena);
+        const result = try self.http.fetch(.{
+            .method = method,
+            .location = .{ .url = url },
+            .payload = body,
+            .response_storage = .{ .dynamic = &buf },
+            .extra_headers = &.{
+                .{ .name = "content-type", .value = "application/json" },
+                .{ .name = "AuthorizationType", .value = "ilink_bot_token" },
+                .{ .name = "Authorization", .value = try std.fmt.allocPrint(arena, "Bearer {s}", .{self.token}) },
+            },
+        });
+        if (result.status != .ok) return error.IlinkHttpStatus;
+        return buf.toOwnedSlice();
+    }
+
+    /// Adapter exposing this Client as a ClientApi for the poller.
+    pub fn api(self: *Client) ClientApi {
+        return .{ .ctx = self, .vtable = &.{
+            .get_updates = apiGetUpdates,
+            .send_text = apiSendText,
+        } };
+    }
+    fn apiGetUpdates(ctx: *anyopaque, buf: []const u8, out_arena: std.mem.Allocator) anyerror!types.GetUpdatesResult {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).getUpdates(out_arena, buf);
+    }
+    fn apiSendText(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).sendText(to_user_id, text, context_token);
+    }
+};
+
+fn qrCodeFromJson(arena: std.mem.Allocator, json: []const u8) !types.QrCode {
+    const W = struct { ret: i64 = 0, qrcode: []const u8 = "", qrcode_img_content: []const u8 = "" };
+    const w = try std.json.parseFromSliceLeaky(W, arena, json, .{ .ignore_unknown_fields = true });
+    return .{ .ret = w.ret, .qrcode = w.qrcode, .qrcode_img_content = w.qrcode_img_content };
+}
+fn qrStatusFromJson(arena: std.mem.Allocator, json: []const u8) !types.QrStatus {
+    const W = struct {
+        ret: i64 = 0,
+        status: []const u8 = "",
+        bot_token: []const u8 = "",
+        baseurl: []const u8 = "",
+        ilink_bot_id: []const u8 = "",
+        ilink_user_id: []const u8 = "",
+    };
+    const w = try std.json.parseFromSliceLeaky(W, arena, json, .{ .ignore_unknown_fields = true });
+    return .{
+        .ret = w.ret,
+        .status = codec.statusKindFromString(w.status),
+        .bot_token = w.bot_token,
+        .base_url = w.baseurl,
+        .bot_id = w.ilink_bot_id,
+        .user_id = w.ilink_user_id,
+    };
+}
+```
+
+- [ ] **Step 2: Compile and iterate on the `std.http` API**
+
+Run: `zig build`
+Expected: this is the iteration point. Fix `std.http.Client.fetch` option names, header struct shape, and the `X-WECHAT-UIN` header (base64 of a random uint string — add it to `extra_headers`) to match Zig 0.15.2. The QR-image header `iLink-App-ClientVersion: 1` is needed on `getQrcodeStatus`; thread an `extra header` param through `fetch` if required. Keep iterating until `zig build` succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/weixin/ilink_client.zig
+git commit -m "feat(weixin): add ilink HTTP client (std.http)"
+```
+
+### Task 10: `src/weixin/poller.zig` — update processing + poll loop
+
+`processUpdates` is pure and testable with fakes (ports `processWeixinUpdates`, `poller.ts:59-83`). The `Poller` thread loop ports the `tick`/generation/staleness machinery; it's compile-checked here and exercised end-to-end on Windows.
+
+**Files:**
+- Create: `src/weixin/poller.zig`
+
+- [ ] **Step 1: Write the failing test for `processUpdates`**
+
+Append to `src/weixin/poller.zig`:
+
+```zig
+const t = std.testing;
+
+const Captured = struct {
+    sent: std.ArrayList([]u8),
+    routed: std.ArrayList([]u8),
+    fn init() Captured {
+        return .{ .sent = std.ArrayList([]u8).init(t.allocator), .routed = std.ArrayList([]u8).init(t.allocator) };
+    }
+    fn deinit(self: *Captured) void {
+        for (self.sent.items) |s| t.allocator.free(s);
+        for (self.routed.items) |s| t.allocator.free(s);
+        self.sent.deinit();
+        self.routed.deinit();
+    }
+};
+
+test "processUpdates routes accepted text and sends replies" {
+    var cap = Captured.init();
+    defer cap.deinit();
+
+    const RouteCtx = struct {
+        cap: *Captured,
+        fn route(ctx: *anyopaque, text: []const u8, reply: *std.ArrayList(u8)) anyerror!bool {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            try self.cap.routed.append(try t.allocator.dupe(u8, text));
+            try reply.appendSlice("ok");
+            return false; // no AI progress
+        }
+    };
+    const SendCtx = struct {
+        cap: *Captured,
+        fn send(ctx: *anyopaque, to: []const u8, text: []const u8, _: []const u8) anyerror!void {
+            _ = to;
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            try self.cap.sent.append(try t.allocator.dupe(u8, text));
+        }
+    };
+    var rctx = RouteCtx{ .cap = &cap };
+    var sctx = SendCtx{ .cap = &cap };
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "c", .item_list = &.{.{ .type = 1, .text = "hi" }} },
+        .{ .from_user_id = "u1", .group_id = "g", .item_list = &.{.{ .type = 1, .text = "ignored" }} }, // group → skip
+    };
+
+    try processUpdates(.{
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &rctx,
+        .route_fn = RouteCtx.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+    });
+
+    try t.expectEqual(@as(usize, 1), cap.routed.items.len);
+    try t.expectEqualStrings("hi", cap.routed.items[0]);
+    try t.expectEqual(@as(usize, 1), cap.sent.items.len);
+    try t.expectEqualStrings("ok", cap.sent.items[0]);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig test src/weixin/poller.zig`
+Expected: FAIL — `processUpdates` undefined.
+
+- [ ] **Step 3: Implement `processUpdates` (the testable core)**
+
+Prepend to `src/weixin/poller.zig`:
+
+```zig
+//! WeChat poll loop. processUpdates is the pure core; Poller wraps it in a
+//! thread with generation/staleness cancellation (port of poller.ts).
+const std = @import("std");
+const types = @import("types.zig");
+const binding = @import("binding.zig");
+
+pub const ProcessInput = struct {
+    owner: []const u8,
+    account_id: []const u8,
+    messages: []const types.Message,
+    route_ctx: *anyopaque,
+    /// returns true if the caller should begin AI-progress streaming
+    route_fn: *const fn (ctx: *anyopaque, text: []const u8, reply: *std.ArrayList(u8)) anyerror!bool,
+    send_ctx: *anyopaque,
+    send_fn: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+};
+
+/// Mirror of processWeixinUpdates: filter, extract, route, reply.
+pub fn processUpdates(input: ProcessInput) !void {
+    for (input.messages) |msg| {
+        if (!binding.shouldHandle(input.owner, input.account_id, msg).ok) continue;
+        const text = binding.extractText(msg);
+        if (text.len == 0) continue;
+
+        var reply = std.ArrayList(u8).init(std.heap.page_allocator);
+        defer reply.deinit();
+        _ = input.route_fn(input.route_ctx, text, &reply) catch continue;
+
+        const trimmed = std.mem.trim(u8, reply.items, " \t\r\n");
+        if (trimmed.len != 0) {
+            input.send_fn(input.send_ctx, msg.from_user_id, trimmed, msg.context_token) catch {};
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `zig test src/weixin/poller.zig`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Add the `Poller` thread loop (compile-checked)**
+
+Append the loop after `processUpdates`. It ports the `tick` flow: load binding/settings, long-poll `getUpdates`, handle `errcode == -14` (disable), call `processUpdates`, persist `get_updates_buf`, reschedule with `longpolling_timeout_ms`. It uses an injected `ClientApi` (Task 9) and a `Control` (Task 5), and runs on a `std.Thread` with an atomic stop flag (mirror `remote_client.zig:85,113,117-123`).
+
+```zig
+const ClientApi = @import("ilink_client.zig").ClientApi;
+const control_mod = @import("control.zig");
+
+pub const SESSION_EXPIRED_ERRCODE: i64 = -14;
+
+pub const Poller = struct {
+    allocator: std.mem.Allocator,
+    client: ClientApi,
+    control: control_mod.Control,
+    owner: []const u8,
+    account_id: []const u8,
+    sync_buf: []u8,
+    on_sync_buf: *const fn (ctx: *anyopaque, buf: []const u8) void,
+    on_sync_ctx: *anyopaque,
+    stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    thread: ?std.Thread = null,
+
+    pub fn start(self: *Poller) !void {
+        self.thread = try std.Thread.spawn(.{}, threadMain, .{self});
+    }
+    pub fn stop(self: *Poller) void {
+        self.stop_requested.store(true, .release);
+        if (self.thread) |th| {
+            th.join();
+            self.thread = null;
+        }
+    }
+
+    fn threadMain(self: *Poller) void {
+        while (!self.stop_requested.load(.acquire)) {
+            self.tickOnce() catch {
+                std.Thread.sleep(5 * std.time.ns_per_s);
+                continue;
+            };
+        }
+    }
+
+    fn tickOnce(self: *Poller) !void {
+        var arena_state = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+
+        const updates = try self.client.getUpdates(self.sync_buf, arena);
+        if (updates.errcode == SESSION_EXPIRED_ERRCODE) {
+            self.stop_requested.store(true, .release);
+            return;
+        }
+        // route_fn / send_fn adapters bind to self.control and self.client.
+        // (Implemented during integration; see Task 13.)
+        // For now, process with no-op routing to keep the loop honest.
+        _ = updates;
+        if (self.stop_requested.load(.acquire)) return;
+    }
+};
+```
+
+> Note: the `route_fn`/`send_fn` adapters that bridge `processUpdates` to `self.control` (agent.route) and `self.client.sendText`, plus AI-progress streaming via `reply_progress` at 10/30/60/120s checkpoints, are wired in Task 13 where the live `Control` exists. This task only needs `zig build` to succeed.
+
+- [ ] **Step 6: Compile**
+
+Run: `zig build`
+Expected: builds. Iterate on `std.Thread`/atomics API names if needed.
+
+- [ ] **Step 7: Register pure modules in the test binary and commit**
+
+Add to `src/test_main.zig` (near the other `_ = @import(...)` lines, ~line 656):
+
+```zig
+    _ = @import("weixin/types.zig");
+    _ = @import("weixin/state_store.zig");
+    _ = @import("weixin/binding.zig");
+    _ = @import("weixin/control.zig");
+    _ = @import("weixin/agent.zig");
+    _ = @import("weixin/reply_progress.zig");
+    _ = @import("weixin/ilink_codec.zig");
+    _ = @import("weixin/ilink_client.zig");
+    _ = @import("weixin/poller.zig");
+```
+
+Run: `zig build` then commit.
+
+```bash
+git add src/weixin/poller.zig src/test_main.zig
+git commit -m "feat(weixin): add poll loop and register weixin test modules"
+```
+
+---
+
+## Phase 3 — `LocalControl` over App/AppWindow (Windows-bound integration)
+
+### Task 11: Implement the live `Control` accessors on the window
+
+The poller's `Control` must resolve the focused window's AI-chat surface, send input, open the AI agent, and read the transcript. The remote path already exposes the building blocks in `src/AppWindow.zig`: `remoteAiSurfaceId(tab_index)` (line 1793), `registerRemoteAiInputSink` (1799) with `thread_message.postPointer(.remote_ai_input, ...)` (1823), and `remoteAiAgentOpen` (1830) using `thread_message.sendPointer(.remote_open_ai_agent, ...)`. Reuse these.
+
+**Files:**
+- Modify: `src/AppWindow.zig` (add `findAiChatSurface`, `latestAiChatTranscript`, `onLayout` analog or a snapshot getter)
+- Modify: `src/App.zig` (expose a `weixinControl(self: *App) control.Control` builder)
+
+- [ ] **Step 1: Investigate the AI transcript source**
+
+The remote worker reconstructs the transcript from published surface output. Locally, find the in-memory transcript on the AI chat session. Run:
+
+```bash
+grep -n "transcript\|renderTranscript\|Session\|aiChatSurface\|ai_chat" src/AppWindow.zig | head -40
+```
+
+Identify the function that yields the rendered "You:/AI:/Status:" text for the focused tab's AI chat. If none exists, add `pub fn aiChatTranscriptAlloc(self: *AppWindow, allocator) ?[]u8` that renders the focused AI session via `ai_chat.zig` into the same label format `reply_progress.zig` parses.
+
+- [ ] **Step 2: Add the surface/transcript accessors**
+
+In `src/AppWindow.zig`, add (adapting names to what Step 1 found):
+
+```zig
+/// Returns the focused tab's AI chat surface id/title if one is open.
+pub fn weixinFindAiSurface(self: *AppWindow) ?weixin_control.Surface {
+    const idx = self.focusedTabIndex() orelse return null;
+    if (!self.tabHasAiChat(idx)) return null;
+    return .{ .id = remoteAiSurfaceId(idx), .title = self.tabs.items[idx].getTitle() };
+}
+
+/// Returns the focused tab's default writable terminal surface id/title.
+pub fn weixinFindTerminalSurface(self: *AppWindow) ?weixin_control.Surface {
+    // reuse the same surface id scheme the renderer/input path uses
+    ...
+}
+
+/// Renders the focused AI chat transcript in the label format reply_progress
+/// expects. Caller owns the returned slice.
+pub fn weixinTranscriptAlloc(self: *AppWindow, allocator: std.mem.Allocator) ?[]u8 {
+    ...
+}
+```
+
+Add `const weixin_control = @import("weixin/control.zig");` to the imports.
+
+- [ ] **Step 3: Build the `Control` in `App`**
+
+In `src/App.zig`, add a builder that fills the vtable by delegating to the focused window. Input delivery reuses the remote marshalling: for AI input, post `.remote_ai_input` (`thread_message.postPointer`); for AI-agent open, send `.remote_open_ai_agent`. `send_input` returns `false` when no window/native handle is available (offline).
+
+```zig
+const weixin_control = @import("weixin/control.zig");
+
+pub fn weixinControl(self: *App) weixin_control.Control {
+    return .{ .ctx = self, .vtable = &weixin_control_vtable };
+}
+
+const weixin_control_vtable = weixin_control.Control.VTable{
+    .is_connected = wxIsConnected,
+    .find_ai_surface = wxFindAi,
+    .find_terminal_surface = wxFindTerm,
+    .open_ai_agent = wxOpenAi,
+    .send_input = wxSendInput,
+    .latest_transcript = wxTranscript,
+};
+// each wx* fn: lock app.mutex, pick the first window with a native handle,
+// delegate to the AppWindow accessors / thread_message marshalling above.
+```
+
+- [ ] **Step 4: Compile (Windows build)**
+
+Run: `zig build`
+Expected: builds on Windows. This task is integration glue — iterate against the compiler. It is not unit-tested on the Linux host (GUI is Windows-only); verify it compiles via `zig build` and defer behavioral verification to the manual Windows smoke test in Task 15.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/App.zig src/AppWindow.zig
+git commit -m "feat(weixin): expose live Control over focused window"
+```
+
+---
+
+## Phase 4 — Controller, lifecycle, mutual exclusion
+
+### Task 12: `src/weixin/controller.zig` — owns the thread and wiring
+
+**Files:**
+- Create: `src/weixin/controller.zig`
+
+- [ ] **Step 1: Implement the controller**
+
+It loads the binding via `state_store`, builds an `ilink_client.Client` + its `ClientApi`, constructs a `Poller`, and wires the `route_fn`/`send_fn` adapters from Task 10's note: `route_fn` calls `agent.route(allocator, control, settings, text, &reply)` and returns `reply.expect_ai_progress`; when true, the controller starts `reply_progress`-based streaming using `control.latestTranscript()` at 10/30/60/120s checkpoints, clamped to `settings.reply_timeout_ms`. `send_fn` calls `client.sendText`. On bind: when `binding.ownerForBind` returns a user_id, persist it via `state_store.save`.
+
+```zig
+const std = @import("std");
+const types = @import("types.zig");
+const state_store = @import("state_store.zig");
+const ilink = @import("ilink_client.zig");
+const poller = @import("poller.zig");
+const agent = @import("agent.zig");
+const reply_progress = @import("reply_progress.zig");
+const control_mod = @import("control.zig");
+
+pub const Controller = struct {
+    allocator: std.mem.Allocator,
+    state_path: []const u8,
+    control: control_mod.Control,
+    settings: types.Settings,
+    client: ?ilink.Client = null,
+    poll: ?poller.Poller = null,
+    // ... login state for the QR panel ...
+
+    pub fn create(allocator, state_path, control, settings) !*Controller { ... }
+    pub fn destroy(self) void { ... }
+
+    /// Begins QR login: getBotQrcode → poll status → on confirmed persist token + start().
+    pub fn startLogin(self: *Controller) !void { ... }
+
+    /// Starts the poll loop using a persisted token.
+    pub fn start(self: *Controller) !void { ... }
+
+    pub fn stop(self: *Controller) void { ... }
+
+    /// Clears owner + token and stops.
+    pub fn unbind(self: *Controller) !void { ... }
+};
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `zig build`
+Expected: builds. Iterate on the wiring until the route/send adapters and progress streaming compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/weixin/controller.zig
+git commit -m "feat(weixin): add controller wiring poller, agent, progress"
+```
+
+### Task 13: App construction + mutual-exclusion guard + status
+
+**Files:**
+- Modify: `src/App.zig` (add a `weixin_controller: ?*weixin.Controller` field near `remote_client`; construct in init after `startRemoteClient`; destroy in `deinit` near line 893; compute the state file path)
+
+- [ ] **Step 1: Add the field and a `startWeixinController` helper**
+
+Mirror `startRemoteClient` (`src/App.zig:253`). Guard:
+
+```zig
+fn startWeixinController(app: *App, cfg: *const Config, remote_active: bool) ?*weixin.Controller {
+    if (!cfg.@"weixin-direct-enabled") return null;
+    if (remote_active) {
+        std.debug.print("weixin-direct disabled: remote-enabled takes precedence\n", .{});
+        return null;
+    }
+    const state_path = weixinStatePath(app.allocator) catch return null; // e.g. <state dir>/weixin.json via platform/dirs.zig
+    const settings = types.Settings{
+        .enabled = true,
+        .reply_timeout_ms = std.math.clamp(cfg.@"weixin-reply-timeout-ms", 5000, 180000),
+        .allowed_user = cfg.@"weixin-allowed-user" orelse "",
+    };
+    return weixin.Controller.create(app.allocator, state_path, app.weixinControl(), settings) catch null;
+}
+```
+
+Wire in `App` init: compute `remote_active = remote_client_ptr != null;` then `.weixin_controller = startWeixinController(app, &cfg, remote_active),` and in `deinit` call `if (self.weixin_controller) |c| c.destroy();`.
+
+> Use `src/platform/dirs.zig` for the state directory (the same module the app uses for per-user data). `weixinStatePath` joins that dir + `"weixin.json"`.
+
+- [ ] **Step 2: Surface status**
+
+`/status` text already comes from `agent.statusText`. Extend it to also report whether a persisted owner exists (pass that in via `Control` or settings). Add a one-line startup log when the controller starts/declines.
+
+- [ ] **Step 3: Compile**
+
+Run: `zig build`
+Expected: builds on Windows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/App.zig
+git commit -m "feat(weixin): construct controller with remote mutual exclusion"
+```
+
+---
+
+## Phase 5 — QR login panel (Windows)
+
+### Task 14: `src/weixin/qr_panel.zig`
+
+**Files:**
+- Create: `src/weixin/qr_panel.zig`
+- Modify: the command palette / action table to add **"Connect WeChat"** and **"WeChat: Unbind"** entries; a keybind is optional.
+
+- [ ] **Step 1: Find the panel + image-decode patterns**
+
+```bash
+grep -n "pub fn\|decode\|Image\|png\|qr" src/image_decoder.zig | head
+sed -n '1,60p' src/markdown_preview_panel.zig
+grep -rn "command_center\|action\|palette\|Command\b" src/command_center_state.zig | head
+```
+
+- [ ] **Step 2: Implement the panel**
+
+The panel holds the QR image (decode `qrcode_img_content` base64 → PNG → `image_decoder`) or renders the `qrcode` string as a QR if only a URL is returned, plus status text (`等待扫码 / 已扫码 / 已确认 / 已过期`). It polls `controller` login state; on `confirmed` it closes; on `expired` it offers retry. Model it on `markdown_preview_panel.zig`'s lifecycle (open/draw/close) found in Step 1.
+
+> If only `qrcode` (a URL/string) is returned and no inline image, v1 may render the string for the user to long-press, or generate a QR bitmap — pick based on what the live API returns during the Windows smoke test (Task 15).
+
+- [ ] **Step 3: Wire the actions**
+
+"Connect WeChat" → `app.weixin_controller.?.startLogin()` and open the panel. "WeChat: Unbind" → `app.weixin_controller.?.unbind()`.
+
+- [ ] **Step 4: Compile**
+
+Run: `zig build`
+Expected: builds on Windows.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weixin/qr_panel.zig src/command_center_state.zig
+git commit -m "feat(weixin): add QR login panel and actions"
+```
+
+---
+
+## Phase 6 — End-to-end verification (Windows)
+
+### Task 15: Manual smoke test on Windows
+
+This feature's runtime is Windows-only; the Linux host only compiles + runs the pure-module `zig test`s. Do a manual smoke test on a Windows build.
+
+- [ ] **Step 1: Build release**
+
+Run: `zig build -Doptimize=ReleaseFast` (on Windows)
+
+- [ ] **Step 2: Configure**
+
+Set in the config file: `weixin-direct-enabled = true`, `remote-enabled = false`. Launch Phantty.
+
+- [ ] **Step 3: Login**
+
+Trigger **"Connect WeChat"**. Confirm the QR panel shows, scan with WeChat, and verify the panel closes on `confirmed` and a `weixin.json` (mode 0600) appears in the state dir with a `bot_token`.
+
+- [ ] **Step 4: Control**
+
+From the bound WeChat account, send `ping` (expect `pong`), `/status`, a plain message (expect it reaches the AI chat and an ack + progress replies arrive), `/term ls` (expect terminal runs `ls`), `/stop`. From a *different* account, send a message and confirm it is ignored.
+
+- [ ] **Step 5: Mutual exclusion + expiry**
+
+Set both `remote-enabled` and `weixin-direct-enabled` true; confirm the startup log says remote wins and direct is disabled. Separately, let the session expire (or simulate errcode −14) and confirm the loop stops cleanly.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "test(weixin): document Windows smoke test results"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §Module layout → Tasks 2–14; §Login flow → Tasks 9,12,14; §Shared control core → Tasks 5,11; §Config/persistence → Tasks 1,3,13; §Authorization → Tasks 4,12; §QR panel → Task 14; §Threading → Tasks 10,12; §Error handling (−14, backoff, expiry) → Tasks 10,12,15; §Testing → Tasks 3,4,6,8,10; §Phasing → matches Phases 0–6; §Non-goals (media, multi-tab) → not implemented (correct).
+- **Layered platform decision:** Phases 0–2 compile + `zig test` on any OS (fits the Linux host); Phases 3–6 are Windows-bound integration verified via `zig build` + the Task 15 smoke test.
+- **Honesty flag:** Tasks 9–14 contain skeletons with real signatures/integration points but require compile iteration against Zig 0.15.2's `std.http`/`std.json`/GUI APIs; they are explicitly marked "compile and iterate," not asserted as compiling verbatim. The pure-logic Tasks 1–8/10-core are full TDD with `zig test`.

--- a/docs/superpowers/specs/2026-05-25-weixin-direct-ilink-design.md
+++ b/docs/superpowers/specs/2026-05-25-weixin-direct-ilink-design.md
@@ -1,0 +1,201 @@
+# WeChat Direct (Embedded ilink) Design
+
+## Goal
+
+Add a second, independent WeChat path that embeds the ilink protocol client
+**inside the Phantty desktop process** (Zig). When `weixin-direct-enabled = true`,
+Phantty long-polls `https://ilinkai.weixin.qq.com` directly, routes inbound
+WeChat messages into the local AI-chat / terminal surfaces, and replies over
+ilink. No Cloudflare Worker, no `wss` relay, and no web login are involved.
+
+This path is **mutually exclusive** with the existing remote (Worker) path:
+exactly one of them may drive a given WeChat bot, because a single `bot_token`
+can have only one active `getUpdates` consumer.
+
+## Relationship to the existing remote bridge
+
+The existing bridge (`docs/superpowers/specs/2026-05-14-remote-weixin-ilink-bridge-design.md`,
+implemented in `remote/src/server/bridge/weixin/`) runs the ilink poller and all
+routing intelligence **on the Cloudflare Worker**. In that model
+`src/remote_client.zig` is a dumb relay: a surface registry plus `input-bytes`
+and `open-ai-agent` frames. The routing brains (command parsing, target
+resolution, AI-reply progress streaming) live in the TypeScript worker
+(`agent.ts`, `poller.ts`).
+
+The direct path has no worker, so that intelligence is **ported into Zig**. The
+TypeScript modules are the reference implementation; their unit tests
+(`remote/test/server/weixin_*.test.ts`) are the source of truth for behavior we
+must preserve.
+
+## Decisions
+
+These were settled during brainstorming and are fixed for v1:
+
+- **Placement:** native embed in the Phantty Zig process (no extra process, no
+  relay).
+- **Platform:** cross-platform via `std.http.Client` (its bundled TLS), not the
+  Windows-only WinHTTP transport used by `remote_transport_windows.zig`.
+- **Feature scope:** full parity with the current WeChat experience, adapted to
+  a single local app — `/ai`, `/term`, `/keys`, `/stop`, `/ping`, `/status`,
+  `/help`, default-text→AI, and AI-reply progress streaming. `/sessions` and
+  `/use` are dropped (there is only one local app).
+- **Login UX:** an in-app QR panel/window.
+- **Coexistence:** mutually exclusive with `remote-enabled`. If both are enabled,
+  **remote wins** and the direct path is disabled with a warning.
+- **Authorization:** the first 1:1 sender after login is auto-bound as the owner
+  and persisted; afterward only that `user_id` is accepted. A configured
+  `weixin-allowed-user` overrides auto-bind.
+- **Internal structure (Approach 1):** factor a shared in-process `LocalControl`
+  view out of `App`/`remote_client` that both the remote client and the new
+  weixin controller consume, so routing/AI-open/transcript logic does not drift.
+
+## Architecture
+
+### Module layout — `src/weixin/`
+
+| File | Responsibility | TS reference |
+|------|----------------|--------------|
+| `ilink_client.zig` | HTTP over `std.http.Client`: `getBotQrcode`, `pollQrStatus`, `getUpdates` (≈35s long-poll), `sendMessage`, `sendTyping`. JSON encode/decode of ilink envelopes. | `client.ts` |
+| `poller.zig` | Poll loop with `generation`/staleness cancellation, sync-buf handling, session-expired (errcode −14) → disable. | `poller.ts` |
+| `agent.zig` | Command routing (`/ai /term /keys /stop /ping /status /help`) + default-text→AI + target resolution. `/sessions` `/use` removed. | `agent.ts` |
+| `reply_progress.zig` | AI-reply progress streaming: transcript section parsing, diffing against a baseline, and 10/30/60/120s checkpoints. | `poller.ts` (`aiReplyProgress`, `startAiFollowup`) |
+| `binding.zig` | Owner auto-bind, message filtering (`shouldHandleWeixinMessage`), text extraction (text item type 1 + voice-transcript item type 3). | `poller.ts`, `binding.ts` |
+| `state_store.zig` | Persist/load `bot_token`, bound `owner_user_id`, and `sync_buf` to a `0600` state file. | `binding.ts` store |
+| `controller.zig` | Owns the background thread; wires poller → agent → `LocalControl`; lifecycle (start / stop / login / unbind). | (worker glue) |
+
+### Shared in-process control core (the Approach-1 refactor)
+
+Define a `LocalControl` abstraction over the surface registry that `App` already
+holds and `remote_client` already borrows. Both `remote_client` and
+`weixin/controller` consume it.
+
+Already present (reused as-is):
+- `sendInput(surface_id, bytes)` — the existing sink `write_fn` path
+  (`remote_client.zig:189` `registerSurface`, dispatch at `remote_client.zig:290`).
+- `openAiAgent(request_id) → status` — existing `registerAiAgentOpener`
+  (`remote_client.zig:213`).
+
+New accessors to add (additive; this is the only change to existing code):
+- `findAiChatSurface() → ?{ id: [16]u8, title }` — query over the surface
+  registry.
+- `latestAiChatTranscript() → []const u8` — reads `ai_chat.zig`'s in-memory
+  transcript. The worker had to reconstruct this from published output frames;
+  locally it is read directly.
+- `onLayout(listener)` — fires on surface add/remove and AI transcript change,
+  used by `reply_progress.zig`.
+
+### Login / QR flow
+
+1. User triggers **"Connect WeChat"** (command-palette action; optional keybind).
+2. `ilink_client.getBotQrcode(bot_type = 3)` → QR image bytes / URL.
+3. The **QR panel** (see UI section) renders the QR and live status;
+   `pollQrStatus` loops `wait → scanned → confirmed`.
+4. On `confirmed`: persist `bot_token` via `state_store`, dismiss the panel, start
+   the poll loop.
+5. On expiry or cancel: close the panel and offer retry.
+
+### Data flow (steady state)
+
+```
+ilink getUpdates ──▶ binding filter ──▶ agent route ──┬─▶ openAiAgent / sendInput(ai, text\r)
+   (poller thread)      (owner check)   (cmd parse)    ├─▶ sendInput(terminal, ...)   [/term /keys]
+        ▲                                              └─▶ immediate reply (sendMessage)
+        │                                                          │
+   sync_buf persist                          reply_progress: diff transcript at
+                                             checkpoints ──▶ sendMessage(progress / final)
+```
+
+Target resolution in v1 routes to the **focused window's** AI-chat surface,
+opening one via `openAiAgent` if absent. Multi-tab/multi-window routing is out of
+scope.
+
+## Configuration & persistence
+
+New keys in `src/config.zig`, alongside the existing `remote-*` keys:
+
+- `weixin-direct-enabled: bool = false`
+- `weixin-base-url: ?[]const u8 = null` (defaults to `https://ilinkai.weixin.qq.com`)
+- `weixin-reply-timeout-ms: u32 = 120000` (clamped to `[5000, 180000]`, matching the TS bridge)
+- `weixin-allowed-user: ?[]const u8 = null` (empty ⇒ first-messenger auto-bind)
+
+**Secrets are never stored in config.** `bot_token`, `owner_user_id`, and
+`sync_buf` live in a `0600` state file in the app data/state directory, using the
+same directory resolution `session_persist.zig` uses for session files.
+
+**Mutual exclusion:** at startup, if both `remote-enabled` and
+`weixin-direct-enabled` are true, log a warning and **disable the direct path**
+(remote wins). This guarantees one bot is never double-polled. The decision is
+surfaced in `/status`.
+
+## Authorization & security
+
+- The first 1:1 sender after login is persisted as `owner_user_id`; afterward
+  only that id is accepted.
+- `weixin-allowed-user`, when set, overrides auto-bind.
+- Group messages and bot self-echo are rejected (carried from
+  `shouldHandleWeixinMessage`).
+- `bot_token` is never logged; the state file is `0600`.
+- Trust caveat (same as remote): an authorized WeChat sender obtains terminal and
+  AI control. This is documented and gated behind the explicit toggle plus owner
+  binding.
+- An **"Unbind / disconnect"** action clears `owner_user_id` and stops the loop.
+
+## QR panel UI
+
+A lightweight in-app panel, a sibling to `markdown_preview_panel.zig` /
+`browser_panel.zig`, that:
+
+- decodes the QR image via `image_decoder.zig` and renders it,
+- shows status text (`等待扫码 / 已扫码 / 已确认 / 已过期`),
+- auto-closes on `confirmed` and offers retry on expiry.
+
+It reuses the existing panel and image-decoder machinery rather than a new
+OS-native modal window.
+
+## Threading
+
+The poller runs on its own background thread, mirroring `remote_client`'s thread
++ queue + heartbeat patterns. All `sendInput` / `openAiAgent` calls marshal onto
+the app thread via the existing threading/mailbox mechanism (`threading.zig`,
+xev-mailbox pattern). `generation` counters cancel in-flight work on stop/disable
+(direct port of the TS staleness logic in `poller.ts`).
+
+## Error handling
+
+- Network/HTTP errors → backoff-and-retry (5s), matching `poller.ts`.
+- ilink errcode −14 (session expired) → persist disabled, stop loop, status
+  message.
+- Long-poll timeout → immediate re-poll, clamped by `longpolling_timeout_ms`.
+- QR expiry → panel retry.
+- App data dir unwritable → login fails loudly (token cannot persist); the failure
+  is surfaced in status.
+
+## Testing
+
+Per the `phantty-test-execution-env` note, tests are compile-only on this host
+except pure modules run via `zig test`.
+
+- **Pure-logic unit tests (`zig test`):** `agent.zig` command parsing,
+  `binding.zig` filtering + auto-bind, `reply_progress.zig` transcript diffing +
+  checkpoints, and ilink JSON encode/decode. These mirror the assertions in
+  `remote/test/server/weixin_*.test.ts` — port them.
+- **`ilink_client.zig` / `poller.zig`:** thread/network code stays compile-only on
+  this host. Structure with an injected client + scheduler (like the TS
+  `WeixinPollerOptions`) so the loop logic is unit-testable without sockets.
+
+## Execution phases
+
+1. **Refactor:** extract `LocalControl` + new read accessors; both
+   `remote_client` and a stub weixin controller compile against it.
+2. **ilink_client + state_store + login/QR panel:** reach a persisted
+   `bot_token`.
+3. **poller + binding + agent (core commands + default→AI):** end-to-end control.
+4. **reply_progress:** AI-reply streaming.
+5. **Config wiring + mutual-exclusion guard + status surfacing.**
+
+## Non-goals (v1)
+
+- Media send/receive (images, files) over ilink CDN with AES — text and
+  voice-transcript only, matching the current bridge.
+- Multi-tab/multi-window routing (`/sessions`, `/use`).
+- Running both remote and direct paths against the same bot simultaneously.

--- a/release-notes/v0.30.0.md
+++ b/release-notes/v0.30.0.md
@@ -1,0 +1,16 @@
+# Phantty v0.30.0
+
+## New
+
+- Added a scrollbar to the AI chat transcript, with drag-to-scroll and hover
+  highlighting.
+- Added Ctrl+X to cut the AI chat input composer.
+- Added Markdown export for AI chat conversations.
+
+## Fixed
+
+- Fixed AI chat transcript text selection: the highlight now lines up with the
+  rendered text, and copying yields exactly the visible text. Previously,
+  selecting a message that contained Markdown formatting (bold, code spans,
+  links) copied a shifted or truncated substring.
+- Fixed Shift+Tab and Alt+Up being swallowed inside full-screen terminal apps.

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantty-remote",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phantty-remote",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantty-remote",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/remote/src/client/version.ts
+++ b/remote/src/client/version.ts
@@ -1,4 +1,4 @@
-export const WEB_VERSION = "v0.29.0";
+export const WEB_VERSION = "v0.30.0";
 export const WEB_BUILD_TIME = normalizedBuildTime(import.meta.env?.VITE_PHANTTY_WEB_BUILD_TIME);
 
 export function webVersionLabel(buildTime: string | null = WEB_BUILD_TIME): string {

--- a/remote/test/client/version.test.ts
+++ b/remote/test/client/version.test.ts
@@ -4,14 +4,14 @@ import assert from "node:assert/strict";
 import { WEB_VERSION, remoteBrandMarkup, webVersionLabel } from "../../src/client/version";
 
 test("web version is exposed for the remote UI", () => {
-  assert.equal(WEB_VERSION, "v0.29.0");
-  assert.equal(webVersionLabel(), "Web v0.29.0");
+  assert.equal(WEB_VERSION, "v0.30.0");
+  assert.equal(webVersionLabel(), "Web v0.30.0");
 });
 
 test("web version label always includes the release version", () => {
-  assert.equal(webVersionLabel("build fixture"), "Web v0.29.0 (build fixture)");
+  assert.equal(webVersionLabel("build fixture"), "Web v0.30.0 (build fixture)");
 });
 
 test("remote brand markup exposes the web version for shell views", () => {
-  assert.equal(remoteBrandMarkup(), 'Phantty Remote <span class="web-version">Web v0.29.0</span>');
+  assert.equal(remoteBrandMarkup(), 'Phantty Remote <span class="web-version">Web v0.30.0</span>');
 });

--- a/src/App.zig
+++ b/src/App.zig
@@ -18,7 +18,6 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const window_backend = @import("platform/window_backend.zig");
 const remote = @import("remote_client.zig");
 const weixin = @import("weixin/controller.zig");
-const weixin_control = @import("weixin/control.zig");
 const weixin_types = @import("weixin/types.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const update_check = @import("update_check.zig");
@@ -281,77 +280,13 @@ fn startRemoteClient(
     };
 }
 
-// =====================================================================
-// WeChat direct (embedded ilink) — host integration.
+// WeChat direct (embedded ilink). App owns the controller's lifecycle; the
+// Control vtable lives in AppWindow (it needs UI-thread tab/overlay state,
+// marshalled from the poller thread). See AppWindow.weixinControl.
 //
-// UNVERIFIED SCAFFOLD: this block compiles against the weixin/ modules but
-// the surface-control vtable bodies are safe stubs. With these stubs the
-// WeChat bridge connects, logs in, and long-polls; control actions report
-// "offline" until the TODOs are wired to the focused AppWindow (mirroring the
-// remote path in AppWindow.zig: remoteAiSurfaceId / remoteAiWrite /
-// remoteAiAgentOpen via thread_message, and activeAiChat() for the transcript).
-// This has not been compiled (the desktop GUI is Windows-only); verify symbol
-// names and signatures against AppWindow.zig during Windows compile iteration.
-// =====================================================================
-
-const weixin_vtable = weixin_control.Control.VTable{
-    .is_connected = wxIsConnected,
-    .find_ai_surface = wxFindAiSurface,
-    .find_terminal_surface = wxFindTerminalSurface,
-    .open_ai_agent = wxOpenAiAgent,
-    .send_input = wxSendInput,
-    .latest_transcript = wxTranscript,
-};
-
-/// Builds the Control the weixin controller drives. `self` must be stable
-/// (this is only valid after App is in its final location — see startWeixin).
-pub fn weixinControl(self: *App) weixin_control.Control {
-    return .{ .ctx = self, .vtable = &weixin_vtable };
-}
-
-fn wxIsConnected(ctx: *anyopaque) bool {
-    const app: *App = @ptrCast(@alignCast(ctx));
-    app.mutex.lock();
-    defer app.mutex.unlock();
-    return app.windows.items.len != 0;
-}
-
-fn wxFindAiSurface(ctx: *anyopaque) ?weixin_control.Surface {
-    _ = ctx;
-    // TODO(weixin-windows): return the focused window's AI-chat surface id/title.
-    // Reuse AppWindow.remoteAiSurfaceId(tab_index) for the active .ai_chat tab.
-    return null;
-}
-
-fn wxFindTerminalSurface(ctx: *anyopaque) ?weixin_control.Surface {
-    _ = ctx;
-    // TODO(weixin-windows): return the active writable terminal surface id/title.
-    return null;
-}
-
-fn wxOpenAiAgent(ctx: *anyopaque, timeout_ms: u32) weixin_control.OpenResult {
-    _ = ctx;
-    _ = timeout_ms;
-    // TODO(weixin-windows): marshal an open-AI-agent request onto the UI thread,
-    // mirroring AppWindow.remoteAiAgentOpen (thread_message .remote_open_ai_agent).
-    return .offline;
-}
-
-fn wxSendInput(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
-    _ = ctx;
-    _ = surface_id;
-    _ = bytes;
-    // TODO(weixin-windows): marshal input to the surface on the UI thread,
-    // mirroring AppWindow.remoteAiWrite (thread_message .remote_ai_input).
-    return false;
-}
-
-fn wxTranscript(ctx: *anyopaque) []const u8 {
-    _ = ctx;
-    // TODO(weixin-windows): render AppWindow.activeAiChat() in the
-    // "You:/AI:/Status:" label format that reply_progress.zig parses.
-    return "";
-}
+// Cross-compiles to the Windows exe; not yet run (no Windows runtime / live
+// WeChat here). /term-/keys terminal delegation and the AI transcript (for
+// reply-progress streaming) remain stubbed in AppWindow — see its TODOs.
 
 /// Creates and starts the WeChat direct controller when enabled and remote is
 /// not active. Call once, after App is at its final address (see main.zig).
@@ -370,7 +305,7 @@ pub fn startWeixin(self: *App, cfg: *const Config) void {
         .reply_timeout_ms = std.math.clamp(cfg.@"weixin-reply-timeout-ms", 5000, 180000),
         .allowed_user = cfg.@"weixin-allowed-user" orelse "",
     };
-    const controller = weixin.Controller.create(self.allocator, state_path, self.weixinControl(), settings) catch |err| {
+    const controller = weixin.Controller.create(self.allocator, state_path, AppWindow.weixinControl(), settings) catch |err| {
         std.debug.print("weixin-direct disabled: {}\n", .{err});
         return;
     };

--- a/src/App.zig
+++ b/src/App.zig
@@ -17,6 +17,10 @@ const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const window_backend = @import("platform/window_backend.zig");
 const remote = @import("remote_client.zig");
+const weixin = @import("weixin/controller.zig");
+const weixin_control = @import("weixin/control.zig");
+const weixin_types = @import("weixin/types.zig");
+const platform_dirs = @import("platform/dirs.zig");
 const update_check = @import("update_check.zig");
 const update_install = @import("update_install.zig");
 
@@ -80,6 +84,9 @@ remote_server_fingerprint: ?[]const u8,
 remote_device_name: ?[]const u8,
 remote_session_key: ?[]const u8,
 remote_client: ?*remote.Client,
+
+// WeChat direct (embedded ilink). Mutually exclusive with remote_client.
+weixin_controller: ?*weixin.Controller,
 
 // AI agent config
 ai_agent_enabled: bool,
@@ -210,6 +217,8 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .remote_device_name = remote_device_name,
         .remote_session_key = remote_session_key,
         .remote_client = remote_client_ptr,
+        // Created later by startWeixin(), once App lives at a stable address.
+        .weixin_controller = null,
         .ai_agent_enabled = cfg.@"ai-agent-enabled",
         .ai_agent_permission = cfg.@"ai-agent-permission",
         .ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
@@ -270,6 +279,103 @@ fn startRemoteClient(
         std.debug.print("Remote client disabled: {}\n", .{err});
         return null;
     };
+}
+
+// =====================================================================
+// WeChat direct (embedded ilink) — host integration.
+//
+// UNVERIFIED SCAFFOLD: this block compiles against the weixin/ modules but
+// the surface-control vtable bodies are safe stubs. With these stubs the
+// WeChat bridge connects, logs in, and long-polls; control actions report
+// "offline" until the TODOs are wired to the focused AppWindow (mirroring the
+// remote path in AppWindow.zig: remoteAiSurfaceId / remoteAiWrite /
+// remoteAiAgentOpen via thread_message, and activeAiChat() for the transcript).
+// This has not been compiled (the desktop GUI is Windows-only); verify symbol
+// names and signatures against AppWindow.zig during Windows compile iteration.
+// =====================================================================
+
+const weixin_vtable = weixin_control.Control.VTable{
+    .is_connected = wxIsConnected,
+    .find_ai_surface = wxFindAiSurface,
+    .find_terminal_surface = wxFindTerminalSurface,
+    .open_ai_agent = wxOpenAiAgent,
+    .send_input = wxSendInput,
+    .latest_transcript = wxTranscript,
+};
+
+/// Builds the Control the weixin controller drives. `self` must be stable
+/// (this is only valid after App is in its final location — see startWeixin).
+pub fn weixinControl(self: *App) weixin_control.Control {
+    return .{ .ctx = self, .vtable = &weixin_vtable };
+}
+
+fn wxIsConnected(ctx: *anyopaque) bool {
+    const app: *App = @ptrCast(@alignCast(ctx));
+    app.mutex.lock();
+    defer app.mutex.unlock();
+    return app.windows.items.len != 0;
+}
+
+fn wxFindAiSurface(ctx: *anyopaque) ?weixin_control.Surface {
+    _ = ctx;
+    // TODO(weixin-windows): return the focused window's AI-chat surface id/title.
+    // Reuse AppWindow.remoteAiSurfaceId(tab_index) for the active .ai_chat tab.
+    return null;
+}
+
+fn wxFindTerminalSurface(ctx: *anyopaque) ?weixin_control.Surface {
+    _ = ctx;
+    // TODO(weixin-windows): return the active writable terminal surface id/title.
+    return null;
+}
+
+fn wxOpenAiAgent(ctx: *anyopaque, timeout_ms: u32) weixin_control.OpenResult {
+    _ = ctx;
+    _ = timeout_ms;
+    // TODO(weixin-windows): marshal an open-AI-agent request onto the UI thread,
+    // mirroring AppWindow.remoteAiAgentOpen (thread_message .remote_open_ai_agent).
+    return .offline;
+}
+
+fn wxSendInput(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
+    _ = ctx;
+    _ = surface_id;
+    _ = bytes;
+    // TODO(weixin-windows): marshal input to the surface on the UI thread,
+    // mirroring AppWindow.remoteAiWrite (thread_message .remote_ai_input).
+    return false;
+}
+
+fn wxTranscript(ctx: *anyopaque) []const u8 {
+    _ = ctx;
+    // TODO(weixin-windows): render AppWindow.activeAiChat() in the
+    // "You:/AI:/Status:" label format that reply_progress.zig parses.
+    return "";
+}
+
+/// Creates and starts the WeChat direct controller when enabled and remote is
+/// not active. Call once, after App is at its final address (see main.zig).
+/// Mutually exclusive with remote: if remote is active, this is skipped.
+pub fn startWeixin(self: *App, cfg: *const Config) void {
+    if (!cfg.@"weixin-direct-enabled") return;
+    if (self.remote_client != null) {
+        std.debug.print("weixin-direct disabled: remote-enabled takes precedence\n", .{});
+        return;
+    }
+    const state_path = platform_dirs.pathInConfigDir(self.allocator, "weixin.json") catch return;
+    defer self.allocator.free(state_path);
+
+    const settings = weixin_types.Settings{
+        .enabled = true,
+        .reply_timeout_ms = std.math.clamp(cfg.@"weixin-reply-timeout-ms", 5000, 180000),
+        .allowed_user = cfg.@"weixin-allowed-user" orelse "",
+    };
+    const controller = weixin.Controller.create(self.allocator, state_path, self.weixinControl(), settings) catch |err| {
+        std.debug.print("weixin-direct disabled: {}\n", .{err});
+        return;
+    };
+    controller.start() catch {};
+    self.weixin_controller = controller;
 }
 
 /// Get the shell command as a native null-terminated command line.
@@ -893,6 +999,11 @@ pub fn deinit(self: *App) void {
     if (self.remote_client) |client| {
         client.destroy();
         self.remote_client = null;
+    }
+
+    if (self.weixin_controller) |controller| {
+        controller.destroy();
+        self.weixin_controller = null;
     }
 
     // Free owned string copies

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -17,6 +17,7 @@ const App = @import("App.zig");
 const Renderer = @import("renderer/Renderer.zig");
 const remote = @import("remote_client.zig");
 const remote_snapshot = @import("remote_snapshot.zig");
+const weixin_control = @import("weixin/control.zig");
 const memory_debug = @import("memory_debug.zig");
 const agent_detector = @import("agent_detector.zig");
 const agent_history = @import("agent_history.zig");
@@ -1934,6 +1935,144 @@ fn handleRemoteAiAgentOpenRequest(request: *RemoteAiAgentOpenRequest) void {
     }
 }
 
+// ============================================================================
+// WeChat direct (embedded ilink) — UI-thread control surface.
+//
+// The weixin poller runs on its own thread, but tab state (tab.g_tabs etc.) is
+// threadlocal to the UI thread. So the Control vtable marshals each request to
+// the UI thread via SendMessage (.weixin_control), where handleWeixinControlRequest
+// reads/acts on tab state, mirroring the remote .remote_ai_input path.
+//
+// UNVERIFIED AT RUNTIME: cross-compiles to the Windows exe, but has not been run
+// (no Windows runtime / live WeChat here). /term-/keys terminal delegation and
+// the AI transcript (for reply-progress streaming) are intentionally stubbed.
+// ============================================================================
+
+var g_weixin_ui_handle = std.atomic.Value(usize).init(0);
+var g_weixin_ctx: u8 = 0;
+
+const WeixinRequest = struct {
+    op: enum { find_ai, open_ai, send_input },
+    // send_input input (valid for the duration of the synchronous call):
+    surface_id: [16]u8 = [_]u8{0} ** 16,
+    bytes: []const u8 = "",
+    // outputs filled by the UI-thread handler:
+    found: bool = false,
+    out_surface_id: [16]u8 = [_]u8{0} ** 16,
+    open_result: weixin_control.OpenResult = .failed,
+    sent: bool = false,
+};
+
+/// Index of the AI-chat tab to target: the active tab if it is AI chat, else the
+/// first AI-chat tab. UI-thread only (reads threadlocal tab state).
+fn weixinActiveAiTabIndex() ?usize {
+    if (tab.g_active_tab < tab.g_tab_count) {
+        if (tab.g_tabs[tab.g_active_tab]) |ts| {
+            if (ts.kind == .ai_chat) return tab.g_active_tab;
+        }
+    }
+    for (0..tab.g_tab_count) |i| {
+        if (tab.g_tabs[i]) |ts| {
+            if (ts.kind == .ai_chat) return i;
+        }
+    }
+    return null;
+}
+
+fn weixinTabIndexFromSurfaceId(id: [16]u8) ?usize {
+    if (!std.mem.eql(u8, id[0..6], "aichat")) return null;
+    return std.fmt.parseInt(usize, id[6..16], 10) catch null;
+}
+
+/// Runs on the UI thread (dispatched from the window message pump).
+fn handleWeixinControlRequest(req: *WeixinRequest) void {
+    switch (req.op) {
+        .find_ai => {
+            if (weixinActiveAiTabIndex()) |idx| {
+                req.out_surface_id = remoteAiSurfaceId(idx);
+                req.found = true;
+            }
+        },
+        .open_ai => {
+            req.open_result = switch (overlays.openDefaultAgentSessionForRemote()) {
+                .opened => .opened,
+                .no_profile => .no_profile,
+                .failed => .failed,
+            };
+            if (req.open_result == .opened) g_force_rebuild = true;
+        },
+        .send_input => {
+            const idx = weixinTabIndexFromSurfaceId(req.surface_id) orelse return;
+            if (idx >= tab.g_tab_count) return;
+            const tab_state = tab.g_tabs[idx] orelse return;
+            if (tab_state.kind != .ai_chat) return;
+            const session = tab_state.ai_chat_session orelse return;
+            session.applyRemoteInput(req.bytes);
+            g_force_rebuild = true;
+            req.sent = true;
+        },
+    }
+}
+
+/// Marshals a request to the UI thread synchronously. Returns false if no UI
+/// window is currently published. Called from the poller thread.
+fn weixinDispatch(req: *WeixinRequest) bool {
+    const bits = g_weixin_ui_handle.load(.acquire);
+    if (bits == 0) return false;
+    const handle = window_backend.nativeHandleFromBits(bits) orelse return false;
+    _ = thread_message.sendPointer(handle, .weixin_control, @intFromPtr(req));
+    return true;
+}
+
+fn wxIsConnected(_: *anyopaque) bool {
+    return g_weixin_ui_handle.load(.acquire) != 0;
+}
+
+fn wxFindAiSurface(_: *anyopaque) ?weixin_control.Surface {
+    var req = WeixinRequest{ .op = .find_ai };
+    if (!weixinDispatch(&req) or !req.found) return null;
+    return .{ .id = req.out_surface_id, .title = "" };
+}
+
+fn wxFindTerminalSurface(_: *anyopaque) ?weixin_control.Surface {
+    // TODO(weixin-windows): resolve the active writable terminal surface and
+    // marshal input to its PTY (the remote path uses per-surface sink write_fn).
+    return null;
+}
+
+fn wxOpenAiAgent(_: *anyopaque, _: u32) weixin_control.OpenResult {
+    var req = WeixinRequest{ .op = .open_ai };
+    if (!weixinDispatch(&req)) return .offline;
+    return req.open_result;
+}
+
+fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
+    var req = WeixinRequest{ .op = .send_input, .surface_id = surface_id, .bytes = bytes };
+    if (!weixinDispatch(&req)) return false;
+    return req.sent;
+}
+
+fn wxTranscript(_: *anyopaque) []const u8 {
+    // TODO(weixin-windows): render activeAiChat() into the "You:/AI:/Status:"
+    // label format that reply_progress.zig parses, to enable progress streaming.
+    return "";
+}
+
+const weixin_vtable = weixin_control.Control.VTable{
+    .is_connected = wxIsConnected,
+    .find_ai_surface = wxFindAiSurface,
+    .find_terminal_surface = wxFindTerminalSurface,
+    .open_ai_agent = wxOpenAiAgent,
+    .send_input = wxSendInput,
+    .latest_transcript = wxTranscript,
+};
+
+/// The Control the weixin controller drives. Backed by process-global state, so
+/// the dummy ctx is unused.
+pub fn weixinControl() weixin_control.Control {
+    return .{ .ctx = &g_weixin_ctx, .vtable = &weixin_vtable };
+}
+
 fn buildRemoteSurfaceSnapshot(allocator: std.mem.Allocator, surface: *Surface) ![]u8 {
     surface.render_state.mutex.lock();
     defer surface.render_state.mutex.unlock();
@@ -2422,6 +2561,7 @@ fn onPlatformMessage(msg: window_backend.MessageId, wParam: window_backend.WordP
         .agent_tab_close => handleAgentTabCloseRequest(@ptrFromInt(decoded.ptr)),
         .remote_ai_input => handleRemoteAiInputRequest(@ptrFromInt(decoded.ptr)),
         .remote_open_ai_agent => handleRemoteAiAgentOpenRequest(@ptrFromInt(decoded.ptr)),
+        .weixin_control => handleWeixinControlRequest(@ptrFromInt(decoded.ptr)),
     }
     return 1;
 }
@@ -2955,6 +3095,10 @@ fn runMainLoop(self: *AppWindow) !void {
     g_window = &backend_window;
     self.native_handle_bits.store(window_backend.nativeHandleBits(&backend_window), .release);
     defer self.native_handle_bits.store(0, .release);
+    // Publish a process-global UI handle so the WeChat poller thread can marshal
+    // control requests here. Last window to init wins; cleared on teardown.
+    g_weixin_ui_handle.store(window_backend.nativeHandleBits(&backend_window), .release);
+    defer g_weixin_ui_handle.store(0, .release);
     if (g_quake_mode and (g_start_maximize or g_start_fullscreen)) {
         std.debug.print("Quake mode disabled for this window because maximize/fullscreen is enabled\n", .{});
         g_quake_mode = false;

--- a/src/appwindow/thread_message.zig
+++ b/src/appwindow/thread_message.zig
@@ -8,6 +8,7 @@ pub const Tag = enum(u8) {
     agent_tab_close,
     remote_ai_input,
     remote_open_ai_agent,
+    weixin_control,
 };
 
 pub const Decoded = struct {
@@ -23,6 +24,7 @@ fn offset(tag: Tag) u32 {
         .remote_ai_input => 0x54,
         .remote_open_ai_agent => 0x55,
         .agent_ssh_save => 0x56,
+        .weixin_control => 0x57,
     };
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -310,6 +310,21 @@ shell: []const u8 = platform_pty_command.default_shell_name,
 /// instance uses it directly and later local instances append _1, _2, ...
 @"remote-session-key": ?[]const u8 = null,
 
+/// Enables the embedded WeChat ilink direct path. Mutually exclusive with
+/// remote-enabled; if both are true, remote wins and this is disabled.
+@"weixin-direct-enabled": bool = false,
+
+/// Override for the ilink API base URL. Defaults to the public endpoint.
+@"weixin-base-url": ?[]const u8 = null,
+
+/// Max time (ms) to keep streaming AI-reply progress to WeChat. Clamped to
+/// [5000, 180000]. Matches the TS bridge default.
+@"weixin-reply-timeout-ms": u32 = 120000,
+
+/// When set, only this ilink user_id may control the terminal/AI. When empty,
+/// the first 1:1 sender after login is auto-bound as owner.
+@"weixin-allowed-user": ?[]const u8 = null,
+
 /// Show a debug FPS overlay in the bottom-right corner.
 @"phantty-debug-fps": bool = false,
 @"phantty-debug-draw-calls": bool = false,
@@ -758,6 +773,23 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         self.@"remote-device-name" = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "remote-session-key")) {
         self.@"remote-session-key" = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "weixin-direct-enabled")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"weixin-direct-enabled" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"weixin-direct-enabled" = false;
+        } else {
+            log.warn("invalid weixin-direct-enabled: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "weixin-base-url")) {
+        self.@"weixin-base-url" = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "weixin-reply-timeout-ms")) {
+        self.@"weixin-reply-timeout-ms" = std.fmt.parseInt(u32, value, 10) catch {
+            log.warn("invalid weixin-reply-timeout-ms: {s}", .{value});
+            return;
+        };
+    } else if (std.mem.eql(u8, key, "weixin-allowed-user")) {
+        self.@"weixin-allowed-user" = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "phantty-debug-fps")) {
         if (std.mem.eql(u8, value, "true")) {
             self.@"phantty-debug-fps" = true;
@@ -1169,6 +1201,10 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --remote-server-fingerprint <fp> Expected relay fingerprint
         \\  --remote-device-name <name>  Friendly device name for remote access
         \\  --remote-session-key <key>   Fixed remote key base; later instances append _1, _2
+        \\  --weixin-direct-enabled <bool> Enable embedded WeChat ilink direct path
+        \\  --weixin-base-url <url>      Override ilink API base URL
+        \\  --weixin-reply-timeout-ms <n> AI-reply streaming window in ms
+        \\  --weixin-allowed-user <id>   Restrict control to one ilink user_id
         \\  --quake-mode <bool>          Enable Quake-style drop-down mode (default: true)
         \\
         \\Color Options (override theme):

--- a/src/main.zig
+++ b/src/main.zig
@@ -139,6 +139,10 @@ pub fn main() !void {
     var app = try App.init(allocator, cfg);
     defer app.deinit();
 
+    // App now lives at a stable address; start the WeChat direct bridge (no-op
+    // unless weixin-direct-enabled and remote is inactive).
+    app.startWeixin(&cfg);
+
     try app.run();
 
     std.debug.print("Phantty exiting...\n", .{});

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -655,6 +655,15 @@ comptime {
     _ = @import("quick_terminal.zig");
     _ = @import("remote_client.zig");
     _ = @import("remote_snapshot.zig");
+    _ = @import("weixin/types.zig");
+    _ = @import("weixin/state_store.zig");
+    _ = @import("weixin/binding.zig");
+    _ = @import("weixin/control.zig");
+    _ = @import("weixin/agent.zig");
+    _ = @import("weixin/reply_progress.zig");
+    _ = @import("weixin/ilink_codec.zig");
+    _ = @import("weixin/ilink_client.zig");
+    _ = @import("weixin/poller.zig");
     _ = @import("renderer/overlay_keys.zig");
     _ = @import("selection_unit.zig");
     _ = @import("session_persist.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -664,6 +664,7 @@ comptime {
     _ = @import("weixin/ilink_codec.zig");
     _ = @import("weixin/ilink_client.zig");
     _ = @import("weixin/poller.zig");
+    _ = @import("weixin/controller.zig");
     _ = @import("renderer/overlay_keys.zig");
     _ = @import("selection_unit.zig");
     _ = @import("session_persist.zig");

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -1,0 +1,238 @@
+//! WeChat command routing into the local Phantty surfaces. Port of agent.ts,
+//! minus /sessions and /use (one local app).
+const std = @import("std");
+const control = @import("control.zig");
+const types = @import("types.zig");
+
+const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。";
+const ESC = "\x1b";
+const AI_OPEN_TIMEOUT_MS: u32 = 2000;
+
+pub const Reply = struct {
+    allocator: std.mem.Allocator,
+    text: std.ArrayListUnmanaged(u8) = .empty,
+    /// true ⇒ caller should start AI-reply progress streaming.
+    expect_ai_progress: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator) Reply {
+        return .{ .allocator = allocator };
+    }
+    pub fn deinit(self: *Reply) void {
+        self.text.deinit(self.allocator);
+    }
+    fn set(self: *Reply, s: []const u8) !void {
+        self.text.clearRetainingCapacity();
+        try self.text.appendSlice(self.allocator, s);
+    }
+};
+
+pub fn defaultSettings() types.Settings {
+    return .{};
+}
+
+/// Returns the command token (including leading '/') and the trimmed argument.
+fn splitCommand(text: []const u8) struct { cmd: []const u8, arg: []const u8 } {
+    if (text.len == 0 or text[0] != '/') return .{ .cmd = "", .arg = text };
+    const sp = std.mem.indexOfScalar(u8, text, ' ') orelse text.len;
+    return .{ .cmd = text[0..sp], .arg = std.mem.trim(u8, text[sp..], " \t\r\n") };
+}
+
+fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+fn isPing(text: []const u8) bool {
+    const n = std.mem.trim(u8, text, " \t\r\n");
+    return eqIgnoreCase(n, "ping") or eqIgnoreCase(n, "/ping");
+}
+
+pub fn route(
+    allocator: std.mem.Allocator,
+    ctrl: control.Control,
+    settings: types.Settings,
+    raw_text: []const u8,
+    out: *Reply,
+) !void {
+    _ = allocator;
+    _ = settings;
+    const text = std.mem.trim(u8, raw_text, " \t\r\n");
+    if (text.len == 0) return;
+    if (isPing(text)) return out.set("pong");
+
+    const parts = splitCommand(text);
+    const cmd = parts.cmd;
+
+    if (eqIgnoreCase(cmd, "/help")) return out.set(helpTextConst);
+    if (eqIgnoreCase(cmd, "/status")) return out.set(statusText(ctrl));
+    if (cmd.len != 0 and !eqIgnoreCase(cmd, "/term") and !eqIgnoreCase(cmd, "/keys") and
+        !eqIgnoreCase(cmd, "/ai") and !eqIgnoreCase(cmd, "/stop"))
+    {
+        return out.set("未知命令。\n\n" ++ helpTextConst);
+    }
+    if (cmd.len != 0 and !eqIgnoreCase(cmd, "/stop") and parts.arg.len == 0) {
+        return out.set(usageText(cmd));
+    }
+
+    if (!ctrl.isConnected()) return out.set("Phantty 当前离线，无法处理。");
+
+    if (eqIgnoreCase(cmd, "/stop")) return stopAi(ctrl, out);
+    if (eqIgnoreCase(cmd, "/term")) return sendTerminal(ctrl, parts.arg, true, out);
+    if (eqIgnoreCase(cmd, "/keys")) return sendTerminal(ctrl, parts.arg, false, out);
+    if (eqIgnoreCase(cmd, "/ai")) return sendAi(ctrl, parts.arg, out);
+    return sendAi(ctrl, text, out);
+}
+
+fn sendAi(ctrl: control.Control, text: []const u8, out: *Reply) !void {
+    const ai = ctrl.findAiSurface() orelse blk: {
+        switch (ctrl.openAiAgent(AI_OPEN_TIMEOUT_MS)) {
+            .no_profile => return out.set("Phantty 尚未配置 AI Chat profile。"),
+            .failed => return out.set("Phantty 无法打开 AI Agent。"),
+            .offline => return out.set("Phantty 当前离线，无法打开 AI Agent。"),
+            .timeout => return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。"),
+            .opened => {},
+        }
+        break :blk ctrl.findAiSurface() orelse return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。");
+    };
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(out.allocator);
+    try buf.appendSlice(out.allocator, text);
+    try buf.append(out.allocator, '\r');
+    if (!ctrl.sendInput(ai.id, buf.items)) return out.set("Phantty 当前离线，无法发送给 AI Agent。");
+    try out.set(AI_ACK);
+    out.expect_ai_progress = true;
+}
+
+fn stopAi(ctrl: control.Control, out: *Reply) !void {
+    const ai = ctrl.findAiSurface() orelse return out.set("当前没有 AI Agent 可停止。");
+    if (!ctrl.sendInput(ai.id, ESC)) return out.set("Phantty 当前离线，无法停止 AI Agent。");
+    return out.set("已发送停止指令。");
+}
+
+fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Reply) !void {
+    const term = ctrl.findTerminalSurface() orelse return out.set("当前没有可写终端 surface。");
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(out.allocator);
+    try buf.appendSlice(out.allocator, text);
+    if (enter) try buf.append(out.allocator, '\r');
+    if (!ctrl.sendInput(term.id, buf.items)) return out.set("Phantty 当前离线，无法发送到终端。");
+    return out.set("已发送到终端。");
+}
+
+const helpTextConst =
+    "Phantty 微信直连命令：\n" ++
+    "/ping 验证连接\n/status 查看状态\n/ai <内容> 发送给 AI Agent\n" ++
+    "/stop 停止当前 AI 处理\n/term <命令> 发送到终端并回车\n/keys <文本> 发送原始文本\n" ++
+    "普通文本默认发送给 AI Agent。";
+
+fn statusText(ctrl: control.Control) []const u8 {
+    return if (ctrl.isConnected()) "微信直连：在线" else "微信直连：离线";
+}
+
+fn usageText(cmd: []const u8) []const u8 {
+    if (eqIgnoreCase(cmd, "/term")) return "用法：/term <命令>";
+    if (eqIgnoreCase(cmd, "/keys")) return "用法：/keys <文本>";
+    if (eqIgnoreCase(cmd, "/ai")) return "用法：/ai <内容>";
+    return helpTextConst;
+}
+
+const t = std.testing;
+
+const FakeControl = struct {
+    connected: bool = true,
+    has_ai: bool = true,
+    buf: [256]u8 = undefined,
+    len: usize = 0,
+    last_surface: [16]u8 = [_]u8{0} ** 16,
+
+    /// Bytes captured from the last send_input. send_input borrows its argument
+    /// (production consumes it synchronously), so the fake copies for inspection.
+    fn lastInput(self: *FakeControl) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    fn is_connected(ctx: *anyopaque) bool {
+        return cast(ctx).connected;
+    }
+    fn find_ai_surface(ctx: *anyopaque) ?control.Surface {
+        return if (cast(ctx).has_ai) .{ .id = aiId(), .title = "AI Chat" } else null;
+    }
+    fn find_terminal_surface(_: *anyopaque) ?control.Surface {
+        return .{ .id = termId(), .title = "zsh" };
+    }
+    fn open_ai_agent(_: *anyopaque, _: u32) control.OpenResult {
+        return .opened;
+    }
+    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
+        const self = cast(ctx);
+        if (!self.connected) return false;
+        self.last_surface = surface_id;
+        const n = @min(bytes.len, self.buf.len);
+        @memcpy(self.buf[0..n], bytes[0..n]);
+        self.len = n;
+        return true;
+    }
+    fn latest_transcript(_: *anyopaque) []const u8 {
+        return "";
+    }
+    fn cast(ctx: *anyopaque) *FakeControl {
+        return @ptrCast(@alignCast(ctx));
+    }
+    fn aiId() [16]u8 {
+        return "aichat0000000000".*;
+    }
+    fn termId() [16]u8 {
+        return "term000000000000".*;
+    }
+    fn control_iface(self: *FakeControl) control.Control {
+        return .{ .ctx = self, .vtable = &.{
+            .is_connected = is_connected,
+            .find_ai_surface = find_ai_surface,
+            .find_terminal_surface = find_terminal_surface,
+            .open_ai_agent = open_ai_agent,
+            .send_input = send_input,
+            .latest_transcript = latest_transcript,
+        } };
+    }
+};
+
+test "ping returns pong without touching surfaces" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "ping", &out);
+    try t.expectEqualStrings("pong", out.text.items);
+    try t.expect(!out.expect_ai_progress);
+}
+
+test "default text goes to the AI surface with a carriage return" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "hello world", &out);
+    try t.expectEqualStrings("hello world\r", fake.lastInput());
+    try t.expectEqualSlices(u8, &FakeControl.aiId(), &fake.last_surface);
+    try t.expect(out.expect_ai_progress);
+}
+
+test "/term sends to terminal with enter, /keys without" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/term ls", &out);
+    try t.expectEqualStrings("ls\r", fake.lastInput());
+
+    var out2 = Reply.init(t.allocator);
+    defer out2.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/keys abc", &out2);
+    try t.expectEqualStrings("abc", fake.lastInput());
+}
+
+test "offline control yields an offline message and no progress" {
+    var fake = FakeControl{ .connected = false };
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "do a thing", &out);
+    try t.expect(!out.expect_ai_progress);
+    try t.expect(std.mem.indexOf(u8, out.text.items, "离线") != null);
+}

--- a/src/weixin/binding.zig
+++ b/src/weixin/binding.zig
@@ -1,0 +1,76 @@
+//! Owner binding + inbound message filtering. Ported from poller.ts.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Decision = struct { ok: bool, reason: []const u8 };
+
+fn trim(s: []const u8) []const u8 {
+    return std.mem.trim(u8, s, " \t\r\n");
+}
+
+/// Mirror of shouldHandleWeixinMessage. `owner` is the bound owner ("" if
+/// unbound); `account_id` is the bot's own id ("" if unknown).
+pub fn shouldHandle(owner: []const u8, account_id: []const u8, msg: types.Message) Decision {
+    const from = trim(msg.from_user_id);
+    const to = trim(msg.to_user_id);
+    if (trim(msg.group_id).len != 0) return .{ .ok = false, .reason = "group_message" };
+    if (from.len == 0) return .{ .ok = false, .reason = "missing_sender" };
+    if (account_id.len != 0 and std.mem.eql(u8, from, account_id)) return .{ .ok = false, .reason = "bot_echo" };
+    if (owner.len != 0 and !std.mem.eql(u8, from, owner)) return .{ .ok = false, .reason = "unexpected_sender" };
+    if (account_id.len != 0 and to.len != 0 and !std.mem.eql(u8, to, account_id)) return .{ .ok = false, .reason = "unexpected_recipient" };
+    return .{ .ok = true, .reason = "" };
+}
+
+/// Mirror of extractWeixinText: text item (type 1), else voice transcript (type 3).
+pub fn extractText(msg: types.Message) []const u8 {
+    for (msg.item_list) |item| {
+        if (item.type == 1) {
+            const text = trim(item.text);
+            if (text.len != 0) return text;
+        }
+        if (item.type == 3) {
+            const text = trim(item.voice_text);
+            if (text.len != 0) return text;
+        }
+    }
+    return "";
+}
+
+/// Returns the user_id to persist as owner, or null if no auto-bind should
+/// happen (already bound, or an explicit allowed_user is configured).
+pub fn ownerForBind(current_owner: []const u8, allowed_user: []const u8, sender: []const u8) ?[]const u8 {
+    if (trim(current_owner).len != 0) return null;
+    if (trim(allowed_user).len != 0) return null;
+    const s = trim(sender);
+    return if (s.len == 0) null else s;
+}
+
+const t = std.testing;
+
+test "rejects group, empty sender, bot echo, and stranger" {
+    try t.expect(!shouldHandle("", "", .{ .from_user_id = "u1", .group_id = "g1" }).ok);
+    try t.expect(!shouldHandle("", "", .{ .from_user_id = "" }).ok);
+    try t.expect(!shouldHandle("", "bot", .{ .from_user_id = "bot" }).ok);
+    try t.expect(!shouldHandle("owner", "", .{ .from_user_id = "stranger" }).ok);
+}
+
+test "accepts the owner and an unbound first sender" {
+    try t.expect(shouldHandle("owner", "", .{ .from_user_id = "owner" }).ok);
+    try t.expect(shouldHandle("", "", .{ .from_user_id = "anybody" }).ok);
+}
+
+test "extractText prefers text item then voice transcript" {
+    try t.expectEqualStrings("hi", extractText(.{ .item_list = &.{
+        .{ .type = 1, .text = "  hi  " },
+    } }));
+    try t.expectEqualStrings("said", extractText(.{ .item_list = &.{
+        .{ .type = 3, .voice_text = "said" },
+    } }));
+    try t.expectEqualStrings("", extractText(.{ .item_list = &.{} }));
+}
+
+test "ownerForBind returns first sender only when unbound and allowed empty" {
+    try t.expectEqualStrings("u1", ownerForBind("", "", "u1").?);
+    try t.expect(ownerForBind("existing", "", "u1") == null);
+    try t.expect(ownerForBind("", "allowed-only", "u1") == null);
+}

--- a/src/weixin/control.zig
+++ b/src/weixin/control.zig
@@ -1,0 +1,40 @@
+//! Boundary between WeChat routing and the live Phantty surfaces. The real
+//! vtable is supplied by controller.zig; tests supply a fake.
+const std = @import("std");
+
+pub const Surface = struct { id: [16]u8, title: []const u8 };
+
+pub const OpenResult = enum { opened, no_profile, failed, offline, timeout };
+
+pub const Control = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        is_connected: *const fn (ctx: *anyopaque) bool,
+        find_ai_surface: *const fn (ctx: *anyopaque) ?Surface,
+        find_terminal_surface: *const fn (ctx: *anyopaque) ?Surface,
+        open_ai_agent: *const fn (ctx: *anyopaque, timeout_ms: u32) OpenResult,
+        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool,
+        latest_transcript: *const fn (ctx: *anyopaque) []const u8,
+    };
+
+    pub fn isConnected(self: Control) bool {
+        return self.vtable.is_connected(self.ctx);
+    }
+    pub fn findAiSurface(self: Control) ?Surface {
+        return self.vtable.find_ai_surface(self.ctx);
+    }
+    pub fn findTerminalSurface(self: Control) ?Surface {
+        return self.vtable.find_terminal_surface(self.ctx);
+    }
+    pub fn openAiAgent(self: Control, timeout_ms: u32) OpenResult {
+        return self.vtable.open_ai_agent(self.ctx, timeout_ms);
+    }
+    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8) bool {
+        return self.vtable.send_input(self.ctx, surface_id, bytes);
+    }
+    pub fn latestTranscript(self: Control) []const u8 {
+        return self.vtable.latest_transcript(self.ctx);
+    }
+};

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -27,6 +27,16 @@ pub const Controller = struct {
     poll: poller.Poller = undefined,
     running: bool = false,
 
+    // QR login, driven by a background thread (network calls must not block the
+    // UI thread). A panel reads loginSnapshot() to render.
+    login_thread: ?std.Thread = null,
+    login_mutex: std.Thread.Mutex = .{},
+    login_active: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    login_status: types.QrStatusKind = .unknown,
+    login_qr_arena: ?std.heap.ArenaAllocator = null,
+    login_qr_string: []const u8 = "",
+    login_qr_img_base64: []const u8 = "",
+
     pub fn create(
         allocator: std.mem.Allocator,
         state_path: []const u8,
@@ -45,10 +55,94 @@ pub const Controller = struct {
     }
 
     pub fn destroy(self: *Controller) void {
+        self.login_active.store(false, .release);
+        if (self.login_thread) |th| {
+            th.join();
+            self.login_thread = null;
+        }
+        if (self.login_qr_arena) |*a| a.deinit();
         self.stop();
         self.clearBinding();
         self.allocator.free(self.state_path);
         self.allocator.destroy(self);
+    }
+
+    /// Starts QR login on a background thread (idempotent). A panel polls
+    /// loginSnapshot() for the QR + status; on confirmation the binding is
+    /// persisted and polling starts automatically.
+    pub fn startLoginAsync(self: *Controller) !void {
+        if (self.login_active.swap(true, .acq_rel)) return; // already running
+        self.setLoginStatus(.wait);
+        self.login_thread = std.Thread.spawn(.{}, loginThreadMain, .{self}) catch |err| {
+            self.login_active.store(false, .release);
+            return err;
+        };
+    }
+
+    pub const LoginSnapshot = struct {
+        status: types.QrStatusKind,
+        qr_string: []const u8,
+        qr_img_base64: []const u8,
+    };
+
+    /// Thread-safe snapshot for a UI panel. Returned strings are copied into `arena`.
+    pub fn loginSnapshot(self: *Controller, arena: std.mem.Allocator) !LoginSnapshot {
+        self.login_mutex.lock();
+        defer self.login_mutex.unlock();
+        return .{
+            .status = self.login_status,
+            .qr_string = try arena.dupe(u8, self.login_qr_string),
+            .qr_img_base64 = try arena.dupe(u8, self.login_qr_img_base64),
+        };
+    }
+
+    fn loginThreadMain(self: *Controller) void {
+        var qr_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer qr_arena.deinit();
+        const qr = self.beginLogin(qr_arena.allocator()) catch {
+            self.setLoginStatus(.expired);
+            self.login_active.store(false, .release);
+            return;
+        };
+        self.setLoginQr(qr.qrcode, qr.qrcode_img_content);
+
+        while (self.login_active.load(.acquire)) {
+            var poll_arena = std.heap.ArenaAllocator.init(self.allocator);
+            const status = self.pollLogin(poll_arena.allocator(), qr.qrcode) catch {
+                poll_arena.deinit();
+                std.Thread.sleep(2 * std.time.ns_per_s);
+                continue;
+            };
+            self.setLoginStatus(status.status);
+            if (status.status == .confirmed) {
+                self.confirmLogin(status) catch {}; // uses `status` before poll_arena frees
+                poll_arena.deinit();
+                break;
+            }
+            if (status.status == .expired) {
+                poll_arena.deinit();
+                break;
+            }
+            poll_arena.deinit();
+            std.Thread.sleep(2 * std.time.ns_per_s);
+        }
+        self.login_active.store(false, .release);
+    }
+
+    fn setLoginQr(self: *Controller, qr_string: []const u8, img_base64: []const u8) void {
+        self.login_mutex.lock();
+        defer self.login_mutex.unlock();
+        if (self.login_qr_arena) |*a| a.deinit();
+        self.login_qr_arena = std.heap.ArenaAllocator.init(self.allocator);
+        const a = self.login_qr_arena.?.allocator();
+        self.login_qr_string = a.dupe(u8, qr_string) catch "";
+        self.login_qr_img_base64 = a.dupe(u8, img_base64) catch "";
+    }
+
+    fn setLoginStatus(self: *Controller, status: types.QrStatusKind) void {
+        self.login_mutex.lock();
+        defer self.login_mutex.unlock();
+        self.login_status = status;
     }
 
     /// Loads the persisted binding; if a token exists, starts polling.
@@ -223,4 +317,18 @@ test "create/start without a persisted token stays idle, destroy is clean" {
 
     try ctrl.start(); // no token file → no poller spawned
     try t.expect(!ctrl.running);
+}
+
+test "loginSnapshot on a fresh controller reports unknown/empty" {
+    const path = "zig-cache-tmp-weixin-ctrl2.json";
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    const ctrl = try Controller.create(t.allocator, path, NoopControl.iface(), .{});
+    defer ctrl.destroy();
+
+    var arena = std.heap.ArenaAllocator.init(t.allocator);
+    defer arena.deinit();
+    const snap = try ctrl.loginSnapshot(arena.allocator());
+    try t.expectEqual(types.QrStatusKind.unknown, snap.status);
+    try t.expectEqual(@as(usize, 0), snap.qr_string.len);
 }

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -1,0 +1,226 @@
+//! Owns the WeChat direct lifecycle: persisted binding, the ilink client, and
+//! the background poller. Built by App with a live Control. This module is
+//! platform-neutral (no GUI deps) so it compiles and is checkable off-Windows;
+//! the GUI parts live in App/AppWindow and the QR panel.
+const std = @import("std");
+const types = @import("types.zig");
+const state_store = @import("state_store.zig");
+const ilink = @import("ilink_client.zig");
+const poller = @import("poller.zig");
+const control_mod = @import("control.zig");
+
+pub const Controller = struct {
+    allocator: std.mem.Allocator,
+    state_path: []u8,
+    control: control_mod.Control,
+    settings: types.Settings,
+
+    // Heap-owned copies of the active binding. Empty slices mean "unset".
+    token: []u8 = &.{},
+    base_url: []u8 = &.{},
+    owner: []u8 = &.{},
+    bot_id: []u8 = &.{},
+
+    // Live while running. `client` must outlive `poll` (poll holds a ClientApi
+    // pointing at it); both are fields of this heap object so addresses are stable.
+    client: ilink.Client = undefined,
+    poll: poller.Poller = undefined,
+    running: bool = false,
+
+    pub fn create(
+        allocator: std.mem.Allocator,
+        state_path: []const u8,
+        control: control_mod.Control,
+        settings: types.Settings,
+    ) !*Controller {
+        const self = try allocator.create(Controller);
+        errdefer allocator.destroy(self);
+        self.* = .{
+            .allocator = allocator,
+            .state_path = try allocator.dupe(u8, state_path),
+            .control = control,
+            .settings = settings,
+        };
+        return self;
+    }
+
+    pub fn destroy(self: *Controller) void {
+        self.stop();
+        self.clearBinding();
+        self.allocator.free(self.state_path);
+        self.allocator.destroy(self);
+    }
+
+    /// Loads the persisted binding; if a token exists, starts polling.
+    pub fn start(self: *Controller) !void {
+        var loaded = try state_store.load(self.allocator, self.state_path);
+        defer loaded.deinit(self.allocator);
+        if (loaded.binding.bot_token.len == 0) return; // not logged in yet
+        try self.startWithBinding(loaded.binding);
+    }
+
+    /// Stops the poller, persisting the latest sync cursor so the next start
+    /// resumes where it left off.
+    pub fn stop(self: *Controller) void {
+        if (!self.running) return;
+        self.poll.stop();
+        // Persist the advanced sync cursor (best-effort).
+        self.persist(self.poll.sync_buf) catch {};
+        self.allocator.free(self.poll.sync_buf);
+        // ilink.Client holds no persistent resources (it opens a fresh
+        // std.http.Client per request), so there is nothing to deinit here.
+        self.running = false;
+    }
+
+    /// Clears the persisted owner + token and stops. Used by "Unbind".
+    pub fn unbind(self: *Controller) !void {
+        self.stop();
+        self.clearBinding();
+        try self.persistBinding(.{});
+    }
+
+    // --- login (driven by the QR panel) ---
+
+    /// Step 1 of login: fetch a QR code. The returned value borrows from `arena`.
+    pub fn beginLogin(self: *Controller, arena: std.mem.Allocator) !types.QrCode {
+        var client = ilink.Client.init(self.allocator, self.configuredBaseUrl(), "");
+        return client.getBotQrcode(arena);
+    }
+
+    /// Step 2 of login: poll a QR code's status. Borrows from `arena`.
+    pub fn pollLogin(self: *Controller, arena: std.mem.Allocator, qrcode: []const u8) !types.QrStatus {
+        var client = ilink.Client.init(self.allocator, self.configuredBaseUrl(), "");
+        return client.getQrcodeStatus(arena, qrcode);
+    }
+
+    /// Step 3: a confirmed QR status carries the bot_token; persist and start.
+    pub fn confirmLogin(self: *Controller, status: types.QrStatus) !void {
+        if (status.status != .confirmed or status.bot_token.len == 0) return error.NotConfirmed;
+        const binding = types.Binding{
+            .bot_token = status.bot_token,
+            .base_url = if (status.base_url.len != 0) status.base_url else self.configuredBaseUrl(),
+            // owner is auto-bound from the first inbound 1:1 message, unless the
+            // config pins an allowed user (settings.allowed_user).
+            .owner_user_id = self.settings.allowed_user,
+            .bot_id = status.bot_id,
+            .sync_buf = "",
+        };
+        try self.persistBinding(binding);
+        try self.startWithBinding(binding);
+    }
+
+    // --- internals ---
+
+    fn configuredBaseUrl(self: *Controller) []const u8 {
+        return if (self.base_url.len != 0) self.base_url else ilink_default_base_url;
+    }
+
+    fn startWithBinding(self: *Controller, binding: types.Binding) !void {
+        if (self.running) return;
+        try self.setBinding(binding);
+
+        self.client = ilink.Client.init(self.allocator, self.base_url, self.token);
+        self.poll = .{
+            .allocator = self.allocator,
+            .client = self.client.api(),
+            .control = self.control,
+            .settings = self.settings,
+            .owner = self.owner,
+            .account_id = self.bot_id,
+            .sync_buf = try self.allocator.dupe(u8, binding.sync_buf),
+        };
+        try self.poll.start();
+        self.running = true;
+    }
+
+    fn setBinding(self: *Controller, b: types.Binding) !void {
+        const token = try self.allocator.dupe(u8, b.bot_token);
+        errdefer self.allocator.free(token);
+        const base_url = try self.allocator.dupe(u8, b.base_url);
+        errdefer self.allocator.free(base_url);
+        const owner = try self.allocator.dupe(u8, b.owner_user_id);
+        errdefer self.allocator.free(owner);
+        const bot_id = try self.allocator.dupe(u8, b.bot_id);
+        errdefer self.allocator.free(bot_id);
+
+        self.clearBinding();
+        self.token = token;
+        self.base_url = base_url;
+        self.owner = owner;
+        self.bot_id = bot_id;
+    }
+
+    fn clearBinding(self: *Controller) void {
+        freeOwned(self.allocator, &self.token);
+        freeOwned(self.allocator, &self.base_url);
+        freeOwned(self.allocator, &self.owner);
+        freeOwned(self.allocator, &self.bot_id);
+    }
+
+    fn persist(self: *Controller, sync_buf: []const u8) !void {
+        try self.persistBinding(.{
+            .bot_token = self.token,
+            .base_url = self.base_url,
+            .owner_user_id = self.owner,
+            .bot_id = self.bot_id,
+            .sync_buf = sync_buf,
+        });
+    }
+
+    fn persistBinding(self: *Controller, binding: types.Binding) !void {
+        try state_store.save(self.allocator, self.state_path, binding);
+    }
+};
+
+const ilink_default_base_url = @import("ilink_codec.zig").DEFAULT_BASE_URL;
+
+fn freeOwned(allocator: std.mem.Allocator, slot: *[]u8) void {
+    if (slot.len != 0) allocator.free(slot.*);
+    slot.* = &.{};
+}
+
+const t = std.testing;
+
+// A no-op Control used to exercise controller lifetime without a GUI.
+const NoopControl = struct {
+    fn is_connected(_: *anyopaque) bool {
+        return false;
+    }
+    fn find_ai_surface(_: *anyopaque) ?control_mod.Surface {
+        return null;
+    }
+    fn find_terminal_surface(_: *anyopaque) ?control_mod.Surface {
+        return null;
+    }
+    fn open_ai_agent(_: *anyopaque, _: u32) control_mod.OpenResult {
+        return .offline;
+    }
+    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8) bool {
+        return false;
+    }
+    fn latest_transcript(_: *anyopaque) []const u8 {
+        return "";
+    }
+    var dummy: u8 = 0;
+    fn iface() control_mod.Control {
+        return .{ .ctx = &dummy, .vtable = &.{
+            .is_connected = is_connected,
+            .find_ai_surface = find_ai_surface,
+            .find_terminal_surface = find_terminal_surface,
+            .open_ai_agent = open_ai_agent,
+            .send_input = send_input,
+            .latest_transcript = latest_transcript,
+        } };
+    }
+};
+
+test "create/start without a persisted token stays idle, destroy is clean" {
+    const path = "zig-cache-tmp-weixin-ctrl.json";
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    const ctrl = try Controller.create(t.allocator, path, NoopControl.iface(), .{});
+    defer ctrl.destroy();
+
+    try ctrl.start(); // no token file → no poller spawned
+    try t.expect(!ctrl.running);
+}

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -1,0 +1,169 @@
+//! ilink HTTP client over std.http.Client. Network calls are not unit-tested on
+//! the dev host (no live WeChat endpoint); logic that consumes this goes through
+//! ClientApi so the poller can be tested with a fake.
+const std = @import("std");
+const codec = @import("ilink_codec.zig");
+const types = @import("types.zig");
+
+/// Abstract transport the poller depends on, so it can be faked in tests.
+pub const ClientApi = struct {
+    ctx: *anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Returned value owns its own arena; caller must call `.deinit()`.
+        get_updates: *const fn (ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates,
+        send_text: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+    };
+
+    pub fn getUpdates(self: ClientApi, buf: []const u8) !codec.ParsedUpdates {
+        return self.vtable.get_updates(self.ctx, buf);
+    }
+    pub fn sendText(self: ClientApi, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        return self.vtable.send_text(self.ctx, to_user_id, text, context_token);
+    }
+};
+
+pub const Client = struct {
+    allocator: std.mem.Allocator,
+    base_url: []const u8,
+    token: []const u8,
+    rng: std.Random.DefaultPrng,
+
+    pub fn init(allocator: std.mem.Allocator, base_url: []const u8, token: []const u8) Client {
+        return .{
+            .allocator = allocator,
+            .base_url = if (base_url.len != 0) base_url else codec.DEFAULT_BASE_URL,
+            .token = token,
+            .rng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp())),
+        };
+    }
+
+    /// GET /ilink/bot/get_bot_qrcode?bot_type=3 — result borrows from `arena`.
+    pub fn getBotQrcode(self: *Client, arena: std.mem.Allocator) !types.QrCode {
+        const resp = try self.fetch(arena, .GET, "/ilink/bot/get_bot_qrcode?bot_type=" ++ codec.BOT_TYPE, null, null);
+        const W = struct { ret: i64 = 0, qrcode: []const u8 = "", qrcode_img_content: []const u8 = "" };
+        const w = try std.json.parseFromSliceLeaky(W, arena, resp, .{ .ignore_unknown_fields = true, .allocate = .alloc_always });
+        return .{ .ret = w.ret, .qrcode = w.qrcode, .qrcode_img_content = w.qrcode_img_content };
+    }
+
+    /// GET /ilink/bot/get_qrcode_status?qrcode=... — result borrows from `arena`.
+    pub fn getQrcodeStatus(self: *Client, arena: std.mem.Allocator, qrcode: []const u8) !types.QrStatus {
+        const path = try std.fmt.allocPrint(arena, "/ilink/bot/get_qrcode_status?qrcode={s}", .{qrcode});
+        const resp = try self.fetch(arena, .GET, path, null, "1");
+        const W = struct {
+            ret: i64 = 0,
+            status: []const u8 = "",
+            bot_token: []const u8 = "",
+            baseurl: []const u8 = "",
+            ilink_bot_id: []const u8 = "",
+            ilink_user_id: []const u8 = "",
+        };
+        const w = try std.json.parseFromSliceLeaky(W, arena, resp, .{ .ignore_unknown_fields = true, .allocate = .alloc_always });
+        return .{
+            .ret = w.ret,
+            .status = codec.statusKindFromString(w.status),
+            .bot_token = w.bot_token,
+            .base_url = w.baseurl,
+            .bot_id = w.ilink_bot_id,
+            .user_id = w.ilink_user_id,
+        };
+    }
+
+    /// POST /ilink/bot/getupdates (≈35s long-poll). Returned value owns its arena.
+    pub fn getUpdates(self: *Client, buf: []const u8) !codec.ParsedUpdates {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+        const body = try codec.buildGetUpdatesBody(a, buf);
+        const resp = try self.fetch(a, .POST, "/ilink/bot/getupdates", body, null);
+        // parseGetUpdates copies (alloc_always) into its own arena, so it is safe
+        // for req_arena (holding `resp`) to be freed on return.
+        return codec.parseGetUpdates(self.allocator, resp);
+    }
+
+    /// POST /ilink/bot/sendmessage.
+    pub fn sendText(self: *Client, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+        const client_id = try std.fmt.allocPrint(a, "phantty-weixin-{d}-{d}", .{
+            std.time.milliTimestamp(), self.rng.random().int(u32),
+        });
+        const body = try codec.buildSendTextBody(a, to_user_id, text, context_token, client_id);
+        _ = try self.fetch(a, .POST, "/ilink/bot/sendmessage", body, null);
+    }
+
+    /// Performs one HTTP request, returning the response body bytes allocated in
+    /// `arena`. `client_version`, when set, adds the iLink-App-ClientVersion header.
+    fn fetch(
+        self: *Client,
+        arena: std.mem.Allocator,
+        method: std.http.Method,
+        path: []const u8,
+        payload: ?[]const u8,
+        client_version: ?[]const u8,
+    ) ![]u8 {
+        var client: std.http.Client = .{ .allocator = self.allocator };
+        defer client.deinit();
+
+        const url = try std.fmt.allocPrint(arena, "{s}{s}", .{ self.base_url, path });
+
+        // X-WECHAT-UIN: base64 of a random uint decimal string (mirrors the TS bridge).
+        var num_buf: [16]u8 = undefined;
+        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{self.rng.random().int(u32)}) catch "0";
+        const uin = try arena.alloc(u8, std.base64.standard.Encoder.calcSize(num_str.len));
+        _ = std.base64.standard.Encoder.encode(uin, num_str);
+
+        var headers_buf: [3]std.http.Header = undefined;
+        headers_buf[0] = .{ .name = "AuthorizationType", .value = "ilink_bot_token" };
+        headers_buf[1] = .{ .name = "X-WECHAT-UIN", .value = uin };
+        var header_count: usize = 2;
+        if (client_version) |cv| {
+            headers_buf[2] = .{ .name = "iLink-App-ClientVersion", .value = cv };
+            header_count = 3;
+        }
+
+        var req_headers: std.http.Client.Request.Headers = .{
+            .content_type = .{ .override = "application/json" },
+        };
+        if (self.token.len != 0) {
+            req_headers.authorization = .{ .override = try std.fmt.allocPrint(arena, "Bearer {s}", .{self.token}) };
+        }
+
+        var body: std.Io.Writer.Allocating = .init(arena);
+        const response = try client.fetch(.{
+            .location = .{ .url = url },
+            .method = method,
+            .keep_alive = false,
+            .payload = payload,
+            .headers = req_headers,
+            .extra_headers = headers_buf[0..header_count],
+            .response_writer = &body.writer,
+        });
+        if (response.status != .ok) return error.IlinkHttpStatus;
+        return body.toArrayList().items;
+    }
+
+    // --- ClientApi adapter ---
+
+    pub fn api(self: *Client) ClientApi {
+        return .{ .ctx = self, .vtable = &.{
+            .get_updates = apiGetUpdates,
+            .send_text = apiSendText,
+        } };
+    }
+    fn apiGetUpdates(ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).getUpdates(buf);
+    }
+    fn apiSendText(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).sendText(to_user_id, text, context_token);
+    }
+};
+
+test "client init defaults the base url" {
+    const c = Client.init(std.testing.allocator, "", "tok");
+    try std.testing.expectEqualStrings(codec.DEFAULT_BASE_URL, c.base_url);
+    const c2 = Client.init(std.testing.allocator, "https://x.test", "tok");
+    try std.testing.expectEqualStrings("https://x.test", c2.base_url);
+}

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -1,0 +1,166 @@
+//! ilink JSON request builders and response parsers. Pure (std.json).
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const CHANNEL_VERSION = "1.0.2";
+pub const BOT_TYPE = "3";
+pub const DEFAULT_BASE_URL = "https://ilinkai.weixin.qq.com";
+
+const BaseInfo = struct { channel_version: []const u8 };
+
+pub fn buildGetUpdatesBody(allocator: std.mem.Allocator, buf: []const u8) ![]u8 {
+    const Body = struct {
+        get_updates_buf: []const u8,
+        base_info: BaseInfo,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .get_updates_buf = buf,
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+const SendItemText = struct { text: []const u8 };
+const SendItem = struct { type: i64 = 1, text_item: SendItemText };
+const SendMsg = struct {
+    to_user_id: []const u8,
+    client_id: []const u8,
+    message_type: i64 = 2,
+    message_state: i64 = 2,
+    context_token: []const u8,
+    item_list: []const SendItem,
+};
+
+pub fn buildSendTextBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    text: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+) ![]u8 {
+    const Body = struct {
+        msg: SendMsg,
+        base_info: BaseInfo,
+    };
+    const items = [_]SendItem{.{ .text_item = .{ .text = text } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn statusKindFromString(s: []const u8) types.QrStatusKind {
+    if (std.mem.eql(u8, s, "wait")) return .wait;
+    if (std.mem.eql(u8, s, "scaned")) return .scaned;
+    if (std.mem.eql(u8, s, "confirmed")) return .confirmed;
+    if (std.mem.eql(u8, s, "expired")) return .expired;
+    return .unknown;
+}
+
+// --- response parsing ---
+
+const WireItem = struct {
+    type: i64 = 0,
+    text_item: ?struct { text: []const u8 = "" } = null,
+    voice_item: ?struct { text: []const u8 = "" } = null,
+};
+const WireMsg = struct {
+    from_user_id: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+    group_id: []const u8 = "",
+    item_list: []const WireItem = &.{},
+};
+const WireUpdates = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    longpolling_timeout_ms: i64 = 0,
+    get_updates_buf: []const u8 = "",
+    msgs: []const WireMsg = &.{},
+};
+
+/// Owns the JSON arena; `value` borrows from it. Free with `deinit`.
+pub const ParsedUpdates = struct {
+    parsed: std.json.Parsed(WireUpdates),
+    value: types.GetUpdatesResult,
+
+    pub fn deinit(self: *ParsedUpdates) void {
+        self.parsed.deinit();
+    }
+};
+
+pub fn parseGetUpdates(allocator: std.mem.Allocator, json: []const u8) !ParsedUpdates {
+    const parsed = try std.json.parseFromSlice(WireUpdates, allocator, json, .{ .ignore_unknown_fields = true });
+    errdefer parsed.deinit();
+    const a = parsed.arena.allocator();
+    const wire = parsed.value;
+
+    const msgs = try a.alloc(types.Message, wire.msgs.len);
+    for (wire.msgs, 0..) |wm, mi| {
+        const items = try a.alloc(types.MessageItem, wm.item_list.len);
+        for (wm.item_list, 0..) |wi, ii| {
+            items[ii] = .{
+                .type = wi.type,
+                .text = if (wi.text_item) |x| x.text else "",
+                .voice_text = if (wi.voice_item) |x| x.text else "",
+            };
+        }
+        msgs[mi] = .{
+            .from_user_id = wm.from_user_id,
+            .to_user_id = wm.to_user_id,
+            .context_token = wm.context_token,
+            .group_id = wm.group_id,
+            .item_list = items,
+        };
+    }
+
+    return .{ .parsed = parsed, .value = .{
+        .ret = wire.ret,
+        .errcode = wire.errcode,
+        .longpolling_timeout_ms = wire.longpolling_timeout_ms,
+        .get_updates_buf = wire.get_updates_buf,
+        .msgs = msgs,
+    } };
+}
+
+const t = std.testing;
+
+test "builds a getupdates body with the channel version" {
+    const body = try buildGetUpdatesBody(t.allocator, "BUF==");
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"get_updates_buf\":\"BUF==\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
+}
+
+test "builds a sendmessage body with the text item" {
+    const body = try buildSendTextBody(t.allocator, "u1", "hello", "ctx", "cid-1");
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"to_user_id\":\"u1\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"text\":\"hello\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"context_token\":\"ctx\"") != null);
+}
+
+test "parses a getupdates response into typed messages" {
+    const json =
+        \\{"ret":0,"longpolling_timeout_ms":1500,"get_updates_buf":"NEXT",
+        \\"msgs":[{"from_user_id":"u1","context_token":"ctx",
+        \\"item_list":[{"type":1,"text_item":{"text":"hi"}}]}]}
+    ;
+    var parsed = try parseGetUpdates(t.allocator, json);
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 1500), parsed.value.longpolling_timeout_ms);
+    try t.expectEqualStrings("NEXT", parsed.value.get_updates_buf);
+    try t.expectEqual(@as(usize, 1), parsed.value.msgs.len);
+    try t.expectEqualStrings("u1", parsed.value.msgs[0].from_user_id);
+    try t.expectEqualStrings("hi", parsed.value.msgs[0].item_list[0].text);
+}
+
+test "maps qrcode status strings to the enum" {
+    try t.expectEqual(types.QrStatusKind.scaned, statusKindFromString("scaned"));
+    try t.expectEqual(types.QrStatusKind.confirmed, statusKindFromString("confirmed"));
+    try t.expectEqual(types.QrStatusKind.unknown, statusKindFromString("nonsense"));
+}

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -94,7 +94,10 @@ pub const ParsedUpdates = struct {
 };
 
 pub fn parseGetUpdates(allocator: std.mem.Allocator, json: []const u8) !ParsedUpdates {
-    const parsed = try std.json.parseFromSlice(WireUpdates, allocator, json, .{ .ignore_unknown_fields = true });
+    const parsed = try std.json.parseFromSlice(WireUpdates, allocator, json, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
     errdefer parsed.deinit();
     const a = parsed.arena.allocator();
     const wire = parsed.value;

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -1,0 +1,180 @@
+//! WeChat poll loop. processUpdates is the pure, tested core; Poller wraps it in
+//! a background thread with stop/staleness handling (port of poller.ts).
+const std = @import("std");
+const types = @import("types.zig");
+const binding = @import("binding.zig");
+const agent = @import("agent.zig");
+const ilink = @import("ilink_client.zig");
+const control_mod = @import("control.zig");
+
+pub const SESSION_EXPIRED_ERRCODE: i64 = -14;
+
+pub const ProcessInput = struct {
+    allocator: std.mem.Allocator,
+    owner: []const u8,
+    account_id: []const u8,
+    messages: []const types.Message,
+    route_ctx: *anyopaque,
+    /// Fills `reply` with the response text; returns true if the caller should
+    /// begin AI-reply progress streaming.
+    route_fn: *const fn (ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool,
+    send_ctx: *anyopaque,
+    send_fn: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+};
+
+/// Mirror of processWeixinUpdates: filter, extract, route, reply.
+pub fn processUpdates(input: ProcessInput) !void {
+    for (input.messages) |msg| {
+        if (!binding.shouldHandle(input.owner, input.account_id, msg).ok) continue;
+        const text = binding.extractText(msg);
+        if (text.len == 0) continue;
+
+        var reply: std.ArrayListUnmanaged(u8) = .empty;
+        defer reply.deinit(input.allocator);
+        _ = input.route_fn(input.route_ctx, text, input.allocator, &reply) catch continue;
+
+        const trimmed = std.mem.trim(u8, reply.items, " \t\r\n");
+        if (trimmed.len != 0) {
+            input.send_fn(input.send_ctx, msg.from_user_id, trimmed, msg.context_token) catch {};
+        }
+    }
+}
+
+/// Background poller. Owns its thread; `sync_buf` is heap-owned and updated each
+/// tick. AI-reply progress streaming (checkpoints) is layered on by the
+/// controller, which observes the `expect_ai_progress` flag from routing.
+pub const Poller = struct {
+    allocator: std.mem.Allocator,
+    client: ilink.ClientApi,
+    control: control_mod.Control,
+    settings: types.Settings,
+    owner: []const u8,
+    account_id: []const u8,
+    sync_buf: []u8,
+    stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    thread: ?std.Thread = null,
+
+    pub fn start(self: *Poller) !void {
+        self.stop_requested.store(false, .release);
+        self.thread = try std.Thread.spawn(.{}, threadMain, .{self});
+    }
+
+    pub fn stop(self: *Poller) void {
+        self.stop_requested.store(true, .release);
+        if (self.thread) |th| {
+            th.join();
+            self.thread = null;
+        }
+    }
+
+    fn threadMain(self: *Poller) void {
+        while (!self.stop_requested.load(.acquire)) {
+            self.tickOnce() catch {
+                std.Thread.sleep(5 * std.time.ns_per_s);
+            };
+        }
+    }
+
+    fn tickOnce(self: *Poller) !void {
+        var updates = try self.client.getUpdates(self.sync_buf);
+        defer updates.deinit();
+
+        if (updates.value.errcode == SESSION_EXPIRED_ERRCODE) {
+            self.stop_requested.store(true, .release);
+            return;
+        }
+
+        try processUpdates(.{
+            .allocator = self.allocator,
+            .owner = self.owner,
+            .account_id = self.account_id,
+            .messages = updates.value.msgs,
+            .route_ctx = self,
+            .route_fn = routeAdapter,
+            .send_ctx = self,
+            .send_fn = sendAdapter,
+        });
+
+        if (updates.value.get_updates_buf.len != 0 and
+            !std.mem.eql(u8, updates.value.get_updates_buf, self.sync_buf))
+        {
+            const next = try self.allocator.dupe(u8, updates.value.get_updates_buf);
+            self.allocator.free(self.sync_buf);
+            self.sync_buf = next;
+        }
+    }
+
+    fn routeAdapter(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        var r = agent.Reply.init(allocator);
+        defer r.deinit();
+        try agent.route(allocator, self.control, self.settings, text, &r);
+        try reply.appendSlice(allocator, r.text.items);
+        return r.expect_ai_progress;
+    }
+
+    fn sendAdapter(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        try self.client.sendText(to_user_id, text, context_token);
+    }
+};
+
+const t = std.testing;
+
+const Captured = struct {
+    sent: std.ArrayListUnmanaged([]u8) = .empty,
+    routed: std.ArrayListUnmanaged([]u8) = .empty,
+    fn deinit(self: *Captured) void {
+        for (self.sent.items) |s| t.allocator.free(s);
+        for (self.routed.items) |s| t.allocator.free(s);
+        self.sent.deinit(t.allocator);
+        self.routed.deinit(t.allocator);
+    }
+};
+
+const RouteCtx = struct {
+    cap: *Captured,
+    fn route(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool {
+        const self: *RouteCtx = @ptrCast(@alignCast(ctx));
+        try self.cap.routed.append(t.allocator, try t.allocator.dupe(u8, text));
+        try reply.appendSlice(allocator, "ok");
+        return false;
+    }
+};
+
+const SendCtx = struct {
+    cap: *Captured,
+    fn send(ctx: *anyopaque, to: []const u8, text: []const u8, _: []const u8) anyerror!void {
+        _ = to;
+        const self: *SendCtx = @ptrCast(@alignCast(ctx));
+        try self.cap.sent.append(t.allocator, try t.allocator.dupe(u8, text));
+    }
+};
+
+test "processUpdates routes accepted text and sends replies" {
+    var cap = Captured{};
+    defer cap.deinit();
+    var rctx = RouteCtx{ .cap = &cap };
+    var sctx = SendCtx{ .cap = &cap };
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "c", .item_list = &.{.{ .type = 1, .text = "hi" }} },
+        .{ .from_user_id = "u1", .group_id = "g", .item_list = &.{.{ .type = 1, .text = "ignored" }} }, // group → skip
+    };
+
+    try processUpdates(.{
+        .allocator = t.allocator,
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &rctx,
+        .route_fn = RouteCtx.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+    });
+
+    try t.expectEqual(@as(usize, 1), cap.routed.items.len);
+    try t.expectEqualStrings("hi", cap.routed.items[0]);
+    try t.expectEqual(@as(usize, 1), cap.sent.items.len);
+    try t.expectEqualStrings("ok", cap.sent.items[0]);
+}

--- a/src/weixin/reply_progress.zig
+++ b/src/weixin/reply_progress.zig
@@ -1,0 +1,187 @@
+//! AI-reply progress detection by diffing the rendered AI chat transcript
+//! against a baseline. Port of poller.ts aiReplyProgress + parseAiSections.
+const std = @import("std");
+
+pub const Progress = struct { done: bool = false, text: []const u8 = "" };
+
+const Role = enum { metadata, user, assistant, tool, reasoning };
+const Section = struct { role: Role, label: []const u8, content: []const u8 };
+
+const MAX_SECTIONS = 256;
+
+/// Compares baseline vs current transcript. `text` borrows from `current`
+/// (or from a static literal for the in-progress messages).
+pub fn progress(baseline: []const u8, current: []const u8) Progress {
+    var base_buf: [MAX_SECTIONS]Section = undefined;
+    var cur_buf: [MAX_SECTIONS]Section = undefined;
+    var base_msg_buf: [MAX_SECTIONS]Section = undefined;
+    var cur_msg_buf: [MAX_SECTIONS]Section = undefined;
+
+    const base_sections = parseSections(baseline, &base_buf);
+    const cur_sections = parseSections(current, &cur_buf);
+    const base_msgs = filterMessages(base_sections, &base_msg_buf);
+    const cur_msgs = filterMessages(cur_sections, &cur_msg_buf);
+    const new_msgs = afterBaseline(base_msgs, cur_msgs);
+    const status = latestStatus(cur_sections);
+
+    var last_assistant: ?[]const u8 = null;
+    for (new_msgs) |m| {
+        if (m.role == .assistant and trim(m.content).len != 0) last_assistant = trim(m.content);
+    }
+
+    if (last_assistant) |content| {
+        if (!isActiveStatus(status)) return .{ .done = true, .text = content };
+    }
+    if (containsIgnoreCase(status, "running tools") or hasRole(new_msgs, .tool)) {
+        return .{ .done = false, .text = "还在处理中，工具调用仍在执行。" };
+    }
+    if (new_msgs.len != 0 or last_assistant != null) {
+        return .{ .done = false, .text = "还在处理中，等待 AI 回复。" };
+    }
+    return .{ .done = false, .text = "" };
+}
+
+fn trim(s: []const u8) []const u8 {
+    return std.mem.trim(u8, s, " \t\r\n");
+}
+
+/// A section starts at a line that is exactly a known label followed by ':'.
+/// Content is every following line until the next label (whitespace-trimmed).
+fn parseSections(transcript: []const u8, buf: []Section) []Section {
+    var count: usize = 0;
+    var pos: usize = 0;
+    var cur_role: ?Role = null;
+    var cur_label: []const u8 = "";
+    var content_start: usize = 0;
+    var content_end: usize = 0;
+
+    while (pos <= transcript.len) {
+        const nl = std.mem.indexOfScalarPos(u8, transcript, pos, '\n') orelse transcript.len;
+        const line = transcript[pos..nl];
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (asLabel(trimmed)) |role| {
+            if (cur_role) |r| {
+                if (count < buf.len) {
+                    buf[count] = .{ .role = r, .label = cur_label, .content = trim(transcript[content_start..content_end]) };
+                    count += 1;
+                }
+            }
+            cur_role = role;
+            cur_label = trimmed[0 .. trimmed.len - 1]; // strip trailing ':'
+            content_start = if (nl < transcript.len) nl + 1 else transcript.len;
+            content_end = content_start;
+        } else if (cur_role != null) {
+            content_end = nl;
+        }
+        if (nl == transcript.len) break;
+        pos = nl + 1;
+    }
+    if (cur_role) |r| {
+        if (count < buf.len) {
+            buf[count] = .{ .role = r, .label = cur_label, .content = trim(transcript[content_start..content_end]) };
+            count += 1;
+        }
+    }
+    return buf[0..count];
+}
+
+fn asLabel(line: []const u8) ?Role {
+    if (line.len < 2 or line[line.len - 1] != ':') return null;
+    const name = line[0 .. line.len - 1];
+    if (eq(name, "You") or eq(name, "User")) return .user;
+    if (eq(name, "AI") or eq(name, "Assistant")) return .assistant;
+    if (eq(name, "Tool")) return .tool;
+    if (eq(name, "Reasoning")) return .reasoning;
+    if (eq(name, "Model") or eq(name, "Status")) return .metadata;
+    return null;
+}
+
+fn filterMessages(sections: []const Section, out: []Section) []Section {
+    var n: usize = 0;
+    for (sections) |s| {
+        if (s.role == .user or s.role == .assistant or s.role == .tool) {
+            if (n >= out.len) break;
+            out[n] = s;
+            n += 1;
+        }
+    }
+    return out[0..n];
+}
+
+/// Returns the suffix of `current` that does not overlap the tail of `baseline`.
+fn afterBaseline(baseline: []const Section, current: []const Section) []const Section {
+    if (baseline.len == 0) return current;
+    if (current.len == 0) return current[0..0];
+    const max_overlap = @min(baseline.len, current.len);
+    var overlap = max_overlap;
+    while (overlap > 0) : (overlap -= 1) {
+        const base_start = baseline.len - overlap;
+        var matched = true;
+        var i: usize = 0;
+        while (i < overlap) : (i += 1) {
+            if (baseline[base_start + i].role != current[i].role or
+                !std.mem.eql(u8, baseline[base_start + i].content, current[i].content))
+            {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return current[overlap..];
+    }
+    return current;
+}
+
+fn latestStatus(sections: []const Section) []const u8 {
+    var i: usize = sections.len;
+    while (i > 0) : (i -= 1) {
+        if (eq(sections[i - 1].label, "Status")) return trim(sections[i - 1].content);
+    }
+    return "";
+}
+
+fn isActiveStatus(status: []const u8) bool {
+    return containsIgnoreCase(status, "running tools") or containsIgnoreCase(status, "thinking") or
+        containsIgnoreCase(status, "streaming") or containsIgnoreCase(status, "stopping");
+}
+
+fn hasRole(msgs: []const Section, role: Role) bool {
+    for (msgs) |m| if (m.role == role) return true;
+    return false;
+}
+
+fn eq(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, a, b);
+}
+
+fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[i .. i + needle.len], needle)) return true;
+    }
+    return false;
+}
+
+const t = std.testing;
+
+test "done when a new assistant message exists and status is idle" {
+    const baseline = "You:\nhi\n";
+    const current = "You:\nhi\nAI:\nthere\nStatus:\nidle\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expectEqualStrings("there", p.text);
+}
+
+test "not done while tools are running" {
+    const baseline = "You:\nhi\n";
+    const current = "You:\nhi\nStatus:\nrunning tools\n";
+    const p = progress(baseline, current);
+    try t.expect(!p.done);
+    try t.expect(p.text.len != 0);
+}
+
+test "empty when nothing new" {
+    const p = progress("You:\nhi\n", "You:\nhi\n");
+    try t.expect(!p.done);
+}

--- a/src/weixin/state_store.zig
+++ b/src/weixin/state_store.zig
@@ -1,0 +1,91 @@
+//! Persists the WeChat direct binding to a 0600 JSON file. Secrets never go in
+//! config; they live here in the app state dir.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Loaded = struct {
+    arena: std.heap.ArenaAllocator,
+    binding: types.Binding,
+
+    pub fn deinit(self: *Loaded, _: std.mem.Allocator) void {
+        self.arena.deinit();
+    }
+};
+
+const Wire = struct {
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    owner_user_id: []const u8 = "",
+    bot_id: []const u8 = "",
+    sync_buf: []const u8 = "",
+};
+
+pub fn save(allocator: std.mem.Allocator, path: []const u8, binding: types.Binding) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.cwd().makePath(dir) catch {};
+    }
+    const wire = Wire{
+        .bot_token = binding.bot_token,
+        .base_url = binding.base_url,
+        .owner_user_id = binding.owner_user_id,
+        .bot_id = binding.bot_id,
+        .sync_buf = binding.sync_buf,
+    };
+    const json = try std.json.Stringify.valueAlloc(allocator, wire, .{});
+    defer allocator.free(json);
+
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    try file.writeAll(json);
+}
+
+pub fn load(allocator: std.mem.Allocator, path: []const u8) !Loaded {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+
+    const data = std.fs.cwd().readFileAlloc(arena.allocator(), path, 1 << 20) catch |err| switch (err) {
+        error.FileNotFound => return .{ .arena = arena, .binding = .{} },
+        else => return err,
+    };
+
+    var parsed = std.json.parseFromSlice(Wire, arena.allocator(), data, .{
+        .ignore_unknown_fields = true,
+    }) catch return .{ .arena = arena, .binding = .{} };
+    defer parsed.deinit();
+
+    // Copy strings into the arena so they outlive `parsed`
+    const a = arena.allocator();
+    return .{ .arena = arena, .binding = .{
+        .bot_token = try a.dupe(u8, parsed.value.bot_token),
+        .base_url = try a.dupe(u8, parsed.value.base_url),
+        .owner_user_id = try a.dupe(u8, parsed.value.owner_user_id),
+        .bot_id = try a.dupe(u8, parsed.value.bot_id),
+        .sync_buf = try a.dupe(u8, parsed.value.sync_buf),
+    } };
+}
+
+test "round-trips binding through a file" {
+    const tmp_path = "zig-cache-tmp-weixin-state.json";
+    defer std.fs.cwd().deleteFile(tmp_path) catch {};
+
+    try save(std.testing.allocator, tmp_path, .{
+        .bot_token = "tok-123",
+        .base_url = "https://example.test",
+        .owner_user_id = "user-9",
+        .bot_id = "bot-1",
+        .sync_buf = "BUF==",
+    });
+
+    var loaded = try load(std.testing.allocator, tmp_path);
+    defer loaded.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("tok-123", loaded.binding.bot_token);
+    try std.testing.expectEqualStrings("user-9", loaded.binding.owner_user_id);
+    try std.testing.expectEqualStrings("BUF==", loaded.binding.sync_buf);
+}
+
+test "load returns empty binding when file is absent" {
+    var loaded = try load(std.testing.allocator, "definitely-not-here-weixin.json");
+    defer loaded.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), loaded.binding.bot_token.len);
+}

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -1,0 +1,59 @@
+//! In-memory representations of ilink protocol values. No I/O lives here;
+//! `ilink_codec.zig` converts wire JSON to/from these.
+
+pub const MessageItem = struct {
+    type: i64 = 0,
+    /// text from a text_item (type 1)
+    text: []const u8 = "",
+    /// transcribed text from a voice_item (type 3)
+    voice_text: []const u8 = "",
+};
+
+pub const Message = struct {
+    from_user_id: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+    group_id: []const u8 = "",
+    item_list: []const MessageItem = &.{},
+};
+
+pub const GetUpdatesResult = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    longpolling_timeout_ms: i64 = 0,
+    get_updates_buf: []const u8 = "",
+    msgs: []const Message = &.{},
+};
+
+pub const QrCode = struct {
+    ret: i64 = 0,
+    qrcode: []const u8 = "",
+    /// base64 PNG content, when the API returns an inline image
+    qrcode_img_content: []const u8 = "",
+};
+
+pub const QrStatusKind = enum { wait, scaned, confirmed, expired, unknown };
+
+pub const QrStatus = struct {
+    ret: i64 = 0,
+    status: QrStatusKind = .unknown,
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    bot_id: []const u8 = "",
+    user_id: []const u8 = "",
+};
+
+pub const Settings = struct {
+    enabled: bool = false,
+    reply_timeout_ms: u32 = 120000,
+    /// empty ⇒ auto-bind first sender
+    allowed_user: []const u8 = "",
+};
+
+pub const Binding = struct {
+    bot_token: []const u8 = "",
+    base_url: []const u8 = "",
+    owner_user_id: []const u8 = "",
+    bot_id: []const u8 = "",
+    sync_buf: []const u8 = "",
+};


### PR DESCRIPTION
## What

Adds a **WeChat direct-connect (ilink)** scheme as a parallel alternative to the existing remote (Cloudflare Worker) path. Instead of going through the web-remote relay, WeChat connects straight to the local Phantty backend via WeChat's ilink protocol, embedded natively in the Phantty process (no relay, no extra process).

The two schemes are **mutually exclusive** — if `remote-enabled` is set, remote wins and the direct scheme stays off.

## How it works

- **Transport / pure logic** (`src/weixin/*.zig`): cross-platform, compiles + unit-tested on Linux host.
  - `ilink_client.zig` — `std.http.Client` against `https://ilinkai.weixin.qq.com` (QR login, getupdates long-poll, sendmessage).
  - `ilink_codec.zig` — request/response JSON (`alloc_always` so parsed strings outlive the HTTP buffer).
  - `poller.zig` — background long-poll loop, generation/stop handling.
  - `agent.zig` — command routing (`/ai /term /keys /stop /ping /status /help` + default text → AI), ported from the TS bot.
  - `reply_progress.zig` — AI-reply progress diffing (`You:/AI:/Status:` sections).
  - `binding.zig` — owner binding + message filtering (first-messenger auto-binds unless `weixin-allowed-user` pins one).
  - `state_store.zig` — 0600 JSON persistence of the binding + sync cursor.
  - `controller.zig` — lifecycle, background QR login orchestration, wires client ↔ poller.
  - `control.zig` — vtable interface so the poller can drive surfaces without GUI deps.
- **GUI integration** (Windows-only build): `App.zig` / `AppWindow.zig` / `thread_message.zig` marshal Control queries onto the UI thread via a synchronous `.weixin_control` message (tab state is threadlocal to the UI thread).

## Config keys (`src/config.zig`)

- `weixin-direct-enabled: bool = false`
- `weixin-base-url: ?[]const u8 = null`
- `weixin-reply-timeout-ms: u32 = 120000` (clamped [5000, 180000])
- `weixin-allowed-user: ?[]const u8 = null`

## Status

- All pure modules compile and pass `zig test` on the Linux host; the Windows GUI cross-compiles green.
- Remaining `TODO(weixin-windows)` items need a Windows runtime to validate: QR image panel + Connect/Unbind actions, first-messenger auto-bind persistence, AI transcript rendering + progress streaming, `/term` `/keys` terminal delegation, on-device smoke test.

## Note

`main` had diverged before the `v0.30.0` release commit, so this PR's diff also folds in the v0.30.0 version bumps (`remote/`, `release-notes/v0.30.0.md`). Design spec + implementation plan are under `docs/superpowers/`.
