### PR TITLE
GPU A3 (1/N): real primitives + cell_renderer through the GPU interface

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,13 @@ mapping in guide §2 and §5.
       `cell_renderer`, `titlebar`, `overlays`, `ai_chat_renderer`,
       `image_renderer`, `post_process`, `background_image`, `fbo`,
       `markdown_preview_renderer`, `file_explorer_renderer`.
+      *Increment 1 done:* real `Buffer`/`Texture`/`Pipeline` primitives exist in
+      `gpu/opengl/`; `cell_renderer` is converted — `drawCells` routes through
+      `cell_pipeline.zig` (cell pipelines built from the primitives) and the pure
+      BG/cursor/selection + glyph-rect logic + instance types moved to std-only,
+      unit-tested `cell_geometry.zig`. *Still pending:* the other 9 files, plus
+      the shared `shader_program`/`overlay_shader`/`simple_color_shader`
+      pipelines (still in `gl_init`).
 - [ ] **A4** Route font atlas → GPU texture through the `Texture` primitive;
       drop `font/manager.zig`'s direct `@cImport("glad/gl.h")`.
 - [ ] **A5** Backend-scope shaders: GLSL under `gpu/opengl/shaders.zig`; reserve

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -207,6 +207,16 @@ with **A**. **D** is deferred until a macOS SDK environment exists.
 > `glad`. Consumers reach the table via `AppWindow.gpu.glTable()` (a transition
 > handle). Next: **A3** routes the renderer files through `gpu.zig` primitives.
 
+> **Status (A3 increment 1 landed).** Real `Buffer`/`Texture`/`Pipeline`
+> primitives now live in `gpu/opengl/` (replacing the reserved stubs).
+> `cell_renderer` is the first converted file: `drawCells` issues its bg/fg/
+> color-emoji passes through `cell_pipeline.zig` (cell pipelines built from the
+> primitives, relocated out of `gl_init`), and the pure snap→instance logic +
+> instance types moved to std-only, unit-tested `cell_geometry.zig`. Pattern for
+> the rest: route draw through primitives + extract pure geometry, one file at a
+> time. Remaining: the other 9 renderer files, the shared pipelines still in
+> `gl_init`, then A4–A6.
+
 - **A1** Define `src/renderer/gpu/gpu.zig` (the `GraphicsAPI` interface:
   `Target`, `Frame`, `RenderPass`, `Pipeline`, `Buffer`, `Texture`, `Sampler`,
   `shaders`) and `src/renderer/gpu/backend.zig` (`Backend{opengl,metal}`,

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-cell-renderer.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-cell-renderer.md
@@ -570,9 +570,9 @@ pub fn init() void {
     gl.VertexAttribDivisor.?(4, 1);
     gl.BindVertexArray.?(0);
 
-    bg = .{ .program = Pipeline.linkProgram(shaders.bg_vertex_source, shaders.bg_fragment_source), .vao = bg_vao };
-    fg = .{ .program = Pipeline.linkProgram(shaders.fg_vertex_source, shaders.fg_fragment_source), .vao = fg_vao };
-    color_fg = .{ .program = Pipeline.linkProgram(shaders.fg_vertex_source, shaders.color_fg_fragment_source), .vao = color_fg_vao };
+    bg = Pipeline.init(shaders.bg_vertex_source, shaders.bg_fragment_source, bg_vao);
+    fg = Pipeline.init(shaders.fg_vertex_source, shaders.fg_fragment_source, fg_vao);
+    color_fg = Pipeline.init(shaders.fg_vertex_source, shaders.color_fg_fragment_source, color_fg_vao);
     if (bg.program == 0) std.debug.print("BG instanced shader failed\n", .{});
     if (fg.program == 0) std.debug.print("FG instanced shader failed\n", .{});
     if (color_fg.program == 0) std.debug.print("Color FG instanced shader failed\n", .{});
@@ -721,7 +721,7 @@ Replace the BG, FG, and color-emoji blocks (the ones guarded by `gl_init.bg_shad
         p.setVec2("cellSize", font.cell_width, font.cell_height);
         p.setVec2("gridOffset", offset_x, offset_y);
         p.setFloat("windowHeight", window_height);
-        p.setProjection(window_height);
+        p.setProjection();
         p.bindVao();
         cell_pipeline.bg_instances.upload(std.mem.sliceAsBytes(rend.bg_cells.items[0..rend.bg_cell_count]));
         p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.bg_cell_count));
@@ -737,7 +737,7 @@ Replace the BG, FG, and color-emoji blocks (the ones guarded by `gl_init.bg_shad
         p.setVec2("cellSize", font.cell_width, font.cell_height);
         p.setVec2("gridOffset", offset_x, offset_y);
         p.setFloat("windowHeight", window_height);
-        p.setProjection(window_height);
+        p.setProjection();
         gpu.Texture.fromHandle(font.g_atlas_texture).bind(0);
         p.setInt("atlas", 0);
         p.bindVao();
@@ -755,7 +755,7 @@ Replace the BG, FG, and color-emoji blocks (the ones guarded by `gl_init.bg_shad
         p.setVec2("cellSize", font.cell_width, font.cell_height);
         p.setVec2("gridOffset", offset_x, offset_y);
         p.setFloat("windowHeight", window_height);
-        p.setProjection(window_height);
+        p.setProjection();
         gpu.Texture.fromHandle(font.g_color_atlas_texture).bind(0);
         p.setInt("atlas", 0);
         p.bindVao();

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-cell-renderer.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-cell-renderer.md
@@ -1,0 +1,867 @@
+# GPU A3 increment 1 (primitives + cell_renderer) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the empty `Buffer`/`Texture`/`Pipeline` stubs in `gpu/opengl/` with real primitive types and convert `cell_renderer.zig` to use them, while extracting its pure cell-geometry logic into a std-only, unit-tested module.
+
+**Architecture:** Pragmatic Ghostty-shaped primitives (thin GL wrappers; no `Frame`/`RenderPass` yet). The cell-specific `bg`/`fg`/`color_fg` instanced pipelines move out of the shared `gl_init` into a cell-owned `cell_pipeline.zig` built from the primitives; `drawCells` routes through them with byte-identical GL ops. The pure snap→instance decision + glyph-rect math + instance data types move into `cell_geometry.zig` (std-only, fast-suite tested). Behavior-preserving — verified by the green baseline plus a manual Windows visual check.
+
+**Tech Stack:** Zig 0.15.2, glad/OpenGL, FreeType. Target `x86_64-windows-gnu`. Tests: `zig build test` (fast), `zig build test-full` (pre-merge, baseline 497/499).
+
+**Spec:** [docs/superpowers/specs/2026-05-26-gpu-a3-cell-renderer-design.md](../specs/2026-05-26-gpu-a3-cell-renderer-design.md)
+
+---
+
+## Conventions
+
+- All primitives call `Context.gl.*` (the GL table in `gpu/opengl/Context.zig`). `c` is `@import("c.zig").c`.
+- `cell_geometry.zig` is **std-only** (imports only `std`) so it runs in `zig build test`. It must never import `AppWindow`/`font`/GL.
+- Behavior-preserving: do not change GL call order, arguments, blend modes, or shader text. The relocated VAO attribute setup must match `initInstancedBuffers` exactly (offsets/divisors/strides).
+
+---
+
+## Task 1: Generic primitives — `Buffer` / `Texture` / `Pipeline`
+
+**Files:**
+- Create: `src/renderer/gpu/opengl/Buffer.zig`, `src/renderer/gpu/opengl/Texture.zig`, `src/renderer/gpu/opengl/Pipeline.zig`
+- Modify: `src/renderer/gpu/opengl/api.zig`, `src/renderer/gpu/gpu.zig`
+
+These are thin GL wrappers; they cannot be unit-tested without a live GL context, so this task is verified by `zig build` (they are exercised at runtime in Task 5 + the manual check).
+
+- [ ] **Step 1: Create `src/renderer/gpu/opengl/Buffer.zig`**
+
+```zig
+//! A GPU buffer (OpenGL VBO). Backend primitive for the GraphicsAPI spine.
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Buffer = @This();
+
+handle: c.GLuint = 0,
+target: c.GLenum,
+
+pub fn init(target: c.GLenum) Buffer {
+    var b = Buffer{ .target = target };
+    Context.gl.GenBuffers.?(1, &b.handle);
+    return b;
+}
+pub fn bind(self: Buffer) void {
+    Context.gl.BindBuffer.?(self.target, self.handle);
+}
+/// Allocate `size` bytes of uninitialized storage with the given usage hint.
+pub fn allocate(self: Buffer, size: usize, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(size), null, usage);
+}
+/// Allocate + fill with `bytes`.
+pub fn uploadData(self: Buffer, bytes: []const u8, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(bytes.len), bytes.ptr, usage);
+}
+/// Overwrite from offset 0 (glBufferSubData).
+pub fn upload(self: Buffer, bytes: []const u8) void {
+    self.bind();
+    Context.gl.BufferSubData.?(self.target, 0, @intCast(bytes.len), bytes.ptr);
+}
+pub fn deinit(self: *Buffer) void {
+    if (self.handle != 0) {
+        Context.gl.DeleteBuffers.?(1, &self.handle);
+        self.handle = 0;
+    }
+}
+```
+
+- [ ] **Step 2: Create `src/renderer/gpu/opengl/Texture.zig`**
+
+```zig
+//! A 2D GPU texture. This increment wraps an existing handle for binding only;
+//! ownership/upload of the font atlas is taken over in A4.
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Texture = @This();
+
+handle: c.GLuint,
+
+pub fn fromHandle(h: c.GLuint) Texture {
+    return .{ .handle = h };
+}
+pub fn bind(self: Texture, unit: u32) void {
+    Context.gl.ActiveTexture.?(c.GL_TEXTURE0 + unit);
+    Context.gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
+}
+```
+
+- [ ] **Step 3: Create `src/renderer/gpu/opengl/Pipeline.zig`**
+
+```zig
+//! A render pipeline (OpenGL program + VAO). The vertex-attribute layout is
+//! built by the caller (it is shader-specific) and the VAO handle handed in.
+const std = @import("std");
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Pipeline = @This();
+
+program: c.GLuint,
+vao: c.GLuint,
+
+/// Compile a shader stage. Returns null on failure (logs to stderr).
+pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
+    const gl = Context.gl;
+    const shader = gl.CreateShader.?(shader_type);
+    if (shader == 0) {
+        const gl_err = if (gl.GetError) |getErr| getErr() else 0;
+        std.debug.print("Shader error: glCreateShader returned 0, type=0x{X}, glError=0x{X}\n", .{ shader_type, gl_err });
+        return null;
+    }
+    gl.ShaderSource.?(shader, 1, &source, null);
+    gl.CompileShader.?(shader);
+    var success: c.GLint = 0;
+    gl.GetShaderiv.?(shader, c.GL_COMPILE_STATUS, &success);
+    if (success == 0) {
+        var info_log: [512]u8 = @splat(0);
+        var log_len: c.GLsizei = 0;
+        gl.GetShaderInfoLog.?(shader, 512, &log_len, &info_log);
+        const len: usize = if (log_len > 0) @intCast(log_len) else 0;
+        if (len > 0) {
+            std.debug.print("Shader compilation failed: {s}\n", .{info_log[0..len]});
+        } else {
+            std.debug.print("Shader compilation failed (no error log, shader={})\n", .{shader});
+        }
+        gl.DeleteShader.?(shader);
+        return null;
+    }
+    return shader;
+}
+
+/// Compile + link a program from vertex/fragment sources. Returns 0 on failure.
+pub fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
+    const gl = Context.gl;
+    const vs = compileShader(c.GL_VERTEX_SHADER, vs_src) orelse return 0;
+    defer gl.DeleteShader.?(vs);
+    const fs = compileShader(c.GL_FRAGMENT_SHADER, fs_src) orelse return 0;
+    defer gl.DeleteShader.?(fs);
+    const prog = gl.CreateProgram.?();
+    gl.AttachShader.?(prog, vs);
+    gl.AttachShader.?(prog, fs);
+    gl.LinkProgram.?(prog);
+    var success: c.GLint = 0;
+    gl.GetProgramiv.?(prog, c.GL_LINK_STATUS, &success);
+    if (success == 0) {
+        var info_log: [512]u8 = @splat(0);
+        var log_len: c.GLsizei = 0;
+        gl.GetProgramInfoLog.?(prog, 512, &log_len, &info_log);
+        const len: usize = if (log_len > 0) @intCast(log_len) else 0;
+        if (len > 0) std.debug.print("Shader link failed: {s}\n", .{info_log[0..len]});
+        gl.DeleteProgram.?(prog);
+        return 0;
+    }
+    return prog;
+}
+
+pub fn use(self: Pipeline) void {
+    Context.gl.UseProgram.?(self.program);
+}
+pub fn bindVao(self: Pipeline) void {
+    Context.gl.BindVertexArray.?(self.vao);
+}
+pub fn setVec2(self: Pipeline, name: [*c]const u8, x: f32, y: f32) void {
+    Context.gl.Uniform2f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y);
+}
+pub fn setFloat(self: Pipeline, name: [*c]const u8, v: f32) void {
+    Context.gl.Uniform1f.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+pub fn setInt(self: Pipeline, name: [*c]const u8, v: i32) void {
+    Context.gl.Uniform1i.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+/// Set the orthographic projection uniform from the current viewport.
+/// `window_height` is accepted for call-site parity but unused (matches the
+/// previous gl_init.setProjectionForProgram behavior).
+pub fn setProjection(self: Pipeline, window_height: f32) void {
+    const gl = Context.gl;
+    var viewport: [4]c.GLint = undefined;
+    gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
+    const width: f32 = @floatFromInt(viewport[2]);
+    const height: f32 = @floatFromInt(viewport[3]);
+    _ = window_height;
+    const projection = [16]f32{
+        2.0 / width, 0.0,          0.0,  0.0,
+        0.0,         2.0 / height, 0.0,  0.0,
+        0.0,         0.0,          -1.0, 0.0,
+        -1.0,        -1.0,         0.0,  1.0,
+    };
+    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(self.program, "projection"), 1, c.GL_FALSE, &projection);
+}
+pub fn drawArraysInstanced(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei, instances: c.GLsizei) void {
+    _ = self;
+    Context.gl.DrawArraysInstanced.?(mode, first, count, instances);
+}
+pub fn deinit(self: *Pipeline) void {
+    if (self.program != 0) Context.gl.DeleteProgram.?(self.program);
+    if (self.vao != 0) Context.gl.DeleteVertexArrays.?(1, &self.vao);
+    self.* = .{ .program = 0, .vao = 0 };
+}
+```
+
+- [ ] **Step 4: Wire the primitives + shaders into `api.zig`**
+
+In `src/renderer/gpu/opengl/api.zig`, replace the three reserved stub lines:
+
+```zig
+pub const Texture = struct {}; // reserved: A4 (font atlas → GPU texture)
+pub const Buffer = struct {}; // reserved: A3
+pub const Pipeline = struct {}; // reserved: A3
+```
+
+with the real types, and add a `shaders` re-export (so cell pipelines can reach the GLSL sources):
+
+```zig
+pub const Buffer = @import("Buffer.zig");
+pub const Texture = @import("Texture.zig");
+pub const Pipeline = @import("Pipeline.zig");
+pub const shaders = @import("shaders.zig");
+```
+
+- [ ] **Step 5: Expose `shaders` from `gpu.zig`**
+
+In `src/renderer/gpu/gpu.zig`, add next to the other re-exports (after the `gl_init` line):
+
+```zig
+pub const shaders = impl.shaders; // backend GLSL sources (for cell pipelines)
+```
+
+The `Texture`/`Buffer`/`Pipeline` re-exports already exist there and now resolve to the real types.
+
+- [ ] **Step 6: Build**
+
+Run: `zig build`
+Expected: success. The primitives are additive and not yet used.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/gpu/opengl/Buffer.zig src/renderer/gpu/opengl/Texture.zig src/renderer/gpu/opengl/Pipeline.zig src/renderer/gpu/opengl/api.zig src/renderer/gpu/gpu.zig
+git commit -m "feat(gpu): real Buffer/Texture/Pipeline primitives [A3]"
+```
+
+---
+
+## Task 2: `cell_geometry.zig` — instance types + pure logic + tests
+
+**Files:**
+- Create: `src/renderer/cell_geometry.zig`
+- Modify: `src/renderer/Renderer.zig` (re-export the moved types), `src/test_fast.zig`
+
+TDD: write the module with tests; the pure functions have known outputs derived from the current `rebuildCells` source.
+
+- [ ] **Step 1: Create `src/renderer/cell_geometry.zig` with types, functions, and tests**
+
+```zig
+//! Pure, std-only cell geometry: the GPU instance data types plus the
+//! presentation-agnostic transforms used to build them (the BG/cursor/selection
+//! decision and the glyph-rect math). No GL, no font, no AppWindow — runs in the
+//! fast test suite. The impure glyph lookup (font.loadGlyph / font.glyphUV)
+//! stays in cell_renderer.
+const std = @import("std");
+
+pub const MAX_GRAPHEME: usize = 8;
+
+/// Background cell instance data for the GPU.
+pub const CellBg = extern struct {
+    grid_col: f32,
+    grid_row: f32,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+};
+
+/// Foreground (glyph) cell instance data for the GPU.
+pub const CellFg = extern struct {
+    grid_col: f32,
+    grid_row: f32,
+    glyph_x: f32,
+    glyph_y: f32,
+    glyph_w: f32,
+    glyph_h: f32,
+    uv_left: f32,
+    uv_top: f32,
+    uv_right: f32,
+    uv_bottom: f32,
+    r: f32,
+    g: f32,
+    b: f32,
+};
+
+/// Snapshot of a single cell's state (copied from the terminal under lock).
+pub const SnapCell = struct {
+    codepoint: u21,
+    fg: [3]f32,
+    bg: ?[3]f32,
+    wide: enum(u2) { narrow = 0, wide = 1, spacer_tail = 2, spacer_head = 3 } = .narrow,
+    grapheme: [MAX_GRAPHEME]u21 = .{0} ** MAX_GRAPHEME,
+    grapheme_len: u4 = 0,
+};
+
+pub const Rgb = [3]f32;
+
+pub const ThemeColors = struct {
+    background: Rgb,
+    cursor_text: ?Rgb,
+    selection_background: Rgb,
+    selection_foreground: ?Rgb,
+    foreground: Rgb,
+};
+
+/// The BG/cursor/selection decision (cell_renderer.rebuildCells lines 257-286).
+/// Returns the optional background instance to emit and the resolved foreground.
+pub fn backgroundFor(
+    cell_bg: ?Rgb,
+    is_cursor: bool,
+    cursor_visible: bool,
+    cursor_is_block: bool,
+    is_selected: bool,
+    theme: ThemeColors,
+    grid_col: f32,
+    grid_row: f32,
+    normal_bg_alpha: f32,
+    base_fg: Rgb,
+) struct { bg: ?CellBg, fg: Rgb } {
+    var fg = base_fg;
+    var bg: ?CellBg = null;
+    if (is_cursor and cursor_visible) {
+        if (cursor_is_block) fg = theme.cursor_text orelse theme.background;
+        if (cell_bg) |b| bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = b[0], .g = b[1], .b = b[2], .a = normal_bg_alpha };
+    } else if (is_selected) {
+        bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = theme.selection_background[0], .g = theme.selection_background[1], .b = theme.selection_background[2], .a = 1.0 };
+        fg = theme.selection_foreground orelse theme.foreground;
+    } else if (cell_bg) |b| {
+        bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = b[0], .g = b[1], .b = b[2], .a = normal_bg_alpha };
+    }
+    return .{ .bg = bg, .fg = fg };
+}
+
+pub const GlyphRect = struct { gx: f32, gy: f32, gw: f32, gh: f32 };
+
+/// Grayscale glyph rect math (cell_renderer lines 369-373).
+pub fn grayscaleGlyphRect(bearing_x: i32, bearing_y: i32, size_x: u32, size_y: u32, cell_baseline: f32) GlyphRect {
+    return .{
+        .gx = @floatFromInt(bearing_x),
+        .gy = cell_baseline - @as(f32, @floatFromInt(@as(i32, @intCast(size_y)) - bearing_y)),
+        .gw = @floatFromInt(size_x),
+        .gh = @floatFromInt(size_y),
+    };
+}
+
+/// Color-emoji aspect-fit + centering (cell_renderer lines 339-348).
+pub fn colorEmojiRect(size_x: u32, size_y: u32, grid_width: f32, cell_w: f32, cell_h: f32) GlyphRect {
+    const emoji_w: f32 = @floatFromInt(size_x);
+    const emoji_h: f32 = @floatFromInt(size_y);
+    const target_w = cell_w * grid_width;
+    const scale = @min(target_w / emoji_w, cell_h / emoji_h);
+    const gw = emoji_w * scale;
+    const gh = emoji_h * scale;
+    return .{ .gx = (target_w - gw) / 2.0, .gy = (cell_h - gh) / 2.0, .gw = gw, .gh = gh };
+}
+
+test "backgroundFor: plain cell emits bg at grid coords, fg unchanged" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.1, 0.2, 0.3 }, false, false, false, false, theme, 3, 4, 0.5, .{ 0.9, 0.8, 0.7 });
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 3), r.bg.?.grid_col);
+    try std.testing.expectEqual(@as(f32, 4), r.bg.?.grid_row);
+    try std.testing.expectEqual(@as(f32, 0.5), r.bg.?.a);
+    try std.testing.expectEqual(@as(f32, 0.1), r.bg.?.r);
+    try std.testing.expectEqual([3]f32{ 0.9, 0.8, 0.7 }, r.fg);
+}
+
+test "backgroundFor: no bg color and not cursor/selected emits nothing" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(null, false, false, false, false, theme, 0, 0, 1.0, .{ 1, 1, 1 });
+    try std.testing.expect(r.bg == null);
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, r.fg);
+}
+
+test "backgroundFor: selected cell uses opaque selection bg and selection fg" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.3, 0.4 }, .selection_foreground = .{ 0.5, 0.6, 0.7 }, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.1, 0.1, 0.1 }, false, false, false, true, theme, 1, 2, 0.3, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 1.0), r.bg.?.a); // selection stays opaque
+    try std.testing.expectEqual(@as(f32, 0.2), r.bg.?.r);
+    try std.testing.expectEqual([3]f32{ 0.5, 0.6, 0.7 }, r.fg);
+}
+
+test "backgroundFor: block cursor overrides fg to cursor_text" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = .{ 0.1, 0.1, 0.1 }, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.4, 0.4, 0.4 }, true, true, true, false, theme, 0, 0, 1.0, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expectEqual([3]f32{ 0.1, 0.1, 0.1 }, r.fg);
+    try std.testing.expect(r.bg != null); // cell bg still drawn normally
+    try std.testing.expectEqual(@as(f32, 0.4), r.bg.?.r);
+}
+
+test "grayscaleGlyphRect: baseline/bearing math" {
+    const r = grayscaleGlyphRect(2, 10, 6, 12, 16.0);
+    try std.testing.expectEqual(@as(f32, 2), r.gx);
+    try std.testing.expectEqual(@as(f32, 16.0 - (12.0 - 10.0)), r.gy); // 14
+    try std.testing.expectEqual(@as(f32, 6), r.gw);
+    try std.testing.expectEqual(@as(f32, 12), r.gh);
+}
+
+test "colorEmojiRect: aspect-fit and centering for a narrow cell" {
+    // 20x10 emoji into a 10x16 cell, grid_width 1 → scale = min(10/20, 16/10)=0.5
+    const r = colorEmojiRect(20, 10, 1.0, 10.0, 16.0);
+    try std.testing.expectEqual(@as(f32, 10), r.gw); // 20*0.5
+    try std.testing.expectEqual(@as(f32, 5), r.gh); // 10*0.5
+    try std.testing.expectEqual(@as(f32, 0), r.gx); // (10-10)/2
+    try std.testing.expectEqual(@as(f32, 5.5), r.gy); // (16-5)/2
+}
+```
+
+- [ ] **Step 2: Re-export the moved types from `Renderer.zig`**
+
+In `src/renderer/Renderer.zig`, delete the local definitions of `MAX_GRAPHEME` (line ~39), `CellBg` (~47-53), `CellFg` (~57-70), and `SnapCell` (~74-80), and add near the top of the file (after the existing imports):
+
+```zig
+const cell_geometry = @import("cell_geometry.zig");
+pub const CellBg = cell_geometry.CellBg;
+pub const CellFg = cell_geometry.CellFg;
+pub const SnapCell = cell_geometry.SnapCell;
+```
+
+Leave `pub const MAX_CELLS` where it is. If `grep -n MAX_GRAPHEME src/renderer/Renderer.zig` shows uses beyond the deleted `SnapCell`, also add `const MAX_GRAPHEME = cell_geometry.MAX_GRAPHEME;`.
+
+- [ ] **Step 3: Register the module in the fast test suite**
+
+In `src/test_fast.zig`, inside the `test { ... }` block:
+
+```zig
+    _ = @import("renderer/cell_geometry.zig");
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `zig build test`
+Expected: PASS (the six `cell_geometry` tests run and pass).
+
+- [ ] **Step 5: Build the full app to confirm the re-export compiles**
+
+Run: `zig build`
+Expected: success (every `Renderer.CellBg`/`CellFg`/`SnapCell` reference resolves through the re-export).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/cell_geometry.zig src/renderer/Renderer.zig src/test_fast.zig
+git commit -m "feat(cells): extract std-only cell_geometry (types + pure logic) [A3]"
+```
+
+---
+
+## Task 3: `cell_pipeline.zig` — cell pipelines built from primitives
+
+**Files:**
+- Create: `src/renderer/cell_pipeline.zig`
+
+Additive: this module is created but not yet wired in (Task 5 switches to it and strips the old globals). It builds the `bg`/`fg`/`color_fg` pipelines from the Task 1 primitives, relocating the VAO attribute setup verbatim from `gl_init.initInstancedBuffers`.
+
+- [ ] **Step 1: Create `src/renderer/cell_pipeline.zig`**
+
+```zig
+//! Cell-grid render pipelines (bg / fg / color-emoji). Cell-specific
+//! presentation, built from the gpu backend primitives + the backend GLSL.
+//! Relocated from gl_init.initInstancedBuffers (A3). The vertex-attribute
+//! layout matches the CellBg/CellFg memory layout exactly.
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const Renderer = @import("Renderer.zig");
+const gpu = AppWindow.gpu;
+const c = gpu.c;
+
+const Pipeline = gpu.Pipeline;
+const Buffer = gpu.Buffer;
+
+pub threadlocal var bg: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var fg: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var color_fg: Pipeline = .{ .program = 0, .vao = 0 };
+
+pub threadlocal var bg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var fg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var color_fg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
+
+/// Build the cell pipelines. Call once after the GL context is current.
+pub fn init() void {
+    const gl = gpu.glTable();
+    const shaders = gpu.shaders;
+
+    // Shared unit quad (triangle strip: 4 verts)
+    const quad_verts = [4][2]f32{
+        .{ 0.0, 0.0 },
+        .{ 1.0, 0.0 },
+        .{ 0.0, 1.0 },
+        .{ 1.0, 1.0 },
+    };
+    quad = Buffer.init(c.GL_ARRAY_BUFFER);
+    quad.uploadData(std.mem.sliceAsBytes(quad_verts[0..]), c.GL_STATIC_DRAW);
+
+    // --- BG VAO ---
+    var bg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &bg_vao);
+    bg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(bg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    bg_instances.allocate(@sizeOf(Renderer.CellBg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    const bg_stride: c.GLsizei = @sizeOf(Renderer.CellBg);
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 3, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 1, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(5 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.BindVertexArray.?(0);
+
+    // --- FG VAO ---
+    var fg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &fg_vao);
+    fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(fg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    const fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg);
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.EnableVertexAttribArray.?(4);
+    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(4, 1);
+    gl.BindVertexArray.?(0);
+
+    // --- Color FG VAO (same layout as FG) ---
+    var color_fg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &color_fg_vao);
+    color_fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(color_fg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    color_fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.EnableVertexAttribArray.?(4);
+    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(4, 1);
+    gl.BindVertexArray.?(0);
+
+    bg = .{ .program = Pipeline.linkProgram(shaders.bg_vertex_source, shaders.bg_fragment_source), .vao = bg_vao };
+    fg = .{ .program = Pipeline.linkProgram(shaders.fg_vertex_source, shaders.fg_fragment_source), .vao = fg_vao };
+    color_fg = .{ .program = Pipeline.linkProgram(shaders.fg_vertex_source, shaders.color_fg_fragment_source), .vao = color_fg_vao };
+    if (bg.program == 0) std.debug.print("BG instanced shader failed\n", .{});
+    if (fg.program == 0) std.debug.print("FG instanced shader failed\n", .{});
+    if (color_fg.program == 0) std.debug.print("Color FG instanced shader failed\n", .{});
+}
+
+pub fn deinit() void {
+    bg.deinit();
+    fg.deinit();
+    color_fg.deinit();
+    bg_instances.deinit();
+    fg_instances.deinit();
+    color_fg_instances.deinit();
+    quad.deinit();
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `zig build`
+Expected: success. `cell_pipeline` compiles but is not yet referenced.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/cell_pipeline.zig
+git commit -m "feat(cells): cell_pipeline built from gpu primitives (unwired) [A3]"
+```
+
+---
+
+## Task 4: Route `rebuildCells` through `cell_geometry` (logic switch)
+
+**Files:**
+- Modify: `src/renderer/cell_renderer.zig` (`rebuildCells`)
+
+Replace the inline BG/cursor/selection decision and glyph-rect math with calls into `cell_geometry`. Behavior identical; the geometry tests from Task 2 cover the extracted logic.
+
+- [ ] **Step 1: Add the import**
+
+In `src/renderer/cell_renderer.zig`, near the other imports add:
+
+```zig
+const cell_geometry = @import("cell_geometry.zig");
+```
+
+- [ ] **Step 2: Replace the BG/cursor/selection decision (current lines ~257-286)**
+
+Replace the block that starts `var fg_color = sc.fg;` and runs through the cursor / `is_selected` / `else if (sc.bg)` branches with:
+
+```zig
+            const cursor_is_block = if (rend.cached_cursor_effective) |s| s == .block else false;
+            const decision = cell_geometry.backgroundFor(
+                sc.bg,
+                is_cursor,
+                rend.cached_cursor_visible,
+                cursor_is_block,
+                is_selected,
+                .{
+                    .background = g_theme.background,
+                    .cursor_text = g_theme.cursor_text,
+                    .selection_background = g_theme.selection_background,
+                    .selection_foreground = g_theme.selection_foreground,
+                    .foreground = g_theme.foreground,
+                },
+                col_f,
+                row_f,
+                normal_bg_alpha,
+                sc.fg,
+            );
+            if (decision.bg) |bg_inst| {
+                if (rend.bg_cell_count < rend.bg_cells.items.len) {
+                    rend.bg_cells.items[rend.bg_cell_count] = bg_inst;
+                    rend.bg_cell_count += 1;
+                }
+            }
+            var fg_color = decision.fg;
+```
+
+(`is_cursor`, `is_selected`, `col_f`, `row_f`, `normal_bg_alpha`, `g_theme` are already in scope above this block.)
+
+- [ ] **Step 3: Replace the grayscale glyph rect (current lines ~370-373)**
+
+The grayscale branch currently reads `const uv_val = font.glyphUV(ch.region, atlas_size);` (line 369) followed by four `const gx/gy/gw/gh = …` lines (370-373). Leave the `uv_val` line untouched; replace **only** the four `gx/gy/gw/gh` lines with:
+
+```zig
+                            const rect = cell_geometry.grayscaleGlyphRect(ch.bearing_x, ch.bearing_y, ch.size_x, ch.size_y, font.cell_baseline);
+                            const gx = rect.gx;
+                            const gy = rect.gy;
+                            const gw = rect.gw;
+                            const gh = rect.gh;
+```
+
+The subsequent `rend.fg_cells.items[...] = .{ … }` assignment (which reads `gx/gy/gw/gh/uv_val`) stays unchanged.
+
+- [ ] **Step 4: Replace the color-emoji rect (current lines ~339-347)**
+
+In the color branch, replace the `emoji_w/emoji_h/target_w/scale/gw/gh/gx/gy` computation (lines 339-347) with the call below. Leave the `const uv_val = font.glyphUV(ch.region, color_atlas_size);` line (348) and the subsequent `rend.color_fg_cells.items[...] = .{ … }` assignment untouched:
+
+```zig
+                            const rect = cell_geometry.colorEmojiRect(ch.size_x, ch.size_y, grid_width, font.cell_width, font.cell_height);
+                            const gx = rect.gx;
+                            const gy = rect.gy;
+                            const gw = rect.gw;
+                            const gh = rect.gh;
+```
+
+- [ ] **Step 5: Build and test**
+
+Run: `zig build && zig build test`
+Expected: `zig build` succeeds; `zig build test` green (geometry tests pass).
+
+Run: `zig build test-full`
+Expected: baseline 497/499 (1 pre-existing Windows-only failure, 1 skip) — no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/cell_renderer.zig
+git commit -m "refactor(cells): rebuildCells uses cell_geometry pure logic [A3]"
+```
+
+---
+
+## Task 5: Route `drawCells` through `cell_pipeline`; strip cell parts from `gl_init` (presentation cutover)
+
+**Files:**
+- Modify: `src/renderer/cell_renderer.zig` (`drawCells`), `src/renderer/gpu/opengl/gl_init.zig`, `src/AppWindow.zig`
+
+This is the atomic presentation cutover: switch `drawCells`, remove the cell-specific globals/setup from `gl_init`, and repoint `AppWindow`'s init/teardown.
+
+- [ ] **Step 1: Add the `cell_pipeline` import to `cell_renderer.zig`**
+
+```zig
+const cell_pipeline = @import("cell_pipeline.zig");
+```
+
+- [ ] **Step 2: Rewrite the three instanced passes in `drawCells` (current lines ~408-468)**
+
+Replace the BG, FG, and color-emoji blocks (the ones guarded by `gl_init.bg_shader != 0` etc.) with:
+
+```zig
+    // --- Draw BG cells ---
+    if (rend.bg_cell_count > 0 and cell_pipeline.bg.program != 0) {
+        const p = cell_pipeline.bg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection(window_height);
+        p.bindVao();
+        cell_pipeline.bg_instances.upload(std.mem.sliceAsBytes(rend.bg_cells.items[0..rend.bg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.bg_cell_count));
+        gl_init.g_draw_call_count += 1;
+    }
+
+    image_renderer.draw(rend, window_height, offset_x, offset_y, .below_text);
+
+    // --- Draw FG cells ---
+    if (rend.fg_cell_count > 0 and cell_pipeline.fg.program != 0) {
+        const p = cell_pipeline.fg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection(window_height);
+        gpu.Texture.fromHandle(font.g_atlas_texture).bind(0);
+        p.setInt("atlas", 0);
+        p.bindVao();
+        cell_pipeline.fg_instances.upload(std.mem.sliceAsBytes(rend.fg_cells.items[0..rend.fg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.fg_cell_count));
+        gl_init.g_draw_call_count += 1;
+    }
+
+    // --- Draw color emoji cells (premultiplied alpha blend) ---
+    if (rend.color_fg_cell_count > 0 and cell_pipeline.color_fg.program != 0) {
+        const gl = AppWindow.gpu.glTable();
+        gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
+        const p = cell_pipeline.color_fg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection(window_height);
+        gpu.Texture.fromHandle(font.g_color_atlas_texture).bind(0);
+        p.setInt("atlas", 0);
+        p.bindVao();
+        cell_pipeline.color_fg_instances.upload(std.mem.sliceAsBytes(rend.color_fg_cells.items[0..rend.color_fg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.color_fg_cell_count));
+        gl_init.g_draw_call_count += 1;
+        gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    }
+```
+
+Notes: `image_renderer.draw(... .below_bg)` before the BG block and `image_renderer.draw(... .above_text)` / `drawUrlUnderline(...)` after the color block stay exactly as they are. The cursor-overlay block (uses `gl_init.shader_program`/`gl_init.vao`/`gl_init.renderQuad`) is **left untouched** — it uses shared pipelines. `gpu` must be in scope: `cell_renderer.zig` already references `AppWindow.gpu.*`; add `const gpu = AppWindow.gpu;` near the imports if not present.
+
+- [ ] **Step 3: Move the shared shader links into `gl_init.initShaders`**
+
+In `src/renderer/gpu/opengl/gl_init.zig`, append to the end of `initShaders` (just before `return true;`):
+
+```zig
+    // Shared simple-color + overlay shaders (used by titlebar/overlays).
+    simple_color_shader = linkProgram(shaders.vertex_shader_source, shaders.simple_color_fragment_source);
+    if (simple_color_shader == 0) std.debug.print("Simple color shader failed\n", .{});
+    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
+    if (overlay_shader == 0) std.debug.print("Overlay shader failed\n", .{});
+```
+
+- [ ] **Step 4: Delete the cell-specific globals + `initInstancedBuffers` + `deinitInstancedResources` from `gl_init.zig`**
+
+Remove these declarations (lines ~25-34): `bg_shader`, `fg_shader`, `color_fg_shader`, `bg_vao`, `fg_vao`, `color_fg_vao`, `bg_instance_vbo`, `fg_instance_vbo`, `color_fg_instance_vbo`, `quad_vbo`. Delete the entire `pub fn initInstancedBuffers` and `pub fn deinitInstancedResources` functions. Keep `linkProgram` (now used by `initShaders`), `compileShader`, `vao`/`vbo`/`shader_program`, `simple_color_shader`, `overlay_shader`, `solid_texture`, `initBuffers`, `initSolidTexture`, `renderQuad`/`renderQuadAlpha`, `setProjection`, `setProjectionForProgram`, `g_draw_call_count`, `g_bg_opacity`.
+
+- [ ] **Step 5: Repoint `AppWindow.zig` init/teardown**
+
+In `src/AppWindow.zig`: add the import near the other renderer re-exports:
+```zig
+pub const cell_pipeline = @import("renderer/cell_pipeline.zig");
+```
+Replace the call `gpu.gl_init.initInstancedBuffers();` (line ~3260) with:
+```zig
+    cell_pipeline.init();
+```
+Replace the call `gpu.gl_init.deinitInstancedResources();` (line ~3324) with:
+```zig
+    cell_pipeline.deinit();
+```
+(`initShaders` now also links the shared simple_color/overlay shaders; no extra call needed.)
+
+- [ ] **Step 6: Verify nothing else references the removed globals**
+
+Run:
+```bash
+grep -rn "gl_init\.\(bg_shader\|fg_shader\|color_fg_shader\|bg_vao\|fg_vao\|color_fg_vao\|bg_instance_vbo\|fg_instance_vbo\|color_fg_instance_vbo\)\|initInstancedBuffers\|deinitInstancedResources" src/
+```
+Expected: no output.
+
+- [ ] **Step 7: Build and test**
+
+Run: `zig build`
+Expected: success.
+
+Run: `zig build test-full`
+Expected: baseline 497/499 (1 pre-existing Windows-only failure, 1 skip) — no new failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(cells): drawCells routes through cell_pipeline; strip cell globals from gl_init [A3]"
+```
+
+---
+
+## Task 6: Docs + final verification
+
+**Files:**
+- Modify: `TODO.md`, `docs/decoupling-guide.md`
+
+- [ ] **Step 1: Note A3 progress in `TODO.md`**
+
+Under Phase A item **A3**, add a sub-note that the first increment landed: real `Buffer`/`Texture`/`Pipeline` primitives exist in `gpu/opengl/`, `cell_renderer` is converted (draw path through `cell_pipeline`; pure logic in std-only `cell_geometry` with unit tests), and the remaining 9 files + the shared pipelines (`shader_program`/`overlay_shader`/`simple_color_shader`) are still pending. Leave A3 unchecked (incomplete).
+
+- [ ] **Step 2: Add a status line under `docs/decoupling-guide.md` §5 Phase A**
+
+Note that A3 began: primitives defined and `cell_renderer` converted as the proving ground; the per-file pattern (route draw through primitives + extract pure geometry) is established for the remaining files.
+
+- [ ] **Step 3: Final verification**
+
+Run: `zig build test-full`
+Expected: 497/499 baseline.
+
+Run: `zig build`
+Expected: a clean `phantty.exe` artifact.
+
+- [ ] **Step 4: Request the manual Windows visual check**
+
+Ask the maintainer to run `phantty.exe` on Windows and confirm the terminal grid renders identically: text fg/bg colors, background-image alpha, selection highlight, all four cursor styles (block/bar/underline/hollow), and color emoji. Behavior-preserving change — any visual difference is a regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TODO.md docs/decoupling-guide.md
+git commit -m "docs(gpu): note A3 increment 1 (primitives + cell_renderer)"
+```
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec coverage:** §2 primitives → Task 1. §3 cell pipelines → Task 3 (build) + Task 5 (wire + strip gl_init). §4 cell_geometry types/logic/tests → Task 2; rebuildCells switch → Task 4. Verification → Task 6. Non-goals (Frame/RenderPass/Target, shared pipelines, other 9 files, A4/A5/A6) are explicitly out.
+- **Type consistency:** `Buffer{ .handle, .target }`, `Pipeline{ .program, .vao }` literals in `cell_pipeline.zig` match the field definitions in Task 1. `cell_geometry.backgroundFor` return `{ bg: ?CellBg, fg: Rgb }` and `GlyphRect{ gx, gy, gw, gh }` are used consistently in Task 4. `Pipeline.setProjection(window_height)` / `setVec2`/`setFloat`/`setInt`/`drawArraysInstanced`/`bindVao`/`use` names match Task 1 ↔ Task 5.
+- **Atomicity:** Task 5 is one commit (the presentation cutover) because `drawCells`, the `gl_init` strip, and the `AppWindow` repoint must land together to keep the build green. Task 4 (logic) is a separate, independently-green commit — consecutive commits within this increment still "touch cell_renderer once" for each purpose.
+- **Behavior preservation:** the relocated VAO attribute setup (Task 3) and the color-emoji blend-mode switch (Task 5) are reproduced exactly from the current `initInstancedBuffers` / `drawCells`; the manual Windows check (Task 6) is the final gate since rendering has no automated coverage.

--- a/docs/superpowers/specs/2026-05-26-gpu-a3-cell-renderer-design.md
+++ b/docs/superpowers/specs/2026-05-26-gpu-a3-cell-renderer-design.md
@@ -1,0 +1,263 @@
+# Design: GPU Phase A3 — primitives + cell_renderer (increment 1)
+
+Status: approved (design); pending spec review
+Date: 2026-05-26
+Scope: TODO.md Phase A item **A3**, first increment only
+References: [decoupling-guide.md](../../decoupling-guide.md) §2/§5, prior spec
+`2026-05-26-gpu-backend-spine-a1-a2-design.md`. Ghostty: `renderer/opengl/`
+(`Buffer`/`Texture`/`Pipeline`), API-agnostic `renderer/cell.zig`.
+
+## 1. Goal & scope
+
+Replace the empty `Buffer`/`Texture`/`Pipeline` stubs in `gpu/opengl/` with real
+primitive types, then convert `cell_renderer.zig` as the proving ground —
+**both decoupling axes in one pass** (the guide's "touch each file once"):
+
+- **Axis A (presentation):** route `drawCells`' draw path through the new
+  primitives instead of raw `gl.*` + `gl_init` global handles.
+- **Axis B (logic):** extract the pure snap→instance decision/math + the
+  instance data types into a std-only, unit-tested module.
+
+### Non-goals (deferred)
+
+- The `Frame`/`RenderPass`/`Target` layer (manages FBO binds, will carry
+  Metal's command encoder) — lands when the FBO/compositing path is converted.
+- The **shared** pipelines `shader_program`, `overlay_shader`,
+  `simple_color_shader` (used by titlebar/overlays/etc.) stay in `gl_init` until
+  those files are converted in later A3 increments.
+- The other 9 A3 renderer files; A4 (font atlas → `Texture` ownership/upload);
+  A5 (MSL); A6 (guards); Metal backend.
+- `Texture` upload/ownership: the font atlas textures remain owned by `font/`;
+  this increment only *wraps existing handles* for binding.
+
+### Decisions locked (from brainstorming)
+
+- **Primitives are pragmatic**, Ghostty-named, growing toward the full
+  hierarchy later (no `Frame`/`RenderPass`/`Step` now).
+- **§2 vertex layout: caller-built VAO.** `Pipeline` holds `program` + `vao` and
+  drives use/uniform/draw; the per-shader `VertexAttribPointer`/`Divisor` setup
+  relocates verbatim into the cell pipeline builder.
+- **§4 logic split: pure pieces only.** Extract the instance data types + the
+  BG/cursor/selection decision + the glyph-rect math. The impure glyph lookup
+  (`font.loadGlyph`/`loadGraphemeGlyph`/`isRegionalIndicator`) stays in
+  `cell_renderer`.
+
+## 2. Generic primitives — `src/renderer/gpu/opengl/`
+
+Thin wrappers over GL handles, each calling `Context.gl.*`. Re-exported through
+`api.zig` → `gpu.zig` (`pub const Buffer/Texture/Pipeline = impl.…`), replacing
+today's `struct {}` stubs.
+
+### `Buffer.zig` — a VBO
+```zig
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Buffer = @This();
+
+handle: c.GLuint = 0,
+target: c.GLenum,
+
+pub fn init(target: c.GLenum) Buffer {
+    var b = Buffer{ .target = target };
+    Context.gl.GenBuffers.?(1, &b.handle);
+    return b;
+}
+pub fn bind(self: Buffer) void { Context.gl.BindBuffer.?(self.target, self.handle); }
+pub fn allocate(self: Buffer, size: usize, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(size), null, usage);
+}
+pub fn uploadData(self: Buffer, bytes: []const u8, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(bytes.len), bytes.ptr, usage);
+}
+pub fn upload(self: Buffer, bytes: []const u8) void { // BufferSubData at offset 0
+    self.bind();
+    Context.gl.BufferSubData.?(self.target, 0, @intCast(bytes.len), bytes.ptr);
+}
+pub fn deinit(self: *Buffer) void {
+    if (self.handle != 0) { Context.gl.DeleteBuffers.?(1, &self.handle); self.handle = 0; }
+}
+```
+
+### `Texture.zig` — wraps an existing handle (font owns the atlas; A4 takes over)
+```zig
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Texture = @This();
+
+handle: c.GLuint,
+
+pub fn fromHandle(h: c.GLuint) Texture { return .{ .handle = h }; }
+pub fn bind(self: Texture, unit: u32) void {
+    Context.gl.ActiveTexture.?(c.GL_TEXTURE0 + unit);
+    Context.gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
+}
+```
+
+### `Pipeline.zig` — program + VAO
+```zig
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Pipeline = @This();
+
+program: c.GLuint,
+vao: c.GLuint,
+
+pub fn use(self: Pipeline) void { Context.gl.UseProgram.?(self.program); }
+pub fn bindVao(self: Pipeline) void { Context.gl.BindVertexArray.?(self.vao); }
+pub fn setVec2(self: Pipeline, name: [*c]const u8, x: f32, y: f32) void {
+    Context.gl.Uniform2f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y);
+}
+pub fn setFloat(self: Pipeline, name: [*c]const u8, v: f32) void {
+    Context.gl.Uniform1f.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+pub fn setInt(self: Pipeline, name: [*c]const u8, v: i32) void {
+    Context.gl.Uniform1i.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+pub fn drawArraysInstanced(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei, instances: c.GLsizei) void {
+    Context.gl.DrawArraysInstanced.?(mode, first, count, instances);
+}
+pub fn deinit(self: *Pipeline) void {
+    if (self.program != 0) Context.gl.DeleteProgram.?(self.program);
+    if (self.vao != 0) Context.gl.DeleteVertexArrays.?(1, &self.vao);
+    self.* = .{ .program = 0, .vao = 0 };
+}
+```
+
+Shader compile/link (`compileShader`, `linkProgram`) is reused from `gl_init`
+(or exposed as a small `Pipeline.link(vertex_src, fragment_src)` helper). The
+projection-matrix uniform is set via the existing `gl_init.setProjectionForProgram`
+behavior, preserved as a `Pipeline.setProjection`-style call in the cell builder.
+
+## 3. Cell pipelines — `src/renderer/cell_pipeline.zig` (new, cell-owned)
+
+The `bg`/`fg`/`color_fg` instanced triples currently built in
+`gl_init.initInstancedBuffers` move here (cell-specific presentation), built from
+the §2 primitives + the GLSL already in `gpu/opengl/shaders.zig`. This module owns:
+
+- `bg`, `fg`, `color_fg`: `Pipeline` (program + VAO; VAO attribs set here,
+  relocated verbatim from `initInstancedBuffers` — `CellBg` is attr0 quad + attr1
+  grid vec2 + attr2 rgb vec3 + attr3 alpha; `CellFg` is attr0 quad + attr1 grid +
+  attr2 glyphRect vec4 + attr3 uv vec4 + attr4 rgb, instance attrs `divisor 1`).
+- `bg_instances`, `fg_instances`, `color_fg_instances`: `Buffer`
+  (`GL_ARRAY_BUFFER`, pre-allocated `@sizeOf(Cell*) * MAX_CELLS`, `STREAM_DRAW`).
+- `quad`: a shared unit-quad `Buffer` (`STATIC_DRAW`).
+- `init()` (build all), `deinit()` (tear down).
+
+`drawCells` then issues each pass through these (BG shown; FG/color_fg mirror it
+with their texture bind + the color_fg blend-mode switch preserved exactly):
+```zig
+if (rend.bg_cell_count > 0) {
+    const p = cell_pipeline.bg;
+    p.use();
+    p.setVec2("cellSize", font.cell_width, font.cell_height);
+    p.setVec2("gridOffset", offset_x, offset_y);
+    p.setFloat("windowHeight", window_height);
+    cell_pipeline.setProjection(p, window_height);
+    p.bindVao();
+    cell_pipeline.bg_instances.upload(std.mem.sliceAsBytes(rend.bg_cells.items[0..rend.bg_cell_count]));
+    p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.bg_cell_count));
+    gl_init.g_draw_call_count += 1;
+}
+```
+The cursor-overlay block in `drawCells` (lines 473-503) uses the *shared*
+`shader_program`/`vao` + `renderQuad`, which stay in `gl_init` this increment —
+that block is left untouched. `image_renderer.draw(...)` calls are likewise
+untouched.
+
+`gl_init.initInstancedBuffers`, `deinitInstancedResources`, and the
+`bg_shader`/`fg_shader`/`color_fg_shader`/`*_vao`/`*_instance_vbo` globals are
+removed; their callers (init/teardown in `AppWindow`) call
+`cell_pipeline.init()`/`deinit()` instead. `g_draw_call_count`/`g_bg_opacity`
+stay in `gl_init` (shared).
+
+## 4. Cell geometry — `src/renderer/cell_geometry.zig` (new, std-only)
+
+Holds the pure, testable pieces. **std-only**: imports only `std` (no
+`AppWindow`/`font`/GL), so it runs in the fast suite.
+
+### Data types (relocated from `Renderer.zig`)
+`CellBg`, `CellFg`, `SnapCell` (plain `extern struct`/`struct`) move here;
+`Renderer.zig` re-imports them (`pub const CellBg = cell_geometry.CellBg;` …) so
+existing references keep working. `MAX_GRAPHEME` moves with `SnapCell`.
+
+### Pure functions
+```zig
+pub const Rgb = [3]f32;
+
+pub const ThemeColors = struct {
+    background: Rgb,
+    cursor_text: ?Rgb,
+    selection_background: Rgb,
+    selection_foreground: ?Rgb,
+    foreground: Rgb,
+};
+
+/// The BG/cursor/selection decision (cell_renderer lines 257-286).
+pub fn backgroundFor(
+    cell_bg: ?Rgb,
+    is_cursor: bool,
+    cursor_visible: bool,
+    cursor_is_block: bool,
+    is_selected: bool,
+    theme: ThemeColors,
+    grid_col: f32,
+    grid_row: f32,
+    normal_bg_alpha: f32,
+    base_fg: Rgb,
+) struct { bg: ?CellBg, fg: Rgb } { … }
+
+pub const GlyphRect = struct { gx: f32, gy: f32, gw: f32, gh: f32 };
+
+/// Grayscale glyph rect math (cell_renderer lines 369-373). Returns only the
+/// position/size rect; the UV is computed by `font.glyphUV` in cell_renderer
+/// (it depends on atlas state) and assembled into the CellFg there.
+pub fn grayscaleGlyphRect(bearing_x: i32, bearing_y: i32, size_x: u32, size_y: u32, cell_baseline: f32) GlyphRect { … }
+
+/// Color-emoji aspect-fit + centering (cell_renderer lines 339-348). Returns
+/// only the rect; UV comes from `font.glyphUV` in cell_renderer.
+pub fn colorEmojiRect(size_x: u32, size_y: u32, grid_width: f32, cell_w: f32, cell_h: f32) GlyphRect { … }
+```
+
+### What stays in `cell_renderer.rebuildCells` (impure orchestration)
+The row/col walk; `font.loadGlyph`/`loadGraphemeGlyph`/`isRegionalIndicator`
+lookups; `font.glyphUV` (atlas-coord computation — depends on atlas state);
+spacer/placeholder/RI skipping; `image_renderer.uploadPending`. It now reads:
+walk → `backgroundFor(...)` → font glyph lookup → `grayscaleGlyphRect` /
+`colorEmojiRect` (+ `font.glyphUV`) → append.
+
+### Unit tests (registered in `src/test_fast.zig`)
+- `backgroundFor`: plain cell (bg present → one bg instance at grid coords,
+  fg unchanged); selected cell (selection bg opaque alpha=1.0, fg = selection
+  fg); cursor-block (fg → cursor_text orelse background, bg drawn normally);
+  no bg + not cursor/selected (no bg instance).
+- `grayscaleGlyphRect`: bearing/baseline math for a known glyph.
+- `colorEmojiRect`: aspect-fit scale + centering for wide vs narrow.
+
+## 5. Verification
+
+- `zig build` clean (x86_64-windows-gnu).
+- `zig build test` includes the new `cell_geometry` tests (green).
+- `zig build test-full` at baseline (497/499; 1 pre-existing Windows-only
+  failure, 1 skip) — no new failures.
+- **Manual Windows visual check (final gate):** terminal grid renders
+  identically — text, fg/bg colors, background-image alpha, selection
+  highlight, block/bar/underline/hollow cursor, and color emoji. This is a
+  behavior-preserving change; any visual difference is a regression.
+
+## 6. Risks
+
+- **Pipeline construction parity.** The relocated VAO attrib setup must match
+  `initInstancedBuffers` byte-for-byte (offsets, divisors, strides) or the grid
+  renders wrong. Mitigation: relocate verbatim; diff against the original.
+- **`color_fg` blend-mode switch.** `drawCells` flips to
+  `(GL_ONE, GL_ONE_MINUS_SRC_ALPHA)` for the emoji pass then restores
+  `(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)`. Must be preserved exactly around the
+  `color_fg` draw.
+- **Shared-vs-cell pipeline split.** Removing only `bg`/`fg`/`color_fg` from
+  `gl_init` while leaving the shared ones requires confirming no other file
+  references the removed globals (grep before removal). The cursor overlay in
+  `drawCells` still uses the shared `shader_program`/`vao` — left intact.
+- **No automated render coverage.** Correctness of the visual result rests on
+  the manual Windows check; the fast tests only cover the extracted pure logic.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -38,6 +38,7 @@ pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
 pub const cell_renderer = @import("renderer/cell_renderer.zig");
+pub const cell_pipeline = @import("renderer/cell_pipeline.zig");
 pub const titlebar = @import("renderer/titlebar.zig");
 pub const input = @import("input.zig");
 pub const overlays = @import("renderer/overlays.zig");
@@ -3257,7 +3258,7 @@ fn runMainLoop(self: *AppWindow) !void {
         return error.ShaderInitFailed;
     }
     gpu.gl_init.initBuffers();
-    gpu.gl_init.initInstancedBuffers();
+    cell_pipeline.init();
     font.preloadCharacters(face);
 
     rebuildTitlebarFont(allocator, requested_font, requested_weight, uiFontSize(font_size), ft_lib);
@@ -3321,7 +3322,7 @@ fn runMainLoop(self: *AppWindow) !void {
     defer {
         background_image.deinit();
         post_process.deinit();
-        gpu.gl_init.deinitInstancedResources();
+        cell_pipeline.deinit();
     }
 
     // Ghostty approach: calculate grid size from ACTUAL window size.

--- a/src/renderer/Renderer.zig
+++ b/src/renderer/Renderer.zig
@@ -35,50 +35,16 @@ pub const GLuint = u32;
 /// Max cells = 300 cols x 100 rows = 30000 (generous)
 pub const MAX_CELLS: usize = 30000;
 
-/// Max codepoints per grapheme cluster (covers flags, ZWJ sequences, etc.)
-const MAX_GRAPHEME: usize = 8;
 pub const MAX_KITTY_PLACEMENTS: usize = 512;
 
 // ============================================================================
-// Cell Types
+// Cell Types (re-exported from cell_geometry — std-only, runs in fast tests)
 // ============================================================================
 
-/// Background cell instance data for GPU
-pub const CellBg = extern struct {
-    grid_col: f32,
-    grid_row: f32,
-    r: f32,
-    g: f32,
-    b: f32,
-    a: f32,
-};
-
-/// Foreground (glyph) cell instance data for GPU
-pub const CellFg = extern struct {
-    grid_col: f32,
-    grid_row: f32,
-    glyph_x: f32,
-    glyph_y: f32,
-    glyph_w: f32,
-    glyph_h: f32,
-    uv_left: f32,
-    uv_top: f32,
-    uv_right: f32,
-    uv_bottom: f32,
-    r: f32,
-    g: f32,
-    b: f32,
-};
-
-/// Snapshot of a single cell's state (copied from terminal under lock)
-pub const SnapCell = struct {
-    codepoint: u21,
-    fg: [3]f32,
-    bg: ?[3]f32,
-    wide: enum(u2) { narrow = 0, wide = 1, spacer_tail = 2, spacer_head = 3 } = .narrow,
-    grapheme: [MAX_GRAPHEME]u21 = .{0} ** MAX_GRAPHEME,
-    grapheme_len: u4 = 0, // 0 = single codepoint, >0 = multi-codepoint cluster
-};
+const cell_geometry = @import("cell_geometry.zig");
+pub const CellBg = cell_geometry.CellBg;
+pub const CellFg = cell_geometry.CellFg;
+pub const SnapCell = cell_geometry.SnapCell;
 
 pub const KittyTexture = struct {
     image_id: u32,

--- a/src/renderer/cell_geometry.zig
+++ b/src/renderer/cell_geometry.zig
@@ -80,6 +80,8 @@ pub fn backgroundFor(
         if (cursor_is_block) fg = theme.cursor_text orelse theme.background;
         if (cell_bg) |b| bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = b[0], .g = b[1], .b = b[2], .a = normal_bg_alpha };
     } else if (is_selected) {
+        // Selected cells stay fully opaque (alpha 1.0) even when normal cell
+        // backgrounds reveal a wallpaper underneath — matches Ghostty.
         bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = theme.selection_background[0], .g = theme.selection_background[1], .b = theme.selection_background[2], .a = 1.0 };
         fg = theme.selection_foreground orelse theme.foreground;
     } else if (cell_bg) |b| {
@@ -91,17 +93,17 @@ pub fn backgroundFor(
 pub const GlyphRect = struct { gx: f32, gy: f32, gw: f32, gh: f32 };
 
 /// Grayscale glyph rect math, extracted from cell_renderer.rebuildCells.
-pub fn grayscaleGlyphRect(bearing_x: i32, bearing_y: i32, size_x: u32, size_y: u32, cell_baseline: f32) GlyphRect {
+pub fn grayscaleGlyphRect(bearing_x: i32, bearing_y: i32, size_x: i32, size_y: i32, cell_baseline: f32) GlyphRect {
     return .{
         .gx = @floatFromInt(bearing_x),
-        .gy = cell_baseline - @as(f32, @floatFromInt(@as(i32, @intCast(size_y)) - bearing_y)),
+        .gy = cell_baseline - @as(f32, @floatFromInt(size_y - bearing_y)),
         .gw = @floatFromInt(size_x),
         .gh = @floatFromInt(size_y),
     };
 }
 
 /// Color-emoji aspect-fit + centering, extracted from cell_renderer.rebuildCells.
-pub fn colorEmojiRect(size_x: u32, size_y: u32, grid_width: f32, cell_w: f32, cell_h: f32) GlyphRect {
+pub fn colorEmojiRect(size_x: i32, size_y: i32, grid_width: f32, cell_w: f32, cell_h: f32) GlyphRect {
     const emoji_w: f32 = @floatFromInt(size_x);
     const emoji_h: f32 = @floatFromInt(size_y);
     const target_w = cell_w * grid_width;

--- a/src/renderer/cell_geometry.zig
+++ b/src/renderer/cell_geometry.zig
@@ -1,0 +1,186 @@
+//! Pure, std-only cell geometry: the GPU instance data types plus the
+//! presentation-agnostic transforms used to build them (the BG/cursor/selection
+//! decision and the glyph-rect math). No GL, no font, no AppWindow — runs in the
+//! fast test suite. The impure glyph lookup (font.loadGlyph / font.glyphUV)
+//! stays in cell_renderer.
+const std = @import("std");
+
+pub const MAX_GRAPHEME: usize = 8;
+
+/// Background cell instance data for the GPU.
+pub const CellBg = extern struct {
+    grid_col: f32,
+    grid_row: f32,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
+};
+
+/// Foreground (glyph) cell instance data for the GPU.
+pub const CellFg = extern struct {
+    grid_col: f32,
+    grid_row: f32,
+    glyph_x: f32,
+    glyph_y: f32,
+    glyph_w: f32,
+    glyph_h: f32,
+    uv_left: f32,
+    uv_top: f32,
+    uv_right: f32,
+    uv_bottom: f32,
+    r: f32,
+    g: f32,
+    b: f32,
+};
+
+/// Snapshot of a single cell's state (copied from the terminal under lock).
+pub const SnapCell = struct {
+    codepoint: u21,
+    fg: [3]f32,
+    bg: ?[3]f32,
+    wide: enum(u2) { narrow = 0, wide = 1, spacer_tail = 2, spacer_head = 3 } = .narrow,
+    grapheme: [MAX_GRAPHEME]u21 = .{0} ** MAX_GRAPHEME,
+    grapheme_len: u4 = 0,
+};
+
+pub const Rgb = [3]f32;
+
+pub const ThemeColors = struct {
+    background: Rgb,
+    cursor_text: ?Rgb,
+    selection_background: Rgb,
+    selection_foreground: ?Rgb,
+    foreground: Rgb,
+};
+
+/// The BG/cursor/selection decision extracted from cell_renderer.rebuildCells
+/// (its cursor / selection / cell-bg branch). Returns the optional background
+/// instance to emit and the resolved foreground.
+///
+/// `cursor_is_block` must already fold in both the cursor's presence and its
+/// effective style — pass `(effective != null and effective.? == .block)`, so
+/// it is false when the cursor is inactive or blinked-off. It only gates the fg
+/// override; the background is emitted from `cell_bg` regardless of it.
+pub fn backgroundFor(
+    cell_bg: ?Rgb,
+    is_cursor: bool,
+    cursor_visible: bool,
+    cursor_is_block: bool,
+    is_selected: bool,
+    theme: ThemeColors,
+    grid_col: f32,
+    grid_row: f32,
+    normal_bg_alpha: f32,
+    base_fg: Rgb,
+) struct { bg: ?CellBg, fg: Rgb } {
+    var fg = base_fg;
+    var bg: ?CellBg = null;
+    if (is_cursor and cursor_visible) {
+        if (cursor_is_block) fg = theme.cursor_text orelse theme.background;
+        if (cell_bg) |b| bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = b[0], .g = b[1], .b = b[2], .a = normal_bg_alpha };
+    } else if (is_selected) {
+        bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = theme.selection_background[0], .g = theme.selection_background[1], .b = theme.selection_background[2], .a = 1.0 };
+        fg = theme.selection_foreground orelse theme.foreground;
+    } else if (cell_bg) |b| {
+        bg = .{ .grid_col = grid_col, .grid_row = grid_row, .r = b[0], .g = b[1], .b = b[2], .a = normal_bg_alpha };
+    }
+    return .{ .bg = bg, .fg = fg };
+}
+
+pub const GlyphRect = struct { gx: f32, gy: f32, gw: f32, gh: f32 };
+
+/// Grayscale glyph rect math, extracted from cell_renderer.rebuildCells.
+pub fn grayscaleGlyphRect(bearing_x: i32, bearing_y: i32, size_x: u32, size_y: u32, cell_baseline: f32) GlyphRect {
+    return .{
+        .gx = @floatFromInt(bearing_x),
+        .gy = cell_baseline - @as(f32, @floatFromInt(@as(i32, @intCast(size_y)) - bearing_y)),
+        .gw = @floatFromInt(size_x),
+        .gh = @floatFromInt(size_y),
+    };
+}
+
+/// Color-emoji aspect-fit + centering, extracted from cell_renderer.rebuildCells.
+pub fn colorEmojiRect(size_x: u32, size_y: u32, grid_width: f32, cell_w: f32, cell_h: f32) GlyphRect {
+    const emoji_w: f32 = @floatFromInt(size_x);
+    const emoji_h: f32 = @floatFromInt(size_y);
+    const target_w = cell_w * grid_width;
+    const scale = @min(target_w / emoji_w, cell_h / emoji_h);
+    const gw = emoji_w * scale;
+    const gh = emoji_h * scale;
+    return .{ .gx = (target_w - gw) / 2.0, .gy = (cell_h - gh) / 2.0, .gw = gw, .gh = gh };
+}
+
+test "backgroundFor: plain cell emits bg at grid coords, fg unchanged" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.1, 0.2, 0.3 }, false, false, false, false, theme, 3, 4, 0.5, .{ 0.9, 0.8, 0.7 });
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 3), r.bg.?.grid_col);
+    try std.testing.expectEqual(@as(f32, 4), r.bg.?.grid_row);
+    try std.testing.expectEqual(@as(f32, 0.5), r.bg.?.a);
+    try std.testing.expectEqual(@as(f32, 0.1), r.bg.?.r);
+    try std.testing.expectEqual([3]f32{ 0.9, 0.8, 0.7 }, r.fg);
+}
+
+test "backgroundFor: no bg color and not cursor/selected emits nothing" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(null, false, false, false, false, theme, 0, 0, 1.0, .{ 1, 1, 1 });
+    try std.testing.expect(r.bg == null);
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, r.fg);
+}
+
+test "backgroundFor: selected cell uses opaque selection bg and selection fg" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.3, 0.4 }, .selection_foreground = .{ 0.5, 0.6, 0.7 }, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.1, 0.1, 0.1 }, false, false, false, true, theme, 1, 2, 0.3, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 1.0), r.bg.?.a);
+    try std.testing.expectEqual(@as(f32, 0.2), r.bg.?.r);
+    try std.testing.expectEqual([3]f32{ 0.5, 0.6, 0.7 }, r.fg);
+}
+
+test "backgroundFor: block cursor overrides fg to cursor_text" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = .{ 0.1, 0.1, 0.1 }, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.4, 0.4, 0.4 }, true, true, true, false, theme, 0, 0, 1.0, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expectEqual([3]f32{ 0.1, 0.1, 0.1 }, r.fg);
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 0.4), r.bg.?.r);
+}
+
+test "grayscaleGlyphRect: baseline/bearing math" {
+    const r = grayscaleGlyphRect(2, 10, 6, 12, 16.0);
+    try std.testing.expectEqual(@as(f32, 2), r.gx);
+    try std.testing.expectEqual(@as(f32, 14.0), r.gy);
+    try std.testing.expectEqual(@as(f32, 6), r.gw);
+    try std.testing.expectEqual(@as(f32, 12), r.gh);
+}
+
+test "colorEmojiRect: aspect-fit and centering for a narrow cell" {
+    const r = colorEmojiRect(20, 10, 1.0, 10.0, 16.0);
+    try std.testing.expectEqual(@as(f32, 10), r.gw);
+    try std.testing.expectEqual(@as(f32, 5), r.gh);
+    try std.testing.expectEqual(@as(f32, 0), r.gx);
+    try std.testing.expectEqual(@as(f32, 5.5), r.gy);
+}
+
+test "backgroundFor: bar cursor (non-block) leaves fg unchanged, still emits cell bg" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = .{ 0.1, 0.1, 0.1 }, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(.{ 0.3, 0.3, 0.3 }, true, true, false, false, theme, 0, 0, 0.8, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expectEqual([3]f32{ 0.9, 0.9, 0.9 }, r.fg); // not block → fg unchanged
+    try std.testing.expect(r.bg != null);
+    try std.testing.expectEqual(@as(f32, 0.3), r.bg.?.r);
+    try std.testing.expectEqual(@as(f32, 0.8), r.bg.?.a);
+}
+
+test "backgroundFor: block cursor with null cursor_text falls back to background" {
+    const theme = ThemeColors{ .background = .{ 0.05, 0.05, 0.05 }, .cursor_text = null, .selection_background = .{ 0.2, 0.2, 0.2 }, .selection_foreground = null, .foreground = .{ 1, 1, 1 } };
+    const r = backgroundFor(null, true, true, true, false, theme, 0, 0, 1.0, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expectEqual([3]f32{ 0.05, 0.05, 0.05 }, r.fg); // cursor_text orelse background
+    try std.testing.expect(r.bg == null); // no cell bg present
+}
+
+test "backgroundFor: selected cell with null selection_foreground falls back to foreground" {
+    const theme = ThemeColors{ .background = .{ 0, 0, 0 }, .cursor_text = null, .selection_background = .{ 0.2, 0.3, 0.4 }, .selection_foreground = null, .foreground = .{ 0.8, 0.8, 0.8 } };
+    const r = backgroundFor(.{ 0.1, 0.1, 0.1 }, false, false, false, true, theme, 0, 0, 1.0, .{ 0.9, 0.9, 0.9 });
+    try std.testing.expectEqual([3]f32{ 0.8, 0.8, 0.8 }, r.fg); // selection_foreground orelse foreground
+    try std.testing.expect(r.bg != null);
+}

--- a/src/renderer/cell_pipeline.zig
+++ b/src/renderer/cell_pipeline.zig
@@ -1,0 +1,125 @@
+//! Cell-grid render pipelines (bg / fg / color-emoji). Cell-specific
+//! presentation, built from the gpu backend primitives + the backend GLSL.
+//! Relocated from gl_init.initInstancedBuffers (A3). The vertex-attribute
+//! layout matches the CellBg/CellFg memory layout exactly.
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const Renderer = @import("Renderer.zig");
+const gpu = AppWindow.gpu;
+const c = gpu.c;
+
+const Pipeline = gpu.Pipeline;
+const Buffer = gpu.Buffer;
+
+pub threadlocal var bg: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var fg: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var color_fg: Pipeline = .{ .program = 0, .vao = 0 };
+
+pub threadlocal var bg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var fg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var color_fg_instances: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
+
+/// Build the cell pipelines. Call once after the GL context is current.
+/// On shader link failure a pipeline's `program` is 0 (draws are guarded on
+/// `program != 0`); its VAO is still owned and released by `deinit()`.
+pub fn init() void {
+    const gl = gpu.glTable();
+    const shaders = gpu.shaders;
+
+    // Shared unit quad (triangle strip: 4 verts)
+    const quad_verts = [4][2]f32{
+        .{ 0.0, 0.0 },
+        .{ 1.0, 0.0 },
+        .{ 0.0, 1.0 },
+        .{ 1.0, 1.0 },
+    };
+    quad = Buffer.init(c.GL_ARRAY_BUFFER);
+    quad.uploadData(std.mem.sliceAsBytes(quad_verts[0..]), c.GL_STATIC_DRAW);
+
+    // --- BG VAO ---
+    var bg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &bg_vao);
+    bg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(bg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    bg_instances.allocate(@sizeOf(Renderer.CellBg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    const bg_stride: c.GLsizei = @sizeOf(Renderer.CellBg);
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 3, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 1, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(5 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.BindVertexArray.?(0);
+
+    // --- FG VAO ---
+    var fg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &fg_vao);
+    fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(fg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    const fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg);
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.EnableVertexAttribArray.?(4);
+    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(4, 1);
+    gl.BindVertexArray.?(0);
+
+    // --- Color FG VAO (same layout as FG) ---
+    var color_fg_vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &color_fg_vao);
+    color_fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
+    gl.BindVertexArray.?(color_fg_vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
+    color_fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
+    const color_fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg); // same CellFg layout as fg
+    gl.EnableVertexAttribArray.?(1);
+    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(0));
+    gl.VertexAttribDivisor.?(1, 1);
+    gl.EnableVertexAttribArray.?(2);
+    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(2, 1);
+    gl.EnableVertexAttribArray.?(3);
+    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(3, 1);
+    gl.EnableVertexAttribArray.?(4);
+    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
+    gl.VertexAttribDivisor.?(4, 1);
+    gl.BindVertexArray.?(0);
+
+    bg = Pipeline.init(shaders.bg_vertex_source, shaders.bg_fragment_source, bg_vao);
+    fg = Pipeline.init(shaders.fg_vertex_source, shaders.fg_fragment_source, fg_vao);
+    color_fg = Pipeline.init(shaders.fg_vertex_source, shaders.color_fg_fragment_source, color_fg_vao);
+    if (bg.program == 0) std.debug.print("BG instanced shader failed\n", .{});
+    if (fg.program == 0) std.debug.print("FG instanced shader failed\n", .{});
+    if (color_fg.program == 0) std.debug.print("Color FG instanced shader failed\n", .{});
+}
+
+pub fn deinit() void {
+    bg.deinit();
+    fg.deinit();
+    color_fg.deinit();
+    bg_instances.deinit();
+    fg_instances.deinit();
+    color_fg_instances.deinit();
+    quad.deinit();
+}

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -333,7 +333,7 @@ pub fn rebuildCells(rend: *Renderer) void {
                         if (ch.is_color) {
                             // Color emoji — route to separate color cell buffer.
                             // Scale the emoji bitmap to fit within grid_width cells, preserving aspect ratio.
-                            const rect = cell_geometry.colorEmojiRect(@intCast(ch.size_x), @intCast(ch.size_y), grid_width, font.cell_width, font.cell_height);
+                            const rect = cell_geometry.colorEmojiRect(ch.size_x, ch.size_y, grid_width, font.cell_width, font.cell_height);
                             const gx = rect.gx;
                             const gy = rect.gy;
                             const gw = rect.gw;
@@ -360,7 +360,7 @@ pub fn rebuildCells(rend: *Renderer) void {
                         } else {
                             // Grayscale text glyph
                             const uv_val = font.glyphUV(ch.region, atlas_size);
-                            const rect = cell_geometry.grayscaleGlyphRect(ch.bearing_x, ch.bearing_y, @intCast(ch.size_x), @intCast(ch.size_y), font.cell_baseline);
+                            const rect = cell_geometry.grayscaleGlyphRect(ch.bearing_x, ch.bearing_y, ch.size_x, ch.size_y, font.cell_baseline);
                             const gx = rect.gx;
                             const gy = rect.gy;
                             const gw = rect.gw;

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -12,7 +12,9 @@ const Renderer = @import("Renderer.zig");
 const AppWindow = @import("../AppWindow.zig");
 const font = AppWindow.font;
 const tab = AppWindow.tab;
-const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const gl_init = gpu.gl_init;
+const cell_pipeline = @import("cell_pipeline.zig");
 const image_renderer = @import("image_renderer.zig");
 const cell_geometry = @import("cell_geometry.zig");
 
@@ -400,64 +402,54 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
     image_renderer.draw(rend, window_height, offset_x, offset_y, .below_bg);
 
     // --- Draw BG cells ---
-    if (rend.bg_cell_count > 0 and gl_init.bg_shader != 0) {
-        gl.UseProgram.?(gl_init.bg_shader);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "cellSize"), font.cell_width, font.cell_height);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "gridOffset"), offset_x, offset_y);
-        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.bg_shader, "windowHeight"), window_height);
-        gl_init.setProjectionForProgram(gl_init.bg_shader, window_height);
-
-        gl.BindVertexArray.?(gl_init.bg_vao);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.bg_instance_vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @intCast(@sizeOf(Renderer.CellBg) * rend.bg_cell_count), rend.bg_cells.items.ptr);
-        gl.DrawArraysInstanced.?(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.bg_cell_count));
+    if (rend.bg_cell_count > 0 and cell_pipeline.bg.program != 0) {
+        const p = cell_pipeline.bg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection();
+        p.bindVao();
+        cell_pipeline.bg_instances.upload(std.mem.sliceAsBytes(rend.bg_cells.items[0..rend.bg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.bg_cell_count));
         gl_init.g_draw_call_count += 1;
     }
 
     image_renderer.draw(rend, window_height, offset_x, offset_y, .below_text);
 
     // --- Draw FG cells ---
-    if (rend.fg_cell_count > 0 and gl_init.fg_shader != 0) {
-        gl.UseProgram.?(gl_init.fg_shader);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.fg_shader, "cellSize"), font.cell_width, font.cell_height);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.fg_shader, "gridOffset"), offset_x, offset_y);
-        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.fg_shader, "windowHeight"), window_height);
-        gl_init.setProjectionForProgram(gl_init.fg_shader, window_height);
-
-        gl.ActiveTexture.?(c.GL_TEXTURE0);
-        gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_atlas_texture);
-        gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.fg_shader, "atlas"), 0);
-
-        gl.BindVertexArray.?(gl_init.fg_vao);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.fg_instance_vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @intCast(@sizeOf(Renderer.CellFg) * rend.fg_cell_count), rend.fg_cells.items.ptr);
-        gl.DrawArraysInstanced.?(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.fg_cell_count));
+    if (rend.fg_cell_count > 0 and cell_pipeline.fg.program != 0) {
+        const p = cell_pipeline.fg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection();
+        gpu.Texture.fromHandle(font.g_atlas_texture).bind(0);
+        p.setInt("atlas", 0);
+        p.bindVao();
+        cell_pipeline.fg_instances.upload(std.mem.sliceAsBytes(rend.fg_cells.items[0..rend.fg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.fg_cell_count));
         gl_init.g_draw_call_count += 1;
     }
 
-    // --- Draw color emoji cells ---
-    // Color emoji use premultiplied alpha, so we switch blend mode to (ONE, ONE_MINUS_SRC_ALPHA)
-    // for this pass, then restore the normal blend mode afterwards.
-    if (rend.color_fg_cell_count > 0 and gl_init.color_fg_shader != 0) {
+    // --- Draw color emoji cells (premultiplied alpha blend) ---
+    if (rend.color_fg_cell_count > 0 and cell_pipeline.color_fg.program != 0) {
+        // Color emoji bitmaps are premultiplied-alpha, so use (ONE, 1-SRC_ALPHA).
         gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
-
-        gl.UseProgram.?(gl_init.color_fg_shader);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.color_fg_shader, "cellSize"), font.cell_width, font.cell_height);
-        gl.Uniform2f.?(gl.GetUniformLocation.?(gl_init.color_fg_shader, "gridOffset"), offset_x, offset_y);
-        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.color_fg_shader, "windowHeight"), window_height);
-        gl_init.setProjectionForProgram(gl_init.color_fg_shader, window_height);
-
-        gl.ActiveTexture.?(c.GL_TEXTURE0);
-        gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_color_atlas_texture);
-        gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.color_fg_shader, "atlas"), 0);
-
-        gl.BindVertexArray.?(gl_init.color_fg_vao);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.color_fg_instance_vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @intCast(@sizeOf(Renderer.CellFg) * rend.color_fg_cell_count), rend.color_fg_cells.items.ptr);
-        gl.DrawArraysInstanced.?(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.color_fg_cell_count));
+        const p = cell_pipeline.color_fg;
+        p.use();
+        p.setVec2("cellSize", font.cell_width, font.cell_height);
+        p.setVec2("gridOffset", offset_x, offset_y);
+        p.setFloat("windowHeight", window_height);
+        p.setProjection();
+        gpu.Texture.fromHandle(font.g_color_atlas_texture).bind(0);
+        p.setInt("atlas", 0);
+        p.bindVao();
+        cell_pipeline.color_fg_instances.upload(std.mem.sliceAsBytes(rend.color_fg_cells.items[0..rend.color_fg_cell_count]));
+        p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.color_fg_cell_count));
         gl_init.g_draw_call_count += 1;
-
-        // Restore normal blend mode for subsequent draws (cursor, titlebar, etc.)
+        // Restore standard blend for the cursor/titlebar draws that follow.
         gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
     }
 

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -14,6 +14,7 @@ const font = AppWindow.font;
 const tab = AppWindow.tab;
 const gl_init = AppWindow.gpu.gl_init;
 const image_renderer = @import("image_renderer.zig");
+const cell_geometry = @import("cell_geometry.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -254,36 +255,32 @@ pub fn rebuildCells(rend: *Renderer) void {
             const is_selected = isCellSelected(rend, col_idx, row_idx);
             const col_f: f32 = @floatFromInt(col_idx);
 
-            var fg_color = sc.fg;
-
-            if (is_cursor and rend.cached_cursor_visible) {
-                // Block cursor: invert fg for text under cursor (bg drawn by overlay)
-                if (rend.cached_cursor_effective) |effective_style| {
-                    if (effective_style == .block) {
-                        fg_color = g_theme.cursor_text orelse g_theme.background;
-                    }
-                }
-                // Draw cell background normally (cursor shape drawn by overlay)
-                if (sc.bg) |bg| {
-                    if (rend.bg_cell_count < rend.bg_cells.items.len) {
-                        rend.bg_cells.items[rend.bg_cell_count] = .{ .grid_col = col_f, .grid_row = row_f, .r = bg[0], .g = bg[1], .b = bg[2], .a = normal_bg_alpha };
-                        rend.bg_cell_count += 1;
-                    }
-                }
-            } else if (is_selected) {
+            const cursor_is_block = if (rend.cached_cursor_effective) |s| s == .block else false;
+            const decision = cell_geometry.backgroundFor(
+                sc.bg,
+                is_cursor,
+                rend.cached_cursor_visible,
+                cursor_is_block,
+                is_selected,
+                .{
+                    .background = g_theme.background,
+                    .cursor_text = g_theme.cursor_text,
+                    .selection_background = g_theme.selection_background,
+                    .selection_foreground = g_theme.selection_foreground,
+                    .foreground = g_theme.foreground,
+                },
+                col_f,
+                row_f,
+                normal_bg_alpha,
+                sc.fg,
+            );
+            if (decision.bg) |bg_inst| {
                 if (rend.bg_cell_count < rend.bg_cells.items.len) {
-                    // Match Ghostty: selected cells stay fully opaque even when
-                    // regular cell backgrounds reveal a wallpaper underneath.
-                    rend.bg_cells.items[rend.bg_cell_count] = .{ .grid_col = col_f, .grid_row = row_f, .r = g_theme.selection_background[0], .g = g_theme.selection_background[1], .b = g_theme.selection_background[2], .a = 1.0 };
-                    rend.bg_cell_count += 1;
-                }
-                fg_color = g_theme.selection_foreground orelse g_theme.foreground;
-            } else if (sc.bg) |bg| {
-                if (rend.bg_cell_count < rend.bg_cells.items.len) {
-                    rend.bg_cells.items[rend.bg_cell_count] = .{ .grid_col = col_f, .grid_row = row_f, .r = bg[0], .g = bg[1], .b = bg[2], .a = normal_bg_alpha };
+                    rend.bg_cells.items[rend.bg_cell_count] = bg_inst;
                     rend.bg_cell_count += 1;
                 }
             }
+            const fg_color = decision.fg;
 
             // Skip spacer cells — the wide character's head cell handles rendering
             // across both cells (like Ghostty).
@@ -336,15 +333,11 @@ pub fn rebuildCells(rend: *Renderer) void {
                         if (ch.is_color) {
                             // Color emoji — route to separate color cell buffer.
                             // Scale the emoji bitmap to fit within grid_width cells, preserving aspect ratio.
-                            const emoji_w = @as(f32, @floatFromInt(ch.size_x));
-                            const emoji_h = @as(f32, @floatFromInt(ch.size_y));
-                            const target_w = font.cell_width * grid_width;
-                            const scale = @min(target_w / emoji_w, font.cell_height / emoji_h);
-                            const gw = emoji_w * scale;
-                            const gh = emoji_h * scale;
-                            // Center within the grid_width cells
-                            const gx = (target_w - gw) / 2.0;
-                            const gy = (font.cell_height - gh) / 2.0;
+                            const rect = cell_geometry.colorEmojiRect(@intCast(ch.size_x), @intCast(ch.size_y), grid_width, font.cell_width, font.cell_height);
+                            const gx = rect.gx;
+                            const gy = rect.gy;
+                            const gw = rect.gw;
+                            const gh = rect.gh;
                             const uv_val = font.glyphUV(ch.region, color_atlas_size);
                             if (rend.color_fg_cell_count < rend.color_fg_cells.items.len) {
                                 rend.color_fg_cells.items[rend.color_fg_cell_count] = .{
@@ -367,10 +360,11 @@ pub fn rebuildCells(rend: *Renderer) void {
                         } else {
                             // Grayscale text glyph
                             const uv_val = font.glyphUV(ch.region, atlas_size);
-                            const gx = @as(f32, @floatFromInt(ch.bearing_x));
-                            const gy = font.cell_baseline - @as(f32, @floatFromInt(@as(i32, @intCast(ch.size_y)) - ch.bearing_y));
-                            const gw = @as(f32, @floatFromInt(ch.size_x));
-                            const gh = @as(f32, @floatFromInt(ch.size_y));
+                            const rect = cell_geometry.grayscaleGlyphRect(ch.bearing_x, ch.bearing_y, @intCast(ch.size_x), @intCast(ch.size_y), font.cell_baseline);
+                            const gx = rect.gx;
+                            const gy = rect.gy;
+                            const gw = rect.gw;
+                            const gh = rect.gh;
                             if (rend.fg_cell_count < rend.fg_cells.items.len) {
                                 rend.fg_cells.items[rend.fg_cell_count] = .{
                                     .grid_col = col_f,

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -17,6 +17,7 @@ const impl = switch (active) {
 pub const Context = impl.Context; // context lifecycle (owns the GL table)
 pub const c = impl.c; // GL constants/types (transition: removed from app code by A6)
 pub const gl_init = impl.gl_init; // GL helpers + buffers (GLSL in shaders.zig)
+pub const shaders = impl.shaders; // backend GLSL sources (for cell pipelines)
 
 /// Pointer to the active backend's GL function table. Transition handle used by
 /// renderer files until they route through the primitives (A3); removed in A6.

--- a/src/renderer/gpu/opengl/Buffer.zig
+++ b/src/renderer/gpu/opengl/Buffer.zig
@@ -1,0 +1,37 @@
+//! A GPU buffer (OpenGL VBO). Backend primitive for the GraphicsAPI spine.
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Buffer = @This();
+
+handle: c.GLuint = 0,
+target: c.GLenum,
+
+pub fn init(target: c.GLenum) Buffer {
+    var b = Buffer{ .target = target };
+    Context.gl.GenBuffers.?(1, &b.handle);
+    return b;
+}
+pub fn bind(self: Buffer) void {
+    Context.gl.BindBuffer.?(self.target, self.handle);
+}
+/// Allocate `size` bytes of uninitialized storage with the given usage hint.
+pub fn allocate(self: Buffer, size: usize, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(size), null, usage);
+}
+/// Allocate + fill with `bytes`.
+pub fn uploadData(self: Buffer, bytes: []const u8, usage: c.GLenum) void {
+    self.bind();
+    Context.gl.BufferData.?(self.target, @intCast(bytes.len), bytes.ptr, usage);
+}
+/// Overwrite from offset 0 (glBufferSubData).
+pub fn upload(self: Buffer, bytes: []const u8) void {
+    self.bind();
+    Context.gl.BufferSubData.?(self.target, 0, @intCast(bytes.len), bytes.ptr);
+}
+pub fn deinit(self: *Buffer) void {
+    if (self.handle != 0) {
+        Context.gl.DeleteBuffers.?(1, &self.handle);
+        self.handle = 0;
+    }
+}

--- a/src/renderer/gpu/opengl/Pipeline.zig
+++ b/src/renderer/gpu/opengl/Pipeline.zig
@@ -1,0 +1,114 @@
+//! A render pipeline (OpenGL program + VAO). The vertex-attribute layout is
+//! built by the caller (it is shader-specific) and the VAO handle handed in.
+const std = @import("std");
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Pipeline = @This();
+
+program: c.GLuint,
+vao: c.GLuint,
+
+/// Compile a shader stage. Returns null on failure (logs to stderr).
+pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
+    const gl = Context.gl;
+    const shader = gl.CreateShader.?(shader_type);
+    if (shader == 0) {
+        const gl_err = if (gl.GetError) |getErr| getErr() else 0;
+        std.debug.print("Shader error: glCreateShader returned 0, type=0x{X}, glError=0x{X}\n", .{ shader_type, gl_err });
+        return null;
+    }
+    gl.ShaderSource.?(shader, 1, &source, null);
+    gl.CompileShader.?(shader);
+    var success: c.GLint = 0;
+    gl.GetShaderiv.?(shader, c.GL_COMPILE_STATUS, &success);
+    if (success == 0) {
+        var info_log: [512]u8 = @splat(0);
+        var log_len: c.GLsizei = 0;
+        gl.GetShaderInfoLog.?(shader, 512, &log_len, &info_log);
+        const len: usize = if (log_len > 0) @intCast(log_len) else 0;
+        if (len > 0) {
+            std.debug.print("Shader compilation failed: {s}\n", .{info_log[0..len]});
+        } else {
+            std.debug.print("Shader compilation failed (no error log, shader={})\n", .{shader});
+        }
+        gl.DeleteShader.?(shader);
+        return null;
+    }
+    return shader;
+}
+
+/// Compile + link a program from vertex/fragment sources. Returns 0 on failure.
+fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
+    const gl = Context.gl;
+    const vs = compileShader(c.GL_VERTEX_SHADER, vs_src) orelse return 0;
+    defer gl.DeleteShader.?(vs);
+    const fs = compileShader(c.GL_FRAGMENT_SHADER, fs_src) orelse return 0;
+    defer gl.DeleteShader.?(fs);
+    const prog = gl.CreateProgram.?();
+    gl.AttachShader.?(prog, vs);
+    gl.AttachShader.?(prog, fs);
+    gl.LinkProgram.?(prog);
+    var success: c.GLint = 0;
+    gl.GetProgramiv.?(prog, c.GL_LINK_STATUS, &success);
+    if (success == 0) {
+        var info_log: [512]u8 = @splat(0);
+        var log_len: c.GLsizei = 0;
+        gl.GetProgramInfoLog.?(prog, 512, &log_len, &info_log);
+        const len: usize = if (log_len > 0) @intCast(log_len) else 0;
+        if (len > 0) std.debug.print("Shader link failed: {s}\n", .{info_log[0..len]});
+        gl.DeleteProgram.?(prog);
+        return 0;
+    }
+    return prog;
+}
+
+/// Build a pipeline: link the program and pair it with a caller-built VAO (the
+/// vertex-attribute layout is shader-specific, so the caller owns it). On link
+/// failure `program` is 0; callers guard draws on `program != 0`.
+pub fn init(vs_src: [*c]const u8, fs_src: [*c]const u8, vao: c.GLuint) Pipeline {
+    return .{ .program = linkProgram(vs_src, fs_src), .vao = vao };
+}
+
+pub fn use(self: Pipeline) void {
+    Context.gl.UseProgram.?(self.program);
+}
+pub fn bindVao(self: Pipeline) void {
+    Context.gl.BindVertexArray.?(self.vao);
+}
+pub fn setVec2(self: Pipeline, name: [*c]const u8, x: f32, y: f32) void {
+    Context.gl.Uniform2f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y);
+}
+pub fn setFloat(self: Pipeline, name: [*c]const u8, v: f32) void {
+    Context.gl.Uniform1f.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+pub fn setInt(self: Pipeline, name: [*c]const u8, v: i32) void {
+    Context.gl.Uniform1i.?(Context.gl.GetUniformLocation.?(self.program, name), v);
+}
+/// Set the orthographic projection uniform from the current GL viewport
+/// (matches the previous gl_init.setProjectionForProgram behavior).
+pub fn setProjection(self: Pipeline) void {
+    const gl = Context.gl;
+    var viewport: [4]c.GLint = undefined;
+    gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
+    const width: f32 = @floatFromInt(viewport[2]);
+    const height: f32 = @floatFromInt(viewport[3]);
+    const projection = [16]f32{
+        2.0 / width, 0.0,          0.0,  0.0,
+        0.0,         2.0 / height, 0.0,  0.0,
+        0.0,         0.0,          -1.0, 0.0,
+        -1.0,        -1.0,         0.0,  1.0,
+    };
+    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(self.program, "projection"), 1, c.GL_FALSE, &projection);
+}
+/// Issue an instanced draw against the currently-bound program/VAO. `self` is
+/// unused today (the bound state carries the pipeline); kept as a method for
+/// call-site ergonomics and so a future backend can attach per-pipeline state.
+pub fn drawArraysInstanced(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei, instances: c.GLsizei) void {
+    _ = self;
+    Context.gl.DrawArraysInstanced.?(mode, first, count, instances);
+}
+pub fn deinit(self: *Pipeline) void {
+    if (self.program != 0) Context.gl.DeleteProgram.?(self.program);
+    if (self.vao != 0) Context.gl.DeleteVertexArrays.?(1, &self.vao);
+    self.* = .{ .program = 0, .vao = 0 };
+}

--- a/src/renderer/gpu/opengl/Texture.zig
+++ b/src/renderer/gpu/opengl/Texture.zig
@@ -10,6 +10,7 @@ pub fn fromHandle(h: c.GLuint) Texture {
     return .{ .handle = h };
 }
 pub fn bind(self: Texture, unit: u32) void {
-    Context.gl.ActiveTexture.?(c.GL_TEXTURE0 + unit);
+    const texture_unit: c.GLenum = @as(c.GLenum, c.GL_TEXTURE0) + unit;
+    Context.gl.ActiveTexture.?(texture_unit);
     Context.gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
 }

--- a/src/renderer/gpu/opengl/Texture.zig
+++ b/src/renderer/gpu/opengl/Texture.zig
@@ -1,0 +1,15 @@
+//! A 2D GPU texture. This increment wraps an existing handle for binding only;
+//! ownership/upload of the font atlas is taken over in A4.
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Texture = @This();
+
+handle: c.GLuint,
+
+pub fn fromHandle(h: c.GLuint) Texture {
+    return .{ .handle = h };
+}
+pub fn bind(self: Texture, unit: u32) void {
+    Context.gl.ActiveTexture.?(c.GL_TEXTURE0 + unit);
+    Context.gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
+}

--- a/src/renderer/gpu/opengl/api.zig
+++ b/src/renderer/gpu/opengl/api.zig
@@ -10,8 +10,7 @@ pub const GlTable = c_mod.c.GladGLContext;   // the table type
 /// gl_init helpers live in the same directory as api.zig.
 pub const gl_init = @import("gl_init.zig");
 
-// Reserved Ghostty-shaped primitive slots. Declared now so gpu.zig's public
-// surface is stable; bodies are filled when the renderers are rewritten.
-pub const Texture = struct {}; // reserved: A4 (font atlas → GPU texture)
-pub const Buffer = struct {}; // reserved: A3
-pub const Pipeline = struct {}; // reserved: A3
+pub const Buffer = @import("Buffer.zig");
+pub const Texture = @import("Texture.zig");
+pub const Pipeline = @import("Pipeline.zig");
+pub const shaders = @import("shaders.zig");

--- a/src/renderer/gpu/opengl/gl_init.zig
+++ b/src/renderer/gpu/opengl/gl_init.zig
@@ -1,11 +1,11 @@
 //! OpenGL initialization and shared rendering primitives.
 //!
-//! Shader sources, compilation, buffer setup (VAO/VBO), instanced rendering
-//! buffers, and shared drawing helpers (renderQuad, setProjection).
+//! Shader compilation, the text-shader VAO/VBO, the shared simple-color/overlay
+//! pipelines, and shared drawing helpers (renderQuad, setProjection). The
+//! cell-grid instanced pipelines live in renderer/cell_pipeline.zig.
 
 const std = @import("std");
 const AppWindow = @import("../../../AppWindow.zig");
-const Renderer = @import("../../Renderer.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -20,18 +20,6 @@ const shaders = @import("shaders.zig");
 pub threadlocal var vao: c.GLuint = 0;
 pub threadlocal var vbo: c.GLuint = 0;
 pub threadlocal var shader_program: c.GLuint = 0;
-
-// GL objects for instanced rendering
-pub threadlocal var bg_shader: c.GLuint = 0;
-pub threadlocal var fg_shader: c.GLuint = 0;
-pub threadlocal var color_fg_shader: c.GLuint = 0; // Color emoji shader (BGRA sampling)
-pub threadlocal var bg_vao: c.GLuint = 0;
-pub threadlocal var fg_vao: c.GLuint = 0;
-pub threadlocal var color_fg_vao: c.GLuint = 0;
-pub threadlocal var bg_instance_vbo: c.GLuint = 0;
-pub threadlocal var fg_instance_vbo: c.GLuint = 0;
-pub threadlocal var color_fg_instance_vbo: c.GLuint = 0;
-threadlocal var quad_vbo: c.GLuint = 0; // shared unit quad for instanced draws
 
 pub threadlocal var simple_color_shader: c.GLuint = 0;
 pub threadlocal var overlay_shader: c.GLuint = 0;
@@ -138,6 +126,12 @@ pub fn initShaders() bool {
         return false;
     }
 
+    // Shared simple-color + overlay shaders (used by titlebar/overlays).
+    simple_color_shader = linkProgram(shaders.vertex_shader_source, shaders.simple_color_fragment_source);
+    if (simple_color_shader == 0) std.debug.print("Simple color shader failed\n", .{});
+    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
+    if (overlay_shader == 0) std.debug.print("Overlay shader failed\n", .{});
+
     return true;
 }
 
@@ -154,124 +148,6 @@ pub fn initBuffers() void {
     gl.BindVertexArray.?(0);
 }
 
-pub fn initInstancedBuffers() void {
-    const gl = AppWindow.gpu.glTable();
-
-    // Shared unit quad (triangle strip: 4 verts)
-    const quad_verts = [4][2]f32{
-        .{ 0.0, 0.0 }, // bottom-left
-        .{ 1.0, 0.0 }, // bottom-right
-        .{ 0.0, 1.0 }, // top-left
-        .{ 1.0, 1.0 }, // top-right
-    };
-    gl.GenBuffers.?(1, &quad_vbo);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, quad_vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(@TypeOf(quad_verts)), &quad_verts, c.GL_STATIC_DRAW);
-
-    // --- BG VAO ---
-    gl.GenVertexArrays.?(1, &bg_vao);
-    gl.GenBuffers.?(1, &bg_instance_vbo);
-    gl.BindVertexArray.?(bg_vao);
-
-    // Attr 0: unit quad (per-vertex)
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, quad_vbo);
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
-
-    // Attrs 1-3: per-instance BG data
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, bg_instance_vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(Renderer.CellBg) * Renderer.MAX_CELLS, null, c.GL_STREAM_DRAW);
-    const bg_stride: c.GLsizei = @sizeOf(Renderer.CellBg);
-    // Attr 1: grid_col, grid_row
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    // Attr 2: r, g, b
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 3, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    // Attr 3: alpha
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 1, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(5 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-
-    gl.BindVertexArray.?(0);
-
-    // --- FG VAO ---
-    gl.GenVertexArrays.?(1, &fg_vao);
-    gl.GenBuffers.?(1, &fg_instance_vbo);
-    gl.BindVertexArray.?(fg_vao);
-
-    // Attr 0: unit quad (per-vertex)
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, quad_vbo);
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
-
-    // Attrs 1-4: per-instance FG data
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, fg_instance_vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, null, c.GL_STREAM_DRAW);
-    const fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg);
-    // Attr 1: grid_col, grid_row
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    // Attr 2: glyph_x, glyph_y, glyph_w, glyph_h
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    // Attr 3: uv_left, uv_top, uv_right, uv_bottom
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-    // Attr 4: r, g, b
-    gl.EnableVertexAttribArray.?(4);
-    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(4, 1);
-
-    gl.BindVertexArray.?(0);
-
-    // --- Color FG VAO (same layout as FG, separate buffer for color emoji) ---
-    gl.GenVertexArrays.?(1, &color_fg_vao);
-    gl.GenBuffers.?(1, &color_fg_instance_vbo);
-    gl.BindVertexArray.?(color_fg_vao);
-
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, quad_vbo);
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
-
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, color_fg_instance_vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, null, c.GL_STREAM_DRAW);
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-    gl.EnableVertexAttribArray.?(4);
-    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(4, 1);
-
-    gl.BindVertexArray.?(0);
-
-    // --- Compile instanced shaders ---
-    bg_shader = linkProgram(shaders.bg_vertex_source, shaders.bg_fragment_source);
-    fg_shader = linkProgram(shaders.fg_vertex_source, shaders.fg_fragment_source);
-    color_fg_shader = linkProgram(shaders.fg_vertex_source, shaders.color_fg_fragment_source);
-    if (bg_shader == 0) std.debug.print("BG instanced shader failed\n", .{});
-    if (fg_shader == 0) std.debug.print("FG instanced shader failed\n", .{});
-    if (color_fg_shader == 0) std.debug.print("Color FG instanced shader failed\n", .{});
-
-    // Simple color shader for titlebar emoji (uses same vertex layout as text shader)
-    simple_color_shader = linkProgram(shaders.vertex_shader_source, shaders.simple_color_fragment_source);
-    if (simple_color_shader == 0) std.debug.print("Simple color shader failed\n", .{});
-
-    // Overlay shader for unfocused split dimming (solid color with alpha)
-    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
-    if (overlay_shader == 0) std.debug.print("Overlay shader failed\n", .{});
-}
 
 pub fn initSolidTexture() void {
     const gl = AppWindow.gpu.glTable();
@@ -281,24 +157,6 @@ pub fn initSolidTexture() void {
     gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RED, 1, 1, 0, c.GL_RED, c.GL_UNSIGNED_BYTE, &white_pixel);
     gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_NEAREST);
     gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_NEAREST);
-}
-
-// ============================================================================
-// Cleanup
-// ============================================================================
-
-pub fn deinitInstancedResources() void {
-    const gl = AppWindow.gpu.glTable();
-    if (bg_shader != 0) gl.DeleteProgram.?(bg_shader);
-    if (fg_shader != 0) gl.DeleteProgram.?(fg_shader);
-    if (color_fg_shader != 0) gl.DeleteProgram.?(color_fg_shader);
-    if (bg_vao != 0) gl.DeleteVertexArrays.?(1, &bg_vao);
-    if (fg_vao != 0) gl.DeleteVertexArrays.?(1, &fg_vao);
-    if (color_fg_vao != 0) gl.DeleteVertexArrays.?(1, &color_fg_vao);
-    if (bg_instance_vbo != 0) gl.DeleteBuffers.?(1, &bg_instance_vbo);
-    if (fg_instance_vbo != 0) gl.DeleteBuffers.?(1, &fg_instance_vbo);
-    if (color_fg_instance_vbo != 0) gl.DeleteBuffers.?(1, &color_fg_instance_vbo);
-    if (quad_vbo != 0) gl.DeleteBuffers.?(1, &quad_vbo);
 }
 
 // ============================================================================

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -32,4 +32,5 @@ test {
     _ = @import("preview_token.zig");
     _ = @import("agent_history.zig");
     _ = @import("renderer/gpu/backend.zig");
+    _ = @import("renderer/cell_geometry.zig");
 }


### PR DESCRIPTION
## Summary

First increment of Phase A3 (TODO.md): replace the reserved `Buffer`/`Texture`/`Pipeline` stubs with real OpenGL primitives and convert `cell_renderer.zig` — the terminal-grid renderer — as the proving ground for routing renderer files through the `gpu.zig` interface. Both decoupling axes in one pass (touch the file once).

- **Primitives** — `src/renderer/gpu/opengl/{Buffer,Texture,Pipeline}.zig` (thin GL wrappers; `Pipeline.init(vs,fs,vao)` links + pairs with a caller-built VAO). Re-exported via `gpu.zig`.
- **Presentation (Axis A)** — `drawCells`' bg/fg/color-emoji instanced passes now run through `cell_pipeline.zig` (cell pipelines built from the primitives), relocated out of the shared `gl_init`. The shared text/overlay pipelines stay in `gl_init`.
- **Logic (Axis B)** — the pure snap→instance decision (`backgroundFor`) + glyph-rect math + the instance types (`CellBg`/`CellFg`/`SnapCell`) moved to std-only, unit-tested `cell_geometry.zig` (9 fast-suite tests); `Renderer.zig` re-exports the types. The impure glyph lookup stays in `cell_renderer`.

Behavior-preserving: per-task spec reviews confirmed `drawCells` is GL-state-equivalent and the relocated VAO attrib setup is byte-for-byte identical; the color-emoji premultiplied-alpha blend bookend is preserved.

Spec + plan: `docs/superpowers/specs/2026-05-26-gpu-a3-cell-renderer-design.md`, `docs/superpowers/plans/2026-05-26-gpu-a3-cell-renderer.md`.

## Test Plan

- [x] `zig build` (x86_64-windows-gnu) — clean `phantty.exe`
- [x] `zig build test-full` — 506/508 (the +9 vs the prior 497 baseline are the new `cell_geometry` unit tests; the 1 failure is the pre-existing Windows-only `window_backend` test)
- [x] `zig build test` (fast) — `cell_geometry`'s 9 pure-logic tests pass
- [x] Manual Windows visual check — terminal grid, fg/bg colors, selection, all four cursor styles, color emoji, background-image alpha all render identically to `main`

## Not in this PR (deferred)

The other 9 renderer files (titlebar, overlays, ai_chat_renderer, image_renderer, post_process, background_image, fbo, markdown_preview_renderer, file_explorer_renderer); the shared `gl_init` pipelines; the `Frame`/`RenderPass`/`Target` layer; A4 (font atlas → `Texture` ownership), A5 (MSL), A6 (guards); the Metal backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)