### PR TITLE
GPU A3 (2/N): shared ui_pipeline + titlebar through the GPU interface

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,9 +110,19 @@ mapping in guide §2 and §5.
       `gpu/opengl/`; `cell_renderer` is converted — `drawCells` routes through
       `cell_pipeline.zig` (cell pipelines built from the primitives) and the pure
       BG/cursor/selection + glyph-rect logic + instance types moved to std-only,
-      unit-tested `cell_geometry.zig`. *Still pending:* the other 9 files, plus
-      the shared `shader_program`/`overlay_shader`/`simple_color_shader`
-      pipelines (still in `gl_init`).
+      unit-tested `cell_geometry.zig`.
+      *Increment 2 done:* the shared UI rendering (solid quad / text-glyph /
+      color-emoji) moved out of `gl_init` into primitives-backed
+      `ui_pipeline.zig`; `gl_init` keeps compat mirror handles (`shader_program`/
+      `simple_color_shader`/`vao`/`vbo`, set via `syncSharedHandles()`) +
+      re-exports `renderQuad`/`renderQuadAlpha`/`setProjection`, so the
+      still-unconverted files are untouched. `titlebar` is converted (glyph/emoji
+      through `ui_pipeline`, no raw `gl.*`/glad) and its pure layout logic moved
+      to std-only `titlebar_layout.zig`. `overlay_shader` stays in `gl_init`.
+      *Still pending:* `overlays`, `ai_chat_renderer`, `image_renderer`,
+      `post_process`, `background_image`, `fbo`, `markdown_preview_renderer`,
+      `file_explorer_renderer` (each converts to `ui_pipeline`, dissolving the
+      compat mirrors as they go).
 - [ ] **A4** Route font atlas → GPU texture through the `Texture` primitive;
       drop `font/manager.zig`'s direct `@cImport("glad/gl.h")`.
 - [ ] **A5** Backend-scope shaders: GLSL under `gpu/opengl/shaders.zig`; reserve

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -217,6 +217,15 @@ with **A**. **D** is deferred until a macOS SDK environment exists.
 > time. Remaining: the other 9 renderer files, the shared pipelines still in
 > `gl_init`, then A4–A6.
 
+> **Status (A3 increment 2 landed).** The shared UI rendering (solid quad /
+> text-glyph / color-emoji) moved out of `gl_init` into primitives-backed
+> `ui_pipeline.zig` (self-contained draw helpers). `gl_init` keeps compat mirror
+> handles + re-exports (`renderQuad` → `ui_pipeline.fillQuad`, etc.) so the
+> still-unconverted files are untouched — the **compat-shim** strategy.
+> `titlebar` is converted (glyph/emoji through `ui_pipeline`, zero raw `gl.*`)
+> and its pure layout logic extracted to std-only `titlebar_layout.zig`. The
+> mirror handles dissolve as each remaining UI file converts to `ui_pipeline`.
+
 - **A1** Define `src/renderer/gpu/gpu.zig` (the `GraphicsAPI` interface:
   `Target`, `Frame`, `RenderPass`, `Pipeline`, `Buffer`, `Texture`, `Sampler`,
   `shaders`) and `src/renderer/gpu/backend.zig` (`Backend{opengl,metal}`,

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-titlebar.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-titlebar.md
@@ -1,0 +1,609 @@
+# GPU A3 increment 2 (shared ui_pipeline + titlebar) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the shared immediate-mode UI rendering (solid quad / text-glyph / color-emoji) out of `gl_init` into a primitives-backed `ui_pipeline.zig`, and convert `titlebar.zig` onto it + extract its pure layout logic.
+
+**Architecture:** `ui_pipeline.zig` owns the text + emoji `gpu.Pipeline`s, the shared dynamic quad `gpu.Buffer`, and the 1×1 solid `gpu.Texture`, with **self-contained** draw helpers (each `use()`s its program + binds its VAO, so callers need no ambient GL state). `gl_init` keeps compat mirror vars (`shader_program`/`simple_color_shader`/`vao`/`vbo`, populated by `gl_init.syncSharedHandles()`) and re-exports `renderQuad`/`renderQuadAlpha`/`setProjection` to `ui_pipeline`, so the ~12 unconverted files are unchanged. titlebar's three raw-`gl.*` glyph/emoji functions route through the helpers; its pure logic moves to std-only `titlebar_layout.zig`.
+
+**Tech Stack:** Zig 0.15.2, glad/OpenGL, FreeType. Target `x86_64-windows-gnu`. Tests: `zig build test` (fast), `zig build test-full` (pre-merge; currently fully green).
+
+**Spec:** [docs/superpowers/specs/2026-05-26-gpu-a3-titlebar-design.md](../specs/2026-05-26-gpu-a3-titlebar-design.md)
+
+---
+
+## Conventions
+
+- `ui_pipeline.zig` imports `AppWindow` only (for `gpu`, `g_theme`, and the draw-call counter via `AppWindow.gpu.gl_init.g_draw_call_count`). It does NOT import `gl_init` directly (avoids a new direct cycle). `gl_init` imports `ui_pipeline` (re-exports + sync).
+- Helpers are **self-contained**: each `use()`s its pipeline and binds its VAO. This is a deliberate, behavior-equivalent refinement of the old ambient-state contract; it lets titlebar drop its frame-setup `UseProgram`/`BindVertexArray` lines.
+- Behavior-preserving: vertex order, uniform names (`projection`, `textColor`, `opacity`), texture targets, and the color-emoji premultiplied-blend bookend are reproduced exactly.
+
+---
+
+## Task 1: `ui_pipeline.zig` (primitives-backed shared UI rendering)
+
+**Files:**
+- Create: `src/renderer/ui_pipeline.zig`
+
+Additive: created but not yet wired in (Task 2 wires it and guts `gl_init`). `gl_init` still owns the live shared objects this task, so `ui_pipeline.init()` is unreferenced. Verified by a clean `zig build`.
+
+- [ ] **Step 1: Create `src/renderer/ui_pipeline.zig`**
+
+```zig
+//! Shared UI render pipelines (solid quad / text-glyph / color-emoji), built
+//! from the gpu backend primitives. Relocated out of gl_init (A3). gl_init keeps
+//! compat mirror handles (set via gl_init.syncSharedHandles) + re-exports, so
+//! the not-yet-converted renderer files are unchanged.
+//!
+//! Draw helpers are self-contained: each use()s its pipeline and binds its VAO,
+//! so callers need no ambient GL program/VAO state.
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const gpu = AppWindow.gpu;
+const c = gpu.c;
+const shaders = gpu.shaders;
+
+const Pipeline = gpu.Pipeline;
+const Buffer = gpu.Buffer;
+const Texture = gpu.Texture;
+
+pub const Rect = struct { x: f32, y: f32, w: f32, h: f32 };
+pub const Uv = struct { u0: f32, v0: f32, u1: f32, v1: f32 };
+
+pub threadlocal var text: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var emoji: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var solid: Texture = .{ .handle = 0 };
+
+fn drawCallTick() void {
+    AppWindow.gpu.gl_init.g_draw_call_count += 1;
+}
+
+/// Build a VAO with the shared text/emoji vertex layout (one vec4 attrib:
+/// xy = position, zw = texcoord), pointing at the shared quad buffer.
+fn buildQuadVao() c.GLuint {
+    const gl = gpu.glTable();
+    var vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &vao);
+    gl.BindVertexArray.?(vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 4, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
+    gl.BindVertexArray.?(0);
+    return vao;
+}
+
+/// Build the shared pipelines, quad buffer, and solid texture. Call once after
+/// the GL context is current (before any UI draw).
+pub fn init() void {
+    const gl = gpu.glTable();
+
+    quad = Buffer.init(c.GL_ARRAY_BUFFER);
+    quad.allocate(@sizeOf(f32) * 6 * 4, c.GL_DYNAMIC_DRAW);
+
+    // Each pipeline owns its own VAO (identical layout) for clean deinit.
+    const text_vao = buildQuadVao();
+    const emoji_vao = buildQuadVao();
+    text = Pipeline.init(shaders.vertex_shader_source, shaders.fragment_shader_source, text_vao);
+    emoji = Pipeline.init(shaders.vertex_shader_source, shaders.simple_color_fragment_source, emoji_vao);
+    if (text.program == 0) std.debug.print("UI text pipeline failed\n", .{});
+    if (emoji.program == 0) std.debug.print("UI emoji pipeline failed\n", .{});
+
+    var solid_handle: c.GLuint = 0;
+    gl.GenTextures.?(1, &solid_handle);
+    gl.BindTexture.?(c.GL_TEXTURE_2D, solid_handle);
+    const white_pixel = [_]u8{255};
+    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RED, 1, 1, 0, c.GL_RED, c.GL_UNSIGNED_BYTE, &white_pixel);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_NEAREST);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_NEAREST);
+    solid = Texture.fromHandle(solid_handle);
+}
+
+pub fn deinit() void {
+    text.deinit();
+    emoji.deinit();
+    quad.deinit();
+    if (solid.handle != 0) {
+        gpu.glTable().DeleteTextures.?(1, &solid.handle);
+        solid.handle = 0;
+    }
+}
+
+fn quadVertices(rect: Rect, uv: Uv) [6][4]f32 {
+    return .{
+        .{ rect.x, rect.y + rect.h, uv.u0, uv.v0 },
+        .{ rect.x, rect.y, uv.u0, uv.v1 },
+        .{ rect.x + rect.w, rect.y, uv.u1, uv.v1 },
+        .{ rect.x, rect.y + rect.h, uv.u0, uv.v0 },
+        .{ rect.x + rect.w, rect.y, uv.u1, uv.v1 },
+        .{ rect.x + rect.w, rect.y + rect.h, uv.u1, uv.v0 },
+    };
+}
+
+/// Set the text pipeline's ortho projection (frame-level; = old gl_init.setProjection).
+pub fn setProjection(width: f32, height: f32) void {
+    const gl = gpu.glTable();
+    const projection = [16]f32{
+        2.0 / width, 0.0,          0.0,  0.0,
+        0.0,         2.0 / height, 0.0,  0.0,
+        0.0,         0.0,          -1.0, 0.0,
+        -1.0,        -1.0,         0.0,  1.0,
+    };
+    gl.UseProgram.?(text.program);
+    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(text.program, "projection"), 1, c.GL_FALSE, &projection);
+}
+
+pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    fillQuadAlpha(x, y, w, h, color, 1.0);
+}
+
+/// Solid color quad (= old gl_init.renderQuadAlpha). Preserves the alpha trick:
+/// blends `color` toward g_theme.background by `alpha` and draws opaque via the
+/// solid texture.
+pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+    const gl = gpu.glTable();
+    const bg = AppWindow.g_theme.background;
+    const r = color[0] * alpha + bg[0] * (1 - alpha);
+    const g = color[1] * alpha + bg[1] * (1 - alpha);
+    const b = color[2] * alpha + bg[2] * (1 - alpha);
+    const verts = quadVertices(.{ .x = x, .y = y, .w = w, .h = h }, .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1 });
+    text.use();
+    text.bindVao();
+    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), r, g, b);
+    solid.bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+}
+
+/// Grayscale/text glyph via the text pipeline (atlas .r as alpha, modulated by color).
+pub fn drawGlyph(rect: Rect, uv: Uv, tex: c.GLuint, color: [3]f32) void {
+    const gl = gpu.glTable();
+    const verts = quadVertices(rect, uv);
+    text.use();
+    text.bindVao();
+    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), color[0], color[1], color[2]);
+    Texture.fromHandle(tex).bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+}
+
+/// Color-emoji via the emoji pipeline: premultiplied-alpha blend bookend +
+/// per-call projection from the current viewport (= old renderBellEmoji /
+/// renderTitlebarChar color branch).
+pub fn drawColorGlyph(rect: Rect, uv: Uv, tex: c.GLuint, opacity: f32) void {
+    const gl = gpu.glTable();
+    var viewport: [4]c.GLint = undefined;
+    gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
+    const vp_w: f32 = @floatFromInt(viewport[2]);
+    const vp_h: f32 = @floatFromInt(viewport[3]);
+    const projection = [16]f32{
+        2.0 / vp_w, 0.0,        0.0,  0.0,
+        0.0,        2.0 / vp_h, 0.0,  0.0,
+        0.0,        0.0,        -1.0, 0.0,
+        -1.0,       -1.0,       0.0,  1.0,
+    };
+    const verts = quadVertices(rect, uv);
+    emoji.use();
+    emoji.bindVao();
+    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(emoji.program, "projection"), 1, c.GL_FALSE, &projection);
+    gl.Uniform1f.?(gl.GetUniformLocation.?(emoji.program, "opacity"), opacity);
+    gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
+    Texture.fromHandle(tex).bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `zig build`
+Expected: success. `ui_pipeline` compiles but is unreferenced.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/ui_pipeline.zig
+git commit -m "feat(gpu): ui_pipeline shared UI render module from primitives (unwired) [A3]"
+```
+
+---
+
+## Task 2: Cutover — gut `gl_init` shared rendering, wire `ui_pipeline` in AppWindow
+
+**Files:**
+- Modify: `src/renderer/gpu/opengl/gl_init.zig`, `src/AppWindow.zig`
+
+Atomic cutover: the shared GL objects now come from `ui_pipeline`; `gl_init` keeps compat mirror vars + re-exports so all ~12 unconverted files (and titlebar's 63 `renderQuad` calls) keep working unchanged.
+
+- [ ] **Step 1: Edit `gl_init.zig` — remove moved bodies, keep compat vars, add re-exports + sync**
+
+In `src/renderer/gpu/opengl/gl_init.zig`:
+
+a) Keep these `pub threadlocal var`s as **compat mirror handles** (add a doc comment): `shader_program`, `simple_color_shader`, `vao`, `vbo`. Keep `overlay_shader`, `g_draw_call_count`, `g_bg_opacity`, `compileShader`, `linkProgram`, `setProjectionForProgram`.
+
+b) Delete the `solid_texture` var and the bodies of `initBuffers`, `initSolidTexture`, `renderQuad`, `renderQuadAlpha`, `setProjection` (they move to `ui_pipeline`).
+
+c) In `initShaders`, delete the `shader_program` link block and the `simple_color_shader` link; keep **only** the `overlay_shader` link. The function still returns `bool`:
+
+```zig
+pub fn initShaders() bool {
+    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
+    if (overlay_shader == 0) {
+        std.debug.print("Overlay shader failed\n", .{});
+        return false;
+    }
+    return true;
+}
+```
+(`linkProgram` fetches the GL table itself, so `initShaders` needs no local `gl`.)
+
+d) Add the `ui_pipeline` import and the re-exports + sync near the top (after the existing imports):
+
+```zig
+const ui_pipeline = @import("../../ui_pipeline.zig");
+
+pub fn renderQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    ui_pipeline.fillQuad(x, y, w, h, color);
+}
+pub fn renderQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+    ui_pipeline.fillQuadAlpha(x, y, w, h, color, alpha);
+}
+pub fn setProjection(width: f32, height: f32) void {
+    ui_pipeline.setProjection(width, height);
+}
+/// Populate the compat mirror handles from the ui_pipeline-owned objects.
+/// Call right after ui_pipeline.init().
+pub fn syncSharedHandles() void {
+    shader_program = ui_pipeline.text.program;
+    simple_color_shader = ui_pipeline.emoji.program;
+    vao = ui_pipeline.text.vao;
+    vbo = ui_pipeline.quad.handle;
+}
+```
+(`gl_init` already imports `AppWindow`; keep that. The `gl_init`→`ui_pipeline` import is one-directional — `ui_pipeline` does not import `gl_init`.)
+
+- [ ] **Step 2: Wire `ui_pipeline` into `AppWindow.zig`**
+
+a) Add the module re-export near the other renderer re-exports:
+```zig
+pub const ui_pipeline = @import("renderer/ui_pipeline.zig");
+```
+
+b) Replace the init calls. Find `gpu.gl_init.initBuffers();` (≈line 3263) and `gpu.gl_init.initSolidTexture();` (≈line 3310). Remove the `initSolidTexture()` call and replace the `initBuffers()` line with:
+```zig
+    ui_pipeline.init();
+    gpu.gl_init.syncSharedHandles();
+```
+Keep `gpu.gl_init.initShaders()` (now overlay-only) and `cell_pipeline.init()` where they are. Resulting order: `initShaders()` → `ui_pipeline.init()` + `syncSharedHandles()` → `cell_pipeline.init()`.
+
+c) In teardown, add `ui_pipeline.deinit();` next to `cell_pipeline.deinit();` (≈line 3328).
+
+- [ ] **Step 3: Verify no stale references to moved symbols**
+
+```bash
+grep -rn "gl_init\.initBuffers\|gl_init\.initSolidTexture\|gl_init\.solid_texture" src/
+```
+Expected: no output. (`gl_init.renderQuad`/`renderQuadAlpha`/`setProjection` still resolve — now re-export wrappers.)
+
+- [ ] **Step 4: Build and test**
+
+Run: `zig build`
+Expected: success. If a comptime import-cycle error names `gl_init`/`ui_pipeline`, the cycle is the tolerated kind elsewhere in the tree; if it genuinely fails, break it by accessing the counter purely through `AppWindow.gpu.gl_init` (already the case) and confirming `ui_pipeline` has no top-level `gl_init` reference.
+
+Run: `zig build test-full`
+Expected: stays green (current fully-green baseline; the weixin `group_message` skip is the only skip). No new failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(gpu): move shared UI rendering to ui_pipeline; gl_init keeps compat shim [A3]"
+```
+
+---
+
+## Task 3: Convert titlebar's raw-GL glyph/emoji through `ui_pipeline` (Axis A)
+
+**Files:**
+- Modify: `src/renderer/titlebar.zig`
+
+Convert the three raw-`gl.*` functions to `ui_pipeline` helpers and drop titlebar's frame-setup `UseProgram`/`BindVertexArray` lines (the self-contained helpers make them unnecessary), so titlebar ends with no raw `gl.*` and no glad `@cImport`.
+
+- [ ] **Step 1: Add the `ui_pipeline` import**
+
+In `src/renderer/titlebar.zig`, near the imports:
+```zig
+const ui_pipeline = AppWindow.ui_pipeline;
+```
+
+- [ ] **Step 2: Convert `renderTitlebarChar` (≈lines 294-373)**
+
+Replace the whole function body's two branches with helper calls (keep the early returns + the glyph metric/UV computation; replace the GL emission):
+
+```zig
+pub fn renderTitlebarChar(codepoint: u32, x: f32, y: f32, color: [3]f32) void {
+    if (codepoint < 32) return;
+    const ch: Character = font.loadTitlebarGlyph(codepoint) orelse return;
+    if (ch.region.width == 0 or ch.region.height == 0) return;
+
+    if (ch.is_color) {
+        const scale = font.g_titlebar_cell_height / @as(f32, @floatFromInt(ch.size_y));
+        const w = @as(f32, @floatFromInt(ch.size_x)) * scale;
+        const h = @as(f32, @floatFromInt(ch.size_y)) * scale;
+        const atlas_size = if (font.g_color_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
+        const uv = font.glyphUV(ch.region, atlas_size);
+        ui_pipeline.drawColorGlyph(
+            .{ .x = x, .y = y, .w = w, .h = h },
+            .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+            font.g_color_atlas_texture,
+            1.0,
+        );
+    } else {
+        const x0 = x + @as(f32, @floatFromInt(ch.bearing_x));
+        const y0 = y + font.g_titlebar_baseline - @as(f32, @floatFromInt(ch.size_y - ch.bearing_y));
+        const w = @as(f32, @floatFromInt(ch.size_x));
+        const h = @as(f32, @floatFromInt(ch.size_y));
+        const atlas_size = if (font.g_titlebar_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
+        const uv = font.glyphUV(ch.region, atlas_size);
+        ui_pipeline.drawGlyph(
+            .{ .x = x0, .y = y0, .w = w, .h = h },
+            .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+            font.g_titlebar_atlas_texture,
+            color,
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Convert `renderBellEmoji` (≈lines 392-444)**
+
+Replace its GL emission with `drawColorGlyph` (keep the bell load/fallback + sizing):
+
+```zig
+pub fn renderBellEmoji(x: f32, y: f32, opacity: f32) void {
+    const bell = font.loadBellEmoji() orelse {
+        renderTitlebarChar(0x1F514, x, y, .{ 1.0, 0.84, 0.0 });
+        return;
+    };
+    const aspect = bell.bmp_w / bell.bmp_h;
+    const h = font.g_titlebar_cell_height * 0.85;
+    const w = h * aspect;
+    const atlas_size = if (font.g_color_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
+    const uv = font.glyphUV(bell.region, atlas_size);
+    ui_pipeline.drawColorGlyph(
+        .{ .x = x, .y = y, .w = w, .h = h },
+        .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+        font.g_color_atlas_texture,
+        opacity,
+    );
+}
+```
+
+- [ ] **Step 4: Convert `renderIconGlyph` (≈lines 447-475)**
+
+```zig
+pub fn renderIconGlyph(ch: Character, btn_x: f32, btn_y: f32, btn_w: f32, btn_h: f32, color: [3]f32, scale: f32) void {
+    if (ch.region.width == 0 or ch.region.height == 0) return;
+    const gw = @as(f32, @floatFromInt(ch.size_x)) * scale;
+    const gh = @as(f32, @floatFromInt(ch.size_y)) * scale;
+    const gx = btn_x + (btn_w - gw) / 2;
+    const gy = btn_y + (btn_h - gh) / 2;
+    const icon_atlas_size = if (font.g_icon_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
+    const uv = font.glyphUV(ch.region, icon_atlas_size);
+    ui_pipeline.drawGlyph(
+        .{ .x = gx, .y = gy, .w = gw, .h = gh },
+        .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+        font.g_icon_atlas_texture,
+        color,
+    );
+}
+```
+
+- [ ] **Step 5: Remove the frame-setup `UseProgram`/`BindVertexArray` lines + now-unused `gl`/`c`**
+
+In `renderTitlebar` (≈494/496), `renderSidebar` (≈1070/1072), `renderPlaceholderTab` (≈1326/1328): delete the two lines
+```zig
+    gl.UseProgram.?(gl_init.shader_program);
+    gl.BindVertexArray.?(gl_init.vao);
+```
+(the self-contained helpers and `gl_init.renderQuad` now bind their own program/VAO). Then in each of these three functions, and in the three converted functions above, remove the now-unused `const gl = AppWindow.gpu.glTable();` line. Finally remove the file's glad cImport block:
+```zig
+const c = @cImport({
+    @cInclude("glad/gl.h");
+});
+```
+if `grep -n "\bc\.\|\bgl\." src/renderer/titlebar.zig` shows no remaining raw `gl.`/`c.GL` uses. (Keep the `gl_init` import — `gl_init.renderQuad` and `gl_init.g_draw_call_count` may still be referenced.)
+
+- [ ] **Step 6: Verify titlebar has no raw GL left**
+
+```bash
+grep -nE "\bgl\.[A-Z]|@cInclude\(\"glad" src/renderer/titlebar.zig
+```
+Expected: no output.
+
+- [ ] **Step 7: Build and test**
+
+Run: `zig build`
+Expected: success (watch for an unused-`const gl`/`const c` error — remove whichever is unused).
+
+Run: `zig build test-full`
+Expected: green baseline, no new failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/renderer/titlebar.zig
+git commit -m "refactor(titlebar): route glyph/emoji draws through ui_pipeline; drop raw GL [A3]"
+```
+
+---
+
+## Task 4: Extract titlebar pure logic → `titlebar_layout.zig` (Axis B)
+
+**Files:**
+- Create: `src/renderer/titlebar_layout.zig`
+- Modify: `src/renderer/titlebar.zig`, `src/test_fast.zig`
+
+- [ ] **Step 1: Create `src/renderer/titlebar_layout.zig` (std-only) with tests**
+
+```zig
+//! Pure, std-only titlebar/sidebar geometry + measurement helpers extracted
+//! from titlebar.zig. No AppWindow/font/GL imports — runs in the fast suite.
+const std = @import("std");
+
+/// Is point (px, py) inside the rect [left, left+width) x [top, top+height)?
+pub fn pointInRect(px: f32, py: f32, left: f32, top: f32, width: f32, height: f32) bool {
+    return px >= left and px < left + width and py >= top and py < top + height;
+}
+
+/// Linear blend of two RGB colors; t clamped to [0,1].
+pub fn blend(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const clamped = @max(0.0, @min(1.0, t));
+    return .{
+        a[0] + (b[0] - a[0]) * clamped,
+        a[1] + (b[1] - a[1]) * clamped,
+        a[2] + (b[2] - a[2]) * clamped,
+    };
+}
+
+/// Max sidebar width for a window, given the bounds.
+pub fn sidebarMaxWidthForWindow(window_width: f32, min_width: f32, max_width: f32, min_content_width: f32) f32 {
+    return @max(min_width, @min(max_width, window_width - min_content_width));
+}
+
+/// Clamp a requested sidebar width to [min_width, max_for_window].
+pub fn clampSidebarWidth(width: f32, max_for_window: f32, min_width: f32) f32 {
+    return @max(min_width, @min(max_for_window, width));
+}
+
+/// Printable-ASCII passthrough, else '?'.
+pub fn fallbackCodepoint(byte: u8) u32 {
+    return if (byte >= 0x20 and byte <= 0x7e) byte else '?';
+}
+
+test "pointInRect inside / edges / outside" {
+    try std.testing.expect(pointInRect(5, 5, 0, 0, 10, 10));
+    try std.testing.expect(pointInRect(0, 0, 0, 0, 10, 10)); // top-left inclusive
+    try std.testing.expect(!pointInRect(10, 5, 0, 0, 10, 10)); // right exclusive
+    try std.testing.expect(!pointInRect(5, 10, 0, 0, 10, 10)); // bottom exclusive
+    try std.testing.expect(!pointInRect(-1, 5, 0, 0, 10, 10));
+}
+
+test "blend endpoints and midpoint" {
+    const a = [3]f32{ 0, 0, 0 };
+    const b = [3]f32{ 1, 1, 1 };
+    try std.testing.expectEqual([3]f32{ 0, 0, 0 }, blend(a, b, 0));
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, blend(a, b, 1));
+    try std.testing.expectEqual([3]f32{ 0.5, 0.5, 0.5 }, blend(a, b, 0.5));
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, blend(a, b, 2)); // t clamped
+}
+
+test "sidebarMaxWidthForWindow respects bounds" {
+    // window roomy: capped by max_width
+    try std.testing.expectEqual(@as(f32, 720), sidebarMaxWidthForWindow(2000, 160, 720, 240));
+    // window tight: capped by window_width - min_content
+    try std.testing.expectEqual(@as(f32, 360), sidebarMaxWidthForWindow(600, 160, 720, 240));
+    // window very tight: floored at min_width
+    try std.testing.expectEqual(@as(f32, 160), sidebarMaxWidthForWindow(300, 160, 720, 240));
+}
+
+test "clampSidebarWidth bounds" {
+    try std.testing.expectEqual(@as(f32, 160), clampSidebarWidth(50, 720, 160));
+    try std.testing.expectEqual(@as(f32, 720), clampSidebarWidth(900, 720, 160));
+    try std.testing.expectEqual(@as(f32, 300), clampSidebarWidth(300, 720, 160));
+}
+
+test "fallbackCodepoint maps printable ASCII, else '?'" {
+    try std.testing.expectEqual(@as(u32, 'A'), fallbackCodepoint('A'));
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x07));
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0xC3));
+}
+```
+
+- [ ] **Step 2: Point titlebar's helpers at the extracted logic**
+
+In `src/renderer/titlebar.zig`, add the import:
+```zig
+const titlebar_layout = @import("titlebar_layout.zig");
+```
+Then rewrite the wrappers to delegate (keep the same titlebar-facing signatures):
+- `blend` → `return titlebar_layout.blend(a, b, t);`
+- `fallbackCodepoint` → `return titlebar_layout.fallbackCodepoint(byte);`
+- `sidebarMaxWidthForWindow(window_width)` → `return titlebar_layout.sidebarMaxWidthForWindow(window_width, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_CONTENT_WIDTH);`
+- `clampSidebarWidth(width, window_width)` → `return titlebar_layout.clampSidebarWidth(width, sidebarMaxWidthForWindow(window_width), SIDEBAR_MIN_WIDTH);`
+- `mouseInRect(left, top, width, height)`: keep the mouse-fetch + negative guard, then `return titlebar_layout.pointInRect(@floatFromInt(mouse.x), @floatFromInt(mouse.y), left, top, width, height);`
+
+Leave `agentBadgeColor` in `titlebar.zig` (its `agent_detector.State` input is not std-only). Leave `setSidebarWidth`, `titlebarTextWidth`, `collectTextCodepoints`, `titlebarGlyphAdvance`, `mouseInTitlebarRange` in `titlebar.zig` (they call the wrappers / depend on font/mouse).
+
+- [ ] **Step 3: Register in the fast suite**
+
+In `src/test_fast.zig`, inside the `test { ... }` block:
+```zig
+    _ = @import("renderer/titlebar_layout.zig");
+```
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `zig build test`
+Expected: PASS (the new `titlebar_layout` tests run).
+
+Run: `zig build`
+Expected: success.
+
+Run: `zig build test-full`
+Expected: green baseline + the new tests, no new failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/titlebar_layout.zig src/renderer/titlebar.zig src/test_fast.zig
+git commit -m "refactor(titlebar): extract std-only titlebar_layout logic + tests [A3]"
+```
+
+---
+
+## Task 5: Docs + final verification
+
+**Files:**
+- Modify: `TODO.md`, `docs/decoupling-guide.md`
+
+- [ ] **Step 1: Note progress in `TODO.md`**
+
+Under Phase A item **A3**, extend the "Increment 1 done" note: increment 2 converted `titlebar` and introduced the shared `ui_pipeline.zig` (solid/text/emoji rendering on primitives) with `gl_init` keeping compat mirror handles + re-exports for the still-unconverted files; titlebar pure logic extracted to std-only `titlebar_layout.zig`. Remaining: overlays, ai_chat_renderer, file_explorer, scrollbar, image_renderer, fbo, background_image, markdown_preview; the compat shim dissolves as they convert.
+
+- [ ] **Step 2: Status line in `docs/decoupling-guide.md` §5 Phase A**
+
+Add a short note that A3 increment 2 landed (shared `ui_pipeline` + titlebar; compat-shim strategy).
+
+- [ ] **Step 3: Final verification**
+
+Run: `zig build test-full`
+Expected: green baseline.
+
+Run: `zig build`
+Expected: clean `phantty.exe`.
+
+- [ ] **Step 4: Request the manual Windows visual check**
+
+Ask the maintainer to run `phantty.exe` on Windows and confirm the titlebar + sidebar render identically: tab strip (active/inactive shading + separators), `+` button, caption buttons (minimize/maximize/close icons), the bell emoji, fallback/menu/gear/help icons, agent badges, sidebar rows/header, and the placeholder tab. Behavior-preserving; any visual difference is a regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TODO.md docs/decoupling-guide.md
+git commit -m "docs(gpu): note A3 increment 2 (shared ui_pipeline + titlebar)"
+```
+
+---
+
+## Self-review notes (resolved)
+
+- **Spec coverage:** §2 ui_pipeline → Task 1; §3 gl_init compat shim + re-exports → Task 2; §4 titlebar Axis A → Task 3, Axis B (`titlebar_layout`) → Task 4; §5 AppWindow wiring → Task 2; §6 verification → Task 5. `agentBadgeColor` left in titlebar per the spec's std-only caveat.
+- **Self-contained helpers** (use+bindVao) are the one intentional refinement vs. the old ambient-state contract; it is behavior-equivalent (same program/VAO/pixels) and is what lets titlebar drop its frame-setup lines (Task 3 Step 5). Flagged for the manual visual check.
+- **Type consistency:** `Rect{x,y,w,h}` and `Uv{u0,v0,u1,v1}` literals at the titlebar call sites (Task 3) match the `ui_pipeline` definitions (Task 1). `fillQuad`/`fillQuadAlpha`/`drawGlyph`/`drawColorGlyph`/`setProjection`/`init`/`deinit`/`syncSharedHandles` names are consistent across Tasks 1–3. `titlebar_layout.{pointInRect,blend,sidebarMaxWidthForWindow,clampSidebarWidth,fallbackCodepoint}` match Task 4's wrappers.
+- **Atomicity:** Task 2 is one commit (the shared-rendering cutover: gl_init + AppWindow must change together to keep the build green); the ~12 unconverted files rely on the compat vars + re-exports and are untouched.
+- **Cycle:** `gl_init`→`ui_pipeline` is one-directional; `ui_pipeline` reaches the draw counter via `AppWindow.gpu.gl_init` (the pre-existing AppWindow cycle), so no new direct cycle. Fallback noted in Task 2 Step 4.

--- a/docs/superpowers/specs/2026-05-26-gpu-a3-titlebar-design.md
+++ b/docs/superpowers/specs/2026-05-26-gpu-a3-titlebar-design.md
@@ -1,0 +1,204 @@
+# Design: GPU A3 increment 2 — shared UI pipeline + titlebar
+
+Status: approved (design); pending spec review
+Date: 2026-05-26
+Scope: TODO.md Phase A item **A3**, second increment
+References: prior A3 spec `2026-05-26-gpu-a3-cell-renderer-design.md`,
+[decoupling-guide.md](../../decoupling-guide.md). Ghostty: `renderer/opengl/`,
+API-agnostic `renderer/cell.zig`.
+
+## 1. Goal, scope & strategy
+
+Move the **shared** immediate-mode UI rendering (solid quads, text/glyph,
+color-emoji) out of `gl_init`'s raw GL into a new primitives-backed module
+`ui_pipeline.zig`, and convert `titlebar.zig` onto it as the proving ground —
+both decoupling axes, touching titlebar once.
+
+**Route A (pragmatic).** The primitives stay OpenGL-shaped for now; the eventual
+API-neutralization (vertex descriptors, indexed bindings, Frame/RenderPass, MSL)
+is a later collation step once all files route through primitives.
+
+**Compat-shim strategy (the key scoping decision).** The shared pipeline handles
+(`shader_program`, `simple_color_shader`, `vao`, `vbo`) are referenced with raw
+GL by ~13 renderer files. Rather than cascade into all of them now,
+`ui_pipeline` **owns** the primitive-built pipelines and `gl_init` keeps those
+four as **compat mirror vars** (populated by `ui_pipeline.init()`) plus
+**re-exports** the moved functions (`renderQuad`, …). Result: the ~12
+not-yet-converted files compile and behave **unchanged**; their `gl_init.*`
+references transparently use the primitive-built objects. The mirror vars
+dissolve from `gl_init` as each file converts in later increments.
+
+A consequence worth stating up front: because `gl_init.renderQuad` is
+re-exported to `ui_pipeline.fillQuad`, titlebar's **63 `renderQuad` call sites
+need no change** — they route through primitives transparently. Titlebar's only
+GL conversion is its three raw-`gl.*` glyph/emoji functions.
+
+### Non-goals (deferred)
+
+- The other ~12 renderer files (overlays, ai_chat_renderer, file_explorer,
+  scrollbar, image_renderer, fbo, background_image, markdown_preview, …) — they
+  keep using the `gl_init` compat vars / re-exports until their own increments.
+- `overlay_shader` stays in `gl_init` (overlays' concern).
+- `cell_renderer.renderChar` + the `drawCells` cursor block keep using the
+  `gl_init` compat vars (untouched this increment).
+- Frame/RenderPass/Target layer, API-neutralization, MSL (Route-A collation,
+  later). A4/A5/A6.
+
+## 2. `ui_pipeline.zig` (new, primitives-backed)
+
+Owns the shared UI rendering, built from `gpu.Pipeline`/`Buffer`/`Texture` +
+`gpu.shaders`. Lives in `src/renderer/`. Imports `AppWindow` for `gpu`,
+`g_theme`, and `gl_init` (for the `g_draw_call_count` counter + to set compat
+vars); the `gl_init↔ui_pipeline` import cycle is tolerated (same as existing
+gl_init↔AppWindow).
+
+### State
+```zig
+pub threadlocal var text: gpu.Pipeline = .{ .program = 0, .vao = 0 };  // shader_program eq (text/glyph + solid)
+pub threadlocal var emoji: gpu.Pipeline = .{ .program = 0, .vao = 0 }; // simple_color_shader eq
+pub threadlocal var quad: gpu.Buffer = .{ .handle = 0, .target = 0 };  // shared dynamic 6-vertex vbo
+pub threadlocal var solid: gpu.Texture = .{ .handle = 0 };             // 1x1 white
+```
+
+### Small value types
+```zig
+pub const Rect = struct { x: f32, y: f32, w: f32, h: f32 };
+pub const Uv = struct { u0: f32, v0: f32, u1: f32, v1: f32 };
+```
+
+### Public API (the helpers titlebar + future files call)
+```zig
+pub fn init() void;     // build text/emoji pipelines, quad buffer, solid texture; set gl_init compat vars
+pub fn deinit() void;
+
+pub fn setProjection() void;  // ortho from current GL viewport, on the text pipeline (= gl_init.setProjection)
+
+/// Solid color quad (= gl_init.renderQuad). fillQuad = fillQuadAlpha(..., 1.0).
+pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void;
+/// Preserves the existing alpha trick: blends `color` toward AppWindow.g_theme.background
+/// by `alpha` and draws opaque via the solid texture (= gl_init.renderQuadAlpha).
+pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void;
+
+/// Grayscale/text glyph via the text pipeline (samples atlas .r as alpha, modulated by color).
+pub fn drawGlyph(rect: Rect, uv: Uv, tex: c.GLuint, color: [3]f32) void;
+
+/// Color-emoji via the emoji pipeline: sets opacity, switches to premultiplied
+/// blend (GL_ONE, GL_ONE_MINUS_SRC_ALPHA) for the draw, then restores
+/// (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA). (= renderTitlebarChar color / renderBellEmoji)
+pub fn drawColorGlyph(rect: Rect, uv: Uv, tex: c.GLuint, opacity: f32) void;
+```
+
+### Internal helper (DRY)
+```zig
+fn quadVertices(rect: Rect, uv: Uv) [6][4]f32; // the (x,y+h,u0,v0)…(x+w,y+h,u1,v0) order used everywhere
+```
+Each draw: `quad.upload(sliceAsBytes(verts))` then `text|emoji.use()` (or use
+once + set uniforms) + uniform/texture binds + `gl.DrawArrays(GL_TRIANGLES,0,6)`
+via the GL table, exactly mirroring the current sequences. `g_draw_call_count`
+increments preserved.
+
+### `init()` builds + populates compat vars
+Builds `text` (program from `shaders.vertex_shader_source` /
+`fragment_shader_source`, VAO = the single vec4 attrib layout from
+`gl_init.initBuffers`, `quad` = its dynamic vbo), `emoji` (program from
+`vertex_shader_source` / `simple_color_fragment_source`, sharing the same VAO
+layout), and `solid` (1×1 white, from `initSolidTexture`). Then mirrors:
+```zig
+gl_init.shader_program = text.program;
+gl_init.simple_color_shader = emoji.program;
+gl_init.vao = text.vao;
+gl_init.vbo = quad.handle;
+```
+
+## 3. `gl_init.zig` after
+
+- **Moved out** (to `ui_pipeline`): `renderQuad`, `renderQuadAlpha`,
+  `setProjection`, `initBuffers`, `initSolidTexture`, `solid_texture`, and the
+  `shader_program`/`simple_color_shader` compile+link (out of `initShaders`).
+- **Kept**: `overlay_shader` (+ its link in `initShaders`), `g_draw_call_count`,
+  `g_bg_opacity`, `compileShader`, `linkProgram`, `setProjectionForProgram`.
+- **Compat mirror vars** (kept as `pub threadlocal var`, written by
+  `ui_pipeline.init()`; doc-commented as transition mirrors removed per file):
+  `shader_program`, `simple_color_shader`, `vao`, `vbo`.
+- **Re-exports** (functions; valid via `pub const`):
+  ```zig
+  pub const renderQuad = ui_pipeline.fillQuad;
+  pub const renderQuadAlpha = ui_pipeline.fillQuadAlpha;
+  pub const setProjection = ui_pipeline.setProjection;
+  ```
+  So every existing `gl_init.renderQuad(...)` / `gl_init.shader_program` /
+  `gl_init.vao` reference in the ~12 unconverted files keeps working unchanged.
+
+`gl_init.initShaders` now links only `overlay_shader`. `ui_pipeline.init()`
+replaces the moved `initBuffers`/`initSolidTexture`/instanced-shader setup for
+the shared pipelines.
+
+## 4. titlebar conversion + logic extraction
+
+### Axis A — convert the three raw-`gl.*` functions
+- `renderTitlebarChar`: grayscale branch → `ui_pipeline.drawGlyph(.{…}, uv,
+  font.g_titlebar_atlas_texture, color)`; color branch → `ui_pipeline.drawColorGlyph(.{…},
+  uv, font.g_color_atlas_texture, 1.0)`.
+- `renderBellEmoji` → `ui_pipeline.drawColorGlyph(.{…}, uv, font.g_color_atlas_texture, opacity)`.
+- `renderIconGlyph` → `ui_pipeline.drawGlyph(.{…}, uv, font.g_icon_atlas_texture, color)`.
+- Remove titlebar's now-unused `const gl = AppWindow.gpu.glTable()` usages and
+  the `@cImport("glad/gl.h")` block once no raw `gl.*`/`c.GL_*` remain.
+- The 63 `gl_init.renderQuad` calls and the layout/draw orchestration in
+  `renderTitlebar`/`renderSidebar`/`renderCaptionButton` are **unchanged**
+  (renderQuad now primitive-backed via the re-export).
+
+### Axis B — `titlebar_layout.zig` (new, std-only)
+Extract the genuinely std-only-extractable pure helpers (geometry/measurement
+with metrics passed as params; imports only `std`), registered in
+`test_fast.zig`:
+- `clampSidebarWidth(width, window_width, min, max) f32`
+- `sidebarMaxWidthForWindow(window_width, fraction, cap) f32`
+- `mouseInRect(px, py, left, top, width, height) bool`
+- `mouseInTitlebarRange(mouse_x, titlebar_h, left, right, ...) bool` (pure form)
+- `blend(a: [3]f32, b: [3]f32, t: f32) [3]f32`
+- `fallbackCodepoint(byte: u8) u32`
+
+**Per-function std-only check is part of the work**: any candidate whose inputs
+pull in a heavy module is either lowered to a plain param type or left in
+`titlebar.zig`. Specifically `agentBadgeColor(state)` depends on
+`agent_detector.State` — extract it only if that enum is std-only-importable;
+otherwise have it take a small local enum / leave it in `titlebar.zig`. The
+font-dependent measurement (`titlebarTextWidth`, `collectTextCodepoints`,
+`titlebarGlyphAdvance`) and the live-mouse wrappers stay in `titlebar.zig`;
+`titlebar.zig` calls the extracted pure helpers (and keeps thin wrappers that
+feed them `mouseX()`/font metrics). Unit tests cover: clamp bounds, max-width
+fraction/cap, `mouseInRect` inside/edge/outside, `mouseInTitlebarRange`,
+`blend` endpoints + midpoint, `fallbackCodepoint` mapping.
+
+## 5. AppWindow wiring
+- Add `pub const ui_pipeline = @import("renderer/ui_pipeline.zig");`.
+- In init: call `ui_pipeline.init()` where the moved `gl_init.initBuffers()` /
+  `initSolidTexture()` were, ordered before `cell_pipeline.init()` and before
+  any draw. `gl_init.initShaders()` (now overlay-only) stays.
+- In teardown: `ui_pipeline.deinit()` alongside the existing renderer deinits.
+
+## 6. Verification
+- `zig build` clean (x86_64-windows-gnu).
+- `zig build test` includes the new `titlebar_layout` tests.
+- `zig build test-full` stays green (current fully-green baseline + the new
+  tests; no new failures).
+- **Manual Windows visual check (final gate):** titlebar + sidebar render
+  identically — tab strip, active/inactive shading, separators, `+` button,
+  caption buttons (min/max/close), the bell emoji, fallback/menu/gear/help
+  icons, agent badges, and placeholder tab. Behavior-preserving; any visual
+  difference is a regression.
+
+## 7. Risks
+- **Compat-var population order.** `ui_pipeline.init()` must run before any file
+  reads `gl_init.shader_program`/`vao`/`vbo` (i.e. before the first frame and
+  before `cell_pipeline.init` if it depended on them — it does not). Mitigation:
+  call `ui_pipeline.init()` at the same point the moved `initBuffers` ran.
+- **Glyph/emoji draw parity.** `drawGlyph`/`drawColorGlyph` must reproduce the
+  exact vertex order, uniform names (`textColor`, `opacity`, `projection`),
+  texture targets, and — for emoji — the premultiplied-blend enter/restore. The
+  helpers are extracted verbatim from the three titlebar functions +
+  `renderChar`.
+- **`renderQuadAlpha` alpha trick.** The blend-toward-`g_theme.background`
+  behavior must be preserved exactly in `fillQuadAlpha`.
+- **No automated render coverage.** Visual correctness rests on the manual
+  Windows check; fast tests cover only the extracted `titlebar_layout` logic.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -39,6 +39,7 @@ pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
 pub const cell_renderer = @import("renderer/cell_renderer.zig");
 pub const cell_pipeline = @import("renderer/cell_pipeline.zig");
+pub const ui_pipeline = @import("renderer/ui_pipeline.zig");
 pub const titlebar = @import("renderer/titlebar.zig");
 pub const input = @import("input.zig");
 pub const overlays = @import("renderer/overlays.zig");
@@ -3260,7 +3261,8 @@ fn runMainLoop(self: *AppWindow) !void {
         std.debug.print("Failed to initialize shaders\n", .{});
         return error.ShaderInitFailed;
     }
-    gpu.gl_init.initBuffers();
+    ui_pipeline.init();
+    gpu.gl_init.syncSharedHandles();
     cell_pipeline.init();
     font.preloadCharacters(face);
 
@@ -3307,8 +3309,6 @@ fn runMainLoop(self: *AppWindow) !void {
             font.g_titlebar_atlas_texture = 0;
         }
     }
-    gpu.gl_init.initSolidTexture();
-
     // Initialize custom post-processing shader if requested
     post_process.init(allocator, shader_path);
     if (g_app) |app| {
@@ -3326,6 +3326,7 @@ fn runMainLoop(self: *AppWindow) !void {
         background_image.deinit();
         post_process.deinit();
         cell_pipeline.deinit();
+        ui_pipeline.deinit();
     }
 
     // Ghostty approach: calculate grid size from ACTUAL window size.

--- a/src/renderer/gpu/opengl/gl_init.zig
+++ b/src/renderer/gpu/opengl/gl_init.zig
@@ -1,8 +1,13 @@
-//! OpenGL initialization and shared rendering primitives.
+//! OpenGL shader-compilation helpers + the overlay shader, plus the transition
+//! compat shim for the shared UI pipelines.
 //!
-//! Shader compilation, the text-shader VAO/VBO, the shared simple-color/overlay
-//! pipelines, and shared drawing helpers (renderQuad, setProjection). The
-//! cell-grid instanced pipelines live in renderer/cell_pipeline.zig.
+//! Owns: `compileShader`/`linkProgram`, the `overlay_shader`, `setProjectionForProgram`.
+//! Compat mirrors: `vao`/`vbo`/`shader_program`/`simple_color_shader` are populated
+//!   by `syncSharedHandles()` after `ui_pipeline.init()`; not-yet-converted renderer
+//!   files still read them directly. They dissolve as each file converts.
+//! Re-exports: `renderQuad`/`renderQuadAlpha`/`setProjection` delegate to ui_pipeline.
+//! The shared UI rendering lives in renderer/ui_pipeline.zig; the cell-grid
+//! instanced pipelines in renderer/cell_pipeline.zig.
 
 const std = @import("std");
 const AppWindow = @import("../../../AppWindow.zig");
@@ -12,20 +17,21 @@ const c = @cImport({
 });
 
 const shaders = @import("shaders.zig");
+const ui_pipeline = @import("../../ui_pipeline.zig");
 
 // ============================================================================
 // GL object handles
 // ============================================================================
 
-pub threadlocal var vao: c.GLuint = 0;
-pub threadlocal var vbo: c.GLuint = 0;
-pub threadlocal var shader_program: c.GLuint = 0;
+// Compat mirror handles, populated by syncSharedHandles() after ui_pipeline.init().
+// Transition shim: not-yet-converted renderer files still read these directly.
+// They dissolve as each file converts to ui_pipeline.
+pub threadlocal var vao: c.GLuint = 0; // compat mirror — from ui_pipeline.text.vao
+pub threadlocal var vbo: c.GLuint = 0; // compat mirror — from ui_pipeline.quad.handle
+pub threadlocal var shader_program: c.GLuint = 0; // compat mirror — from ui_pipeline.text.program
+pub threadlocal var simple_color_shader: c.GLuint = 0; // compat mirror — from ui_pipeline.emoji.program
 
-pub threadlocal var simple_color_shader: c.GLuint = 0;
-pub threadlocal var overlay_shader: c.GLuint = 0;
-
-// Solid white texture for drawing filled quads
-threadlocal var solid_texture: c.GLuint = 0;
+pub threadlocal var overlay_shader: c.GLuint = 0; // gl_init-owned — compiled in initShaders()
 
 // Draw call counter (reset each frame)
 pub threadlocal var g_draw_call_count: u32 = 0;
@@ -97,120 +103,39 @@ fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
 // ============================================================================
 
 pub fn initShaders() bool {
-    const gl = AppWindow.gpu.glTable();
-    const vertex_shader = compileShader(c.GL_VERTEX_SHADER, shaders.vertex_shader_source) orelse return false;
-    defer gl.DeleteShader.?(vertex_shader);
-
-    const fragment_shader = compileShader(c.GL_FRAGMENT_SHADER, shaders.fragment_shader_source) orelse return false;
-    defer gl.DeleteShader.?(fragment_shader);
-
-    shader_program = gl.CreateProgram.?();
-    gl.AttachShader.?(shader_program, vertex_shader);
-    gl.AttachShader.?(shader_program, fragment_shader);
-    gl.LinkProgram.?(shader_program);
-
-    var success: c.GLint = 0;
-    gl.GetProgramiv.?(shader_program, c.GL_LINK_STATUS, &success);
-    if (success == 0) {
-        var info_log: [512]u8 = @splat(0);
-        var log_len: c.GLsizei = 0;
-        gl.GetProgramInfoLog.?(shader_program, 512, &log_len, &info_log);
-        const len: usize = if (log_len > 0) @intCast(log_len) else 0;
-        if (len > 0) {
-            std.debug.print("Shader linking failed: {s}\n", .{info_log[0..len]});
-        } else {
-            std.debug.print("Shader linking failed (no error log available)\n", .{});
-        }
-        gl.DeleteProgram.?(shader_program);
-        shader_program = 0;
+    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
+    if (overlay_shader == 0) {
+        std.debug.print("Overlay shader failed\n", .{});
         return false;
     }
-
-    // Shared simple-color + overlay shaders (used by titlebar/overlays).
-    simple_color_shader = linkProgram(shaders.vertex_shader_source, shaders.simple_color_fragment_source);
-    if (simple_color_shader == 0) std.debug.print("Simple color shader failed\n", .{});
-    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
-    if (overlay_shader == 0) std.debug.print("Overlay shader failed\n", .{});
-
     return true;
 }
 
-pub fn initBuffers() void {
-    const gl = AppWindow.gpu.glTable();
-    gl.GenVertexArrays.?(1, &vao);
-    gl.GenBuffers.?(1, &vbo);
-    gl.BindVertexArray.?(vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(f32) * 6 * 4, null, c.GL_DYNAMIC_DRAW);
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 4, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.BindVertexArray.?(0);
-}
-
-
-pub fn initSolidTexture() void {
-    const gl = AppWindow.gpu.glTable();
-    const white_pixel = [_]u8{255};
-    gl.GenTextures.?(1, &solid_texture);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, solid_texture);
-    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RED, 1, 1, 0, c.GL_RED, c.GL_UNSIGNED_BYTE, &white_pixel);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_NEAREST);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_NEAREST);
-}
-
 // ============================================================================
-// Render helpers
+// Render helpers — re-export wrappers delegating to ui_pipeline
 // ============================================================================
 
 pub fn renderQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    renderQuadAlpha(x, y, w, h, color, 1.0);
+    ui_pipeline.fillQuad(x, y, w, h, color);
 }
-
 pub fn renderQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
-    const gl = AppWindow.gpu.glTable();
-    const vertices = [6][4]f32{
-        .{ x, y + h, 0.0, 0.0 },
-        .{ x, y, 0.0, 1.0 },
-        .{ x + w, y, 1.0, 1.0 },
-        .{ x, y + h, 0.0, 0.0 },
-        .{ x + w, y, 1.0, 1.0 },
-        .{ x + w, y + h, 1.0, 0.0 },
-    };
-
-    // Pre-multiply alpha into color and use the solid texture (which has alpha=1).
-    // With GL_SRC_ALPHA blending, we set textColor to full RGB and modulate alpha
-    // via the vec4 output. Since our fragment shader does:
-    //   color = vec4(textColor, 1.0) * sampled
-    // and sampled = vec4(1,1,1, texture.r) with solid_texture.r = 1,
-    // the output alpha is always 1. To get transparency we use a small trick:
-    // temporarily blend manually by dimming the color toward the background.
-    // This avoids needing a shader change.
-    const bg = AppWindow.g_theme.background;
-    const r = color[0] * alpha + bg[0] * (1 - alpha);
-    const g = color[1] * alpha + bg[1] * (1 - alpha);
-    const b = color[2] * alpha + bg[2] * (1 - alpha);
-
-    gl.Uniform3f.?(gl.GetUniformLocation.?(shader_program, "textColor"), r, g, b);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, solid_texture);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    g_draw_call_count += 1;
+    ui_pipeline.fillQuadAlpha(x, y, w, h, color, alpha);
+}
+pub fn setProjection(width: f32, height: f32) void {
+    ui_pipeline.setProjection(width, height);
 }
 
-pub fn setProjection(width: f32, height: f32) void {
-    const gl = AppWindow.gpu.glTable();
-    const projection = [16]f32{
-        2.0 / width, 0.0,          0.0,  0.0,
-        0.0,         2.0 / height, 0.0,  0.0,
-        0.0,         0.0,          -1.0, 0.0,
-        -1.0,        -1.0,         0.0,  1.0,
-    };
+// ============================================================================
+// Compat shim — populate the mirror handles from ui_pipeline (transition)
+// ============================================================================
 
-    gl.UseProgram.?(shader_program);
-    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(shader_program, "projection"), 1, c.GL_FALSE, &projection);
+/// Populate the compat mirror handles from the ui_pipeline-owned objects.
+/// Call right after ui_pipeline.init().
+pub fn syncSharedHandles() void {
+    shader_program = ui_pipeline.text.program;
+    simple_color_shader = ui_pipeline.emoji.program;
+    vao = ui_pipeline.text.vao;
+    vbo = ui_pipeline.quad.handle;
 }
 
 /// Set the orthographic projection matrix on a specific shader program.

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
+const ui_pipeline = AppWindow.ui_pipeline;
 const font = AppWindow.font;
 const tab = AppWindow.tab;
 const cell_renderer = AppWindow.cell_renderer;
@@ -14,9 +15,6 @@ const font_backend = @import("../platform/font_backend.zig");
 const window_backend = @import("../platform/window_backend.zig");
 const agent_detector = @import("../agent_detector.zig");
 const keybind = @import("../keybind.zig");
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
 const Character = font.Character;
 
 pub const CaptionButtonType = enum { minimize, maximize, close };
@@ -292,83 +290,35 @@ fn renderCloseIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
 /// Render a titlebar glyph at 1:1 atlas size (no scaling).
 /// Supports both grayscale (titlebar atlas) and color emoji (color atlas).
 pub fn renderTitlebarChar(codepoint: u32, x: f32, y: f32, color: [3]f32) void {
-    const gl = AppWindow.gpu.glTable();
     if (codepoint < 32) return;
     const ch: Character = font.loadTitlebarGlyph(codepoint) orelse return;
     if (ch.region.width == 0 or ch.region.height == 0) return;
 
     if (ch.is_color) {
-        // Color emoji — scale down to fit titlebar height and render with simple color shader
         const scale = font.g_titlebar_cell_height / @as(f32, @floatFromInt(ch.size_y));
         const w = @as(f32, @floatFromInt(ch.size_x)) * scale;
         const h = @as(f32, @floatFromInt(ch.size_y)) * scale;
-        const x0 = x;
-        const y0 = y;
-
         const atlas_size = if (font.g_color_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
         const uv = font.glyphUV(ch.region, atlas_size);
-
-        const vertices = [6][4]f32{
-            .{ x0, y0 + h, uv.u0, uv.v0 },
-            .{ x0, y0, uv.u0, uv.v1 },
-            .{ x0 + w, y0, uv.u1, uv.v1 },
-            .{ x0, y0 + h, uv.u0, uv.v0 },
-            .{ x0 + w, y0, uv.u1, uv.v1 },
-            .{ x0 + w, y0 + h, uv.u1, uv.v0 },
-        };
-
-        // Use simple color shader (same vertex layout as text shader, but samples RGBA)
-        // Set projection matrix from current viewport (same ortho as text shader)
-        var viewport: [4]c.GLint = undefined;
-        gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
-        const vp_w: f32 = @floatFromInt(viewport[2]);
-        const vp_h: f32 = @floatFromInt(viewport[3]);
-        const projection = [16]f32{
-            2.0 / vp_w, 0.0,        0.0,  0.0,
-            0.0,        2.0 / vp_h, 0.0,  0.0,
-            0.0,        0.0,        -1.0, 0.0,
-            -1.0,       -1.0,       0.0,  1.0,
-        };
-        gl.UseProgram.?(gl_init.simple_color_shader);
-        gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "projection"), 1, c.GL_FALSE, &projection);
-        gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
-        // Premultiplied alpha blend for color emoji (BGRA bitmaps from FreeType)
-        gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
-        gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_color_atlas_texture);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-        gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-        gl_init.g_draw_call_count += 1;
-        // Restore text shader and standard alpha blend
-        gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-        gl.UseProgram.?(gl_init.shader_program);
+        ui_pipeline.drawColorGlyph(
+            .{ .x = x, .y = y, .w = w, .h = h },
+            .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+            font.g_color_atlas_texture,
+            1.0,
+        );
     } else {
-        // Grayscale glyph — render with text shader from titlebar atlas
         const x0 = x + @as(f32, @floatFromInt(ch.bearing_x));
         const y0 = y + font.g_titlebar_baseline - @as(f32, @floatFromInt(ch.size_y - ch.bearing_y));
         const w = @as(f32, @floatFromInt(ch.size_x));
         const h = @as(f32, @floatFromInt(ch.size_y));
-
         const atlas_size = if (font.g_titlebar_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
         const uv = font.glyphUV(ch.region, atlas_size);
-
-        const vertices = [6][4]f32{
-            .{ x0, y0 + h, uv.u0, uv.v0 },
-            .{ x0, y0, uv.u0, uv.v1 },
-            .{ x0 + w, y0, uv.u1, uv.v1 },
-            .{ x0, y0 + h, uv.u0, uv.v0 },
-            .{ x0 + w, y0, uv.u1, uv.v1 },
-            .{ x0 + w, y0 + h, uv.u1, uv.v0 },
-        };
-
-        gl.Uniform3f.?(gl.GetUniformLocation.?(gl_init.shader_program, "textColor"), color[0], color[1], color[2]);
-        gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_titlebar_atlas_texture);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-        gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-        gl_init.g_draw_call_count += 1;
+        ui_pipeline.drawGlyph(
+            .{ .x = x0, .y = y0, .w = w, .h = h },
+            .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+            font.g_titlebar_atlas_texture,
+            color,
+        );
     }
 }
 
@@ -390,88 +340,38 @@ pub fn titlebarGlyphAdvance(codepoint: u32) f32 {
 }
 
 pub fn renderBellEmoji(x: f32, y: f32, opacity: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const bell = font.loadBellEmoji() orelse {
         renderTitlebarChar(0x1F514, x, y, .{ 1.0, 0.84, 0.0 });
         return;
     };
-
     const aspect = bell.bmp_w / bell.bmp_h;
     const h = font.g_titlebar_cell_height * 0.85;
     const w = h * aspect;
-    const x0 = x;
-    const y0 = y;
-
     const atlas_size = if (font.g_color_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
     const uv = font.glyphUV(bell.region, atlas_size);
-
-    const vertices = [6][4]f32{
-        .{ x0, y0 + h, uv.u0, uv.v0 },
-        .{ x0, y0, uv.u0, uv.v1 },
-        .{ x0 + w, y0, uv.u1, uv.v1 },
-        .{ x0, y0 + h, uv.u0, uv.v0 },
-        .{ x0 + w, y0, uv.u1, uv.v1 },
-        .{ x0 + w, y0 + h, uv.u1, uv.v0 },
-    };
-
-    // Compute projection from current viewport
-    var viewport: [4]c.GLint = undefined;
-    gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
-    const vp_w: f32 = @floatFromInt(viewport[2]);
-    const vp_h: f32 = @floatFromInt(viewport[3]);
-    const projection = [16]f32{
-        2.0 / vp_w, 0.0,        0.0,  0.0,
-        0.0,        2.0 / vp_h, 0.0,  0.0,
-        0.0,        0.0,        -1.0, 0.0,
-        -1.0,       -1.0,       0.0,  1.0,
-    };
-
-    // Render with simple color shader (premultiplied alpha + opacity fade)
-    gl.UseProgram.?(gl_init.simple_color_shader);
-    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "projection"), 1, c.GL_FALSE, &projection);
-    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), opacity);
-    gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_color_atlas_texture);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
-
-    // Restore text shader and standard blend
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
+    ui_pipeline.drawColorGlyph(
+        .{ .x = x, .y = y, .w = w, .h = h },
+        .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+        font.g_color_atlas_texture,
+        opacity,
+    );
 }
 
 /// Render an icon glyph centered within a button rect, using the icon atlas.
 pub fn renderIconGlyph(ch: Character, btn_x: f32, btn_y: f32, btn_w: f32, btn_h: f32, color: [3]f32, scale: f32) void {
-    const gl = AppWindow.gpu.glTable();
     if (ch.region.width == 0 or ch.region.height == 0) return;
-
     const gw = @as(f32, @floatFromInt(ch.size_x)) * scale;
     const gh = @as(f32, @floatFromInt(ch.size_y)) * scale;
     const gx = btn_x + (btn_w - gw) / 2;
     const gy = btn_y + (btn_h - gh) / 2;
-
     const icon_atlas_size = if (font.g_icon_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
     const uv = font.glyphUV(ch.region, icon_atlas_size);
-
-    const vertices = [6][4]f32{
-        .{ gx, gy + gh, uv.u0, uv.v0 },
-        .{ gx, gy, uv.u0, uv.v1 },
-        .{ gx + gw, gy, uv.u1, uv.v1 },
-        .{ gx, gy + gh, uv.u0, uv.v0 },
-        .{ gx + gw, gy, uv.u1, uv.v1 },
-        .{ gx + gw, gy + gh, uv.u1, uv.v0 },
-    };
-
-    gl.Uniform3f.?(gl.GetUniformLocation.?(gl_init.shader_program, "textColor"), color[0], color[1], color[2]);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_icon_atlas_texture);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
+    ui_pipeline.drawGlyph(
+        .{ .x = gx, .y = gy, .w = gw, .h = gh },
+        .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+        font.g_icon_atlas_texture,
+        color,
+    );
 }
 
 /// Render the Ghostty-style tab bar.
@@ -488,12 +388,10 @@ pub fn renderIconGlyph(ch: Character, btn_x: f32, btn_y: f32, btn_w: f32, btn_h:
 ///
 /// OpenGL Y=0 is BOTTOM, so titlebar top = window_height - titlebar_h.
 pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) void {
-    const gl = AppWindow.gpu.glTable();
     if (titlebar_h <= 0) return;
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
+    // No GL program/VAO setup here: the ui_pipeline helpers (and gl_init.renderQuad,
+    // which now delegates to ui_pipeline) are self-contained — each binds its own
+    // program + VAO per draw.
 
     const tb_top = window_height - titlebar_h; // top of titlebar in GL coords
     const bg = AppWindow.g_theme.background;
@@ -1066,11 +964,6 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
     if (!tab.g_sidebar_visible) return;
     const sidebar_w = sidebarWidth();
 
-    const gl = AppWindow.gpu.glTable();
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
@@ -1322,11 +1215,6 @@ pub fn renderCaptionButton(x: f32, y: f32, w: f32, h: f32, btn_type: CaptionButt
 
 /// Render placeholder content for tabs that don't have a terminal yet.
 pub fn renderPlaceholderTab(window_width: f32, window_height: f32, top_pad: f32) void {
-    const gl = AppWindow.gpu.glTable();
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const msg = "Tabs not yet implemented";
     var shortcut_buf: [64]u8 = undefined;
     const shortcut = keybind.formatActionShortcut(&AppWindow.g_keybinds, .new_session, &shortcut_buf) orelse "the new session shortcut";

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -5,6 +5,7 @@
 //! primitives. Depends on font module for glyph loading and tab module for state.
 
 const std = @import("std");
+const titlebar_layout = @import("titlebar_layout.zig");
 const AppWindow = @import("../AppWindow.zig");
 const ui_pipeline = AppWindow.ui_pipeline;
 const font = AppWindow.font;
@@ -59,9 +60,7 @@ fn mouseX() ?f32 {
 fn mouseInRect(left: f32, top: f32, width: f32, height: f32) bool {
     const mouse = currentMousePosition() orelse return false;
     if (mouse.x < 0 or mouse.y < 0) return false;
-    const mx: f32 = @floatFromInt(mouse.x);
-    const my: f32 = @floatFromInt(mouse.y);
-    return mx >= left and mx < left + width and my >= top and my < top + height;
+    return titlebar_layout.pointInRect(@floatFromInt(mouse.x), @floatFromInt(mouse.y), left, top, width, height);
 }
 
 fn mouseInTitlebarRange(titlebar_h: f32, left: f32, right: f32) bool {
@@ -74,11 +73,11 @@ fn currentWindowIsMaximized() bool {
 }
 
 pub fn sidebarMaxWidthForWindow(window_width: f32) f32 {
-    return @max(SIDEBAR_MIN_WIDTH, @min(SIDEBAR_MAX_WIDTH, window_width - SIDEBAR_MIN_CONTENT_WIDTH));
+    return titlebar_layout.sidebarMaxWidthForWindow(window_width, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_CONTENT_WIDTH);
 }
 
 pub fn clampSidebarWidth(width: f32, window_width: f32) f32 {
-    return @max(SIDEBAR_MIN_WIDTH, @min(sidebarMaxWidthForWindow(window_width), width));
+    return titlebar_layout.clampSidebarWidth(width, SIDEBAR_MIN_WIDTH, sidebarMaxWidthForWindow(window_width));
 }
 
 pub fn setSidebarWidth(width: f32, window_width: f32) bool {
@@ -89,12 +88,7 @@ pub fn setSidebarWidth(width: f32, window_width: f32) bool {
 }
 
 fn blend(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
-    const clamped = @max(0.0, @min(1.0, t));
-    return .{
-        a[0] + (b[0] - a[0]) * clamped,
-        a[1] + (b[1] - a[1]) * clamped,
-        a[2] + (b[2] - a[2]) * clamped,
-    };
+    return titlebar_layout.blend(a, b, t);
 }
 
 fn titlebarTextWidth(text: []const u8) f32 {
@@ -140,7 +134,7 @@ fn renderAgentBadge(detection: agent_detector.Detection, x: f32, text_y: f32, ac
 }
 
 fn fallbackCodepoint(byte: u8) u32 {
-    return if (byte >= 0x20 and byte <= 0x7e) byte else '?';
+    return titlebar_layout.fallbackCodepoint(byte);
 }
 
 fn renderFallbackBytesLimited(text: []const u8, x: f32, y: f32, color: [3]f32, max_w: f32) f32 {

--- a/src/renderer/titlebar_layout.zig
+++ b/src/renderer/titlebar_layout.zig
@@ -1,0 +1,75 @@
+//! Pure, std-only titlebar/sidebar geometry + measurement helpers extracted
+//! from titlebar.zig. No AppWindow/font/GL imports — runs in the fast suite.
+const std = @import("std");
+
+/// Is point (px, py) inside the rect [left, left+width) x [top, top+height)?
+pub fn pointInRect(px: f32, py: f32, left: f32, top: f32, width: f32, height: f32) bool {
+    return px >= left and px < left + width and py >= top and py < top + height;
+}
+
+/// Linear blend of two RGB colors; t clamped to [0,1].
+pub fn blend(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const clamped = @max(0.0, @min(1.0, t));
+    return .{
+        a[0] + (b[0] - a[0]) * clamped,
+        a[1] + (b[1] - a[1]) * clamped,
+        a[2] + (b[2] - a[2]) * clamped,
+    };
+}
+
+/// Max sidebar width for a window: min(max_width, window_width - min_content_width),
+/// but never below min_width (so a too-narrow window still yields min_width).
+pub fn sidebarMaxWidthForWindow(window_width: f32, min_width: f32, max_width: f32, min_content_width: f32) f32 {
+    return @max(min_width, @min(max_width, window_width - min_content_width));
+}
+
+/// Clamp a requested sidebar width to [min_width, max_for_window].
+/// Args follow std.math.clamp order: (value, min, max).
+pub fn clampSidebarWidth(width: f32, min_width: f32, max_for_window: f32) f32 {
+    return @max(min_width, @min(max_for_window, width));
+}
+
+/// Printable-ASCII passthrough, else '?'.
+pub fn fallbackCodepoint(byte: u8) u32 {
+    return if (byte >= 0x20 and byte <= 0x7e) byte else '?';
+}
+
+test "pointInRect inside / edges / outside" {
+    try std.testing.expect(pointInRect(5, 5, 0, 0, 10, 10));
+    try std.testing.expect(pointInRect(0, 0, 0, 0, 10, 10)); // top-left inclusive
+    try std.testing.expect(!pointInRect(10, 5, 0, 0, 10, 10)); // right exclusive
+    try std.testing.expect(!pointInRect(5, 10, 0, 0, 10, 10)); // bottom exclusive
+    try std.testing.expect(!pointInRect(-1, 5, 0, 0, 10, 10));
+}
+
+test "blend endpoints and midpoint" {
+    const a = [3]f32{ 0, 0, 0 };
+    const b = [3]f32{ 1, 1, 1 };
+    try std.testing.expectEqual([3]f32{ 0, 0, 0 }, blend(a, b, 0));
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, blend(a, b, 1));
+    try std.testing.expectEqual([3]f32{ 0.5, 0.5, 0.5 }, blend(a, b, 0.5));
+    try std.testing.expectEqual([3]f32{ 1, 1, 1 }, blend(a, b, 2)); // t clamped
+}
+
+test "sidebarMaxWidthForWindow respects bounds" {
+    try std.testing.expectEqual(@as(f32, 720), sidebarMaxWidthForWindow(2000, 160, 720, 240));
+    try std.testing.expectEqual(@as(f32, 360), sidebarMaxWidthForWindow(600, 160, 720, 240));
+    try std.testing.expectEqual(@as(f32, 160), sidebarMaxWidthForWindow(300, 160, 720, 240));
+}
+
+test "clampSidebarWidth bounds" {
+    // args: (width, min_width, max_for_window)
+    try std.testing.expectEqual(@as(f32, 160), clampSidebarWidth(50, 160, 720));
+    try std.testing.expectEqual(@as(f32, 720), clampSidebarWidth(900, 160, 720));
+    try std.testing.expectEqual(@as(f32, 300), clampSidebarWidth(300, 160, 720));
+}
+
+test "fallbackCodepoint maps printable ASCII, else '?'" {
+    try std.testing.expectEqual(@as(u32, 'A'), fallbackCodepoint('A'));
+    try std.testing.expectEqual(@as(u32, 0x20), fallbackCodepoint(0x20)); // space — inclusive low bound
+    try std.testing.expectEqual(@as(u32, 0x7e), fallbackCodepoint(0x7e)); // '~' — inclusive high bound
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x1f)); // just below
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x7f)); // just above
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x07));
+    try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0xC3));
+}

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -1,0 +1,158 @@
+//! Shared UI render pipelines (solid quad / text-glyph / color-emoji), built
+//! from the gpu backend primitives. Relocated out of gl_init (A3). gl_init keeps
+//! compat mirror handles (set via gl_init.syncSharedHandles) + re-exports, so
+//! the not-yet-converted renderer files are unchanged.
+//!
+//! Draw helpers are self-contained: each use()s its pipeline and binds its VAO,
+//! so callers need no ambient GL program/VAO state.
+const std = @import("std");
+const AppWindow = @import("../AppWindow.zig");
+const gpu = AppWindow.gpu;
+const c = gpu.c;
+const shaders = gpu.shaders;
+
+const Pipeline = gpu.Pipeline;
+const Buffer = gpu.Buffer;
+const Texture = gpu.Texture;
+
+pub const Rect = struct { x: f32, y: f32, w: f32, h: f32 };
+pub const Uv = struct { u0: f32, v0: f32, u1: f32, v1: f32 };
+
+pub threadlocal var text: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var emoji: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
+pub threadlocal var solid: Texture = .{ .handle = 0 };
+
+fn drawCallTick() void {
+    AppWindow.gpu.gl_init.g_draw_call_count += 1;
+}
+
+/// Build a VAO with the shared text/emoji vertex layout (one vec4 attrib:
+/// xy = position, zw = texcoord), pointing at the shared quad buffer.
+fn buildQuadVao() c.GLuint {
+    const gl = gpu.glTable();
+    var vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &vao);
+    gl.BindVertexArray.?(vao);
+    quad.bind();
+    gl.EnableVertexAttribArray.?(0);
+    gl.VertexAttribPointer.?(0, 4, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
+    gl.BindVertexArray.?(0);
+    return vao;
+}
+
+/// Build the shared pipelines, quad buffer, and solid texture. Call once after
+/// the GL context is current (before any UI draw).
+pub fn init() void {
+    const gl = gpu.glTable();
+
+    quad = Buffer.init(c.GL_ARRAY_BUFFER);
+    quad.allocate(@sizeOf(f32) * 6 * 4, c.GL_DYNAMIC_DRAW);
+
+    // Each pipeline owns its own VAO (identical layout) for clean deinit.
+    const text_vao = buildQuadVao();
+    const emoji_vao = buildQuadVao();
+    text = Pipeline.init(shaders.vertex_shader_source, shaders.fragment_shader_source, text_vao);
+    emoji = Pipeline.init(shaders.vertex_shader_source, shaders.simple_color_fragment_source, emoji_vao);
+    if (text.program == 0) std.debug.print("UI text pipeline failed\n", .{});
+    if (emoji.program == 0) std.debug.print("UI emoji pipeline failed\n", .{});
+
+    var solid_handle: c.GLuint = 0;
+    gl.GenTextures.?(1, &solid_handle);
+    gl.BindTexture.?(c.GL_TEXTURE_2D, solid_handle);
+    const white_pixel = [_]u8{255};
+    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RED, 1, 1, 0, c.GL_RED, c.GL_UNSIGNED_BYTE, &white_pixel);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_NEAREST);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_NEAREST);
+    solid = Texture.fromHandle(solid_handle);
+}
+
+pub fn deinit() void {
+    text.deinit();
+    emoji.deinit();
+    quad.deinit();
+    if (solid.handle != 0) {
+        gpu.glTable().DeleteTextures.?(1, &solid.handle);
+        solid.handle = 0;
+    }
+}
+
+fn quadVertices(rect: Rect, uv: Uv) [6][4]f32 {
+    return .{
+        .{ rect.x, rect.y + rect.h, uv.u0, uv.v0 },
+        .{ rect.x, rect.y, uv.u0, uv.v1 },
+        .{ rect.x + rect.w, rect.y, uv.u1, uv.v1 },
+        .{ rect.x, rect.y + rect.h, uv.u0, uv.v0 },
+        .{ rect.x + rect.w, rect.y, uv.u1, uv.v1 },
+        .{ rect.x + rect.w, rect.y + rect.h, uv.u1, uv.v0 },
+    };
+}
+
+/// Set the text pipeline's ortho projection (frame-level; = old gl_init.setProjection).
+/// The emoji pipeline needs no frame-level update — drawColorGlyph re-derives its
+/// projection from the viewport per call.
+pub fn setProjection(width: f32, height: f32) void {
+    const gl = gpu.glTable();
+    const projection = [16]f32{
+        2.0 / width, 0.0,          0.0,  0.0,
+        0.0,         2.0 / height, 0.0,  0.0,
+        0.0,         0.0,          -1.0, 0.0,
+        -1.0,        -1.0,         0.0,  1.0,
+    };
+    gl.UseProgram.?(text.program);
+    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(text.program, "projection"), 1, c.GL_FALSE, &projection);
+}
+
+pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    fillQuadAlpha(x, y, w, h, color, 1.0);
+}
+
+/// Solid color quad (= old gl_init.renderQuadAlpha). Preserves the alpha trick:
+/// blends `color` toward g_theme.background by `alpha` and draws opaque via the
+/// solid texture (no BlendFunc needed — alpha is baked into the color channel).
+pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+    const gl = gpu.glTable();
+    const bg = AppWindow.g_theme.background;
+    const r = color[0] * alpha + bg[0] * (1 - alpha);
+    const g = color[1] * alpha + bg[1] * (1 - alpha);
+    const b = color[2] * alpha + bg[2] * (1 - alpha);
+    const verts = quadVertices(.{ .x = x, .y = y, .w = w, .h = h }, .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1 });
+    text.use();
+    text.bindVao();
+    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), r, g, b);
+    solid.bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+}
+
+/// Grayscale/text glyph via the text pipeline (atlas .r as alpha, modulated by color).
+pub fn drawGlyph(rect: Rect, uv: Uv, tex: c.GLuint, color: [3]f32) void {
+    const gl = gpu.glTable();
+    const verts = quadVertices(rect, uv);
+    text.use();
+    text.bindVao();
+    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), color[0], color[1], color[2]);
+    Texture.fromHandle(tex).bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+}
+
+/// Color-emoji via the emoji pipeline: premultiplied-alpha blend bookend +
+/// per-call projection from the current viewport (= old renderBellEmoji /
+/// renderTitlebarChar color branch).
+pub fn drawColorGlyph(rect: Rect, uv: Uv, tex: c.GLuint, opacity: f32) void {
+    const gl = gpu.glTable();
+    const verts = quadVertices(rect, uv);
+    emoji.use();
+    emoji.bindVao();
+    emoji.setProjection(); // viewport-derived ortho on the emoji program (Pipeline.setProjection)
+    gl.Uniform1f.?(gl.GetUniformLocation.?(emoji.program, "opacity"), opacity);
+    gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
+    Texture.fromHandle(tex).bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -33,4 +33,5 @@ test {
     _ = @import("agent_history.zig");
     _ = @import("renderer/gpu/backend.zig");
     _ = @import("renderer/cell_geometry.zig");
+    _ = @import("renderer/titlebar_layout.zig");
 }


### PR DESCRIPTION
## Summary

Second A3 increment (TODO.md Phase A): move the shared immediate-mode UI rendering (solid quad / text-glyph / color-emoji) out of `gl_init` into a primitives-backed `ui_pipeline.zig`, and convert `titlebar.zig` onto it as the proving ground. Both decoupling axes, touching titlebar once.

- **`ui_pipeline.zig`** (new) — owns text + emoji `gpu.Pipeline`, a dynamic quad `gpu.Buffer`, a 1×1 `solid` `gpu.Texture`; self-contained draw helpers `fillQuad`/`fillQuadAlpha`/`drawGlyph`/`drawColorGlyph`/`setProjection` (each binds its own program + VAO).
- **Compat shim** — `gl_init` keeps mirror handles (`shader_program`/`simple_color_shader`/`vao`/`vbo`, set by `syncSharedHandles()` after `ui_pipeline.init()`) + re-exports `renderQuad`/`renderQuadAlpha`/`setProjection` → `ui_pipeline`. So the ~12 not-yet-converted renderer files are **untouched** and keep working; the mirrors dissolve as each converts.
- **titlebar Axis A** — the 3 raw-GL glyph/emoji functions now call `ui_pipeline.drawGlyph`/`drawColorGlyph`; the ambient `UseProgram`/`BindVertexArray` frame-setup + the glad `@cImport` are gone (titlebar has zero raw `gl.*`). The 63 `gl_init.renderQuad` calls are unchanged (route through `ui_pipeline` via the re-export).
- **titlebar Axis B** — pure layout/geometry logic (`pointInRect`/`blend`/`sidebarMaxWidthForWindow`/`clampSidebarWidth`/`fallbackCodepoint`) extracted to std-only `titlebar_layout.zig` with unit tests.

Behavior-preserving: per-task spec reviews confirmed GL-behavior equivalence (glyph/emoji draws, the `renderQuadAlpha` alpha trick, the color-emoji premultiplied-blend bookend) and that the ~12 unconverted files self-bind their own program/VAO (so dropping titlebar's frame-setup is safe). The final whole-increment review verified resource lifecycle (no double-free), init-order/compat-var timing, and cross-file ambient-state safety.

Spec + plan: `docs/superpowers/specs/2026-05-26-gpu-a3-titlebar-design.md`, `docs/superpowers/plans/2026-05-26-gpu-a3-titlebar.md`.

## Test Plan

- [x] `zig build` (x86_64-windows-gnu) — clean `phantty.exe`
- [x] `zig build test-full` — 516/517 passed, 1 skipped, 0 failed (the skip = weixin group_message)
- [x] `zig build test` — `titlebar_layout`'s pure-logic tests pass in the fast suite
- [x] Manual Windows visual check — titlebar (tabs/shading/separators/`+`/caption buttons/agent badges), bell emoji + icons, sidebar rows/header/drag-resize, and the terminal grid/overlays/panels all render identically to `main`

## Known follow-up (non-blocking)

Shader **link-failure** handling softened from hard-abort to print-and-continue when the shared-rendering pipelines moved into `ui_pipeline.init()` (consistent with how `cell_pipeline` already behaves). The clean fix is a holistic "GPU pipeline init returns errors → AppWindow aborts" pass covering both `ui_pipeline` and `cell_pipeline` — deferred to its own task.

## Not in this PR (deferred)

The remaining UI files (overlays, ai_chat_renderer, image_renderer, post_process, background_image, fbo, markdown_preview_renderer, file_explorer_renderer) — each converts to `ui_pipeline`, dissolving the compat mirrors. Then A4 (font atlas → `Texture`), A5 (MSL), A6 (guards), and the API-neutralization collation step before the Metal backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)