### PR TITLE
Add phantty_docs agent tool for built-in documentation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -735,6 +735,15 @@ fn createAppModuleWithRoot(
     app_options.addOption([]const u8, "app_version", app_version);
     app_mod.addOptions("build_options", app_options);
 
+    // Embed user-facing docs so the phantty_docs agent tool can read them at
+    // runtime. @embedFile cannot escape src/, so docs/ files are wired in here
+    // as named embed imports consumed by src/phantty_docs.zig.
+    app_mod.addAnonymousImport("phantty_doc_faq", .{ .root_source_file = b.path("docs/faq.md") });
+    app_mod.addAnonymousImport("phantty_doc_configuration", .{ .root_source_file = b.path("docs/configuration.md") });
+    app_mod.addAnonymousImport("phantty_doc_ai_agent", .{ .root_source_file = b.path("docs/ai-agent.md") });
+    app_mod.addAnonymousImport("phantty_doc_file_explorer", .{ .root_source_file = b.path("docs/file-explorer.md") });
+    app_mod.addAnonymousImport("phantty_doc_media", .{ .root_source_file = b.path("docs/media.md") });
+
     // Add ghostty-vt dependency with SIMD disabled for cross-compilation.
     if (b.lazyDependency("ghostty", .{
         .target = target,

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -79,3 +79,15 @@ right-click-action = paste
 
 `right-click-action = copy-or-paste` copies when a terminal selection is active
 and pastes when there is no selection.
+
+## Asking About Phantty Itself
+
+The agent can read Phantty's own user documentation on demand through the
+`phantty_docs` tool. Ask a natural question such as "how do I change the font?"
+or "what clipboard options exist?" and the agent first lists the available
+topics (`faq`, `configuration`, `ai-agent`, `file-explorer`, `media`), then
+reads the relevant one and answers from it.
+
+The docs are embedded in the Phantty binary, so this works offline and without
+the source tree. The system prompt only carries a one-line pointer to the tool;
+the documentation text is loaded only when the agent calls `phantty_docs`.

--- a/docs/superpowers/plans/2026-05-27-phantty-docs-tool.md
+++ b/docs/superpowers/plans/2026-05-27-phantty-docs-tool.md
@@ -1,0 +1,566 @@
+# Phantty Docs Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `phantty_docs` agent tool that lists and reads Phantty's own user-facing docs on demand, with only a one-line pointer added to the system prompt.
+
+**Architecture:** Five user-facing `docs/*.md` files are embedded into the binary via build.zig named embed imports (because `@embedFile` cannot escape `src/`). A new `src/phantty_docs.zig` module exposes `listTopics` / `readTopic` over those embeds. A new tool `phantty_docs` is declared in both protocol schema builders and dispatched in `ai_chat.zig`. The per-OS system prompt gains one hint line.
+
+**Tech Stack:** Zig 0.15.2, the existing Phantty AI-chat tool framework (`ai_chat.zig`, `ai_chat_protocol.zig`, `platform/agent_prompt.zig`).
+
+---
+
+## Background facts (verified, do not re-derive)
+
+- `@embedFile("../docs/x.md")` from a file in `src/` FAILS: `error: embed of file outside package path`. The working mechanism (verified with a standalone Zig 0.15.2 build) is `module.addAnonymousImport("name", .{ .root_source_file = b.path("docs/x.md") })` in build.zig, then `@embedFile("name")` in code.
+- `build.zig` builds both the exe and the full test binary through `createAppModuleWithRoot` (exe root `src/main.zig`, full-test root `src/test_main.zig`). Adding the embed imports there covers both.
+- Test split: `zig build test` runs ONLY the fast suite (`src/test_fast.zig`), which deliberately excludes `ai_chat.zig` and the app graph. The new module and all new tests run under **`zig build test-full`** (root `src/test_main.zig`). The fast suite never imports `phantty_docs.zig`, so it is unaffected.
+- `ArrayListUnmanaged(u8)` in this codebase supports `.empty`, `.appendSlice(allocator, s)`, `.append(allocator, c)`, `.print(allocator, fmt, args)`, `.toOwnedSlice(allocator)`, `.deinit(allocator)` (see `terminalListTool` / `listSkillsForDisplay`).
+- `jsonStringArg` returns `null` for a missing key AND for an empty-string value, so an empty `topic` naturally falls through to "list topics".
+- The Windows prompt is currently **1543** chars; the existing test asserts `DEFAULT_SYSTEM_PROMPT.len < 1600`. Adding the hint (~118 chars) pushes it over, so the cap is bumped to `< 1800` in Task 4.
+
+---
+
+## File structure
+
+- **Create** `src/phantty_docs.zig` — embedded-doc registry: `Topic`, `topics`, `listTopics`, `readTopic`. One clear responsibility: own the embedded docs and present them.
+- **Modify** `build.zig` (`createAppModuleWithRoot`) — register the five docs as named embed imports.
+- **Modify** `src/test_main.zig` — register `phantty_docs.zig` in the full-suite import list.
+- **Modify** `src/ai_chat_protocol.zig` — declare `phantty_docs` in `appendToolSchemas` (Chat Completions) and `appendResponseToolSchemas` (Responses) + a schema test.
+- **Modify** `src/ai_chat.zig` — import the module, add the dispatch branch, add `phanttyDocsTool` helper + tests.
+- **Modify** `src/platform/agent_prompt.zig` — add the one-line hint to the shared section + a test.
+- **Modify** `src/prompt.md` — mirror the hint line (doc copy of the prompt).
+- **Modify** `docs/ai-agent.md` — document the new capability.
+
+---
+
+## Task 1: Embedded docs module
+
+**Files:**
+- Create: `src/phantty_docs.zig`
+- Modify: `build.zig` (inside `fn createAppModuleWithRoot`, just after `app_mod.addOptions("build_options", app_options);`)
+- Modify: `src/test_main.zig:588` (the `comptime { _ = @import(...) }` list)
+
+- [ ] **Step 1: Wire the embed imports in build.zig**
+
+In `build.zig`, find this line inside `createAppModuleWithRoot`:
+
+```zig
+    app_mod.addOptions("build_options", app_options);
+```
+
+Immediately after it, add:
+
+```zig
+    // Embed user-facing docs so the phantty_docs agent tool can read them at
+    // runtime. @embedFile cannot escape src/, so docs/ files are wired in here
+    // as named embed imports consumed by src/phantty_docs.zig.
+    app_mod.addAnonymousImport("phantty_doc_faq", .{ .root_source_file = b.path("docs/faq.md") });
+    app_mod.addAnonymousImport("phantty_doc_configuration", .{ .root_source_file = b.path("docs/configuration.md") });
+    app_mod.addAnonymousImport("phantty_doc_ai_agent", .{ .root_source_file = b.path("docs/ai-agent.md") });
+    app_mod.addAnonymousImport("phantty_doc_file_explorer", .{ .root_source_file = b.path("docs/file-explorer.md") });
+    app_mod.addAnonymousImport("phantty_doc_media", .{ .root_source_file = b.path("docs/media.md") });
+```
+
+- [ ] **Step 2: Create the module with its tests**
+
+Create `src/phantty_docs.zig`:
+
+```zig
+//! Built-in Phantty documentation, embedded at build time.
+//!
+//! The agent reads these on demand through the `phantty_docs` tool so the
+//! system prompt only needs a one-line pointer instead of the full text.
+//! Doc files live under `docs/` and are wired in as named embed imports by
+//! build.zig (`createAppModuleWithRoot`). The import names below MUST match
+//! the names registered there.
+
+const std = @import("std");
+
+pub const Topic = struct {
+    name: []const u8,
+    summary: []const u8,
+    content: []const u8,
+};
+
+pub const topics = [_]Topic{
+    .{
+        .name = "faq",
+        .summary = "Frequently asked questions and troubleshooting.",
+        .content = @embedFile("phantty_doc_faq"),
+    },
+    .{
+        .name = "configuration",
+        .summary = "Config file location, options, keybindings, and clipboard behavior.",
+        .content = @embedFile("phantty_doc_configuration"),
+    },
+    .{
+        .name = "ai-agent",
+        .summary = "AI chat and agent usage: profiles, providers, skills, and exports.",
+        .content = @embedFile("phantty_doc_ai_agent"),
+    },
+    .{
+        .name = "file-explorer",
+        .summary = "Using the built-in file explorer and preview panel.",
+        .content = @embedFile("phantty_doc_file_explorer"),
+    },
+    .{
+        .name = "media",
+        .summary = "Showing images, background images, and inline remote images.",
+        .content = @embedFile("phantty_doc_media"),
+    },
+};
+
+/// Returns the embedded markdown for an exact topic name, or null if unknown.
+pub fn readTopic(name: []const u8) ?[]const u8 {
+    for (topics) |topic| {
+        if (std.mem.eql(u8, topic.name, name)) return topic.content;
+    }
+    return null;
+}
+
+/// Builds a model-readable list of topics: one `name — summary` line each,
+/// plus a trailing hint. Caller owns the returned slice.
+pub fn listTopics(allocator: std.mem.Allocator) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "Phantty documentation topics:\n");
+    for (topics) |topic| {
+        try out.print(allocator, "- {s} — {s}\n", .{ topic.name, topic.summary });
+    }
+    try out.appendSlice(allocator, "\nCall phantty_docs again with one topic name to read its full text.");
+    return out.toOwnedSlice(allocator);
+}
+
+test "phantty_docs: every topic has non-empty name, summary, and content" {
+    for (topics) |topic| {
+        try std.testing.expect(topic.name.len > 0);
+        try std.testing.expect(topic.summary.len > 0);
+        try std.testing.expect(topic.content.len > 0);
+    }
+}
+
+test "phantty_docs: readTopic returns content for known topics and null otherwise" {
+    try std.testing.expect(readTopic("faq") != null);
+    try std.testing.expect(readTopic("configuration") != null);
+    try std.testing.expect(readTopic("ai-agent") != null);
+    try std.testing.expect(readTopic("file-explorer") != null);
+    try std.testing.expect(readTopic("media") != null);
+    try std.testing.expect(readTopic("nope") == null);
+}
+
+test "phantty_docs: listTopics lists every topic name and the read hint" {
+    const text = try listTopics(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    for (topics) |topic| {
+        try std.testing.expect(std.mem.indexOf(u8, text, topic.name) != null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, text, "phantty_docs") != null);
+}
+```
+
+- [ ] **Step 3: Register the module in the full test suite**
+
+In `src/test_main.zig`, find this line (in the `comptime { ... }` import block, near line 588):
+
+```zig
+    _ = @import("memory_debug.zig");
+```
+
+Add immediately after it:
+
+```zig
+    _ = @import("phantty_docs.zig");
+```
+
+- [ ] **Step 4: Run the tests — expect PASS**
+
+Run: `zig build test-full`
+Expected: builds and passes. The three `phantty_docs:` tests are included. (Standalone `zig test src/phantty_docs.zig` will NOT work — the embed imports are only defined by build.zig.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phantty_docs.zig build.zig src/test_main.zig
+git commit -m "$(cat <<'EOF'
+Add embedded phantty_docs module
+
+Embeds the five user-facing docs via build.zig named embed imports and
+exposes listTopics/readTopic for the upcoming phantty_docs agent tool.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Declare the `phantty_docs` tool schema
+
+**Files:**
+- Modify: `src/ai_chat_protocol.zig` (`appendToolSchemas` ~line 432, `appendResponseToolSchemas` ~line 487)
+- Test: `src/ai_chat_protocol.zig` (new test alongside the existing `buildRequestJson` tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test in `src/ai_chat_protocol.zig` after the test `"buildRequestJson chat_completions emits tool_calls when present"` (~line 888):
+
+```zig
+test "buildRequestJson includes phantty_docs tool for both protocols" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("hi") }};
+
+    const chat = RequestParams{ .model = "m", .system_prompt = "", .protocol = .chat_completions, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const chat_json = try buildRequestJson(a, chat, &msgs, true);
+    defer a.free(chat_json);
+    try std.testing.expect(std.mem.indexOf(u8, chat_json, "\"phantty_docs\"") != null);
+
+    const resp = RequestParams{ .model = "m", .system_prompt = "", .protocol = .responses, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const resp_json = try buildRequestJson(a, resp, &msgs, true);
+    defer a.free(resp_json);
+    try std.testing.expect(std.mem.indexOf(u8, resp_json, "\"phantty_docs\"") != null);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `zig build test-full`
+Expected: FAIL — the new test's `indexOf` assertions fail because `phantty_docs` is not yet in the schema.
+
+- [ ] **Step 3: Add the tool to the Chat Completions schema**
+
+In `appendToolSchemas`, find the `skill_info` line (~432):
+
+```zig
+    try out.appendSlice(allocator, toolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ']');
+```
+
+Insert the `phantty_docs` tool between those two lines:
+
+```zig
+    try out.appendSlice(allocator, toolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, toolSchema("phantty_docs", "Read Phantty's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}"));
+    try out.append(allocator, ']');
+```
+
+- [ ] **Step 4: Add the tool to the Responses schema**
+
+In `appendResponseToolSchemas`, find the `skill_info` line (~487):
+
+```zig
+    try out.appendSlice(allocator, responseToolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ']');
+```
+
+Insert the `phantty_docs` tool between those two lines:
+
+```zig
+    try out.appendSlice(allocator, responseToolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, responseToolSchema("phantty_docs", "Read Phantty's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}"));
+    try out.append(allocator, ']');
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS — including `"buildRequestJson includes phantty_docs tool for both protocols"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai_chat_protocol.zig
+git commit -m "$(cat <<'EOF'
+Declare phantty_docs tool in both protocol schemas
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Dispatch the `phantty_docs` tool
+
+**Files:**
+- Modify: `src/ai_chat.zig` (imports near top; `executeToolCall` ~line 3117; new helper after `skillInfoToolFromRoots` ~line 3175)
+- Test: `src/ai_chat.zig` (new tests with the other ai_chat tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests in `src/ai_chat.zig` near the other tool tests (e.g. just before the existing `test "ai chat skill_info loads from explicit root paths"` at ~line 4360):
+
+```zig
+test "phantty_docs tool lists topics when no topic is given" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, null);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "faq") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "configuration") != null);
+}
+
+test "phantty_docs tool returns content for a known topic" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, "faq");
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "FAQ") != null);
+}
+
+test "phantty_docs tool reports unknown topic with the topic list" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, "does-not-exist");
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Unknown topic") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "faq") != null);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `zig build test-full`
+Expected: FAIL — compile error `use of undeclared identifier 'phanttyDocsTool'`.
+
+- [ ] **Step 3: Import the module**
+
+In `src/ai_chat.zig`, find the existing import of the skill registry near the top:
+
+```zig
+const skill_registry = @import("skill_registry.zig");
+```
+
+Add immediately after it:
+
+```zig
+const phantty_docs = @import("phantty_docs.zig");
+```
+
+(If `skill_registry` is imported with a different surrounding style, place `phantty_docs` alongside the other top-of-file `@import` declarations.)
+
+- [ ] **Step 4: Add the helper function**
+
+In `src/ai_chat.zig`, add this function right after `skillInfoToolFromRoots` (which ends at ~line 3175, just before `fn toolSurfaceKind`):
+
+```zig
+fn phanttyDocsTool(allocator: std.mem.Allocator, topic: ?[]const u8) ![]u8 {
+    if (topic) |name| {
+        if (phantty_docs.readTopic(name)) |content| {
+            return allocator.dupe(u8, content);
+        }
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer out.deinit(allocator);
+        try out.print(allocator, "Unknown topic \"{s}\". Available topics:", .{name});
+        for (phantty_docs.topics) |t| {
+            try out.print(allocator, " {s}", .{t.name});
+        }
+        return out.toOwnedSlice(allocator);
+    }
+    return phantty_docs.listTopics(allocator);
+}
+```
+
+- [ ] **Step 5: Add the dispatch branch**
+
+In `executeToolCall`, find the `skill_info` branch followed by the unknown-tool fallthrough (~line 3117-3123):
+
+```zig
+    if (std.mem.eql(u8, call.name, "skill_info")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const skill_name = jsonStringArg(args.value, "skill_name") orelse return request.allocator.dupe(u8, "Missing skill_name");
+        return skillInfoTool(request.allocator, skill_name);
+    }
+    return std.fmt.allocPrint(request.allocator, "Unknown tool: {s}", .{call.name});
+```
+
+Insert the `phantty_docs` branch between the `skill_info` block and the `return std.fmt.allocPrint(...)` line:
+
+```zig
+    if (std.mem.eql(u8, call.name, "skill_info")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const skill_name = jsonStringArg(args.value, "skill_name") orelse return request.allocator.dupe(u8, "Missing skill_name");
+        return skillInfoTool(request.allocator, skill_name);
+    }
+    if (std.mem.eql(u8, call.name, "phantty_docs")) {
+        const args = parseArgs(request.allocator, call.arguments);
+        defer if (args) |parsed| parsed.deinit();
+        const topic = if (args) |parsed| jsonStringArg(parsed.value, "topic") else null;
+        return phanttyDocsTool(request.allocator, topic);
+    }
+    return std.fmt.allocPrint(request.allocator, "Unknown tool: {s}", .{call.name});
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `zig build test-full`
+Expected: PASS — including the three `phantty_docs tool ...` tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai_chat.zig
+git commit -m "$(cat <<'EOF'
+Dispatch phantty_docs tool to embedded docs
+
+No-topic calls list topics; a topic returns its embedded markdown; an
+unknown topic returns an error naming the valid topics.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: System-prompt hint
+
+**Files:**
+- Modify: `src/platform/agent_prompt.zig` (`common_tools_after_wsl`)
+- Test: `src/platform/agent_prompt.zig` (new test) and `src/ai_chat.zig` (bump length cap, add hint assertion)
+- Modify: `src/prompt.md` (mirror the line)
+
+- [ ] **Step 1: Write the failing prompt test**
+
+In `src/platform/agent_prompt.zig`, add this test after the existing `"platform agent prompt has macOS-specific shell wording"` test (~line 104):
+
+```zig
+test "platform agent prompt points at the phantty_docs tool on every OS" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "phantty_docs") != null);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `zig build test-full`
+Expected: FAIL — the prompt does not yet mention `phantty_docs`. (The existing `DEFAULT_SYSTEM_PROMPT.len < 1600` test still passes at this point.)
+
+- [ ] **Step 3: Add the hint line to the shared prompt section**
+
+In `src/platform/agent_prompt.zig`, find this in `common_tools_after_wsl`:
+
+```zig
+    \\- Open a new local terminal with `tab_new` only when no suitable terminal exists.
+    \\
+    \\Python:
+```
+
+Insert the hint line after the `tab_new` line:
+
+```zig
+    \\- Open a new local terminal with `tab_new` only when no suitable terminal exists.
+    \\- For questions about Phantty itself (features, config, shortcuts), call `phantty_docs` to list and read the built-in docs.
+    \\
+    \\Python:
+```
+
+- [ ] **Step 4: Bump the prompt length cap**
+
+In `src/ai_chat.zig`, find this assertion in the test `"ai chat default system prompt comes from platform agent prompt"` (~line 4705):
+
+```zig
+    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 1600);
+```
+
+Replace it with a bumped cap plus an assertion that the hint is present:
+
+```zig
+    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 1800);
+    try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "phantty_docs") != null);
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS — the new prompt test and the bumped/extended default-prompt test both pass.
+
+- [ ] **Step 6: Mirror the line into prompt.md**
+
+In `src/prompt.md`, find:
+
+```text
+- Open a new local terminal with `tab_new` only when no suitable terminal exists.
+```
+
+Add immediately after it:
+
+```text
+- For questions about Phantty itself (features, config, shortcuts), call `phantty_docs` to list and read the built-in docs.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/platform/agent_prompt.zig src/ai_chat.zig src/prompt.md
+git commit -m "$(cat <<'EOF'
+Point the agent prompt at the phantty_docs tool
+
+Adds a one-line hint to the shared prompt section and bumps the prompt
+length cap to accommodate it.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Document the capability
+
+**Files:**
+- Modify: `docs/ai-agent.md`
+
+- [ ] **Step 1: Add a section to docs/ai-agent.md**
+
+In `docs/ai-agent.md`, after the closing paragraph of the `## Agent Skills` section (after the `right-click-action = copy-or-paste ...` paragraph at the end of the file), append:
+
+```markdown
+
+## Asking About Phantty Itself
+
+The agent can read Phantty's own user documentation on demand through the
+`phantty_docs` tool. Ask a natural question such as "how do I change the font?"
+or "what clipboard options exist?" and the agent first lists the available
+topics (`faq`, `configuration`, `ai-agent`, `file-explorer`, `media`), then
+reads the relevant one and answers from it.
+
+The docs are embedded in the Phantty binary, so this works offline and without
+the source tree. The system prompt only carries a one-line pointer to the tool;
+the documentation text is loaded only when the agent calls `phantty_docs`.
+```
+
+- [ ] **Step 2: Verify the docs still embed cleanly**
+
+Run: `zig build test-full`
+Expected: PASS. (Editing `docs/ai-agent.md` changes the embedded `ai-agent` topic content; the `phantty_docs:` content tests assert only non-emptiness, so they still pass.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ai-agent.md
+git commit -m "$(cat <<'EOF'
+Document the phantty_docs agent capability
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full suite once more: `zig build test-full` — expect PASS.
+- [ ] Build the app to confirm the exe compiles with the new embeds: `zig build` — expect success.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** module (`phantty_docs.zig`) → Task 1; embed-in-binary delivery → Task 1 (build.zig); tool in both protocols → Task 2; dispatch list/read/unknown → Task 3; one-line prompt hint + prompt.md mirror + length-cap bump → Task 4; tests for module/schema/dispatch/prompt → Tasks 1-4; docs note → Task 5. All spec sections covered.
+- **Type consistency:** `phanttyDocsTool(allocator, ?[]const u8)`, `phantty_docs.readTopic([]const u8) ?[]const u8`, `phantty_docs.listTopics(allocator) ![]u8`, and `phantty_docs.topics` are referenced identically across Tasks 1 and 3. Embed import names (`phantty_doc_*`) match between build.zig (Task 1 Step 1) and `phantty_docs.zig` (Task 1 Step 2).
+- **No placeholders:** every code/edit step shows complete content and an exact anchor.

--- a/docs/superpowers/specs/2026-05-27-phantty-docs-tool-design.md
+++ b/docs/superpowers/specs/2026-05-27-phantty-docs-tool-design.md
@@ -1,0 +1,156 @@
+# Built-in Phantty Docs Tool (`phantty_docs`) — Design
+
+Date: 2026-05-27
+Status: Approved (pending implementation plan)
+
+## Problem
+
+Users want to ask the in-terminal AI agent questions about Phantty itself
+("how do I configure X", "what shortcut does Y", "how does the AI agent
+work"). Today the agent has no knowledge of Phantty's own documentation, and
+the rich docs in `docs/*.md` are not shipped with release binaries (only
+`plugins/skills/` is bundled).
+
+We must NOT load the documentation into the system prompt — the prompt is
+deliberately tiny (a test enforces `DEFAULT_SYSTEM_PROMPT.len < 1600`). Instead
+the prompt should contain only a short pointer telling the agent where to find
+the docs, and the agent reads them on demand.
+
+## Goal
+
+Add a dedicated agent tool, `phantty_docs`, that lets the agent list and read
+Phantty's user-facing documentation on demand. The system prompt gains exactly
+one short hint line; documentation content never sits in the prompt.
+
+## Non-goals (YAGNI)
+
+- Developer-internal docs (`architecture.md`, `development.md`,
+  `decoupling-guide.md`) — out of scope; user-facing only.
+- Localization: the embedded docs are English. If a user asks in another
+  language, the model reads the English doc and answers in that language. We do
+  not embed `.zh` variants (the `.md` docs have no `.zh` variants anyway).
+- Fuzzy / partial topic matching.
+- Runtime doc reloading from disk — docs are embedded at build time.
+
+## Architecture
+
+### 1. New module: `src/phantty_docs.zig`
+
+- Uses `@embedFile` at build time to embed the five user-facing docs (paths
+  relative to the source file):
+  - `../docs/faq.md`
+  - `../docs/configuration.md`
+  - `../docs/ai-agent.md`
+  - `../docs/file-explorer.md`
+  - `../docs/media.md`
+- Embedding means the docs auto-sync whenever those files are edited and work
+  inside a standalone `phantty.exe` with no docs present on disk.
+- A static, comptime-known table of entries:
+  `{ name: []const u8, summary: []const u8, content: []const u8 }`.
+  - `name` — topic key the agent passes (e.g. `faq`, `configuration`,
+    `ai-agent`, `file-explorer`, `media`).
+  - `summary` — a hand-written one-line description (rarely changes).
+  - `content` — the embedded markdown (live).
+- Public API:
+  - `pub const topics: []const Topic` — the table.
+  - `fn listTopics(allocator) ![]u8` — builds a human/model-readable list of
+    `name — summary` lines, plus a trailing usage hint
+    ("Call phantty_docs with a topic to read it.").
+  - `fn readTopic(name: []const u8) ?[]const u8` — returns the embedded content
+    for an exact-match topic name, or `null` if unknown.
+
+Proposed summaries (hand-written):
+
+| topic           | summary                                                        |
+|-----------------|----------------------------------------------------------------|
+| `faq`           | Common questions and troubleshooting.                          |
+| `configuration` | Config file location, options, keybindings, clipboard behavior.|
+| `ai-agent`      | AI chat/agent usage: profiles, providers, skills, exports.     |
+| `file-explorer` | Built-in file explorer usage.                                  |
+| `media`         | Displaying images/media in the terminal.                       |
+
+(Summaries are confirmed/adjusted against each doc's actual H1 + intro during
+implementation.)
+
+### 2. Tool declaration: `src/ai_chat_protocol.zig`
+
+Add `phantty_docs` to BOTH schema builders so it is offered under both
+provider protocols:
+
+- `toolSchema(...)` — OpenAI-compatible Chat Completions block.
+- `responseToolSchema(...)` — OpenAI Responses API block.
+
+Tool spec:
+
+- name: `phantty_docs`
+- description: `"Read Phantty's own documentation (features, configuration,
+  shortcuts, AI agent, file explorer, media). Call with no topic to list
+  available topics, then call again with a topic to read its full text."`
+- parameters JSON:
+  `{"topic":{"type":"string","description":"Topic name from the list. Omit to list available topics."}}`
+
+### 3. Tool dispatch: `src/ai_chat.zig`
+
+Add a branch alongside the existing `if (std.mem.eql(u8, call.name, "..."))`
+handlers (near the `terminal_list` dispatch, ~line 3030):
+
+- Parse optional `topic` from `call.arguments`.
+- Empty / missing `topic` → return `phantty_docs.listTopics(...)` output as the
+  tool result.
+- Non-empty `topic`:
+  - `readTopic(topic)` hit → return the embedded content as the tool result.
+  - miss → return an error-style result: `"Unknown topic \"<topic>\". Available
+    topics: <list of names>."`
+- The result is recorded as a tool message like the other tool handlers (reuse
+  the existing tool-result message construction path).
+
+### 4. System-prompt hint: `src/platform/agent_prompt.zig`
+
+Add one line to the shared tool guidance (the `common_tools_*` section so it
+appears for Windows, macOS, and POSIX prompts):
+
+> `- For questions about Phantty itself (features, config, shortcuts), call \`phantty_docs\` to list and read the built-in docs.`
+
+- Mirror the same line into `src/prompt.md` (the documentation copy of the
+  prompt) to keep them consistent.
+- If adding the line pushes `DEFAULT_SYSTEM_PROMPT` past the existing
+  `< 1600` length assertion, bump that threshold in the corresponding test to a
+  value that still guards against unbounded growth (e.g. `< 1800`).
+
+## Data flow
+
+1. User asks the agent a Phantty question.
+2. Prompt hint makes the model call `phantty_docs` (no topic).
+3. Dispatch returns the topic list.
+4. Model calls `phantty_docs` with the relevant topic.
+5. Dispatch returns the embedded markdown.
+6. Model answers from that content.
+
+## Error handling
+
+- Unknown topic → explicit tool result naming the bad topic and listing valid
+  ones (lets the model self-correct without an extra round trip to list).
+- Malformed/empty `arguments` JSON → treated as "no topic" → list topics.
+
+## Testing
+
+- `phantty_docs` module:
+  - `listTopics` output contains all five topic names and is non-empty.
+  - `readTopic` returns non-empty content for each known topic.
+  - `readTopic` returns `null` for an unknown topic.
+- Tool schema (`ai_chat_protocol.zig`): generated Chat Completions JSON and
+  Responses JSON both contain `"phantty_docs"`.
+- System prompt: `DEFAULT_SYSTEM_PROMPT` contains `phantty_docs`; length stays
+  under the (possibly bumped) cap.
+- Dispatch (`ai_chat.zig`): a `phantty_docs` call with no topic yields a result
+  listing topics; a call with a known topic yields that doc's content; an
+  unknown topic yields the error-style result.
+
+## Decisions made (not asked)
+
+- Single tool with an optional `topic` param, rather than separate `list` and
+  `read` tools — keeps the tool count low and matches the natural
+  list-then-read flow.
+- Hand-written one-line summaries for the topic list, rather than
+  auto-extracting each doc's first heading — simpler and stable; doc bodies
+  still auto-sync via embedding.

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -4748,7 +4748,8 @@ test "ai chat responses endpoint normalization" {
 }
 
 test "ai chat default system prompt comes from platform agent prompt" {
-    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 1600);
+    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 1800);
+    try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "phantty_docs") != null);
     try std.testing.expectEqualStrings(platform_agent_prompt.defaultSystemPrompt, DEFAULT_SYSTEM_PROMPT);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "uv") != null);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "Python") != null);

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -14,6 +14,7 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const agent_detector = @import("agent_detector.zig");
 const agent_history = @import("agent_history.zig");
 const skill_registry = @import("skill_registry.zig");
+const phantty_docs = @import("phantty_docs.zig");
 const markdown_text = @import("markdown_text.zig");
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
 const ai_chat_composer = @import("ai_chat_composer.zig");
@@ -3120,6 +3121,12 @@ fn executeToolCall(request: *ChatRequest, call: ToolCall) ![]u8 {
         const skill_name = jsonStringArg(args.value, "skill_name") orelse return request.allocator.dupe(u8, "Missing skill_name");
         return skillInfoTool(request.allocator, skill_name);
     }
+    if (std.mem.eql(u8, call.name, "phantty_docs")) {
+        const args = parseArgs(request.allocator, call.arguments);
+        defer if (args) |parsed| parsed.deinit();
+        const topic = if (args) |parsed| jsonStringArg(parsed.value, "topic") else null;
+        return phanttyDocsTool(request.allocator, topic);
+    }
     return std.fmt.allocPrint(request.allocator, "Unknown tool: {s}", .{call.name});
 }
 
@@ -3172,6 +3179,22 @@ fn skillInfoToolFromRoots(allocator: std.mem.Allocator, skill_name: []const u8, 
     };
     defer snapshot.deinit(allocator);
     return allocator.dupe(u8, snapshot.content);
+}
+
+fn phanttyDocsTool(allocator: std.mem.Allocator, topic: ?[]const u8) ![]u8 {
+    if (topic) |name| {
+        if (phantty_docs.readTopic(name)) |content| {
+            return allocator.dupe(u8, content);
+        }
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer out.deinit(allocator);
+        try out.print(allocator, "Unknown topic \"{s}\". Available topics:", .{name});
+        for (phantty_docs.topics) |t| {
+            try out.print(allocator, " {s}", .{t.name});
+        }
+        return out.toOwnedSlice(allocator);
+    }
+    return phantty_docs.listTopics(allocator);
 }
 
 fn toolSurfaceKind(surface: ToolSurface) []const u8 {
@@ -4355,6 +4378,29 @@ test "ai chat lists skills from explicit root paths" {
     defer allocator.free(output);
 
     try std.testing.expect(std.mem.indexOf(u8, output, "- $pdf: Work with PDF files.") != null);
+}
+
+test "phantty_docs tool lists topics when no topic is given" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, null);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "faq") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "configuration") != null);
+}
+
+test "phantty_docs tool returns content for a known topic" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, "faq");
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "FAQ") != null);
+}
+
+test "phantty_docs tool reports unknown topic with the topic list" {
+    const a = std.testing.allocator;
+    const text = try phanttyDocsTool(a, "does-not-exist");
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "Unknown topic") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "faq") != null);
 }
 
 test "ai chat skill_info loads from explicit root paths" {

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -430,6 +430,8 @@ fn appendToolSchemas(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(
     try out.appendSlice(allocator, toolSchema("tab_close", "Close a terminal tab by zero-based tab_index, surface_id, title, or the active terminal tab when no selector is provided. Cannot close the AI chat tab running the agent.", "{\"tab_index\":{\"type\":\"integer\",\"description\":\"Zero-based tab index from terminal_list.\"},\"tab_number\":{\"type\":\"integer\",\"description\":\"One-based UI tab number, accepted as a convenience.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list.\"},\"title\":{\"type\":\"string\",\"description\":\"Terminal tab title to close, such as CPU2.\"}}"));
     try out.append(allocator, ',');
     try out.appendSlice(allocator, toolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, toolSchema("phantty_docs", "Read Phantty's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}"));
     try out.append(allocator, ']');
     try out.appendSlice(allocator, ",\"tool_choice\":\"auto\"");
 }
@@ -485,6 +487,8 @@ fn appendResponseToolSchemas(allocator: std.mem.Allocator, out: *std.ArrayListUn
     try out.appendSlice(allocator, responseToolSchema("tab_close", "Close a terminal tab by zero-based tab_index, surface_id, title, or the active terminal tab when no selector is provided. Cannot close the AI chat tab running the agent.", "{\"tab_index\":{\"type\":\"integer\",\"description\":\"Zero-based tab index from terminal_list.\"},\"tab_number\":{\"type\":\"integer\",\"description\":\"One-based UI tab number, accepted as a convenience.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list.\"},\"title\":{\"type\":\"string\",\"description\":\"Terminal tab title to close, such as CPU2.\"}}"));
     try out.append(allocator, ',');
     try out.appendSlice(allocator, responseToolSchema("skill_info", "Load a Phantty skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}"));
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, responseToolSchema("phantty_docs", "Read Phantty's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}"));
     try out.append(allocator, ']');
     try out.appendSlice(allocator, ",\"tool_choice\":\"auto\"");
 }
@@ -885,6 +889,21 @@ test "buildRequestJson chat_completions emits tool_calls when present" {
     defer a.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"tool_calls\":[") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"terminal_list\"") != null);
+}
+
+test "buildRequestJson includes phantty_docs tool for both protocols" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("hi") }};
+
+    const chat = RequestParams{ .model = "m", .system_prompt = "", .protocol = .chat_completions, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const chat_json = try buildRequestJson(a, chat, &msgs, true);
+    defer a.free(chat_json);
+    try std.testing.expect(std.mem.indexOf(u8, chat_json, "\"phantty_docs\"") != null);
+
+    const resp = RequestParams{ .model = "m", .system_prompt = "", .protocol = .responses, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const resp_json = try buildRequestJson(a, resp, &msgs, true);
+    defer a.free(resp_json);
+    try std.testing.expect(std.mem.indexOf(u8, resp_json, "\"phantty_docs\"") != null);
 }
 
 test "parseApiResponse reads responses-protocol output text" {

--- a/src/phantty_docs.zig
+++ b/src/phantty_docs.zig
@@ -1,0 +1,90 @@
+//! Built-in Phantty documentation, embedded at build time.
+//!
+//! The agent reads these on demand through the `phantty_docs` tool so the
+//! system prompt only needs a one-line pointer instead of the full text.
+//! Doc files live under `docs/` and are wired in as named embed imports by
+//! build.zig (`createAppModuleWithRoot`). The import names below MUST match
+//! the names registered there.
+
+const std = @import("std");
+
+pub const Topic = struct {
+    name: []const u8,
+    summary: []const u8,
+    content: []const u8,
+};
+
+pub const topics = [_]Topic{
+    .{
+        .name = "faq",
+        .summary = "Frequently asked questions and troubleshooting.",
+        .content = @embedFile("phantty_doc_faq"),
+    },
+    .{
+        .name = "configuration",
+        .summary = "Config file location, options, keybindings, and clipboard behavior.",
+        .content = @embedFile("phantty_doc_configuration"),
+    },
+    .{
+        .name = "ai-agent",
+        .summary = "AI chat and agent usage: profiles, providers, skills, and exports.",
+        .content = @embedFile("phantty_doc_ai_agent"),
+    },
+    .{
+        .name = "file-explorer",
+        .summary = "Using the built-in file explorer and preview panel.",
+        .content = @embedFile("phantty_doc_file_explorer"),
+    },
+    .{
+        .name = "media",
+        .summary = "Showing images, background images, and inline remote images.",
+        .content = @embedFile("phantty_doc_media"),
+    },
+};
+
+/// Returns the embedded markdown for an exact topic name, or null if unknown.
+pub fn readTopic(name: []const u8) ?[]const u8 {
+    for (topics) |topic| {
+        if (std.mem.eql(u8, topic.name, name)) return topic.content;
+    }
+    return null;
+}
+
+/// Builds a model-readable list of topics: one `name — summary` line each,
+/// plus a trailing hint. Caller owns the returned slice.
+pub fn listTopics(allocator: std.mem.Allocator) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "Phantty documentation topics:\n");
+    for (topics) |topic| {
+        try out.print(allocator, "- {s} — {s}\n", .{ topic.name, topic.summary });
+    }
+    try out.appendSlice(allocator, "\nCall phantty_docs again with one topic name to read its full text.");
+    return out.toOwnedSlice(allocator);
+}
+
+test "phantty_docs: every topic has non-empty name, summary, and content" {
+    for (topics) |topic| {
+        try std.testing.expect(topic.name.len > 0);
+        try std.testing.expect(topic.summary.len > 0);
+        try std.testing.expect(topic.content.len > 0);
+    }
+}
+
+test "phantty_docs: readTopic returns content for known topics and null otherwise" {
+    try std.testing.expect(readTopic("faq") != null);
+    try std.testing.expect(readTopic("configuration") != null);
+    try std.testing.expect(readTopic("ai-agent") != null);
+    try std.testing.expect(readTopic("file-explorer") != null);
+    try std.testing.expect(readTopic("media") != null);
+    try std.testing.expect(readTopic("nope") == null);
+}
+
+test "phantty_docs: listTopics lists every topic name and the read hint" {
+    const text = try listTopics(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    for (topics) |topic| {
+        try std.testing.expect(std.mem.indexOf(u8, text, topic.name) != null);
+    }
+    try std.testing.expect(std.mem.indexOf(u8, text, "phantty_docs") != null);
+}

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -30,6 +30,7 @@ const common_tools_after_wsl =
     \\- If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use `terminal_repl_exec`.
     \\- Do not paste shell commands into Codex or Claude Code; send user-facing text there, not shell commands.
     \\- Open a new local terminal with `tab_new` only when no suitable terminal exists.
+    \\- For questions about Phantty itself (features, config, shortcuts), call `phantty_docs` to list and read the built-in docs.
     \\
     \\Python:
     \\- Use uv for Python environments and dependencies.
@@ -101,4 +102,11 @@ test "platform agent prompt has macOS-specific shell wording" {
     try std.testing.expect(std.mem.indexOf(u8, macos, "shell_exec") != null);
     try std.testing.expect(std.mem.indexOf(u8, macos, "PowerShell") == null);
     try std.testing.expect(std.mem.indexOf(u8, macos, "wsl_session_exec") == null);
+}
+
+test "platform agent prompt points at the phantty_docs tool on every OS" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "phantty_docs") != null);
+    }
 }

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -13,6 +13,7 @@ Terminal tools:
 - If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use `terminal_repl_exec`.
 - Do not paste shell commands into Codex or Claude Code; send user-facing text there.
 - Open a new local terminal with `tab_new` only when no suitable terminal exists.
+- For questions about Phantty itself (features, config, shortcuts), call `phantty_docs` to list and read the built-in docs.
 
 Python:
 - Use uv for Python environments and dependencies.

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -586,6 +586,7 @@ comptime {
     _ = @import("markdown_preview.zig");
     _ = @import("markdown_text.zig");
     _ = @import("memory_debug.zig");
+    _ = @import("phantty_docs.zig");
     _ = @import("platform/atomic_file.zig");
     _ = @import("platform/clipboard.zig");
     _ = @import("platform/com.zig");


### PR DESCRIPTION
## Summary
- Add a `phantty_docs` agent tool so Phantty's built-in AI agent can answer questions about Phantty itself by reading the app's user docs on demand
- Docs (`faq`, `configuration`, `ai-agent`, `file-explorer`, `media`) are embedded into the binary at build time, so this works offline with no source tree
- The system prompt only gains a one-line pointer to the tool — full doc text is never loaded into the prompt; it is fetched only when the agent calls `phantty_docs`
- Tool is offered under both Chat Completions and Responses protocols; no-topic calls list topics, a topic returns its markdown, an unknown topic returns an error naming the valid topics

## Implementation
- `src/phantty_docs.zig` (new): embedded-doc registry (`topics`, `readTopic`, `listTopics`); docs wired in via `build.zig` named embed imports (`@embedFile` cannot escape `src/`)
- `src/ai_chat_protocol.zig`: declares `phantty_docs` in both schema builders
- `src/ai_chat.zig`: `phanttyDocsTool` helper + dispatch branch
- `src/platform/agent_prompt.zig` + `src/prompt.md`: one-line hint added to the shared prompt section (length cap bumped 1600→1800)
- `docs/ai-agent.md`: documents the capability
- Design spec and implementation plan under `docs/superpowers/`

## Test Plan
- [x] `zig build test-full` passes (module tests, schema-in-both-protocols test, dispatch list/known/unknown tests, per-OS prompt-pointer test)
- [x] `zig build` produces the exe with all five docs embedded

🤖 Generated with [Claude Code](https://claude.com/claude-code)