### PR TITLE
fix(macos): land Metal render-state + AI-chat restore on main

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,13 @@ code only — not the `remote/` web console or packaged `plugins/`.
   regression-locks the decoupled feature files. A small documented residue of
   files still calls `gpu.glTable()` (the GL presentation layer + not-yet-extracted
   plumbing) — to be absorbed as the primitive set grows. → **Phase D** (Metal/Linux
-  backends) is now the gate. See guide §1.
+  backends) is now the gate. See guide §1. **D1.y render-correctness work done:
+  per-pane viewport/scissor (P0, fixes the split bug), blend-mode PSO variants
+  (P1), sampler filter/wrap (P2), and frame throughput (P3) all land + verify on
+  three platforms. The only D1.y item left — FBO render-target switching — is
+  DEFERRED into a separate "macOS custom-shader" feature, because its sole
+  consumer (post-process GLSL) needs a GLSL→MSL layer before an FBO is useful on
+  Metal. See D1.y.**
 - **Giant files conflate presentation + logic.** `ai_chat.zig` (248 KB),
   `input.zig` (3,462 ln), `AppWindow.zig` (3,742 ln), `overlays.zig` (171 KB).
   → **Phase B**.
@@ -309,6 +315,129 @@ services, and `.app` packaging. Ghostty reference: `src/renderer/metal/`,
       lists the symmetric set: text/glyph, instanced bg/fg cells, color-emoji,
       simple-textured, overlay). Native proof: `zig build test-metal` compiles
       every bundled MSL shader pair into `MTLRenderPipelineState`.
+
+**D1.y — Metal render-state application (split / scissor / blend) — INCOMPLETE**
+
+> **Found on-device (2026-05-28):** creating a split pane on macOS renders both
+> panes blank and draws the shell prompt over the title bar (the split *logic*
+> is fine — `Split created: ... tree nodes: 3`). Root cause: the Metal backend
+> **records render state into thread-locals but never applies it to the
+> `MTLRenderCommandEncoder`.** A single full-window surface accidentally hides
+> this (origin is `(0,0)`, nothing needs clipping, plain alpha blend is enough);
+> the moment a feature needs a sub-rectangle origin, a clip, or a non-alpha
+> blend, it breaks. So D1's "Metal GPU backend" is functionally complete only
+> for the full-window single-surface path. The state-application layer below is
+> the real gap.
+>
+> **Architecture note vs. Ghostty.** Ghostty renders each terminal surface into
+> its **own** `NSView` + `CAMetalLayer`; AppKit's split container lays the views
+> out, so each Metal renderer instance owns a drawable that *is* the pane — it
+> never needs per-pane viewport/scissor inside one drawable. Phantty instead
+> keeps **one window / one `CAMetalLayer` / one drawable** and renders every pane
+> in a loop with per-pane viewport + scissor (symmetric with its Windows OpenGL
+> path: `AppWindow.zig:3893-3947`). **Decision: keep Phantty's single-drawable
+> model and make Metal honor `setViewport:`/`setScissorRect:` per draw** (Option
+> A — symmetric with OpenGL, low risk, no AppKit/host rework). Option B (one
+> layer per surface, Ghostty-style) is a much larger host refactor and is *not*
+> chosen here.
+>
+> **Verified against Ghostty/cmux (2026-05-28).** Ghostty's Metal renderer is
+> one `IOSurfaceLayer` + one renderer instance **per surface**; its
+> `metal/RenderPass.zig` calls **neither** `setViewport` **nor**
+> `setScissorRect` — the drawable *is* the pane, so padding rides in the
+> projection/cell coordinates and clipping is unneeded. cmux is a Ghostty-based
+> macOS terminal (vertical tabs, splits, embedded browser, agent socket API) and
+> inherits this rendering model. Phantty's single-drawable choice is the
+> deliberate trade for sharing one render loop with Windows; the cost is that
+> Phantty **must** implement the per-draw `setViewport:`/`setScissorRect:` that
+> Ghostty sidesteps. That is standard Metal usage (an encoder's viewport and
+> scissor are mutable between draws), so **the architecture is sound — only the
+> application step is missing.** Keep Option A; revisit per-surface layers
+> (Option B) only if multi-split frame pacing on the single render thread ever
+> becomes a problem.
+
+- [x] **P0 — Apply viewport origin to the encoder (fixes split positioning).**
+      Done. `render_state.setViewport` now forwards to the C bridge
+      (`phantty_metal_set_viewport`); `phantty_metal_apply_viewport_scissor`
+      emits `[encoder setViewport:]` before every draw with the GL bottom-left →
+      Metal top-left flip (`originY = drawable_h - y - h`, drawable size captured
+      at frame begin). `metal/gl_init.zig:setProjection` no longer clobbers the
+      viewport to `(0,0)`; projection stays width/height-only (origin honored by
+      the encoder viewport, like OpenGL's `glViewport`). Proof: `zig build
+      test-metal` (new viewport/scissor assertion), `zig build test-full
+      -Dtarget=aarch64-macos`, `zig build -Dtarget=x86_64-windows-gnu` (no
+      regression). **On-device split visual check still pending.**
+- [x] **P0 — Apply scissor to the encoder (fixes clip overflow).** Done.
+      `setScissor`/`disableScissor`/`restoreScissor` forward to
+      `phantty_metal_set_scissor`; the apply helper emits
+      `[encoder setScissorRect:]` per draw — enabled → recorded box (y-flipped),
+      disabled → full drawable (Metal has no "scissor off"). The rect is
+      **clamped to the drawable** (an out-of-bounds `MTLScissorRect` raises and
+      kills the command buffer); the test-metal assertion feeds a deliberately
+      out-of-bounds box to lock the clamp. Unblocks
+      `markdown_preview_renderer.zig:610-614` and `ui_pipeline.zig:110-121`.
+- [x] **P1 — Blend modes as pipeline variants (fixes color-emoji / bg image).**
+      Done. `pipeline_create` now builds three `MTLRenderPipelineState` variants
+      per shader via `phantty_metal_make_pso` (alpha `(src_alpha,1-src_alpha)` /
+      premultiplied `(one,1-src_alpha)` / blending-disabled);
+      `phantty_metal_set_blend_enabled`/`phantty_metal_set_blend_mode` record the
+      state and `encode_draw` selects the matching PSO. `render_state.setBlendMode`/
+      `setBlendEnabled` now forward instead of no-op'ing, so `cell_renderer.zig:425`
+      (premultiplied color emoji) and `background_image.zig:215`
+      (`setBlendEnabled(false)` opaque wallpaper) behave like the OpenGL backend.
+      Proof: `zig build test-metal` (new blend-variant assertion). **On-device
+      visual check (emoji brightness, wallpaper) still pending.**
+      *Ghostty does this differently and more simply: `metal/Pipeline.zig` uses
+      **one** blend config everywhere — premultiplied alpha (`src=one`,
+      `dst=one_minus_source_alpha`; comment: "We always use premultiplied alpha
+      blending for now") — and every fragment shader emits premultiplied color.
+      That removes `setBlendMode` entirely and structurally avoids the
+      color-emoji double-multiply. **Long-term Phantty should consider converging
+      on this** (rewrite each MSL fragment shader to output premultiplied RGB, so
+      one PSO blend config serves all draws) instead of carrying alpha +
+      premultiplied PSO variants; short-term the variants are the lower-risk fix.*
+- [x] **P2 — Sampler filter/wrap state (fixes `nearest` blur).** Done. The four
+      texture-sampling MSL shaders now take `sampler s [[sampler(0)]]` instead of
+      a hard-coded `constexpr sampler`; `bridge.m` lazily builds an
+      `MTLSamplerState` per (filter, wrap) and `encode_draw` binds it with
+      `setFragmentSamplerState:` from the active texture's recorded filter/wrap;
+      `Texture.upload2D` now forwards `o.filter`. Default behavior is unchanged
+      (everything currently uses linear/clamp) but `.nearest` is now honored.
+      Proof: `zig build test-metal`, `zig build test-full -Dtarget=aarch64-macos`.
+      *Mirrors Ghostty's dedicated `metal/Sampler.zig` + `setFragmentSamplerState:`.*
+- [ ] **P2 — Framebuffer render-target switching — DEFERRED (needs a GLSL→MSL
+      path first; not a standalone task).** Evaluated 2026-05-28. The FBO itself
+      has a clean Metal equivalent — render-to-texture (end the current encoder,
+      open a new render pass whose color attachment is the offscreen `MTLTexture`,
+      restore on `unbind`); `metal/Framebuffer.zig` already holds the texture, only
+      `bind`/`unbind` need to switch the render pass. **But its only consumer is
+      `post_process.zig`, whose custom shaders are Shadertoy-style GLSL**
+      (`#version 330 core` + `mainImage`, wrapped in `buildPostFragmentSource`).
+      **Metal cannot compile GLSL** (it runs MSL), so even with the FBO wired up
+      the user's `custom-shader` would not run on macOS — the FBO would have no
+      working consumer. The real macOS work is a **GLSL→MSL translation layer**,
+      exactly what Ghostty does in `src/renderer/shadertoy.zig`: GLSL →SPIR-V
+      (glslang) →MSL (SPIRV-Cross), so one Shadertoy GLSL runs on every backend.
+      → Track this as a separate **"macOS custom-shader support"** feature (FBO
+      render-to-texture **plus** the glslang+SPIRV-Cross translation + the
+      Shadertoy uniform struct), not as part of D1.y's render-correctness scope.
+      `g_post_enabled` defaults off and `fbo.zig` is currently un-wired, so there
+      is no regression today.
+- [x] **P3 — Frame throughput.** Done. `phantty_metal_frame_end` no longer calls
+      `waitUntilCompleted` every frame (that serialized CPU and GPU with zero
+      overlap); GPU errors are now reported via `addCompletedHandler` and our own
+      command-buffer/drawable refs are released right after `commit` (Metal
+      retains them until the GPU finishes + the frame presents). Proof: `zig build
+      test-metal`, `zig build test-full -Dtarget=aarch64-macos`. **On-device
+      frame-pacing/no-flicker check still pending.** Per-upload fresh `MTLBuffer`
+      allocation (intentional, `bridge.m` comment) can later become a ring buffer
+      if profiling shows it matters.
+
+> **Native proof for D1.y:** extend `zig build test-metal` with viewport-origin,
+> scissor-rect, and blend-variant assertions; keep `zig build test-full
+> -Dtarget=aarch64-macos` green; and verify on-device that a split positions both
+> panes correctly with no clip overflow, color emoji render at full brightness,
+> and the markdown preview / file explorer clip to their regions.
 
 **D2 — AppKit host** (`window_backend_macos.zig` + `window_macos.zig`)
 - [x] `NSApplication`/`NSWindow` + the AppKit run loop (AppKit owns the event

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -94,6 +94,10 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
 
     try ensureGlobalAgentHistoryStore(allocator);
     tab.g_ai_history_change_hook = saveAiHistoryChangeEvent;
+    // Let session restore reopen AI Chat tabs from their persisted history
+    // session id. AppWindow owns the agent history store, so it supplies the
+    // hook tab.zig calls from restoreTab (which only knows the session id).
+    tab.g_ai_restore_hook = reopenAiChatTabFromHistorySessionId;
 
     // Apply config from App to globals
     g_theme = app.theme;

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -102,6 +102,11 @@ pub threadlocal var g_scrollback_limit: u32 = 10_000_000;
 pub threadlocal var g_remote_client: ?*remote_client.Client = null;
 pub threadlocal var g_ai_history_change_hook: ?ai_chat.HistoryChangeHook = null;
 
+// Restore hook: rebuild an AI Chat tab from its persisted agent-history session
+// id. Registered by AppWindow (which owns the history store), so tab.zig stays
+// free of that dependency. Returns true if the tab was reopened.
+pub threadlocal var g_ai_restore_hook: ?*const fn (session_id: []const u8) bool = null;
+
 // Forced title from config (overrides all tab titles)
 pub threadlocal var g_forced_title: ?[]const u8 = null;
 
@@ -933,6 +938,20 @@ pub fn handleRenameChar(codepoint: u21) void {
 /// is the caller's responsibility to free (via Session.deinit pattern, or
 /// shared across all tabs in a session).
 pub fn snapshotTab(arena: std.mem.Allocator, t: *const TabState) !session_persist.TabSnap {
+    // AI Chat tabs persist only their history session id; the conversation
+    // itself lives in the agent history store. `tree` is a required field, so
+    // emit an ignored placeholder leaf — restoreTab routes by ai_session_id.
+    if (t.kind == .ai_chat) {
+        const session = t.ai_chat_session orelse return error.NoAiSession;
+        const sid = try arena.dupe(u8, session.sessionId());
+        return session_persist.TabSnap{
+            .title_override = null,
+            .focused_leaf = 0,
+            .zoomed_leaf = null,
+            .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+            .ai_session_id = sid,
+        };
+    }
     if (t.kind != .terminal) return error.NotTerminalTab;
     if (t.tree.isEmpty()) return error.EmptyTree;
 
@@ -1149,6 +1168,15 @@ pub fn restoreTab(
 ) bool {
     if (g_tab_count >= MAX_TABS) return false;
 
+    // AI Chat tab: rebuild from its persisted history session via the hook
+    // AppWindow installed (it owns the history store). The placeholder `tree` in
+    // the snapshot is ignored. If the hook isn't installed or the session is
+    // gone from history, skip this tab rather than restoring a wrong terminal.
+    if (snap.ai_session_id) |sid| {
+        const hook = g_ai_restore_hook orelse return false;
+        return hook(sid);
+    }
+
     // Populate the thread-local restore context so surfaceFromSnap can read
     // these values without changing the SplitTree.fromSnapshot factory ABI.
     g_restore_cols = cols;
@@ -1311,6 +1339,48 @@ fn makeTestTabState() TabState {
         .focused = .root,
         .ai_chat_session = null,
     };
+}
+
+test "tab: restoreTab routes ai_session_id through the restore hook" {
+    resetTestTabGlobals();
+    const previous_hook = g_ai_restore_hook;
+    defer g_ai_restore_hook = previous_hook;
+
+    const Captured = struct {
+        var session_id: []const u8 = "";
+        var called: bool = false;
+        fn hook(session_id_in: []const u8) bool {
+            session_id = session_id_in;
+            called = true;
+            return true;
+        }
+    };
+    Captured.called = false;
+    Captured.session_id = "";
+    g_ai_restore_hook = Captured.hook;
+
+    const snap = session_persist.TabSnap{
+        .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+        .ai_session_id = "sess-xyz",
+    };
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(Captured.called);
+    try std.testing.expectEqualStrings("sess-xyz", Captured.session_id);
+    // The hook owns tab creation; restoreTab must not also build a terminal tab.
+    try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+}
+
+test "tab: restoreTab skips an ai tab when no restore hook is installed" {
+    resetTestTabGlobals();
+    const previous_hook = g_ai_restore_hook;
+    defer g_ai_restore_hook = previous_hook;
+    g_ai_restore_hook = null;
+
+    const snap = session_persist.TabSnap{
+        .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+        .ai_session_id = "sess-xyz",
+    };
+    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
 }
 
 test "tab: reorder moves active tab forward" {

--- a/src/renderer/gpu/metal/Texture.zig
+++ b/src/renderer/gpu/metal/Texture.zig
@@ -9,7 +9,7 @@ const Texture = @This();
 handle: c.GLuint,
 
 extern fn phantty_metal_texture_create() c.GLuint;
-extern fn phantty_metal_texture_upload_2d(handle: c.GLuint, device: ?*anyopaque, width: c_int, height: c_int, data: ?*const anyopaque, format: c.GLenum, data_type: c.GLenum, wrap: c_uint, error_buf: [*]u8, error_buf_len: usize) bool;
+extern fn phantty_metal_texture_upload_2d(handle: c.GLuint, device: ?*anyopaque, width: c_int, height: c_int, data: ?*const anyopaque, format: c.GLenum, data_type: c.GLenum, wrap: c_uint, filter: c_uint, error_buf: [*]u8, error_buf_len: usize) bool;
 extern fn phantty_metal_texture_sub_image_2d(handle: c.GLuint, x: c_int, y: c_int, width: c_int, height: c_int, data: ?*const anyopaque, format: c.GLenum, data_type: c.GLenum, error_buf: [*]u8, error_buf_len: usize) bool;
 extern fn phantty_metal_texture_set_wrap(handle: c.GLuint, wrap: c_uint) void;
 extern fn phantty_metal_texture_bind(handle: c.GLuint, unit: c_uint) void;
@@ -46,7 +46,6 @@ pub fn create() Texture {
 /// Bind + upload (or allocate, if `data` is null) a 2D image.
 pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopaque, o: Upload) void {
     _ = o.internal_format;
-    _ = o.filter;
     _ = o.unpack_alignment;
     _ = runBool("Metal texture upload2D failed", phantty_metal_texture_upload_2d(
         self.handle,
@@ -57,6 +56,7 @@ pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopa
         o.format,
         o.data_type,
         wrapInt(o.wrap),
+        filterInt(o.filter),
         &scratch_error,
         scratch_error.len,
     ));
@@ -106,6 +106,13 @@ fn wrapInt(wrap: Wrap) c_uint {
     return switch (wrap) {
         .clamp_to_edge => 0,
         .repeat => 1,
+    };
+}
+
+fn filterInt(filter: Filter) c_uint {
+    return switch (filter) {
+        .nearest => 0,
+        .linear => 1,
     };
 }
 

--- a/src/renderer/gpu/metal/bridge.m
+++ b/src/renderer/gpu/metal/bridge.m
@@ -44,7 +44,8 @@ static _Thread_local unsigned int phantty_metal_next_buffer = 1;
 
 typedef struct PhanttyMetalTextureSlot {
     id<MTLTexture> texture;
-    unsigned int wrap;
+    unsigned int wrap;   // 0 = clamp-to-edge, 1 = repeat
+    unsigned int filter; // 0 = nearest, 1 = linear
     size_t width;
     size_t height;
     size_t bpp;
@@ -54,7 +55,12 @@ static _Thread_local PhanttyMetalTextureSlot phantty_metal_textures[PHANTTY_META
 static _Thread_local unsigned int phantty_metal_next_texture = 1;
 
 typedef struct PhanttyMetalPipelineSlot {
-    id<MTLRenderPipelineState> pipeline;
+    // Metal bakes blend into the pipeline state, so each logical pipeline keeps
+    // one PSO per blend mode and the encoder picks by the current blend state.
+    // `pipeline` is the straight-alpha default (the `!= nil` validity check).
+    id<MTLRenderPipelineState> pipeline;          // alpha: (src_alpha, 1-src_alpha)
+    id<MTLRenderPipelineState> pipeline_premult;  // premultiplied: (one, 1-src_alpha)
+    id<MTLRenderPipelineState> pipeline_opaque;   // blending disabled
     unsigned int vao;
     struct {
         float projection[16];
@@ -68,6 +74,116 @@ typedef struct PhanttyMetalPipelineSlot {
 static _Thread_local PhanttyMetalPipelineSlot phantty_metal_pipelines[PHANTTY_METAL_MAX_PIPELINES];
 static _Thread_local unsigned int phantty_metal_next_pipeline = 1;
 static _Thread_local unsigned int phantty_metal_active_textures[16];
+
+// Encoder render state recorded by the Zig render_state layer (GL lower-left
+// convention) and applied on the active encoder before each draw. The drawable
+// size is captured at frame begin so we can flip y to Metal's upper-left origin.
+static _Thread_local int phantty_metal_vp_x = 0;
+static _Thread_local int phantty_metal_vp_y = 0;
+static _Thread_local int phantty_metal_vp_w = 0;
+static _Thread_local int phantty_metal_vp_h = 0;
+static _Thread_local bool phantty_metal_vp_set = false;
+static _Thread_local bool phantty_metal_scissor_enabled = false;
+static _Thread_local int phantty_metal_sc_x = 0;
+static _Thread_local int phantty_metal_sc_y = 0;
+static _Thread_local int phantty_metal_sc_w = 0;
+static _Thread_local int phantty_metal_sc_h = 0;
+static _Thread_local int phantty_metal_drawable_w = 0;
+static _Thread_local int phantty_metal_drawable_h = 0;
+
+void phantty_metal_set_viewport(int x, int y, int w, int h) {
+    phantty_metal_vp_x = x;
+    phantty_metal_vp_y = y;
+    phantty_metal_vp_w = w;
+    phantty_metal_vp_h = h;
+    phantty_metal_vp_set = true;
+}
+
+void phantty_metal_set_scissor(bool enabled, int x, int y, int w, int h) {
+    phantty_metal_scissor_enabled = enabled;
+    phantty_metal_sc_x = x;
+    phantty_metal_sc_y = y;
+    phantty_metal_sc_w = w;
+    phantty_metal_sc_h = h;
+}
+
+// Blend state recorded by the Zig render_state layer. Metal can't change blend
+// on the encoder (it is fixed in the PSO), so encode_draw selects the matching
+// per-mode PSO instead.
+static _Thread_local bool phantty_metal_blend_enabled = true;
+static _Thread_local bool phantty_metal_blend_premult = false;
+
+void phantty_metal_set_blend_enabled(bool enabled) {
+    phantty_metal_blend_enabled = enabled;
+}
+
+void phantty_metal_set_blend_mode(int premultiplied) {
+    phantty_metal_blend_premult = (premultiplied != 0);
+}
+
+// Lazily-built MTLSamplerState cache, indexed by (filter, wrap). Replaces the
+// per-shader `constexpr sampler` so a texture's configured filter/wrap (e.g.
+// nearest for pixel-exact bitmaps) actually applies, mirroring the GL backend's
+// sampler parameters. Threadlocal to match the per-render-thread registries.
+static _Thread_local id<MTLSamplerState> phantty_metal_samplers[4]; // idx = filter*2 + wrap
+
+static id<MTLSamplerState> phantty_metal_sampler_for(id<MTLDevice> device, unsigned int filter, unsigned int wrap) {
+    if (device == nil) return nil;
+    const unsigned int idx = (filter ? 2u : 0u) + (wrap ? 1u : 0u);
+    if (phantty_metal_samplers[idx] == nil) {
+        MTLSamplerDescriptor *desc = [[MTLSamplerDescriptor alloc] init];
+        const MTLSamplerMinMagFilter f = filter ? MTLSamplerMinMagFilterLinear : MTLSamplerMinMagFilterNearest;
+        desc.minFilter = f;
+        desc.magFilter = f;
+        const MTLSamplerAddressMode mode = wrap ? MTLSamplerAddressModeRepeat : MTLSamplerAddressModeClampToEdge;
+        desc.sAddressMode = mode;
+        desc.tAddressMode = mode;
+        phantty_metal_samplers[idx] = [device newSamplerStateWithDescriptor:desc];
+        [desc release];
+    }
+    return phantty_metal_samplers[idx];
+}
+
+// Apply the recorded viewport + scissor to the encoder before a draw. Without a
+// per-pane viewport every split pane drew at the window origin; without scissor
+// the markdown preview / file explorer clip regions had no effect. Both convert
+// GL lower-left → Metal upper-left; the scissor is clamped to the drawable
+// because an out-of-bounds MTLScissorRect raises and kills the command buffer.
+static void phantty_metal_apply_viewport_scissor(id<MTLRenderCommandEncoder> encoder) {
+    int dw = phantty_metal_drawable_w;
+    int dh = phantty_metal_drawable_h;
+    if (dw <= 0 || dh <= 0) return; // drawable size unknown — keep encoder defaults
+
+    int vx, vy, vw, vh;
+    if (phantty_metal_vp_set && phantty_metal_vp_w > 0 && phantty_metal_vp_h > 0) {
+        vx = phantty_metal_vp_x;
+        vw = phantty_metal_vp_w;
+        vh = phantty_metal_vp_h;
+        vy = dh - phantty_metal_vp_y - phantty_metal_vp_h;
+    } else {
+        vx = 0; vy = 0; vw = dw; vh = dh;
+    }
+    [encoder setViewport:(MTLViewport){ (double)vx, (double)vy, (double)vw, (double)vh, 0.0, 1.0 }];
+
+    int sx, sy, sw, sh;
+    if (phantty_metal_scissor_enabled) {
+        sx = phantty_metal_sc_x;
+        sw = phantty_metal_sc_w;
+        sh = phantty_metal_sc_h;
+        sy = dh - phantty_metal_sc_y - phantty_metal_sc_h;
+    } else {
+        sx = 0; sy = 0; sw = dw; sh = dh; // Metal has no scissor-off; reset to full
+    }
+    if (sx < 0) { sw += sx; sx = 0; }
+    if (sy < 0) { sh += sy; sy = 0; }
+    if (sx > dw) sx = dw;
+    if (sy > dh) sy = dh;
+    if (sw < 0) sw = 0;
+    if (sh < 0) sh = 0;
+    if (sx + sw > dw) sw = dw - sx;
+    if (sy + sh > dh) sh = dh - sy;
+    [encoder setScissorRect:(MTLScissorRect){ (NSUInteger)sx, (NSUInteger)sy, (NSUInteger)sw, (NSUInteger)sh }];
+}
 
 static void phantty_metal_set_error(char *error_buf, size_t error_buf_len, const char *message) {
     if (error_buf == NULL || error_buf_len == 0) return;
@@ -396,6 +512,7 @@ bool phantty_metal_texture_upload_2d(
     unsigned int format,
     unsigned int data_type,
     unsigned int wrap,
+    unsigned int filter,
     char *error_buf,
     size_t error_buf_len
 ) {
@@ -445,6 +562,7 @@ bool phantty_metal_texture_upload_2d(
         }
         phantty_metal_textures[handle].texture = texture;
         phantty_metal_textures[handle].wrap = wrap;
+        phantty_metal_textures[handle].filter = filter;
         phantty_metal_textures[handle].width = (size_t)width;
         phantty_metal_textures[handle].height = (size_t)height;
         phantty_metal_textures[handle].bpp = bpp;
@@ -522,6 +640,40 @@ void phantty_metal_texture_destroy(unsigned int handle) {
     }
 }
 
+// Build one MTLRenderPipelineState for a given blend mode. Metal fixes blend in
+// the pipeline state, so Phantty mirrors the OpenGL backend's mutable
+// glBlendFunc by pre-building a PSO per mode; encode_draw selects by the
+// recorded blend state.
+static id<MTLRenderPipelineState> phantty_metal_make_pso(
+    id<MTLDevice> device,
+    id<MTLFunction> vertex_fn,
+    id<MTLFunction> fragment_fn,
+    bool blend_enabled,
+    bool premultiplied,
+    NSError **error
+) {
+    MTLRenderPipelineDescriptor *desc = [[MTLRenderPipelineDescriptor alloc] init];
+    desc.vertexFunction = vertex_fn;
+    desc.fragmentFunction = fragment_fn;
+    MTLRenderPipelineColorAttachmentDescriptor *color = desc.colorAttachments[0];
+    color.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    if (blend_enabled) {
+        MTLBlendFactor src = premultiplied ? MTLBlendFactorOne : MTLBlendFactorSourceAlpha;
+        color.blendingEnabled = YES;
+        color.rgbBlendOperation = MTLBlendOperationAdd;
+        color.alphaBlendOperation = MTLBlendOperationAdd;
+        color.sourceRGBBlendFactor = src;
+        color.sourceAlphaBlendFactor = src;
+        color.destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+        color.destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+    } else {
+        color.blendingEnabled = NO;
+    }
+    id<MTLRenderPipelineState> pso = [device newRenderPipelineStateWithDescriptor:desc error:error];
+    [desc release];
+    return pso;
+}
+
 unsigned int phantty_metal_pipeline_create(
     void *device_handle,
     const char *vertex_source,
@@ -560,28 +712,21 @@ unsigned int phantty_metal_pipeline_create(
             return 0;
         }
 
-        MTLRenderPipelineDescriptor *desc = [[MTLRenderPipelineDescriptor alloc] init];
-        desc.vertexFunction = vertex_fn;
-        desc.fragmentFunction = fragment_fn;
-        MTLRenderPipelineColorAttachmentDescriptor *color = desc.colorAttachments[0];
-        color.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        color.blendingEnabled = YES;
-        color.rgbBlendOperation = MTLBlendOperationAdd;
-        color.alphaBlendOperation = MTLBlendOperationAdd;
-        color.sourceRGBBlendFactor = MTLBlendFactorSourceAlpha;
-        color.destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
-        color.sourceAlphaBlendFactor = MTLBlendFactorSourceAlpha;
-        color.destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
-
         error = nil;
-        id<MTLRenderPipelineState> pipeline = [device newRenderPipelineStateWithDescriptor:desc error:&error];
+        id<MTLRenderPipelineState> pipeline = phantty_metal_make_pso(device, vertex_fn, fragment_fn, true, false, &error);
+        id<MTLRenderPipelineState> pipeline_premult = (pipeline != nil)
+            ? phantty_metal_make_pso(device, vertex_fn, fragment_fn, true, true, &error) : nil;
+        id<MTLRenderPipelineState> pipeline_opaque = (pipeline_premult != nil)
+            ? phantty_metal_make_pso(device, vertex_fn, fragment_fn, false, false, &error) : nil;
 
-        [desc release];
         [vertex_fn release];
         [fragment_fn release];
         [library release];
 
-        if (pipeline == nil) {
+        if (pipeline == nil || pipeline_premult == nil || pipeline_opaque == nil) {
+            if (pipeline != nil) [pipeline release];
+            if (pipeline_premult != nil) [pipeline_premult release];
+            if (pipeline_opaque != nil) [pipeline_opaque release];
             const char *message = error != nil ? [[error localizedDescription] UTF8String] : "newRenderPipelineStateWithDescriptor returned nil";
             phantty_metal_set_error(error_buf, error_buf_len, message);
             return 0;
@@ -594,6 +739,8 @@ unsigned int phantty_metal_pipeline_create(
             }
             if (phantty_metal_pipelines[handle].pipeline == nil) {
                 phantty_metal_pipelines[handle].pipeline = pipeline;
+                phantty_metal_pipelines[handle].pipeline_premult = pipeline_premult;
+                phantty_metal_pipelines[handle].pipeline_opaque = pipeline_opaque;
                 phantty_metal_pipelines[handle].vao = vao;
                 phantty_metal_pipeline_init_uniforms(&phantty_metal_pipelines[handle]);
                 phantty_metal_set_error(error_buf, error_buf_len, "");
@@ -602,6 +749,8 @@ unsigned int phantty_metal_pipeline_create(
         }
 
         [pipeline release];
+        [pipeline_premult release];
+        [pipeline_opaque release];
         phantty_metal_set_error(error_buf, error_buf_len, "Metal pipeline registry is full");
         return 0;
     }
@@ -614,7 +763,15 @@ void phantty_metal_pipeline_destroy(unsigned int handle) {
         if (phantty_metal_pipelines[handle].pipeline != nil) {
             [phantty_metal_pipelines[handle].pipeline release];
         }
+        if (phantty_metal_pipelines[handle].pipeline_premult != nil) {
+            [phantty_metal_pipelines[handle].pipeline_premult release];
+        }
+        if (phantty_metal_pipelines[handle].pipeline_opaque != nil) {
+            [phantty_metal_pipelines[handle].pipeline_opaque release];
+        }
         phantty_metal_pipelines[handle].pipeline = nil;
+        phantty_metal_pipelines[handle].pipeline_premult = nil;
+        phantty_metal_pipelines[handle].pipeline_opaque = nil;
         phantty_metal_pipelines[handle].vao = 0;
         phantty_metal_pipeline_init_uniforms(&phantty_metal_pipelines[handle]);
     }
@@ -706,6 +863,11 @@ bool phantty_metal_frame_begin(
         }
         [drawable retain];
 
+        // Capture the drawable size so per-pane viewport/scissor can flip y to
+        // Metal's upper-left origin (see phantty_metal_apply_viewport_scissor).
+        phantty_metal_drawable_w = (int)drawable.texture.width;
+        phantty_metal_drawable_h = (int)drawable.texture.height;
+
         id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
         if (command_buffer == nil) {
             [drawable release];
@@ -755,17 +917,21 @@ bool phantty_metal_frame_end(PhanttyMetalContext *ctx, char *error_buf, size_t e
 
         [encoder endEncoding];
         if (drawable != nil) [command_buffer presentDrawable:drawable];
-        [command_buffer commit];
-        [command_buffer waitUntilCompleted];
 
-        bool ok = command_buffer.status != MTLCommandBufferStatusError;
-        if (!ok) {
-            NSError *error = command_buffer.error;
-            const char *message = error != nil ? [[error localizedDescription] UTF8String] : "Metal command buffer failed";
-            phantty_metal_set_error(error_buf, error_buf_len, message);
-        } else {
-            phantty_metal_set_error(error_buf, error_buf_len, "");
-        }
+        // Report GPU errors asynchronously rather than blocking the render
+        // thread on waitUntilCompleted every frame (that serialized CPU and GPU
+        // with zero overlap). Metal retains the command buffer + drawable until
+        // the GPU finishes and the frame is presented, so releasing our own refs
+        // right after commit is safe without waiting.
+        [command_buffer addCompletedHandler:^(id<MTLCommandBuffer> completed) {
+            if (completed.status == MTLCommandBufferStatusError) {
+                NSError *error = completed.error;
+                fprintf(stderr, "Metal command buffer error: %s\n",
+                        error != nil ? [[error localizedDescription] UTF8String] : "unknown");
+            }
+        }];
+        [command_buffer commit];
+        phantty_metal_set_error(error_buf, error_buf_len, "");
 
         [encoder release];
         if (command_buffer != nil) [command_buffer release];
@@ -773,7 +939,7 @@ bool phantty_metal_frame_end(PhanttyMetalContext *ctx, char *error_buf, size_t e
         ctx->encoder = NULL;
         ctx->command_buffer = NULL;
         ctx->drawable = NULL;
-        return ok;
+        return true;
     }
 }
 
@@ -805,7 +971,14 @@ static bool phantty_metal_encode_draw(
     @autoreleasepool {
         id<MTLRenderCommandEncoder> encoder = (id<MTLRenderCommandEncoder>)ctx->encoder;
         PhanttyMetalPipelineSlot *slot = &phantty_metal_pipelines[handle];
-        [encoder setRenderPipelineState:slot->pipeline];
+        id<MTLRenderPipelineState> pso = slot->pipeline; // straight-alpha default
+        if (!phantty_metal_blend_enabled) {
+            pso = slot->pipeline_opaque;
+        } else if (phantty_metal_blend_premult) {
+            pso = slot->pipeline_premult;
+        }
+        [encoder setRenderPipelineState:pso];
+        phantty_metal_apply_viewport_scissor(encoder);
 
         id<MTLBuffer> vertex0 = phantty_metal_buffer_object(buffer0);
         id<MTLBuffer> vertex1 = phantty_metal_buffer_object(buffer1);
@@ -816,8 +989,16 @@ static bool phantty_metal_encode_draw(
         [encoder setVertexBytes:&slot->uniforms length:sizeof(slot->uniforms) atIndex:uniform_index];
         [encoder setFragmentBytes:&slot->uniforms length:sizeof(slot->uniforms) atIndex:1];
 
-        id<MTLTexture> texture0 = phantty_metal_texture_object(phantty_metal_active_textures[0]);
-        if (texture0 != nil) [encoder setFragmentTexture:texture0 atIndex:0];
+        const unsigned int tex_handle0 = phantty_metal_active_textures[0];
+        id<MTLTexture> texture0 = phantty_metal_texture_object(tex_handle0);
+        if (texture0 != nil) {
+            [encoder setFragmentTexture:texture0 atIndex:0];
+            id<MTLSamplerState> sampler0 = phantty_metal_sampler_for(
+                (id<MTLDevice>)ctx->device,
+                phantty_metal_textures[tex_handle0].filter,
+                phantty_metal_textures[tex_handle0].wrap);
+            if (sampler0 != nil) [encoder setFragmentSamplerState:sampler0 atIndex:0];
+        }
 
         MTLPrimitiveType primitive = phantty_metal_primitive_type(mode);
         if (instances > 1) {

--- a/src/renderer/gpu/metal/gl_init.zig
+++ b/src/renderer/gpu/metal/gl_init.zig
@@ -93,7 +93,12 @@ pub fn renderQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32
     if (g_hooks) |hk| hk.fillQuadAlpha(x, y, w, h, color, alpha);
 }
 pub fn setProjection(width: f32, height: f32) void {
-    render_state.setViewport(0, 0, @intFromFloat(width), @intFromFloat(height));
+    // Do NOT touch the viewport here. The viewport (including its per-pane
+    // origin) is set by the caller via `gpu.state.setViewport` immediately
+    // before this call; overwriting it to (0,0,w,h) dropped the origin and made
+    // every split pane render at the window origin. Projection is width/height
+    // only — the origin is honored by the encoder viewport (see bridge.m), the
+    // same way the OpenGL backend relies on `glViewport`.
     if (g_hooks) |hk| hk.setProjection(width, height);
 }
 

--- a/src/renderer/gpu/metal/render_state.zig
+++ b/src/renderer/gpu/metal/render_state.zig
@@ -23,6 +23,18 @@ threadlocal var scratch_error: [256]u8 = @splat(0);
 
 extern fn phantty_metal_frame_begin(ctx: *Context.Handles, r: f32, g: f32, b: f32, a: f32, error_buf: [*]u8, error_buf_len: usize) bool;
 extern fn phantty_metal_frame_end(ctx: *Context.Handles, error_buf: [*]u8, error_buf_len: usize) bool;
+// Viewport/scissor are encoder state: the renderer records them here per pane,
+// and the C bridge applies them on the active `MTLRenderCommandEncoder` before
+// each draw (with the GL bottom-left → Metal top-left y-flip and a clamp to the
+// drawable for the scissor). x/y/w/h use the GL convention (lower-left origin),
+// matching the OpenGL backend's `setViewport`/`setScissor` callers.
+extern fn phantty_metal_set_viewport(x: c_int, y: c_int, w: c_int, h: c_int) void;
+extern fn phantty_metal_set_scissor(enabled: bool, x: c_int, y: c_int, w: c_int, h: c_int) void;
+// Blend is baked into the Metal PSO (unlike GL's mutable glBlendFunc), so the
+// bridge keeps one PSO per mode and picks by this recorded state. `mode`: 0 =
+// straight alpha, 1 = premultiplied.
+extern fn phantty_metal_set_blend_enabled(enabled: bool) void;
+extern fn phantty_metal_set_blend_mode(mode: c_int) void;
 
 /// Frame seam — the Metal backend owns the command buffer / drawable here.
 pub fn beginFrame() void {
@@ -54,10 +66,15 @@ pub fn endFrame() void {
 
 pub fn setBlendEnabled(enabled: bool) void {
     blend_enabled = enabled;
+    phantty_metal_set_blend_enabled(enabled);
 }
 
 pub fn setBlendMode(mode: BlendMode) void {
     blend_mode = mode;
+    phantty_metal_set_blend_mode(switch (mode) {
+        .alpha => 0,
+        .premultiplied => 1,
+    });
 }
 
 pub fn clear(r: f32, g: f32, b: f32, a: f32) void {
@@ -67,6 +84,7 @@ pub fn clear(r: f32, g: f32, b: f32, a: f32) void {
 
 pub fn setViewport(x: i32, y: i32, w: i32, h: i32) void {
     viewport = .{ .x = x, .y = y, .w = w, .h = h };
+    phantty_metal_set_viewport(@intCast(x), @intCast(y), @intCast(w), @intCast(h));
 }
 
 pub fn viewportSize() Size {
@@ -75,10 +93,12 @@ pub fn viewportSize() Size {
 
 pub fn setScissor(rect: Rect) void {
     scissor = .{ .enabled = true, .box = rect };
+    phantty_metal_set_scissor(true, @intCast(rect.x), @intCast(rect.y), @intCast(rect.w), @intCast(rect.h));
 }
 
 pub fn disableScissor() void {
     scissor.enabled = false;
+    phantty_metal_set_scissor(false, 0, 0, 0, 0);
 }
 
 pub fn scissorState() ScissorState {
@@ -87,6 +107,7 @@ pub fn scissorState() ScissorState {
 
 pub fn restoreScissor(s: ScissorState) void {
     scissor = s;
+    phantty_metal_set_scissor(s.enabled, @intCast(s.box.x), @intCast(s.box.y), @intCast(s.box.w), @intCast(s.box.h));
 }
 
 pub fn isFrameActive() bool {

--- a/src/renderer/gpu/metal/shaders.zig
+++ b/src/renderer/gpu/metal/shaders.zig
@@ -39,8 +39,8 @@ pub const vertex_shader_source: [*c]const u8 =
 pub const fragment_shader_source: [*c]const u8 =
     \\fragment float4 fragment_main(QuadOut in [[stage_in]],
     \\                              texture2d<float> text [[texture(0)]],
+    \\                              sampler s [[sampler(0)]],
     \\                              constant Uniforms& uniforms [[buffer(1)]]) {
-    \\    constexpr sampler s(address::clamp_to_edge, filter::linear);
     \\    float alpha = text.sample(s, in.texCoord).r;
     \\    return float4(uniforms.textColor.rgb, 1.0) * float4(1.0, 1.0, 1.0, alpha);
     \\}
@@ -162,8 +162,8 @@ pub const fg_vertex_source: [*c]const u8 =
 
 pub const fg_fragment_source: [*c]const u8 =
     \\fragment float4 fragment_main(FgOut in [[stage_in]],
-    \\                              texture2d<float> atlas [[texture(0)]]) {
-    \\    constexpr sampler s(address::clamp_to_edge, filter::linear);
+    \\                              texture2d<float> atlas [[texture(0)]],
+    \\                              sampler s [[sampler(0)]]) {
     \\    float alpha = atlas.sample(s, in.texCoord).r;
     \\    return float4(in.color, 1.0) * float4(1.0, 1.0, 1.0, alpha);
     \\}
@@ -172,8 +172,8 @@ pub const fg_fragment_source: [*c]const u8 =
 /// Color (emoji) cell glyphs.
 pub const color_fg_fragment_source: [*c]const u8 =
     \\fragment float4 fragment_main(FgOut in [[stage_in]],
-    \\                              texture2d<float> atlas [[texture(0)]]) {
-    \\    constexpr sampler s(address::clamp_to_edge, filter::linear);
+    \\                              texture2d<float> atlas [[texture(0)]],
+    \\                              sampler s [[sampler(0)]]) {
     \\    return atlas.sample(s, in.texCoord);
     \\}
 ;
@@ -182,8 +182,8 @@ pub const color_fg_fragment_source: [*c]const u8 =
 pub const simple_color_fragment_source: [*c]const u8 =
     \\fragment float4 fragment_main(QuadOut in [[stage_in]],
     \\                              texture2d<float> text [[texture(0)]],
+    \\                              sampler s [[sampler(0)]],
     \\                              constant Uniforms& uniforms [[buffer(1)]]) {
-    \\    constexpr sampler s(address::clamp_to_edge, filter::linear);
     \\    return text.sample(s, in.texCoord) * uniforms.scalars.y;
     \\}
 ;

--- a/src/renderer/gpu/metal/test.zig
+++ b/src/renderer/gpu/metal/test.zig
@@ -162,6 +162,105 @@ test "render_state batches multiple Metal draws into one presented frame" {
     try std.testing.expect(!render_state.isFrameActive());
 }
 
+test "viewport and scissor apply to the encoder without breaking draws" {
+    try Context.init(null);
+    defer Context.deinit();
+
+    const vs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\vertex float4 vertex_main(uint vertex_id [[vertex_id]]) {
+        \\    float2 positions[3] = {
+        \\        float2(-1.0, -1.0),
+        \\        float2( 3.0, -1.0),
+        \\        float2(-1.0,  3.0),
+        \\    };
+        \\    return float4(positions[vertex_id], 0.0, 1.0);
+        \\}
+    ;
+    const fs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\fragment float4 fragment_main() {
+        \\    return float4(0.0, 0.0, 1.0, 1.0);
+        \\}
+    ;
+
+    var pipeline = Pipeline.init(vs, fs, 0);
+    defer pipeline.deinit();
+
+    render_state.clear(0, 0, 0, 1);
+
+    // A sub-rectangle viewport + scissor (GL lower-left convention) — the split
+    // pane case. The standalone test layer is 64x64, so these stay in bounds.
+    render_state.setViewport(10, 10, 40, 30);
+    render_state.setScissor(.{ .x = 12, .y = 12, .w = 20, .h = 16 });
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    // Disabling scissor must reset to the full drawable and still draw.
+    render_state.disableScissor();
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    // An intentionally out-of-bounds scissor must be clamped, not crash the
+    // command buffer (MTLScissorRect outside the render target raises).
+    render_state.setScissor(.{ .x = -100, .y = -100, .w = 100000, .h = 100000 });
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    render_state.endFrame();
+}
+
+test "blend modes select pipeline variants without breaking draws" {
+    try Context.init(null);
+    defer Context.deinit();
+
+    const vs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\vertex float4 vertex_main(uint vertex_id [[vertex_id]]) {
+        \\    float2 positions[3] = {
+        \\        float2(-1.0, -1.0),
+        \\        float2( 3.0, -1.0),
+        \\        float2(-1.0,  3.0),
+        \\    };
+        \\    return float4(positions[vertex_id], 0.0, 1.0);
+        \\}
+    ;
+    const fs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\fragment float4 fragment_main() {
+        \\    return float4(0.5, 0.5, 0.5, 0.5);
+        \\}
+    ;
+
+    var pipeline = Pipeline.init(vs, fs, 0);
+    defer pipeline.deinit();
+    try std.testing.expect(pipeline.program != 0);
+
+    render_state.clear(0, 0, 0, 1);
+
+    // Each blend mode must pick a valid pre-built PSO and draw successfully.
+    render_state.setBlendEnabled(true);
+    render_state.setBlendMode(.alpha);
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    render_state.setBlendMode(.premultiplied);
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    render_state.setBlendEnabled(false);
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+
+    render_state.setBlendEnabled(true);
+    render_state.setBlendMode(.alpha);
+    render_state.endFrame();
+}
+
 test "vertex builder returns stable nonzero layout handles" {
     try Context.init(null);
     defer Context.deinit();

--- a/src/session_persist.zig
+++ b/src/session_persist.zig
@@ -53,6 +53,11 @@ pub const TabSnap = struct {
     focused_leaf: u32 = 0,
     zoomed_leaf: ?u32 = null,
     tree: NodeSnap,
+    // When non-null this tab is an AI Chat tab: it is restored by reopening the
+    // agent history session of this id (the conversation lives in the persisted
+    // agent history store, not in this snapshot), and `tree` is an ignored
+    // placeholder. Absent in older snapshots → null → ordinary terminal tab.
+    ai_session_id: ?[]const u8 = null,
 };
 
 pub const Session = struct {
@@ -199,6 +204,44 @@ test "session_persist: round-trip simple local-shell session via JSON" {
     };
     try std.testing.expectEqualStrings("/home/user", sh.cwd.?);
     try std.testing.expect(sh.command == null);
+}
+
+test "session_persist: AI chat tab round-trips its ai_session_id" {
+    const allocator = std.testing.allocator;
+
+    const placeholder = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    const tabs = [_]TabSnap{.{
+        .tree = placeholder,
+        .ai_session_id = "sess-abc-123",
+    }};
+    const original: Session = .{ .active_tab = 0, .tabs = @constCast(&tabs) };
+
+    const json = try dumpSessionToString(allocator, original);
+    defer allocator.free(json);
+
+    var parsed = try loadSessionFromString(allocator, json);
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.tabs.len);
+    try std.testing.expect(parsed.value.tabs[0].ai_session_id != null);
+    try std.testing.expectEqualStrings("sess-abc-123", parsed.value.tabs[0].ai_session_id.?);
+}
+
+test "session_persist: tab without ai_session_id defaults to null (back-compat)" {
+    const allocator = std.testing.allocator;
+
+    // An older snapshot has no ai_session_id field; it must parse as a terminal
+    // tab (ai_session_id == null), not error.
+    const json =
+        \\{ "version": 1, "active_tab": 0, "tabs": [
+        \\  { "focused_leaf": 0, "tree": { "leaf": { "surface": { "local_shell": {} } } } }
+        \\] }
+    ;
+    var parsed = try loadSessionFromString(allocator, json);
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.tabs.len);
+    try std.testing.expect(parsed.value.tabs[0].ai_session_id == null);
 }
 
 test "session_persist: round-trip nested split with SSH leaf" {


### PR DESCRIPTION
## Why this PR exists
PRs #85 (Metal render-state) and #86 (AI-chat restore) were **stacked on `fix/test-full-macos-close-guard`** and got merged **into that branch**, not into `main`. #84 already merged the guard fix into `main`, so `main` is missing the Metal fix — which is why a `main` build still shows the split-rendering bug (content over the titlebar/sidebar, blank right pane). This PR brings the remaining two fixes onto `main`.

## What it lands
- **Metal render-state per draw** (#85) — the actual fix for the reported macOS rendering bug: per-pane viewport origin + scissor, blend PSO variants, sampler state, frame throughput. **Verified on-device:** split now renders both panes with a clean divider and no titlebar/sidebar overlap.
- **AI-chat tab restore** (#86) — registers `tab.g_ai_restore_hook` so AI chat tabs restore from their persisted history session id.

Guard fix (#84) is already on `main`; the only `AppWindow.zig` delta here is the AI-restore hook registration.

## Test plan
- [x] `zig build test-full -Dtarget=aarch64-macos` exits 0
- [x] `zig build test-metal` exits 0
- [x] `zig build test` (fast) exits 0
- [x] `zig build -Dtarget=x86_64-windows-gnu` exits 0
- [x] `zig build macos-app -Dtarget=aarch64-macos` exits 0
- [x] On-device: launched the built `.app`, single pane + `Cmd+Shift+O` split both render correctly (no overlap, right pane live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)