### PR TITLE
[codex] Open web URLs in default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A terminal written in Zig, powered by [libghostty-vt](https://github.com/ghostty
 - **Background image and shaders** - wallpaper blending plus Ghostty-compatible GLSL post-processing
 - **Splits and tabs** - vertical/horizontal splits, tab strip, focus-follows-mouse, equalize sizes
 - **File Explorer and previews** - browse local, WSL, and SSH files; preview Markdown/text/tables/images without leaving the terminal
-- **Embedded browser panel** - open web URLs in a side WebView2 panel, with SSH loopback tunneling for profile sessions
+- **Embedded browser panel** - open web URLs in a side WebView2 panel or the default browser, with SSH loopback tunneling for profile sessions
 - **AI Agent sessions** - launch OpenAI-compatible Agent tabs, configure profiles, restore history, and export full or clean Markdown transcripts
 - **Kitty Graphics protocol** - display inline images and PDFs from remote shells via `imgcat.py` / `pdfcat.py`
 - **Opt-in remote access** - share a session key over a Cloudflare-hosted relay (disabled by default)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ quake-mode = true
 keybind = global:ctrl+backquote=toggle_quake
 keybind = ctrl+shift+p=toggle_command_palette
 scrollback-limit = 10000000
+url-open-mode = embedded
 custom-shader = path/to/shader.glsl
 background-image = C:\Users\me\Pictures\wallpaper.png
 background-opacity = 0.85
@@ -62,6 +63,7 @@ remote-session-key = Workstation
 | `quake-mode`                | `true`     | Start as a Quake-style drop-down terminal. The `toggle_quake` keybind hides or shows the same window while preserving terminal state.                                                                                    |
 | `keybind`                   | defaults   | Configure an app-level shortcut. Can be repeated. Syntax: `keybind = [global:]modifier+key=action`; use `keybind = clear` before custom bindings to remove all defaults.                                                 |
 | `scrollback-limit`          | `10000000` | Scrollback buffer limit in bytes                                                                                                                                                                                        |
+| `url-open-mode`             | `embedded` | Where web URLs open: `embedded` uses the right-side browser panel when available, while `system-browser` always opens the Windows default browser.                                                                         |
 | `restore-tabs-on-startup`   | `false`    | Persist tab/split layout to `%APPDATA%\phantty\session.json` on close and rebuild it on next launch. SSH passwords are never persisted; reconnects re-prompt. CLI overrides (`--cwd`) take precedence and skip restore. |
 | `auto-update-check`         | `true`     | Check GitHub Releases after startup and show a clickable prompt when a newer version is available. Set to `false` to disable startup checks.                                                                             |
 | `config-file`               | *(none)*   | Include another config file (prefix with `?` to make optional)                                                                                                                                                          |

--- a/docs/file-explorer.md
+++ b/docs/file-explorer.md
@@ -24,8 +24,10 @@ the embedded WebView2 browser panel when WebView2 support is available.
 `Ctrl`-clicking an `http://` or `https://` URL in terminal output opens it in
 the same right-side WebView2 panel when available; builds without embedded
 WebView2 support, or without a usable WebView2 loader/runtime, open URLs in the
-system default browser instead. In SSH profile sessions with embedded WebView2
-support, loopback URLs such as `http://127.0.0.1:4232` and
+system default browser instead. Set `url-open-mode = system-browser` to always
+open web URLs in the Windows default browser, including when embedded WebView2
+support is available. In SSH profile sessions, loopback URLs such as
+`http://127.0.0.1:4232` and
 `http://localhost:43455` are opened through an automatic local SSH tunnel;
 the tunnel prefers the same local port and only increments when that port is
 already occupied.

--- a/src/App.zig
+++ b/src/App.zig
@@ -70,6 +70,7 @@ split_divider_color: ?Config.Color,
 focus_follows_mouse: bool,
 copy_on_select: bool,
 right_click_action: Config.RightClickAction,
+url_open_mode: Config.UrlOpenMode,
 ssh_legacy_algorithms: bool,
 
 // Background image
@@ -207,6 +208,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .focus_follows_mouse = cfg.@"focus-follows-mouse",
         .copy_on_select = cfg.@"copy-on-select",
         .right_click_action = cfg.@"right-click-action",
+        .url_open_mode = cfg.@"url-open-mode",
         .ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms",
         .background_image = background_image,
         .background_opacity = cfg.@"background-opacity",
@@ -373,6 +375,7 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.focus_follows_mouse = cfg.@"focus-follows-mouse";
     self.copy_on_select = cfg.@"copy-on-select";
     self.right_click_action = cfg.@"right-click-action";
+    self.url_open_mode = cfg.@"url-open-mode";
     self.ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     self.replaceOptStr(&self.background_image, cfg.@"background-image");
     self.background_opacity = cfg.@"background-opacity";

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -103,6 +103,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     g_focus_follows_mouse = app.focus_follows_mouse;
     g_copy_on_select = app.copy_on_select;
     g_right_click_action = app.right_click_action;
+    input.g_url_open_mode = app.url_open_mode;
     g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     tab.g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     overlays.g_split_divider_color = app.split_divider_color;
@@ -1391,6 +1392,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     g_focus_follows_mouse = cfg.@"focus-follows-mouse";
     g_copy_on_select = cfg.@"copy-on-select";
     g_right_click_action = cfg.@"right-click-action";
+    input.g_url_open_mode = cfg.@"url-open-mode";
     g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     tab.g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     overlays.g_split_divider_color = cfg.@"split-divider-color";

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -217,26 +217,28 @@ pub fn openForSurface(allocator: std.mem.Allocator, parent: ?window_backend.Nati
         return false;
     }
 
-    var target = url;
-    var tunneled_url: ?[]u8 = null;
-    defer if (tunneled_url) |owned| allocator.free(owned);
-
-    if (sshLoopbackUrl(surface, target)) |request| {
-        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host), browser_url.remoteTunnelHost(request.parsed.host)) orelse return false;
-        tunneled_url = browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port) orelse return false;
-        target = tunneled_url.?;
-    } else {
-        stopTunnel();
-        if (browser_url.parseHttpUrl(target)) |parsed| {
-            if (browser_url.isUnspecifiedHost(parsed.host)) {
-                tunneled_url = browser_url.buildLocalTunnelUrl(allocator, parsed, parsed.port) orelse return false;
-                target = tunneled_url.?;
-            }
-        }
-    }
+    const target = externalUrlForSurface(allocator, url, surface) orelse return false;
+    defer allocator.free(target);
 
     open(parent, target);
     return true;
+}
+
+pub fn externalUrlForSurface(allocator: std.mem.Allocator, url: []const u8, surface: ?*const Surface) ?[]u8 {
+    const target = url;
+    if (sshLoopbackUrl(surface, target)) |request| {
+        const local_port = ensureSshTunnel(allocator, &request.conn, request.parsed.port, browser_url.localTunnelHost(request.parsed.host), browser_url.remoteTunnelHost(request.parsed.host)) orelse return null;
+        return browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port);
+    }
+
+    stopTunnel();
+    if (browser_url.parseHttpUrl(target)) |parsed| {
+        if (browser_url.isUnspecifiedHost(parsed.host)) {
+            return browser_url.buildLocalTunnelUrl(allocator, parsed, parsed.port);
+        }
+    }
+
+    return allocator.dupe(u8, target) catch null;
 }
 
 pub fn toggle(parent: ?window_backend.NativeHandle) void {
@@ -739,6 +741,20 @@ test "browser_panel: public parent handle API uses window backend handle" {
 
     const submit_info = @typeInfo(@TypeOf(submitUrlBar)).@"fn";
     try std.testing.expect(submit_info.params[1].type.? == ?window_backend.NativeHandle);
+}
+
+test "browser_panel external URL helper preserves public URLs" {
+    const target = externalUrlForSurface(std.testing.allocator, "https://example.com/app?q=1", null) orelse unreachable;
+    defer std.testing.allocator.free(target);
+
+    try std.testing.expectEqualStrings("https://example.com/app?q=1", target);
+}
+
+test "browser_panel external URL helper maps unspecified hosts to loopback" {
+    const target = externalUrlForSurface(std.testing.allocator, "http://0.0.0.0:1234/app?q=1", null) orelse unreachable;
+    defer std.testing.allocator.free(target);
+
+    try std.testing.expectEqualStrings("http://127.0.0.1:1234/app?q=1", target);
 }
 
 test "reservePreferredLocalPort returns the preferred port when it is free" {

--- a/src/browser_panel_stub.zig
+++ b/src/browser_panel_stub.zig
@@ -119,6 +119,11 @@ pub fn openForSurface(allocator: std.mem.Allocator, parent: ?window_backend.Nati
     return false;
 }
 
+pub fn externalUrlForSurface(allocator: std.mem.Allocator, url: []const u8, surface: ?*const Surface) ?[]u8 {
+    _ = surface;
+    return allocator.dupe(u8, url) catch null;
+}
+
 pub fn toggle(parent: ?window_backend.NativeHandle) void {
     _ = parent;
     g_visible = false;

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -60,7 +60,7 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "Close Panel / Tab", .detail = "Close focused panel or tab; press again for the last panel", .shortcut = "", .action = .close_split_or_tab },
     .{ .title = "Toggle Sidebar", .detail = "Show or hide the tab sidebar", .shortcut = "", .action = .toggle_sidebar },
     .{ .title = "Toggle File Explorer", .detail = "Show or hide the left-side file explorer", .shortcut = "", .action = .toggle_file_explorer },
-    .{ .title = "Toggle Browser", .detail = "Show embedded browser for local or SSH URLs", .shortcut = "", .action = .toggle_browser_panel },
+    .{ .title = "Toggle Browser", .detail = "Open the configured browser for local or SSH URLs", .shortcut = "", .action = .toggle_browser_panel },
     .{ .title = "Toggle Quake Window", .detail = "Show or hide the drop-down terminal window", .shortcut = "", .action = .toggle_quake },
     .{ .title = "Keyboard Shortcuts", .detail = "Show the shortcut reference overlay", .shortcut = "", .action = .show_shortcuts },
     .{ .title = "Open Config", .detail = "Open the Phantty config file", .shortcut = "", .action = .open_config },

--- a/src/config.zig
+++ b/src/config.zig
@@ -20,6 +20,7 @@ const Config = @This();
 const std = @import("std");
 const ai_chat = @import("ai_chat.zig");
 const keybind = @import("keybind.zig");
+const link_open = @import("link_open.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_editor = @import("platform/editor.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
@@ -161,6 +162,8 @@ pub const RightClickAction = enum {
     }
 };
 
+pub const UrlOpenMode = link_open.Mode;
+
 // ============================================================================
 // Background Image
 // ============================================================================
@@ -269,6 +272,9 @@ theme: ?[]const u8 = null,
 
 /// Right-click action for terminal surfaces.
 @"right-click-action": RightClickAction = .copy,
+
+/// Where Ctrl-clicked web URLs open.
+@"url-open-mode": UrlOpenMode = .embedded,
 
 /// Add legacy OpenSSH algorithms for older bastion/servers.
 @"ssh-legacy-algorithms": bool = false,
@@ -727,6 +733,12 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             self.@"right-click-action" = action;
         } else {
             log.warn("invalid right-click-action: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "url-open-mode")) {
+        if (UrlOpenMode.parse(value)) |mode| {
+            self.@"url-open-mode" = mode;
+        } else {
+            log.warn("invalid url-open-mode: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "ssh-legacy-algorithms")) {
         if (std.mem.eql(u8, value, "true")) {
@@ -1195,6 +1207,7 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --scrollback-limit <bytes>   Scrollback buffer size (default: 10000000)
         \\  --copy-on-select <bool>      Copy terminal selection when mouse selection completes
         \\  --right-click-action <mode>  ignore | copy | paste | copy-or-paste
+        \\  --url-open-mode <mode>       embedded | system-browser
         \\  --ssh-legacy-algorithms <bool> Enable legacy ssh-rsa/ssh-dss OpenSSH options
         \\  --ai-agent-enabled <bool>    Enable AI Chat agent tools by default
         \\  --ai-agent-permission <mode> Agent tool permission: confirm | full
@@ -1510,6 +1523,7 @@ const default_config_template =
     \\# Terminal mouse/clipboard behavior
     \\# copy-on-select = false
     \\# right-click-action = copy   # ignore | copy | paste | copy-or-paste
+    \\# url-open-mode = embedded    # embedded | system-browser
     \\
     \\# SSH compatibility for older bastions/servers.
     \\# Adds ssh-rsa/ssh-dss and legacy KEX/cipher options to profile/helper SSH.
@@ -1806,12 +1820,21 @@ test "config: copy and right click options parse" {
 
     try std.testing.expectEqual(false, cfg.@"copy-on-select");
     try std.testing.expectEqual(RightClickAction.copy, cfg.@"right-click-action");
+    try std.testing.expectEqual(UrlOpenMode.embedded, cfg.@"url-open-mode");
 
     cfg.applyKeyValue(allocator, "copy-on-select", "true", ".");
     cfg.applyKeyValue(allocator, "right-click-action", "copy-or-paste", ".");
+    cfg.applyKeyValue(allocator, "url-open-mode", "system-browser", ".");
 
     try std.testing.expectEqual(true, cfg.@"copy-on-select");
     try std.testing.expectEqual(RightClickAction.copy_or_paste, cfg.@"right-click-action");
+    try std.testing.expectEqual(UrlOpenMode.system_browser, cfg.@"url-open-mode");
+
+    cfg.applyKeyValue(allocator, "url-open-mode", "default-browser", ".");
+    try std.testing.expectEqual(UrlOpenMode.system_browser, cfg.@"url-open-mode");
+
+    cfg.applyKeyValue(allocator, "url-open-mode", "embedded", ".");
+    try std.testing.expectEqual(UrlOpenMode.embedded, cfg.@"url-open-mode");
 }
 
 test "config: ssh legacy algorithm option parses" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -236,6 +236,7 @@ threadlocal var g_markdown_preview_image_drag_last_x: f64 = 0;
 threadlocal var g_markdown_preview_image_drag_last_y: f64 = 0;
 pub threadlocal var g_browser_resize_hover: bool = false; // Mouse is over the embedded browser edge
 pub threadlocal var g_browser_resize_dragging: bool = false; // Currently dragging the browser edge
+pub threadlocal var g_url_open_mode: link_open.Mode = .embedded;
 const SIDEBAR_TAB_DRAG_THRESHOLD_PX: f64 = 6.0;
 threadlocal var g_sidebar_tab_drag_pressed: ?usize = null;
 threadlocal var g_sidebar_tab_drag_current: ?usize = null;
@@ -384,6 +385,12 @@ pub fn toggleBrowserPanel() void {
     const allocator = AppWindow.g_allocator orelse return;
     const parent = AppWindow.currentNativeHandle();
     const surface = AppWindow.activeSurface();
+    if (g_url_open_mode == .system_browser and !browser_panel.isVisibleForActiveTab()) {
+        const target = browser_panel.externalUrlForSurface(allocator, browser_panel.DEFAULT_URL, surface) orelse return;
+        defer allocator.free(target);
+        _ = platform_open_url.open(allocator, .{ .url = target });
+        return;
+    }
     if (!browser_panel.toggleForSurface(allocator, parent, surface)) return;
     if (AppWindow.g_window) |win| {
         syncPanelGridFromWindow(win);
@@ -2106,7 +2113,7 @@ fn openUrl(surface: *Surface, url: []const u8) bool {
     defer allocator.free(target);
 
     const handle = AppWindow.currentNativeHandle();
-    switch (link_open.destinationForUrlClick(browser_panel.embeddedBrowserAvailable())) {
+    switch (link_open.destinationForUrlClick(browser_panel.embeddedBrowserAvailable(), g_url_open_mode)) {
         .embedded_browser => {
             if (!browser_panel.openForSurface(allocator, handle, target, surface)) return false;
             if (AppWindow.g_window) |win| {
@@ -2116,7 +2123,11 @@ fn openUrl(surface: *Surface, url: []const u8) bool {
             AppWindow.g_cells_valid = false;
             return true;
         },
-        .system_browser => return platform_open_url.open(allocator, .{ .url = target }),
+        .system_browser => {
+            const external_target = browser_panel.externalUrlForSurface(allocator, target, surface) orelse return false;
+            defer allocator.free(external_target);
+            return platform_open_url.open(allocator, .{ .url = external_target });
+        },
     }
 }
 

--- a/src/link_open.zig
+++ b/src/link_open.zig
@@ -5,14 +5,43 @@ pub const Destination = enum {
     system_browser,
 };
 
-pub fn destinationForUrlClick(embedded_browser_available: bool) Destination {
+pub const Mode = enum {
+    embedded,
+    system_browser,
+
+    pub fn parse(value: []const u8) ?Mode {
+        if (std.mem.eql(u8, value, "embedded")) return .embedded;
+        if (std.mem.eql(u8, value, "embedded-browser")) return .embedded;
+        if (std.mem.eql(u8, value, "webview")) return .embedded;
+        if (std.mem.eql(u8, value, "system-browser")) return .system_browser;
+        if (std.mem.eql(u8, value, "default-browser")) return .system_browser;
+        if (std.mem.eql(u8, value, "external")) return .system_browser;
+        return null;
+    }
+
+    pub fn name(self: Mode) []const u8 {
+        return switch (self) {
+            .embedded => "embedded",
+            .system_browser => "system-browser",
+        };
+    }
+};
+
+pub fn destinationForUrlClick(embedded_browser_available: bool, mode: Mode) Destination {
+    if (mode == .system_browser) return .system_browser;
     return if (embedded_browser_available) .embedded_browser else .system_browser;
 }
 
 test "URL clicks use the system browser when embedded WebView is unavailable" {
-    try std.testing.expectEqual(Destination.system_browser, destinationForUrlClick(false));
+    try std.testing.expectEqual(Destination.system_browser, destinationForUrlClick(false, .embedded));
 }
 
 test "URL clicks use the embedded browser when it is available" {
-    try std.testing.expectEqual(Destination.embedded_browser, destinationForUrlClick(true));
+    try std.testing.expectEqual(Destination.embedded_browser, destinationForUrlClick(true, .embedded));
+}
+
+test "URL clicks can force the system browser even when embedded WebView is available" {
+    try std.testing.expectEqual(Destination.system_browser, destinationForUrlClick(true, .system_browser));
+    try std.testing.expectEqual(Mode.system_browser, Mode.parse("default-browser").?);
+    try std.testing.expectEqualStrings("system-browser", Mode.system_browser.name());
 }


### PR DESCRIPTION
## Summary

- Add `url-open-mode = embedded | system-browser` so users can force web URLs into the Windows default browser.
- Thread the URL open mode through app config reload and Ctrl-click URL handling.
- Reuse browser-panel URL normalization for external browser launches, including SSH loopback tunnel targets and `0.0.0.0` loopback conversion.
- Document the new setting in README and configuration/file explorer docs.

## Validation

- `zig test src\link_open.zig`
- `zig test src\config.zig`
- `zig test src\browser_url.zig`
- `zig build test`
- `zig build`
- `zig build test-full` currently reaches 500/502 passed, 1 skipped, then fails on the existing `src/platform/window_backend.zig:645` create return-type assertion unrelated to this change.