### PR TITLE
fix(font): guard glyph atlas against degenerate sizes + diagnostic CI (#90)

### DIFF
--- a/.github/workflows/macos-debug.yml
+++ b/.github/workflows/macos-debug.yml
@@ -1,0 +1,151 @@
+name: Build macOS Diagnostic
+
+# Manually-triggered diagnostic build. Produces an UNSIGNED, ad-hoc-signed
+# macOS .app built with runtime safety checks on (ReleaseSafe / Debug) so that
+# integer overflow and out-of-bounds access panic at their real location with
+# a stack trace, instead of silently corrupting memory and crashing later
+# somewhere unrelated (see issue #90). Not for release — for handing to a user
+# to reproduce a crash and capture diagnostics.
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: Target architecture
+        type: choice
+        default: x86_64
+        options:
+          - x86_64
+          - aarch64
+      optimize:
+        description: Optimize mode (ReleaseSafe keeps safety checks; Debug adds richer traces)
+        type: choice
+        default: ReleaseSafe
+        options:
+          - ReleaseSafe
+          - Debug
+
+permissions:
+  contents: read
+
+jobs:
+  build-debug:
+    name: Build macOS diagnostic (${{ github.event.inputs.arch }}, ${{ github.event.inputs.optimize }})
+    runs-on: macos-latest
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-global-cache
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Cache Zig packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache/p
+            .zig-global-cache
+          key: ${{ runner.os }}-${{ github.event.inputs.arch }}-zig-0.15.2-${{ hashFiles('build.zig', 'build.zig.zon', 'pkg/**/build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.event.inputs.arch }}-zig-0.15.2-
+
+      - name: Fetch dependencies and build diagnostic .app
+        shell: bash
+        run: |
+          set -euo pipefail
+          arch="${{ github.event.inputs.arch }}"
+          opt="${{ github.event.inputs.optimize }}"
+
+          retry() {
+            local name="$1"; shift
+            local attempts=5
+            for (( attempt=1; attempt<=attempts; attempt++ )); do
+              echo "::group::${name} (attempt ${attempt}/${attempts})"
+              if "$@"; then
+                echo "::endgroup::"
+                return 0
+              fi
+              echo "::endgroup::"
+              if (( attempt < attempts )); then
+                local delay=$(( 15 * attempt ))
+                (( delay > 120 )) && delay=120
+                echo "::warning::${name} failed; retrying in ${delay}s"
+                sleep "${delay}"
+              fi
+            done
+            return 1
+          }
+
+          retry "zig dependency fetch" zig build "-Doptimize=${opt}" --fetch
+          retry "macos-app build" zig build macos-app \
+            "-Doptimize=${opt}" \
+            "-Dtarget=${arch}-macos"
+
+      - name: Ad-hoc sign the bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          app="zig-out/bin/WispTerm.app"
+          if [[ ! -d "$app" ]]; then
+            echo "App bundle not found: $app" >&2
+            exit 1
+          fi
+          # Ad-hoc signature (identity "-") so Gatekeeper does not kill an
+          # unsigned binary on launch. Not notarized — see run instructions.
+          codesign --force --deep --sign - "$app"
+          codesign --verify --verbose=2 "$app" || true
+
+      - name: Package bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          arch="${{ github.event.inputs.arch }}"
+          opt="${{ github.event.inputs.optimize }}"
+          sha="${GITHUB_SHA::8}"
+          out="WispTerm-debug-${arch}-${opt}-${sha}.zip"
+          # ditto preserves the .app bundle structure and resource forks.
+          ditto -c -k --keepParent "zig-out/bin/WispTerm.app" "$out"
+          echo "ASSET_PATH=${out}" >> "${GITHUB_ENV}"
+          echo "ASSET_NAME=WispTerm-debug-${arch}-${opt}-${sha}" >> "${GITHUB_ENV}"
+
+      - name: Upload diagnostic artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ASSET_NAME }}
+          path: ${{ env.ASSET_PATH }}
+          if-no-files-found: error
+
+      - name: How to run and capture diagnostics
+        shell: bash
+        run: |
+          cat <<'EOF'
+          ================ DIAGNOSTIC BUILD — TEST INSTRUCTIONS ================
+
+          This .app is unsigned (ad-hoc only) and NOT notarized. To run it:
+
+          1. Unzip and move WispTerm.app to /Applications (or anywhere).
+          2. Strip the quarantine flag:
+                 xattr -dr com.apple.quarantine /Applications/WispTerm.app
+
+          3. RUN FROM TERMINAL so you can see the crash output directly:
+                 WISPTERM_RENDER_DIAGNOSTICS=1 \
+                   /Applications/WispTerm.app/Contents/MacOS/WispTerm
+
+             - This build has runtime safety checks ON, so any overflow or
+               out-of-bounds access prints a panic + stack trace to the
+               terminal at the REAL fault location (instead of crashing later
+               inside FreeType).
+             - DPI / glyph-size diagnostics are written to:
+                   ~/Library/Application Support/wispterm/render-diagnostic.log
+
+          4. Send back BOTH:
+             - the full terminal output (everything after the command), and
+             - the render-diagnostic.log file.
+
+          =====================================================================
+          EOF

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2963,6 +2963,23 @@ fn handleWindowDpiChanged(
 ) void {
     const new_dpi = window_backend.effectiveDpi(win);
     if (new_dpi == 0) return;
+
+    // Reject a degenerate DPI before it reaches font sizing (see #90). A bogus
+    // value (observed on some multi-monitor / HiDPI setups during the startup
+    // resize) would scale glyph bitmaps to absurd dimensions; while the atlas
+    // packer now rejects oversized glyphs, keeping the old DPI here also avoids
+    // a window full of unrenderable text. The cap is 32x the platform baseline
+    // (display.default_dpi), far above any real display.
+    const max_sane_dpi: u32 = platform_display.default_dpi * 32;
+    if (new_dpi > max_sane_dpi) {
+        render_diagnostics.log(
+            "dpi-change reject implausible new_dpi={} (max={}) keeping font_dpi={}",
+            .{ new_dpi, max_sane_dpi, font.g_dpi },
+        );
+        std.debug.print("Ignoring implausible DPI {} (keeping {})\n", .{ new_dpi, font.g_dpi });
+        return;
+    }
+
     const client_before = window_backend.clientSize(win);
     const fb_before = window_backend.framebufferSize(win);
     render_diagnostics.log(

--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -86,6 +86,13 @@ pub fn deinit(self: *Atlas, allocator: std.mem.Allocator) void {
 /// Returns the region (top-left x, y, width, height) where pixels should be written.
 /// Returns `error.AtlasFull` if the glyph doesn't fit.
 pub fn reserve(self: *Atlas, allocator: std.mem.Allocator, width: u32, height: u32) !Region {
+    // Defense in depth (see #90): a glyph larger than the maximum atlas size
+    // can never fit, and a near-`maxInt` value would overflow the `+ 1`
+    // padding below (silently wrapping in ReleaseFast). Reject early so the
+    // size math here and in `set` stays well-defined.
+    const max_atlas_dim: u32 = 8192;
+    if (width > max_atlas_dim or height > max_atlas_dim) return error.AtlasFull;
+
     // Add 1px padding around each glyph to prevent GL_LINEAR from
     // sampling neighboring glyphs in the atlas.
     const padded_width = width + 1;

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -14,9 +14,25 @@ const font_backend = @import("../platform/font_backend.zig");
 const embedded = @import("embedded.zig");
 const Config = @import("../config.zig");
 const AppWindow = @import("../AppWindow.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
 
 const gpu = AppWindow.gpu;
 const c = gpu.c;
+
+/// Hard ceiling on a single glyph bitmap dimension (in pixels).
+///
+/// Real glyphs at any sane font size and DPI stay far below this. A value
+/// above it means the face is in a degenerate state — most commonly a bogus
+/// DPI computed during a startup resize on some multi-monitor / HiDPI setups
+/// (see issue #90) — which would make the size arithmetic below
+/// (`width * height [* depth]`, all `u32`) overflow. In a ReleaseFast build
+/// that overflow silently wraps to a tiny value, the destination buffer is
+/// under-allocated, and the per-row `@memcpy` scribbles past it, corrupting
+/// the heap. The corruption later surfaces as an unrelated crash (e.g. deep
+/// inside FreeType's autofitter). Rejecting the glyph here keeps that wrapping
+/// from ever happening and turns a silent heap smash into a skipped glyph plus
+/// a diagnostic log line.
+pub const MAX_GLYPH_DIM: u32 = 4096;
 
 pub const FontAtlas = @import("Atlas.zig");
 
@@ -493,14 +509,25 @@ pub fn packBitmapIntoAtlas(
         return .{ .x = 0, .y = 0, .width = 0, .height = 0 };
     }
 
+    // Reject degenerate bitmap sizes before any size arithmetic (see #90).
+    if (width > MAX_GLYPH_DIM or height > MAX_GLYPH_DIM) {
+        render_diagnostics.log(
+            "atlas-pack reject oversized glyph {}x{} (max={}) dpi={} font_size={}",
+            .{ width, height, MAX_GLYPH_DIM, g_dpi, g_font_size },
+        );
+        return null;
+    }
+
     // Ensure atlas exists
     if (atlas_ptr.* == null) {
         atlas_ptr.* = FontAtlas.init(alloc, 512, .grayscale) catch return null;
     }
     var atlas = &atlas_ptr.*.?;
 
-    // Copy source bitmap to tightly-packed buffer (FreeType pitch may != width)
-    const tight = alloc.alloc(u8, width * height) catch return null;
+    // Copy source bitmap to tightly-packed buffer (FreeType pitch may != width).
+    // `width`/`height` are bounded by MAX_GLYPH_DIM above, so the usize product
+    // cannot overflow.
+    const tight = alloc.alloc(u8, @as(usize, width) * height) catch return null;
     defer alloc.free(tight);
     const src = src_buffer orelse return null;
     for (0..height) |row| {
@@ -543,6 +570,15 @@ pub fn packPixelsIntoAtlas(
         return .{ .x = 0, .y = 0, .width = 0, .height = 0 };
     }
 
+    // Reject degenerate sizes before any atlas arithmetic (see #90).
+    if (width > MAX_GLYPH_DIM or height > MAX_GLYPH_DIM) {
+        render_diagnostics.log(
+            "atlas-pack-pixels reject oversized {}x{} (max={}) dpi={} font_size={}",
+            .{ width, height, MAX_GLYPH_DIM, g_dpi, g_font_size },
+        );
+        return null;
+    }
+
     if (atlas_ptr.* == null) {
         atlas_ptr.* = FontAtlas.init(alloc, 512, .grayscale) catch return null;
     }
@@ -579,14 +615,24 @@ pub fn packColorBitmapIntoAtlas(
         return .{ .x = 0, .y = 0, .width = 0, .height = 0 };
     }
 
+    // Reject degenerate bitmap sizes before any size arithmetic (see #90).
+    if (width > MAX_GLYPH_DIM or height > MAX_GLYPH_DIM) {
+        render_diagnostics.log(
+            "atlas-pack-color reject oversized {}x{} (max={}) dpi={} font_size={}",
+            .{ width, height, MAX_GLYPH_DIM, g_dpi, g_font_size },
+        );
+        return null;
+    }
+
     if (g_color_atlas == null) {
         g_color_atlas = FontAtlas.init(alloc, 512, .bgra) catch return null;
     }
     var atlas = &g_color_atlas.?;
 
-    // Copy source bitmap to tightly-packed BGRA buffer
+    // Copy source bitmap to tightly-packed BGRA buffer. `width`/`height` are
+    // bounded by MAX_GLYPH_DIM above, so the usize product cannot overflow.
     const depth: u32 = 4; // BGRA
-    const tight = alloc.alloc(u8, width * height * depth) catch return null;
+    const tight = alloc.alloc(u8, @as(usize, width) * height * depth) catch return null;
     defer alloc.free(tight);
     const src = src_buffer orelse return null;
     for (0..height) |row| {


### PR DESCRIPTION
## Context — issue #90

Crash-on-launch on a multi-monitor HiDPI **Hackintosh** (macOS 13.5.2, Intel, 4K + QHD displays). The Apple report shows `EXC_BAD_ACCESS` deep inside FreeType's CJK autofitter:

```
0  af_cjk_metrics_init_widths + 77
1  af_cjk_metrics_init
2  FT_Load_Glyph
3  font.manager.loadTitlebarGlyph
4  renderer.overlays.sessionTwoColumnWidth
...
8  AppWindow.onPlatformResize
9  AppWindow.handleWindowDpiChanged
```

Decoding the registers against FreeType 2.13.2 `afcjk.c`: the fault is `metrics->root.style_class->script`, where `metrics->root.style_class` itself is a garbage pointer (`0x150e7a398`, an unmapped VM gap). That field should point into FreeType's static `af_style_classes` table — so **FreeType's per-face autofit block was scribbled by an out-of-bounds write**; it is not a logic bug in FreeType nor a malformed font.

Trigger path: the startup **DPI-changed** event → `handleWindowDpiChanged` → `reloadFontFaces` (rebuilds all faces) → render session launcher → measure CJK text (user has Chinese profile/SSH/AI field names) → load glyph.

## Most plausible corruption site

The atlas packers compute buffer sizes as `width * height [* depth]` in `u32` and the per-row `@memcpy` writes `width` bytes/row. A bogus DPI (the known multi-monitor/HiDPI hazard, cf. #46/#47) scales a glyph bitmap to absurd dimensions; in a **ReleaseFast** build the `u32` size math silently wraps, the destination is under-allocated, and the copy smashes the heap — surfacing later as the FreeType crash.

## Changes

**Hardening (commit 1):**
- `manager.zig`: reject glyph bitmaps larger than `MAX_GLYPH_DIM` (4096) in all three atlas packers, logging dimensions/DPI via `render_diagnostics`; compute tight-buffer sizes with `usize`.
- `Atlas.reserve`: reject dimensions above the max atlas size (defense in depth; avoids the `+ 1` padding wrap).
- `handleWindowDpiChanged`: ignore an implausible DPI (> 32× the platform baseline) and keep the previous one.

**Diagnostic CI (commit 2):**
- `.github/workflows/macos-debug.yml` — manual (`workflow_dispatch`) build of an ad-hoc-signed, unsigned `.app` with **runtime safety checks on** (ReleaseSafe default, Debug optional). So if anything still overflows/over-reads, it panics at the **real** fault site with a stack trace instead of corrupting memory and crashing later in FreeType. Job summary includes run instructions.

## Verification
- `zig build test` (native) — green.
- `zig build test-full -Dtarget=x86_64-windows-gnu` — compiles clean (matches known baseline).
- Cannot reproduce the Hackintosh crash locally; the diagnostic build is meant to confirm root cause on the affected machine.

> [!NOTE]
> `workflow_dispatch` only becomes runnable from the Actions tab once `macos-debug.yml` is on the **default branch**, so this needs to merge before the diagnostic build can be triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)