### PR TITLE
[codex] feat: open AI config from missing API key

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1081,6 +1081,22 @@ pub const Session = struct {
         return self.api_key_buf[0..self.api_key_len];
     }
 
+    pub fn missingApiKey(self: *const Session) bool {
+        return self.api_key_len == 0;
+    }
+
+    pub fn thinkingConfigValue(self: *const Session) []const u8 {
+        return if (self.thinking_enabled) "enabled" else "disabled";
+    }
+
+    pub fn streamConfigValue(self: *const Session) []const u8 {
+        return if (self.stream) "true" else "false";
+    }
+
+    pub fn agentConfigValue(self: *const Session) []const u8 {
+        return if (self.agent_enabled) "true" else "false";
+    }
+
     pub fn input(self: *const Session) []const u8 {
         return self.input_buf[0..self.input_len];
     }

--- a/src/input.zig
+++ b/src/input.zig
@@ -2623,6 +2623,20 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     AppWindow.g_cells_valid = false;
                     return;
                 }
+                if (AppWindow.ai_chat_renderer.missingApiKeyStatusHitTest(
+                    chat,
+                    xpos,
+                    ypos,
+                    @floatFromInt(fb.width),
+                    @floatCast(titlebarHeight()),
+                    AppWindow.leftPanelsWidth(),
+                    AppWindow.rightPanelsWidthForWindow(fb.width),
+                )) {
+                    overlays.openAiConfigForSession(chat);
+                    AppWindow.g_force_rebuild = true;
+                    AppWindow.g_cells_valid = false;
+                    return;
+                }
                 if (AppWindow.ai_chat_renderer.interactionHitTest(
                     chat,
                     xpos,

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -59,6 +59,7 @@ const SUGGESTION_PAD_Y: f32 = 6;
 const SUGGESTION_GAP: f32 = 6;
 const SUGGESTION_MAX_W: f32 = 560;
 const SUGGESTION_COMMAND_W: f32 = 148;
+const MISSING_API_KEY_ACTION_TEXT = "Missing API key. Click to configure";
 
 pub const HitTarget = union(enum) {
     copy_message: usize,
@@ -155,8 +156,14 @@ pub fn render(
     if (session.request_inflight) {
         renderStopButton(stopButtonRect(x, w, top), window_height, session.request_stopping);
     } else {
-        const status_w = measureText(session.status());
-        _ = titlebar.renderTextLimited(session.status(), x + w - LINE_PAD_X - @min(status_w, STATUS_SLOT_W), header_y + 10, muted, STATUS_SLOT_W);
+        const missing_api_key = session.missingApiKey();
+        const status_text = if (missing_api_key) MISSING_API_KEY_ACTION_TEXT else session.status();
+        const status_color = if (missing_api_key) mixColor(fg, accent, 0.22) else muted;
+        const status_rect = statusActionRect(x, w, top, status_text);
+        _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, status_color, STATUS_SLOT_W);
+        if (missing_api_key) {
+            ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, accent, 0.34);
+        }
     }
 
     const input_text = session.input();
@@ -508,6 +515,26 @@ pub fn permissionChipHitTest(
         .w = PERMISSION_CHIP_W,
         .h = PERMISSION_CHIP_H,
     });
+}
+
+pub fn missingApiKeyStatusHitTest(
+    session: *ai_chat.Session,
+    xpos: f64,
+    ypos: f64,
+    window_width: f32,
+    titlebar_offset: f32,
+    left_panels_w: f32,
+    right_panels_w: f32,
+) bool {
+    session.mutex.lock();
+    const clickable = !session.request_inflight and session.missingApiKey();
+    session.mutex.unlock();
+    if (!clickable) return false;
+
+    const x = @round(left_panels_w);
+    const w = @round(@max(1.0, window_width - left_panels_w - right_panels_w));
+    const rect = statusActionRect(x, w, titlebar_offset, MISSING_API_KEY_ACTION_TEXT);
+    return pointInRect(@floatCast(xpos), @floatCast(ypos), rect);
 }
 
 pub fn inputFieldMetricsAt(
@@ -1042,6 +1069,16 @@ fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
     return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STOP_BUTTON_W, STOP_BUTTON_H, HEADER_H);
 }
 
+fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8) Rect {
+    const status_w = @min(measureText(text), STATUS_SLOT_W);
+    return .{
+        .x = x + w - LINE_PAD_X - status_w,
+        .top_px = titlebar_offset + 8,
+        .w = @max(1.0, status_w),
+        .h = 32,
+    };
+}
+
 fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) void {
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -1463,7 +1500,6 @@ fn byteOffsetForMarkdownPoint(
 
     return display_cursor;
 }
-
 
 fn byteOffsetForWrappedPoint(
     text: []const u8,
@@ -1925,4 +1961,3 @@ fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
         a[2] + (b[2] - a[2]) * clamped,
     };
 }
-

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2320,6 +2320,58 @@ fn openAiFormEdit(index: usize) void {
     openAiForm();
 }
 
+pub fn openAiConfigForSession(session: *AppWindow.ai_chat.Session) void {
+    loadAiProfiles();
+
+    session.mutex.lock();
+    const profile_idx = findAiProfileForSession(session.title(), session.baseUrl(), session.model());
+    session.mutex.unlock();
+
+    if (profile_idx) |idx| {
+        openAiFormEdit(idx);
+        g_ai_focus = @intFromEnum(AiField.api_key);
+        return;
+    }
+
+    clearAiForm();
+    session.mutex.lock();
+    setAiDefault(.name, if (session.title().len > 0) session.title() else AppWindow.ai_chat.DEFAULT_NAME);
+    setAiDefault(.base_url, session.baseUrl());
+    setAiDefault(.api_key, session.apiKey());
+    setAiDefault(.model, session.model());
+    setAiDefault(.system_prompt, session.systemPrompt());
+    setAiDefault(.thinking, session.thinkingConfigValue());
+    setAiDefault(.reasoning_effort, session.reasoningEffort());
+    setAiDefault(.stream, session.streamConfigValue());
+    setAiDefault(.agent, session.agentConfigValue());
+    setAiDefault(.protocol, session.apiProtocolName());
+    session.mutex.unlock();
+
+    g_ai_edit_index = AI_PROFILE_NONE;
+    openAiForm();
+    g_ai_focus = @intFromEnum(AiField.api_key);
+}
+
+fn findAiProfileForSession(name: []const u8, base_url: []const u8, model: []const u8) ?usize {
+    if (name.len > 0) {
+        for (0..g_ai_profile_count) |idx| {
+            if (std.mem.eql(u8, aiProfileField(&g_ai_profiles[idx], .name), name)) return idx;
+        }
+    }
+
+    if (base_url.len > 0 and model.len > 0) {
+        for (0..g_ai_profile_count) |idx| {
+            if (std.mem.eql(u8, aiProfileField(&g_ai_profiles[idx], .base_url), base_url) and
+                std.mem.eql(u8, aiProfileField(&g_ai_profiles[idx], .model), model))
+            {
+                return idx;
+            }
+        }
+    }
+
+    return null;
+}
+
 fn openAiForm() void {
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;


### PR DESCRIPTION
## What changed
- Makes the AI Chat missing API key status read as a clickable configuration action.
- Opens the matching AI profile editor from that status, focusing the API key field.
- Prefills a new profile from the active session when no saved profile matches.

## Why
Entering a prompt with no API key previously left users with a passive status message. This gives them a direct path to fix the profile from the same screen.

## Validation
- zig build test
- zig build test-full