### PR TITLE
[codex] fix Reasonix flicker and IME caret drift

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -35,6 +35,7 @@ const quick_terminal = @import("quick_terminal.zig");
 const keybind = @import("keybind.zig");
 const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
+const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
 pub const font = @import("font/manager.zig");
@@ -338,6 +339,18 @@ pub const DEFAULT_PADDING = split_layout.DEFAULT_PADDING;
 pub const surfaceAtPoint = split_layout.surfaceAtPoint;
 pub const hitTestDivider = split_layout.hitTestDivider;
 const computeSplitLayout = split_layout.computeSplitLayout;
+
+fn synchronizedOutputPendingForVisibleSplits(split_count: usize) bool {
+    for (0..split_count) |i| {
+        const surface = split_layout.g_split_rects[i].surface;
+        surface.render_state.mutex.lock();
+        const pending = surface.synchronizedOutputPendingLocked();
+        surface.render_state.mutex.unlock();
+
+        if (pending) return true;
+    }
+    return false;
+}
 
 pub const MAX_TABS = tab.MAX_TABS;
 
@@ -3070,6 +3083,12 @@ fn syncImeCaretPosition(win: *window_backend.Window, split_count: usize) void {
 
     const surface = activeSurface() orelse return;
 
+    // Once the IME starts composing, keep the candidate window and inline
+    // preedit anchored to the last stable position. TUIs can repaint status
+    // areas while composing, and moving the OS IME window mid-composition is
+    // more disruptive than waiting for the next composition session.
+    if (win.ime_composing) return;
+
     var caret: ImeCaret = undefined;
     {
         surface.render_state.mutex.lock();
@@ -3077,16 +3096,11 @@ fn syncImeCaretPosition(win: *window_backend.Window, split_count: usize) void {
         caret = imeCaretFromSurfaceLocked(surface);
     }
 
-    // For regular terminal cursors, keep the existing composition freeze. Some
-    // TUIs render transient status lines with cursor save/restore while IME is
-    // active, and moving the IMM popup mid-composition is visually noisy.
-    if (caret.source == .terminal_cursor and win.ime_composing) return;
-
     // Require two consecutive frames at the same terminal-cursor position
     // before committing, so single-frame transients during status-line
     // animations are skipped. Visual inverse carets are app-drawn stable cells
-    // (Claude Code hides the terminal cursor and draws one this way), so accept
-    // them immediately and allow them to correct a stale composition anchor.
+    // (some TUIs hide the terminal cursor and draw one this way), so accept
+    // them immediately.
     const sx: i64 = @intCast(caret.x);
     const sy: i64 = @intCast(caret.y);
     if (caret.source == .terminal_cursor) {
@@ -3163,17 +3177,19 @@ fn imeCaretFromSurfaceLocked(surface: *Surface) ImeCaret {
     }
 
     if (!terminal.modes.get(.cursor_visible)) {
-        if (visualInverseImeCaretLocked(surface)) |visual| return visual;
+        if (visualInverseImeCaretLocked(surface, caret)) |visual| return visual;
     }
 
     return caret;
 }
 
-fn visualInverseImeCaretLocked(surface: *Surface) ?ImeCaret {
+fn visualInverseImeCaretLocked(surface: *Surface, anchor: ImeCaret) ?ImeCaret {
     const terminal = &surface.terminal;
     const screen = terminal.screens.active;
     const render_cols = @as(usize, terminal.cols);
     var best: ?ImeCaret = null;
+    var best_point: ?ime_caret.Point = null;
+    const anchor_point: ime_caret.Point = .{ .x = anchor.x, .y = anchor.y };
 
     var row_it = screen.pages.rowIterator(.right_down, .{ .viewport = .{} }, null);
     var row_idx: usize = 0;
@@ -3194,11 +3210,14 @@ fn visualInverseImeCaretLocked(surface: *Surface) ?ImeCaret {
             while (col < num_cols and isInverseBlankImeCell(p, &page_cells[col])) : (col += 1) {}
             const run_len = col - run_start;
             if (run_len <= 2) {
+                const point: ime_caret.Point = .{ .x = run_start, .y = row_idx };
+                if (!ime_caret.isBetterCandidate(anchor_point, best_point, point)) continue;
                 best = .{
                     .x = run_start,
                     .y = row_idx,
                     .source = .visual_inverse,
                 };
+                best_point = point;
             }
         }
     }
@@ -3816,6 +3835,10 @@ fn runMainLoop(self: *AppWindow) !void {
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
             syncRemoteLayout(allocator);
             syncImeCaretPosition(win, split_count);
+            if (active_tab.kind != .ai_chat and synchronizedOutputPendingForVisibleSplits(split_count)) {
+                std.Thread.sleep(std.time.ns_per_ms);
+                continue;
+            }
 
             // Debug: print split count on first few frames
             // GL rendering

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -20,6 +20,7 @@ const RendererThread = @import("RendererThread.zig");
 const remote = @import("remote_client.zig");
 const threading = @import("threading.zig");
 const agent_detector = @import("agent_detector.zig");
+const sync_output = @import("sync_output.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 
 const Surface = @This();
@@ -127,7 +128,20 @@ pub const VtHandler = struct {
             self.surface.bell_pending.store(true, .release);
             return;
         }
+
+        const sync_before = self.surface.terminal.modes.get(.synchronized_output);
+        const sync_mode_touched = switch (action) {
+            .set_mode,
+            .reset_mode,
+            .restore_mode,
+            => value.mode == .synchronized_output,
+            else => false,
+        };
         self.inner.vt(action, value);
+        const sync_after = self.surface.terminal.modes.get(.synchronized_output);
+        if (sync_mode_touched or sync_before != sync_after) {
+            self.surface.noteSynchronizedOutputMode(sync_after);
+        }
     }
 };
 
@@ -183,6 +197,9 @@ renderer_thread: RendererThread,
 /// Dirty flag — set by IO thread (Phase 2), read by render loop.
 /// For Phase 1 this is always effectively true (we render every frame).
 dirty: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+
+/// Deadline state for DEC synchronized output mode (2026).
+sync_output_state: sync_output.State = .{},
 
 /// Set when the PTY process has exited.
 exited: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -352,6 +369,7 @@ pub fn init(
     surface.vt_stream = surface.initVtStream();
     errdefer surface.vt_stream.deinit();
     surface.dirty = std.atomic.Value(bool).init(true);
+    surface.sync_output_state = .{};
     surface.exited = std.atomic.Value(bool).init(false);
     surface.resize_in_progress = std.atomic.Value(bool).init(false);
 
@@ -759,6 +777,46 @@ fn captureInitialCwd(self: *Surface, cwd: platform_pty_command.Cwd) void {
 /// Reset OSC batch state — call before each PTY read batch.
 pub fn resetOscBatch(self: *Surface) void {
     self.got_osc7_this_batch = false;
+}
+
+/// Track DEC synchronized output mode (2026) transitions. This mirrors
+/// Ghostty's behavior: rendering waits while the mode is enabled, but a
+/// watchdog prevents an application from hiding the terminal indefinitely.
+pub fn noteSynchronizedOutputMode(self: *Surface, enabled: bool) void {
+    if (enabled) {
+        self.sync_output_state.start(std.time.milliTimestamp());
+    } else {
+        self.sync_output_state.stop();
+        self.surface_renderer.force_rebuild = true;
+    }
+    self.dirty.store(true, .release);
+}
+
+/// Clear synchronized output after an external terminal state change such as
+/// resize. Caller must hold render_state.mutex.
+pub fn clearSynchronizedOutputLocked(self: *Surface) void {
+    self.terminal.modes.set(.synchronized_output, false);
+    self.sync_output_state.stop();
+    self.surface_renderer.force_rebuild = true;
+    self.dirty.store(true, .release);
+}
+
+/// Return true while a visible frame should be deferred for synchronized
+/// output. Caller must hold render_state.mutex.
+pub fn synchronizedOutputPendingLocked(self: *Surface) bool {
+    return switch (self.sync_output_state.poll(
+        self.terminal.modes.get(.synchronized_output),
+        std.time.milliTimestamp(),
+    )) {
+        .inactive => false,
+        .pending => true,
+        .expired => expired: {
+            self.terminal.modes.set(.synchronized_output, false);
+            self.surface_renderer.force_rebuild = true;
+            self.dirty.store(true, .release);
+            break :expired false;
+        },
+    };
 }
 
 /// Feed terminal output to the VT parser, translating Phantty's private OSC

--- a/src/ime_caret.zig
+++ b/src/ime_caret.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub const Point = struct {
+    x: usize,
+    y: usize,
+};
+
+pub fn candidateScore(anchor: Point, candidate: Point) usize {
+    const row_distance = absDiff(anchor.y, candidate.y);
+    const col_distance = absDiff(anchor.x, candidate.x);
+    return row_distance * 4096 + col_distance;
+}
+
+pub fn isBetterCandidate(anchor: Point, current: ?Point, candidate: Point) bool {
+    const current_point = current orelse return true;
+    const candidate_score = candidateScore(anchor, candidate);
+    const current_score = candidateScore(anchor, current_point);
+    if (candidate_score != current_score) return candidate_score < current_score;
+    if (candidate.y != current_point.y) return candidate.y > current_point.y;
+    return candidate.x < current_point.x;
+}
+
+fn absDiff(a: usize, b: usize) usize {
+    return if (a > b) a - b else b - a;
+}
+
+test "IME visual caret prefers nearest candidate to terminal anchor" {
+    const anchor: Point = .{ .x = 4, .y = 20 };
+    const near: Point = .{ .x = 5, .y = 20 };
+    const far_right: Point = .{ .x = 100, .y = 20 };
+
+    try std.testing.expect(isBetterCandidate(anchor, null, far_right));
+    try std.testing.expect(isBetterCandidate(anchor, far_right, near));
+    try std.testing.expect(!isBetterCandidate(anchor, near, far_right));
+}
+
+test "IME visual caret ranks row distance ahead of column distance" {
+    const anchor: Point = .{ .x = 60, .y = 12 };
+    const same_row: Point = .{ .x = 12, .y = 12 };
+    const next_row_near_x: Point = .{ .x = 60, .y = 13 };
+
+    try std.testing.expect(isBetterCandidate(anchor, next_row_near_x, same_row));
+}

--- a/src/sync_output.zig
+++ b/src/sync_output.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+
+/// DEC synchronized output (mode 2026) must not be allowed to leave the
+/// terminal hidden forever if an application crashes before resetting it.
+/// Ghostty uses the same 1 second safety reset.
+pub const reset_ms: i64 = 1000;
+
+pub const Poll = enum {
+    inactive,
+    pending,
+    expired,
+};
+
+pub const State = struct {
+    deadline_ms: i64 = 0,
+
+    pub fn start(self: *State, now_ms: i64) void {
+        self.deadline_ms = now_ms + reset_ms;
+    }
+
+    pub fn stop(self: *State) void {
+        self.deadline_ms = 0;
+    }
+
+    pub fn poll(self: *State, mode_enabled: bool, now_ms: i64) Poll {
+        if (!mode_enabled) {
+            self.stop();
+            return .inactive;
+        }
+
+        if (self.deadline_ms == 0) {
+            self.start(now_ms);
+        }
+
+        if (now_ms >= self.deadline_ms) {
+            self.stop();
+            return .expired;
+        }
+
+        return .pending;
+    }
+};
+
+test "synchronized output starts pending until deadline" {
+    var state: State = .{};
+
+    try std.testing.expectEqual(Poll.inactive, state.poll(false, 100));
+
+    state.start(100);
+    try std.testing.expectEqual(@as(i64, 1100), state.deadline_ms);
+    try std.testing.expectEqual(Poll.pending, state.poll(true, 1099));
+    try std.testing.expectEqual(Poll.expired, state.poll(true, 1100));
+    try std.testing.expectEqual(@as(i64, 0), state.deadline_ms);
+}
+
+test "synchronized output recovers when mode is already enabled" {
+    var state: State = .{};
+
+    try std.testing.expectEqual(Poll.pending, state.poll(true, 50));
+    try std.testing.expectEqual(@as(i64, 1050), state.deadline_ms);
+
+    try std.testing.expectEqual(Poll.inactive, state.poll(false, 60));
+    try std.testing.expectEqual(@as(i64, 0), state.deadline_ms);
+}

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -166,8 +166,7 @@ fn applyResize(surface: *Surface, grid: renderer.size.GridSize) void {
 
     // Match Ghostty's Termio.resize behavior: a resize is allowed to break
     // synchronized output mode so TUI redraws become visible immediately.
-    surface.terminal.modes.set(.synchronized_output, false);
-    surface.surface_renderer.force_rebuild = true;
+    surface.clearSynchronizedOutputLocked();
 
     surface.terminal.scrollViewport(.{ .bottom = {} });
     surface.dirty.store(true, .release);

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -30,6 +30,8 @@ test {
     _ = @import("selection_unit.zig");
     _ = @import("scrollbar_model.zig");
     _ = @import("preview_token.zig");
+    _ = @import("ime_caret.zig");
+    _ = @import("sync_output.zig");
     _ = @import("agent_history.zig");
     _ = @import("render_diagnostics.zig");
     _ = @import("renderer/gpu/backend.zig");


### PR DESCRIPTION
## Summary
- Add DEC synchronized output (mode 2026) handling so TUI frame batches are held until the app exits sync mode or the 1s watchdog expires.
- Clear synchronized output state during resize so terminal redraws are not hidden behind stale mode state.
- Stabilize IME positioning for hidden-cursor TUIs by ranking visual inverse cursor candidates near the terminal cursor anchor and freezing the IME anchor during composition.

## Root Cause
DeepSeek-Reasonix renders through Ink with synchronized update sequences (`CSI ?2026h` / `CSI ?2026l`). Phantty parsed the mode through libghostty-vt but still presented intermediate OpenGL frames, which exposed partial TUI patches as visible flicker.

For IME, Phantty also accepted the last blank inverse cell in the viewport as an app-drawn cursor when the terminal cursor was hidden. Reasonix-style status regions can contain unrelated inverse cells, so the IME preedit/candidate window could jump to the lower-right status area.

## Ghostty Reference
- Ghostty skips renderer frame production while `.synchronized_output` is enabled, and starts a watchdog when mode 2026 is entered.
- Ghostty uses a 1000ms synchronized output reset deadline and clears synchronized output on resize.
- Ghostty derives IME placement from the surface renderer cursor/preedit state instead of scanning arbitrary screen highlights.

## Validation
- `zig build test`
- `zig build`
- `zig build test-full`
- Windows checkout safety checks: reserved names, illegal characters, case-fold collisions, symlinks, and path length
