### PR TITLE
fix(macos): NSWindow creation off main thread + titlebar polish

### DIFF
--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -726,75 +726,90 @@ void *phantty_macos_window_create(
     bool has_position,
     bool maximize
 ) {
-    @autoreleasepool {
-        phantty_macos_app_ensure();
+    __block PhanttyMacWindowState *result = NULL;
+    dispatch_block_t create_block = ^{
+        @autoreleasepool {
+            phantty_macos_app_ensure();
 
-        PhanttyMacWindowState *state = calloc(1, sizeof(PhanttyMacWindowState));
-        if (state == NULL) return NULL;
+            PhanttyMacWindowState *state = calloc(1, sizeof(PhanttyMacWindowState));
+            if (state == NULL) return;
 
-        NSRect content_rect = NSMakeRect(
-            has_position ? (CGFloat)x : 120.0,
-            has_position ? (CGFloat)y : 120.0,
-            width > 0 ? (CGFloat)width : 800.0,
-            height > 0 ? (CGFloat)height : 600.0
-        );
-        NSUInteger style =
-            NSWindowStyleMaskTitled |
-            NSWindowStyleMaskClosable |
-            NSWindowStyleMaskMiniaturizable |
-            NSWindowStyleMaskResizable;
-        NSWindow *window = [[NSWindow alloc]
-            initWithContentRect:content_rect
-                      styleMask:style
-                        backing:NSBackingStoreBuffered
-                          defer:NO];
-        if (window == nil) {
-            free(state);
-            return NULL;
+            NSRect content_rect = NSMakeRect(
+                has_position ? (CGFloat)x : 120.0,
+                has_position ? (CGFloat)y : 120.0,
+                width > 0 ? (CGFloat)width : 800.0,
+                height > 0 ? (CGFloat)height : 600.0
+            );
+            NSUInteger style =
+                NSWindowStyleMaskTitled |
+                NSWindowStyleMaskClosable |
+                NSWindowStyleMaskMiniaturizable |
+                NSWindowStyleMaskResizable;
+            NSWindow *window = [[NSWindow alloc]
+                initWithContentRect:content_rect
+                          styleMask:style
+                            backing:NSBackingStoreBuffered
+                              defer:NO];
+            if (window == nil) {
+                free(state);
+                return;
+            }
+
+            NSString *window_title = phantty_macos_title_from_utf16(title);
+            [window setTitle:window_title];
+            [window_title release];
+            [window setReleasedWhenClosed:NO];
+            [window setSharingType:NSWindowSharingReadOnly];
+
+            PhanttyMacContentView *view = [[PhanttyMacContentView alloc] initWithFrame:NSMakeRect(0, 0, content_rect.size.width, content_rect.size.height)];
+            CAMetalLayer *layer = [CAMetalLayer layer];
+            id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+            layer.device = device;
+            layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+            layer.framebufferOnly = YES;
+            if (device != nil) [device release];
+            [view setWantsLayer:YES];
+            [view setLayer:layer];
+            [view registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
+            [window setContentView:view];
+
+            PhanttyMacWindowDelegate *delegate = [[PhanttyMacWindowDelegate alloc] init];
+            delegate.state = state;
+            [window setDelegate:delegate];
+
+            state->window = window;
+            state->view = view;
+            state->layer = [layer retain];
+            state->delegate = delegate;
+            state->close_requested = false;
+            state->ime_caret_x = 0;
+            state->ime_caret_y = 0;
+            state->ime_caret_height = 16;
+            state->ime_preedit[0] = 0;
+            state->ime_preedit_len = 0;
+            view.state = state;
+            phantty_macos_sync_layer(state);
+
+            [window setAcceptsMouseMovedEvents:YES];
+            [window makeKeyAndOrderFront:nil];
+            [window makeFirstResponder:view];
+            [NSApp activateIgnoringOtherApps:NO];
+            if (maximize) [window zoom:nil];
+            result = state;
         }
+    };
 
-        NSString *window_title = phantty_macos_title_from_utf16(title);
-        [window setTitle:window_title];
-        [window_title release];
-        [window setReleasedWhenClosed:NO];
-        [window setSharingType:NSWindowSharingReadOnly];
-
-        PhanttyMacContentView *view = [[PhanttyMacContentView alloc] initWithFrame:NSMakeRect(0, 0, content_rect.size.width, content_rect.size.height)];
-        CAMetalLayer *layer = [CAMetalLayer layer];
-        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-        layer.device = device;
-        layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        layer.framebufferOnly = YES;
-        if (device != nil) [device release];
-        [view setWantsLayer:YES];
-        [view setLayer:layer];
-        [view registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
-        [window setContentView:view];
-
-        PhanttyMacWindowDelegate *delegate = [[PhanttyMacWindowDelegate alloc] init];
-        delegate.state = state;
-        [window setDelegate:delegate];
-
-        state->window = window;
-        state->view = view;
-        state->layer = [layer retain];
-        state->delegate = delegate;
-        state->close_requested = false;
-        state->ime_caret_x = 0;
-        state->ime_caret_y = 0;
-        state->ime_caret_height = 16;
-        state->ime_preedit[0] = 0;
-        state->ime_preedit_len = 0;
-        view.state = state;
-        phantty_macos_sync_layer(state);
-
-        [window setAcceptsMouseMovedEvents:YES];
-        [window makeKeyAndOrderFront:nil];
-        [window makeFirstResponder:view];
-        [NSApp activateIgnoringOtherApps:NO];
-        if (maximize) [window zoom:nil];
-        return state;
+    // AppKit window construction (NSApplication/NSWindow) is main-thread only;
+    // macOS 26 raises NSInternalInconsistencyException from -[NSWindow _initContent:]
+    // when invoked off-main. Worker threads (e.g. App.requestNewWindow) marshal
+    // here via the main queue; if we are already on the main thread, run inline
+    // to avoid a dispatch_sync self-deadlock.
+    if ([NSThread isMainThread]) {
+        create_block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), create_block);
     }
+    return result;
 }
 
 void phantty_macos_window_destroy(void *handle) {

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -5,6 +5,7 @@
 //! primitives. Depends on font module for glyph loading and tab module for state.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const titlebar_layout = @import("titlebar_layout.zig");
 const AppWindow = @import("../AppWindow.zig");
 const ui_pipeline = AppWindow.ui_pipeline;
@@ -27,8 +28,10 @@ pub const SIDEBAR_RESIZE_HIT_WIDTH: f32 = 8;
 pub const SIDEBAR_ROW_H: f32 = 42;
 pub const SIDEBAR_HEADER_H: f32 = 46;
 pub const TITLEBAR_TOGGLE_W: f32 = 46;
-pub const TITLEBAR_CONFIG_W: f32 = 46;
-pub const TITLEBAR_HELP_W: f32 = 46;
+// On macOS the native menu bar (Phantty › Settings…, command palette) replaces
+// these in-titlebar buttons, so they collapse to zero width and are not drawn.
+pub const TITLEBAR_CONFIG_W: f32 = if (builtin.os.tag == .macos) 0 else 46;
+pub const TITLEBAR_HELP_W: f32 = if (builtin.os.tag == .macos) 0 else 46;
 pub threadlocal var g_sidebar_width: f32 = SIDEBAR_WIDTH;
 
 pub fn sidebarWidth() f32 {
@@ -424,33 +427,37 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
 
         const top_caption_start = window_width - top_caption_area_w;
         const config_x = top_caption_start - TITLEBAR_CONFIG_W;
-        const config_hovered = mouseInTitlebarRange(titlebar_h, config_x, config_x + TITLEBAR_CONFIG_W);
-        if (config_hovered) {
-            gl_init.renderQuad(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, hover_bg);
-        }
-        if (font.icon_face != null) {
-            if (font.loadIconGlyph(0xE713)) |ch| {
-                renderIconGlyph(ch, config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color, 1.0);
+        if (TITLEBAR_CONFIG_W > 0) {
+            const config_hovered = mouseInTitlebarRange(titlebar_h, config_x, config_x + TITLEBAR_CONFIG_W);
+            if (config_hovered) {
+                gl_init.renderQuad(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, hover_bg);
+            }
+            if (font.icon_face != null) {
+                if (font.loadIconGlyph(0xE713)) |ch| {
+                    renderIconGlyph(ch, config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color, 1.0);
+                } else {
+                    renderFallbackGearIcon(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
+                }
             } else {
                 renderFallbackGearIcon(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
             }
-        } else {
-            renderFallbackGearIcon(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
         }
 
         const help_x = config_x - TITLEBAR_HELP_W;
-        const help_hovered = mouseInTitlebarRange(titlebar_h, help_x, help_x + TITLEBAR_HELP_W);
-        if (help_hovered) {
-            gl_init.renderQuad(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, hover_bg);
-        }
-        if (font.icon_face != null) {
-            if (font.loadIconGlyph(0xEDA7)) |ch| {
-                renderIconGlyph(ch, help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color, 1.0);
+        if (TITLEBAR_HELP_W > 0) {
+            const help_hovered = mouseInTitlebarRange(titlebar_h, help_x, help_x + TITLEBAR_HELP_W);
+            if (help_hovered) {
+                gl_init.renderQuad(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, hover_bg);
+            }
+            if (font.icon_face != null) {
+                if (font.loadIconGlyph(0xEDA7)) |ch| {
+                    renderIconGlyph(ch, help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color, 1.0);
+                } else {
+                    renderFallbackHelpIcon(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color);
+                }
             } else {
                 renderFallbackHelpIcon(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color);
             }
-        } else {
-            renderFallbackHelpIcon(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color);
         }
 
         if (tab.activeTab()) |active_tab| {


### PR DESCRIPTION
## Summary

Two small macOS UI fixes that surfaced while exercising multi-window flows on macOS 26.

### 1. NSWindow construction must happen on the main thread (commit 28d53aa)

`App.requestNewWindow` spawns a worker thread that runs `AppWindow.runMainLoop`, which in turn calls `phantty_macos_window_create`. With another window already alive on the main thread, the second window's create call lands on the worker. macOS 26 raises `NSInternalInconsistencyException` out of `-[NSWindow _initContent:...]` when invoked off-main, which unwinds through `objc_exception_throw` to `abort()`.

Reproducer: press \`Ctrl+Shift+N\` once another phantty window is already open on macOS 26 — second window crashes the app.

**Fix**: wrap the create-window body in a dispatch block and run it via \`dispatch_sync(dispatch_get_main_queue(), …)\` when called off-main. When the caller is already on the main thread, run inline to avoid a \`dispatch_sync\` self-deadlock. The main thread is already pumping its CFRunLoop in \`phantty_macos_window_poll\` each frame, so the queued block is picked up promptly.

### 2. Hide titlebar Settings / Help buttons on macOS (commit 59db9b4)

The gear (⚙) and help (?) buttons in the top-right of the custom titlebar duplicate entries that already live in the native macOS menu bar (Phantty › Settings…, the command palette, etc.), and they also compete with the system traffic-light controls for space.

**Fix**: collapse \`TITLEBAR_CONFIG_W\` / \`TITLEBAR_HELP_W\` to 0 on macOS via a comptime \`builtin.os.tag\` check and skip the corresponding draw + hit blocks when the width is zero. Windows / Linux titlebars are unchanged.

## Test plan

- [ ] On macOS 26: open phantty, then \`Ctrl+Shift+N\` (or wherever new-window is bound) — second window opens and doesn't crash; both windows pump events normally
- [ ] On macOS: top-right of the titlebar shows tabs / window controls without the gear or help glyph; clicking near the old positions does nothing (no phantom hit)
- [ ] On Windows / Linux: titlebar still has the gear + help icons, hover state, and click behavior intact
- [ ] \`zig build test\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)