### PR TITLE
Add issue templates and contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: 🐛 Bug Report
+description: Report something that isn't working as expected
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please search [existing issues](https://github.com/xuzhougeng/phantty/issues) first to avoid duplicates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Tell us exactly how to trigger the bug.
+      placeholder: |
+        1. Open phantty
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Phantty version
+      description: Output of the version command, or the commit/release you built from.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any relevant log output or attach screenshots. This is automatically formatted, no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/xuzhougeng/phantty/discussions
+    about: Have a question or want to discuss an idea? Please use Discussions instead of opening an issue.
+  - name: 📖 Documentation
+    url: https://github.com/xuzhougeng/phantty#readme
+    about: Please check the README before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: ✨ Enhancement / Feature Request
+description: Suggest a new feature or an improvement to an existing one
+title: "[Enhancement] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please search [existing issues](https://github.com/xuzhougeng/phantty/issues) first to see if it has already been proposed.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what use case does it enable? Is your request related to a frustration?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've thought about.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, or any other context.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Phantty
+
+Thanks for your interest in contributing! This document explains how to report
+issues and submit changes.
+
+## Reporting issues
+
+Before opening an issue, please:
+
+1. **Search [existing issues](https://github.com/xuzhougeng/phantty/issues)** to
+   avoid duplicates.
+2. **Pick the right category** when you click *New issue*:
+   - 🐛 **Bug Report** — something isn't working as expected.
+   - ✨ **Enhancement / Feature Request** — a new feature or an improvement.
+3. **Use the template fields.** Good bug reports include clear reproduction
+   steps, the expected behavior, your OS, and the Phantty version.
+
+For open-ended questions or ideas, please use
+[Discussions](https://github.com/xuzhougeng/phantty/discussions) rather than
+opening an issue.
+
+## Submitting changes
+
+1. Fork the repository and create a branch from `main`
+   (e.g. `feat/my-feature` or `fix/some-bug`).
+2. Build and test locally:
+
+   ```powershell
+   zig build                         # Debug build for development
+   zig build -Doptimize=ReleaseFast  # ReleaseFast build for distribution
+   zig build test                    # Run the test suite
+   ```
+
+3. Keep changes focused — one logical change per pull request.
+4. Match the surrounding code style (naming, formatting, comment density).
+5. Open a pull request against `main` and describe **what** changed and **why**.
+   Link any related issue (e.g. `Closes #123`).
+
+For architecture, packaging, and release details, see
+[docs/development.md](docs/development.md).
+
+## Code of conduct
+
+Be respectful and constructive. We want Phantty to be a welcoming project for
+everyone.


### PR DESCRIPTION
## Summary

- Add structured GitHub issue forms for **bug reports** and **enhancement requests**
- Disable blank issues and route open-ended questions to Discussions via `config.yml`
- Add `CONTRIBUTING.md` describing how to report issues and submit PRs

## Notes

- Templates/CONTRIBUTING link to GitHub Discussions — enable it in repo settings for those links to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)