### PR TITLE
D-prep: neutralize GPU layer + Metal stub so the macOS port can start cold

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -190,7 +190,16 @@ mapping in guide §2 and §5.
 
 The actual port work, gated on Phase A (GPU spine) and Phase C (POSIX PTY).
 **Focus: macOS.** Per AGENTS.md, compare each track against Ghostty before
-starting. macOS reuses the platform-neutral core; it needs a Metal GPU backend,
+starting.
+
+> **D-prep landed** (see `docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md`):
+> the rendering layer is fully backend-neutral (no raw `gl.*`, guard-enforced), a
+> `gpu/metal/` stub skeleton mirrors `gpu/opengl/api.zig` (`@panic` bodies), the
+> project cross-compiles to `aarch64-macos`, and the macOS pty constants are in.
+> Starting macOS = fill in the `metal: TODO D1` stubs + the AppKit host + CoreText
+> against a building skeleton — no core/OpenGL refactoring needed on the Mac.
+
+macOS reuses the platform-neutral core; it needs a Metal GPU backend,
 an AppKit host, CoreText fonts, `_macos` siblings of the `_windows` platform
 services, and `.app` packaging. Ghostty reference: `src/renderer/metal/`,
 `macos/` (AppKit app + GhosttyKit), `src/font/discovery.zig` (CoreText),

--- a/docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md
+++ b/docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md
@@ -62,10 +62,23 @@ possible: add `_macos`/`_unsupported` fallbacks for any platform `<cap>` facade 
 so missing-symbol errors surface HERE, not on the Mac. Renderer/Metal bodies panic at runtime (stub) but
 must compile. Document the residual gaps the Mac must fill.
 
-## Done = "ready to start macOS cold"
-- No raw `gpu.glTable()` in the rendering layer (guard-enforced).
-- Neutral surface seam (drawable, not glGetProcAddress).
-- `gpu/metal/api.zig` contract compiles; `gpu.zig` `.metal` wired.
-- macOS pty constants in; `backendForOs(.macos)=.posix`.
-- `zig build -Dtarget=aarch64-macos` compiles the core+platform layer (renderer stubs panic at runtime).
-- Windows `zig build test-full` stays green throughout.
+## Done = "ready to start macOS cold" — ✅ COMPLETE
+- ✅ **①** No raw `gpu.glTable()`/`gpu.Context.gl` in the rendering layer — `ui_pipeline`/
+  `cell_pipeline`/`cell_renderer`/`post_process`/`Renderer`/`markdown`/`weixin`/`overlays/*`/
+  `titlebar`/`ai_chat`/`file_explorer`/`image`/`background`/`fbo`/`font.manager` all route
+  through `gpu.Pipeline`/`Buffer`/`Texture`/`Framebuffer`/`state`/`vertex`; AppWindow's
+  frame-loop render-state too. Guard-enforced (`gl_backend_guard.zig`, ①c). Residue:
+  AppWindow's `Context.init` seam + a diagnostics snapshot (host-specific).
+- ✅ **②** Surface seam documented as per-backend `Context.init` (GL loader vs `CAMetalLayer`)
+  in `window_backend.zig` + `gpu/metal/Context.zig`.
+- ✅ **③** `gpu/metal/*` stub mirrors `opengl/api.zig`'s full interface (`@panic("metal: TODO D1")`
+  bodies); `gpu.zig` `.metal` branch wired (lazy imports so glad isn't analyzed on Darwin).
+- ✅ **④** macOS pty ioctl constants OS-dispatched; `backendForOs(.macos)=.posix`.
+- ✅ **⑤** `zig build test-full -Dtarget=aarch64-macos` compiles (renderer/Metal/host bodies
+  are `@panic` stubs to fill on a Mac); platform facades' `_unsupported` macOS fallbacks sufficed.
+- ✅ Windows `zig build`/`test`/`test-full` + Linux native pty tests stayed green throughout.
+
+**Mac fill-in TODO** (the skeleton to flesh out on a Mac, all tagged `metal: TODO D1`):
+implement `gpu/metal/` bodies (Context/Buffer/Texture/Pipeline/Framebuffer/render_state/vertex
++ real MSL in `shaders.zig`), the AppKit host (`window_backend_macos.zig`) feeding a
+`CAMetalLayer` to `Context.init`, CoreText fonts, and the `_macos` platform-service impls.

--- a/docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md
+++ b/docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md
@@ -1,0 +1,71 @@
+# D-prep — make the codebase "ready to start the macOS port cold"
+
+Branch `feat/d-prep-gpu-neutralize`. All items are platform-neutral and
+**verifiable on Windows/Linux** (OpenGL behavior preserved). After these, the
+macOS work is pure fill-in against defined seams (Metal/AppKit/CoreText), with no
+need to refactor the core or OpenGL code on the Mac. Each step: `zig build` +
+`zig build test-full -Dtarget=x86_64-windows-gnu` green.
+
+## ① Render-layer de-GL-ification (the linchpin; prerequisite for ③/⑤)
+Today these call `gpu.glTable()` directly (raw GL): `ui_pipeline`(10), `cell_pipeline`(1+VAO builds),
+`cell_renderer`(3), `Renderer`(2), `post_process`(3), `markdown_preview_renderer`(1),
+`weixin_qr_renderer`(2), `overlays/{resize,scrollbar,startup_shortcuts}`(1 each), `AppWindow`(26 frame-loop).
+Distinct ops to absorb into the gpu interface: VAO/vertex-attrib (VertexAttribPointer/
+EnableVertexAttribArray/BindVertexArray/VertexAttribDivisor/Gen/DeleteVertexArrays),
+blend (Enable/Disable/BlendFunc), scissor (Enable/Disable/Scissor/IsEnabled/GetIntegerv SCISSOR_BOX),
+clear/viewport (Clear/ClearColor/Viewport/GetIntegerv VIEWPORT), draw (DrawArrays), and stray
+Uniform*/BindTexture/TexParameteri/BindBuffer/BufferSubData (→ existing Pipeline/Texture/Buffer methods).
+
+### ①a — extend the gpu interface (additive, opengl impl, build stays green)
+- **Vertex layout / VAO** — a declarative attribute layout so callers don't issue raw VAO ops.
+  e.g. `gpu.VertexAttr{ index, size, gl_type, normalized, stride, offset, divisor }` + a builder
+  `gpu.buildVertexArray(buffer, attrs) -> Vao` (OpenGL: GenVertexArrays + EnableVertexAttribArray +
+  VertexAttribPointer + VertexAttribDivisor; Metal: a vertex descriptor on the pipeline). Replaces the
+  VAO building in `ui_pipeline.buildQuadVao` + `cell_pipeline`'s 3 VAOs.
+- **Render state** — `gpu.setBlendEnabled(bool)`, `gpu.setBlendMode(.alpha|.premultiplied)` (the two
+  BlendFunc modes in use), `gpu.setScissor(rect)`/`gpu.clearScissor()`/`gpu.scissorState()` (save/restore
+  for markdown), `gpu.clear(rgba)`, `gpu.setViewport(x,y,w,h)`, `gpu.viewportSize() -> {w,h}`.
+- **Frame seam** — `gpu.beginFrame()` / `gpu.endFrame()` (OpenGL: no-op / flush hook; Metal: command
+  buffer + drawable). Lets the host drive frames without backend-specific calls. Present/swap stays host.
+- Put these on `gpu.zig` (dispatch to the active backend) or as backend-exported fns; opengl implements
+  them over `Context.gl`. `ui_pipeline.setBlendEnabled`/`beginClip`/`endClip` fold into these.
+
+### ①b… — rewire each file off `glTable()` onto the interface (one at a time, verified)
+Order: ui_pipeline → cell_pipeline (VAO builder) → cell_renderer → post_process → Renderer →
+markdown_preview → weixin_qr_renderer → overlays/{resize,scrollbar,startup_shortcuts} → AppWindow frame loop.
+Each: replace raw gl ops with the new gpu methods; `zig build` + windows `test-full` green.
+
+### ①c — strengthen `gl_backend_guard`
+Once a file is glTable-free, move it from the (documented) allowlist into the regression-locked set.
+Goal end-state: **no `gpu.glTable()` outside `src/renderer/gpu/opengl/`** (+ the host context-creation seam).
+
+## ② Host↔renderer surface seam
+`window_backend` exposes `glGetProcAddress` (GL-specific). Add a neutral surface/drawable seam so the
+renderer gets an abstract surface (Windows: still creates the GL context; Metal host: hands a `CAMetalLayer`).
+Design + verify on Windows.
+
+## ③ Metal backend interface contract + compiling stub
+Create `src/renderer/gpu/metal/api.zig` exporting the SAME surface as `opengl/api.zig` (Context/Buffer/
+Texture/Pipeline/Framebuffer/shaders/render-state/frame), with stub bodies (`@panic("metal: TODO D1")`)
+that **compile**. Replace `gpu.zig`'s `.metal => @compileError(...)` with `=> @import("metal/api.zig")`.
+This proves the neutral interface is implementable and gives the Mac work a fill-in target. Verify the
+opengl path is unaffected; the metal path only compiles under a Darwin target.
+
+## ④ macOS pty ioctl constants (quick, certain)
+`pty_posix.zig`: OS-dispatch the ioctl request numbers (macOS `TIOCSWINSZ=0x80087467`, `TIOCSCTTY=0x20007461`,
+`FIONREAD=0x4004667f` differ from `std.os.linux.T`); add `O_CLOEXEC` to master + cancel-pipe fds. Then
+`pty.zig` `backendForOs(.macos) => .posix`. Can't run on Linux, but the values are fixed → Mac-ready.
+
+## ⑤ macOS cross-compile reaches the platform layer
+With ③'s metal stub compiling, get `zig build -Dtarget=aarch64-macos` (and `test`) to compile as far as
+possible: add `_macos`/`_unsupported` fallbacks for any platform `<cap>` facade that only has `_windows`,
+so missing-symbol errors surface HERE, not on the Mac. Renderer/Metal bodies panic at runtime (stub) but
+must compile. Document the residual gaps the Mac must fill.
+
+## Done = "ready to start macOS cold"
+- No raw `gpu.glTable()` in the rendering layer (guard-enforced).
+- Neutral surface seam (drawable, not glGetProcAddress).
+- `gpu/metal/api.zig` contract compiles; `gpu.zig` `.metal` wired.
+- macOS pty constants in; `backendForOs(.macos)=.posix`.
+- `zig build -Dtarget=aarch64-macos` compiles the core+platform layer (renderer stubs panic at runtime).
+- Windows `zig build test-full` stays green throughout.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -394,8 +394,7 @@ const RemoteAiAgentOpenRequest = struct {
 /// background image (if any) over the cleared color. The current viewport
 /// must already cover (0,0)..(fb_w,fb_h).
 fn clearWithBackground(fb_w: c_int, fb_h: c_int) void {
-    gpu.glTable().ClearColor.?(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
-    gpu.glTable().Clear.?(gpu.c.GL_COLOR_BUFFER_BIT);
+    gpu.state.clear(g_theme.background[0], g_theme.background[1], g_theme.background[2], 1.0);
     background_image.drawFullscreen(@floatFromInt(fb_w), @floatFromInt(fb_h));
 }
 
@@ -530,7 +529,7 @@ fn logSwapDiagnosticsIfChanged(win: *window_backend.Window, fb_width: c_int, fb_
 }
 
 fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
-    gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
     gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
     clearWithBackground(fb_width, fb_height);
     titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -1404,7 +1403,7 @@ fn onPlatformResize(width: i32, height: i32) void {
                 }
                 if (needs_rebuild) cell_renderer.rebuildCells(rend);
 
-                gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+                gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                 gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
                 clearWithBackground(fb_width, fb_height);
 
@@ -1420,7 +1419,7 @@ fn onPlatformResize(width: i32, height: i32) void {
             }
         } else {
             // Multiple splits: render each surface in its own viewport
-            gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+            gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
             gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
             clearWithBackground(fb_width, fb_height);
 
@@ -1435,7 +1434,7 @@ fn onPlatformResize(width: i32, height: i32) void {
                 const rend = &rect.surface.surface_renderer;
 
                 const viewport_y = fb_height - rect.y - rect.height;
-                gpu.glTable().Viewport.?(rect.x, viewport_y, rect.width, rect.height);
+                gpu.state.setViewport(rect.x, viewport_y, rect.width, rect.height);
                 gpu.gl_init.setProjection(@floatFromInt(rect.width), @floatFromInt(rect.height));
 
                 {
@@ -1462,12 +1461,12 @@ fn onPlatformResize(width: i32, height: i32) void {
             }
 
             // Restore full viewport for dividers
-            gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+            gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
             gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
             overlays.renderSplitDividers(active_tab, content_x, content_y, content_w, content_h, @floatFromInt(fb_height));
         }
     } else {
-        gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+        gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
         gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
         clearWithBackground(fb_width, fb_height);
         titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -2848,7 +2847,8 @@ fn clearIconFont(allocator: std.mem.Allocator) void {
         font.g_icon_atlas = null;
     }
     if (font.g_icon_atlas_texture != 0) {
-        gpu.glTable().DeleteTextures.?(1, &font.g_icon_atlas_texture);
+        var t = gpu.Texture.fromHandle(font.g_icon_atlas_texture);
+        t.destroy();
         font.g_icon_atlas_texture = 0;
         font.g_icon_atlas_modified = 0;
     }
@@ -2878,7 +2878,8 @@ fn clearTitlebarFont(allocator: std.mem.Allocator) void {
         font.g_titlebar_atlas = null;
     }
     if (font.g_titlebar_atlas_texture != 0) {
-        gpu.glTable().DeleteTextures.?(1, &font.g_titlebar_atlas_texture);
+        var t = gpu.Texture.fromHandle(font.g_titlebar_atlas_texture);
+        t.destroy();
         font.g_titlebar_atlas_texture = 0;
         font.g_titlebar_atlas_modified = 0;
     }
@@ -3273,8 +3274,6 @@ fn renderImePreedit(win: *window_backend.Window, fb_width: i32, fb_height: i32) 
     const bg = g_theme.selection_background;
     const fg = g_theme.selection_foreground orelse g_theme.foreground;
 
-    gpu.glTable().UseProgram.?(gpu.gl_init.shader_program);
-    gpu.glTable().BindVertexArray.?(gpu.gl_init.vao);
     gpu.gl_init.renderQuad(x, y, width, height, bg);
     gpu.gl_init.renderQuad(x, y, width, @max(1.0, @as(f32, @floatFromInt(font.box_thickness))), g_theme.cursor_color);
 
@@ -3285,9 +3284,6 @@ fn renderImePreedit(win: *window_backend.Window, fb_width: i32, fb_height: i32) 
         cell_renderer.renderChar(@intCast(cp), cursor_x, y, fg);
         cursor_x += font.cell_width;
     }
-
-    gpu.glTable().BindVertexArray.?(0);
-    gpu.glTable().BindTexture.?(gpu.c.GL_TEXTURE_2D, 0);
 }
 
 /// Handle a bell notification from the terminal.
@@ -3495,7 +3491,8 @@ fn runMainLoop(self: *AppWindow) !void {
             font.g_icon_atlas = null;
         }
         if (font.g_icon_atlas_texture != 0) {
-            gpu.glTable().DeleteTextures.?(1, &font.g_icon_atlas_texture);
+            var t = gpu.Texture.fromHandle(font.g_icon_atlas_texture);
+            t.destroy();
             font.g_icon_atlas_texture = 0;
         }
 
@@ -3508,7 +3505,8 @@ fn runMainLoop(self: *AppWindow) !void {
             font.g_titlebar_atlas = null;
         }
         if (font.g_titlebar_atlas_texture != 0) {
-            gpu.glTable().DeleteTextures.?(1, &font.g_titlebar_atlas_texture);
+            var t = gpu.Texture.fromHandle(font.g_titlebar_atlas_texture);
+            t.destroy();
             font.g_titlebar_atlas_texture = 0;
         }
     }
@@ -3658,8 +3656,8 @@ fn runMainLoop(self: *AppWindow) !void {
         }
     }
 
-    gpu.glTable().Enable.?(gpu.c.GL_BLEND);
-    gpu.glTable().BlendFunc.?(gpu.c.GL_SRC_ALPHA, gpu.c.GL_ONE_MINUS_SRC_ALPHA);
+    gpu.state.setBlendEnabled(true);
+    gpu.state.setBlendMode(.alpha);
     logGpuDiagnosticsOnce();
 
     // Register resize callback so newly exposed pixels get filled with the
@@ -3853,7 +3851,7 @@ fn runMainLoop(self: *AppWindow) !void {
                     }
                     if (needs_rebuild) cell_renderer.rebuildCells(rend);
 
-                    gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+                    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                     gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
                     clearWithBackground(fb_width, fb_height);
 
@@ -3872,7 +3870,7 @@ fn runMainLoop(self: *AppWindow) !void {
                 }
             } else {
                 // Multiple splits: render with scissor/viewport per surface
-                gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+                gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                 gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
                 clearWithBackground(fb_width, fb_height);
 
@@ -3891,7 +3889,7 @@ fn runMainLoop(self: *AppWindow) !void {
                         // Set viewport to this split's region
                         // OpenGL viewport: (x, y, width, height) where y is from bottom
                         const viewport_y = fb_height - rect.y - rect.height;
-                        gpu.glTable().Viewport.?(rect.x, viewport_y, rect.width, rect.height);
+                        gpu.state.setViewport(rect.x, viewport_y, rect.width, rect.height);
 
                         // Set projection for this viewport size
                         gpu.gl_init.setProjection(@floatFromInt(rect.width), @floatFromInt(rect.height));
@@ -3931,7 +3929,7 @@ fn runMainLoop(self: *AppWindow) !void {
                     }
 
                     // Restore full viewport for dividers
-                    gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+                    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                     gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
 
                     // Draw split dividers
@@ -3939,7 +3937,7 @@ fn runMainLoop(self: *AppWindow) !void {
                 }
             }
         } else if (!post_process.g_post_enabled) {
-            gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+            gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
             gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
             clearWithBackground(fb_width, fb_height);
             titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -3948,7 +3946,7 @@ fn runMainLoop(self: *AppWindow) !void {
             file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         }
 
-        gpu.glTable().Viewport.?(0, 0, fb_width, fb_height);
+        gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
         gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderBrowserUrlBar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderStartupShortcutsOverlay(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);

--- a/src/platform/pty.zig
+++ b/src/platform/pty.zig
@@ -10,11 +10,11 @@ pub const Backend = enum {
 pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
-        // Only Linux is implemented + verified. The POSIX backend uses
-        // std.os.linux ioctl request numbers (TIOCSWINSZ/TIOCSCTTY/FIONREAD),
-        // which differ on macOS and the BSDs — those stay unsupported until
-        // their request codes are added (Phase D, on a machine that can run them).
-        .linux => .posix,
+        // Linux (verified) + macOS (OS-dispatched ioctl constants in
+        // pty_posix.zig, compile-checked here, runnable on a Mac). The BSDs use
+        // the same IOC scheme as macOS but their exact request codes are
+        // unverified, so they stay unsupported until added on real hardware.
+        .linux, .macos => .posix,
         else => .unsupported,
     };
 }
@@ -78,7 +78,8 @@ test "platform pty owns pipe IO operations" {
 test "platform pty selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
     try std.testing.expectEqual(Backend.posix, backendForOs(.linux));
-    // macOS/BSD use different ioctl request codes; unsupported until Phase D.
-    try std.testing.expectEqual(Backend.unsupported, backendForOs(.macos));
+    try std.testing.expectEqual(Backend.posix, backendForOs(.macos));
+    // BSD IOC codes unverified; wasi has no pty.
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.freebsd));
     try std.testing.expectEqual(Backend.unsupported, backendForOs(.wasi));
 }

--- a/src/platform/pty_posix.zig
+++ b/src/platform/pty_posix.zig
@@ -1,8 +1,10 @@
-//! POSIX PTY backend (Linux only for now).
+//! POSIX PTY backend (Linux + macOS).
 //!
-//! The ioctl request numbers come from `std.os.linux.T`, so macOS and the BSDs
-//! (which use different request codes) are routed to `.unsupported` by
-//! `pty.zig`'s `backendForOs` until those constants are added in Phase D.
+//! The ioctl request numbers are OS-dispatched: Linux uses `std.os.linux.T`,
+//! macOS uses the BSD IOC-encoded constants below (verified values, but the
+//! macOS path is compile-checked, not run, on the Linux dev box). The BSDs use
+//! the same IOC scheme as macOS but their exact codes are unverified, so
+//! `pty.zig`'s `backendForOs` still routes them to `.unsupported`.
 //!
 //! Mirrors the `Pty` API of `pty_windows.zig`. Uses libc (link with `-lc`):
 //! `posix_openpt`/`grantpt`/`unlockpt`/`ptsname_r` to allocate a master fd plus
@@ -16,10 +18,22 @@ const pty_command = @import("pty_command.zig");
 
 const fd_t = c.fd_t;
 
-/// ioctl request numbers (per-arch Linux values). macOS/BSD differ, hence the
-/// Linux-only `backendForOs` mapping in pty.zig.
-const T = std.os.linux.T;
+/// ioctl request numbers, OS-dispatched. Linux: `std.os.linux.T` (per-arch).
+/// macOS: BSD `_IOW('t',103,struct winsize)` etc. — fixed values. Untyped so
+/// they coerce to whatever `c.ioctl`'s request param is on each target (the
+/// macOS values exceed i32, and macOS `ioctl` takes `c_ulong`).
+const T = switch (builtin.os.tag) {
+    .macos => struct {
+        pub const IOCSWINSZ = 0x80087467; // _IOW('t', 103, struct winsize)
+        pub const IOCSCTTY = 0x20007461; // _IO('t', 97)
+        pub const FIONREAD = 0x4004667f; // _IOR('f', 127, int)
+    },
+    else => std.os.linux.T,
+};
 
+// C `ioctl` takes `unsigned long` for the request on both Linux and macOS;
+// std.c.ioctl types it as c_int, which can't hold the macOS IOC codes (> i32).
+extern "c" fn ioctl(fd: fd_t, request: c_ulong, ...) c_int;
 extern "c" fn posix_openpt(oflag: c_int) c_int;
 extern "c" fn grantpt(fd: c_int) c_int;
 extern "c" fn unlockpt(fd: c_int) c_int;
@@ -99,7 +113,7 @@ pub const Pty = struct {
 
         // Apply the initial window size to the master.
         var os_ws = osWinsize(size);
-        _ = c.ioctl(master, T.IOCSWINSZ, &os_ws);
+        _ = ioctl(master, T.IOCSWINSZ, &os_ws);
 
         return self;
     }
@@ -125,7 +139,7 @@ pub const Pty = struct {
 
     pub fn setSize(self: *Pty, s: winsize) !void {
         var os_ws = osWinsize(s);
-        if (c.ioctl(self.master, T.IOCSWINSZ, &os_ws) != 0) {
+        if (ioctl(self.master, T.IOCSWINSZ, &os_ws) != 0) {
             return error.SetSizeFailed;
         }
         self.size = s;
@@ -200,7 +214,7 @@ pub const Pty = struct {
 
     pub fn outputAvailable(self: *Pty) ?usize {
         var n: c_int = 0;
-        if (c.ioctl(self.master, T.FIONREAD, &n) != 0) return null;
+        if (ioctl(self.master, T.FIONREAD, &n) != 0) return null;
         if (n < 0) return null;
         return @intCast(n);
     }
@@ -239,7 +253,7 @@ fn childExec(
     if (slave < 0) _exit(127);
 
     // Claim the slave as the controlling terminal for this session.
-    _ = c.ioctl(slave, T.IOCSCTTY, @as(c_int, 0));
+    _ = ioctl(slave, T.IOCSCTTY, @as(c_int, 0));
 
     _ = c.dup2(slave, 0);
     _ = c.dup2(slave, 1);
@@ -301,11 +315,12 @@ fn parseArgv(
 
 const backend_facade = @import("pty.zig");
 
-test "posix backend selected for linux; macos/bsd unsupported until Phase D" {
+test "posix backend selected for linux + macos; bsd/wasi unsupported" {
     try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.linux));
+    try std.testing.expectEqual(backend_facade.Backend.posix, backend_facade.backendForOs(.macos));
     try std.testing.expectEqual(backend_facade.Backend.windows, backend_facade.backendForOs(.windows));
-    // macOS/BSD ioctl request codes differ from std.os.linux.T — see backendForOs.
-    try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.macos));
+    // BSD IOC codes are unverified; wasi has no pty.
+    try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.freebsd));
     try std.testing.expectEqual(backend_facade.Backend.unsupported, backend_facade.backendForOs(.wasi));
 }
 

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -77,6 +77,11 @@ pub const EventHandlers = struct {
 };
 
 pub const setGlobalWindow = impl.setGlobalWindow;
+/// Renderer surface seam (host → GPU backend). This is OpenGL-shaped: the host
+/// supplies a GL proc-address loader, which `gpu.Context.init` consumes. The
+/// seam is per-backend by design — a macOS/AppKit host pairs with the Metal
+/// backend and hands `gpu.Context.init` a `CAMetalLayer` instead (see the
+/// surface-seam note in `gpu/metal/Context.zig`); it does not call this.
 pub const glGetProcAddress = impl.glGetProcAddress;
 
 pub fn create(allocator: std.mem.Allocator, options: CreateOptions) !Window {

--- a/src/renderer/Renderer.zig
+++ b/src/renderer/Renderer.zig
@@ -12,8 +12,8 @@
 /// 3. No scissor needed - each surface has isolated render target
 ///
 /// Note: the GL context is owned by the GPU backend (`renderer/gpu/`); GL
-/// operations run against `AppWindow.gpu.glTable()`. Renderer just stores the
-/// handles.
+/// operations route through the gpu primitives (gpu.state, gpu.Texture, etc.).
+/// Renderer just stores the handles.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ghostty_vt = @import("ghostty-vt");
@@ -301,9 +301,10 @@ pub fn fboPixelBytes(self: *const Renderer) usize {
 }
 
 fn deinitKittyResources(self: *Renderer) void {
-    const gl = AppWindow.gpu.glTable();
     for (self.kitty_textures.items) |*tex| {
-        if (tex.texture != 0) gl.DeleteTextures.?(1, &tex.texture);
+        var t = AppWindow.gpu.Texture.fromHandle(tex.texture);
+        t.destroy();
+        tex.texture = 0;
     }
     self.kitty_textures.deinit(self.surface.allocator);
 

--- a/src/renderer/cell_pipeline.zig
+++ b/src/renderer/cell_pipeline.zig
@@ -24,7 +24,6 @@ pub threadlocal var quad: Buffer = .{ .handle = 0, .target = 0 };
 /// On shader link failure a pipeline's `program` is 0 (draws are guarded on
 /// `program != 0`); its VAO is still owned and released by `deinit()`.
 pub fn init() void {
-    const gl = gpu.glTable();
     const shaders = gpu.shaders;
 
     // Shared unit quad (triangle strip: 4 verts)
@@ -38,73 +37,78 @@ pub fn init() void {
     quad.uploadData(std.mem.sliceAsBytes(quad_verts[0..]), c.GL_STATIC_DRAW);
 
     // --- BG VAO ---
-    var bg_vao: c.GLuint = 0;
-    gl.GenVertexArrays.?(1, &bg_vao);
+    // attr 0 (loc=0, count=2): position xy from quad buffer (divisor=0)
+    // attr 1 (loc=1, count=2): grid_col/grid_row from bg_instances (divisor=1)
+    // attr 2 (loc=2, count=3): r/g/b from bg_instances (divisor=1)
+    // attr 3 (loc=3, count=1): alpha from bg_instances (divisor=1)
     bg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
-    gl.BindVertexArray.?(bg_vao);
-    quad.bind();
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
     bg_instances.allocate(@sizeOf(Renderer.CellBg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
-    const bg_stride: c.GLsizei = @sizeOf(Renderer.CellBg);
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 3, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 1, c.GL_FLOAT, c.GL_FALSE, bg_stride, @ptrFromInt(5 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-    gl.BindVertexArray.?(0);
+    const bg_stride = @sizeOf(Renderer.CellBg);
+    const bg_vao = gpu.vertex.buildVertexArray(&.{
+        .{
+            .buffer = quad,
+            .attrs = &.{
+                .{ .loc = 0, .count = 2, .stride = 2 * @sizeOf(f32), .offset = 0 },
+            },
+        },
+        .{
+            .buffer = bg_instances,
+            .attrs = &.{
+                .{ .loc = 1, .count = 2, .stride = bg_stride, .offset = 0,                  .divisor = 1 },
+                .{ .loc = 2, .count = 3, .stride = bg_stride, .offset = 2 * @sizeOf(f32),   .divisor = 1 },
+                .{ .loc = 3, .count = 1, .stride = bg_stride, .offset = 5 * @sizeOf(f32),   .divisor = 1 },
+            },
+        },
+    });
 
     // --- FG VAO ---
-    var fg_vao: c.GLuint = 0;
-    gl.GenVertexArrays.?(1, &fg_vao);
+    // attr 0 (loc=0, count=2): position xy from quad buffer (divisor=0)
+    // attr 1 (loc=1, count=2): grid_col/grid_row (divisor=1)
+    // attr 2 (loc=2, count=4): glyph_x/y/w/h (divisor=1)
+    // attr 3 (loc=3, count=4): uv_left/top/right/bottom (divisor=1)
+    // attr 4 (loc=4, count=3): r/g/b (divisor=1)
     fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
-    gl.BindVertexArray.?(fg_vao);
-    quad.bind();
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
     fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
-    const fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg);
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-    gl.EnableVertexAttribArray.?(4);
-    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(4, 1);
-    gl.BindVertexArray.?(0);
+    const fg_stride = @sizeOf(Renderer.CellFg);
+    const fg_vao = gpu.vertex.buildVertexArray(&.{
+        .{
+            .buffer = quad,
+            .attrs = &.{
+                .{ .loc = 0, .count = 2, .stride = 2 * @sizeOf(f32), .offset = 0 },
+            },
+        },
+        .{
+            .buffer = fg_instances,
+            .attrs = &.{
+                .{ .loc = 1, .count = 2, .stride = fg_stride, .offset = 0,                   .divisor = 1 },
+                .{ .loc = 2, .count = 4, .stride = fg_stride, .offset = 2  * @sizeOf(f32),   .divisor = 1 },
+                .{ .loc = 3, .count = 4, .stride = fg_stride, .offset = 6  * @sizeOf(f32),   .divisor = 1 },
+                .{ .loc = 4, .count = 3, .stride = fg_stride, .offset = 10 * @sizeOf(f32),   .divisor = 1 },
+            },
+        },
+    });
 
     // --- Color FG VAO (same layout as FG) ---
-    var color_fg_vao: c.GLuint = 0;
-    gl.GenVertexArrays.?(1, &color_fg_vao);
     color_fg_instances = Buffer.init(c.GL_ARRAY_BUFFER);
-    gl.BindVertexArray.?(color_fg_vao);
-    quad.bind();
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 2 * @sizeOf(f32), null);
     color_fg_instances.allocate(@sizeOf(Renderer.CellFg) * Renderer.MAX_CELLS, c.GL_STREAM_DRAW);
-    const color_fg_stride: c.GLsizei = @sizeOf(Renderer.CellFg); // same CellFg layout as fg
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(0));
-    gl.VertexAttribDivisor.?(1, 1);
-    gl.EnableVertexAttribArray.?(2);
-    gl.VertexAttribPointer.?(2, 4, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(2 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(2, 1);
-    gl.EnableVertexAttribArray.?(3);
-    gl.VertexAttribPointer.?(3, 4, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(6 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(3, 1);
-    gl.EnableVertexAttribArray.?(4);
-    gl.VertexAttribPointer.?(4, 3, c.GL_FLOAT, c.GL_FALSE, color_fg_stride, @ptrFromInt(10 * @sizeOf(f32)));
-    gl.VertexAttribDivisor.?(4, 1);
-    gl.BindVertexArray.?(0);
+    const color_fg_stride = @sizeOf(Renderer.CellFg); // same CellFg layout as fg
+    const color_fg_vao = gpu.vertex.buildVertexArray(&.{
+        .{
+            .buffer = quad,
+            .attrs = &.{
+                .{ .loc = 0, .count = 2, .stride = 2 * @sizeOf(f32), .offset = 0 },
+            },
+        },
+        .{
+            .buffer = color_fg_instances,
+            .attrs = &.{
+                .{ .loc = 1, .count = 2, .stride = color_fg_stride, .offset = 0,                   .divisor = 1 },
+                .{ .loc = 2, .count = 4, .stride = color_fg_stride, .offset = 2  * @sizeOf(f32),   .divisor = 1 },
+                .{ .loc = 3, .count = 4, .stride = color_fg_stride, .offset = 6  * @sizeOf(f32),   .divisor = 1 },
+                .{ .loc = 4, .count = 3, .stride = color_fg_stride, .offset = 10 * @sizeOf(f32),   .divisor = 1 },
+            },
+        },
+    });
 
     bg = Pipeline.init(shaders.bg_vertex_source, shaders.bg_fragment_source, bg_vao);
     fg = Pipeline.init(shaders.fg_vertex_source, shaders.fg_fragment_source, fg_vao);

--- a/src/renderer/cell_renderer.zig
+++ b/src/renderer/cell_renderer.zig
@@ -14,6 +14,7 @@ const font = AppWindow.font;
 const tab = AppWindow.tab;
 const gpu = AppWindow.gpu;
 const gl_init = gpu.gl_init;
+const ui_pipeline = @import("ui_pipeline.zig");
 const cell_pipeline = @import("cell_pipeline.zig");
 const image_renderer = @import("image_renderer.zig");
 const cell_geometry = @import("cell_geometry.zig");
@@ -37,8 +38,6 @@ pub threadlocal var g_current_render_surface: ?*Surface = null;
 /// Render a single character at the given position using the text shader.
 /// Used for UI text (placeholder messages, overlays), not terminal cells.
 pub fn renderChar(codepoint: u32, x: f32, y: f32, color: [3]f32) void {
-    const gl = AppWindow.gpu.glTable();
-
     // Skip control characters
     if (codepoint < 32) return;
 
@@ -56,22 +55,12 @@ pub fn renderChar(codepoint: u32, x: f32, y: f32, color: [3]f32) void {
     const atlas_size = if (font.g_atlas) |a| @as(f32, @floatFromInt(a.size)) else 512.0;
     const uv = font.glyphUV(ch.region, atlas_size);
 
-    const vertices = [6][4]f32{
-        .{ x0, y0 + h, uv.u0, uv.v0 },
-        .{ x0, y0, uv.u0, uv.v1 },
-        .{ x0 + w, y0, uv.u1, uv.v1 },
-        .{ x0, y0 + h, uv.u0, uv.v0 },
-        .{ x0 + w, y0, uv.u1, uv.v1 },
-        .{ x0 + w, y0 + h, uv.u1, uv.v0 },
-    };
-
-    gl.Uniform3f.?(gl.GetUniformLocation.?(gl_init.shader_program, "textColor"), color[0], color[1], color[2]);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, font.g_atlas_texture);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, gl_init.vbo);
-    gl.BufferSubData.?(c.GL_ARRAY_BUFFER, 0, @sizeOf(@TypeOf(vertices)), &vertices);
-    gl.BindBuffer.?(c.GL_ARRAY_BUFFER, 0);
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
-    gl_init.g_draw_call_count += 1;
+    ui_pipeline.drawGlyph(
+        .{ .x = x0, .y = y0, .w = w, .h = h },
+        .{ .u0 = uv.u0, .v0 = uv.v0, .u1 = uv.u1, .v1 = uv.v1 },
+        font.g_atlas_texture,
+        color,
+    );
 }
 
 /// Update terminal cells for a specific surface in a split tree.
@@ -394,7 +383,6 @@ pub fn rebuildCells(rend: *Renderer) void {
 /// Draw terminal grid from CPU cell buffers. Does NOT require the terminal
 /// mutex — all terminal state was already read by updateTerminalCells().
 pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offset_y: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const g_theme = AppWindow.g_theme;
 
     image_renderer.draw(rend, window_height, offset_x, offset_y, .below_bg);
@@ -434,7 +422,7 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
     // --- Draw color emoji cells (premultiplied alpha blend) ---
     if (rend.color_fg_cell_count > 0 and cell_pipeline.color_fg.program != 0) {
         // Color emoji bitmaps are premultiplied-alpha, so use (ONE, 1-SRC_ALPHA).
-        gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
+        gpu.state.setBlendMode(.premultiplied);
         const p = cell_pipeline.color_fg;
         p.use();
         p.setVec2("cellSize", font.cell_width, font.cell_height);
@@ -448,7 +436,7 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
         p.drawArraysInstanced(c.GL_TRIANGLE_STRIP, 0, 4, @intCast(rend.color_fg_cell_count));
         gl_init.g_draw_call_count += 1;
         // Restore standard blend for the cursor/titlebar draws that follow.
-        gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+        gpu.state.setBlendMode(.alpha);
     }
 
     image_renderer.draw(rend, window_height, offset_x, offset_y, .above_text);
@@ -461,9 +449,6 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
         if (rend.cached_cursor_effective) |style| {
             const px = offset_x + @as(f32, @floatFromInt(rend.cached_cursor_x)) * font.cell_width;
             const py = window_height - offset_y - ((@as(f32, @floatFromInt(rend.cached_cursor_y)) + 1) * font.cell_height);
-
-            gl.UseProgram.?(gl_init.shader_program);
-            gl.BindVertexArray.?(gl_init.vao);
 
             const cursor_color = g_theme.cursor_color;
             const cursor_thickness: f32 = @max(2.0, @as(f32, @floatFromInt(font.box_thickness)));
@@ -486,18 +471,12 @@ pub fn drawCells(rend: *const Renderer, window_height: f32, offset_x: f32, offse
         }
     }
 
-    gl.BindVertexArray.?(0);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, 0);
 }
 
 fn drawUrlUnderline(rend: *const Renderer, window_height: f32, offset_x: f32, offset_y: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const thickness: f32 = @max(1.0, @as(f32, @floatFromInt(font.box_thickness)));
     const underline_y_offset: f32 = @max(2.0, thickness);
     const color = AppWindow.g_theme.cursor_color;
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.BindVertexArray.?(gl_init.vao);
 
     for (0..rend.snap_rows) |row| {
         var col: usize = 0;

--- a/src/renderer/gpu/gl_backend_guard.zig
+++ b/src/renderer/gpu/gl_backend_guard.zig
@@ -1,31 +1,32 @@
 //! Compile-time guard: raw OpenGL belongs only to the gpu/opengl backend.
 //!
-//! Phase A / A6. Two invariants, enforced as comptime source-text scans
-//! (mirroring `platform/apprt_win32_guard.zig`) so they run on every build of
-//! the test graph without compiling anything backend-specific. `test_main.zig`
-//! imports this module so the checks execute under `zig build test`/`test-full`.
+//! Phase A / A6 + D-prep ①c. Comptime source-text scans (mirroring
+//! `platform/apprt_win32_guard.zig`), imported by `test_main.zig` so they run
+//! under `zig build test`/`test-full`.
 //!
 //!   1. **glad containment** — no app/renderer/font file outside
-//!      `src/renderer/gpu/opengl/` may `@cInclude("glad/gl.h")`. The raw GPU API
-//!      header is included only by the backend; everyone else uses `gpu.c`.
-//!      `AppWindow.zig` is included here — the host must not pull in glad either.
-//!   2. **raw-GL regression-lock** — the renderer feature files decoupled in
-//!      A3/A4 must not re-acquire a raw GL function table via `gpu.glTable()`.
+//!      `src/renderer/gpu/opengl/` may `@cInclude("glad/gl.h")`. Everyone else
+//!      uses `gpu.c`. `AppWindow.zig` included (the host must not pull in glad).
+//!   2. **raw-GL lock** — the renderer/presentation layer must not touch the raw
+//!      GL function table, neither via `gpu.glTable()` nor by reaching into
+//!      `gpu.Context.gl` directly. All GPU work goes through the gpu interface
+//!      (`gpu.Pipeline`/`Buffer`/`Texture`/`Framebuffer`/`state`/`vertex`), so a
+//!      Metal backend can implement the same calls. This now covers the whole
+//!      rendering layer (D-prep ① neutralized `ui_pipeline`/`cell_pipeline`/
+//!      `cell_renderer`/`post_process`/`Renderer`/`markdown`/`weixin`/`overlays/*`).
 //!
-//! Known residue (intentionally NOT in `gl_table_free`): the GL presentation
-//! layer (`ui_pipeline`, `cell_pipeline`), render coordination (`Renderer`,
-//! `cell_renderer`, `post_process`), and the not-yet-extracted plumbing in
-//! `markdown_preview_renderer`, `weixin_qr_renderer`, and
-//! `overlays/{resize,scrollbar,startup_shortcuts}` still call `gpu.glTable()`.
-//! They hold the table from the gpu module (no glad include); the gpu primitive
-//! set grows to absorb them. None of them is permitted a glad `@cInclude`.
+//! Residue (intentionally NOT locked): `AppWindow.zig` still calls `glTable()`
+//! for the GL-context-creation seam (`Context.init` via `glGetProcAddress`) and a
+//! render-diagnostics snapshot — both host-specific, replaced by the macOS host /
+//! generalized by the surface seam in Phase D.
 
 const std = @import("std");
 
 const glad_include = "@cInclude(\"glad/gl.h\")";
 const gl_table_call = "glTable(";
+const gl_context_bypass = "gpu.Context.gl";
 
-// Single embed per file; the two rule lists reference these.
+// Single embed per file; the rule lists reference these.
 const src_app_window = @embedFile("../../AppWindow.zig");
 const src_font_manager = @embedFile("../../font/manager.zig");
 const src_titlebar = @embedFile("../titlebar.zig");
@@ -38,9 +39,12 @@ const src_background = @embedFile("../background_image.zig");
 const src_post_process = @embedFile("../post_process.zig");
 const src_fbo = @embedFile("../fbo.zig");
 const src_cell_renderer = @embedFile("../cell_renderer.zig");
+const src_cell_pipeline = @embedFile("../cell_pipeline.zig");
+const src_ui_pipeline = @embedFile("../ui_pipeline.zig");
 const src_weixin = @embedFile("../weixin_qr_renderer.zig");
 const src_renderer = @embedFile("../Renderer.zig");
 const src_ov_resize = @embedFile("../overlays/resize.zig");
+const src_ov_scrollbar = @embedFile("../overlays/scrollbar.zig");
 const src_ov_startup = @embedFile("../overlays/startup_shortcuts.zig");
 
 const Entry = struct { name: []const u8, source: []const u8 };
@@ -65,20 +69,30 @@ const glad_free = [_]Entry{
     .{ .name = "renderer/overlays/startup_shortcuts.zig", .source = src_ov_startup },
 };
 
-/// Rule 2 — feature files decoupled in A3/A4: locked against re-acquiring a raw
-/// GL table. (A subset of `glad_free` that must hold ZERO `gpu.glTable()` calls.)
-const gl_table_free = [_]Entry{
+/// Rule 2 — the whole rendering/presentation layer: no `gpu.glTable()` and no
+/// `gpu.Context.gl` reach-around. (D-prep ① made all of these GL-table-free.)
+const raw_gl_free = [_]Entry{
+    .{ .name = "renderer/ui_pipeline.zig", .source = src_ui_pipeline },
+    .{ .name = "renderer/cell_pipeline.zig", .source = src_cell_pipeline },
+    .{ .name = "renderer/cell_renderer.zig", .source = src_cell_renderer },
+    .{ .name = "renderer/post_process.zig", .source = src_post_process },
+    .{ .name = "renderer/Renderer.zig", .source = src_renderer },
     .{ .name = "renderer/titlebar.zig", .source = src_titlebar },
     .{ .name = "renderer/ai_chat_renderer.zig", .source = src_ai_chat },
     .{ .name = "renderer/file_explorer_renderer.zig", .source = src_file_explorer },
+    .{ .name = "renderer/markdown_preview_renderer.zig", .source = src_markdown },
     .{ .name = "renderer/image_renderer.zig", .source = src_image },
     .{ .name = "renderer/background_image.zig", .source = src_background },
     .{ .name = "renderer/fbo.zig", .source = src_fbo },
+    .{ .name = "renderer/weixin_qr_renderer.zig", .source = src_weixin },
     .{ .name = "renderer/overlays.zig", .source = src_overlays },
+    .{ .name = "renderer/overlays/resize.zig", .source = src_ov_resize },
+    .{ .name = "renderer/overlays/scrollbar.zig", .source = src_ov_scrollbar },
+    .{ .name = "renderer/overlays/startup_shortcuts.zig", .source = src_ov_startup },
     .{ .name = "font/manager.zig", .source = src_font_manager },
 };
 
-/// Returns the offending file name if `source` violates the named rule, else null.
+/// Returns the offending file name if any entry contains `needle`, else null.
 /// Pure helper so the logic is unit-testable independently of the comptime scan.
 fn firstMatch(comptime entries: []const Entry, needle: []const u8) ?[]const u8 {
     for (entries) |entry| {
@@ -88,25 +102,31 @@ fn firstMatch(comptime entries: []const Entry, needle: []const u8) ?[]const u8 {
 }
 
 comptime {
-    @setEvalBranchQuota(20_000_000);
+    @setEvalBranchQuota(40_000_000);
     if (firstMatch(&glad_free, glad_include)) |name| {
         @compileError(name ++ " must not @cInclude(\"glad/gl.h\") — raw GL is backend-only (src/renderer/gpu/opengl/); use gpu.c");
     }
-    if (firstMatch(&gl_table_free, gl_table_call)) |name| {
-        @compileError(name ++ " must not call gpu.glTable() — it was decoupled in A3/A4; route draws through ui_pipeline / gpu primitives");
+    if (firstMatch(&raw_gl_free, gl_table_call)) |name| {
+        @compileError(name ++ " must not call gpu.glTable() — route GPU work through the gpu interface (Pipeline/Buffer/Texture/Framebuffer/state/vertex)");
+    }
+    if (firstMatch(&raw_gl_free, gl_context_bypass)) |name| {
+        @compileError(name ++ " must not reach into gpu.Context.gl — that bypasses the gpu interface; use gpu.state/vertex/Pipeline instead");
     }
 }
 
-test "guard data is internally consistent (no glad include / glTable in locked files)" {
-    // The comptime block above already enforces this at build time; this test
-    // makes the failure legible if it ever regresses and documents the contract.
+test "guard data is internally consistent (locked files are clean)" {
     try std.testing.expect(firstMatch(&glad_free, glad_include) == null);
-    try std.testing.expect(firstMatch(&gl_table_free, gl_table_call) == null);
+    try std.testing.expect(firstMatch(&raw_gl_free, gl_table_call) == null);
+    try std.testing.expect(firstMatch(&raw_gl_free, gl_context_bypass) == null);
 }
 
-test "firstMatch detects a planted needle" {
-    const planted = [_]Entry{.{ .name = "x.zig", .source = "a\n@cInclude(\"glad/gl.h\")\nb" }};
-    try std.testing.expectEqualStrings("x.zig", firstMatch(&planted, glad_include).?);
-    const clean = [_]Entry{.{ .name = "y.zig", .source = "const c = gpu.c;" }};
-    try std.testing.expect(firstMatch(&clean, glad_include) == null);
+test "firstMatch detects planted needles" {
+    const planted_glad = [_]Entry{.{ .name = "x.zig", .source = "a\n@cInclude(\"glad/gl.h\")\nb" }};
+    try std.testing.expectEqualStrings("x.zig", firstMatch(&planted_glad, glad_include).?);
+    const planted_table = [_]Entry{.{ .name = "y.zig", .source = "const gl = gpu.glTable();" }};
+    try std.testing.expectEqualStrings("y.zig", firstMatch(&planted_table, gl_table_call).?);
+    const planted_ctx = [_]Entry{.{ .name = "z.zig", .source = "const gl = gpu.Context.gl;" }};
+    try std.testing.expectEqualStrings("z.zig", firstMatch(&planted_ctx, gl_context_bypass).?);
+    const clean = [_]Entry{.{ .name = "ok.zig", .source = "gpu.state.clear(0,0,0,1);" }};
+    try std.testing.expect(firstMatch(&clean, gl_table_call) == null);
 }

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -2,14 +2,16 @@
 //! style, no runtime vtable) and re-exports its types. See
 //! docs/decoupling-guide.md §2 and the spec for the abstraction hierarchy.
 const builtin = @import("builtin");
-const opengl = @import("opengl/api.zig");
 
 pub const Backend = @import("backend.zig").Backend;
 pub const active: Backend = Backend.default(builtin.os.tag);
 
+// Resolve the active backend lazily inside each branch so a non-selected
+// backend's C imports (e.g. the OpenGL backend's `@cInclude("glad/gl.h")`) are
+// never analyzed on a target that doesn't ship them (macOS → Metal).
 const impl = switch (active) {
-    .opengl => opengl,
-    .metal => @compileError("metal backend is Phase D (not yet implemented)"),
+    .opengl => @import("opengl/api.zig"),
+    .metal => @import("metal/api.zig"),
 };
 
 // The active backend's surface. The GL table lives in the backend (moved out

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -30,3 +30,5 @@ pub const Texture = impl.Texture;
 pub const Buffer = impl.Buffer;
 pub const Pipeline = impl.Pipeline;
 pub const Framebuffer = impl.Framebuffer;
+pub const state = impl.render_state;
+pub const vertex = impl.vertex;

--- a/src/renderer/gpu/metal/Buffer.zig
+++ b/src/renderer/gpu/metal/Buffer.zig
@@ -1,0 +1,41 @@
+//! Metal backend GPU buffer. Mirrors `gpu/opengl/Buffer.zig`'s public surface.
+//! D-prep STUB: same public fields (`handle`, `target`) + same method
+//! signatures; bodies are `@panic("metal: TODO D1")`. A real backend will back
+//! `handle` with an `MTLBuffer` (or an index into a buffer pool).
+const c = @import("c.zig");
+const Buffer = @This();
+
+handle: c.GLuint = 0,
+target: c.GLenum,
+
+pub fn init(target: c.GLenum) Buffer {
+    _ = target;
+    @panic("metal: TODO D1 — Buffer.init (allocate MTLBuffer)");
+}
+pub fn bind(self: Buffer) void {
+    _ = self;
+    @panic("metal: TODO D1 — Buffer.bind");
+}
+/// Allocate `size` bytes of uninitialized storage with the given usage hint.
+pub fn allocate(self: Buffer, size: usize, usage: c.GLenum) void {
+    _ = self;
+    _ = size;
+    _ = usage;
+    @panic("metal: TODO D1 — Buffer.allocate");
+}
+/// Allocate + fill with `bytes`.
+pub fn uploadData(self: Buffer, bytes: []const u8, usage: c.GLenum) void {
+    _ = self;
+    _ = bytes;
+    _ = usage;
+    @panic("metal: TODO D1 — Buffer.uploadData");
+}
+/// Overwrite from offset 0.
+pub fn upload(self: Buffer, bytes: []const u8) void {
+    _ = self;
+    _ = bytes;
+    @panic("metal: TODO D1 — Buffer.upload");
+}
+pub fn deinit(self: *Buffer) void {
+    self.handle = 0;
+}

--- a/src/renderer/gpu/metal/Context.zig
+++ b/src/renderer/gpu/metal/Context.zig
@@ -1,0 +1,31 @@
+//! Metal backend context lifecycle. Symmetric counterpart to
+//! `gpu/opengl/Context.zig`.
+//!
+//! D-prep STUB: the real implementation will own the Metal device, command
+//! queue, and the CAMetalLayer the AppKit host hands in. For now it exposes the
+//! same public surface the spine + diagnostics need:
+//!   - `gl`: the transitional GL-flavored table (`gpu.glTable()` returns `&gl`).
+//!   - `init(...)`: context bring-up. Signature kept identical to the OpenGL
+//!     backend (`init(loader: c.GLADloadfunc) !void`) so the AppWindow call site
+//!     `gpu.Context.init(@ptrCast(&window_backend.glGetProcAddress))` compiles
+//!     unchanged. On the real Mac backend this parameter is the surface seam:
+//!     the AppKit host passes the CAMetalLayer / device handle (re-typed there)
+//!     instead of a GL proc-address loader.
+const c = @import("c.zig");
+const GlTable = @import("GlTable.zig").GlTable;
+
+/// Transitional GL-flavored table (see GlTable.zig). Threadlocal to match the
+/// OpenGL backend's storage class (rendering runs on the renderer thread).
+pub threadlocal var gl: GlTable = .{};
+
+/// Bring up the Metal context. STUB — fill in on a Mac:
+///   1. Take the CAMetalLayer the AppKit host created for the window.
+///   2. Acquire `MTLCreateSystemDefaultDevice()` + a command queue.
+///   3. Wire the device/queue/layer into module state for the primitives.
+/// The `loader` parameter is the macOS surface seam (today typed as the OpenGL
+/// backend's `GLADloadfunc` so the shared call site compiles; re-type it to
+/// `?*anyopaque` / `*CAMetalLayer` when implementing).
+pub fn init(loader: c.GLADloadfunc) !void {
+    _ = loader;
+    @panic("metal: TODO D1 — Context.init (acquire MTLDevice + CAMetalLayer)");
+}

--- a/src/renderer/gpu/metal/Framebuffer.zig
+++ b/src/renderer/gpu/metal/Framebuffer.zig
@@ -1,0 +1,35 @@
+//! Metal backend off-screen framebuffer. Mirrors `gpu/opengl/Framebuffer.zig`'s
+//! public surface: fields `handle`/`color`/`width`/`height` and methods
+//! `initColor`/`bind`/`unbind`/`deinit`. D-prep STUB: GPU bodies
+//! `@panic("metal: TODO D1")`. A real backend backs this with an off-screen
+//! `MTLTexture` render target + a render pass descriptor.
+const c = @import("c.zig");
+const Framebuffer = @This();
+
+handle: c.GLuint = 0,
+color: c.GLuint = 0,
+width: c_int = 0,
+height: c_int = 0,
+
+/// Create an off-screen color render target. STUB.
+pub fn initColor(width: c_int, height: c_int) ?Framebuffer {
+    _ = width;
+    _ = height;
+    @panic("metal: TODO D1 — Framebuffer.initColor (off-screen MTLTexture target)");
+}
+
+/// Bind this framebuffer and set the viewport to its full size.
+pub fn bind(self: Framebuffer) void {
+    _ = self;
+    @panic("metal: TODO D1 — Framebuffer.bind");
+}
+
+/// Bind the default (window) framebuffer.
+pub fn unbind() void {
+    @panic("metal: TODO D1 — Framebuffer.unbind");
+}
+
+/// Delete the framebuffer and its color texture; zero the struct.
+pub fn deinit(self: *Framebuffer) void {
+    self.* = .{};
+}

--- a/src/renderer/gpu/metal/GlTable.zig
+++ b/src/renderer/gpu/metal/GlTable.zig
@@ -1,0 +1,23 @@
+//! Transitional "GL function table" for the Metal backend.
+//!
+//! The OpenGL backend exposes `c.GladGLContext` (a struct of optional function
+//! pointers) as its `GlTable`, and `gpu.glTable()` hands the app a `*GlTable`.
+//! AppWindow's render diagnostics still reach through that table directly
+//! (`glTable().GetString.?(...)`, `.GetIntegerv.?(...)`, `.IsEnabled.?(...)`).
+//!
+//! Until those diagnostics are routed through the backend-neutral `state`
+//! primitives, the Metal backend must hand back a type-compatible table so the
+//! shared code compiles. The fields default to `null`; calling `.?` on them at
+//! runtime is the documented "metal: TODO" panic (an unimplemented optional).
+//! A real Metal backend will instead expose Metal device/queue introspection
+//! here (or, preferably, the diagnostics will be converted off `gpu.c.*`).
+const c = @import("c.zig");
+
+/// Mirrors the subset of glad's `GladGLContext` fields the app references via
+/// `gpu.glTable()`. Same field names + compatible function-pointer shapes so
+/// call sites type-check unchanged.
+pub const GlTable = struct {
+    GetString: ?*const fn (name: c.GLenum) callconv(.c) [*c]const c.GLubyte = null,
+    GetIntegerv: ?*const fn (pname: c.GLenum, data: [*c]c.GLint) callconv(.c) void = null,
+    IsEnabled: ?*const fn (cap: c.GLenum) callconv(.c) c.GLboolean = null,
+};

--- a/src/renderer/gpu/metal/Pipeline.zig
+++ b/src/renderer/gpu/metal/Pipeline.zig
@@ -1,0 +1,104 @@
+//! Metal backend render pipeline. Mirrors `gpu/opengl/Pipeline.zig`'s public
+//! surface: fields `program`/`vao` and every method the renderer calls
+//! (`use`, `bindVao`, `setVec2/3/4`, `setFloat`, `setInt`, `setMat4`,
+//! `setProjection`, `drawArrays`, `drawArraysInstanced`, `deinit`, the public
+//! `compileShader`, and `init`). D-prep STUB: bodies `@panic("metal: TODO D1")`.
+//!
+//! Note: callers pass MSL sources (from `gpu/metal/shaders.zig`) to `init`. A
+//! real backend will build an `MTLRenderPipelineState` here; `program`/`vao`
+//! become indices/handles into Metal pipeline + vertex-descriptor pools. The
+//! `program != 0` "link succeeded" convention the callers guard on is preserved.
+const c = @import("c.zig");
+const Pipeline = @This();
+
+program: c.GLuint,
+vao: c.GLuint,
+
+/// Compile a shader stage. STUB returns null (mirrors the OpenGL failure path).
+pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
+    _ = shader_type;
+    _ = source;
+    @panic("metal: TODO D1 — Pipeline.compileShader (compile MSL)");
+}
+
+/// Build a pipeline from vertex/fragment sources, paired with a caller-built
+/// VAO handle. STUB.
+pub fn init(vs_src: [*c]const u8, fs_src: [*c]const u8, vao: c.GLuint) Pipeline {
+    _ = vs_src;
+    _ = fs_src;
+    _ = vao;
+    @panic("metal: TODO D1 — Pipeline.init (build MTLRenderPipelineState)");
+}
+
+pub fn use(self: Pipeline) void {
+    _ = self;
+    @panic("metal: TODO D1 — Pipeline.use");
+}
+pub fn bindVao(self: Pipeline) void {
+    _ = self;
+    @panic("metal: TODO D1 — Pipeline.bindVao");
+}
+pub fn setVec2(self: Pipeline, name: [*c]const u8, x: f32, y: f32) void {
+    _ = self;
+    _ = name;
+    _ = x;
+    _ = y;
+    @panic("metal: TODO D1 — Pipeline.setVec2");
+}
+pub fn setFloat(self: Pipeline, name: [*c]const u8, v: f32) void {
+    _ = self;
+    _ = name;
+    _ = v;
+    @panic("metal: TODO D1 — Pipeline.setFloat");
+}
+pub fn setInt(self: Pipeline, name: [*c]const u8, v: i32) void {
+    _ = self;
+    _ = name;
+    _ = v;
+    @panic("metal: TODO D1 — Pipeline.setInt");
+}
+pub fn setProjection(self: Pipeline) void {
+    _ = self;
+    @panic("metal: TODO D1 — Pipeline.setProjection");
+}
+pub fn setMat4(self: Pipeline, name: [*c]const u8, m: *const [16]f32) void {
+    _ = self;
+    _ = name;
+    _ = m;
+    @panic("metal: TODO D1 — Pipeline.setMat4");
+}
+pub fn setVec3(self: Pipeline, name: [*c]const u8, x: f32, y: f32, z: f32) void {
+    _ = self;
+    _ = name;
+    _ = x;
+    _ = y;
+    _ = z;
+    @panic("metal: TODO D1 — Pipeline.setVec3");
+}
+pub fn setVec4(self: Pipeline, name: [*c]const u8, x: f32, y: f32, z: f32, w: f32) void {
+    _ = self;
+    _ = name;
+    _ = x;
+    _ = y;
+    _ = z;
+    _ = w;
+    @panic("metal: TODO D1 — Pipeline.setVec4");
+}
+pub fn drawArrays(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei) void {
+    _ = self;
+    _ = mode;
+    _ = first;
+    _ = count;
+    @panic("metal: TODO D1 — Pipeline.drawArrays");
+}
+pub fn drawArraysInstanced(self: Pipeline, mode: c.GLenum, first: c.GLint, count: c.GLsizei, instances: c.GLsizei) void {
+    _ = self;
+    _ = mode;
+    _ = first;
+    _ = count;
+    _ = instances;
+    @panic("metal: TODO D1 — Pipeline.drawArraysInstanced");
+}
+pub fn deinit(self: *Pipeline) void {
+    self.* = .{ .program = 0, .vao = 0 };
+}

--- a/src/renderer/gpu/metal/Texture.zig
+++ b/src/renderer/gpu/metal/Texture.zig
@@ -1,0 +1,77 @@
+//! Metal backend 2D texture. Mirrors `gpu/opengl/Texture.zig`'s public surface
+//! (field `handle`, the `Filter`/`Wrap`/`Upload` types, and every method the
+//! callers use). D-prep STUB: bodies are `@panic("metal: TODO D1")`. A real
+//! backend will back `handle` with an `MTLTexture`.
+const c = @import("c.zig");
+const Texture = @This();
+
+handle: c.GLuint,
+
+pub fn fromHandle(h: c.GLuint) Texture {
+    return .{ .handle = h };
+}
+pub fn bind(self: Texture, unit: u32) void {
+    _ = self;
+    _ = unit;
+    @panic("metal: TODO D1 — Texture.bind");
+}
+
+pub const Filter = enum { nearest, linear };
+pub const Wrap = enum { clamp_to_edge, repeat };
+
+/// Options for a 2D texture data upload. Same public fields as the OpenGL
+/// backend's `Upload` so call sites (`.{ .format = ..., .filter = ... }`)
+/// type-check unchanged.
+pub const Upload = struct {
+    internal_format: c.GLenum = c.GL_RGBA8,
+    format: c.GLenum = c.GL_RGBA,
+    data_type: c.GLenum = c.GL_UNSIGNED_BYTE,
+    filter: Filter = .linear,
+    wrap: Wrap = .clamp_to_edge,
+    unpack_alignment: ?c.GLint = null,
+};
+
+/// Allocate a new texture.
+pub fn create() Texture {
+    @panic("metal: TODO D1 — Texture.create (allocate MTLTexture)");
+}
+
+/// Bind + upload (or allocate, if `data` is null) a 2D image.
+pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopaque, o: Upload) void {
+    _ = self;
+    _ = width;
+    _ = height;
+    _ = data;
+    _ = o;
+    @panic("metal: TODO D1 — Texture.upload2D");
+}
+
+/// Update only the wrap_s/wrap_t parameters.
+pub fn setWrap(self: Texture, wrap: Wrap) void {
+    _ = self;
+    _ = wrap;
+    @panic("metal: TODO D1 — Texture.setWrap");
+}
+
+/// Update a sub-region of an already-allocated texture.
+pub fn subImage2D(self: Texture, x: c_int, y: c_int, width: c_int, height: c_int, data: ?*const anyopaque, o: Upload) void {
+    _ = self;
+    _ = x;
+    _ = y;
+    _ = width;
+    _ = height;
+    _ = data;
+    _ = o;
+    @panic("metal: TODO D1 — Texture.subImage2D");
+}
+
+/// Read back the width of mip level 0.
+pub fn levelWidth(self: Texture) c_int {
+    _ = self;
+    @panic("metal: TODO D1 — Texture.levelWidth");
+}
+
+/// Delete the texture and zero the handle.
+pub fn destroy(self: *Texture) void {
+    self.handle = 0;
+}

--- a/src/renderer/gpu/metal/api.zig
+++ b/src/renderer/gpu/metal/api.zig
@@ -1,0 +1,22 @@
+//! Metal backend root. Symmetric counterpart to `gpu/opengl/api.zig`: re-exports
+//! the backend's primitives for `gpu.zig` to resolve at comptime on Darwin.
+//!
+//! D-prep STUB: every primitive mirrors the OpenGL backend's PUBLIC surface
+//! (same exported symbols, same public field/method shapes) with
+//! `@panic("metal: TODO D1")` bodies for GPU work, so the shared rendering layer
+//! + AppWindow compile against a building Metal skeleton. A Mac dev fills in the
+//! real Metal/AppKit bodies without touching the rendering layer.
+
+pub const c = @import("c.zig"); // GL-flavored constants/types shim (no @cInclude)
+pub const Context = @import("Context.zig"); // context lifecycle + GL table
+pub const GlTable = @import("GlTable.zig").GlTable; // the table type (for gpu.glTable())
+
+pub const gl_init = @import("gl_init.zig");
+
+pub const Buffer = @import("Buffer.zig");
+pub const Texture = @import("Texture.zig");
+pub const Pipeline = @import("Pipeline.zig");
+pub const Framebuffer = @import("Framebuffer.zig");
+pub const shaders = @import("shaders.zig");
+pub const render_state = @import("render_state.zig");
+pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/metal/c.zig
+++ b/src/renderer/gpu/metal/c.zig
@@ -1,0 +1,116 @@
+//! Metal backend "GL-flavored" constants/types shim.
+//!
+//! This is a TRANSITIONAL leak: the renderer + AppWindow still reach GPU
+//! enums/types through `gpu.c.*` (a GL vocabulary that A6 is meant to remove).
+//! Until that lands, the Metal backend must expose the SAME names so the
+//! shared rendering layer compiles. These are plain Zig consts — NO
+//! `@cInclude` (glad lives only under `gpu/opengl/`). The values are dummies;
+//! the real Metal backend will MAP these enums to MTL* equivalents (or, better,
+//! the callers will be converted off `gpu.c.*` entirely).
+//!
+//! Mirrors the public type/constant surface of `gpu/opengl/c.zig`'s `c` namespace
+//! that the app references (discovered by compiling for aarch64-macos).
+
+// ---------------------------------------------------------------------------
+// GL scalar types (aliases — the app uses these for buffers/uniforms/handles).
+// ---------------------------------------------------------------------------
+pub const GLuint = u32;
+pub const GLint = i32;
+pub const GLenum = u32;
+pub const GLsizei = i32;
+pub const GLfloat = f32;
+pub const GLboolean = u8;
+pub const GLbitfield = u32;
+pub const GLchar = u8;
+pub const GLubyte = u8;
+pub const GLsizeiptr = isize;
+pub const GLintptr = isize;
+pub const GLvoid = anyopaque;
+
+/// glad's loader function-pointer type. The macOS host (AppKit) supplies the
+/// proc-address loader analogue; Metal does not actually use a GL loader, so on
+/// the real backend this becomes the CAMetalLayer/device handoff seam.
+pub const GLADloadfunc = ?*const fn ([*c]const u8) callconv(.c) ?*const fn () callconv(.c) void;
+
+// ---------------------------------------------------------------------------
+// GL enum constants. Dummy values — only their identity matters to the stub.
+// Kept distinct so any accidental switch/equality logic still behaves sanely.
+// ---------------------------------------------------------------------------
+pub const GL_FALSE: GLboolean = 0;
+pub const GL_TRUE: GLboolean = 1;
+
+// Primitive modes
+pub const GL_TRIANGLES: GLenum = 0x0004;
+pub const GL_TRIANGLE_STRIP: GLenum = 0x0005;
+
+// Pixel formats / internal formats
+pub const GL_RED: GLenum = 0x1903;
+pub const GL_RGB: GLenum = 0x1907;
+pub const GL_RGBA: GLenum = 0x1908;
+pub const GL_RGBA8: GLenum = 0x8058;
+pub const GL_BGRA: GLenum = 0x80E1;
+
+// Buffer targets / usage
+pub const GL_ARRAY_BUFFER: GLenum = 0x8892;
+pub const GL_ELEMENT_ARRAY_BUFFER: GLenum = 0x8893;
+pub const GL_STATIC_DRAW: GLenum = 0x88E4;
+pub const GL_DYNAMIC_DRAW: GLenum = 0x88E8;
+pub const GL_STREAM_DRAW: GLenum = 0x88E0;
+
+// Data types
+pub const GL_UNSIGNED_BYTE: GLenum = 0x1401;
+pub const GL_BYTE: GLenum = 0x1400;
+pub const GL_UNSIGNED_INT: GLenum = 0x1405;
+pub const GL_INT: GLenum = 0x1404;
+pub const GL_FLOAT: GLenum = 0x1406;
+
+// Texture units / targets / params
+pub const GL_TEXTURE_2D: GLenum = 0x0DE1;
+pub const GL_TEXTURE0: GLenum = 0x84C0;
+pub const GL_TEXTURE_MIN_FILTER: GLenum = 0x2801;
+pub const GL_TEXTURE_MAG_FILTER: GLenum = 0x2800;
+pub const GL_TEXTURE_WRAP_S: GLenum = 0x2802;
+pub const GL_TEXTURE_WRAP_T: GLenum = 0x2803;
+pub const GL_TEXTURE_WIDTH: GLenum = 0x1000;
+pub const GL_NEAREST: GLint = 0x2600;
+pub const GL_LINEAR: GLint = 0x2601;
+pub const GL_CLAMP_TO_EDGE: GLint = 0x812F;
+pub const GL_REPEAT: GLint = 0x2901;
+pub const GL_UNPACK_ALIGNMENT: GLenum = 0x0CF5;
+
+// Shader objects
+pub const GL_VERTEX_SHADER: GLenum = 0x8B31;
+pub const GL_FRAGMENT_SHADER: GLenum = 0x8B30;
+pub const GL_COMPILE_STATUS: GLenum = 0x8B81;
+pub const GL_LINK_STATUS: GLenum = 0x8B82;
+
+// Framebuffers
+pub const GL_FRAMEBUFFER: GLenum = 0x8D40;
+pub const GL_COLOR_ATTACHMENT0: GLenum = 0x8CE0;
+pub const GL_FRAMEBUFFER_COMPLETE: GLenum = 0x8CD5;
+
+// Clear / state
+pub const GL_COLOR_BUFFER_BIT: GLbitfield = 0x00004000;
+pub const GL_DEPTH_BUFFER_BIT: GLbitfield = 0x00000100;
+pub const GL_SCISSOR_TEST: GLenum = 0x0C11;
+pub const GL_SCISSOR_BOX: GLenum = 0x0C10;
+pub const GL_VIEWPORT: GLenum = 0x0BA2;
+pub const GL_BLEND: GLenum = 0x0BE2;
+
+// Blend factors
+pub const GL_SRC_ALPHA: GLenum = 0x0302;
+pub const GL_ONE_MINUS_SRC_ALPHA: GLenum = 0x0303;
+pub const GL_ONE: GLenum = 1;
+pub const GL_ZERO: GLenum = 0;
+
+// Blend-state query enums (used by AppWindow swap diagnostics)
+pub const GL_BLEND_SRC_RGB: GLenum = 0x80C9;
+pub const GL_BLEND_DST_RGB: GLenum = 0x80C8;
+pub const GL_BLEND_SRC_ALPHA: GLenum = 0x80CB;
+pub const GL_BLEND_DST_ALPHA: GLenum = 0x80CA;
+
+// glGetString names (GPU diagnostics)
+pub const GL_VENDOR: GLenum = 0x1F00;
+pub const GL_RENDERER: GLenum = 0x1F01;
+pub const GL_VERSION: GLenum = 0x1F02;
+pub const GL_SHADING_LANGUAGE_VERSION: GLenum = 0x8B8C;

--- a/src/renderer/gpu/metal/gl_init.zig
+++ b/src/renderer/gpu/metal/gl_init.zig
@@ -1,0 +1,91 @@
+//! Metal backend gl_init mirror. Symmetric counterpart to
+//! `gpu/opengl/gl_init.zig`. Mirrors the PUBLIC surface the app reaches through
+//! `gpu.gl_init.*`:
+//!   - data the renderer reads/writes every frame: `g_draw_call_count`,
+//!     `g_bg_opacity`, and the compat mirror handles
+//!     (`vao`/`vbo`/`shader_program`/`simple_color_shader`). These stay as plain
+//!     vars (default-initialized) so the read/write call sites compile and run.
+//!   - hooks/helpers: `initShaders`, `renderQuad`, `renderQuadAlpha`,
+//!     `setProjection`, `syncSharedHandles`, `compileShader`, `linkProgram`,
+//!     `setProjectionForProgram`. GPU-work bodies are `@panic("metal: TODO D1")`.
+//!
+//! NOTE: unlike the OpenGL backend, this file does NOT import `ui_pipeline`/
+//! `AppWindow` — the Metal render helpers will be wired when the backend lands,
+//! and keeping the import out avoids extra coupling in the stub.
+const c = @import("c.zig");
+
+// ----------------------------------------------------------------------------
+// Compat mirror handles (populated by syncSharedHandles on the real backend).
+// Threadlocal to match the OpenGL backend's storage class.
+// ----------------------------------------------------------------------------
+pub threadlocal var vao: c.GLuint = 0;
+pub threadlocal var vbo: c.GLuint = 0;
+pub threadlocal var shader_program: c.GLuint = 0;
+pub threadlocal var simple_color_shader: c.GLuint = 0;
+
+/// Draw-call counter (reset each frame by the renderer).
+pub threadlocal var g_draw_call_count: u32 = 0;
+
+/// Opacity for cell background quads (0..1). Set from config; read by the
+/// renderer. Plain data — kept live so the read/write sites work.
+pub threadlocal var g_bg_opacity: f32 = 1.0;
+
+// ----------------------------------------------------------------------------
+// Shader compilation / linking — STUBs.
+// ----------------------------------------------------------------------------
+pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
+    _ = shader_type;
+    _ = source;
+    @panic("metal: TODO D1 — gl_init.compileShader (compile MSL)");
+}
+
+fn linkProgram(vs_src: [*c]const u8, fs_src: [*c]const u8) c.GLuint {
+    _ = vs_src;
+    _ = fs_src;
+    @panic("metal: TODO D1 — gl_init.linkProgram");
+}
+
+// ----------------------------------------------------------------------------
+// Init hook — stable; nothing to compile here (pipelines built by ui_pipeline).
+// ----------------------------------------------------------------------------
+pub fn initShaders() bool {
+    return true;
+}
+
+// ----------------------------------------------------------------------------
+// Render helpers — STUBs (delegated to ui_pipeline on the real backend).
+// ----------------------------------------------------------------------------
+pub fn renderQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    _ = x;
+    _ = y;
+    _ = w;
+    _ = h;
+    _ = color;
+    @panic("metal: TODO D1 — gl_init.renderQuad");
+}
+pub fn renderQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+    _ = x;
+    _ = y;
+    _ = w;
+    _ = h;
+    _ = color;
+    _ = alpha;
+    @panic("metal: TODO D1 — gl_init.renderQuadAlpha");
+}
+pub fn setProjection(width: f32, height: f32) void {
+    _ = width;
+    _ = height;
+    @panic("metal: TODO D1 — gl_init.setProjection");
+}
+
+/// Populate the compat mirror handles from the backend-owned objects.
+pub fn syncSharedHandles() void {
+    @panic("metal: TODO D1 — gl_init.syncSharedHandles");
+}
+
+/// Set the orthographic projection matrix on a specific program. STUB.
+pub fn setProjectionForProgram(program: c.GLuint, window_height: f32) void {
+    _ = program;
+    _ = window_height;
+    @panic("metal: TODO D1 — gl_init.setProjectionForProgram");
+}

--- a/src/renderer/gpu/metal/render_state.zig
+++ b/src/renderer/gpu/metal/render_state.zig
@@ -1,0 +1,68 @@
+//! Metal backend render-state + frame seam. Mirrors `gpu/opengl/render_state.zig`:
+//! same public types (`Rect`/`Size`/`BlendMode`/`ScissorState`) and same fns
+//! (`beginFrame`/`endFrame`/`setBlendEnabled`/`setBlendMode`/`clear`/
+//! `setViewport`/`viewportSize`/`setScissor`/`disableScissor`/`scissorState`/
+//! `restoreScissor`). D-prep STUB: bodies `@panic("metal: TODO D1")` (the
+//! OpenGL frame seam was a no-op, but the Metal backend OWNS the command buffer
+//! here, so even `beginFrame`/`endFrame` become real work — left as TODO).
+
+pub const Rect = struct { x: i32, y: i32, w: i32, h: i32 };
+pub const Size = struct { w: i32, h: i32 };
+pub const BlendMode = enum { alpha, premultiplied };
+pub const ScissorState = struct { enabled: bool, box: Rect };
+
+/// Frame seam — the Metal backend owns the command buffer / drawable here.
+pub fn beginFrame() void {
+    @panic("metal: TODO D1 — render_state.beginFrame (acquire drawable + command buffer)");
+}
+pub fn endFrame() void {
+    @panic("metal: TODO D1 — render_state.endFrame (commit + present drawable)");
+}
+
+pub fn setBlendEnabled(enabled: bool) void {
+    _ = enabled;
+    @panic("metal: TODO D1 — render_state.setBlendEnabled");
+}
+
+pub fn setBlendMode(mode: BlendMode) void {
+    _ = mode;
+    @panic("metal: TODO D1 — render_state.setBlendMode");
+}
+
+pub fn clear(r: f32, g: f32, b: f32, a: f32) void {
+    _ = r;
+    _ = g;
+    _ = b;
+    _ = a;
+    @panic("metal: TODO D1 — render_state.clear");
+}
+
+pub fn setViewport(x: i32, y: i32, w: i32, h: i32) void {
+    _ = x;
+    _ = y;
+    _ = w;
+    _ = h;
+    @panic("metal: TODO D1 — render_state.setViewport");
+}
+
+pub fn viewportSize() Size {
+    @panic("metal: TODO D1 — render_state.viewportSize");
+}
+
+pub fn setScissor(rect: Rect) void {
+    _ = rect;
+    @panic("metal: TODO D1 — render_state.setScissor");
+}
+
+pub fn disableScissor() void {
+    @panic("metal: TODO D1 — render_state.disableScissor");
+}
+
+pub fn scissorState() ScissorState {
+    @panic("metal: TODO D1 — render_state.scissorState");
+}
+
+pub fn restoreScissor(s: ScissorState) void {
+    _ = s;
+    @panic("metal: TODO D1 — render_state.restoreScissor");
+}

--- a/src/renderer/gpu/metal/shaders.zig
+++ b/src/renderer/gpu/metal/shaders.zig
@@ -22,4 +22,34 @@
 //! future `gpu.zig` Metal branch points `shaders` here. See `gpu/opengl/shaders.zig`
 //! for the authoritative source/uniform contracts each entry must reproduce.
 
-// Intentionally empty until the Metal backend (D1) is implemented.
+// D-prep STUB: the source strings below are PLACEHOLDER MSL so the
+// backend-neutral pipeline builders (`ui_pipeline`, `cell_pipeline`) — which
+// pass these to `Pipeline.init(...)` — type-check against the same public
+// symbol set as `gpu/opengl/shaders.zig`. They are NOT real MSL translations;
+// a Mac dev replaces each body with the MSL equivalent of the GLSL contract
+// documented above (and `Pipeline.init` actually compiles them in D1). Until
+// then `Pipeline.init` panics before the source is ever consumed, so the
+// placeholder text is never compiled by Metal.
+
+const TODO_MSL: [*c]const u8 =
+    \\// metal: TODO D1 — translate the matching GLSL source from
+    \\// gpu/opengl/shaders.zig into MSL (see the per-entry contract in the
+    \\// module doc comment above). Placeholder until the Metal backend lands.
+;
+
+/// Textured quad (pos.xy, uv.zw) + mat4 projection.
+pub const vertex_shader_source: [*c]const u8 = TODO_MSL;
+/// Grayscale glyph (atlas .r as alpha × textColor).
+pub const fragment_shader_source: [*c]const u8 = TODO_MSL;
+/// Instanced cell backgrounds.
+pub const bg_vertex_source: [*c]const u8 = TODO_MSL;
+pub const bg_fragment_source: [*c]const u8 = TODO_MSL;
+/// Instanced cell foreground glyphs.
+pub const fg_vertex_source: [*c]const u8 = TODO_MSL;
+pub const fg_fragment_source: [*c]const u8 = TODO_MSL;
+/// Color (emoji) cell glyphs.
+pub const color_fg_fragment_source: [*c]const u8 = TODO_MSL;
+/// Textured RGBA quad with opacity.
+pub const simple_color_fragment_source: [*c]const u8 = TODO_MSL;
+/// Flat-color tint (overlayColor).
+pub const overlay_fragment_source: [*c]const u8 = TODO_MSL;

--- a/src/renderer/gpu/metal/vertex.zig
+++ b/src/renderer/gpu/metal/vertex.zig
@@ -1,0 +1,35 @@
+//! Metal backend declarative vertex-array builder. Mirrors
+//! `gpu/opengl/vertex.zig`'s public surface: the `VaoHandle` type, the
+//! `VertexAttr`/`BufferLayout` structs (same public fields callers populate),
+//! and `buildVertexArray`/`deleteVertexArray`. D-prep STUB: the build/delete
+//! bodies `@panic("metal: TODO D1")`. A real backend translates a layout into
+//! an `MTLVertexDescriptor` + a buffer-binding table.
+const c = @import("c.zig");
+const Buffer = @import("Buffer.zig");
+
+pub const VaoHandle = c.GLuint;
+
+/// One float vertex attribute (same public fields as the OpenGL backend).
+pub const VertexAttr = struct {
+    loc: u32,
+    count: u32,
+    stride: usize,
+    offset: usize,
+    divisor: u32 = 0,
+};
+
+/// A buffer + the attributes sourced from it.
+pub const BufferLayout = struct {
+    buffer: Buffer,
+    attrs: []const VertexAttr,
+};
+
+/// Build a vertex-array binding from the layouts. STUB.
+pub fn buildVertexArray(layouts: []const BufferLayout) VaoHandle {
+    _ = layouts;
+    @panic("metal: TODO D1 — vertex.buildVertexArray (build MTLVertexDescriptor)");
+}
+
+pub fn deleteVertexArray(vao: VaoHandle) void {
+    _ = vao;
+}

--- a/src/renderer/gpu/opengl/Pipeline.zig
+++ b/src/renderer/gpu/opengl/Pipeline.zig
@@ -100,6 +100,10 @@ pub fn setProjection(self: Pipeline) void {
     };
     gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(self.program, "projection"), 1, c.GL_FALSE, &projection);
 }
+pub fn setMat4(self: Pipeline, name: [*c]const u8, m: *const [16]f32) void {
+    Context.gl.UseProgram.?(self.program);
+    Context.gl.UniformMatrix4fv.?(Context.gl.GetUniformLocation.?(self.program, name), 1, c.GL_FALSE, m);
+}
 pub fn setVec3(self: Pipeline, name: [*c]const u8, x: f32, y: f32, z: f32) void {
     Context.gl.Uniform3f.?(Context.gl.GetUniformLocation.?(self.program, name), x, y, z);
 }

--- a/src/renderer/gpu/opengl/api.zig
+++ b/src/renderer/gpu/opengl/api.zig
@@ -15,3 +15,5 @@ pub const Texture = @import("Texture.zig");
 pub const Pipeline = @import("Pipeline.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
 pub const shaders = @import("shaders.zig");
+pub const render_state = @import("render_state.zig");
+pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/opengl/render_state.zig
+++ b/src/renderer/gpu/opengl/render_state.zig
@@ -1,0 +1,74 @@
+//! GL render-state + frame seam over Context.gl. Backend-level helpers that
+//! eliminate direct glTable() calls for common state mutations. The Metal
+//! backend will mirror this file with its own command-buffer seam.
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+
+pub const Rect = struct { x: i32, y: i32, w: i32, h: i32 };
+pub const Size = struct { w: i32, h: i32 };
+pub const BlendMode = enum { alpha, premultiplied };
+pub const ScissorState = struct { enabled: bool, box: Rect };
+
+/// Frame seam (OpenGL: no-ops; the Metal backend will own a command buffer here).
+pub fn beginFrame() void {}
+pub fn endFrame() void {}
+
+pub fn setBlendEnabled(enabled: bool) void {
+    if (enabled) Context.gl.Enable.?(c.GL_BLEND) else Context.gl.Disable.?(c.GL_BLEND);
+}
+
+/// .alpha = (SRC_ALPHA, ONE_MINUS_SRC_ALPHA); .premultiplied = (ONE, ONE_MINUS_SRC_ALPHA)
+pub fn setBlendMode(mode: BlendMode) void {
+    switch (mode) {
+        .alpha => Context.gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA),
+        .premultiplied => Context.gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA),
+    }
+}
+
+pub fn clear(r: f32, g: f32, b: f32, a: f32) void {
+    Context.gl.ClearColor.?(r, g, b, a);
+    Context.gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+}
+
+pub fn setViewport(x: i32, y: i32, w: i32, h: i32) void {
+    Context.gl.Viewport.?(@intCast(x), @intCast(y), @intCast(w), @intCast(h));
+}
+
+pub fn viewportSize() Size {
+    var vp: [4]c.GLint = undefined;
+    Context.gl.GetIntegerv.?(c.GL_VIEWPORT, &vp);
+    return .{ .w = @intCast(vp[2]), .h = @intCast(vp[3]) };
+}
+
+pub fn setScissor(rect: Rect) void {
+    Context.gl.Enable.?(c.GL_SCISSOR_TEST);
+    Context.gl.Scissor.?(@intCast(rect.x), @intCast(rect.y), @intCast(rect.w), @intCast(rect.h));
+}
+
+pub fn disableScissor() void {
+    Context.gl.Disable.?(c.GL_SCISSOR_TEST);
+}
+
+/// Save/restore helper (markdown_preview nests a scissor over an outer one).
+pub fn scissorState() ScissorState {
+    const enabled = Context.gl.IsEnabled.?(c.GL_SCISSOR_TEST) == c.GL_TRUE;
+    var box: [4]c.GLint = undefined;
+    Context.gl.GetIntegerv.?(c.GL_SCISSOR_BOX, &box);
+    return .{
+        .enabled = enabled,
+        .box = .{
+            .x = @intCast(box[0]),
+            .y = @intCast(box[1]),
+            .w = @intCast(box[2]),
+            .h = @intCast(box[3]),
+        },
+    };
+}
+
+pub fn restoreScissor(s: ScissorState) void {
+    if (s.enabled) {
+        setScissor(s.box);
+    } else {
+        disableScissor();
+    }
+}

--- a/src/renderer/gpu/opengl/vertex.zig
+++ b/src/renderer/gpu/opengl/vertex.zig
@@ -1,0 +1,48 @@
+//! Declarative vertex-array builder. Lets callers describe VAO layouts without
+//! issuing raw GL ops. Supports multiple buffer sources per VAO (needed by
+//! cell_pipeline's bg/fg VAOs that pull attribute 0 from a static quad buffer
+//! and instanced attributes from a separate instances buffer).
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+const Buffer = @import("Buffer.zig");
+
+pub const VaoHandle = c.GLuint;
+
+/// One float vertex attribute. `count` = number of floats (1..4). `divisor` > 0
+/// makes it instanced (advances per `divisor` instances).
+pub const VertexAttr = struct {
+    loc: u32,
+    count: u32,
+    stride: usize,
+    offset: usize,
+    divisor: u32 = 0,
+};
+
+/// A buffer + the attributes sourced from it.
+pub const BufferLayout = struct {
+    buffer: Buffer,
+    attrs: []const VertexAttr,
+};
+
+/// Build a VAO binding each layout's buffer and configuring its float attributes.
+pub fn buildVertexArray(layouts: []const BufferLayout) VaoHandle {
+    const gl = Context.gl;
+    var vao: c.GLuint = 0;
+    gl.GenVertexArrays.?(1, &vao);
+    gl.BindVertexArray.?(vao);
+    for (layouts) |layout| {
+        layout.buffer.bind();
+        for (layout.attrs) |a| {
+            gl.EnableVertexAttribArray.?(a.loc);
+            gl.VertexAttribPointer.?(a.loc, @intCast(a.count), c.GL_FLOAT, c.GL_FALSE, @intCast(a.stride), @ptrFromInt(a.offset));
+            if (a.divisor > 0) gl.VertexAttribDivisor.?(a.loc, a.divisor);
+        }
+    }
+    gl.BindVertexArray.?(0);
+    return vao;
+}
+
+pub fn deleteVertexArray(vao: VaoHandle) void {
+    var v = vao;
+    Context.gl.DeleteVertexArrays.?(1, &v);
+}

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -600,25 +600,18 @@ fn renderImageDocument(
     const draw_top = body_top + (body_h - draw_h) / 2 + panel.imagePanY();
     const draw_y = window_height - draw_top - draw_h;
 
-    const gl = gpu.glTable();
-    const clip_x: gpu.c.GLint = @intFromFloat(@max(0, @floor(content_x)));
-    const clip_y: gpu.c.GLint = @intFromFloat(@max(0, @floor(window_height - body_top - body_h)));
-    const clip_w: gpu.c.GLsizei = @intFromFloat(@max(0, @ceil(content_w)));
-    const clip_h: gpu.c.GLsizei = @intFromFloat(@max(0, @ceil(body_h)));
+    const clip_x: i32 = @intFromFloat(@max(0, @floor(content_x)));
+    const clip_y: i32 = @intFromFloat(@max(0, @floor(window_height - body_top - body_h)));
+    const clip_w: i32 = @intFromFloat(@max(0, @ceil(content_w)));
+    const clip_h: i32 = @intFromFloat(@max(0, @ceil(body_h)));
     if (clip_w <= 0 or clip_h <= 0) return;
 
-    const scissor_was_enabled = gl.IsEnabled.?(gpu.c.GL_SCISSOR_TEST) == gpu.c.GL_TRUE;
-    var previous_scissor: [4]gpu.c.GLint = undefined;
-    if (scissor_was_enabled) gl.GetIntegerv.?(gpu.c.GL_SCISSOR_BOX, &previous_scissor);
-    gl.Enable.?(gpu.c.GL_SCISSOR_TEST);
-    gl.Scissor.?(clip_x, clip_y, clip_w, clip_h);
+    // Clip the image to the body area, restoring any outer scissor afterward.
+    const saved_scissor = gpu.state.scissorState();
+    gpu.state.setScissor(.{ .x = clip_x, .y = clip_y, .w = clip_w, .h = clip_h });
     ui_pipeline.fillQuad(draw_x - 1, draw_y - 1, draw_w + 2, draw_h + 2, border);
     drawImageTexture(draw_x, draw_y, draw_w, draw_h, window_height);
-    if (scissor_was_enabled) {
-        gl.Scissor.?(previous_scissor[0], previous_scissor[1], previous_scissor[2], previous_scissor[3]);
-    } else {
-        gl.Disable.?(gpu.c.GL_SCISSOR_TEST);
-    }
+    gpu.state.restoreScissor(saved_scissor);
 }
 
 fn renderStatusMessage(

--- a/src/renderer/overlays/resize.zig
+++ b/src/renderer/overlays/resize.zig
@@ -148,7 +148,6 @@ pub fn renderResizeOverlayForSurface(surface: *Surface, window_width: f32, windo
 
 /// Core function to render a resize overlay with specific dimensions.
 fn renderResizeOverlayText(cols: u16, rows: u16, window_width: f32, window_height: f32, top_offset: f32, alpha: f32) void {
-    const gl = AppWindow.gpu.glTable();
     if (alpha <= 0.01) return;
 
     // Format the size string: "cols x rows"
@@ -175,12 +174,6 @@ fn renderResizeOverlayText(cols: u16, rows: u16, window_width: f32, window_heigh
     const box_x = (window_width - box_width) / 2;
     const box_y = (content_height - box_height) / 2; // Centered in content area (GL coords)
 
-    // Enable blending
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.BindVertexArray.?(gl_init.vao);
 
     // Draw rounded background box (black with alpha, slightly more transparent than scrollbar)
     const corner_radius: f32 = 6;

--- a/src/renderer/overlays/scrollbar.zig
+++ b/src/renderer/overlays/scrollbar.zig
@@ -115,7 +115,6 @@ fn scrollbarUpdateFade(surface: *Surface) void {
 /// view_width/view_height are the viewport dimensions (not full window).
 /// top_padding is the padding from the top of the viewport to the terminal content.
 pub fn renderScrollbarForSurface(surface: *Surface, view_width: f32, view_height: f32, top_padding: f32) void {
-    const gl = AppWindow.gpu.glTable();
     const geo = scrollbarGeometryForSurface(surface, view_height, top_padding) orelse return;
 
     scrollbarUpdateFade(surface);
@@ -125,9 +124,6 @@ pub fn renderScrollbarForSurface(surface: *Surface, view_width: f32, view_height
     const bar_x = view_width - SCROLLBAR_WIDTH;
     const bar_w = SCROLLBAR_WIDTH;
 
-    // Use the shader_program for quad rendering
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.BindVertexArray.?(gl_init.vao);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -167,8 +167,6 @@ pub fn renderStartupShortcutsOverlay(window_width: f32, window_height: f32, top_
     const alpha = startupShortcutsOpacity();
     if (alpha <= 0.01) return;
 
-    const gl = AppWindow.gpu.glTable();
-
     var max_keys_width: f32 = 0;
     var max_action_width: f32 = 0;
     for (STARTUP_SHORTCUT_ENTRIES) |entry| {
@@ -206,12 +204,6 @@ pub fn renderStartupShortcutsOverlay(window_width: f32, window_height: f32, top_
 
     const box_x = @round(@max(12, (window_width - box_width) / 2));
     const box_y = @round(@max(12, (content_height - box_height) / 2));
-
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
 
     const panel_color = mixColor(AppWindow.g_theme.background, AppWindow.g_theme.foreground, 0.035);
     const border_color = mixColor(AppWindow.g_theme.background, AppWindow.g_theme.cursor_color, 0.24);

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -77,7 +77,7 @@ fn buildPostFragmentSource(allocator: std.mem.Allocator, user_shader: []const u8
 
 /// Load and compile a custom post-processing shader from a file
 fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
-    const gl = gpu.glTable();
+    const gl = &gpu.Context.gl;
     // Read shader source file
     const file = std.fs.cwd().openFile(shader_path, .{}) catch |err| {
         std.debug.print("Failed to open shader file '{s}': {}\n", .{ shader_path, err });
@@ -150,11 +150,10 @@ fn ensurePostFBO(width: c_int, height: c_int) void {
 
 /// Render the fullscreen quad with post-processing shader applied
 fn renderPostProcess(width: c_int, height: c_int) void {
-    const gl = gpu.glTable();
     // Bind default framebuffer (screen)
     gpu.Framebuffer.unbind();
-    gl.Viewport.?(0, 0, width, height);
-    gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+    gpu.state.setViewport(0, 0, width, height);
+    gpu.state.clear(0, 0, 0, 1);
 
     // Disable blending for the fullscreen quad - shader output is final color
     ui_pipeline.setBlendEnabled(false);
@@ -192,14 +191,12 @@ fn renderPostProcess(width: c_int, height: c_int) void {
 /// Render with post-processing. Called after updateTerminalCells() has
 /// already been called under the lock — this only does GL work.
 pub fn renderFrameWithPostFromCells(rend: *const Renderer, width: c_int, height: c_int, padding: f32) void {
-    const gl = gpu.glTable();
     ensurePostFBO(width, height);
 
     // 1. Render terminal to FBO
     g_post_fb.bind();
     ui_pipeline.setProjection(@floatFromInt(width), @floatFromInt(height));
-    gl.ClearColor.?(AppWindow.g_theme.background[0], AppWindow.g_theme.background[1], AppWindow.g_theme.background[2], 1.0);
-    gl.Clear.?(c.GL_COLOR_BUFFER_BIT);
+    gpu.state.clear(AppWindow.g_theme.background[0], AppWindow.g_theme.background[1], AppWindow.g_theme.background[2], 1.0);
     background_image.drawFullscreen(@floatFromInt(width), @floatFromInt(height));
     cell_renderer.drawCells(rend, @floatFromInt(height), padding, padding);
 

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -77,7 +77,6 @@ fn buildPostFragmentSource(allocator: std.mem.Allocator, user_shader: []const u8
 
 /// Load and compile a custom post-processing shader from a file
 fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
-    const gl = &gpu.Context.gl;
     // Read shader source file
     const file = std.fs.cwd().openFile(shader_path, .{}) catch |err| {
         std.debug.print("Failed to open shader file '{s}': {}\n", .{ shader_path, err });
@@ -114,24 +113,20 @@ fn initPostShader(allocator: std.mem.Allocator, shader_path: []const u8) bool {
     g_post_vbo_buf = gpu.Buffer.init(c.GL_ARRAY_BUFFER);
     g_post_vbo_buf.uploadData(std.mem.sliceAsBytes(quad_verts[0..]), c.GL_STATIC_DRAW);
 
-    var vao: c.GLuint = 0;
-    gl.GenVertexArrays.?(1, &vao);
-    gl.BindVertexArray.?(vao);
-    g_post_vbo_buf.bind();
-    // position (location 0)
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
-    // texcoord (location 1)
-    gl.EnableVertexAttribArray.?(1);
-    gl.VertexAttribPointer.?(1, 2, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), @ptrFromInt(2 * @sizeOf(f32)));
-    gl.BindVertexArray.?(0);
+    // Fullscreen quad VAO: vec2 position (loc 0) + vec2 texcoord (loc 1), interleaved.
+    const vao = gpu.vertex.buildVertexArray(&.{
+        .{ .buffer = g_post_vbo_buf, .attrs = &.{
+            .{ .loc = 0, .count = 2, .stride = 4 * @sizeOf(f32), .offset = 0 },
+            .{ .loc = 1, .count = 2, .stride = 4 * @sizeOf(f32), .offset = 2 * @sizeOf(f32) },
+        } },
+    });
 
     // Compile and link via Pipeline.init (logs errors itself)
     g_post_pipeline = gpu.Pipeline.init(post_vertex_source, frag_source.ptr, vao);
     if (g_post_pipeline.program == 0) {
         // Pipeline.init already logged the failure; clean up vbo and vao
         g_post_vbo_buf.deinit();
-        gl.DeleteVertexArrays.?(1, &vao);
+        gpu.vertex.deleteVertexArray(vao);
         return false;
     }
 

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -31,22 +31,15 @@ fn drawCallTick() void {
 /// Build a VAO with the shared text/emoji vertex layout (one vec4 attrib:
 /// xy = position, zw = texcoord), pointing at the shared quad buffer.
 fn buildQuadVao() c.GLuint {
-    const gl = gpu.glTable();
-    var vao: c.GLuint = 0;
-    gl.GenVertexArrays.?(1, &vao);
-    gl.BindVertexArray.?(vao);
-    quad.bind();
-    gl.EnableVertexAttribArray.?(0);
-    gl.VertexAttribPointer.?(0, 4, c.GL_FLOAT, c.GL_FALSE, 4 * @sizeOf(f32), null);
-    gl.BindVertexArray.?(0);
-    return vao;
+    return gpu.vertex.buildVertexArray(&.{.{
+        .buffer = quad,
+        .attrs = &.{.{ .loc = 0, .count = 4, .stride = 4 * @sizeOf(f32), .offset = 0 }},
+    }});
 }
 
 /// Build the shared pipelines, quad buffer, and solid texture. Call once after
 /// the GL context is current (before any UI draw).
 pub fn init() void {
-    const gl = gpu.glTable();
-
     quad = Buffer.init(c.GL_ARRAY_BUFFER);
     quad.allocate(@sizeOf(f32) * 6 * 4, c.GL_DYNAMIC_DRAW);
 
@@ -62,14 +55,15 @@ pub fn init() void {
     overlay = Pipeline.init(shaders.vertex_shader_source, shaders.overlay_fragment_source, overlay_vao);
     if (overlay.program == 0) std.debug.print("UI overlay pipeline failed\n", .{});
 
-    var solid_handle: c.GLuint = 0;
-    gl.GenTextures.?(1, &solid_handle);
-    gl.BindTexture.?(c.GL_TEXTURE_2D, solid_handle);
     const white_pixel = [_]u8{255};
-    gl.TexImage2D.?(c.GL_TEXTURE_2D, 0, c.GL_RED, 1, 1, 0, c.GL_RED, c.GL_UNSIGNED_BYTE, &white_pixel);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MIN_FILTER, c.GL_NEAREST);
-    gl.TexParameteri.?(c.GL_TEXTURE_2D, c.GL_TEXTURE_MAG_FILTER, c.GL_NEAREST);
-    solid = Texture.fromHandle(solid_handle);
+    solid = Texture.create();
+    solid.upload2D(1, 1, &white_pixel, .{
+        .internal_format = c.GL_RED,
+        .format = c.GL_RED,
+        .filter = .nearest,
+        .wrap = .clamp_to_edge,
+        .unpack_alignment = 1,
+    });
 }
 
 pub fn deinit() void {
@@ -77,10 +71,7 @@ pub fn deinit() void {
     emoji.deinit();
     overlay.deinit();
     quad.deinit();
-    if (solid.handle != 0) {
-        gpu.glTable().DeleteTextures.?(1, &solid.handle);
-        solid.handle = 0;
-    }
+    solid.destroy();
 }
 
 fn quadVertices(rect: Rect, uv: Uv) [6][4]f32 {
@@ -98,43 +89,39 @@ fn quadVertices(rect: Rect, uv: Uv) [6][4]f32 {
 /// The emoji pipeline needs no frame-level update — drawColorGlyph re-derives its
 /// projection from the viewport per call.
 pub fn setProjection(width: f32, height: f32) void {
-    const gl = gpu.glTable();
     const projection = [16]f32{
         2.0 / width, 0.0,          0.0,  0.0,
         0.0,         2.0 / height, 0.0,  0.0,
         0.0,         0.0,          -1.0, 0.0,
         -1.0,        -1.0,         0.0,  1.0,
     };
-    gl.UseProgram.?(text.program);
-    gl.UniformMatrix4fv.?(gl.GetUniformLocation.?(text.program, "projection"), 1, c.GL_FALSE, &projection);
+    text.use();
+    text.setMat4("projection", &projection);
 }
 
 /// Enable scissor clipping to `rect` (window-space, same convention as the
 /// caller's existing glScissor: x/y are the lower-left corner in GL pixels).
 /// Rounds to integer pixels, matching the prior @intFromFloat(@round(...)) calls.
 pub fn beginClip(rect: Rect) void {
-    const gl = gpu.glTable();
-    gl.Enable.?(c.GL_SCISSOR_TEST);
-    gl.Scissor.?(
-        @intFromFloat(@round(rect.x)),
-        @intFromFloat(@round(rect.y)),
-        @intFromFloat(@round(rect.w)),
-        @intFromFloat(@round(rect.h)),
-    );
+    gpu.state.setScissor(.{
+        .x = @intFromFloat(@round(rect.x)),
+        .y = @intFromFloat(@round(rect.y)),
+        .w = @intFromFloat(@round(rect.w)),
+        .h = @intFromFloat(@round(rect.h)),
+    });
 }
 
 /// Disable scissor clipping (= the prior gl.Disable(GL_SCISSOR_TEST)). Flat
 /// enable/disable — clip regions are not nested.
 pub fn endClip() void {
-    gpu.glTable().Disable.?(c.GL_SCISSOR_TEST);
+    gpu.state.disableScissor();
 }
 
 /// Toggle GL_BLEND. Lets callers that draw opaque content (e.g. a background
 /// image or post-process pass) disable blending for a draw and restore it,
 /// without touching raw GL (= the prior gl.Disable/Enable(GL_BLEND) bookends).
 pub fn setBlendEnabled(enabled: bool) void {
-    const gl = gpu.glTable();
-    if (enabled) gl.Enable.?(c.GL_BLEND) else gl.Disable.?(c.GL_BLEND);
+    gpu.state.setBlendEnabled(enabled);
 }
 
 pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
@@ -145,7 +132,6 @@ pub fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
 /// blends `color` toward g_theme.background by `alpha` and draws opaque via the
 /// solid texture (no BlendFunc needed — alpha is baked into the color channel).
 pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
-    const gl = gpu.glTable();
     const bg = AppWindow.g_theme.background;
     const r = color[0] * alpha + bg[0] * (1 - alpha);
     const g = color[1] * alpha + bg[1] * (1 - alpha);
@@ -153,23 +139,22 @@ pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) 
     const verts = quadVertices(.{ .x = x, .y = y, .w = w, .h = h }, .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1 });
     text.use();
     text.bindVao();
-    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), r, g, b);
+    text.setVec3("textColor", r, g, b);
     solid.bind(0);
     quad.upload(std.mem.sliceAsBytes(verts[0..]));
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    text.drawArrays(c.GL_TRIANGLES, 0, 6);
     drawCallTick();
 }
 
 /// Grayscale/text glyph via the text pipeline (atlas .r as alpha, modulated by color).
 pub fn drawGlyph(rect: Rect, uv: Uv, tex: c.GLuint, color: [3]f32) void {
-    const gl = gpu.glTable();
     const verts = quadVertices(rect, uv);
     text.use();
     text.bindVao();
-    gl.Uniform3f.?(gl.GetUniformLocation.?(text.program, "textColor"), color[0], color[1], color[2]);
+    text.setVec3("textColor", color[0], color[1], color[2]);
     Texture.fromHandle(tex).bind(0);
     quad.upload(std.mem.sliceAsBytes(verts[0..]));
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    text.drawArrays(c.GL_TRIANGLES, 0, 6);
     drawCallTick();
 }
 
@@ -177,18 +162,17 @@ pub fn drawGlyph(rect: Rect, uv: Uv, tex: c.GLuint, color: [3]f32) void {
 /// per-call projection from the current viewport (= old renderBellEmoji /
 /// renderTitlebarChar color branch).
 pub fn drawColorGlyph(rect: Rect, uv: Uv, tex: c.GLuint, opacity: f32) void {
-    const gl = gpu.glTable();
     const verts = quadVertices(rect, uv);
     emoji.use();
     emoji.bindVao();
     emoji.setProjection(); // viewport-derived ortho on the emoji program (Pipeline.setProjection)
-    gl.Uniform1f.?(gl.GetUniformLocation.?(emoji.program, "opacity"), opacity);
-    gl.BlendFunc.?(c.GL_ONE, c.GL_ONE_MINUS_SRC_ALPHA);
+    emoji.setFloat("opacity", opacity);
+    gpu.state.setBlendMode(.premultiplied);
     Texture.fromHandle(tex).bind(0);
     quad.upload(std.mem.sliceAsBytes(verts[0..]));
-    gl.DrawArrays.?(c.GL_TRIANGLES, 0, 6);
+    emoji.drawArrays(c.GL_TRIANGLES, 0, 6);
     drawCallTick();
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
+    gpu.state.setBlendMode(.alpha);
 }
 
 /// Draw a textured RGBA quad through the emoji/color pipeline (the old

--- a/src/renderer/weixin_qr_renderer.zig
+++ b/src/renderer/weixin_qr_renderer.zig
@@ -38,13 +38,6 @@ fn rectY(window_height: f32, rect: qr_panel.Rect) f32 {
     return @round(window_height - rect.top_px - rect.h);
 }
 
-fn beginUi() void {
-    const gl = AppWindow.gpu.glTable();
-    gl.UseProgram.?(gl_init.shader_program);
-    gl.ActiveTexture.?(c.GL_TEXTURE0);
-    gl.BindVertexArray.?(gl_init.vao);
-}
-
 pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     if (!qr_panel.visible()) return;
 
@@ -55,10 +48,8 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     }
     if (!qr_panel.visible()) return;
 
-    const gl = AppWindow.gpu.glTable();
-    gl.Enable.?(c.GL_BLEND);
-    gl.BlendFunc.?(c.GL_SRC_ALPHA, c.GL_ONE_MINUS_SRC_ALPHA);
-    beginUi();
+    AppWindow.gpu.state.setBlendEnabled(true);
+    AppWindow.gpu.state.setBlendMode(.alpha);
 
     const l = qr_panel.layout(window_width, window_height, top_offset);
     const panel_y = rectY(window_height, l.panel);

--- a/src/shared_compile_test.zig
+++ b/src/shared_compile_test.zig
@@ -19,6 +19,11 @@ comptime {
     _ = @import("update_check.zig");
     _ = @import("update_install.zig");
     _ = @import("platform/webview.zig");
+    // GPU backend spine: forces the active backend (Metal on macOS, OpenGL
+    // elsewhere) to be analyzed for the selected target so the cross-compile
+    // gate actually exercises the backend. gpu.zig is self-contained (it does
+    // not pull in AppWindow), so this stays a shared compile-only check.
+    _ = @import("renderer/gpu/gpu.zig");
 }
 
 test "shared compile target has app metadata" {


### PR DESCRIPTION
Makes the codebase **ready to start the macOS port cold** — the rendering layer no longer hard-wires OpenGL, the project cross-compiles to `aarch64-macos` against a Metal stub skeleton, and the macOS pty is ready. None of this needs a Mac; all verified on Linux/Windows. The Mac work becomes "fill in `metal: TODO D1` bodies + AppKit host + CoreText against a building skeleton".

## ① Render-layer de-GL-ification (the linchpin)
Added a backend-neutral gpu interface — `gpu.state` (blend/scissor/clear/viewport/frame seam), `gpu.vertex` (declarative multi-buffer VAO builder), `Pipeline.setMat4` — and routed the **entire rendering layer** off raw GL onto it: `ui_pipeline`, `cell_pipeline`, `cell_renderer`, `post_process`, `Renderer`, `markdown_preview`, `weixin_qr_renderer`, `overlays/{resize,scrollbar,startup_shortcuts}`, plus AppWindow's frame-loop render-state. No file outside `gpu/opengl/` calls `gpu.glTable()` or reaches into `gpu.Context.gl` (the one residue: AppWindow's `Context.init` host seam + a diagnostics snapshot).
- **`gl_backend_guard` strengthened (①c):** the whole rendering layer is regression-locked against re-acquiring the GL table (both `glTable()` and the `gpu.Context.gl` bypass), comptime-enforced via `test_main`.

## ② Surface seam
Documented the host→GPU surface contract as per-backend `Context.init` (OpenGL: GL proc-loader; Metal: `CAMetalLayer`) in `window_backend.zig` + `gpu/metal/Context.zig`.

## ③ Metal backend stub
`src/renderer/gpu/metal/*` mirrors `gpu/opengl/api.zig`'s full public interface (`Context`/`Buffer`/`Texture`/`Pipeline`/`Framebuffer`/`render_state`/`vertex`/`c`/`gl_init`/`shaders`) with `@panic("metal: TODO D1")` bodies and matching field/method shapes; `gpu.zig`'s `.metal` branch is wired (lazy imports so glad isn't analyzed on Darwin). This is the literal fill-in target for the Mac dev.

## ④ macOS pty constants
OS-dispatched `TIOCSWINSZ`/`TIOCSCTTY`/`FIONREAD` (macOS BSD-IOC values) + a local `ioctl` extern with a `c_ulong` request (the macOS codes exceed `i32`); `pty.zig` `backendForOs(.macos) = .posix`.

## ⑤ macOS cross-compile
`zig build test-full -Dtarget=aarch64-macos` **compiles** (renderer/Metal/host bodies are stubs; platform facades' `_unsupported` macOS fallbacks sufficed — no new facade work needed).

## Verification
- `zig build` (Windows) clean; `zig build test` green; `zig build test-full -Dtarget=x86_64-windows-gnu` green (guard satisfied).
- `zig build test-full -Dtarget=aarch64-macos` compiles.
- Linux native pty tests still green.
- Behavior-preserving on OpenGL — no runtime change on Windows. (Cell-grid/glyph parity was reviewed: `renderChar`→`drawGlyph` is byte-identical vertices; instanced VAO layouts transcribed attribute-for-attribute; blend bookends preserved.)

Plan: `docs/superpowers/plans/2026-05-26-d-prep-gpu-neutralize.md`. Next (on a Mac): D1 Metal bodies + MSL shaders, D2 AppKit host feeding the `CAMetalLayer`, D3 CoreText.

🤖 Generated with [Claude Code](https://claude.com/claude-code)