### PR TITLE
fix(weixin): deliver slow AI replies within the 30-min context-token window

### DIFF
--- a/remote/src/server/bridge/weixin/poller.ts
+++ b/remote/src/server/bridge/weixin/poller.ts
@@ -36,6 +36,23 @@ export type WeixinPollerOptions = {
 };
 
 const DEFAULT_AI_REPLY_CHECKPOINTS_MS = [10000, 30000, 60000, 120000];
+/** The WeChat context_token that lets the bot reply to an inbound message is only
+ * valid for ~30 minutes; a reply sent with an expired token is rejected by the
+ * server and the user silently receives nothing — the root cause of "the bot just
+ * stops replying" for slow AI tasks. The follow-up must finish (or hand back)
+ * within this window, regardless of reply_timeout_ms. */
+const CONTEXT_TOKEN_WINDOW_MS = 30 * 60 * 1000;
+/** Send the final answer / heartbeat / resend notice this far before the hard
+ * expiry so it still goes out on a valid token. */
+const AI_REPLY_EXPIRY_NOTICE_MARGIN_MS = 30 * 1000;
+/** Latest elapsed time at which the follow-up still sends on the original token. */
+const AI_REPLY_DEADLINE_MS = CONTEXT_TOKEN_WINDOW_MS - AI_REPLY_EXPIRY_NOTICE_MARGIN_MS;
+/** After the dense early checkpoints, ping "still working" this often so the user
+ * knows a long-running task is alive. */
+const AI_REPLY_HEARTBEAT_MS = 5 * 60 * 1000;
+/** Sent once when the window closes with no final answer: the token is about to
+ * expire, so a fresh inbound message is needed to keep the conversation going. */
+const AI_REPLY_WINDOW_EXPIRED_NOTICE = "AI 处理已超过 30 分钟仍未完成，微信回复窗口即将关闭。请重新发送一条消息以继续接收回复。";
 
 export function shouldHandleWeixinMessage(binding: WeixinBindingRecord, message: WeixinMessage): HandleDecision {
   const from = (message.from_user_id ?? "").trim();
@@ -191,7 +208,6 @@ export class WeixinPoller {
             client,
             contextToken: message.context_token ?? "",
             generation,
-            replyTimeoutMs: settings.reply_timeout_ms,
             toUserId: message.from_user_id ?? "",
           });
         },
@@ -219,17 +235,22 @@ export class WeixinPoller {
       client: WeixinPollerClient;
       contextToken: string;
       generation: number;
-      replyTimeoutMs: number;
       toUserId: string;
     },
   ): void {
     if (!options.toUserId || this.isStale(options.generation)) return;
-    const maxCheckpointMs = Math.max(0, ...this.aiReplyCheckpointsMs);
-    const effectiveReplyTimeoutMs = Math.max(options.replyTimeoutMs, maxCheckpointMs);
+    // Dense early checkpoints for quick feedback, then a steady heartbeat — all
+    // within the context_token's ~30-minute validity. The old code stopped after
+    // max(reply_timeout_ms, 120s) <= 3 min, so slower AI tasks never delivered
+    // their final answer (the "no reply" bug).
     const checkpoints = this.aiReplyCheckpointsMs
-      .filter((ms) => ms > 0 && ms <= effectiveReplyTimeoutMs)
+      .filter((ms) => ms > 0 && ms < AI_REPLY_DEADLINE_MS)
       .sort((a, b) => a - b);
-    if (checkpoints.length === 0) return;
+    const heartbeats: number[] = [];
+    for (let ms = AI_REPLY_HEARTBEAT_MS; ms < AI_REPLY_DEADLINE_MS; ms += AI_REPLY_HEARTBEAT_MS) {
+      heartbeats.push(ms);
+    }
+    const progressDelays = [...checkpoints, ...heartbeats];
 
     const timers = new Set<unknown>();
     const observableSession = ai.session as WeixinAiFollowup["session"] & {
@@ -267,6 +288,23 @@ export class WeixinPoller {
         }
       })();
     };
+    // Reached the token's expiry margin with no final answer: deliver it if it
+    // just landed, otherwise prompt the user to resend. A silent stop here looks
+    // exactly like the original "no reply" bug.
+    const handleDeadline = () => {
+      if (finished || this.isStale(options.generation)) return;
+      finish();
+      void (async () => {
+        const progress = aiReplyProgress(ai.baselineTranscript, ai.session.latestAiChatTranscript());
+        const text = progress.done && progress.text ? progress.text : AI_REPLY_WINDOW_EXPIRED_NOTICE;
+        try {
+          if (this.isStale(options.generation)) return;
+          await options.client.sendTextMessage(options.toUserId, text, options.contextToken);
+        } catch (err) {
+          if (!this.isStale(options.generation)) this.logger.warn("weixin ai followup deadline send failed", err);
+        }
+      })();
+    };
 
     cleanup = finish;
     this.aiReplyCleanups.add(cleanup);
@@ -274,7 +312,7 @@ export class WeixinPoller {
       unsubscribeLayout = observableSession.onLayout(() => checkProgress(false));
     }
 
-    for (const delay of checkpoints) {
+    for (const delay of progressDelays) {
       let timer: unknown = null;
       timer = this.scheduler.setTimeout(() => {
         if (timer !== null) {
@@ -287,6 +325,17 @@ export class WeixinPoller {
       timers.add(timer);
       this.aiReplyTimers.add(timer);
     }
+
+    let deadlineTimer: unknown = null;
+    deadlineTimer = this.scheduler.setTimeout(() => {
+      if (deadlineTimer !== null) {
+        timers.delete(deadlineTimer);
+        this.aiReplyTimers.delete(deadlineTimer);
+      }
+      handleDeadline();
+    }, AI_REPLY_DEADLINE_MS);
+    timers.add(deadlineTimer);
+    this.aiReplyTimers.add(deadlineTimer);
   }
 }
 

--- a/remote/test/server/weixin_poller.test.ts
+++ b/remote/test/server/weixin_poller.test.ts
@@ -396,6 +396,76 @@ test("WeixinPoller sends AI progress checkpoints at 10, 30, 60, and 120 seconds 
   assert.equal(events.filter((event) => event === "send:还在处理中，工具调用仍在执行。").length, 4);
 });
 
+test("WeixinPoller keeps the AI reply window open for ~30 minutes and asks the user to resend on timeout", async () => {
+  const expiredNotice = "AI 处理已超过 30 分钟仍未完成，微信回复窗口即将关闭。请重新发送一条消息以继续接收回复。";
+  const events: string[] = [];
+  let transcript = "Model:\r\nDeepSeek\r\n\r\nStatus:\r\nReady\r\n\r\nAI:\r\nready";
+  const scheduler = fakeManualScheduler();
+  const poller = new WeixinPoller(
+    fakeStore({
+      loadSettings: async () => ({ enabled: true, target_session: "alpha", reply_timeout_ms: 60000 }),
+    }),
+    () => [{
+      key: "alpha",
+      session: {
+        isWispTermConnected: () => true,
+        findAiChatSurface: () => ({ id: "ai", title: "AI", kind: "ai_chat" }),
+        latestAiChatTranscript: () => transcript,
+        onLayout: () => () => {},
+        sendInput: (_surfaceId: string, text: string) => {
+          events.push(`input:${text}`);
+          transcript = `${transcript}\r\n\r\nYou:\r\n${text.trim()}`;
+          return true;
+        },
+      },
+    }] as never,
+    { warn: () => {} },
+    {
+      createClient: () => ({
+        getUpdates: async () => ({
+          ret: 0,
+          get_updates_buf: "next-cursor",
+          longpolling_timeout_ms: 1000,
+          msgs: [{
+            from_user_id: "user@im.wechat",
+            to_user_id: "bot@im.bot",
+            context_token: "ctx",
+            item_list: [{ type: 1, text_item: { text: "slow task" } }],
+          }],
+        }),
+        sendTextMessage: async (_to, text) => {
+          events.push(`send:${text}`);
+        },
+      }),
+      scheduler,
+    },
+  );
+
+  await poller.runOnceForTest();
+  assert.deepEqual(events, ["input:slow task\r", `send:${AI_ACK_TEXT}`]);
+
+  const delays = scheduler.delays();
+  // Dense early checkpoints, then a "still working" heartbeat every 5 minutes.
+  assert.deepEqual(delays.slice(0, 4), [10000, 30000, 60000, 120000]);
+  assert.equal(delays[4], 300000);
+  assert.equal(delays[5], 600000);
+  // The resend prompt is the longest-lived timer, fired just before the
+  // 30-minute context_token expiry — far beyond the old <= 3 min cap.
+  const deadlineDelay = 30 * 60 * 1000 - 30 * 1000;
+  assert.equal(Math.max(...delays), deadlineDelay);
+
+  // A heartbeat reports the task is still running, not done.
+  transcript = `${transcript}\r\n\r\nStatus:\r\nRunning tools...\r\n\r\nTool:\r\nterminal_snapshot`;
+  scheduler.fire(4);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(events.at(-1), "send:还在处理中，工具调用仍在执行。");
+
+  // Window closes with no final answer → prompt the user to resend.
+  scheduler.fire(delays.indexOf(deadlineDelay));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(events.at(-1), `send:${expiredNotice}`);
+});
+
 test("WeixinPoller sends the final AI reply when it completes after all progress checkpoints", async () => {
   const events: string[] = [];
   let transcript = "Model:\r\nDeepSeek\r\n\r\nStatus:\r\nReady\r\n\r\nAI:\r\nready";

--- a/src/config.zig
+++ b/src/config.zig
@@ -334,8 +334,9 @@ shell: []const u8 = platform_pty_command.default_shell_name,
 /// Override for the ilink API base URL. Defaults to the public endpoint.
 @"weixin-base-url": ?[]const u8 = null,
 
-/// Max time (ms) to keep streaming AI-reply progress to WeChat. Clamped to
-/// [5000, 180000]. Matches the TS bridge default.
+/// Deprecated (no-op): AI-reply delivery now waits until the WeChat
+/// context_token window (~30 min) closes, then prompts the user to resend.
+/// Retained so existing configs keep parsing; the value no longer affects timing.
 @"weixin-reply-timeout-ms": u32 = 120000,
 
 /// When set, only this ilink user_id may control the terminal/AI. When empty,
@@ -1234,7 +1235,7 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --remote-session-key <key>   Fixed remote key base; later instances append _1, _2
         \\  --weixin-direct-enabled <bool> Enable embedded WeChat ilink direct path
         \\  --weixin-base-url <url>      Override ilink API base URL
-        \\  --weixin-reply-timeout-ms <n> AI-reply streaming window in ms
+        \\  --weixin-reply-timeout-ms <n> Deprecated (no-op); AI-reply window is ~30 min
         \\  --weixin-allowed-user <id>   Restrict control to one ilink user_id
         \\  --quake-mode <bool>          Enable Quake-style drop-down mode (default: true)
         \\

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -13,6 +13,23 @@ const AI_REPLY_CHECKPOINTS_MS = [_]u64{ 10_000, 30_000, 60_000, 120_000 };
 const AI_REPLY_POLL_MS: u64 = 1_000;
 const POLL_ERROR_BACKOFF_MS: u64 = 1_000;
 const SHUTDOWN_JOIN_TIMEOUT_MS: u32 = 1500;
+/// The WeChat `context_token` that lets the bot reply to an inbound message is
+/// only valid for ~30 minutes. A reply sent with an expired token is rejected by
+/// the server and the user silently receives nothing — the root cause of "the
+/// bot just stops replying" for slow AI tasks. The follow-up must therefore
+/// finish (or hand back) within this window, regardless of reply_timeout_ms.
+const CONTEXT_TOKEN_WINDOW_MS: u64 = 30 * 60 * 1000;
+/// Send the final answer / heartbeat / resend notice this far before the hard
+/// expiry so it still goes out on a valid token.
+const EXPIRY_NOTICE_MARGIN_MS: u64 = 30 * 1000;
+/// Latest elapsed time at which the follow-up still sends on the original token.
+const AI_REPLY_DEADLINE_MS: u64 = CONTEXT_TOKEN_WINDOW_MS - EXPIRY_NOTICE_MARGIN_MS;
+/// After the dense early checkpoints, ping "still working" this often so the
+/// user knows a long-running task is alive.
+const AI_REPLY_HEARTBEAT_MS: u64 = 5 * 60 * 1000;
+/// Sent once when the window closes with no final answer: the token is about to
+/// expire, so a fresh inbound message is needed to keep the conversation going.
+const AI_REPLY_WINDOW_EXPIRED_NOTICE = "AI 处理已超过 30 分钟仍未完成，微信回复窗口即将关闭。请重新发送一条消息以继续接收回复。";
 
 pub const RouteResult = struct {
     expect_ai_progress: bool = false,
@@ -360,14 +377,14 @@ pub const Poller = struct {
             self.allocator.destroy(job);
         }
 
-        const max_checkpoint = AI_REPLY_CHECKPOINTS_MS[AI_REPLY_CHECKPOINTS_MS.len - 1];
-        const deadline_ms = @max(@as(u64, self.settings.reply_timeout_ms), max_checkpoint);
+        var schedule = ProgressSchedule{};
         var elapsed_ms: u64 = 0;
-        var checkpoint_index: usize = 0;
 
+        // Wait for the AI's answer up to the context_token's validity window, not
+        // the old reply_timeout_ms (<= 3 min) cap that abandoned slow tasks.
         while (!self.stop_requested.load(.acquire) and
             self.followup_generation.load(.acquire) == generation and
-            elapsed_ms <= deadline_ms)
+            elapsed_ms < AI_REPLY_DEADLINE_MS)
         {
             std.Thread.sleep(AI_REPLY_POLL_MS * std.time.ns_per_ms);
             elapsed_ms += AI_REPLY_POLL_MS;
@@ -388,21 +405,30 @@ pub const Poller = struct {
                 return;
             }
 
-            if (checkpoint_index < AI_REPLY_CHECKPOINTS_MS.len and elapsed_ms >= AI_REPLY_CHECKPOINTS_MS[checkpoint_index]) {
-                checkpoint_index += 1;
-                if (progress.text.len != 0) {
-                    std.debug.print(
-                        "weixin send({d}): kind=ai_progress generation={d} checkpoint={d} to_len={d} to_hash={x} bytes={d} context={}\n",
-                        .{ debugNowMs(), generation, checkpoint_index, job.to_user_id.len, debugHash(job.to_user_id), progress.text.len, job.context_token.len != 0 },
-                    );
-                    self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
-                        std.debug.print("weixin send({d}): kind=ai_progress generation={d} checkpoint={d} status=failed err={}\n", .{ debugNowMs(), generation, checkpoint_index, err });
-                        continue;
-                    };
-                    std.debug.print("weixin send({d}): kind=ai_progress generation={d} checkpoint={d} status=sent bytes={d}\n", .{ debugNowMs(), generation, checkpoint_index, progress.text.len });
-                }
+            if (schedule.pingDue(elapsed_ms) and progress.text.len != 0) {
+                std.debug.print(
+                    "weixin send({d}): kind=ai_progress generation={d} elapsed_ms={d} to_len={d} to_hash={x} bytes={d} context={}\n",
+                    .{ debugNowMs(), generation, elapsed_ms, job.to_user_id.len, debugHash(job.to_user_id), progress.text.len, job.context_token.len != 0 },
+                );
+                self.sendTextLocked(job.to_user_id, progress.text, job.context_token) catch |err| {
+                    std.debug.print("weixin send({d}): kind=ai_progress generation={d} status=failed err={}\n", .{ debugNowMs(), generation, err });
+                    continue;
+                };
+                std.debug.print("weixin send({d}): kind=ai_progress generation={d} status=sent bytes={d}\n", .{ debugNowMs(), generation, progress.text.len });
             }
         }
+
+        // Reached the window's edge with no final answer (the loop ran out, not a
+        // stop/refresh). The token is about to expire, so prompt the user to send
+        // a fresh message — a silent stop here looks exactly like the old bug.
+        if (self.stop_requested.load(.acquire) or self.followup_generation.load(.acquire) != generation) return;
+        std.debug.print(
+            "weixin send({d}): kind=ai_window_expired generation={d} to_len={d} to_hash={x} context={}\n",
+            .{ debugNowMs(), generation, job.to_user_id.len, debugHash(job.to_user_id), job.context_token.len != 0 },
+        );
+        self.sendTextLocked(job.to_user_id, AI_REPLY_WINDOW_EXPIRED_NOTICE, job.context_token) catch |err| {
+            std.debug.print("weixin send({d}): kind=ai_window_expired generation={d} status=failed err={}\n", .{ debugNowMs(), generation, err });
+        };
     }
 
     fn allocProgressText(self: *Poller, baseline_transcript: []const u8) !struct { done: bool, text: []u8 } {
@@ -427,6 +453,29 @@ fn debugHash(bytes: []const u8) u64 {
 fn debugNowMs() i64 {
     return std.time.milliTimestamp();
 }
+
+/// Decides when an AI follow-up should ping progress: dense early checkpoints for
+/// quick feedback, then a steady heartbeat for long tasks. Pure and
+/// state-advancing so each checkpoint/heartbeat fires exactly once; the caller
+/// drives it with monotonically increasing `elapsed_ms` at AI_REPLY_POLL_MS steps.
+const ProgressSchedule = struct {
+    checkpoint_index: usize = 0,
+    next_heartbeat_ms: u64 = AI_REPLY_HEARTBEAT_MS,
+
+    fn pingDue(self: *ProgressSchedule, elapsed_ms: u64) bool {
+        if (self.checkpoint_index < AI_REPLY_CHECKPOINTS_MS.len and
+            elapsed_ms >= AI_REPLY_CHECKPOINTS_MS[self.checkpoint_index])
+        {
+            self.checkpoint_index += 1;
+            return true;
+        }
+        if (elapsed_ms >= self.next_heartbeat_ms) {
+            self.next_heartbeat_ms += AI_REPLY_HEARTBEAT_MS;
+            return true;
+        }
+        return false;
+    }
+};
 
 const FollowupJob = struct {
     baseline_transcript: []u8 = &.{},
@@ -662,4 +711,42 @@ test "poller bootstrap advances cursor without replying to historical messages" 
     try t.expect(!p.bootstrap_skip_pending);
     try t.expectEqualStrings("NEXT", p.sync_buf);
     try t.expectEqualStrings("NEXT", sync.value.items);
+}
+
+test "ai reply window extends to the 30-minute context-token validity with a resend margin" {
+    // The bug: replies were abandoned after deadline = max(reply_timeout_ms, 120s)
+    // <= 180s, so any AI task slower than ~3 minutes never delivered its answer.
+    // The real ceiling is the WeChat context_token validity (~30 minutes).
+    try t.expectEqual(@as(u64, 30 * 60 * 1000), CONTEXT_TOKEN_WINDOW_MS);
+    // We keep waiting (and can deliver a final answer) far beyond the old cap.
+    try t.expect(AI_REPLY_DEADLINE_MS > 180_000);
+    try t.expect(AI_REPLY_DEADLINE_MS >= 25 * 60 * 1000);
+    // The resend notice still goes out on a valid token, before the hard expiry.
+    try t.expect(AI_REPLY_DEADLINE_MS < CONTEXT_TOKEN_WINDOW_MS);
+    try t.expectEqual(CONTEXT_TOKEN_WINDOW_MS - EXPIRY_NOTICE_MARGIN_MS, AI_REPLY_DEADLINE_MS);
+}
+
+test "progress schedule pings at dense early checkpoints then a steady heartbeat" {
+    var sched = ProgressSchedule{};
+    var pings: std.ArrayListUnmanaged(u64) = .empty;
+    defer pings.deinit(t.allocator);
+
+    var elapsed_ms: u64 = 0;
+    while (elapsed_ms < AI_REPLY_DEADLINE_MS) {
+        elapsed_ms += AI_REPLY_POLL_MS;
+        if (sched.pingDue(elapsed_ms)) try pings.append(t.allocator, elapsed_ms);
+    }
+
+    // Dense early feedback at the fixed checkpoints.
+    try t.expectEqual(@as(u64, 10_000), pings.items[0]);
+    try t.expectEqual(@as(u64, 30_000), pings.items[1]);
+    try t.expectEqual(@as(u64, 60_000), pings.items[2]);
+    try t.expectEqual(@as(u64, 120_000), pings.items[3]);
+    // Then a "still working" heartbeat every AI_REPLY_HEARTBEAT_MS (5 min).
+    try t.expectEqual(@as(u64, AI_REPLY_HEARTBEAT_MS), pings.items[4]);
+    try t.expectEqual(@as(u64, 2 * AI_REPLY_HEARTBEAT_MS), pings.items[5]);
+    // Heartbeats run right up to — but never past — the send deadline.
+    const last = pings.items[pings.items.len - 1];
+    try t.expect(last <= AI_REPLY_DEADLINE_MS);
+    try t.expect(last + AI_REPLY_HEARTBEAT_MS > AI_REPLY_DEADLINE_MS);
 }


### PR DESCRIPTION
## Summary
WeChat sometimes "stopped replying": after the `信息已收到，开始处理` ack, the AI's final answer never arrived for any task slower than ~3 minutes.

**Root cause:** the AI-reply follow-up waited only `max(reply_timeout_ms, 120s) ≤ 3 min` (`reply_timeout_ms` is clamped to ≤180s), then abandoned the wait — the final answer was never sent. The real ceiling is the WeChat `context_token` validity (~30 min); replying with an expired token is silently rejected by the server.

## Changes
- Wait for the AI answer up to the ~30-min `context_token` window (minus a 30s margin) instead of the old ≤3-min cap, so long-running agent replies are delivered.
- Keep the dense early checkpoints (10/30/60/120s), then a "still working" heartbeat every 5 minutes.
- When the window closes with no final answer, send a `请重新发送一条消息` notice on the still-valid token instead of stopping silently.
- Applied to both the embedded Zig poller (`src/weixin/poller.zig`) and the remote TS bridge (`remote/src/server/bridge/weixin/poller.ts`).
- `weixin-reply-timeout-ms` / `--weixin-reply-timeout-ms` is now a no-op (the protocol token window governs); field doc + CLI help updated.

## Testing
- `zig test src/weixin/poller.zig` — 22/22 (incl. 2 new)
- `zig build test` — pass
- `node --import tsx --test remote/test/server/*.test.ts` — 92/92 (incl. 1 new)
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)