### PR TITLE
Phase C: POSIX PTY/process backend (Linux)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -168,13 +168,23 @@ mapping in guide §2 and §5.
       orchestration, and input routing (GL binding removed in A2).
 - [ ] **B4** Unit tests for the extracted pure logic (`zig test`).
 
-### Phase C — POSIX PTY/process backend (actionable now; unit-testable on Linux)
+### Phase C — POSIX PTY/process backend (Linux done; macOS/BSD deferred to Phase D)
 
-- [ ] **C1** `src/platform/pty_posix.zig`: `openpty`/`fork`/`exec` +
-      `ioctl(TIOCSWINSZ)` satisfying the `pty.zig` facade. *Ghostty:
-      `src/pty.zig` (POSIX).*
-- [ ] **C2** Complete `src/platform/process_posix.zig` to drive the PTY.
-- [ ] **C3** Linux unit tests for spawn/resize/teardown.
+- [x] **C1** `src/platform/pty_posix.zig` satisfies the `pty.zig` facade:
+      `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` for the master + slave path,
+      `fork`+`setsid`/`TIOCSCTTY`/`dup2`/`chdir`/`execvp` in the child (pid stored
+      in the `Command`), `ioctl(TIOCSWINSZ)` for size, poll-based `readOutput`
+      with a self-pipe so `cancelOutputRead` breaks the blocking read, `FIONREAD`
+      for `outputAvailable`, EIO→`BrokenPipe`. `pty.zig` gains a `.posix` backend
+      (Linux only — macOS/BSD use different ioctl request codes, deferred).
+- [x] **C2** `process_posix.zig` `waitForPid`/`childExited` implemented via a
+      shared `reapChild` (raw `wait4` syscall on Linux so the no-libc fast-test
+      graph links; `std.c.waitpid` elsewhere); `pty_command` POSIX `Command` got
+      a `pid` + waitpid-based `wait`/`deinit` (zombie reaping).
+- [x] **C3** Native Linux tests in `pty_posix.zig` (real `fork`/`exec`/`poll`/
+      `waitpid`): backend selection, open+resize, spawn+read, child-exit→
+      `BrokenPipe`/0 + `wait` exit code, `outputAvailable` count, cancel breaks a
+      blocking read. Run via `zig test src/platform/pty_posix.zig -lc`.
 
 ### Phase D — Native host implementations (deferred; needs macOS/Linux SDK)
 

--- a/docs/superpowers/plans/2026-05-26-phase-c-posix-pty.md
+++ b/docs/superpowers/plans/2026-05-26-phase-c-posix-pty.md
@@ -1,0 +1,72 @@
+# Phase C — POSIX PTY/process backend
+
+Branch `feat/phase-c-posix-pty`. Make the local-shell PTY work on POSIX (Linux first;
+macOS shares the code). This env is Linux/WSL, so it builds + runs natively.
+
+## Contract (from pty_windows.zig / pty.zig facade)
+`Pty` must expose: `open(winsize) !Pty`, `deinit(*Pty)`, `getSize(*const Pty) winsize`,
+`setSize(*Pty, winsize) !void`, `startCommand(*Pty, *pty_command.Command, pty_command.CommandLine, pty_command.Cwd) !void`,
+`readOutput(*Pty, []u8) ReadError!usize`, `writeInput(*Pty, []const u8) WriteError!void`,
+`outputAvailable(*Pty) ?usize`, `cancelOutputRead(*Pty) void`. Plus `ReadError`, `WriteError`, `winsize`.
+- `winsize = { ws_col: u16, ws_row: u16, ws_xpixel=0, ws_ypixel=0 }`.
+- `CommandLine = [:0]const u8` (the shell command line); `Cwd = ?[*:0]const u8`.
+- `Command` (`pty_command_unsupported.Command`) is populated by `startCommand`; `Command.wait(*const,block) !?Exit`, `Exit = union{exited:u32, unknown}`, `deinit(*Command)`.
+
+## Consumer IO model (termio/ReadThread.zig, Surface.zig)
+- ReadThread loops **blocking** `readOutput`; `error.ReadInterrupted`→retry, `error.BrokenPipe` or `0`→child exited.
+- During resize it polls `outputAvailable()` (byte count; 0→sleep) then reads.
+- Shutdown calls `cancelOutputRead()` to break the blocking read so the thread exits.
+- `Surface` spawns via `Command.start(&pty, cmd, cwd)` → `pty.startCommand(&impl, cmd, cwd)`.
+
+## C1 — `src/platform/pty_posix.zig` (Pty)
+Use libc (link libC) via `std.c` / `extern "c"`: `posix_openpt(O_RDWR|O_NOCTTY)`, `grantpt`, `unlockpt`,
+`ptsname_r`. Fields: `master: fd_t`, `slave_path: [N]u8`, `size: winsize`, `cancel_pipe: [2]fd_t`.
+- `open`: posix_openpt → grantpt → unlockpt → ptsname_r(master) into slave_path; create cancel self-pipe
+  (`std.posix.pipe`); `setSize`-equivalent `ioctl(master, TIOCSWINSZ, &os_ws)`. `os_ws` is the OS
+  `struct winsize {ws_row, ws_col, ws_xpixel, ws_ypixel}` — map `ws_row=size.ws_row, ws_col=size.ws_col`
+  (note OS order is row,col).
+- `setSize`: `ioctl(master, TIOCSWINSZ, &os_ws)`; store `self.size`.
+- `startCommand`: `std.posix.fork()`. Child: `setsid()`; `open(slave_path, O_RDWR)`; `ioctl(slave, TIOCSCTTY, 0)`;
+  `dup2 slave→0,1,2`; close slave/master/cancel fds; `chdir(cwd)` if non-null; parse `command_line` into argv
+  (split on ascii whitespace) and `execvpeZ`(argv[0], argv, environ); on exec failure `_exit(127)`.
+  Parent: store child pid into `command.pid`; (keep master open).
+- `readOutput`: `poll([{master,POLLIN},{cancel_read,POLLIN}], -1)`. cancel ready → drain it, return
+  `error.ReadInterrupted`. master ready → `read(master,buf)`; `0`→return 0; `EINTR`→`ReadInterrupted`;
+  `EIO`→`error.BrokenPipe` (Linux signals slave-closed via EIO); else `ReadFailed`. Return bytes.
+- `writeInput`: loop `write(master, ...)`; `EPIPE`/`EIO`→`BrokenPipe`; else `WriteFailed`.
+- `outputAvailable`: `ioctl(master, FIONREAD, &n)` → `@intCast(n)`; error → `null`.
+- `cancelOutputRead`: `write(cancel_pipe[1], &[1]u8{0})` (best-effort).
+- `deinit`: close master + cancel_pipe.
+Constants (TIOCSWINSZ/TIOCSCTTY/FIONREAD, O_RDWR/O_NOCTTY): from `std.os.linux`/`std.posix` where present,
+else `extern`/`const` literals. Resolve by compiling.
+
+## C1b — `pty_command_unsupported.zig` `Command`
+Add `pid: std.c.pid_t = -1`. `wait(block)`: if `pid <= 0` return `null`; `waitpid(pid, &status, if (block) 0 else WNOHANG)`;
+ret==0 → `null` (still running); on reap → `WIFEXITED` ? `.{ .exited = WEXITSTATUS }` : `.unknown`.
+`deinit`: best-effort non-blocking reap to avoid zombie. Guard POSIX syscalls so the file still *compiles*
+under a Windows target build if it is ever in that graph (use `std.c`/`std.posix`; add `builtin.os.tag` guard only if needed).
+
+## C2 — `src/platform/process_posix.zig`
+Complete the stubs with real waitpid:
+- `waitForPid(pid, timeout_ms, diag)`: poll `waitpid(pid, &st, WNOHANG)` until reaped or timeout (sleep ~5ms steps).
+- `childExited(id, timeout_ms)`: `waitpid(id, &st, WNOHANG)`; true if reaped/no-such-child within timeout.
+- Keep `terminateChild`/`writeAllToPipe`/`spawnDetachedWithOptions`/`currentProcessId` as-is.
+
+## Facade wiring — `pty.zig`
+`Backend` += `posix`; `backendForOs`: `.windows=>.windows, .linux,.macos,.freebsd,...=>.posix, else=>.unsupported`;
+`impl` switch += `.posix => @import("pty_posix.zig")`. Update the codified test (`backendForOs(.linux)`/`.macos`
+now expect `.posix`). `pty_command.zig` stays as-is (its `.unsupported` backend already supplies POSIX
+Command/CommandLine/Cwd + shell text).
+
+## C3 — tests (in `pty_posix.zig`, native)
+- backend selection (`.linux`/`.macos` → `.posix`).
+- open → getSize → setSize(resize) → getSize reflects new size.
+- spawn: `startCommand` with `"/bin/echo phantty\n"`-style or `sh -c 'printf hi'`; read until output contains
+  the expected bytes; then child exits → `readOutput` eventually returns `BrokenPipe`/0; `command.wait(true)` → `.exited`.
+- `outputAvailable` returns a count after the child writes.
+- teardown: `deinit` closes fds; `command.deinit()` reaps.
+
+## Verify
+- Native (Linux): `zig test src/platform/pty_posix.zig -lc` green (real fork/exec/openpty).
+- Windows pre-merge gate unaffected: `zig build test-full -Dtarget=x86_64-windows-gnu` green (pty_posix not in that graph).
+- `zig build` (default windows target) clean.

--- a/src/platform/process_posix.zig
+++ b/src/platform/process_posix.zig
@@ -5,16 +5,52 @@ pub fn currentProcessId() u32 {
     return @intCast(std.c.getpid());
 }
 
+const POLL_STEP_MS: u32 = 5;
+
+/// Polls a non-blocking child reap until the child is reaped or `timeout_ms`
+/// elapses. Reaping (or a vanished/unknown child) is treated as success; an
+/// outright timeout returns `error.WaitTimeout`.
 pub fn waitForPid(pid: u32, timeout_ms: u32, diagnostic: ?*shared.WaitForPidDiagnostic) !void {
-    _ = pid;
-    _ = timeout_ms;
-    _ = diagnostic;
+    const target: i32 = @intCast(pid);
+    var elapsed: u32 = 0;
+    while (true) {
+        switch (shared.reapChild(target, shared.WNOHANG)) {
+            .reaped, .reaped_unknown, .no_child => return,
+            .still_running => {},
+        }
+
+        if (elapsed >= timeout_ms) {
+            if (diagnostic) |d| {
+                d.operation = "waitpid";
+                d.code = 0;
+                d.wait_result = 0;
+            }
+            return error.WaitTimeout;
+        }
+
+        const step = @min(POLL_STEP_MS, timeout_ms - elapsed);
+        std.Thread.sleep(@as(u64, step) * std.time.ns_per_ms);
+        elapsed += step;
+    }
 }
 
+/// Returns true if the child has exited (reaped now) or is no longer a child of
+/// this process, polling up to `timeout_ms`. Still-running within the window
+/// returns false.
 pub fn childExited(id: std.process.Child.Id, timeout_ms: u32) bool {
-    _ = id;
-    _ = timeout_ms;
-    return false;
+    const target: i32 = @intCast(id);
+    var elapsed: u32 = 0;
+    while (true) {
+        switch (shared.reapChild(target, shared.WNOHANG)) {
+            .reaped, .reaped_unknown, .no_child => return true,
+            .still_running => {},
+        }
+
+        if (elapsed >= timeout_ms) return false;
+        const step = @min(POLL_STEP_MS, timeout_ms - elapsed);
+        std.Thread.sleep(@as(u64, step) * std.time.ns_per_ms);
+        elapsed += step;
+    }
 }
 
 pub fn terminateChild(id: std.process.Child.Id) void {

--- a/src/platform/process_shared.zig
+++ b/src/platform/process_shared.zig
@@ -11,3 +11,49 @@ pub const WaitForPidDiagnostic = struct {
 };
 
 pub const PipeWriteError = error{ BrokenPipe, WriteFailed };
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const WaitResult = union(enum) {
+    /// Child reaped via a normal exit: `code` is the exit status.
+    reaped: u32,
+    /// Child reaped, but not via a normal exit (killed by a signal, etc.).
+    reaped_unknown,
+    /// `WNOHANG`: the child is still running.
+    still_running,
+    /// No such child (already reaped, or never ours) — treat as done.
+    no_child,
+};
+
+pub const WNOHANG: u32 = 1;
+
+/// Non-blocking-or-blocking child reap that works WITHOUT libc on Linux (raw
+/// `wait4` syscall) and via libc `waitpid` elsewhere. This matters because the
+/// fast native test build does not link libc, yet pulls in the POSIX process
+/// helpers transitively.
+pub fn reapChild(pid: i32, options: u32) WaitResult {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var status: u32 = 0;
+        const rc = linux.syscall4(
+            .wait4,
+            @as(usize, @bitCast(@as(isize, pid))),
+            @intFromPtr(&status),
+            options,
+            0,
+        );
+        const signed: isize = @bitCast(rc);
+        if (signed < 0) return .no_child; // ECHILD / ESRCH / EINVAL
+        if (signed == 0) return .still_running;
+        if (linux.W.IFEXITED(status)) return .{ .reaped = linux.W.EXITSTATUS(status) };
+        return .reaped_unknown;
+    } else {
+        var status: c_int = 0;
+        const r = std.c.waitpid(pid, &status, @intCast(options));
+        if (r < 0) return .no_child;
+        if (r == 0) return .still_running;
+        if ((status & 0x7f) == 0) return .{ .reaped = @intCast((status & 0xff00) >> 8) };
+        return .reaped_unknown;
+    }
+}

--- a/src/platform/pty.zig
+++ b/src/platform/pty.zig
@@ -10,7 +10,11 @@ pub const Backend = enum {
 pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
-        .linux, .macos, .freebsd, .netbsd, .openbsd, .dragonfly, .solaris, .illumos => .posix,
+        // Only Linux is implemented + verified. The POSIX backend uses
+        // std.os.linux ioctl request numbers (TIOCSWINSZ/TIOCSCTTY/FIONREAD),
+        // which differ on macOS and the BSDs — those stay unsupported until
+        // their request codes are added (Phase D, on a machine that can run them).
+        .linux => .posix,
         else => .unsupported,
     };
 }
@@ -74,6 +78,7 @@ test "platform pty owns pipe IO operations" {
 test "platform pty selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
     try std.testing.expectEqual(Backend.posix, backendForOs(.linux));
-    try std.testing.expectEqual(Backend.posix, backendForOs(.macos));
+    // macOS/BSD use different ioctl request codes; unsupported until Phase D.
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.macos));
     try std.testing.expectEqual(Backend.unsupported, backendForOs(.wasi));
 }

--- a/src/platform/pty.zig
+++ b/src/platform/pty.zig
@@ -3,18 +3,21 @@ const builtin = @import("builtin");
 
 pub const Backend = enum {
     windows,
+    posix,
     unsupported,
 };
 
 pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
+        .linux, .macos, .freebsd, .netbsd, .openbsd, .dragonfly, .solaris, .illumos => .posix,
         else => .unsupported,
     };
 }
 
 const impl = switch (backendForOs(builtin.os.tag)) {
     .windows => @import("pty_windows.zig"),
+    .posix => @import("pty_posix.zig"),
     .unsupported => @import("pty_unsupported.zig"),
 };
 
@@ -70,6 +73,7 @@ test "platform pty owns pipe IO operations" {
 
 test "platform pty selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
-    try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
-    try std.testing.expectEqual(Backend.unsupported, backendForOs(.macos));
+    try std.testing.expectEqual(Backend.posix, backendForOs(.linux));
+    try std.testing.expectEqual(Backend.posix, backendForOs(.macos));
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.wasi));
 }

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const process_shared = @import("process_shared.zig");
 
 pub const CommandLineBuffer = [256]u8;
 pub const CwdBuffer = [260]u8;
@@ -73,14 +75,31 @@ pub const Command = struct {
         unknown,
     };
 
+    /// Child PID populated by the POSIX `Pty.startCommand`. `-1` means "no
+    /// child" (not yet spawned, or already reaped).
+    pid: std.c.pid_t = -1,
+
     pub fn wait(self: *const Command, block: bool) !?Exit {
-        _ = self;
-        _ = block;
-        return null;
+        if (self.pid <= 0) return null;
+        // POSIX-only: guarded so this file still compiles under a Windows
+        // target build (it is selected only for non-windows hosts).
+        if (builtin.os.tag == .windows) return null;
+
+        const options: u32 = if (block) 0 else process_shared.WNOHANG;
+        switch (process_shared.reapChild(self.pid, options)) {
+            .still_running => return null,
+            .no_child => return null,
+            .reaped => |code| return Exit{ .exited = code },
+            .reaped_unknown => return .unknown,
+        }
     }
 
     pub fn deinit(self: *Command) void {
-        _ = self;
+        // Best-effort non-blocking reap so we don't leak a zombie.
+        if (self.pid > 0 and builtin.os.tag != .windows) {
+            _ = process_shared.reapChild(self.pid, process_shared.WNOHANG);
+            self.pid = -1;
+        }
     }
 };
 

--- a/src/platform/pty_posix.zig
+++ b/src/platform/pty_posix.zig
@@ -1,4 +1,8 @@
-//! POSIX PTY backend (Linux first; macOS shares the code).
+//! POSIX PTY backend (Linux only for now).
+//!
+//! The ioctl request numbers come from `std.os.linux.T`, so macOS and the BSDs
+//! (which use different request codes) are routed to `.unsupported` by
+//! `pty.zig`'s `backendForOs` until those constants are added in Phase D.
 //!
 //! Mirrors the `Pty` API of `pty_windows.zig`. Uses libc (link with `-lc`):
 //! `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` to allocate a master fd plus
@@ -12,8 +16,8 @@ const pty_command = @import("pty_command.zig");
 
 const fd_t = c.fd_t;
 
-/// ioctl request numbers. `std.os.linux.T` carries the per-arch Linux values.
-/// On macOS these differ; that path is unverified here (Linux-only box).
+/// ioctl request numbers (per-arch Linux values). macOS/BSD differ, hence the
+/// Linux-only `backendForOs` mapping in pty.zig.
 const T = std.os.linux.T;
 
 extern "c" fn posix_openpt(oflag: c_int) c_int;
@@ -21,6 +25,9 @@ extern "c" fn grantpt(fd: c_int) c_int;
 extern "c" fn unlockpt(fd: c_int) c_int;
 extern "c" fn ptsname_r(fd: c_int, buf: [*]u8, buflen: usize) c_int;
 extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+/// Raw `_exit(2)` — used in the forked child so we never run libc `atexit`
+/// handlers or flush stdio buffers inherited from the parent.
+extern "c" fn _exit(code: c_int) noreturn;
 
 const SLAVE_PATH_MAX = 128;
 const MAX_ARGV = 64;
@@ -130,7 +137,7 @@ pub const Pty = struct {
             // Child: set up the slave as the controlling tty, then exec.
             childExec(self.master, self.slave_path[0..], self.cancel_pipe, command_line, cwd);
             // childExec never returns; if it somehow does, bail out.
-            std.posix.exit(127);
+            _exit(127);
         }
         // Parent: keep the master open; record the child pid.
         command.pid = pid;
@@ -224,12 +231,12 @@ fn childExec(
     while (path_len < slave_path.len and slave_path[path_len] != 0) : (path_len += 1) {
         path_buf[path_len] = slave_path[path_len];
     }
-    if (path_len >= path_buf.len) std.posix.exit(127);
+    if (path_len >= path_buf.len) _exit(127);
     path_buf[path_len] = 0;
 
     const open_flags = std.posix.O{ .ACCMODE = .RDWR };
     const slave = c.open(@ptrCast(&path_buf), open_flags, @as(c.mode_t, 0));
-    if (slave < 0) std.posix.exit(127);
+    if (slave < 0) _exit(127);
 
     // Claim the slave as the controlling terminal for this session.
     _ = c.ioctl(slave, T.IOCSCTTY, @as(c_int, 0));
@@ -251,12 +258,12 @@ fn childExec(
     var arg_storage: [ARG_BUF]u8 = undefined;
     var argv: [MAX_ARGV + 1]?[*:0]const u8 = undefined;
     const argc = parseArgv(command_line, &arg_storage, &argv);
-    if (argc == 0) std.posix.exit(127);
+    if (argc == 0) _exit(127);
     argv[argc] = null;
 
     _ = execvp(argv[0].?, @ptrCast(&argv));
     // execvp only returns on failure.
-    std.posix.exit(127);
+    _exit(127);
 }
 
 /// Splits `command_line` on ASCII whitespace into NUL-terminated argv entries
@@ -294,10 +301,11 @@ fn parseArgv(
 
 const backend_facade = @import("pty.zig");
 
-test "posix backend selected for unix targets" {
+test "posix backend selected for linux; macos/bsd unsupported until Phase D" {
     try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.linux));
-    try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.macos));
     try std.testing.expectEqual(backend_facade.Backend.windows, backend_facade.backendForOs(.windows));
+    // macOS/BSD ioctl request codes differ from std.os.linux.T — see backendForOs.
+    try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.macos));
     try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.wasi));
 }
 

--- a/src/platform/pty_posix.zig
+++ b/src/platform/pty_posix.zig
@@ -1,0 +1,440 @@
+//! POSIX PTY backend (Linux first; macOS shares the code).
+//!
+//! Mirrors the `Pty` API of `pty_windows.zig`. Uses libc (link with `-lc`):
+//! `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` to allocate a master fd plus
+//! a slave device path, `fork`/`setsid`/`TIOCSCTTY`/`dup2`/`execvp` to launch
+//! the child on the slave side, and a self-pipe so `cancelOutputRead` can break
+//! the blocking `poll`-based `readOutput`.
+const std = @import("std");
+const builtin = @import("builtin");
+const c = std.c;
+const pty_command = @import("pty_command.zig");
+
+const fd_t = c.fd_t;
+
+/// ioctl request numbers. `std.os.linux.T` carries the per-arch Linux values.
+/// On macOS these differ; that path is unverified here (Linux-only box).
+const T = std.os.linux.T;
+
+extern "c" fn posix_openpt(oflag: c_int) c_int;
+extern "c" fn grantpt(fd: c_int) c_int;
+extern "c" fn unlockpt(fd: c_int) c_int;
+extern "c" fn ptsname_r(fd: c_int, buf: [*]u8, buflen: usize) c_int;
+extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+
+const SLAVE_PATH_MAX = 128;
+const MAX_ARGV = 64;
+const ARG_BUF = 1024;
+
+fn errno() c.E {
+    return @enumFromInt(c._errno().*);
+}
+
+pub const ReadError = error{ ReadInterrupted, BrokenPipe, ReadFailed };
+pub const WriteError = error{ BrokenPipe, WriteFailed };
+
+pub const winsize = struct {
+    ws_col: u16,
+    ws_row: u16,
+    ws_xpixel: u16 = 0,
+    ws_ypixel: u16 = 0,
+};
+
+/// OS `struct winsize` layout: row, col, xpixel, ypixel.
+const OsWinsize = extern struct {
+    ws_row: u16,
+    ws_col: u16,
+    ws_xpixel: u16,
+    ws_ypixel: u16,
+};
+
+fn osWinsize(s: winsize) OsWinsize {
+    return .{
+        .ws_row = s.ws_row,
+        .ws_col = s.ws_col,
+        .ws_xpixel = s.ws_xpixel,
+        .ws_ypixel = s.ws_ypixel,
+    };
+}
+
+pub const Pty = struct {
+    master: fd_t,
+    slave_path: [SLAVE_PATH_MAX]u8,
+    size: winsize,
+    cancel_pipe: [2]fd_t,
+
+    pub fn open(size: winsize) !Pty {
+        var self: Pty = undefined;
+        self.size = size;
+
+        const open_flags = std.posix.O{ .ACCMODE = .RDWR, .NOCTTY = true };
+        const o_int: c_int = @bitCast(open_flags);
+        const master = posix_openpt(o_int);
+        if (master < 0) return error.OpenPtFailed;
+        errdefer _ = c.close(master);
+
+        if (grantpt(master) != 0) return error.GrantPtFailed;
+        if (unlockpt(master) != 0) return error.UnlockPtFailed;
+
+        self.slave_path = std.mem.zeroes([SLAVE_PATH_MAX]u8);
+        if (ptsname_r(master, &self.slave_path, SLAVE_PATH_MAX) != 0) {
+            return error.PtsnameFailed;
+        }
+
+        self.master = master;
+
+        // Self-pipe used to interrupt the blocking poll in readOutput.
+        self.cancel_pipe = try std.posix.pipe();
+        errdefer {
+            std.posix.close(self.cancel_pipe[0]);
+            std.posix.close(self.cancel_pipe[1]);
+        }
+
+        // Apply the initial window size to the master.
+        var os_ws = osWinsize(size);
+        _ = c.ioctl(master, T.IOCSWINSZ, &os_ws);
+
+        return self;
+    }
+
+    pub fn deinit(self: *Pty) void {
+        if (self.master >= 0) {
+            _ = c.close(self.master);
+            self.master = -1;
+        }
+        if (self.cancel_pipe[0] >= 0) {
+            std.posix.close(self.cancel_pipe[0]);
+            self.cancel_pipe[0] = -1;
+        }
+        if (self.cancel_pipe[1] >= 0) {
+            std.posix.close(self.cancel_pipe[1]);
+            self.cancel_pipe[1] = -1;
+        }
+    }
+
+    pub fn getSize(self: *const Pty) winsize {
+        return self.size;
+    }
+
+    pub fn setSize(self: *Pty, s: winsize) !void {
+        var os_ws = osWinsize(s);
+        if (c.ioctl(self.master, T.IOCSWINSZ, &os_ws) != 0) {
+            return error.SetSizeFailed;
+        }
+        self.size = s;
+    }
+
+    pub fn startCommand(self: *Pty, command: *pty_command.Command, command_line: pty_command.CommandLine, cwd: pty_command.Cwd) !void {
+        const pid = std.posix.fork() catch return error.ForkFailed;
+        if (pid == 0) {
+            // Child: set up the slave as the controlling tty, then exec.
+            childExec(self.master, self.slave_path[0..], self.cancel_pipe, command_line, cwd);
+            // childExec never returns; if it somehow does, bail out.
+            std.posix.exit(127);
+        }
+        // Parent: keep the master open; record the child pid.
+        command.pid = pid;
+    }
+
+    pub fn readOutput(self: *Pty, buffer: []u8) ReadError!usize {
+        if (buffer.len == 0) return 0;
+
+        while (true) {
+            var fds = [2]std.posix.pollfd{
+                .{ .fd = self.master, .events = std.posix.POLL.IN, .revents = 0 },
+                .{ .fd = self.cancel_pipe[0], .events = std.posix.POLL.IN, .revents = 0 },
+            };
+
+            const ready = c.poll(&fds, fds.len, -1);
+            if (ready < 0) {
+                if (errno() == c.E.INTR) return error.ReadInterrupted;
+                return error.ReadFailed;
+            }
+
+            // Cancellation requested: drain the self-pipe and report interruption.
+            if (fds[1].revents & (std.posix.POLL.IN | std.posix.POLL.HUP) != 0) {
+                var drain: [64]u8 = undefined;
+                _ = c.read(self.cancel_pipe[0], &drain, drain.len);
+                return error.ReadInterrupted;
+            }
+
+            if (fds[0].revents & (std.posix.POLL.IN | std.posix.POLL.HUP | std.posix.POLL.ERR) != 0) {
+                const n = c.read(self.master, buffer.ptr, buffer.len);
+                if (n < 0) {
+                    return switch (errno()) {
+                        c.E.INTR => error.ReadInterrupted,
+                        // Linux signals slave-side close via EIO on the master.
+                        c.E.IO => error.BrokenPipe,
+                        else => error.ReadFailed,
+                    };
+                }
+                return @intCast(n);
+            }
+
+            // No data and not cancelled (e.g. spurious wakeup); loop again.
+        }
+    }
+
+    pub fn writeInput(self: *Pty, data: []const u8) WriteError!void {
+        var offset: usize = 0;
+        while (offset < data.len) {
+            const n = c.write(self.master, data[offset..].ptr, data.len - offset);
+            if (n < 0) {
+                return switch (errno()) {
+                    c.E.INTR => continue,
+                    c.E.PIPE, c.E.IO => error.BrokenPipe,
+                    else => error.WriteFailed,
+                };
+            }
+            if (n == 0) return error.BrokenPipe;
+            offset += @intCast(n);
+        }
+    }
+
+    pub fn outputAvailable(self: *Pty) ?usize {
+        var n: c_int = 0;
+        if (c.ioctl(self.master, T.FIONREAD, &n) != 0) return null;
+        if (n < 0) return null;
+        return @intCast(n);
+    }
+
+    pub fn cancelOutputRead(self: *Pty) void {
+        const byte = [1]u8{0};
+        _ = c.write(self.cancel_pipe[1], &byte, 1);
+    }
+};
+
+/// Runs entirely in the forked child. Sets up the controlling terminal on the
+/// slave device, wires stdio to it, optionally changes directory, then execs
+/// the parsed command line. Never returns on success; on any failure it exits
+/// with code 127.
+fn childExec(
+    master: fd_t,
+    slave_path: []const u8,
+    cancel_pipe: [2]fd_t,
+    command_line: pty_command.CommandLine,
+    cwd: pty_command.Cwd,
+) void {
+    // New session so we can claim a controlling terminal.
+    _ = c.setsid();
+
+    // Build a NUL-terminated copy of the slave path on the stack.
+    var path_buf: [SLAVE_PATH_MAX]u8 = undefined;
+    var path_len: usize = 0;
+    while (path_len < slave_path.len and slave_path[path_len] != 0) : (path_len += 1) {
+        path_buf[path_len] = slave_path[path_len];
+    }
+    if (path_len >= path_buf.len) std.posix.exit(127);
+    path_buf[path_len] = 0;
+
+    const open_flags = std.posix.O{ .ACCMODE = .RDWR };
+    const slave = c.open(@ptrCast(&path_buf), open_flags, @as(c.mode_t, 0));
+    if (slave < 0) std.posix.exit(127);
+
+    // Claim the slave as the controlling terminal for this session.
+    _ = c.ioctl(slave, T.IOCSCTTY, @as(c_int, 0));
+
+    _ = c.dup2(slave, 0);
+    _ = c.dup2(slave, 1);
+    _ = c.dup2(slave, 2);
+
+    if (slave > 2) _ = c.close(slave);
+    _ = c.close(master);
+    _ = c.close(cancel_pipe[0]);
+    _ = c.close(cancel_pipe[1]);
+
+    if (cwd) |dir| {
+        _ = c.chdir(dir);
+    }
+
+    // Parse command line into argv (split on ASCII whitespace).
+    var arg_storage: [ARG_BUF]u8 = undefined;
+    var argv: [MAX_ARGV + 1]?[*:0]const u8 = undefined;
+    const argc = parseArgv(command_line, &arg_storage, &argv);
+    if (argc == 0) std.posix.exit(127);
+    argv[argc] = null;
+
+    _ = execvp(argv[0].?, @ptrCast(&argv));
+    // execvp only returns on failure.
+    std.posix.exit(127);
+}
+
+/// Splits `command_line` on ASCII whitespace into NUL-terminated argv entries
+/// written into `storage`. Returns the argument count (0 if empty / overflow).
+fn parseArgv(
+    command_line: []const u8,
+    storage: *[ARG_BUF]u8,
+    argv: *[MAX_ARGV + 1]?[*:0]const u8,
+) usize {
+    var argc: usize = 0;
+    var write_pos: usize = 0;
+    var i: usize = 0;
+    const n = command_line.len;
+    while (i < n) {
+        // Skip leading whitespace.
+        while (i < n and std.ascii.isWhitespace(command_line[i])) : (i += 1) {}
+        if (i >= n) break;
+        if (argc >= MAX_ARGV) return 0;
+
+        const arg_start = write_pos;
+        while (i < n and !std.ascii.isWhitespace(command_line[i])) : (i += 1) {
+            if (write_pos + 1 >= storage.len) return 0;
+            storage[write_pos] = command_line[i];
+            write_pos += 1;
+        }
+        if (write_pos + 1 > storage.len) return 0;
+        storage[write_pos] = 0;
+        write_pos += 1;
+
+        argv[argc] = @ptrCast(&storage[arg_start]);
+        argc += 1;
+    }
+    return argc;
+}
+
+const backend_facade = @import("pty.zig");
+
+test "posix backend selected for unix targets" {
+    try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.linux));
+    try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.macos));
+    try std.testing.expectEqual(backend_facade.Backend.windows, backend_facade.backendForOs(.windows));
+    try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.wasi));
+}
+
+test "open then resize is reflected by getSize" {
+    var pty = try Pty.open(.{ .ws_col = 80, .ws_row = 24 });
+    defer pty.deinit();
+
+    try std.testing.expectEqual(@as(u16, 80), pty.getSize().ws_col);
+    try std.testing.expectEqual(@as(u16, 24), pty.getSize().ws_row);
+
+    try pty.setSize(.{ .ws_col = 120, .ws_row = 40 });
+    try std.testing.expectEqual(@as(u16, 120), pty.getSize().ws_col);
+    try std.testing.expectEqual(@as(u16, 40), pty.getSize().ws_row);
+}
+
+test "spawn child writes output that readOutput receives" {
+    var pty = try Pty.open(.{ .ws_col = 80, .ws_row = 24 });
+    defer pty.deinit();
+
+    var command: pty_command.Command = .{};
+    defer command.deinit();
+
+    try pty.startCommand(&command, "/bin/echo phantty-marker", null);
+
+    var buf: [4096]u8 = undefined;
+    var collected: std.ArrayListUnmanaged(u8) = .empty;
+    defer collected.deinit(std.testing.allocator);
+
+    // Bounded loop: read until we see the marker or the child exits / iterations run out.
+    var iterations: usize = 0;
+    var saw_marker = false;
+    while (iterations < 200) : (iterations += 1) {
+        const n = pty.readOutput(&buf) catch |err| switch (err) {
+            error.BrokenPipe => break,
+            error.ReadInterrupted => continue,
+            else => return err,
+        };
+        if (n == 0) break;
+        try collected.appendSlice(std.testing.allocator, buf[0..n]);
+        if (std.mem.indexOf(u8, collected.items, "phantty-marker") != null) {
+            saw_marker = true;
+            break;
+        }
+    }
+
+    try std.testing.expect(saw_marker);
+}
+
+test "child exit surfaces BrokenPipe/EOF and wait reports exit code" {
+    var pty = try Pty.open(.{ .ws_col = 80, .ws_row = 24 });
+    defer pty.deinit();
+
+    var command: pty_command.Command = .{};
+    defer command.deinit();
+
+    // Spawn an interactive shell, then drive it via writeInput (matching the
+    // real IO model). The command line is whitespace-split into argv, so we
+    // avoid embedded-quote arguments and feed the script over stdin instead.
+    try pty.startCommand(&command, "/bin/sh", null);
+    try pty.writeInput("printf hi\nexit 7\n");
+
+    var buf: [4096]u8 = undefined;
+    var saw_hi = false;
+    var got_eof = false;
+    var iterations: usize = 0;
+    while (iterations < 500) : (iterations += 1) {
+        const n = pty.readOutput(&buf) catch |err| switch (err) {
+            error.BrokenPipe => {
+                got_eof = true;
+                break;
+            },
+            error.ReadInterrupted => continue,
+            else => return err,
+        };
+        if (n == 0) {
+            got_eof = true;
+            break;
+        }
+        if (std.mem.indexOf(u8, buf[0..n], "hi") != null) saw_hi = true;
+    }
+
+    try std.testing.expect(saw_hi);
+    try std.testing.expect(got_eof);
+
+    // Blocking wait must reap the child and report the exit status.
+    const exit = (try command.wait(true)) orelse return error.ExpectedExit;
+    switch (exit) {
+        .exited => |code| try std.testing.expectEqual(@as(u32, 7), code),
+        .unknown => return error.UnexpectedUnknownExit,
+    }
+}
+
+test "outputAvailable returns a byte count after child writes" {
+    var pty = try Pty.open(.{ .ws_col = 80, .ws_row = 24 });
+    defer pty.deinit();
+
+    var command: pty_command.Command = .{};
+    defer command.deinit();
+
+    try pty.startCommand(&command, "/bin/echo phantty-avail", null);
+
+    // Wait (bounded) until the kernel reports bytes available on the master.
+    var iterations: usize = 0;
+    var available: usize = 0;
+    while (iterations < 500) : (iterations += 1) {
+        if (pty.outputAvailable()) |n| {
+            if (n > 0) {
+                available = n;
+                break;
+            }
+        }
+        std.Thread.sleep(2 * std.time.ns_per_ms);
+    }
+
+    try std.testing.expect(available > 0);
+
+    // Drain so the child can exit cleanly and deinit doesn't leave a zombie.
+    var buf: [4096]u8 = undefined;
+    _ = pty.readOutput(&buf) catch {};
+}
+
+test "cancelOutputRead interrupts a blocking readOutput" {
+    var pty = try Pty.open(.{ .ws_col = 80, .ws_row = 24 });
+    defer pty.deinit();
+
+    // No child spawned: readOutput would block on poll forever without a cancel.
+    const Ctx = struct {
+        pty: *Pty,
+        fn run(p: *Pty) void {
+            std.Thread.sleep(20 * std.time.ns_per_ms);
+            p.cancelOutputRead();
+        }
+    };
+    var thread = try std.Thread.spawn(.{}, Ctx.run, .{&pty});
+    defer thread.join();
+
+    var buf: [16]u8 = undefined;
+    const result = pty.readOutput(&buf);
+    try std.testing.expectError(error.ReadInterrupted, result);
+}


### PR DESCRIPTION
Implements **Phase C** — the POSIX PTY/process backend, so the local shell runs on Linux. **Built + tested with real `fork`/`exec`/`poll`/`waitpid` on Linux.**

## C1 — `src/platform/pty_posix.zig` (new)
A `Pty` mirroring `pty_windows.zig`'s API, over libc:
- `open`: `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` → master fd + slave path; a **self-pipe** for cancellation; initial `ioctl(TIOCSWINSZ)`.
- `startCommand`: `fork`; child does `setsid` → open slave → `ioctl(TIOCSCTTY)` → `dup2`→0/1/2 → close master/slave/cancel → `chdir(cwd)` → whitespace-split argv → `execvp`; on failure raw **`_exit(127)`** (never libc `exit` in a forked child). Parent stores the child pid in the `Command`.
- `readOutput`: `poll([master, cancel])` (blocking); cancel → `ReadInterrupted`; master → `read` (`EIO`→`BrokenPipe`; `0`→EOF).
- `writeInput`/`outputAvailable`(`FIONREAD`)/`cancelOutputRead`(self-pipe)/`deinit`.

## C2 — process reaping
- `pty_command` POSIX `Command` gains `pid` + `wait`(waitpid)/`deinit`(zombie reap).
- `process_posix.zig` `waitForPid`/`childExited` via a shared `reapChild` using the **raw `wait4` syscall on Linux** (the no-libc fast-test graph transitively pulls in `process_posix`, so `std.c.waitpid` couldn't link); `std.c.waitpid` elsewhere.

## Facade
`pty.zig` gains a `.posix` backend, **Linux only**: the ioctl request numbers come from `std.os.linux.T`, which differ on macOS/BSD — those stay `.unsupported` until Phase D adds their codes (avoids a silently-broken backend).

## C3 — native tests (in `pty_posix.zig`)
Backend selection · open→resize · spawn `/bin/echo` + read marker · drive `/bin/sh`, child exit → `BrokenPipe`/0 + `wait` → `.exited = 7` · `outputAvailable` count · `cancelOutputRead` breaks a blocking read.

## Verification
- `zig test src/platform/pty_posix.zig -lc` → **23 passed, 1 skipped, 0 failed** (real syscalls, deterministic).
- `zig build` clean; `zig build test` green; `zig build test-full -Dtarget=x86_64-windows-gnu` compiles clean (pty_posix not in that graph).
- Reviewed for fork/exec/fd-leak/zombie/cancellation; both review findings (`_exit`, Linux-only mapping) fixed here.

Deferred (Phase D): macOS/BSD ioctl constants; `O_CLOEXEC`. Plan: `docs/superpowers/plans/2026-05-26-phase-c-posix-pty.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)