### PR TITLE
GPU A3 increment 3: route ai_chat_renderer through ui_pipeline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -119,8 +119,14 @@ mapping in guide §2 and §5.
       still-unconverted files are untouched. `titlebar` is converted (glyph/emoji
       through `ui_pipeline`, no raw `gl.*`/glad) and its pure layout logic moved
       to std-only `titlebar_layout.zig`. `overlay_shader` stays in `gl_init`.
-      *Still pending:* `overlays`, `ai_chat_renderer`, `image_renderer`,
-      `post_process`, `background_image`, `fbo`, `markdown_preview_renderer`,
+      *Increment 3 done:* `ai_chat_renderer` is converted — its 56 quad draws
+      route through `ui_pipeline.fillQuad*`, the two scissor regions through new
+      `ui_pipeline.beginClip`/`endClip`, and the redundant local blend setup +
+      `glad` cImport + `gl_init` import are gone (the file is now raw-`gl.*`-free,
+      like `titlebar`). Its pure rect geometry moved to std-only, unit-tested
+      `ai_chat_layout.zig`.
+      *Still pending:* `overlays`, `image_renderer`, `post_process`,
+      `background_image`, `fbo`, `markdown_preview_renderer`,
       `file_explorer_renderer` (each converts to `ui_pipeline`, dissolving the
       compat mirrors as they go).
 - [ ] **A4** Route font atlas → GPU texture through the `Texture` primitive;

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
@@ -450,7 +450,7 @@ fn copyButtonRectForBubble(bubble_x: f32, top_px: f32, bubble_w: f32) CopyButton
 }
 
 fn permissionChipX(x: f32, w: f32) f32 {
-    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, STATUS_SLOT_W, PERMISSION_CHIP_W);
+    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, STATUS_SLOT_W, 12, PERMISSION_CHIP_W);
 }
 
 fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
@@ -4,7 +4,7 @@
 
 **Goal:** Route `src/renderer/ai_chat_renderer.zig` entirely through the shared `ui_pipeline` (plus a new clip helper), ending with zero raw `gl.*` and no `glad` cImport, and extract its pure rect-geometry into a std-only, unit-tested `ai_chat_layout.zig`.
 
-**Architecture:** Axis A — replace the 56 `gl_init.renderQuad*` calls with `ui_pipeline.fillQuad*`, the two `GL_SCISSOR_TEST` regions with new `ui_pipeline.pushClip/popClip`, and delete the now-redundant ambient blend/program setup (blend is frame-level in `AppWindow`). Axis B — move 7 pure rect-geometry functions into `src/ai_chat_layout.zig` (std-only, constants/metrics passed as params), with `ai_chat_renderer` keeping thin wrappers so internal call sites are unchanged.
+**Architecture:** Axis A — replace the 56 `gl_init.renderQuad*` calls with `ui_pipeline.fillQuad*`, the two `GL_SCISSOR_TEST` regions with new `ui_pipeline.beginClip/endClip`, and delete the now-redundant ambient blend/program setup (blend is frame-level in `AppWindow`). Axis B — move 7 pure rect-geometry functions into `src/ai_chat_layout.zig` (std-only, constants/metrics passed as params), with `ai_chat_renderer` keeping thin wrappers so internal call sites are unchanged.
 
 **Tech Stack:** Zig 0.15.2; OpenGL via the `gpu` backend primitives; tests via `zig build test` (fast, std-only) and `zig build test-full` (full app binary, pre-merge gate).
 
@@ -15,7 +15,7 @@
 ## File Structure
 
 - **Create** `src/ai_chat_layout.zig` — std-only pure rect geometry + unit tests. Sibling of the existing `ai_chat_composer_layout.zig` / `ai_chat_scrollbar_model.zig`.
-- **Modify** `src/renderer/ui_pipeline.zig` — add `pushClip(rect)` / `popClip()`.
+- **Modify** `src/renderer/ui_pipeline.zig` — add `beginClip(rect)` / `endClip()`.
 - **Modify** `src/renderer/ai_chat_renderer.zig` — quad/scissor/ambient conversion; alias `Rect`/`BubbleGeometry` and wrap geometry via `ai_chat_layout`; drop the `glad` cImport.
 - **Modify** `src/test_fast.zig` — register `ai_chat_layout.zig`.
 
@@ -100,7 +100,7 @@ test "detailCopyButtonRect centers in header_h" {
 }
 
 test "permissionChipX" {
-    const px = permissionChipX(0, 1000, 18, 280, 104); // w - line_pad - status - 12 - chip
+    const px = permissionChipX(0, 1000, 18, 280, 12, 104); // w - line_pad - status - gap - chip
     try std.testing.expectApproxEqAbs(@as(f32, 586), px, 0.001);
 }
 
@@ -177,8 +177,8 @@ pub fn detailCopyButtonRect(
     };
 }
 
-pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip_w: f32) f32 {
-    return x + w - line_pad_x - status_slot_w - 12 - chip_w;
+pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip_gap: f32, chip_w: f32) f32 {
+    return x + w - line_pad_x - status_slot_w - chip_gap - chip_w;
 }
 
 pub fn stopButtonRect(
@@ -215,7 +215,7 @@ Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 
 ---
 
-## Task 2: `ui_pipeline.pushClip` / `popClip` (Axis A infra)
+## Task 2: `ui_pipeline.beginClip` / `endClip` (Axis A infra)
 
 **Files:**
 - Modify: `src/renderer/ui_pipeline.zig`
@@ -228,7 +228,7 @@ In `src/renderer/ui_pipeline.zig`, add after the `setProjection` function (befor
 /// Enable scissor clipping to `rect` (window-space, same convention as the
 /// caller's existing glScissor: x/y are the lower-left corner in GL pixels).
 /// Rounds to integer pixels, matching the prior @intFromFloat(@round(...)) calls.
-pub fn pushClip(rect: Rect) void {
+pub fn beginClip(rect: Rect) void {
     const gl = gpu.glTable();
     gl.Enable.?(c.GL_SCISSOR_TEST);
     gl.Scissor.?(
@@ -241,7 +241,7 @@ pub fn pushClip(rect: Rect) void {
 
 /// Disable scissor clipping (= the prior gl.Disable(GL_SCISSOR_TEST)). Flat
 /// enable/disable, not a nesting stack — ai_chat never nests clip regions.
-pub fn popClip() void {
+pub fn endClip() void {
     gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
 }
 ```
@@ -257,7 +257,7 @@ Expected: clean build, no errors.
 
 ```bash
 git add src/renderer/ui_pipeline.zig
-git commit -m "feat: add ui_pipeline.pushClip/popClip scissor helpers (A3 increment 3)
+git commit -m "feat: add ui_pipeline.beginClip/endClip scissor helpers (A3 increment 3)
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 ```
@@ -304,7 +304,7 @@ Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
 
 ---
 
-## Task 4: Scissor → pushClip/popClip, drop ambient setup + glad cImport (Axis A)
+## Task 4: Scissor → beginClip/endClip, drop ambient setup + glad cImport (Axis A)
 
 **Files:**
 - Modify: `src/renderer/ai_chat_renderer.zig`
@@ -341,10 +341,10 @@ Replace the input-field scissor enable (currently ~183-189):
 with:
 
 ```zig
-    ui_pipeline.pushClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
+    ui_pipeline.beginClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
 ```
 
-And its matching disable (currently ~255): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.popClip();`
+And its matching disable (currently ~255): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.endClip();`
 
 - [ ] **Step 3: Convert the transcript scissor region**
 
@@ -363,10 +363,10 @@ Replace the transcript scissor enable (currently ~281-287):
 with:
 
 ```zig
-    ui_pipeline.pushClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
+    ui_pipeline.beginClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
 ```
 
-And its matching disable (currently ~332): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.popClip();`
+And its matching disable (currently ~332): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.endClip();`
 
 - [ ] **Step 4: Remove the glad cImport**
 
@@ -503,7 +503,7 @@ The AI chat panel must render identically. Verify:
 - Message bubbles: user right-aligned (0.82 width), assistant full-width; selection rule; **copy buttons** (hover/click hit area unchanged).
 - Tool / reasoning cards: collapse arrows, header, copy button placement.
 - Usage footer.
-- Input field: typing, multi-line, and **scroll-clipping** — text scrolled past the field edge clips exactly as before (this exercises the new `pushClip`).
+- Input field: typing, multi-line, and **scroll-clipping** — text scrolled past the field edge clips exactly as before (this exercises the new `beginClip`).
 - Input + transcript **scrollbars**: track/thumb render, drag.
 - Composer suggestion popup, approval card, markdown / table content, text selection.
 - **Blend sanity (primary risk):** bubbles, cards, and glyph text blend correctly with no premultiplied-alpha artifacts. If any appear, the fallback per the spec is to add a single explicit `BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` reset at the top of `render()` (via a small `ui_pipeline.resetBlend()` helper) rather than restoring the whole ambient block.
@@ -515,5 +515,5 @@ Behavior-preserving — any visual difference is a regression.
 ## Self-review notes
 
 - **Spec coverage:** §2 clip helper → Task 2; §3 quad/scissor/ambient/cImport → Tasks 3-4; §4 ai_chat_layout extraction → Tasks 1 & 5; §5 verification → Task 6; §6 blend risk → Task 6 Step 3 fallback. All covered.
-- **Type consistency:** `Rect{x,top_px,w,h}` and `BubbleGeometry{x,w}` defined once in `ai_chat_layout.zig` (Task 1), aliased in the renderer (Task 5). `ui_pipeline.Rect{x,y,w,h}` is the existing distinct type used only by `pushClip` (Task 2/4) — the field name `y` (not `top_px`) is intentional and matches glScissor's lower-left origin.
+- **Type consistency:** `Rect{x,top_px,w,h}` and `BubbleGeometry{x,w}` defined once in `ai_chat_layout.zig` (Task 1), aliased in the renderer (Task 5). `ui_pipeline.Rect{x,y,w,h}` is the existing distinct type used only by `beginClip` (Task 2/4) — the field name `y` (not `top_px`) is intentional and matches glScissor's lower-left origin.
 - **No placeholders:** every code step shows the actual code; every run step states the expected result.

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md
@@ -1,0 +1,519 @@
+# GPU A3 Increment 3 — ai_chat_renderer → ui_pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `src/renderer/ai_chat_renderer.zig` entirely through the shared `ui_pipeline` (plus a new clip helper), ending with zero raw `gl.*` and no `glad` cImport, and extract its pure rect-geometry into a std-only, unit-tested `ai_chat_layout.zig`.
+
+**Architecture:** Axis A — replace the 56 `gl_init.renderQuad*` calls with `ui_pipeline.fillQuad*`, the two `GL_SCISSOR_TEST` regions with new `ui_pipeline.pushClip/popClip`, and delete the now-redundant ambient blend/program setup (blend is frame-level in `AppWindow`). Axis B — move 7 pure rect-geometry functions into `src/ai_chat_layout.zig` (std-only, constants/metrics passed as params), with `ai_chat_renderer` keeping thin wrappers so internal call sites are unchanged.
+
+**Tech Stack:** Zig 0.15.2; OpenGL via the `gpu` backend primitives; tests via `zig build test` (fast, std-only) and `zig build test-full` (full app binary, pre-merge gate).
+
+**Reference:** spec `docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md`. Prior increments: `titlebar_layout.zig`, `cell_geometry.zig`, `ui_pipeline.zig`.
+
+---
+
+## File Structure
+
+- **Create** `src/ai_chat_layout.zig` — std-only pure rect geometry + unit tests. Sibling of the existing `ai_chat_composer_layout.zig` / `ai_chat_scrollbar_model.zig`.
+- **Modify** `src/renderer/ui_pipeline.zig` — add `pushClip(rect)` / `popClip()`.
+- **Modify** `src/renderer/ai_chat_renderer.zig` — quad/scissor/ambient conversion; alias `Rect`/`BubbleGeometry` and wrap geometry via `ai_chat_layout`; drop the `glad` cImport.
+- **Modify** `src/test_fast.zig` — register `ai_chat_layout.zig`.
+
+---
+
+## Task 1: `ai_chat_layout.zig` — pure rect geometry (Axis B, TDD)
+
+**Files:**
+- Create: `src/ai_chat_layout.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Create the module with types + tests only (no impls yet)**
+
+Create `src/ai_chat_layout.zig`:
+
+```zig
+//! Pure rect geometry for the AI Chat renderer.
+//!
+//! No GL, font, or platform imports so it can be unit-tested in the fast test
+//! build (mirrors ai_chat_composer_layout.zig / ai_chat_scrollbar_model.zig,
+//! extracted for the same reason — src/renderer/ai_chat_renderer.zig @cImports
+//! OpenGL historically and the font globals are not part of the test build).
+//! Callers pass font-derived metrics (e.g. header_h) and layout constants as
+//! params; this module owns none of them.
+
+const std = @import("std");
+
+/// Window-space rect with a top-left-origin `top_px` (matches the renderer's
+/// existing Rect: hit-tests compare against top_px, draws convert to GL y).
+pub const Rect = struct {
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const BubbleGeometry = struct {
+    x: f32,
+    w: f32,
+};
+
+test "pointInRect inside, edges, outside" {
+    const r = Rect{ .x = 0, .top_px = 0, .w = 20, .h = 20 };
+    try std.testing.expect(pointInRect(10, 10, r));
+    try std.testing.expect(pointInRect(0, 0, r)); // top-left edge inclusive
+    try std.testing.expect(pointInRect(20, 20, r)); // bottom-right edge inclusive
+    try std.testing.expect(!pointInRect(21, 10, r));
+    try std.testing.expect(!pointInRect(10, 21, r));
+}
+
+test "bubbleGeometry user vs assistant" {
+    const u = bubbleGeometry(true, 100, 200); // 0.82 width, right-aligned
+    try std.testing.expectApproxEqAbs(@as(f32, 164), u.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 136), u.x, 0.001);
+    const a = bubbleGeometry(false, 100, 200); // full width, left
+    try std.testing.expectApproxEqAbs(@as(f32, 200), a.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 100), a.x, 0.001);
+}
+
+test "copyButtonRectForBubble placement" {
+    const r = copyButtonRectForBubble(100, 50, 200, 14, 24, 8);
+    try std.testing.expectApproxEqAbs(@as(f32, 262), r.x, 0.001); // 100+200-14-24
+    try std.testing.expectApproxEqAbs(@as(f32, 58), r.top_px, 0.001); // 50+8
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
+}
+
+test "detailHeaderRect passes header_h through" {
+    const r = detailHeaderRect(10, 20, 300, 40);
+    try std.testing.expectApproxEqAbs(@as(f32, 10), r.x, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 20), r.top_px, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 300), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 40), r.h, 0.001);
+}
+
+test "detailCopyButtonRect centers in header_h" {
+    const r = detailCopyButtonRect(10, 20, 300, 40, 14, 24);
+    try std.testing.expectApproxEqAbs(@as(f32, 272), r.x, 0.001); // 10+300-14-24
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.top_px, 0.001); // 20+round((40-24)/2)
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
+}
+
+test "permissionChipX" {
+    const px = permissionChipX(0, 1000, 18, 280, 104); // w - line_pad - status - 12 - chip
+    try std.testing.expectApproxEqAbs(@as(f32, 586), px, 0.001);
+}
+
+test "stopButtonRect centers in header_h" {
+    const r = stopButtonRect(0, 1000, 5, 18, 104, 28, 54);
+    try std.testing.expectApproxEqAbs(@as(f32, 878), r.x, 0.001); // 1000-18-104
+    try std.testing.expectApproxEqAbs(@as(f32, 18), r.top_px, 0.001); // 5+round((54-28)/2)
+    try std.testing.expectApproxEqAbs(@as(f32, 104), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.h, 0.001);
+}
+```
+
+- [ ] **Step 2: Register the module and run tests to verify they FAIL**
+
+Add to `src/test_fast.zig`, immediately after the `renderer/titlebar_layout.zig` line:
+
+```zig
+    _ = @import("ai_chat_layout.zig");
+```
+
+Run: `zig build test`
+Expected: FAIL — compile error, the test bodies reference `pointInRect`, `bubbleGeometry`, etc. which are not yet defined (`error: use of undeclared identifier`).
+
+- [ ] **Step 3: Add the function implementations**
+
+Insert these `pub fn`s into `src/ai_chat_layout.zig` between the `BubbleGeometry` struct and the first `test` block (transcribed verbatim from the current `ai_chat_renderer.zig` bodies, with constants/metrics lifted to params):
+
+```zig
+pub fn pointInRect(px: f32, py: f32, rect: Rect) bool {
+    return px >= rect.x and px <= rect.x + rect.w and py >= rect.top_px and py <= rect.top_px + rect.h;
+}
+
+pub fn bubbleGeometry(is_user: bool, x: f32, w: f32) BubbleGeometry {
+    const bubble_w = @min(w, if (is_user) w * 0.82 else w);
+    return .{
+        .x = if (is_user) x + w - bubble_w else x,
+        .w = bubble_w,
+    };
+}
+
+pub fn copyButtonRectForBubble(
+    bubble_x: f32,
+    top_px: f32,
+    bubble_w: f32,
+    bubble_pad_x: f32,
+    button_size: f32,
+    button_pad: f32,
+) Rect {
+    return .{
+        .x = bubble_x + bubble_w - bubble_pad_x - button_size,
+        .top_px = top_px + button_pad,
+        .w = button_size,
+        .h = button_size,
+    };
+}
+
+pub fn detailHeaderRect(x: f32, top_px: f32, w: f32, header_h: f32) Rect {
+    return .{ .x = x, .top_px = top_px, .w = w, .h = header_h };
+}
+
+pub fn detailCopyButtonRect(
+    x: f32,
+    top_px: f32,
+    w: f32,
+    header_h: f32,
+    detail_pad_x: f32,
+    button_size: f32,
+) Rect {
+    return .{
+        .x = x + w - detail_pad_x - button_size,
+        .top_px = top_px + @round((header_h - button_size) / 2),
+        .w = button_size,
+        .h = button_size,
+    };
+}
+
+pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip_w: f32) f32 {
+    return x + w - line_pad_x - status_slot_w - 12 - chip_w;
+}
+
+pub fn stopButtonRect(
+    x: f32,
+    w: f32,
+    titlebar_offset: f32,
+    line_pad_x: f32,
+    stop_w: f32,
+    stop_h: f32,
+    header_h: f32,
+) Rect {
+    return .{
+        .x = x + w - line_pad_x - stop_w,
+        .top_px = titlebar_offset + @round((header_h - stop_h) / 2),
+        .w = stop_w,
+        .h = stop_h,
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they PASS**
+
+Run: `zig build test`
+Expected: PASS (all `ai_chat_layout` tests green; no other test regresses).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_layout.zig src/test_fast.zig
+git commit -m "feat: extract ai_chat_layout pure rect geometry (A3 increment 3, Axis B)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `ui_pipeline.pushClip` / `popClip` (Axis A infra)
+
+**Files:**
+- Modify: `src/renderer/ui_pipeline.zig`
+
+- [ ] **Step 1: Add the clip helpers**
+
+In `src/renderer/ui_pipeline.zig`, add after the `setProjection` function (before `fillQuad`):
+
+```zig
+/// Enable scissor clipping to `rect` (window-space, same convention as the
+/// caller's existing glScissor: x/y are the lower-left corner in GL pixels).
+/// Rounds to integer pixels, matching the prior @intFromFloat(@round(...)) calls.
+pub fn pushClip(rect: Rect) void {
+    const gl = gpu.glTable();
+    gl.Enable.?(c.GL_SCISSOR_TEST);
+    gl.Scissor.?(
+        @intFromFloat(@round(rect.x)),
+        @intFromFloat(@round(rect.y)),
+        @intFromFloat(@round(rect.w)),
+        @intFromFloat(@round(rect.h)),
+    );
+}
+
+/// Disable scissor clipping (= the prior gl.Disable(GL_SCISSOR_TEST)). Flat
+/// enable/disable, not a nesting stack — ai_chat never nests clip regions.
+pub fn popClip() void {
+    gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
+}
+```
+
+(`Rect`, `gpu`, and `c` are already in scope at the top of `ui_pipeline.zig`.)
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `zig build`
+Expected: clean build, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/ui_pipeline.zig
+git commit -m "feat: add ui_pipeline.pushClip/popClip scissor helpers (A3 increment 3)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: ai_chat_renderer quad conversion + ui_pipeline import (Axis A)
+
+**Files:**
+- Modify: `src/renderer/ai_chat_renderer.zig`
+
+- [ ] **Step 1: Add the ui_pipeline import**
+
+In `src/renderer/ai_chat_renderer.zig`, after the `const titlebar = AppWindow.titlebar;` line (line 25), add:
+
+```zig
+const ui_pipeline = @import("ui_pipeline.zig");
+```
+
+- [ ] **Step 2: Replace all renderQuad / renderQuadAlpha calls**
+
+Replace every occurrence (56 sites) — the signatures are identical, so this is a pure rename:
+- `gl_init.renderQuadAlpha(` → `ui_pipeline.fillQuadAlpha(`
+- `gl_init.renderQuad(` → `ui_pipeline.fillQuad(`
+
+(Do the `renderQuadAlpha` pattern first; the trailing `(` already prevents `renderQuad(` from matching `renderQuadAlpha(`, so order is safe either way.)
+
+- [ ] **Step 3: Verify no renderQuad calls remain and build**
+
+Run: `grep -nE "gl_init\.renderQuad" src/renderer/ai_chat_renderer.zig`
+Expected: no output (all converted).
+
+Run: `zig build`
+Expected: clean build. (`gl_init` is still imported — used for the soon-to-be-removed ambient block; that is removed in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/ai_chat_renderer.zig
+git commit -m "refactor: ai_chat_renderer quads via ui_pipeline.fillQuad (A3 increment 3)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Scissor → pushClip/popClip, drop ambient setup + glad cImport (Axis A)
+
+**Files:**
+- Modify: `src/renderer/ai_chat_renderer.zig`
+
+- [ ] **Step 1: Delete the redundant ambient block**
+
+In `render()`, remove these six lines (currently ~124-129):
+
+```zig
+    const gl = AppWindow.gpu.glTable();
+    gl.Enable.?(c.GL_BLEND);
+    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    gl.UseProgram.?(gl_init.shader_program);
+    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    gl.BindVertexArray.?(gl_init.vao);
+```
+
+(Blend is enabled frame-level in `AppWindow.zig`; the program/VAO binds are dead now that `ui_pipeline`/`titlebar` draw helpers are self-contained. The following `const bg = AppWindow.g_theme.background;` line stays as the new first statement.)
+
+- [ ] **Step 2: Convert the input-field scissor region**
+
+Replace the input-field scissor enable (currently ~183-189):
+
+```zig
+    gl.Enable.?(c.GL_SCISSOR_TEST);
+    gl.Scissor.?(
+        @intFromFloat(@round(layout.field_x)),
+        @intFromFloat(@round(layout.field_y)),
+        @intFromFloat(@round(layout.field_w)),
+        @intFromFloat(@round(layout.field_h)),
+    );
+```
+
+with:
+
+```zig
+    ui_pipeline.pushClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
+```
+
+And its matching disable (currently ~255): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.popClip();`
+
+- [ ] **Step 3: Convert the transcript scissor region**
+
+Replace the transcript scissor enable (currently ~281-287):
+
+```zig
+    gl.Enable.?(c.GL_SCISSOR_TEST);
+    gl.Scissor.?(
+        @intFromFloat(@round(x)),
+        @intFromFloat(@round(transcript_bottom)),
+        @intFromFloat(@round(w)),
+        @intFromFloat(@round(transcript_h)),
+    );
+```
+
+with:
+
+```zig
+    ui_pipeline.pushClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
+```
+
+And its matching disable (currently ~332): `gl.Disable.?(c.GL_SCISSOR_TEST);` → `ui_pipeline.popClip();`
+
+- [ ] **Step 4: Remove the glad cImport**
+
+Delete the cImport block (currently lines 27-29):
+
+```zig
+const c = @cImport({
+    @cInclude("glad/gl.h");
+});
+```
+
+- [ ] **Step 5: Verify no raw GL remains and build**
+
+Run: `grep -nE "\bgl\.|\bc\.|glad" src/renderer/ai_chat_renderer.zig`
+Expected: no output (no raw `gl.`, no `c.`, no `glad`).
+
+Run: `zig build`
+Expected: clean build. (If the compiler reports `c` or `gl` unused/undeclared, a reference was missed — re-grep.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/ai_chat_renderer.zig
+git commit -m "refactor: ai_chat_renderer scissor via ui_pipeline clip, drop glad cImport (A3 increment 3)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire ai_chat_layout (Axis B), keep call sites unchanged
+
+**Files:**
+- Modify: `src/renderer/ai_chat_renderer.zig`
+
+- [ ] **Step 1: Add the import and alias the value types**
+
+After the `const ui_pipeline = @import("ui_pipeline.zig");` line, add:
+
+```zig
+const ai_chat_layout = @import("../ai_chat_layout.zig");
+```
+
+Replace the local `Rect` and `BubbleGeometry` struct definitions (currently the `const Rect = struct { x: f32, top_px: f32, w: f32, h: f32 };` at ~1040-1045 and the `const BubbleGeometry = struct { x: f32, w: f32 };` at ~1035-1038) with aliases:
+
+```zig
+const Rect = ai_chat_layout.Rect;
+const BubbleGeometry = ai_chat_layout.BubbleGeometry;
+```
+
+Leave the existing `const CopyButtonRect = Rect;` and `const HeaderButtonRect = Rect;` aliases as-is (they now alias the shared `Rect`).
+
+- [ ] **Step 2: Convert the geometry functions into thin wrappers**
+
+Replace each function body so it delegates to `ai_chat_layout`, feeding the renderer's constants/metrics. The public signatures are unchanged, so all internal call sites and `input.zig` hit-tests stay untouched:
+
+```zig
+fn pointInRect(px: f32, py: f32, rect: Rect) bool {
+    return ai_chat_layout.pointInRect(px, py, rect);
+}
+
+fn bubbleGeometry(role: ai_chat.Role, x: f32, w: f32) BubbleGeometry {
+    return ai_chat_layout.bubbleGeometry(role == .user, x, w);
+}
+
+fn detailHeaderRect(x: f32, top_px: f32, w: f32) Rect {
+    return ai_chat_layout.detailHeaderRect(x, top_px, w, detailHeaderHeight());
+}
+
+fn detailCopyButtonRect(x: f32, top_px: f32, w: f32) CopyButtonRect {
+    return ai_chat_layout.detailCopyButtonRect(x, top_px, w, detailHeaderHeight(), DETAIL_PAD_X, COPY_BUTTON_SIZE);
+}
+
+fn copyButtonRect(role: ai_chat.Role, x: f32, top_px: f32, w: f32) CopyButtonRect {
+    const bubble = bubbleGeometry(role, x, w);
+    return copyButtonRectForBubble(bubble.x, top_px, bubble.w);
+}
+
+fn copyButtonRectForBubble(bubble_x: f32, top_px: f32, bubble_w: f32) CopyButtonRect {
+    return ai_chat_layout.copyButtonRectForBubble(bubble_x, top_px, bubble_w, BUBBLE_PAD_X, COPY_BUTTON_SIZE, COPY_BUTTON_PAD);
+}
+
+fn permissionChipX(x: f32, w: f32) f32 {
+    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, STATUS_SLOT_W, PERMISSION_CHIP_W);
+}
+
+fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
+    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STOP_BUTTON_W, STOP_BUTTON_H, HEADER_H);
+}
+```
+
+(`detailHeaderHeight()` stays in `ai_chat_renderer.zig` — it reads the `font` global. The layout constants `DETAIL_PAD_X`, `COPY_BUTTON_SIZE`, `COPY_BUTTON_PAD`, `BUBBLE_PAD_X`, `LINE_PAD_X`, `STATUS_SLOT_W`, `PERMISSION_CHIP_W`, `STOP_BUTTON_W`, `STOP_BUTTON_H`, `HEADER_H` stay declared in `ai_chat_renderer.zig` and are passed in.)
+
+- [ ] **Step 3: Build and run the full test suite**
+
+Run: `zig build`
+Expected: clean build.
+
+Run: `zig build test`
+Expected: PASS (the `ai_chat_layout` tests from Task 1 plus all existing fast tests).
+
+Run: `zig build test-full`
+Expected: matches the current fully-green baseline plus the new tests — no new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/ai_chat_renderer.zig
+git commit -m "refactor: ai_chat_renderer geometry via ai_chat_layout (A3 increment 3, Axis B)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Final verification gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm the file is fully raw-GL-free**
+
+Run: `grep -nE "\bgl\.|\bc\.GL|glad|gl_init\.(shader_program|simple_color_shader|vao|vbo|renderQuad)" src/renderer/ai_chat_renderer.zig`
+Expected: no output. (`gl_init` may still be imported only if something else references it — verify with `grep -n "gl_init" src/renderer/ai_chat_renderer.zig`; if the only remaining hits are gone, remove the now-unused `const gl_init = AppWindow.gpu.gl_init;` import and rebuild.)
+
+- [ ] **Step 2: Full build + test gate**
+
+Run: `zig build && zig build test-full`
+Expected: clean build; test-full green at the baseline (no new failures).
+
+- [ ] **Step 3: Manual Windows visual check (human gate — hand back to the user)**
+
+The AI chat panel must render identically. Verify:
+- Header bar: model / mode / permission chip / status text; **stop button** (position, label, icon) when a request is running.
+- Message bubbles: user right-aligned (0.82 width), assistant full-width; selection rule; **copy buttons** (hover/click hit area unchanged).
+- Tool / reasoning cards: collapse arrows, header, copy button placement.
+- Usage footer.
+- Input field: typing, multi-line, and **scroll-clipping** — text scrolled past the field edge clips exactly as before (this exercises the new `pushClip`).
+- Input + transcript **scrollbars**: track/thumb render, drag.
+- Composer suggestion popup, approval card, markdown / table content, text selection.
+- **Blend sanity (primary risk):** bubbles, cards, and glyph text blend correctly with no premultiplied-alpha artifacts. If any appear, the fallback per the spec is to add a single explicit `BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` reset at the top of `render()` (via a small `ui_pipeline.resetBlend()` helper) rather than restoring the whole ambient block.
+
+Behavior-preserving — any visual difference is a regression.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §2 clip helper → Task 2; §3 quad/scissor/ambient/cImport → Tasks 3-4; §4 ai_chat_layout extraction → Tasks 1 & 5; §5 verification → Task 6; §6 blend risk → Task 6 Step 3 fallback. All covered.
+- **Type consistency:** `Rect{x,top_px,w,h}` and `BubbleGeometry{x,w}` defined once in `ai_chat_layout.zig` (Task 1), aliased in the renderer (Task 5). `ui_pipeline.Rect{x,y,w,h}` is the existing distinct type used only by `pushClip` (Task 2/4) — the field name `y` (not `top_px`) is intentional and matches glScissor's lower-left origin.
+- **No placeholders:** every code step shows the actual code; every run step states the expected result.

--- a/docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md
+++ b/docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md
@@ -63,20 +63,21 @@ caller needs no raw GL; `overlays`/`markdown` reuse it later, and it advances A6
 /// Enable scissor clipping to `rect` (window-space, y-up bottom-left origin —
 /// same convention as glScissor / the existing ai_chat scissor calls). Rounds
 /// to integer pixels.
-pub fn pushClip(rect: Rect) void;
+pub fn beginClip(rect: Rect) void;
 /// Disable scissor clipping (= the old gl.Disable(GL_SCISSOR_TEST)).
-pub fn popClip() void;
+pub fn endClip() void;
 ```
 
 - Implemented over `gpu.glTable()` (`Enable`/`Disable(GL_SCISSOR_TEST)`,
   `Scissor`), living with the other `ui_pipeline` helpers.
-- `pushClip` takes `Rect{ x, y, w, h }`; the caller passes the same
+- `beginClip` takes `Rect{ x, y, w, h }`; the caller passes the same
   field/transcript rect it currently feeds to `glScissor` (verbatim arithmetic,
   preserving the `@intFromFloat(@round(...))` rounding inside the helper).
 - Scope note: this is a flat enable/disable mirror of today's behavior, not a
   nesting stack. `ai_chat` never nests scissor regions, so a single
-  enable/disable pair per region is sufficient; the `push`/`pop` naming reserves
-  room without implementing a stack now (YAGNI).
+  enable/disable pair per region is sufficient. Named `beginClip`/`endClip`
+  (not `push`/`pop`) so the name reflects the flat semantics rather than
+  implying a stack that does not exist (YAGNI).
 
 No other `ui_pipeline` API changes; `fillQuad`/`fillQuadAlpha`/`drawGlyph` are
 used as-is.
@@ -89,8 +90,8 @@ used as-is.
    `gl_init` re-export anyway; this drops the indirection so the file imports
    `ui_pipeline` directly.)
 2. **Scissor (2 regions):** the `Enable(GL_SCISSOR_TEST)+Scissor(...)` /
-   `Disable(GL_SCISSOR_TEST)` pairs → `ui_pipeline.pushClip(rect)` /
-   `ui_pipeline.popClip()`.
+   `Disable(GL_SCISSOR_TEST)` pairs → `ui_pipeline.beginClip(rect)` /
+   `ui_pipeline.endClip()`.
 3. **Delete dead setup:** remove the `Enable(GL_BLEND)+BlendFunc` and the
    `UseProgram+ActiveTexture+BindVertexArray` ambient block at the top of
    `render()` (redundant per §1.1).
@@ -171,7 +172,7 @@ and `detailCopyButtonRect` placement (incl. the `header_h` centering); `permissi
   `BlendFunc`). If an artifact appears, the fallback is a single
   `ui_pipeline.resetBlend()` call (or keeping one explicit `BlendFunc`) at the
   top of `render()` rather than reintroducing the full ambient block.
-- **Scissor coordinate parity.** `pushClip` must reproduce the exact
+- **Scissor coordinate parity.** `beginClip` must reproduce the exact
   `@intFromFloat(@round(...))` rounding and the y-up window-space origin of the
   current `glScissor` calls; the input-field and transcript clip rects are passed
   verbatim.

--- a/docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md
+++ b/docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md
@@ -1,0 +1,183 @@
+# Design: GPU A3 increment 3 — ai_chat_renderer → ui_pipeline
+
+Status: approved (design); pending spec review
+Date: 2026-05-26
+Scope: TODO.md Phase A item **A3**, third increment
+References: prior A3 specs `2026-05-26-gpu-a3-cell-renderer-design.md`,
+`2026-05-26-gpu-a3-titlebar-design.md`, [decoupling-guide.md](../../decoupling-guide.md).
+
+## 1. Goal, scope & strategy
+
+Route `src/renderer/ai_chat_renderer.zig` entirely through the shared
+`ui_pipeline` (and a small new clip primitive), ending with **zero raw `gl.*`
+and no `@cInclude("glad/gl.h")`** — matching `titlebar.zig`. Behavior-preserving.
+Both decoupling axes, touching the file once.
+
+This is the first conversion to **consume** the `ui_pipeline` foundation built in
+increment 2 rather than extend it (apart from the one clip helper). It proves the
+pattern on a large, quad-heavy UI file before the 4564-line `overlays`.
+
+### Why this file (vs overlays)
+
+- `ai_chat_renderer` is ~1984 lines; its 56 `gl_init.renderQuad`/`renderQuadAlpha`
+  sites map 1:1 to `ui_pipeline.fillQuad`/`fillQuadAlpha`. Its text already routes
+  through `titlebar.renderTextLimited` (converted). It does **not** touch
+  `overlay_shader`, so there is no cross-file entanglement.
+- `overlays` owns one of the two remaining `overlay_shader` draw sites (the other
+  is in `background_image`); a clean conversion couples those two files into one
+  larger increment. Deferred to a later increment.
+
+### Two findings that shape the conversion
+
+1. **Blend is already frame-level.** `AppWindow.zig` enables `GL_BLEND` + the
+   standard `BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` once per frame
+   before the UI phase; `titlebar` relies on this and touches no blend. So
+   `ai_chat`'s local `Enable(GL_BLEND)+BlendFunc` (render() lines ~125-126) and
+   the `UseProgram(gl_init.shader_program)+ActiveTexture+BindVertexArray(gl_init.vao)`
+   ambient setup (~127-129) are now **redundant** — the `ui_pipeline` draw helpers
+   are self-contained (each `use()`s its pipeline and binds its VAO), and
+   `cell_renderer` restores standard blend after its premultiplied pass, which
+   runs before the UI phase.
+2. **Axis B is mostly pre-done.** `ai_chat_renderer` already delegates pure logic
+   to std-only `ai_chat_composer_layout.zig` and `ai_chat_scrollbar_model.zig`.
+   So this increment is **Axis-A-dominant** with a small Axis-B top-up (§4).
+
+### Non-goals (deferred)
+
+- `overlays`, `markdown_preview_renderer`, `file_explorer_renderer`, and the
+  GPU-effect files (`image_renderer`, `post_process`, `background_image`, `fbo`)
+  — their own increments; they keep the `gl_init` compat vars / re-exports.
+- `overlay_shader` stays in `gl_init`.
+- The height/measurement helpers (`bubbleHeight`, `toolCardHeight`, …) depend on
+  font-global `measureText`; they stay inline (extracting them would mean
+  injecting a measure-fn — YAGNI for this increment).
+- Frame/RenderPass/Target layer, API-neutralization, MSL. A4/A5/A6.
+
+## 2. New shared primitive: `ui_pipeline` clip helpers
+
+`ai_chat` uses `GL_SCISSOR_TEST` to clip two regions (the input field and the
+scrollable transcript). `ui_pipeline` gains a thin, reusable clip wrapper so the
+caller needs no raw GL; `overlays`/`markdown` reuse it later, and it advances A6.
+
+```zig
+/// Enable scissor clipping to `rect` (window-space, y-up bottom-left origin —
+/// same convention as glScissor / the existing ai_chat scissor calls). Rounds
+/// to integer pixels.
+pub fn pushClip(rect: Rect) void;
+/// Disable scissor clipping (= the old gl.Disable(GL_SCISSOR_TEST)).
+pub fn popClip() void;
+```
+
+- Implemented over `gpu.glTable()` (`Enable`/`Disable(GL_SCISSOR_TEST)`,
+  `Scissor`), living with the other `ui_pipeline` helpers.
+- `pushClip` takes `Rect{ x, y, w, h }`; the caller passes the same
+  field/transcript rect it currently feeds to `glScissor` (verbatim arithmetic,
+  preserving the `@intFromFloat(@round(...))` rounding inside the helper).
+- Scope note: this is a flat enable/disable mirror of today's behavior, not a
+  nesting stack. `ai_chat` never nests scissor regions, so a single
+  enable/disable pair per region is sufficient; the `push`/`pop` naming reserves
+  room without implementing a stack now (YAGNI).
+
+No other `ui_pipeline` API changes; `fillQuad`/`fillQuadAlpha`/`drawGlyph` are
+used as-is.
+
+## 3. ai_chat_renderer Axis-A conversion
+
+1. **Quads (56 sites):** `gl_init.renderQuad(...)` → `ui_pipeline.fillQuad(...)`;
+   `gl_init.renderQuadAlpha(...)` → `ui_pipeline.fillQuadAlpha(...)`. Identical
+   signatures — pure rename. (Both currently route to `ui_pipeline` via the
+   `gl_init` re-export anyway; this drops the indirection so the file imports
+   `ui_pipeline` directly.)
+2. **Scissor (2 regions):** the `Enable(GL_SCISSOR_TEST)+Scissor(...)` /
+   `Disable(GL_SCISSOR_TEST)` pairs → `ui_pipeline.pushClip(rect)` /
+   `ui_pipeline.popClip()`.
+3. **Delete dead setup:** remove the `Enable(GL_BLEND)+BlendFunc` and the
+   `UseProgram+ActiveTexture+BindVertexArray` ambient block at the top of
+   `render()` (redundant per §1.1).
+4. **Drop the GL include:** once no `gl.*` / `c.GL_*` remain, remove the
+   `const c = @cImport({ @cInclude("glad/gl.h") })` block and the
+   `const gl = AppWindow.gpu.glTable()` locals. Add
+   `const ui_pipeline = @import("ui_pipeline.zig");` (the file already imports
+   `gl_init`, `titlebar`, `AppWindow`).
+5. **Verify `c` is fully unused** afterward via grep (`c\.` → no hits); Zig will
+   not error on an unused container-level `const`, so this is a manual gate.
+
+The layout/draw orchestration, hit-tests, markdown/table rendering, and text via
+`titlebar.renderTextLimited` are otherwise unchanged.
+
+## 4. Axis B — `ai_chat_layout.zig` (new, std-only)
+
+Extract the pure, metrics-free rect geometry into a std-only module
+(imports only `std`), registered in `test_fast.zig`. Candidates (all currently
+pure functions of `x`/`w`/role + layout constants):
+
+- `pointInRect(px, py, rect) bool`
+- `bubbleGeometry(is_user, x, w) -> { x, w }`
+- `copyButtonRectForBubble(bubble_x, top_px, bubble_w) -> Rect`
+- `detailCopyButtonRect(x, top_px, w, header_h) -> Rect`  *(header_h injected)*
+- `detailHeaderRect(x, top_px, w, header_h) -> Rect`  *(header_h injected)*
+- `permissionChipX(x, w) f32`
+- `stopButtonRect(x, w, titlebar_offset) -> Rect`
+
+Threading rules (the titlebar_layout pattern):
+
+- The module owns its own `Rect`/`Geometry` value structs (plain `f32` fields);
+  `ai_chat_renderer` maps to/from its existing `Rect`/`BubbleGeometry` at the
+  call site, or aliases them to the layout module's types.
+- Functions whose value depends on font globals take that metric as a **param**:
+  `detailHeaderHeight()` (font-derived) is computed in the renderer and passed in
+  as `header_h`. No `font`/`AppWindow`/`ai_chat` imports in the layout module.
+- `bubbleGeometry` takes `is_user: bool` (not `ai_chat.Role`) to stay std-only;
+  the renderer passes `role == .user`.
+- Static layout constants used by these helpers (`COPY_BUTTON_SIZE`,
+  `COPY_BUTTON_PAD`, `BUBBLE_PAD_X`, `DETAIL_PAD_X`, `LINE_PAD_X`,
+  `STATUS_SLOT_W`, `PERMISSION_CHIP_W`, `STOP_BUTTON_W`, `STOP_BUTTON_H`,
+  `HEADER_H`) move into `ai_chat_layout.zig`; `ai_chat_renderer` imports them
+  back (or re-declares aliases) so existing references elsewhere keep compiling.
+- `ai_chat_renderer`'s `fn pointInRect`/`fn bubbleGeometry`/… become thin
+  wrappers delegating to the module (or call sites switch directly).
+
+**Per-function std-only check is part of the work:** any candidate that turns out
+to pull in a heavy import is lowered to a plain param type or left inline.
+
+Unit tests cover: `pointInRect` inside/edge/outside; `bubbleGeometry` user
+(0.82 width, right-aligned) vs non-user (full width, left); `copyButtonRectForBubble`
+and `detailCopyButtonRect` placement (incl. the `header_h` centering); `permissionChipX`;
+`stopButtonRect` vertical centering within `HEADER_H`.
+
+## 5. Verification
+
+- `zig build` clean (x86_64-windows-gnu).
+- `zig build test` includes the new `ai_chat_layout` tests.
+- `zig build test-full` stays green (current fully-green baseline + new tests; no
+  new failures).
+- **Manual Windows visual check (final gate):** the AI chat panel renders
+  identically — header bar (model/mode/permission chip/status, stop button),
+  message bubbles (user right-aligned, assistant full-width, selection rule,
+  copy buttons), tool/reasoning cards (collapse arrows, copy), usage footer,
+  input field with **scroll-clipping** (multi-line text scrolled past the field
+  edge must clip exactly as before), input + transcript scrollbars (track/thumb,
+  drag), composer suggestion popup, approval card, markdown/table content,
+  text selection. Behavior-preserving; any visual difference is a regression.
+
+## 6. Risks
+
+- **Blend-state assumption (primary).** Dropping `ai_chat`'s local `BlendFunc`
+  assumes standard alpha blend is active when the AI panel renders. This holds
+  because `AppWindow` sets it frame-level and `cell_renderer` restores it after
+  its premultiplied pass — but it is the one behavioral change, so the Windows
+  visual check must confirm bubbles/cards/text blend correctly (watch for
+  premultiplied-blend artifacts if some prior renderer left a non-standard
+  `BlendFunc`). If an artifact appears, the fallback is a single
+  `ui_pipeline.resetBlend()` call (or keeping one explicit `BlendFunc`) at the
+  top of `render()` rather than reintroducing the full ambient block.
+- **Scissor coordinate parity.** `pushClip` must reproduce the exact
+  `@intFromFloat(@round(...))` rounding and the y-up window-space origin of the
+  current `glScissor` calls; the input-field and transcript clip rects are passed
+  verbatim.
+- **`ai_chat_layout` extraction parity.** The metrics-injected functions must
+  return identical rects to the inline versions; the `header_h` param must be fed
+  the same `detailHeaderHeight()` value. Unit tests + visual check on copy-button
+  hit areas.
+- **No automated render coverage.** Visual correctness rests on the manual
+  Windows check; fast tests cover only the extracted `ai_chat_layout` logic.

--- a/src/ai_chat_layout.zig
+++ b/src/ai_chat_layout.zig
@@ -1,0 +1,150 @@
+//! Pure rect geometry for the AI Chat renderer.
+//!
+//! No GL, font, or platform imports so it can be unit-tested in the fast test
+//! build (mirrors ai_chat_composer_layout.zig / ai_chat_scrollbar_model.zig,
+//! extracted for the same reason — src/renderer/ai_chat_renderer.zig @cImports
+//! OpenGL historically and the font globals are not part of the test build).
+//! Callers pass font-derived metrics (e.g. header_h) and layout constants as
+//! params; this module owns none of them.
+
+const std = @import("std");
+
+/// Window-space rect with a top-left-origin `top_px` (matches the renderer's
+/// existing Rect: hit-tests compare against top_px, draws convert to GL y).
+pub const Rect = struct {
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+};
+
+/// Horizontal placement of a message bubble: `x` is its left edge (which is
+/// right-shifted for the right-aligned user bubble) and `w` its width.
+pub const BubbleGeometry = struct {
+    x: f32,
+    w: f32,
+};
+
+pub fn pointInRect(px: f32, py: f32, rect: Rect) bool {
+    return px >= rect.x and px <= rect.x + rect.w and py >= rect.top_px and py <= rect.top_px + rect.h;
+}
+
+pub fn bubbleGeometry(is_user: bool, x: f32, w: f32) BubbleGeometry {
+    const bubble_w = @min(w, if (is_user) w * 0.82 else w);
+    return .{
+        .x = if (is_user) x + w - bubble_w else x,
+        .w = bubble_w,
+    };
+}
+
+pub fn copyButtonRectForBubble(
+    bubble_x: f32,
+    top_px: f32,
+    bubble_w: f32,
+    bubble_pad_x: f32,
+    button_size: f32,
+    button_pad: f32,
+) Rect {
+    return .{
+        .x = bubble_x + bubble_w - bubble_pad_x - button_size,
+        .top_px = top_px + button_pad,
+        .w = button_size,
+        .h = button_size,
+    };
+}
+
+pub fn detailHeaderRect(x: f32, top_px: f32, w: f32, header_h: f32) Rect {
+    return .{ .x = x, .top_px = top_px, .w = w, .h = header_h };
+}
+
+pub fn detailCopyButtonRect(
+    x: f32,
+    top_px: f32,
+    w: f32,
+    header_h: f32,
+    detail_pad_x: f32,
+    button_size: f32,
+) Rect {
+    return .{
+        .x = x + w - detail_pad_x - button_size,
+        .top_px = top_px + @round((header_h - button_size) / 2),
+        .w = button_size,
+        .h = button_size,
+    };
+}
+
+pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip_gap: f32, chip_w: f32) f32 {
+    return x + w - line_pad_x - status_slot_w - chip_gap - chip_w;
+}
+
+pub fn stopButtonRect(
+    x: f32,
+    w: f32,
+    titlebar_offset: f32,
+    line_pad_x: f32,
+    stop_w: f32,
+    stop_h: f32,
+    header_h: f32,
+) Rect {
+    return .{
+        .x = x + w - line_pad_x - stop_w,
+        .top_px = titlebar_offset + @round((header_h - stop_h) / 2),
+        .w = stop_w,
+        .h = stop_h,
+    };
+}
+
+test "pointInRect inside, edges, outside" {
+    const r = Rect{ .x = 0, .top_px = 0, .w = 20, .h = 20 };
+    try std.testing.expect(pointInRect(10, 10, r));
+    try std.testing.expect(pointInRect(0, 0, r)); // top-left edge inclusive
+    try std.testing.expect(pointInRect(20, 20, r)); // bottom-right edge inclusive
+    try std.testing.expect(!pointInRect(21, 10, r));
+    try std.testing.expect(!pointInRect(10, 21, r));
+}
+
+test "bubbleGeometry user vs assistant" {
+    const u = bubbleGeometry(true, 100, 200); // 0.82 width, right-aligned
+    try std.testing.expectApproxEqAbs(@as(f32, 164), u.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 136), u.x, 0.001);
+    const a = bubbleGeometry(false, 100, 200); // full width, left
+    try std.testing.expectApproxEqAbs(@as(f32, 200), a.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 100), a.x, 0.001);
+}
+
+test "copyButtonRectForBubble placement" {
+    const r = copyButtonRectForBubble(100, 50, 200, 14, 24, 8);
+    try std.testing.expectApproxEqAbs(@as(f32, 262), r.x, 0.001); // 100+200-14-24
+    try std.testing.expectApproxEqAbs(@as(f32, 58), r.top_px, 0.001); // 50+8
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
+}
+
+test "detailHeaderRect passes header_h through" {
+    const r = detailHeaderRect(10, 20, 300, 40);
+    try std.testing.expectApproxEqAbs(@as(f32, 10), r.x, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 20), r.top_px, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 300), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 40), r.h, 0.001);
+}
+
+test "detailCopyButtonRect centers in header_h" {
+    const r = detailCopyButtonRect(10, 20, 300, 40, 14, 24);
+    try std.testing.expectApproxEqAbs(@as(f32, 272), r.x, 0.001); // 10+300-14-24
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.top_px, 0.001); // 20+round((40-24)/2)
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
+}
+
+test "permissionChipX" {
+    const px = permissionChipX(0, 1000, 18, 280, 12, 104); // w - line_pad - status - gap - chip
+    try std.testing.expectApproxEqAbs(@as(f32, 586), px, 0.001);
+}
+
+test "stopButtonRect centers in header_h" {
+    const r = stopButtonRect(0, 1000, 5, 18, 104, 28, 54);
+    try std.testing.expectApproxEqAbs(@as(f32, 878), r.x, 0.001); // 1000-18-104
+    try std.testing.expectApproxEqAbs(@as(f32, 18), r.top_px, 0.001); // 5+round((54-28)/2)
+    try std.testing.expectApproxEqAbs(@as(f32, 104), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.h, 0.001);
+}

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -171,7 +171,7 @@ pub fn render(
     ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, layout.field_h, field_bg, 0.95);
     ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, 1, mixColor(bg, accent, 0.38), 0.6);
 
-    ui_pipeline.pushClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
+    ui_pipeline.beginClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
 
     if (input_text.len == 0) {
         session.input_scroll_row = 0;
@@ -237,7 +237,7 @@ pub fn render(
             }
         }
     }
-    ui_pipeline.popClip();
+    ui_pipeline.endClip();
 
     const approval = session.approvalView();
     const approval_h: f32 = if (approval != null) APPROVAL_H + APPROVAL_GAP else 0;
@@ -263,7 +263,7 @@ pub fn render(
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
 
-    ui_pipeline.pushClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
+    ui_pipeline.beginClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
 
     const gravity_offset = @max(0.0, transcript_h - content_h);
     const palette = markdownPalette(bg, fg, accent);
@@ -308,7 +308,7 @@ pub fn render(
         cursor_top += BUBBLE_GAP;
     }
 
-    ui_pipeline.popClip();
+    ui_pipeline.endClip();
 
     renderTranscriptScrollbar(session, x, w, transcript_top, transcript_h, content_h, window_height);
 

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -25,7 +25,6 @@ const titlebar = AppWindow.titlebar;
 const ui_pipeline = @import("ui_pipeline.zig");
 const ai_chat_layout = @import("../ai_chat_layout.zig");
 
-
 pub const LINE_PAD_X: f32 = 18;
 const HEADER_H: f32 = 54;
 pub const INPUT_H: f32 = composer_layout.input_min_h;

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -24,6 +24,7 @@ const font = AppWindow.font;
 const gl_init = AppWindow.gpu.gl_init;
 const titlebar = AppWindow.titlebar;
 const ui_pipeline = @import("ui_pipeline.zig");
+const ai_chat_layout = @import("../ai_chat_layout.zig");
 
 
 pub const LINE_PAD_X: f32 = 18;
@@ -1003,51 +1004,27 @@ fn sectionVisible(top_px: f32, h: f32, viewport_top: f32, viewport_bottom_top_px
 }
 
 fn bubbleGeometry(role: ai_chat.Role, x: f32, w: f32) BubbleGeometry {
-    const is_user = role == .user;
-    const bubble_w = @min(w, if (is_user) w * 0.82 else w);
-    return .{
-        .x = if (is_user) x + w - bubble_w else x,
-        .w = bubble_w,
-    };
+    return ai_chat_layout.bubbleGeometry(role == .user, x, w);
 }
 
-const BubbleGeometry = struct {
-    x: f32,
-    w: f32,
-};
+const BubbleGeometry = ai_chat_layout.BubbleGeometry;
 
-const Rect = struct {
-    x: f32,
-    top_px: f32,
-    w: f32,
-    h: f32,
-};
+const Rect = ai_chat_layout.Rect;
 
 const CopyButtonRect = Rect;
 
 const HeaderButtonRect = Rect;
 
 fn pointInRect(px: f32, py: f32, rect: Rect) bool {
-    return px >= rect.x and px <= rect.x + rect.w and py >= rect.top_px and py <= rect.top_px + rect.h;
+    return ai_chat_layout.pointInRect(px, py, rect);
 }
 
 fn detailHeaderRect(x: f32, top_px: f32, w: f32) Rect {
-    return .{
-        .x = x,
-        .top_px = top_px,
-        .w = w,
-        .h = detailHeaderHeight(),
-    };
+    return ai_chat_layout.detailHeaderRect(x, top_px, w, detailHeaderHeight());
 }
 
 fn detailCopyButtonRect(x: f32, top_px: f32, w: f32) CopyButtonRect {
-    const header_h = detailHeaderHeight();
-    return .{
-        .x = x + w - DETAIL_PAD_X - COPY_BUTTON_SIZE,
-        .top_px = top_px + @round((header_h - COPY_BUTTON_SIZE) / 2),
-        .w = COPY_BUTTON_SIZE,
-        .h = COPY_BUTTON_SIZE,
-    };
+    return ai_chat_layout.detailCopyButtonRect(x, top_px, w, detailHeaderHeight(), DETAIL_PAD_X, COPY_BUTTON_SIZE);
 }
 
 fn copyButtonRect(role: ai_chat.Role, x: f32, top_px: f32, w: f32) CopyButtonRect {
@@ -1056,25 +1033,15 @@ fn copyButtonRect(role: ai_chat.Role, x: f32, top_px: f32, w: f32) CopyButtonRec
 }
 
 fn copyButtonRectForBubble(bubble_x: f32, top_px: f32, bubble_w: f32) CopyButtonRect {
-    return .{
-        .x = bubble_x + bubble_w - BUBBLE_PAD_X - COPY_BUTTON_SIZE,
-        .top_px = top_px + COPY_BUTTON_PAD,
-        .w = COPY_BUTTON_SIZE,
-        .h = COPY_BUTTON_SIZE,
-    };
+    return ai_chat_layout.copyButtonRectForBubble(bubble_x, top_px, bubble_w, BUBBLE_PAD_X, COPY_BUTTON_SIZE, COPY_BUTTON_PAD);
 }
 
 fn permissionChipX(x: f32, w: f32) f32 {
-    return x + w - LINE_PAD_X - STATUS_SLOT_W - 12 - PERMISSION_CHIP_W;
+    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, STATUS_SLOT_W, 12, PERMISSION_CHIP_W);
 }
 
 fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
-    return .{
-        .x = x + w - LINE_PAD_X - STOP_BUTTON_W,
-        .top_px = titlebar_offset + @round((HEADER_H - STOP_BUTTON_H) / 2),
-        .w = STOP_BUTTON_W,
-        .h = STOP_BUTTON_H,
-    };
+    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STOP_BUTTON_W, STOP_BUTTON_H, HEADER_H);
 }
 
 fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) void {

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -21,7 +21,6 @@ const isMarkdownTableStart = md.isMarkdownTableStart;
 const tableBlockEnd = md.tableBlockEnd;
 
 const font = AppWindow.font;
-const gl_init = AppWindow.gpu.gl_init;
 const titlebar = AppWindow.titlebar;
 const ui_pipeline = @import("ui_pipeline.zig");
 const ai_chat_layout = @import("../ai_chat_layout.zig");

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -25,9 +25,6 @@ const gl_init = AppWindow.gpu.gl_init;
 const titlebar = AppWindow.titlebar;
 const ui_pipeline = @import("ui_pipeline.zig");
 
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
 
 pub const LINE_PAD_X: f32 = 18;
 const HEADER_H: f32 = 54;
@@ -122,13 +119,6 @@ pub fn render(
     left_panels_w: f32,
     right_panels_w: f32,
 ) void {
-    const gl = AppWindow.gpu.glTable();
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
@@ -181,13 +171,7 @@ pub fn render(
     ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, layout.field_h, field_bg, 0.95);
     ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, 1, mixColor(bg, accent, 0.38), 0.6);
 
-    gl.Enable.?(c.GL_SCISSOR_TEST);
-    gl.Scissor.?(
-        @intFromFloat(@round(layout.field_x)),
-        @intFromFloat(@round(layout.field_y)),
-        @intFromFloat(@round(layout.field_w)),
-        @intFromFloat(@round(layout.field_h)),
-    );
+    ui_pipeline.pushClip(.{ .x = layout.field_x, .y = layout.field_y, .w = layout.field_w, .h = layout.field_h });
 
     if (input_text.len == 0) {
         session.input_scroll_row = 0;
@@ -253,7 +237,7 @@ pub fn render(
             }
         }
     }
-    gl.Disable.?(c.GL_SCISSOR_TEST);
+    ui_pipeline.popClip();
 
     const approval = session.approvalView();
     const approval_h: f32 = if (approval != null) APPROVAL_H + APPROVAL_GAP else 0;
@@ -279,13 +263,7 @@ pub fn render(
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
 
-    gl.Enable.?(c.GL_SCISSOR_TEST);
-    gl.Scissor.?(
-        @intFromFloat(@round(x)),
-        @intFromFloat(@round(transcript_bottom)),
-        @intFromFloat(@round(w)),
-        @intFromFloat(@round(transcript_h)),
-    );
+    ui_pipeline.pushClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
 
     const gravity_offset = @max(0.0, transcript_h - content_h);
     const palette = markdownPalette(bg, fg, accent);
@@ -330,7 +308,7 @@ pub fn render(
         cursor_top += BUBBLE_GAP;
     }
 
-    gl.Disable.?(c.GL_SCISSOR_TEST);
+    ui_pipeline.popClip();
 
     renderTranscriptScrollbar(session, x, w, transcript_top, transcript_h, content_h, window_height);
 

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -23,6 +23,7 @@ const tableBlockEnd = md.tableBlockEnd;
 const font = AppWindow.font;
 const gl_init = AppWindow.gpu.gl_init;
 const titlebar = AppWindow.titlebar;
+const ui_pipeline = @import("ui_pipeline.zig");
 
 const c = @cImport({
     @cInclude("glad/gl.h");
@@ -141,14 +142,14 @@ pub fn render(
     const h = @round(@max(1.0, window_height - top));
     if (w <= 1 or h <= 1) return;
 
-    gl_init.renderQuad(x, 0, w, h, bg);
+    ui_pipeline.fillQuad(x, 0, w, h, bg);
 
     session.mutex.lock();
     defer session.mutex.unlock();
 
     const header_y = window_height - top - HEADER_H;
-    gl_init.renderQuadAlpha(x, header_y, w, HEADER_H, panel, 0.95);
-    gl_init.renderQuadAlpha(x, header_y, w, 1, line, 0.8);
+    ui_pipeline.fillQuadAlpha(x, header_y, w, HEADER_H, panel, 0.95);
+    ui_pipeline.fillQuadAlpha(x, header_y, w, 1, line, 0.8);
     _ = titlebar.renderTextLimited(session.model(), x + LINE_PAD_X, header_y + 10, mixColor(fg, accent, 0.12), w * 0.48);
 
     const permission = ai_chat.agentPermission();
@@ -160,7 +161,7 @@ pub fn render(
     const perm_text = permissionDisplayName(permission);
     const perm_color = if (permission == .full) mixColor(fg, accent, 0.25) else mixColor(bg, fg, 0.66);
     _ = titlebar.renderTextLimited(perm_text, chip_x, header_y + 10, perm_color, PERMISSION_CHIP_W);
-    gl_init.renderQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, if (permission == .full) 0.38 else 0.16);
+    ui_pipeline.fillQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, if (permission == .full) 0.38 else 0.16);
 
     if (session.request_inflight) {
         renderStopButton(stopButtonRect(x, w, top), window_height, session.request_stopping);
@@ -173,12 +174,12 @@ pub fn render(
     const layout = inputLayout(x, w, input_text);
     const input_h = layout.input_h;
     const input_y: f32 = 0;
-    gl_init.renderQuadAlpha(x, input_y, w, input_h, panel, 0.98);
-    gl_init.renderQuadAlpha(x, input_y + input_h - 1, w, 1, line, 0.72);
+    ui_pipeline.fillQuadAlpha(x, input_y, w, input_h, panel, 0.98);
+    ui_pipeline.fillQuadAlpha(x, input_y + input_h - 1, w, 1, line, 0.72);
 
     const field_bg = mixColor(bg, fg, 0.075);
-    gl_init.renderQuadAlpha(layout.field_x, layout.field_y, layout.field_w, layout.field_h, field_bg, 0.95);
-    gl_init.renderQuadAlpha(layout.field_x, layout.field_y, layout.field_w, 1, mixColor(bg, accent, 0.38), 0.6);
+    ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, layout.field_h, field_bg, 0.95);
+    ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, 1, mixColor(bg, accent, 0.38), 0.6);
 
     gl.Enable.?(c.GL_SCISSOR_TEST);
     gl.Scissor.?(
@@ -200,7 +201,7 @@ pub fn render(
         );
     } else {
         if (session.input_select_all) {
-            gl_init.renderQuadAlpha(
+            ui_pipeline.fillQuadAlpha(
                 layout.field_x + 8,
                 layout.field_y + 8,
                 @max(1.0, layout.field_w - 16),
@@ -248,7 +249,7 @@ pub fn render(
                 const field_top_px = window_height - layout.field_y - layout.field_h;
                 const cursor_top_px = field_top_px + composer_layout.Field.pad_top + @as(f32, @floatFromInt(row)) * lineHeight();
                 const cursor_y = window_height - cursor_top_px - font.g_titlebar_cell_height;
-                gl_init.renderQuad(cursor.x, cursor_y, 1, font.g_titlebar_cell_height, accent);
+                ui_pipeline.fillQuad(cursor.x, cursor_y, 1, font.g_titlebar_cell_height, accent);
             }
         }
     }
@@ -827,9 +828,9 @@ fn renderMessageBubble(
     else
         mixColor(bg, fg, 0.07);
 
-    gl_init.renderQuadAlpha(bubble.x, bubble_y, bubble.w, h, bubble_bg, 0.92);
-    gl_init.renderQuadAlpha(bubble.x, bubble_y + h - 1, bubble.w, 1, if (is_user) accent else mixColor(bg, fg, 0.18), 0.55);
-    if (selected) gl_init.renderQuadAlpha(bubble.x, bubble_y, 3, h, accent, 0.72);
+    ui_pipeline.fillQuadAlpha(bubble.x, bubble_y, bubble.w, h, bubble_bg, 0.92);
+    ui_pipeline.fillQuadAlpha(bubble.x, bubble_y + h - 1, bubble.w, 1, if (is_user) accent else mixColor(bg, fg, 0.18), 0.55);
+    if (selected) ui_pipeline.fillQuadAlpha(bubble.x, bubble_y, 3, h, accent, 0.72);
 
     const label_color = if (is_user) mixColor(fg, accent, 0.18) else mixColor(fg, accent, 0.05);
     _ = titlebar.renderTextLimited(role.label(), bubble.x + BUBBLE_PAD_X, bubble_y + h - BUBBLE_PAD_Y - font.g_titlebar_cell_height, label_color, bubble.w - BUBBLE_PAD_X * 2);
@@ -857,11 +858,11 @@ fn renderToolCard(msg: ai_chat.Message, x: f32, top_px: f32, w: f32, h: f32, win
     const header_bg = if (selected) mixColor(bg, accent, 0.28) else mixColor(bg, fg, 0.08);
     const header_y = y + h - header_h;
 
-    gl_init.renderQuadAlpha(x, y, w, h, card_bg, 0.94);
-    gl_init.renderQuadAlpha(x, y + h - 1, w, 1, mixColor(bg, fg, 0.20), 0.65);
-    gl_init.renderQuadAlpha(x, y + h - header_h, w, header_h, header_bg, 0.98);
-    gl_init.renderQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.78 else 0.52);
-    if (selected) gl_init.renderQuadAlpha(x, y, 1, h, accent, 0.90);
+    ui_pipeline.fillQuadAlpha(x, y, w, h, card_bg, 0.94);
+    ui_pipeline.fillQuadAlpha(x, y + h - 1, w, 1, mixColor(bg, fg, 0.20), 0.65);
+    ui_pipeline.fillQuadAlpha(x, y + h - header_h, w, header_h, header_bg, 0.98);
+    ui_pipeline.fillQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.78 else 0.52);
+    if (selected) ui_pipeline.fillQuadAlpha(x, y, 1, h, accent, 0.90);
 
     const arrow_x = x + DETAIL_PAD_X;
     const arrow_y = header_y + @round((header_h - font.g_titlebar_cell_height) / 2);
@@ -905,9 +906,9 @@ fn renderReasoningCard(text: []const u8, collapsed: bool, x: f32, top_px: f32, w
     const header_bg = if (selected) mixColor(bg, accent, 0.22) else mixColor(bg, fg, 0.06);
     const header_y = y + h - header_h;
 
-    gl_init.renderQuadAlpha(x, y, w, h, card_bg, 0.88);
-    gl_init.renderQuadAlpha(x, header_y, w, header_h, header_bg, 0.96);
-    gl_init.renderQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.76 else 0.34);
+    ui_pipeline.fillQuadAlpha(x, y, w, h, card_bg, 0.88);
+    ui_pipeline.fillQuadAlpha(x, header_y, w, header_h, header_bg, 0.96);
+    ui_pipeline.fillQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.76 else 0.34);
 
     const arrow_x = x + DETAIL_PAD_X;
     const arrow_y = header_y + @round((header_h - font.g_titlebar_cell_height) / 2);
@@ -953,7 +954,7 @@ fn renderUsageFooter(text: []const u8, x: f32, top_px: f32, w: f32, h: f32, wind
         window_height,
     );
     const y = window_height - top_px - h;
-    gl_init.renderQuadAlpha(body_x, y + h - 1, @max(1.0, @min(body_w, measureText(text))), 1, mixColor(bg, accent, 0.28), 0.34);
+    ui_pipeline.fillQuadAlpha(body_x, y + h - 1, @max(1.0, @min(body_w, measureText(text))), 1, mixColor(bg, accent, 0.28), 0.34);
 }
 
 fn renderInputScrollbar(layout: InputLayout, total_rows: usize, visible_rows_raw: usize, first_row: usize) void {
@@ -965,8 +966,8 @@ fn renderInputScrollbar(layout: InputLayout, total_rows: usize, visible_rows_raw
     const track_y = @round(layout.field_y + INPUT_SCROLLBAR_PAD);
     const thumb_y = track_y + (geo.track_h - geo.thumb_h) * (1.0 - @as(f32, @floatFromInt(@min(first_row, geo.max_scroll_row))) / @as(f32, @floatFromInt(geo.max_scroll_row)));
 
-    gl_init.renderQuadAlpha(geo.track_x, track_y, INPUT_SCROLLBAR_W, geo.track_h, mixColor(bg, fg, 0.24), 0.35);
-    gl_init.renderQuadAlpha(geo.track_x, @round(thumb_y), INPUT_SCROLLBAR_W, geo.thumb_h, mixColor(fg, accent, 0.18), 0.72);
+    ui_pipeline.fillQuadAlpha(geo.track_x, track_y, INPUT_SCROLLBAR_W, geo.track_h, mixColor(bg, fg, 0.24), 0.35);
+    ui_pipeline.fillQuadAlpha(geo.track_x, @round(thumb_y), INPUT_SCROLLBAR_W, geo.thumb_h, mixColor(fg, accent, 0.18), 0.72);
 }
 
 fn renderTranscriptScrollbar(
@@ -989,8 +990,8 @@ fn renderTranscriptScrollbar(
     const track_y = window_height - geo.track_top_px - geo.track_h;
     const thumb_y = window_height - geo.thumb_top_px - geo.thumb_h;
 
-    gl_init.renderQuadAlpha(geo.track_x, track_y, scrollbar_model.WIDTH, geo.track_h, mixColor(bg, fg, 0.18), opacity * 0.20);
-    gl_init.renderQuadAlpha(geo.track_x, thumb_y, scrollbar_model.WIDTH, geo.thumb_h, mixColor(bg, fg, 0.46), opacity * 0.62);
+    ui_pipeline.fillQuadAlpha(geo.track_x, track_y, scrollbar_model.WIDTH, geo.track_h, mixColor(bg, fg, 0.18), opacity * 0.20);
+    ui_pipeline.fillQuadAlpha(geo.track_x, thumb_y, scrollbar_model.WIDTH, geo.thumb_h, mixColor(bg, fg, 0.46), opacity * 0.62);
 }
 
 fn inputScrollbarGeometry(layout: InputLayout, window_height: f32, total_rows: usize, visible_rows_raw: usize, first_row_raw: usize) ?InputScrollbarGeometry {
@@ -1105,14 +1106,14 @@ fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) 
     const y = window_height - rect.top_px - rect.h;
     const fill = if (stopping) mixColor(bg, fg, 0.12) else mixColor(bg, accent, 0.20);
     const stroke = if (stopping) mixColor(bg, fg, 0.42) else accent;
-    gl_init.renderQuadAlpha(rect.x, y, rect.w, rect.h, fill, 0.92);
-    gl_init.renderQuadAlpha(rect.x, y + rect.h - 1, rect.w, 1, stroke, 0.70);
-    gl_init.renderQuadAlpha(rect.x, y, rect.w, 1, mixColor(bg, fg, 0.20), 0.70);
+    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, rect.h, fill, 0.92);
+    ui_pipeline.fillQuadAlpha(rect.x, y + rect.h - 1, rect.w, 1, stroke, 0.70);
+    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, 1, mixColor(bg, fg, 0.20), 0.70);
 
     const icon_size: f32 = 8;
     const icon_x = rect.x + 12;
     const icon_y = y + @round((rect.h - icon_size) / 2);
-    gl_init.renderQuad(icon_x, icon_y, icon_size, icon_size, if (stopping) mixColor(bg, fg, 0.62) else mixColor(fg, accent, 0.10));
+    ui_pipeline.fillQuad(icon_x, icon_y, icon_size, icon_size, if (stopping) mixColor(bg, fg, 0.62) else mixColor(fg, accent, 0.10));
 
     const label = if (stopping) "Stopping" else "Esc Stop";
     _ = titlebar.renderTextLimited(label, rect.x + 28, y + @round((rect.h - font.g_titlebar_cell_height) / 2), if (stopping) mixColor(bg, fg, 0.72) else fg, rect.w - 34);
@@ -1141,18 +1142,18 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout) voi
     const border = mixColor(bg, accent, 0.36);
     const selected = @min(session.suggestion_selected, count - 1);
 
-    gl_init.renderQuadAlpha(popup_x, popup_y, popup_w, popup_h, popup_bg, 0.98);
-    gl_init.renderQuadAlpha(popup_x, popup_y + popup_h - 1, popup_w, 1, border, 0.78);
-    gl_init.renderQuadAlpha(popup_x, popup_y, popup_w, 1, mixColor(bg, fg, 0.20), 0.82);
-    gl_init.renderQuadAlpha(popup_x, popup_y, 1, popup_h, mixColor(bg, fg, 0.16), 0.72);
-    gl_init.renderQuadAlpha(popup_x + popup_w - 1, popup_y, 1, popup_h, mixColor(bg, fg, 0.16), 0.72);
+    ui_pipeline.fillQuadAlpha(popup_x, popup_y, popup_w, popup_h, popup_bg, 0.98);
+    ui_pipeline.fillQuadAlpha(popup_x, popup_y + popup_h - 1, popup_w, 1, border, 0.78);
+    ui_pipeline.fillQuadAlpha(popup_x, popup_y, popup_w, 1, mixColor(bg, fg, 0.20), 0.82);
+    ui_pipeline.fillQuadAlpha(popup_x, popup_y, 1, popup_h, mixColor(bg, fg, 0.16), 0.72);
+    ui_pipeline.fillQuadAlpha(popup_x + popup_w - 1, popup_y, 1, popup_h, mixColor(bg, fg, 0.16), 0.72);
 
     const top = popup_y + popup_h - SUGGESTION_PAD_Y;
     for (0..count) |i| {
         const row_y = top - @as(f32, @floatFromInt(i + 1)) * SUGGESTION_ROW_H;
         if (i == selected) {
-            gl_init.renderQuadAlpha(popup_x + 4, row_y + 2, popup_w - 8, SUGGESTION_ROW_H - 4, mixColor(bg, accent, 0.18), 0.90);
-            gl_init.renderQuadAlpha(popup_x + 4, row_y + 2, 3, SUGGESTION_ROW_H - 4, accent, 0.82);
+            ui_pipeline.fillQuadAlpha(popup_x + 4, row_y + 2, popup_w - 8, SUGGESTION_ROW_H - 4, mixColor(bg, accent, 0.18), 0.90);
+            ui_pipeline.fillQuadAlpha(popup_x + 4, row_y + 2, 3, SUGGESTION_ROW_H - 4, accent, 0.82);
         }
         const suggestion = ai_chat.composerSuggestionAtForInput(input_text, session.input_cursor, session.skill_suggestions, i) orelse continue;
         const text_y = row_y + @round((SUGGESTION_ROW_H - font.g_titlebar_cell_height) / 2);
@@ -1189,10 +1190,10 @@ fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
     const card_bg = mixColor(bg, accent, 0.08);
-    gl_init.renderQuadAlpha(x, y, w, h, card_bg, 0.98);
-    gl_init.renderQuadAlpha(x, y + h - 1, w, 1, accent, 0.65);
-    gl_init.renderQuadAlpha(x, y, w, 1, mixColor(bg, fg, 0.18), 0.8);
-    gl_init.renderQuadAlpha(x, y, 4, h, accent, 0.85);
+    ui_pipeline.fillQuadAlpha(x, y, w, h, card_bg, 0.98);
+    ui_pipeline.fillQuadAlpha(x, y + h - 1, w, 1, accent, 0.65);
+    ui_pipeline.fillQuadAlpha(x, y, w, 1, mixColor(bg, fg, 0.18), 0.8);
+    ui_pipeline.fillQuadAlpha(x, y, 4, h, accent, 0.85);
 
     var title_buf: [256]u8 = undefined;
     const title = std.fmt.bufPrint(&title_buf, "Approve {s}?", .{view.tool}) catch "Approve tool?";
@@ -1202,7 +1203,7 @@ fn renderApprovalCard(view: ai_chat.ApprovalView, x: f32, y: f32, w: f32, h: f32
         _ = titlebar.renderTextLimited(view.reason, x + 16, y + h - 74, mixColor(bg, fg, 0.70), w - 32);
     }
     const command_bg = mixColor(bg, fg, 0.065);
-    gl_init.renderQuadAlpha(x + 12, y + 10, w - 24, 34, command_bg, 0.95);
+    ui_pipeline.fillQuadAlpha(x + 12, y + 10, w - 24, 34, command_bg, 0.95);
     _ = titlebar.renderTextLimited(view.command, x + 20, y + 18, fg, w - 40);
 }
 
@@ -1213,7 +1214,7 @@ fn renderCopyButton(rect: CopyButtonRect, window_height: f32, selected: bool) vo
     const button_bg = if (selected) mixColor(bg, accent, 0.24) else mixColor(bg, fg, 0.10);
     const icon = if (selected) mixColor(fg, accent, 0.14) else mixColor(bg, fg, 0.72);
     const y = window_height - rect.top_px - rect.h;
-    gl_init.renderQuadAlpha(rect.x, y, rect.w, rect.h, button_bg, 0.72);
+    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, rect.h, button_bg, 0.72);
 
     const t: f32 = 1.3;
     const back_x = rect.x + 7;
@@ -1227,10 +1228,10 @@ fn renderCopyButton(rect: CopyButtonRect, window_height: f32, selected: bool) vo
 }
 
 fn drawOutlineRect(x: f32, y: f32, w: f32, h: f32, t: f32, color: [3]f32) void {
-    gl_init.renderQuad(x, y + h - t, w, t, color);
-    gl_init.renderQuad(x, y, w, t, color);
-    gl_init.renderQuad(x, y, t, h, color);
-    gl_init.renderQuad(x + w - t, y, t, h, color);
+    ui_pipeline.fillQuad(x, y + h - t, w, t, color);
+    ui_pipeline.fillQuad(x, y, w, t, color);
+    ui_pipeline.fillQuad(x, y, t, h, color);
+    ui_pipeline.fillQuad(x + w - t, y, t, h, color);
 }
 
 const ToolSectionMeta = struct {
@@ -1613,11 +1614,11 @@ fn renderTableBlock(
     const total_h = tableBlockHeight(text, start, end);
     const table_y = window_height - top_px - total_h;
 
-    gl_init.renderQuadAlpha(x, table_y, table_w, total_h, palette.table_bg, 0.94);
-    gl_init.renderQuadAlpha(x, table_y, DETAIL_RULE_W, total_h, palette.table_border, 0.85);
-    gl_init.renderQuadAlpha(x, table_y, table_w, 1, palette.table_border, 0.85);
-    gl_init.renderQuadAlpha(x, table_y + total_h - 1, table_w, 1, palette.table_border, 0.85);
-    gl_init.renderQuadAlpha(x + table_w - 1, table_y, 1, total_h, palette.table_border, 0.85);
+    ui_pipeline.fillQuadAlpha(x, table_y, table_w, total_h, palette.table_bg, 0.94);
+    ui_pipeline.fillQuadAlpha(x, table_y, DETAIL_RULE_W, total_h, palette.table_border, 0.85);
+    ui_pipeline.fillQuadAlpha(x, table_y, table_w, 1, palette.table_border, 0.85);
+    ui_pipeline.fillQuadAlpha(x, table_y + total_h - 1, table_w, 1, palette.table_border, 0.85);
+    ui_pipeline.fillQuadAlpha(x + table_w - 1, table_y, 1, total_h, palette.table_border, 0.85);
 
     var cursor = start;
     var row_index: usize = 0;
@@ -1636,12 +1637,12 @@ fn renderTableBlock(
             palette.table_bg
         else
             palette.table_alt;
-        gl_init.renderQuadAlpha(x, row_y, table_w, row_h, row_bg, if (row_index == 0) 0.98 else 0.92);
-        gl_init.renderQuadAlpha(x, row_y, table_w, 1, palette.table_border, 0.85);
+        ui_pipeline.fillQuadAlpha(x, row_y, table_w, row_h, row_bg, if (row_index == 0) 0.98 else 0.92);
+        ui_pipeline.fillQuadAlpha(x, row_y, table_w, 1, palette.table_border, 0.85);
 
         var cell_x = x + 1;
         for (0..col_count) |col| {
-            if (col > 0) gl_init.renderQuadAlpha(cell_x - 1, row_y, 1, row_h, palette.table_border, 0.85);
+            if (col > 0) ui_pipeline.fillQuadAlpha(cell_x - 1, row_y, 1, row_h, palette.table_border, 0.85);
             const text_w = widths[col];
             const cell_w = text_w + TABLE_CELL_PAD_X * 2 + 1;
             var clean_buf: [256]u8 = undefined;
@@ -1813,7 +1814,7 @@ fn renderTextLine(text: []const u8, x: f32, top_px: f32, max_w: f32, color: [3]f
 
 fn renderTopQuad(x: f32, w: f32, window_height: f32, top_px: f32, h: f32, color: [3]f32) void {
     const y = window_height - top_px - h;
-    gl_init.renderQuadAlpha(x, y, w, h, color, 0.96);
+    ui_pipeline.fillQuadAlpha(x, y, w, h, color, 0.96);
 }
 
 const CodepointItem = struct {

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -106,7 +106,7 @@ pub fn setProjection(width: f32, height: f32) void {
 /// Enable scissor clipping to `rect` (window-space, same convention as the
 /// caller's existing glScissor: x/y are the lower-left corner in GL pixels).
 /// Rounds to integer pixels, matching the prior @intFromFloat(@round(...)) calls.
-pub fn pushClip(rect: Rect) void {
+pub fn beginClip(rect: Rect) void {
     const gl = gpu.glTable();
     gl.Enable.?(c.GL_SCISSOR_TEST);
     gl.Scissor.?(
@@ -118,8 +118,8 @@ pub fn pushClip(rect: Rect) void {
 }
 
 /// Disable scissor clipping (= the prior gl.Disable(GL_SCISSOR_TEST)). Flat
-/// enable/disable, not a nesting stack — ai_chat never nests clip regions.
-pub fn popClip() void {
+/// enable/disable — clip regions are not nested.
+pub fn endClip() void {
     gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
 }
 

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -103,6 +103,26 @@ pub fn setProjection(width: f32, height: f32) void {
     gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(text.program, "projection"), 1, c.GL_FALSE, &projection);
 }
 
+/// Enable scissor clipping to `rect` (window-space, same convention as the
+/// caller's existing glScissor: x/y are the lower-left corner in GL pixels).
+/// Rounds to integer pixels, matching the prior @intFromFloat(@round(...)) calls.
+pub fn pushClip(rect: Rect) void {
+    const gl = gpu.glTable();
+    gl.Enable.?(c.GL_SCISSOR_TEST);
+    gl.Scissor.?(
+        @intFromFloat(@round(rect.x)),
+        @intFromFloat(@round(rect.y)),
+        @intFromFloat(@round(rect.w)),
+        @intFromFloat(@round(rect.h)),
+    );
+}
+
+/// Disable scissor clipping (= the prior gl.Disable(GL_SCISSOR_TEST)). Flat
+/// enable/disable, not a nesting stack — ai_chat never nests clip regions.
+pub fn popClip() void {
+    gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
+}
+
 pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
     fillQuadAlpha(x, y, w, h, color, 1.0);
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -35,4 +35,5 @@ test {
     _ = @import("renderer/gpu/backend.zig");
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");
+    _ = @import("ai_chat_layout.zig");
 }


### PR DESCRIPTION
Third increment of **Phase A / A3** (decoupling the renderer from raw OpenGL behind the `gpu`/`ui_pipeline` layer, toward native macOS/Linux ports). Routes `src/renderer/ai_chat_renderer.zig` entirely through the shared `ui_pipeline` and extracts its pure geometry into a std-only, unit-tested module. **Behavior-preserving.**

After this PR, `ai_chat_renderer.zig` is **raw-GL-free** — zero `gl.*` / `c.GL_*` / `glad` / `gl_init` references (matching the already-converted `titlebar.zig`).

## Changes

- **`src/ai_chat_layout.zig` (new)** — std-only module with 7 pure rect-geometry functions (`pointInRect`, `bubbleGeometry`, `copyButtonRectForBubble`, `detailHeaderRect`, `detailCopyButtonRect`, `permissionChipX`, `stopButtonRect`) + 7 unit tests. Layout constants and font-derived metrics are passed in as params, so the module imports only `std` (Axis B).
- **`src/renderer/ui_pipeline.zig`** — new `beginClip(rect)` / `endClip()` scissor helpers (reusable by `overlays`/`markdown` later; advances A6).
- **`src/renderer/ai_chat_renderer.zig`** —
  - 56 `gl_init.renderQuad*` calls → `ui_pipeline.fillQuad*`
  - both `GL_SCISSOR_TEST` regions (input field + transcript) → `beginClip`/`endClip`
  - removed the now-redundant local ambient blend/program/VAO setup (blend is enabled frame-level in `AppWindow`)
  - dropped the `@cInclude("glad/gl.h")` cImport and the dead `gl_init` import
  - geometry helpers became thin wrappers delegating to `ai_chat_layout` (signatures unchanged → call sites and `input.zig` untouched)
- **`src/test_fast.zig`** — registers `ai_chat_layout` in the fast test build.

## Verification

- `zig build` clean; `zig build test` (incl. new `ai_chat_layout` tests) and `zig build test-full` green.
- Geometry wrappers verified constant-for-constant against the original inline bodies (no behavior change).
- Manual Windows visual check passed: AI chat panel (header/stop button, bubbles, copy buttons, tool/reasoning cards, input scroll-clipping, scrollbars, suggestion popup, approval card, markdown/tables, selection) renders identically; no blend artifacts.

Spec: `docs/superpowers/specs/2026-05-26-gpu-a3-ai-chat-renderer-design.md`
Plan: `docs/superpowers/plans/2026-05-26-gpu-a3-ai-chat-renderer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)