### PR TITLE
release: v0.34.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .phantty,
-    .version = "0.33.0",
+    .version = "0.34.0",
     .fingerprint = 0xdb7ae949ae4818ac,
     .minimum_zig_version = "0.15.2",
 

--- a/release-notes/v0.34.0.md
+++ b/release-notes/v0.34.0.md
@@ -1,0 +1,44 @@
+# Phantty v0.34.0
+
+## Added
+
+- Added a tag-triggered macOS release workflow that builds signed and
+  notarized DMGs for both `aarch64-macos` and `x86_64-macos`, publishes
+  them as GitHub release assets, and mirrors the existing Windows
+  release flow.
+- Bundled the Phantty application icon (`assets/phantty.icns`) into
+  `Phantty.app/Contents/Resources` and referenced it from
+  `CFBundleIconFile` so Finder, Dock, and cmd-tab pick it up.
+- Built an embedded `phantty_docs` agent tool and routed both protocol
+  schemas through the in-process docs dispatcher.
+
+## Fixed
+
+- Apple Color Emoji and other sbix / CBDT color-emoji fonts now render
+  correctly: FreeType is built with libpng so PNG strikes decode, and
+  the font manager falls back to `FT_Select_Size` for bitmap-only faces.
+- macOS keyboard input: Cmd-shortcuts now reach the keybind layer,
+  `interpretKeyEvents:` no longer rings the system bell on Return /
+  Backspace, and Cmd+C / Cmd+V default to the macOS conventional copy /
+  paste bindings.
+- `.app` bundle launches no longer drop into `/`: phantty reroots its
+  own cwd to `$HOME` when launched at the filesystem root, and the
+  child PTY falls back to `$HOME` when no explicit cwd is supplied.
+- Shells spawned by phantty on macOS now start as login shells (argv[0]
+  prefixed with `-`) so `/etc/zprofile` and `~/.zprofile` run and PATH
+  picks up `/opt/homebrew/bin`.
+- `TERM=xterm-256color`, `COLORTERM=truecolor`, and `TERM_PROGRAM=phantty`
+  are now set in every spawned POSIX shell so prompt frameworks and
+  line editors render correctly under GUI launches.
+- Avoided a double-close of the SCP child stdin pipe that crashed
+  uploads under Zig 0.15's stricter `posix.close` path.
+
+## Internal
+
+- Captured the macOS UI port lessons (Metal / AppKit / Zig 0.15 gotchas)
+  for future native-platform work.
+- Continued the `AppWindow.zig` decoupling effort (B2 / B3 refactors):
+  extracted the API wire format, pure agent-history flush scheduler, and
+  IME caret pixel placement / stability tracker.
+- Added issue templates and a contributing guide.
+- Improved Phantty startup crash diagnostics.


### PR DESCRIPTION
## Summary

Cuts the v0.34.0 release: bumps `build.zig.zon` from 0.33.0 → 0.34.0 and adds `release-notes/v0.34.0.md`. After this merges, push the `v0.34.0` tag to trigger both the Windows and the (new) macOS release workflows end-to-end.

## Highlights since v0.33.0

- **macOS signed release pipeline** (PR #76, fixed by #77) — tag-triggered workflow that builds and notarizes aarch64 + x86_64 DMGs.
- **macOS .app polish** — bundled `.icns` icon, Apple Color Emoji rendering, login-shell spawning, `\$HOME` reroot, TERM defaults.
- **macOS keyboard fixes** (PR #75) — Cmd shortcuts plumbed through, Return / Backspace bell silenced, Cmd+C / Cmd+V default bindings.
- **SCP upload fix** (PR #75) — no more double-close panic.
- **`phantty_docs` agent tool** (PR #74) — in-process docs dispatcher.
- **AppWindow refactor** (B2 / B3) — API wire-format, history flush scheduler, and IME caret tracker extracted.

## Test plan

- [ ] Merge this PR
- [ ] Push the `v0.34.0` tag: `git tag v0.34.0 <merge-commit> && git push origin v0.34.0`
- [ ] Watch the `Publish macOS Release` workflow on Actions — both arch jobs should succeed, DMGs should sign + notarize + staple
- [ ] Confirm the v0.34.0 GitHub release ends up with both `phantty-macos-aarch64-v0.34.0.dmg` and `phantty-macos-x86_64-v0.34.0.dmg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)