### PR TITLE
AI profile management in Command Center + default profile in Settings

### DIFF
--- a/docs/superpowers/plans/2026-05-26-ai-profile-command-center-management.md
+++ b/docs/superpowers/plans/2026-05-26-ai-profile-command-center-management.md
@@ -1,0 +1,797 @@
+# AI Profile Management in Command Center + Default Profile in Settings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface AI profile management in the Command Center (Ctrl+Shift+P) as per-profile launch rows plus a "Manage AI Profiles" entry that revives the existing New/Edit/Delete overlay, and let Settings pick the default AI profile via a cycle row.
+
+**Architecture:** Phantty's command palette (`src/renderer/overlays.zig`) already mixes static commands with dynamic rows (SSH profiles, themes) through a `PaletteItem` union and `rebuildPaletteScratch`. We add an `ai_profile` variant the same way, a static "Manage AI Profiles" command that calls the orphaned `openAiList()` overlay, a config key `ai-default-profile` (resolved by name, falling back to the first profile), and a Settings row that cycles the default. Pure matching/resolution logic lives in `src/command_palette_model.zig` so it is unit-testable with `zig test`.
+
+**Tech Stack:** Zig 0.15.2. Pure modules tested with `zig test src/<module>.zig`. The full GUI build (`zig build test`) targets x86_64-windows on this host and is **compile-only** (foreign-target test runs are skipped) — GUI wiring in `overlays.zig` and the table in `command_center_state.zig` are verified by compilation, runtime behavior confirmed manually.
+
+---
+
+## Testing notes (read first)
+
+- `zig test src/command_palette_model.zig` — **executes** (pure module, std-only). Real red→green here.
+- `zig test src/config.zig` — **executes** natively; `config.zig` pulls in unrelated modules. Use `--test-filter` to scope to the new test. (One pre-existing `markdown_text` test may fail in some environments; ignore it — only the filtered test matters.)
+- `zig build test` — **compile-only** on this host (default target is foreign/windows; foreign test runs are skipped). Use it to prove `command_center_state.zig` and `overlays.zig` changes compile. The `command_center_state.zig` tests cannot run standalone with `zig test` because it imports `build_options.app_version`.
+
+Commit messages end with the trailer:
+```
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+```
+
+---
+
+## Task 1: Config key `ai-default-profile`
+
+**Files:**
+- Modify: `src/config.zig` (struct field near `shell` at :290; parse branch near :758; new test near the existing config tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test at the end of `src/config.zig` (after the last existing `test "..."` block):
+
+```zig
+test "config parses ai-default-profile" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    cfg.applyKeyValue(allocator, "ai-default-profile", "GPT-4o", ".");
+    try std.testing.expectEqualStrings("GPT-4o", cfg.@"ai-default-profile");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig test src/config.zig --test-filter "ai-default-profile"`
+Expected: compile error — `no field named 'ai-default-profile' in struct 'Config'`.
+
+- [ ] **Step 3: Add the struct field**
+
+In `src/config.zig`, immediately after the `shell` field (currently at :290):
+
+```zig
+shell: []const u8 = platform_pty_command.default_shell_name,
+
+/// Name of the saved AI profile used as the default for startup auto-open,
+/// remote auto-open, and the "New Agent" command. Empty falls back to the
+/// first saved profile.
+@"ai-default-profile": []const u8 = "",
+```
+
+- [ ] **Step 4: Add the parse branch**
+
+In `applyKeyValue`, right after the `shell` branch (currently at :758-759):
+
+```zig
+    } else if (std.mem.eql(u8, key, "shell")) {
+        self.shell = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "ai-default-profile")) {
+        self.@"ai-default-profile" = self.dupeString(allocator, value) orelse return;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `zig test src/config.zig --test-filter "ai-default-profile"`
+Expected: the filtered test passes (`1 passed`). Ignore any unrelated `markdown_text` failure.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.zig
+git commit -m "$(cat <<'EOF'
+feat(config): add ai-default-profile key
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Pure model helpers — `aiProfileLabelMatchesFilter` + `resolveDefaultIndex`
+
+**Files:**
+- Modify: `src/command_palette_model.zig` (add `ResultGroup.ai_profile`, two functions, tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests at the end of `src/command_palette_model.zig`:
+
+```zig
+test "ai profile label matches the ai token and the name" {
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "ai"));
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "deep"));
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "SEEK"));
+}
+
+test "ai profile label does not match unrelated filter and hides on empty" {
+    try std.testing.expect(!aiProfileLabelMatchesFilter("DeepSeek", "gpt"));
+    try std.testing.expect(!aiProfileLabelMatchesFilter("DeepSeek", ""));
+}
+
+test "resolve default index matches by name with fallback to first" {
+    const names = [_][]const u8{ "DeepSeek", "GPT-4o", "Local" };
+    try std.testing.expectEqual(@as(usize, 1), resolveDefaultIndex(&names, "GPT-4o"));
+    try std.testing.expectEqual(@as(usize, 0), resolveDefaultIndex(&names, ""));
+    try std.testing.expectEqual(@as(usize, 0), resolveDefaultIndex(&names, "missing"));
+}
+
+test "command palette model orders AI profiles between SSH and themes" {
+    try std.testing.expect(resultGroupRank(.ssh_profile) < resultGroupRank(.ai_profile));
+    try std.testing.expect(resultGroupRank(.ai_profile) < resultGroupRank(.theme));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig test src/command_palette_model.zig`
+Expected: compile error — `aiProfileLabelMatchesFilter` / `resolveDefaultIndex` / `ResultGroup.ai_profile` undefined.
+
+- [ ] **Step 3: Add `ai_profile` to the result-group enum and ranking**
+
+Replace the `ResultGroup` enum and `resultGroupRank` (currently :3-17):
+
+```zig
+pub const ResultGroup = enum {
+    command_title,
+    command_secondary,
+    ssh_profile,
+    ai_profile,
+    theme,
+};
+
+pub fn resultGroupRank(group: ResultGroup) u8 {
+    return switch (group) {
+        .command_title => 0,
+        .command_secondary => 1,
+        .ssh_profile => 2,
+        .ai_profile => 3,
+        .theme => 4,
+    };
+}
+```
+
+- [ ] **Step 4: Add the two helper functions**
+
+Add after `sshProfileNameMatchesFilter` (currently ends :47):
+
+```zig
+/// True when a non-empty filter should surface an AI profile launch row.
+/// Typing "ai" lists every profile; typing part of the name narrows.
+pub fn aiProfileLabelMatchesFilter(name: []const u8, filter: []const u8) bool {
+    if (filter.len == 0) return false;
+    return containsIgnoreCase(name, filter) or containsIgnoreCase("ai", filter);
+}
+
+/// Index of the profile whose name equals `default_name`. Returns 0 when
+/// `default_name` is empty or unmatched (caller guards the empty-list case).
+pub fn resolveDefaultIndex(names: []const []const u8, default_name: []const u8) usize {
+    if (default_name.len == 0) return 0;
+    for (names, 0..) |name, i| {
+        if (std.mem.eql(u8, name, default_name)) return i;
+    }
+    return 0;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `zig test src/command_palette_model.zig`
+Expected: `All N tests passed.` (the four new tests plus the four pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/command_palette_model.zig
+git commit -m "$(cat <<'EOF'
+feat(palette): add AI profile match + default-index helpers
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Command Center "Manage AI Profiles" entry
+
+**Files:**
+- Modify: `src/command_center_state.zig` (add `manage_ai_profiles` to `CommandAction` :5-38; add command entry :47-80; add test near :244)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test in `src/command_center_state.zig` after the `test "command center includes New Agent action"` block (:244-246):
+
+```zig
+test "command center includes Manage AI Profiles action" {
+    try std.testing.expectEqual(CommandAction.manage_ai_profiles, findCommandAction("Manage AI Profiles"));
+}
+```
+
+- [ ] **Step 2: Verify it fails to compile**
+
+Run: `zig build test`
+Expected: compile error — `no member named 'manage_ai_profiles' in enum 'CommandAction'`.
+
+- [ ] **Step 3: Add the enum member**
+
+In the `CommandAction` enum, add after `select_agent_history` (:8):
+
+```zig
+    new_agent,
+    manage_ai_profiles,
+    select_agent_history,
+```
+
+- [ ] **Step 4: Add the command entry**
+
+In `command_entries`, add after the "New Agent" entry (:49):
+
+```zig
+    .{ .title = "New Agent", .detail = "Open a new Agent tab with the default AI config", .shortcut = "", .action = .new_agent },
+    .{ .title = "Manage AI Profiles", .detail = "Create, edit, or delete saved AI profiles", .shortcut = "", .action = .manage_ai_profiles },
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `zig build test`
+Expected: build succeeds (no errors). On this host the test run is skipped (foreign target); a clean compile is the pass condition.
+
+> NOTE: this step will still fail to compile until Task 4 Step 3 adds the matching `executeCommand` switch arm in `overlays.zig`, because Zig requires the switch over `CommandAction` to be exhaustive. If `zig build test` reports `switch must handle all possibilities` for `manage_ai_profiles`, proceed to Task 4 and re-run the build there. Commit this task's files together with Task 4 if needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/command_center_state.zig
+git commit -m "$(cat <<'EOF'
+feat(command-center): add Manage AI Profiles command entry
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Default-profile resolution + revive `openAiList` from the command
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+  - Add default-name cache + `defaultAiProfileIndex()` near the AI profile helpers (after `spawnAiProfileWithAgentOverride`, :2579)
+  - Add `.manage_ai_profiles` arm to `executeCommand` (:434)
+  - Swap four hardcoded `0` default call sites (`openDefaultAiSession` :2554/:2550, `openDefaultAgentSessionFromCommandCenter` :2257, `openDefaultAgentSessionForStartup` :2272, `openDefaultAgentSessionForRemote` :2278)
+
+- [ ] **Step 1: Add the default-name cache and resolver**
+
+Insert immediately after `spawnAiProfileWithAgentOverride` (after its closing brace at :2579):
+
+```zig
+threadlocal var g_ai_default_name_buf: [AI_FIELD_MAX]u8 = undefined;
+threadlocal var g_ai_default_name_len: usize = 0;
+threadlocal var g_ai_default_loaded: bool = false;
+
+/// Cached value of the `ai-default-profile` config key. Cached to avoid file
+/// IO on every render frame; invalidated on in-app writes.
+fn aiDefaultProfileName() []const u8 {
+    if (!g_ai_default_loaded) {
+        g_ai_default_loaded = true;
+        g_ai_default_name_len = 0;
+        const allocator = AppWindow.g_allocator orelse return "";
+        var cfg = Config.load(allocator) catch return "";
+        defer cfg.deinit(allocator);
+        const name = cfg.@"ai-default-profile";
+        const len = @min(name.len, g_ai_default_name_buf.len);
+        @memcpy(g_ai_default_name_buf[0..len], name[0..len]);
+        g_ai_default_name_len = len;
+    }
+    return g_ai_default_name_buf[0..g_ai_default_name_len];
+}
+
+fn invalidateAiDefaultName() void {
+    g_ai_default_loaded = false;
+}
+
+/// Index of the default AI profile, resolved by name from config. Falls back
+/// to the first profile. Returns 0 when no profiles exist (callers guard).
+fn defaultAiProfileIndex() usize {
+    loadAiProfiles();
+    if (g_ai_profile_count == 0) return 0;
+    var names: [AI_PROFILE_MAX][]const u8 = undefined;
+    for (0..g_ai_profile_count) |i| {
+        names[i] = aiProfileField(&g_ai_profiles[i], .name);
+    }
+    return command_palette_model.resolveDefaultIndex(names[0..g_ai_profile_count], aiDefaultProfileName());
+}
+```
+
+- [ ] **Step 2: Swap the four default call sites to use `defaultAiProfileIndex()`**
+
+In `openDefaultAiSession` (:2244-2251), change the connect line:
+
+```zig
+fn openDefaultAiSession() void {
+    loadAiProfiles();
+    if (g_ai_profile_count == 0) {
+        openAiFormNew();
+        return;
+    }
+    connectAiProfile(defaultAiProfileIndex());
+}
+```
+
+(Note: `openAiFormNewWithMode(.session_setup)` becomes `openAiFormNew()` after Task 7. If implementing Task 4 before Task 7, keep `openAiFormNewWithMode(.session_setup)` here and adjust in Task 7.)
+
+In `openDefaultAgentSessionFromCommandCenter` (:2253-2259):
+
+```zig
+        .connect_default_profile_as_agent => connectAiProfileWithAgentOverride(defaultAiProfileIndex(), "true"),
+```
+
+In `openDefaultAgentSessionForStartup` (:2266-2273):
+
+```zig
+    return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
+```
+
+In `openDefaultAgentSessionForRemote` (:2275-2279):
+
+```zig
+    return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
+```
+
+- [ ] **Step 3: Wire the `manage_ai_profiles` command**
+
+In `executeCommand` (:433), add an arm after `.new_agent`:
+
+```zig
+        .new_agent => openDefaultAgentSessionFromCommandCenter(),
+        .manage_ai_profiles => openAiList(),
+```
+
+(The palette is already closed by `commandPaletteExecuteSelected` / `commandPaletteExecuteAt` before this runs, so `openAiList()` cleanly shows the overlay.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `zig build test`
+Expected: clean compile (foreign test run skipped). The `manage_ai_profiles` switch arm now makes Task 3's enum exhaustive.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/overlays.zig src/command_center_state.zig
+git commit -m "$(cat <<'EOF'
+feat(ai): resolve default profile by name; revive manage overlay
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: AI profile launch rows in the command palette
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+  - `PaletteItem` union (:184-188)
+  - `rebuildPaletteScratch` — inject AI rows after SSH loop (:721)
+  - `executePaletteItem` (:730-736)
+  - palette row rendering — add `.ai_profile` branch (:1279-1313)
+
+- [ ] **Step 1: Add the `ai_profile` variant to the union**
+
+Replace `PaletteItem` (:184-188):
+
+```zig
+const PaletteItem = union(enum) {
+    command: usize,
+    ssh_profile: usize,
+    ai_profile: usize,
+    theme: usize,
+};
+```
+
+- [ ] **Step 2: Inject AI profile rows in `rebuildPaletteScratch`**
+
+In `rebuildPaletteScratch`, after the SSH-profile loop (the block ending at :721, right before the `for (&themes_embed.entries, 0..)` theme loop), insert:
+
+```zig
+    loadAiProfiles();
+    for (0..g_ai_profile_count) |ai_idx| {
+        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        const profile = &g_ai_profiles[ai_idx];
+        if (!command_palette_model.aiProfileLabelMatchesFilter(aiProfileField(profile, .name), filter)) continue;
+        g_palette_scratch[g_palette_scratch_len] = .{ .ai_profile = ai_idx };
+        g_palette_scratch_len += 1;
+    }
+```
+
+- [ ] **Step 3: Execute launch rows**
+
+Replace `executePaletteItem` (:730-736):
+
+```zig
+fn executePaletteItem(item: PaletteItem) void {
+    switch (item) {
+        .command => |cmd_idx| executeCommand(COMMAND_ENTRIES[cmd_idx].action),
+        .ssh_profile => |profile_idx| connectSshProfile(profile_idx),
+        .ai_profile => |profile_idx| _ = spawnAiProfileWithAgentOverride(profile_idx, null),
+        .theme => |ti| applyEmbeddedThemeFromPalette(ti),
+    }
+}
+```
+
+(`null` makes the launched tab use the profile's own stored `agent` field. `spawnAiProfileWithAgentOverride` internally calls `sessionLauncherClose()`, which is harmless here.)
+
+- [ ] **Step 4: Render the launch rows**
+
+In the palette row-rendering switch (:1279-1313), add an `.ai_profile` branch after the `.ssh_profile` branch:
+
+```zig
+                    .ai_profile => |profile_idx| {
+                        if (profile_idx >= g_ai_profile_count) continue;
+                        const profile = &g_ai_profiles[profile_idx];
+                        var title_buf: [AI_FIELD_MAX + 8]u8 = undefined;
+                        const ai_title = std.fmt.bufPrint(title_buf[0..], "AI: {s}", .{aiProfileField(profile, .name)}) catch "AI";
+                        var tag_buf: [24]u8 = undefined;
+                        const mode = aiProfileModeLabel(profile);
+                        const tag = if (profile_idx == defaultAiProfileIndex())
+                            (std.fmt.bufPrint(tag_buf[0..], "{s} · default", .{mode}) catch mode)
+                        else
+                            mode;
+                        const tag_w = measureTitlebarText(tag);
+                        const tag_left = @round(layout.box_x + layout.box_w - pad_x - tag_w);
+                        renderTitlebarText(tag, tag_left, text_y, shortcut_color);
+                        renderTitlebarTextLimited(ai_title, title_x, text_y, row_title_color, @max(1.0, tag_left - title_x - 18));
+                    },
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `zig build test`
+Expected: clean compile.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "$(cat <<'EOF'
+feat(command-center): add AI profile launch rows
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `(default)` marker in the manage list + clear default on delete
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+  - `renderAiProfileRow` (:3063-3067)
+  - `deleteAiProfile` (:2478-2488)
+
+- [ ] **Step 1: Show the default marker in the manage list**
+
+Replace `renderAiProfileRow` (:3063-3067):
+
+```zig
+fn renderAiProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const AiProfile, selected: bool) void {
+    const name = aiProfileField(profile, .name);
+    const mode = aiProfileModeLabel(profile);
+    var detail_buf: [24]u8 = undefined;
+    const detail = if (row == defaultAiProfileIndex())
+        (std.fmt.bufPrint(detail_buf[0..], "{s} · default", .{mode}) catch mode)
+    else
+        mode;
+    renderSessionRow(layout, window_height, row, name, detail, selected);
+}
+```
+
+(In `.manage` mode the list row index equals the profile index — the render loop iterates `&g_ai_profiles[row]` — so `row == defaultAiProfileIndex()` is the correct comparison.)
+
+- [ ] **Step 2: Clear the default key when the default profile is deleted**
+
+Replace `deleteAiProfile` (:2478-2488):
+
+```zig
+fn deleteAiProfile(idx: usize) void {
+    if (g_ai_profile_count == 0) return;
+    if (idx >= g_ai_profile_count) return;
+    const deleted_is_default = std.mem.eql(u8, aiProfileField(&g_ai_profiles[idx], .name), aiDefaultProfileName());
+    var i = idx;
+    while (i + 1 < g_ai_profile_count) : (i += 1) {
+        g_ai_profiles[i] = g_ai_profiles[i + 1];
+    }
+    g_ai_profile_count -= 1;
+    g_ai_list_selected = @min(g_ai_list_selected, aiListRowCount() - 1);
+    if (deleted_is_default) {
+        if (AppWindow.g_allocator) |allocator| Config.setConfigValue(allocator, "ai-default-profile", "") catch {};
+        invalidateAiDefaultName();
+    }
+    if (AppWindow.g_allocator) |allocator| saveAiProfiles(allocator);
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `zig build test`
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "$(cat <<'EOF'
+feat(ai): mark default profile and clear it on delete
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Settings "Default AI" cycle row + remove the settings edit-form path
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+  - `SettingsAction` enum (:3230-3241)
+  - `settingsHitTest` row map (:3377)
+  - `runSettingsFocusPrimary` row map (:3425)
+  - `executeSettingsAction` arm (:3403)
+  - `renderSettingsPage` AI row (:3623-3626)
+  - Add `nextDefaultAiProfileName()` helper
+  - Remove `openAiSettings` (:2281-2288) and the `AiFormMode` `.settings` path (enum :1386-1389, var :1448, resets :1526 & :3269, `openAiForm*` :2309-2343, `saveAiFormOnly` :2495-2501, `cancelAiFormOrLauncher` :2503-2509, `runAiFormFocusAction` :2511-2521)
+
+- [ ] **Step 1: Replace the settings action enum member**
+
+In `SettingsAction` (:3230-3241), replace `open_ai_settings` with `cycle_default_ai_profile`:
+
+```zig
+const SettingsAction = enum {
+    font_size_minus,
+    font_size_plus,
+    cycle_theme,
+    cycle_cursor_style,
+    toggle_cursor_blink,
+    toggle_focus_follows_mouse,
+    cycle_shell,
+    cycle_default_ai_profile,
+    open_raw_config,
+    close,
+};
+```
+
+- [ ] **Step 2: Add the next-default helper**
+
+Add next to `defaultAiProfileIndex()` (from Task 4):
+
+```zig
+/// Name of the profile after the current default, wrapping around. Empty when
+/// no profiles exist.
+fn nextDefaultAiProfileName() []const u8 {
+    loadAiProfiles();
+    if (g_ai_profile_count == 0) return "";
+    const next = (defaultAiProfileIndex() + 1) % g_ai_profile_count;
+    return aiProfileField(&g_ai_profiles[next], .name);
+}
+```
+
+- [ ] **Step 3: Update the hit-test and keyboard row maps**
+
+In `settingsHitTest` (:3372-3381), change row 4:
+
+```zig
+    return switch (row - SETTINGS_CONTROL_ROW_START) {
+        0 => .cycle_cursor_style,
+        1 => .toggle_cursor_blink,
+        2 => .toggle_focus_follows_mouse,
+        3 => .cycle_shell,
+        4 => .cycle_default_ai_profile,
+        5 => .open_raw_config,
+        6 => .close,
+        else => null,
+    };
+```
+
+In `runSettingsFocusPrimary` (:3425), change the row-4 arm:
+
+```zig
+        SETTINGS_CONTROL_ROW_START + 4 => executeSettingsAction(.cycle_default_ai_profile),
+```
+
+- [ ] **Step 4: Replace the execute arm**
+
+In `executeSettingsAction` (:3403), replace the `.open_ai_settings` arm:
+
+```zig
+        .cycle_default_ai_profile => {
+            loadAiProfiles();
+            if (g_ai_profile_count > 0) {
+                const next_name = nextDefaultAiProfileName();
+                Config.setConfigValue(allocator, "ai-default-profile", next_name) catch {};
+                invalidateAiDefaultName();
+            }
+        },
+```
+
+(`nextDefaultAiProfileName()` reads the still-current default before the write; the `invalidate` makes the next render reflect the new default.)
+
+- [ ] **Step 5: Update the settings row rendering**
+
+Replace the AI row block in `renderSettingsPage` (:3623-3626):
+
+```zig
+    loadAiProfiles();
+    const ai_default_value = if (g_ai_profile_count > 0)
+        aiProfileField(&g_ai_profiles[defaultAiProfileIndex()], .name)
+    else
+        "(none)";
+    const ai_default_hint = if (g_ai_profile_count > 0)
+        aiProfileModeLabel(&g_ai_profiles[defaultAiProfileIndex()])
+    else
+        "Add profiles via Command Center";
+    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 4, "Default AI", ai_default_value, ai_default_hint, true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 4);
+```
+
+- [ ] **Step 6: Remove `openAiSettings`**
+
+Delete the entire `openAiSettings` function (:2281-2288).
+
+- [ ] **Step 7: Collapse `AiFormMode` to a single path**
+
+7a. Delete the `AiFormMode` enum (:1386-1389).
+
+7b. Delete the `g_ai_form_mode` declaration (:1448) and the reset line in `sessionLauncherClose` (:1526 — remove `g_ai_form_mode = .session_setup;`).
+
+7c. In `settingsPageOpen` (:3269), remove the line `g_ai_form_mode = .session_setup;`.
+
+7d. Replace the `openAiForm*` cluster (:2309-2343) with mode-free versions:
+
+```zig
+fn openAiFormNew() void {
+    clearAiForm();
+    g_ai_edit_index = AI_PROFILE_NONE;
+    openAiForm();
+}
+
+fn openAiFormEdit(index: usize) void {
+    if (index >= g_ai_profile_count) return;
+    clearAiForm();
+    for (0..AI_FIELD_COUNT) |i| {
+        g_ai_lens[i] = @min(g_ai_profiles[index].lens[i], AI_FIELD_MAX);
+        @memcpy(g_ai_bufs[i][0..g_ai_lens[i]], g_ai_profiles[index].fields[i][0..g_ai_lens[i]]);
+    }
+    g_ai_edit_index = index;
+    openAiForm();
+}
+
+fn openAiForm() void {
+    g_ssh_list_visible = false;
+    g_ssh_form_visible = false;
+    g_ai_list_visible = false;
+    g_session_launcher_visible = false;
+    g_settings_visible = false;
+    g_ai_form_visible = true;
+    g_ai_focus = @intFromEnum(AiField.name);
+}
+```
+
+7e. Replace `saveAiFormOnly` (:2495-2501):
+
+```zig
+fn saveAiFormOnly() void {
+    _ = saveAiFormProfile() orelse return;
+    sessionLauncherClose();
+}
+```
+
+7f. Replace `cancelAiFormOrLauncher` (:2503-2509):
+
+```zig
+fn cancelAiFormOrLauncher() void {
+    sessionLauncherClose();
+}
+```
+
+7g. Replace `runAiFormFocusAction` (:2511-2521):
+
+```zig
+fn runAiFormFocusAction() void {
+    if (g_ai_focus < AI_FIELD_COUNT) {
+        g_ai_focus = (g_ai_focus + 1) % (AI_FIELD_COUNT + 3);
+        return;
+    }
+    switch (g_ai_focus - AI_FIELD_COUNT) {
+        0 => connectAiFromForm(),
+        1 => saveAiFormOnly(),
+        else => cancelAiFormOrLauncher(),
+    }
+}
+```
+
+7h. If Task 4 Step 2 left `openAiFormNewWithMode(.session_setup)` in `openDefaultAiSession`, change it to `openAiFormNew()` now. Also check `openDefaultAgentSessionForStartup` (:2269) which calls `openAiFormNewWithMode(.session_setup)` — change to `openAiFormNew()`.
+
+- [ ] **Step 8: Verify no stale references remain**
+
+Run: `rtk proxy grep -rn "AiFormMode\|g_ai_form_mode\|open_ai_settings\|openAiSettings\|openAiFormNewWithMode\|openAiFormEditWithMode\|openAiFormWithMode" src/renderer/overlays.zig`
+Expected: no matches.
+
+- [ ] **Step 9: Verify it compiles**
+
+Run: `zig build test`
+Expected: clean compile.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "$(cat <<'EOF'
+feat(settings): cycle default AI profile; drop settings edit-form path
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full build verification + manual check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the pure module tests**
+
+Run: `zig test src/command_palette_model.zig`
+Expected: `All N tests passed.`
+
+Run: `zig test src/config.zig --test-filter "ai-default-profile"`
+Expected: the filtered test passes.
+
+- [ ] **Step 2: Compile the full suite**
+
+Run: `zig build test`
+Expected: clean compile (foreign test run skipped on this host).
+
+- [ ] **Step 3: Manual verification checklist (record results)**
+
+Document these in the task notes when run on a real build:
+
+1. Ctrl+Shift+P → type `ai` → each saved profile appears as `AI: <name>` with an `Agent`/`Chat` tag; the default shows `· default`. Enter launches it (agent profiles open as agents, chat profiles as chat).
+2. Ctrl+Shift+P → `Manage AI Profiles` → overlay opens with profiles + New / Edit / Delete / Cancel. New adds a profile; Edit opens the form for a chosen profile; Delete removes a chosen profile. Esc/Cancel returns.
+3. Delete the current default profile → `ai-default-profile` is cleared; default falls back to the first remaining profile (verify the `· default` marker moves).
+4. Settings → `Default AI` row shows the current default name; Enter/Right/click cycles to the next saved profile and persists (reopen Settings to confirm). With zero profiles it shows `(none)`.
+5. Restart with a default set by name → startup auto-opens that profile (not necessarily index 0).
+
+- [ ] **Step 4: Final commit (only if any verification fix was needed)**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+test: verify AI profile command-center + default flows
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- §1 default resolution (config key + helper + 4 call-site swaps) → Tasks 1, 2 (`resolveDefaultIndex`), 4. ✓
+- §2 command center (`PaletteItem.ai_profile`, "Manage AI Profiles", matcher, execute, render, `manage_ai_profiles`) → Tasks 2, 3, 4 (command wiring), 5. ✓
+- §3 manage overlay (revive + `(default)` marker + delete clears default) → Tasks 4 (revive), 6. ✓
+- §4 settings (cycle row, remove `open_ai_settings`/`openAiSettings`/`.settings` form mode) → Task 7. ✓
+- §5 tests (model matcher + resolveDefaultIndex; "Manage AI Profiles" entry; config parse) → Tasks 2, 3, 1. ✓
+
+**Deviation from spec (intentional):** `resolveDefaultIndex` lives in `command_palette_model.zig` (not `command_center_state.zig` as the spec drafted) so it runs under `zig test` — `command_center_state.zig` can't run standalone (needs `build_options.app_version`). Logic and call sites are unchanged.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code; the one cross-task ordering caveat (Task 3 exhaustive-switch / Task 4) is called out explicitly. ✓
+
+**Type consistency:** `defaultAiProfileIndex()`, `aiDefaultProfileName()`, `invalidateAiDefaultName()`, `nextDefaultAiProfileName()`, `aiProfileLabelMatchesFilter()`, `resolveDefaultIndex()`, `PaletteItem.ai_profile`, `CommandAction.manage_ai_profiles`, `SettingsAction.cycle_default_ai_profile` are named identically across all tasks that reference them. ✓

--- a/docs/superpowers/specs/2026-05-26-ai-profile-command-center-management-design.md
+++ b/docs/superpowers/specs/2026-05-26-ai-profile-command-center-management-design.md
@@ -1,0 +1,246 @@
+# AI Profile Management in Command Center + Default Profile in Settings
+
+Date: 2026-05-26
+Status: Approved (design)
+
+## Problem
+
+Phantty supports up to 16 saved AI Chat profiles (`AI_PROFILE_MAX = 16` in
+`src/renderer/overlays.zig`), stored in the `ai_profiles` config file as
+tab-separated, hex-encoded rows. Each profile holds nine fields: `name`,
+`base_url`, `api_key`, `model`, `system_prompt`, `thinking`,
+`reasoning_effort`, `stream`, `agent`.
+
+A complete multi-profile management overlay (`openAiList`, with New / Edit /
+Delete actions and a profile picker) exists in the code but is **orphaned**.
+Commit `e192e42` ("Streamline AI agent session launch") repointed the session
+launcher's AI row from `openAiList()` to `openDefaultAiSession()`, leaving
+`openAiList` reachable only by recursion from within itself. As a result the
+current wired UI can only:
+
+- Create the *first* profile (when zero exist), and
+- Edit *profile index 0* via Settings.
+
+There is no UI path to add a second profile, edit/delete non-zero profiles, or
+choose which profile is the default. Everywhere a "default" profile is used,
+the code hardcodes index `0` (startup auto-open, remote auto-open, the
+"New Agent" command).
+
+## Goal
+
+1. Surface AI profile management in the Command Center (Ctrl+Shift+P), matching
+   the flat command style used by the WeChat entries: each saved profile is a
+   launchable row (quick switch), plus a single "Manage AI Profiles" command
+   that opens the revived New / Edit / Delete overlay.
+2. Let Settings choose the default AI profile (used by startup auto-open,
+   remote auto-open, and "New Agent") and quickly switch among saved profiles.
+
+## Decisions (locked during brainstorming)
+
+- **Command Center layout**: per-profile launch rows + one "Manage AI Profiles"
+  entry that opens the existing `openAiList` overlay for create/edit/delete.
+- **Launch mode**: launching a profile row respects that profile's own stored
+  `agent` field (`agent` profiles open as agents, `chat` profiles as chat).
+- **Default storage**: a config key `ai-default-profile` holding the profile
+  *name*. Falls back to the first saved profile when empty, unset, or unmatched.
+  The `ai_profiles` file order stays stable.
+- **Settings switch UX**: a "Default AI" row showing the current default name;
+  click/Enter cycles to the next saved profile and writes `ai-default-profile`
+  (mirrors the existing `cycle_theme` / `cycle_shell` rows).
+- **Settings scope**: Settings handles default selection only. All
+  create/edit/delete moves to the Command Center "Manage AI Profiles" overlay.
+- **Palette visibility**: profile launch rows surface only when the palette
+  filter is non-empty and matches (consistent with how SSH profiles and themes
+  already behave). "Manage AI Profiles" is a static, always-listed command.
+
+## Design
+
+### 1. Default profile resolution (config)
+
+- Add config field `@"ai-default-profile": []const u8 = ""` to the `Config`
+  struct in `src/config.zig`, plus a parse branch in the key/value applier
+  (alongside the other string keys). The value is the profile `name`.
+- Add a pure, unit-testable helper in `src/command_center_state.zig`:
+
+  ```zig
+  pub fn resolveDefaultIndex(names: []const []const u8, default_name: []const u8) usize
+  ```
+
+  Returns the index of the first `names[i]` equal to `default_name`; returns `0`
+  when `default_name` is empty or no name matches (and `0` when `names` is empty,
+  callers must guard the empty-profile case separately).
+- Add `defaultAiProfileIndex()` in `src/renderer/overlays.zig`: calls
+  `loadAiProfiles()`, builds the slice of profile names, reads the current
+  config value, and returns `resolveDefaultIndex(...)`.
+- Replace the hardcoded `0` with `defaultAiProfileIndex()` at these call sites
+  in `overlays.zig`:
+  - `openDefaultAiSession` → `connectAiProfile(defaultAiProfileIndex())`
+  - `openDefaultAgentSessionFromCommandCenter` →
+    `connectAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")`
+  - `openDefaultAgentSessionForStartup` →
+    `spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")`
+  - `openDefaultAgentSessionForRemote` →
+    `spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")`
+
+  (The agent-mode override behavior of these four sites is unchanged; only the
+  index changes.)
+
+### 2. Command Center (Ctrl+Shift+P)
+
+- Extend the palette item union in `overlays.zig`:
+
+  ```zig
+  const PaletteItem = union(enum) {
+      command: usize,
+      ssh_profile: usize,
+      ai_profile: usize,   // new
+      theme: usize,
+  };
+  ```
+
+- Add a static command entry to `command_entries` in
+  `src/command_center_state.zig`, placed near "New Agent":
+
+  ```zig
+  .{ .title = "Manage AI Profiles",
+     .detail = "Create, edit, or delete saved AI profiles",
+     .shortcut = "", .action = .manage_ai_profiles },
+  ```
+
+  Add `manage_ai_profiles` to the `CommandAction` enum.
+
+- In `executeCommand` (`overlays.zig`), handle
+  `.manage_ai_profiles => openAiList()`. The palette is already closed by the
+  caller (`commandPaletteExecuteSelected` / `commandPaletteExecuteAt` call
+  `commandPaletteClose()` before `executePaletteItem`). Opening `openAiList()`
+  sets `g_ai_list_visible = true`; because
+  `command_center_state.State.sessionLauncherVisible()` returns true when
+  `ai_list_visible` is set, the top-level input router dispatches keys to
+  `sessionLauncherHandleKey` → `handleAiListKey`, and the overlay renders. No
+  new plumbing required.
+
+- In `rebuildPaletteScratch` (`overlays.zig`), after the SSH-profile loop and
+  before/around the theme loop, inject AI profile launch rows when the filter is
+  non-empty:
+
+  ```zig
+  loadAiProfiles();
+  for (0..g_ai_profile_count) |idx| {
+      if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+      const profile = &g_ai_profiles[idx];
+      if (!command_palette_model.aiProfileLabelMatchesFilter(
+          aiProfileField(profile, .name), filter)) continue;
+      g_palette_scratch[g_palette_scratch_len] = .{ .ai_profile = idx };
+      g_palette_scratch_len += 1;
+  }
+  ```
+
+- Add the matcher to `src/command_palette_model.zig`:
+
+  ```zig
+  pub fn aiProfileLabelMatchesFilter(name: []const u8, filter: []const u8) bool
+  ```
+
+  Matches when `filter` is empty-guarded by the caller (only called with
+  non-empty filter), and `containsIgnoreCase("ai: " ++ name, filter)` is true —
+  i.e. typing `ai` lists all profiles, typing part of a name narrows. Add an
+  `ai_profile` variant to the model's `ResultGroup` for ranking, ordered after
+  `ssh_profile` (or adjacent — exact rank to be set so AI rows group sensibly;
+  ranking only affects ordering, not correctness).
+
+- Execute launch rows in `executePaletteItem`:
+
+  ```zig
+  .ai_profile => |idx| _ = spawnAiProfileWithAgentOverride(idx, null),
+  ```
+
+  `null` means the spawned tab uses the profile's own `agent` field.
+  `spawnAiProfileWithAgentOverride` already calls `sessionLauncherClose()`
+  internally; that is harmless here since the palette is already closed.
+
+- **Rendering**: extend the palette row renderer to handle the `ai_profile`
+  variant. Title = `AI: <name>`. Right-aligned tag = the profile's mode derived
+  from its `agent` field (`agent` when truthy, else `chat`), with a `(default)`
+  suffix on the profile whose name equals `ai-default-profile` (or the first
+  profile when the key is empty). Follow the existing theme-row tag rendering as
+  the template.
+
+### 3. Manage overlay (revive `openAiList`)
+
+The overlay's New / Edit / Delete flow and file persistence already work
+(`runAiListRow`, `saveAiFormProfile`, `deleteAiProfile`, `saveAiProfiles`). It
+becomes reachable again purely via the new command. Two additions:
+
+- `(default)` marker in the manage-list row rendering, consistent with the
+  palette rows.
+- `deleteAiProfile`: if the deleted profile's name equals the current
+  `ai-default-profile` config value, clear the key (write empty) so resolution
+  falls back to the first remaining profile.
+
+### 4. Settings page
+
+- Repurpose the existing AI settings row in `overlays.zig`:
+  - Add `cycle_default_ai_profile` to `SettingsAction`; remove
+    `open_ai_settings`.
+  - The row label is "Default AI"; its value shows the current default profile
+    name (resolved via `defaultAiProfileIndex()` → profile name), or `(none)`
+    when zero profiles exist.
+  - Activating the row cycles to the next saved profile name and writes it to
+    `ai-default-profile` via `Config.setConfigValue`. No-op when zero profiles
+    exist.
+- Remove the now-unused `openAiSettings` function and the `.settings`
+  `AiFormMode` branch (the only consumer of the settings form mode). This
+  simplifies `openAiFormWithMode`, `saveAiFormOnly`, `cancelAiFormOrLauncher`,
+  and `runAiFormFocusAction` to a single form mode (session setup). This is the
+  one refactor included beyond rewiring, and it is in scope because the Settings
+  AI behavior is changing.
+
+### 5. Tests
+
+Per this host's compile-only constraint for the GUI modules, logic that needs
+runtime assertions lives in pure modules runnable with `zig test`:
+
+- `src/command_palette_model.zig`:
+  - `aiProfileLabelMatchesFilter("DeepSeek", "ai")` is true.
+  - `aiProfileLabelMatchesFilter("DeepSeek", "deep")` is true (case-insensitive).
+  - `aiProfileLabelMatchesFilter("DeepSeek", "gpt")` is false.
+- `src/command_center_state.zig`:
+  - "Manage AI Profiles" maps to `CommandAction.manage_ai_profiles`
+    (via the existing `findCommandAction` test helper).
+  - `resolveDefaultIndex(&.{"a","b","c"}, "b") == 1`.
+  - `resolveDefaultIndex(&.{"a","b"}, "") == 0` (empty default).
+  - `resolveDefaultIndex(&.{"a","b"}, "missing") == 0` (no match → first).
+- `src/config.zig`:
+  - Applying `ai-default-profile = GPT-4o` sets the field to `"GPT-4o"`.
+
+GUI wiring in `overlays.zig` (palette injection, rendering, settings row,
+overlay revival) is verified by compilation; runtime behavior is confirmed
+manually.
+
+## Affected files
+
+- `src/config.zig` — new `ai-default-profile` field + parse branch + test.
+- `src/command_center_state.zig` — `manage_ai_profiles` action + command entry;
+  `resolveDefaultIndex` helper + tests.
+- `src/command_palette_model.zig` — `aiProfileLabelMatchesFilter` + `ResultGroup`
+  variant + tests.
+- `src/renderer/overlays.zig` — `PaletteItem.ai_profile`, palette injection &
+  rendering, `manage_ai_profiles` handler, `defaultAiProfileIndex`, four default
+  call-site swaps, `deleteAiProfile` default-clear, Settings row repurpose,
+  removal of `open_ai_settings` / `openAiSettings` / `.settings` form mode.
+
+## Out of scope (YAGNI)
+
+- Drag-reorder, import/export, or per-profile keybindings.
+- Always-visible (unfiltered) profile rows in the palette — they surface only
+  when filtered, consistent with SSH profiles and themes.
+- Any change to the profile field set or the `ai_profiles` file format.
+
+## Risks / notes
+
+- `COMMAND_PALETTE_MAX_VISIBLE_ROWS = 14` caps total visible rows; AI profile
+  rows share this budget with commands, SSH profiles, and themes. With <=16
+  profiles and name-filtering, this is acceptable and matches existing behavior.
+- Removing the `.settings` form mode touches several small functions; the change
+  is mechanical (collapsing a two-variant enum to one path) but should be done
+  carefully to avoid leaving dangling references.

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -5,6 +5,7 @@ const std = @import("std");
 pub const CommandAction = enum {
     new_tab,
     new_agent,
+    manage_ai_profiles,
     select_agent_history,
     split_right,
     split_down,
@@ -47,6 +48,7 @@ pub const CommandEntry = struct {
 pub const command_entries = [_]CommandEntry{
     .{ .title = "New Session", .detail = platform_pty_command.session_launcher_detail, .shortcut = "", .action = .new_tab },
     .{ .title = "New Agent", .detail = "Open a new Agent tab with the default AI config", .shortcut = "", .action = .new_agent },
+    .{ .title = "Manage AI Profiles", .detail = "Create, edit, or delete saved AI profiles", .shortcut = "", .action = .manage_ai_profiles },
     .{ .title = "Select Agent History", .detail = "Open the command-center agent history picker", .shortcut = "", .action = .select_agent_history },
     .{ .title = "Split Right", .detail = "Create a panel to the right", .shortcut = "", .action = .split_right },
     .{ .title = "Split Down", .detail = "Create a panel below", .shortcut = "", .action = .split_down },
@@ -243,6 +245,10 @@ pub fn resolveNewAgentLaunch(has_profiles: bool) NewAgentLaunchAction {
 
 test "command center includes New Agent action" {
     try std.testing.expectEqual(CommandAction.new_agent, findCommandAction("New Agent"));
+}
+
+test "command center includes Manage AI Profiles action" {
+    try std.testing.expectEqual(CommandAction.manage_ai_profiles, findCommandAction("Manage AI Profiles"));
 }
 
 test "command center includes Select Agent History action" {

--- a/src/command_palette_model.zig
+++ b/src/command_palette_model.zig
@@ -4,6 +4,7 @@ pub const ResultGroup = enum {
     command_title,
     command_secondary,
     ssh_profile,
+    ai_profile,
     theme,
 };
 
@@ -12,7 +13,8 @@ pub fn resultGroupRank(group: ResultGroup) u8 {
         .command_title => 0,
         .command_secondary => 1,
         .ssh_profile => 2,
-        .theme => 3,
+        .ai_profile => 3,
+        .theme => 4,
     };
 }
 
@@ -46,6 +48,24 @@ pub fn sshProfileNameMatchesFilter(name: []const u8, filter: []const u8) bool {
     return shouldSearchSshProfiles(filter) and containsIgnoreCase(name, filter);
 }
 
+/// True when a non-empty filter should surface an AI profile launch row.
+/// Any filter that is a substring of "ai" (i.e. "a", "i", or "ai") lists
+/// every profile; otherwise the filter must match part of the name.
+pub fn aiProfileLabelMatchesFilter(name: []const u8, filter: []const u8) bool {
+    if (filter.len == 0) return false;
+    return containsIgnoreCase(name, filter) or containsIgnoreCase("ai", filter);
+}
+
+/// Index of the profile whose name equals `default_name`. Returns 0 when
+/// `default_name` is empty or unmatched (caller guards the empty-list case).
+pub fn resolveDefaultIndex(names: []const []const u8, default_name: []const u8) usize {
+    if (default_name.len == 0) return 0;
+    for (names, 0..) |name, i| {
+        if (std.mem.eql(u8, name, default_name)) return i;
+    }
+    return 0;
+}
+
 test "command palette model matches SSH profile names case-insensitively" {
     try std.testing.expect(sshProfileNameMatchesFilter("LabServer", "labserver"));
 }
@@ -64,4 +84,27 @@ test "command palette model orders SSH results after commands and before themes"
     try std.testing.expect(resultGroupRank(.command_title) < resultGroupRank(.command_secondary));
     try std.testing.expect(resultGroupRank(.command_secondary) < resultGroupRank(.ssh_profile));
     try std.testing.expect(resultGroupRank(.ssh_profile) < resultGroupRank(.theme));
+}
+
+test "ai profile label matches the ai token and the name" {
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "ai"));
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "deep"));
+    try std.testing.expect(aiProfileLabelMatchesFilter("DeepSeek", "SEEK"));
+}
+
+test "ai profile label does not match unrelated filter and hides on empty" {
+    try std.testing.expect(!aiProfileLabelMatchesFilter("DeepSeek", "gpt"));
+    try std.testing.expect(!aiProfileLabelMatchesFilter("DeepSeek", ""));
+}
+
+test "resolve default index matches by name with fallback to first" {
+    const names = [_][]const u8{ "DeepSeek", "GPT-4o", "Local" };
+    try std.testing.expectEqual(@as(usize, 1), resolveDefaultIndex(&names, "GPT-4o"));
+    try std.testing.expectEqual(@as(usize, 0), resolveDefaultIndex(&names, ""));
+    try std.testing.expectEqual(@as(usize, 0), resolveDefaultIndex(&names, "missing"));
+}
+
+test "command palette model orders AI profiles between SSH and themes" {
+    try std.testing.expect(resultGroupRank(.ssh_profile) < resultGroupRank(.ai_profile));
+    try std.testing.expect(resultGroupRank(.ai_profile) < resultGroupRank(.theme));
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -289,6 +289,11 @@ theme: ?[]const u8 = null,
 /// platform/pty_command.zig; any other value is treated as a raw command path.
 shell: []const u8 = platform_pty_command.default_shell_name,
 
+/// Name of the saved AI profile used as the default for startup auto-open,
+/// remote auto-open, and the "New Agent" command. Empty falls back to the
+/// first saved profile.
+@"ai-default-profile": []const u8 = "",
+
 // ============================================================================
 // Remote Access (opt-in foundations)
 // ============================================================================
@@ -757,6 +762,8 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         };
     } else if (std.mem.eql(u8, key, "shell")) {
         self.shell = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "ai-default-profile")) {
+        self.@"ai-default-profile" = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "remote-enabled")) {
         if (std.mem.eql(u8, value, "true")) {
             self.@"remote-enabled" = true;
@@ -1830,4 +1837,13 @@ test "config: remote session key parses" {
 test "config: version flags are special commands" {
     try std.testing.expect(isSpecialCommand("version"));
     try std.testing.expect(isSpecialCommand("v"));
+}
+
+test "config: ai-default-profile parses" {
+    const allocator = std.testing.allocator;
+    var cfg: Config = .{};
+    defer cfg.deinit(allocator);
+    try std.testing.expectEqualStrings("", cfg.@"ai-default-profile");
+    cfg.applyKeyValue(allocator, "ai-default-profile", "GPT-4o", ".");
+    try std.testing.expectEqualStrings("GPT-4o", cfg.@"ai-default-profile");
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2527,7 +2527,8 @@ fn saveAiFormProfile() ?usize {
     if (base_url.len == 0 or model.len == 0) return null;
     if (!isHttpUrlish(base_url)) return null;
 
-    const idx = if (g_ai_edit_index != AI_PROFILE_NONE)
+    const editing_existing = g_ai_edit_index != AI_PROFILE_NONE;
+    const idx = if (editing_existing)
         g_ai_edit_index
     else blk: {
         if (g_ai_profile_count >= AI_PROFILE_MAX) return null;
@@ -2535,6 +2536,17 @@ fn saveAiFormProfile() ?usize {
         g_ai_profile_count += 1;
         break :blk next;
     };
+
+    // Capture the pre-edit name so a rename of the current default profile
+    // can keep `ai-default-profile` pointing at it instead of falling back
+    // to the first profile.
+    var old_name_buf: [256]u8 = undefined;
+    var old_name_len: usize = 0;
+    if (editing_existing) {
+        const old_name = aiProfileField(&g_ai_profiles[idx], .name);
+        old_name_len = @min(old_name.len, old_name_buf.len);
+        @memcpy(old_name_buf[0..old_name_len], old_name[0..old_name_len]);
+    }
 
     for (0..AI_FIELD_COUNT) |i| {
         g_ai_profiles[idx].lens[i] = g_ai_lens[i];
@@ -2544,6 +2556,15 @@ fn saveAiFormProfile() ?usize {
         const len = @min(model.len, AI_FIELD_MAX);
         @memcpy(g_ai_profiles[idx].fields[@intFromEnum(AiField.name)][0..len], model[0..len]);
         g_ai_profiles[idx].lens[@intFromEnum(AiField.name)] = len;
+    }
+
+    if (editing_existing and old_name_len > 0) {
+        const old_name = old_name_buf[0..old_name_len];
+        const new_name = aiProfileField(&g_ai_profiles[idx], .name);
+        if (!std.mem.eql(u8, old_name, new_name) and std.mem.eql(u8, old_name, aiDefaultProfileName())) {
+            Config.setConfigValue(allocator, "ai-default-profile", new_name) catch {};
+            invalidateAiDefaultName();
+        }
     }
 
     saveAiProfiles(allocator);
@@ -3122,7 +3143,7 @@ fn aiProfileModeLabel(profile: *const AiProfile) []const u8 {
 
 fn defaultAiModeLabel() []const u8 {
     loadAiProfiles();
-    if (g_ai_profile_count > 0) return aiProfileModeLabel(&g_ai_profiles[0]);
+    if (g_ai_profile_count > 0) return aiProfileModeLabel(&g_ai_profiles[defaultAiProfileIndex()]);
     return aiModeText(AppWindow.ai_chat.DEFAULT_AGENT);
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2505,12 +2505,17 @@ fn runAiListRow(row: usize) void {
 fn deleteAiProfile(idx: usize) void {
     if (g_ai_profile_count == 0) return;
     if (idx >= g_ai_profile_count) return;
+    const deleted_is_default = std.mem.eql(u8, aiProfileField(&g_ai_profiles[idx], .name), aiDefaultProfileName());
     var i = idx;
     while (i + 1 < g_ai_profile_count) : (i += 1) {
         g_ai_profiles[i] = g_ai_profiles[i + 1];
     }
     g_ai_profile_count -= 1;
     g_ai_list_selected = @min(g_ai_list_selected, aiListRowCount() - 1);
+    if (deleted_is_default) {
+        if (AppWindow.g_allocator) |allocator| Config.removeConfigKeys(allocator, &.{"ai-default-profile"}) catch {};
+        invalidateAiDefaultName();
+    }
     if (AppWindow.g_allocator) |allocator| saveAiProfiles(allocator);
 }
 
@@ -3126,7 +3131,12 @@ fn sshProfileTarget(profile: *const SshProfile, target_buf: []u8) []const u8 {
 
 fn renderAiProfileRow(layout: SessionLayout, window_height: f32, row: usize, profile: *const AiProfile, selected: bool) void {
     const name = aiProfileField(profile, .name);
-    const detail = aiProfileModeLabel(profile);
+    const mode = aiProfileModeLabel(profile);
+    var detail_buf: [24]u8 = undefined;
+    const detail = if (row == defaultAiProfileIndex())
+        (std.fmt.bufPrint(detail_buf[0..], "{s} · default", .{mode}) catch mode)
+    else
+        mode;
     renderSessionRow(layout, window_height, row, name, detail, selected);
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1410,11 +1410,6 @@ const AiListMode = enum {
     delete_select,
 };
 
-const AiFormMode = enum {
-    session_setup,
-    settings,
-};
-
 const SshProfile = struct {
     fields: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined,
     lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT,
@@ -1472,7 +1467,6 @@ threadlocal var g_ai_profiles_loaded: bool = false;
 threadlocal var g_ai_list_selected: usize = 0;
 threadlocal var g_ai_list_mode: AiListMode = .manage;
 threadlocal var g_ai_edit_index: usize = AI_PROFILE_NONE;
-threadlocal var g_ai_form_mode: AiFormMode = .session_setup;
 
 pub const RemoteAgentOpenResult = enum {
     opened,
@@ -1550,7 +1544,6 @@ pub fn sessionLauncherClose() void {
     commandCenterStateCommit(state);
     g_ssh_list_mode = .manage;
     g_ai_list_mode = .manage;
-    g_ai_form_mode = .session_setup;
 }
 
 pub fn sessionLauncherInsertChar(codepoint: u21) void {
@@ -2271,7 +2264,7 @@ fn openAiList() void {
 fn openDefaultAiSession() void {
     loadAiProfiles();
     if (g_ai_profile_count == 0) {
-        openAiFormNewWithMode(.session_setup);
+        openAiFormNew();
         return;
     }
     connectAiProfile(defaultAiProfileIndex());
@@ -2280,7 +2273,7 @@ fn openDefaultAiSession() void {
 fn openDefaultAgentSessionFromCommandCenter() void {
     loadAiProfiles();
     switch (command_center_state.resolveNewAgentLaunch(g_ai_profile_count != 0)) {
-        .open_form => openAiFormNewWithMode(.session_setup),
+        .open_form => openAiFormNew(),
         .connect_default_profile_as_agent => connectAiProfileWithAgentOverride(defaultAiProfileIndex(), "true"),
     }
 }
@@ -2293,7 +2286,7 @@ pub fn hasAiProfiles() bool {
 pub fn openDefaultAgentSessionForStartup() DefaultAgentOpenResult {
     loadAiProfiles();
     if (g_ai_profile_count == 0) {
-        openAiFormNewWithMode(.session_setup);
+        openAiFormNew();
         return .form_opened;
     }
     return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
@@ -2303,15 +2296,6 @@ pub fn openDefaultAgentSessionForRemote() RemoteAgentOpenResult {
     loadAiProfiles();
     if (g_ai_profile_count == 0) return .no_profile;
     return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
-}
-
-fn openAiSettings() void {
-    loadAiProfiles();
-    if (g_ai_profile_count == 0) {
-        openAiFormNewWithMode(.settings);
-        return;
-    }
-    openAiFormEditWithMode(0, .settings);
 }
 
 fn openAiEditPicker() void {
@@ -2334,20 +2318,12 @@ fn openAiProfilePicker(mode: AiListMode) void {
 }
 
 fn openAiFormNew() void {
-    openAiFormNewWithMode(.session_setup);
-}
-
-fn openAiFormNewWithMode(mode: AiFormMode) void {
     clearAiForm();
     g_ai_edit_index = AI_PROFILE_NONE;
-    openAiFormWithMode(mode);
+    openAiForm();
 }
 
 fn openAiFormEdit(index: usize) void {
-    openAiFormEditWithMode(index, .session_setup);
-}
-
-fn openAiFormEditWithMode(index: usize, mode: AiFormMode) void {
     if (index >= g_ai_profile_count) return;
     clearAiForm();
     for (0..AI_FIELD_COUNT) |i| {
@@ -2355,17 +2331,16 @@ fn openAiFormEditWithMode(index: usize, mode: AiFormMode) void {
         @memcpy(g_ai_bufs[i][0..g_ai_lens[i]], g_ai_profiles[index].fields[i][0..g_ai_lens[i]]);
     }
     g_ai_edit_index = index;
-    openAiFormWithMode(mode);
+    openAiForm();
 }
 
-fn openAiFormWithMode(mode: AiFormMode) void {
+fn openAiForm() void {
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;
     g_ai_list_visible = false;
     g_session_launcher_visible = false;
     g_settings_visible = false;
     g_ai_form_visible = true;
-    g_ai_form_mode = mode;
     g_ai_focus = @intFromEnum(AiField.name);
 }
 
@@ -2526,17 +2501,10 @@ fn connectAiFromForm() void {
 
 fn saveAiFormOnly() void {
     _ = saveAiFormProfile() orelse return;
-    switch (g_ai_form_mode) {
-        .settings => settingsPageOpen(),
-        .session_setup => sessionLauncherClose(),
-    }
+    sessionLauncherClose();
 }
 
 fn cancelAiFormOrLauncher() void {
-    if (g_ai_form_visible and g_ai_form_mode == .settings) {
-        settingsPageOpen();
-        return;
-    }
     sessionLauncherClose();
 }
 
@@ -2546,8 +2514,8 @@ fn runAiFormFocusAction() void {
         return;
     }
     switch (g_ai_focus - AI_FIELD_COUNT) {
-        0 => if (g_ai_form_mode == .settings) saveAiFormOnly() else connectAiFromForm(),
-        1 => if (g_ai_form_mode == .settings) connectAiFromForm() else saveAiFormOnly(),
+        0 => connectAiFromForm(),
+        1 => saveAiFormOnly(),
         else => cancelAiFormOrLauncher(),
     }
 }
@@ -2645,6 +2613,15 @@ fn defaultAiProfileIndex() usize {
         names[i] = aiProfileField(&g_ai_profiles[i], .name);
     }
     return command_palette_model.resolveDefaultIndex(names[0..g_ai_profile_count], aiDefaultProfileName());
+}
+
+/// Name of the profile after the current default, wrapping around. Empty when
+/// no profiles exist.
+fn nextDefaultAiProfileName() []const u8 {
+    loadAiProfiles();
+    if (g_ai_profile_count == 0) return "";
+    const next = (defaultAiProfileIndex() + 1) % g_ai_profile_count;
+    return aiProfileField(&g_ai_profiles[next], .name);
 }
 
 fn isHttpUrlish(value: []const u8) bool {
@@ -2816,10 +2793,7 @@ fn sessionTwoColumnWidth(left: []const u8, right: []const u8) f32 {
 
 fn sessionLauncherTitle() []const u8 {
     if (g_ai_form_visible) {
-        return switch (g_ai_form_mode) {
-            .settings => "AI Settings",
-            .session_setup => "AI Agent",
-        };
+        return "AI Agent";
     }
     if (g_ai_list_visible) {
         return switch (g_ai_list_mode) {
@@ -2841,10 +2815,7 @@ fn sessionLauncherTitle() []const u8 {
 
 fn sessionLauncherHint() []const u8 {
     if (g_ai_form_visible) {
-        return switch (g_ai_form_mode) {
-            .settings => "Tab changes field, Enter saves",
-            .session_setup => "Configure once, then Enter opens",
-        };
+        return "Configure once, then Enter opens";
     }
     if (g_ai_list_visible) {
         return switch (g_ai_list_mode) {
@@ -2881,7 +2852,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("Stream", aiField(.stream)));
         desired = @max(desired, sessionTwoColumnWidth("Save & Open", "agent"));
         desired = @max(desired, sessionTwoColumnWidth("Save", "profile"));
-        desired = @max(desired, sessionTwoColumnWidth("Back", "Settings"));
+        desired = @max(desired, sessionTwoColumnWidth("Cancel", "Esc"));
         return desired;
     }
 
@@ -3257,15 +3228,9 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.reasoning_effort), "Effort", aiField(.reasoning_effort), false);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.stream), "Stream", aiField(.stream), false);
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.agent), "Agent", aiField(.agent), false);
-        if (g_ai_form_mode == .settings) {
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save", "settings", g_ai_focus == AI_FIELD_COUNT);
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save & Open", "agent", g_ai_focus == AI_FIELD_COUNT + 1);
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Back", "Settings", g_ai_focus == AI_FIELD_COUNT + 2);
-        } else {
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save & Open", "agent", g_ai_focus == AI_FIELD_COUNT);
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save", "profile", g_ai_focus == AI_FIELD_COUNT + 1);
-            renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Cancel", "Esc", g_ai_focus == AI_FIELD_COUNT + 2);
-        }
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT, "Save & Open", "agent", g_ai_focus == AI_FIELD_COUNT);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, "Save", "profile", g_ai_focus == AI_FIELD_COUNT + 1);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, "Cancel", "Esc", g_ai_focus == AI_FIELD_COUNT + 2);
         return;
     }
 
@@ -3309,7 +3274,7 @@ const SettingsAction = enum {
     toggle_cursor_blink,
     toggle_focus_follows_mouse,
     cycle_shell,
-    open_ai_settings,
+    cycle_default_ai_profile,
     open_raw_config,
     close,
 };
@@ -3340,7 +3305,6 @@ pub fn settingsPageOpen() void {
     commandCenterStateCommit(state);
     g_settings_focus = SETTINGS_THEME_ROW;
     g_ai_list_mode = .manage;
-    g_ai_form_mode = .session_setup;
     g_settings_cfg_dirty = true;
 }
 
@@ -3448,7 +3412,7 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, 
         1 => .toggle_cursor_blink,
         2 => .toggle_focus_follows_mouse,
         3 => .cycle_shell,
-        4 => .open_ai_settings,
+        4 => .cycle_default_ai_profile,
         5 => .open_raw_config,
         6 => .close,
         else => null,
@@ -3474,7 +3438,14 @@ fn executeSettingsAction(action: SettingsAction) void {
         .toggle_cursor_blink => Config.setConfigValue(allocator, "cursor-style-blink", if (cfg.@"cursor-style-blink") "false" else "true") catch {},
         .toggle_focus_follows_mouse => Config.setConfigValue(allocator, "focus-follows-mouse", if (cfg.@"focus-follows-mouse") "false" else "true") catch {},
         .cycle_shell => Config.setConfigValue(allocator, "shell", platform_pty_command.nextConfigShell(cfg.shell)) catch {},
-        .open_ai_settings => openAiSettings(),
+        .cycle_default_ai_profile => {
+            loadAiProfiles();
+            if (g_ai_profile_count > 0) {
+                const next_name = nextDefaultAiProfileName();
+                Config.setConfigValue(allocator, "ai-default-profile", next_name) catch {};
+                invalidateAiDefaultName();
+            }
+        },
         .open_raw_config => Config.openConfigInEditor(allocator),
         .close => settingsPageClose(),
     }
@@ -3496,7 +3467,7 @@ fn runSettingsFocusPrimary() void {
         SETTINGS_CONTROL_ROW_START + 1 => executeSettingsAction(.toggle_cursor_blink),
         SETTINGS_CONTROL_ROW_START + 2 => executeSettingsAction(.toggle_focus_follows_mouse),
         SETTINGS_CONTROL_ROW_START + 3 => executeSettingsAction(.cycle_shell),
-        SETTINGS_CONTROL_ROW_START + 4 => executeSettingsAction(.open_ai_settings),
+        SETTINGS_CONTROL_ROW_START + 4 => executeSettingsAction(.cycle_default_ai_profile),
         SETTINGS_CONTROL_ROW_START + 5 => executeSettingsAction(.open_raw_config),
         SETTINGS_CONTROL_ROW_START + 6 => executeSettingsAction(.close),
         else => {},
@@ -3695,9 +3666,15 @@ pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 2, "Focus follows mouse", boolText(cfg.@"focus-follows-mouse"), "Enter / Right", true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 2);
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 3, "Shell for new tabs", cfg.shell, platform_pty_command.shellSettingChoicesHint(), true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 3);
     loadAiProfiles();
-    const ai_profile_value = if (g_ai_profile_count > 0) aiProfileField(&g_ai_profiles[0], .name) else "configure";
-    const ai_profile_hint = if (g_ai_profile_count > 0) aiProfileModeLabel(&g_ai_profiles[0]) else "Required before first AI session";
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 4, "AI agent profile", ai_profile_value, ai_profile_hint, true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 4);
+    const ai_default_value = if (g_ai_profile_count > 0)
+        aiProfileField(&g_ai_profiles[defaultAiProfileIndex()], .name)
+    else
+        "(none)";
+    const ai_default_hint = if (g_ai_profile_count > 0)
+        aiProfileModeLabel(&g_ai_profiles[defaultAiProfileIndex()])
+    else
+        "Add profiles via Command Center";
+    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 4, "Default AI", ai_default_value, ai_default_hint, true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 4);
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 5, "Raw config file", "open", "Advanced editor", true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 5);
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 6, "Close settings", "Esc", "", true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 6);
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -434,6 +434,7 @@ fn executeCommand(action: CommandAction) void {
     switch (action) {
         .new_tab => sessionLauncherOpen(),
         .new_agent => openDefaultAgentSessionFromCommandCenter(),
+        .manage_ai_profiles => openAiList(),
         .select_agent_history => commandPaletteOpenAgentHistory(),
         .split_right => AppWindow.splitFocused(.right),
         .split_down => AppWindow.splitFocused(.down),
@@ -2247,14 +2248,14 @@ fn openDefaultAiSession() void {
         openAiFormNewWithMode(.session_setup);
         return;
     }
-    connectAiProfile(0);
+    connectAiProfile(defaultAiProfileIndex());
 }
 
 fn openDefaultAgentSessionFromCommandCenter() void {
     loadAiProfiles();
     switch (command_center_state.resolveNewAgentLaunch(g_ai_profile_count != 0)) {
         .open_form => openAiFormNewWithMode(.session_setup),
-        .connect_default_profile_as_agent => connectAiProfileWithAgentOverride(0, "true"),
+        .connect_default_profile_as_agent => connectAiProfileWithAgentOverride(defaultAiProfileIndex(), "true"),
     }
 }
 
@@ -2269,13 +2270,13 @@ pub fn openDefaultAgentSessionForStartup() DefaultAgentOpenResult {
         openAiFormNewWithMode(.session_setup);
         return .form_opened;
     }
-    return if (spawnAiProfileWithAgentOverride(0, "true")) .opened else .failed;
+    return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
 }
 
 pub fn openDefaultAgentSessionForRemote() RemoteAgentOpenResult {
     loadAiProfiles();
     if (g_ai_profile_count == 0) return .no_profile;
-    return if (spawnAiProfileWithAgentOverride(0, "true")) .opened else .failed;
+    return if (spawnAiProfileWithAgentOverride(defaultAiProfileIndex(), "true")) .opened else .failed;
 }
 
 fn openAiSettings() void {
@@ -2576,6 +2577,43 @@ fn spawnAiProfileWithAgentOverride(idx: usize, agent_override: ?[]const u8) bool
 
     sessionLauncherClose();
     return AppWindow.spawnAiChatTab(name, base_url, api_key, model, system_prompt, thinking, reasoning_effort, stream_val, agent_val);
+}
+
+threadlocal var g_ai_default_name_buf: [256]u8 = undefined;
+threadlocal var g_ai_default_name_len: usize = 0;
+threadlocal var g_ai_default_loaded: bool = false;
+
+/// Cached value of the `ai-default-profile` config key. Cached to avoid file
+/// IO on every render frame; invalidated on in-app writes.
+fn aiDefaultProfileName() []const u8 {
+    if (!g_ai_default_loaded) {
+        g_ai_default_loaded = true;
+        g_ai_default_name_len = 0;
+        const allocator = AppWindow.g_allocator orelse return "";
+        var cfg = Config.load(allocator) catch return "";
+        defer cfg.deinit(allocator);
+        const name = cfg.@"ai-default-profile";
+        const len = @min(name.len, g_ai_default_name_buf.len);
+        @memcpy(g_ai_default_name_buf[0..len], name[0..len]);
+        g_ai_default_name_len = len;
+    }
+    return g_ai_default_name_buf[0..g_ai_default_name_len];
+}
+
+fn invalidateAiDefaultName() void {
+    g_ai_default_loaded = false;
+}
+
+/// Index of the default AI profile, resolved by name from config. Falls back
+/// to the first profile. Returns 0 when no profiles exist (callers guard).
+fn defaultAiProfileIndex() usize {
+    loadAiProfiles();
+    if (g_ai_profile_count == 0) return 0;
+    var names: [AI_PROFILE_MAX][]const u8 = undefined;
+    for (0..g_ai_profile_count) |i| {
+        names[i] = aiProfileField(&g_ai_profiles[i], .name);
+    }
+    return command_palette_model.resolveDefaultIndex(names[0..g_ai_profile_count], aiDefaultProfileName());
 }
 
 fn isHttpUrlish(value: []const u8) bool {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -184,6 +184,7 @@ const COMMAND_ENTRIES = command_center_state.command_entries;
 const PaletteItem = union(enum) {
     command: usize,
     ssh_profile: usize,
+    ai_profile: usize,
     theme: usize,
 };
 
@@ -720,6 +721,14 @@ fn rebuildPaletteScratch() void {
         g_palette_scratch[g_palette_scratch_len] = .{ .ssh_profile = profile_idx };
         g_palette_scratch_len += 1;
     }
+    loadAiProfiles();
+    for (0..g_ai_profile_count) |ai_idx| {
+        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        const profile = &g_ai_profiles[ai_idx];
+        if (!command_palette_model.aiProfileLabelMatchesFilter(aiProfileField(profile, .name), filter)) continue;
+        g_palette_scratch[g_palette_scratch_len] = .{ .ai_profile = ai_idx };
+        g_palette_scratch_len += 1;
+    }
     for (&themes_embed.entries, 0..) |th, ti| {
         if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
         if (!containsIgnoreCase(th.name, filter)) continue;
@@ -732,6 +741,7 @@ fn executePaletteItem(item: PaletteItem) void {
     switch (item) {
         .command => |cmd_idx| executeCommand(COMMAND_ENTRIES[cmd_idx].action),
         .ssh_profile => |profile_idx| connectSshProfile(profile_idx),
+        .ai_profile => |profile_idx| _ = spawnAiProfileWithAgentOverride(profile_idx, null),
         .theme => |ti| applyEmbeddedThemeFromPalette(ti),
     }
 }
@@ -1302,6 +1312,22 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
                         const target_left = @round(layout.box_x + layout.box_w - pad_x - target_max_w);
                         renderTitlebarTextLimited(target, target_left, text_y, shortcut_color, target_max_w);
                         renderTitlebarTextLimited(ssh_title, title_x, text_y, row_title_color, @max(1.0, target_left - title_x - 18));
+                    },
+                    .ai_profile => |profile_idx| {
+                        if (profile_idx >= g_ai_profile_count) continue;
+                        const profile = &g_ai_profiles[profile_idx];
+                        var title_buf: [AI_FIELD_MAX + 8]u8 = undefined;
+                        const ai_title = std.fmt.bufPrint(title_buf[0..], "AI: {s}", .{aiProfileField(profile, .name)}) catch "AI";
+                        var tag_buf: [24]u8 = undefined;
+                        const mode = aiProfileModeLabel(profile);
+                        const tag = if (profile_idx == defaultAiProfileIndex())
+                            (std.fmt.bufPrint(tag_buf[0..], "{s} · default", .{mode}) catch mode)
+                        else
+                            mode;
+                        const tag_w = measureTitlebarText(tag);
+                        const tag_left = @round(layout.box_x + layout.box_w - pad_x - tag_w);
+                        renderTitlebarText(tag, tag_left, text_y, shortcut_color);
+                        renderTitlebarTextLimited(ai_title, title_x, text_y, row_title_color, @max(1.0, tag_left - title_x - 18));
                     },
                     .theme => |ti| {
                         const name = themes_embed.entries[ti].name;


### PR DESCRIPTION
## Summary
- Add a **Manage AI Profiles** command to the Command Center (Ctrl+Shift+P) that opens the (previously orphaned) New/Edit/Delete overlay, plus per-profile **launch rows** (`AI: <name>`) surfaced when filtering — launching uses each profile's own `agent` setting.
- Add an **`ai-default-profile`** config key (resolved by name, falling back to the first profile) used by startup auto-open, remote auto-open, and "New Agent"; replaces the previously hardcoded index 0 at all four launch sites.
- Add a **Default AI** cycle row in Settings to pick the default profile; mark the default in the palette and manage list with `· default`.
- Move all create/edit/delete into the Command Center overlay and remove the old Settings edit-form path (collapsing the AI form's two-mode design to one).
- Renaming or deleting the default profile keeps `ai-default-profile` in sync.

Design: `docs/superpowers/specs/2026-05-26-ai-profile-command-center-management-design.md`
Plan: `docs/superpowers/plans/2026-05-26-ai-profile-command-center-management.md`

## Test Plan
- [x] `zig test src/command_palette_model.zig` — 8/8 (label match + default-index resolution)
- [x] `zig test src/config.zig --test-filter "ai-default-profile"` — passes
- [x] `zig build test` — 520/523 (the only 2 failures are pre-existing, unrelated Windows-API tests: `window_backend` powershell + `updater_core` restore backup)
- [ ] Manual: Ctrl+Shift+P → type `ai` → profiles launch; `Manage AI Profiles` → New/Edit/Delete works
- [ ] Manual: Settings → `Default AI` cycles & persists; delete/rename default keeps it consistent
- [ ] Manual: startup auto-opens the configured default profile (not necessarily index 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)