### PR TITLE
fix(ci): repair macos-release.yml heredoc breaking YAML parse

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -210,15 +210,13 @@ jobs:
             exit 1
           fi
 
-          asset_notes=$(cat <<'EOF'
-macOS assets included in this release:
-
-- aarch64 DMG: native build for Apple Silicon Macs
-- x86_64 DMG: native build for Intel Macs
-
-Both DMGs are signed with a Developer ID Application certificate and notarized by Apple.
-EOF
-)
+          asset_notes=$(printf '%s\n' \
+            'macOS assets included in this release:' \
+            '' \
+            '- aarch64 DMG: native build for Apple Silicon Macs' \
+            '- x86_64 DMG: native build for Intel Macs' \
+            '' \
+            'Both DMGs are signed with a Developer ID Application certificate and notarized by Apple.')
 
           release_notes_path="release-notes/${tag}.md"
           if [[ -f "${release_notes_path}" ]]; then


### PR DESCRIPTION
## Summary

`.github/workflows/macos-release.yml` failed to parse at GitHub Actions startup, surfacing as \"This run likely failed because of a workflow file issue\" on every push that touched the file (including the merge of #76 to main).

Root cause: the asset_notes block used a flush-left heredoc inside a YAML `run: |` block scalar. YAML scalars take their required indent from the first content line — here column 10. Lines at column 0 (the heredoc body) ended the scalar early, so the parser saw `Both DMGs are signed ...` as a top-level YAML node missing a `:` and rejected the file.

Because YAML parsing happens before `on.push.tags` filtering, the broken file produced failed runs even on branch pushes, not just tag pushes.

## Fix

Swap the heredoc for `printf '%s\n' …` with each line as its own argument. Every line is now indented inside the run block, the produced text is byte-identical, and `actionlint` passes clean.

## Verification

- Local: \`actionlint .github/workflows/macos-release.yml\` → no output (clean)
- Local: ran the same printf to confirm output matches the original asset_notes text

## Test plan

- [ ] Confirm GitHub Actions no longer flags the file (no startup-failure run on the merge of this PR)
- [ ] Next \`vX.Y.Z\` tag push triggers \`build-macos\` × 2 architectures and the \`publish\` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)