### PR TITLE
GPU A3: convert the remaining 7 renderer files (A3 complete)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,11 +101,11 @@ mapping in guide §2 and §5.
       under `gpu/opengl/`, and `AppWindow.zig` no longer `@cImport`s `glad`
       (consumers reach the table via `AppWindow.gpu.glTable()`). Renderer files
       keep their own `glad` includes until A6.
-- [ ] **A3** Route renderer files from raw `gl.*` to `gpu.zig`, splitting each
+- [x] **A3** Route renderer files from raw `gl.*` to `gpu.zig`, splitting each
       file's presentation/logic in the same pass (one touch each):
       `cell_renderer`, `titlebar`, `overlays`, `ai_chat_renderer`,
       `image_renderer`, `post_process`, `background_image`, `fbo`,
-      `markdown_preview_renderer`, `file_explorer_renderer`.
+      `markdown_preview_renderer`, `file_explorer_renderer` — **all converted**.
       *Increment 1 done:* real `Buffer`/`Texture`/`Pipeline` primitives exist in
       `gpu/opengl/`; `cell_renderer` is converted — `drawCells` routes through
       `cell_pipeline.zig` (cell pipelines built from the primitives) and the pure
@@ -125,10 +125,17 @@ mapping in guide §2 and §5.
       `glad` cImport + `gl_init` import are gone (the file is now raw-`gl.*`-free,
       like `titlebar`). Its pure rect geometry moved to std-only, unit-tested
       `ai_chat_layout.zig`.
-      *Still pending:* `overlays`, `image_renderer`, `post_process`,
-      `background_image`, `fbo`, `markdown_preview_renderer`,
-      `file_explorer_renderer` (each converts to `ui_pipeline`, dissolving the
-      compat mirrors as they go).
+      *Increment 4 done (remaining 7 files):* `file_explorer_renderer` (quads →
+      `ui_pipeline.fillQuad`). Added GPU primitives — `Texture.create/upload2D/
+      setWrap/destroy`, new `Framebuffer`, `Pipeline.setVec3/setVec4/drawArrays`
+      — plus `ui_pipeline.drawTextureQuad`/`fillOverlay`/`setBlendEnabled` and a
+      `ui_pipeline`-owned `overlay` pipeline (so `overlay_shader` left `gl_init`).
+      `fbo`/`post_process` → `gpu.Framebuffer`; `image_renderer`/`background_image`/
+      `markdown_preview_renderer` image uploads → `gpu.Texture` + `drawTextureQuad`;
+      `overlays`/`background_image` tint → `fillOverlay`; `markdown_preview` +
+      `overlays` quads → `fillQuad`. None carries its own `@cInclude("glad/gl.h")`;
+      `markdown_preview`/`post_process` keep `gpu.glTable()` plumbing for VAO
+      build / scissor save-restore / Clear-Viewport (the `cell_pipeline` bar).
 - [ ] **A4** Route font atlas → GPU texture through the `Texture` primitive;
       drop `font/manager.zig`'s direct `@cImport("glad/gl.h")`.
 - [ ] **A5** Backend-scope shaders: GLSL under `gpu/opengl/shaders.zig`; reserve

--- a/docs/superpowers/plans/2026-05-26-gpu-a3-remaining-files.md
+++ b/docs/superpowers/plans/2026-05-26-gpu-a3-remaining-files.md
@@ -1,0 +1,78 @@
+# GPU A3 — remaining 7 files: plan
+
+Goal: route the last A3 renderer files through `gpu`/`ui_pipeline`, raw-GL-free, behavior-preserving. Branch `feat/gpu-a3-remaining` (off the ai_chat branch, so `beginClip`/`endClip` exist).
+
+## File categories
+
+**Group 1 — UI quad/text (existing `ui_pipeline` pattern):**
+- `file_explorer_renderer` ✅ DONE — 13 quads→fillQuad, ambient/glad/gl_init removed.
+- `markdown_preview_renderer` — 12 quads→fillQuad, 2 scissor→beginClip/endClip; PLUS its own image texture (see Group 2 infra).
+- `overlays` (4564 ln) — 27 quads→fillQuad; 3 `overlay_shader` sites→`ui_pipeline.fillOverlay`; 9 UseProgram/bind ambient blocks.
+
+**Group 2 — GPU-effect (need new primitives):**
+- `fbo` — FBO mgmt + textured-quad composite (uses `simple_color_shader`).
+- `image_renderer` — kitty image texture upload + textured-quad draw (uses `simple_color_shader`).
+- `background_image` — stb_image texture load + textured-quad draw + `overlay_shader` tint pass.
+- `post_process` — off-screen FBO + dynamic user shader (Shadertoy uniforms) + fullscreen quad.
+
+## Primitive infrastructure to add (additive, build stays green)
+
+### P1 — `gpu/opengl/Texture.zig` extensions
+Current: only `fromHandle`, `bind`. Add (keep callers storing raw `GLuint` via `.handle` to avoid Renderer struct ripple):
+```zig
+pub const Filter = enum { nearest, linear };
+pub const Wrap = enum { clamp_to_edge, repeat };
+pub const Upload = struct {
+    internal_format: c.GLint = c.GL_RGBA8,
+    format: c.GLenum = c.GL_RGBA,
+    data_type: c.GLenum = c.GL_UNSIGNED_BYTE,
+    filter: Filter = .linear,
+    wrap: Wrap = .clamp_to_edge,
+    unpack_alignment: ?c.GLint = null, // when set, PixelStorei(UNPACK_ALIGNMENT, v)
+};
+pub fn create() Texture;                              // GenTextures
+pub fn upload2D(self: Texture, w: c_int, h: c_int, data: ?*const anyopaque, o: Upload) void;
+pub fn setWrap(self: Texture, wrap: Wrap) void;       // bind + TexParameteri WRAP_S/T
+pub fn destroy(self: *Texture) void;                  // DeleteTextures, handle=0
+```
+`upload2D`: bind, set MIN/MAG filter + WRAP_S/T, optional PixelStorei, TexImage2D. `data` may be null (FBO color attach).
+
+### P2 — `gpu/opengl/Framebuffer.zig` (new) + export via `gpu.zig`/`api.zig`
+```zig
+handle: c.GLuint = 0,
+color: c.GLuint = 0,
+width: c_int = 0,
+height: c_int = 0,
+pub fn initColor(w: c_int, h: c_int) ?Framebuffer;   // gen fbo + color tex (RGBA8 LINEAR CLAMP) + attach + completeness; null+cleanup if incomplete
+pub fn bind(self: Framebuffer) void;                  // BindFramebuffer(FRAMEBUFFER, handle) + Viewport(0,0,w,h)
+pub fn unbind() void;                                 // BindFramebuffer(FRAMEBUFFER, 0)
+pub fn deinit(self: *Framebuffer) void;               // delete fbo + color tex
+```
+Used by `fbo.zig` (per-Renderer; Renderer keeps raw handles — use `Framebuffer{ .handle=…, .color=…, .width=…, .height=… }` round-trips or store the struct) and `post_process.zig`.
+
+### P3 — `gpu/opengl/Pipeline.zig` extensions
+Add: `setVec3(name,x,y,z)`, `setVec4(name,x,y,z,w)`, `drawArrays(mode, first, count)` (non-instanced; increments g_draw_call_count via gl_init).
+
+### P4 — `ui_pipeline.zig`: textured-quad + overlay
+- `drawTextureQuad(verts: [6][4]f32, tex: c.GLuint, opacity: f32) void` — emoji pipeline (the `simple_color_shader`): use+bindVao+setProjection(viewport)+opacity uniform+`text`=0+bind tex+upload verts to `quad`+DrawArrays. **No blend change** (caller controls blend, matching the originals).
+- New `overlay` pipeline owned by ui_pipeline (built in `init()` from `shaders.vertex_shader_source`/`shaders.overlay_fragment_source`, own VAO over `quad`). Helper `fillOverlay(verts: [6][4]f32, color: [4]f32) void` — use+bindVao+setProjection+`overlayColor`=color+upload+DrawArrays.
+- `gl_init.overlay_shader` becomes a compat mirror synced from `ui_pipeline.overlay.program` in `syncSharedHandles()` (so unconverted users keep working). Remove from `gl_init.initShaders` once both `overlays`+`background_image` are converted.
+
+## Conversion order (each: build + `zig build test` + `test-full` green, commit; Windows visual check batched at end)
+
+1. ✅ `file_explorer_renderer`
+2. P1+P3 (Texture + Pipeline extensions) — additive
+3. P2 (Framebuffer) — additive
+4. P4 (ui_pipeline textured-quad + overlay) — additive, wire into ui_pipeline.init + syncSharedHandles
+5. `fbo` → Framebuffer + drawTextureQuad
+6. `image_renderer` → Texture.upload2D + drawTextureQuad
+7. `background_image` → Texture + drawTextureQuad + fillOverlay
+8. `post_process` → Framebuffer + dedicated pipeline (Pipeline.init from dynamic source + setVec3) ; keep its own NDC fullscreen-quad VAO/VBO via gpu.Buffer
+9. `markdown_preview_renderer` → fillQuad + beginClip/endClip + image part via Texture/drawTextureQuad
+10. `overlays` → fillQuad + fillOverlay ; then drop `overlay_shader` from gl_init
+
+## Notes / invariants
+- Behavior-preserving: blend bookends stay where they were (background_image disables blend around its image draw; image_renderer relies on ambient). `drawTextureQuad` must NOT change blend.
+- `g_draw_call_count` increments preserved on every converted draw.
+- After all conversions, each file: no `gl.*`, no `@cInclude("glad/gl.h")`, no `gl_init.*` (except where a file legitimately still needs a gl_init-owned helper — aim for none).
+- A6 guard (forbid gl.* outside gpu/opengl) becomes possible once all renderer files convert — out of scope here but this unblocks it.

--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -8,9 +8,10 @@ const std = @import("std");
 const Config = @import("../config.zig");
 const AppWindow = @import("../AppWindow.zig");
 const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const ui_pipeline = @import("ui_pipeline.zig");
 
 const c = @cImport({
-    @cInclude("glad/gl.h");
     @cInclude("stb_image.h");
 });
 
@@ -19,7 +20,7 @@ pub const Mode = Config.BackgroundImageMode;
 pub threadlocal var g_enabled: bool = false;
 pub threadlocal var g_mode: Mode = .fill;
 
-threadlocal var g_texture: c.GLuint = 0;
+threadlocal var g_texture: gpu.c.GLuint = 0;
 threadlocal var g_width: c_int = 0;
 threadlocal var g_height: c_int = 0;
 /// Owned copy of the currently-loaded image path. The module owns this slice
@@ -51,11 +52,10 @@ fn freeLoadedPath() void {
 pub fn load(allocator: std.mem.Allocator, path: ?[]const u8) void {
     if (isLoaded(path)) return;
 
-    const gl = AppWindow.gpu.glTable();
-
     // Reset existing state
     if (g_texture != 0) {
-        gl.DeleteTextures.?(1, &g_texture);
+        var tex = gpu.Texture.fromHandle(g_texture);
+        tex.destroy();
         g_texture = 0;
     }
     g_enabled = false;
@@ -84,15 +84,12 @@ pub fn load(allocator: std.mem.Allocator, path: ?[]const u8) void {
     }
     defer c.stbi_image_free(data);
 
-    gl.GenTextures.?(1, &g_texture);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
-    const wrap: c.GLint = if (g_mode == .tile) c.GL_REPEAT else c.GL_CLAMP_TO_EDGE;
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrap);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrap);
-    gl.PixelStorei.?(c.GL_UNPACK_ALIGNMENT, 1);
-    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RGBA8, w, h, 0, c.GL_RGBA, c.GL_UNSIGNED_BYTE, data);
+    const tex = gpu.Texture.create();
+    g_texture = tex.handle;
+    tex.upload2D(w, h, data, .{
+        .wrap = if (g_mode == .tile) .repeat else .clamp_to_edge,
+        .unpack_alignment = 1,
+    });
 
     g_width = w;
     g_height = h;
@@ -110,17 +107,13 @@ pub fn load(allocator: std.mem.Allocator, path: ?[]const u8) void {
 /// Update the wrap mode after `g_mode` changes (without reloading the image).
 pub fn refreshWrapMode() void {
     if (g_texture == 0) return;
-    const gl = AppWindow.gpu.glTable();
-    const wrap: c.GLint = if (g_mode == .tile) c.GL_REPEAT else c.GL_CLAMP_TO_EDGE;
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrap);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrap);
+    gpu.Texture.fromHandle(g_texture).setWrap(if (g_mode == .tile) .repeat else .clamp_to_edge);
 }
 
 pub fn deinit() void {
     if (g_texture != 0) {
-        const gl = AppWindow.gpu.glTable();
-        gl.DeleteTextures.?(1, &g_texture);
+        var tex = gpu.Texture.fromHandle(g_texture);
+        tex.destroy();
         g_texture = 0;
     }
     g_enabled = false;
@@ -198,21 +191,12 @@ fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) Uv {
 /// (used to flip Y in the projection matrix used by the simple shader).
 pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
     if (!g_enabled or g_texture == 0) return;
-    const gl = AppWindow.gpu.glTable();
-    if (gl_init.simple_color_shader == 0) return;
+    if (ui_pipeline.emoji.program == 0) return;
 
     const uv = computeUv(viewport_width, viewport_height, g_mode);
 
-    // The simple_color_shader uses gl_init.shader_program's vertex layout
-    // (vec4: xy=pos, zw=texcoord) and gl_init.setProjection's projection
-    // matrix. We bind the simple_color_shader and set its uniforms.
-    gl.UseProgram.?(gl_init.simple_color_shader);
-    gl_init.setProjectionForProgram(gl_init.simple_color_shader, viewport_height);
-    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
-    gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "text"), 0);
-
     // Two triangles covering the whole viewport in pixel coords.
-    // setProjectionForProgram maps [0..w] x [0..h] to NDC.
+    // drawTextureQuad's setProjection maps [0..w] x [0..h] to NDC.
     const x_lo: f32 = 0;
     const y_lo: f32 = 0;
     const x_hi: f32 = viewport_width;
@@ -226,38 +210,19 @@ pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
         .{ x_hi, y_hi, uv.u_max, uv.v_min }, // top-right
     };
 
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_texture);
-    gl.BindVertexArray.?(gl_init.vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-
     // The image is opaque RGBA; we want to write it directly without blending
     // against whatever ClearColor wrote. Disable blending for this single draw.
-    gl.Disable.?(c.GL_BLEND);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl.Enable.?(c.GL_BLEND);
-    gl_init.g_draw_call_count += 1;
+    ui_pipeline.setBlendEnabled(false);
+    ui_pipeline.drawTextureQuad(vertices, g_texture, 1.0);
+    ui_pipeline.setBlendEnabled(true);
 
     // Tint pass: blend the theme background color over the image at
     // `g_bg_opacity`. Without this, default-bg cells (which emit no per-cell
     // bg quad) would show the image at 100% regardless of opacity. With it,
     // default cells end up as `(1-opacity)*image + opacity*theme_bg`, which
     // matches the documented intent. Skip only at opacity == 0 (no-op).
-    if (gl_init.g_bg_opacity > 0.0 and gl_init.overlay_shader != 0) {
+    if (gl_init.g_bg_opacity > 0.0 and ui_pipeline.overlay.program != 0) {
         const theme = AppWindow.g_theme.background;
-        gl.UseProgram.?(gl_init.overlay_shader);
-        gl_init.setProjectionForProgram(gl_init.overlay_shader, viewport_height);
-        gl.Uniform4f.?(
-            gl.GetUniformLocation.?(gl_init.overlay_shader, "overlayColor"),
-            theme[0],
-            theme[1],
-            theme[2],
-            gl_init.g_bg_opacity,
-        );
-        // Reuse the same fullscreen vertices (overlay shader ignores texcoords).
-        gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-        gl_init.g_draw_call_count += 1;
+        ui_pipeline.fillOverlay(vertices, .{ theme[0], theme[1], theme[2], gl_init.g_bg_opacity });
     }
 }

--- a/src/renderer/fbo.zig
+++ b/src/renderer/fbo.zig
@@ -5,103 +5,53 @@
 
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
-const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const ui_pipeline = @import("ui_pipeline.zig");
 const Renderer = @import("Renderer.zig");
-
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
 
 /// Create or resize an FBO for a renderer.
 /// Must be called from main thread with GL context current.
 pub fn ensureRendererFBO(rend: *Renderer, width: u32, height: u32) void {
     if (!rend.needsFBOUpdate(width, height)) return;
 
-    const gl = AppWindow.gpu.glTable();
-
     // Clean up existing FBO if resizing
     if (rend.isFBOReady()) {
         cleanupRendererFBO(rend);
     }
 
-    // Create framebuffer
-    var fbo: c.GLuint = 0;
-    gl.GenFramebuffers.?(1, &fbo);
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, fbo);
-
-    // Create texture for color attachment
-    var texture: c.GLuint = 0;
-    gl.GenTextures.?(1, &texture);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, texture);
-    gl.TexImage2D.?(
-        c.GL_TEXTURE_2D,
-        0,
-        c.GL_RGBA8,
-        @intCast(width),
-        @intCast(height),
-        0,
-        c.GL_RGBA,
-        c.GL_UNSIGNED_BYTE,
-        null,
-    );
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, c.GL_CLAMP_TO_EDGE);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, c.GL_CLAMP_TO_EDGE);
-
-    // Attach texture to framebuffer
-    gl.FramebufferTexture2D.?(c.GL_FRAMEBUFFER, c.GL_COLOR_ATTACHMENT0, c.GL_TEXTURE_2D, texture, 0);
-
-    // Check framebuffer completeness
-    const status = gl.CheckFramebufferStatus.?(c.GL_FRAMEBUFFER);
-
-    // Unbind
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, 0);
-
-    if (status != c.GL_FRAMEBUFFER_COMPLETE) {
-        std.debug.print("FBO incomplete: 0x{X}, cleaning up\n", .{status});
-        gl.DeleteTextures.?(1, &texture);
-        gl.DeleteFramebuffers.?(1, &fbo);
-        return;
-    }
-
-    // Store handles in renderer
-    rend.setFBOHandles(fbo, texture, width, height);
+    const framebuffer = gpu.Framebuffer.initColor(@intCast(width), @intCast(height)) orelse return;
+    rend.setFBOHandles(framebuffer.handle, framebuffer.color, width, height);
 }
 
 /// Clean up FBO resources for a renderer.
 pub fn cleanupRendererFBO(rend: *Renderer) void {
     if (!rend.isFBOReady()) return;
-
-    const gl = AppWindow.gpu.glTable();
-
-    var texture = rend.getTexture();
-    var fbo = rend.getFBO();
-
-    if (texture != 0) {
-        gl.DeleteTextures.?(1, &texture);
-    }
-    if (fbo != 0) {
-        gl.DeleteFramebuffers.?(1, &fbo);
-    }
-
+    var framebuffer = gpu.Framebuffer{
+        .handle = rend.getFBO(),
+        .color = rend.getTexture(),
+        .width = 0,
+        .height = 0,
+    };
+    framebuffer.deinit();
     rend.clearFBOHandles();
 }
 
 /// Bind a renderer's FBO for drawing.
 pub fn bindRendererFBO(rend: *Renderer) void {
     if (!rend.isFBOReady()) return;
-    const gl = AppWindow.gpu.glTable();
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, rend.getFBO());
     const size = rend.getFBOSize();
-    gl.Viewport.?(0, 0, @intCast(size.width), @intCast(size.height));
+    const framebuffer = gpu.Framebuffer{
+        .handle = rend.getFBO(),
+        .color = rend.getTexture(),
+        .width = @intCast(size.width),
+        .height = @intCast(size.height),
+    };
+    framebuffer.bind();
 }
 
 /// Unbind FBO (return to default framebuffer).
 pub fn unbindFBO() void {
-    const gl = AppWindow.gpu.glTable();
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
+    gpu.Framebuffer.unbind();
 }
 
 /// Draw a renderer's FBO texture as a quad at the given screen position.
@@ -109,9 +59,12 @@ pub fn unbindFBO() void {
 pub fn drawRendererFBOToScreen(rend: *Renderer, x: f32, y: f32, w: f32, h: f32, window_height: f32, window_width: f32) void {
     if (!rend.isFBOReady()) return;
 
-    const gl = AppWindow.gpu.glTable();
+    _ = window_width;
 
     // Convert from top-left screen coords to OpenGL bottom-left coords
+    // NOTE: window_width is unused; drawTextureQuad derives the ortho projection
+    // from the current viewport, which equals the window dimensions when
+    // compositing to the default framebuffer.
     const gl_y = window_height - y - h;
 
     // Vertices for textured quad (position + texcoord)
@@ -124,25 +77,5 @@ pub fn drawRendererFBOToScreen(rend: *Renderer, x: f32, y: f32, w: f32, h: f32, 
         .{ x + w, gl_y + h, 1.0, 1.0 }, // top-right
     };
 
-    // Set up projection matrix for screen space
-    const projection = [16]f32{
-        2.0 / window_width, 0.0,                 0.0,  0.0,
-        0.0,                2.0 / window_height, 0.0,  0.0,
-        0.0,                0.0,                 -1.0, 0.0,
-        -1.0,               -1.0,                0.0,  1.0,
-    };
-
-    // Use the color texture shader (samples RGBA directly)
-    gl.UseProgram.?(gl_init.simple_color_shader);
-    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "projection"), 1, c.GL_FALSE, &projection);
-    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, rend.getTexture());
-    gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "text"), 0);
-    gl.BindVertexArray.?(gl_init.vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
+    ui_pipeline.drawTextureQuad(vertices, rend.getTexture(), 1.0);
 }

--- a/src/renderer/file_explorer_renderer.zig
+++ b/src/renderer/file_explorer_renderer.zig
@@ -1,18 +1,15 @@
 //! File explorer sidebar renderer.
 //!
 //! Renders the left-side file explorer panel using the same OpenGL primitives
-//! as the left tab sidebar (titlebar.zig). Uses gl_init.renderQuad for backgrounds
+//! as the left tab sidebar (titlebar.zig). Uses ui_pipeline.fillQuad for backgrounds
 //! and titlebar.renderTextLimited / renderTitlebarChar for text.
 
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
 const titlebar = AppWindow.titlebar;
+const ui_pipeline = @import("ui_pipeline.zig");
 const font = AppWindow.font;
-const gl_init = AppWindow.gpu.gl_init;
 const file_explorer = @import("../file_explorer.zig");
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
 
 fn blend(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
     const clamped = @max(0.0, @min(1.0, t));
@@ -44,11 +41,6 @@ pub fn render(window_width: f32, window_height: f32, titlebar_h: f32) void {
     const row_h = file_explorer.rowHeight();
     const explorer_w = file_explorer.width();
     if (explorer_w <= 0) return;
-
-    const gl = AppWindow.gpu.glTable();
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -82,7 +74,7 @@ pub fn render(window_width: f32, window_height: f32, titlebar_h: f32) void {
     const panel_right = panel_x + explorer_w;
 
     // Background
-    gl_init.renderQuad(panel_x, 0, explorer_w, side_h, sidebar_bg);
+    ui_pipeline.fillQuad(panel_x, 0, explorer_w, side_h, sidebar_bg);
 
     // Right border (resize edge between explorer and terminal content)
     const resize_hovered = blk: {
@@ -94,7 +86,7 @@ pub fn render(window_width: f32, window_height: f32, titlebar_h: f32) void {
         break :blk mx >= panel_right - half_hit and mx <= panel_right + half_hit and my >= titlebar_h and my < window_height;
     };
     const edge_color = if (resize_hovered) blend(bg, accent, 0.38) else border_color;
-    gl_init.renderQuad(panel_right - 1, 0, if (resize_hovered) 2 else 1, side_h, edge_color);
+    ui_pipeline.fillQuad(panel_right - 1, 0, if (resize_hovered) 2 else 1, side_h, edge_color);
 
     switch (file_explorer.g_panel_mode) {
         .files => renderFiles(window_height, titlebar_h, header_h, row_h, panel_x, explorer_w, palette),
@@ -132,7 +124,7 @@ fn renderFiles(
     const header_text_y = header_y + (header_h - font.g_titlebar_cell_height) / 2;
     const label_end = titlebar.renderTextLimited(mode_label, panel_x + 12, header_text_y, mode_color, explorer_w - 24);
     _ = titlebar.renderTextLimited(" Explorer", label_end, header_text_y, header_text, explorer_w - (label_end - panel_x) - 12);
-    gl_init.renderQuad(panel_x, header_y, explorer_w, 1, border_color);
+    ui_pipeline.fillQuad(panel_x, header_y, explorer_w, 1, border_color);
 
     // File entries
     const list_top_px = titlebar_h + header_h;
@@ -163,9 +155,9 @@ fn renderFiles(
         const is_selected = if (file_explorer.g_selected) |sel| sel == i else false;
 
         if (is_selected) {
-            gl_init.renderQuad(panel_x, row_y, explorer_w, row_h, selected_bg);
+            ui_pipeline.fillQuad(panel_x, row_y, explorer_w, row_h, selected_bg);
         } else if (row_hovered) {
-            gl_init.renderQuad(panel_x, row_y, explorer_w, row_h, hover_bg);
+            ui_pipeline.fillQuad(panel_x, row_y, explorer_w, row_h, hover_bg);
         }
 
         // Expand/collapse indicator for directories
@@ -216,7 +208,7 @@ fn renderFiles(
         const new_row_top = list_top_px + @as(f32, @floatFromInt(file_explorer.g_entry_count)) * row_h - scroll;
         if (new_row_top >= 0 and new_row_top < visible_height) {
             const new_row_y = window_height - new_row_top - row_h;
-            gl_init.renderQuad(panel_x, new_row_y, explorer_w, row_h, selected_bg);
+            ui_pipeline.fillQuad(panel_x, new_row_y, explorer_w, row_h, selected_bg);
             const label = if (file_explorer.g_op_mode == .new_dir) "New folder: " else "New file: ";
             const input_y = new_row_y + (row_h - font.g_titlebar_cell_height) / 2;
             const op_label_end = titlebar.renderTextLimited(label, panel_x + 8, input_y, header_text, explorer_w - 16);
@@ -227,7 +219,7 @@ fn renderFiles(
         if (del_row_top >= 0 and del_row_top < visible_height) {
             const del_row_y = window_height - del_row_top - row_h;
             const warn_bg = blend(bg, .{ 0.8, 0.2, 0.2 }, 0.2);
-            gl_init.renderQuad(panel_x, del_row_y, explorer_w, row_h, warn_bg);
+            ui_pipeline.fillQuad(panel_x, del_row_y, explorer_w, row_h, warn_bg);
             _ = titlebar.renderTextLimited("Delete? Enter=yes Esc=no", panel_x + 8, del_row_y + (row_h - font.g_titlebar_cell_height) / 2, fg, explorer_w - 16);
         }
     }
@@ -237,7 +229,7 @@ fn renderFiles(
     if (file_explorer.g_loading) {
         const status_h: f32 = @max(24, font.g_titlebar_cell_height + 8);
         const status_y: f32 = 0;
-        gl_init.renderQuad(panel_x, status_y, explorer_w, status_h, blend(bg, accent, 0.15));
+        ui_pipeline.fillQuad(panel_x, status_y, explorer_w, status_h, blend(bg, accent, 0.15));
         const ty = status_y + (status_h - font.g_titlebar_cell_height) / 2;
         const prefix_end = titlebar.renderTextLimited("Loading: ", panel_x + 8, ty, accent, explorer_w - 16);
         _ = titlebar.renderTextLimited(file_explorer.g_loading_msg[0..file_explorer.g_loading_msg_len], prefix_end, ty, fg, explorer_w - (prefix_end - panel_x) - 8);
@@ -257,7 +249,7 @@ fn renderAgentHistory(
     const header_text_y = header_y + (header_h - font.g_titlebar_cell_height) / 2;
     const agent_end = titlebar.renderTextLimited("AGENT", panel_x + 12, header_text_y, palette.accent, explorer_w - 24);
     _ = titlebar.renderTextLimited(" History", agent_end, header_text_y, palette.header_text, explorer_w - (agent_end - panel_x) - 12);
-    gl_init.renderQuad(panel_x, header_y, explorer_w, 1, palette.border_color);
+    ui_pipeline.fillQuad(panel_x, header_y, explorer_w, 1, palette.border_color);
 
     const list_top_px = titlebar_h + header_h;
     const visible_height = window_height - list_top_px;
@@ -285,9 +277,9 @@ fn renderAgentHistory(
 
         const is_selected = if (file_explorer.g_history_selected) |selected| selected == i else false;
         if (is_selected) {
-            gl_init.renderQuad(panel_x, row_y, explorer_w, row_h, palette.selected_bg);
+            ui_pipeline.fillQuad(panel_x, row_y, explorer_w, row_h, palette.selected_bg);
         } else if (row_hovered) {
-            gl_init.renderQuad(panel_x, row_y, explorer_w, row_h, palette.hover_bg);
+            ui_pipeline.fillQuad(panel_x, row_y, explorer_w, row_h, palette.hover_bg);
         }
 
         const title = historyRowTitle(i, row);
@@ -331,6 +323,6 @@ fn renderInputField(x: f32, y: f32, max_w: f32, text_color: [3]f32, cursor_color
     const now = std.time.milliTimestamp();
     if (@mod(@divTrunc(now, 530), 2) == 0) {
         const font_mod = @import("../font/manager.zig");
-        gl_init.renderQuad(text_end + 1, y, 1, font_mod.g_titlebar_cell_height, cursor_color);
+        ui_pipeline.fillQuad(text_end + 1, y, 1, font_mod.g_titlebar_cell_height, cursor_color);
     }
 }

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -29,3 +29,4 @@ pub inline fn glTable() *impl.GlTable {
 pub const Texture = impl.Texture;
 pub const Buffer = impl.Buffer;
 pub const Pipeline = impl.Pipeline;
+pub const Framebuffer = impl.Framebuffer;

--- a/src/renderer/gpu/opengl/Framebuffer.zig
+++ b/src/renderer/gpu/opengl/Framebuffer.zig
@@ -1,0 +1,59 @@
+//! An off-screen framebuffer with a single RGBA8 color-texture attachment.
+//! Wraps the GenFramebuffers + color-texture + completeness-check sequence used
+//! by the per-surface FBO compositor and the post-processing pass.
+const std = @import("std");
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Texture = @import("Texture.zig");
+const Framebuffer = @This();
+
+handle: c.GLuint = 0,
+color: c.GLuint = 0,
+width: c_int = 0,
+height: c_int = 0,
+
+/// Create an FBO with a fresh RGBA8 LINEAR/CLAMP_TO_EDGE color texture attached.
+/// Returns null (after cleaning up) if the framebuffer is incomplete.
+pub fn initColor(width: c_int, height: c_int) ?Framebuffer {
+    const gl = Context.gl;
+    var handle: c.GLuint = 0;
+    gl.GenFramebuffers.?(1, &handle);
+    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, handle);
+
+    const color = Texture.create();
+    color.upload2D(width, height, null, .{}); // RGBA8, LINEAR, CLAMP_TO_EDGE
+    gl.FramebufferTexture2D.?(c.GL_FRAMEBUFFER, c.GL_COLOR_ATTACHMENT0, c.GL_TEXTURE_2D, color.handle, 0);
+
+    const status = gl.CheckFramebufferStatus.?(c.GL_FRAMEBUFFER);
+    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
+    gl.BindTexture.?(c.GL_TEXTURE_2D, 0);
+
+    if (status != c.GL_FRAMEBUFFER_COMPLETE) {
+        std.debug.print("Framebuffer incomplete: 0x{X}\n", .{status});
+        var tex = color;
+        tex.destroy();
+        gl.DeleteFramebuffers.?(1, &handle);
+        return null;
+    }
+    return .{ .handle = handle, .color = color.handle, .width = width, .height = height };
+}
+
+/// Bind this framebuffer and set the viewport to its full size.
+pub fn bind(self: Framebuffer) void {
+    const gl = Context.gl;
+    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, self.handle);
+    gl.Viewport.?(0, 0, self.width, self.height);
+}
+
+/// Bind the default (window) framebuffer.
+pub fn unbind() void {
+    Context.gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
+}
+
+/// Delete the framebuffer and its color texture; zero the struct.
+pub fn deinit(self: *Framebuffer) void {
+    const gl = Context.gl;
+    if (self.color != 0) gl.DeleteTextures.?(1, &self.color);
+    if (self.handle != 0) gl.DeleteFramebuffers.?(1, &self.handle);
+    self.* = .{};
+}

--- a/src/renderer/gpu/opengl/Pipeline.zig
+++ b/src/renderer/gpu/opengl/Pipeline.zig
@@ -100,6 +100,18 @@ pub fn setProjection(self: Pipeline) void {
     };
     gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(self.program, "projection"), 1, c.GL_FALSE, &projection);
 }
+pub fn setVec3(self: Pipeline, name: [*c]const u8, x: f32, y: f32, z: f32) void {
+    Context.gl.Uniform3f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y, z);
+}
+pub fn setVec4(self: Pipeline, name: [*c]const u8, x: f32, y: f32, z: f32, w: f32) void {
+    Context.gl.Uniform4f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y, z, w);
+}
+/// Non-instanced draw against the currently-bound program/VAO. Does NOT touch
+/// any draw-call counter (callers tick their own, same as drawArraysInstanced).
+pub fn drawArrays(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei) void {
+    _ = self;
+    Context.gl.DrawArrays.?(mode, first, count);
+}
 /// Issue an instanced draw against the currently-bound program/VAO. `self` is
 /// unused today (the bound state carries the pipeline); kept as a method for
 /// call-site ergonomics and so a future backend can attach per-pipeline state.

--- a/src/renderer/gpu/opengl/Texture.zig
+++ b/src/renderer/gpu/opengl/Texture.zig
@@ -14,3 +14,68 @@ pub fn bind(self: Texture, unit: u32) void {
     Context.gl.ActiveTexture.?(texture_unit);
     Context.gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
 }
+
+pub const Filter = enum { nearest, linear };
+pub const Wrap = enum { clamp_to_edge, repeat };
+
+/// Options for a 2D texture data upload.
+pub const Upload = struct {
+    /// Uses GLenum (unsigned int) to match GL_RGBA8 etc.; cast to GLint at TexImage2D call.
+    internal_format: c.GLenum = c.GL_RGBA8,
+    format: c.GLenum = c.GL_RGBA,
+    data_type: c.GLenum = c.GL_UNSIGNED_BYTE,
+    filter: Filter = .linear,
+    wrap: Wrap = .clamp_to_edge,
+    /// When non-null, calls glPixelStorei(GL_UNPACK_ALIGNMENT, v) before upload.
+    unpack_alignment: ?c.GLint = null,
+};
+
+fn filterEnum(f: Filter) c.GLint {
+    return switch (f) {
+        .nearest => c.GL_NEAREST,
+        .linear => c.GL_LINEAR,
+    };
+}
+fn wrapEnum(w: Wrap) c.GLint {
+    return switch (w) {
+        .clamp_to_edge => c.GL_CLAMP_TO_EDGE,
+        .repeat => c.GL_REPEAT,
+    };
+}
+
+/// Allocate a new GL texture name.
+pub fn create() Texture {
+    var handle: c.GLuint = 0;
+    Context.gl.GenTextures.?(1, &handle);
+    return .{ .handle = handle };
+}
+
+/// Bind and upload (or allocate, if `data` is null) a 2D image, setting
+/// min/mag filter and wrap_s/wrap_t. Mirrors the raw GenTextures+TexParameteri+
+/// TexImage2D sequences being replaced.
+pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopaque, o: Upload) void {
+    const gl = Context.gl;
+    gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, filterEnum(o.filter));
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, filterEnum(o.filter));
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrapEnum(o.wrap));
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrapEnum(o.wrap));
+    if (o.unpack_alignment) |a| gl.PixelStorei.?(c.GL_UNPACK_ALIGNMENT, a);
+    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, @intCast(o.internal_format), width, height, 0, o.format, o.data_type, data);
+}
+
+/// Update only the wrap_s/wrap_t parameters (binds the texture).
+pub fn setWrap(self: Texture, wrap: Wrap) void {
+    const gl = Context.gl;
+    gl.BindTexture.?(c.GL_TEXTURE_2D, self.handle);
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, wrapEnum(wrap));
+    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, wrapEnum(wrap));
+}
+
+/// Delete the GL texture and zero the handle.
+pub fn destroy(self: *Texture) void {
+    if (self.handle != 0) {
+        Context.gl.DeleteTextures.?(1, &self.handle);
+        self.handle = 0;
+    }
+}

--- a/src/renderer/gpu/opengl/api.zig
+++ b/src/renderer/gpu/opengl/api.zig
@@ -13,4 +13,5 @@ pub const gl_init = @import("gl_init.zig");
 pub const Buffer = @import("Buffer.zig");
 pub const Texture = @import("Texture.zig");
 pub const Pipeline = @import("Pipeline.zig");
+pub const Framebuffer = @import("Framebuffer.zig");
 pub const shaders = @import("shaders.zig");

--- a/src/renderer/gpu/opengl/gl_init.zig
+++ b/src/renderer/gpu/opengl/gl_init.zig
@@ -2,10 +2,9 @@
 //! shared UI pipelines.
 //!
 //! Owns: `compileShader`/`linkProgram`, `setProjectionForProgram`.
-//! Compat mirrors: `vao`/`vbo`/`shader_program`/`simple_color_shader`/`overlay_shader`
+//! Compat mirrors: `vao`/`vbo`/`shader_program`/`simple_color_shader`
 //!   are populated by `syncSharedHandles()` after `ui_pipeline.init()`; not-yet-converted
 //!   renderer files still read them directly. They dissolve as each file converts.
-//!   `overlay_shader` is a compat mirror of ui_pipeline.overlay.program.
 //! Re-exports: `renderQuad`/`renderQuadAlpha`/`setProjection` delegate to ui_pipeline.
 //! The shared UI rendering lives in renderer/ui_pipeline.zig; the cell-grid
 //! instanced pipelines in renderer/cell_pipeline.zig.
@@ -31,8 +30,6 @@ pub threadlocal var vao: c.GLuint = 0; // compat mirror — from ui_pipeline.tex
 pub threadlocal var vbo: c.GLuint = 0; // compat mirror — from ui_pipeline.quad.handle
 pub threadlocal var shader_program: c.GLuint = 0; // compat mirror — from ui_pipeline.text.program
 pub threadlocal var simple_color_shader: c.GLuint = 0; // compat mirror — from ui_pipeline.emoji.program
-
-pub threadlocal var overlay_shader: c.GLuint = 0; // compat mirror — from ui_pipeline.overlay.program (set by syncSharedHandles)
 
 // Draw call counter (reset each frame)
 pub threadlocal var g_draw_call_count: u32 = 0;
@@ -104,8 +101,8 @@ fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
 // ============================================================================
 
 pub fn initShaders() bool {
-    // overlay_shader is now owned by ui_pipeline (synced into the mirror below
-    // via syncSharedHandles); nothing to build here yet.
+    // All shared pipelines (text/emoji/overlay) are built by ui_pipeline.init();
+    // nothing to compile here. Kept as a stable init hook.
     return true;
 }
 
@@ -134,7 +131,6 @@ pub fn syncSharedHandles() void {
     simple_color_shader = ui_pipeline.emoji.program;
     vao = ui_pipeline.text.vao;
     vbo = ui_pipeline.quad.handle;
-    overlay_shader = ui_pipeline.overlay.program;
 }
 
 /// Set the orthographic projection matrix on a specific shader program.

--- a/src/renderer/gpu/opengl/gl_init.zig
+++ b/src/renderer/gpu/opengl/gl_init.zig
@@ -1,10 +1,11 @@
-//! OpenGL shader-compilation helpers + the overlay shader, plus the transition
-//! compat shim for the shared UI pipelines.
+//! OpenGL shader-compilation helpers, plus the transition compat shim for the
+//! shared UI pipelines.
 //!
-//! Owns: `compileShader`/`linkProgram`, the `overlay_shader`, `setProjectionForProgram`.
-//! Compat mirrors: `vao`/`vbo`/`shader_program`/`simple_color_shader` are populated
-//!   by `syncSharedHandles()` after `ui_pipeline.init()`; not-yet-converted renderer
-//!   files still read them directly. They dissolve as each file converts.
+//! Owns: `compileShader`/`linkProgram`, `setProjectionForProgram`.
+//! Compat mirrors: `vao`/`vbo`/`shader_program`/`simple_color_shader`/`overlay_shader`
+//!   are populated by `syncSharedHandles()` after `ui_pipeline.init()`; not-yet-converted
+//!   renderer files still read them directly. They dissolve as each file converts.
+//!   `overlay_shader` is a compat mirror of ui_pipeline.overlay.program.
 //! Re-exports: `renderQuad`/`renderQuadAlpha`/`setProjection` delegate to ui_pipeline.
 //! The shared UI rendering lives in renderer/ui_pipeline.zig; the cell-grid
 //! instanced pipelines in renderer/cell_pipeline.zig.
@@ -31,7 +32,7 @@ pub threadlocal var vbo: c.GLuint = 0; // compat mirror — from ui_pipeline.qua
 pub threadlocal var shader_program: c.GLuint = 0; // compat mirror — from ui_pipeline.text.program
 pub threadlocal var simple_color_shader: c.GLuint = 0; // compat mirror — from ui_pipeline.emoji.program
 
-pub threadlocal var overlay_shader: c.GLuint = 0; // gl_init-owned — compiled in initShaders()
+pub threadlocal var overlay_shader: c.GLuint = 0; // compat mirror — from ui_pipeline.overlay.program (set by syncSharedHandles)
 
 // Draw call counter (reset each frame)
 pub threadlocal var g_draw_call_count: u32 = 0;
@@ -103,11 +104,8 @@ fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
 // ============================================================================
 
 pub fn initShaders() bool {
-    overlay_shader = linkProgram(shaders.vertex_shader_source, shaders.overlay_fragment_source);
-    if (overlay_shader == 0) {
-        std.debug.print("Overlay shader failed\n", .{});
-        return false;
-    }
+    // overlay_shader is now owned by ui_pipeline (synced into the mirror below
+    // via syncSharedHandles); nothing to build here yet.
     return true;
 }
 
@@ -136,6 +134,7 @@ pub fn syncSharedHandles() void {
     simple_color_shader = ui_pipeline.emoji.program;
     vao = ui_pipeline.text.vao;
     vbo = ui_pipeline.quad.handle;
+    overlay_shader = ui_pipeline.overlay.program;
 }
 
 /// Set the orthographic projection matrix on a specific shader program.

--- a/src/renderer/image_renderer.zig
+++ b/src/renderer/image_renderer.zig
@@ -2,12 +2,9 @@ const std = @import("std");
 const ghostty_vt = @import("ghostty-vt");
 const Renderer = @import("Renderer.zig");
 const AppWindow = @import("../AppWindow.zig");
-const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const ui_pipeline = @import("ui_pipeline.zig");
 const font = AppWindow.font;
-
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
 
 const KittyImage = ghostty_vt.kitty.graphics.Image;
 const KittyStorage = ghostty_vt.kitty.graphics.ImageStorage;
@@ -81,15 +78,15 @@ pub fn snapshot(rend: *Renderer, terminal: *ghostty_vt.Terminal) void {
 }
 
 pub fn uploadPending(rend: *Renderer) void {
-    const gl = AppWindow.gpu.glTable();
     const alloc = rend.surface.allocator;
 
     for (rend.kitty_pending_uploads.items) |pending| {
-        var texture_handle: c.GLuint = 0;
+        var texture_handle: Renderer.GLuint = 0;
         if (findTexture(rend, pending.image_id)) |existing| {
             texture_handle = existing.texture;
         } else {
-            gl.GenTextures.?(1, &texture_handle);
+            const new_tex = gpu.Texture.create();
+            texture_handle = new_tex.handle;
             rend.kitty_textures.append(alloc, .{
                 .image_id = pending.image_id,
                 .width = pending.width,
@@ -97,28 +94,18 @@ pub fn uploadPending(rend: *Renderer) void {
                 .transmit_time = pending.transmit_time,
                 .texture = texture_handle,
             }) catch {
-                gl.DeleteTextures.?(1, &texture_handle);
+                var t = gpu.Texture.fromHandle(texture_handle);
+                t.destroy();
                 alloc.free(pending.rgba);
                 continue;
             };
         }
 
-        gl.BindTexture.?(c.GL_TEXTURE_2D, texture_handle);
-        gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
-        gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
-        gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, c.GL_CLAMP_TO_EDGE);
-        gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, c.GL_CLAMP_TO_EDGE);
-        gl.PixelStorei.?(c.GL_UNPACK_ALIGNMENT, 1);
-        gl.TexImage2D.?(
-            c.GL_TEXTURE_2D,
-            0,
-            c.GL_RGBA8,
+        gpu.Texture.fromHandle(texture_handle).upload2D(
             @intCast(pending.width),
             @intCast(pending.height),
-            0,
-            c.GL_RGBA,
-            c.GL_UNSIGNED_BYTE,
             pending.rgba.ptr,
+            .{ .filter = .linear, .wrap = .clamp_to_edge, .unpack_alignment = 1 },
         );
 
         if (findTextureMut(rend, pending.image_id)) |tex| {
@@ -141,15 +128,7 @@ pub fn draw(
     offset_y: f32,
     layer: Renderer.KittyLayer,
 ) void {
-    const gl = AppWindow.gpu.glTable();
-    if (gl_init.simple_color_shader == 0) return;
-
-    gl.UseProgram.?(gl_init.simple_color_shader);
-    gl_init.setProjectionForProgram(gl_init.simple_color_shader, window_height);
-    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
-    gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "text"), 0);
-    gl.BindVertexArray.?(gl_init.vao);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
+    if (ui_pipeline.emoji.program == 0) return;
 
     for (rend.kitty_placements.items) |placement| {
         if (placement.layer != layer) continue;
@@ -171,12 +150,7 @@ pub fn draw(
             .{ x + placement.width, y + placement.height, placement.uv_right, placement.uv_top },
         };
 
-        gl.BindTexture.?(c.GL_TEXTURE_2D, texture.texture);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-        gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-        gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-        gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-        gl_init.g_draw_call_count += 1;
+        ui_pipeline.drawTextureQuad(vertices, texture.texture, 1.0);
     }
 }
 

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -7,9 +7,9 @@ const markdown_preview = @import("../markdown_preview.zig");
 const ui_perf = @import("../ui_perf.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
-const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const ui_pipeline = @import("ui_pipeline.zig");
 const c = @cImport({
-    @cInclude("glad/gl.h");
     @cInclude("stb_image.h");
 });
 
@@ -24,7 +24,7 @@ const TABLE_MIN_COL_W: f32 = 64;
 const TABLE_MAX_COL_W: f32 = 220;
 const TABLE_FIT_MIN_COL_W: f32 = 28;
 
-threadlocal var g_image_texture: c.GLuint = 0;
+threadlocal var g_image_texture: gpu.c.GLuint = 0;
 threadlocal var g_image_width: c_int = 0;
 threadlocal var g_image_height: c_int = 0;
 threadlocal var g_image_generation: u64 = std.math.maxInt(u64);
@@ -55,11 +55,6 @@ pub fn render(window_width: f32, window_height: f32, titlebar_h: f32, right_offs
 
     const panel_x = window_width - right_offset - panel_w;
 
-    const gl = AppWindow.gpu.glTable();
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
@@ -80,8 +75,8 @@ pub fn render(window_width: f32, window_height: f32, titlebar_h: f32, right_offs
     };
     const edge_color = if (resize_hovered or AppWindow.input.g_markdown_preview_resize_dragging) blend(bg, accent, 0.38) else border;
 
-    gl_init.renderQuad(panel_x, 0, panel_w, side_h, panel_bg);
-    gl_init.renderQuad(panel_x, 0, if (resize_hovered or AppWindow.input.g_markdown_preview_resize_dragging) 2 else 1, side_h, edge_color);
+    ui_pipeline.fillQuad(panel_x, 0, panel_w, side_h, panel_bg);
+    ui_pipeline.fillQuad(panel_x, 0, if (resize_hovered or AppWindow.input.g_markdown_preview_resize_dragging) 2 else 1, side_h, edge_color);
 
     renderFooter(panel_x, panel_w, card_bg, border, muted, normal, accent);
 
@@ -97,8 +92,8 @@ fn renderFooter(
     normal: [3]f32,
     accent: [3]f32,
 ) void {
-    gl_init.renderQuad(panel_x, 0, panel_w, FOOTER_HEIGHT, card_bg);
-    gl_init.renderQuad(panel_x, FOOTER_HEIGHT - 1, panel_w, 1, border);
+    ui_pipeline.fillQuad(panel_x, 0, panel_w, FOOTER_HEIGHT, card_bg);
+    ui_pipeline.fillQuad(panel_x, FOOTER_HEIGHT - 1, panel_w, 1, border);
 
     const badge = switch (panel.g_kind) {
         .markdown => "MD",
@@ -544,9 +539,9 @@ fn renderTableHover(
 
     const popup_y = window_height - popup_top - popup_h;
     const popup_bg = blend(AppWindow.g_theme.background, code_bg, 0.82);
-    gl_init.renderQuad(popup_x - 1, popup_y - 1, popup_w + 2, popup_h + 2, border);
-    gl_init.renderQuad(popup_x, popup_y, popup_w, popup_h, popup_bg);
-    gl_init.renderQuad(popup_x, popup_y + popup_h - 2, popup_w, 2, strong);
+    ui_pipeline.fillQuad(popup_x - 1, popup_y - 1, popup_w + 2, popup_h + 2, border);
+    ui_pipeline.fillQuad(popup_x, popup_y, popup_w, popup_h, popup_bg);
+    ui_pipeline.fillQuad(popup_x, popup_y + popup_h - 2, popup_w, 2, strong);
 
     for (0..line_count) |idx| {
         const line_top = popup_top + 8 + @as(f32, @floatFromInt(idx)) * row_h;
@@ -605,24 +600,24 @@ fn renderImageDocument(
     const draw_top = body_top + (body_h - draw_h) / 2 + panel.imagePanY();
     const draw_y = window_height - draw_top - draw_h;
 
-    const gl = AppWindow.gpu.glTable();
-    const clip_x: c.GLint = @intFromFloat(@max(0, @floor(content_x)));
-    const clip_y: c.GLint = @intFromFloat(@max(0, @floor(window_height - body_top - body_h)));
-    const clip_w: c.GLsizei = @intFromFloat(@max(0, @ceil(content_w)));
-    const clip_h: c.GLsizei = @intFromFloat(@max(0, @ceil(body_h)));
+    const gl = gpu.glTable();
+    const clip_x: gpu.c.GLint = @intFromFloat(@max(0, @floor(content_x)));
+    const clip_y: gpu.c.GLint = @intFromFloat(@max(0, @floor(window_height - body_top - body_h)));
+    const clip_w: gpu.c.GLsizei = @intFromFloat(@max(0, @ceil(content_w)));
+    const clip_h: gpu.c.GLsizei = @intFromFloat(@max(0, @ceil(body_h)));
     if (clip_w <= 0 or clip_h <= 0) return;
 
-    const scissor_was_enabled = gl.IsEnabled.?(c.GL_SCISSOR_TEST) == c.GL_TRUE;
-    var previous_scissor: [4]c.GLint = undefined;
-    if (scissor_was_enabled) gl.GetIntegerv.?(c.GL_SCISSOR_BOX, &previous_scissor);
-    gl.Enable.?(c.GL_SCISSOR_TEST);
+    const scissor_was_enabled = gl.IsEnabled.?(gpu.c.GL_SCISSOR_TEST) == gpu.c.GL_TRUE;
+    var previous_scissor: [4]gpu.c.GLint = undefined;
+    if (scissor_was_enabled) gl.GetIntegerv.?(gpu.c.GL_SCISSOR_BOX, &previous_scissor);
+    gl.Enable.?(gpu.c.GL_SCISSOR_TEST);
     gl.Scissor.?(clip_x, clip_y, clip_w, clip_h);
-    gl_init.renderQuad(draw_x - 1, draw_y - 1, draw_w + 2, draw_h + 2, border);
+    ui_pipeline.fillQuad(draw_x - 1, draw_y - 1, draw_w + 2, draw_h + 2, border);
     drawImageTexture(draw_x, draw_y, draw_w, draw_h, window_height);
     if (scissor_was_enabled) {
         gl.Scissor.?(previous_scissor[0], previous_scissor[1], previous_scissor[2], previous_scissor[3]);
     } else {
-        gl.Disable.?(c.GL_SCISSOR_TEST);
+        gl.Disable.?(gpu.c.GL_SCISSOR_TEST);
     }
 }
 
@@ -659,17 +654,11 @@ fn ensureImageTexture() bool {
     if (data == null or w <= 0 or h <= 0) return false;
     defer c.stbi_image_free(data);
 
-    const gl = AppWindow.gpu.glTable();
-    gl.GenTextures.?(1, &g_image_texture);
+    const t = gpu.Texture.create();
+    g_image_texture = t.handle;
     if (g_image_texture == 0) return false;
 
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_image_texture);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, c.GL_CLAMP_TO_EDGE);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, c.GL_CLAMP_TO_EDGE);
-    gl.PixelStorei.?(c.GL_UNPACK_ALIGNMENT, 1);
-    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RGBA8, w, h, 0, c.GL_RGBA, c.GL_UNSIGNED_BYTE, data);
+    gpu.Texture.fromHandle(g_image_texture).upload2D(w, h, @ptrCast(data), .{ .unpack_alignment = 1 });
 
     g_image_width = w;
     g_image_height = h;
@@ -678,13 +667,8 @@ fn ensureImageTexture() bool {
 }
 
 fn drawImageTexture(x: f32, y: f32, w: f32, h: f32, window_height: f32) void {
-    if (g_image_texture == 0 or gl_init.simple_color_shader == 0) return;
-    const gl = AppWindow.gpu.glTable();
-
-    gl.UseProgram.?(gl_init.simple_color_shader);
-    gl_init.setProjectionForProgram(gl_init.simple_color_shader, window_height);
-    gl.Uniform1f.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "opacity"), 1.0);
-    gl.Uniform1i.?(gl.GetUniformLocation.?(gl_init.simple_color_shader, "text"), 0);
+    _ = window_height;
+    if (g_image_texture == 0 or ui_pipeline.emoji.program == 0) return;
 
     const vertices = [6][4]f32{
         .{ x, y + h, 0, 0 },
@@ -695,20 +679,13 @@ fn drawImageTexture(x: f32, y: f32, w: f32, h: f32, window_height: f32) void {
         .{ x + w, y + h, 1, 0 },
     };
 
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_image_texture);
-    gl.BindVertexArray.?(gl_init.vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
+    ui_pipeline.drawTextureQuad(vertices, g_image_texture, 1.0);
 }
 
 fn unloadImageTexture() void {
     if (g_image_texture != 0) {
-        const gl = AppWindow.gpu.glTable();
-        gl.DeleteTextures.?(1, &g_image_texture);
+        var t = gpu.Texture.fromHandle(g_image_texture);
+        t.destroy();
         g_image_texture = 0;
     }
     g_image_width = 0;
@@ -744,7 +721,7 @@ fn renderMarkdownLine(
         const line_y_top = y_from_top + row_h * 0.15;
         if (line_y_top + row_h >= body_top and line_y_top <= body_top + body_h) {
             const gl_y = window_height - line_y_top - row_h * 0.75;
-            gl_init.renderQuad(x, gl_y, max_w, 1, border);
+            ui_pipeline.fillQuad(x, gl_y, max_w, 1, border);
             const lang = fenceLanguage(trimmed);
             if (lang.len > 0 and in_code.*) {
                 _ = titlebar.renderTextLimited(lang, x + 8, gl_y + 5, muted, max_w - 16);
@@ -808,7 +785,7 @@ fn renderMarkdownLine(
         const line_y_top = y_from_top + row_h * 0.5;
         if (line_y_top >= body_top and line_y_top <= body_top + body_h) {
             const gl_y = window_height - line_y_top - 1;
-            gl_init.renderQuad(x, gl_y, max_w, 1, muted);
+            ui_pipeline.fillQuad(x, gl_y, max_w, 1, muted);
         }
         return row_h;
     } else if (listBody(trimmed)) |list| {
@@ -835,7 +812,7 @@ fn renderMarkdownLine(
         const line_y_top = y_from_top + line_h - 4;
         if (line_y_top >= body_top and line_y_top <= body_top + body_h) {
             const gl_y = window_height - line_y_top - 1;
-            gl_init.renderQuad(x, gl_y, max_w, 1, blend(AppWindow.g_theme.background, accent, 0.32));
+            ui_pipeline.fillQuad(x, gl_y, max_w, 1, blend(AppWindow.g_theme.background, accent, 0.32));
         }
     }
 
@@ -894,7 +871,7 @@ fn renderTopQuad(
     const bottom = @min(y_from_top + h, body_top + body_h);
     if (bottom <= top) return;
     const gl_y = window_height - bottom;
-    gl_init.renderQuad(x, gl_y, w, bottom - top, color);
+    ui_pipeline.fillQuad(x, gl_y, w, bottom - top, color);
 }
 
 fn wrapEnd(text: []const u8, start: usize, max_chars: usize) usize {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -30,9 +30,7 @@ const overlay_keys = @import("overlay_keys.zig");
 const weixin_qr_panel = @import("../weixin/qr_panel.zig");
 const weixin_types = @import("../weixin/types.zig");
 
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
+const ui_pipeline = @import("ui_pipeline.zig");
 
 const TabState = tab.TabState;
 const SplitRect = split_layout.SplitRect;
@@ -1112,13 +1110,6 @@ pub fn renderBrowserUrlBar(window_width: f32, window_height: f32, top_offset: f3
     );
     const url_bar = browser_panel.urlBarBounds(bounds) orelse return;
 
-    const gl = AppWindow.gpu.glTable();
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
@@ -1134,7 +1125,7 @@ pub fn renderBrowserUrlBar(window_width: f32, window_height: f32, top_offset: f3
     const bar_bottom: f32 = @floatFromInt(url_bar.bottom);
     const bar_h = @max(1.0, bar_bottom - bar_top);
     const bar_y = @round(window_height - bar_bottom);
-    gl_init.renderQuadAlpha(panel_x, bar_y, panel_w, bar_h, panel_bg, 0.98);
+    ui_pipeline.fillQuadAlpha(panel_x, bar_y, panel_w, bar_h, panel_bg, 0.98);
 
     const margin = browser_panel.URL_BAR_MARGIN;
     const input_x = @round(@as(f32, @floatFromInt(url_bar.left)) + margin);
@@ -1158,10 +1149,10 @@ pub fn renderBrowserUrlBar(window_width: f32, window_height: f32, top_offset: f3
 
     if (browser_panel.urlBarFocused() and !browser_panel.urlBarSelectAll()) {
         const cursor_x = @min(input_x + input_w - 10, @max(text_x, text_end + 1));
-        gl_init.renderQuadAlpha(cursor_x, input_y + 6, 1.5, @max(8.0, input_h - 12), accent, 0.90);
+        ui_pipeline.fillQuadAlpha(cursor_x, input_y + 6, 1.5, @max(8.0, input_h - 12), accent, 0.90);
     }
 
-    gl_init.renderQuadAlpha(panel_x, bar_y, panel_w, 1, mixColor(bg, fg, 0.18), 0.55);
+    ui_pipeline.fillQuadAlpha(panel_x, bar_y, panel_w, 1, mixColor(bg, fg, 0.18), 0.55);
 }
 
 /// Render the command center overlay.
@@ -1169,15 +1160,8 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     if (!g_command_palette_visible) return;
     commandPaletteSyncAgentHistoryRows();
 
-    const gl = AppWindow.gpu.glTable();
     const layout = commandPaletteLayout(window_width, window_height, top_offset);
     const box_y = @round(window_height - layout.box_top_px - layout.box_h);
-
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -1192,7 +1176,7 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     const selected_bg = mixColor(bg, accent, 0.50);
     const selected_border = mixColor(accent, fg, 0.16);
 
-    gl_init.renderQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.22);
+    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.22);
     renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 9, border_color, 0.42);
     renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 8, panel_color, 0.98);
 
@@ -3073,8 +3057,8 @@ fn renderSessionRow(layout: SessionLayout, window_height: f32, row: usize, left:
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
     const row_color = if (selected) mixColor(bg, accent, 0.34) else mixColor(bg, fg, 0.055);
-    gl_init.renderQuadAlpha(x, row_y + 3, w, layout.row_h - 6, row_color, if (selected) 0.82 else 0.78);
-    if (selected) gl_init.renderQuadAlpha(x, row_y + 3, 3, layout.row_h - 6, accent, 0.86);
+    ui_pipeline.fillQuadAlpha(x, row_y + 3, w, layout.row_h - 6, row_color, if (selected) 0.82 else 0.78);
+    if (selected) ui_pipeline.fillQuadAlpha(x, row_y + 3, 3, layout.row_h - 6, accent, 0.86);
     const text_y = rowTextY(row_y, layout.row_h);
     const left_color = if (selected) mixColor(fg, accent, 0.12) else mixColor(bg, fg, 0.88);
     const left_x = x + 12;
@@ -3155,15 +3139,9 @@ fn defaultAiModeLabel() []const u8 {
 pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: f32) void {
     if (!sessionLauncherVisible()) return;
 
-    const gl = AppWindow.gpu.glTable();
     const layout = sessionLayout(window_width, window_height, top_offset);
     const box_y = @round(window_height - layout.box_top_px - layout.box_h);
 
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
@@ -3172,7 +3150,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     const title_color = mixColor(fg, accent, 0.14);
     const muted_color = mixColor(bg, fg, 0.58);
 
-    gl_init.renderQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.18);
+    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.18);
     renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 11, border_color, 0.24);
     renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 10, panel_color, 0.96);
 
@@ -3614,8 +3592,8 @@ fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, tit
 
     if (clickable) {
         const row_color = if (selected) mixColor(bg, accent, 0.24) else if (active) mixColor(bg, accent, 0.18) else mixColor(bg, fg, 0.055);
-        gl_init.renderQuadAlpha(x, gl_y + 3, w, layout.row_h - 6, row_color, if (selected) 0.72 else if (active) 0.44 else 0.82);
-        if (selected) gl_init.renderQuadAlpha(x, gl_y + 3, 3, layout.row_h - 6, accent, 0.82);
+        ui_pipeline.fillQuadAlpha(x, gl_y + 3, w, layout.row_h - 6, row_color, if (selected) 0.72 else if (active) 0.44 else 0.82);
+        if (selected) ui_pipeline.fillQuadAlpha(x, gl_y + 3, 3, layout.row_h - 6, accent, 0.82);
     }
 
     const text_y = rowTextY(gl_y, layout.row_h);
@@ -3653,15 +3631,8 @@ pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32
 
     const cfg = settingsCfg(allocator);
 
-    const gl = AppWindow.gpu.glTable();
     const layout = settingsLayout(window_width, window_height, top_offset);
     const box_y = @round(window_height - layout.box_top_px - layout.box_h);
-
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -3670,7 +3641,7 @@ pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32
     const border_color = mixColor(bg, accent, 0.24);
     const muted_color = mixColor(bg, fg, 0.58);
 
-    gl_init.renderQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.16);
+    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.16);
     renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 11, border_color, 0.24);
     renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 10, panel_color, 0.96);
 
@@ -3722,12 +3693,8 @@ threadlocal var g_fps_value: f32 = 0; // Current FPS value to display
 
 /// Render a semi-transparent overlay over an unfocused split pane.
 pub fn renderUnfocusedOverlay(rect: SplitRect, window_height: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const opacity = 1.0 - g_unfocused_split_opacity;
     if (opacity < 0.01) return;
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.BindVertexArray.?(gl_init.vao);
 
     // Draw semi-transparent background color overlay
     const px: f32 = @floatFromInt(rect.x);
@@ -3736,14 +3703,13 @@ pub fn renderUnfocusedOverlay(rect: SplitRect, window_height: f32) void {
     const ph: f32 = @floatFromInt(rect.height);
 
     // Use background color with alpha for the overlay
-    gl_init.renderQuadAlpha(px, py, pw, ph, AppWindow.g_theme.background, opacity);
+    ui_pipeline.fillQuadAlpha(px, py, pw, ph, AppWindow.g_theme.background, opacity);
 }
 
 /// Render unfocused overlay within current viewport (for split rendering).
 /// Assumes viewport is already set to the split's region.
 /// Uses true alpha blending so it blends with actual rendered content.
 pub fn renderUnfocusedOverlaySimple(width: f32, height: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const alpha = 1.0 - g_unfocused_split_opacity;
     if (alpha < 0.01) return;
 
@@ -3756,44 +3722,18 @@ pub fn renderUnfocusedOverlaySimple(width: f32, height: f32) void {
         .{ width, height, 1.0, 0.0 },
     };
 
-    // Use overlay shader with true alpha blending
-    gl.UseProgram.?(gl_init.overlay_shader);
-
-    // Set overlay color (background color with alpha)
-    gl.Uniform4f.?(
-        gl.GetUniformLocation.?(gl_init.overlay_shader, "overlayColor"),
+    ui_pipeline.fillOverlay(vertices, .{
         AppWindow.g_theme.background[0],
         AppWindow.g_theme.background[1],
         AppWindow.g_theme.background[2],
         alpha,
-    );
-
-    // Set projection for current viewport
-    var viewport: [4]c.GLint = undefined;
-    gl.GetIntegerv.?(c.GL_VIEWPORT, &viewport);
-    const vp_width: f32 = @floatFromInt(viewport[2]);
-    const vp_height: f32 = @floatFromInt(viewport[3]);
-    const projection = [16]f32{
-        2.0 / vp_width, 0.0,             0.0,  0.0,
-        0.0,            2.0 / vp_height, 0.0,  0.0,
-        0.0,            0.0,             -1.0, 0.0,
-        -1.0,           -1.0,            0.0,  1.0,
-    };
-    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(gl_init.overlay_shader, "projection"), 1, c.GL_FALSE, &projection);
-
-    gl.BindVertexArray.?(gl_init.vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
+    });
 }
 
 /// Render split dividers between panes in the active tab.
 /// If split-divider-color is configured, uses that color (solid).
 /// Otherwise uses scrollbar-style rendering: black with alpha transparency.
 pub fn renderSplitDividers(active_tab: *const TabState, content_x: i32, content_y: i32, content_w: i32, content_h: i32, window_height: f32) void {
-    const gl = AppWindow.gpu.glTable();
     if (!active_tab.tree.isSplit()) return;
 
     const allocator = AppWindow.g_allocator orelse return;
@@ -3801,9 +3741,6 @@ pub fn renderSplitDividers(active_tab: *const TabState, content_x: i32, content_
     // Get spatial representation
     var spatial = active_tab.tree.spatial(allocator) catch return;
     defer spatial.deinit(allocator);
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.BindVertexArray.?(gl_init.vao);
 
     // Check if custom color is configured
     const use_custom_color = g_split_divider_color != null;
@@ -3828,9 +3765,9 @@ pub fn renderSplitDividers(active_tab: *const TabState, content_x: i32, content_
                         const div_x = slot_x + slot_w * @as(f32, @floatCast(s.ratio)) - @as(f32, @floatFromInt(@divTrunc(SPLIT_DIVIDER_WIDTH, 2)));
                         const div_y = window_height - slot_y - slot_h;
                         if (use_custom_color) {
-                            gl_init.renderQuad(div_x, div_y, @floatFromInt(SPLIT_DIVIDER_WIDTH), slot_h, custom_color);
+                            ui_pipeline.fillQuad(div_x, div_y, @floatFromInt(SPLIT_DIVIDER_WIDTH), slot_h, custom_color);
                         } else {
-                            gl_init.renderQuadAlpha(div_x, div_y, @floatFromInt(SPLIT_DIVIDER_WIDTH), slot_h, .{ 0, 0, 0 }, default_alpha);
+                            ui_pipeline.fillQuadAlpha(div_x, div_y, @floatFromInt(SPLIT_DIVIDER_WIDTH), slot_h, .{ 0, 0, 0 }, default_alpha);
                         }
                     },
                     .vertical => {
@@ -3838,9 +3775,9 @@ pub fn renderSplitDividers(active_tab: *const TabState, content_x: i32, content_
                         const div_x = slot_x;
                         const div_y = window_height - slot_y - slot_h * @as(f32, @floatCast(s.ratio)) - @as(f32, @floatFromInt(@divTrunc(SPLIT_DIVIDER_WIDTH, 2)));
                         if (use_custom_color) {
-                            gl_init.renderQuad(div_x, div_y, slot_w, @floatFromInt(SPLIT_DIVIDER_WIDTH), custom_color);
+                            ui_pipeline.fillQuad(div_x, div_y, slot_w, @floatFromInt(SPLIT_DIVIDER_WIDTH), custom_color);
                         } else {
-                            gl_init.renderQuadAlpha(div_x, div_y, slot_w, @floatFromInt(SPLIT_DIVIDER_WIDTH), .{ 0, 0, 0 }, default_alpha);
+                            ui_pipeline.fillQuadAlpha(div_x, div_y, slot_w, @floatFromInt(SPLIT_DIVIDER_WIDTH), .{ 0, 0, 0 }, default_alpha);
                         }
                     },
                 }
@@ -4174,13 +4111,6 @@ pub fn showCloseShortcutConfirm(duration_ms: i64) void {
 pub fn renderWindowCloseConfirm(window_width: f32, window_height: f32) void {
     if (!g_window_close_confirm_visible) return;
 
-    const gl = AppWindow.gpu.glTable();
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-
     const layout = windowCloseConfirmLayout(window_width, window_height);
     const panel_y = @round(window_height - layout.panel_top_px - layout.panel_h);
     const close_y = @round(window_height - layout.close_top_px - layout.close_h);
@@ -4199,12 +4129,12 @@ pub fn renderWindowCloseConfirm(window_width: f32, window_height: f32) void {
     const danger_soft = mixColor(bg, danger, 0.20);
     const warning = .{ 0.95, 0.62, 0.18 };
 
-    gl_init.renderQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.46);
+    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.46);
     renderRoundedQuadAlpha(layout.panel_x + 10, panel_y - 10, layout.panel_w, layout.panel_h, 13, .{ 0.0, 0.0, 0.0 }, 0.26);
     renderRoundedQuadAlpha(layout.panel_x - 1, panel_y - 1, layout.panel_w + 2, layout.panel_h + 2, 13, panel_border, 0.42);
     renderRoundedQuadAlpha(layout.panel_x, panel_y, layout.panel_w, layout.panel_h, 12, panel, 0.99);
     renderRoundedQuadAlpha(layout.panel_x + 1, panel_y + layout.panel_h - 76, layout.panel_w - 2, 75, 12, panel_top, 0.78);
-    gl_init.renderQuadAlpha(layout.panel_x + 1, panel_y + layout.panel_h - 76, layout.panel_w - 2, 1, quiet_border, 0.40);
+    ui_pipeline.fillQuadAlpha(layout.panel_x + 1, panel_y + layout.panel_h - 76, layout.panel_w - 2, 1, quiet_border, 0.40);
     renderRoundedQuadAlpha(layout.panel_x, panel_y, 5, layout.panel_h, 12, danger, 0.84);
 
     const pad: f32 = 34;
@@ -4227,7 +4157,7 @@ pub fn renderWindowCloseConfirm(window_width: f32, window_height: f32) void {
     renderTitlebarTextLimited("Press Esc or Cancel to keep working.", text_x, hint_y, muted, text_right - text_x);
 
     const footer_y = close_y + layout.close_h + 20;
-    gl_init.renderQuadAlpha(layout.panel_x + 5, footer_y, layout.panel_w - 5, 1, quiet_border, 0.46);
+    ui_pipeline.fillQuadAlpha(layout.panel_x + 5, footer_y, layout.panel_w - 5, 1, quiet_border, 0.46);
 
     renderRoundedQuadAlpha(layout.close_x - 1, close_y - 1, layout.close_w + 2, layout.close_h + 2, 8, danger, 0.48);
     renderRoundedQuadAlpha(layout.close_x, close_y, layout.close_w, layout.close_h, 7, danger_soft, 0.96);
@@ -4303,8 +4233,8 @@ pub fn renderCloseShortcutConfirm(window_width: f32, window_height: f32) void {
     const bg_x = @round((window_width - bg_w) / 2);
     const bg_y: f32 = 60;
 
-    gl_init.renderQuad(bg_x, bg_y, bg_w, line_h, .{ 0.18, 0.11, 0.08 });
-    gl_init.renderQuad(bg_x, bg_y + line_h - 2, bg_w, 2, .{ 0.86, 0.48, 0.20 });
+    ui_pipeline.fillQuad(bg_x, bg_y, bg_w, line_h, .{ 0.18, 0.11, 0.08 });
+    ui_pipeline.fillQuad(bg_x, bg_y + line_h - 2, bg_w, 2, .{ 0.86, 0.48, 0.20 });
     renderTitlebarText(text, bg_x + pad_h, bg_y + pad_v, .{ 1.0, 0.82, 0.56 });
 }
 
@@ -4328,7 +4258,7 @@ pub fn renderCopyToast(window_width: f32, window_height: f32) void {
     const bg_x = (window_width - bg_w) / 2;
     const bg_y: f32 = 60; // GL y=0 at bottom — float above the prompt area
 
-    gl_init.renderQuad(bg_x, bg_y, bg_w, line_h, .{ 0.10, 0.14, 0.10 });
+    ui_pipeline.fillQuad(bg_x, bg_y, bg_w, line_h, .{ 0.10, 0.14, 0.10 });
 
     var x = bg_x + pad_h;
     const y = bg_y + pad_v;
@@ -4385,10 +4315,10 @@ pub fn renderTransferToast(window_width: f32, window_height: f32) void {
         .idle => AppWindow.g_theme.foreground,
     };
     const bg = mixColor(AppWindow.g_theme.background, accent, 0.16);
-    gl_init.renderQuadAlpha(layout.x, layout.y, layout.w, layout.h, bg, 0.96);
-    gl_init.renderQuadAlpha(layout.x, layout.y, 3, layout.h, accent, 0.88);
+    ui_pipeline.fillQuadAlpha(layout.x, layout.y, layout.w, layout.h, bg, 0.96);
+    ui_pipeline.fillQuadAlpha(layout.x, layout.y, 3, layout.h, accent, 0.88);
     if (g_transfer_toast_clickable) {
-        gl_init.renderQuadAlpha(layout.x, layout.y + layout.h - 2, layout.w, 2, accent, 0.64);
+        ui_pipeline.fillQuadAlpha(layout.x, layout.y + layout.h - 2, layout.w, 2, accent, 0.64);
     }
 
     const text_x = layout.x + pad_h;
@@ -4420,9 +4350,9 @@ pub fn renderUpdatePrompt(window_width: f32, window_height: f32) void {
 
     const bg_color: [3]f32 = if (g_update_prompt_clickable) .{ 0.18, 0.14, 0.06 } else .{ 0.08, 0.13, 0.16 };
     const text_color: [3]f32 = if (g_update_prompt_clickable) .{ 1.0, 0.82, 0.38 } else .{ 0.55, 0.85, 0.95 };
-    gl_init.renderQuad(bg_x, bg_y, bg_w, line_h, bg_color);
+    ui_pipeline.fillQuad(bg_x, bg_y, bg_w, line_h, bg_color);
     if (g_update_prompt_clickable) {
-        gl_init.renderQuad(bg_x, bg_y + line_h - 2, bg_w, 2, .{ 0.86, 0.48, 0.20 });
+        ui_pipeline.fillQuad(bg_x, bg_y + line_h - 2, bg_w, 2, .{ 0.86, 0.48, 0.20 });
         g_update_prompt_rect = .{ .x = bg_x, .y = bg_y, .w = bg_w, .h = line_h };
     }
 
@@ -4533,12 +4463,7 @@ fn remoteStateColor(state: @import("../remote_client.zig").State) [3]f32 {
 }
 
 fn renderDebugLine(window_width: f32, y_pos: *f32, margin: f32, pad_h: f32, pad_v: f32, line_h: f32, text: []const u8, text_color: [3]f32) ?DebugLineRect {
-    const gl = AppWindow.gpu.glTable();
     if (text.len == 0) return null;
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
 
     var text_width: f32 = 0;
     for (text) |ch| {
@@ -4549,7 +4474,7 @@ fn renderDebugLine(window_width: f32, y_pos: *f32, margin: f32, pad_h: f32, pad_
     const bg_x = window_width - bg_w - margin;
     const bg_y = y_pos.*;
 
-    gl_init.renderQuad(bg_x, bg_y, bg_w, line_h, .{ 0.0, 0.0, 0.0 });
+    ui_pipeline.fillQuad(bg_x, bg_y, bg_w, line_h, .{ 0.0, 0.0, 0.0 });
 
     var x = bg_x + pad_h;
     const y = bg_y + pad_v;

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -12,24 +12,18 @@
 
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
-const gl_init = AppWindow.gpu.gl_init;
+const gpu = AppWindow.gpu;
+const c = gpu.c;
+const ui_pipeline = @import("ui_pipeline.zig");
 const cell_renderer = AppWindow.cell_renderer;
 const background_image = AppWindow.background_image;
 const Renderer = @import("Renderer.zig");
 
-const c = @cImport({
-    @cInclude("glad/gl.h");
-});
-
-// Post-processing state
-threadlocal var g_post_fbo: c.GLuint = 0; // Framebuffer object for off-screen render
-threadlocal var g_post_texture: c.GLuint = 0; // Color attachment texture
-threadlocal var g_post_program: c.GLuint = 0; // Post-processing shader program
-threadlocal var g_post_vao: c.GLuint = 0; // Fullscreen quad VAO
-threadlocal var g_post_vbo: c.GLuint = 0; // Fullscreen quad VBO
+// Post-processing state (gpu-primitive-backed)
+threadlocal var g_post_fb: gpu.Framebuffer = .{};
+threadlocal var g_post_pipeline: gpu.Pipeline = .{ .program = 0, .vao = 0 };
+threadlocal var g_post_vbo_buf: gpu.Buffer = .{ .handle = 0, .target = 0 };
 pub threadlocal var g_post_enabled: bool = false; // Whether custom shader is active
-threadlocal var g_post_fb_width: c_int = 0; // Current FBO texture dimensions
-threadlocal var g_post_fb_height: c_int = 0;
 threadlocal var g_frame_count: u32 = 0; // Frame counter for iFrame
 threadlocal var g_start_time: i64 = 0; // Start time for iTime
 
@@ -83,7 +77,7 @@ fn buildPostFragmentSource(allocator: std.mem.Allocator, user_shader: []const u8
 
 /// Load and compile a custom post-processing shader from a file
 fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
-    const gl = AppWindow.gpu.glTable();
+    const gl = gpu.glTable();
     // Read shader source file
     const file = std.fs.cwd().openFile(shader_path, .{}) catch |err| {
         std.debug.print("Failed to open shader file '{s}': {}\n", .{ shader_path, err });
@@ -104,31 +98,6 @@ fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
     };
     defer allocator.free(frag_source);
 
-    // Compile vertex shader
-    const vert = gl_init.compileShader(c.GL_VERTEX_SHADER, post_vertex_source) orelse return false;
-    defer gl.DeleteShader.?(vert);
-
-    // Compile fragment shader
-    const frag = gl_init.compileShader(c.GL_FRAGMENT_SHADER, frag_source.ptr) orelse return false;
-    defer gl.DeleteShader.?(frag);
-
-    // Link program
-    g_post_program = gl.CreateProgram.?();
-    gl.AttachShader.?(g_post_program, vert);
-    gl.AttachShader.?(g_post_program, frag);
-    gl.LinkProgram.?(g_post_program);
-
-    var success: c.GLint = 0;
-    gl.GetProgramiv.?(g_post_program, c.GL_LINK_STATUS, &success);
-    if (success == 0) {
-        var info_log: [512]u8 = undefined;
-        gl.GetProgramInfoLog.?(g_post_program, 512, null, &info_log);
-        std.debug.print("Post shader linking failed: {s}\n", .{&info_log});
-        gl.DeleteProgram.?(g_post_program);
-        g_post_program = 0;
-        return false;
-    }
-
     // Set up fullscreen quad VAO/VBO
     // Two triangles covering [-1,1] NDC with tex coords [0,1]
     const quad_verts = [_]f32{
@@ -142,11 +111,13 @@ fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
         -1.0, 1.0,  0.0, 1.0,
     };
 
-    gl.GenVertexArrays.?(1, &g_post_vao);
-    gl.GenBuffers.?(1, &g_post_vbo);
-    gl.BindVertexArray.?(g_post_vao);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, g_post_vbo);
-    gl.BufferData.?(c.GL_ARRAY_BUFFER, @sizeOf(@TypeOf(quad_verts)), &quad_verts, c.GL_STATIC_DRAW);
+    g_post_vbo_buf = gpu.Buffer.init(c.GL_ARRAY_BUFFER);
+    g_post_vbo_buf.uploadData(std.mem.sliceAsBytes(quad_verts[0..]), c.GL_STATIC_DRAW);
+
+    var vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &vao);
+    gl.BindVertexArray.?(vao);
+    g_post_vbo_buf.bind();
     // position (location 0)
     gl.EnableVertexAttribArray.?(0);
     gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
@@ -155,65 +126,40 @@ fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
     gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), @ptrFromInt(2 * @sizeOf(f32)));
     gl.BindVertexArray.?(0);
 
+    // Compile and link via Pipeline.init (logs errors itself)
+    g_post_pipeline = gpu.Pipeline.init(post_vertex_source, frag_source.ptr, vao);
+    if (g_post_pipeline.program == 0) {
+        // Pipeline.init already logged the failure; clean up vbo and vao
+        g_post_vbo_buf.deinit();
+        gl.DeleteVertexArrays.?(1, &vao);
+        return false;
+    }
+
     std.debug.print("Custom shader loaded: {s}\n", .{shader_path});
     return true;
 }
 
 /// Create or resize the off-screen framebuffer for post-processing
 fn ensurePostFBO(width: c_int, height: c_int) void {
-    const gl = AppWindow.gpu.glTable();
-    if (width == g_post_fb_width and height == g_post_fb_height and g_post_fbo != 0) return;
+    if (g_post_fb.width == width and g_post_fb.height == height and g_post_fb.handle != 0) return;
 
-    // Delete old FBO/texture if resizing
-    if (g_post_fbo != 0) {
-        gl.DeleteFramebuffers.?(1, &g_post_fbo);
-        gl.DeleteTextures.?(1, &g_post_texture);
-    }
+    if (g_post_fb.handle != 0) g_post_fb.deinit();
 
-    // Create FBO
-    gl.GenFramebuffers.?(1, &g_post_fbo);
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, g_post_fbo);
-
-    // Create color texture
-    gl.GenTextures.?(1, &g_post_texture);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_post_texture);
-    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RGBA8, width, height, 0, c.GL_RGBA, c.GL_UNSIGNED_BYTE, null);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_LINEAR);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_S, c.GL_CLAMP_TO_EDGE);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_WRAP_T, c.GL_CLAMP_TO_EDGE);
-
-    // Attach to FBO
-    gl.FramebufferTexture2D.?(c.GL_FRAMEBUFFER, c.GL_COLOR_ATTACHMENT0, c.GL_TEXTURE_2D, g_post_texture, 0);
-
-    const status = gl.CheckFramebufferStatus.?(c.GL_FRAMEBUFFER);
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
-
-    if (status != c.GL_FRAMEBUFFER_COMPLETE) {
-        std.debug.print("Post-processing FBO is incomplete: 0x{X}, cleaning up\n", .{status});
-        gl.DeleteTextures.?(1, &g_post_texture);
-        gl.DeleteFramebuffers.?(1, &g_post_fbo);
-        g_post_texture = 0;
-        g_post_fbo = 0;
-        return;
-    }
-
-    g_post_fb_width = width;
-    g_post_fb_height = height;
+    g_post_fb = gpu.Framebuffer.initColor(width, height) orelse return;
 }
 
 /// Render the fullscreen quad with post-processing shader applied
 fn renderPostProcess(width: c_int, height: c_int) void {
-    const gl = AppWindow.gpu.glTable();
+    const gl = gpu.glTable();
     // Bind default framebuffer (screen)
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, 0);
+    gpu.Framebuffer.unbind();
     gl.Viewport.?(0, 0, width, height);
     gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
 
     // Disable blending for the fullscreen quad - shader output is final color
-    gl.Disable.?(c.GL_BLEND);
+    ui_pipeline.setBlendEnabled(false);
 
-    gl.UseProgram.?(g_post_program);
+    g_post_pipeline.use();
 
     // Set uniforms (Ghostty/Shadertoy conventions)
     const w_f: f32 = @floatFromInt(width);
@@ -221,31 +167,23 @@ fn renderPostProcess(width: c_int, height: c_int) void {
     const now_ms = std.time.milliTimestamp();
     const elapsed: f32 = @floatCast(@as(f64, @floatFromInt(now_ms - g_start_time)) / 1000.0);
 
-    // iResolution
-    gl.Uniform3f.?(gl.GetUniformLocation.?(g_post_program, "iResolution"), w_f, h_f, 1.0);
-    // iTime
-    gl.Uniform1f.?(gl.GetUniformLocation.?(g_post_program, "iTime"), elapsed);
-    // iTimeDelta (approximate ~16ms)
-    gl.Uniform1f.?(gl.GetUniformLocation.?(g_post_program, "iTimeDelta"), 0.016);
-    // iFrame
-    gl.Uniform1i.?(gl.GetUniformLocation.?(g_post_program, "iFrame"), @intCast(g_frame_count));
-    // iChannel0 = texture unit 0
-    gl.Uniform1i.?(gl.GetUniformLocation.?(g_post_program, "iChannel0"), 0);
-    // iChannelResolution[0]
-    gl.Uniform3f.?(gl.GetUniformLocation.?(g_post_program, "iChannelResolution[0]"), w_f, h_f, 1.0);
+    g_post_pipeline.setVec3("iResolution", w_f, h_f, 1.0);
+    g_post_pipeline.setFloat("iTime", elapsed);
+    g_post_pipeline.setFloat("iTimeDelta", 0.016);
+    g_post_pipeline.setInt("iFrame", @intCast(g_frame_count));
+    g_post_pipeline.setInt("iChannel0", 0);
+    g_post_pipeline.setVec3("iChannelResolution[0]", w_f, h_f, 1.0);
 
     // Bind the terminal framebuffer texture
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, g_post_texture);
+    gpu.Texture.fromHandle(g_post_fb.color).bind(0);
 
     // Draw fullscreen quad
-    gl.BindVertexArray.?(g_post_vao);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
-    gl.BindVertexArray.?(0);
+    g_post_pipeline.bindVao();
+    g_post_pipeline.drawArrays(c.GL_TRIANGLES, 0, 6);
+    AppWindow.gpu.gl_init.g_draw_call_count += 1;
 
     // Re-enable blending for next terminal render pass
-    gl.Enable.?(c.GL_BLEND);
+    ui_pipeline.setBlendEnabled(true);
 
     g_frame_count +%= 1;
 }
@@ -254,13 +192,12 @@ fn renderPostProcess(width: c_int, height: c_int) void {
 /// Render with post-processing. Called after updateTerminalCells() has
 /// already been called under the lock — this only does GL work.
 pub fn renderFrameWithPostFromCells(rend: *const Renderer, width: c_int, height: c_int, padding: f32) void {
-    const gl = AppWindow.gpu.glTable();
+    const gl = gpu.glTable();
     ensurePostFBO(width, height);
 
     // 1. Render terminal to FBO
-    gl.BindFramebuffer.?(c.GL_FRAMEBUFFER, g_post_fbo);
-    gl.Viewport.?(0, 0, width, height);
-    gl_init.setProjection(@floatFromInt(width), @floatFromInt(height));
+    g_post_fb.bind();
+    ui_pipeline.setProjection(@floatFromInt(width), @floatFromInt(height));
     gl.ClearColor.?(AppWindow.g_theme.background[0], AppWindow.g_theme.background[1], AppWindow.g_theme.background[2], 1.0);
     gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
     background_image.drawFullscreen(@floatFromInt(width), @floatFromInt(height));
@@ -284,12 +221,7 @@ pub fn init(allocator: std.mem.Allocator, shader_path: ?[]const u8) void {
 /// Clean up post-processing GL resources.
 pub fn deinit() void {
     if (!g_post_enabled) return;
-    const gl = AppWindow.gpu.glTable();
-    gl.DeleteProgram.?(g_post_program);
-    gl.DeleteVertexArrays.?(1, &g_post_vao);
-    gl.DeleteBuffers.?(1, &g_post_vbo);
-    if (g_post_fbo != 0) {
-        gl.DeleteFramebuffers.?(1, &g_post_fbo);
-        gl.DeleteTextures.?(1, &g_post_texture);
-    }
+    g_post_pipeline.deinit();
+    g_post_vbo_buf.deinit();
+    g_post_fb.deinit();
 }

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -129,6 +129,14 @@ pub fn endClip() void {
     gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
 }
 
+/// Toggle GL_BLEND. Lets callers that draw opaque content (e.g. a background
+/// image or post-process pass) disable blending for a draw and restore it,
+/// without touching raw GL (= the prior gl.Disable/Enable(GL_BLEND) bookends).
+pub fn setBlendEnabled(enabled: bool) void {
+    const gl = gpu.glTable();
+    if (enabled) gl.Enable.?(c.GL_BLEND) else gl.Disable.?(c.GL_BLEND);
+}
+
 pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
     fillQuadAlpha(x, y, w, h, color, 1.0);
 }

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -20,6 +20,7 @@ pub const Uv = struct { u0: f32, v0: f32, u1: f32, v1: f32 };
 
 pub threadlocal var text: Pipeline = .{ .program = 0, .vao = 0 };
 pub threadlocal var emoji: Pipeline = .{ .program = 0, .vao = 0 };
+pub threadlocal var overlay: Pipeline = .{ .program = 0, .vao = 0 }; // flat-color tint (was gl_init.overlay_shader)
 pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
 pub threadlocal var solid: Texture = .{ .handle = 0 };
 
@@ -57,6 +58,10 @@ pub fn init() void {
     if (text.program == 0) std.debug.print("UI text pipeline failed\n", .{});
     if (emoji.program == 0) std.debug.print("UI emoji pipeline failed\n", .{});
 
+    const overlay_vao = buildQuadVao();
+    overlay = Pipeline.init(shaders.vertex_shader_source, shaders.overlay_fragment_source, overlay_vao);
+    if (overlay.program == 0) std.debug.print("UI overlay pipeline failed\n", .{});
+
     var solid_handle: c.GLuint = 0;
     gl.GenTextures.?(1, &solid_handle);
     gl.BindTexture.?(c.GL_TEXTURE_2D, solid_handle);
@@ -70,6 +75,7 @@ pub fn init() void {
 pub fn deinit() void {
     text.deinit();
     emoji.deinit();
+    overlay.deinit();
     quad.deinit();
     if (solid.handle != 0) {
         gpu.glTable().DeleteTextures.?(1, &solid.handle);
@@ -175,4 +181,34 @@ pub fn drawColorGlyph(rect: Rect, uv: Uv, tex: c.GLuint, opacity: f32) void {
     gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
     drawCallTick();
     gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+}
+
+/// Draw a textured RGBA quad through the emoji/color pipeline (the old
+/// gl_init.simple_color_shader path). `verts` is 6 vertices of (x, y, u, v).
+/// `opacity` modulates alpha; the texture is sampled on unit 0. Does NOT change
+/// blend state — the caller sets blend as needed.
+pub fn drawTextureQuad(verts: [6][4]f32, tex: c.GLuint, opacity: f32) void {
+    emoji.use();
+    emoji.bindVao();
+    emoji.setProjection();
+    emoji.setFloat("opacity", opacity);
+    emoji.setInt("text", 0);
+    Texture.fromHandle(tex).bind(0);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    emoji.drawArrays(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
+}
+
+/// Draw a flat-color quad through the overlay pipeline (the old
+/// gl_init.overlay_shader path). `verts` is 6 vertices of (x, y, u, v) — the
+/// overlay shader ignores the uv. `color` is RGBA (alpha = tint strength).
+/// Does NOT change blend state.
+pub fn fillOverlay(verts: [6][4]f32, color: [4]f32) void {
+    overlay.use();
+    overlay.bindVao();
+    overlay.setProjection();
+    overlay.setVec4("overlayColor", color[0], color[1], color[2], color[3]);
+    quad.upload(std.mem.sliceAsBytes(verts[0..]));
+    overlay.drawArrays(c.GL_TRIANGLES, 0, 6);
+    drawCallTick();
 }


### PR DESCRIPTION
Completes **Phase A / A3** — routes the last 7 renderer files off raw OpenGL and onto the `gpu`/`ui_pipeline` layer. Behavior-preserving. Stacked on #56 (base = `feat/gpu-a3-ai-chat`); merge after #56.

With this, **all 10 A3 renderer files are converted** and `gl_init.overlay_shader` is retired.

## New gpu infrastructure (additive)
- `gpu.Texture`: `create` / `upload2D` / `setWrap` / `destroy`.
- `gpu.Framebuffer` (new): `initColor` / `bind` / `unbind` / `deinit` (FBO + RGBA8 color attachment).
- `gpu.Pipeline`: `setVec3` / `setVec4` / `drawArrays`.
- `ui_pipeline`: `drawTextureQuad` (textured RGBA quad via the color shader), `fillOverlay` (+ a `ui_pipeline`-owned `overlay` pipeline, replacing `gl_init.overlay_shader`), `setBlendEnabled`.

## Files converted
| File | How |
|------|-----|
| `file_explorer_renderer` | 13 quads → `fillQuad`; ambient/glad/`gl_init` removed (raw-GL-free) |
| `markdown_preview_renderer` | 12 quads → `fillQuad`; image → `Texture`+`drawTextureQuad`; scissor save/restore via `gpu.glTable()` |
| `overlays` | 27 quads → `fillQuad`; unfocused-dim → `fillOverlay`; 8 dead ambient blocks removed (raw-GL-free) |
| `image_renderer` | kitty texture upload → `Texture`; draw → `drawTextureQuad` (raw-GL-free) |
| `background_image` | stb_image upload → `Texture`; draw → `drawTextureQuad`+`setBlendEnabled`; tint → `fillOverlay` (drops glad, keeps stb_image) |
| `post_process` | FBO → `Framebuffer`; program → `Pipeline`; sampling → `Texture` |
| `fbo` | per-surface FBO → `Framebuffer`; composite → `drawTextureQuad` (raw-GL-free) |

None carries its own `@cInclude("glad/gl.h")`. `markdown_preview`/`post_process` keep `gpu.glTable()` plumbing for VAO build / scissor save-restore / Clear-Viewport — the same bar as the already-merged `cell_pipeline`.

## Verification
- `zig build` clean; `zig build test` + `zig build test-full` green.
- ⚠️ **Manual Windows visual QA still needed** (no automated render tests). Please check: file-explorer panel, markdown preview (incl. embedded images + table-hover clip), command palette / session launcher / settings / close-confirm / **unfocused-split dim** / split dividers (overlays), kitty/terminal images, background-image modes (fill/fit/center/tile + opacity tint), and a custom post-process shader.

Plan: `docs/superpowers/plans/2026-05-26-gpu-a3-remaining-files.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)