### PR TITLE
[codex] Add render diagnostics and fix DPI resize rendering

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2870,7 +2870,8 @@ fn handleWindowDpiChanged(
         return;
     }
 
-    std.debug.print("DPI changed: {} -> {}\n", .{ font.g_dpi, new_dpi });
+    const old_font_dpi = font.g_dpi;
+    std.debug.print("DPI changed: {} -> {}\n", .{ old_font_dpi, new_dpi });
     font.g_dpi = new_dpi;
     if (reloadFontFaces(allocator, family, weight, font.g_font_size, ft_lib)) {
         const size = window_backend.clientSize(win);
@@ -2881,8 +2882,14 @@ fn handleWindowDpiChanged(
         );
         onPlatformResize(size.width, size.height);
     } else {
-        render_diagnostics.log("dpi-change font-reload-failed new_dpi={} kept_cell={d:.2}x{d:.2}", .{ new_dpi, font.cell_width, font.cell_height });
+        font.g_dpi = old_font_dpi;
+        const size = window_backend.clientSize(win);
+        render_diagnostics.log(
+            "dpi-change font-reload-failed new_dpi={} restored_font_dpi={} kept_cell={d:.2}x{d:.2}",
+            .{ new_dpi, old_font_dpi, font.cell_width, font.cell_height },
+        );
         std.debug.print("DPI font reload failed, keeping previous font\n", .{});
+        onPlatformResize(size.width, size.height);
     }
 }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -34,6 +34,7 @@ const startup_tabs = @import("startup_tabs.zig");
 const quick_terminal = @import("quick_terminal.zig");
 const keybind = @import("keybind.zig");
 const thread_message = @import("appwindow/thread_message.zig");
+const render_diagnostics = @import("render_diagnostics.zig");
 pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
@@ -395,6 +396,61 @@ fn clearWithBackground(fb_w: c_int, fb_h: c_int) void {
     gpu.glTable().ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
     gpu.glTable().Clear.?(gpu.c.GL_COLOR_BUFFER_BIT);
     background_image.drawFullscreen(@floatFromInt(fb_w), @floatFromInt(fb_h));
+}
+
+threadlocal var g_diag_last_fb_w: c_int = -1;
+threadlocal var g_diag_last_fb_h: c_int = -1;
+threadlocal var g_diag_last_client_w: i32 = -1;
+threadlocal var g_diag_last_client_h: i32 = -1;
+threadlocal var g_diag_last_dpi: u32 = 0;
+threadlocal var g_diag_last_cell_w: f32 = 0;
+threadlocal var g_diag_last_cell_h: f32 = 0;
+
+fn logFrameGeometryIfChanged(win: *window_backend.Window, fb_width: c_int, fb_height: c_int, titlebar_offset: f32) void {
+    if (!render_diagnostics.enabled()) return;
+
+    const client = window_backend.clientSize(win);
+    const dpi_now = window_backend.effectiveDpi(win);
+    if (fb_width == g_diag_last_fb_w and
+        fb_height == g_diag_last_fb_h and
+        client.width == g_diag_last_client_w and
+        client.height == g_diag_last_client_h and
+        dpi_now == g_diag_last_dpi and
+        font.cell_width == g_diag_last_cell_w and
+        font.cell_height == g_diag_last_cell_h)
+    {
+        return;
+    }
+
+    g_diag_last_fb_w = fb_width;
+    g_diag_last_fb_h = fb_height;
+    g_diag_last_client_w = client.width;
+    g_diag_last_client_h = client.height;
+    g_diag_last_dpi = dpi_now;
+    g_diag_last_cell_w = font.cell_width;
+    g_diag_last_cell_h = font.cell_height;
+
+    render_diagnostics.log(
+        "frame-geometry client={}x{} fb={}x{} dpi={} font_dpi={} cell={d:.2}x{d:.2} titlebar={d:.1} panels_l={d:.1} panels_r={d:.1} term={}x{} max={} full={} min={}",
+        .{
+            client.width,
+            client.height,
+            fb_width,
+            fb_height,
+            dpi_now,
+            font.g_dpi,
+            font.cell_width,
+            font.cell_height,
+            titlebar_offset,
+            leftPanelsWidth(),
+            rightPanelsWidthForWindow(fb_width),
+            term_cols,
+            term_rows,
+            window_backend.isMaximized(win),
+            window_backend.isFullscreen(win),
+            window_backend.isMinimized(win),
+        },
+    );
 }
 
 fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
@@ -1158,6 +1214,35 @@ fn onPlatformResize(width: i32, height: i32) void {
     if (g_allocator == null) return;
     const resize_perf = ui_perf.begin("appwindow.on_platform_resize");
     defer resize_perf.end();
+    if (g_window) |w| {
+        const client = window_backend.clientSize(w);
+        const fb = window_backend.framebufferSize(w);
+        render_diagnostics.log(
+            "platform-resize begin arg={}x{} client={}x{} fb={}x{} dpi={} font_dpi={} cell={d:.2}x{d:.2} term={}x{} pending={} max={} full={}",
+            .{
+                width,
+                height,
+                client.width,
+                client.height,
+                fb.width,
+                fb.height,
+                window_backend.effectiveDpi(w),
+                font.g_dpi,
+                font.cell_width,
+                font.cell_height,
+                term_cols,
+                term_rows,
+                g_pending_resize,
+                window_backend.isMaximized(w),
+                window_backend.isFullscreen(w),
+            },
+        );
+    } else {
+        render_diagnostics.log(
+            "platform-resize begin arg={}x{} no-window font_dpi={} cell={d:.2}x{d:.2} term={}x{} pending={}",
+            .{ width, height, font.g_dpi, font.cell_width, font.cell_height, term_cols, term_rows, g_pending_resize },
+        );
+    }
 
     // Match exactly what computeSplitLayout → setScreenSize computes for a
     // root (full-window) surface, so term_cols/term_rows stay in sync and
@@ -1181,6 +1266,10 @@ fn onPlatformResize(width: i32, height: i32) void {
 
     const new_cols: u16 = @intFromFloat(@max(1, avail_w / font.cell_width));
     const new_rows: u16 = @intFromFloat(@max(1, avail_h / font.cell_height));
+    render_diagnostics.log(
+        "platform-resize grid avail={d:.1}x{d:.1} panels_l={d:.1} panels_r={d:.1} titlebar={d:.1} new={}x{} old={}x{}",
+        .{ avail_w, avail_h, left_panels_w, right_panels_w, tb, new_cols, new_rows, term_cols, term_rows },
+    );
 
     // Update root grid dimensions (used for spawning new tabs).
     // Actual terminal + PTY resize is handled by computeSplitLayout → setScreenSize
@@ -1190,6 +1279,7 @@ fn onPlatformResize(width: i32, height: i32) void {
         term_rows = new_rows;
         // Clear any pending coalesced resize — we're handling it now
         g_pending_resize = false;
+        render_diagnostics.log("platform-resize root-grid-updated {}x{}", .{ term_cols, term_rows });
     }
 
     // Sync atlas textures
@@ -1323,6 +1413,10 @@ fn onPlatformResize(width: i32, height: i32) void {
     overlays.renderUpdatePrompt(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
 
+    render_diagnostics.log(
+        "platform-resize swap fb={}x{} term={}x{} draw_calls={}",
+        .{ fb_width, fb_height, term_cols, term_rows, gpu.gl_init.g_draw_call_count },
+    );
     if (g_window) |w| window_backend.swapBuffers(w);
 }
 
@@ -2749,8 +2843,29 @@ fn handleWindowDpiChanged(
 ) void {
     const new_dpi = window_backend.effectiveDpi(win);
     if (new_dpi == 0) return;
+    const client_before = window_backend.clientSize(win);
+    const fb_before = window_backend.framebufferSize(win);
+    render_diagnostics.log(
+        "dpi-change begin old_font_dpi={} new_dpi={} client={}x{} fb={}x{} cell={d:.2}x{d:.2} term={}x{}",
+        .{
+            font.g_dpi,
+            new_dpi,
+            client_before.width,
+            client_before.height,
+            fb_before.width,
+            fb_before.height,
+            font.cell_width,
+            font.cell_height,
+            term_cols,
+            term_rows,
+        },
+    );
     if (font.g_dpi == new_dpi) {
         const size = window_backend.clientSize(win);
+        render_diagnostics.log(
+            "dpi-change same-dpi render-refresh client={}x{} font_dpi={} cell={d:.2}x{d:.2}",
+            .{ size.width, size.height, font.g_dpi, font.cell_width, font.cell_height },
+        );
         onPlatformResize(size.width, size.height);
         return;
     }
@@ -2759,8 +2874,14 @@ fn handleWindowDpiChanged(
     font.g_dpi = new_dpi;
     if (reloadFontFaces(allocator, family, weight, font.g_font_size, ft_lib)) {
         const size = window_backend.clientSize(win);
+        const fb_after = window_backend.framebufferSize(win);
+        render_diagnostics.log(
+            "dpi-change font-reloaded client={}x{} fb={}x{} font_dpi={} cell={d:.2}x{d:.2} term={}x{}",
+            .{ size.width, size.height, fb_after.width, fb_after.height, font.g_dpi, font.cell_width, font.cell_height, term_cols, term_rows },
+        );
         onPlatformResize(size.width, size.height);
     } else {
+        render_diagnostics.log("dpi-change font-reload-failed new_dpi={} kept_cell={d:.2}x{d:.2}", .{ new_dpi, font.cell_width, font.cell_height });
         std.debug.print("DPI font reload failed, keeping previous font\n", .{});
     }
 }
@@ -3594,6 +3715,7 @@ fn runMainLoop(self: *AppWindow) !void {
         const left_panels_w = leftPanelsWidth();
         const right_panels_w = rightPanelsWidthForWindow(fb_width);
         const top_padding: f32 = padding + titlebar_offset;
+        logFrameGeometryIfChanged(win, fb_width, fb_height, titlebar_offset);
         {
             const perf = ui_perf.begin("appwindow.browser_panel_sync");
             defer perf.end();
@@ -3779,6 +3901,8 @@ fn runMainLoop(self: *AppWindow) !void {
     // and renderer resources start tearing down. The App-level controller is
     // stopped shortly after this window loop returns.
     g_weixin_ui_handle.store(0, .release);
+    render_diagnostics.log("shutdown window-loop-ended", .{});
+    render_diagnostics.close();
 
     // Clean up file explorer async state (join background thread, free job)
     file_explorer.deinit();

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1412,9 +1412,19 @@ fn pushImeResultString(w: *Window) void {
     w.clearImePreedit();
 }
 
-fn getResizeBorderThickness() i32 {
+const GetSystemMetricsForDpiFn = *const fn (INT, UINT) callconv(.winapi) INT;
+
+fn systemMetricForDpi(metric: INT, dpi: u32) INT {
+    const user32 = GetModuleHandleW(std.unicode.utf8ToUtf16LeStringLiteral("user32.dll")) orelse return GetSystemMetrics(metric);
+    const proc = GetProcAddress(user32, "GetSystemMetricsForDpi") orelse return GetSystemMetrics(metric);
+    const get_for_dpi: GetSystemMetricsForDpiFn = @ptrCast(proc);
+    const effective_dpi: UINT = if (dpi == 0) GetDpiForSystem() else dpi;
+    return get_for_dpi(metric, effective_dpi);
+}
+
+fn getResizeBorderThickness(dpi: u32) i32 {
     // SM_CXSIZEFRAME + SM_CXPADDEDBORDER gives the total resize border width
-    return GetSystemMetrics(SM_CXSIZEFRAME) + GetSystemMetrics(SM_CXPADDEDBORDER);
+    return systemMetricForDpi(SM_CXSIZEFRAME, dpi) + systemMetricForDpi(SM_CXPADDEDBORDER, dpi);
 }
 
 /// Get the caption button width (min/max/close area).
@@ -1453,7 +1463,7 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             if (g_win32_window) |w| {
                 if (IsZoomed(hwnd) != 0 and !w.is_fullscreen) {
                     const params: *NCCALCSIZE_PARAMS = @ptrFromInt(@as(usize, @bitCast(lParam)));
-                    const border = getResizeBorderThickness();
+                    const border = getResizeBorderThickness(w.dpi);
                     const before = params.rgrc[0];
                     params.rgrc[0].top += border;
                     params.rgrc[0].left += border;
@@ -1538,6 +1548,13 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             // Render a frame immediately so newly exposed pixels show
             // the terminal background instead of black. This runs inside
             // the Win32 modal resize loop where our main loop is blocked.
+            if (w.dpi_changed) {
+                render_diagnostics.log(
+                    "WM_SIZE defer-sync-render pending-dpi client={}x{} dpi={}",
+                    .{ width, height, w.dpi },
+                );
+                return 0;
+            }
             if (w.on_resize) |cb| cb(width, height);
             return 0;
         },
@@ -1652,7 +1669,7 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             var client_rect: RECT = undefined;
             _ = GetClientRect(hwnd, &client_rect);
 
-            const border = getResizeBorderThickness();
+            const border = getResizeBorderThickness(w.dpi);
             const titlebar_h = w.titlebar_height;
 
             // Resize borders (top, left, right, bottom, corners)

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const windows = std.os.windows;
 const platform_input = @import("../platform/input_events.zig");
 const platform_window = @import("../platform/window.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
 
 // ============================================================================
 // Win32 API types
@@ -1198,6 +1199,10 @@ pub const Window = struct {
         };
         // AdjustWindowRectEx to account for chrome
         adjustWindowRectEx(&rect, WS_OVERLAPPEDWINDOW, 0, WS_EX_APPWINDOW);
+        render_diagnostics.log(
+            "setSize client={}x{} outer={}x{} dpi={} zoomed={} fullscreen={}",
+            .{ w, h, rect.right - rect.left, rect.bottom - rect.top, self.dpi, IsZoomed(self.hwnd) != 0, self.is_fullscreen },
+        );
         _ = SetWindowPos(
             self.hwnd,
             null,
@@ -1210,6 +1215,10 @@ pub const Window = struct {
     }
 
     pub fn setOuterFrame(self: *Window, x: i32, y: i32, w: i32, h: i32, topmost: bool) void {
+        render_diagnostics.log(
+            "setOuterFrame outer=({},{} {}x{}) topmost={} dpi={} zoomed={} fullscreen={}",
+            .{ x, y, w, h, topmost, self.dpi, IsZoomed(self.hwnd) != 0, self.is_fullscreen },
+        );
         _ = SetWindowPos(
             self.hwnd,
             if (topmost) HWND_TOPMOST else HWND_NOTOPMOST,
@@ -1445,10 +1454,28 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
                 if (IsZoomed(hwnd) != 0 and !w.is_fullscreen) {
                     const params: *NCCALCSIZE_PARAMS = @ptrFromInt(@as(usize, @bitCast(lParam)));
                     const border = getResizeBorderThickness();
+                    const before = params.rgrc[0];
                     params.rgrc[0].top += border;
                     params.rgrc[0].left += border;
                     params.rgrc[0].right -= border;
                     params.rgrc[0].bottom -= border;
+                    const after = params.rgrc[0];
+                    render_diagnostics.log(
+                        "WM_NCCALCSIZE zoomed border={} dpi={} fullscreen={} before=({},{} {}x{}) after=({},{} {}x{})",
+                        .{
+                            border,
+                            w.dpi,
+                            w.is_fullscreen,
+                            before.left,
+                            before.top,
+                            before.right - before.left,
+                            before.bottom - before.top,
+                            after.left,
+                            after.top,
+                            after.right - after.left,
+                            after.bottom - after.top,
+                        },
+                    );
                 }
             }
             return 0;
@@ -1475,10 +1502,15 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             const width: i32 = @as(i16, @bitCast(@as(u16, @intCast(lParam & 0xFFFF))));
             const height: i32 = @as(i16, @bitCast(@as(u16, @intCast((lParam >> 16) & 0xFFFF))));
             const size_type: UINT = @intCast(wParam & 0xFFFF);
+            render_diagnostics.log(
+                "WM_SIZE raw={}x{} type={} dpi={} dpi_changed={} zoomed={} fullscreen={}",
+                .{ width, height, size_type, w.dpi, w.dpi_changed, IsZoomed(hwnd) != 0, w.is_fullscreen },
+            );
             if (size_type == SIZE_MINIMIZED or width <= 0 or height <= 0) {
                 w.is_minimized = true;
                 w.size_changed = false;
                 w.clearTransientInputQueues();
+                render_diagnostics.log("WM_SIZE minimized-or-empty raw={}x{} type={}", .{ width, height, size_type });
                 return 0;
             }
 
@@ -1486,6 +1518,23 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             w.width = width;
             w.height = height;
             w.size_changed = true;
+            {
+                var rect: RECT = undefined;
+                _ = GetClientRect(hwnd, &rect);
+                render_diagnostics.log(
+                    "WM_SIZE state client={}x{} stored={}x{} dpi={} dpi_changed={} zoomed={} fullscreen={}",
+                    .{
+                        rect.right - rect.left,
+                        rect.bottom - rect.top,
+                        w.width,
+                        w.height,
+                        w.dpi,
+                        w.dpi_changed,
+                        IsZoomed(hwnd) != 0,
+                        w.is_fullscreen,
+                    },
+                );
+            }
             // Render a frame immediately so newly exposed pixels show
             // the terminal background instead of black. This runs inside
             // the Win32 modal resize loop where our main loop is blocked.
@@ -1494,10 +1543,26 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         },
         WM_DPICHANGED => {
             const new_dpi: u32 = @intCast(wParam & 0xFFFF);
+            const old_dpi = w.dpi;
+            const suggested: *const RECT = @ptrFromInt(@as(usize, @bitCast(lParam)));
+            render_diagnostics.log(
+                "WM_DPICHANGED begin old_dpi={} new_dpi={} suggested=({},{} {}x{}) stored={}x{} zoomed={} fullscreen={}",
+                .{
+                    old_dpi,
+                    new_dpi,
+                    suggested.left,
+                    suggested.top,
+                    suggested.right - suggested.left,
+                    suggested.bottom - suggested.top,
+                    w.width,
+                    w.height,
+                    IsZoomed(hwnd) != 0,
+                    w.is_fullscreen,
+                },
+            );
             if (new_dpi != 0) w.dpi = new_dpi;
             w.dpi_changed = true;
 
-            const suggested: *const RECT = @ptrFromInt(@as(usize, @bitCast(lParam)));
             _ = SetWindowPos(
                 hwnd,
                 null,
@@ -1513,6 +1578,10 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
             w.width = rect.right - rect.left;
             w.height = rect.bottom - rect.top;
             w.size_changed = true;
+            render_diagnostics.log(
+                "WM_DPICHANGED end dpi={} win_dpi={} client={}x{} stored={}x{} size_changed={}",
+                .{ w.dpi, GetDpiForWindow(hwnd), rect.right - rect.left, rect.bottom - rect.top, w.width, w.height, w.size_changed },
+            );
             return 0;
         },
         WM_ACTIVATE => {
@@ -1697,6 +1766,10 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
                         return 0;
                     },
                     .maximize => {
+                        render_diagnostics.log(
+                            "caption-maximize clicked dpi={} zoomed={} fullscreen={} stored={}x{}",
+                            .{ w.dpi, IsZoomed(hwnd) != 0, w.is_fullscreen, w.width, w.height },
+                        );
                         if (w.is_fullscreen) {
                             w.key_events.push(.{ .key_code = VK_RETURN, .alt = false, .ctrl = true, .shift = false });
                         } else if (IsZoomed(hwnd) != 0) {

--- a/src/input.zig
+++ b/src/input.zig
@@ -17,6 +17,7 @@ const markdown_preview_panel = AppWindow.markdown_preview_panel;
 const preview_token = @import("preview_token.zig");
 const browser_panel = AppWindow.browser_panel;
 const ui_perf = AppWindow.ui_perf;
+const render_diagnostics = @import("render_diagnostics.zig");
 const link_open = @import("link_open.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_local_path = @import("platform/local_path.zig");
@@ -275,6 +276,24 @@ fn syncGridFromWindowSize(width: i32, height: i32) void {
     const new_rows: u16 = @intFromFloat(@max(1, avail_height / font.cell_height));
 
     if (new_cols != AppWindow.term_cols or new_rows != AppWindow.term_rows) {
+        render_diagnostics.log(
+            "input-grid-sync source={}x{} avail={d:.1}x{d:.1} panels_l={d:.1} panels_r={d:.1} titlebar={d:.1} cell={d:.2}x{d:.2} pending={}x{} old={}x{}",
+            .{
+                width,
+                height,
+                avail_width,
+                avail_height,
+                left_panels_w,
+                right_panels_w,
+                tb_offset,
+                font.cell_width,
+                font.cell_height,
+                new_cols,
+                new_rows,
+                AppWindow.term_cols,
+                AppWindow.term_rows,
+            },
+        );
         AppWindow.g_pending_resize = true;
         AppWindow.g_pending_cols = new_cols;
         AppWindow.g_pending_rows = new_rows;
@@ -691,6 +710,10 @@ fn processSizeChange(win: anytype) void {
     if (!window_backend.consumeSizeChanged(win)) return;
     const size = window_backend.clientSize(win);
     if (window_backend.isMinimized(win) or size.width <= 0 or size.height <= 0) return;
+    render_diagnostics.log(
+        "input-size-change client={}x{} dpi={} font_dpi={} cell={d:.2}x{d:.2} term={}x{}",
+        .{ size.width, size.height, window_backend.effectiveDpi(win), font.g_dpi, font.cell_width, font.cell_height, AppWindow.term_cols, AppWindow.term_rows },
+    );
     if (titlebar.setSidebarWidth(titlebar.g_sidebar_width, @floatFromInt(size.width))) {
         syncSidebarWidthToBackend(win);
         AppWindow.g_force_rebuild = true;
@@ -3481,6 +3504,11 @@ fn toggleAiAgentPermission() void {
 
 pub fn toggleMaximize() void {
     const win = AppWindow.g_window orelse return;
+    const size = window_backend.clientSize(win);
+    render_diagnostics.log(
+        "toggle-maximize requested client={}x{} dpi={} full={} max={}",
+        .{ size.width, size.height, window_backend.effectiveDpi(win), window_backend.isFullscreen(win), window_backend.isMaximized(win) },
+    );
 
     if (window_backend.isFullscreen(win)) {
         toggleFullscreen();
@@ -3494,6 +3522,11 @@ pub fn toggleMaximize() void {
 
 pub fn toggleFullscreen() void {
     const win = AppWindow.g_window orelse return;
+    const size = window_backend.clientSize(win);
+    render_diagnostics.log(
+        "toggle-fullscreen requested client={}x{} dpi={} full={} max={}",
+        .{ size.width, size.height, window_backend.effectiveDpi(win), window_backend.isFullscreen(win), window_backend.isMaximized(win) },
+    );
 
     if (window_backend.isFullscreen(win)) {
         // Restore windowed mode

--- a/src/render_diagnostics.zig
+++ b/src/render_diagnostics.zig
@@ -1,0 +1,108 @@
+//! Opt-in rendering/window geometry diagnostics.
+//!
+//! Enable with `PHANTTY_RENDER_DIAGNOSTICS=1`. Logs go to
+//! `%APPDATA%\phantty\render-diagnostic.log` on Windows, matching the config
+//! directory convention used elsewhere in the app.
+
+const std = @import("std");
+const platform_dirs = @import("platform/dirs.zig");
+
+const ENV_NAME = "PHANTTY_RENDER_DIAGNOSTICS";
+const LOG_BASENAME = "render-diagnostic.log";
+
+threadlocal var g_checked: bool = false;
+threadlocal var g_enabled: bool = false;
+threadlocal var g_file_open: bool = false;
+threadlocal var g_file: std.fs.File = undefined;
+threadlocal var g_start_ms: i64 = 0;
+
+pub fn enabled() bool {
+    if (g_checked) return g_enabled;
+    g_checked = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, ENV_NAME) catch {
+        g_enabled = false;
+        return g_enabled;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    g_enabled = parseEnabledValue(value);
+    return g_enabled;
+}
+
+pub fn log(comptime fmt: []const u8, args: anytype) void {
+    if (!enabled()) return;
+
+    const file = ensureFile() catch |err| {
+        std.debug.print("[render-diag] failed to open log: {}\n", .{err});
+        std.debug.print("[render-diag] " ++ fmt ++ "\n", args);
+        return;
+    };
+
+    const now = std.time.milliTimestamp();
+    const elapsed = if (g_start_ms == 0) 0 else now - g_start_ms;
+    var write_buf: [4096]u8 = undefined;
+    var writer = file.writerStreaming(&write_buf);
+    writer.interface.print("[+{d}ms] ", .{elapsed}) catch return;
+    writer.interface.print(fmt, args) catch return;
+    writer.interface.writeAll("\n") catch return;
+    writer.end() catch return;
+}
+
+pub fn close() void {
+    if (!g_file_open) return;
+    g_file.close();
+    g_file_open = false;
+}
+
+pub fn logFilePath(allocator: std.mem.Allocator) ![]const u8 {
+    return platform_dirs.pathInConfigDir(allocator, LOG_BASENAME);
+}
+
+fn ensureFile() !*std.fs.File {
+    if (g_file_open) return &g_file;
+
+    const allocator = std.heap.page_allocator;
+    const dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+
+    const path = try std.fs.path.join(allocator, &.{ dir, LOG_BASENAME });
+    defer allocator.free(path);
+
+    g_file = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+    g_file_open = true;
+    g_start_ms = std.time.milliTimestamp();
+    var write_buf: [1024]u8 = undefined;
+    var writer = g_file.writerStreaming(&write_buf);
+    writer.interface.print(
+        "Phantty render diagnostics started timestamp_ms={d} env={s}\n",
+        .{ g_start_ms, ENV_NAME },
+    ) catch {};
+    writer.end() catch {};
+    return &g_file;
+}
+
+fn parseEnabledValue(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.mem.eql(u8, trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+test "render diagnostics enabled parser accepts common truthy values" {
+    try std.testing.expect(parseEnabledValue("1"));
+    try std.testing.expect(parseEnabledValue("true"));
+    try std.testing.expect(parseEnabledValue("TRUE"));
+    try std.testing.expect(parseEnabledValue("yes"));
+    try std.testing.expect(parseEnabledValue("on"));
+}
+
+test "render diagnostics enabled parser rejects empty and falsey values" {
+    try std.testing.expect(!parseEnabledValue(""));
+    try std.testing.expect(!parseEnabledValue("0"));
+    try std.testing.expect(!parseEnabledValue("false"));
+    try std.testing.expect(!parseEnabledValue("off"));
+    try std.testing.expect(!parseEnabledValue("anything-else"));
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -31,6 +31,7 @@ test {
     _ = @import("scrollbar_model.zig");
     _ = @import("preview_token.zig");
     _ = @import("agent_history.zig");
+    _ = @import("render_diagnostics.zig");
     _ = @import("renderer/gpu/backend.zig");
     _ = @import("renderer/cell_geometry.zig");
 }


### PR DESCRIPTION
## Summary

- add opt-in render diagnostics logging via `PHANTTY_RENDER_DIAGNOSTICS`
- log Win32 resize, DPI-change, frame geometry, maximize/fullscreen, and grid recalculation paths
- defer synchronous resize rendering while a DPI change is pending so Phantty does not draw with mismatched window DPI and font metrics
- use per-DPI system metrics for custom-frame resize borders during maximize and hit testing

## Root Cause

The diagnostic run showed that `WM_DPICHANGED` could update the window DPI and synchronously trigger resize rendering before font faces and cell metrics were reloaded. That produced transient frames such as `dpi=96 font_dpi=144`, which can expose stale geometry as black or offset regions on slower/high-DPI systems.

The custom frame also used process/system metrics for resize borders, so maximized bounds were not DPI-aware on mixed-DPI monitors.

Related to #46 and #47.

## Validation

- `zig build`
- `zig build test`
- `zig build test-full`
- `git diff --check`
- manual diagnostic run across 144 DPI and 96 DPI displays confirmed resize rendering now occurs after `dpi == font_dpi`, and maximize borders differ by DPI (`144 -> 11`, `96 -> 8`)