### PR TITLE
fix(input): report mouse button clicks and drags to the PTY

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -45,6 +45,7 @@ const clipboard = @import("input/clipboard.zig");
 const click_tracker = @import("input/click_tracker.zig");
 const hit_test = @import("input/hit_test.zig");
 const preview_source = @import("input/preview_source.zig");
+const mouse_report = @import("input/mouse_report.zig");
 const writeToPty = clipboard.writeToPty;
 pub const copyTextToClipboard = clipboard.copyTextToClipboard;
 const activeTerminalSelectionExists = clipboard.activeTerminalSelectionExists;
@@ -250,6 +251,15 @@ pub threadlocal var g_selecting: bool = false; // True while mouse button is hel
 pub threadlocal var g_click_x: f64 = 0; // X position of initial click (for threshold calculation)
 pub threadlocal var g_click_y: f64 = 0; // Y position of initial click
 var g_selection_changed_for_copy: bool = false;
+
+// Terminal mouse reporting drag state. When a press is delivered to the PTY
+// (the focused program enabled mouse tracking and Shift wasn't held), the
+// matching drag-motion and release are routed to the PTY too — until the
+// button lifts — instead of driving local text selection. See
+// input/mouse_report.zig for the protocol encoder.
+threadlocal var g_mouse_report_button: ?mouse_report.Button = null;
+threadlocal var g_mouse_report_surface: ?*Surface = null;
+threadlocal var g_mouse_report_last_cell: ?CellPos = null;
 threadlocal var g_left_click_tracker: click_tracker.ClickTracker = .{};
 const MULTI_CLICK_INTERVAL_MS: i64 = 500;
 const MAX_SELECTION_COLS: usize = 4096;
@@ -2540,6 +2550,21 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             return;
         }
     }
+
+    // Terminal mouse reporting (xterm 1000/1002/1003). When the focused
+    // program has enabled mouse tracking, deliver button events to the PTY
+    // instead of driving local selection / paste / context-menu. A release
+    // always finishes an in-progress reported drag — any modifier, anywhere —
+    // so state never leaks. A press starts reporting only over terminal
+    // content, with Shift up (Shift forces the terminal's own selection) and
+    // without the link-open modifier (Ctrl/Cmd keeps opening links/previews
+    // through the existing path below).
+    if (ev.action == .release) {
+        if (finishTerminalMouseReport(ev)) return;
+    } else if (!ev.shift and !(primaryOpenMod(ev.ctrl, ev.super) and !ev.alt)) {
+        if (beginTerminalMouseReport(ev)) return;
+    }
+
     // Double-click on tab text to rename, elsewhere to maximize
     if (ev.button == .left and ev.action == .double_click) {
         const xpos: f64 = @floatFromInt(ev.x);
@@ -3367,6 +3392,13 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
         return;
     }
 
+    // Reported mouse drag: stream motion to the PTY (button/any tracking
+    // modes) and suppress local hover/selection while the button is held.
+    if (g_mouse_report_button) |button| {
+        if (g_mouse_report_surface) |surface| reportMouseMotion(surface, button, ev);
+        return;
+    }
+
     if (AppWindow.g_window) |hover_win| {
         if (AppWindow.activeAiChat()) |chat| {
             const hover_fb = window_backend.framebufferSize(hover_win);
@@ -3625,6 +3657,168 @@ fn appendAlternateScrollKeys(surface: *Surface, ev: platform_input.MouseWheelEve
         if (!appendBytes(out, len, seq)) return false;
     }
     return true;
+}
+
+// --- Terminal mouse button reporting --------------------------------------
+// Companion to appendMouseWheelReport: encodes button presses, releases and
+// drags so mouse-aware TUIs (nvim, tmux, htop) receive clicks, not just wheel
+// scrolls. The pure protocol encoder lives in input/mouse_report.zig; these
+// helpers map ghostty-vt's flags onto it and deliver the bytes to the PTY.
+
+// Map ghostty-vt's mouse flags onto the local encoder enums. Typed `anytype`
+// because the enums aren't re-exported from the ghostty-vt module root; the
+// switch over enum literals coerces to whatever enum the flags field holds
+// (the same literals the wheel path compares against in appendMouseWheelReport).
+fn mouseReportEvent(mode: anytype) mouse_report.Event {
+    return switch (mode) {
+        .none => .none,
+        .x10 => .x10,
+        .normal => .normal,
+        .button => .button,
+        .any => .any,
+    };
+}
+
+fn mouseReportFormat(fmt: anytype) mouse_report.Format {
+    return switch (fmt) {
+        .x10 => .x10,
+        .utf8 => .utf8,
+        .sgr => .sgr,
+        .urxvt => .urxvt,
+        .sgr_pixels => .sgr_pixels,
+    };
+}
+
+fn platformMouseButton(button: platform_input.MouseButton) mouse_report.Button {
+    return switch (button) {
+        .left => .left,
+        .middle => .middle,
+        .right => .right,
+    };
+}
+
+/// Encode and deliver one mouse button/motion event to the surface's PTY.
+/// Returns true if bytes were written (false when the active mode does not
+/// report this event — e.g. motion in normal mode, or no tracking at all).
+fn sendTerminalMouseReport(
+    surface: *Surface,
+    action: mouse_report.Action,
+    button: ?mouse_report.Button,
+    x_px: i32,
+    y_px: i32,
+    mods: mouse_report.Mods,
+) bool {
+    var buf: [512]u8 = undefined;
+    var len: usize = 0;
+    surface.render_state.mutex.lock();
+    const mode = mouseReportEvent(surface.terminal.flags.mouse_event);
+    const fmt = mouseReportFormat(surface.terminal.flags.mouse_format);
+    if (mode == .none) {
+        surface.render_state.mutex.unlock();
+        return false;
+    }
+    const cell = mouseToSurfaceCell(surface, @floatFromInt(x_px), @floatFromInt(y_px));
+    const pixel = mouseToSurfacePixel(surface, x_px, y_px);
+    _ = mouse_report.encode(mode, fmt, action, button, mods, cell.col, cell.row, pixel.x, pixel.y, &buf, &len);
+    surface.render_state.mutex.unlock();
+    if (len == 0) return false;
+    writeToPty(surface, buf[0..len]);
+    return true;
+}
+
+/// True when the AI copilot sidebar is shown and covers (xf, yf).
+fn aiCopilotRegionContains(xf: f64, yf: f64) bool {
+    if (!AppWindow.aiCopilotVisible()) return false;
+    const win = AppWindow.g_window orelse return false;
+    const fb = window_backend.framebufferSize(win);
+    const bounds = ai_sidebar.boundsForWindow(
+        @intCast(fb.width),
+        @intCast(fb.height),
+        @floatCast(titlebarHeight()),
+        AppWindow.leftPanelsWidth(),
+        0,
+    );
+    return xf >= @as(f64, @floatFromInt(bounds.left)) and xf < @as(f64, @floatFromInt(bounds.right)) and
+        yf >= @as(f64, @floatFromInt(bounds.top)) and yf < @as(f64, @floatFromInt(bounds.bottom));
+}
+
+/// The surface that should receive a mouse report for an event at (x, y), or
+/// null when the point is over window chrome / side panels or the focused
+/// program has not enabled mouse tracking. Mirrors the chrome exclusions the
+/// left-press path walks before it reaches terminal content.
+fn terminalMouseReportTarget(x_i: i32, y_i: i32) ?*Surface {
+    const xf: f64 = @floatFromInt(x_i);
+    const yf: f64 = @floatFromInt(y_i);
+    if (yf < titlebarHeight()) return null; // titlebar
+    if (AppWindow.activeAiChat() != null) return null; // AI chat tab: no terminal
+    if (tab.g_sidebar_visible and xf < @as(f64, @floatCast(titlebar.sidebarWidth()))) return null;
+    if (hitTestFileExplorer(xf, yf)) return null;
+    if (hitTestBrowserUrlBar(xf, yf)) return null;
+    if (hitTestBrowserPanel(xf, yf)) return null;
+    if (hitTestMarkdownPreviewPanel(xf, yf)) return null;
+    if (aiCopilotRegionContains(xf, yf)) return null;
+    const surface = split_layout.surfaceAtPoint(x_i, y_i) orelse return null;
+    surface.render_state.mutex.lock();
+    const mode = surface.terminal.flags.mouse_event;
+    surface.render_state.mutex.unlock();
+    if (mode == .none) return null;
+    return surface;
+}
+
+/// Begin a reported press for an event that landed on terminal content.
+/// Returns true if the press was consumed (delivered to the PTY).
+fn beginTerminalMouseReport(ev: platform_input.MouseButtonEvent) bool {
+    const surface = terminalMouseReportTarget(ev.x, ev.y) orelse return false;
+    const button = platformMouseButton(ev.button);
+    updateFocusFromMouse(ev.x, ev.y);
+    _ = sendTerminalMouseReport(surface, .press, button, ev.x, ev.y, .{
+        .shift = ev.shift,
+        .alt = ev.alt,
+        .ctrl = ev.ctrl,
+    });
+    g_mouse_report_button = button;
+    g_mouse_report_surface = surface;
+    g_mouse_report_last_cell = null;
+    return true;
+}
+
+/// Finish a reported drag on button release (wherever the pointer ends up, and
+/// regardless of modifiers) so the app always sees button-up and state never
+/// leaks. Returns true if a matching reported press was in progress.
+fn finishTerminalMouseReport(ev: platform_input.MouseButtonEvent) bool {
+    const active = g_mouse_report_button orelse return false;
+    if (active != platformMouseButton(ev.button)) return false;
+    const surface = g_mouse_report_surface;
+    g_mouse_report_button = null;
+    g_mouse_report_surface = null;
+    g_mouse_report_last_cell = null;
+    if (surface) |s| {
+        _ = sendTerminalMouseReport(s, .release, active, ev.x, ev.y, .{
+            .shift = ev.shift,
+            .alt = ev.alt,
+            .ctrl = ev.ctrl,
+        });
+    }
+    return true;
+}
+
+/// Stream a drag-motion report while a reported press is held, deduplicated by
+/// cell so we don't flood the PTY with one report per pixel.
+fn reportMouseMotion(surface: *Surface, button: mouse_report.Button, ev: platform_input.MouseMoveEvent) void {
+    const cell = blk: {
+        surface.render_state.mutex.lock();
+        defer surface.render_state.mutex.unlock();
+        break :blk mouseToSurfaceCell(surface, @floatFromInt(ev.x), @floatFromInt(ev.y));
+    };
+    if (g_mouse_report_last_cell) |last| {
+        if (last.col == cell.col and last.row == cell.row) return;
+    }
+    g_mouse_report_last_cell = cell;
+    _ = sendTerminalMouseReport(surface, .motion, button, ev.x, ev.y, .{
+        .shift = ev.shift,
+        .alt = ev.alt,
+        .ctrl = ev.ctrl,
+    });
 }
 
 fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {

--- a/src/input/mouse_report.zig
+++ b/src/input/mouse_report.zig
@@ -1,0 +1,266 @@
+//! Pure xterm mouse *button* report encoding.
+//!
+//! Encodes mouse button presses, releases and drag-motion into the escape
+//! sequences a PTY application (nvim, tmux, htop, …) expects when it has
+//! enabled mouse tracking via DECSET `?1000h` (normal) / `?1002h` (button) /
+//! `?1003h` (any), in any of the X10 / UTF-8 (1005) / SGR (1006) / urxvt
+//! (1015) / SGR-pixels (1016) report formats.
+//!
+//! This mirrors ghostty's `src/input/mouse_encode.zig` (shouldReport /
+//! buttonCode / encode) so behaviour matches the reference terminal. It is
+//! intentionally dependency-free — it does NOT import `ghostty-vt` — so it
+//! compiles and runs in the fast unit-test suite (`zig build test`). The
+//! caller (`input.zig`) maps `ghostty_vt.MouseEvent`/`MouseFormat` onto the
+//! local `Event`/`Format` enums.
+//!
+//! The codebase already encodes the mouse *wheel* in `input.zig`
+//! (`appendMouseWheelReport`); this module covers the button events that path
+//! never handled, which is why clicks did nothing inside mouse-aware TUIs.
+
+const std = @import("std");
+
+/// Mouse tracking mode the application requested (mutually exclusive).
+pub const Event = enum { none, x10, normal, button, any };
+
+/// Report wire format the application requested (mutually exclusive).
+pub const Format = enum { x10, utf8, sgr, urxvt, sgr_pixels };
+
+/// The button involved in an event. Wheel buttons are handled separately by
+/// the existing wheel path, so only the three physical buttons appear here.
+pub const Button = enum { left, middle, right };
+
+/// The kind of event being reported.
+pub const Action = enum { press, release, motion };
+
+/// Keyboard modifiers held during the event.
+pub const Mods = struct {
+    shift: bool = false,
+    alt: bool = false,
+    ctrl: bool = false,
+};
+
+/// Returns true if an event should be reported under the active tracking
+/// mode. `button` is null only for a motion event with no button held.
+pub fn shouldReport(event: Event, action: Action, button: ?Button) bool {
+    return switch (event) {
+        .none => false,
+        // X10 only reports presses of a physical button.
+        .x10 => action == .press and button != null,
+        // Normal mode reports presses and releases but no motion.
+        .normal => action != .motion,
+        // Button mode adds motion, but only while a button is held.
+        .button => button != null,
+        // Any mode reports everything, including button-less motion.
+        .any => true,
+    };
+}
+
+/// Low 7-bit button code before format framing. Mirrors ghostty buttonCode().
+fn buttonCode(event: Event, format: Format, action: Action, button: ?Button, mods: Mods) u8 {
+    var acc: u8 = code: {
+        // Motion with no held button is reported as button 3.
+        if (button == null) break :code 3;
+        // Legacy (non-SGR) releases collapse to button 3 because the wire
+        // format can't distinguish which button was released.
+        if (action == .release and format != .sgr and format != .sgr_pixels) break :code 3;
+        break :code switch (button.?) {
+            .left => 0,
+            .middle => 1,
+            .right => 2,
+        };
+    };
+
+    // X10 predates modifier reporting.
+    if (event != .x10) {
+        if (mods.shift) acc += 4;
+        if (mods.alt) acc += 8;
+        if (mods.ctrl) acc += 16;
+    }
+
+    // Motion sets the extra "drag" bit.
+    if (action == .motion) acc += 32;
+
+    return acc;
+}
+
+fn appendBytes(out: []u8, len: *usize, bytes: []const u8) bool {
+    if (len.* + bytes.len > out.len) return false;
+    @memcpy(out[len.* .. len.* + bytes.len], bytes);
+    len.* += bytes.len;
+    return true;
+}
+
+fn appendByte(out: []u8, len: *usize, byte: u8) bool {
+    if (len.* >= out.len) return false;
+    out[len.*] = byte;
+    len.* += 1;
+    return true;
+}
+
+fn appendFmt(out: []u8, len: *usize, comptime fmt: []const u8, args: anytype) bool {
+    const written = std.fmt.bufPrint(out[len.*..], fmt, args) catch return false;
+    len.* += written.len;
+    return true;
+}
+
+/// Legacy single-/multi-byte coordinate encoding shared by X10 and UTF-8.
+fn encodeLegacy(code: u8, col: usize, row: usize, out: []u8, len: *usize, utf8: bool) bool {
+    if (!appendBytes(out, len, "\x1b[M")) return false;
+    if (!appendByte(out, len, 32 +| code)) return false;
+    if (utf8) {
+        // 1005: coordinates are UTF-8 codepoints offset by 33 (32 + 1-based).
+        var buf: [4]u8 = undefined;
+        const x_cp: u21 = @intCast(col + 33);
+        const y_cp: u21 = @intCast(row + 33);
+        const xl = std.unicode.utf8Encode(x_cp, &buf) catch return false;
+        if (!appendBytes(out, len, buf[0..xl])) return false;
+        const yl = std.unicode.utf8Encode(y_cp, &buf) catch return false;
+        if (!appendBytes(out, len, buf[0..yl])) return false;
+        return true;
+    }
+    // X10: one byte per coordinate, 1-based, capped at column/row 223.
+    if (col > 222 or row > 222) return false;
+    if (!appendByte(out, len, 32 + @as(u8, @intCast(col)) + 1)) return false;
+    if (!appendByte(out, len, 32 + @as(u8, @intCast(row)) + 1)) return false;
+    return true;
+}
+
+/// Encode one mouse button event, appending the bytes to `out` starting at
+/// `len.*` and advancing `len`. Returns true if any bytes were written.
+///
+/// `col`/`row` are zero-based cell coordinates; `pixel_x`/`pixel_y` are
+/// terminal-space pixels used only by the SGR-pixels format.
+pub fn encode(
+    event: Event,
+    format: Format,
+    action: Action,
+    button: ?Button,
+    mods: Mods,
+    col: usize,
+    row: usize,
+    pixel_x: i32,
+    pixel_y: i32,
+    out: []u8,
+    len: *usize,
+) bool {
+    if (!shouldReport(event, action, button)) return false;
+    const code = buttonCode(event, format, action, button, mods);
+    const release = action == .release;
+    return switch (format) {
+        .sgr => appendFmt(out, len, "\x1b[<{d};{d};{d}{c}", .{
+            code, col + 1, row + 1, @as(u8, if (release) 'm' else 'M'),
+        }),
+        .urxvt => appendFmt(out, len, "\x1b[{d};{d};{d}M", .{
+            32 + @as(u16, code), col + 1, row + 1,
+        }),
+        .sgr_pixels => appendFmt(out, len, "\x1b[<{d};{d};{d}{c}", .{
+            code, @max(0, pixel_x), @max(0, pixel_y), @as(u8, if (release) 'm' else 'M'),
+        }),
+        .x10 => encodeLegacy(code, col, row, out, len, false),
+        .utf8 => encodeLegacy(code, col, row, out, len, true),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+fn expectEncode(
+    expected: []const u8,
+    event: Event,
+    format: Format,
+    action: Action,
+    button: ?Button,
+    mods: Mods,
+    col: usize,
+    row: usize,
+    pixel_x: i32,
+    pixel_y: i32,
+) !void {
+    var buf: [64]u8 = undefined;
+    var len: usize = 0;
+    const wrote = encode(event, format, action, button, mods, col, row, pixel_x, pixel_y, &buf, &len);
+    try testing.expect(wrote);
+    try testing.expectEqualSlices(u8, expected, buf[0..len]);
+}
+
+fn expectNoEncode(
+    event: Event,
+    format: Format,
+    action: Action,
+    button: ?Button,
+    mods: Mods,
+) !void {
+    var buf: [64]u8 = undefined;
+    var len: usize = 0;
+    const wrote = encode(event, format, action, button, mods, 0, 0, 0, 0, &buf, &len);
+    try testing.expect(!wrote);
+    try testing.expectEqual(@as(usize, 0), len);
+}
+
+test "shouldReport gates by tracking mode" {
+    // none: never reports
+    try testing.expect(!shouldReport(.none, .press, .left));
+    // x10: only button presses
+    try testing.expect(shouldReport(.x10, .press, .left));
+    try testing.expect(!shouldReport(.x10, .release, .left));
+    try testing.expect(!shouldReport(.x10, .motion, .left));
+    // normal: presses and releases, but not motion
+    try testing.expect(shouldReport(.normal, .press, .left));
+    try testing.expect(shouldReport(.normal, .release, .left));
+    try testing.expect(!shouldReport(.normal, .motion, .left));
+    // button: motion only with a held button
+    try testing.expect(shouldReport(.button, .motion, .left));
+    try testing.expect(!shouldReport(.button, .motion, null));
+    // any: everything, including button-less motion
+    try testing.expect(shouldReport(.any, .motion, null));
+}
+
+test "SGR encodes press and release with M/m and 1-based coords" {
+    try expectEncode("\x1b[<0;1;1M", .normal, .sgr, .press, .left, .{}, 0, 0, 0, 0);
+    try expectEncode("\x1b[<0;1;1m", .normal, .sgr, .release, .left, .{}, 0, 0, 0, 0);
+    try expectEncode("\x1b[<2;5;3M", .normal, .sgr, .press, .right, .{}, 4, 2, 0, 0);
+    try expectEncode("\x1b[<1;1;1M", .normal, .sgr, .press, .middle, .{}, 0, 0, 0, 0);
+}
+
+test "SGR encodes modifier bits (shift=4 alt=8 ctrl=16)" {
+    try expectEncode("\x1b[<4;1;1M", .normal, .sgr, .press, .left, .{ .shift = true }, 0, 0, 0, 0);
+    try expectEncode("\x1b[<8;1;1M", .normal, .sgr, .press, .left, .{ .alt = true }, 0, 0, 0, 0);
+    try expectEncode("\x1b[<16;1;1M", .normal, .sgr, .press, .left, .{ .ctrl = true }, 0, 0, 0, 0);
+}
+
+test "SGR encodes motion with the +32 motion bit" {
+    try expectEncode("\x1b[<32;4;2M", .button, .sgr, .motion, .left, .{}, 3, 1, 0, 0);
+    // any-mode button-less motion: code 3 + 32 = 35
+    try expectEncode("\x1b[<35;1;1M", .any, .sgr, .motion, null, .{}, 0, 0, 0, 0);
+}
+
+test "SGR-pixels uses pixel coordinates" {
+    try expectEncode("\x1b[<0;100;50M", .normal, .sgr_pixels, .press, .left, .{}, 0, 0, 100, 50);
+}
+
+test "legacy X10 encodes single-byte coords offset by 32, release as button 3" {
+    // press left @ (0,0): ESC [ M, (32+0), (32+0+1), (32+0+1)
+    try expectEncode(&[_]u8{ 0x1b, '[', 'M', 32, 33, 33 }, .normal, .x10, .press, .left, .{}, 0, 0, 0, 0);
+    // legacy release collapses to button 3 (32+3 = 35)
+    try expectEncode(&[_]u8{ 0x1b, '[', 'M', 35, 33, 33 }, .normal, .x10, .release, .left, .{}, 0, 0, 0, 0);
+}
+
+test "UTF-8 format encodes coordinates as UTF-8 codepoints" {
+    // small coord (<95) is identical to single byte
+    try expectEncode(&[_]u8{ 0x1b, '[', 'M', 32, 33, 33 }, .normal, .utf8, .press, .left, .{}, 0, 0, 0, 0);
+    // col 200 -> codepoint 233 (U+00E9) -> 0xC3 0xA9 multibyte; row 0 -> 33
+    try expectEncode(&[_]u8{ 0x1b, '[', 'M', 32, 0xC3, 0xA9, 33 }, .normal, .utf8, .press, .left, .{}, 200, 0, 0, 0);
+}
+
+test "urxvt format frames code as 32+code with decimal coords" {
+    try expectEncode("\x1b[32;1;1M", .normal, .urxvt, .press, .left, .{}, 0, 0, 0, 0);
+}
+
+test "no output when mode is none or event not reportable" {
+    try expectNoEncode(.none, .sgr, .press, .left, .{});
+    try expectNoEncode(.normal, .sgr, .motion, .left, .{}); // normal never reports motion
+    try expectNoEncode(.x10, .sgr, .release, .left, .{}); // x10 never reports release
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -23,6 +23,7 @@ test {
     _ = @import("input/command_dispatch.zig");
     _ = @import("input/click_tracker.zig");
     _ = @import("input/hit_test.zig");
+    _ = @import("input/mouse_report.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");


### PR DESCRIPTION
## Problem

Reported: opening a file in **nvim** (with `mouse=a`), only **wheel-scroll** works — clicking does nothing — even though nvim's mouse is enabled and other terminals behave normally.

## Root cause

Terminal mouse reporting only ever encoded the **wheel**. `ghostty-vt` correctly parses `?1000h/?1002h/?1003h/?1006h` and sets `terminal.flags.mouse_event`/`mouse_format`, but `input.zig` read those flags in **three wheel-only spots** (`appendMouseWheelReport`, `appendAlternateScrollKeys`, `handleMouseWheel`). `handleMouseButton` always routed terminal-area clicks to **local text selection** and never wrote a button report to the PTY — so mouse-aware TUIs (nvim, tmux, htop) saw scrolls but never clicks or drags.

## Fix

- **New dependency-free encoder** `src/input/mouse_report.zig`, mirroring ghostty's `mouse_encode` (`shouldReport` / `buttonCode` / `encode`). Covers press / release / motion in **X10, UTF-8 (1005), SGR (1006), urxvt (1015), SGR-pixels (1016)** formats. Kept dep-free so it runs in the fast unit-test suite; **9 unit tests** wired into `test_fast.zig`.
- **`input.zig` wiring**: when the focused program has enabled mouse tracking, left/middle/right **press, release and drag-motion** are delivered to the PTY instead of driving local selection / paste / context-menu.
  - **Shift** = force the terminal's own selection (standard bypass).
  - **Ctrl/Cmd+click** still opens links/previews (defers to the existing path).
  - Clicks on titlebar / sidebar / browser / preview / copilot panels are never intercepted.
  - Drag-motion is deduplicated by cell to avoid flooding the PTY.

## Testing

- `zig build` ✅
- `zig build test` (fast, incl. the new encoder tests) ✅
- `zig build test-full` ✅

⚠️ Not yet verified live in the GUI (build target is `x86_64-windows-gnu`; couldn't drive a real nvim click from a headless WSL shell). **Please click-test in nvim** (cursor positioning, drag selection, visual mode) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)