### PR TITLE
fix(macos): color emoji rendering + Cmd-based shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ keybind = alt+f10=toggle_command_palette
 keybind = global:ctrl+backquote=toggle_quake
 ```
 
-Use `keybind = clear` before custom bindings if you want to remove all defaults and rebuild the table from scratch. To confirm the running desktop version, open the command center with the configured command-center shortcut (default `Ctrl+Shift+P`), type `version`, and press Enter.
+Use `keybind = clear` before custom bindings if you want to remove all defaults and rebuild the table from scratch. To confirm the running desktop version, open the command center with the configured command-center shortcut (default `Ctrl+Shift+P`, or `Cmd+Shift+P` on macOS), type `version`, and press Enter.
 
+> **On macOS**, application shortcuts use **Cmd** in place of Ctrl (e.g. `Cmd+Shift+P` opens the command center) and **Option** in place of Alt. Two bindings keep Ctrl to avoid colliding with macOS system shortcuts: **Ctrl+`** (Quake drop-down — `Cmd+`` is the system window cycler) and **Ctrl+Tab** / **Ctrl+Shift+Tab** (tab switching — `Cmd+Tab` is the system app switcher). The table below lists the Windows/Linux (Ctrl) bindings; read "Ctrl" as "Cmd" on macOS except for those two.
 
 | Shortcut                                                                       | Action                                                                             |
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |

--- a/build.zig
+++ b/build.zig
@@ -565,6 +565,13 @@ pub fn build(b: *std.Build) void {
     const fast_test_options = b.addOptions();
     fast_test_options.addOption([]const u8, "app_version", app_version);
     fast_test_mod.addOptions("build_options", fast_test_options);
+    // Mirror the app's doc embeds: a fast-test module (ai_chat_protocol) pulls in
+    // phantty_docs, whose @embedFile names must resolve here too.
+    fast_test_mod.addAnonymousImport("phantty_doc_faq", .{ .root_source_file = b.path("docs/faq.md") });
+    fast_test_mod.addAnonymousImport("phantty_doc_configuration", .{ .root_source_file = b.path("docs/configuration.md") });
+    fast_test_mod.addAnonymousImport("phantty_doc_ai_agent", .{ .root_source_file = b.path("docs/ai-agent.md") });
+    fast_test_mod.addAnonymousImport("phantty_doc_file_explorer", .{ .root_source_file = b.path("docs/file-explorer.md") });
+    fast_test_mod.addAnonymousImport("phantty_doc_media", .{ .root_source_file = b.path("docs/media.md") });
     const fast_tests = b.addTest(.{
         .name = "phantty-fast-test",
         .root_module = fast_test_mod,

--- a/src/config.zig
+++ b/src/config.zig
@@ -18,6 +18,7 @@
 const Config = @This();
 
 const std = @import("std");
+const builtin = @import("builtin");
 const ai_chat = @import("ai_chat.zig");
 const keybind = @import("keybind.zig");
 const link_open = @import("link_open.zig");
@@ -1783,16 +1784,18 @@ test "config: inline comments after values are ignored" {
 test "config: keybind directives override default action bindings" {
     const allocator = std.testing.allocator;
     var cfg: Config = .{};
+    const is_macos = builtin.target.os.tag == .macos;
 
+    // Command palette default is Cmd+Shift+P on macOS, Ctrl+Shift+P elsewhere.
     try std.testing.expectEqual(keybind.Action.toggle_command_palette, cfg.keybinds.lookupApp(.{
-        .mods = .{ .ctrl = true, .shift = true },
+        .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }).?);
 
     cfg.applyKeyValue(allocator, "keybind", "alt+f10=toggle_command_palette", ".");
 
     try std.testing.expect(cfg.keybinds.lookupApp(.{
-        .mods = .{ .ctrl = true, .shift = true },
+        .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }) == null);
     try std.testing.expectEqual(keybind.Action.toggle_command_palette, cfg.keybinds.lookupApp(.{

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -1260,15 +1260,26 @@ pub fn findOrLoadFallbackFace(codepoint: u32, alloc: std.mem.Allocator) ?freetyp
         return null;
     };
 
-    if (glyph_face) |primary_face| {
+    if (ft_face.hasColor() and ft_face.hasFixedSizes()) {
+        // Color bitmap fonts (Apple Color Emoji's sbix strikes, Noto CBDT,
+        // etc.): pin a fixed strike explicitly. On these faces FT_Set_Char_Size
+        // can *succeed* without selecting a strike (e.g. Apple Color Emoji at
+        // Retina DPI), leaving the face in scalable mode — FT_LOAD_COLOR then
+        // renders a tiny gray outline instead of the color bitmap, so the cell
+        // appears blank. We must also skip the metric rescale below: its
+        // FT_Set_Char_Size would unpin the strike again. The renderer scales
+        // the BGRA bitmap down to cell height at draw time.
+        selectClosestFixedStrike(ft_face, g_font_size) catch {
+            ft_face.deinit();
+            return null;
+        };
+    } else if (glyph_face) |primary_face| {
         const scale = fallbackScaleFactor(primary_face, ft_face, codepoint);
         if (@abs(scale - 1.0) > 0.01) {
             const scaled_size = @max(8.0, @round(@as(f64, @floatFromInt(g_font_size)) * scale));
             ft_face.setCharSize(0, @intFromFloat(scaled_size * 64.0), @intCast(g_dpi), @intCast(g_dpi)) catch {
-                // Bitmap-only fallbacks (Apple Color Emoji etc.) can't be
-                // rescaled here; the strike already chosen in
-                // setFacePointSize stays in effect. Renderer scales the
-                // BGRA bitmap down to cell height at draw time.
+                // Non-color bitmap-only fallbacks can't be rescaled here; the
+                // strike already chosen in setFacePointSize stays in effect.
                 if (!ft_face.hasFixedSizes()) {
                     ft_face.deinit();
                     return null;

--- a/src/input.zig
+++ b/src/input.zig
@@ -1063,17 +1063,19 @@ fn handleKey(ev: platform_input.KeyEvent) void {
         return;
     }
     if (AppWindow.activeAiChat()) |chat| {
-        if (ev.ctrl and !ev.alt and ev.key_code == 0x41) { // Ctrl+A
+        // Accept Cmd (super, macOS) or Ctrl (Windows) for chat editing keys.
+        const mod = ev.ctrl or ev.super;
+        if (mod and !ev.alt and ev.key_code == 0x41) { // select all
             chat.selectAll();
             AppWindow.g_force_rebuild = true;
             AppWindow.g_cells_valid = false;
             return;
         }
-        if (ev.ctrl and !ev.alt and ev.key_code == 0x43) { // Ctrl+C / Ctrl+Shift+C
+        if (mod and !ev.alt and ev.key_code == 0x43) { // copy
             copyAiChatToClipboard(chat);
             return;
         }
-        if (ev.ctrl and !ev.alt and ev.key_code == 0x58) { // Ctrl+X (cut input)
+        if (mod and !ev.alt and ev.key_code == 0x58) { // cut input
             copyAiChatCutToClipboard(chat);
             return;
         }

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -119,16 +119,26 @@ pub const Set = struct {
             set.len += 1;
         }
         if (builtin.target.os.tag == .macos) {
-            // On macOS the conventional clipboard shortcuts use Cmd (the
-            // `win`/super modifier) rather than Ctrl, which in a terminal is
-            // reserved for control sequences (Ctrl+C = SIGINT, Ctrl+V = literal
-            // next key). Migrate each Ctrl-based default to its Cmd equivalent
-            // and also add a bare Cmd+C alongside the shifted form so both the
-            // macOS convention (Cmd+C) and the historic Ctrl+Shift+C muscle
-            // memory work for plain copy.
-            set.replaceTrigger(.copy, .{ .mods = .{ .win = true, .shift = true }, .key_code = 'C' });
-            set.replaceTrigger(.paste, .{ .mods = .{ .win = true }, .key_code = 'V' });
-            set.replaceTrigger(.paste_image, .{ .mods = .{ .win = true, .shift = true }, .key_code = 'V' });
+            // On macOS, application shortcuts use Cmd (the `win`/super modifier)
+            // instead of Ctrl: Ctrl is reserved for terminal control sequences
+            // (Ctrl+C = SIGINT, Ctrl+V = literal-next) and mac users expect Cmd.
+            // Remap every Ctrl-based default to its Cmd equivalent, except two
+            // that would collide with the system:
+            //   - the global Quake hotkey (Cmd+` is the macOS "cycle windows" key)
+            //   - tab switching on Tab (Cmd+Tab / Cmd+Shift+Tab are the system
+            //     app switcher)
+            // which keep Ctrl. Alt/Option-based defaults are already mac-native
+            // and untouched.
+            for (set.items[0..set.len]) |*b| {
+                if (b.global) continue;
+                if (b.trigger.key_code == Key.tab) continue;
+                if (b.trigger.mods.ctrl) {
+                    b.trigger.mods.ctrl = false;
+                    b.trigger.mods.win = true;
+                }
+            }
+            // Plain Cmd+C alongside Cmd+Shift+C, matching the macOS copy
+            // convention (Cmd+Shift+C still works as the historic muscle memory).
             set.appendIfRoom(.{ .trigger = .{ .mods = .{ .win = true }, .key_code = 'C' }, .action = .copy });
         }
         return set;
@@ -265,8 +275,8 @@ pub fn formatTrigger(trigger: Trigger, buf: []u8) ![]const u8 {
 
     if (trigger.mods.ctrl) try writer.writeAll("Ctrl+");
     if (trigger.mods.shift) try writer.writeAll("Shift+");
-    if (trigger.mods.alt) try writer.writeAll("Alt+");
-    if (trigger.mods.win) try writer.writeAll("Win+");
+    if (trigger.mods.alt) try writer.writeAll(if (builtin.target.os.tag == .macos) "Option+" else "Alt+");
+    if (trigger.mods.win) try writer.writeAll(if (builtin.target.os.tag == .macos) "Cmd+" else "Win+");
     try writeKeyLabel(writer, trigger.key_code);
 
     return stream.getWritten();
@@ -435,24 +445,30 @@ test "keybind parses ghostty-style global trigger and action" {
 
 test "keybind defaults include global quake and command palette" {
     const set = Set.defaults();
+    const is_macos = builtin.target.os.tag == .macos;
 
+    // Quake stays Ctrl+` on every platform (global; Cmd+` is the macOS window cycler).
     try std.testing.expectEqual(Action.toggle_quake, set.lookupGlobal(.{
         .mods = .{ .ctrl = true },
         .key_code = Key.backquote,
     }).?);
+    // Command palette migrates Ctrl→Cmd (win) on macOS; Ctrl elsewhere.
     try std.testing.expectEqual(Action.toggle_command_palette, set.lookupApp(.{
-        .mods = .{ .ctrl = true, .shift = true },
+        .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }).?);
 }
 
 test "keybind overriding an action removes its old default trigger" {
     var set = Set.defaults();
+    const is_macos = builtin.target.os.tag == .macos;
 
     try set.apply("alt+f10=toggle_command_palette");
 
+    // The original default trigger (Cmd+Shift+P on macOS, Ctrl+Shift+P elsewhere)
+    // must be gone after the override.
     try std.testing.expect(set.lookupApp(.{
-        .mods = .{ .ctrl = true, .shift = true },
+        .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }) == null);
     try std.testing.expectEqual(Action.toggle_command_palette, set.lookupApp(.{
@@ -463,15 +479,19 @@ test "keybind overriding an action removes its old default trigger" {
 
 test "keybind overriding a trigger removes the old action binding" {
     var set = Set.defaults();
+    const is_macos = builtin.target.os.tag == .macos;
 
     try set.apply("ctrl+shift+p=new_session");
 
+    // The explicit user binding uses Ctrl on every platform.
     try std.testing.expectEqual(Action.new_session, set.lookupApp(.{
         .mods = .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }).?);
+    // new_session's original default (Cmd+Shift+T on macOS, Ctrl+Shift+T else)
+    // must be gone now that new_session was rebound.
     try std.testing.expect(set.lookupApp(.{
-        .mods = .{ .ctrl = true, .shift = true },
+        .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'T',
     }) == null);
 }
@@ -488,6 +508,7 @@ test "keybind clear removes defaults before adding custom bindings" {
 
 test "keybind formats display labels" {
     var buf: [64]u8 = undefined;
+    const is_macos = builtin.target.os.tag == .macos;
 
     try std.testing.expectEqualStrings(
         "Ctrl+Backquote",
@@ -497,9 +518,15 @@ test "keybind formats display labels" {
         "Ctrl++",
         try formatTrigger(.{ .mods = .{ .ctrl = true }, .key_code = Key.plus }, &buf),
     );
+    // Alt renders as Option on macOS, Alt elsewhere.
     try std.testing.expectEqualStrings(
-        "Alt+KeyCode 0xAB",
+        if (is_macos) "Option+KeyCode 0xAB" else "Alt+KeyCode 0xAB",
         try formatTrigger(.{ .mods = .{ .alt = true }, .key_code = 0xAB }, &buf),
+    );
+    // The win/super modifier renders as Cmd on macOS, Win elsewhere.
+    try std.testing.expectEqualStrings(
+        if (is_macos) "Cmd+P" else "Win+P",
+        try formatTrigger(.{ .mods = .{ .win = true }, .key_code = 'P' }, &buf),
     );
 }
 

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -1,6 +1,7 @@
 //! Startup keyboard shortcuts overlay.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const AppWindow = @import("../../AppWindow.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
@@ -24,6 +25,10 @@ const StartupShortcutKind = enum {
 
 const StartupShortcut = struct {
     keys: []const u8,
+    // macOS-specific literal text (Cmd instead of Ctrl). Only used for `.literal`
+    // entries whose keys were migrated to Cmd; `.action`-family entries derive
+    // their text from the live keybind via formatTrigger and ignore this.
+    keys_macos: ?[]const u8 = null,
     kind: StartupShortcutKind = .literal,
     first: ?keybind.Action = null,
     second: ?keybind.Action = null,
@@ -48,9 +53,9 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+Shift+W", .kind = .action, .first = .close_panel_or_tab, .action = "Close panel / tab; confirm last" },
     .{ .keys = "Ctrl+Shift+C / Ctrl+V", .kind = .pair, .first = .copy, .second = .paste, .action = "Copy / paste text" },
     .{ .keys = "Shift-click text", .action = "Select from anchor" },
-    .{ .keys = "Drag in AI / Ctrl+C", .action = "Copy answer selection" },
+    .{ .keys = "Drag in AI / Ctrl+C", .keys_macos = "Drag in AI / Cmd+C", .action = "Copy answer selection" },
     .{ .keys = "Shift-drag in AI", .action = "Copy answer selection" },
-    .{ .keys = "Ctrl+A / Ctrl+C in AI", .action = "Select / copy chat" },
+    .{ .keys = "Ctrl+A / Ctrl+C in AI", .keys_macos = "Cmd+A / Cmd+C in AI", .action = "Select / copy chat" },
     .{ .keys = "Right-click selection", .action = "Copy selection" },
     .{ .keys = "Ctrl+Shift+V", .kind = .action, .first = .paste_image, .action = "Paste image" },
     .{ .keys = "Ctrl+,", .kind = .action, .first = .open_config, .action = "Open config" },
@@ -135,7 +140,12 @@ fn writeActionShortcut(writer: anytype, action: keybind.Action) !bool {
 }
 
 fn startupShortcutKeys(entry: StartupShortcut, buf: []u8) []const u8 {
-    if (entry.kind == .literal) return entry.keys;
+    if (entry.kind == .literal) {
+        if (builtin.target.os.tag == .macos) {
+            if (entry.keys_macos) |m| return m;
+        }
+        return entry.keys;
+    }
 
     var stream = std.io.fixedBufferStream(buf);
     const writer = stream.writer();


### PR DESCRIPTION
## Summary

Two self-contained macOS improvements from one session:

- **Color emoji now render** (`src/font/manager.zig`). Apple Color Emoji / Noto CBDT glyphs (e.g. starship's 🥟 bun and 🐍 python prompt icons) previously rendered as blank cells. `findOrLoadFallbackFace` assumed `FT_Set_Char_Size` always fails on bitmap-only faces and only then picked a strike — but on Apple Color Emoji that call can *succeed* (leaving the face scalable), or the metric rescale re-runs it and unpins the strike, so `FT_LOAD_COLOR` produced a gray outline instead of the BGRA bitmap. Fix: for `hasColor() && hasFixedSizes()` faces, force `selectClosestFixedStrike` and skip the rescale that would unpin it. Scalable COLR emoji (Segoe UI Emoji on Windows) are unaffected.
- **macOS uses Cmd instead of Ctrl** for in-app shortcuts (`keybind.zig`, `input.zig`, `startup_shortcuts.zig`, `config.zig`, `README.md`): command center `Cmd+Shift+P`, AI-chat editing `Cmd+A/C/X`, and `Cmd+`/`Option+` modifier labels. System-conflicting bindings stay on Ctrl (`Ctrl+\``, `Ctrl+Tab`, `Ctrl+Shift+Tab`); Alt-class actions map to Option.
- **Build fix** (`build.zig`): give the `phantty_docs` `@embedFile` inputs to the fast-test module so `zig build test` compiles (it reaches `phantty_docs.zig` via `ai_chat_protocol`). Without this, `zig build test` fails on `unable to open 'phantty_doc_faq'`.

## Verification

Root cause for the emoji bug was isolated with a standalone FreeType probe (Apple Color Emoji renders BGRA only when a strike is pinned) and confirmed in-app: glyph load went from `GRAY 14×13` → `BGRA 32×32`, and the starship prompt visually renders full-color 🥟 / 🐍 where blanks used to be.

- [x] `zig build test` (fast) — exit 0
- [x] `zig build macos-app -Dtarget=aarch64-macos` — exit 0
- [x] `zig build -Dtarget=x86_64-windows` (cross-compile) — exit 0
- [x] On-device: color emoji render in the starship prompt; macOS shortcuts trigger on Cmd

## Note

`zig build test-full -Dtarget=aarch64-macos` is **red on `main` already** (pre-existing, unrelated to this PR): `test_main.zig`'s architecture guard forbids a bare `builtin.os.tag` in `AppWindow.zig`, and `AppWindow.zig:3740` has one. This PR touches neither file. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)