### PR TITLE
fix(weixin): stabilize direct login controls

### DIFF
--- a/docs/superpowers/weixin-direct-windows-handoff.md
+++ b/docs/superpowers/weixin-direct-windows-handoff.md
@@ -13,9 +13,12 @@ builds for Windows (`build.zig`: `uses_windows_backend = os_tag == .windows`).
 - Ships **off by default**: `weixin-direct-enabled = false`.
 - Backend is wired: config → `App.startWeixin` → `weixin.Controller` →
   `ilink.Client` + `poller.Poller`, with Control marshalled to the UI thread.
-- GUI login entry point now exists: Command Center → **Connect WeChat** starts
-  `controller.startLoginAsync()` and renders the QR login panel. Command Center
-  → **WeChat: Unbind** clears the stored binding.
+- GUI login/control entries now exist: Command Center → **Connect WeChat**
+  starts `controller.startLoginAsync()` and renders the QR login panel. Command
+  Center → **WeChat: Start** starts polling from the saved binding,
+  **WeChat: Stop** stops polling while keeping the binding,
+  **WeChat: Status** shows the current state, and **WeChat: Unbind** clears the
+  stored binding.
 - `/term` and `/keys` now resolve the active terminal surface and write through
   the same queued PTY input boundary used by remote input.
 - AI follow-up sends are wired: after the ACK, the poller compares AI transcript
@@ -81,6 +84,8 @@ Pick one:
   `confirmed`, the controller persists `weixin.json` and starts polling
   automatically (`controller.confirmLogin`, `controller.zig:191`).
 - Add an "Unbind" action → `controller.unbind()`.
+- Command Center also exposes "Start", "Stop", and "Status" actions for the
+  saved binding, so you can pause/resume polling without clearing the token.
 
 **Option B (quick smoke without UI) — pre-seed the state file.**
 If you already have a bot token, drop a `weixin.json` at

--- a/docs/superpowers/weixin-direct-windows-handoff.md
+++ b/docs/superpowers/weixin-direct-windows-handoff.md
@@ -13,11 +13,27 @@ builds for Windows (`build.zig`: `uses_windows_backend = os_tag == .windows`).
 - Ships **off by default**: `weixin-direct-enabled = false`.
 - Backend is wired: config → `App.startWeixin` → `weixin.Controller` →
   `ilink.Client` + `poller.Poller`, with Control marshalled to the UI thread.
-- **Blocker for the full loop:** no GUI login entry point exists. The QR-login
-  backend (`controller.startLoginAsync()` / `loginSnapshot()`) is done, but
-  nothing calls it. `startWeixin` only calls `controller.start()`, which loads a
-  *persisted* binding from `weixin.json` and stays idle if there is no token.
-  → You must either build the QR panel, or pre-seed `weixin.json` (see Phase 1).
+- GUI login entry point now exists: Command Center → **Connect WeChat** starts
+  `controller.startLoginAsync()` and renders the QR login panel. Command Center
+  → **WeChat: Unbind** clears the stored binding.
+- `/term` and `/keys` now resolve the active terminal surface and write through
+  the same queued PTY input boundary used by remote input.
+- AI follow-up sends are wired: after the ACK, the poller compares AI transcript
+  snapshots against the baseline and sends progress/final replies back through
+  iLink. This still needs live Windows/WeChat smoke testing across slow tool
+  calls and final replies.
+- Live Windows fixes applied after initial smoke:
+  - QR panel renders the ilink QR payload directly instead of trying to decode
+    it as a PNG.
+  - Config hot-reload only reacts to the actual config file mtime, so WeChat
+    state writes no longer spam config reloads.
+  - Inline config comments after values are stripped, so
+    `background-image-mode fill   # fill | fit | center | tile` parses as
+    `fill`.
+  - App shutdown uses a bounded WeChat process-exit path. It asks Windows to
+    cancel synchronous I/O on the poll/login/follow-up threads, waits briefly,
+    and only detaches/leaks the controller if a long-poll refuses to return
+    before process exit.
 
 ---
 
@@ -51,16 +67,16 @@ builds for Windows (`build.zig`: `uses_windows_backend = os_tag == .windows`).
 
 ---
 
-## Phase 1 — Login / binding  ⚠️ BLOCKED until a login entry exists
+## Phase 1 — Login / binding
 
 Pick one:
 
-**Option A (recommended) — build the QR panel + "Connect WeChat" action.**
-Backend is ready; you only need UI glue:
+**Option A (recommended) — use the QR panel + "Connect WeChat" action.**
 - On the action, call `controller.startLoginAsync()` (spawns the login thread).
-- Each frame, call `controller.loginSnapshot(arena)` → `{status, qr_string, qr_img_base64}`.
-  Render `qr_img_base64` (base64 PNG; decode via `src/image_decoder.zig`) or the
-  raw `qr_string` as a QR.
+- Each frame, call `controller.loginSnapshot(arena)` → `{status, qr_string, qr_content}`.
+  `qrcode_img_content` is a QR payload string, not an inline PNG; `src/weixin/qr_panel.zig`
+  encodes it with `src/weixin/qr_code.zig`, and
+  `src/renderer/weixin_qr_renderer.zig` renders the QR matrix directly.
 - `status` transitions `wait → scaned → confirmed` (or `expired`). On
   `confirmed`, the controller persists `weixin.json` and starts polling
   automatically (`controller.confirmLogin`, `controller.zig:191`).
@@ -101,22 +117,37 @@ What this exercises: `wxIsConnected`, `wxFindAiSurface`, `wxOpenAiAgent`,
 `wxSendInput` (all in `AppWindow.zig:2027+`), marshalled to the UI thread via the
 synchronous `.weixin_control` message; routing in `src/weixin/agent.zig`.
 
+Expected logs while testing:
+- `weixin poll received N message(s)` when iLink delivers inbound messages.
+- `weixin reply sent: N bytes` for the immediate ACK/command reply.
+- `weixin AI followup started` then `weixin AI followup final sent: N bytes`
+  when the AI transcript produces a final answer.
+- `warning(stream): unimplemented mode: 9001` can appear from terminal VT input
+  and is unrelated to WeChat.
+
+If replies feel delayed, distinguish the paths:
+- Inbound message delivery depends on iLink long-poll waking. The local poller
+  is not intentionally sleeping 5 seconds after successful polls.
+- The AI final reply is transcript-driven and checked once per second after the
+  immediate ACK.
+- Repeated `Config file changed, reloading...` after WeChat messages should no
+  longer happen; if it does, inspect `%APPDATA%\phantty` writes and
+  `src/config_watcher.zig`.
+
+Shutdown smoke:
+- Close the window after WeChat direct is connected and idle. The process should
+  exit without needing Ctrl+C and without a post-close segfault.
+- Repeat while a message is being handled or while an AI follow-up is waiting.
+  A shutdown timeout log is acceptable only if iLink is still blocking, but the
+  process should still terminate promptly.
+
 ---
 
-## Phase 3 — Known gaps (won't work until implemented)
+## Phase 3 — Known gaps
 
-All marked `TODO(weixin-windows)`:
+Current gaps:
 
-1. **`/term` and `/keys` do nothing** — `wxFindTerminalSurface` returns `null`
-   (`AppWindow.zig:2037`). Needs: resolve the active writable terminal surface
-   and write to its PTY (mirror the remote path's per-surface `write_fn`).
-
-2. **No AI progress streaming** — `wxTranscript` returns `""`
-   (`AppWindow.zig:2055`). Needs: render `activeAiChat()` into the
-   `You:/AI:/Status:` label format that `src/weixin/reply_progress.zig` parses,
-   then have the poller act on `expect_ai_progress`.
-
-3. **Auto-bind owner not persisted** — without `weixin-allowed-user`, any sender
+1. **Auto-bind owner not persisted** — without `weixin-allowed-user`, any sender
    is accepted within a session but the owner isn't written back to
    `weixin.json`. Needs a bind-callback from the poller to `controller.persist`.
    (Security note: until then, set `weixin-allowed-user` explicitly for any

--- a/src/App.zig
+++ b/src/App.zig
@@ -942,7 +942,8 @@ pub fn deinit(self: *App) void {
             .request_synchronous_io_cancel = platform_thread_control.requestSynchronousIoCancel,
             .wait_for_exit = platform_thread_control.waitForExit,
         })) {
-            std.debug.print("weixin controller left allocated for process exit after shutdown timeout\n", .{});
+            std.debug.print("weixin controller left allocated for process exit after shutdown timeout; exiting now\n", .{});
+            std.process.exit(0);
         }
         self.weixin_controller = null;
     }

--- a/src/App.zig
+++ b/src/App.zig
@@ -15,6 +15,7 @@ const platform_display = @import("platform/display.zig");
 const font_backend = @import("platform/font_backend.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
+const platform_thread_control = @import("platform/thread_control.zig");
 const window_backend = @import("platform/window_backend.zig");
 const remote = @import("remote_client.zig");
 const weixin = @import("weixin/controller.zig");
@@ -937,7 +938,12 @@ pub fn deinit(self: *App) void {
     }
 
     if (self.weixin_controller) |controller| {
-        controller.destroy();
+        if (!controller.destroyForProcessExit(.{
+            .request_synchronous_io_cancel = platform_thread_control.requestSynchronousIoCancel,
+            .wait_for_exit = platform_thread_control.waitForExit,
+        })) {
+            std.debug.print("weixin controller left allocated for process exit after shutdown timeout\n", .{});
+        }
         self.weixin_controller = null;
     }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -50,6 +50,8 @@ pub const file_explorer = @import("file_explorer.zig");
 pub const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig");
 pub const markdown_preview_panel = @import("markdown_preview_panel.zig");
 pub const markdown_preview_renderer = @import("renderer/markdown_preview_renderer.zig");
+pub const weixin_qr_panel = @import("weixin/qr_panel.zig");
+pub const weixin_qr_renderer = @import("renderer/weixin_qr_renderer.zig");
 pub const browser_panel = if (build_options.webview)
     @import("browser_panel.zig")
 else
@@ -1315,6 +1317,7 @@ fn onPlatformResize(width: i32, height: i32) void {
     overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderSessionLauncher(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderDebugOverlay(@floatFromInt(fb_width));
     overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -1944,15 +1947,18 @@ fn handleRemoteAiAgentOpenRequest(request: *RemoteAiAgentOpenRequest) void {
 // reads/acts on tab state, mirroring the remote .remote_ai_input path.
 //
 // UNVERIFIED AT RUNTIME: cross-compiles to the Windows exe, but has not been run
-// (no Windows runtime / live WeChat here). /term-/keys terminal delegation and
-// the AI transcript (for reply-progress streaming) are intentionally stubbed.
+// (no Windows runtime / live WeChat here). AI progress follow-up timers remain
+// in the poller backlog; the UI control surface below exposes terminal writes
+// and AI transcript snapshots for that layer.
 // ============================================================================
 
 var g_weixin_ui_handle = std.atomic.Value(usize).init(0);
 var g_weixin_ctx: u8 = 0;
+var g_weixin_transcript_mutex: std.Thread.Mutex = .{};
+var g_weixin_transcript_owned: []u8 = &.{};
 
 const WeixinRequest = struct {
-    op: enum { find_ai, open_ai, send_input },
+    op: enum { find_ai, find_term, open_ai, send_input, latest_transcript },
     // send_input input (valid for the duration of the synchronous call):
     surface_id: [16]u8 = [_]u8{0} ** 16,
     bytes: []const u8 = "",
@@ -1961,6 +1967,7 @@ const WeixinRequest = struct {
     out_surface_id: [16]u8 = [_]u8{0} ** 16,
     open_result: weixin_control.OpenResult = .failed,
     sent: bool = false,
+    transcript: []u8 = &.{},
 };
 
 /// Index of the AI-chat tab to target: the active tab if it is AI chat, else the
@@ -1984,12 +1991,48 @@ fn weixinTabIndexFromSurfaceId(id: [16]u8) ?usize {
     return std.fmt.parseInt(usize, id[6..16], 10) catch null;
 }
 
+fn weixinActiveTerminalSurface() ?*Surface {
+    if (tab.g_active_tab < tab.g_tab_count) {
+        if (tab.g_tabs[tab.g_active_tab]) |ts| {
+            if (ts.kind == .terminal) {
+                if (ts.focusedSurface()) |surface| return surface;
+            }
+        }
+    }
+    for (0..tab.g_tab_count) |i| {
+        if (tab.g_tabs[i]) |ts| {
+            if (ts.kind == .terminal) {
+                if (ts.focusedSurface()) |surface| return surface;
+            }
+        }
+    }
+    return null;
+}
+
+fn weixinTerminalSurfaceFromId(id: [16]u8) ?*Surface {
+    for (0..tab.g_tab_count) |tab_index| {
+        const tab_state = tab.g_tabs[tab_index] orelse continue;
+        if (tab_state.kind != .terminal) continue;
+        var it = tab_state.tree.iterator();
+        while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.surface.remote_id[0..], id[0..])) return entry.surface;
+        }
+    }
+    return null;
+}
+
 /// Runs on the UI thread (dispatched from the window message pump).
 fn handleWeixinControlRequest(req: *WeixinRequest) void {
     switch (req.op) {
         .find_ai => {
             if (weixinActiveAiTabIndex()) |idx| {
                 req.out_surface_id = remoteAiSurfaceId(idx);
+                req.found = true;
+            }
+        },
+        .find_term => {
+            if (weixinActiveTerminalSurface()) |surface| {
+                req.out_surface_id = surface.remote_id;
                 req.found = true;
             }
         },
@@ -2002,14 +2045,27 @@ fn handleWeixinControlRequest(req: *WeixinRequest) void {
             if (req.open_result == .opened) g_force_rebuild = true;
         },
         .send_input => {
-            const idx = weixinTabIndexFromSurfaceId(req.surface_id) orelse return;
-            if (idx >= tab.g_tab_count) return;
+            if (weixinTabIndexFromSurfaceId(req.surface_id)) |idx| {
+                if (idx >= tab.g_tab_count) return;
+                const tab_state = tab.g_tabs[idx] orelse return;
+                if (tab_state.kind != .ai_chat) return;
+                const session = tab_state.ai_chat_session orelse return;
+                session.applyRemoteInput(req.bytes);
+                g_force_rebuild = true;
+                req.sent = true;
+                return;
+            }
+            const surface = weixinTerminalSurfaceFromId(req.surface_id) orelse return;
+            surface.queuePtyWrite(req.bytes);
+            req.sent = true;
+        },
+        .latest_transcript => {
+            const idx = weixinActiveAiTabIndex() orelse return;
             const tab_state = tab.g_tabs[idx] orelse return;
             if (tab_state.kind != .ai_chat) return;
             const session = tab_state.ai_chat_session orelse return;
-            session.applyRemoteInput(req.bytes);
-            g_force_rebuild = true;
-            req.sent = true;
+            req.transcript = session.allocRemoteSnapshot(std.heap.page_allocator) catch return;
+            req.found = true;
         },
     }
 }
@@ -2035,9 +2091,9 @@ fn wxFindAiSurface(_: *anyopaque) ?weixin_control.Surface {
 }
 
 fn wxFindTerminalSurface(_: *anyopaque) ?weixin_control.Surface {
-    // TODO(weixin-windows): resolve the active writable terminal surface and
-    // marshal input to its PTY (the remote path uses per-surface sink write_fn).
-    return null;
+    var req = WeixinRequest{ .op = .find_term };
+    if (!weixinDispatch(&req) or !req.found) return null;
+    return .{ .id = req.out_surface_id, .title = "" };
 }
 
 fn wxOpenAiAgent(_: *anyopaque, _: u32) weixin_control.OpenResult {
@@ -2053,9 +2109,14 @@ fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
 }
 
 fn wxTranscript(_: *anyopaque) []const u8 {
-    // TODO(weixin-windows): render activeAiChat() into the "You:/AI:/Status:"
-    // label format that reply_progress.zig parses, to enable progress streaming.
-    return "";
+    var req = WeixinRequest{ .op = .latest_transcript };
+    if (!weixinDispatch(&req) or !req.found) return "";
+
+    g_weixin_transcript_mutex.lock();
+    defer g_weixin_transcript_mutex.unlock();
+    if (g_weixin_transcript_owned.len != 0) std.heap.page_allocator.free(g_weixin_transcript_owned);
+    g_weixin_transcript_owned = req.transcript;
+    return g_weixin_transcript_owned;
 }
 
 const weixin_vtable = weixin_control.Control.VTable{
@@ -2071,6 +2132,13 @@ const weixin_vtable = weixin_control.Control.VTable{
 /// the dummy ctx is unused.
 pub fn weixinControl() weixin_control.Control {
     return .{ .ctx = &g_weixin_ctx, .vtable = &weixin_vtable };
+}
+
+fn clearWeixinTranscriptCache() void {
+    g_weixin_transcript_mutex.lock();
+    defer g_weixin_transcript_mutex.unlock();
+    if (g_weixin_transcript_owned.len != 0) std.heap.page_allocator.free(g_weixin_transcript_owned);
+    g_weixin_transcript_owned = &.{};
 }
 
 fn buildRemoteSurfaceSnapshot(allocator: std.mem.Allocator, surface: *Surface) ![]u8 {
@@ -3689,6 +3757,7 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderSessionLauncher(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+        weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderDebugOverlay(@floatFromInt(fb_width));
         overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -3715,8 +3784,16 @@ fn runMainLoop(self: *AppWindow) !void {
         }
     }
 
+    // Stop accepting cross-thread WeChat control calls before UI-owned globals
+    // and renderer resources start tearing down. The App-level controller is
+    // stopped shortly after this window loop returns.
+    g_weixin_ui_handle.store(0, .release);
+
     // Clean up file explorer async state (join background thread, free job)
     file_explorer.deinit();
+    weixin_qr_renderer.deinit();
+    weixin_qr_panel.deinit();
+    clearWeixinTranscriptCache();
     markdown_preview_renderer.deinit();
     markdown_preview_panel.deinit();
     browser_panel.deinit();

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -25,6 +25,9 @@ pub const CommandAction = enum {
     toggle_maximize,
     copy_remote_key,
     connect_wechat,
+    start_wechat,
+    stop_wechat,
+    wechat_status,
     unbind_wechat,
     export_ai_chat_markdown,
     export_ai_chat_markdown_clean,
@@ -64,6 +67,9 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "Toggle Maximize", .detail = "Maximize or restore the window", .shortcut = "", .action = .toggle_maximize },
     .{ .title = "Copy Remote Key", .detail = "Copy the active Phantty remote session key", .shortcut = "click Remote key", .action = .copy_remote_key },
     .{ .title = "Connect WeChat", .detail = "Scan a QR code to connect WeChat direct control", .shortcut = "", .action = .connect_wechat },
+    .{ .title = "WeChat: Start", .detail = "Start polling with the saved WeChat binding", .shortcut = "", .action = .start_wechat },
+    .{ .title = "WeChat: Stop", .detail = "Stop polling and keep the saved WeChat binding", .shortcut = "", .action = .stop_wechat },
+    .{ .title = "WeChat: Status", .detail = "Show the WeChat direct connection state", .shortcut = "", .action = .wechat_status },
     .{ .title = "WeChat: Unbind", .detail = "Clear the stored WeChat direct binding", .shortcut = "", .action = .unbind_wechat },
     .{ .title = "Export AI Chat Markdown", .detail = "Save the active AI Chat transcript as Markdown", .shortcut = "", .action = .export_ai_chat_markdown },
     .{ .title = "Export AI Chat Markdown Clean", .detail = "Save user prompts and the final AI result without thinking", .shortcut = "", .action = .export_ai_chat_markdown_clean },
@@ -256,6 +262,9 @@ test "command center includes AI Markdown export actions" {
 
 test "command center includes WeChat direct actions" {
     try std.testing.expectEqual(CommandAction.connect_wechat, findCommandAction("Connect WeChat"));
+    try std.testing.expectEqual(CommandAction.start_wechat, findCommandAction("WeChat: Start"));
+    try std.testing.expectEqual(CommandAction.stop_wechat, findCommandAction("WeChat: Stop"));
+    try std.testing.expectEqual(CommandAction.wechat_status, findCommandAction("WeChat: Status"));
     try std.testing.expectEqual(CommandAction.unbind_wechat, findCommandAction("WeChat: Unbind"));
 }
 

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -24,6 +24,8 @@ pub const CommandAction = enum {
     font_size_increase,
     toggle_maximize,
     copy_remote_key,
+    connect_wechat,
+    unbind_wechat,
     export_ai_chat_markdown,
     export_ai_chat_markdown_clean,
     show_version,
@@ -61,6 +63,8 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "Increase Font Size", .detail = "Make terminal text larger", .shortcut = "", .action = .font_size_increase },
     .{ .title = "Toggle Maximize", .detail = "Maximize or restore the window", .shortcut = "", .action = .toggle_maximize },
     .{ .title = "Copy Remote Key", .detail = "Copy the active Phantty remote session key", .shortcut = "click Remote key", .action = .copy_remote_key },
+    .{ .title = "Connect WeChat", .detail = "Scan a QR code to connect WeChat direct control", .shortcut = "", .action = .connect_wechat },
+    .{ .title = "WeChat: Unbind", .detail = "Clear the stored WeChat direct binding", .shortcut = "", .action = .unbind_wechat },
     .{ .title = "Export AI Chat Markdown", .detail = "Save the active AI Chat transcript as Markdown", .shortcut = "", .action = .export_ai_chat_markdown },
     .{ .title = "Export AI Chat Markdown Clean", .detail = "Save user prompts and the final AI result without thinking", .shortcut = "", .action = .export_ai_chat_markdown_clean },
     .{ .title = "Version", .detail = "Show Phantty version", .shortcut = app_metadata.version, .action = .show_version },
@@ -248,6 +252,11 @@ test "command center includes update check actions" {
 test "command center includes AI Markdown export actions" {
     try std.testing.expectEqual(CommandAction.export_ai_chat_markdown, findCommandAction("Export AI Chat Markdown"));
     try std.testing.expectEqual(CommandAction.export_ai_chat_markdown_clean, findCommandAction("Export AI Chat Markdown Clean"));
+}
+
+test "command center includes WeChat direct actions" {
+    try std.testing.expectEqual(CommandAction.connect_wechat, findCommandAction("Connect WeChat"));
+    try std.testing.expectEqual(CommandAction.unbind_wechat, findCommandAction("WeChat: Unbind"));
 }
 
 test "command center browser text is backend neutral" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -640,7 +640,7 @@ fn parseContent(self: *Config, allocator: std.mem.Allocator, content: []const u8
 
         if (std.mem.indexOf(u8, trimmed, "=")) |eq_pos| {
             const key = std.mem.trim(u8, trimmed[0..eq_pos], " \t");
-            const raw_value = std.mem.trim(u8, trimmed[eq_pos + 1 ..], " \t");
+            const raw_value = stripInlineComment(std.mem.trim(u8, trimmed[eq_pos + 1 ..], " \t"));
             // Strip optional quotes
             const value = stripQuotes(raw_value);
 
@@ -1542,6 +1542,24 @@ fn stripQuotes(s: []const u8) []const u8 {
     return s;
 }
 
+fn stripInlineComment(s: []const u8) []const u8 {
+    var in_quotes = false;
+    var escaped = false;
+    for (s, 0..) |ch, i| {
+        if (in_quotes and ch == '\\' and !escaped) {
+            escaped = true;
+            continue;
+        }
+        if (ch == '"' and !escaped) {
+            in_quotes = !in_quotes;
+        } else if (ch == '#' and !in_quotes and i > 0 and std.ascii.isWhitespace(s[i - 1])) {
+            return std.mem.trimRight(u8, s[0..i], " \t");
+        }
+        escaped = false;
+    }
+    return s;
+}
+
 pub fn hexToColor(hex: u24) Color {
     const r: f32 = @as(f32, @floatFromInt((hex >> 16) & 0xFF)) / 255.0;
     const g: f32 = @as(f32, @floatFromInt((hex >> 8) & 0xFF)) / 255.0;
@@ -1716,6 +1734,24 @@ test "config: quake mode defaults enabled and parses true false" {
 
     cfg.applyKeyValue(allocator, "quake-mode", "maybe", ".");
     try std.testing.expectEqual(true, cfg.@"quake-mode");
+}
+
+test "config: inline comments after values are ignored" {
+    const allocator = std.testing.allocator;
+    var cfg: Config = .{};
+    defer cfg.deinit(allocator);
+
+    cfg.parseContent(
+        allocator,
+        "background-image-mode = fit   # fill | fit | center | tile\n" ++
+            "background = #112233   # color comment\n" ++
+            "title = \"hello # not a comment\"\n",
+        ".",
+    );
+
+    try std.testing.expectEqual(BackgroundImageMode.fit, cfg.@"background-image-mode");
+    try std.testing.expectEqual(hexToColor(0x112233), cfg.background.?);
+    try std.testing.expectEqualStrings("hello # not a comment", cfg.title.?);
 }
 
 test "config: keybind directives override default action bindings" {

--- a/src/config_watcher.zig
+++ b/src/config_watcher.zig
@@ -9,6 +9,9 @@ const platform_config_watcher = @import("platform/config_watcher.zig");
 const ConfigWatcher = @This();
 
 watcher: platform_config_watcher.DirectoryWatcher,
+allocator: std.mem.Allocator,
+config_path: []const u8,
+last_mtime: ?i128,
 
 /// Open the config directory and start watching for changes.
 pub fn init(allocator: std.mem.Allocator) ?ConfigWatcher {
@@ -16,25 +19,51 @@ pub fn init(allocator: std.mem.Allocator) ?ConfigWatcher {
         std.debug.print("ConfigWatcher: failed to get config path: {}\n", .{err});
         return null;
     };
-    defer allocator.free(path);
 
     const dir_path = std.fs.path.dirname(path) orelse {
         std.debug.print("ConfigWatcher: failed to get directory from path\n", .{});
+        allocator.free(path);
         return null;
     };
 
-    const watcher = platform_config_watcher.DirectoryWatcher.initPath(dir_path) orelse return null;
-    std.debug.print("ConfigWatcher: watching {s}\n", .{dir_path});
-    return .{ .watcher = watcher };
+    const watcher = platform_config_watcher.DirectoryWatcher.initPath(dir_path) orelse {
+        allocator.free(path);
+        return null;
+    };
+    std.debug.print("ConfigWatcher: watching {s}\\config\n", .{dir_path});
+    return .{
+        .watcher = watcher,
+        .allocator = allocator,
+        .config_path = path,
+        .last_mtime = configMtime(path),
+    };
 }
 
-/// Non-blocking check: has the config directory changed?
+/// Non-blocking check: has the config file changed?
 pub fn hasChanged(self: *ConfigWatcher) bool {
-    return self.watcher.hasChanged();
+    if (!self.watcher.hasChanged()) return false;
+    const next_mtime = configMtime(self.config_path);
+    if (optionalMtimeEql(self.last_mtime, next_mtime)) return false;
+    self.last_mtime = next_mtime;
+    return true;
 }
 
 pub fn deinit(self: *ConfigWatcher) void {
     self.watcher.deinit();
+    self.allocator.free(self.config_path);
+}
+
+fn configMtime(path: []const u8) ?i128 {
+    const stat = std.fs.cwd().statFile(path) catch return null;
+    return stat.mtime;
+}
+
+fn optionalMtimeEql(a: ?i128, b: ?i128) bool {
+    if (a) |av| {
+        if (b) |bv| return av == bv;
+        return false;
+    }
+    return b == null;
 }
 
 test "config watcher wraps platform directory watcher" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -1025,6 +1025,14 @@ fn handleKey(ev: platform_input.KeyEvent) void {
         overlays.settingsPageHandleKey(key_event);
         return;
     }
+    if (AppWindow.weixin_qr_panel.visible()) {
+        switch (ev.key_code) {
+            platform_input.key_escape => overlays.weixinQrPanelHandleAction(.close),
+            platform_input.key_enter => if (AppWindow.weixin_qr_panel.status() == .expired) overlays.weixinQrPanelHandleAction(.retry),
+            else => {},
+        }
+        return;
+    }
     // File explorer key handling (when focused and in operation mode)
     if (file_explorer.g_focused and file_explorer.isVisibleForActiveTab()) {
         if (handleFileExplorerKey(ev)) return;
@@ -2333,6 +2341,19 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             if (!overlays.commandPaletteContainsPoint(xpos, ypos, w_f, h_f, top_offset)) {
                 overlays.commandPaletteClose();
             }
+        }
+        return;
+    }
+    if (AppWindow.weixin_qr_panel.visible()) {
+        if (ev.button == .left and ev.action == .press) {
+            const win = AppWindow.g_window orelse return;
+            const fb = window_backend.framebufferSize(win);
+            const w_f: f32 = @floatFromInt(fb.width);
+            const h_f: f32 = @floatFromInt(fb.height);
+            const top_offset: f32 = @floatCast(titlebarHeight());
+            const xpos: f64 = @floatFromInt(ev.x);
+            const ypos: f64 = @floatFromInt(ev.y);
+            overlays.weixinQrPanelHandleAction(AppWindow.weixin_qr_panel.executeAt(xpos, ypos, w_f, h_f, top_offset));
         }
         return;
     }

--- a/src/platform/thread_control.zig
+++ b/src/platform/thread_control.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Backend = enum {
+    windows,
+    unsupported,
+};
+
+pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
+    return switch (os_tag) {
+        .windows => .windows,
+        else => .unsupported,
+    };
+}
+
+const impl = switch (backendForOs(builtin.os.tag)) {
+    .windows => @import("thread_control_windows.zig"),
+    .unsupported => @import("thread_control_unsupported.zig"),
+};
+
+pub const requestSynchronousIoCancel = impl.requestSynchronousIoCancel;
+pub const waitForExit = impl.waitForExit;
+
+test "platform thread control selects backend by target OS" {
+    try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.macos));
+}

--- a/src/platform/thread_control_unsupported.zig
+++ b/src/platform/thread_control_unsupported.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+pub fn requestSynchronousIoCancel(thread: std.Thread) bool {
+    _ = thread;
+    return false;
+}
+
+pub fn waitForExit(thread: std.Thread, timeout_ms: u32) bool {
+    _ = thread;
+    _ = timeout_ms;
+    return false;
+}

--- a/src/platform/thread_control_windows.zig
+++ b/src/platform/thread_control_windows.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const windows = std.os.windows;
+
+extern "kernel32" fn CancelSynchronousIo(hThread: windows.HANDLE) callconv(.winapi) windows.BOOL;
+
+/// Best-effort cancellation for blocking synchronous Win32 I/O issued by
+/// `thread`. This is intentionally advisory; callers still need to wait or
+/// detach according to their shutdown policy.
+pub fn requestSynchronousIoCancel(thread: std.Thread) bool {
+    return CancelSynchronousIo(thread.getHandle()) != 0;
+}
+
+pub fn waitForExit(thread: std.Thread, timeout_ms: u32) bool {
+    windows.WaitForSingleObject(thread.getHandle(), timeout_ms) catch |err| switch (err) {
+        error.WaitTimeOut => return false,
+        else => return false,
+    };
+    return true;
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -27,6 +27,7 @@ const update_check = @import("../update_check.zig");
 const keybind = @import("../keybind.zig");
 const overlay_keys = @import("overlay_keys.zig");
 const weixin_qr_panel = @import("../weixin/qr_panel.zig");
+const weixin_types = @import("../weixin/types.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -453,6 +454,9 @@ fn executeCommand(action: CommandAction) void {
             _ = AppWindow.input.copyRemoteSessionKeyToClipboard();
         },
         .connect_wechat => connectWeixinDirect(),
+        .start_wechat => startWeixinDirect(),
+        .stop_wechat => stopWeixinDirect(),
+        .wechat_status => showWeixinDirectStatus(),
         .unbind_wechat => unbindWeixinDirect(),
         .export_ai_chat_markdown => AppWindow.exportActiveAiChatMarkdown(.full),
         .export_ai_chat_markdown_clean => AppWindow.exportActiveAiChatMarkdown(.clean),
@@ -494,6 +498,87 @@ fn connectWeixinDirect() void {
     };
     AppWindow.g_force_rebuild = true;
     AppWindow.g_cells_valid = false;
+}
+
+fn startWeixinDirect() void {
+    const controller = activeWeixinController() orelse {
+        showStatusToast("Enable weixin-direct-enabled first");
+        return;
+    };
+    const before = controller.statusSnapshot();
+    if (before.running) {
+        showStatusToast("WeChat poller already running");
+        return;
+    }
+    controller.start() catch |err| {
+        std.debug.print("weixin direct start failed from command palette: {}\n", .{err});
+        showStatusToast("WeChat start failed");
+        return;
+    };
+    const after = controller.statusSnapshot();
+    if (after.running) {
+        showStatusToast("WeChat poller started");
+    } else if (after.has_token) {
+        showStatusToast("WeChat binding saved; poller stopped");
+    } else {
+        showStatusToast("WeChat not connected");
+    }
+}
+
+fn stopWeixinDirect() void {
+    const controller = activeWeixinController() orelse {
+        showStatusToast("WeChat direct is not active");
+        return;
+    };
+    const before = controller.statusSnapshot();
+    if (!before.running and !before.has_token and !before.login_active) {
+        showStatusToast("WeChat not connected");
+        return;
+    }
+    controller.stop();
+    if (before.running) {
+        showStatusToast("WeChat poller stopped");
+    } else if (before.login_active) {
+        showStatusToast("WeChat login is still waiting");
+    } else {
+        showStatusToast("WeChat poller already stopped");
+    }
+}
+
+fn showWeixinDirectStatus() void {
+    const controller = activeWeixinController() orelse {
+        showStatusToast("WeChat direct disabled");
+        return;
+    };
+    const s = controller.statusSnapshot();
+    var buf: [64]u8 = undefined;
+    const msg = weixinStatusMessage(&buf, s);
+    showStatusToast(msg);
+}
+
+fn weixinStatusMessage(buf: []u8, s: weixin_qr_panel.Controller.Status) []const u8 {
+    if (s.login_active) {
+        return std.fmt.bufPrint(buf, "WeChat login: {s}", .{weixinLoginStatusName(s.login_status)}) catch "WeChat login active";
+    }
+    if (s.running) {
+        return std.fmt.bufPrint(buf, "WeChat running (owner={s}, bot={s})", .{ yesNo(s.has_owner), yesNo(s.has_bot_id) }) catch "WeChat running";
+    }
+    if (s.has_token) return "WeChat stopped (binding saved)";
+    return "WeChat not connected";
+}
+
+fn yesNo(value: bool) []const u8 {
+    return if (value) "yes" else "no";
+}
+
+fn weixinLoginStatusName(status: weixin_types.QrStatusKind) []const u8 {
+    return switch (status) {
+        .wait => "waiting",
+        .scaned => "scanned",
+        .confirmed => "confirmed",
+        .expired => "expired",
+        .unknown => "unknown",
+    };
 }
 
 fn unbindWeixinDirect() void {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -26,6 +26,7 @@ const platform_pty_command = @import("../platform/pty_command.zig");
 const update_check = @import("../update_check.zig");
 const keybind = @import("../keybind.zig");
 const overlay_keys = @import("overlay_keys.zig");
+const weixin_qr_panel = @import("../weixin/qr_panel.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -451,6 +452,8 @@ fn executeCommand(action: CommandAction) void {
         .copy_remote_key => {
             _ = AppWindow.input.copyRemoteSessionKeyToClipboard();
         },
+        .connect_wechat => connectWeixinDirect(),
+        .unbind_wechat => unbindWeixinDirect(),
         .export_ai_chat_markdown => AppWindow.exportActiveAiChatMarkdown(.full),
         .export_ai_chat_markdown_clean => AppWindow.exportActiveAiChatMarkdown(.clean),
         .show_version => showVersionToast(),
@@ -471,6 +474,63 @@ fn executeCommand(action: CommandAction) void {
             }
         },
         .open_latest_release => openLatestRelease(),
+    }
+}
+
+fn activeWeixinController() ?*weixin_qr_panel.Controller {
+    const app = AppWindow.g_app orelse return null;
+    return app.weixin_controller;
+}
+
+fn connectWeixinDirect() void {
+    const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
+    const controller = activeWeixinController() orelse {
+        showStatusToast("Enable weixin-direct-enabled first");
+        return;
+    };
+    weixin_qr_panel.start(allocator, controller) catch {
+        showStatusToast("WeChat login failed to start");
+        return;
+    };
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+}
+
+fn unbindWeixinDirect() void {
+    const controller = activeWeixinController() orelse {
+        showStatusToast("WeChat direct is not active");
+        return;
+    };
+    controller.unbind() catch {
+        showStatusToast("WeChat unbind failed");
+        return;
+    };
+    weixin_qr_panel.close();
+    showStatusToast("WeChat unbound");
+}
+
+pub fn weixinQrPanelHandleAction(action: weixin_qr_panel.Action) void {
+    switch (action) {
+        .none => {},
+        .close => {
+            weixin_qr_panel.close();
+            AppWindow.g_force_rebuild = true;
+            AppWindow.g_cells_valid = false;
+        },
+        .retry => {
+            const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
+            const controller = weixin_qr_panel.controller() orelse activeWeixinController() orelse {
+                showStatusToast("WeChat direct is not active");
+                return;
+            };
+            weixin_qr_panel.start(allocator, controller) catch {
+                showStatusToast("WeChat login failed to start");
+                return;
+            };
+            AppWindow.g_force_rebuild = true;
+            AppWindow.g_cells_valid = false;
+        },
+        .unbind => unbindWeixinDirect(),
     }
 }
 

--- a/src/renderer/weixin_qr_renderer.zig
+++ b/src/renderer/weixin_qr_renderer.zig
@@ -1,0 +1,171 @@
+//! Renderer for the WeChat QR login panel.
+
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const qr_panel = @import("../weixin/qr_panel.zig");
+const titlebar = AppWindow.titlebar;
+const font = AppWindow.font;
+const gl_init = AppWindow.gl_init;
+
+const c = @cImport({
+    @cInclude("glad/gl.h");
+});
+
+fn mix(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const amount = @max(0.0, @min(1.0, t));
+    const inv = 1.0 - amount;
+    return .{
+        a[0] * inv + b[0] * amount,
+        a[1] * inv + b[1] * amount,
+        a[2] * inv + b[2] * amount,
+    };
+}
+
+fn textWidth(text: []const u8) f32 {
+    var width: f32 = 0;
+    const view = std.unicode.Utf8View.init(text) catch {
+        for (text) |byte| width += titlebar.titlebarGlyphAdvance(if (byte >= 0x20 and byte <= 0x7e) byte else '?');
+        return width;
+    };
+    var it = view.iterator();
+    while (it.nextCodepoint()) |cp| width += titlebar.titlebarGlyphAdvance(cp);
+    return width;
+}
+
+fn textYFromTop(window_height: f32, top_px: f32) f32 {
+    return @round(window_height - top_px - font.g_titlebar_cell_height);
+}
+
+fn rectY(window_height: f32, rect: qr_panel.Rect) f32 {
+    return @round(window_height - rect.top_px - rect.h);
+}
+
+fn beginUi() void {
+    const gl = AppWindow.gl;
+    gl.UseProgram.?(gl_init.shader_program);
+    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    gl.BindVertexArray.?(gl_init.vao);
+}
+
+pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
+    if (!qr_panel.visible()) return;
+
+    const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
+    if (qr_panel.refresh(allocator)) {
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+    }
+    if (!qr_panel.visible()) return;
+
+    const gl = AppWindow.gl;
+    gl.Enable.?(c.GL_BLEND);
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    beginUi();
+
+    const l = qr_panel.layout(window_width, window_height, top_offset);
+    const panel_y = rectY(window_height, l.panel);
+    const qr_y = rectY(window_height, l.qr);
+
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const panel_bg = mix(bg, fg, 0.045);
+    const panel_border = mix(bg, fg, 0.22);
+    const qr_bg = .{ 0.96, 0.97, 0.98 };
+    const qr_border = mix(bg, fg, 0.30);
+    const normal = mix(bg, fg, 0.90);
+    const muted = mix(bg, fg, 0.62);
+    const danger = .{ 0.88, 0.28, 0.24 };
+
+    AppWindow.overlays.renderRoundedQuadAlpha(0, 0, window_width, window_height, 1, .{ 0.0, 0.0, 0.0 }, 0.28);
+    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x - 1, panel_y - 1, l.panel.w + 2, l.panel.h + 2, 10, panel_border, 0.50);
+    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x, panel_y, l.panel.w, l.panel.h, 9, panel_bg, 0.98);
+
+    const pad_x: f32 = 28;
+    const title_y = textYFromTop(window_height, l.panel.top_px + 24);
+    _ = titlebar.renderTextLimited("Connect WeChat", l.panel.x + pad_x, title_y, normal, l.panel.w - pad_x * 2);
+
+    const status_label = qr_panel.statusLabel(qr_panel.status());
+    const status_color = switch (qr_panel.status()) {
+        .expired => danger,
+        .confirmed => accent,
+        .scaned => accent,
+        else => normal,
+    };
+    const status_y = textYFromTop(window_height, l.panel.top_px + 60);
+    _ = titlebar.renderTextLimited(status_label, l.panel.x + pad_x, status_y, status_color, l.panel.w - pad_x * 2);
+
+    const detail_y = textYFromTop(window_height, l.panel.top_px + 94);
+    _ = titlebar.renderTextLimited(qr_panel.statusDetail(qr_panel.status()), l.panel.x + pad_x, detail_y, muted, l.panel.w - pad_x * 2);
+
+    gl_init.renderQuadAlpha(l.qr.x - 10, qr_y - 10, l.qr.w + 20, l.qr.h + 20, qr_border, 0.42);
+    gl_init.renderQuadAlpha(l.qr.x - 8, qr_y - 8, l.qr.w + 16, l.qr.h + 16, qr_bg, 1.0);
+
+    if (qr_panel.qrMatrix()) |matrix| {
+        renderQrMatrix(matrix, l.qr, window_height);
+    } else {
+        renderQrFallback(l, window_height, normal, muted);
+    }
+
+    const button_top = l.close.top_px;
+    const hint_y = textYFromTop(window_height, button_top - 34);
+    _ = titlebar.renderTextLimited("Token is saved locally after confirmation.", l.panel.x + pad_x, hint_y, muted, l.panel.w - pad_x * 2);
+
+    if (qr_panel.status() == .expired) {
+        renderButton(l.retry, window_height, "Retry", accent, .{ 1.0, 1.0, 1.0 }, true);
+    }
+    renderButton(l.unbind, window_height, "Unbind", danger, .{ 1.0, 1.0, 1.0 }, false);
+    renderButton(l.close, window_height, "Close", panel_border, normal, false);
+}
+
+fn renderQrMatrix(matrix: qr_panel.QrMatrixView, rect: qr_panel.Rect, window_height: f32) void {
+    const quiet_modules: usize = 4;
+    const total_modules = matrix.size + quiet_modules * 2;
+    const module_px = @max(1.0, @floor(rect.w / @as(f32, @floatFromInt(total_modules))));
+    const draw_size = module_px * @as(f32, @floatFromInt(total_modules));
+    const start_x = @round(rect.x + (rect.w - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
+    const start_top = @round(rect.top_px + (rect.h - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
+
+    const black = .{ 0.03, 0.04, 0.05 };
+    for (0..matrix.size) |y| {
+        const y_top = start_top + module_px * @as(f32, @floatFromInt(y));
+        const gl_y = @round(window_height - y_top - module_px);
+        for (0..matrix.size) |x| {
+            if (!matrix.isBlack(x, y)) continue;
+            const gl_x = start_x + module_px * @as(f32, @floatFromInt(x));
+            gl_init.renderQuadAlpha(gl_x, gl_y, module_px, module_px, black, 1.0);
+        }
+    }
+}
+
+fn renderQrFallback(l: qr_panel.Layout, window_height: f32, normal: [3]f32, muted: [3]f32) void {
+    const qr_y = rectY(window_height, l.qr);
+    const message = if (qr_panel.qrGenerationFailed())
+        "QR code could not be generated"
+    else
+        "Requesting QR code...";
+
+    const msg_w = textWidth(message);
+    const msg_y = qr_y + l.qr.h * 0.52;
+    _ = titlebar.renderTextLimited(message, l.qr.x + @max(8.0, (l.qr.w - msg_w) / 2.0), msg_y, normal, l.qr.w - 16);
+
+    const qr_text = qr_panel.qrString();
+    if (qr_panel.qrGenerationFailed() and qr_text.len > 0) {
+        const text_y = msg_y - font.g_titlebar_cell_height - 10;
+        _ = titlebar.renderTextLimited(qr_text, l.qr.x + 12, text_y, muted, l.qr.w - 24);
+    }
+}
+
+fn renderButton(rect: qr_panel.Rect, window_height: f32, label: []const u8, base: [3]f32, text_color: [3]f32, primary: bool) void {
+    const y = rectY(window_height, rect);
+    const bg = if (primary) base else mix(AppWindow.g_theme.background, base, 0.30);
+    const border = if (primary) mix(base, .{ 1.0, 1.0, 1.0 }, 0.18) else base;
+    AppWindow.overlays.renderRoundedQuadAlpha(rect.x - 1, y - 1, rect.w + 2, rect.h + 2, 6, border, if (primary) 0.74 else 0.42);
+    AppWindow.overlays.renderRoundedQuadAlpha(rect.x, y, rect.w, rect.h, 5, bg, if (primary) 0.92 else 0.58);
+
+    const label_w = textWidth(label);
+    const text_y = @round(y + (rect.h - font.g_titlebar_cell_height) / 2.0);
+    _ = titlebar.renderTextLimited(label, rect.x + @max(8.0, (rect.w - label_w) / 2.0), text_y, text_color, rect.w - 16);
+}
+
+pub fn deinit() void {}

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -645,6 +645,7 @@ comptime {
     _ = @import("platform/remote_transport.zig");
     _ = @import("platform/session_lock.zig");
     _ = @import("platform/text.zig");
+    _ = @import("platform/thread_control.zig");
     _ = @import("platform/threading.zig");
     _ = @import("platform/update_package.zig");
     _ = @import("platform/webview.zig");
@@ -666,6 +667,8 @@ comptime {
     _ = @import("weixin/ilink_client.zig");
     _ = @import("weixin/poller.zig");
     _ = @import("weixin/controller.zig");
+    _ = @import("weixin/qr_code.zig");
+    _ = @import("weixin/qr_panel.zig");
     _ = @import("renderer/overlay_keys.zig");
     _ = @import("selection_unit.zig");
     _ = @import("session_persist.zig");

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -108,6 +108,32 @@ pub const Controller = struct {
         qr_content: []const u8,
     };
 
+    pub const Status = struct {
+        running: bool,
+        has_token: bool,
+        has_owner: bool,
+        has_bot_id: bool,
+        login_active: bool,
+        login_status: types.QrStatusKind,
+    };
+
+    pub fn statusSnapshot(self: *Controller) Status {
+        const login_active = self.login_active.load(.acquire);
+        self.login_mutex.lock();
+        const login_status = self.login_status;
+        self.login_mutex.unlock();
+        const poller_active = self.running and !self.poll.stop_requested.load(.acquire);
+
+        return .{
+            .running = poller_active,
+            .has_token = self.token.len != 0,
+            .has_owner = self.owner.len != 0,
+            .has_bot_id = self.bot_id.len != 0,
+            .login_active = login_active,
+            .login_status = login_status,
+        };
+    }
+
     /// Thread-safe snapshot for a UI panel. Returned strings are copied into `arena`.
     pub fn loginSnapshot(self: *Controller, arena: std.mem.Allocator) !LoginSnapshot {
         self.login_mutex.lock();
@@ -183,16 +209,22 @@ pub const Controller = struct {
         var loaded = try state_store.load(self.allocator, self.state_path);
         defer loaded.deinit(self.allocator);
         if (loaded.binding.bot_token.len == 0) return; // not logged in yet
-        try self.startWithBinding(loaded.binding);
+        try self.startWithBinding(loaded.binding, .{
+            .bootstrap_skip_pending = loaded.binding.sync_buf.len == 0,
+        });
     }
 
     /// Stops the poller, persisting the latest sync cursor so the next start
     /// resumes where it left off.
     pub fn stop(self: *Controller) void {
+        self.stopInternal(true);
+    }
+
+    fn stopInternal(self: *Controller, persist_sync: bool) void {
         if (!self.running) return;
         self.poll.stop();
         // Persist the advanced sync cursor (best-effort).
-        self.persist(self.poll.sync_buf) catch {};
+        if (persist_sync) self.persist(self.poll.sync_buf) catch {};
         self.allocator.free(self.poll.sync_buf);
         // ilink.Client holds no persistent resources (it opens a fresh
         // std.http.Client per request), so there is nothing to deinit here.
@@ -244,7 +276,7 @@ pub const Controller = struct {
             .sync_buf = "",
         };
         try self.persistBinding(binding);
-        try self.startWithBinding(binding);
+        try self.startWithBinding(binding, .{ .bootstrap_skip_pending = false });
         std.debug.print("weixin QR login confirmed; polling started\n", .{});
     }
 
@@ -254,8 +286,15 @@ pub const Controller = struct {
         return if (self.base_url.len != 0) self.base_url else ilink_default_base_url;
     }
 
-    fn startWithBinding(self: *Controller, binding: types.Binding) !void {
-        if (self.running) return;
+    const StartOptions = struct {
+        bootstrap_skip_pending: bool = false,
+    };
+
+    fn startWithBinding(self: *Controller, binding: types.Binding, options: StartOptions) !void {
+        if (self.running) {
+            std.debug.print("weixin direct binding refresh requested; stopping existing poller\n", .{});
+            self.stopInternal(false);
+        }
         try self.setBinding(binding);
 
         self.client = ilink.Client.init(self.allocator, self.base_url, self.token);
@@ -267,6 +306,8 @@ pub const Controller = struct {
             .owner = self.owner,
             .account_id = self.bot_id,
             .sync_buf = try self.allocator.dupe(u8, binding.sync_buf),
+            .sync_callback = .{ .ctx = self, .callback = persistSyncAdapter },
+            .bootstrap_skip_pending = options.bootstrap_skip_pending,
         };
         try self.poll.start();
         self.running = true;
@@ -309,6 +350,11 @@ pub const Controller = struct {
 
     fn persistBinding(self: *Controller, binding: types.Binding) !void {
         try state_store.save(self.allocator, self.state_path, binding);
+    }
+
+    fn persistSyncAdapter(ctx: *anyopaque, sync_buf: []const u8) anyerror!void {
+        const self: *Controller = @ptrCast(@alignCast(ctx));
+        try self.persist(sync_buf);
     }
 
     fn joinLoginThreadForProcessExit(self: *Controller, thread_control: ThreadControl) bool {
@@ -393,4 +439,20 @@ test "loginSnapshot on a fresh controller reports unknown/empty" {
     const snap = try ctrl.loginSnapshot(arena.allocator());
     try t.expectEqual(types.QrStatusKind.unknown, snap.status);
     try t.expectEqual(@as(usize, 0), snap.qr_string.len);
+}
+
+test "status on a fresh controller reports disconnected idle" {
+    const path = "zig-cache-tmp-weixin-ctrl-status.json";
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    const ctrl = try Controller.create(t.allocator, path, NoopControl.iface(), .{});
+    defer ctrl.destroy();
+
+    const s = ctrl.statusSnapshot();
+    try t.expect(!s.running);
+    try t.expect(!s.has_token);
+    try t.expect(!s.has_owner);
+    try t.expect(!s.has_bot_id);
+    try t.expect(!s.login_active);
+    try t.expectEqual(types.QrStatusKind.unknown, s.login_status);
 }

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -9,6 +9,9 @@ const ilink = @import("ilink_client.zig");
 const poller = @import("poller.zig");
 const control_mod = @import("control.zig");
 
+const SHUTDOWN_JOIN_TIMEOUT_MS: u32 = 1500;
+pub const ThreadControl = poller.ThreadControl;
+
 pub const Controller = struct {
     allocator: std.mem.Allocator,
     state_path: []u8,
@@ -35,7 +38,7 @@ pub const Controller = struct {
     login_status: types.QrStatusKind = .unknown,
     login_qr_arena: ?std.heap.ArenaAllocator = null,
     login_qr_string: []const u8 = "",
-    login_qr_img_base64: []const u8 = "",
+    login_qr_content: []const u8 = "",
 
     pub fn create(
         allocator: std.mem.Allocator,
@@ -67,22 +70,42 @@ pub const Controller = struct {
         self.allocator.destroy(self);
     }
 
+    /// Process-exit variant: do not block forever on iLink long-poll/login HTTP
+    /// calls. If a worker cannot be joined promptly, it is detached and this
+    /// Controller intentionally remains allocated until the process exits.
+    pub fn destroyForProcessExit(self: *Controller, thread_control: ThreadControl) bool {
+        self.login_active.store(false, .release);
+        if (!self.joinLoginThreadForProcessExit(thread_control)) return false;
+        if (!self.stopForProcessExit(thread_control)) return false;
+
+        if (self.login_qr_arena) |*a| a.deinit();
+        self.clearBinding();
+        self.allocator.free(self.state_path);
+        self.allocator.destroy(self);
+        return true;
+    }
+
     /// Starts QR login on a background thread (idempotent). A panel polls
     /// loginSnapshot() for the QR + status; on confirmation the binding is
     /// persisted and polling starts automatically.
     pub fn startLoginAsync(self: *Controller) !void {
         if (self.login_active.swap(true, .acq_rel)) return; // already running
-        self.setLoginStatus(.wait);
+        if (self.login_thread) |th| {
+            th.join();
+            self.login_thread = null;
+        }
+        self.resetLoginSnapshot(.wait);
         self.login_thread = std.Thread.spawn(.{}, loginThreadMain, .{self}) catch |err| {
             self.login_active.store(false, .release);
             return err;
         };
+        std.debug.print("weixin QR login started\n", .{});
     }
 
     pub const LoginSnapshot = struct {
         status: types.QrStatusKind,
         qr_string: []const u8,
-        qr_img_base64: []const u8,
+        qr_content: []const u8,
     };
 
     /// Thread-safe snapshot for a UI panel. Returned strings are copied into `arena`.
@@ -92,7 +115,7 @@ pub const Controller = struct {
         return .{
             .status = self.login_status,
             .qr_string = try arena.dupe(u8, self.login_qr_string),
-            .qr_img_base64 = try arena.dupe(u8, self.login_qr_img_base64),
+            .qr_content = try arena.dupe(u8, self.login_qr_content),
         };
     }
 
@@ -129,14 +152,24 @@ pub const Controller = struct {
         self.login_active.store(false, .release);
     }
 
-    fn setLoginQr(self: *Controller, qr_string: []const u8, img_base64: []const u8) void {
+    fn setLoginQr(self: *Controller, qr_string: []const u8, qr_content: []const u8) void {
         self.login_mutex.lock();
         defer self.login_mutex.unlock();
         if (self.login_qr_arena) |*a| a.deinit();
         self.login_qr_arena = std.heap.ArenaAllocator.init(self.allocator);
         const a = self.login_qr_arena.?.allocator();
         self.login_qr_string = a.dupe(u8, qr_string) catch "";
-        self.login_qr_img_base64 = a.dupe(u8, img_base64) catch "";
+        self.login_qr_content = a.dupe(u8, qr_content) catch "";
+    }
+
+    fn resetLoginSnapshot(self: *Controller, status: types.QrStatusKind) void {
+        self.login_mutex.lock();
+        defer self.login_mutex.unlock();
+        if (self.login_qr_arena) |*a| a.deinit();
+        self.login_qr_arena = null;
+        self.login_qr_string = "";
+        self.login_qr_content = "";
+        self.login_status = status;
     }
 
     fn setLoginStatus(self: *Controller, status: types.QrStatusKind) void {
@@ -164,6 +197,17 @@ pub const Controller = struct {
         // ilink.Client holds no persistent resources (it opens a fresh
         // std.http.Client per request), so there is nothing to deinit here.
         self.running = false;
+    }
+
+    fn stopForProcessExit(self: *Controller, thread_control: ThreadControl) bool {
+        if (!self.running) return true;
+        if (!self.poll.stopForProcessExit(thread_control)) return false;
+
+        // Persist the advanced sync cursor (best-effort).
+        self.persist(self.poll.sync_buf) catch {};
+        self.allocator.free(self.poll.sync_buf);
+        self.running = false;
+        return true;
     }
 
     /// Clears the persisted owner + token and stops. Used by "Unbind".
@@ -201,6 +245,7 @@ pub const Controller = struct {
         };
         try self.persistBinding(binding);
         try self.startWithBinding(binding);
+        std.debug.print("weixin QR login confirmed; polling started\n", .{});
     }
 
     // --- internals ---
@@ -225,6 +270,7 @@ pub const Controller = struct {
         };
         try self.poll.start();
         self.running = true;
+        std.debug.print("weixin direct binding loaded; poller active\n", .{});
     }
 
     fn setBinding(self: *Controller, b: types.Binding) !void {
@@ -263,6 +309,22 @@ pub const Controller = struct {
 
     fn persistBinding(self: *Controller, binding: types.Binding) !void {
         try state_store.save(self.allocator, self.state_path, binding);
+    }
+
+    fn joinLoginThreadForProcessExit(self: *Controller, thread_control: ThreadControl) bool {
+        if (self.login_thread) |th| {
+            _ = thread_control.request_synchronous_io_cancel(th);
+            if (thread_control.wait_for_exit(th, SHUTDOWN_JOIN_TIMEOUT_MS)) {
+                th.join();
+                self.login_thread = null;
+                return true;
+            }
+            th.detach();
+            self.login_thread = null;
+            std.debug.print("weixin QR login shutdown timed out; detaching for process exit\n", .{});
+            return false;
+        }
+        return true;
     }
 };
 

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -29,6 +29,7 @@ pub const Client = struct {
     base_url: []const u8,
     token: []const u8,
     rng: std.Random.DefaultPrng,
+    rng_mutex: std.Thread.Mutex = .{},
 
     pub fn init(allocator: std.mem.Allocator, base_url: []const u8, token: []const u8) Client {
         return .{
@@ -88,7 +89,7 @@ pub const Client = struct {
         defer req_arena.deinit();
         const a = req_arena.allocator();
         const client_id = try std.fmt.allocPrint(a, "phantty-weixin-{d}-{d}", .{
-            std.time.milliTimestamp(), self.rng.random().int(u32),
+            std.time.milliTimestamp(), self.nextRandomU32(),
         });
         const body = try codec.buildSendTextBody(a, to_user_id, text, context_token, client_id);
         const resp = try self.fetch(a, .POST, "/ilink/bot/sendmessage", body, null);
@@ -99,7 +100,7 @@ pub const Client = struct {
         });
         if (w.ret) |ret| {
             if (ret != 0) {
-                std.debug.print("weixin sendmessage failed: ret={} errcode={} message={s}\n", .{ ret, w.errcode, w.message });
+                std.debug.print("weixin send({d}): kind=sendmessage status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
                 return error.IlinkSendMessageFailed;
             }
         }
@@ -122,7 +123,7 @@ pub const Client = struct {
 
         // X-WECHAT-UIN: base64 of a random uint decimal string (mirrors the TS bridge).
         var num_buf: [16]u8 = undefined;
-        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{self.rng.random().int(u32)}) catch "0";
+        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{self.nextRandomU32()}) catch "0";
         const uin = try arena.alloc(u8, std.base64.standard.Encoder.calcSize(num_str.len));
         _ = std.base64.standard.Encoder.encode(uin, num_str);
 
@@ -154,6 +155,12 @@ pub const Client = struct {
         });
         if (response.status != .ok) return error.IlinkHttpStatus;
         return body.toArrayList().items;
+    }
+
+    fn nextRandomU32(self: *Client) u32 {
+        self.rng_mutex.lock();
+        defer self.rng_mutex.unlock();
+        return self.rng.random().int(u32);
     }
 
     // --- ClientApi adapter ---

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -91,7 +91,18 @@ pub const Client = struct {
             std.time.milliTimestamp(), self.rng.random().int(u32),
         });
         const body = try codec.buildSendTextBody(a, to_user_id, text, context_token, client_id);
-        _ = try self.fetch(a, .POST, "/ilink/bot/sendmessage", body, null);
+        const resp = try self.fetch(a, .POST, "/ilink/bot/sendmessage", body, null);
+        const W = struct { ret: ?i64 = null, errcode: i64 = 0, message: []const u8 = "" };
+        const w = try std.json.parseFromSliceLeaky(W, a, resp, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        });
+        if (w.ret) |ret| {
+            if (ret != 0) {
+                std.debug.print("weixin sendmessage failed: ret={} errcode={} message={s}\n", .{ ret, w.errcode, w.message });
+                return error.IlinkSendMessageFailed;
+            }
+        }
     }
 
     /// Performs one HTTP request, returning the response body bytes allocated in

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -25,6 +25,11 @@ pub const ThreadControl = struct {
     wait_for_exit: *const fn (thread: std.Thread, timeout_ms: u32) bool,
 };
 
+pub const SyncCallback = struct {
+    ctx: *anyopaque,
+    callback: *const fn (ctx: *anyopaque, sync_buf: []const u8) anyerror!void,
+};
+
 pub const ProcessInput = struct {
     allocator: std.mem.Allocator,
     owner: []const u8,
@@ -42,39 +47,63 @@ pub const ProcessInput = struct {
 
 /// Mirror of processWeixinUpdates: filter, extract, route, reply.
 pub fn processUpdates(input: ProcessInput) !void {
-    for (input.messages) |msg| {
+    for (input.messages, 0..) |msg, i| {
+        std.debug.print(
+            "weixin process({d}): index={d} from_len={d} from_hash={x} to_len={d} to_hash={x} group={} context={} items={d}\n",
+            .{
+                debugNowMs(),
+                i,
+                msg.from_user_id.len,
+                debugHash(msg.from_user_id),
+                msg.to_user_id.len,
+                debugHash(msg.to_user_id),
+                msg.group_id.len != 0,
+                msg.context_token.len != 0,
+                msg.item_list.len,
+            },
+        );
         const decision = binding.shouldHandle(input.owner, input.account_id, msg);
         if (!decision.ok) {
-            std.debug.print("weixin message skipped: {s}\n", .{decision.reason});
+            std.debug.print("weixin process({d}): index={d} skipped reason={s}\n", .{ debugNowMs(), i, decision.reason });
             continue;
         }
         const text = binding.extractText(msg);
         if (text.len == 0) {
-            std.debug.print("weixin message skipped: no_text_item\n", .{});
+            std.debug.print("weixin process({d}): index={d} skipped reason=no_text_item\n", .{ debugNowMs(), i });
             continue;
         }
+        std.debug.print("weixin process({d}): index={d} text_bytes={d} route=begin\n", .{ debugNowMs(), i, text.len });
 
         var reply: std.ArrayListUnmanaged(u8) = .empty;
         defer reply.deinit(input.allocator);
         const route_result = input.route_fn(input.route_ctx, text, input.allocator, &reply) catch |err| {
-            std.debug.print("weixin route failed: {}\n", .{err});
+            std.debug.print("weixin process({d}): index={d} route=failed err={}\n", .{ debugNowMs(), i, err });
             continue;
         };
         defer if (route_result.baseline_transcript.len != 0) input.allocator.free(route_result.baseline_transcript);
+        std.debug.print(
+            "weixin process({d}): index={d} route=done reply_bytes={d} ai_followup={} baseline_bytes={d}\n",
+            .{ debugNowMs(), i, reply.items.len, route_result.expect_ai_progress, route_result.baseline_transcript.len },
+        );
 
         const trimmed = std.mem.trim(u8, reply.items, " \t\r\n");
         if (trimmed.len != 0) {
+            std.debug.print(
+                "weixin send({d}): index={d} kind=reply to_len={d} to_hash={x} bytes={d} context={}\n",
+                .{ debugNowMs(), i, msg.from_user_id.len, debugHash(msg.from_user_id), trimmed.len, msg.context_token.len != 0 },
+            );
             input.send_fn(input.send_ctx, msg.from_user_id, trimmed, msg.context_token) catch |err| {
-                std.debug.print("weixin reply send failed: {}\n", .{err});
+                std.debug.print("weixin send({d}): index={d} kind=reply status=failed err={}\n", .{ debugNowMs(), i, err });
                 continue;
             };
-            std.debug.print("weixin reply sent: {d} bytes\n", .{trimmed.len});
+            std.debug.print("weixin send({d}): index={d} kind=reply status=sent bytes={d}\n", .{ debugNowMs(), i, trimmed.len });
         }
         if (route_result.expect_ai_progress) {
             if (input.progress_ctx) |ctx| {
                 if (input.start_progress_fn) |start| {
+                    std.debug.print("weixin process({d}): index={d} ai_followup=start\n", .{ debugNowMs(), i });
                     start(ctx, route_result.baseline_transcript, msg.from_user_id, msg.context_token) catch |err| {
-                        std.debug.print("weixin AI followup failed to start: {}\n", .{err});
+                        std.debug.print("weixin process({d}): index={d} ai_followup=failed err={}\n", .{ debugNowMs(), i, err });
                     };
                 }
             }
@@ -93,9 +122,10 @@ pub const Poller = struct {
     owner: []const u8,
     account_id: []const u8,
     sync_buf: []u8,
+    sync_callback: ?SyncCallback = null,
+    bootstrap_skip_pending: bool = false,
     stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     thread: ?std.Thread = null,
-    client_mutex: std.Thread.Mutex = .{},
     transcript_mutex: std.Thread.Mutex = .{},
     followup_mutex: std.Thread.Mutex = .{},
     followup_generation: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
@@ -156,11 +186,31 @@ pub const Poller = struct {
             self.stop_requested.store(true, .release);
             return;
         }
-        if (updates.value.ret != 0 or updates.value.errcode != 0) {
-            std.debug.print("weixin getupdates returned ret={} errcode={}\n", .{ updates.value.ret, updates.value.errcode });
+        const bootstrap_skip = self.bootstrap_skip_pending;
+        self.bootstrap_skip_pending = false;
+        const sync_changed = updates.value.get_updates_buf.len != 0 and
+            !std.mem.eql(u8, updates.value.get_updates_buf, self.sync_buf);
+        if (updates.value.msgs.len != 0 or updates.value.ret != 0 or updates.value.errcode != 0 or sync_changed or bootstrap_skip) {
+            std.debug.print(
+                "weixin receive({d}): ret={} errcode={} messages={d} sync_len={d} next_sync_len={d} sync_changed={} bootstrap={}\n",
+                .{
+                    debugNowMs(),
+                    updates.value.ret,
+                    updates.value.errcode,
+                    updates.value.msgs.len,
+                    self.sync_buf.len,
+                    updates.value.get_updates_buf.len,
+                    sync_changed,
+                    bootstrap_skip,
+                },
+            );
         }
-        if (updates.value.msgs.len != 0) {
-            std.debug.print("weixin poll received {d} message(s)\n", .{updates.value.msgs.len});
+        try self.advanceSyncBuf(updates.value.get_updates_buf);
+        if (bootstrap_skip) {
+            if (updates.value.msgs.len != 0) {
+                std.debug.print("weixin process({d}): bootstrap_skip historical_messages={d}\n", .{ debugNowMs(), updates.value.msgs.len });
+            }
+            return;
         }
 
         try processUpdates(.{
@@ -175,14 +225,6 @@ pub const Poller = struct {
             .progress_ctx = self,
             .start_progress_fn = startProgressAdapter,
         });
-
-        if (updates.value.get_updates_buf.len != 0 and
-            !std.mem.eql(u8, updates.value.get_updates_buf, self.sync_buf))
-        {
-            const next = try self.allocator.dupe(u8, updates.value.get_updates_buf);
-            self.allocator.free(self.sync_buf);
-            self.sync_buf = next;
-        }
     }
 
     fn routeAdapter(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
@@ -217,14 +259,26 @@ pub const Poller = struct {
     }
 
     fn getUpdatesLocked(self: *Poller, sync_buf_value: []const u8) !@import("ilink_codec.zig").ParsedUpdates {
-        self.client_mutex.lock();
-        defer self.client_mutex.unlock();
         return self.client.getUpdates(sync_buf_value);
     }
 
+    fn advanceSyncBuf(self: *Poller, next_buf: []const u8) !void {
+        if (next_buf.len == 0 or std.mem.eql(u8, next_buf, self.sync_buf)) return;
+
+        const old_len = self.sync_buf.len;
+        const next = try self.allocator.dupe(u8, next_buf);
+        self.allocator.free(self.sync_buf);
+        self.sync_buf = next;
+        std.debug.print("weixin receive({d}): sync_cursor=advanced old_len={d} new_len={d}\n", .{ debugNowMs(), old_len, self.sync_buf.len });
+
+        if (self.sync_callback) |cb| {
+            cb.callback(cb.ctx, self.sync_buf) catch |err| {
+                std.debug.print("weixin receive({d}): sync_cursor=persist_failed err={}\n", .{ debugNowMs(), err });
+            };
+        }
+    }
+
     fn sendTextLocked(self: *Poller, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
-        self.client_mutex.lock();
-        defer self.client_mutex.unlock();
         try self.client.sendText(to_user_id, text, context_token);
     }
 
@@ -294,7 +348,10 @@ pub const Poller = struct {
         self.followup_mutex.lock();
         self.followup_thread = th;
         self.followup_mutex.unlock();
-        std.debug.print("weixin AI followup started\n", .{});
+        std.debug.print(
+            "weixin process({d}): ai_followup=started generation={d} baseline_bytes={d} to_len={d} to_hash={x} context={}\n",
+            .{ debugNowMs(), generation, baseline_owned.len, to_owned.len, debugHash(to_owned), context_owned.len != 0 },
+        );
     }
 
     fn followupThreadMain(self: *Poller, job: *FollowupJob, generation: u64) void {
@@ -319,22 +376,30 @@ pub const Poller = struct {
             defer if (progress.text.len != 0) self.allocator.free(progress.text);
 
             if (progress.done and progress.text.len != 0) {
+                std.debug.print(
+                    "weixin send({d}): kind=ai_final generation={d} to_len={d} to_hash={x} bytes={d} context={}\n",
+                    .{ debugNowMs(), generation, job.to_user_id.len, debugHash(job.to_user_id), progress.text.len, job.context_token.len != 0 },
+                );
                 self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
-                    std.debug.print("weixin AI followup final send failed: {}\n", .{err});
+                    std.debug.print("weixin send({d}): kind=ai_final generation={d} status=failed err={}\n", .{ debugNowMs(), generation, err });
                     return;
                 };
-                std.debug.print("weixin AI followup final sent: {d} bytes\n", .{progress.text.len});
+                std.debug.print("weixin send({d}): kind=ai_final generation={d} status=sent bytes={d}\n", .{ debugNowMs(), generation, progress.text.len });
                 return;
             }
 
             if (checkpoint_index < AI_REPLY_CHECKPOINTS_MS.len and elapsed_ms >= AI_REPLY_CHECKPOINTS_MS[checkpoint_index]) {
                 checkpoint_index += 1;
                 if (progress.text.len != 0) {
+                    std.debug.print(
+                        "weixin send({d}): kind=ai_progress generation={d} checkpoint={d} to_len={d} to_hash={x} bytes={d} context={}\n",
+                        .{ debugNowMs(), generation, checkpoint_index, job.to_user_id.len, debugHash(job.to_user_id), progress.text.len, job.context_token.len != 0 },
+                    );
                     self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
-                        std.debug.print("weixin AI followup progress send failed: {}\n", .{err});
+                        std.debug.print("weixin send({d}): kind=ai_progress generation={d} checkpoint={d} status=failed err={}\n", .{ debugNowMs(), generation, checkpoint_index, err });
                         continue;
                     };
-                    std.debug.print("weixin AI followup progress sent: {d} bytes\n", .{progress.text.len});
+                    std.debug.print("weixin send({d}): kind=ai_progress generation={d} checkpoint={d} status=sent bytes={d}\n", .{ debugNowMs(), generation, checkpoint_index, progress.text.len });
                 }
             }
         }
@@ -354,6 +419,15 @@ pub const Poller = struct {
     }
 };
 
+fn debugHash(bytes: []const u8) u64 {
+    if (bytes.len == 0) return 0;
+    return std.hash.Wyhash.hash(0, bytes);
+}
+
+fn debugNowMs() i64 {
+    return std.time.milliTimestamp();
+}
+
 const FollowupJob = struct {
     baseline_transcript: []u8 = &.{},
     to_user_id: []u8 = &.{},
@@ -368,6 +442,7 @@ const FollowupJob = struct {
 };
 
 const t = std.testing;
+const codec = @import("ilink_codec.zig");
 
 const Captured = struct {
     sent: std.ArrayListUnmanaged([]u8) = .empty,
@@ -417,6 +492,79 @@ const ProgressCtx = struct {
         try self.baseline.appendSlice(t.allocator, baseline_transcript);
         try self.to_user_id.appendSlice(t.allocator, to_user_id);
         try self.context_token.appendSlice(t.allocator, context_token);
+    }
+};
+
+const FakeClient = struct {
+    get_calls: usize = 0,
+    send_count: usize = 0,
+
+    fn api(self: *FakeClient) ilink.ClientApi {
+        return .{ .ctx = self, .vtable = &.{
+            .get_updates = getUpdates,
+            .send_text = sendText,
+        } };
+    }
+
+    fn getUpdates(ctx: *anyopaque, _: []const u8) anyerror!codec.ParsedUpdates {
+        const self: *FakeClient = @ptrCast(@alignCast(ctx));
+        self.get_calls += 1;
+        return codec.parseGetUpdates(t.allocator,
+            \\{"ret":0,"get_updates_buf":"NEXT",
+            \\"msgs":[{"from_user_id":"u1","context_token":"ctx",
+            \\"item_list":[{"type":1,"text_item":{"text":"old"}}]}]}
+        );
+    }
+
+    fn sendText(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) anyerror!void {
+        const self: *FakeClient = @ptrCast(@alignCast(ctx));
+        self.send_count += 1;
+    }
+};
+
+const SyncCapture = struct {
+    value: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *SyncCapture) void {
+        self.value.deinit(t.allocator);
+    }
+
+    fn save(ctx: *anyopaque, sync_buf: []const u8) anyerror!void {
+        const self: *SyncCapture = @ptrCast(@alignCast(ctx));
+        self.value.clearRetainingCapacity();
+        try self.value.appendSlice(t.allocator, sync_buf);
+    }
+};
+
+const NoopControl = struct {
+    fn isConnected(_: *anyopaque) bool {
+        return true;
+    }
+    fn findAiSurface(_: *anyopaque) ?control_mod.Surface {
+        return null;
+    }
+    fn findTerminalSurface(_: *anyopaque) ?control_mod.Surface {
+        return null;
+    }
+    fn openAiAgent(_: *anyopaque, _: u32) control_mod.OpenResult {
+        return .offline;
+    }
+    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8) bool {
+        return false;
+    }
+    fn latestTranscript(_: *anyopaque) []const u8 {
+        return "";
+    }
+    var dummy: u8 = 0;
+    fn iface() control_mod.Control {
+        return .{ .ctx = &dummy, .vtable = &.{
+            .is_connected = isConnected,
+            .find_ai_surface = findAiSurface,
+            .find_terminal_surface = findTerminalSurface,
+            .open_ai_agent = openAiAgent,
+            .send_input = sendInput,
+            .latest_transcript = latestTranscript,
+        } };
     }
 };
 
@@ -487,4 +635,31 @@ test "processUpdates starts AI followup after ack reply is sent" {
     try t.expectEqualStrings("Status:\nReady\n", pctx.baseline.items);
     try t.expectEqualStrings("u1", pctx.to_user_id.items);
     try t.expectEqualStrings("ctx", pctx.context_token.items);
+}
+
+test "poller bootstrap advances cursor without replying to historical messages" {
+    var fake = FakeClient{};
+    var sync = SyncCapture{};
+    defer sync.deinit();
+
+    var p = Poller{
+        .allocator = t.allocator,
+        .client = fake.api(),
+        .control = NoopControl.iface(),
+        .settings = .{},
+        .owner = "u1",
+        .account_id = "",
+        .sync_buf = try t.allocator.dupe(u8, "OLD"),
+        .sync_callback = .{ .ctx = &sync, .callback = SyncCapture.save },
+        .bootstrap_skip_pending = true,
+    };
+    defer t.allocator.free(p.sync_buf);
+
+    try p.tickOnce();
+
+    try t.expectEqual(@as(usize, 1), fake.get_calls);
+    try t.expectEqual(@as(usize, 0), fake.send_count);
+    try t.expect(!p.bootstrap_skip_pending);
+    try t.expectEqualStrings("NEXT", p.sync_buf);
+    try t.expectEqualStrings("NEXT", sync.value.items);
 }

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -6,8 +6,24 @@ const binding = @import("binding.zig");
 const agent = @import("agent.zig");
 const ilink = @import("ilink_client.zig");
 const control_mod = @import("control.zig");
+const reply_progress = @import("reply_progress.zig");
 
 pub const SESSION_EXPIRED_ERRCODE: i64 = -14;
+const AI_REPLY_CHECKPOINTS_MS = [_]u64{ 10_000, 30_000, 60_000, 120_000 };
+const AI_REPLY_POLL_MS: u64 = 1_000;
+const POLL_ERROR_BACKOFF_MS: u64 = 1_000;
+const SHUTDOWN_JOIN_TIMEOUT_MS: u32 = 1500;
+
+pub const RouteResult = struct {
+    expect_ai_progress: bool = false,
+    /// Heap-owned by ProcessInput. Freed after start_progress_fn returns.
+    baseline_transcript: []u8 = &.{},
+};
+
+pub const ThreadControl = struct {
+    request_synchronous_io_cancel: *const fn (thread: std.Thread) bool,
+    wait_for_exit: *const fn (thread: std.Thread, timeout_ms: u32) bool,
+};
 
 pub const ProcessInput = struct {
     allocator: std.mem.Allocator,
@@ -17,25 +33,51 @@ pub const ProcessInput = struct {
     route_ctx: *anyopaque,
     /// Fills `reply` with the response text; returns true if the caller should
     /// begin AI-reply progress streaming.
-    route_fn: *const fn (ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool,
+    route_fn: *const fn (ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult,
     send_ctx: *anyopaque,
     send_fn: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+    progress_ctx: ?*anyopaque = null,
+    start_progress_fn: ?*const fn (ctx: *anyopaque, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void = null,
 };
 
 /// Mirror of processWeixinUpdates: filter, extract, route, reply.
 pub fn processUpdates(input: ProcessInput) !void {
     for (input.messages) |msg| {
-        if (!binding.shouldHandle(input.owner, input.account_id, msg).ok) continue;
+        const decision = binding.shouldHandle(input.owner, input.account_id, msg);
+        if (!decision.ok) {
+            std.debug.print("weixin message skipped: {s}\n", .{decision.reason});
+            continue;
+        }
         const text = binding.extractText(msg);
-        if (text.len == 0) continue;
+        if (text.len == 0) {
+            std.debug.print("weixin message skipped: no_text_item\n", .{});
+            continue;
+        }
 
         var reply: std.ArrayListUnmanaged(u8) = .empty;
         defer reply.deinit(input.allocator);
-        _ = input.route_fn(input.route_ctx, text, input.allocator, &reply) catch continue;
+        const route_result = input.route_fn(input.route_ctx, text, input.allocator, &reply) catch |err| {
+            std.debug.print("weixin route failed: {}\n", .{err});
+            continue;
+        };
+        defer if (route_result.baseline_transcript.len != 0) input.allocator.free(route_result.baseline_transcript);
 
         const trimmed = std.mem.trim(u8, reply.items, " \t\r\n");
         if (trimmed.len != 0) {
-            input.send_fn(input.send_ctx, msg.from_user_id, trimmed, msg.context_token) catch {};
+            input.send_fn(input.send_ctx, msg.from_user_id, trimmed, msg.context_token) catch |err| {
+                std.debug.print("weixin reply send failed: {}\n", .{err});
+                continue;
+            };
+            std.debug.print("weixin reply sent: {d} bytes\n", .{trimmed.len});
+        }
+        if (route_result.expect_ai_progress) {
+            if (input.progress_ctx) |ctx| {
+                if (input.start_progress_fn) |start| {
+                    start(ctx, route_result.baseline_transcript, msg.from_user_id, msg.context_token) catch |err| {
+                        std.debug.print("weixin AI followup failed to start: {}\n", .{err});
+                    };
+                }
+            }
         }
     }
 }
@@ -53,35 +95,72 @@ pub const Poller = struct {
     sync_buf: []u8,
     stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     thread: ?std.Thread = null,
+    client_mutex: std.Thread.Mutex = .{},
+    transcript_mutex: std.Thread.Mutex = .{},
+    followup_mutex: std.Thread.Mutex = .{},
+    followup_generation: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    followup_thread: ?std.Thread = null,
 
     pub fn start(self: *Poller) !void {
         self.stop_requested.store(false, .release);
         self.thread = try std.Thread.spawn(.{}, threadMain, .{self});
+        std.debug.print("weixin poller started\n", .{});
     }
 
     pub fn stop(self: *Poller) void {
         self.stop_requested.store(true, .release);
+        self.cancelAiFollowup();
         if (self.thread) |th| {
             th.join();
             self.thread = null;
         }
+        self.cancelAiFollowup();
+        std.debug.print("weixin poller stopped\n", .{});
+    }
+
+    pub fn stopForProcessExit(self: *Poller, thread_control: ThreadControl) bool {
+        self.stop_requested.store(true, .release);
+        var clean = self.cancelAiFollowupForProcessExit(thread_control);
+        if (self.thread) |th| {
+            _ = thread_control.request_synchronous_io_cancel(th);
+            if (thread_control.wait_for_exit(th, SHUTDOWN_JOIN_TIMEOUT_MS)) {
+                th.join();
+            } else {
+                th.detach();
+                clean = false;
+                std.debug.print("weixin poller shutdown timed out; detaching for process exit\n", .{});
+            }
+            self.thread = null;
+        }
+        clean = self.cancelAiFollowupForProcessExit(thread_control) and clean;
+        if (clean) std.debug.print("weixin poller stopped\n", .{});
+        return clean;
     }
 
     fn threadMain(self: *Poller) void {
         while (!self.stop_requested.load(.acquire)) {
-            self.tickOnce() catch {
-                std.Thread.sleep(5 * std.time.ns_per_s);
+            self.tickOnce() catch |err| {
+                std.debug.print("weixin poll failed: {}; retrying in {d}ms\n", .{ err, POLL_ERROR_BACKOFF_MS });
+                std.Thread.sleep(POLL_ERROR_BACKOFF_MS * std.time.ns_per_ms);
             };
         }
     }
 
     fn tickOnce(self: *Poller) !void {
-        var updates = try self.client.getUpdates(self.sync_buf);
+        var updates = try self.getUpdatesLocked(self.sync_buf);
         defer updates.deinit();
+        if (self.stop_requested.load(.acquire)) return;
 
         if (updates.value.errcode == SESSION_EXPIRED_ERRCODE) {
+            std.debug.print("weixin session expired; stopping poller\n", .{});
             self.stop_requested.store(true, .release);
             return;
+        }
+        if (updates.value.ret != 0 or updates.value.errcode != 0) {
+            std.debug.print("weixin getupdates returned ret={} errcode={}\n", .{ updates.value.ret, updates.value.errcode });
+        }
+        if (updates.value.msgs.len != 0) {
+            std.debug.print("weixin poll received {d} message(s)\n", .{updates.value.msgs.len});
         }
 
         try processUpdates(.{
@@ -93,6 +172,8 @@ pub const Poller = struct {
             .route_fn = routeAdapter,
             .send_ctx = self,
             .send_fn = sendAdapter,
+            .progress_ctx = self,
+            .start_progress_fn = startProgressAdapter,
         });
 
         if (updates.value.get_updates_buf.len != 0 and
@@ -104,18 +185,185 @@ pub const Poller = struct {
         }
     }
 
-    fn routeAdapter(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool {
+    fn routeAdapter(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
         const self: *Poller = @ptrCast(@alignCast(ctx));
+        if (self.stop_requested.load(.acquire)) return error.PollerStopped;
+        const baseline = try self.allocTranscriptSnapshot(allocator);
+        errdefer if (baseline.len != 0) allocator.free(baseline);
+
         var r = agent.Reply.init(allocator);
         defer r.deinit();
         try agent.route(allocator, self.control, self.settings, text, &r);
         try reply.appendSlice(allocator, r.text.items);
-        return r.expect_ai_progress;
+        if (!r.expect_ai_progress) {
+            if (baseline.len != 0) allocator.free(baseline);
+            return .{};
+        }
+        return .{
+            .expect_ai_progress = true,
+            .baseline_transcript = baseline,
+        };
     }
 
     fn sendAdapter(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
         const self: *Poller = @ptrCast(@alignCast(ctx));
+        if (self.stop_requested.load(.acquire)) return error.PollerStopped;
+        try self.sendTextLocked(to_user_id, text, context_token);
+    }
+
+    fn startProgressAdapter(ctx: *anyopaque, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        try self.startAiFollowup(baseline_transcript, to_user_id, context_token);
+    }
+
+    fn getUpdatesLocked(self: *Poller, sync_buf_value: []const u8) !@import("ilink_codec.zig").ParsedUpdates {
+        self.client_mutex.lock();
+        defer self.client_mutex.unlock();
+        return self.client.getUpdates(sync_buf_value);
+    }
+
+    fn sendTextLocked(self: *Poller, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        self.client_mutex.lock();
+        defer self.client_mutex.unlock();
         try self.client.sendText(to_user_id, text, context_token);
+    }
+
+    fn allocTranscriptSnapshot(self: *Poller, allocator: std.mem.Allocator) ![]u8 {
+        self.transcript_mutex.lock();
+        defer self.transcript_mutex.unlock();
+        const snapshot = self.control.latestTranscript();
+        if (snapshot.len == 0) return &.{};
+        return allocator.dupe(u8, snapshot);
+    }
+
+    fn cancelAiFollowup(self: *Poller) void {
+        _ = self.followup_generation.fetchAdd(1, .acq_rel);
+        var thread_to_join: ?std.Thread = null;
+        {
+            self.followup_mutex.lock();
+            defer self.followup_mutex.unlock();
+            thread_to_join = self.followup_thread;
+            self.followup_thread = null;
+        }
+        if (thread_to_join) |th| th.join();
+    }
+
+    fn cancelAiFollowupForProcessExit(self: *Poller, thread_control: ThreadControl) bool {
+        _ = self.followup_generation.fetchAdd(1, .acq_rel);
+        var thread_to_join: ?std.Thread = null;
+        {
+            self.followup_mutex.lock();
+            defer self.followup_mutex.unlock();
+            thread_to_join = self.followup_thread;
+            self.followup_thread = null;
+        }
+        if (thread_to_join) |th| {
+            _ = thread_control.request_synchronous_io_cancel(th);
+            if (thread_control.wait_for_exit(th, SHUTDOWN_JOIN_TIMEOUT_MS)) {
+                th.join();
+                return true;
+            }
+            th.detach();
+            std.debug.print("weixin AI followup shutdown timed out; detaching for process exit\n", .{});
+            return false;
+        }
+        return true;
+    }
+
+    fn startAiFollowup(self: *Poller, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        if (self.stop_requested.load(.acquire)) return;
+        self.cancelAiFollowup();
+
+        const generation = self.followup_generation.fetchAdd(1, .acq_rel) + 1;
+        const baseline_owned = try self.allocator.dupe(u8, baseline_transcript);
+        errdefer self.allocator.free(baseline_owned);
+        const to_owned = try self.allocator.dupe(u8, to_user_id);
+        errdefer self.allocator.free(to_owned);
+        const context_owned = try self.allocator.dupe(u8, context_token);
+        errdefer self.allocator.free(context_owned);
+
+        const job = try self.allocator.create(FollowupJob);
+        errdefer self.allocator.destroy(job);
+        job.* = .{
+            .baseline_transcript = baseline_owned,
+            .to_user_id = to_owned,
+            .context_token = context_owned,
+        };
+
+        const th = try std.Thread.spawn(.{}, followupThreadMain, .{ self, job, generation });
+        self.followup_mutex.lock();
+        self.followup_thread = th;
+        self.followup_mutex.unlock();
+        std.debug.print("weixin AI followup started\n", .{});
+    }
+
+    fn followupThreadMain(self: *Poller, job: *FollowupJob, generation: u64) void {
+        defer {
+            job.deinit(self.allocator);
+            self.allocator.destroy(job);
+        }
+
+        const max_checkpoint = AI_REPLY_CHECKPOINTS_MS[AI_REPLY_CHECKPOINTS_MS.len - 1];
+        const deadline_ms = @max(@as(u64, self.settings.reply_timeout_ms), max_checkpoint);
+        var elapsed_ms: u64 = 0;
+        var checkpoint_index: usize = 0;
+
+        while (!self.stop_requested.load(.acquire) and
+            self.followup_generation.load(.acquire) == generation and
+            elapsed_ms <= deadline_ms)
+        {
+            std.Thread.sleep(AI_REPLY_POLL_MS * std.time.ns_per_ms);
+            elapsed_ms += AI_REPLY_POLL_MS;
+
+            const progress = self.allocProgressText(job.baseline_transcript) catch continue;
+            defer if (progress.text.len != 0) self.allocator.free(progress.text);
+
+            if (progress.done and progress.text.len != 0) {
+                self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
+                    std.debug.print("weixin AI followup final send failed: {}\n", .{err});
+                    return;
+                };
+                std.debug.print("weixin AI followup final sent: {d} bytes\n", .{progress.text.len});
+                return;
+            }
+
+            if (checkpoint_index < AI_REPLY_CHECKPOINTS_MS.len and elapsed_ms >= AI_REPLY_CHECKPOINTS_MS[checkpoint_index]) {
+                checkpoint_index += 1;
+                if (progress.text.len != 0) {
+                    self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
+                        std.debug.print("weixin AI followup progress send failed: {}\n", .{err});
+                        continue;
+                    };
+                    std.debug.print("weixin AI followup progress sent: {d} bytes\n", .{progress.text.len});
+                }
+            }
+        }
+    }
+
+    fn allocProgressText(self: *Poller, baseline_transcript: []const u8) !struct { done: bool, text: []u8 } {
+        self.transcript_mutex.lock();
+        defer self.transcript_mutex.unlock();
+
+        const current = self.control.latestTranscript();
+        const progress_value = reply_progress.progress(baseline_transcript, current);
+        if (progress_value.text.len == 0) return .{ .done = progress_value.done, .text = &.{} };
+        return .{
+            .done = progress_value.done,
+            .text = try self.allocator.dupe(u8, progress_value.text),
+        };
+    }
+};
+
+const FollowupJob = struct {
+    baseline_transcript: []u8 = &.{},
+    to_user_id: []u8 = &.{},
+    context_token: []u8 = &.{},
+
+    fn deinit(self: *FollowupJob, allocator: std.mem.Allocator) void {
+        if (self.baseline_transcript.len != 0) allocator.free(self.baseline_transcript);
+        if (self.to_user_id.len != 0) allocator.free(self.to_user_id);
+        if (self.context_token.len != 0) allocator.free(self.context_token);
+        self.* = .{};
     }
 };
 
@@ -134,11 +382,11 @@ const Captured = struct {
 
 const RouteCtx = struct {
     cap: *Captured,
-    fn route(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!bool {
+    fn route(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
         const self: *RouteCtx = @ptrCast(@alignCast(ctx));
         try self.cap.routed.append(t.allocator, try t.allocator.dupe(u8, text));
         try reply.appendSlice(allocator, "ok");
-        return false;
+        return .{};
     }
 };
 
@@ -148,6 +396,27 @@ const SendCtx = struct {
         _ = to;
         const self: *SendCtx = @ptrCast(@alignCast(ctx));
         try self.cap.sent.append(t.allocator, try t.allocator.dupe(u8, text));
+    }
+};
+
+const ProgressCtx = struct {
+    started: bool = false,
+    baseline: std.ArrayListUnmanaged(u8) = .empty,
+    to_user_id: std.ArrayListUnmanaged(u8) = .empty,
+    context_token: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *ProgressCtx) void {
+        self.baseline.deinit(t.allocator);
+        self.to_user_id.deinit(t.allocator);
+        self.context_token.deinit(t.allocator);
+    }
+
+    fn start(ctx: *anyopaque, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
+        const self: *ProgressCtx = @ptrCast(@alignCast(ctx));
+        self.started = true;
+        try self.baseline.appendSlice(t.allocator, baseline_transcript);
+        try self.to_user_id.appendSlice(t.allocator, to_user_id);
+        try self.context_token.appendSlice(t.allocator, context_token);
     }
 };
 
@@ -177,4 +446,45 @@ test "processUpdates routes accepted text and sends replies" {
     try t.expectEqualStrings("hi", cap.routed.items[0]);
     try t.expectEqual(@as(usize, 1), cap.sent.items.len);
     try t.expectEqualStrings("ok", cap.sent.items[0]);
+}
+
+test "processUpdates starts AI followup after ack reply is sent" {
+    const Route = struct {
+        fn route(_: *anyopaque, _: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+            try reply.appendSlice(allocator, "ack");
+            return .{
+                .expect_ai_progress = true,
+                .baseline_transcript = try allocator.dupe(u8, "Status:\nReady\n"),
+            };
+        }
+    };
+    var cap = Captured{};
+    defer cap.deinit();
+    var sctx = SendCtx{ .cap = &cap };
+    var pctx = ProgressCtx{};
+    defer pctx.deinit();
+    var route_ctx: u8 = 0;
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "ctx", .item_list = &.{.{ .type = 1, .text = "hello" }} },
+    };
+
+    try processUpdates(.{
+        .allocator = t.allocator,
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &route_ctx,
+        .route_fn = Route.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+        .progress_ctx = &pctx,
+        .start_progress_fn = ProgressCtx.start,
+    });
+
+    try t.expectEqualStrings("ack", cap.sent.items[0]);
+    try t.expect(pctx.started);
+    try t.expectEqualStrings("Status:\nReady\n", pctx.baseline.items);
+    try t.expectEqualStrings("u1", pctx.to_user_id.items);
+    try t.expectEqualStrings("ctx", pctx.context_token.items);
 }

--- a/src/weixin/qr_code.zig
+++ b/src/weixin/qr_code.zig
@@ -1,0 +1,501 @@
+//! Minimal QR Code Model 2 encoder for the WeChat login panel.
+//!
+//! The ilink API returns the text that should be encoded into the QR code, not
+//! a PNG. We only need byte mode and low error correction for this UI.
+
+const std = @import("std");
+
+const MAX_VERSION = 10;
+const MAX_SIZE = 17 + 4 * MAX_VERSION;
+const MAX_DATA_CODEWORDS = 274;
+const MAX_BLOCKS = 4;
+const MAX_BLOCK_DATA_CODEWORDS = 116;
+const MAX_ECC_CODEWORDS = 30;
+const MAX_RAW_CODEWORDS = 346;
+
+pub const EncodeError = error{
+    EmptyPayload,
+    PayloadTooLong,
+};
+
+pub const Matrix = struct {
+    allocator: std.mem.Allocator,
+    size: usize,
+    version: u8,
+    modules: []u8,
+
+    pub fn deinit(self: *Matrix) void {
+        if (self.modules.len != 0) self.allocator.free(self.modules);
+        self.* = .{
+            .allocator = self.allocator,
+            .size = 0,
+            .version = 0,
+            .modules = &.{},
+        };
+    }
+
+    pub fn isBlack(self: Matrix, x: usize, y: usize) bool {
+        return x < self.size and y < self.size and self.modules[y * self.size + x] != 0;
+    }
+};
+
+const BlockGroup = struct {
+    count: usize,
+    data_codewords: usize,
+};
+
+const VersionSpec = struct {
+    data_codewords: usize,
+    ecc_codewords_per_block: usize,
+    groups: []const BlockGroup,
+};
+
+const Block = struct {
+    data_len: usize = 0,
+    data: [MAX_BLOCK_DATA_CODEWORDS]u8 = undefined,
+    ecc: [MAX_ECC_CODEWORDS]u8 = undefined,
+};
+
+pub fn encodeText(allocator: std.mem.Allocator, payload: []const u8) (EncodeError || std.mem.Allocator.Error)!Matrix {
+    if (payload.len == 0) return EncodeError.EmptyPayload;
+
+    const version = chooseVersion(payload.len) orelse return EncodeError.PayloadTooLong;
+    const spec = versionSpec(version);
+
+    var data_codewords: [MAX_DATA_CODEWORDS]u8 = undefined;
+    const data_len = try encodePayloadBits(payload, version, spec.data_codewords, &data_codewords);
+    std.debug.assert(data_len == spec.data_codewords);
+
+    var raw_codewords: [MAX_RAW_CODEWORDS]u8 = undefined;
+    const raw_len = makeRawCodewords(spec, data_codewords[0..data_len], &raw_codewords);
+
+    const size: usize = 17 + 4 * @as(usize, version);
+    const modules = try allocator.alloc(u8, size * size);
+    errdefer allocator.free(modules);
+    @memset(modules, 0);
+
+    const function_modules = try allocator.alloc(u8, size * size);
+    defer allocator.free(function_modules);
+    @memset(function_modules, 0);
+
+    drawFunctionPatterns(modules, function_modules, size, version);
+    drawCodewords(modules, function_modules, size, raw_codewords[0..raw_len], 0);
+    drawFormatBits(modules, function_modules, size, 0);
+
+    return .{
+        .allocator = allocator,
+        .size = size,
+        .version = version,
+        .modules = modules,
+    };
+}
+
+fn chooseVersion(payload_len: usize) ?u8 {
+    for (1..MAX_VERSION + 1) |version_usize| {
+        const version: u8 = @intCast(version_usize);
+        const spec = versionSpec(version);
+        const count_bits: usize = if (version <= 9) 8 else 16;
+        if (payload_len > std.math.maxInt(u16)) return null;
+        const needed_bits = 4 + count_bits + payload_len * 8;
+        if (needed_bits <= spec.data_codewords * 8) return version;
+    }
+    return null;
+}
+
+fn versionSpec(version: u8) VersionSpec {
+    return switch (version) {
+        1 => .{ .data_codewords = 19, .ecc_codewords_per_block = 7, .groups = &.{.{ .count = 1, .data_codewords = 19 }} },
+        2 => .{ .data_codewords = 34, .ecc_codewords_per_block = 10, .groups = &.{.{ .count = 1, .data_codewords = 34 }} },
+        3 => .{ .data_codewords = 55, .ecc_codewords_per_block = 15, .groups = &.{.{ .count = 1, .data_codewords = 55 }} },
+        4 => .{ .data_codewords = 80, .ecc_codewords_per_block = 20, .groups = &.{.{ .count = 1, .data_codewords = 80 }} },
+        5 => .{ .data_codewords = 108, .ecc_codewords_per_block = 26, .groups = &.{.{ .count = 1, .data_codewords = 108 }} },
+        6 => .{ .data_codewords = 136, .ecc_codewords_per_block = 18, .groups = &.{.{ .count = 2, .data_codewords = 68 }} },
+        7 => .{ .data_codewords = 156, .ecc_codewords_per_block = 20, .groups = &.{.{ .count = 2, .data_codewords = 78 }} },
+        8 => .{ .data_codewords = 194, .ecc_codewords_per_block = 24, .groups = &.{.{ .count = 2, .data_codewords = 97 }} },
+        9 => .{ .data_codewords = 232, .ecc_codewords_per_block = 30, .groups = &.{.{ .count = 2, .data_codewords = 116 }} },
+        10 => .{ .data_codewords = 274, .ecc_codewords_per_block = 18, .groups = &.{
+            .{ .count = 2, .data_codewords = 68 },
+            .{ .count = 2, .data_codewords = 69 },
+        } },
+        else => unreachable,
+    };
+}
+
+fn encodePayloadBits(payload: []const u8, version: u8, capacity_codewords: usize, out: *[MAX_DATA_CODEWORDS]u8) EncodeError!usize {
+    var bits: [MAX_DATA_CODEWORDS * 8]u8 = undefined;
+    var bit_len: usize = 0;
+    const capacity_bits = capacity_codewords * 8;
+
+    appendBits(&bits, &bit_len, 0b0100, 4); // byte mode
+    appendBits(&bits, &bit_len, @intCast(payload.len), if (version <= 9) 8 else 16);
+    for (payload) |byte| appendBits(&bits, &bit_len, byte, 8);
+    if (bit_len > capacity_bits) return EncodeError.PayloadTooLong;
+
+    const terminator_len = @min(@as(usize, 4), capacity_bits - bit_len);
+    appendBits(&bits, &bit_len, 0, terminator_len);
+    while (bit_len % 8 != 0) appendBits(&bits, &bit_len, 0, 1);
+
+    @memset(out[0..capacity_codewords], 0);
+    for (0..bit_len) |i| {
+        if (bits[i] != 0) out[i / 8] |= @as(u8, 1) << @intCast(7 - (i % 8));
+    }
+
+    var used_codewords = bit_len / 8;
+    var pad: u8 = 0xEC;
+    while (used_codewords < capacity_codewords) {
+        out[used_codewords] = pad;
+        used_codewords += 1;
+        pad = if (pad == 0xEC) 0x11 else 0xEC;
+    }
+    return used_codewords;
+}
+
+fn appendBits(bits: *[MAX_DATA_CODEWORDS * 8]u8, bit_len: *usize, value: u32, count: usize) void {
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const shift: u5 = @intCast(count - 1 - i);
+        bits[bit_len.*] = @intCast((value >> shift) & 1);
+        bit_len.* += 1;
+    }
+}
+
+fn makeRawCodewords(spec: VersionSpec, data_codewords: []const u8, out: *[MAX_RAW_CODEWORDS]u8) usize {
+    var blocks: [MAX_BLOCKS]Block = undefined;
+    var block_count: usize = 0;
+    var data_pos: usize = 0;
+
+    for (spec.groups) |group| {
+        for (0..group.count) |_| {
+            std.debug.assert(block_count < blocks.len);
+            var block = Block{ .data_len = group.data_codewords };
+            @memcpy(block.data[0..group.data_codewords], data_codewords[data_pos..][0..group.data_codewords]);
+            reedSolomonRemainder(block.data[0..group.data_codewords], spec.ecc_codewords_per_block, block.ecc[0..spec.ecc_codewords_per_block]);
+            blocks[block_count] = block;
+            block_count += 1;
+            data_pos += group.data_codewords;
+        }
+    }
+    std.debug.assert(data_pos == data_codewords.len);
+
+    var out_len: usize = 0;
+    var max_data_len: usize = 0;
+    for (blocks[0..block_count]) |block| max_data_len = @max(max_data_len, block.data_len);
+
+    for (0..max_data_len) |i| {
+        for (blocks[0..block_count]) |block| {
+            if (i < block.data_len) {
+                out[out_len] = block.data[i];
+                out_len += 1;
+            }
+        }
+    }
+    for (0..spec.ecc_codewords_per_block) |i| {
+        for (blocks[0..block_count]) |block| {
+            out[out_len] = block.ecc[i];
+            out_len += 1;
+        }
+    }
+    return out_len;
+}
+
+fn drawFunctionPatterns(modules: []u8, function_modules: []u8, size: usize, version: u8) void {
+    drawFinderPattern(modules, function_modules, size, 0, 0);
+    drawFinderPattern(modules, function_modules, size, size - 7, 0);
+    drawFinderPattern(modules, function_modules, size, 0, size - 7);
+
+    for (8..size - 8) |i| {
+        const black = i % 2 == 0;
+        setFunction(modules, function_modules, size, i, 6, black);
+        setFunction(modules, function_modules, size, 6, i, black);
+    }
+
+    const positions = alignmentPatternPositions(version);
+    for (positions) |cy| {
+        for (positions) |cx| {
+            if (function_modules[index(size, cx, cy)] != 0) continue;
+            drawAlignmentPattern(modules, function_modules, size, cx, cy);
+        }
+    }
+
+    drawFormatBits(modules, function_modules, size, 0);
+    drawVersionBits(modules, function_modules, size, version);
+}
+
+fn drawFinderPattern(modules: []u8, function_modules: []u8, size: usize, left: usize, top: usize) void {
+    const left_i: i32 = @intCast(left);
+    const top_i: i32 = @intCast(top);
+    var dy: i32 = -1;
+    while (dy <= 7) : (dy += 1) {
+        var dx: i32 = -1;
+        while (dx <= 7) : (dx += 1) {
+            const x = left_i + dx;
+            const y = top_i + dy;
+            if (x < 0 or y < 0 or x >= @as(i32, @intCast(size)) or y >= @as(i32, @intCast(size))) continue;
+            const in_finder = dx >= 0 and dx <= 6 and dy >= 0 and dy <= 6;
+            const black = in_finder and
+                (dx == 0 or dx == 6 or dy == 0 or dy == 6 or
+                    (dx >= 2 and dx <= 4 and dy >= 2 and dy <= 4));
+            setFunction(modules, function_modules, size, @intCast(x), @intCast(y), black);
+        }
+    }
+}
+
+fn drawAlignmentPattern(modules: []u8, function_modules: []u8, size: usize, cx: usize, cy: usize) void {
+    const cx_i: i32 = @intCast(cx);
+    const cy_i: i32 = @intCast(cy);
+    var dy: i32 = -2;
+    while (dy <= 2) : (dy += 1) {
+        var dx: i32 = -2;
+        while (dx <= 2) : (dx += 1) {
+            const dist = @max(@abs(dx), @abs(dy));
+            const black = dist != 1;
+            setFunction(modules, function_modules, size, @intCast(cx_i + dx), @intCast(cy_i + dy), black);
+        }
+    }
+}
+
+fn alignmentPatternPositions(version: u8) []const usize {
+    return switch (version) {
+        1 => &.{},
+        2 => &.{ 6, 18 },
+        3 => &.{ 6, 22 },
+        4 => &.{ 6, 26 },
+        5 => &.{ 6, 30 },
+        6 => &.{ 6, 34 },
+        7 => &.{ 6, 22, 38 },
+        8 => &.{ 6, 24, 42 },
+        9 => &.{ 6, 26, 46 },
+        10 => &.{ 6, 28, 50 },
+        else => unreachable,
+    };
+}
+
+fn drawCodewords(modules: []u8, function_modules: []u8, size: usize, data: []const u8, mask: u3) void {
+    var bit_index: usize = 0;
+    var right: i32 = @intCast(size - 1);
+    var y: i32 = @intCast(size - 1);
+    var upward = true;
+
+    while (right > 0) : (right -= 2) {
+        if (right == 6) right -= 1;
+        while (true) {
+            for (0..2) |dx| {
+                const x: usize = @intCast(right - @as(i32, @intCast(dx)));
+                const y_usize: usize = @intCast(y);
+                const idx = index(size, x, y_usize);
+                if (function_modules[idx] == 0) {
+                    var black = false;
+                    if (bit_index < data.len * 8) {
+                        black = ((data[bit_index / 8] >> @intCast(7 - (bit_index % 8))) & 1) != 0;
+                    }
+                    if (maskCondition(mask, x, y_usize)) black = !black;
+                    modules[idx] = if (black) 1 else 0;
+                    bit_index += 1;
+                }
+            }
+
+            if (upward) {
+                if (y == 0) {
+                    upward = false;
+                    break;
+                }
+                y -= 1;
+            } else {
+                if (y == @as(i32, @intCast(size - 1))) {
+                    upward = true;
+                    break;
+                }
+                y += 1;
+            }
+        }
+    }
+}
+
+fn maskCondition(mask: u3, x: usize, y: usize) bool {
+    return switch (mask) {
+        0 => (x + y) % 2 == 0,
+        1 => y % 2 == 0,
+        2 => x % 3 == 0,
+        3 => (x + y) % 3 == 0,
+        4 => (x / 3 + y / 2) % 2 == 0,
+        5 => ((x * y) % 2 + (x * y) % 3) == 0,
+        6 => (((x * y) % 2 + (x * y) % 3) % 2) == 0,
+        7 => (((x + y) % 2 + (x * y) % 3) % 2) == 0,
+    };
+}
+
+fn drawFormatBits(modules: []u8, function_modules: []u8, size: usize, mask: u3) void {
+    const bits = formatBits(mask);
+
+    for (0..6) |i| setFunction(modules, function_modules, size, 8, i, bit(bits, i));
+    setFunction(modules, function_modules, size, 8, 7, bit(bits, 6));
+    setFunction(modules, function_modules, size, 8, 8, bit(bits, 7));
+    setFunction(modules, function_modules, size, 7, 8, bit(bits, 8));
+    for (9..15) |i| setFunction(modules, function_modules, size, 14 - i, 8, bit(bits, i));
+
+    for (0..8) |i| setFunction(modules, function_modules, size, size - 1 - i, 8, bit(bits, i));
+    for (8..15) |i| setFunction(modules, function_modules, size, 8, size - 15 + i, bit(bits, i));
+    setFunction(modules, function_modules, size, 8, size - 8, true);
+}
+
+fn formatBits(mask: u3) u16 {
+    const ecc_low_format_bits: u16 = 1;
+    const data: u16 = (ecc_low_format_bits << 3) | mask;
+    var rem: u16 = data;
+    for (0..10) |_| {
+        rem = (rem << 1) ^ if ((rem & (1 << 9)) != 0) @as(u16, 0x537) else @as(u16, 0);
+    }
+    return ((data << 10) | (rem & 0x03FF)) ^ 0x5412;
+}
+
+fn drawVersionBits(modules: []u8, function_modules: []u8, size: usize, version: u8) void {
+    if (version < 7) return;
+    const bits = versionBits(version);
+    for (0..18) |i| {
+        const a = size - 11 + i % 3;
+        const b = i / 3;
+        const black = bit(bits, i);
+        setFunction(modules, function_modules, size, a, b, black);
+        setFunction(modules, function_modules, size, b, a, black);
+    }
+}
+
+fn versionBits(version: u8) u32 {
+    var rem: u32 = version;
+    for (0..12) |_| {
+        rem = (rem << 1) ^ if ((rem & (1 << 11)) != 0) @as(u32, 0x1F25) else @as(u32, 0);
+    }
+    return (@as(u32, version) << 12) | (rem & 0x0FFF);
+}
+
+fn bit(value: anytype, index_value: usize) bool {
+    return ((value >> @intCast(index_value)) & 1) != 0;
+}
+
+fn setFunction(modules: []u8, function_modules: []u8, size: usize, x: usize, y: usize, black: bool) void {
+    const idx = index(size, x, y);
+    modules[idx] = if (black) 1 else 0;
+    function_modules[idx] = 1;
+}
+
+fn index(size: usize, x: usize, y: usize) usize {
+    return y * size + x;
+}
+
+fn reedSolomonRemainder(data: []const u8, degree: usize, out: []u8) void {
+    var divisor: [MAX_ECC_CODEWORDS]u8 = undefined;
+    reedSolomonGenerator(degree, divisor[0..degree]);
+
+    @memset(out[0..degree], 0);
+    for (data) |byte| {
+        const factor = byte ^ out[0];
+        std.mem.copyForwards(u8, out[0 .. degree - 1], out[1..degree]);
+        out[degree - 1] = 0;
+        for (0..degree) |i| out[i] ^= reedSolomonMultiply(divisor[i], factor);
+    }
+}
+
+fn reedSolomonGenerator(degree: usize, out: []u8) void {
+    @memset(out[0..degree], 0);
+    out[degree - 1] = 1;
+
+    var root: u8 = 1;
+    for (0..degree) |_| {
+        for (0..degree) |i| {
+            out[i] = reedSolomonMultiply(out[i], root);
+            if (i + 1 < degree) out[i] ^= out[i + 1];
+        }
+        root = reedSolomonMultiply(root, 0x02);
+    }
+}
+
+fn reedSolomonMultiply(x: u8, y: u8) u8 {
+    var z: u16 = 0;
+    var a: u16 = x;
+    var b: u16 = y;
+    while (b != 0) {
+        if ((b & 1) != 0) z ^= a;
+        b >>= 1;
+        a <<= 1;
+        if ((a & 0x100) != 0) a ^= 0x11D;
+    }
+    return @intCast(z & 0xFF);
+}
+
+test "qr_code: encodes a small byte payload" {
+    var qr = try encodeText(std.testing.allocator, "weixin://qr-content");
+    defer qr.deinit();
+
+    try std.testing.expectEqual(@as(usize, 25), qr.size);
+    try std.testing.expectEqual(@as(u8, 2), qr.version);
+    try std.testing.expect(qr.isBlack(0, 0));
+    try std.testing.expect(qr.isBlack(6, 0));
+    try std.testing.expect(qr.isBlack(0, 6));
+    try std.testing.expect(!qr.isBlack(7, 7));
+}
+
+test "qr_code: byte payload matches a reference encoder with mask 0" {
+    const expected_rows = [_][]const u8{
+        "1111111001001111001111111",
+        "1000001000111011101000001",
+        "1011101011101010001011101",
+        "1011101001110011001011101",
+        "1011101000100001001011101",
+        "1000001001000111001000001",
+        "1111111010101010101111111",
+        "0000000011101101100000000",
+        "1110111110110010011000100",
+        "1011100000110000101001111",
+        "1011111001000100101101111",
+        "0111000100010000100010000",
+        "1110001000001001111001011",
+        "0111000110011100101101111",
+        "1011101010111010001100111",
+        "0110010100101110111010001",
+        "1011011010110011111110011",
+        "0000000010110011100011101",
+        "1111111011000101101011111",
+        "1000001010010000100010001",
+        "1011101011101000111110001",
+        "1011101001011100110110100",
+        "1011101011011010100010001",
+        "1000001010101111101111010",
+        "1111111011010011111001011",
+    };
+
+    var qr = try encodeText(std.testing.allocator, "weixin://qr-content");
+    defer qr.deinit();
+
+    try std.testing.expectEqual(expected_rows.len, qr.size);
+    for (expected_rows, 0..) |row, y| {
+        try std.testing.expectEqual(row.len, qr.size);
+        for (row, 0..) |expected, x| {
+            const actual = qr.isBlack(x, y);
+            if ((expected == '1') != actual) {
+                std.debug.print("QR mismatch at row {d}, column {d}: expected {c}, actual {c}\n", .{
+                    y,
+                    x,
+                    expected,
+                    if (actual) @as(u8, '1') else @as(u8, '0'),
+                });
+                return error.TestExpectedEqual;
+            }
+        }
+    }
+}
+
+test "qr_code: grows through supported versions" {
+    const payload = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    var qr = try encodeText(std.testing.allocator, payload);
+    defer qr.deinit();
+
+    try std.testing.expect(qr.version > 4);
+    try std.testing.expect(qr.size == 17 + 4 * @as(usize, qr.version));
+}
+
+test "qr_code: rejects empty and oversized payloads" {
+    try std.testing.expectError(EncodeError.EmptyPayload, encodeText(std.testing.allocator, ""));
+
+    const payload = [_]u8{'x'} ** 400;
+    try std.testing.expectError(EncodeError.PayloadTooLong, encodeText(std.testing.allocator, &payload));
+}

--- a/src/weixin/qr_panel.zig
+++ b/src/weixin/qr_panel.zig
@@ -43,9 +43,9 @@ pub const QrMatrixView = struct {
 };
 
 const PANEL_MIN_W: f32 = 380;
-const PANEL_MAX_W: f32 = 540;
+const PANEL_MAX_W: f32 = 900;
 const PANEL_MIN_H: f32 = 500;
-const PANEL_MAX_H: f32 = 580;
+const PANEL_MAX_H: f32 = 620;
 const PANEL_MARGIN: f32 = 24;
 const BUTTON_H: f32 = 38;
 const BUTTON_W: f32 = 118;
@@ -305,6 +305,14 @@ test "qr_panel: layout keeps buttons inside the panel" {
     try std.testing.expect(l.retry.x >= l.panel.x);
     try std.testing.expect(l.close.x + l.close.w <= l.panel.x + l.panel.w);
     try std.testing.expect(l.close.top_px + l.close.h <= l.panel.top_px + l.panel.h);
+}
+
+test "qr_panel: wide layout expands text room without enlarging QR" {
+    const l = layout(1200, 900, 0);
+    try std.testing.expectEqual(@as(f32, 900), l.panel.w);
+    try std.testing.expectEqual(@as(f32, 620), l.panel.h);
+    try std.testing.expectEqual(@as(f32, 292), l.qr.w);
+    try std.testing.expectEqual(@as(f32, 292), l.qr.h);
 }
 
 test "qr_panel: expired status exposes retry hit target" {

--- a/src/weixin/qr_panel.zig
+++ b/src/weixin/qr_panel.zig
@@ -1,0 +1,318 @@
+//! UI-thread state for the WeChat QR login panel.
+//!
+//! The controller owns the network/login thread; this module only snapshots its
+//! login state, keeps an owned copy of the QR payload for rendering, and exposes
+//! layout/hit-test helpers for the renderer/input layers.
+
+const std = @import("std");
+const controller_mod = @import("controller.zig");
+const qr_code = @import("qr_code.zig");
+const types = @import("types.zig");
+
+pub const Controller = controller_mod.Controller;
+
+pub const Action = enum {
+    none,
+    retry,
+    close,
+    unbind,
+};
+
+pub const Rect = struct {
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const Layout = struct {
+    panel: Rect,
+    qr: Rect,
+    retry: Rect,
+    close: Rect,
+    unbind: Rect,
+};
+
+pub const QrMatrixView = struct {
+    size: usize,
+    modules: []const u8,
+
+    pub fn isBlack(self: QrMatrixView, x: usize, y: usize) bool {
+        return x < self.size and y < self.size and self.modules[y * self.size + x] != 0;
+    }
+};
+
+const PANEL_MIN_W: f32 = 380;
+const PANEL_MAX_W: f32 = 540;
+const PANEL_MIN_H: f32 = 500;
+const PANEL_MAX_H: f32 = 580;
+const PANEL_MARGIN: f32 = 24;
+const BUTTON_H: f32 = 38;
+const BUTTON_W: f32 = 118;
+const BUTTON_GAP: f32 = 10;
+
+pub threadlocal var g_visible: bool = false;
+threadlocal var g_controller: ?*Controller = null;
+threadlocal var g_status: types.QrStatusKind = .unknown;
+threadlocal var g_qr_string: ?[]u8 = null;
+threadlocal var g_qr_content: ?[]u8 = null;
+threadlocal var g_qr_matrix: ?qr_code.Matrix = null;
+threadlocal var g_qr_generation: u64 = 0;
+threadlocal var g_qr_generation_failed: bool = false;
+threadlocal var g_last_qr_hash: u64 = 0;
+
+pub fn start(allocator: std.mem.Allocator, ctrl: *Controller) !void {
+    try ctrl.startLoginAsync();
+    open(ctrl);
+    _ = refresh(allocator);
+}
+
+pub fn open(ctrl: *Controller) void {
+    if (g_controller != ctrl) {
+        clearSnapshot();
+        g_controller = ctrl;
+    }
+    g_visible = true;
+    if (g_status == .unknown) g_status = .wait;
+}
+
+pub fn close() void {
+    g_visible = false;
+}
+
+pub fn visible() bool {
+    return g_visible;
+}
+
+pub fn controller() ?*Controller {
+    return g_controller;
+}
+
+pub fn status() types.QrStatusKind {
+    return g_status;
+}
+
+pub fn statusLabel(s: types.QrStatusKind) []const u8 {
+    return switch (s) {
+        .wait => "等待扫码",
+        .scaned => "已扫码",
+        .confirmed => "已确认",
+        .expired => "已过期",
+        .unknown => "准备登录",
+    };
+}
+
+pub fn statusDetail(s: types.QrStatusKind) []const u8 {
+    return switch (s) {
+        .wait => "Open WeChat and scan the QR code.",
+        .scaned => "Confirm the login request in WeChat.",
+        .confirmed => "WeChat is connected.",
+        .expired => "The QR code expired. Retry to request a fresh code.",
+        .unknown => "Requesting a QR code from the WeChat ilink service.",
+    };
+}
+
+pub fn qrString() []const u8 {
+    return g_qr_string orelse "";
+}
+
+pub fn qrContent() []const u8 {
+    return g_qr_content orelse "";
+}
+
+pub fn qrMatrix() ?QrMatrixView {
+    if (g_qr_matrix) |matrix| {
+        return .{ .size = matrix.size, .modules = matrix.modules };
+    }
+    return null;
+}
+
+pub fn qrGeneration() u64 {
+    return g_qr_generation;
+}
+
+pub fn qrGenerationFailed() bool {
+    return g_qr_generation_failed;
+}
+
+/// Pulls the latest controller login state into UI-owned storage. Returns true
+/// when visible UI should be redrawn.
+pub fn refresh(allocator: std.mem.Allocator) bool {
+    if (!g_visible) return false;
+    const ctrl = g_controller orelse return false;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const snap = ctrl.loginSnapshot(arena.allocator()) catch {
+        if (g_status == .unknown and g_qr_generation_failed) return false;
+        g_status = .unknown;
+        g_qr_generation_failed = true;
+        return true;
+    };
+
+    var changed = false;
+    if (snap.status != g_status) {
+        g_status = snap.status;
+        changed = true;
+    }
+
+    if (!optionalEql(g_qr_string, snap.qr_string)) {
+        replaceQrString(snap.qr_string);
+        changed = true;
+    }
+
+    changed = updateQrContent(snap.qr_content, snap.qr_string) or changed;
+
+    if (snap.status == .confirmed) {
+        close();
+        changed = true;
+    }
+
+    return changed;
+}
+
+pub fn layout(window_width: f32, window_height: f32, top_offset: f32) Layout {
+    const content_h = @max(1.0, window_height - top_offset);
+    const panel_w = @round(@min(PANEL_MAX_W, @max(PANEL_MIN_W, window_width - PANEL_MARGIN * 2)));
+    const panel_h = @round(@min(PANEL_MAX_H, @max(PANEL_MIN_H, content_h - PANEL_MARGIN * 2)));
+    const panel_x = @round(@max(12.0, (window_width - panel_w) / 2.0));
+    const panel_top = @round(top_offset + @max(12.0, (content_h - panel_h) / 2.0));
+
+    const qr_size = @round(@max(180.0, @min(@min(panel_w - 104.0, panel_h - 254.0), 292.0)));
+    const qr_x = @round(panel_x + (panel_w - qr_size) / 2.0);
+    const qr_top = @round(panel_top + 136.0);
+
+    const close_x = @round(panel_x + panel_w - 24.0 - BUTTON_W);
+    const unbind_x = @round(close_x - BUTTON_GAP - BUTTON_W);
+    const retry_x = @round(panel_x + 24.0);
+    const button_top = @round(panel_top + panel_h - 24.0 - BUTTON_H);
+
+    return .{
+        .panel = .{ .x = panel_x, .top_px = panel_top, .w = panel_w, .h = panel_h },
+        .qr = .{ .x = qr_x, .top_px = qr_top, .w = qr_size, .h = qr_size },
+        .retry = .{ .x = retry_x, .top_px = button_top, .w = BUTTON_W, .h = BUTTON_H },
+        .close = .{ .x = close_x, .top_px = button_top, .w = BUTTON_W, .h = BUTTON_H },
+        .unbind = .{ .x = unbind_x, .top_px = button_top, .w = BUTTON_W, .h = BUTTON_H },
+    };
+}
+
+pub fn containsPoint(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) bool {
+    if (!g_visible) return false;
+    const l = layout(window_width, window_height, top_offset);
+    return pointInRect(xpos, ypos, l.panel);
+}
+
+pub fn executeAt(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) Action {
+    if (!g_visible) return .none;
+    const l = layout(window_width, window_height, top_offset);
+    if (g_status == .expired and pointInRect(xpos, ypos, l.retry)) return .retry;
+    if (pointInRect(xpos, ypos, l.unbind)) return .unbind;
+    if (pointInRect(xpos, ypos, l.close)) return .close;
+    return .none;
+}
+
+pub fn deinit() void {
+    g_visible = false;
+    g_controller = null;
+    clearSnapshot();
+}
+
+fn optionalEql(current: ?[]u8, next: []const u8) bool {
+    if (current) |value| return std.mem.eql(u8, value, next);
+    return next.len == 0;
+}
+
+fn replaceQrString(value: []const u8) void {
+    if (g_qr_string) |old| std.heap.page_allocator.free(old);
+    g_qr_string = null;
+    if (value.len == 0) return;
+    g_qr_string = std.heap.page_allocator.dupe(u8, value) catch null;
+}
+
+fn updateQrContent(qr_content_raw: []const u8, qr_string_raw: []const u8) bool {
+    const qr_content = std.mem.trim(u8, if (qr_content_raw.len != 0) qr_content_raw else qr_string_raw, " \t\r\n");
+    if (qr_content.len == 0) {
+        const had_qr = g_qr_content != null or g_qr_matrix != null or g_last_qr_hash != 0 or g_qr_generation_failed;
+        clearQr();
+        if (had_qr) g_qr_generation +%= 1;
+        return had_qr;
+    }
+
+    const next_hash = std.hash.Wyhash.hash(0, qr_content);
+    if (next_hash == g_last_qr_hash) return false;
+
+    replaceQrContent(qr_content);
+    const matrix = qr_code.encodeText(std.heap.page_allocator, qr_content) catch {
+        clearQrMatrix();
+        g_last_qr_hash = next_hash;
+        g_qr_generation_failed = true;
+        g_qr_generation +%= 1;
+        return true;
+    };
+
+    clearQrMatrix();
+    g_qr_matrix = matrix;
+    g_last_qr_hash = next_hash;
+    g_qr_generation_failed = false;
+    g_qr_generation +%= 1;
+    return true;
+}
+
+fn clearSnapshot() void {
+    replaceQrString("");
+    clearQr();
+    g_status = .unknown;
+}
+
+fn replaceQrContent(value: []const u8) void {
+    if (g_qr_content) |old| std.heap.page_allocator.free(old);
+    g_qr_content = std.heap.page_allocator.dupe(u8, value) catch null;
+}
+
+fn clearQr() void {
+    if (g_qr_content) |old| std.heap.page_allocator.free(old);
+    g_qr_content = null;
+    clearQrMatrix();
+    g_last_qr_hash = 0;
+    g_qr_generation_failed = false;
+}
+
+fn clearQrMatrix() void {
+    if (g_qr_matrix) |*old| old.deinit();
+    g_qr_matrix = null;
+}
+
+fn pointInRect(xpos: f64, ypos: f64, rect: Rect) bool {
+    const x: f32 = @floatCast(xpos);
+    const y: f32 = @floatCast(ypos);
+    return x >= rect.x and x <= rect.x + rect.w and
+        y >= rect.top_px and y <= rect.top_px + rect.h;
+}
+
+test "qr_panel: stores a generated matrix from qrcode content" {
+    clearSnapshot();
+    defer deinit();
+
+    try std.testing.expect(updateQrContent("weixin://qr-content", ""));
+    try std.testing.expectEqualStrings("weixin://qr-content", qrContent());
+    try std.testing.expect(qrMatrix() != null);
+    try std.testing.expect(!qrGenerationFailed());
+}
+
+test "qr_panel: layout keeps buttons inside the panel" {
+    const l = layout(800, 600, 32);
+    try std.testing.expect(l.retry.x >= l.panel.x);
+    try std.testing.expect(l.close.x + l.close.w <= l.panel.x + l.panel.w);
+    try std.testing.expect(l.close.top_px + l.close.h <= l.panel.top_px + l.panel.h);
+}
+
+test "qr_panel: expired status exposes retry hit target" {
+    g_visible = true;
+    g_status = .expired;
+    defer deinit();
+
+    const l = layout(800, 600, 0);
+    const action = executeAt(l.retry.x + 4, l.retry.top_px + 4, 800, 600, 0);
+    try std.testing.expectEqual(Action.retry, action);
+}

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -28,7 +28,7 @@ pub const GetUpdatesResult = struct {
 pub const QrCode = struct {
     ret: i64 = 0,
     qrcode: []const u8 = "",
-    /// base64 PNG content, when the API returns an inline image
+    /// Text payload that must be encoded into the scanable QR image.
     qrcode_img_content: []const u8 = "",
 };
 


### PR DESCRIPTION
## Summary
- stabilize WeChat direct startup, bootstrap cursor handling, send latency, and shutdown behavior
- add Command Center actions for WeChat Start, Stop, Status, plus the existing Connect/Unbind flow
- enlarge the WeChat QR login panel while preserving the QR image size, and refresh the Windows handoff checklist

## Validation
- zig test src\weixin\controller.zig
- zig test src\weixin\qr_panel.zig
- zig build --prefix .zig-cache\debug-check
- git diff --check

## Notes
- Full `zig build test` reached 506/509 passing, with unrelated existing failures in `platform.window_backend` and `updater_core`.