### PR TITLE
feat(diag): user-facing render debug mode for #46/#47 high-DPI glitch

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,7 @@ const windows_system_libraries = [_][]const u8{
     "winhttp",
     "ole32",
     "psapi",
+    "shcore", // GetDpiForMonitor for render diagnostics (per-monitor DPI)
 };
 
 const EmbeddedBrowserBackend = enum {
@@ -134,9 +135,10 @@ test "platform feature gates only enable windows artifacts on windows" {
 
 test "windows system libraries are gated by platform" {
     const windows = PlatformFeatures.forOs(.windows);
-    try std.testing.expectEqual(@as(usize, 12), systemLibrariesFor(windows).len);
+    try std.testing.expectEqual(@as(usize, 13), systemLibrariesFor(windows).len);
     try std.testing.expectEqualStrings("user32", systemLibrariesFor(windows)[0]);
     try std.testing.expectEqualStrings("psapi", systemLibrariesFor(windows)[11]);
+    try std.testing.expectEqualStrings("shcore", systemLibrariesFor(windows)[12]);
 
     const linux = PlatformFeatures.forOs(.linux);
     try std.testing.expectEqual(@as(usize, 0), systemLibrariesFor(linux).len);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -454,6 +454,81 @@ fn logFrameGeometryIfChanged(win: *window_backend.Window, fb_width: c_int, fb_he
     );
 }
 
+fn glDiagString(name: gpu.c.GLenum) []const u8 {
+    const ptr = gpu.glTable().GetString.?(name);
+    if (ptr == null) return "(null)";
+    return std.mem.span(@as([*:0]const u8, @ptrCast(ptr)));
+}
+
+/// Log GPU vendor/renderer/version and the backbuffer clear-alpha fact once,
+/// after the GL context + glad table are ready. Lets the analyst correlate
+/// glitches with a specific driver (AMD/Intel/NVIDIA) and confirm the alpha=1
+/// clear that feeds DWM composition.
+fn logGpuDiagnosticsOnce() void {
+    if (!render_diagnostics.enabled()) return;
+    if (g_gpu_diag_logged) return;
+    g_gpu_diag_logged = true;
+    render_diagnostics.log(
+        "gpu vendor=\"{s}\" renderer=\"{s}\" version=\"{s}\" glsl=\"{s}\" clear_alpha=1.0 dwm_frame_extend_top=-1",
+        .{
+            glDiagString(gpu.c.GL_VENDOR),
+            glDiagString(gpu.c.GL_RENDERER),
+            glDiagString(gpu.c.GL_VERSION),
+            glDiagString(gpu.c.GL_SHADING_LANGUAGE_VERSION),
+        },
+    );
+}
+
+threadlocal var g_gpu_diag_logged: bool = false;
+threadlocal var g_diag_last_vp: [4]gpu.c.GLint = .{ -1, -1, -1, -1 };
+threadlocal var g_diag_last_blend: [5]gpu.c.GLint = .{ -1, -1, -1, -1, -1 };
+threadlocal var g_diag_last_swap_client_w: i32 = -1;
+threadlocal var g_diag_last_swap_client_h: i32 = -1;
+
+/// Just before SwapBuffers, snapshot the *actual* GL viewport, re-read the
+/// client rect, and read the active blend state. Logged only when one of these
+/// changes (or when viewport diverges from the client size) so it stays
+/// analyzable. Targets the viewport/client-size desync (hypothesis ②) and the
+/// backbuffer-alpha blend mode (hypothesis ①).
+fn logSwapDiagnosticsIfChanged(win: *window_backend.Window, fb_width: c_int, fb_height: c_int) void {
+    if (!render_diagnostics.enabled()) return;
+    const gl = gpu.glTable();
+
+    var vp: [4]gpu.c.GLint = undefined;
+    gl.GetIntegerv.?(gpu.c.GL_VIEWPORT, &vp);
+
+    var blend: [5]gpu.c.GLint = undefined;
+    blend[0] = @intFromBool(gl.IsEnabled.?(gpu.c.GL_BLEND) != 0);
+    gl.GetIntegerv.?(gpu.c.GL_BLEND_SRC_RGB, &blend[1]);
+    gl.GetIntegerv.?(gpu.c.GL_BLEND_DST_RGB, &blend[2]);
+    gl.GetIntegerv.?(gpu.c.GL_BLEND_SRC_ALPHA, &blend[3]);
+    gl.GetIntegerv.?(gpu.c.GL_BLEND_DST_ALPHA, &blend[4]);
+
+    const client = window_backend.clientSize(win);
+    const vp_matches_client = (vp[2] == client.width and vp[3] == client.height);
+
+    const unchanged = std.mem.eql(gpu.c.GLint, &vp, &g_diag_last_vp) and
+        std.mem.eql(gpu.c.GLint, &blend, &g_diag_last_blend) and
+        client.width == g_diag_last_swap_client_w and
+        client.height == g_diag_last_swap_client_h;
+    if (unchanged) return;
+
+    g_diag_last_vp = vp;
+    g_diag_last_blend = blend;
+    g_diag_last_swap_client_w = client.width;
+    g_diag_last_swap_client_h = client.height;
+
+    render_diagnostics.log(
+        "swap viewport=({},{} {}x{}) client={}x{} fb={}x{} vp_matches_client={} blend_enabled={} blend_rgb=({},{}) blend_alpha=({},{})",
+        .{
+            vp[0],             vp[1],         vp[2],    vp[3],
+            client.width,      client.height, fb_width, fb_height,
+            vp_matches_client, blend[0] != 0, blend[1], blend[2],
+            blend[3],          blend[4],
+        },
+    );
+}
+
 fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
     gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
     gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -3585,6 +3660,7 @@ fn runMainLoop(self: *AppWindow) !void {
 
     gpu.glTable().Enable.?(gpu.c.GL_BLEND);
     gpu.glTable().BlendFunc.?(gpu.c.GL_SRC_ALPHA, gpu.c.GL_ONE_MINUS_SRC_ALPHA);
+    logGpuDiagnosticsOnce();
 
     // Register resize callback so newly exposed pixels get filled with the
     // terminal background during live resize. Some platform resize loops block
@@ -3671,6 +3747,7 @@ fn runMainLoop(self: *AppWindow) !void {
         }
 
         if (window_backend.consumeDpiChanged(win)) {
+            render_diagnostics.log("main-loop consume-dpi-changed dpi={} font_dpi={}", .{ window_backend.effectiveDpi(win), font.g_dpi });
             handleWindowDpiChanged(allocator, win, ft_lib, requested_font, requested_weight);
         }
 
@@ -3888,6 +3965,7 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         renderImePreedit(win, fb_width, fb_height);
 
+        logSwapDiagnosticsIfChanged(win, fb_width, fb_height);
         window_backend.swapBuffers(win);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -640,6 +640,12 @@ extern "user32" fn GetWindowLongW(hWnd: HWND, nIndex: INT) callconv(.winapi) LON
 extern "user32" fn SetWindowLongW(hWnd: HWND, nIndex: INT, dwNewLong: LONG) callconv(.winapi) LONG;
 extern "user32" fn MonitorFromWindow(hWnd: HWND, dwFlags: DWORD) callconv(.winapi) ?HMONITOR;
 extern "user32" fn GetMonitorInfoW(hMonitor: HMONITOR, lpmi: *MONITORINFO) callconv(.winapi) BOOL;
+extern "user32" fn EnumDisplayMonitors(hdc: ?HDC, lprcClip: ?*const RECT, lpfnEnum: MonitorEnumProc, dwData: LPARAM) callconv(.winapi) BOOL;
+extern "shcore" fn GetDpiForMonitor(hmonitor: HMONITOR, dpiType: c_int, dpiX: *UINT, dpiY: *UINT) callconv(.winapi) windows.HRESULT;
+
+const MonitorEnumProc = *const fn (HMONITOR, ?HDC, *RECT, LPARAM) callconv(.winapi) BOOL;
+const MONITOR_DEFAULTTONEAREST: DWORD = 2;
+const MDT_EFFECTIVE_DPI: c_int = 0;
 
 pub const HMONITOR = *opaque {};
 pub const MONITORINFO = extern struct {
@@ -1151,6 +1157,12 @@ pub const Window = struct {
             window.height = rect.bottom - rect.top;
         }
 
+        // Record the full monitor topology (bounds + per-monitor DPI) and the
+        // monitor this window started on — the baseline for diagnosing
+        // drag-between-monitors / high-DPI render glitches.
+        logDisplayTopology();
+        logWindowMonitor(hwnd, "startup");
+
         return window;
     }
 
@@ -1248,6 +1260,62 @@ fn enableDpiAwareness() void {
 fn currentSystemDpi() u32 {
     const dpi = GetDpiForSystem();
     return if (dpi == 0) 96 else dpi;
+}
+
+/// EnumDisplayMonitors callback: log every monitor's bounds + effective DPI.
+/// Used to record the full multi-monitor topology when diagnostics start, so
+/// the high-vs-low DPI pair behind drag-between-monitors glitches is visible.
+fn logMonitorEnumProc(hmon: HMONITOR, _: ?HDC, _: *RECT, _: LPARAM) callconv(.winapi) BOOL {
+    var mi = MONITORINFO{};
+    if (GetMonitorInfoW(hmon, &mi) == 0) return 1;
+    var dx: UINT = 0;
+    var dy: UINT = 0;
+    _ = GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dx, &dy);
+    render_diagnostics.log(
+        "monitor-enum rcMonitor=({},{} {}x{}) rcWork=({},{} {}x{}) dpi={}x{} primary={}",
+        .{
+            mi.rcMonitor.left,                      mi.rcMonitor.top,
+            mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top,
+            mi.rcWork.left,                         mi.rcWork.top,
+            mi.rcWork.right - mi.rcWork.left,       mi.rcWork.bottom - mi.rcWork.top,
+            dx,                                     dy,
+            (mi.dwFlags & 1) != 0, // MONITORINFOF_PRIMARY
+        },
+    );
+    return 1;
+}
+
+/// Log the full monitor topology once (e.g. at startup). No-op unless
+/// diagnostics are enabled.
+pub fn logDisplayTopology() void {
+    if (!render_diagnostics.enabled()) return;
+    _ = EnumDisplayMonitors(null, null, &logMonitorEnumProc, 0);
+}
+
+/// Log the monitor the given window currently sits on, tagged with `tag`
+/// (e.g. "dpi-change"). Useful to correlate a DPI transition with which
+/// physical monitor the window moved onto.
+pub fn logWindowMonitor(hwnd: HWND, tag: []const u8) void {
+    if (!render_diagnostics.enabled()) return;
+    const hmon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) orelse return;
+    var mi = MONITORINFO{};
+    if (GetMonitorInfoW(hmon, &mi) == 0) return;
+    var dx: UINT = 0;
+    var dy: UINT = 0;
+    _ = GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dx, &dy);
+    render_diagnostics.log(
+        "window-monitor {s} rcMonitor=({},{} {}x{}) mon_dpi={}x{} win_dpi={}",
+        .{
+            tag,
+            mi.rcMonitor.left,
+            mi.rcMonitor.top,
+            mi.rcMonitor.right - mi.rcMonitor.left,
+            mi.rcMonitor.bottom - mi.rcMonitor.top,
+            dx,
+            dy,
+            GetDpiForWindow(hwnd),
+        },
+    );
 }
 
 fn scaleFrom96(value: i32, dpi: u32) i32 {
@@ -1599,6 +1667,7 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
                 "WM_DPICHANGED end dpi={} win_dpi={} client={}x{} stored={}x{} size_changed={}",
                 .{ w.dpi, GetDpiForWindow(hwnd), rect.right - rect.left, rect.bottom - rect.top, w.width, w.height, w.size_changed },
             );
+            logWindowMonitor(hwnd, "dpi-change-end");
             return 0;
         },
         WM_ACTIVATE => {

--- a/src/config.zig
+++ b/src/config.zig
@@ -340,6 +340,11 @@ shell: []const u8 = platform_pty_command.default_shell_name,
 @"phantty-debug-fps": bool = false,
 @"phantty-debug-draw-calls": bool = false,
 @"phantty-debug-memory": bool = false,
+/// Write rendering/window-geometry diagnostics to
+/// `%APPDATA%\phantty\render-diagnostic.log` (Windows). Equivalent to setting
+/// the `PHANTTY_RENDER_DIAGNOSTICS=1` env var, but survives restarts and needs
+/// no shell setup — intended for users helping debug resize/DPI render glitches.
+@"phantty-debug-render": bool = false,
 
 // ============================================================================
 // Split pane configuration

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const image_decoder = @import("image_decoder.zig");
 const app_metadata = @import("app_metadata.zig");
 const platform_console = @import("platform/console.zig");
 const font_backend = @import("platform/font_backend.zig");
+const render_diagnostics = @import("render_diagnostics.zig");
 
 // ============================================================================
 // Font Discovery Test Functions (use --list-fonts or --test-font-discovery)
@@ -134,6 +135,10 @@ pub fn main() !void {
     } else {
         std.debug.print("No config file found, using defaults\n", .{});
     }
+
+    // Honor the config opt-in for render diagnostics before any window/GL
+    // exists, so the very first WM_SIZE/WM_DPICHANGED events are captured.
+    render_diagnostics.enableFromConfig(cfg.@"phantty-debug-render");
 
     // Create the App and run (first window on main thread, spawned windows on separate threads)
     var app = try App.init(allocator, cfg);

--- a/src/render_diagnostics.zig
+++ b/src/render_diagnostics.zig
@@ -1,6 +1,7 @@
 //! Opt-in rendering/window geometry diagnostics.
 //!
-//! Enable with `PHANTTY_RENDER_DIAGNOSTICS=1`. Logs go to
+//! Enable with either the `PHANTTY_RENDER_DIAGNOSTICS=1` env var or the
+//! `phantty-debug-render = true` config key (see `enableFromConfig`). Logs go to
 //! `%APPDATA%\phantty\render-diagnostic.log` on Windows, matching the config
 //! directory convention used elsewhere in the app.
 
@@ -16,7 +17,20 @@ threadlocal var g_file_open: bool = false;
 threadlocal var g_file: std.fs.File = undefined;
 threadlocal var g_start_ms: i64 = 0;
 
+/// Process-global override flipped on by the `phantty-debug-render` config key.
+/// Unlike the threadlocal env-var cache above, this is visible to every thread
+/// that logs, and is consulted before the (cached) env-var check so a config
+/// opt-in works even if a thread already evaluated the env var as off.
+var g_config_force = std.atomic.Value(bool).init(false);
+
+/// Force diagnostics on from config. Call once, as early as the config is
+/// available (before any window/GL exists) so startup geometry is captured.
+pub fn enableFromConfig(on: bool) void {
+    if (on) g_config_force.store(true, .seq_cst);
+}
+
 pub fn enabled() bool {
+    if (g_config_force.load(.seq_cst)) return true;
     if (g_checked) return g_enabled;
     g_checked = true;
 
@@ -105,4 +119,20 @@ test "render diagnostics enabled parser rejects empty and falsey values" {
     try std.testing.expect(!parseEnabledValue("false"));
     try std.testing.expect(!parseEnabledValue("off"));
     try std.testing.expect(!parseEnabledValue("anything-else"));
+}
+
+test "enableFromConfig forces diagnostics on regardless of cached env check" {
+    // Simulate a thread that already evaluated the env var as off.
+    g_checked = true;
+    g_enabled = false;
+    defer {
+        g_checked = false;
+        g_enabled = false;
+        g_config_force.store(false, .seq_cst);
+    }
+    try std.testing.expect(!enabled());
+    enableFromConfig(false); // no-op
+    try std.testing.expect(!enabled());
+    enableFromConfig(true);
+    try std.testing.expect(enabled());
 }


### PR DESCRIPTION
## Why

Issues #46 (drag window 2K↔1K monitor → render glitch, 100% reproducible) and #47 (resize on 2.8K screen → intermittent glitch) **do not reproduce on our hardware**. This PR adds instrumentation so affected users can hand back logs we can analyze.

**No render/behavior fix is applied** — this is Phase-1 evidence gathering only. In particular the blend func is left untouched; the logs will tell us whether the backbuffer-alpha-pollution hypothesis is real before we change anything.

## Activation (easy for end users)

```
phantty-debug-render = true
```

in the config file (ORs the existing `PHANTTY_RENDER_DIAGNOSTICS=1` env var). Enabled in `main.zig` before any window/GL exists, so the first DPI/resize events are captured. Logs to `%APPDATA%\phantty\render-diagnostic.log`.

## New signals → hypotheses

| Log line | Captures | Hypothesis |
|---|---|---|
| `gpu vendor=… renderer=… version=… clear_alpha=1.0 dwm_frame_extend_top=-1` | driver identity + confirms clear alpha=1 | driver correlation / alpha context |
| `monitor-enum …` (all monitors) | per-monitor DPI + bounds (the 2K/1K pair) | #46 topology |
| `window-monitor startup\|dpi-change-end …` | which monitor + DPI at each transition | #46 |
| `swap viewport=(…) client=… vp_matches_client=… blend_alpha=(src,dst)` | per-frame (change-gated) actual glViewport vs `GetClientRect` + active blend mode | viewport/client desync + backbuffer alpha |
| `main-loop consume-dpi-changed …` | marks the deferred-resize handoff in the timeline | DPICHANGED→resize timeline |

**Smoking guns for analysis:** `vp_matches_client=false` near a DPI change → viewport desync; `blend_alpha=(770,771)` is the alpha-pollution path (`GL_SRC_ALPHA`/`GL_ONE_MINUS_SRC_ALPHA`).

## Notes

- Adds `shcore` to linked libs for `GetDpiForMonitor` (build.zig lib-count test 12→13).
- For the #46 reporter: set the config key, reproduce the 2K→1K drag once, attach the log.

## Verification

- `zig build test` → pass (incl. new `render_diagnostics` config-override test)
- `zig build -Dtarget=x86_64-windows-gnu` → builds clean
- `zig build test-full -Dtarget=x86_64-windows-gnu` → pass
- `zig fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)