### PR TITLE
fix(macos): keep window-close confirmation policy behind window_backend

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -5,7 +5,6 @@
 //! will be converted to struct fields in a future refactoring step.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const ghostty_vt = @import("ghostty-vt");
 const freetype = @import("freetype");
 const Config = @import("config.zig");
@@ -3736,11 +3735,10 @@ fn runMainLoop(self: *AppWindow) !void {
         }
         if (window_backend.closeRequested(win)) {
             window_backend.clearCloseRequested(win);
-            if (builtin.os.tag == .macos) {
-                // macOS semantics: the red traffic-light closes this window
-                // immediately. Closing the last window does NOT terminate the
-                // process — App.run() keeps the NSApp alive so the Dock icon
-                // can re-open a window (handled by PhanttyAppDelegate).
+            if (!window_backend.closeRequestPromptsConfirmation()) {
+                // Backend tears the window down immediately with no in-app
+                // prompt; closing this window does not necessarily end the app
+                // session (the backend owns process lifecycle).
                 g_should_close = true;
                 running = false;
                 continue;

--- a/src/input.zig
+++ b/src/input.zig
@@ -170,7 +170,7 @@ test "input: WeChat QR panel consumes text input while visible" {
     try std.testing.expect(weixinQrPanelConsumesChar());
 }
 
-test "input: Ctrl+Shift+P toggles command center" {
+test "input: command palette shortcut toggles command center" {
     const previous_keybinds = AppWindow.g_keybinds;
     defer AppWindow.g_keybinds = previous_keybinds;
     defer overlays.commandPaletteClose();
@@ -178,14 +178,25 @@ test "input: Ctrl+Shift+P toggles command center" {
     AppWindow.g_keybinds = keybind.Set.defaults();
     overlays.commandPaletteClose();
 
-    handleKey(.{ .key_code = 'P', .ctrl = true, .shift = true, .alt = false });
+    // macOS migrates app shortcuts to Cmd (the super modifier); other platforms
+    // keep Ctrl. So the command palette is Cmd+Shift+P on macOS, Ctrl+Shift+P else.
+    const is_macos = builtin.os.tag == .macos;
+    const palette_key = platform_input.KeyEvent{
+        .key_code = 'P',
+        .ctrl = !is_macos,
+        .shift = true,
+        .alt = false,
+        .super = is_macos,
+    };
+
+    handleKey(palette_key);
     try std.testing.expect(overlays.commandPaletteVisible());
 
-    handleKey(.{ .key_code = 'P', .ctrl = true, .shift = true, .alt = false });
+    handleKey(palette_key);
     try std.testing.expect(!overlays.commandPaletteVisible());
 }
 
-test "macOS UI smoke: Ctrl+Shift+B toggles the tab sidebar" {
+test "macOS UI smoke: Cmd+Shift+B toggles the tab sidebar" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
 
     const previous_keybinds = AppWindow.g_keybinds;
@@ -196,10 +207,19 @@ test "macOS UI smoke: Ctrl+Shift+B toggles the tab sidebar" {
     AppWindow.g_keybinds = keybind.Set.defaults();
     tab.g_sidebar_visible = false;
 
-    handleKey(.{ .key_code = 'B', .ctrl = true, .shift = true, .alt = false });
+    // macOS uses Cmd (super) for the sidebar toggle, not Ctrl.
+    const sidebar_key = platform_input.KeyEvent{
+        .key_code = 'B',
+        .ctrl = false,
+        .shift = true,
+        .alt = false,
+        .super = true,
+    };
+
+    handleKey(sidebar_key);
     try std.testing.expect(tab.g_sidebar_visible);
 
-    handleKey(.{ .key_code = 'B', .ctrl = true, .shift = true, .alt = false });
+    handleKey(sidebar_key);
     try std.testing.expect(!tab.g_sidebar_visible);
 }
 

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -403,6 +403,20 @@ pub fn clearCloseRequested(window: *Window) void {
     window.close_requested = false;
 }
 
+fn closeRequestPromptsConfirmationForBackend(backend: Backend) bool {
+    // macOS follows traffic-light semantics: the red close button tears down
+    // this window immediately with no in-app prompt, and closing the last
+    // window does not end the process — App.run() keeps the NSApp alive so the
+    // Dock icon can re-open a window. Other backends confirm before closing.
+    return backend != .macos;
+}
+
+/// Whether an OS window-close request should open an in-app confirmation prompt
+/// before the window is torn down, instead of closing immediately.
+pub fn closeRequestPromptsConfirmation() bool {
+    return closeRequestPromptsConfirmationForBackend(comptime backendForOs(builtin.os.tag));
+}
+
 pub fn consumeDpiChanged(window: *Window) bool {
     const changed = window.dpi_changed;
     window.dpi_changed = false;
@@ -786,4 +800,10 @@ test "platform window backend selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
     try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
     try std.testing.expectEqual(Backend.macos, backendForOs(.macos));
+}
+
+test "platform window backend resolves close-request confirmation policy per backend" {
+    try std.testing.expect(closeRequestPromptsConfirmationForBackend(.windows));
+    try std.testing.expect(closeRequestPromptsConfirmationForBackend(.unsupported));
+    try std.testing.expect(!closeRequestPromptsConfirmationForBackend(.macos));
 }


### PR DESCRIPTION
## Summary
- `zig build test-full -Dtarget=aarch64-macos` failed to compile: the `test_main.zig` comptime guard forbids native OS switches in `AppWindow.zig`, but the main loop branched on `builtin.os.tag == .macos` to implement macOS red-traffic-light close semantics.
- Move that decision behind a platform-neutral `window_backend.closeRequestPromptsConfirmation()` (macOS closes the window immediately; other backends open the in-app confirmation prompt), drop the now-unused `builtin` import from `AppWindow.zig`, and add a backend-policy unit test. **macOS behavior is unchanged.**
- Fix two stale `input.zig` tests that still asserted `Ctrl+Shift+P` / `Ctrl+Shift+B` after commit 82e7a60 migrated macOS app shortcuts to Cmd. They now use the platform app modifier (Cmd/`super` on macOS, Ctrl elsewhere), matching the convention that commit established in `keybind.zig`.

## Test plan
- [x] `zig build test-full -Dtarget=aarch64-macos` exits 0 (verified via `; echo EXIT=$?`, no pipe)
- [x] `zig build test` (fast test) exits 0
- [x] `zig build macos-app -Dtarget=aarch64-macos` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)