### PR TITLE
[codex] add SSH quick jump to command palette

### DIFF
--- a/docs/superpowers/plans/2026-05-25-command-palette-ssh-quick-jump.md
+++ b/docs/superpowers/plans/2026-05-25-command-palette-ssh-quick-jump.md
@@ -1,0 +1,128 @@
+# Command Palette SSH Quick Jump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add saved SSH profile quick-jump results to the `Ctrl+Shift+P` command center, matched only by server name.
+
+**Architecture:** Put pure command-palette matching and ordering rules in `src/command_palette_model.zig` so they can be tested without pulling in the heavy overlay renderer dependencies. Keep rendering, selection, and SSH connection execution in `src/renderer/overlays.zig`, reusing existing SSH profile storage and connection helpers.
+
+**Tech Stack:** Zig 0.15.2, Phantty overlay renderer, existing SSH profile storage, `zig build test`, `zig build`.
+
+---
+
+### Task 1: Add Testable Command Palette Model
+
+**Files:**
+- Create: `src/command_palette_model.zig`
+- Modify: `src/test_main.zig`
+
+- [ ] **Step 1: Add failing model tests**
+
+Create `src/command_palette_model.zig` with tests for:
+
+```zig
+test "command palette model matches SSH profile names case-insensitively" {
+    try std.testing.expect(sshProfileNameMatchesFilter("LabServer", "labserver"));
+}
+
+test "command palette model hides SSH profiles when filter is empty" {
+    try std.testing.expect(!shouldSearchSshProfiles(""));
+    try std.testing.expect(!sshProfileNameMatchesFilter("LabServer", ""));
+}
+
+test "command palette model does not match non-name SSH profile fields" {
+    try std.testing.expect(!sshProfileNameMatchesFilter("ProdBox", "needle-host"));
+    try std.testing.expect(!sshProfileNameMatchesFilter("ProdBox", "needle-user"));
+}
+
+test "command palette model orders SSH results after commands and before themes" {
+    try std.testing.expect(resultGroupRank(.command_title) < resultGroupRank(.command_secondary));
+    try std.testing.expect(resultGroupRank(.command_secondary) < resultGroupRank(.ssh_profile));
+    try std.testing.expect(resultGroupRank(.ssh_profile) < resultGroupRank(.theme));
+}
+```
+
+Import `command_palette_model.zig` from `src/test_main.zig`.
+
+- [ ] **Step 2: Implement model functions**
+
+Implement:
+
+```zig
+pub const ResultGroup = enum {
+    command_title,
+    command_secondary,
+    ssh_profile,
+    theme,
+};
+
+pub fn resultGroupRank(group: ResultGroup) u8;
+pub fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool;
+pub fn shouldSearchSshProfiles(filter: []const u8) bool;
+pub fn sshProfileNameMatchesFilter(name: []const u8, filter: []const u8) bool;
+```
+
+- [ ] **Step 3: Verify model tests**
+
+Run: `zig build test`
+
+Expected: the new command-palette model tests pass. Existing baseline failures in `platform.window_backend` and `updater_core` may remain.
+
+### Task 2: Add SSH Profiles To Command Center Results
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+
+- [ ] **Step 1: Extend palette item type**
+
+Add an `ssh_profile: usize` variant to `PaletteItem`.
+
+- [ ] **Step 2: Append SSH profile matches**
+
+In `rebuildPaletteScratch()`, keep the existing empty-filter behavior unchanged. For non-empty filters, append matching SSH profiles after command title/detail matches and before theme matches:
+
+```zig
+loadSshProfiles();
+for (0..g_ssh_profile_count) |profile_idx| {
+    if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+    const profile = &g_ssh_profiles[profile_idx];
+    if (!command_palette_model.sshProfileNameMatchesFilter(profileField(profile, .name), filter)) continue;
+    g_palette_scratch[g_palette_scratch_len] = .{ .ssh_profile = profile_idx };
+    g_palette_scratch_len += 1;
+}
+```
+
+- [ ] **Step 3: Execute SSH profile items**
+
+In `executePaletteItem()`, call the existing connection path:
+
+```zig
+.ssh_profile => |profile_idx| connectSshProfile(profile_idx),
+```
+
+- [ ] **Step 4: Render SSH profile rows**
+
+Render rows as `SSH: <server name>` with the safe target detail `user@host[:port]`. Extract the existing SSH launcher target formatting into `sshProfileTarget()` and use `renderTitlebarTextLimited()` on the detail to avoid overlap.
+
+- [ ] **Step 5: Verify desktop compile**
+
+Run: `zig build`
+
+Expected: the Windows desktop target builds successfully.
+
+### Task 3: Final Verification
+
+**Files:**
+- No additional files.
+
+- [ ] **Step 1: Run full tests**
+
+Run: `zig build test`
+
+Expected: all command-palette model tests pass. Known baseline failures may remain in `platform.window_backend` and `updater_core`.
+
+- [ ] **Step 2: Run Windows checkout safety checks**
+
+Run the Windows path checks from `docs/development.md` against tracked and newly-added files.
+
+Expected: zero Windows name violations, zero case-fold collisions, and no symlinks.

--- a/docs/superpowers/specs/2026-05-25-command-palette-ssh-quick-jump-design.md
+++ b/docs/superpowers/specs/2026-05-25-command-palette-ssh-quick-jump-design.md
@@ -1,0 +1,57 @@
+# Command Palette SSH Quick Jump Design
+
+## Goal
+
+Make saved SSH servers directly reachable from the `Ctrl+Shift+P` command center. A user should be able to open the command center, type a saved SSH server name, and press Enter to open a new SSH tab for that profile.
+
+## Ghostty Reference
+
+Ghostty's command palette combines static command entries with dynamic jump entries. In `macos/Sources/Features/Command Palette/TerminalCommandPalette.swift`, `commandOptions` appends update commands, terminal commands, and dynamic `jumpOptions` before passing them to the searchable palette view. In `macos/Sources/Features/Command Palette/CommandPalette.swift`, options filter by title and subtitle and run their action directly on submit.
+
+Phantty should follow that shape: keep the command center as one searchable action list, add SSH profiles as dynamic action entries, and execute the selected profile directly rather than adding a second picker step.
+
+## Behavior
+
+The command center continues to open with the existing `Ctrl+Shift+P` binding. When the filter is empty, it shows the existing command entries only, preserving the current default list.
+
+When the filter is non-empty, the result set is:
+
+1. Command title matches.
+2. Command detail or shortcut matches.
+3. Saved SSH profile name matches.
+4. Built-in theme name matches.
+
+SSH matching is case-insensitive and checks only the saved server name. It does not match host/IP, user, password, or port. This keeps the feature focused on "type the saved server name" and avoids noisy or surprising matches.
+
+An SSH result renders as `SSH: <server name>`. The right-side detail shows the existing safe connection target, such as `alice@example.com:2222`, using the same profile fields already shown in the SSH launcher. Passwords are never rendered or matched.
+
+Pressing Enter or clicking an SSH result closes the command center and opens a new SSH tab using the existing profile connection path. If the profile fails validation or the tab cannot be created, the command center still closes, matching current command/theme execution behavior.
+
+## Architecture
+
+The implementation stays in `src/renderer/overlays.zig`, where the command center, theme search, SSH profile storage, and SSH connection actions already live.
+
+`PaletteItem` gains an SSH profile case that stores a profile index. `rebuildPaletteScratch()` loads saved SSH profiles only when the command-center filter is non-empty, then appends matching profile entries after command matches and before theme matches. Existing SSH profile storage remains unchanged.
+
+Execution reuses the existing `connectSshProfile()`/`connectSshProfileReturningSurface()` path, so password scheduling, OpenSSH command construction, legacy algorithm flags, and SSH session metadata stay centralized.
+
+Rendering reuses the existing SSH profile field helpers and target formatting pattern from the session launcher. The command center row layout remains unchanged.
+
+## Testing
+
+Add focused Zig tests in `src/renderer/overlays.zig` for:
+
+- SSH profiles do not appear when the command-center filter is empty.
+- A non-empty filter matches saved SSH profile names case-insensitively.
+- Host/IP and user values do not match when the server name does not match.
+- SSH profile results are ordered after command matches and before theme matches.
+
+Run the focused test target after each red/green step. The current branch baseline has known pre-existing `zig build test` failures in `platform.window_backend` and `updater_core`; final verification should report those separately unless they are fixed in this branch.
+
+## Out Of Scope
+
+This does not change keyboard bindings, so `README.md` shortcut documentation does not need an update.
+
+This does not change SSH profile file format, SSH/SCP helper behavior, OpenSSH options, or the session launcher SSH list behavior.
+
+This does not add host/IP/user matching. The user explicitly chose server-name-only matching.

--- a/src/command_palette_model.zig
+++ b/src/command_palette_model.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+
+pub const ResultGroup = enum {
+    command_title,
+    command_secondary,
+    ssh_profile,
+    theme,
+};
+
+pub fn resultGroupRank(group: ResultGroup) u8 {
+    return switch (group) {
+        .command_title => 0,
+        .command_secondary => 1,
+        .ssh_profile => 2,
+        .theme => 3,
+    };
+}
+
+fn lowerAscii(ch: u8) u8 {
+    return if (ch >= 'A' and ch <= 'Z') ch + 32 else ch;
+}
+
+pub fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+
+    var start: usize = 0;
+    while (start + needle.len <= haystack.len) : (start += 1) {
+        var matched = true;
+        for (needle, 0..) |needle_ch, i| {
+            if (lowerAscii(haystack[start + i]) != lowerAscii(needle_ch)) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return true;
+    }
+    return false;
+}
+
+pub fn shouldSearchSshProfiles(filter: []const u8) bool {
+    return filter.len > 0;
+}
+
+pub fn sshProfileNameMatchesFilter(name: []const u8, filter: []const u8) bool {
+    return shouldSearchSshProfiles(filter) and containsIgnoreCase(name, filter);
+}
+
+test "command palette model matches SSH profile names case-insensitively" {
+    try std.testing.expect(sshProfileNameMatchesFilter("LabServer", "labserver"));
+}
+
+test "command palette model hides SSH profiles when filter is empty" {
+    try std.testing.expect(!shouldSearchSshProfiles(""));
+    try std.testing.expect(!sshProfileNameMatchesFilter("LabServer", ""));
+}
+
+test "command palette model does not match non-name SSH profile fields" {
+    try std.testing.expect(!sshProfileNameMatchesFilter("ProdBox", "needle-host"));
+    try std.testing.expect(!sshProfileNameMatchesFilter("ProdBox", "needle-user"));
+}
+
+test "command palette model orders SSH results after commands and before themes" {
+    try std.testing.expect(resultGroupRank(.command_title) < resultGroupRank(.command_secondary));
+    try std.testing.expect(resultGroupRank(.command_secondary) < resultGroupRank(.ssh_profile));
+    try std.testing.expect(resultGroupRank(.ssh_profile) < resultGroupRank(.theme));
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -19,6 +19,7 @@ const input_key = @import("../input/key.zig");
 const ssh_prompt = @import("../ssh_prompt.zig");
 const app_metadata = @import("../app_metadata.zig");
 const command_center_state = @import("../command_center_state.zig");
+const command_palette_model = @import("../command_palette_model.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_dirs = @import("../platform/dirs.zig");
 const platform_open_url = @import("../platform/open_url.zig");
@@ -180,6 +181,7 @@ const COMMAND_ENTRIES = command_center_state.command_entries;
 
 const PaletteItem = union(enum) {
     command: usize,
+    ssh_profile: usize,
     theme: usize,
 };
 
@@ -485,26 +487,8 @@ fn commandPaletteFilter() []const u8 {
     return g_command_palette_filter[0..g_command_palette_filter_len];
 }
 
-fn lowerAscii(ch: u8) u8 {
-    return if (ch >= 'A' and ch <= 'Z') ch + 32 else ch;
-}
-
 fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
-    if (needle.len == 0) return true;
-    if (needle.len > haystack.len) return false;
-
-    var start: usize = 0;
-    while (start + needle.len <= haystack.len) : (start += 1) {
-        var matched = true;
-        for (needle, 0..) |needle_ch, i| {
-            if (lowerAscii(haystack[start + i]) != lowerAscii(needle_ch)) {
-                matched = false;
-                break;
-            }
-        }
-        if (matched) return true;
-    }
-    return false;
+    return command_palette_model.containsIgnoreCase(haystack, needle);
 }
 
 fn commandEntryMatches(entry: CommandEntry) bool {
@@ -581,6 +565,14 @@ fn rebuildPaletteScratch() void {
         g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
         g_palette_scratch_len += 1;
     }
+    loadSshProfiles();
+    for (0..g_ssh_profile_count) |profile_idx| {
+        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        const profile = &g_ssh_profiles[profile_idx];
+        if (!command_palette_model.sshProfileNameMatchesFilter(profileField(profile, .name), filter)) continue;
+        g_palette_scratch[g_palette_scratch_len] = .{ .ssh_profile = profile_idx };
+        g_palette_scratch_len += 1;
+    }
     for (&themes_embed.entries, 0..) |th, ti| {
         if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
         if (!containsIgnoreCase(th.name, filter)) continue;
@@ -592,6 +584,7 @@ fn rebuildPaletteScratch() void {
 fn executePaletteItem(item: PaletteItem) void {
     switch (item) {
         .command => |cmd_idx| executeCommand(COMMAND_ENTRIES[cmd_idx].action),
+        .ssh_profile => |profile_idx| connectSshProfile(profile_idx),
         .theme => |ti| applyEmbeddedThemeFromPalette(ti),
     }
 }
@@ -1149,6 +1142,19 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
                             renderTitlebarText(shortcut, shortcut_left, text_y, shortcut_color);
                         }
                         renderTitlebarTextLimited(entry.title, title_x, text_y, row_title_color, shortcut_left - title_x - 18);
+                    },
+                    .ssh_profile => |profile_idx| {
+                        if (profile_idx >= g_ssh_profile_count) continue;
+                        const profile = &g_ssh_profiles[profile_idx];
+                        var title_buf: [SSH_FIELD_MAX + 5]u8 = undefined;
+                        const ssh_title = std.fmt.bufPrint(title_buf[0..], "SSH: {s}", .{profileField(profile, .name)}) catch "SSH";
+                        var target_buf: [SSH_FIELD_MAX * 2]u8 = undefined;
+                        const target = sshProfileTarget(profile, target_buf[0..]);
+                        const target_w = measureTitlebarText(target);
+                        const target_max_w = @min(target_w, @max(80.0, layout.box_w * 0.40));
+                        const target_left = @round(layout.box_x + layout.box_w - pad_x - target_max_w);
+                        renderTitlebarTextLimited(target, target_left, text_y, shortcut_color, target_max_w);
+                        renderTitlebarTextLimited(ssh_title, title_x, text_y, row_title_color, @max(1.0, target_left - title_x - 18));
                     },
                     .theme => |ti| {
                         const name = themes_embed.entries[ti].name;
@@ -2894,14 +2900,18 @@ fn renderSessionFieldValue(layout: SessionLayout, window_height: f32, row: usize
 
 fn renderSshProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const SshProfile, selected: bool) void {
     var target_buf: [SSH_FIELD_MAX * 2]u8 = undefined;
+    const target = sshProfileTarget(profile, target_buf[0..]);
+    renderSessionRow(layout, window_height, row, profileField(profile, .name), target, selected);
+}
+
+fn sshProfileTarget(profile: *const SshProfile, target_buf: []u8) []const u8 {
     const host = profileField(profile, .ip);
     const user = profileField(profile, .user);
     const port = profileField(profile, .port);
-    const target = if (port.len > 0)
-        std.fmt.bufPrint(&target_buf, "{s}@{s}:{s}", .{ user, host, port }) catch ""
+    return if (port.len > 0)
+        std.fmt.bufPrint(target_buf, "{s}@{s}:{s}", .{ user, host, port }) catch host
     else
-        std.fmt.bufPrint(&target_buf, "{s}@{s}", .{ user, host }) catch "";
-    renderSessionRow(layout, window_height, row, profileField(profile, .name), target, selected);
+        std.fmt.bufPrint(target_buf, "{s}@{s}", .{ user, host }) catch host;
 }
 
 fn renderAiProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const AiProfile, selected: bool) void {

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -604,6 +604,7 @@ comptime {
     _ = @import("browser_url.zig");
     _ = @import("build_guards.zig");
     _ = @import("command_center_state.zig");
+    _ = @import("command_palette_model.zig");
     _ = @import("config.zig");
     _ = @import("config_watcher.zig");
     _ = @import("file_backend.zig");


### PR DESCRIPTION
## Summary
- Add command-palette model tests for SSH profile name matching and result ordering.
- Show saved SSH profiles in Ctrl+Shift+P results when the typed filter matches the server name.
- Reuse the existing SSH profile connection path and render safe `user@host[:port]` detail text.

## Impact
Users can type a saved SSH server name in the command center and press Enter to open that SSH profile directly. Matching intentionally uses only the saved server name, not host/IP/user/password/port.

## Validation
- `zig build` passed.
- `zig build test` ran with new command-palette tests passing; existing baseline failures remain in `platform.window_backend.test.platform window backend exposes backend-neutral create options` and `updater_core.test.updater_core: restore backup reports failure` (`497/500 passed, 1 skipped, 2 failed`).
- Windows checkout path-safety checks passed: 0 name violations, 0 casefold collisions, no symlinks.