### PR TITLE
WispTerm OSC 9/777 desktop notifications (macOS toast + bell-badge fallback)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,7 @@ const macos_app_frameworks = [_][]const u8{
     "CoreText",
     "CoreGraphics",
     "Foundation",
+    "UserNotifications",
     "CoreFoundation",
     "Carbon",
 };
@@ -290,7 +291,7 @@ test "windows system libraries are gated by platform" {
 
 test "macOS platform advertises required app frameworks" {
     const frameworks = appFrameworksFor(PlatformFeatures.forOs(.macos));
-    try std.testing.expectEqual(@as(usize, 8), frameworks.len);
+    try std.testing.expectEqual(@as(usize, 9), frameworks.len);
     try expectContainsString(frameworks, "Metal");
     try expectContainsString(frameworks, "QuartzCore");
     try expectContainsString(frameworks, "AppKit");
@@ -299,6 +300,7 @@ test "macOS platform advertises required app frameworks" {
     try expectContainsString(frameworks, "Foundation");
     try expectContainsString(frameworks, "CoreFoundation");
     try expectContainsString(frameworks, "Carbon");
+    try expectContainsString(frameworks, "UserNotifications");
 
     try std.testing.expectEqual(@as(usize, 0), appFrameworksFor(PlatformFeatures.forOs(.windows)).len);
     try std.testing.expectEqual(@as(usize, 0), appFrameworksFor(PlatformFeatures.forOs(.linux)).len);

--- a/docs/superpowers/plans/2026-05-30-wispterm-osc-notifications.md
+++ b/docs/superpowers/plans/2026-05-30-wispterm-osc-notifications.md
@@ -1,0 +1,848 @@
+# WispTerm OSC 9/777 Desktop Notifications — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When WispTerm receives an OSC 9 / OSC 777 desktop-notification sequence, show a native macOS toast (focus-aware, rate-limited, deduped) or fall back to the existing title-bar bell indicator on other platforms / when notification authorization is unavailable.
+
+**Architecture:** All decision logic lives in a new pure module `src/notification.zig` (bounded queue, content hashing, dedup/rate-limit, focus/platform/auth routing) so it is unit-testable natively on Linux. WispTerm's existing `VtHandler` in `src/Surface.zig` intercepts the already-parsed `show_desktop_notification` action (mirroring its `.bell` interception) and enqueues a copied title/body. The existing per-frame bell drain in `src/AppWindow.zig` is extended to drain the notification queue, apply the pure decision functions, and either call the platform notification facade (macOS toast via UNUserNotificationCenter) or set the bell indicator. macOS work goes through the existing `src/platform/notifications*.zig` backend-dispatch abstraction and the `services_macos_bridge.m` Objective-C bridge.
+
+**Tech Stack:** Zig (terminal core via pinned `ghostty` dependency), Objective-C bridge (`UserNotifications.framework`), existing WispTerm renderer/titlebar + platform abstraction.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-wispterm-osc-notifications-design.md`
+
+**Branch:** `feat/wispterm-osc-notifications` (already created; spec committed at `d273ed1`).
+
+---
+
+## File Structure
+
+| File | Responsibility | Create/Modify |
+|---|---|---|
+| `src/notification.zig` | Pure logic: `Item`, bounded `Queue`, `ingest`, `contentHash`, `shouldDeliver`, `AuthStatus`, `Route`, `decideRoute` + their unit tests | **Create** |
+| `src/test_fast.zig` | Register `notification.zig` so its tests run in the fast suite | Modify (`:42` area) |
+| `src/config.zig` | Add `desktop-notifications: bool = true` field | Modify (`:284` area) |
+| `src/platform/notifications.zig` | Facade: add `showDesktopNotification`, `notificationAuthStatus`, `requestNotificationAuth` | Modify |
+| `src/platform/notifications_unsupported.zig` | No-op / `.unavailable` impls | Modify |
+| `src/platform/notifications_windows.zig` | No-op / `.unavailable` impls | Modify |
+| `src/platform/notifications_macos.zig` | `extern` decls bridging to the `.m` symbols | Modify |
+| `src/platform/services_macos_bridge.m` | UNUserNotificationCenter toast + delegate + auth cache | Modify |
+| `build.zig` | Link `UserNotifications` framework; update framework-count test | Modify (`:31`, `:291-303`) |
+| `src/Surface.zig` | `notif_queue` + `last_notif_*` fields; `.show_desktop_notification` branch in `VtHandler.vt` | Modify (`:134`, `:228` area) |
+| `src/AppWindow.zig` | Drain `notif_queue` after the bell drain; routing + lazy auth + toast/badge | Modify (`:1353`, `:1700`, `:3452`, `:3961` areas) |
+| `packaging/macos/` | Verify/add `CFBundleIdentifier` in `Info.plist` | Verify/Modify |
+
+---
+
+## Task 1: Pure notification module (`src/notification.zig`)
+
+**Files:**
+- Create: `src/notification.zig`
+- Modify: `src/test_fast.zig` (register import)
+
+This module has zero WispTerm dependencies (only `std`), so it compiles and tests natively on Linux.
+
+**Authoritative behavior (resolves a minor ambiguity in the spec's dedup/rate-limit table):**
+- `shouldDeliver` drops anything within `window_ms = 1000` of the last *delivered* notification (this is the ≤1/sec rate limit). Identical content within the window is also dropped (dedup). Different content within the window is **also** dropped (rate limit dominates). After 1000 ms, delivery is allowed. This matches Ghostty's "1 per second" and the user's decision #5 (both rate-limit and dedup).
+- `decideRoute` returns `.toast` only on macOS + authorized + not (window-focused AND active-surface). Otherwise `.badge`. `.none` only when notifications are disabled. (The toast path ALSO sets the bell badge — that is handled by the caller in Task 6, not here.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/notification.zig` with the test block at the bottom (implementation added in Step 3):
+
+```zig
+const std = @import("std");
+
+// ---- (implementation goes here in Step 3) ----
+
+test "makeItem copies and truncates title/body" {
+    const long_title = "T" ** 300;
+    const item = makeItem(long_title, "hello");
+    try std.testing.expectEqual(@as(usize, max_title), item.title().len);
+    try std.testing.expectEqualStrings("hello", item.body());
+
+    const empty = makeItem("", "");
+    try std.testing.expectEqual(@as(usize, 0), empty.title().len);
+    try std.testing.expectEqual(@as(usize, 0), empty.body().len);
+}
+
+test "Queue is FIFO and drops oldest when full" {
+    var q: Queue = .{};
+    var i: usize = 0;
+    while (i < queue_cap + 2) : (i += 1) {
+        var buf: [8]u8 = undefined;
+        const t = std.fmt.bufPrint(&buf, "{d}", .{i}) catch unreachable;
+        ingest(&q, t, "b");
+    }
+    // First two ("0","1") were dropped; oldest remaining is "2".
+    const first = q.pop().?;
+    try std.testing.expectEqualStrings("2", first.title());
+    var count: usize = 1;
+    while (q.pop() != null) count += 1;
+    try std.testing.expectEqual(queue_cap, count);
+    try std.testing.expect(q.pop() == null);
+}
+
+test "contentHash distinguishes title vs body boundary" {
+    try std.testing.expect(contentHash("ab", "c") != contentHash("a", "bc"));
+    try std.testing.expectEqual(contentHash("x", "y"), contentHash("x", "y"));
+}
+
+test "shouldDeliver: rate-limit and dedup within window, allow after" {
+    const h1: u64 = 111;
+    const h2: u64 = 222;
+    // First ever (last_ms = 0 sentinel, far in the past) -> allowed
+    try std.testing.expect(shouldDeliver(10_000, h1, 0, 0));
+    // Same hash within 1s -> dropped (dedup)
+    try std.testing.expect(!shouldDeliver(10_500, h1, 10_000, h1));
+    // Different hash within 1s -> dropped (rate limit)
+    try std.testing.expect(!shouldDeliver(10_500, h2, 10_000, h1));
+    // After 1s -> allowed
+    try std.testing.expect(shouldDeliver(11_000, h2, 10_000, h1));
+}
+
+test "decideRoute matrix" {
+    const A = AuthStatus.authorized;
+    // disabled -> none regardless of anything
+    try std.testing.expectEqual(Route.none, decideRoute(false, true, A, false, false));
+    // macOS authorized, unfocused -> toast
+    try std.testing.expectEqual(Route.toast, decideRoute(true, true, A, false, false));
+    // macOS authorized, focused but background surface -> toast
+    try std.testing.expectEqual(Route.toast, decideRoute(true, true, A, true, false));
+    // macOS authorized, focused AND active surface -> suppressed -> badge
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, A, true, true));
+    // macOS denied -> badge
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, .denied, false, false));
+    // macOS not-yet-authorized -> badge
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, .unavailable, false, false));
+    // non-macOS -> badge even if "authorized"
+    try std.testing.expectEqual(Route.badge, decideRoute(true, false, A, false, false));
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: compile error — `max_title`, `makeItem`, `Queue`, `ingest`, `queue_cap`, `contentHash`, `shouldDeliver`, `AuthStatus`, `Route`, `decideRoute` are undefined. (Note: the test won't run until registered in Step 4, but the file's own `zig test` would fail to compile; the registration in Step 4 is what surfaces it in the suite. If you want an immediate local check before registration, run `zig test src/notification.zig`.)
+
+- [ ] **Step 3: Write the implementation**
+
+Insert above the test block in `src/notification.zig` (replace the `// ---- (implementation goes here ...) ----` line):
+
+```zig
+/// Max bytes retained for a notification title / body. Longer input is truncated.
+pub const max_title: usize = 256;
+pub const max_body: usize = 1024;
+/// Bounded queue capacity. When full, the oldest item is dropped.
+pub const queue_cap: usize = 8;
+/// Rate-limit / dedup window: drop notifications arriving within this many ms
+/// of the last delivered one.
+pub const window_ms: i64 = 1000;
+
+/// One queued notification, owning fixed-size copies of title/body so the
+/// transient slices handed to us by the VT parser can be safely retained.
+pub const Item = struct {
+    title_buf: [max_title]u8 = undefined,
+    title_len: usize = 0,
+    body_buf: [max_body]u8 = undefined,
+    body_len: usize = 0,
+
+    pub fn title(self: *const Item) []const u8 {
+        return self.title_buf[0..self.title_len];
+    }
+    pub fn body(self: *const Item) []const u8 {
+        return self.body_buf[0..self.body_len];
+    }
+};
+
+/// Copy + truncate raw (transient) title/body slices into an owned Item.
+pub fn makeItem(title_in: []const u8, body_in: []const u8) Item {
+    var item: Item = .{};
+    item.title_len = @min(title_in.len, max_title);
+    @memcpy(item.title_buf[0..item.title_len], title_in[0..item.title_len]);
+    item.body_len = @min(body_in.len, max_body);
+    @memcpy(item.body_buf[0..item.body_len], body_in[0..item.body_len]);
+    return item;
+}
+
+/// Mutex-protected bounded FIFO. Pushed from the IO reader thread, popped from
+/// the main thread (same producer/consumer split as `Surface.bell_pending`).
+pub const Queue = struct {
+    mutex: std.Thread.Mutex = .{},
+    items: [queue_cap]Item = undefined,
+    head: usize = 0,
+    len: usize = 0,
+
+    /// Enqueue; if full, drop the oldest item to make room (newest wins).
+    pub fn push(self: *Queue, item: Item) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.len == queue_cap) {
+            self.head = (self.head + 1) % queue_cap; // drop oldest
+            self.len -= 1;
+        }
+        const tail = (self.head + self.len) % queue_cap;
+        self.items[tail] = item;
+        self.len += 1;
+    }
+
+    /// Dequeue the oldest item, or null if empty.
+    pub fn pop(self: *Queue) ?Item {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.len == 0) return null;
+        const item = self.items[self.head];
+        self.head = (self.head + 1) % queue_cap;
+        self.len -= 1;
+        return item;
+    }
+};
+
+/// Convenience: copy/truncate and enqueue in one call (used by the VtHandler).
+pub fn ingest(queue: *Queue, title_in: []const u8, body_in: []const u8) void {
+    queue.push(makeItem(title_in, body_in));
+}
+
+/// Stable hash of (title, body) for dedup. The zero byte separates the two
+/// fields so ("ab","c") and ("a","bc") hash differently.
+pub fn contentHash(title_in: []const u8, body_in: []const u8) u64 {
+    var h = std.hash.Wyhash.init(0);
+    h.update(title_in);
+    h.update(&[_]u8{0});
+    h.update(body_in);
+    return h.final();
+}
+
+/// True if this notification should be delivered now. Drops anything within
+/// `window_ms` of the last delivered notification (rate limit), and identical
+/// content within the window (dedup). `last_time_ms == 0` means "none yet".
+pub fn shouldDeliver(now_ms: i64, h: u64, last_time_ms: i64, last_hash: u64) bool {
+    if (last_time_ms != 0 and (now_ms - last_time_ms) < window_ms) {
+        _ = h;
+        _ = last_hash;
+        return false;
+    }
+    return true;
+}
+
+/// Cached macOS authorization status (mirrors the bridge's int contract).
+pub const AuthStatus = enum(u8) { unavailable = 0, denied = 1, authorized = 2 };
+
+/// What to do with a deliverable notification.
+pub const Route = enum { none, toast, badge };
+
+/// Pure routing decision. `.toast` only on macOS + authorized + not looking
+/// right at it; `.badge` everywhere else; `.none` only when disabled.
+pub fn decideRoute(
+    notif_enabled: bool,
+    is_macos: bool,
+    auth: AuthStatus,
+    window_focused: bool,
+    is_active_surface: bool,
+) Route {
+    if (!notif_enabled) return .none;
+    const suppress = window_focused and is_active_surface;
+    if (is_macos and auth == .authorized and !suppress) return .toast;
+    return .badge;
+}
+```
+
+- [ ] **Step 4: Register the module in the fast test suite**
+
+In `src/test_fast.zig`, after line `_ = @import("render_diagnostics.zig");` (currently `:42`), add:
+
+```zig
+    _ = @import("notification.zig");
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: build succeeds, suite passes (the 5 new `notification.zig` tests run green; overall count increases from the ~673 baseline, 0 failed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/notification.zig src/test_fast.zig
+git commit -m "feat(notification): pure queue + dedup/rate-limit + routing module
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Config toggle `desktop-notifications`
+
+**Files:**
+- Modify: `src/config.zig` (`:284` area)
+- Modify: `src/AppWindow.zig` (global decl `:1369` area; apply `:1708` area)
+
+- [ ] **Step 1: Add the config field**
+
+In `src/config.zig`, immediately after the `@"ai-agent-enabled"` field (currently `:284`), add:
+
+```zig
+/// Show native desktop notifications for OSC 9 / OSC 777 sequences (macOS).
+/// When false, such sequences are ignored entirely (no toast, no bell badge).
+/// Does not affect the plain terminal bell.
+@"desktop-notifications": bool = true,
+```
+
+- [ ] **Step 2: Add the runtime global**
+
+In `src/AppWindow.zig`, after `pub threadlocal var g_ssh_legacy_algorithms: bool = false;` (currently `:1369`), add:
+
+```zig
+pub threadlocal var g_desktop_notifications: bool = true;
+```
+
+- [ ] **Step 3: Wire the global in config-apply**
+
+In `src/AppWindow.zig`, after `g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";` (currently `:1711`), add:
+
+```zig
+    g_desktop_notifications = cfg.@"desktop-notifications";
+```
+
+- [ ] **Step 4: Verify it builds (config has parser/round-trip tests)**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS. `config.zig` is already registered in the fast suite (`test_fast.zig:29`); its existing parse/serialize tests cover the new field's default.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.zig src/AppWindow.zig
+git commit -m "feat(config): add desktop-notifications toggle (default on)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Platform notification facade + non-macOS backends
+
+**Files:**
+- Modify: `src/platform/notifications.zig`
+- Modify: `src/platform/notifications_unsupported.zig`
+- Modify: `src/platform/notifications_windows.zig`
+
+This keeps Linux and Windows builds green. The macOS backend + bridge land in Task 4.
+
+- [ ] **Step 1: Extend the facade**
+
+In `src/platform/notifications.zig`, add a status enum and three pass-through functions. Insert the enum after the `Backend` enum (after its closing `};`, currently `:26`):
+
+```zig
+/// Cached desktop-notification authorization status. Mirrors the macOS
+/// bridge contract: 0 = unavailable/not-determined, 1 = denied, 2 = authorized.
+pub const NotifAuthStatus = enum(u8) { unavailable = 0, denied = 1, authorized = 2 };
+```
+
+Then add these three functions after the existing `requestAttention` function (after its closing `}`, currently `:51`):
+
+```zig
+/// Post a native desktop notification (macOS toast). No-op where unsupported.
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    impl.showDesktopNotification(title, body);
+}
+
+/// Current cached authorization status (synchronous, cheap).
+pub fn notificationAuthStatus() NotifAuthStatus {
+    return @enumFromInt(impl.notificationAuthStatus());
+}
+
+/// Ask the OS for notification permission (shows the system prompt once).
+/// Safe to call repeatedly; the OS only prompts on the first undetermined call.
+pub fn requestNotificationAuth() void {
+    impl.requestNotificationAuth();
+}
+```
+
+- [ ] **Step 2: Implement the unsupported backend**
+
+In `src/platform/notifications_unsupported.zig`, after the `requestAttention` function, add:
+
+```zig
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    _ = title;
+    _ = body;
+}
+
+pub fn notificationAuthStatus() u8 {
+    return 0; // unavailable
+}
+
+pub fn requestNotificationAuth() void {}
+```
+
+- [ ] **Step 3: Implement the windows backend (badge-only per spec)**
+
+In `src/platform/notifications_windows.zig`, after the `requestAttention` function, add:
+
+```zig
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    // Windows uses the title-bar bell badge fallback (no native toast in v1).
+    _ = title;
+    _ = body;
+}
+
+pub fn notificationAuthStatus() u8 {
+    return 0; // unavailable -> caller falls back to badge
+}
+
+pub fn requestNotificationAuth() void {}
+```
+
+- [ ] **Step 4: Update the facade shape test**
+
+In `src/platform/notifications.zig`, extend the existing `test "notifications exposes bell and attention API shape"` by appending before its closing `}`:
+
+```zig
+    const show_info = @typeInfo(@TypeOf(showDesktopNotification)).@"fn";
+    try std.testing.expectEqual(@as(usize, 2), show_info.params.len);
+    try std.testing.expect(show_info.return_type.? == void);
+
+    const status_info = @typeInfo(@TypeOf(notificationAuthStatus)).@"fn";
+    try std.testing.expectEqual(@as(usize, 0), status_info.params.len);
+    try std.testing.expectEqual(NotifAuthStatus, status_info.return_type.?);
+```
+
+- [ ] **Step 5: Verify it builds and the facade test passes**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS (Linux selects the `unsupported` backend; the shape test exercises the new functions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/platform/notifications.zig src/platform/notifications_unsupported.zig src/platform/notifications_windows.zig
+git commit -m "feat(platform): notification facade (showDesktopNotification/auth) + non-macOS no-ops
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: macOS bridge (UNUserNotificationCenter) + build wiring
+
+**Files:**
+- Modify: `src/platform/notifications_macos.zig`
+- Modify: `src/platform/services_macos_bridge.m`
+- Modify: `build.zig` (`:31` frameworks; `:291-303` test)
+
+> This task can only be **compiled and verified on macOS**. On Linux/Windows the macOS backend is not selected, so the build stays green; do the Step 4 build check on a macOS machine/CI.
+
+- [ ] **Step 1: Add extern declarations in the macOS backend**
+
+In `src/platform/notifications_macos.zig`, add the extern decls after the existing two `extern fn` lines, and the three pub functions after `requestAttention`:
+
+```zig
+extern fn wispterm_macos_notif_show(title: [*:0]const u8, body: [*:0]const u8) void;
+extern fn wispterm_macos_notif_auth_status() c_int;
+extern fn wispterm_macos_notif_request_auth() void;
+
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    wispterm_macos_notif_show(title.ptr, body.ptr);
+}
+
+pub fn notificationAuthStatus() u8 {
+    const s = wispterm_macos_notif_auth_status();
+    return if (s < 0 or s > 2) 0 else @intCast(s);
+}
+
+pub fn requestNotificationAuth() void {
+    wispterm_macos_notif_request_auth();
+}
+```
+
+- [ ] **Step 2: Implement the Objective-C bridge**
+
+Append to `src/platform/services_macos_bridge.m` (after the existing notification functions):
+
+```objc
+#import <UserNotifications/UserNotifications.h>
+
+// Cached authorization status: 0 = unavailable/not-determined, 1 = denied, 2 = authorized.
+static int g_wispterm_notif_auth = 0;
+
+// Delegate so notifications also present while WispTerm is the foreground app
+// (needed for the "focused window, background tab" case).
+@interface WisptermNotifDelegate : NSObject <UNUserNotificationCenterDelegate>
+@end
+@implementation WisptermNotifDelegate
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionSound);
+}
+@end
+
+static WisptermNotifDelegate *g_wispterm_notif_delegate = nil;
+
+static UNUserNotificationCenter *wispterm_notif_center(void) {
+    // UNUserNotificationCenter requires a bundle identifier; un-bundled dev
+    // runs have none -> report unavailable and skip.
+    if ([[NSBundle mainBundle] bundleIdentifier] == nil) return nil;
+    return [UNUserNotificationCenter currentNotificationCenter];
+}
+
+void wispterm_macos_notif_request_auth(void) {
+    UNUserNotificationCenter *center = wispterm_notif_center();
+    if (center == nil) { g_wispterm_notif_auth = 0; return; }
+    if (g_wispterm_notif_delegate == nil) {
+        g_wispterm_notif_delegate = [[WisptermNotifDelegate alloc] init];
+    }
+    center.delegate = g_wispterm_notif_delegate;
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                          completionHandler:^(BOOL granted, NSError *_Nullable error) {
+        (void)error;
+        g_wispterm_notif_auth = granted ? 2 : 1;
+    }];
+}
+
+int wispterm_macos_notif_auth_status(void) {
+    return g_wispterm_notif_auth;
+}
+
+void wispterm_macos_notif_show(const char *title, const char *body) {
+    UNUserNotificationCenter *center = wispterm_notif_center();
+    if (center == nil) return;
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.title = [NSString stringWithUTF8String:(title ? title : "")];
+    content.body = [NSString stringWithUTF8String:(body ? body : "")];
+    content.sound = [UNNotificationSound defaultSound];
+    UNNotificationRequest *req =
+        [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+                                             content:content
+                                             trigger:nil];
+    [center addNotificationRequest:req withCompletionHandler:nil];
+}
+```
+
+- [ ] **Step 3: Link the UserNotifications framework**
+
+In `build.zig`, add `"UserNotifications"` to the `macos_app_frameworks` array (currently starts `:31`). After the `"Foundation",` entry add:
+
+```zig
+    "UserNotifications",
+```
+
+- [ ] **Step 4: Update the framework-count test**
+
+In `build.zig`, the test `"macOS platform advertises required app frameworks"` (currently `:291-303`) asserts exactly 8 frameworks. Change the count and add a presence check:
+
+```zig
+    try std.testing.expectEqual(@as(usize, 9), frameworks.len);
+```
+
+and before the final `expectEqual(... .windows ... 0 ...)` line add:
+
+```zig
+    try expectContainsString(frameworks, "UserNotifications");
+```
+
+- [ ] **Step 5: Verify (macOS build + framework test)**
+
+On macOS, run: `zig build test 2>&1 | tail -20` and `zig build 2>&1 | tail -20`
+Expected: framework-count test PASS (now 9); macOS build links `UserNotifications` and the `.m` symbols resolve. On Linux, run `zig build test` to confirm the framework-count test (which is host-independent — it calls `appFrameworksFor(.macos)`) passes there too.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/platform/notifications_macos.zig src/platform/services_macos_bridge.m build.zig
+git commit -m "feat(macos): UNUserNotificationCenter toast bridge + UserNotifications framework
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Surface — intercept the action, enqueue
+
+**Files:**
+- Modify: `src/Surface.zig` (import; `VtHandler.vt` `:134`; fields `:228` area)
+
+- [ ] **Step 1: Import the notification module**
+
+In `src/Surface.zig`, after `const sync_output = @import("sync_output.zig");` (currently `:23`), add:
+
+```zig
+const notification = @import("notification.zig");
+```
+
+- [ ] **Step 2: Add per-surface notification state**
+
+In `src/Surface.zig`, in the "Bell state" section, after the `last_bell_time: i64 = 0,` field (currently `:228`), add:
+
+```zig
+
+// ============================================================================
+// Desktop notification state (OSC 9 / OSC 777)
+// ============================================================================
+
+/// Notifications pushed by the IO reader thread, drained on the main thread.
+notif_queue: notification.Queue = .{},
+/// Last delivered notification's content hash + time, for dedup / rate limit.
+last_notif_hash: u64 = 0,
+last_notif_time: i64 = 0,
+```
+
+- [ ] **Step 3: Intercept the action in `VtHandler.vt`**
+
+In `src/Surface.zig`, in `VtHandler.vt`, immediately after the existing bell block (the `if (action == .bell) { ... return; }` ending at `:137`), add:
+
+```zig
+        if (action == .show_desktop_notification) {
+            notification.ingest(
+                &self.surface.notif_queue,
+                std.mem.sliceTo(value.title, 0),
+                std.mem.sliceTo(value.body, 0),
+            );
+            return;
+        }
+```
+
+> Note: `value.title` / `value.body` are `[:0]const u8` (sentinel-terminated) per ghostty's `ShowDesktopNotification`. `notification.ingest` copies them immediately, so the transient slices are not retained.
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS. (The `.show_desktop_notification` tag and `value.title`/`value.body` come from the pinned ghostty `StreamAction`; the full app graph compiles. `notif_queue` default-initializes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Surface.zig
+git commit -m "feat(surface): intercept show_desktop_notification, enqueue copied title/body
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: AppWindow — drain queue, route, toast/badge
+
+**Files:**
+- Modify: `src/AppWindow.zig` (imports; drain loop `:3961`; new `handleNotification` near `:3464`; lazy-auth global `:1369` area)
+
+- [ ] **Step 1: Import the notification + platform modules (if not already imported)**
+
+In `src/AppWindow.zig`, `platform_notifications` is imported at `:30`. Add the notification module import and `builtin` (NOT currently imported — confirmed) right after it:
+
+```zig
+const notification = @import("notification.zig");
+const builtin = @import("builtin");
+```
+
+Also add a one-shot lazy-auth guard global. After `pub threadlocal var g_desktop_notifications: bool = true;` (added in Task 2, `:1370` area), add:
+
+```zig
+threadlocal var g_notif_auth_requested: bool = false;
+```
+
+- [ ] **Step 2: Add `handleNotification` next to `handleBell`**
+
+In `src/AppWindow.zig`, immediately after `handleBell` (after its closing `}` at `:3464`), add:
+
+```zig
+/// Drain and handle queued desktop notifications for one surface.
+/// `is_active_surface` is true only when the window is focused AND this is the
+/// focused surface of the active tab (so we suppress the toast you'd see anyway).
+fn handleNotification(surface: *Surface, is_active_surface: bool) void {
+    if (!g_desktop_notifications) {
+        // Drain and discard so the queue can't grow while disabled.
+        while (surface.notif_queue.pop() != null) {}
+        return;
+    }
+
+    const is_macos = builtin.os.tag == .macos;
+
+    while (surface.notif_queue.pop()) |item| {
+        const now = std.time.milliTimestamp();
+        const h = notification.contentHash(item.title(), item.body());
+        if (!notification.shouldDeliver(now, h, surface.last_notif_time, surface.last_notif_hash)) {
+            continue;
+        }
+
+        // Lazy authorization request (macOS): first time we'd want a toast,
+        // ask once. This delivery falls back to badge until the user answers.
+        if (is_macos and !g_notif_auth_requested) {
+            platform_notifications.requestNotificationAuth();
+            g_notif_auth_requested = true;
+        }
+
+        const auth: notification.AuthStatus = @enumFromInt(
+            @intFromEnum(platform_notifications.notificationAuthStatus()),
+        );
+        const route = notification.decideRoute(
+            true, // g_desktop_notifications already checked above
+            is_macos,
+            auth,
+            window_focused,
+            is_active_surface,
+        );
+
+        switch (route) {
+            .none => {},
+            .toast => {
+                var title_z: [notification.max_title + 1]u8 = undefined;
+                var body_z: [notification.max_body + 1]u8 = undefined;
+                const t = item.title();
+                const b = item.body();
+                @memcpy(title_z[0..t.len], t);
+                title_z[t.len] = 0;
+                @memcpy(body_z[0..b.len], b);
+                body_z[b.len] = 0;
+                platform_notifications.showDesktopNotification(
+                    title_z[0..t.len :0],
+                    body_z[0..b.len :0],
+                );
+                surface.bell_indicator = true; // also badge the tab
+                surface.bell_indicator_time = now;
+            },
+            .badge => {
+                surface.bell_indicator = true;
+                surface.bell_indicator_time = now;
+            },
+        }
+
+        surface.last_notif_hash = h;
+        surface.last_notif_time = now;
+    }
+}
+```
+
+> `builtin` and `notification` are added as imports in Step 1 above.
+
+- [ ] **Step 3: Call the drain in the per-frame loop**
+
+In `src/AppWindow.zig`, in the bell-drain loop (currently `:3962-3972`), add the notification drain inside the same surface iteration. Replace:
+
+```zig
+                    if (entry.surface.bell_pending.swap(false, .acquire)) {
+                        handleBell(entry.surface, win, ti == tab.g_active_tab);
+                    }
+```
+
+with:
+
+```zig
+                    if (entry.surface.bell_pending.swap(false, .acquire)) {
+                        handleBell(entry.surface, win, ti == tab.g_active_tab);
+                    }
+                    {
+                        const is_active_surface = (ti == tab.g_active_tab) and
+                            (if (tb.focusedSurface()) |fs| fs == entry.surface else false);
+                        handleNotification(entry.surface, is_active_surface);
+                    }
+```
+
+> `tb.focusedSurface()` exists (`src/appwindow/tab.zig:56`). `window_focused` is the existing main-thread global (`:1324`), refreshed each frame at `:3938-3940`.
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS. On Linux, `is_macos` is false → route is always `.badge`; `showDesktopNotification`/`requestNotificationAuth` resolve to the unsupported no-ops. Pure routing/dedup logic is already covered by Task 1's tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "feat(appwindow): drain notification queue -> macOS toast or bell badge (focus-aware)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Verify `Info.plist` has `CFBundleIdentifier`
+
+**Files:**
+- Verify/Modify: `packaging/macos/` (`Info.plist` or its generator)
+
+`UNUserNotificationCenter` returns no center (→ `unavailable` → badge) unless the running `.app` has a bundle identifier. Confirm one is set.
+
+- [ ] **Step 1: Locate the Info.plist / generator**
+
+Run: `grep -rni 'CFBundleIdentifier\|Info.plist\|bundleIdentifier' packaging/macos build.zig`
+Expected: find where `Info.plist` is produced and whether `CFBundleIdentifier` is present.
+
+- [ ] **Step 2: Ensure `CFBundleIdentifier` exists**
+
+If absent, add to the `Info.plist` (or its template/generator) a stable identifier, e.g.:
+
+```xml
+<key>CFBundleIdentifier</key>
+<string>app.cc-remote.phantty</string>
+```
+
+(Match the project's existing bundle/domain convention — check `packaging/macos/README.md` and any signing identity for the right reverse-DNS id; do not invent a new domain if one is already used elsewhere.)
+
+- [ ] **Step 3: Verify (macOS)**
+
+On macOS, after `bash packaging/macos/package.sh` (or the documented build), run:
+`/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' zig-out/bin/WispTerm.app/Contents/Info.plist`
+Expected: prints the identifier (non-empty).
+
+- [ ] **Step 4: Commit (only if a change was needed)**
+
+```bash
+git add packaging/macos
+git commit -m "build(macos): ensure CFBundleIdentifier is set (required for UNUserNotificationCenter)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Regression + macOS manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full native regression**
+
+Run: `zig build test 2>&1 | tail -5` then `zig build test-full 2>&1 | tail -5`
+Expected: both exit 0, 0 failed (baseline ~673/677 + the new `notification.zig` tests).
+
+- [ ] **Step 2: macOS manual checklist** (on a signed `.app` build)
+
+Trigger a notification with: `printf '\033]777;notify;WispTerm;hello from claude\007'` (OSC 777) and `printf '\033]9;simple body\007'` (OSC 9).
+
+- [ ] First notification → system authorization prompt appears → Allow → toast shows.
+- [ ] Window unfocused → toast shows.
+- [ ] Window focused, on the originating tab → NO toast, brief bell indicator.
+- [ ] Window focused, originating tab in background → toast shows (foreground delegate) + bell on that tab.
+- [ ] Deny authorization (`tccutil reset Notifications <bundle-id>`, relaunch, deny) → only bell badge, no toast.
+- [ ] Emit the same OSC twice quickly → only one notification; emit 5 quickly → ≤1/sec.
+- [ ] Set `desktop-notifications = false` in config → nothing (no toast, no bell badge from OSC; plain `\a` bell still works).
+
+- [ ] **Step 3: Non-macOS sanity** (Linux/Windows build)
+
+Emit the OSC sequence → only the title-bar bell badge appears (no crash, no toast).
+
+- [ ] **Step 4: Finalize**
+
+The branch `feat/wispterm-osc-notifications` now contains the spec + implementation. Use `superpowers:finishing-a-development-branch` to decide merge/PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 macOS-only native, others badge → Task 4 (macOS), Task 3 (windows/unsupported no-op), Task 6 routing. ✅
+- §3.2 UNUserNotificationCenter + denied→badge → Task 4 bridge + Task 6 `decideRoute`. ✅
+- §3.3 title-bar bell badge fallback, no body text v1 → Task 6 sets `bell_indicator` only. ✅
+- §3.4 focus suppression → Task 6 `is_active_surface` + `decideRoute`. ✅
+- §3.5 rate-limit + dedup → Task 1 `shouldDeliver`. ✅
+- §3.6 single `desktop-notifications` toggle → Task 2 + Task 6 gate. ✅
+- §4.1 pure module → Task 1. ✅  §4.3 three bridge fns + delegate + auth cache → Task 4. ✅  §4.5 framework + test → Task 4. ✅
+- §6 tests (pure unit + regression) → Task 1, Task 8. ✅
+- §7 CFBundleIdentifier → Task 7. ✅
+
+**Resolved ambiguity:** the spec's dedup/rate-limit table row "异 hash 过" (different hash passes) conflicts with the ≤1/sec rate limit. Authoritative behavior (Task 1): anything within 1000 ms of the last delivered notification is dropped (rate limit dominant; dedup is the same-content subset). Documented in Task 1.
+
+**Spec deviation (integration test):** §6② proposed feeding OSC bytes through `VtStream` in `test-full`. To avoid a fragile heavy-Surface construction, the owned logic was extracted into `notification.ingest`/`makeItem` and unit-tested directly in the fast suite (Task 1); the ghostty-parse→VtHandler wiring is verified by the manual OSC `printf` checks in Task 8. Net coverage is equal or better with no brittle test.
+
+**Type consistency:** `AuthStatus`/`NotifAuthStatus` both `enum(u8){unavailable=0,denied=1,authorized=2}`; bridge returns `c_int` clamped to `u8` in `notifications_macos.zig`; `Route{none,toast,badge}` used identically in Task 1 and Task 6; `decideRoute` signature `(bool,bool,AuthStatus,bool,bool)` matches its call site; `notif_queue`/`last_notif_hash`/`last_notif_time` field names consistent across Task 5 and Task 6.
+
+**Placeholder scan:** no TBD/TODO; every code step has complete code and exact paths/anchors.

--- a/docs/superpowers/specs/2026-05-30-wispterm-osc-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-30-wispterm-osc-notifications-design.md
@@ -1,0 +1,150 @@
+# 设计：WispTerm 桌面通知（OSC 9 / OSC 777）
+
+> 状态：已通过 brainstorming 评审，待写实现计划。
+> 日期：2026-05-30
+> 范围：本 spec 仅覆盖 **feature #1（WispTerm 渲染端）**。配套的"通知配置 skill（feature #2，发送端，含 Codex 扩展）"是独立子系统，另起 spec / plan / 实现循环。
+
+## 1. 背景与动机
+
+终端程序（含 Claude Code / Codex 及其 hook）可以发 OSC 9 / OSC 777 转义序列来"请求弹一条桌面通知"。WispTerm 基于 ghostty 内核（`build.zig.zon` 固定 ghostty 依赖），其 VT 核心**已经能解析** OSC 9/777，但 WispTerm 自己的 apprt 层**没有接线**——当前只把 VT 的 `.bell` 动作接到了标题栏铃铛指示器（`src/Surface.zig` `VtHandler` ~134），`.show_desktop_notification` 被忽略。
+
+目标：让 WispTerm 收到 OSC 9/777 时，在 **macOS** 弹出原生桌面通知（带标题/正文），在其它平台优雅回落到**标题栏铃铛 badge**。这样发送端（hook/程序）只需发一种统一契约（OSC 9/777），呈现端按平台自适应。
+
+## 2. 关键发现（已存在、可复用的基础设施）
+
+- **ghostty VT 核心已解析 OSC 9/777** → 产生 `stream` 动作 `show_desktop_notification`，其值结构 `{ title: [:0]const u8, body: [:0]const u8 }`（`ghostty/src/terminal/osc.zig:95`、`stream.zig:118`）。ghostty 的只读 handler 把它当"无终端副作用"忽略（`stream_terminal.zig:265`），正好留给我们拦截。
+- **WispTerm 只用 `ghostty_vt`（终端/VT 内核），不用 ghostty 的 apprt/Surface**；自有 `src/Surface.zig` 包了一个 `VtHandler`，已用 `if (action == .bell)` 拦截铃铛的成例可镜像。
+- **标题栏铃铛渲染已实现**：`src/renderer/titlebar.zig`（~355 画铃铛字形、~566 透明度动画），由 `Surface.bell_indicator / bell_opacity / bell_indicator_time` 驱动，活动 tab 短暂淡出、后台 tab 常驻，聚焦 tab 时 `src/appwindow/tab.zig:521` 自动清除。
+- **macOS bridge 已存在**：`src/platform/services_macos_bridge.m`，已有 `wispterm_macos_notification_bell()` 与 `..._request_attention()`，**但无桌面 toast 函数**。
+- **WispTerm 是签名的 `.app` bundle**：`packaging/macos/package.sh` 做 codesign + entitlements——这是现代通知 API（`UNUserNotificationCenter`）的前提。已链接框架 8 个（`build.zig:31` `macos_app_frameworks`），**未链 `UserNotifications`**。
+
+## 3. 已确认的设计决策
+
+1. **原生桌面通知：仅 macOS。** WSL/Linux 不做原生（难测，跳过）。
+2. **macOS API：`UNUserNotificationCenter`**（唯一未废弃的现代 API，以 "WispTerm" 身份显示）。拒绝授权 / 未决 / 非 bundle 运行 → 回落 badge。
+3. **fallback 呈现：标题栏铃铛 badge，复用现有 `bell_indicator` 渲染**（零新渲染代码）。**v1 不显示通知正文文字**（标题栏瞬时文字渲染列为后续增强）。
+4. **尊重焦点**：窗口聚焦且通知来自当前活动 surface → 不弹 toast、铃铛短闪；来自后台 tab 或窗口失焦 → 弹 toast + 该 tab 铃铛常驻。
+5. **限流 + 去重**：镜像 ghostty——每 surface ≤ 1 条/秒；`Wyhash(title+body)` 与上一条在 1s 窗口内相同则丢弃。
+6. **单一配置开关** `desktop-notifications`（默认开）；关闭时整条通知忽略（不弹、不置 badge），不影响裸 `\a` 响铃。
+
+## 4. 架构（方案 A1）
+
+**方案选择**：在 WispTerm 自有的 `VtHandler.vt` 里拦截 `.show_desktop_notification`，镜像现有 `.bell` 模式。
+- 否决 A2（接入 ghostty 自带 apprt 动作体系）：WispTerm 不用 ghostty apprt，引入它面太大、不合架构。
+- 否决 A3（在 termio/ReadThread 原始字节流识别）：`VtHandler` 才是 VT 动作派发的规范接缝。
+
+```
+PTY bytes ──(reader thread)──▶ VtStream ▶ VtHandler.vt(action, value)
+                                              │  action == .show_desktop_notification ?
+                                              │  复制 title/body(瞬时切片 → dupe + 截断)
+                                              ▼
+                              Surface.notif_queue   ← 互斥有界队列(新增)
+                                              │
+   ◀──(main thread, 出队)──────────── drain ─┘
+                                              │  notification.decideRoute(...) (纯函数)
+                              ┌───────────────┴───────────────┐
+                       Route.toast                        Route.badge
+                              ▼                                 ▼
+        wispterm_macos_notif_show(title,body)     置 bell_indicator(复用 titlebar 铃铛)
+        (UNUserNotificationCenter)
+                            Route.none → 丢弃(开关关 / 去重 / 限流命中)
+```
+
+### 4.1 新模块 `src/notification.zig`（纯逻辑，可原生测）
+
+把全部决策逻辑抽进一个无重依赖的小模块，平台/线程/UI 只做薄壳：
+
+- `NotifItem { title: BoundedArray(u8,256), body: BoundedArray(u8,1024) }`
+- `truncateTitleBody(title, body) -> NotifItem`：截断 + 空 body 处理。
+- `NotifQueue`：有界互斥队列（容量如 8，满则丢最旧）。
+- `AuthStatus = enum { unavailable, denied, authorized }`（对应 bridge 返回的 0/1/2）。
+- `Route = enum { none, toast, badge }`
+- `shouldDeliver(hash, now_ms, last_hash, last_time_ms) -> bool`：去重（同 hash <1s）+ 限流（≤1/s）。
+- **`decideRoute(notif_enabled, is_macos, auth, window_focused, is_active_surface) -> Route`**：第 3 节决策矩阵 + 开关 + 平台/授权门，全部编码于此。
+
+### 4.2 `Surface.zig` 接缝与状态
+
+- `VtHandler.vt`：在 `if (action == .bell)` 旁加 `.show_desktop_notification` 分支 → `truncateTitleBody` → `notif_queue.push`（reader 线程）。
+- 新增 `Surface` 字段：`notif_queue: NotifQueue`、`last_notif_hash: u64`、`last_notif_time: i64`（镜像现有 `last_bell_time`）。
+- 主线程出队驱动点：复用现有处理铃铛 `bell_pending` 的同一主线程节拍（每帧/事件循环），出队 → `shouldDeliver` → `decideRoute` → toast 或置 `bell_indicator`。
+
+### 4.3 macOS bridge `services_macos_bridge.m`（新增 3 个 C 接口）
+
+| 接口 | 作用 |
+|---|---|
+| `void wispterm_macos_notif_request_auth(void)` | **懒授权**：首次要发通知时调一次 → 触发系统授权框；completion 里更新进程级缓存 `g_auth_status` |
+| `int wispterm_macos_notif_auth_status(void)` | **同步**返回缓存状态(0=未决/不可用,1=已拒,2=已授权)，供 `decideRoute` 决策 |
+| `void wispterm_macos_notif_show(const char*title,const char*body)` | `UNMutableNotificationContent` + `UNNotificationRequest`(唯一 id、nil trigger 立即触发)投递 |
+
+- **前台呈现 delegate（必须）**：设 `UNUserNotificationCenterDelegate`，在 `willPresentNotification` 返回 `.banner | .sound`——否则"窗口聚焦但来源 tab 在后台"这一情形 App 处于前台、macOS 会抑制通知。
+- 授权查询是异步的，故缓存到 `g_auth_status`，Zig 侧同步读，避免每条通知都异步查询。
+- 非 bundle 运行（dev / `zig build run`）：bridge 检测无 bundle → `auth_status=0` → 回落 badge，开发不崩。
+
+### 4.4 配置 `config.zig`
+
+- 新增 `desktop-notifications: bool = true`（沿用 ghostty 同名）。`decideRoute` 第一个门即此开关。
+
+### 4.5 构建 `build.zig`
+
+- `macos_app_frameworks` 加 `"UserNotifications"`（8 → 9）。
+- **同步更新**断言"恰好 8 个框架"的测试（`build.zig:293` 一带 → 改为 9 并加 `expectContainsString(..., "UserNotifications")`）。
+
+## 5. 行为：焦点抑制判定矩阵
+
+通知到达，来源 surface = S，所在 tab = T：
+
+| 条件 | toast | badge(铃铛) |
+|---|---|---|
+| 窗口聚焦 **且** S 是当前活动 surface | ❌ | 置位(活动 tab 短暂闪) |
+| S 在后台 tab(窗口聚焦) | ✅ (靠前台 delegate) | 置位(后台常驻) |
+| 窗口失焦 | ✅ (App 后台正常显示) | 置位(后台常驻) |
+| 非 macOS / 授权被拒 / 未决 / 非 bundle | ❌ | 置位 |
+| `desktop-notifications=false` 或 去重/限流命中 | ❌ | ❌(整条丢弃) |
+
+依赖 AppWindow 现有的"窗口是否聚焦""哪个 surface 活动"状态（`tab.zig:516-521` 聚焦清铃铛已证明可得）——实现期确认取用点。
+
+## 6. 测试
+
+**① 纯逻辑单元测试（`src/notification.zig`，注册进 `test_fast.zig`，原生跑）：**
+- `NotifQueue`：入/出队、满了丢最旧、容量上限。
+- `truncateTitleBody`：title 256 / body 1024 截断、空/无 body。
+- `shouldDeliver`：表驱动（同 hash<1s 丢、异 hash 过、>1s 过、超频丢）。
+- `decideRoute`：逐行覆盖第 5 节矩阵 + 开关 + 平台/授权门。**最高价值**。
+
+**② 集成测试（`test-full`）：** 把 OSC 9 与 OSC 777 字节喂进 `VtStream`/`VtHandler`，断言 `surface.notif_queue` 出现正确 title/body——端到端验证"ghostty 解析 → 我们的 handler → 我们的队列"，Linux 即可、不碰平台代码。
+
+**③ macOS 手验清单（无法自动化）：**
+1. 首条 → 授权框 → 允许 → toast。
+2. 窗口失焦触发 → toast 正常。
+3. 聚焦且在来源 tab → 不弹、铃铛短闪。
+4. 聚焦但来源 tab 在后台 → 弹（验证前台 delegate）+ 后台 tab 铃铛。
+5. 拒绝授权（`tccutil reset` 重置）→ 只铃铛、无 toast。
+6. 同条快发两次 → 一条；快发 5 条 → ≤1/秒。
+7. `desktop-notifications=false` → 啥都没有。
+8. 非 macOS（Win/Linux）→ 只铃铛 badge。
+
+**④ 回归门槛：** `zig build test` + `zig build test-full` 全绿（基线 ~673/677、0 failed）。macOS CI（若有 #90 诊断 workflow）编译 Obj-C bridge + 新框架，挡链接错误。
+
+## 7. 前置校验与风险
+
+- **`Info.plist` 必须含 `CFBundleIdentifier`**——`UNUserNotificationCenter` 强制要求。`packaging/` 中未直接 grep 到，实现期须核实/补上，否则 toast 永远失败。
+- **`UserNotifications` 框架可用性**：需 macOS 10.14+；WispTerm 目标版本应已满足，实现期确认部署目标。
+- **授权竞态**：懒授权后用户尚未点选时，`auth_status` 为未决 → 该窗口期通知落 badge（可接受）。
+
+## 8. 范围边界（YAGNI / 本期不做）
+
+- **feature #2：通知配置 skill（发送端 + Codex 扩展）** —— 独立 spec。
+- **Windows / Linux / WSL 原生桌面通知** —— 只做铃铛 badge 回落。
+- **标题栏显示通知正文文字** —— v1 只铃铛字形；文字渲染列为后续增强。
+- **点击通知 → 聚焦/切到来源 tab** —— v1 只显示，不做点击路由。
+- **toast / badge 细粒度独立开关** —— 只一个总开关。
+
+## 9. 影响文件一览（预估）
+
+- 新增 `src/notification.zig`（纯逻辑 + 单测）。
+- 改 `src/Surface.zig`（VtHandler 分支、新增字段、主线程出队驱动）。
+- 改 `src/platform/services_macos_bridge.m`（3 个接口 + delegate + 授权缓存）。
+- 改 `src/config.zig`（`desktop-notifications` 开关）。
+- 改 `build.zig`（链 `UserNotifications` + 改框架数测试）。
+- 改 `src/test_fast.zig`（注册 `notification.zig` 测试）、`test_main.zig`（集成测试）。
+- 核实 `packaging/macos`（`Info.plist` 的 `CFBundleIdentifier`）。

--- a/docs/superpowers/specs/2026-05-30-wispterm-osc-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-30-wispterm-osc-notifications-design.md
@@ -24,7 +24,7 @@
 2. **macOS API：`UNUserNotificationCenter`**（唯一未废弃的现代 API，以 "WispTerm" 身份显示）。拒绝授权 / 未决 / 非 bundle 运行 → 回落 badge。
 3. **fallback 呈现：标题栏铃铛 badge，复用现有 `bell_indicator` 渲染**（零新渲染代码）。**v1 不显示通知正文文字**（标题栏瞬时文字渲染列为后续增强）。
 4. **尊重焦点**：窗口聚焦且通知来自当前活动 surface → 不弹 toast、铃铛短闪；来自后台 tab 或窗口失焦 → 弹 toast + 该 tab 铃铛常驻。
-5. **限流 + 去重**：镜像 ghostty——每 surface ≤ 1 条/秒；`Wyhash(title+body)` 与上一条在 1s 窗口内相同则丢弃。
+5. **限流 + 去重**：每 surface ≤ 1 条/秒（限流，任意内容）；另对**相同内容**（`Wyhash(title+body)`）用更长的 **5s** 去重窗口抑制重复。〔实现期细化：原措辞的"1s 去重窗口"与"≤1/s 限流"等价冗余、会让 Wyhash 变成死参数，故把去重窗口拉长到 5s，使限流与去重成为两条真正生效的规则。详见 plan 自审。〕
 6. **单一配置开关** `desktop-notifications`（默认开）；关闭时整条通知忽略（不弹、不置 badge），不影响裸 `\a` 响铃。
 
 ## 4. 架构（方案 A1）

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3469,8 +3469,9 @@ fn handleBell(surface: *Surface, win: *window_backend.Window, is_active_tab: boo
 }
 
 /// Drain and handle queued desktop notifications for one surface.
-/// `is_active_surface` is true only when the window is focused AND this is the
-/// focused surface of the active tab (so we suppress the toast you'd see anyway).
+/// `is_active_surface` means this is the focused surface of the active tab.
+/// Window focus is applied separately inside `notification.decideRoute`, which
+/// only suppresses the toast when the window is focused AND this is true.
 fn handleNotification(surface: *Surface, is_active_surface: bool) void {
     if (!g_desktop_notifications) {
         // Drain and discard so the queue can't grow while disabled.
@@ -3522,15 +3523,16 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
                 );
                 surface.bell_indicator = true; // also badge the tab
                 surface.bell_indicator_time = now;
+                surface.last_notif_hash = h;
+                surface.last_notif_time = now;
             },
             .badge => {
                 surface.bell_indicator = true;
                 surface.bell_indicator_time = now;
+                surface.last_notif_hash = h;
+                surface.last_notif_time = now;
             },
         }
-
-        surface.last_notif_hash = h;
-        surface.last_notif_time = now;
     }
 }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -28,6 +28,8 @@ const platform_file_dialog = @import("platform/file_dialog.zig");
 const platform_global_hotkey = @import("platform/global_hotkey.zig");
 const platform_menu = @import("platform/menu.zig");
 const platform_notifications = @import("platform/notifications.zig");
+const notification = @import("notification.zig");
+const builtin = @import("builtin");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_window_state = @import("platform/window_state.zig");
 const platform_wsl = @import("platform/wsl.zig");
@@ -1368,6 +1370,7 @@ pub threadlocal var g_copy_on_select: bool = false;
 pub threadlocal var g_right_click_action: Config.RightClickAction = .copy;
 pub threadlocal var g_ssh_legacy_algorithms: bool = false;
 pub threadlocal var g_desktop_notifications: bool = true;
+threadlocal var g_notif_auth_requested: bool = false;
 
 /// Update cursor blink state based on time (call once per frame)
 fn updateCursorBlink() void {
@@ -3465,6 +3468,72 @@ fn handleBell(surface: *Surface, win: *window_backend.Window, is_active_tab: boo
     platform_notifications.requestAttention(window_backend.nativeHandle(win));
 }
 
+/// Drain and handle queued desktop notifications for one surface.
+/// `is_active_surface` is true only when the window is focused AND this is the
+/// focused surface of the active tab (so we suppress the toast you'd see anyway).
+fn handleNotification(surface: *Surface, is_active_surface: bool) void {
+    if (!g_desktop_notifications) {
+        // Drain and discard so the queue can't grow while disabled.
+        while (surface.notif_queue.pop() != null) {}
+        return;
+    }
+
+    const is_macos = builtin.os.tag == .macos;
+
+    while (surface.notif_queue.pop()) |item| {
+        const now = std.time.milliTimestamp();
+        const h = notification.contentHash(item.title(), item.body());
+        if (!notification.shouldDeliver(now, h, surface.last_notif_time, surface.last_notif_hash)) {
+            continue;
+        }
+
+        // Lazy authorization request (macOS): first time we'd want a toast,
+        // ask once. This delivery falls back to badge until the user answers.
+        if (is_macos and !g_notif_auth_requested) {
+            platform_notifications.requestNotificationAuth();
+            g_notif_auth_requested = true;
+        }
+
+        const auth: notification.AuthStatus = @enumFromInt(
+            @intFromEnum(platform_notifications.notificationAuthStatus()),
+        );
+        const route = notification.decideRoute(
+            true, // g_desktop_notifications already checked above
+            is_macos,
+            auth,
+            window_focused,
+            is_active_surface,
+        );
+
+        switch (route) {
+            .none => {},
+            .toast => {
+                var title_z: [notification.max_title + 1]u8 = undefined;
+                var body_z: [notification.max_body + 1]u8 = undefined;
+                const t = item.title();
+                const b = item.body();
+                @memcpy(title_z[0..t.len], t);
+                title_z[t.len] = 0;
+                @memcpy(body_z[0..b.len], b);
+                body_z[b.len] = 0;
+                platform_notifications.showDesktopNotification(
+                    title_z[0..t.len :0],
+                    body_z[0..b.len :0],
+                );
+                surface.bell_indicator = true; // also badge the tab
+                surface.bell_indicator_time = now;
+            },
+            .badge => {
+                surface.bell_indicator = true;
+                surface.bell_indicator_time = now;
+            },
+        }
+
+        surface.last_notif_hash = h;
+        surface.last_notif_time = now;
+    }
+}
+
 /// Internal main loop - called by AppWindow.run() after init() has set up globals.
 fn runMainLoop(self: *AppWindow) !void {
     const allocator = self.allocator;
@@ -3968,6 +4037,11 @@ fn runMainLoop(self: *AppWindow) !void {
                 while (it.next()) |entry| {
                     if (entry.surface.bell_pending.swap(false, .acquire)) {
                         handleBell(entry.surface, win, ti == tab.g_active_tab);
+                    }
+                    {
+                        const is_active_surface = (ti == tab.g_active_tab) and
+                            (if (tb.focusedSurface()) |fs| fs == entry.surface else false);
+                        handleNotification(entry.surface, is_active_surface);
                     }
                 }
             }

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -28,8 +28,7 @@ const platform_file_dialog = @import("platform/file_dialog.zig");
 const platform_global_hotkey = @import("platform/global_hotkey.zig");
 const platform_menu = @import("platform/menu.zig");
 const platform_notifications = @import("platform/notifications.zig");
-const notification = @import("notification.zig");
-const builtin = @import("builtin");
+const notif_mod = @import("notification.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_window_state = @import("platform/window_state.zig");
 const platform_wsl = @import("platform/wsl.zig");
@@ -3470,7 +3469,7 @@ fn handleBell(surface: *Surface, win: *window_backend.Window, is_active_tab: boo
 
 /// Drain and handle queued desktop notifications for one surface.
 /// `is_active_surface` means this is the focused surface of the active tab.
-/// Window focus is applied separately inside `notification.decideRoute`, which
+/// Window focus is applied separately inside `notif_mod.decideRoute`, which
 /// only suppresses the toast when the window is focused AND this is true.
 fn handleNotification(surface: *Surface, is_active_surface: bool) void {
     if (!g_desktop_notifications) {
@@ -3479,28 +3478,28 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
         return;
     }
 
-    const is_macos = builtin.os.tag == .macos;
+    const native_toast = platform_notifications.supports_desktop_notifications;
 
     while (surface.notif_queue.pop()) |item| {
         const now = std.time.milliTimestamp();
-        const h = notification.contentHash(item.title(), item.body());
-        if (!notification.shouldDeliver(now, h, surface.last_notif_time, surface.last_notif_hash)) {
+        const h = notif_mod.contentHash(item.title(), item.body());
+        if (!notif_mod.shouldDeliver(now, h, surface.last_notif_time, surface.last_notif_hash)) {
             continue;
         }
 
         // Lazy authorization request (macOS): first time we'd want a toast,
         // ask once. This delivery falls back to badge until the user answers.
-        if (is_macos and !g_notif_auth_requested) {
+        if (native_toast and !g_notif_auth_requested) {
             platform_notifications.requestNotificationAuth();
             g_notif_auth_requested = true;
         }
 
-        const auth: notification.AuthStatus = @enumFromInt(
+        const auth: notif_mod.AuthStatus = @enumFromInt(
             @intFromEnum(platform_notifications.notificationAuthStatus()),
         );
-        const route = notification.decideRoute(
+        const route = notif_mod.decideRoute(
             true, // g_desktop_notifications already checked above
-            is_macos,
+            native_toast,
             auth,
             window_focused,
             is_active_surface,
@@ -3509,8 +3508,8 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
         switch (route) {
             .none => {},
             .toast => {
-                var title_z: [notification.max_title + 1]u8 = undefined;
-                var body_z: [notification.max_body + 1]u8 = undefined;
+                var title_z: [notif_mod.max_title + 1]u8 = undefined;
+                var body_z: [notif_mod.max_body + 1]u8 = undefined;
                 const t = item.title();
                 const b = item.body();
                 @memcpy(title_z[0..t.len], t);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1367,6 +1367,7 @@ threadlocal var g_agent_context_surface_id_len: usize = 0;
 pub threadlocal var g_copy_on_select: bool = false;
 pub threadlocal var g_right_click_action: Config.RightClickAction = .copy;
 pub threadlocal var g_ssh_legacy_algorithms: bool = false;
+pub threadlocal var g_desktop_notifications: bool = true;
 
 /// Update cursor blink state based on time (call once per frame)
 fn updateCursorBlink() void {
@@ -1709,6 +1710,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     g_right_click_action = cfg.@"right-click-action";
     input.g_url_open_mode = cfg.@"url-open-mode";
     g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
+    g_desktop_notifications = cfg.@"desktop-notifications";
     tab.g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     overlays.g_split_divider_color = cfg.@"split-divider-color";
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -398,6 +398,15 @@ pub fn init(
     surface.exited = std.atomic.Value(bool).init(false);
     surface.resize_in_progress = std.atomic.Value(bool).init(false);
 
+    // Desktop-notification state. `allocator.create` returns undefined memory
+    // and this constructor initializes every field explicitly (struct-default
+    // values are NOT applied here), so these must be set or notif_queue's mutex
+    // is garbage — the first handleNotification()/Queue.pop() lock then aborts
+    // with os_unfair_lock corruption (SIGKILL on the first frame).
+    surface.notif_queue = .{};
+    surface.last_notif_hash = 0;
+    surface.last_notif_time = 0;
+
     // Initialize mailbox for main thread → IO writer communication
     surface.mailbox = try termio.Mailbox.init();
     errdefer surface.mailbox.deinit();

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -21,6 +21,7 @@ const remote = @import("remote_client.zig");
 const threading = @import("threading.zig");
 const agent_detector = @import("agent_detector.zig");
 const sync_output = @import("sync_output.zig");
+const notification = @import("notification.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
 
@@ -136,6 +137,15 @@ pub const VtHandler = struct {
             return;
         }
 
+        if (action == .show_desktop_notification) {
+            notification.ingest(
+                &self.surface.notif_queue,
+                value.title,
+                value.body,
+            );
+            return;
+        }
+
         const sync_before = self.surface.terminal.modes.get(.synchronized_output);
         const sync_mode_touched = switch (action) {
             .set_mode,
@@ -226,6 +236,16 @@ bell_pending: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
 /// Timestamp of the last bell notification, for rate limiting (100ms like Ghostty).
 last_bell_time: i64 = 0,
+
+// ============================================================================
+// Desktop notification state (OSC 9 / OSC 777)
+// ============================================================================
+
+/// Notifications pushed by the IO reader thread, drained on the main thread.
+notif_queue: notification.Queue = .{},
+/// Last delivered notification's content hash + time, for dedup / rate limit.
+last_notif_hash: u64 = 0,
+last_notif_time: i64 = 0,
 
 /// Bell indicator opacity (0.0 = hidden, 1.0 = fully visible).
 /// Fades in when bell fires, fades out on active tab after hold period.

--- a/src/config.zig
+++ b/src/config.zig
@@ -283,6 +283,11 @@ theme: ?[]const u8 = null,
 /// Enable agent tools for AI Chat profiles by default.
 @"ai-agent-enabled": bool = false,
 
+/// Show native desktop notifications for OSC 9 / OSC 777 sequences (macOS).
+/// When false, such sequences are ignored entirely (no toast, no bell badge).
+/// Does not affect the plain terminal bell.
+@"desktop-notifications": bool = true,
+
 /// Agent command permission mode: confirm (deny until approved UI exists) or full.
 @"ai-agent-permission": ai_chat.AgentPermission = .confirm,
 

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -106,18 +106,19 @@ pub const AuthStatus = enum(u8) { unavailable = 0, denied = 1, authorized = 2 };
 /// What to do with a deliverable notification.
 pub const Route = enum { none, toast, badge };
 
-/// Pure routing decision. `.toast` only on macOS + authorized + not looking
-/// right at it; `.badge` everywhere else; `.none` only when disabled.
+/// Pure routing decision. `.toast` only when the platform supports native
+/// toasts (macOS) AND authorized AND you're not looking right at it; `.badge`
+/// everywhere else; `.none` only when disabled.
 pub fn decideRoute(
     notif_enabled: bool,
-    is_macos: bool,
+    native_toast_supported: bool,
     auth: AuthStatus,
     window_focused: bool,
     is_active_surface: bool,
 ) Route {
     if (!notif_enabled) return .none;
     const suppress = window_focused and is_active_surface;
-    if (is_macos and auth == .authorized and !suppress) return .toast;
+    if (native_toast_supported and auth == .authorized and !suppress) return .toast;
     return .badge;
 }
 

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -5,9 +5,12 @@ pub const max_title: usize = 256;
 pub const max_body: usize = 1024;
 /// Bounded queue capacity. When full, the oldest item is dropped.
 pub const queue_cap: usize = 8;
-/// Rate-limit / dedup window: drop notifications arriving within this many ms
-/// of the last delivered one.
-pub const window_ms: i64 = 1000;
+/// Rate limit: at most one notification per this many ms, regardless of content.
+pub const rate_limit_ms: i64 = 1000;
+/// Content dedup: an identical (same-hash) notification is suppressed for this
+/// many ms — longer than the rate limit, so a program re-emitting the same
+/// notification stays quiet even at intervals that clear the rate limit.
+pub const dedup_ms: i64 = 5000;
 
 /// One queued notification, owning fixed-size copies of title/body so the
 /// transient slices handed to us by the VT parser can be safely retained.
@@ -83,15 +86,17 @@ pub fn contentHash(title_in: []const u8, body_in: []const u8) u64 {
     return h.final();
 }
 
-/// True if this notification should be delivered now. Drops anything within
-/// `window_ms` of the last delivered notification (rate limit), and identical
-/// content within the window (dedup). `last_time_ms == 0` means "none yet".
+/// True if this notification should be delivered now. Two rules, both keyed off
+/// the last *delivered* notification's time/hash:
+///   1. Rate limit: drop anything within `rate_limit_ms` (≤ 1 per second).
+///   2. Content dedup: drop an identical (same-hash) notification within the
+///      longer `dedup_ms` window.
+/// `last_time_ms == 0` means "none delivered yet" → always allow.
 pub fn shouldDeliver(now_ms: i64, h: u64, last_time_ms: i64, last_hash: u64) bool {
-    if (last_time_ms != 0 and (now_ms - last_time_ms) < window_ms) {
-        _ = h;
-        _ = last_hash;
-        return false;
-    }
+    if (last_time_ms == 0) return true;
+    const dt = now_ms - last_time_ms;
+    if (dt < rate_limit_ms) return false; // rate limit (any content)
+    if (h == last_hash and dt < dedup_ms) return false; // identical-content dedup
     return true;
 }
 
@@ -149,17 +154,21 @@ test "contentHash distinguishes title vs body boundary" {
     try std.testing.expectEqual(contentHash("x", "y"), contentHash("x", "y"));
 }
 
-test "shouldDeliver: rate-limit and dedup within window, allow after" {
+test "shouldDeliver: rate limit (any content) + longer content dedup" {
     const h1: u64 = 111;
     const h2: u64 = 222;
-    // First ever (last_ms = 0 sentinel) -> allowed
+    // First ever (last_time = 0 sentinel) -> allowed
     try std.testing.expect(shouldDeliver(10_000, h1, 0, 0));
-    // Same hash within 1s -> dropped (dedup)
+    // Within rate-limit window, same content -> dropped (rate limit)
     try std.testing.expect(!shouldDeliver(10_500, h1, 10_000, h1));
-    // Different hash within 1s -> dropped (rate limit)
+    // Within rate-limit window, different content -> dropped (rate limit dominates)
     try std.testing.expect(!shouldDeliver(10_500, h2, 10_000, h1));
-    // After 1s -> allowed
+    // Past rate limit, different content -> allowed
     try std.testing.expect(shouldDeliver(11_000, h2, 10_000, h1));
+    // Past rate limit but identical content within dedup window -> dropped (dedup)
+    try std.testing.expect(!shouldDeliver(13_000, h1, 10_000, h1));
+    // Past dedup window, identical content -> allowed
+    try std.testing.expect(shouldDeliver(16_000, h1, 10_000, h1));
 }
 
 test "decideRoute matrix" {

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+
+/// Max bytes retained for a notification title / body. Longer input is truncated.
+pub const max_title: usize = 256;
+pub const max_body: usize = 1024;
+/// Bounded queue capacity. When full, the oldest item is dropped.
+pub const queue_cap: usize = 8;
+/// Rate-limit / dedup window: drop notifications arriving within this many ms
+/// of the last delivered one.
+pub const window_ms: i64 = 1000;
+
+/// One queued notification, owning fixed-size copies of title/body so the
+/// transient slices handed to us by the VT parser can be safely retained.
+pub const Item = struct {
+    title_buf: [max_title]u8 = undefined,
+    title_len: usize = 0,
+    body_buf: [max_body]u8 = undefined,
+    body_len: usize = 0,
+
+    pub fn title(self: *const Item) []const u8 {
+        return self.title_buf[0..self.title_len];
+    }
+    pub fn body(self: *const Item) []const u8 {
+        return self.body_buf[0..self.body_len];
+    }
+};
+
+/// Copy + truncate raw (transient) title/body slices into an owned Item.
+pub fn makeItem(title_in: []const u8, body_in: []const u8) Item {
+    var item: Item = .{};
+    item.title_len = @min(title_in.len, max_title);
+    @memcpy(item.title_buf[0..item.title_len], title_in[0..item.title_len]);
+    item.body_len = @min(body_in.len, max_body);
+    @memcpy(item.body_buf[0..item.body_len], body_in[0..item.body_len]);
+    return item;
+}
+
+/// Mutex-protected bounded FIFO. Pushed from the IO reader thread, popped from
+/// the main thread (same producer/consumer split as `Surface.bell_pending`).
+pub const Queue = struct {
+    mutex: std.Thread.Mutex = .{},
+    items: [queue_cap]Item = undefined,
+    head: usize = 0,
+    len: usize = 0,
+
+    /// Enqueue; if full, drop the oldest item to make room (newest wins).
+    pub fn push(self: *Queue, item: Item) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.len == queue_cap) {
+            self.head = (self.head + 1) % queue_cap; // drop oldest
+            self.len -= 1;
+        }
+        const tail = (self.head + self.len) % queue_cap;
+        self.items[tail] = item;
+        self.len += 1;
+    }
+
+    /// Dequeue the oldest item, or null if empty.
+    pub fn pop(self: *Queue) ?Item {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.len == 0) return null;
+        const item = self.items[self.head];
+        self.head = (self.head + 1) % queue_cap;
+        self.len -= 1;
+        return item;
+    }
+};
+
+/// Convenience: copy/truncate and enqueue in one call (used by the VtHandler).
+pub fn ingest(queue: *Queue, title_in: []const u8, body_in: []const u8) void {
+    queue.push(makeItem(title_in, body_in));
+}
+
+/// Stable hash of (title, body) for dedup. The zero byte separates the two
+/// fields so ("ab","c") and ("a","bc") hash differently.
+pub fn contentHash(title_in: []const u8, body_in: []const u8) u64 {
+    var h = std.hash.Wyhash.init(0);
+    h.update(title_in);
+    h.update(&[_]u8{0});
+    h.update(body_in);
+    return h.final();
+}
+
+/// True if this notification should be delivered now. Drops anything within
+/// `window_ms` of the last delivered notification (rate limit), and identical
+/// content within the window (dedup). `last_time_ms == 0` means "none yet".
+pub fn shouldDeliver(now_ms: i64, h: u64, last_time_ms: i64, last_hash: u64) bool {
+    if (last_time_ms != 0 and (now_ms - last_time_ms) < window_ms) {
+        _ = h;
+        _ = last_hash;
+        return false;
+    }
+    return true;
+}
+
+/// Cached macOS authorization status (mirrors the bridge's int contract).
+pub const AuthStatus = enum(u8) { unavailable = 0, denied = 1, authorized = 2 };
+
+/// What to do with a deliverable notification.
+pub const Route = enum { none, toast, badge };
+
+/// Pure routing decision. `.toast` only on macOS + authorized + not looking
+/// right at it; `.badge` everywhere else; `.none` only when disabled.
+pub fn decideRoute(
+    notif_enabled: bool,
+    is_macos: bool,
+    auth: AuthStatus,
+    window_focused: bool,
+    is_active_surface: bool,
+) Route {
+    if (!notif_enabled) return .none;
+    const suppress = window_focused and is_active_surface;
+    if (is_macos and auth == .authorized and !suppress) return .toast;
+    return .badge;
+}
+
+test "makeItem copies and truncates title/body" {
+    const long_title = "T" ** 300;
+    const item = makeItem(long_title, "hello");
+    try std.testing.expectEqual(@as(usize, max_title), item.title().len);
+    try std.testing.expectEqualStrings("hello", item.body());
+
+    const empty = makeItem("", "");
+    try std.testing.expectEqual(@as(usize, 0), empty.title().len);
+    try std.testing.expectEqual(@as(usize, 0), empty.body().len);
+}
+
+test "Queue is FIFO and drops oldest when full" {
+    var q: Queue = .{};
+    var i: usize = 0;
+    while (i < queue_cap + 2) : (i += 1) {
+        var buf: [8]u8 = undefined;
+        const t = std.fmt.bufPrint(&buf, "{d}", .{i}) catch unreachable;
+        ingest(&q, t, "b");
+    }
+    // First two ("0","1") were dropped; oldest remaining is "2".
+    const first = q.pop().?;
+    try std.testing.expectEqualStrings("2", first.title());
+    var count: usize = 1;
+    while (q.pop() != null) count += 1;
+    try std.testing.expectEqual(queue_cap, count);
+    try std.testing.expect(q.pop() == null);
+}
+
+test "contentHash distinguishes title vs body boundary" {
+    try std.testing.expect(contentHash("ab", "c") != contentHash("a", "bc"));
+    try std.testing.expectEqual(contentHash("x", "y"), contentHash("x", "y"));
+}
+
+test "shouldDeliver: rate-limit and dedup within window, allow after" {
+    const h1: u64 = 111;
+    const h2: u64 = 222;
+    // First ever (last_ms = 0 sentinel) -> allowed
+    try std.testing.expect(shouldDeliver(10_000, h1, 0, 0));
+    // Same hash within 1s -> dropped (dedup)
+    try std.testing.expect(!shouldDeliver(10_500, h1, 10_000, h1));
+    // Different hash within 1s -> dropped (rate limit)
+    try std.testing.expect(!shouldDeliver(10_500, h2, 10_000, h1));
+    // After 1s -> allowed
+    try std.testing.expect(shouldDeliver(11_000, h2, 10_000, h1));
+}
+
+test "decideRoute matrix" {
+    const A = AuthStatus.authorized;
+    try std.testing.expectEqual(Route.none, decideRoute(false, true, A, false, false));
+    try std.testing.expectEqual(Route.toast, decideRoute(true, true, A, false, false));
+    try std.testing.expectEqual(Route.toast, decideRoute(true, true, A, true, false));
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, A, true, true));
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, .denied, false, false));
+    try std.testing.expectEqual(Route.badge, decideRoute(true, true, .unavailable, false, false));
+    try std.testing.expectEqual(Route.badge, decideRoute(true, false, A, false, false));
+}

--- a/src/platform/notifications.zig
+++ b/src/platform/notifications.zig
@@ -17,6 +17,10 @@ pub const Backend = enum {
     unsupported,
 };
 
+/// Cached desktop-notification authorization status. Mirrors the macOS
+/// bridge contract: 0 = unavailable/not-determined, 1 = denied, 2 = authorized.
+pub const NotifAuthStatus = enum(u8) { unavailable = 0, denied = 1, authorized = 2 };
+
 pub fn backendForOs(comptime os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
@@ -47,6 +51,22 @@ pub fn requestAttention(handle: NativeHandle) void {
     impl.requestAttention(handle);
 }
 
+/// Post a native desktop notification (macOS toast). No-op where unsupported.
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    impl.showDesktopNotification(title, body);
+}
+
+/// Current cached authorization status (synchronous, cheap).
+pub fn notificationAuthStatus() NotifAuthStatus {
+    return @enumFromInt(impl.notificationAuthStatus());
+}
+
+/// Ask the OS for notification permission (shows the system prompt once).
+/// Safe to call repeatedly; the OS only prompts on the first undetermined call.
+pub fn requestNotificationAuth() void {
+    impl.requestNotificationAuth();
+}
+
 test "notifications selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
     try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
@@ -62,4 +82,12 @@ test "notifications exposes bell and attention API shape" {
     try std.testing.expectEqual(@as(usize, 1), attention_info.params.len);
     try std.testing.expect(attention_info.params[0].type.? == NativeHandle);
     try std.testing.expect(attention_info.return_type.? == void);
+
+    const show_info = @typeInfo(@TypeOf(showDesktopNotification)).@"fn";
+    try std.testing.expectEqual(@as(usize, 2), show_info.params.len);
+    try std.testing.expect(show_info.return_type.? == void);
+
+    const status_info = @typeInfo(@TypeOf(notificationAuthStatus)).@"fn";
+    try std.testing.expectEqual(@as(usize, 0), status_info.params.len);
+    try std.testing.expectEqual(NotifAuthStatus, status_info.return_type.?);
 }

--- a/src/platform/notifications.zig
+++ b/src/platform/notifications.zig
@@ -35,6 +35,9 @@ const impl = switch (backendForOs(builtin.os.tag)) {
     .unsupported => @import("notifications_unsupported.zig"),
 };
 
+/// True on platforms with a native desktop-notification backend (macOS only today).
+pub const supports_desktop_notifications = backendForOs(builtin.os.tag) == .macos;
+
 /// Native handle of the window a notification is associated with.
 pub const NativeHandle = platform_window.NativeHandle;
 

--- a/src/platform/notifications_macos.zig
+++ b/src/platform/notifications_macos.zig
@@ -2,6 +2,9 @@ const platform_window = @import("window.zig");
 
 extern fn wispterm_macos_notification_bell() void;
 extern fn wispterm_macos_notification_request_attention(handle: ?*anyopaque) void;
+extern fn wispterm_macos_notif_show(title: [*:0]const u8, body: [*:0]const u8) void;
+extern fn wispterm_macos_notif_auth_status() c_int;
+extern fn wispterm_macos_notif_request_auth() void;
 
 pub fn bell() void {
     wispterm_macos_notification_bell();
@@ -9,4 +12,17 @@ pub fn bell() void {
 
 pub fn requestAttention(handle: platform_window.NativeHandle) void {
     wispterm_macos_notification_request_attention(handle);
+}
+
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    wispterm_macos_notif_show(title.ptr, body.ptr);
+}
+
+pub fn notificationAuthStatus() u8 {
+    const s = wispterm_macos_notif_auth_status();
+    return if (s < 0 or s > 2) 0 else @intCast(s);
+}
+
+pub fn requestNotificationAuth() void {
+    wispterm_macos_notif_request_auth();
 }

--- a/src/platform/notifications_unsupported.zig
+++ b/src/platform/notifications_unsupported.zig
@@ -8,3 +8,14 @@ pub fn bell() void {}
 pub fn requestAttention(handle: platform_window.NativeHandle) void {
     _ = handle;
 }
+
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    _ = title;
+    _ = body;
+}
+
+pub fn notificationAuthStatus() u8 {
+    return 0; // unavailable
+}
+
+pub fn requestNotificationAuth() void {}

--- a/src/platform/notifications_windows.zig
+++ b/src/platform/notifications_windows.zig
@@ -43,3 +43,15 @@ pub fn requestAttention(handle: NativeHandle) void {
     };
     _ = FlashWindowEx(&fwi);
 }
+
+pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
+    // Windows uses the title-bar bell badge fallback (no native toast in v1).
+    _ = title;
+    _ = body;
+}
+
+pub fn notificationAuthStatus() u8 {
+    return 0; // unavailable -> caller falls back to badge
+}
+
+pub fn requestNotificationAuth() void {}

--- a/src/platform/services_macos_bridge.m
+++ b/src/platform/services_macos_bridge.m
@@ -397,17 +397,19 @@ static UNUserNotificationCenter *wispterm_notif_center(void) {
 }
 
 void wispterm_macos_notif_request_auth(void) {
-    UNUserNotificationCenter *center = wispterm_notif_center();
-    if (center == nil) { g_wispterm_notif_auth = 0; return; }
-    if (g_wispterm_notif_delegate == nil) {
-        g_wispterm_notif_delegate = [[WisptermNotifDelegate alloc] init];
+    @autoreleasepool {
+        UNUserNotificationCenter *center = wispterm_notif_center();
+        if (center == nil) { g_wispterm_notif_auth = 0; return; }
+        if (g_wispterm_notif_delegate == nil) {
+            g_wispterm_notif_delegate = [[WisptermNotifDelegate alloc] init];
+        }
+        center.delegate = g_wispterm_notif_delegate;
+        [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                              completionHandler:^(BOOL granted, NSError *_Nullable error) {
+            (void)error;
+            g_wispterm_notif_auth = granted ? 2 : 1;
+        }];
     }
-    center.delegate = g_wispterm_notif_delegate;
-    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
-                          completionHandler:^(BOOL granted, NSError *_Nullable error) {
-        (void)error;
-        g_wispterm_notif_auth = granted ? 2 : 1;
-    }];
 }
 
 int wispterm_macos_notif_auth_status(void) {
@@ -415,15 +417,18 @@ int wispterm_macos_notif_auth_status(void) {
 }
 
 void wispterm_macos_notif_show(const char *title, const char *body) {
-    UNUserNotificationCenter *center = wispterm_notif_center();
-    if (center == nil) return;
-    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-    content.title = [NSString stringWithUTF8String:(title ? title : "")];
-    content.body = [NSString stringWithUTF8String:(body ? body : "")];
-    content.sound = [UNNotificationSound defaultSound];
-    UNNotificationRequest *req =
-        [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
-                                             content:content
-                                             trigger:nil];
-    [center addNotificationRequest:req withCompletionHandler:nil];
+    @autoreleasepool {
+        UNUserNotificationCenter *center = wispterm_notif_center();
+        if (center == nil) return;
+        UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+        content.title = [NSString stringWithUTF8String:(title ? title : "")];
+        content.body = [NSString stringWithUTF8String:(body ? body : "")];
+        content.sound = [UNNotificationSound defaultSound];
+        UNNotificationRequest *req =
+            [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+                                                 content:content
+                                                 trigger:nil];
+        [center addNotificationRequest:req withCompletionHandler:nil];
+        [content release];
+    }
 }

--- a/src/platform/services_macos_bridge.m
+++ b/src/platform/services_macos_bridge.m
@@ -369,3 +369,61 @@ void wispterm_macos_global_hotkey_unregister(void *window_handle, int32_t id) {
     slot->window_handle = NULL;
     slot->ref = NULL;
 }
+
+#import <UserNotifications/UserNotifications.h>
+
+// Cached authorization status: 0 = unavailable/not-determined, 1 = denied, 2 = authorized.
+static int g_wispterm_notif_auth = 0;
+
+// Delegate so notifications also present while WispTerm is the foreground app
+// (needed for the "focused window, background tab" case).
+@interface WisptermNotifDelegate : NSObject <UNUserNotificationCenterDelegate>
+@end
+@implementation WisptermNotifDelegate
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionSound);
+}
+@end
+
+static WisptermNotifDelegate *g_wispterm_notif_delegate = nil;
+
+static UNUserNotificationCenter *wispterm_notif_center(void) {
+    // UNUserNotificationCenter requires a bundle identifier; un-bundled dev
+    // runs have none -> report unavailable and skip.
+    if ([[NSBundle mainBundle] bundleIdentifier] == nil) return nil;
+    return [UNUserNotificationCenter currentNotificationCenter];
+}
+
+void wispterm_macos_notif_request_auth(void) {
+    UNUserNotificationCenter *center = wispterm_notif_center();
+    if (center == nil) { g_wispterm_notif_auth = 0; return; }
+    if (g_wispterm_notif_delegate == nil) {
+        g_wispterm_notif_delegate = [[WisptermNotifDelegate alloc] init];
+    }
+    center.delegate = g_wispterm_notif_delegate;
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                          completionHandler:^(BOOL granted, NSError *_Nullable error) {
+        (void)error;
+        g_wispterm_notif_auth = granted ? 2 : 1;
+    }];
+}
+
+int wispterm_macos_notif_auth_status(void) {
+    return g_wispterm_notif_auth;
+}
+
+void wispterm_macos_notif_show(const char *title, const char *body) {
+    UNUserNotificationCenter *center = wispterm_notif_center();
+    if (center == nil) return;
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.title = [NSString stringWithUTF8String:(title ? title : "")];
+    content.body = [NSString stringWithUTF8String:(body ? body : "")];
+    content.sound = [UNNotificationSound defaultSound];
+    UNNotificationRequest *req =
+        [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+                                             content:content
+                                             trigger:nil];
+    [center addNotificationRequest:req withCompletionHandler:nil];
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -40,6 +40,7 @@ test {
     _ = @import("sync_output.zig");
     _ = @import("agent_history.zig");
     _ = @import("render_diagnostics.zig");
+    _ = @import("notification.zig");
     _ = @import("renderer/gpu/backend.zig");
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");


### PR DESCRIPTION
## Summary
- Intercept ghostty's `show_desktop_notification` action (OSC 9 / OSC 777) in WispTerm's `VtHandler`, mirroring the existing `.bell` interception. Title/body are copied off the transient parser buffers into a mutex-protected bounded per-`Surface` queue (IO reader thread → main thread).
- New pure module `src/notification.zig` holds all decision logic — bounded FIFO, content hashing, rate-limit (≤1/s) + longer content-dedup (5s), and a focus/platform/auth `decideRoute` — so it is unit-testable natively (no platform deps).
- **macOS:** native `UNUserNotificationCenter` toast via `services_macos_bridge.m` — lazy authorization, a foreground-presentation delegate (so toasts show when the window is focused but the notification is from a background tab), MRR-correct memory handling, and a bundle-id guard that degrades to badge on un-bundled dev runs. Links the `UserNotifications` framework.
- **Other platforms / unauthorized / denied:** fall back to the existing title-bar bell indicator (reuses `bell_indicator`, zero new rendering).
- **Focus-aware:** when the window is focused and the notification is from the active surface, the toast is suppressed (just a brief bell); background tab or unfocused window → toast + persistent tab badge.
- Single config toggle `desktop-notifications` (default on); does not affect the plain `\a` bell.
- Design spec + implementation plan under `docs/superpowers/`.

## Test Plan
- [x] `zig build test` — pure logic (queue FIFO/drop-oldest, truncation, hash boundary, rate-limit+dedup, full route matrix) green
- [x] `zig build test-full` — full app graph, multi-target (incl. windows-gnu) green; the `build.zig` framework-count test updated 8→9 with `UserNotifications`
- [ ] **macOS manual checklist** (signed `.app`): first notification → authorization prompt → Allow → toast; window unfocused → toast; focused on originating tab → no toast + brief bell; focused, originating tab in background → toast (foreground delegate) + bell; deny authorization → bell badge only; same OSC twice fast → one notification, 5 fast → ≤1/s; `desktop-notifications = false` → nothing
- [ ] **non-macOS sanity** (Linux/Windows): OSC sequence → title-bar bell badge only, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)