### PR TITLE
Fix macOS keyboard input, set TERM in PTY, fix SCP upload crash

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -803,6 +803,9 @@ fn handleChar(ev: platform_input.CharEvent) void {
     // we must allow chars when both Ctrl and Alt are held (AltGr chars).
     // This matches Ghostty's consumed_mods / effectiveMods approach.
     if (ev.alt and !ev.ctrl) return;
+    // Cmd / Super shortcuts (macOS Cmd+C, Win key on other platforms) are
+    // commands, not text input — never inject them into the PTY.
+    if (ev.super) return;
     const surface = AppWindow.activeSurface() orelse return;
     AppWindow.resetCursorBlink();
     {
@@ -819,7 +822,7 @@ const KeybindPhase = command_dispatch.Phase;
 
 fn triggerFromKeyEvent(ev: platform_input.KeyEvent) keybind.Trigger {
     return .{
-        .mods = .{ .ctrl = ev.ctrl, .shift = ev.shift, .alt = ev.alt },
+        .mods = .{ .ctrl = ev.ctrl, .shift = ev.shift, .alt = ev.alt, .win = ev.super },
         .key_code = @intCast(ev.key_code),
     };
 }

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const MAX_BINDINGS: usize = 64;
 
@@ -117,7 +118,36 @@ pub const Set = struct {
             set.items[set.len] = binding;
             set.len += 1;
         }
+        if (builtin.target.os.tag == .macos) {
+            // On macOS the conventional clipboard shortcuts use Cmd (the
+            // `win`/super modifier) rather than Ctrl, which in a terminal is
+            // reserved for control sequences (Ctrl+C = SIGINT, Ctrl+V = literal
+            // next key). Migrate each Ctrl-based default to its Cmd equivalent
+            // and also add a bare Cmd+C alongside the shifted form so both the
+            // macOS convention (Cmd+C) and the historic Ctrl+Shift+C muscle
+            // memory work for plain copy.
+            set.replaceTrigger(.copy, .{ .mods = .{ .win = true, .shift = true }, .key_code = 'C' });
+            set.replaceTrigger(.paste, .{ .mods = .{ .win = true }, .key_code = 'V' });
+            set.replaceTrigger(.paste_image, .{ .mods = .{ .win = true, .shift = true }, .key_code = 'V' });
+            set.appendIfRoom(.{ .trigger = .{ .mods = .{ .win = true }, .key_code = 'C' }, .action = .copy });
+        }
         return set;
+    }
+
+    fn replaceTrigger(self: *Set, action: Action, new_trigger: Trigger) void {
+        for (self.items[0..self.len]) |*b| {
+            if (b.action == action) {
+                b.trigger = new_trigger;
+                return;
+            }
+        }
+        self.appendIfRoom(.{ .trigger = new_trigger, .action = action });
+    }
+
+    fn appendIfRoom(self: *Set, binding: Binding) void {
+        if (self.len >= self.items.len) return;
+        self.items[self.len] = binding;
+        self.len += 1;
     }
 
     pub fn apply(self: *Set, value: []const u8) !void {

--- a/src/platform/input_events.zig
+++ b/src/platform/input_events.zig
@@ -31,6 +31,7 @@ pub const KeyEvent = struct {
     ctrl: bool,
     shift: bool,
     alt: bool,
+    super: bool = false,
 };
 
 pub const CharEvent = struct {
@@ -38,6 +39,7 @@ pub const CharEvent = struct {
     ctrl: bool = false,
     shift: bool = false,
     alt: bool = false,
+    super: bool = false,
 };
 
 pub const MouseButton = enum { left, right, middle };

--- a/src/platform/pty_posix.zig
+++ b/src/platform/pty_posix.zig
@@ -39,6 +39,8 @@ extern "c" fn grantpt(fd: c_int) c_int;
 extern "c" fn unlockpt(fd: c_int) c_int;
 extern "c" fn ptsname_r(fd: c_int, buf: [*]u8, buflen: usize) c_int;
 extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+extern "c" fn unsetenv(name: [*:0]const u8) c_int;
 /// Raw `_exit(2)` — used in the forked child so we never run libc `atexit`
 /// handlers or flush stdio buffers inherited from the parent.
 extern "c" fn _exit(code: c_int) noreturn;
@@ -301,6 +303,20 @@ fn childExec(
     if (cwd) |dir| {
         _ = c.chdir(dir);
     }
+
+    // GUI-launched apps on macOS inherit a minimal environment from launchd, so
+    // TERM is usually unset. Without it, shells fall back to "dumb" or other
+    // limited profiles — Starship rendered a stub prompt, zsh-autosuggestions
+    // miscalculated redraw widths, and line-edit redraws left stale glyphs on
+    // screen. xterm-256color is the most broadly supported terminfo entry and
+    // matches the SGR / cursor-control set our ghostty-vt parser implements.
+    _ = setenv("TERM", "xterm-256color", 1);
+    _ = setenv("COLORTERM", "truecolor", 1);
+    _ = setenv("TERM_PROGRAM", "phantty", 1);
+    // Some shells refuse to load completions when TERMINFO points at a value
+    // that doesn't exist for our TERM choice. Clearing it lets ncurses fall
+    // back to the system database.
+    _ = unsetenv("TERMINFO");
 
     // Parse command line into argv (split on ASCII whitespace).
     var arg_storage: [ARG_BUF]u8 = undefined;

--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -52,6 +52,7 @@ const RawKeyEvent = extern struct {
     ctrl: bool,
     shift: bool,
     alt: bool,
+    super: bool,
 };
 
 const RawCharEvent = extern struct {
@@ -59,6 +60,7 @@ const RawCharEvent = extern struct {
     ctrl: bool,
     shift: bool,
     alt: bool,
+    super: bool,
 };
 
 const RawMouseButtonEvent = extern struct {
@@ -274,6 +276,7 @@ pub const Window = struct {
                 .ctrl = key.ctrl,
                 .shift = key.shift,
                 .alt = key.alt,
+                .super = key.super,
             });
         }
 
@@ -285,6 +288,7 @@ pub const Window = struct {
                     .ctrl = char.ctrl,
                     .shift = char.shift,
                     .alt = char.alt,
+                    .super = char.super,
                 });
             }
         }

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -18,6 +18,7 @@ typedef struct PhanttyMacKeyEvent {
     bool ctrl;
     bool shift;
     bool alt;
+    bool super;
 } PhanttyMacKeyEvent;
 
 typedef struct PhanttyMacCharEvent {
@@ -25,6 +26,7 @@ typedef struct PhanttyMacCharEvent {
     bool ctrl;
     bool shift;
     bool alt;
+    bool super;
 } PhanttyMacCharEvent;
 
 typedef struct PhanttyMacMouseButtonEvent {
@@ -319,10 +321,11 @@ static bool phantty_macos_pop_file_drop_event(PhanttyMacWindowState *state, Phan
     return true;
 }
 
-static void phantty_macos_mods(NSEventModifierFlags flags, bool *ctrl, bool *shift, bool *alt) {
+static void phantty_macos_mods(NSEventModifierFlags flags, bool *ctrl, bool *shift, bool *alt, bool *super) {
     if (ctrl != NULL) *ctrl = (flags & NSEventModifierFlagControl) != 0;
     if (shift != NULL) *shift = (flags & NSEventModifierFlagShift) != 0;
     if (alt != NULL) *alt = (flags & NSEventModifierFlagOption) != 0;
+    if (super != NULL) *super = (flags & NSEventModifierFlagCommand) != 0;
 }
 
 static PhanttyMacKeyEvent phantty_macos_key_event(uintptr_t key_code, NSEventModifierFlags flags) {
@@ -331,12 +334,13 @@ static PhanttyMacKeyEvent phantty_macos_key_event(uintptr_t key_code, NSEventMod
         .ctrl = (flags & NSEventModifierFlagControl) != 0,
         .shift = (flags & NSEventModifierFlagShift) != 0,
         .alt = (flags & NSEventModifierFlagOption) != 0,
+        .super = (flags & NSEventModifierFlagCommand) != 0,
     };
 }
 
 static PhanttyMacCharEvent phantty_macos_char_event(uint32_t codepoint, NSEventModifierFlags flags) {
-    PhanttyMacCharEvent event = { .codepoint = codepoint, .ctrl = false, .shift = false, .alt = false };
-    phantty_macos_mods(flags, &event.ctrl, &event.shift, &event.alt);
+    PhanttyMacCharEvent event = { .codepoint = codepoint, .ctrl = false, .shift = false, .alt = false, .super = false };
+    phantty_macos_mods(flags, &event.ctrl, &event.shift, &event.alt, &event.super);
     return event;
 }
 
@@ -524,10 +528,26 @@ static void phantty_macos_set_preedit(PhanttyMacWindowState *state, id string_or
     [self interpretKeyEvents:@[event]];
 }
 
+- (BOOL)performKeyEquivalent:(NSEvent *)event {
+    // Cmd shortcuts never reach -keyDown:, so we intercept them here.
+    // Pushing the event ourselves and returning YES prevents AppKit from
+    // emitting the unhandled-shortcut system beep.
+    if ((event.modifierFlags & NSEventModifierFlagCommand) == 0) return NO;
+    if (self.state == NULL) return NO;
+    NSString *characters = phantty_macos_key_characters(event);
+    uintptr_t key_code = phantty_macos_map_key_code(event.keyCode, characters);
+    phantty_macos_push_key_event(self.state, phantty_macos_key_event(key_code, event.modifierFlags));
+    return YES;
+}
+
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange {
     (void)replacementRange;
     phantty_macos_push_string(self.state, string, 0);
     phantty_macos_set_preedit(self.state, nil);
+}
+
+- (void)doCommandBySelector:(SEL)selector {
+    (void)selector;
 }
 
 - (void)setMarkedText:(id)string selectedRange:(NSRange)selectedRange replacementRange:(NSRange)replacementRange {
@@ -595,7 +615,7 @@ static void phantty_macos_set_preedit(PhanttyMacWindowState *state, id string_or
         .shift = false,
         .alt = false,
     };
-    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt);
+    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt, NULL);
     return out;
 }
 
@@ -632,7 +652,7 @@ static void phantty_macos_set_preedit(PhanttyMacWindowState *state, id string_or
         .shift = false,
         .alt = false,
     };
-    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt);
+    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt, NULL);
     phantty_macos_push_mouse_move_event(self.state, out);
 }
 
@@ -651,7 +671,7 @@ static void phantty_macos_set_preedit(PhanttyMacWindowState *state, id string_or
         .shift = false,
         .alt = false,
     };
-    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt);
+    phantty_macos_mods(event.modifierFlags, &out.ctrl, &out.shift, &out.alt, NULL);
     phantty_macos_push_mouse_wheel_event(self.state, out);
 }
 

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -432,6 +432,10 @@ fn sshStreamUpload(
             };
         }
         in.close();
+        // child.stdin still owns the same fd; nulling it prevents
+        // Child.cleanupStreams from closing it again during wait() and
+        // crashing on EBADF (Zig's posix.close treats EBADF as unreachable).
+        child.stdin = null;
     } else {
         write_ok = false;
     }


### PR DESCRIPTION
## Summary

Three independent macOS fixes that came up together while testing the
v0.33.0 macOS build:

- **macOS keyboard input.** Backspace produced the system "ding";
  `Cmd+C` / `Cmd+V` did nothing and also beeped; the Command modifier
  was completely invisible to the keybind layer.
- **PTY environment.** `\$TERM` was unset in the spawned shell on
  GUI-launched builds. Starship fell back to a stub prompt and
  `zsh-autosuggestions` left visual artifacts (`t` rendered as
  `ttop`, Backspace scattered glyphs across the row).
- **SCP upload crash.** Finishing a file-explorer SSH upload aborted
  the process with `abort()` from inside `process.Child.cleanupStreams`.

## What changed

### macOS keyboard (5 files)

- `src/platform/window_macos_bridge.m`
  - Track `NSEventModifierFlagCommand` in `phantty_macos_mods` /
    `phantty_macos_key_event` / `phantty_macos_char_event`.
  - Implement empty `-doCommandBySelector:` so `interpretKeyEvents:`
    can't bubble unhandled command selectors (e.g. `deleteBackward:`
    for Backspace) up to NSBeep.
  - Implement `-performKeyEquivalent:` to claim any event with the
    Command modifier, push it through our normal key event queue,
    and return `YES` so AppKit doesn't emit the unhandled-shortcut
    beep.
- `src/platform/window_backend_macos.zig` / `src/platform/input_events.zig`
  - Add a `super` field to `RawKeyEvent` / `RawCharEvent` and the
    platform-neutral `KeyEvent` / `CharEvent`. Default is `false`,
    so Windows callsites compile unchanged.
- `src/input.zig`
  - Map `ev.super` to `keybind.Trigger.mods.win`.
  - Skip char events when `ev.super` is set, so a `Cmd+letter` combo
    never leaks into the PTY as text input.
- `src/keybind.zig`
  - In `Set.defaults()` on macOS: migrate `copy` to `Cmd+Shift+C`,
    `paste` to `Cmd+V`, `paste_image` to `Cmd+Shift+V`, and append a
    bare `Cmd+C` → `copy` so both the macOS-conventional `Cmd+C`
    and the historic shifted form work for plain copy. Added
    `replaceTrigger` / `appendIfRoom` helpers so we don't accidentally
    evict an action's freshly-installed binding when adding a second
    trigger for it.

### PTY environment (1 file)

- `src/platform/pty_posix.zig`
  - In the forked child before `execvp`, `setenv TERM=xterm-256color`,
    `COLORTERM=truecolor`, `TERM_PROGRAM=phantty`, and `unsetenv
    TERMINFO`. `xterm-256color` is the most broadly-available
    terminfo entry and matches the SGR / cursor-control set our
    ghostty-vt parser implements.

### SCP upload crash (1 file)

- `src/scp.zig`
  - `sshStreamUpload` was closing the child's stdin pipe manually
    after the write loop but leaving `child.stdin` non-null.
    `Child.wait()`'s `cleanupStreams()` then closed the same fd a
    second time; Zig's `posix.close` treats `EBADF` as unreachable
    and aborted the process. Set `child.stdin = null` after the
    manual close so cleanup skips the already-closed handle.

## Why a reviewer should care

- The `KeyEvent` / `CharEvent` schema gained a new field. The Windows
  backend was audited — its push sites use named-field struct
  literals and the new field has a `false` default, so nothing on
  the Win32 path needs to change. Cross-build for
  `x86_64-windows-gnu` was verified.
- `keybind.Set.defaults()` is the only place that branches on
  `builtin.target.os.tag`; the static `default_bindings` array is
  untouched, so non-macOS targets keep their existing Ctrl-based
  copy/paste defaults.
- The TERM change matches the standard pattern other terminal
  emulators use (Alacritty / kitty / Terminal.app all set TERM in
  the child).
- The SCP fix is local to `sshStreamUpload`. `sshStreamDownload` and
  the other `Child` users in the codebase don't manually close
  streams, so they were already correct.

## Test plan

- [x] `zig build macos-app -Dtarget=aarch64-macos`
- [x] `zig build -Dtarget=x86_64-windows-gnu`
- [ ] Install the new bundle and verify: Backspace no longer beeps;
      `Cmd+C` / `Cmd+V` / `Cmd+Shift+V` work and do not beep;
      `echo \$TERM` inside Phantty prints `xterm-256color`; a fresh
      shell shows the full Starship prompt instead of a stub.
- [ ] Drag-upload a small file via the file explorer to a remote SSH
      host and confirm Phantty no longer crashes after the transfer
      completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)