### PR TITLE
macOS: window lifecycle, unified title bar, and CJK font fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -437,18 +437,113 @@ macOS pty constants in D4.** Services / webview / packaging follow.
 - [ ] **D7.3 Localize menu titles.** Currently English-only; add a localized
       string table that matches the rest of Phantty's locale story.
 
-### macOS UI status (post D1.x + D7.1)
+### Phase D8 — macOS window lifecycle, native title bar & CJK fallback
+
+Polish/bugfix pass after the D-phase skeleton landed. Surfaced by real on-device
+use; the Windows port (`builtin.os.tag != .macos`) is unchanged throughout —
+every behavior is gated behind a macOS check. Status: implemented, builds clean
+for both `aarch64-macos` and the default `x86_64-windows-gnu`; on-device
+verification in progress.
+
+- [x] **D8.1 Close button keeps the process alive (Terminal.app / VS Code
+      semantics).** The red traffic-light used to tear down the whole process.
+      Added `PhanttyAppDelegate` in `window_macos_bridge.m`:
+      `applicationShouldTerminateAfterLastWindowClosed:` → NO,
+      `applicationShouldHandleReopen:hasVisibleWindows:` sets an atomic reopen
+      flag, `applicationShouldTerminate:` sets a quit flag and `performClose:`-es
+      every live window then returns `NSTerminateCancel` (zig owns shutdown).
+      Bridge exposes `consume_reopen` / `consume_quit` / `request_quit` /
+      `pump_events(timeout)`; wired through `window_macos.zig` → `window.zig`
+      facade → `window_backend.zig` (no-op stubs for Windows/unsupported). On
+      macOS the close button now sets `g_should_close` directly (no confirm
+      overlay). `App.run()` runs the first window on the main thread, then enters
+      `macIdleUntilQuit()`: blocks in `pumpAppEvents(0.25)`, spawns a fresh window
+      on Dock reopen, returns on quit.
+- [x] **D8.2 Dock reopen spawns on a worker thread, not the main thread.**
+      Reusing the main thread for a second window session resurfaced
+      "single-run" thread-local state (font caches, atlas handles, UI flags).
+      Reopen now calls `requestNewWindow(null, null)` (same path as `⌃⇧N`), so
+      the new window's thread-locals start at their declared defaults. Also fixed
+      two latent single-run bugs this exposed: `AppWindow.zig` shutdown defer now
+      resets `font.icon_cache` / `font.g_titlebar_cache` to `.empty` after
+      `deinit` (a re-entrant `clearTitlebarFont` was double-freeing dangling
+      hash-map metadata → `incorrectAlignment` panic).
+- [x] **D8.3 NSWindow operations marshalled to the main thread (crash fix).**
+      Root macOS-port architecture bug: every `AppWindow` runs its event/render
+      loop on a spawned thread but called NSWindow APIs directly, tripping
+      AppKit's "Must only be used from the main thread" assertion (crashed in
+      `setContentSize` → `-[NSWMWindowCoordinator performTransactionUsingBlock:]`
+      on resize/reopen). Added `phantty_macos_run_on_main(block)` (inline on the
+      main thread, else `dispatch_sync` to the main queue) and wrapped
+      `set_content_size` / `set_frame` / `show` / `hide` / `make_key` / `zoom` /
+      `destroy`. `window_poll` only pumps `[NSApp nextEvent]` on the main thread
+      (worker threads just sync the Metal layer; AppKit dispatches their events to
+      the window delegate which fills the per-window buffer). `pump_events` gained
+      a blocking `timeout` so the main run loop drains the GCD main queue —
+      otherwise worker `dispatch_sync` would deadlock against a spin-sleep.
+- [ ] **D8.3a Event buffer cross-thread safety (follow-up).** The per-window
+      key/char/mouse/file-drop/message ring buffers in `window_macos_bridge.m` are
+      SPSC and lock-free; with D8.3 the producer is now the main thread (AppKit
+      delegate) and the consumer is the worker thread. Add an `os_unfair_lock` (or
+      atomic head/count) before relying on this under load — watch for dropped
+      keystrokes / input lag as the symptom.
+- [x] **D8.4 Unified title bar + traffic-light-aware toggle placement.** macOS no
+      longer shows the empty native title strip above Phantty's own bar. NSWindow
+      gains `NSWindowStyleMaskFullSizeContentView` + `titlebarAppearsTransparent`
+      + `titleVisibility = NSWindowTitleHidden`, so the app-drawn titlebar extends
+      under the traffic lights (Codex / VS Code style). `titlebar.zig` reserves a
+      DPI-scaled strip on the left (`titlebarLeftReserved()` = 80 logical px ×
+      `g_dpi/96`, in framebuffer pixels) so the sidebar-toggle hamburger and tab
+      title sit to the right of the red/yellow/green controls; `input.zig`
+      hit-tests shift to match. (Supersedes the D2 note that macOS skips the
+      app-drawn titlebar entirely.)
+- [ ] **D8.4a Draggable titlebar region (follow-up).** With the native title bar
+      hidden the window is only draggable via the traffic-light gaps. Give the
+      non-interactive part of the app-drawn titlebar a window-drag affordance
+      (`-mouseDownCanMoveWindow` / a hit-test drag region).
+- [x] **D8.5 CJK fallback no longer renders tofu.** macOS 26 moved PingFang into
+      `PrivateFrameworks/.../Reserved/PingFangUI.ttc`, a system-reserved `.ttc`
+      that FreeType cannot open (`FT_New_Face` → err 144) — and CoreText's default
+      cascade prefers exactly that font, so every CJK glyph fell through to a
+      blank box. `font/manager.zig`: `preferredFallbackFamilies` gained a macOS
+      branch listing FreeType-loadable public system fonts (`Hiragino Sans GB`,
+      `Songti SC`, `Heiti SC`, `STHeiti`, …); `findOrLoadFallbackFace` was
+      restructured to try candidates in priority order (config → preferred →
+      CoreText default), each validated by `openFallbackFreetypeFace` which
+      actually opens the file with FreeType and confirms the glyph exists — so an
+      unloadable reserved font no longer aborts the lookup. First candidate
+      (`Hiragino Sans GB` → `/System/Library/Fonts/Hiragino Sans GB.ttc`) resolves
+      cleanly.
+- [ ] **D8.6 Window position persistence is wrong on macOS (known bug, not yet
+      fixed).** `window_state.zig` saves `rect.left/top`, but on macOS
+      `phantty_macos_rect_from_nsrect` stores `NSMinY` (the window's *bottom* edge
+      in AppKit's bottom-left origin) into the `top` field. Combined with
+      `isPointOnAnyDisplay` only validating a single `(x+50, y+50)` point, a
+      previously off-screen / multi-monitor position can be restored off-screen.
+      Fix: translate NSRect into Windows-style top-left semantics (or persist
+      native AppKit coords separately), validate the whole frame against
+      `visibleFrame`, and default new windows to `[NSWindow center]` / cascade
+      instead of the hard-coded `(120, 120)`.
+
+### macOS UI status (post D1.x + D7.1 + D8)
 
 | Feature | Status on macOS |
 |---|---|
 | Terminal text rendering | ✅ works (cell pipeline + CoreText/FreeType) |
+| CJK / 中文 rendering | ✅ fixed in D8.5 (public-font fallback; PingFang reserved-ttc was unloadable) |
 | Default shell | ✅ `zsh` (was `sh` until 2026-05-27) |
 | NSMenu (Phantty / File / Edit / View / Window) | ✅ visible, clickable, key equivalents fire |
+| Window title bar | ✅ unified — app-drawn bar extends under traffic lights (D8.4) |
+| Close button (red) | ✅ closes window, keeps process in Dock; Dock icon reopens (D8.1) |
+| cmd+Q | ✅ tears down the whole app (D8.1) |
+| Window resize / reopen | ✅ no longer crashes — NSWindow ops marshalled to main thread (D8.3) |
 | Command center / settings page / SSH form / AI form / session launcher | ✅ render fully (panels, borders, selection highlights, text) |
 | Tab sidebar | ✅ renders rows, selection highlight, tab numbers |
 | File explorer panel | ✅ unblocked by D1.x; verify icons/scroll on real workloads |
 | Markdown / image preview | ✅ unblocked by D1.x; verify chrome on real previews |
 | Quake-style drop-down | ✅ window position + overlay rendering |
+| Window position restore | ⚠️ buggy on macOS (D8.6 — coordinate-system mismatch) |
+| Draggable titlebar | ⚠️ only via traffic-light gaps until D8.4a |
 | Embedded browser panel | ❌ disabled (D5 — no WKWebView backend yet) |
 
 ### Linux — deferred

--- a/src/App.zig
+++ b/src/App.zig
@@ -5,6 +5,7 @@
 //! OpenGL context, fonts, and terminal state.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Config = @import("config.zig");
 const AppWindow = @import("AppWindow.zig");
 const ai_chat = @import("ai_chat.zig");
@@ -707,22 +708,40 @@ fn joinDownloadThread(self: *App) void {
 
 /// Run the first window on the main thread. Blocks until that window closes.
 /// After returning, waits for all spawned window threads to finish.
+///
+/// On macOS the close-button no longer terminates the process (matches
+/// Terminal.app / VS Code). After the first window closes the main thread
+/// enters an idle pump loop:
+///   * Dock-icon reopen → spawn a fresh window on a new thread (so all
+///     thread-local globals — font atlas, glyph cache, UI flags — start
+///     from their declared defaults instead of inheriting stale state from
+///     the previous main-thread session).
+///   * cmd+Q / app-menu Quit → drain the quit flag and tear down.
 pub fn run(self: *App) !void {
-    // Create and run the first window on the main thread
+    try self.runFirstWindowOnce();
+
+    if (builtin.os.tag == .macos) {
+        self.macIdleUntilQuit();
+    }
+
+    // Wait for all spawned window threads to finish
+    self.joinAllWindowThreads();
+}
+
+/// Construct and run a first-window on the main thread (one window session).
+/// Adds to / removes from the global window list around the run call.
+fn runFirstWindowOnce(self: *App) !void {
     var first_window = try AppWindow.init(self.allocator, self);
     defer first_window.deinit();
 
-    // Add to window list
     {
         self.mutex.lock();
         defer self.mutex.unlock();
         try self.windows.append(self.allocator, &first_window);
     }
 
-    // Run blocks until window closes
     first_window.run();
 
-    // Remove from list
     {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -733,9 +752,29 @@ pub fn run(self: *App) !void {
             }
         }
     }
+}
 
-    // Wait for all spawned window threads to finish
-    self.joinAllWindowThreads();
+/// macOS-only: main-thread idle loop that runs once the initial first-window
+/// has returned. Pumps NSApp events so AppDelegate callbacks (reopen,
+/// terminate) fire, and either spawns a fresh window on a worker thread when
+/// the user clicks the Dock icon or returns when quit is requested.
+fn macIdleUntilQuit(self: *App) void {
+    while (true) {
+        // Block (up to 250ms) waiting for the next AppKit event. The blocking
+        // wait keeps the main run loop alive, which is what drains the GCD
+        // main queue used by phantty_macos_run_on_main(). Without it, worker
+        // threads calling setContentSize/setFrame/etc would deadlock waiting
+        // for the main thread to come back from std.Thread.sleep().
+        window_backend.pumpAppEvents(0.25);
+
+        if (window_backend.consumeQuitRequest()) return;
+        if (window_backend.consumeReopenRequest()) {
+            // Spawn on a worker thread (same code path as Ctrl+Shift+N) so
+            // thread-local globals start fresh. Main thread keeps idling so
+            // it can pump AppKit and respond to the next reopen/quit.
+            self.requestNewWindow(null, null);
+        }
+    }
 }
 
 /// Request a new window to be spawned on a separate thread.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -5,6 +5,7 @@
 //! will be converted to struct fields in a future refactoring step.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const ghostty_vt = @import("ghostty-vt");
 const freetype = @import("freetype");
 const Config = @import("config.zig");
@@ -3475,8 +3476,11 @@ fn runMainLoop(self: *AppWindow) !void {
         // Clean up glyph cache and atlas
         font.clearGlyphCache(allocator);
         font.clearFallbackFaces(allocator);
-        // Clean up icon cache and icon atlas
+        // Clean up icon cache and icon atlas. Reset to .empty so the
+        // threadlocal slot is safe to re-use if the main thread spawns
+        // another first-window (e.g. macOS Dock reopen).
         font.icon_cache.deinit(allocator);
+        font.icon_cache = .empty;
         if (font.g_icon_atlas) |*a| {
             a.deinit(allocator);
             font.g_icon_atlas = null;
@@ -3487,10 +3491,12 @@ fn runMainLoop(self: *AppWindow) !void {
             font.g_icon_atlas_texture = 0;
         }
 
-        // Clean up titlebar font
+        // Clean up titlebar font. Reset cache to .empty for the same reason
+        // as icon_cache above.
         if (font.g_titlebar_face) |f| f.deinit();
         font.g_titlebar_face = null;
         font.g_titlebar_cache.deinit(allocator);
+        font.g_titlebar_cache = .empty;
         if (font.g_titlebar_atlas) |*a| {
             a.deinit(allocator);
             font.g_titlebar_atlas = null;
@@ -3730,6 +3736,15 @@ fn runMainLoop(self: *AppWindow) !void {
         }
         if (window_backend.closeRequested(win)) {
             window_backend.clearCloseRequested(win);
+            if (builtin.os.tag == .macos) {
+                // macOS semantics: the red traffic-light closes this window
+                // immediately. Closing the last window does NOT terminate the
+                // process — App.run() keeps the NSApp alive so the Dock icon
+                // can re-open a window (handled by PhanttyAppDelegate).
+                g_should_close = true;
+                running = false;
+                continue;
+            }
             overlays.windowCloseConfirmOpen();
             g_force_rebuild = true;
             g_cells_valid = false;

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -5,6 +5,7 @@
 //! Uses AppWindow's GL context for GPU texture operations.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const freetype = @import("freetype");
 const harfbuzz = @import("harfbuzz");
 const sprite = @import("sprite.zig");
@@ -333,6 +334,26 @@ fn isCjkCodepoint(codepoint: u32) bool {
 
 fn preferredFallbackFamilies(codepoint: u32) []const []const u8 {
     if (isCjkCodepoint(codepoint)) {
+        if (builtin.os.tag == .macos) {
+            // macOS 26 moved PingFang into PrivateFrameworks/.../Reserved as a
+            // system-reserved .ttc that FreeType cannot open (FT_New_Face fails),
+            // and CoreText's default cascade prefers exactly that reserved font —
+            // which is why CJK rendered as tofu. List the public system CJK
+            // families (all FreeType-loadable from /System/Library/Fonts) first
+            // so findOrLoadFallbackFace resolves a usable face before falling
+            // back to the broken CoreText default. Third-party families follow
+            // for users who installed them.
+            return &.{
+                "Hiragino Sans GB",
+                "Songti SC",
+                "Heiti SC",
+                "STHeiti",
+                "Hiragino Sans",
+                "Apple SD Gothic Neo",
+                "Sarasa Mono SC",
+                "Noto Sans CJK SC",
+            };
+        }
         return &.{
             "Maple Mono NF CN",
             "Sarasa Mono SC",
@@ -1149,6 +1170,47 @@ pub fn loadBellEmoji() ?BellCache {
 // ============================================================================
 
 /// Find or load a fallback font that contains the given codepoint
+/// Resolve a FallbackFont to a FreeType face, verifying FreeType can actually
+/// open the file AND that the face contains `codepoint`. Returns null (after
+/// cleaning up) if either check fails, so callers can try the next candidate.
+/// This is the crux of the macOS CJK fix: CoreText happily hands back the
+/// reserved PingFangUI.ttc which FreeType cannot open, so we must validate the
+/// load rather than trust the discovery result.
+fn openFallbackFreetypeFace(
+    ft_lib: freetype.Library,
+    font: *font_backend.FallbackFont,
+    codepoint: u32,
+    alloc: std.mem.Allocator,
+) ?freetype.Face {
+    var font_path = font_backend.fontFilePathAlloc(alloc, font) orelse return null;
+    defer font_path.deinit();
+
+    const ft_face = ft_lib.initFace(font_path.path, @intCast(font_path.face_index)) catch return null;
+    if ((ft_face.getCharIndex(codepoint) orelse 0) == 0) {
+        ft_face.deinit();
+        return null;
+    }
+    return ft_face;
+}
+
+/// Try each family in order; return the first one FreeType can load with a
+/// glyph for `codepoint`.
+fn tryFamiliesForFallback(
+    discovery: *font_backend.FontDiscovery,
+    ft_lib: freetype.Library,
+    codepoint: u32,
+    families: []const []const u8,
+    alloc: std.mem.Allocator,
+) ?freetype.Face {
+    for (families) |family_name| {
+        const font = (discovery.findFont(family_name, .NORMAL, .NORMAL) catch null) orelse continue;
+        defer font.release();
+        if (!font.hasCharacter(codepoint)) continue;
+        if (openFallbackFreetypeFace(ft_lib, font, codepoint, alloc)) |face| return face;
+    }
+    return null;
+}
+
 pub fn findOrLoadFallbackFace(codepoint: u32, alloc: std.mem.Allocator) ?freetype.Face {
     // Check if we already have a fallback for this codepoint
     if (g_fallback_faces.get(codepoint)) |face| {
@@ -1164,26 +1226,31 @@ pub fn findOrLoadFallbackFace(codepoint: u32, alloc: std.mem.Allocator) ?freetyp
     const discovery = g_font_discovery orelse return null;
     const ft_lib = g_ft_lib orelse return null;
 
-    const preferred_families = preferredFallbackFamilies(codepoint);
-    const maybe_font = findConfiguredFallbackFont(discovery, codepoint) orelse if (preferred_families.len > 0)
-        ((discovery.findPreferredFallbackFont(codepoint, preferred_families) catch null) orelse
-            (discovery.findFallbackFont(codepoint) catch null))
-    else
-        (discovery.findFallbackFont(codepoint) catch null);
+    // Resolve a FreeType-loadable face, trying candidates in priority order.
+    // Each candidate is validated by actually opening it with FreeType (see
+    // openFallbackFreetypeFace) so an unloadable system-reserved font does not
+    // abort the whole lookup.
+    const ft_face: freetype.Face = blk: {
+        // 1. Explicit user configuration (cjk-font / fallback CSV).
+        if (findConfiguredFallbackFont(discovery, codepoint)) |font| {
+            defer font.release();
+            if (openFallbackFreetypeFace(ft_lib, font, codepoint, alloc)) |face| break :blk face;
+        }
 
-    // Use the system font backend to find a font with this codepoint
-    const font = maybe_font orelse {
-        // Cache the negative result to avoid repeated system font queries
+        // 2. Platform preferred families (FreeType-loadable system fonts).
+        const preferred = preferredFallbackFamilies(codepoint);
+        if (tryFamiliesForFallback(discovery, ft_lib, codepoint, preferred, alloc)) |face| break :blk face;
+
+        // 3. CoreText / platform default cascade as a last resort.
+        if (discovery.findFallbackFont(codepoint) catch null) |font| {
+            defer font.release();
+            if (openFallbackFreetypeFace(ft_lib, font, codepoint, alloc)) |face| break :blk face;
+        }
+
+        // Nothing usable — cache the negative result to avoid repeated queries.
         g_no_fallback.put(alloc, codepoint, {}) catch {};
         return null;
     };
-    defer font.release();
-
-    var font_path = font_backend.fontFilePathAlloc(alloc, font) orelse return null;
-    defer font_path.deinit();
-
-    // Load with FreeType
-    const ft_face = ft_lib.initFace(font_path.path, @intCast(font_path.face_index)) catch return null;
 
     // Start from the primary point size, then normalize fallback metrics to
     // the active terminal face. This follows Ghostty's overall approach of

--- a/src/input.zig
+++ b/src/input.zig
@@ -1724,7 +1724,9 @@ fn hitTestHelpButton(xpos: f64, ypos: f64) bool {
 }
 
 fn handleTopbarPress(xpos: f64) void {
-    if (xpos >= 0 and xpos < @as(f64, titlebar.TITLEBAR_TOGGLE_W)) {
+    const toggle_x: f64 = @floatCast(titlebar.titlebarLeftReserved());
+    const toggle_end: f64 = toggle_x + @as(f64, titlebar.TITLEBAR_TOGGLE_W);
+    if (xpos >= toggle_x and xpos < toggle_end) {
         toggleSidebar();
         return;
     }
@@ -2374,7 +2376,9 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         if (ypos < titlebar_h) {
             if (hitTestConfigButton(xpos, ypos)) {
                 overlays.settingsPageOpen();
-            } else if (xpos >= @as(f64, titlebar.TITLEBAR_TOGGLE_W)) {
+            } else if (xpos >= @as(f64, titlebar.titlebarLeftReserved() + titlebar.TITLEBAR_TOGGLE_W)) {
+                // Double-clicking on bare titlebar (not on the toggle, and not
+                // on the macOS traffic-light strip) zooms / unzooms.
                 toggleMaximize();
             }
         } else if (hitTestSidebarTab(xpos, ypos)) |tab_idx| {

--- a/src/platform/window.zig
+++ b/src/platform/window.zig
@@ -71,6 +71,10 @@ pub const setWindowFrameRaw = impl.setWindowFrameRaw;
 pub const setOuterFrame = impl.setOuterFrame;
 pub const nearestMonitorRect = impl.nearestMonitorRect;
 pub const nearestMonitorWorkArea = impl.nearestMonitorWorkArea;
+pub const consumeReopenRequest = impl.consumeReopenRequest;
+pub const consumeQuitRequest = impl.consumeQuitRequest;
+pub const requestQuit = impl.requestQuit;
+pub const pumpAppEvents = impl.pumpAppEvents;
 
 test "platform window exposes native handle helpers" {
     const rect_info = @typeInfo(@TypeOf(getWindowRect)).@"fn";

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -227,6 +227,35 @@ pub fn setOuterFrame(window: *Window, rect: Rect, topmost: bool) bool {
     return platform_window.setOuterFrame(nativeHandle(window), rectToPlatform(rect), topmost);
 }
 
+/// macOS-only: returns true if the user clicked the Dock icon while no window
+/// was visible (NSApplicationDelegate.applicationShouldHandleReopen). Other
+/// platforms return false.
+pub fn consumeReopenRequest() bool {
+    return platform_window.consumeReopenRequest();
+}
+
+/// macOS-only: returns true if the user invoked Quit (cmd+Q or menu) and the
+/// app should tear down. Other platforms return false.
+pub fn consumeQuitRequest() bool {
+    return platform_window.consumeQuitRequest();
+}
+
+/// macOS-only: signal the idle loop that the app should quit (used when zig
+/// initiates a quit, e.g. from a menu handler). No-op elsewhere.
+pub fn requestQuit() void {
+    platform_window.requestQuit();
+}
+
+/// macOS-only: pump pending NSApp events without owning a window — needed by
+/// the idle loop in App.run() so AppDelegate callbacks (Dock reopen, cmd+Q)
+/// keep firing between window sessions. `timeout_seconds` is the max time the
+/// main thread will block waiting for an event (also drains the GCD main
+/// queue, which worker threads use to marshal NSWindow modifications back to
+/// the main thread). No-op elsewhere.
+pub fn pumpAppEvents(timeout_seconds: f64) void {
+    platform_window.pumpAppEvents(timeout_seconds);
+}
+
 pub fn refreshClientSizeFromNative(window: *Window) bool {
     const rect = clientRect(window) orelse return false;
     setClientSize(window, rect.right - rect.left, rect.bottom - rect.top);

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -41,6 +41,10 @@ extern fn phantty_macos_window_zoom(handle: NativeHandle) void;
 extern fn phantty_macos_window_set_frame(handle: NativeHandle, x: i32, y: i32, width: i32, height: i32) bool;
 extern fn phantty_macos_window_nearest_monitor_frame(handle: NativeHandle, rect: *Rect) bool;
 extern fn phantty_macos_window_nearest_monitor_work_area(handle: NativeHandle, rect: *Rect) bool;
+extern fn phantty_macos_app_consume_reopen() bool;
+extern fn phantty_macos_app_consume_quit() bool;
+extern fn phantty_macos_app_request_quit() void;
+extern fn phantty_macos_app_pump_events(timeout_seconds: f64) void;
 
 pub fn appMessage(offset: u32) MessageId {
     return wm_app + offset;
@@ -164,6 +168,25 @@ pub fn nearestMonitorWorkArea(hwnd: NativeHandle) ?Rect {
     var rect: Rect = undefined;
     if (!phantty_macos_window_nearest_monitor_work_area(hwnd, &rect)) return null;
     return rect;
+}
+
+pub fn consumeReopenRequest() bool {
+    return phantty_macos_app_consume_reopen();
+}
+
+pub fn consumeQuitRequest() bool {
+    return phantty_macos_app_consume_quit();
+}
+
+pub fn requestQuit() void {
+    phantty_macos_app_request_quit();
+}
+
+/// Pump pending NSApp events; blocks up to `timeout_seconds` waiting for the
+/// first event so the main thread's run loop also drains the GCD main queue
+/// (needed for worker-thread dispatch_sync to the main thread).
+pub fn pumpAppEvents(timeout_seconds: f64) void {
+    phantty_macos_app_pump_events(timeout_seconds);
 }
 
 test "macOS window constants defer caption controls to AppKit" {

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -1,6 +1,7 @@
 #import <AppKit/AppKit.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -126,12 +127,90 @@ struct PhanttyMacWindowState {
 }
 @end
 
+// ---------------------------------------------------------------------------
+// PhanttyAppDelegate — owns app-level lifecycle so closing the last window
+// does not terminate the process (Terminal.app / VS Code semantics). A reopen
+// (Dock icon click when no visible window) is reported back to zig either via
+// a registered C callback or via an atomic flag the zig idle loop polls.
+// ---------------------------------------------------------------------------
+
+typedef void (*phantty_macos_reopen_callback)(void *userdata);
+
+static phantty_macos_reopen_callback g_reopen_callback = NULL;
+static void *g_reopen_userdata = NULL;
+// _Atomic(bool) is not supported by Clang's __atomic_* builtins on all targets,
+// and stdatomic.h's atomic_bool is the portable way to express the same intent.
+static atomic_bool g_reopen_pending = false;
+static atomic_bool g_quit_pending = false;
+
+@interface PhanttyAppDelegate : NSObject <NSApplicationDelegate>
+@end
+
+@implementation PhanttyAppDelegate
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+    (void)sender;
+    return NO;
+}
+
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag {
+    (void)sender;
+    if (flag) return YES;
+    atomic_store_explicit(&g_reopen_pending, true, memory_order_release);
+    if (g_reopen_callback != NULL) g_reopen_callback(g_reopen_userdata);
+    return NO;
+}
+
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
+    (void)sender;
+    atomic_store_explicit(&g_quit_pending, true, memory_order_release);
+    // Ask every live window to close. Each AppWindow's main loop observes
+    // the close_requested flag and exits cleanly; App.run() then drains the
+    // quit flag and breaks out of its idle loop. We return Cancel so AppKit
+    // doesn't tear NSApp down underneath us — zig owns the actual shutdown.
+    NSArray<NSWindow *> *snapshot = [[NSApp windows] copy];
+    for (NSWindow *win in snapshot) {
+        [win performClose:nil];
+    }
+    [snapshot release];
+    return NSTerminateCancel;
+}
+@end
+
+static PhanttyAppDelegate *g_app_delegate = nil;
+
 static void phantty_macos_app_ensure(void) {
     @autoreleasepool {
         NSApplication *app = [NSApplication sharedApplication];
         [app setActivationPolicy:NSApplicationActivationPolicyRegular];
+        if (g_app_delegate == nil) {
+            g_app_delegate = [[PhanttyAppDelegate alloc] init];
+            [app setDelegate:g_app_delegate];
+        }
         [app finishLaunching];
     }
+}
+
+void phantty_macos_app_install_reopen_handler(phantty_macos_reopen_callback cb, void *userdata) {
+    g_reopen_callback = cb;
+    g_reopen_userdata = userdata;
+}
+
+bool phantty_macos_app_consume_reopen(void) {
+    bool expected = true;
+    return atomic_compare_exchange_strong_explicit(
+        &g_reopen_pending, &expected, false,
+        memory_order_acq_rel, memory_order_acquire);
+}
+
+bool phantty_macos_app_consume_quit(void) {
+    bool expected = true;
+    return atomic_compare_exchange_strong_explicit(
+        &g_quit_pending, &expected, false,
+        memory_order_acq_rel, memory_order_acquire);
+}
+
+void phantty_macos_app_request_quit(void) {
+    atomic_store_explicit(&g_quit_pending, true, memory_order_release);
 }
 
 static NSString *phantty_macos_title_from_utf16(const uint16_t *title) {
@@ -150,6 +229,23 @@ static PhanttyMacWindowState *phantty_macos_state(void *handle) {
 
 static int32_t phantty_macos_round_double(double value) {
     return (int32_t)(value + (value >= 0 ? 0.5 : -0.5));
+}
+
+// Marshal an AppKit operation onto the main thread. NSWindow modifiers
+// (setFrame, setContentSize, makeKeyAndOrderFront, close, zoom, …) trip the
+// "Must only be used from the main thread" assertion on macOS 14+ when called
+// off-main. phantty spawns per-window worker threads (windowThreadMain) that
+// own the zig event/render loop, so every wrapper that mutates NSWindow state
+// must run through here. Inline if we're already on main to avoid a
+// dispatch_sync self-deadlock; otherwise wait for the main run loop to drain
+// the block (the main thread idles in -nextEventMatchingMask: which keeps the
+// main queue running).
+static void phantty_macos_run_on_main(dispatch_block_t block) {
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), block);
+    }
 }
 
 static void phantty_macos_rect_from_nsrect(NSRect rect, PhanttyMacRect *out) {
@@ -740,11 +836,17 @@ void *phantty_macos_window_create(
                 width > 0 ? (CGFloat)width : 800.0,
                 height > 0 ? (CGFloat)height : 600.0
             );
+            // FullSizeContentView lets phantty's own GL/Metal-drawn titlebar
+            // extend behind the traffic-light buttons, matching Codex / VS
+            // Code / Ghostty. titlebarAppearsTransparent + titleVisibility
+            // hide the system-drawn title chrome so only the traffic lights
+            // remain visible on top of our content.
             NSUInteger style =
                 NSWindowStyleMaskTitled |
                 NSWindowStyleMaskClosable |
                 NSWindowStyleMaskMiniaturizable |
-                NSWindowStyleMaskResizable;
+                NSWindowStyleMaskResizable |
+                NSWindowStyleMaskFullSizeContentView;
             NSWindow *window = [[NSWindow alloc]
                 initWithContentRect:content_rect
                           styleMask:style
@@ -754,6 +856,8 @@ void *phantty_macos_window_create(
                 free(state);
                 return;
             }
+            [window setTitlebarAppearsTransparent:YES];
+            [window setTitleVisibility:NSWindowTitleHidden];
 
             NSString *window_title = phantty_macos_title_from_utf16(title);
             [window setTitle:window_title];
@@ -813,35 +917,79 @@ void *phantty_macos_window_create(
 }
 
 void phantty_macos_window_destroy(void *handle) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL) return;
-        [state->window setDelegate:nil];
-        [state->window orderOut:nil];
-        [state->layer release];
-        [state->view release];
-        [state->delegate release];
-        [state->window close];
-        [state->window release];
-        free(state);
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window setDelegate:nil];
+            [state->window orderOut:nil];
+            [state->layer release];
+            [state->view release];
+            [state->delegate release];
+            [state->window close];
+            [state->window release];
+            free(state);
+        }
+    });
 }
 
 void phantty_macos_window_poll(void *handle) {
     @autoreleasepool {
         PhanttyMacWindowState *state = phantty_macos_state(handle);
         if (state == NULL) return;
+        // -nextEventMatchingMask: / -sendEvent: must run on the main thread.
+        // Worker AppWindow threads still call into here every frame; for them
+        // we skip the AppKit pump (the main thread idle loop drains events
+        // and AppKit dispatches them to PhanttyMacWindowDelegate, which pushes
+        // into state->*_events). Worker threads only need to sync the Metal
+        // layer to the current backing scale.
+        if ([NSThread isMainThread]) {
+            for (;;) {
+                NSEvent *event = [NSApp
+                    nextEventMatchingMask:NSEventMaskAny
+                                 untilDate:[NSDate distantPast]
+                                    inMode:NSDefaultRunLoopMode
+                                   dequeue:YES];
+                if (event == nil) break;
+                [NSApp sendEvent:event];
+            }
+            [NSApp updateWindows];
+        }
+        phantty_macos_sync_layer(state);
+    }
+}
+
+// Pump pending NSApp events without requiring a window handle. Used by the
+// zig idle loop in App.run() between window sessions so the AppDelegate's
+// reopen / terminate callbacks (Dock icon, cmd+Q) still fire while no
+// AppWindow loop is running.
+//
+// `timeout_seconds` is how long the main thread is willing to block waiting
+// for the next event. Blocking (rather than spinning + sleeping in zig) is
+// what keeps the main run loop alive — that's how dispatch_get_main_queue()
+// blocks posted from worker threads via phantty_macos_run_on_main() actually
+// get drained. With distantPast (0s) the main queue never runs and any
+// worker dispatch_sync to main deadlocks until something else wakes the run
+// loop.
+void phantty_macos_app_pump_events(double timeout_seconds) {
+    @autoreleasepool {
+        NSDate *first_until = (timeout_seconds > 0)
+            ? [NSDate dateWithTimeIntervalSinceNow:timeout_seconds]
+            : [NSDate distantPast];
+        // Block once for up to timeout_seconds (or until any event arrives),
+        // then drain anything else without blocking.
+        NSDate *until = first_until;
         for (;;) {
             NSEvent *event = [NSApp
                 nextEventMatchingMask:NSEventMaskAny
-                             untilDate:[NSDate distantPast]
+                             untilDate:until
                                 inMode:NSDefaultRunLoopMode
                                dequeue:YES];
             if (event == nil) break;
             [NSApp sendEvent:event];
+            until = [NSDate distantPast];
         }
         [NSApp updateWindows];
-        phantty_macos_sync_layer(state);
     }
 }
 
@@ -1018,12 +1166,14 @@ void phantty_macos_window_get_framebuffer_size(void *handle, int32_t *width, int
 }
 
 void phantty_macos_window_set_content_size(void *handle, int32_t width, int32_t height) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return;
-        [state->window setContentSize:NSMakeSize(width > 0 ? width : 1, height > 0 ? height : 1)];
-        phantty_macos_sync_layer(state);
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window setContentSize:NSMakeSize(width > 0 ? width : 1, height > 0 ? height : 1)];
+            phantty_macos_sync_layer(state);
+        }
+    });
 }
 
 void *phantty_macos_window_metal_layer(void *handle) {
@@ -1056,28 +1206,34 @@ uint32_t phantty_macos_window_dpi(void *handle) {
 }
 
 void phantty_macos_window_show(void *handle) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return;
-        [state->window makeKeyAndOrderFront:nil];
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window makeKeyAndOrderFront:nil];
+        }
+    });
 }
 
 void phantty_macos_window_hide(void *handle) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return;
-        [state->window orderOut:nil];
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window orderOut:nil];
+        }
+    });
 }
 
 void phantty_macos_window_make_key(void *handle) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return;
-        [state->window makeKeyWindow];
-        [NSApp activateIgnoringOtherApps:NO];
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window makeKeyWindow];
+            [NSApp activateIgnoringOtherApps:NO];
+        }
+    });
 }
 
 bool phantty_macos_window_is_zoomed(void *handle) {
@@ -1086,22 +1242,26 @@ bool phantty_macos_window_is_zoomed(void *handle) {
 }
 
 void phantty_macos_window_zoom(void *handle) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return;
-        [state->window zoom:nil];
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            [state->window zoom:nil];
+        }
+    });
 }
 
 bool phantty_macos_window_set_frame(void *handle, int32_t x, int32_t y, int32_t width, int32_t height) {
-    @autoreleasepool {
-        PhanttyMacWindowState *state = phantty_macos_state(handle);
-        if (state == NULL || state->window == nil) return false;
-        NSRect frame = NSMakeRect(x, y, width > 0 ? width : 1, height > 0 ? height : 1);
-        [state->window setFrame:frame display:YES];
-        phantty_macos_sync_layer(state);
-        return true;
-    }
+    PhanttyMacWindowState *state = phantty_macos_state(handle);
+    if (state == NULL || state->window == nil) return false;
+    phantty_macos_run_on_main(^{
+        @autoreleasepool {
+            NSRect frame = NSMakeRect(x, y, width > 0 ? width : 1, height > 0 ? height : 1);
+            [state->window setFrame:frame display:YES];
+            phantty_macos_sync_layer(state);
+        }
+    });
+    return true;
 }
 
 bool phantty_macos_window_nearest_monitor_frame(void *handle, PhanttyMacRect *out) {

--- a/src/platform/window_unsupported.zig
+++ b/src/platform/window_unsupported.zig
@@ -156,3 +156,17 @@ pub fn nearestMonitorWorkArea(hwnd: NativeHandle) ?Rect {
     _ = hwnd;
     return null;
 }
+
+pub fn consumeReopenRequest() bool {
+    return false;
+}
+
+pub fn consumeQuitRequest() bool {
+    return false;
+}
+
+pub fn requestQuit() void {}
+
+pub fn pumpAppEvents(timeout_seconds: f64) void {
+    _ = timeout_seconds;
+}

--- a/src/platform/window_windows.zig
+++ b/src/platform/window_windows.zig
@@ -201,6 +201,20 @@ pub fn nearestMonitorWorkArea(hwnd: NativeHandle) ?Rect {
     };
 }
 
+pub fn consumeReopenRequest() bool {
+    return false;
+}
+
+pub fn consumeQuitRequest() bool {
+    return false;
+}
+
+pub fn requestQuit() void {}
+
+pub fn pumpAppEvents(timeout_seconds: f64) void {
+    _ = timeout_seconds;
+}
+
 const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 const sw_hide: i32 = 0;

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -32,6 +32,21 @@ pub const TITLEBAR_TOGGLE_W: f32 = 46;
 // these in-titlebar buttons, so they collapse to zero width and are not drawn.
 pub const TITLEBAR_CONFIG_W: f32 = if (builtin.os.tag == .macos) 0 else 46;
 pub const TITLEBAR_HELP_W: f32 = if (builtin.os.tag == .macos) 0 else 46;
+// macOS draws the close / minimize / zoom (red / yellow / green) controls over
+// the left edge of the titlebar via AppKit when NSWindowStyleMaskFullSizeContentView
+// is set. Reserve a strip in *framebuffer pixels* so phantty's own toggle and
+// tab title don't sit underneath them. AppKit positions the traffic lights in
+// LOGICAL pixels (~80 across), whereas phantty renders/hit-tests in framebuffer
+// pixels — on a 2x Retina display 80 logical = 160 fb, so we must scale by the
+// current DPI ratio. Non-macOS platforms reserve nothing.
+const TITLEBAR_LEFT_RESERVED_LOGICAL: f32 = 80;
+
+pub fn titlebarLeftReserved() f32 {
+    if (builtin.os.tag != .macos) return 0;
+    const dpi: f32 = @floatFromInt(font.g_dpi);
+    const scale = if (dpi > 0) dpi / 96.0 else 1.0;
+    return @round(TITLEBAR_LEFT_RESERVED_LOGICAL * scale);
+}
 pub threadlocal var g_sidebar_width: f32 = SIDEBAR_WIDTH;
 
 pub fn sidebarWidth() f32 {
@@ -406,18 +421,19 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         gl_init.renderQuad(0, tb_top, window_width, titlebar_h, top_bg);
         gl_init.renderQuad(0, tb_top, window_width, 1, border_color_simple);
 
-        const toggle_hovered = mouseInTitlebarRange(titlebar_h, 0, TITLEBAR_TOGGLE_W);
+        const toggle_x = titlebarLeftReserved();
+        const toggle_hovered = mouseInTitlebarRange(titlebar_h, toggle_x, toggle_x + TITLEBAR_TOGGLE_W);
         if (toggle_hovered) {
-            gl_init.renderQuad(0, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, hover_bg);
+            gl_init.renderQuad(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, hover_bg);
         }
         if (font.icon_face != null) {
             if (font.loadIconGlyph(0xE700)) |ch| {
-                renderIconGlyph(ch, 0, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color, 1.0);
+                renderIconGlyph(ch, toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color, 1.0);
             } else {
-                renderFallbackMenuIcon(0, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
+                renderFallbackMenuIcon(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
             }
         } else {
-            renderFallbackMenuIcon(0, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
+            renderFallbackMenuIcon(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
         }
 
         const top_caption_btn_w = window_backend.caption_button_visual_style.width;
@@ -463,7 +479,8 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         if (tab.activeTab()) |active_tab| {
             const title = active_tab.getTitle();
             const text_y = tb_top + (titlebar_h - font.g_titlebar_cell_height) / 2;
-            _ = renderTextLimited(title, TITLEBAR_TOGGLE_W + 10, text_y, blend(bg, fg, 0.90), help_x - TITLEBAR_TOGGLE_W - 22);
+            const text_x = titlebarLeftReserved() + TITLEBAR_TOGGLE_W + 10;
+            _ = renderTextLimited(title, text_x, text_y, blend(bg, fg, 0.90), help_x - text_x - 12);
         }
 
         renderCaptionButton(top_caption_start, tb_top, top_caption_btn_w, top_btn_h, .minimize, top_hovered == .minimize);


### PR DESCRIPTION
## Summary

A polish/bugfix pass on the macOS port, surfaced by real on-device use. Three independent problems plus follow-up bookkeeping. Every change is gated behind `builtin.os.tag == .macos`; the Windows build is untouched and both `aarch64-macos` and `x86_64-windows-gnu` compile clean.

## What changed

### 1. Window lifecycle — Terminal.app / VS Code semantics
- New `PhanttyAppDelegate`: the red close button **no longer terminates the process**. Closing the last window keeps the app in the Dock; clicking the Dock icon reopens a window; **cmd+Q** is the real quit.
- `App.run()` runs the first window on the main thread, then idles in `macIdleUntilQuit()` pumping NSApp events — spawning a fresh window on Dock reopen, returning on quit.

### 2. Crash fixes
- **Main-thread marshalling (the big one).** Each `AppWindow` runs its event/render loop on a spawned thread but called NSWindow APIs directly, tripping AppKit's *"Must only be used from the main thread"* assertion (crashed in `setContentSize` → `-[NSWMWindowCoordinator performTransactionUsingBlock:]` on resize/reopen). All NSWindow mutators now go through `phantty_macos_run_on_main()`. `window_poll` only pumps `[NSApp nextEvent]` on the main thread; `pump_events` blocks with a timeout so the GCD main queue drains (otherwise worker `dispatch_sync` deadlocks against a spin-sleep).
- **Re-entrant double-free.** Dock reopen used to reuse the main thread, resurrecting "single-run" thread-local state. Reopen now spawns on a worker thread (same path as new-window) so thread-locals start fresh, and the shutdown defer resets `font.icon_cache` / `font.g_titlebar_cache` to `.empty` after `deinit` — a re-entrant `clearTitlebarFont` was double-freeing dangling hash-map metadata (`incorrectAlignment` panic).

### 3. Unified title bar
- NSWindow gains `FullSizeContentView` + `titlebarAppearsTransparent` + hidden title, so the app-drawn bar extends under the traffic lights (Codex / VS Code style — no more empty native strip).
- `titlebar.zig` reserves a **DPI-scaled** left strip (`titlebarLeftReserved()`) so the sidebar-toggle hamburger and tab title sit to the right of the red/yellow/green controls; `input.zig` hit-tests shift to match.

### 4. CJK fallback (中文 tofu fix)
- macOS 26 moved PingFang into a reserved `.ttc` that FreeType cannot open (`FT_New_Face` → err 144), and CoreText's default cascade *prefers* it → every CJK glyph rendered as a blank box.
- `preferredFallbackFamilies` now lists FreeType-loadable public system fonts on macOS (`Hiragino Sans GB`, `Songti SC`, `Heiti SC`, …), and `findOrLoadFallbackFace` validates each candidate by **actually opening it with FreeType** (`openFallbackFreetypeFace`) before use, so an unloadable reserved font no longer aborts the lookup.

### 5. Docs
- `TODO.md`: documents the above as **Phase D8** and refreshes the macOS UI status table.

## Reviewer notes

- **No on-device automated proof yet** — verified by `zig build -Dtarget=aarch64-macos` + `zig build` (Windows) compiling clean and manual on-device testing of close/reopen/resize/cmd+Q and CJK rendering. The renderer is GUI, so behavior was confirmed by hand, not unit tests.
- Coordinate system: phantty renders/hit-tests in **framebuffer pixels** while AppKit lays out traffic lights in **logical pixels** — hence the `g_dpi/96` scale in `titlebarLeftReserved()`.
- The branch is one commit behind `main`; no conflicts expected.

## Known follow-ups (tracked in TODO.md, not in this PR)

- **D8.3a** Event-buffer cross-thread safety: the per-window ring buffers are now produced on the main thread and consumed on the worker thread — add a lock before relying on this under heavy input.
- **D8.4a** Draggable titlebar region (window is currently only draggable via the traffic-light gaps).
- **D8.6** Window-position persistence is wrong on macOS (NSRect bottom-left origin stored into a top-left `top` field) — pre-existing, not addressed here.

## Test plan

- [x] Launch → click red **x** → process stays in the Dock (menu bar still shows Phantty)
- [x] Click the Dock icon → a new window opens **with correct fonts** (no tofu, no crash)
- [x] Resize a window by dragging an edge → no crash
- [x] Open two windows, close one → the other survives
- [x] **cmd+Q** → the whole app quits
- [x] Type / display Chinese (e.g. `echo 你好`, AI chat) → renders, not boxes
- [x] Hamburger toggle sits right of the traffic lights and toggles the sidebar
- [x] Double-click bare titlebar zooms; double-clicking the traffic-light strip does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)