### PR TITLE
Complete macOS UI: NSMenu + Metal overlay rendering + zsh default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -268,14 +268,43 @@ services, and `.app` packaging. Ghostty reference: `src/renderer/metal/`,
       covers context, buffers, textures, framebuffers, pipelines, vertex layout
       handles, compatibility helpers, and a committed simple draw. *Ghostty:
       `renderer/metal/`.*
-- [x] **Neutralize the GL-shaped presentation layer (prerequisite).**
+- [x] **Neutralize the GL-shaped presentation layer (prerequisite, call sites only).**
       `ui_pipeline.zig`, `cell_pipeline.zig`, and the render-coordination files
-      still call `gpu.glTable()` directly (the residue `gl_backend_guard`
-      documents) — OpenGL-only. Route their draws through the backend-dispatched
-      `gpu.Pipeline`/`Buffer`/`Texture`/`Framebuffer` methods so they compile and
-      render on Metal. This is guard-enforced by `gl_backend_guard`; only the
-      documented AppWindow diagnostics/context residue still touches
-      `gpu.glTable()`.
+      no longer call `gpu.glTable()` directly (guard-enforced by
+      `gl_backend_guard`); only the documented AppWindow diagnostics/context
+      residue still touches `gpu.glTable()`. **However, this only neutralized the
+      call sites — the Metal-backend implementations of those primitives are
+      still partial. See D1.x below.**
+- [x] **D1.x — Wire the Metal `gl_init` stub to `ui_pipeline` (macOS UI gap).**
+      Root cause turned out to be two narrow bugs, not the missing-pipeline
+      story I originally feared. The MSL shaders and the `gpu.Pipeline`/
+      `Buffer`/`Texture` primitives were already complete enough for
+      `ui_pipeline.fillQuad`; the call never made it to the GPU because:
+      1. `src/renderer/gpu/metal/gl_init.zig`'s `renderQuad`/`renderQuadAlpha`/
+         `setProjection` were stubs that dropped their arguments. In
+         particular, `setProjection` only updated the viewport — it never
+         pushed the orthographic projection into the text pipeline's
+         uniforms, so every vertex came out at `(0, 0, 0, 0)` in clip space.
+         Now they dispatch through a `BackendHooks` function-pointer table
+         registered by `ui_pipeline.init()` (the indirection is needed because
+         `test-metal`'s module root sits inside `gpu/metal/`, which forbids
+         walking out to `renderer/ui_pipeline.zig` with a static `@import`).
+      2. `phantty_metal_buffer_upload` reused the same `MTLBuffer` storage
+         across uploads (`memcpy([buffer contents])`). Metal's
+         `setVertexBuffer:offset:atIndex:` captures the buffer pointer at
+         encoding time but the GPU only reads its bytes at command-buffer
+         commit, so successive `ui_pipeline.fillQuad` calls all shared the
+         last upload — every overlay piled up at the same coordinates and
+         the prior contents were silently overwritten. Upload now always
+         allocates a fresh `MTLBuffer`; Metal's encoder retain keeps the
+         prior one alive until the command buffer completes, then drops it
+         asynchronously.
+      Native proof: `zig build test-metal` (new hook-dispatch assertion),
+      `zig build test-macos-ui`, `zig build test`, and
+      `zig build test-full -Dtarget=aarch64-macos`; plus the macOS app now
+      renders the tab sidebar, NSMenu "Open Command Center" overlay, SSH
+      Server / AI Agent forms, and settings page with backgrounds, borders,
+      selection highlights, and text all visible.
 - [x] Port the shader set to MSL in `gpu/metal/shaders.zig` (the A5 slot already
       lists the symmetric set: text/glyph, instanced bg/fg cells, color-emoji,
       simple-textured, overlay). Native proof: `zig build test-metal` compiles
@@ -380,6 +409,47 @@ services, and `.app` packaging. Ghostty reference: `src/renderer/metal/`,
 Critical path to "a shell renders on screen": **D0 → D1 (Metal + presentation-
 layer neutralization) → D2 (AppKit host + drawable seam) → D3 (CoreText) → the
 macOS pty constants in D4.** Services / webview / packaging follow.
+
+**D7 — Native macOS app menu (NSMenu)**
+- [x] **D7.1 NSMenu skeleton.** Phantty had no application menu on macOS — the
+      only way to reach the command center, settings, or sidebar toggle was the
+      keyboard shortcut, which gets eaten by IME/remote-control software
+      (ToDesk, etc.). Added a thin Objective-C bridge
+      (`src/platform/menu_macos_bridge.m`) that builds the standard macOS
+      menu set (`Phantty / File / Edit / View / Window`) with menu items wired
+      to the existing keybind `Action` enum: Open Command Center
+      (`⌃⇧P`), Settings… (`⌘,`), New Tab (`⌃⇧T`), New Window (`⌃⇧N`),
+      Toggle Tab Sidebar (`⌃⇧B`), Toggle File Explorer (`⌃⇧⌥E`), Split Right
+      (`⌃⇧O`), Equalize Splits (`⌃⇧Z`), Next/Previous Tab, Minimize, Zoom.
+      A C ABI shim hands action ids back to Zig
+      (`src/platform/menu_macos.zig`) which dispatches via
+      `input.invokeKeybindAction`. Bonus: NSMenu key equivalents are handled
+      earlier in the AppKit responder chain than `keyDown:`, so they keep
+      working even when third-party utilities intercept the chord at the
+      `keyDown:` layer. Native proof: `zig build test-macos-menu`
+      validates menu install, item count, action encoding, and round-trip
+      decode; covered also by `zig build test-full -Dtarget=aarch64-macos`.
+- [ ] **D7.2 Menu items reflect runtime state.** Add NSMenuItem validation:
+      grey out actions when no surface is focused, mark the sidebar/command-
+      center items checked when the panel is currently visible, surface the
+      configured shortcut text from `keybind.Set` instead of hardcoded
+      equivalents (so user remaps show in the menu).
+- [ ] **D7.3 Localize menu titles.** Currently English-only; add a localized
+      string table that matches the rest of Phantty's locale story.
+
+### macOS UI status (post D1.x + D7.1)
+
+| Feature | Status on macOS |
+|---|---|
+| Terminal text rendering | ✅ works (cell pipeline + CoreText/FreeType) |
+| Default shell | ✅ `zsh` (was `sh` until 2026-05-27) |
+| NSMenu (Phantty / File / Edit / View / Window) | ✅ visible, clickable, key equivalents fire |
+| Command center / settings page / SSH form / AI form / session launcher | ✅ render fully (panels, borders, selection highlights, text) |
+| Tab sidebar | ✅ renders rows, selection highlight, tab numbers |
+| File explorer panel | ✅ unblocked by D1.x; verify icons/scroll on real workloads |
+| Markdown / image preview | ✅ unblocked by D1.x; verify chrome on real previews |
+| Quake-style drop-down | ✅ window position + overlay rendering |
+| Embedded browser panel | ❌ disabled (D5 — no WKWebView backend yet) |
 
 ### Linux — deferred
 

--- a/build.zig
+++ b/build.zig
@@ -44,6 +44,7 @@ const macos_objective_c_sources = [_][]const u8{
     "src/platform/window_macos_bridge.m",
     "src/platform/font_macos_bridge.m",
     "src/platform/services_macos_bridge.m",
+    "src/platform/menu_macos_bridge.m",
 };
 
 const MacosBundleMetadata = struct {
@@ -395,6 +396,14 @@ test "macOS UI smoke test step is declared" {
     try expectSourceContains(source, "src/test_macos_ui.zig");
 }
 
+test "macOS NSMenu smoke test step is declared" {
+    const source = @embedFile("build.zig");
+
+    try expectSourceContains(source, "b.step(\"test-macos-menu\"");
+    try expectSourceContains(source, "src/test_macos_menu.zig");
+    try expectSourceContains(source, "src/platform/menu_macos_bridge.m");
+}
+
 test "macOS Info.plist renders app bundle metadata and package type" {
     const metadata = macosBundleMetadata();
     try std.testing.expectEqualStrings("Phantty.app", metadata.bundle_dir);
@@ -508,6 +517,7 @@ pub fn build(b: *std.Build) void {
     const test_macos_font_step = b.step("test-macos-font", "Run native macOS CoreText font backend smoke tests");
     const test_macos_services_step = b.step("test-macos-services", "Run native macOS platform service smoke tests");
     const test_macos_ui_step = b.step("test-macos-ui", "Run native macOS UI smoke tests");
+    const test_macos_menu_step = b.step("test-macos-menu", "Run native macOS NSMenu smoke tests");
     const macos_app_step = b.step("macos-app", "Build and install the native macOS .app bundle");
     const macos_dist_step = b.step("macos-dist", "Build, sign, and package the native macOS .app into a DMG");
 
@@ -667,12 +677,29 @@ pub fn build(b: *std.Build) void {
         });
         apple_sdk.addPaths(b, macos_ui_tests) catch @panic("failed to locate native Apple SDK for macOS UI tests");
         test_macos_ui_step.dependOn(&b.addRunArtifact(macos_ui_tests).step);
+
+        const macos_menu_test_mod = createAppModuleWithRoot(
+            b,
+            "src/test_macos_menu.zig",
+            b.resolveTargetQuery(.{}),
+            optimize,
+            app_version,
+            PlatformFeatures.forOs(.macos),
+            false,
+        );
+        const macos_menu_tests = b.addTest(.{
+            .name = "phantty-macos-menu-test",
+            .root_module = macos_menu_test_mod,
+        });
+        apple_sdk.addPaths(b, macos_menu_tests) catch @panic("failed to locate native Apple SDK for macOS menu tests");
+        test_macos_menu_step.dependOn(&b.addRunArtifact(macos_menu_tests).step);
     } else {
         test_metal_step.dependOn(&b.addFail("test-metal requires a macOS host with Metal").step);
         test_macos_window_step.dependOn(&b.addFail("test-macos-window requires a macOS host with AppKit").step);
         test_macos_font_step.dependOn(&b.addFail("test-macos-font requires a macOS host with CoreText").step);
         test_macos_services_step.dependOn(&b.addFail("test-macos-services requires a macOS host with AppKit").step);
         test_macos_ui_step.dependOn(&b.addFail("test-macos-ui requires a macOS host with AppKit").step);
+        test_macos_menu_step.dependOn(&b.addFail("test-macos-menu requires a macOS host with AppKit").step);
     }
 
     if (platform.supports_desktop_exe) {

--- a/docs/development.md
+++ b/docs/development.md
@@ -122,6 +122,12 @@ the `Settings` command, and the Settings page writes to an isolated test config
 file. The test intentionally avoids external keyboard/screenshot automation so
 it does not depend on macOS Accessibility or Screen Recording permissions.
 
+For the Metal-backend and AppKit-host gotchas surfaced during the macOS port
+(deferred MTLBuffer semantics, NSMenu vs. keyDown interception, Zig 0.15
+module-path constraints on cross-backend imports, IME swallowing letter keys,
+etc.) see [macos-ui-lessons.md](macos-ui-lessons.md). Read this before
+touching anything under `src/renderer/gpu/metal/` or `src/platform/*_macos*`.
+
 ## Windows Checkout Safety
 
 This repository must remain safe to check out and develop on Windows. Before

--- a/docs/macos-ui-lessons.md
+++ b/docs/macos-ui-lessons.md
@@ -1,0 +1,320 @@
+# macOS UI 开发经验总结
+
+本文档记录把 Phantty 从"只有外壳"的 macOS 端口推到"功能与 Windows 对齐"过程中踩到的坑。
+对应的代码改动见 [PR #73](https://github.com/xuzhougeng/phantty/pull/73)（Complete macOS UI: NSMenu + Metal overlay rendering + zsh default）。
+
+适用对象：未来想把 Phantty 移植到新平台、或在现有 Metal/AppKit 代码上做改动的人。
+
+---
+
+## 表象 vs. 根因
+
+最初的症状是 macOS 端的 Phantty 启动后只看到终端字符 `sh-3.2$`，但
+**所有 overlay（命令面板、侧边栏、SSH 表单、设置页）都不可见**。NSMenu 回调能触发、
+state 切换正确，但屏幕上看不到任何 panel/边框/高亮。
+
+如果只看症状，很自然会怀疑：
+- "Metal pipeline 还没接好" — 实际 MSL shader、Pipeline、Buffer、Texture 早已就绪
+- "需要新写一套 solid-color quad batch" — 实际 ui_pipeline 已经是 cross-backend 的，
+  Metal 的 Pipeline.drawArrays 也真的把命令编进了 MTLRenderCommandEncoder
+- "需要做 ring buffer / triple-buffering" — 实际只需要一处 buffer-allocation 修复
+
+**真正的两个 bug 都只有几行代码**，但它们各自打断了 OpenGL→Metal 的等价契约，
+诊断花了不少时间。下文按"发现顺序"展开。
+
+---
+
+## Bug #1：Metal stub 没委托给 ui_pipeline
+
+### 现象
+- `ui_pipeline.fillQuad/fillQuadAlpha` 在 OpenGL 上正常画方块
+- 同一份 `ui_pipeline.zig` 在 Metal 上不画方块
+- `gpu/metal/Pipeline.drawArrays` 添加 fprintf 后**能**看到 draw 调用进入 Metal encoder
+- 但屏幕没有任何 fillQuad 结果
+
+### 根因
+对比 `gpu/opengl/gl_init.zig` 和 `gpu/metal/gl_init.zig`：
+
+```zig
+// opengl/gl_init.zig
+pub fn setProjection(width: f32, height: f32) void {
+    ui_pipeline.setProjection(width, height);  // 把矩阵写入 text pipeline 的 uniform
+}
+
+// metal/gl_init.zig  (原版 stub)
+pub fn setProjection(width: f32, height: f32) void {
+    render_state.setViewport(0, 0, @intFromFloat(width), @intFromFloat(height));
+    // ← 漏了 ui_pipeline.setProjection！
+}
+```
+
+`ui_pipeline.setProjection` 是唯一往 text pipeline 写正交投影矩阵的入口。Metal 后端
+没调用它 → text pipeline 的 `uniforms.projection` 永远是 `calloc` 出来的**零矩阵** →
+每个顶点 `(x, y, 0, 1) × 零矩阵 = (0, 0, 0, 0)` → 全部塌缩到 clip space 原点 →
+看起来"完全没渲染"。
+
+终端字符之所以能显示，是因为它走的是 `cell_pipeline`，那条路径有自己的 projection
+uniform 注入（不经过 ui_pipeline.setProjection），所以幸免于难。
+
+### 教训
+- **OpenGL↔Metal 的等价契约要在两个文件级别都对齐**。"stub 仅占位"的注释非常危险，
+  因为它绕过了类型检查 —— stub 完全合法编译，但语义上偷偷少做了一件事。
+- 加 comptime 守卫，比如要求两个 `gl_init.zig` 暴露完全相同的 public 函数体（不只是签名），
+  会让这类断点在编译期就暴露。
+- 调试时**对比 OpenGL 等价路径**比单独 trace Metal 路径更快定位。
+
+### 工程化修复
+不能简单地在 `metal/gl_init.zig` 顶部加 `@import("../../ui_pipeline.zig")`，
+因为 `test-metal` 的 module root 是 `gpu/metal/`，Zig 0.15 拒绝 import 走出 root：
+
+```
+error: import of file outside module path
+const ui_pipeline = @import("../../ui_pipeline.zig");
+```
+
+解法：**函数指针 hooks**。`metal/gl_init.zig` 声明 `BackendHooks`，
+`ui_pipeline.init()` 在 app 启动时调 `setBackendHooks` 注册。
+hooks nil 时 helper 静默 no-op（满足 test-metal 没有 ui_pipeline 的场景），
+hooks 非 nil 时正常委托。
+
+```zig
+// gpu/metal/gl_init.zig
+pub const BackendHooks = struct {
+    fillQuad: *const fn (f32, f32, f32, f32, [3]f32) void,
+    fillQuadAlpha: *const fn (f32, f32, f32, f32, [3]f32, f32) void,
+    setProjection: *const fn (f32, f32) void,
+};
+threadlocal var g_hooks: ?BackendHooks = null;
+
+pub fn setBackendHooks(hooks: BackendHooks) void { g_hooks = hooks; }
+pub fn setProjection(width: f32, height: f32) void {
+    render_state.setViewport(0, 0, @intFromFloat(width), @intFromFloat(height));
+    if (g_hooks) |h| h.setProjection(width, height);
+}
+
+// renderer/ui_pipeline.zig
+fn registerMetalBackendHooks() void {
+    if (!@hasDecl(AppWindow.gpu.gl_init, "setBackendHooks")) return;
+    AppWindow.gpu.gl_init.setBackendHooks(.{ /* ... */ });
+}
+```
+
+`@hasDecl` 让同一段代码在 OpenGL backend（没有 BackendHooks 这个符号）下编译成 no-op。
+
+---
+
+## Bug #2：Metal MTLBuffer 共享 storage 在 deferred commit 下被覆盖
+
+### 现象（在 Bug #1 修好之后才暴露出来）
+- 文字渲染正常
+- 但所有 `ui_pipeline.fillQuad` 调用画出来的 quad 只剩**最后一个**
+
+### 根因：Metal 异步执行 vs. OpenGL 同步
+
+OpenGL 的 `glBufferSubData` 即便不 fence，驱动也会在 next draw 之前把新数据落地，
+所以 "upload+draw, upload+draw, upload+draw" 工作正常。
+
+Metal 不一样：
+
+```objc
+[encoder setVertexBuffer:buf offset:0 atIndex:0];  // 记录指针，不读数据
+[encoder drawPrimitives:...];                       // 命令进队，GPU 还没执行
+// ... 同一个 buffer 又一次 memcpy 进新数据 ...
+[encoder setVertexBuffer:buf offset:0 atIndex:0];  // 还是同一个 buffer 指针
+[encoder drawPrimitives:...];
+[commandBuffer commit];                             // GPU 才真正读 buffer
+                                                    // → 所有 draw 都读到最后一次 upload
+```
+
+Phantty 的 `ui_pipeline` 在一帧里反复 "upload quad verts → drawArrays"，
+共享同一个 `quad` MTLBuffer。结果：N 个 fillQuad 调用，GPU 看到的是 N 次 draw
+**都读最后那次 upload 的坐标**。所有 overlay panel 全部堆在最后一个 quad 的位置，
+其它位置一片空白。
+
+### 教训
+- **凡是"upload + immediate draw"模式从 OpenGL 移植到 Metal，都要重新审计 buffer 生命周期**。
+- Metal `setVertexBuffer:` 是 "记录指针 + 命令 buffer 持有引用直到 commit"，
+  不是 "立即复制内容"。这一点 Apple 文档不算显眼，容易踩。
+- 小数据（≤4KB）可以走 `setVertexBytes:length:atIndex:`，它在 call 时**就**复制 inline，
+  完全避开这个坑。对 ui_pipeline 的 96 字节/quad 这条路径其实更合适。
+
+### 修复
+最简单的方案：**每次 upload 都 newBufferWithBytes**，把旧 buffer release 掉。
+Metal 的 `setVertexBuffer:` 已经 retain 了旧 buffer（commit 完成才释放），所以
+release 是安全的——旧 buffer 的实际 dealloc 是 GPU 完成后异步的。
+
+```c
+// bridge.m phantty_metal_buffer_upload
+@autoreleasepool {
+    id<MTLBuffer> old = phantty_metal_buffers[handle].buffer;
+    id<MTLBuffer> new_buffer = phantty_metal_new_buffer(device, bytes, len);
+    if (new_buffer == nil) return false;
+    phantty_metal_buffers[handle].buffer = new_buffer;
+    if (old != nil) [old release];  // command buffer 仍持有它，Metal 延迟实际释放
+    return true;
+}
+```
+
+每帧上百个 fillQuad → 上百次 `newBufferWithBytes:`，对小 quad（96 bytes）开销可忽略。
+更优解（未实施）：每帧一个 transient arena MTLBuffer，upload 累加 offset，
+`setVertexBuffer:offset:` 传 offset。Ghostty 用的就是这种方案。
+
+---
+
+## macOS 环境层面的坑
+
+### 1. `[NSApp activateIgnoringOtherApps:NO]` 不会真正激活
+
+Phantty 的 `window_macos_bridge.m` 早期用了 `NO`。结果：
+- AppKit 给 NSWindow 加了 traffic lights、设了 frontmost
+- 但**键盘焦点没真正给 Phantty**，输入跑去其它进程
+- `osascript "frontmost = true"` 也只能短暂强占焦点
+
+正确做法：`activateIgnoringOtherApps:YES`，或者用 macOS 14+ 的 `[NSApp activate:options:]`。
+
+### 2. ToDesk / 远程控制软件拦截 keyDown:
+
+在远程控制软件运行时，CGEventPost 合成的键盘事件会被 ToDesk 在 `keyDown:` 层拦截，
+**永远不会到达** Phantty 的 NSView。但 NSMenu 的 key equivalents 不受影响 ——
+AppKit 在 `performKeyEquivalent:` 阶段处理 NSMenu，**早于** `keyDown:` 的远程控制 hook。
+
+这意味着：
+- 在有 ToDesk 的开发机上调试快捷键，要么关掉 ToDesk，要么通过 NSMenu 测
+- **NSMenu 不只是 UX 加分项 —— 它是快捷键在敌对环境下唯一可靠的触发路径**
+- 对最终用户：即便用户的 IME / 远程工具吃了 `Ctrl+Shift+P`，菜单点击仍然有效
+
+### 3. 中文 IME 吞掉字母键
+
+测试时发现 `mcp__computer-use__key text="a"` 在 Phantty 里弹出了**拼音候选框**
+("啊 阿 嗄 锕 澳")。即使 macOS 系统输入源是 "ABC"，依然可能有某个 input method
+(如 macOS 自带的 PressAndHold、或第三方拼音) 在 NSTextInputClient 路径上接管。
+
+副作用：
+- "type 'echo hello' 测终端" 不会工作 —— IME 把它当成拼音输入
+- 但 NSMenu / 带 Ctrl 修饰键的快捷键不进 IME，所以可以用它们做端到端测试
+
+### 4. macOS 26 (Sequoia 后续) 上 `System Events` 的 frontmost 查询时不时挂
+
+```
+System Events 遇到一个错误：不能获得 "process 1 whose frontmost = true"。无效的索引。
+```
+
+不可重现的间歇性错误。重试通常能恢复。和我们的代码无关，但调试脚本需要兜底。
+
+### 5. macOS 的 traffic lights 不能自己画
+
+Phantty Windows 端有 app-drawn titlebar + caption buttons。
+macOS 上 AppKit 强制接管标题栏 + 红绿黄按钮（`NSWindowStyleMaskTitled`），
+所以 Phantty 的 app-drawn titlebar 路径在 macOS 上被禁用了
+(`titlebar_height = 0`)。
+
+后果：
+- macOS 上**没有窗口内的菜单/齿轮/帮助按钮** —— 这些原本画在 app titlebar 上的
+  控件全部消失（在 Windows 上汉堡菜单是入口）
+- 用户只能靠键盘快捷键 → 这就是为什么 D7.1 NSMenu 是必要的
+- 长期：考虑在 macOS 上把这些图标画在 AppKit titlebar 下方的窄条里
+
+### 6. `[NSApp sendEvent:]` 是从 main thread 同步派发，threadlocal 安全
+
+Phantty 用了大量 `threadlocal var g_xxx` 存 UI 状态。
+担心过：NSMenu 回调如果在另一个线程触发，状态不可见。
+
+实测：AppKit 在 `[NSApp sendEvent:]` 阶段同步派发 menu action 到 main thread，
+Phantty 的渲染主循环也跑在 main thread (`first_window.run()` per App.zig:723)。
+所以 menu callback 和渲染读写同一份 threadlocal storage。
+**前提是新窗口创建时不要把 menu 安装挪到 spawned thread**。
+
+---
+
+## Zig 0.15.x 的小陷阱
+
+### `@import` 不能走出 module root
+
+`test-metal` 的 module root 是 `gpu/metal/test.zig`，
+所以 `gpu/metal/gl_init.zig` 里 `@import("../../ui_pipeline.zig")` 会被拒：
+
+```
+error: import of file outside module path
+```
+
+App 主 build 的 module root 高（包含整个 `src/`），所以没事。
+
+变通方案：
+- **函数指针 hooks**（本 PR 用的）—— 把对方做成 register/dispatch 协议
+- **build.zig 加 module 依赖** —— 让 metal_test_mod 也能看到 ui_pipeline
+- **延迟 import** —— 在函数体里 `const x = @import(...)` 但**还是会被静态检查**，
+  和顶层 import 同等待遇，**这条路不通**（我先试过）
+
+### `@hasDecl` 用在 import 结果上
+
+`AppWindow.gpu.gl_init` 是 `@import` 的结果（namespace 类型），不是值。
+直接 `@hasDecl(AppWindow.gpu.gl_init, "setBackendHooks")` 即可。
+`@TypeOf(gl_init)` 在这里反而是错的。
+
+---
+
+## 调试方法论的几点经验
+
+### 1. "Unit tests pass but app doesn't render" 是常态
+
+`zig build test`、`test-macos-ui`、`test-metal` 全部绿，但 app 跑起来啥都不画。
+原因：unit tests 验证**逻辑**（state machine、keybind dispatch、文件 IO），
+不验证**像素**。Metal stub 完全无 panic、单测正常通过，
+但把"用 quad 画背景"丢进了 `_ = x;` 也合法。
+
+防御：
+- 像素级回归测试（offscreen Metal target + image diff）—— 本 PR 没做，作为下一轮 todo
+- 至少 NSMenu / overlay state 改了就**手工跑 .app 看一下**
+
+### 2. 在 ObjC bridge 里加 `fprintf(stderr, ...)` 是最快的诊断手段
+
+`phantty_metal_pipeline_draw_arrays` 加 fprintf 立刻看出每一帧确实有 ~200 个 draw call，
+排除"没 dispatch 到 Metal" 这个假设。
+**不要怕在 bridge.m 里临时加 printf**，commit 前去掉就行。
+
+### 3. 对比 OpenGL 等价路径
+
+每次 Metal 不对，先问：OpenGL 的 `gl_init.renderQuad` 怎么实现的？两边公共 API 哪里差异？
+本 PR 的 Bug #1 就是这样发现的（OpenGL 委托给 ui_pipeline.setProjection，Metal 没委托）。
+
+### 4. Logs 越早越好
+
+`g_command_palette_visible` 是 threadlocal —— 在 menu callback 里 print 一下
+toggle 前后的值，立刻确认 state 转变是否成功，下一步该看渲染路径。
+不要陷入"我猜是 threadlocal cross-thread 问题"，先**测一下**。
+
+---
+
+## 这次没做但值得做的事
+
+1. **像素回归测试**：用 offscreen `MTLTexture` 当 framebuffer 跑一帧，比对参考截图。
+   能挡住 Bug #1 这种"逻辑过但视觉错"的退化。
+
+2. **Metal frame transient buffer arena**：当前每个 ui_pipeline.fillQuad 都
+   `newBufferWithBytes:`。对手游级别的 draw 数量（每帧几十）完全 OK，
+   但如果引入 SSH 客户端的大文件预览或图像 grid，会变成瓶颈。
+   Ghostty 的方案：单个大 MTLBuffer + 累加 offset + `setVertexBuffer:offset:`。
+
+3. **App-drawn 状态栏 / 工具栏在 macOS 上的归宿**：Windows 端 titlebar 里的
+   汉堡/齿轮/帮助图标在 macOS 上没了。考虑画在 AppKit titlebar 下方的窄条里，
+   或者完全靠 NSMenu。
+
+4. **`setVertexBytes` 改造小 buffer**：`ui_pipeline` 的 quad 数据 96 字节，
+   完全适合走 `setVertexBytes`，可以省掉每次 `newBufferWithBytes` 的分配。
+
+5. **NSMenu 项动态状态**：勾选项反映 sidebar/command-center 当前是否打开，
+   快捷键文字反映用户配置的实际 keybind（不是写死的）。
+
+---
+
+## TL;DR
+
+把任何"自带 OpenGL 模型的 cross-backend renderer"移植到 Metal，三个最痛的坑：
+
+1. **Metal stub 的 no-op 看着无害但偷偷少做事** —— 必须挨个对照 OpenGL 等价路径。
+2. **MTLBuffer 不是 GL buffer** —— `setVertexBuffer:` 不复制数据，`commit` 之前的所有
+   buffer 修改都会被同一次 commit 看到。upload+immediate-draw 模式需要重新设计 buffer 生命周期。
+3. **NSMenu 不是装饰** —— 它是在 IME/远程控制等敌对 keyDown 环境下唯一保证可达的入口。
+
+Bonus：**Zig 0.15 的 module path 检查**让 cross-backend 委托不能用最直接的 `@import`，
+需要 BackendHooks / 函数指针 / build.zig 加 module dep 之类的迂回。

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -26,6 +26,7 @@ const platform_display = @import("platform/display.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_file_dialog = @import("platform/file_dialog.zig");
 const platform_global_hotkey = @import("platform/global_hotkey.zig");
+const platform_menu = @import("platform/menu.zig");
 const platform_notifications = @import("platform/notifications.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_window_state = @import("platform/window_state.zig");
@@ -2819,6 +2820,15 @@ fn installRemoteControlHandlers(self: *AppWindow) void {
     }
 }
 
+fn onPlatformMenuAction(action: keybind.Action) void {
+    _ = input.invokeKeybindAction(action);
+}
+
+fn installPlatformMenu() void {
+    if (platform_menu.isInstalled()) return;
+    platform_menu.install(onPlatformMenuAction);
+}
+
 fn uiFontSize(term_font_size: u32) u32 {
     return @min(24, @max(9, term_font_size));
 }
@@ -3354,6 +3364,7 @@ fn runMainLoop(self: *AppWindow) !void {
     defer if (g_quake_hotkey_registered) platform_global_hotkey.unregister(window_backend.nativeHandle(&backend_window), quick_terminal.HOTKEY_ID);
     installAgentToolHost(self);
     installRemoteControlHandlers(self);
+    installPlatformMenu();
     font.g_dpi = window_backend.dpi(&backend_window);
 
     // --- Initialize the active GPU backend through the host surface seam ---

--- a/src/input.zig
+++ b/src/input.zig
@@ -915,6 +915,14 @@ fn handleConfiguredKeybindAction(action: keybind.Action, phase: KeybindPhase) bo
     return executeCommand(cmd);
 }
 
+/// Dispatch a keybind action through both early and late phases. Used by UI
+/// entrypoints (NSMenu items, future buttons) so a click takes the same path
+/// as a keyboard shortcut without reproducing the early/late split logic.
+pub fn invokeKeybindAction(action: keybind.Action) bool {
+    if (handleConfiguredKeybindAction(action, .early)) return true;
+    return handleConfiguredKeybindAction(action, .late);
+}
+
 fn executeCommand(cmd: command_dispatch.Command) bool {
     switch (cmd) {
         // Early

--- a/src/platform/menu.zig
+++ b/src/platform/menu.zig
@@ -1,0 +1,41 @@
+//! Application menu facade.
+//!
+//! Provides a unified API for installing the platform's application menu (e.g.,
+//! macOS NSMenu). On platforms without a native app menu, the calls are no-ops.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const keybind = @import("../keybind.zig");
+
+pub const Backend = enum {
+    macos,
+    unsupported,
+};
+
+pub fn backendForOs(comptime os_tag: std.Target.Os.Tag) Backend {
+    return switch (os_tag) {
+        .macos => .macos,
+        else => .unsupported,
+    };
+}
+
+const impl = switch (backendForOs(builtin.os.tag)) {
+    .macos => @import("menu_macos.zig"),
+    .unsupported => @import("menu_unsupported.zig"),
+};
+
+/// Invoked when a menu item that maps to a Phantty keybind action is clicked.
+pub const ActionHandler = *const fn (action: keybind.Action) void;
+
+/// Build and install the platform application menu. On platforms without a
+/// native app menu this returns silently. Idempotent: calling twice rebuilds
+/// the menu so the second call wins.
+pub fn install(handler: ActionHandler) void {
+    impl.install(handler);
+}
+
+/// Returns true once `install` has successfully attached a menu to the
+/// platform's menu host. Mainly useful in tests.
+pub fn isInstalled() bool {
+    return impl.isInstalled();
+}

--- a/src/platform/menu_macos.zig
+++ b/src/platform/menu_macos.zig
@@ -1,0 +1,155 @@
+//! macOS NSMenu implementation behind `platform/menu.zig`.
+//!
+//! Builds a Phantty main menu (Phantty / File / Edit / View / Window) by
+//! driving the ObjC bridge with structured calls. Each user-facing menu item
+//! carries an action id derived from `keybind.Action`'s integer index so the
+//! callback can re-enter the standard action dispatcher and reuse the exact
+//! same code path that keyboard shortcuts go through.
+
+const std = @import("std");
+const keybind = @import("../keybind.zig");
+const menu = @import("menu.zig");
+
+// Modifier bitmask values must mirror the PHANTTY_MAC_MENU_MOD_* constants in
+// the ObjC bridge.
+pub const ModCmd: u32 = 1 << 0;
+pub const ModShift: u32 = 1 << 1;
+pub const ModOpt: u32 = 1 << 2;
+pub const ModCtrl: u32 = 1 << 3;
+
+pub const SystemAction = enum(i32) {
+    about = -2,
+    hide = -3,
+    hide_others = -4,
+    show_all = -5,
+    quit = -6,
+};
+
+const CCallback = *const fn (action_id: i32) callconv(.c) void;
+
+extern fn phantty_macos_menu_install(callback: CCallback) void;
+extern fn phantty_macos_menu_begin() void;
+extern fn phantty_macos_menu_begin_submenu(title: [*:0]const u8) void;
+extern fn phantty_macos_menu_add_item(
+    title: [*:0]const u8,
+    action_id: i32,
+    key_equivalent: [*:0]const u8,
+    modifier_mask: u32,
+) void;
+extern fn phantty_macos_menu_add_separator() void;
+extern fn phantty_macos_menu_end_submenu() void;
+extern fn phantty_macos_menu_finalize() void;
+extern fn phantty_macos_menu_is_installed() bool;
+
+// Test-only inspection functions exposed by the bridge.
+pub extern fn phantty_macos_menu_top_level_count_for_test() i32;
+pub extern fn phantty_macos_menu_item_count_for_test(menu_index: i32) i32;
+pub extern fn phantty_macos_menu_item_action_for_test(menu_index: i32, item_index: i32) i32;
+pub extern fn phantty_macos_menu_item_title_for_test(menu_index: i32, item_index: i32) ?[*:0]const u8;
+pub extern fn phantty_macos_menu_item_modifier_for_test(menu_index: i32, item_index: i32) u32;
+pub extern fn phantty_macos_menu_item_key_equivalent_for_test(menu_index: i32, item_index: i32) ?[*:0]const u8;
+pub extern fn phantty_macos_menu_invoke_for_test(menu_index: i32, item_index: i32) void;
+
+var g_handler: ?menu.ActionHandler = null;
+
+fn onCAction(action_id: i32) callconv(.c) void {
+    const action = actionFromId(action_id) orelse return;
+    if (g_handler) |handler| handler(action);
+}
+
+pub fn install(handler: menu.ActionHandler) void {
+    g_handler = handler;
+    phantty_macos_menu_install(onCAction);
+    buildDefaultMenu();
+}
+
+pub fn isInstalled() bool {
+    return phantty_macos_menu_is_installed();
+}
+
+pub fn actionFromId(action_id: i32) ?keybind.Action {
+    if (action_id < 0) return null;
+    const field_count = std.meta.fields(keybind.Action).len;
+    if (@as(usize, @intCast(action_id)) >= field_count) return null;
+    return @as(keybind.Action, @enumFromInt(@as(@typeInfo(keybind.Action).@"enum".tag_type, @intCast(action_id))));
+}
+
+inline fn id(action: keybind.Action) i32 {
+    return @intCast(@intFromEnum(action));
+}
+
+fn buildDefaultMenu() void {
+    phantty_macos_menu_begin();
+
+    // Phantty (application) menu.
+    phantty_macos_menu_begin_submenu("Phantty");
+    phantty_macos_menu_add_item("About Phantty", @intFromEnum(SystemAction.about), "", 0);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Settings…", id(.open_config), ",", ModCmd);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Hide Phantty", @intFromEnum(SystemAction.hide), "h", ModCmd);
+    phantty_macos_menu_add_item("Hide Others", @intFromEnum(SystemAction.hide_others), "h", ModCmd | ModOpt);
+    phantty_macos_menu_add_item("Show All", @intFromEnum(SystemAction.show_all), "", 0);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Quit Phantty", @intFromEnum(SystemAction.quit), "q", ModCmd);
+    phantty_macos_menu_end_submenu();
+
+    // File.
+    phantty_macos_menu_begin_submenu("File");
+    phantty_macos_menu_add_item("New Tab", id(.new_session), "t", ModCtrl | ModShift);
+    phantty_macos_menu_add_item("New Window", id(.new_window), "n", ModCtrl | ModShift);
+    phantty_macos_menu_add_item("Split Right", id(.split_right), "o", ModCtrl | ModShift);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Close Tab", id(.close_panel_or_tab), "w", ModCtrl | ModShift);
+    phantty_macos_menu_end_submenu();
+
+    // Edit.
+    phantty_macos_menu_begin_submenu("Edit");
+    phantty_macos_menu_add_item("Copy", id(.copy), "c", ModCtrl | ModShift);
+    phantty_macos_menu_add_item("Paste", id(.paste), "v", ModCtrl);
+    phantty_macos_menu_add_item("Paste Image", id(.paste_image), "v", ModCtrl | ModShift);
+    phantty_macos_menu_end_submenu();
+
+    // View.
+    phantty_macos_menu_begin_submenu("View");
+    phantty_macos_menu_add_item("Open Command Center", id(.toggle_command_palette), "p", ModCtrl | ModShift);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Toggle Tab Sidebar", id(.toggle_sidebar), "b", ModCtrl | ModShift);
+    phantty_macos_menu_add_item("Toggle File Explorer", id(.toggle_file_explorer), "e", ModCtrl | ModShift | ModOpt);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Increase Font Size", id(.font_size_increase), "+", ModCtrl);
+    phantty_macos_menu_add_item("Decrease Font Size", id(.font_size_decrease), "-", ModCtrl);
+    phantty_macos_menu_end_submenu();
+
+    // Window.
+    phantty_macos_menu_begin_submenu("Window");
+    phantty_macos_menu_add_item("Toggle Maximize", id(.toggle_maximize), "\r", ModOpt);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Next Tab", id(.next_tab), "\t", ModCtrl);
+    phantty_macos_menu_add_item("Previous Tab", id(.previous_tab), "\t", ModCtrl | ModShift);
+    phantty_macos_menu_add_separator();
+    phantty_macos_menu_add_item("Equalize Splits", id(.equalize_splits), "z", ModCtrl | ModShift);
+    phantty_macos_menu_end_submenu();
+
+    phantty_macos_menu_finalize();
+}
+
+test "menu_macos: actionFromId round-trips known Phantty actions" {
+    if (@import("builtin").os.tag != .macos) return error.SkipZigTest;
+    const expected = keybind.Action.toggle_command_palette;
+    const action_id: i32 = @intCast(@intFromEnum(expected));
+    try std.testing.expectEqual(@as(?keybind.Action, expected), actionFromId(action_id));
+}
+
+test "menu_macos: actionFromId rejects system action ids" {
+    if (@import("builtin").os.tag != .macos) return error.SkipZigTest;
+    try std.testing.expectEqual(@as(?keybind.Action, null), actionFromId(@intFromEnum(SystemAction.quit)));
+    try std.testing.expectEqual(@as(?keybind.Action, null), actionFromId(-1));
+}
+
+test "menu_macos: actionFromId rejects out-of-range ids" {
+    if (@import("builtin").os.tag != .macos) return error.SkipZigTest;
+    const max_id: i32 = @intCast(std.meta.fields(keybind.Action).len);
+    try std.testing.expectEqual(@as(?keybind.Action, null), actionFromId(max_id));
+    try std.testing.expectEqual(@as(?keybind.Action, null), actionFromId(max_id + 5));
+}

--- a/src/platform/menu_macos_bridge.m
+++ b/src/platform/menu_macos_bridge.m
@@ -1,0 +1,275 @@
+// Programmatic macOS NSMenu for Phantty.
+//
+// The Zig side drives the menu structure: it calls `menu_begin`, `menu_add`,
+// `menu_add_separator`, `menu_end_submenu`, and finally `menu_finalize` to
+// publish the constructed NSMenu via `[NSApp setMainMenu:]`. When an item is
+// clicked, the registered action callback is invoked with the Zig-supplied
+// integer action id so the dispatcher can route to the right
+// keybind.Action.
+//
+// Modifier-mask bits accepted by `phantty_macos_menu_add_item` mirror
+// NSEventModifierFlag* constants and are listed in PhanttyMacMenuMod below so
+// the Zig side can stay AppKit-agnostic.
+
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+// Modifier bitmask values exposed to Zig. The numeric values are stable and
+// don't depend on NSEventModifierFlag* internals — the bridge translates.
+//   PHANTTY_MAC_MENU_MOD_NONE  = 0
+//   PHANTTY_MAC_MENU_MOD_CMD   = 1 << 0
+//   PHANTTY_MAC_MENU_MOD_SHIFT = 1 << 1
+//   PHANTTY_MAC_MENU_MOD_OPT   = 1 << 2
+//   PHANTTY_MAC_MENU_MOD_CTRL  = 1 << 3
+#define PHANTTY_MAC_MENU_MOD_CMD   (1 << 0)
+#define PHANTTY_MAC_MENU_MOD_SHIFT (1 << 1)
+#define PHANTTY_MAC_MENU_MOD_OPT   (1 << 2)
+#define PHANTTY_MAC_MENU_MOD_CTRL  (1 << 3)
+
+// Sentinel action id meaning "no Phantty action" (separator, system-provided).
+#define PHANTTY_MAC_MENU_ACTION_NONE (-1)
+
+// System-action ids (negative values reserved by the bridge).
+#define PHANTTY_MAC_MENU_SYSTEM_ABOUT      (-2)
+#define PHANTTY_MAC_MENU_SYSTEM_HIDE       (-3)
+#define PHANTTY_MAC_MENU_SYSTEM_HIDE_OTHER (-4)
+#define PHANTTY_MAC_MENU_SYSTEM_SHOW_ALL   (-5)
+#define PHANTTY_MAC_MENU_SYSTEM_QUIT       (-6)
+
+typedef void (*PhanttyMacMenuActionCallback)(int32_t action_id);
+
+void phantty_macos_menu_install(PhanttyMacMenuActionCallback callback);
+void phantty_macos_menu_begin(void);
+void phantty_macos_menu_begin_submenu(const char *title);
+void phantty_macos_menu_add_item(
+    const char *title,
+    int32_t action_id,
+    const char *key_equivalent,
+    uint32_t modifier_mask
+);
+void phantty_macos_menu_add_separator(void);
+void phantty_macos_menu_end_submenu(void);
+void phantty_macos_menu_finalize(void);
+bool phantty_macos_menu_is_installed(void);
+int32_t phantty_macos_menu_top_level_count_for_test(void);
+int32_t phantty_macos_menu_item_count_for_test(int32_t menu_index);
+int32_t phantty_macos_menu_item_action_for_test(int32_t menu_index, int32_t item_index);
+const char *phantty_macos_menu_item_title_for_test(int32_t menu_index, int32_t item_index);
+uint32_t phantty_macos_menu_item_modifier_for_test(int32_t menu_index, int32_t item_index);
+const char *phantty_macos_menu_item_key_equivalent_for_test(int32_t menu_index, int32_t item_index);
+void phantty_macos_menu_invoke_for_test(int32_t menu_index, int32_t item_index);
+
+static PhanttyMacMenuActionCallback g_action_callback = NULL;
+
+@interface PhanttyMacMenuTarget : NSObject
+- (void)invokePhanttyAction:(id)sender;
+@end
+
+@implementation PhanttyMacMenuTarget
+- (void)invokePhanttyAction:(id)sender {
+    if (g_action_callback == NULL) return;
+    if (![sender isKindOfClass:[NSMenuItem class]]) return;
+    NSMenuItem *item = (NSMenuItem *)sender;
+    int32_t action_id = (int32_t)item.tag;
+    if (action_id == PHANTTY_MAC_MENU_ACTION_NONE) return;
+    if (action_id < 0) {
+        // System-action ids resolved by AppKit selectors; fall through.
+        return;
+    }
+    g_action_callback(action_id);
+}
+@end
+
+static PhanttyMacMenuTarget *g_menu_target = nil;
+static NSMenu *g_main_menu = nil;          // installed (live) menu
+static NSMenu *g_building_menu = nil;      // menu currently being built
+static NSMenu *g_building_submenu = nil;   // active submenu inside build
+
+static NSEventModifierFlags phantty_macos_translate_mods(uint32_t mask) {
+    NSEventModifierFlags flags = 0;
+    if (mask & PHANTTY_MAC_MENU_MOD_CMD) flags |= NSEventModifierFlagCommand;
+    if (mask & PHANTTY_MAC_MENU_MOD_SHIFT) flags |= NSEventModifierFlagShift;
+    if (mask & PHANTTY_MAC_MENU_MOD_OPT) flags |= NSEventModifierFlagOption;
+    if (mask & PHANTTY_MAC_MENU_MOD_CTRL) flags |= NSEventModifierFlagControl;
+    return flags;
+}
+
+static SEL phantty_macos_system_selector(int32_t action_id) {
+    switch (action_id) {
+        case PHANTTY_MAC_MENU_SYSTEM_ABOUT: return @selector(orderFrontStandardAboutPanel:);
+        case PHANTTY_MAC_MENU_SYSTEM_HIDE: return @selector(hide:);
+        case PHANTTY_MAC_MENU_SYSTEM_HIDE_OTHER: return @selector(hideOtherApplications:);
+        case PHANTTY_MAC_MENU_SYSTEM_SHOW_ALL: return @selector(unhideAllApplications:);
+        case PHANTTY_MAC_MENU_SYSTEM_QUIT: return @selector(terminate:);
+        default: return (SEL)0;
+    }
+}
+
+void phantty_macos_menu_install(PhanttyMacMenuActionCallback callback) {
+    g_action_callback = callback;
+    if (g_menu_target == nil) {
+        g_menu_target = [[PhanttyMacMenuTarget alloc] init];
+    }
+}
+
+void phantty_macos_menu_begin(void) {
+    @autoreleasepool {
+        if (g_building_menu != nil) {
+            [g_building_menu release];
+            g_building_menu = nil;
+        }
+        g_building_submenu = nil;
+        g_building_menu = [[NSMenu alloc] initWithTitle:@""];
+    }
+}
+
+void phantty_macos_menu_begin_submenu(const char *title) {
+    @autoreleasepool {
+        if (g_building_menu == nil) return;
+        NSString *title_ns = title != NULL ? [NSString stringWithUTF8String:title] : @"";
+        NSMenuItem *holder = [[NSMenuItem alloc] init];
+        NSMenu *sub = [[NSMenu alloc] initWithTitle:title_ns];
+        [holder setSubmenu:sub];
+        [g_building_menu addItem:holder];
+        if (g_building_submenu != nil) {
+            [g_building_submenu release];
+        }
+        g_building_submenu = sub; // retained by holder; we keep a strong ref too
+        [g_building_submenu retain];
+        [holder release];
+    }
+}
+
+void phantty_macos_menu_add_item(
+    const char *title,
+    int32_t action_id,
+    const char *key_equivalent,
+    uint32_t modifier_mask
+) {
+    @autoreleasepool {
+        if (g_building_submenu == nil) return;
+        NSString *title_ns = title != NULL ? [NSString stringWithUTF8String:title] : @"";
+        NSString *key_ns = (key_equivalent != NULL && key_equivalent[0] != '\0')
+            ? [NSString stringWithUTF8String:key_equivalent]
+            : @"";
+        SEL action_sel;
+        if (action_id < 0) {
+            action_sel = phantty_macos_system_selector(action_id);
+            if (action_sel == (SEL)0) action_sel = @selector(invokePhanttyAction:);
+        } else {
+            action_sel = @selector(invokePhanttyAction:);
+        }
+        NSMenuItem *item = [[NSMenuItem alloc]
+            initWithTitle:title_ns
+                   action:action_sel
+            keyEquivalent:key_ns];
+        if (action_id >= 0) [item setTarget:g_menu_target];
+        [item setTag:(NSInteger)action_id];
+        if (key_ns.length > 0) {
+            [item setKeyEquivalentModifierMask:phantty_macos_translate_mods(modifier_mask)];
+        }
+        [g_building_submenu addItem:item];
+        [item release];
+    }
+}
+
+void phantty_macos_menu_add_separator(void) {
+    if (g_building_submenu == nil) return;
+    [g_building_submenu addItem:[NSMenuItem separatorItem]];
+}
+
+void phantty_macos_menu_end_submenu(void) {
+    if (g_building_submenu != nil) {
+        [g_building_submenu release];
+        g_building_submenu = nil;
+    }
+}
+
+void phantty_macos_menu_finalize(void) {
+    @autoreleasepool {
+        if (g_building_menu == nil) return;
+        if (g_building_submenu != nil) {
+            [g_building_submenu release];
+            g_building_submenu = nil;
+        }
+        if (g_main_menu != nil) {
+            [g_main_menu release];
+            g_main_menu = nil;
+        }
+        g_main_menu = g_building_menu;
+        g_building_menu = nil;
+        if (NSApp != nil) [NSApp setMainMenu:g_main_menu];
+    }
+}
+
+bool phantty_macos_menu_is_installed(void) {
+    return g_main_menu != nil;
+}
+
+int32_t phantty_macos_menu_top_level_count_for_test(void) {
+    if (g_main_menu == nil) return -1;
+    return (int32_t)g_main_menu.numberOfItems;
+}
+
+int32_t phantty_macos_menu_item_count_for_test(int32_t menu_index) {
+    if (g_main_menu == nil) return -1;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return -1;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return -1;
+    return (int32_t)sub.numberOfItems;
+}
+
+int32_t phantty_macos_menu_item_action_for_test(int32_t menu_index, int32_t item_index) {
+    if (g_main_menu == nil) return PHANTTY_MAC_MENU_ACTION_NONE;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return PHANTTY_MAC_MENU_ACTION_NONE;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return PHANTTY_MAC_MENU_ACTION_NONE;
+    if (item_index < 0 || item_index >= (int32_t)sub.numberOfItems) return PHANTTY_MAC_MENU_ACTION_NONE;
+    NSMenuItem *item = [sub itemAtIndex:item_index];
+    if (item.isSeparatorItem) return PHANTTY_MAC_MENU_ACTION_NONE;
+    return (int32_t)item.tag;
+}
+
+const char *phantty_macos_menu_item_title_for_test(int32_t menu_index, int32_t item_index) {
+    if (g_main_menu == nil) return NULL;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return NULL;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return NULL;
+    if (item_index < 0 || item_index >= (int32_t)sub.numberOfItems) return NULL;
+    return [[sub itemAtIndex:item_index].title UTF8String];
+}
+
+uint32_t phantty_macos_menu_item_modifier_for_test(int32_t menu_index, int32_t item_index) {
+    if (g_main_menu == nil) return 0;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return 0;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return 0;
+    if (item_index < 0 || item_index >= (int32_t)sub.numberOfItems) return 0;
+    NSEventModifierFlags flags = [sub itemAtIndex:item_index].keyEquivalentModifierMask;
+    uint32_t out = 0;
+    if (flags & NSEventModifierFlagCommand) out |= PHANTTY_MAC_MENU_MOD_CMD;
+    if (flags & NSEventModifierFlagShift) out |= PHANTTY_MAC_MENU_MOD_SHIFT;
+    if (flags & NSEventModifierFlagOption) out |= PHANTTY_MAC_MENU_MOD_OPT;
+    if (flags & NSEventModifierFlagControl) out |= PHANTTY_MAC_MENU_MOD_CTRL;
+    return out;
+}
+
+const char *phantty_macos_menu_item_key_equivalent_for_test(int32_t menu_index, int32_t item_index) {
+    if (g_main_menu == nil) return NULL;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return NULL;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return NULL;
+    if (item_index < 0 || item_index >= (int32_t)sub.numberOfItems) return NULL;
+    return [[sub itemAtIndex:item_index].keyEquivalent UTF8String];
+}
+
+void phantty_macos_menu_invoke_for_test(int32_t menu_index, int32_t item_index) {
+    if (g_main_menu == nil) return;
+    if (menu_index < 0 || menu_index >= (int32_t)g_main_menu.numberOfItems) return;
+    NSMenu *sub = [g_main_menu itemAtIndex:menu_index].submenu;
+    if (sub == nil) return;
+    if (item_index < 0 || item_index >= (int32_t)sub.numberOfItems) return;
+    NSMenuItem *item = [sub itemAtIndex:item_index];
+    if (item.tag < 0) return; // system items are AppKit-driven; tests skip
+    [g_menu_target invokePhanttyAction:item];
+}

--- a/src/platform/menu_unsupported.zig
+++ b/src/platform/menu_unsupported.zig
@@ -1,0 +1,20 @@
+//! No-op application menu backend for platforms that don't have (or don't yet
+//! support) a native app menu. The interface mirrors `platform/menu.zig`.
+
+const keybind = @import("../keybind.zig");
+const menu = @import("menu.zig");
+
+pub fn install(handler: menu.ActionHandler) void {
+    _ = handler;
+}
+
+pub fn isInstalled() bool {
+    return false;
+}
+
+// Stub for cross-platform callers that go through the facade's actionFromId
+// helper. The macOS backend exposes the real implementation.
+pub fn actionFromId(action_id: i32) ?keybind.Action {
+    _ = action_id;
+    return null;
+}

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -180,7 +180,13 @@ pub const default_shell_name = defaultShellNameForOs(builtin.os.tag);
 pub fn defaultShellNameForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
         .windows => "cmd",
-        .unsupported => "sh",
+        // POSIX: macOS has shipped zsh as the default user shell since
+        // Catalina; Linux distros still default to bash/sh, so keep sh
+        // there until we add a Linux-specific override.
+        .unsupported => switch (os_tag) {
+            .macos => "zsh",
+            else => "sh",
+        },
     };
 }
 
@@ -219,7 +225,10 @@ pub const default_shell_assignment_comment = defaultShellAssignmentCommentForOs(
 pub fn defaultShellAssignmentCommentForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
         .windows => "# shell = cmd",
-        .unsupported => "# shell = sh",
+        .unsupported => switch (os_tag) {
+            .macos => "# shell = zsh",
+            else => "# shell = sh",
+        },
     };
 }
 
@@ -533,7 +542,11 @@ test "platform pty command exposes configured local shell launcher by target OS"
         },
         .unsupported => {
             try std.testing.expect(!shellCommandLooksLikeConfiguredLocalShell(current_shell));
-            try std.testing.expectEqualStrings("sh", configuredLocalShellCommandForShell(current_shell));
+            const expected_shell: []const u8 = switch (builtin.os.tag) {
+                .macos => "zsh",
+                else => "sh",
+            };
+            try std.testing.expectEqualStrings(expected_shell, configuredLocalShellCommandForShell(current_shell));
         },
     }
 }
@@ -541,7 +554,7 @@ test "platform pty command exposes configured local shell launcher by target OS"
 test "platform pty command exposes shell config defaults by target OS" {
     try std.testing.expectEqualStrings("cmd", defaultShellNameForOs(.windows));
     try std.testing.expectEqualStrings("sh", defaultShellNameForOs(.linux));
-    try std.testing.expectEqualStrings("sh", defaultShellNameForOs(.macos));
+    try std.testing.expectEqualStrings("zsh", defaultShellNameForOs(.macos));
 
     try std.testing.expect(std.mem.indexOf(u8, shellSettingChoicesHintForOs(.windows), "powershell") != null);
     try std.testing.expect(std.mem.indexOf(u8, shellSettingChoicesHintForOs(.linux), "powershell") == null);

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -123,7 +123,10 @@ pub fn shellCommandLooksLikeConfiguredLocalShell(shell_cmd: CommandLine) bool {
 
 pub fn configuredLocalShellCommandForShell(shell_cmd: CommandLine) []const u8 {
     _ = shell_cmd;
-    return "sh";
+    return switch (builtin.os.tag) {
+        .macos => "zsh",
+        else => "sh",
+    };
 }
 
 pub fn tabCommandForKind(kind: []const u8, current_shell: CommandLine) ![]const u8 {

--- a/src/renderer/gpu/metal/bridge.m
+++ b/src/renderer/gpu/metal/bridge.m
@@ -325,21 +325,24 @@ bool phantty_metal_buffer_upload(unsigned int handle, void *device_handle, const
         return true;
     }
 
+    // IMPORTANT: every upload allocates a fresh MTLBuffer. Reusing the same
+    // backing storage (via memcpy) is unsafe under Metal's deferred-execution
+    // model: setVertexBuffer:offset:atIndex: stores a pointer that's only read
+    // when the command buffer commits, so multiple "upload + drawArrays" pairs
+    // sharing a single MTLBuffer all end up reading the *last* upload — every
+    // overlay/quad gets stamped at the same coordinates. The previous buffer
+    // is released here; Metal keeps it alive via the encoder's retain until
+    // commit completes, then deallocates asynchronously. The per-call alloc
+    // cost is negligible for the small vertex blobs ui_pipeline uses (~96B/quad).
     @autoreleasepool {
-        id<MTLBuffer> buffer = phantty_metal_buffers[handle].buffer;
-        if (buffer == nil || [buffer length] < len) {
-            id<MTLBuffer> new_buffer = phantty_metal_new_buffer(device_handle, bytes, len);
-            if (new_buffer == nil) {
-                phantty_metal_set_error(error_buf, error_buf_len, "newBufferWithBytes returned nil");
-                return false;
-            }
-            if (buffer != nil) [buffer release];
-            phantty_metal_buffers[handle].buffer = new_buffer;
-            phantty_metal_set_error(error_buf, error_buf_len, "");
-            return true;
+        id<MTLBuffer> old_buffer = phantty_metal_buffers[handle].buffer;
+        id<MTLBuffer> new_buffer = phantty_metal_new_buffer(device_handle, bytes, len);
+        if (new_buffer == nil) {
+            phantty_metal_set_error(error_buf, error_buf_len, "newBufferWithBytes returned nil");
+            return false;
         }
-
-        memcpy([buffer contents], bytes, len);
+        phantty_metal_buffers[handle].buffer = new_buffer;
+        if (old_buffer != nil) [old_buffer release];
         phantty_metal_set_error(error_buf, error_buf_len, "");
         return true;
     }

--- a/src/renderer/gpu/metal/gl_init.zig
+++ b/src/renderer/gpu/metal/gl_init.zig
@@ -9,12 +9,42 @@
 //!     `setProjection`, `syncSharedHandles`, `compileShader`, `linkProgram`,
 //!     `setProjectionForProgram`.
 //!
-//! NOTE: unlike the OpenGL backend, this file does NOT import `ui_pipeline`/
-//! `AppWindow` — the Metal render helpers will be wired when the backend lands,
-//! and keeping the import out avoids extra coupling in the stub.
+//! D1.x: this file now mirrors `gpu/opengl/gl_init.zig`'s delegation to
+//! `ui_pipeline` for the solid-color quad helpers and `setProjection`. The
+//! prior stub silently dropped these calls — leaving the text pipeline's
+//! projection at zero — and every overlay (command center, sidebar, settings
+//! page, SSH list, …) rendered into the wrong clip space.
+//!
+//! NOTE: `ui_pipeline` cannot be imported here at file scope because the
+//! `test-metal` build step roots its module at `gpu/metal/test.zig`, and
+//! Zig 0.15 rejects imports that walk outside the module root. Instead,
+//! `ui_pipeline.init()` registers a `BackendHooks` snapshot via
+//! `setBackendHooks()` at startup; the helpers below dispatch through the
+//! installed function pointers (and silently no-op if the renderer hasn't
+//! booted yet — which is the case in the Metal smoke tests).
+const std = @import("std");
 const c = @import("c.zig");
 const Pipeline = @import("Pipeline.zig");
 const render_state = @import("render_state.zig");
+
+/// Function-pointer surface the renderer fills in at startup so this file
+/// (which sits inside the Metal backend's module root) can call into
+/// `renderer/ui_pipeline.zig` without an absolute import path.
+pub const BackendHooks = struct {
+    fillQuad: *const fn (x: f32, y: f32, w: f32, h: f32, color: [3]f32) void,
+    fillQuadAlpha: *const fn (x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void,
+    setProjection: *const fn (width: f32, height: f32) void,
+};
+
+threadlocal var g_hooks: ?BackendHooks = null;
+
+pub fn setBackendHooks(hooks: BackendHooks) void {
+    g_hooks = hooks;
+}
+
+pub fn clearBackendHooks() void {
+    g_hooks = null;
+}
 
 // ----------------------------------------------------------------------------
 // Compat mirror handles (populated by syncSharedHandles on the real backend).
@@ -52,27 +82,19 @@ pub fn initShaders() bool {
 }
 
 // ----------------------------------------------------------------------------
-// Render helpers — compatibility shims until all call sites use ui_pipeline.
+// Render helpers — dispatch through the BackendHooks registered by
+// ui_pipeline.init() (parity with the OpenGL backend, but with an indirection
+// to keep the test-metal compile happy).
 // ----------------------------------------------------------------------------
 pub fn renderQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    _ = x;
-    _ = y;
-    _ = w;
-    _ = h;
-    _ = color;
-    g_draw_call_count += 1;
+    if (g_hooks) |hk| hk.fillQuad(x, y, w, h, color);
 }
 pub fn renderQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
-    _ = x;
-    _ = y;
-    _ = w;
-    _ = h;
-    _ = color;
-    _ = alpha;
-    g_draw_call_count += 1;
+    if (g_hooks) |hk| hk.fillQuadAlpha(x, y, w, h, color, alpha);
 }
 pub fn setProjection(width: f32, height: f32) void {
     render_state.setViewport(0, 0, @intFromFloat(width), @intFromFloat(height));
+    if (g_hooks) |hk| hk.setProjection(width, height);
 }
 
 /// Populate the compat mirror handles from the backend-owned objects.

--- a/src/renderer/gpu/metal/test.zig
+++ b/src/renderer/gpu/metal/test.zig
@@ -192,7 +192,39 @@ test "gl_init compatibility helpers do not panic on Metal" {
     gl_init.setProjection(80, 40);
     gl_init.renderQuad(1, 2, 3, 4, .{ 1, 0, 0 });
     gl_init.renderQuadAlpha(1, 2, 3, 4, .{ 0, 1, 0 }, 0.5);
-    try std.testing.expectEqual(@as(u32, 2), gl_init.g_draw_call_count);
+    // The render helpers now dispatch through BackendHooks installed by
+    // ui_pipeline.init() in the real app; the Metal smoke test runs without
+    // that registration, so the helpers are no-ops here and the draw counter
+    // stays at zero. The test still checks the calls don't panic.
+    try std.testing.expectEqual(@as(u32, 0), gl_init.g_draw_call_count);
+
+    // Verify BackendHooks dispatch fires when a hook table is installed.
+    const HookCounter = struct {
+        var calls: u32 = 0;
+        fn fillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+            _ = x; _ = y; _ = w; _ = h; _ = color;
+            calls += 1;
+        }
+        fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+            _ = x; _ = y; _ = w; _ = h; _ = color; _ = alpha;
+            calls += 1;
+        }
+        fn setProjection(width: f32, height: f32) void {
+            _ = width; _ = height;
+            calls += 1;
+        }
+    };
+    HookCounter.calls = 0;
+    gl_init.setBackendHooks(.{
+        .fillQuad = &HookCounter.fillQuad,
+        .fillQuadAlpha = &HookCounter.fillQuadAlpha,
+        .setProjection = &HookCounter.setProjection,
+    });
+    defer gl_init.clearBackendHooks();
+    gl_init.setProjection(80, 40);
+    gl_init.renderQuad(1, 2, 3, 4, .{ 1, 0, 0 });
+    gl_init.renderQuadAlpha(1, 2, 3, 4, .{ 0, 1, 0 }, 0.5);
+    try std.testing.expectEqual(@as(u32, 3), HookCounter.calls);
 
     gl_init.syncSharedHandles();
     gl_init.setProjectionForProgram(0, 40);

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -40,6 +40,10 @@ fn buildQuadVao() c.GLuint {
 /// Build the shared pipelines, quad buffer, and solid texture. Call once after
 /// the GL context is current (before any UI draw).
 pub fn init() void {
+    // Make the Metal backend's gl_init shim able to call back into ui_pipeline
+    // without an absolute import (see gpu/metal/gl_init.zig BackendHooks).
+    registerMetalBackendHooks();
+
     quad = Buffer.init(c.GL_ARRAY_BUFFER);
     quad.allocate(@sizeOf(f32) * 6 * 4, c.GL_DYNAMIC_DRAW);
 
@@ -203,4 +207,33 @@ pub fn fillOverlay(verts: [6][4]f32, color: [4]f32) void {
     quad.upload(std.mem.sliceAsBytes(verts[0..]));
     overlay.drawArrays(c.GL_TRIANGLES, 0, 6);
     drawCallTick();
+}
+
+// ---------------------------------------------------------------------------
+// Metal-backend dispatcher registration
+// ---------------------------------------------------------------------------
+// The Metal `gpu/metal/gl_init.zig` shim cannot `@import("../../ui_pipeline.zig")`
+// directly (the `test-metal` build step's module root is `gpu/metal/`, so the
+// path walks outside the allowed tree). Instead we hand it a small function-
+// pointer table at app startup. On the OpenGL backend `gpu.gl_init` is the
+// OpenGL `gl_init.zig`, which already imports `ui_pipeline` directly and
+// exposes neither `BackendHooks` nor `setBackendHooks` — guard with comptime
+// `@hasDecl` so the call compiles away to nothing there.
+fn metalFillQuad(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    fillQuad(x, y, w, h, color);
+}
+fn metalFillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+    fillQuadAlpha(x, y, w, h, color, alpha);
+}
+fn metalSetProjection(width: f32, height: f32) void {
+    setProjection(width, height);
+}
+
+fn registerMetalBackendHooks() void {
+    if (!@hasDecl(AppWindow.gpu.gl_init, "setBackendHooks")) return;
+    AppWindow.gpu.gl_init.setBackendHooks(.{
+        .fillQuad = &metalFillQuad,
+        .fillQuadAlpha = &metalFillQuadAlpha,
+        .setProjection = &metalSetProjection,
+    });
 }

--- a/src/test_macos_menu.zig
+++ b/src/test_macos_menu.zig
@@ -1,0 +1,173 @@
+//! Native macOS NSMenu smoke tests.
+//!
+//! Verifies that the bridge constructs the full menu tree, that user-facing
+//! menu items carry the expected keybind.Action ids, that key equivalents and
+//! modifier masks line up with the default key bindings, and that invoking a
+//! menu item drives the registered C callback.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const platform_menu = @import("platform/menu.zig");
+const menu_macos = @import("platform/menu_macos.zig");
+const keybind = @import("keybind.zig");
+
+threadlocal var g_last_action: i32 = -100;
+
+fn testActionHandler(action: keybind.Action) void {
+    g_last_action = @intCast(@intFromEnum(action));
+}
+
+fn installFreshMenu() void {
+    g_last_action = -100;
+    platform_menu.install(testActionHandler);
+}
+
+fn requireSubmenuTitled(expected: []const u8) !i32 {
+    const count = menu_macos.phantty_macos_menu_top_level_count_for_test();
+    try std.testing.expect(count > 0);
+    var i: i32 = 0;
+    while (i < count) : (i += 1) {
+        const item_count = menu_macos.phantty_macos_menu_item_count_for_test(i);
+        if (item_count <= 0) continue;
+        const j: i32 = 0;
+        const title_ptr = menu_macos.phantty_macos_menu_item_title_for_test(i, j);
+        _ = title_ptr;
+        // Walk every item until one matches; the menu holder title isn't
+        // exposed, so we rely on a known signature item (e.g., "About Phantty"
+        // for the Phantty submenu, "New Tab" for File, "Open Command Center"
+        // for View).
+        if (containsItem(i, expected)) return i;
+    }
+    return error.SubmenuNotFound;
+}
+
+fn containsItem(menu_index: i32, expected_title: []const u8) bool {
+    const item_count = menu_macos.phantty_macos_menu_item_count_for_test(menu_index);
+    if (item_count <= 0) return false;
+    var i: i32 = 0;
+    while (i < item_count) : (i += 1) {
+        const ptr = menu_macos.phantty_macos_menu_item_title_for_test(menu_index, i) orelse continue;
+        const slice = std.mem.span(ptr);
+        if (std.mem.eql(u8, slice, expected_title)) return true;
+    }
+    return false;
+}
+
+fn findItemIndex(menu_index: i32, expected_title: []const u8) !i32 {
+    const item_count = menu_macos.phantty_macos_menu_item_count_for_test(menu_index);
+    try std.testing.expect(item_count > 0);
+    var i: i32 = 0;
+    while (i < item_count) : (i += 1) {
+        const ptr = menu_macos.phantty_macos_menu_item_title_for_test(menu_index, i) orelse continue;
+        if (std.mem.eql(u8, std.mem.span(ptr), expected_title)) return i;
+    }
+    return error.ItemNotFound;
+}
+
+test "menu_macos: install publishes the main menu" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    try std.testing.expect(menu_macos.isInstalled());
+    try std.testing.expect(menu_macos.phantty_macos_menu_top_level_count_for_test() >= 5);
+}
+
+test "menu_macos: top-level menus include Phantty/File/Edit/View/Window" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    // Each submenu is identified by a signature item.
+    _ = try requireSubmenuTitled("About Phantty");
+    _ = try requireSubmenuTitled("New Tab");
+    _ = try requireSubmenuTitled("Copy");
+    _ = try requireSubmenuTitled("Open Command Center");
+    _ = try requireSubmenuTitled("Next Tab");
+}
+
+test "menu_macos: View > Open Command Center carries the toggle_command_palette action and ⌃⇧P" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const view_idx = try requireSubmenuTitled("Open Command Center");
+    const item_idx = try findItemIndex(view_idx, "Open Command Center");
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.toggle_command_palette))),
+        menu_macos.phantty_macos_menu_item_action_for_test(view_idx, item_idx),
+    );
+    const key_ptr = menu_macos.phantty_macos_menu_item_key_equivalent_for_test(view_idx, item_idx);
+    try std.testing.expect(key_ptr != null);
+    try std.testing.expectEqualStrings("p", std.mem.span(key_ptr.?));
+    try std.testing.expectEqual(
+        menu_macos.ModCtrl | menu_macos.ModShift,
+        menu_macos.phantty_macos_menu_item_modifier_for_test(view_idx, item_idx),
+    );
+}
+
+test "menu_macos: View > Toggle Tab Sidebar carries toggle_sidebar and ⌃⇧B" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const view_idx = try requireSubmenuTitled("Open Command Center");
+    const item_idx = try findItemIndex(view_idx, "Toggle Tab Sidebar");
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.toggle_sidebar))),
+        menu_macos.phantty_macos_menu_item_action_for_test(view_idx, item_idx),
+    );
+    const key_ptr = menu_macos.phantty_macos_menu_item_key_equivalent_for_test(view_idx, item_idx);
+    try std.testing.expectEqualStrings("b", std.mem.span(key_ptr.?));
+    try std.testing.expectEqual(
+        menu_macos.ModCtrl | menu_macos.ModShift,
+        menu_macos.phantty_macos_menu_item_modifier_for_test(view_idx, item_idx),
+    );
+}
+
+test "menu_macos: Phantty > Settings carries open_config and ⌘," {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const phantty_idx = try requireSubmenuTitled("About Phantty");
+    const item_idx = try findItemIndex(phantty_idx, "Settings…");
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.open_config))),
+        menu_macos.phantty_macos_menu_item_action_for_test(phantty_idx, item_idx),
+    );
+    const key_ptr = menu_macos.phantty_macos_menu_item_key_equivalent_for_test(phantty_idx, item_idx);
+    try std.testing.expectEqualStrings(",", std.mem.span(key_ptr.?));
+    try std.testing.expectEqual(
+        menu_macos.ModCmd,
+        menu_macos.phantty_macos_menu_item_modifier_for_test(phantty_idx, item_idx),
+    );
+}
+
+test "menu_macos: invoking Open Command Center fires the action callback with the right id" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const view_idx = try requireSubmenuTitled("Open Command Center");
+    const item_idx = try findItemIndex(view_idx, "Open Command Center");
+    g_last_action = -100;
+    menu_macos.phantty_macos_menu_invoke_for_test(view_idx, item_idx);
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.toggle_command_palette))),
+        g_last_action,
+    );
+}
+
+test "menu_macos: invoking Toggle Tab Sidebar fires the action callback" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const view_idx = try requireSubmenuTitled("Open Command Center");
+    const item_idx = try findItemIndex(view_idx, "Toggle Tab Sidebar");
+    g_last_action = -100;
+    menu_macos.phantty_macos_menu_invoke_for_test(view_idx, item_idx);
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.toggle_sidebar))),
+        g_last_action,
+    );
+}
+
+test "menu_macos: system items (About/Quit) are not routed through the action callback" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const phantty_idx = try requireSubmenuTitled("About Phantty");
+    const about_idx = try findItemIndex(phantty_idx, "About Phantty");
+    g_last_action = -100;
+    menu_macos.phantty_macos_menu_invoke_for_test(phantty_idx, about_idx);
+    // The helper short-circuits on system tags (tag < 0); callback must stay
+    // untouched.
+    try std.testing.expectEqual(@as(i32, -100), g_last_action);
+}


### PR DESCRIPTION
## Summary

Closes the gap between the macOS .app and the Windows build — the app
went from a *terminal-only shell* (overlay panels rendering blank, no
menu, `sh` instead of `zsh`) to a fully usable client matching Windows
in feature parity.

Three threads landed together because they each unblock a piece of the
same end-user complaint ("I can't see the command palette / sidebar /
SSH form on macOS"):

1. **Metal overlay rendering (D1.x)** — root cause was *not* a missing
   Metal pipeline (the MSL shaders + `gpu.Pipeline`/`Buffer`/`Texture`
   were already complete). It was two narrow bugs:
   - `src/renderer/gpu/metal/gl_init.zig`'s `setProjection`/`renderQuad`/
     `renderQuadAlpha` were stubs that dropped their arguments. In
     particular `setProjection` only set the viewport — it never pushed
     the orthographic matrix into the text pipeline's uniforms, so every
     `ui_pipeline` vertex came out at `(0,0,0,0)` in clip space and
     every overlay (command center, sidebar, settings page, SSH/AI
     forms, scrollbar, …) drew invisibly. Helpers now dispatch through
     a `BackendHooks` function-pointer table registered by
     `ui_pipeline.init()`. The indirection is required because
     `test-metal`'s module root is `gpu/metal/`, blocking a static
     \`@import\` walk out to `renderer/ui_pipeline.zig`.
   - `gpu/metal/bridge.m`'s `phantty_metal_buffer_upload` was reusing
     the same `MTLBuffer` storage via `memcpy([buffer contents])`. Under
     Metal's deferred-execution model, `setVertexBuffer:offset:atIndex:`
     captures a pointer at encode time but the GPU only reads the bytes
     at command-buffer commit, so every \`ui_pipeline.fillQuad\` call in
     a frame ended up reading the **last** upload. Upload now allocates
     a fresh `MTLBuffer` per call; Metal's encoder retain keeps the
     prior buffer alive until commit completes and it's released
     asynchronously.

2. **macOS app menu (D7.1)** — new `src/platform/menu*` facade + thin
   Objective-C bridge that installs `Phantty / File / Edit / View /
   Window` menus and wires each item to a `keybind.Action`. Selected
   items route through `input.invokeKeybindAction` so a menu click
   takes the same path as the keyboard shortcut. Bonus: NSMenu key
   equivalents are dispatched earlier in the AppKit responder chain
   than `keyDown:`, so the chord paths survive third-party
   keyDown-layer interception (IME, ToDesk-style remote helpers).

3. **Default shell on macOS** — `pty_command{,_unsupported}.zig` now
   return `\"zsh\"` instead of `\"sh\"` on Darwin (Catalina+ default
   user shell); Linux/BSD keep `\"sh\"`.

## Test plan

Native test sweep (all green):
- [x] `zig build test`
- [x] `zig build test-metal` (incl. new hook-dispatch assertion)
- [x] `zig build test-macos-ui`
- [x] `zig build test-macos-window`
- [x] `zig build test-macos-services`
- [x] `zig build test-macos-font`
- [x] `zig build test-macos-menu` (new)
- [x] `zig build test-full -Dtarget=aarch64-macos`

Visual verification on the running `.app`:
- [x] App menu bar shows \`Phantty File Edit View Window\` with key
      equivalents (\`⌘,\`, \`⌃⇧P\`, \`⌃⇧T\`, \`⌃⇧B\`, …)
- [x] View → Open Command Center shows the SSH Server form (and
      Settings, Toggle Sidebar, Toggle File Explorer all dispatch)
- [x] Tab sidebar renders: Tabs label, numbered rows, selection
      highlight, hamburger menu icon
- [x] Session launcher / AI Agent form / SSH Server form panels
      render with backgrounds, borders, selection highlights, text
- [x] Terminal launches into `zsh` (per stderr `Shell command
      resolved: 'zsh'`)

## Reviewer notes

- The `BackendHooks` indirection is a deliberate workaround for Zig
  0.15's "import of file outside module path" check. The OpenGL
  backend keeps its direct `@import` since its module root is the app
  build (no path-walk issue).
- One residue bug fix that's worth a separate look: each
  `Buffer.upload` now allocates a fresh `MTLBuffer`. For the small
  vertex blobs `ui_pipeline` uses (~96B/quad) this is fine; the
  `cell_pipeline` instance buffers only upload once per frame so they
  weren't affected by the original bug and aren't hot-path with the
  new behavior either.
- The macOS overlay rendering tests assert hook dispatch counters
  rather than pixel content. A future improvement would be an
  offscreen-Metal screenshot test that diffs the rendered pixels of an
  open command palette against a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)