### PR TITLE
refactor(b1): decouple input.zig — extract pure logic into testable modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -160,8 +160,17 @@ mapping in guide §2 and §5.
 
 ### Phase B — Presentation/logic separation (actionable now; verifiable on Windows)
 
-- [ ] **B1** `input.zig`: extract keybind parsing + command dispatch from
-      platform input handling into pure, unit-testable modules.
+- [x] **B1** `input.zig`: extract keybind parsing + command dispatch from
+      platform input handling into pure, unit-testable modules. Done via targeted
+      pure-module extraction (no global struct-ification): `input/click_tracker.zig`
+      (multi-click counter), `input/hit_test.zig` (sidebar geometry over a
+      `SidebarLayout` descriptor), `input/command_dispatch.zig` (pure
+      `resolve(action, phase) → ?Command`; `input.zig` keeps `executeCommand`).
+      19 std-only unit tests, run in the fast loop via `test_fast.zig` and
+      regression-locked in `test_main.zig`; `input.zig` 3573 → 3467 ln. Spec/plan:
+      `docs/superpowers/{specs/2026-05-27-b1-input-decouple-design,plans/2026-05-27-b1-input-decouple}.md`.
+      Native proof: `zig build test` (268 tests) and
+      `zig build test-full -Dtarget=x86_64-windows-gnu`.
 - [ ] **B2** `ai_chat.zig`: separate conversation/state/protocol logic from UI
       state into independently testable sub-modules.
 - [ ] **B3** `AppWindow.zig`: layer tab/split orchestration, render

--- a/docs/superpowers/specs/2026-05-27-b1-input-decouple-design.md
+++ b/docs/superpowers/specs/2026-05-27-b1-input-decouple-design.md
@@ -1,0 +1,162 @@
+# B1 — Decouple `input.zig` (presentation/logic separation)
+
+Phase B, item B1 of the cross-platform portability roadmap
+([TODO.md](../../../TODO.md), [decoupling-guide.md](../../decoupling-guide.md) §5).
+
+## Goal
+
+Extract the **pure decision logic** out of `src/input.zig` into std-only,
+unit-testable sibling modules, leaving `input.zig` as the thin platform-event +
+global-state + side-effect-execution shell. This satisfies B1 ("extract keybind
+parsing and command dispatch from platform input-event handling into pure,
+unit-testable modules") and produces B4 unit tests in the same pass.
+
+Approach (chosen): **targeted pure-module extraction**, matching the established
+repo pattern (`keybind.zig`, `input_shortcuts.zig`, `selection_unit.zig`,
+`ai_chat_layout.zig`, `titlebar_layout.zig`, …): pure logic moves to sibling
+modules with std-only `test` blocks, `input.zig` delegates, and the modules are
+regression-locked by `_ = @import(...)` in `src/test_main.zig`.
+
+**Explicitly NOT chosen:** struct-ifying the 31 global `threadlocal var`s into an
+injected `InputState`. That is the "aggressive" path with a large blast radius
+on every call site and is out of scope for B1.
+
+## Current state (the coupling)
+
+`src/input.zig` is a module-level singleton (~3,573 ln, 31 global
+`threadlocal var g_*`) mixing:
+
+- platform event pumping (`processEvents`, `handleKey`, `handleChar`),
+- keybind action dispatch (`handleConfiguredKeybindAction`, `switchTabActionIndex`),
+- hit-testing (`hitTestSidebar*`, panel resize handles, scrollbar targets),
+- click/drag state machines (`nextLeftClickCount`, sidebar tab drag),
+- selection (`activateSelection`, …) — partly already in `selection_unit.zig`.
+
+`handleConfiguredKeybindAction(action, phase)` is the central dispatch: it
+interleaves the *decision* (which command this `keybind.Action` triggers in the
+`.early`/`.late` phase, and whether it is consumed) with the *execution* (the
+`AppWindow.*` / `overlays.*` side-effect calls). That interleaving is the B1
+seam.
+
+## Design — three new modules under `src/input/`
+
+### 1. `src/input/command_dispatch.zig` (pure)
+
+Splits the *decision* from the *execution* in `handleConfiguredKeybindAction`.
+
+- `Phase = enum { early, late }` (moved/mirrored from `input.zig`'s
+  `KeybindPhase`).
+- `Command` — a tagged union describing the intent of each dispatched action,
+  e.g.: `toggle_quake`, `toggle_command_palette`, `new_window`, `new_session`,
+  `split_right`, `toggle_file_explorer`, `toggle_sidebar`, `close_panel_or_tab`,
+  `toggle_maximize`, `font_size: i32` (±1), `copy`, `paste`, `paste_image`,
+  `focus_split: keybind`-direction, `equalize_splits`, `next_tab`,
+  `previous_tab`, `open_config`, `switch_tab: usize`.
+- `resolve(action: keybind.Action, phase: Phase) ?Command` — **pure**, no globals,
+  no side effects. Returns the command for that action in that phase, or `null`
+  if the action is not handled in that phase. Absorbs `switchTabActionIndex`
+  (pure `Action → ?usize`, surfaced as `Command.switch_tab`).
+
+`input.zig` retains an `executeCommand(cmd: Command) bool` that performs the
+side effects — including the "performable" actions (`focus_*`, `switch_tab`)
+whose *consumed* result depends on runtime state (does a split/tab exist), which
+is intentionally NOT pure. `handleConfiguredKeybindAction` becomes:
+
+```zig
+fn handleConfiguredKeybindAction(action: keybind.Action, phase: KeybindPhase) bool {
+    const cmd = command_dispatch.resolve(action, mapPhase(phase)) orelse return false;
+    return executeCommand(cmd);
+}
+```
+
+**Behavior invariant:** the `commitTabRenameIfActive()` calls currently sprinkled
+through the `.early` arm are preserved — either folded into `executeCommand`'s
+early-command prologue or kept as the executor's responsibility, so the observed
+behavior is byte-identical.
+
+**Tests:** every `keybind.Action` resolves to the expected `Command` in the
+correct phase; actions handled only in `.early` return `null` in `.late` and
+vice-versa; `switch_tab_1..9` → `Command.switch_tab` with index 0..8; unhandled
+actions → `null` in both phases.
+
+### 2. `src/input/hit_test.zig` (pure)
+
+Pure geometry: a layout descriptor + coordinates → a hit target. No `tab.g_*` or
+`titlebar.*()` reads inside the module.
+
+- Descriptor structs, e.g.
+  `SidebarLayout{ visible: bool, width: f64, header_h: f64, row_h: f64, titlebar_h: f64, tab_count: usize }`.
+- Functions (pure): `sidebarTabAt(layout, x, y) ?usize`,
+  `sidebarPlusButton(layout, x, y) bool`,
+  `sidebarTabCloseButton(layout, x, y, tab_idx) bool`,
+  `sidebarTabIndexForDragY(layout, y) ?usize`, plus the panel **resize-handle**
+  and **width-from-mouse** math and the **scrollbar target** geometry — all of
+  which are pure arithmetic over current global state today.
+- `input.zig` keeps thin wrappers (same signatures as today) that read the
+  globals into a descriptor and call the pure function, so external callers are
+  untouched.
+
+**Scope control:** B1 extracts the sidebar family + panel resize-handle/
+width-from-mouse math + scrollbar target geometry. Hit-tests that are thin
+delegations into other modules' own state (e.g. file-explorer/markdown internal
+hit-testing) stay as-is — only their pure arithmetic, if any, moves.
+
+**Tests:** boundary cases per region — just inside/outside each edge, `y` above
+the list top, empty tab list, index past `tab_count` clamped, single-tab
+close-button suppression, resize-handle hit band, scrollbar thumb vs. track.
+
+### 3. `src/input/click_tracker.zig` (pure)
+
+- `ClickTracker = struct { count: u8 = 0, time_ms: i64 = 0, x: f64 = 0, y: f64 = 0 }`
+  with `register(self: *ClickTracker, x: f64, y: f64, now_ms: i64, max_distance: f64, interval_ms: i64) u8`
+  reproducing `nextLeftClickCount` exactly (reset when outside interval OR
+  distance; increment; wrap >4 → 1; update last position/time; return count).
+- `input.zig` holds one global `var g_left_click_tracker: ClickTracker = .{}`;
+  `nextLeftClickCount(x, y)` computes `max_distance` from `font.cell_*` and the
+  `MULTI_CLICK_INTERVAL_MS` constant, then delegates.
+
+**Tests:** first click → 1; fast + near → 2, 3, 4; fifth fast+near → wraps to 1;
+slow (beyond interval) → reset to 1; far (beyond distance) → reset to 1.
+
+## B4 — tests & regression-lock
+
+- Unit tests live inside each new module as std-only `test` blocks (runnable via
+  `zig test src/input/<mod>.zig` and through `zig build test`).
+- Each module is added to the `comptime { _ = @import(...); }` block in
+  `src/test_main.zig` so a regression fails `zig build test`.
+- The existing integration tests already in `input.zig`
+  (`"input: Ctrl+Shift+P toggles command center"`, the macOS sidebar smoke test)
+  stay and must remain green — they exercise `handleKey` → `handleConfiguredKeybindAction`,
+  which now routes through `command_dispatch.resolve` + `executeCommand`.
+
+## Out of scope
+
+- No struct-ification of the global state.
+- No change to selection logic beyond what already lives in `selection_unit.zig`.
+- Drag *state machines* keep their globals in `input.zig`; only their pure
+  geometry (e.g. `sidebarTabIndexForDragY`, the drag-threshold distance check)
+  moves to `hit_test.zig`.
+- No renderer/platform changes; `input.zig`'s public API to other modules is
+  unchanged.
+
+## Verification
+
+- `zig build test` (native here — the canonical loop).
+- `zig build test-full -Dtarget=x86_64-windows-gnu` — keep the memory baseline
+  (497/499; 1 known Windows-API failure + 1 skip).
+- `zig build test-full -Dtarget=aarch64-macos` — keep macOS green.
+
+## Risks & mitigations
+
+- **Behavior drift in dispatch.** Mitigated by keeping `executeCommand` a literal
+  move of today's side-effect bodies, the `resolve` mapping exhaustively covering
+  the same `keybind.Action` arms, and the existing integration tests guarding the
+  end-to-end path.
+- **Hidden global reads in "pure" candidates.** Mitigated by passing every input
+  as an explicit descriptor parameter; the module compiles std-only, so any stray
+  global reference fails to build.
+
+## Ghostty reference
+
+`input/` + `Binding.zig` are separate from apprt input handling — the same
+decision-vs-execution split this design applies.

--- a/src/input.zig
+++ b/src/input.zig
@@ -41,6 +41,7 @@ const CellPos = struct { col: usize, row: usize };
 
 const clipboard = @import("input/clipboard.zig");
 const click_tracker = @import("input/click_tracker.zig");
+const hit_test = @import("input/hit_test.zig");
 const preview_source = @import("input/preview_source.zig");
 const writeToPty = clipboard.writeToPty;
 pub const copyTextToClipboard = clipboard.copyTextToClipboard;
@@ -1293,17 +1294,21 @@ fn handleBrowserUrlBarKey(ev: platform_input.KeyEvent) void {
     }
 }
 
+fn sidebarLayout() hit_test.SidebarLayout {
+    return .{
+        .visible = tab.g_sidebar_visible,
+        .titlebar_h = titlebarHeight(),
+        .width = @floatCast(titlebar.sidebarWidth()),
+        .header_h = @floatCast(titlebar.sidebarHeaderHeight()),
+        .row_h = @floatCast(titlebar.sidebarRowHeight()),
+        .tab_count = tab.g_tab_count,
+        .resize_hit_width = @floatCast(titlebar.SIDEBAR_RESIZE_HIT_WIDTH),
+        .close_btn_w = @floatCast(tab.TAB_CLOSE_BTN_W),
+    };
+}
+
 fn hitTestSidebarTab(xpos: f64, ypos: f64) ?usize {
-    if (!tab.g_sidebar_visible) return null;
-    if (xpos < 0 or xpos >= @as(f64, @floatCast(titlebar.sidebarWidth()))) return null;
-
-    const list_top = titlebarHeight() + @as(f64, @floatCast(titlebar.sidebarHeaderHeight())) + 6;
-    if (ypos < list_top) return null;
-
-    const idx_f = (ypos - list_top) / @as(f64, @floatCast(titlebar.sidebarRowHeight()));
-    const idx: usize = @intFromFloat(@floor(idx_f));
-    if (idx >= tab.g_tab_count) return null;
-    return idx;
+    return hit_test.sidebarTabAt(sidebarLayout(), xpos, ypos);
 }
 
 fn resetSidebarTabDragState() void {
@@ -1324,16 +1329,7 @@ fn beginSidebarTabPotentialDrag(tab_idx: usize, xpos: f64, ypos: f64) void {
 }
 
 fn sidebarTabIndexForDragY(ypos: f64) ?usize {
-    if (!tab.g_sidebar_visible or tab.g_tab_count == 0) return null;
-
-    const list_top = titlebarHeight() + @as(f64, @floatCast(titlebar.sidebarHeaderHeight())) + 6;
-    const row_h = @as(f64, @floatCast(titlebar.sidebarRowHeight()));
-    if (ypos < list_top) return 0;
-
-    const idx_f = (ypos - list_top) / row_h;
-    const idx_raw: usize = @intFromFloat(@floor(idx_f));
-    if (idx_raw >= tab.g_tab_count) return tab.g_tab_count - 1;
-    return idx_raw;
+    return hit_test.sidebarTabIndexForDragY(sidebarLayout(), ypos);
 }
 
 fn updateSidebarTabDrag(xpos: f64, ypos: f64) bool {
@@ -1367,36 +1363,24 @@ fn finishSidebarTabDrag() bool {
 }
 
 fn hitTestSidebarPlusButton(xpos: f64, ypos: f64) bool {
-    if (!tab.g_sidebar_visible) return false;
-    const top = titlebarHeight();
-    const plus_w: f64 = 42;
-    const plus_x = @as(f64, @floatCast(titlebar.sidebarWidth())) - plus_w - 6;
-    return xpos >= plus_x and xpos < plus_x + plus_w and
-        ypos >= top and ypos < top + @as(f64, @floatCast(titlebar.sidebarHeaderHeight()));
+    return hit_test.sidebarPlusButton(sidebarLayout(), xpos, ypos);
 }
 
 fn hitTestSidebarTabCloseButton(xpos: f64, ypos: f64, tab_idx: usize) bool {
-    if (!tab.g_sidebar_visible or tab_idx >= tab.g_tab_count or tab.g_tab_count <= 1) return false;
-    const row = hitTestSidebarTab(xpos, ypos) orelse return false;
-    if (row != tab_idx) return false;
-    const close_x = @as(f64, @floatCast(titlebar.sidebarWidth() - tab.TAB_CLOSE_BTN_W - 4));
-    return xpos >= close_x and xpos < close_x + @as(f64, tab.TAB_CLOSE_BTN_W);
+    return hit_test.sidebarTabCloseButton(sidebarLayout(), xpos, ypos, tab_idx);
 }
 
 fn shouldStartSidebarTabRename(xpos: f64, ypos: f64, tab_idx: usize) bool {
     if (tab_idx >= tab.g_tab_count) return false;
-    if (hitTestSidebarPlusButton(xpos, ypos)) return false;
-    if (hitTestSidebarResizeHandle(xpos, ypos)) return false;
-    if (hitTestSidebarTabCloseButton(xpos, ypos, tab_idx)) return false;
+    const layout = sidebarLayout();
+    if (hit_test.sidebarPlusButton(layout, xpos, ypos)) return false;
+    if (hit_test.sidebarResizeHandle(layout, xpos, ypos)) return false;
+    if (hit_test.sidebarTabCloseButton(layout, xpos, ypos, tab_idx)) return false;
     return true;
 }
 
 fn hitTestSidebarResizeHandle(xpos: f64, ypos: f64) bool {
-    if (!tab.g_sidebar_visible) return false;
-    if (ypos < titlebarHeight()) return false;
-    const sidebar_w: f64 = @floatCast(titlebar.sidebarWidth());
-    const half_hit: f64 = @as(f64, @floatCast(titlebar.SIDEBAR_RESIZE_HIT_WIDTH)) / 2;
-    return xpos >= sidebar_w - half_hit and xpos <= sidebar_w + half_hit;
+    return hit_test.sidebarResizeHandle(sidebarLayout(), xpos, ypos);
 }
 
 fn applySidebarWidthFromMouse(xpos: f64) void {

--- a/src/input.zig
+++ b/src/input.zig
@@ -32,6 +32,7 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const platform_wsl = @import("platform/wsl.zig");
 const window_backend = @import("platform/window_backend.zig");
 const input_key = @import("input/key.zig");
+const command_dispatch = @import("input/command_dispatch.zig");
 const Config = @import("config.zig");
 const Surface = @import("Surface.zig");
 const SplitTree = @import("split_tree.zig");
@@ -814,7 +815,7 @@ fn handleChar(ev: platform_input.CharEvent) void {
     writeToPty(surface, buf[0..len]);
 }
 
-const KeybindPhase = enum { early, late };
+const KeybindPhase = command_dispatch.Phase;
 
 fn triggerFromKeyEvent(ev: platform_input.KeyEvent) keybind.Trigger {
     return .{
@@ -908,134 +909,61 @@ fn requestNewWindowFromActiveCwd() void {
     app.requestNewWindow(handle, cwd);
 }
 
-fn switchTabActionIndex(action: keybind.Action) ?usize {
-    return switch (action) {
-        .switch_tab_1 => 0,
-        .switch_tab_2 => 1,
-        .switch_tab_3 => 2,
-        .switch_tab_4 => 3,
-        .switch_tab_5 => 4,
-        .switch_tab_6 => 5,
-        .switch_tab_7 => 6,
-        .switch_tab_8 => 7,
-        .switch_tab_9 => 8,
-        else => null,
-    };
+fn handleConfiguredKeybindAction(action: keybind.Action, phase: KeybindPhase) bool {
+    const cmd = command_dispatch.resolve(action, phase) orelse return false;
+    if (phase == .early) commitTabRenameIfActive();
+    return executeCommand(cmd);
 }
 
-fn handleConfiguredKeybindAction(action: keybind.Action, phase: KeybindPhase) bool {
-    switch (phase) {
-        .early => switch (action) {
-            .toggle_quake => {
-                commitTabRenameIfActive();
-                AppWindow.toggleQuakeVisibility();
-                return true;
-            },
-            .toggle_command_palette => {
-                commitTabRenameIfActive();
-                overlays.commandPaletteToggle();
-                return true;
-            },
-            .new_window => {
-                commitTabRenameIfActive();
-                requestNewWindowFromActiveCwd();
-                return true;
-            },
-            .new_session => {
-                commitTabRenameIfActive();
-                overlays.sessionLauncherOpen();
-                return true;
-            },
-            .split_right => {
-                commitTabRenameIfActive();
-                AppWindow.splitFocused(.right);
-                return true;
-            },
-            .toggle_file_explorer => {
-                commitTabRenameIfActive();
-                toggleFileExplorer();
-                return true;
-            },
-            .toggle_sidebar => {
-                commitTabRenameIfActive();
-                toggleSidebar();
-                return true;
-            },
-            .close_panel_or_tab => {
-                commitTabRenameIfActive();
-                closePanelOrTab();
-                return true;
-            },
-            .toggle_maximize => {
-                commitTabRenameIfActive();
-                toggleMaximize();
-                return true;
-            },
-            .font_size_increase => {
-                commitTabRenameIfActive();
-                adjustFontSize(1);
-                return true;
-            },
-            .font_size_decrease => {
-                commitTabRenameIfActive();
-                adjustFontSize(-1);
-                return true;
-            },
-            else => return false,
+fn executeCommand(cmd: command_dispatch.Command) bool {
+    switch (cmd) {
+        // Early
+        .toggle_quake => AppWindow.toggleQuakeVisibility(),
+        .toggle_command_palette => overlays.commandPaletteToggle(),
+        .new_window => requestNewWindowFromActiveCwd(),
+        .new_session => overlays.sessionLauncherOpen(),
+        .split_right => AppWindow.splitFocused(.right),
+        .toggle_file_explorer => toggleFileExplorer(),
+        .toggle_sidebar => toggleSidebar(),
+        .close_panel_or_tab => closePanelOrTab(),
+        .toggle_maximize => toggleMaximize(),
+        .font_size => |delta| adjustFontSize(delta),
+        // Late
+        .copy => copySelectionToClipboard(),
+        .paste => {
+            if (AppWindow.activeAiChat()) |chat| {
+                pasteFromClipboardIntoAiChat(chat);
+            } else {
+                pasteFromClipboard();
+            }
         },
-        .late => switch (action) {
-            .copy => {
-                copySelectionToClipboard();
-                return true;
-            },
-            .paste => {
-                if (AppWindow.activeAiChat()) |chat| {
-                    pasteFromClipboardIntoAiChat(chat);
-                } else {
-                    pasteFromClipboard();
-                }
-                return true;
-            },
-            .paste_image => {
-                pasteImageFromClipboard();
-                return true;
-            },
-            // Panel-focus shortcuts are "performable": if there is no pane in
-            // the requested direction, don't consume the key so it falls
-            // through to the terminal (e.g. Alt+Up reaches a TUI like Claude
-            // Code as \x1b[1;3A when running in a single pane).
-            .focus_left => return AppWindow.gotoSplit(.{ .spatial = .left }),
-            .focus_right => return AppWindow.gotoSplit(.{ .spatial = .right }),
-            .focus_up => return AppWindow.gotoSplit(.{ .spatial = .up }),
-            .focus_down => return AppWindow.gotoSplit(.{ .spatial = .down }),
-            .focus_previous => return AppWindow.gotoSplit(.previous_wrapped),
-            .focus_next => return AppWindow.gotoSplit(.next_wrapped),
-            .equalize_splits => {
-                AppWindow.equalizeSplits();
-                return true;
-            },
-            .next_tab => {
-                AppWindow.switchTab((tab.g_active_tab + 1) % tab.g_tab_count);
-                return true;
-            },
-            .previous_tab => {
-                if (tab.g_active_tab > 0) AppWindow.switchTab(tab.g_active_tab - 1) else AppWindow.switchTab(tab.g_tab_count - 1);
-                return true;
-            },
-            .open_config => {
-                std.debug.print("[keybind] open_config pressed\n", .{});
-                if (AppWindow.g_allocator) |alloc| Config.openConfigInEditor(alloc);
-                return true;
-            },
-            else => {
-                if (switchTabActionIndex(action)) |tab_idx| {
-                    if (tab_idx < tab.g_tab_count) AppWindow.switchTab(tab_idx);
-                    return true;
-                }
-                return false;
-            },
+        .paste_image => pasteImageFromClipboard(),
+        // Panel-focus shortcuts are "performable": if there is no pane in
+        // the requested direction, don't consume the key so it falls
+        // through to the terminal (e.g. Alt+Up reaches a TUI like Claude
+        // Code as \x1b[1;3A when running in a single pane).
+        .focus_split => |target| return switch (target) {
+            .left => AppWindow.gotoSplit(.{ .spatial = .left }),
+            .right => AppWindow.gotoSplit(.{ .spatial = .right }),
+            .up => AppWindow.gotoSplit(.{ .spatial = .up }),
+            .down => AppWindow.gotoSplit(.{ .spatial = .down }),
+            .previous => AppWindow.gotoSplit(.previous_wrapped),
+            .next => AppWindow.gotoSplit(.next_wrapped),
+        },
+        .equalize_splits => AppWindow.equalizeSplits(),
+        .next_tab => AppWindow.switchTab((tab.g_active_tab + 1) % tab.g_tab_count),
+        .previous_tab => {
+            if (tab.g_active_tab > 0) AppWindow.switchTab(tab.g_active_tab - 1) else AppWindow.switchTab(tab.g_tab_count - 1);
+        },
+        .open_config => {
+            std.debug.print("[keybind] open_config pressed\n", .{});
+            if (AppWindow.g_allocator) |alloc| Config.openConfigInEditor(alloc);
+        },
+        .switch_tab => |idx| {
+            if (idx < tab.g_tab_count) AppWindow.switchTab(idx);
         },
     }
+    return true;
 }
 
 fn handleKey(ev: platform_input.KeyEvent) void {

--- a/src/input.zig
+++ b/src/input.zig
@@ -40,6 +40,7 @@ const Selection = Surface.Selection;
 const CellPos = struct { col: usize, row: usize };
 
 const clipboard = @import("input/clipboard.zig");
+const click_tracker = @import("input/click_tracker.zig");
 const preview_source = @import("input/preview_source.zig");
 const writeToPty = clipboard.writeToPty;
 pub const copyTextToClipboard = clipboard.copyTextToClipboard;
@@ -209,10 +210,7 @@ pub threadlocal var g_selecting: bool = false; // True while mouse button is hel
 pub threadlocal var g_click_x: f64 = 0; // X position of initial click (for threshold calculation)
 pub threadlocal var g_click_y: f64 = 0; // Y position of initial click
 var g_selection_changed_for_copy: bool = false;
-threadlocal var g_left_click_count: u8 = 0;
-threadlocal var g_left_click_time_ms: i64 = 0;
-threadlocal var g_left_click_x: f64 = 0;
-threadlocal var g_left_click_y: f64 = 0;
+threadlocal var g_left_click_tracker: click_tracker.ClickTracker = .{};
 const MULTI_CLICK_INTERVAL_MS: i64 = 500;
 const MAX_SELECTION_COLS: usize = 4096;
 
@@ -1854,27 +1852,11 @@ fn markSelectionChanged() void {
 fn nextLeftClickCount(xpos: f64, ypos: f64) u8 {
     const now = std.time.milliTimestamp();
     const max_distance: f64 = @floatCast(@max(font.cell_width, font.cell_height));
-    const dx = xpos - g_left_click_x;
-    const dy = ypos - g_left_click_y;
-    const distance = @sqrt(dx * dx + dy * dy);
-    const within_interval = g_left_click_count > 0 and now - g_left_click_time_ms <= MULTI_CLICK_INTERVAL_MS;
-    const within_distance = g_left_click_count > 0 and distance <= max_distance;
-
-    if (!within_interval or !within_distance) g_left_click_count = 0;
-
-    g_left_click_count += 1;
-    if (g_left_click_count > 4) g_left_click_count = 1;
-    g_left_click_time_ms = now;
-    g_left_click_x = xpos;
-    g_left_click_y = ypos;
-    return g_left_click_count;
+    return g_left_click_tracker.register(xpos, ypos, now, max_distance, MULTI_CLICK_INTERVAL_MS);
 }
 
 fn resetLeftClickCount() void {
-    g_left_click_count = 0;
-    g_left_click_time_ms = 0;
-    g_left_click_x = 0;
-    g_left_click_y = 0;
+    g_left_click_tracker.reset();
 }
 
 fn readViewportRowLocked(surface: *Surface, row: usize, buf: *[MAX_SELECTION_COLS]u21) []const u21 {

--- a/src/input/click_tracker.zig
+++ b/src/input/click_tracker.zig
@@ -1,0 +1,91 @@
+//! Pure multi-click (double/triple/quad) counting state machine.
+//! Extracted from input.zig's nextLeftClickCount so the logic is std-only and
+//! unit-testable. input.zig owns one instance and supplies time/distance.
+const std = @import("std");
+
+pub const ClickTracker = struct {
+    count: u8 = 0,
+    time_ms: i64 = 0,
+    x: f64 = 0,
+    y: f64 = 0,
+
+    /// Register a click at (x, y) occurring at now_ms. A click continues the
+    /// streak only if it is within interval_ms of the previous click AND within
+    /// max_distance pixels of it; otherwise the streak resets. The count cycles
+    /// 1→2→3→4→1. Returns the new count.
+    pub fn register(self: *ClickTracker, x: f64, y: f64, now_ms: i64, max_distance: f64, interval_ms: i64) u8 {
+        const dx = x - self.x;
+        const dy = y - self.y;
+        const distance = @sqrt(dx * dx + dy * dy);
+        const within_interval = self.count > 0 and now_ms - self.time_ms <= interval_ms;
+        const within_distance = self.count > 0 and distance <= max_distance;
+        if (!within_interval or !within_distance) self.count = 0;
+        self.count += 1;
+        if (self.count > 4) self.count = 1;
+        self.time_ms = now_ms;
+        self.x = x;
+        self.y = y;
+        return self.count;
+    }
+
+    pub fn reset(self: *ClickTracker) void {
+        self.* = .{};
+    }
+};
+
+const max_dist: f64 = 10;
+const interval: i64 = 500; // matches MULTI_CLICK_INTERVAL_MS in input.zig
+
+test "first click returns 1" {
+    var t: ClickTracker = .{};
+    try std.testing.expectEqual(@as(u8, 1), t.register(100, 100, 1000, max_dist, interval));
+}
+
+test "fast, near clicks increment to 2, 3, 4" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 2), t.register(101, 101, 1100, max_dist, interval));
+    try std.testing.expectEqual(@as(u8, 3), t.register(102, 102, 1200, max_dist, interval));
+    try std.testing.expectEqual(@as(u8, 4), t.register(103, 103, 1300, max_dist, interval));
+}
+
+test "fifth fast, near click wraps to 1" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    _ = t.register(100, 100, 1100, max_dist, interval);
+    _ = t.register(100, 100, 1200, max_dist, interval);
+    _ = t.register(100, 100, 1300, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 1), t.register(100, 100, 1400, max_dist, interval));
+}
+
+test "click beyond interval resets to 1" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 1), t.register(100, 100, 1000 + interval + 1, max_dist, interval));
+}
+
+test "click beyond distance resets to 1" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 1), t.register(100 + max_dist + 1, 100, 1050, max_dist, interval));
+}
+
+test "reset clears the streak" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    _ = t.register(100, 100, 1100, max_dist, interval);
+    t.reset();
+    try std.testing.expectEqual(@as(u8, 1), t.register(100, 100, 1200, max_dist, interval));
+}
+
+test "click exactly at interval boundary stays in streak" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 2), t.register(100, 100, 1000 + interval, max_dist, interval));
+}
+
+test "click exactly at distance boundary stays in streak" {
+    var t: ClickTracker = .{};
+    _ = t.register(100, 100, 1000, max_dist, interval);
+    try std.testing.expectEqual(@as(u8, 2), t.register(100 + max_dist, 100, 1050, max_dist, interval));
+}

--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -10,7 +10,8 @@ const keybind = @import("../keybind.zig");
 /// routing) or `late` (after).
 pub const Phase = enum { early, late };
 
-/// The six split-focus directions a focus_split command can target.
+/// Where a focus_split command moves focus: four spatial directions plus
+/// previous/next ordering.
 pub const FocusTarget = enum { left, right, up, down, previous, next };
 
 pub const Command = union(enum) {

--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -1,0 +1,121 @@
+//! Pure keybind-action → command-intent resolution, extracted from input.zig's
+//! handleConfiguredKeybindAction. `resolve` answers "what command does this
+//! action trigger in this phase?" with no side effects; input.zig's
+//! executeCommand performs the effect (and decides consumption for the
+//! performable focus/switch commands, which depends on runtime state).
+const std = @import("std");
+const keybind = @import("../keybind.zig");
+
+/// Which keybind-processing pass this is: `early` (before overlay/palette
+/// routing) or `late` (after).
+pub const Phase = enum { early, late };
+
+/// The six split-focus directions a focus_split command can target.
+pub const FocusTarget = enum { left, right, up, down, previous, next };
+
+pub const Command = union(enum) {
+    // Early commands (input.zig commits any active tab rename before executing).
+    toggle_quake,
+    toggle_command_palette,
+    new_window,
+    new_session,
+    split_right,
+    toggle_file_explorer,
+    toggle_sidebar,
+    close_panel_or_tab,
+    toggle_maximize,
+    font_size: i32,
+    // Late commands.
+    copy,
+    paste,
+    paste_image,
+    focus_split: FocusTarget,
+    equalize_splits,
+    next_tab,
+    previous_tab,
+    open_config,
+    switch_tab: usize,
+};
+
+/// Map a configured action + phase to the command it triggers, or null if the
+/// action is not handled in that phase. Pure: no globals, no side effects.
+pub fn resolve(action: keybind.Action, phase: Phase) ?Command {
+    return switch (phase) {
+        .early => switch (action) {
+            .toggle_quake => .toggle_quake,
+            .toggle_command_palette => .toggle_command_palette,
+            .new_window => .new_window,
+            .new_session => .new_session,
+            .split_right => .split_right,
+            .toggle_file_explorer => .toggle_file_explorer,
+            .toggle_sidebar => .toggle_sidebar,
+            .close_panel_or_tab => .close_panel_or_tab,
+            .toggle_maximize => .toggle_maximize,
+            .font_size_increase => .{ .font_size = 1 },
+            .font_size_decrease => .{ .font_size = -1 },
+            else => null,
+        },
+        .late => switch (action) {
+            .copy => .copy,
+            .paste => .paste,
+            .paste_image => .paste_image,
+            .focus_left => .{ .focus_split = .left },
+            .focus_right => .{ .focus_split = .right },
+            .focus_up => .{ .focus_split = .up },
+            .focus_down => .{ .focus_split = .down },
+            .focus_previous => .{ .focus_split = .previous },
+            .focus_next => .{ .focus_split = .next },
+            .equalize_splits => .equalize_splits,
+            .next_tab => .next_tab,
+            .previous_tab => .previous_tab,
+            .open_config => .open_config,
+            else => if (switchTabIndex(action)) |idx| .{ .switch_tab = idx } else null,
+        },
+    };
+}
+
+/// switch_tab_1..9 → 0-based index, else null. (Was switchTabActionIndex.)
+fn switchTabIndex(action: keybind.Action) ?usize {
+    return switch (action) {
+        .switch_tab_1 => 0,
+        .switch_tab_2 => 1,
+        .switch_tab_3 => 2,
+        .switch_tab_4 => 3,
+        .switch_tab_5 => 4,
+        .switch_tab_6 => 5,
+        .switch_tab_7 => 6,
+        .switch_tab_8 => 7,
+        .switch_tab_9 => 8,
+        else => null,
+    };
+}
+
+test "early commands resolve only in the early phase" {
+    try std.testing.expectEqual(Command.toggle_quake, resolve(.toggle_quake, .early).?);
+    try std.testing.expectEqual(Command.split_right, resolve(.split_right, .early).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.toggle_quake, .late));
+}
+
+test "font size carries the delta" {
+    try std.testing.expectEqual(Command{ .font_size = 1 }, resolve(.font_size_increase, .early).?);
+    try std.testing.expectEqual(Command{ .font_size = -1 }, resolve(.font_size_decrease, .early).?);
+}
+
+test "late commands resolve only in the late phase" {
+    try std.testing.expectEqual(Command.copy, resolve(.copy, .late).?);
+    try std.testing.expectEqual(Command.open_config, resolve(.open_config, .late).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.copy, .early));
+}
+
+test "focus actions map to focus_split targets" {
+    try std.testing.expectEqual(Command{ .focus_split = .left }, resolve(.focus_left, .late).?);
+    try std.testing.expectEqual(Command{ .focus_split = .previous }, resolve(.focus_previous, .late).?);
+    try std.testing.expectEqual(Command{ .focus_split = .next }, resolve(.focus_next, .late).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.focus_left, .early));
+}
+
+test "switch_tab_N maps to a zero-based index" {
+    try std.testing.expectEqual(Command{ .switch_tab = 0 }, resolve(.switch_tab_1, .late).?);
+    try std.testing.expectEqual(Command{ .switch_tab = 8 }, resolve(.switch_tab_9, .late).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.switch_tab_1, .early));
+}

--- a/src/input/hit_test.zig
+++ b/src/input/hit_test.zig
@@ -1,0 +1,135 @@
+//! Pure sidebar hit-test geometry, extracted from input.zig. Callers gather the
+//! current layout into a SidebarLayout and ask which region a point hits. No
+//! globals here — the math is std-only and unit-testable.
+const std = @import("std");
+
+pub const SidebarLayout = struct {
+    visible: bool,
+    titlebar_h: f64,
+    width: f64, // titlebar.sidebarWidth()
+    header_h: f64, // titlebar.sidebarHeaderHeight()
+    row_h: f64, // titlebar.sidebarRowHeight()
+    tab_count: usize,
+    resize_hit_width: f64, // titlebar.SIDEBAR_RESIZE_HIT_WIDTH
+    close_btn_w: f64, // tab.TAB_CLOSE_BTN_W
+};
+
+fn listTop(l: SidebarLayout) f64 {
+    return l.titlebar_h + l.header_h + 6;
+}
+
+/// Which tab row a point falls on, or null if outside the tab list.
+pub fn sidebarTabAt(l: SidebarLayout, x: f64, y: f64) ?usize {
+    if (!l.visible) return null;
+    if (x < 0 or x >= l.width) return null;
+    const top = listTop(l);
+    if (y < top) return null;
+    const idx_f = (y - top) / l.row_h;
+    const idx: usize = @intFromFloat(@floor(idx_f));
+    if (idx >= l.tab_count) return null;
+    return idx;
+}
+
+/// Drag-target row for a given y: clamps to [0, tab_count-1] instead of
+/// returning null, so a drag above/below the list snaps to the ends.
+pub fn sidebarTabIndexForDragY(l: SidebarLayout, y: f64) ?usize {
+    if (!l.visible or l.tab_count == 0) return null;
+    const top = listTop(l);
+    if (y < top) return 0;
+    const idx_f = (y - top) / l.row_h;
+    const idx_raw: usize = @intFromFloat(@floor(idx_f));
+    if (idx_raw >= l.tab_count) return l.tab_count - 1;
+    return idx_raw;
+}
+
+/// True if (x, y) falls within the + (new-tab) button in the sidebar header.
+pub fn sidebarPlusButton(l: SidebarLayout, x: f64, y: f64) bool {
+    if (!l.visible) return false;
+    const plus_w: f64 = 42;
+    const plus_x = l.width - plus_w - 6;
+    return x >= plus_x and x < plus_x + plus_w and
+        y >= l.titlebar_h and y < l.titlebar_h + l.header_h;
+}
+
+/// True if (x, y) is over the close button of the given tab row, and the
+/// sidebar has more than one tab (close is suppressed on the last tab).
+pub fn sidebarTabCloseButton(l: SidebarLayout, x: f64, y: f64, tab_idx: usize) bool {
+    if (!l.visible or tab_idx >= l.tab_count or l.tab_count <= 1) return false;
+    const row = sidebarTabAt(l, x, y) orelse return false;
+    if (row != tab_idx) return false;
+    const close_x = l.width - l.close_btn_w - 4;
+    return x >= close_x and x < close_x + l.close_btn_w;
+}
+
+/// True if (x, y) is within the horizontal resize-hit band around the sidebar
+/// right edge and below the titlebar.
+pub fn sidebarResizeHandle(l: SidebarLayout, x: f64, y: f64) bool {
+    if (!l.visible) return false;
+    if (y < l.titlebar_h) return false;
+    const half_hit = l.resize_hit_width / 2;
+    return x >= l.width - half_hit and x <= l.width + half_hit;
+}
+
+const sample: SidebarLayout = .{
+    .visible = true,
+    .titlebar_h = 30,
+    .width = 200,
+    .header_h = 40,
+    .row_h = 28,
+    .tab_count = 3,
+    .resize_hit_width = 8,
+    .close_btn_w = 36,
+};
+
+test "sidebarTabAt: invisible sidebar never hits" {
+    var l = sample;
+    l.visible = false;
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabAt(l, 10, 100));
+}
+
+test "sidebarTabAt: row math and bounds" {
+    // list_top = 30 + 40 + 6 = 76; row_h = 28
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabAt(sample, 10, 75)); // above list
+    try std.testing.expectEqual(@as(?usize, 0), sidebarTabAt(sample, 10, 76)); // first row top
+    try std.testing.expectEqual(@as(?usize, 0), sidebarTabAt(sample, 10, 103)); // still row 0
+    try std.testing.expectEqual(@as(?usize, 1), sidebarTabAt(sample, 10, 104)); // row 1
+    try std.testing.expectEqual(@as(?usize, 2), sidebarTabAt(sample, 10, 132)); // row 2 (last)
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabAt(sample, 10, 160)); // past tab_count
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabAt(sample, 200, 100)); // x == width (outside)
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabAt(sample, -1, 100)); // x < 0
+}
+
+test "sidebarTabIndexForDragY: clamps to ends" {
+    try std.testing.expectEqual(@as(?usize, 0), sidebarTabIndexForDragY(sample, 0)); // above -> 0
+    try std.testing.expectEqual(@as(?usize, 2), sidebarTabIndexForDragY(sample, 9999)); // below -> last
+    try std.testing.expectEqual(@as(?usize, 1), sidebarTabIndexForDragY(sample, 104));
+    var empty = sample;
+    empty.tab_count = 0;
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabIndexForDragY(empty, 100));
+}
+
+test "sidebarPlusButton: top-right header box" {
+    // plus_x = 200 - 42 - 6 = 152; spans x in [152, 194); y in [30, 70)
+    try std.testing.expect(sidebarPlusButton(sample, 160, 50));
+    try std.testing.expect(!sidebarPlusButton(sample, 151, 50)); // left of box
+    try std.testing.expect(!sidebarPlusButton(sample, 160, 70)); // y == header bottom (outside)
+}
+
+test "sidebarTabCloseButton: only on its own hovered row, needs >1 tab" {
+    // close_x = 200 - 36 - 4 = 160; spans [160, 196); row 0 spans y in [76, 104)
+    try std.testing.expect(sidebarTabCloseButton(sample, 170, 80, 0));
+    try std.testing.expect(!sidebarTabCloseButton(sample, 100, 80, 0)); // left of close box
+    try std.testing.expect(!sidebarTabCloseButton(sample, 170, 80, 1)); // hovering row 0, asking row 1
+    var one = sample;
+    one.tab_count = 1;
+    try std.testing.expect(!sidebarTabCloseButton(one, 170, 80, 0)); // single tab: no close
+}
+
+test "sidebarResizeHandle: band around the right edge" {
+    // half_hit = 4; band x in [196, 204]; needs y >= titlebar_h (30)
+    try std.testing.expect(sidebarResizeHandle(sample, 200, 100));
+    try std.testing.expect(sidebarResizeHandle(sample, 196, 100));
+    try std.testing.expect(sidebarResizeHandle(sample, 204, 100));
+    try std.testing.expect(!sidebarResizeHandle(sample, 195, 100)); // left of band
+    try std.testing.expect(!sidebarResizeHandle(sample, 200, 20)); // above titlebar
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -20,6 +20,9 @@ const std = @import("std");
 const app_metadata = @import("app_metadata.zig");
 
 test {
+    _ = @import("input/command_dispatch.zig");
+    _ = @import("input/click_tracker.zig");
+    _ = @import("input/hit_test.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -571,6 +571,7 @@ comptime {
     _ = @import("input.zig");
     _ = @import("input/clipboard.zig");
     _ = @import("input/click_tracker.zig");
+    _ = @import("input/command_dispatch.zig");
     _ = @import("input/hit_test.zig");
     _ = @import("input/key.zig");
     _ = @import("input/preview_source.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -571,6 +571,7 @@ comptime {
     _ = @import("input.zig");
     _ = @import("input/clipboard.zig");
     _ = @import("input/click_tracker.zig");
+    _ = @import("input/hit_test.zig");
     _ = @import("input/key.zig");
     _ = @import("input/preview_source.zig");
     _ = @import("input_shortcuts.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -570,6 +570,7 @@ comptime {
     _ = @import("file_explorer.zig");
     _ = @import("input.zig");
     _ = @import("input/clipboard.zig");
+    _ = @import("input/click_tracker.zig");
     _ = @import("input/key.zig");
     _ = @import("input/preview_source.zig");
     _ = @import("input_shortcuts.zig");


### PR DESCRIPTION
## Summary

Phase B item **B1**: decouple the giant `src/input.zig` (3,573 ln) by extracting its pure *decision* logic into std-only, unit-tested sibling modules, leaving `input.zig` as the thin platform-event + global-state + side-effect shell. Targeted pure-module extraction (no global struct-ification), matching the established repo pattern (`selection_unit.zig`, `titlebar_layout.zig`, …).

Three new modules under `src/input/`:
- **`click_tracker.zig`** — `ClickTracker` multi-click state machine (was `nextLeftClickCount`); 8 tests.
- **`hit_test.zig`** — pure sidebar geometry over a `SidebarLayout` descriptor (was the `hitTestSidebar*` family); `input.zig` gathers globals into the descriptor; 6 tests.
- **`command_dispatch.zig`** — pure `resolve(action, phase) → ?Command`; `input.zig` keeps `executeCommand` for the side effects (was the interleaved `handleConfiguredKeybindAction`); 5 tests.

`input.zig` 3,573 → 3,467 ln; the four `g_left_click_*` globals and `switchTabActionIndex` are gone. All three modules run in the fast loop via `test_fast.zig` and are regression-locked in `test_main.zig`. Behavior is byte-identical (verified arm-by-arm, incl. the `commitTabRenameIfActive` hoist and `focus_split`/`switch_tab` consumption semantics).

Spec: `docs/superpowers/specs/2026-05-27-b1-input-decouple-design.md`
Plan: `docs/superpowers/plans/2026-05-27-b1-input-decouple.md`

## Test Plan

- [x] `zig build test` — 268 tests pass (includes the 19 new unit tests; verified they run via a break/revert check)
- [x] `zig build test-full -Dtarget=x86_64-windows-gnu` — exit 0, no new failures
- [x] B1 pure modules compile-check clean for `aarch64-macos` (the `test-full -Dtarget=aarch64-macos` step is blocked by a pre-existing vendored C-lib zlib/freetype cross-compile issue, unrelated to this change)
- [x] Per-task spec + code-quality reviews passed; final whole-implementation review: ready to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)