### PR TITLE
feat: forward agent notifications to bound WeChat

### DIFF
--- a/docs/superpowers/plans/2026-05-31-wispterm-wechat-notify-forward.md
+++ b/docs/superpowers/plans/2026-05-31-wispterm-wechat-notify-forward.md
@@ -1,0 +1,567 @@
+# WispTerm 微信通知转发 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 当 Claude Code / Codex「完成 / 需确认」时，WispTerm 在弹本地通知的同时，把这条通知额外推送到它已绑定的微信 owner（复用内置 iLink 直连，无第三方中转）。
+
+**Architecture:** notify 脚本在它发的 OSC 777 通知 body 末尾追加一个零宽标记（U+200B）。WispTerm 在 `notification.makeItem` 解析时检测并剥离该标记、置位 `Item.forward_wechat`（body 显示/去重都干净）。主线程 `AppWindow.handleNotification` 出队时，若该位为真、`weixin-notify-forward` 开、存在活动绑定且 owner 已绑、且你没正盯着这个 pane，则调 `weixin.Controller.enqueueNotify`，它在一条「即用即弃」的后台线程上用既有 `ilink.Client.sendText(owner, ...)` 发送，绝不阻塞 UI。
+
+**Tech Stack:** Zig（WispTerm 本体，libghostty-vt 内核）、POSIX sh（notify 脚本 + 测试）。测试：`zig build test`（快速纯逻辑，含 `notification.zig`）、`zig build test-full`（全量，含 `weixin/controller.zig`）、`sh .../test-install.sh`（脚本）。
+
+**关键约束（来自调研）：** ghostty 的 OSC 777 解析（`rxvt_extension.zig:30-37`）把 `body` 当作第二个 `;` 之后的**全部剩余字符串**，所以标记只能藏进 body、由 WispTerm 剥离；WispTerm 只看 ghostty 解析后的 `{title, body}`，看不到原始 OSC 字节，故无法用私有 OSC 旁路。
+
+**已知 v1 限制：** 转发依赖 `desktop-notifications=on`（默认即 on）。`handleNotification` 在该开关关闭时整条 early-return，故关闭桌面通知也会关掉微信转发。记录在 SKILL 文档，本期不解耦。
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 改动 |
+|---|---|---|
+| `src/notification.zig` | 通知 Item / 队列 / 纯路由逻辑 | 加 `Item.forward_wechat` + `makeItem` 剥离零宽标记 + 单测 |
+| `src/weixin/controller.zig` | 微信绑定生命周期 + 发送 | 加 `enqueueNotify` + `PushJob`「即用即弃」发送线程 + 纯 `buildNotifyText` + 单测 |
+| `src/config.zig` | 配置字段 / 解析 / `--help` | 加 `weixin-notify-forward: bool` |
+| `src/AppWindow.zig` | 主线程通知出队 + 配置应用 | 加 `g_weixin_notify_forward` 全局 + `handleNotification` 转发分支 |
+| `plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh` | 发送端 OSC | body 末尾追加零宽标记 |
+| `plugins/skills/wispterm-notify-setup/scripts/test-install.sh` | 脚本测试 | 更新 OSC 断言含标记 |
+| `plugins/skills/wispterm-notify-setup/SKILL.md` | skill 文档 | 加「微信转发」一节 |
+
+标记字节统一为 **U+200B = `E2 80 8B`**：Zig 侧字面量 `"\u{200b}"`，sh 侧八进制 `\342\200\213`。
+
+---
+
+## Task 1: notification.zig — 检测并剥离零宽标记
+
+**Files:**
+- Modify: `src/notification.zig`（`Item` 结构 ~17-29、`makeItem` ~31-39）
+- Test: `src/notification.zig`（同文件 `test` 块；由 `src/test_fast.zig:43` 注册）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/notification.zig` 末尾（最后一个 `test` 之后）追加：
+
+```zig
+test "makeItem strips the trailing wechat marker and sets forward_wechat" {
+    const marked = "完成，轮到你了" ++ wechat_marker;
+    const item = makeItem("Claude Code", marked);
+    try std.testing.expect(item.forward_wechat);
+    try std.testing.expectEqualStrings("完成，轮到你了", item.body());
+    try std.testing.expectEqualStrings("Claude Code", item.title());
+}
+
+test "makeItem without the marker keeps body intact and forward_wechat false" {
+    const item = makeItem("t", "完成，轮到你了");
+    try std.testing.expect(!item.forward_wechat);
+    try std.testing.expectEqualStrings("完成，轮到你了", item.body());
+}
+```
+
+- [ ] **Step 2: 跑测试，确认编译失败**
+
+Run: `zig build test`
+Expected: 编译错误 —— `wechat_marker` 未定义、`Item` 无 `forward_wechat` 字段。
+
+- [ ] **Step 3: 加字段 + 常量 + 剥离逻辑**
+
+在 `Item` 结构里（`body_len: usize = 0,` 之后）加字段：
+
+```zig
+    /// True when the body carried the WispTerm notifier's WeChat-forward marker
+    /// (stripped before storage). Read by AppWindow.handleNotification.
+    forward_wechat: bool = false,
+```
+
+在 `pub fn makeItem` 之前加常量：
+
+```zig
+/// Zero-width space (U+200B) the WispTerm notifier appends to a notification's
+/// OSC 777 body to mark it for forwarding to the bound WeChat owner. It is
+/// invisible in every renderer, so a build that does not strip it still shows a
+/// clean toast. We strip it here so the stored/hashed/displayed body is clean.
+pub const wechat_marker = "\u{200b}"; // bytes E2 80 8B
+```
+
+把 `makeItem` 改为（替换整个函数体的 body 处理）：
+
+```zig
+pub fn makeItem(title_in: []const u8, body_in: []const u8) Item {
+    var item: Item = .{};
+    item.title_len = @min(title_in.len, max_title);
+    @memcpy(item.title_buf[0..item.title_len], title_in[0..item.title_len]);
+
+    var body = body_in;
+    if (std.mem.endsWith(u8, body, wechat_marker)) {
+        item.forward_wechat = true;
+        body = body[0 .. body.len - wechat_marker.len];
+    }
+    item.body_len = @min(body.len, max_body);
+    @memcpy(item.body_buf[0..item.body_len], body[0..item.body_len]);
+    return item;
+}
+```
+
+- [ ] **Step 4: 跑测试，确认通过**
+
+Run: `zig build test`
+Expected: PASS（新增 2 个测试 + 既有 `makeItem`/`Queue`/`contentHash`/`shouldDeliver`/`decideRoute` 测试全绿）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/notification.zig
+git commit -m "feat(notification): strip wechat-forward marker, set forward_wechat
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: notify 脚本发标记 + 更新脚本测试
+
+**Files:**
+- Modify: `plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh`（OSC 输出，~77-80）
+- Test: `plugins/skills/wispterm-notify-setup/scripts/test-install.sh`（OSC 断言，~24-47）
+
+- [ ] **Step 1: 先更新脚本测试，使其失败**
+
+在 `test-install.sh` 顶部、`BEL="$(printf '\007')"` 之后加一行：
+
+```sh
+MARKER="$(printf '\342\200\213')"
+```
+
+把以下 5 处 OSC 断言的「`...${BEL}`」改成「`...${MARKER}${BEL}`」：
+
+```sh
+assert_contains "$t" "${ESC}]777;notify;WispTerm;hi${MARKER}${BEL}" "CC Notification -> OSC777 title+body"
+```
+```sh
+assert_contains "$t" "${ESC}]777;notify;Claude Code;完成，轮到你了${MARKER}${BEL}" "CC Stop -> OSC777 Claude Code title+body"
+```
+```sh
+assert_contains "$t" "${ESC}]777;notify;Codex;done deal${MARKER}${BEL}" "Codex argv -> OSC777 Codex/body"
+```
+```sh
+assert_contains "$t" "${ESC}]777;notify;ab;xy${MARKER}${BEL}" "sanitize strips ';' from title and body"
+```
+```sh
+assert_contains "$t" "${ESC}]777;notify;a;bcd${MARKER}${BEL}" "sanitize strips ESC/BEL control bytes from body"
+```
+
+（`assert_contains "$t" "$BEL"` 那条「emits BEL」与空载荷两条不动。）
+
+- [ ] **Step 2: 跑脚本测试，确认失败**
+
+Run: `sh plugins/skills/wispterm-notify-setup/scripts/test-install.sh`
+Expected: 上述 5 条 FAIL（脚本还没发标记，实际输出无 `MARKER`）。
+
+- [ ] **Step 3: 让脚本发标记**
+
+在 `wispterm-notify.sh` 把这段：
+
+```sh
+{
+  printf '\033]777;notify;%s;%s\007' "$title" "$body"
+  printf '\a'
+} >"$notify_tty" 2>/dev/null || true
+```
+
+改为（仅在 OSC 的 body 后、终止 BEL 前插入零宽标记 `\342\200\213`）：
+
+```sh
+{
+  printf '\033]777;notify;%s;%s\342\200\213\007' "$title" "$body"
+  printf '\a'
+} >"$notify_tty" 2>/dev/null || true
+```
+
+同时更新该 `printf` 上方的注释段（`# --- 5. ...`）末尾补一句：
+
+```sh
+# A trailing zero-width space (U+200B) in the body marks the notification for
+# WeChat forwarding; WispTerm strips it (notification.zig). Other terminals show
+# nothing extra. The bare BEL after is the bell-badge fallback.
+```
+
+- [ ] **Step 4: 跑脚本测试，确认通过**
+
+Run: `sh plugins/skills/wispterm-notify-setup/scripts/test-install.sh`
+Expected: 末行 `0 test(s) failed`，退出码 0。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh \
+        plugins/skills/wispterm-notify-setup/scripts/test-install.sh
+git commit -m "feat(notify-setup): append zero-width WeChat-forward marker to OSC 777
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: config `weixin-notify-forward` 开关 + 全局
+
+**Files:**
+- Modify: `src/config.zig`（字段 ~343、解析 ~822、help ~1238）
+- Modify: `src/AppWindow.zig`（全局声明 ~1371、应用 ~1715）
+
+- [ ] **Step 1: 加配置字段**
+
+`src/config.zig`，在 `@"weixin-allowed-user": ?[]const u8 = null,`（~343）之后插入：
+
+```zig
+/// When true (with weixin-direct-enabled and a bound owner), also forward agent
+/// finish/confirm notifications to the bound WeChat owner. Opt-in; default off.
+@"weixin-notify-forward": bool = false,
+```
+
+- [ ] **Step 2: 加解析分支**
+
+`src/config.zig`，在 `weixin-allowed-user` 解析分支之后（`self.@"weixin-allowed-user" = self.dupeString(...)` 的那个 `else if` 块结束处，~822-823）插入新分支：
+
+```zig
+    } else if (std.mem.eql(u8, key, "weixin-notify-forward")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"weixin-notify-forward" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"weixin-notify-forward" = false;
+        } else {
+            log.warn("invalid weixin-notify-forward: {s}", .{value});
+        }
+```
+
+（即接在 `weixin-allowed-user` 分支与其后下一个 `} else if` 之间。）
+
+- [ ] **Step 3: 加 `--help` 行**
+
+`src/config.zig`，在 help 文本的 `--weixin-allowed-user <id> ...` 行（~1238）之后插入：
+
+```zig
+        \\  --weixin-notify-forward <bool> Forward agent notifications to the bound WeChat owner
+```
+
+- [ ] **Step 4: 加全局并在配置应用处赋值**
+
+`src/AppWindow.zig`，在 `pub threadlocal var g_desktop_notifications: bool = true;`（~1371）之后插入：
+
+```zig
+pub threadlocal var g_weixin_notify_forward: bool = false;
+```
+
+在 `applyReloadedConfig` 里 `g_desktop_notifications = cfg.@"desktop-notifications";`（~1715）之后插入：
+
+```zig
+    g_weixin_notify_forward = cfg.@"weixin-notify-forward";
+```
+
+- [ ] **Step 5: 编译 + 跑全量测试**
+
+Run: `zig build && zig build test && zig build test-full`
+Expected: 编译通过；测试全绿（config 仅有路径相关测试，新增 key 不破坏断言）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/config.zig src/AppWindow.zig
+git commit -m "feat(config): add weixin-notify-forward opt-in flag + g_weixin_notify_forward
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: controller `enqueueNotify` + 后台发送线程
+
+**Files:**
+- Modify: `src/weixin/controller.zig`（在 `Controller` struct 内加方法 + 文件内加 `PushJob` + 纯函数 + 单测；由 `src/test_main.zig:638` 注册）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/weixin/controller.zig` 末尾（最后一个 `test` 之后）追加：
+
+```zig
+test "buildNotifyText joins title and body with a newline" {
+    var buf: [64]u8 = undefined;
+    try t.expectEqualStrings("Claude Code\n完成", buildNotifyText("Claude Code", "完成", &buf));
+}
+
+test "buildNotifyText omits the newline when body is empty" {
+    var buf: [64]u8 = undefined;
+    try t.expectEqualStrings("Codex", buildNotifyText("Codex", "", &buf));
+}
+
+test "buildNotifyText truncates to fit the output buffer" {
+    var buf: [5]u8 = undefined;
+    try t.expectEqualStrings("Title", buildNotifyText("Title", "body", &buf));
+}
+
+test "enqueueNotify is a no-op when no binding is active (owner unbound)" {
+    const path = "zig-cache-tmp-weixin-ctrl-enqueue.json";
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    const ctrl = try Controller.create(t.allocator, path, NoopControl.iface(), .{});
+    defer ctrl.destroy();
+
+    // Never started → running=false, owner empty: must not spawn a thread or crash.
+    ctrl.enqueueNotify("Claude Code", "完成");
+    try t.expect(!ctrl.running);
+}
+```
+
+- [ ] **Step 2: 跑测试，确认编译失败**
+
+Run: `zig build test-full`
+Expected: 编译错误 —— `buildNotifyText` / `enqueueNotify` 未定义。
+
+- [ ] **Step 3: 实现 `buildNotifyText`、`PushJob`、`enqueueNotify`**
+
+在 `src/weixin/controller.zig` 文件顶部常量区（`const SHUTDOWN_JOIN_TIMEOUT_MS ...` 一带）加：
+
+```zig
+const NOTIFY_TEXT_MAX: usize = 2000;
+```
+
+在 `Controller` struct **之后**、`const ilink_default_base_url = ...` **之前**，加纯函数与 `PushJob`：
+
+```zig
+/// Builds the WeChat push text "<title>\n<body>" into `out`, truncating to fit.
+/// Pure (no allocation/IO) so it is unit-tested directly.
+fn buildNotifyText(title: []const u8, body: []const u8, out: []u8) []const u8 {
+    var n: usize = 0;
+    const tcopy = title[0..@min(title.len, out.len)];
+    @memcpy(out[0..tcopy.len], tcopy);
+    n = tcopy.len;
+    if (body.len != 0 and n < out.len) {
+        out[n] = '\n';
+        n += 1;
+        const bcopy = body[0..@min(body.len, out.len - n)];
+        @memcpy(out[n..][0..bcopy.len], bcopy);
+        n += bcopy.len;
+    }
+    return out[0..n];
+}
+
+/// A self-contained, owned copy of everything one push needs, so the send can
+/// run on a detached thread without touching mutable Controller state.
+const PushJob = struct {
+    allocator: std.mem.Allocator,
+    base_url: []u8,
+    token: []u8,
+    owner: []u8,
+    text: []u8,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        base_url: []const u8,
+        token: []const u8,
+        owner: []const u8,
+        text: []const u8,
+    ) !*PushJob {
+        const self = try allocator.create(PushJob);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.base_url = try allocator.dupe(u8, base_url);
+        errdefer allocator.free(self.base_url);
+        self.token = try allocator.dupe(u8, token);
+        errdefer allocator.free(self.token);
+        self.owner = try allocator.dupe(u8, owner);
+        errdefer allocator.free(self.owner);
+        self.text = try allocator.dupe(u8, text);
+        return self;
+    }
+
+    fn destroy(self: *PushJob) void {
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.token);
+        self.allocator.free(self.owner);
+        self.allocator.free(self.text);
+        self.allocator.destroy(self);
+    }
+
+    fn run(self: *PushJob) void {
+        var client = ilink.Client.init(self.allocator, self.base_url, self.token);
+        client.sendText(self.owner, self.text, "") catch |err| {
+            std.debug.print("weixin notify forward failed: {}\n", .{err});
+        };
+        self.destroy();
+    }
+};
+```
+
+在 `Controller` struct 内部（例如紧跟 `unbind` 之后）加方法：
+
+```zig
+    /// Forward one notification to the bound owner's WeChat. No-op unless a
+    /// binding is live with a bound owner. The network send runs on a detached
+    /// one-shot thread so this never blocks the caller (the UI thread).
+    /// Best-effort: allocation/spawn/send failures only log.
+    pub fn enqueueNotify(self: *Controller, title: []const u8, body: []const u8) void {
+        if (!self.running or self.owner.len == 0 or self.token.len == 0) return;
+
+        var text_buf: [NOTIFY_TEXT_MAX]u8 = undefined;
+        const text = buildNotifyText(title, body, &text_buf);
+
+        const job = PushJob.create(self.allocator, self.base_url, self.token, self.owner, text) catch return;
+        const th = std.Thread.spawn(.{}, PushJob.run, .{job}) catch {
+            job.destroy();
+            return;
+        };
+        th.detach();
+    }
+```
+
+- [ ] **Step 4: 跑测试，确认通过**
+
+Run: `zig build test-full`
+Expected: PASS（新增 4 个测试 + 既有 controller 测试全绿）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/weixin/controller.zig
+git commit -m "feat(weixin): add Controller.enqueueNotify for off-thread WeChat push
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: AppWindow.handleNotification 接线转发
+
+**Files:**
+- Modify: `src/AppWindow.zig`（`handleNotification` 出队循环，~3486-3537）
+
+- [ ] **Step 1: 在出队循环里加转发分支**
+
+`src/AppWindow.zig` `handleNotification` 中，`while (surface.notif_queue.pop()) |item| { ... }` 循环体内、`switch (route) { ... }` 这一整块**之后**、循环 `}` **之前**，插入：
+
+```zig
+        // Forward to the bound WeChat owner when the notifier marked it, the
+        // opt-in is on, and you are not looking right at this surface. The
+        // controller self-guards on an active binding + bound owner and sends
+        // off-thread, so this never blocks. (Reaches here only after the
+        // shouldDeliver gate above, so it inherits rate-limit/dedup.)
+        if (item.forward_wechat and g_weixin_notify_forward and
+            !(window_focused and is_active_surface))
+        {
+            if (g_app) |app| {
+                if (app.weixin_controller) |ctrl| ctrl.enqueueNotify(item.title(), item.body());
+            }
+        }
+```
+
+- [ ] **Step 2: 编译**
+
+Run: `zig build`
+Expected: 通过。（`item` 为 `notification.Item`，已含 `forward_wechat`/`title()`/`body()`；`g_weixin_notify_forward`/`g_app`/`window_focused` 均在作用域。）
+
+- [ ] **Step 3: 跑全量测试，确认无回归**
+
+Run: `zig build test && zig build test-full`
+Expected: 全绿。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "feat(appwindow): forward marked notifications to bound WeChat owner
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> **注：** `handleNotification` 是 UI 线程私有函数且依赖 tab/窗口状态，无清晰的纯单测接缝。转发**决策**已被 Task 1（标记/置位）与 Task 4（`enqueueNotify` 守卫）单测覆盖；本任务的接线靠编译 + Task 6 手验确认。
+
+---
+
+## Task 6: SKILL 文档 + 全量回归
+
+**Files:**
+- Modify: `plugins/skills/wispterm-notify-setup/SKILL.md`
+
+- [ ] **Step 1: 加「微信转发」文档节**
+
+在 `SKILL.md` 的 `## Notes` 之前插入：
+
+```markdown
+## WeChat forwarding (optional)
+
+In addition to the in-terminal toast/bell, WispTerm can forward each agent
+finish / confirmation notification to a WeChat account you've already bound to
+WispTerm's built-in iLink direct connection — no third-party relay.
+
+**Prerequisites (all required):**
+1. A WispTerm build that includes notification → WeChat forwarding.
+2. `weixin-direct-enabled = true` in your WispTerm config.
+3. Scan the QR (WispTerm's WeChat panel) to bind, then **send the bot at least
+   one message** so it auto-binds you as owner (or pin `weixin-allowed-user`).
+4. `weixin-notify-forward = true` in your WispTerm config.
+5. Keep `desktop-notifications = on` (default) — forwarding rides the same
+   notification pipeline and is skipped when desktop notifications are off.
+
+**Behavior:** a push is sent only when the notification is from this notifier,
+the binding is live with a bound owner, and you are **not** actively viewing
+that pane (window unfocused, or a different tab/split). The phone message is
+`<title>\n<body>`, e.g. `Claude Code` / `完成，轮到你了`.
+
+**Verify:** run the test command below to trigger one notification while the
+WispTerm window is unfocused, and confirm the message arrives in WeChat.
+```
+
+- [ ] **Step 2: 全量回归（脚本 + Zig）**
+
+Run:
+```bash
+sh plugins/skills/wispterm-notify-setup/scripts/test-install.sh
+zig build && zig build test && zig build test-full
+```
+Expected: 脚本 `0 test(s) failed`；Zig 编译通过、测试全绿。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add plugins/skills/wispterm-notify-setup/SKILL.md
+git commit -m "docs(notify-setup): document WeChat notification forwarding
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## 手动验证清单（无 live WeChat endpoint，无法自动化）
+
+真实绑定（`weixin-direct-enabled=true`、扫码、给 bot 发过消息、`weixin-notify-forward=true`、`desktop-notifications=on`）下：
+
+1. 在 WispTerm 内跑 agent，窗口**失焦**时触发完成 → 手机微信收到 `Claude Code\n完成，轮到你了`，内容干净（无可见标记）。
+2. 触发「需确认」(Notification) → 同样收到。
+3. 焦点**正在**该 agent pane → 不推（仅本地铃铛短闪）。
+4. 切到另一个 tab，agent 在后台 pane 完成 → 推。
+5. `weixin-notify-forward=false` → 不推。
+6. owner 未绑（从没给 bot 发过消息）→ 静默不推、不崩。
+7. `desktop-notifications=false` → 既无 toast 也无微信推送（已知限制）。
+8. 快速重复同内容通知 → 受既有去重/限流约束，不轰炸。
+
+---
+
+## Self-Review
+
+**Spec coverage（逐节核对）：**
+- §3.1 A2 标记式 → Task 1（剥离）+ Task 2（发标记）✅
+- §3.2 转发全部事件 → notify 脚本所有路径都发标记（Task 2），WispTerm 不按事件类型过滤 ✅
+- §3.3 焦点门控 → Task 5 `!(window_focused and is_active_surface)` ✅
+- §3.4 零宽标记 + WispTerm 剥离 → Task 1/2，字节 `E2 80 8B` 双侧一致 ✅
+- §3.5 空 context_token → Task 4 `sendText(owner, text, "")` ✅
+- §3.6 `weixin-notify-forward` 开关默认 false → Task 3 ✅
+- §6.1 notification.zig → Task 1 ✅
+- §6.2 handleNotification 转发分支 + 去重继承 → Task 5（置于 shouldDeliver 之后）✅
+- §6.3 controller.enqueueNotify 不阻塞主线程 + owner 空丢弃 + 失败仅 log → Task 4 ✅（用「即用即弃」detached 线程替代「常驻发送线程+队列」，等价满足「不阻塞 UI、失败仅 log」且更少生命周期耦合；spec §6.3 的常驻线程为建议非约束）
+- §6.4 config 开关 + --help → Task 3 ✅
+- §7 skill 三处改动 → Task 2（脚本×2）+ Task 6（SKILL.md）✅
+- §8 测试 → Task 1/4 纯单测、Task 2 脚本测、Task 5/6 编译+回归、手验清单 ✅
+- §9 风险（运行期未验证、线程边界、owner 时序）→ 手验清单 + Task 4 守卫 ✅
+
+**Placeholder scan：** 无 TBD/TODO；每个改代码的 step 都给了完整代码与确切命令/预期。✅
+
+**Type consistency：** `wechat_marker`（notification.zig）双侧字节一致；`forward_wechat`、`Item.title()/body()`、`enqueueNotify(title, body)`、`buildNotifyText(title, body, out)`、`PushJob.create/run/destroy`、`g_weixin_notify_forward`、`@"weixin-notify-forward"` 在定义与使用处命名一致。✅
+
+**偏离 spec 说明：** §6.3 采用 detached 即用即弃线程而非常驻队列线程——更简单、无需与 poller 协调生命周期；通知频率低且受 shouldDeliver 限流，每事件一线程开销可接受。`ilink.Client` 每请求自建 `std.http.Client`、无持久资源，适合一次性使用。

--- a/docs/superpowers/specs/2026-05-31-wispterm-wechat-notify-forward-design.md
+++ b/docs/superpowers/specs/2026-05-31-wispterm-wechat-notify-forward-design.md
@@ -1,0 +1,126 @@
+# 设计：把 WispTerm 通知转发到已绑定的微信（A2 标记式）
+
+> 状态：已通过 brainstorming 评审，待写实现计划。
+> 日期：2026-05-31
+> 范围：在「OSC 桌面通知（feature #1）」与「notify-setup skill（feature #2）」之上，新增 **feature #3：把 agent 通知额外转发到 WispTerm 已绑定的微信 owner**。复用 `src/weixin/` 既有 iLink 绑定与发送链路，不引入任何第三方中转服务（ServerChan / PushPlus 等）。
+
+## 1. 背景与动机
+
+`wispterm-notify-setup` skill 目前只让 Claude Code / Codex 在「完成 / 需确认」时弹一条 WispTerm 桌面通知（OSC 777 toast + 标题栏铃铛）。这要求人盯着屏幕。诉求是：人离开工位时，也能在**微信**上收到「任务完成 / 需要你操作」的主动通知。
+
+微信对个人号没有开放推送 API，常规做法是接 ServerChan / PushPlus 等中转。但 WispTerm **本体已经内置了一套微信 iLink 直连**（`src/weixin/`，扫码登录 → 绑定 owner → 双向收发）。因此本设计直接**复用这套已绑定的微信通道**：不注册外部服务、不在 shell 里保管 token、跨平台可用。
+
+## 2. 关键发现（已存在、可复用的基础设施）
+
+- **微信发送原语已存在**：`src/weixin/ilink_client.zig:87` `sendText(to_user_id, text, context_token)` → POST `/ilink/bot/sendmessage`。poller 已在自有线程上用它给 owner 回消息——「给微信推一条」是已解决的能力，只是缺一个「通知触发」的接线。
+- **绑定与 owner 已持久化**：`src/weixin/controller.zig` 持有活动 `ilink.Client`（base_url + bot_token）与绑定的 `owner`；App 全局 `App.weixin_controller`（`src/App.zig:92`），由 `weixin-direct-enabled` 配置开启（`src/App.zig:305`），状态落盘 `~/.config/wispterm/weixin.json`（0600，`src/weixin/state_store.zig`）。owner 来自首条入站消息 auto-bind，或被 `weixin-allowed-user` 钉死（`src/weixin/binding.zig:41` `ownerForBind`）。
+- **通知解析/出队链路已存在**：notify 脚本发 OSC 777 → ghostty VT 核心解析成 `show_desktop_notification {title, body}` → `src/Surface.zig:140` `VtHandler.vt` 调 `notification.ingest()` 压入**每 surface** 的 `notif_queue` → 主线程在 `AppWindow.handleNotification`（`src/AppWindow.zig:3474`，调用点 `:4045`）出队 → `decideRoute` 决定 toast / badge / none。**转发分支正好挂在这里。**
+- **主线程可达 controller**：`handleNotification` 是 UI 线程函数；UI 线程的 `g_app: ?*App`（`src/AppWindow.zig:308`，init 时 `:94` 赋值）可拿到 `App.weixin_controller`。`window_focused`（`src/AppWindow.zig` 全局）与 `is_active_surface`（出队点已在算）都现成。
+- **ghostty OSC 777 文法约束（决定标记机制）**：`rxvt_extension.zig:30-37`——`777;notify;title;body` 中 `title` 取到**第二个 `;`**，而 **`body` = 其后的全部剩余字符串**（含任何后续 `;`）。所以**不能**简单加第 4 个 `;` 字段（会被并进 body、污染 toast）。且 WispTerm **只看 ghostty 解析后的 `{title, body}`**，看不到原始 OSC 字节（未知 OSC 被 ghostty 丢弃），故「私有 OSC 旁路」在不 fork 固定版 ghostty 的前提下不可行（feature #1 spec 已否决在原始字节流里识别）。
+
+## 3. 已确认的设计决策
+
+1. **方案 A2（标记式内部转发）**：WispTerm 内部把**带标记的** agent 通知转发给已绑定微信 owner，而非接第三方中转（A1=转发所有 OSC 777 被否；B=脚本自行 POST 被否：会在 shell 重写 iLink 协议 + 读 0600 密钥、易随 Zig 客户端漂移）。
+2. **转发哪些事件**：**全部**——Claude Code `Stop` / Codex `agent-turn-complete`（完成）与 Claude Code `Notification`（需确认/输入）都转发。
+3. **焦点门控**：**只在你没看着它时推**——`window_focused && is_active_surface` 为真时不推（你正盯着这个 pane，已经看到了），其余（窗口失焦 / 在别的 tab / 后台 surface）才推。镜像 feature #1 的 toast 抑制矩阵。
+4. **标记机制：零宽标记藏进 body**。notify 脚本在 OSC 777 的 body 末尾追加一个 **U+200B（零宽空格）**；WispTerm 在 `ingest` 时检测并**剥离**它，置位 `forward_wechat`。零宽空格：① 过得了脚本 sanitize（不在被删字节集、非 `;`）；② 过得了 ghostty（可打印、无 `;`）；③ 在任何渲染器里不可见——即便某旧 WispTerm 还不剥离它，toast 也不露馅。**脚本保持「哑」：所有 agent 事件无条件加标记，是否真转发由 WispTerm 端策略决定。**（备选：显式可见标签如 `\u{200B}WT`，更直观但旧构建会露出 `WT`——否决，取纯零宽。）
+5. **主动推送用空 `context_token`**：本通知是无来由的主动推送（非对某条入站消息的回复），`sendText(owner, text, "")`。`buildSendTextBody`（`ilink_codec.zig:33`）原样序列化，结构上成立；服务端是否接受空值列为运行期手验项。
+6. **配置开关** `weixin-notify-forward: bool = false`（opt-in）。关 / 无绑定 / owner 未绑 → 静默跳过转发，完全不影响既有 toast/badge。
+
+## 4. 架构与数据流
+
+```
+notify.sh (hook)  ──OSC 777;notify;<title>;<body>\u{200B}──▶  PTY (agent pane)
+   ▶ ghostty 解析 ▶ VtHandler.vt(.show_desktop_notification {title, body})   [reader 线程]
+        │  notification.ingest(): 检测并剥离尾部 \u{200B} → forward_wechat=true
+        │  notif_queue.push(Item{ title, body(已净化), forward_wechat })
+        ▼
+   AppWindow.handleNotification(surface, is_active_surface)                    [主线程]
+        │  既有：shouldDeliver → decideRoute → toast / badge（body 已无标记，显示干净）
+        │  新增转发门控（与 toast/badge 相互独立）：
+        │     item.forward_wechat
+        │  && g_desktop... 无关；读 weixin-notify-forward == true
+        │  && g_app.weixin_controller 存在且 has_token && has_owner
+        │  && !(window_focused && is_active_surface)
+        ▼
+   controller.enqueueNotify(title, body)   ──拷贝入有界队列──▶  发送线程
+        ▼
+   ilink Client.sendText(owner, "<title>\n<body>", "")   → POST /ilink/bot/sendmessage
+                                                            （失败仅 log，绝不影响 UI/agent）
+```
+
+要点：通知挂在 agent pane 对应的 surface 上，焦点门控天然用该 surface 的 active/focused 状态；微信 owner 是 App 全局唯一绑定，一人一微信，语义自洽。
+
+## 5. 标记机制（细化）
+
+- **notify 脚本侧**：现 `printf '\033]777;notify;%s;%s\007' "$title" "$body"`。改为在 body 之后、BEL 之前追加 `\u{200B}`（UTF-8 字节 `E2 80 8B`）。标记在 `sanitize` **之后**追加，长度上限照旧（标记本身极短，可忽略或并入截断预算）。脚本所有事件路径（Stop / Notification / Codex）都加。
+- **WispTerm 侧**：`notification.ingest` / `makeItem` 在拷贝 body 前，若 body 以 `\u{200B}` 结尾则剥离该 3 字节并置 `Item.forward_wechat = true`；否则 `false`。剥离发生在入队前 → `contentHash(title, body)` 去重基于净化后的 body，稳定；toast / 微信消息都拿到干净 body。
+
+## 6. WispTerm 侧改动（Zig）
+
+### 6.1 `src/notification.zig`
+- `Item` 加字段 `forward_wechat: bool = false`。
+- `makeItem(title, body)`：检测 body 尾部 `\u{200B}` → 剥离 + 置位（纯逻辑，可原生单测）。
+- `ingest` 透传该位（仍是 `push(makeItem(...))`）。
+
+### 6.2 `src/AppWindow.zig` `handleNotification`
+- 在既有 `switch (route)` 之后（或并行）加转发判定。**注意**：转发与 `route`（toast/badge/none）**独立**——例如 `route==.none` 是因 `desktop-notifications=false` 或去重/限流；转发应遵循自己的门控（第 4 节）。实现期明确：转发是否也受 `shouldDeliver` 去重约束？**取「是」**——复用同一 `shouldDeliver` 结果做转发去重，避免快速重复推送轰炸微信/手机（与 toast 共用 last_notif 去重状态即可）。
+- 门控：`item.forward_wechat && weixinForwardEnabled() && ctrl.has_token && ctrl.has_owner && !(window_focused && is_active_surface)` → `ctrl.enqueueNotify(item.title(), item.body())`。
+- 取 controller：`if (g_app) |app| if (app.weixin_controller) |ctrl| ...`；`weixin-notify-forward` 经 `g_desktop_notifications` 同款 threadlocal 缓存或直接读 config 缓存（实现期与现有 config 取用点对齐）。
+
+### 6.3 `src/weixin/controller.zig`
+- 新增 `pub fn enqueueNotify(self: *Controller, title: []const u8, body: []const u8) void`：
+  - **绝不在主线程做网络 I/O**。拷贝 `"<title>\n<body>"`（截断至合理上限）入一个互斥有界队列；由一个**轻量发送线程**消费（绑定激活时随 poller 一并启动 / 停止；poller 自身在长轮询 getupdates，不复用它做发送）。
+  - 消费端调 `self.client.sendText(self.owner, msg, "")`；`owner.len==0` 时直接丢弃。
+  - 失败（网络 / `IlinkSendMessageFailed`）只 `std.debug.print` log，不向上抛、不阻塞。
+  - 队列满（如容量 8）丢最旧，语义同 `notification.Queue`。
+- 生命周期：发送线程在 `startWithBinding` 起、`stop` / `destroy*` 停（与现有 `stopForProcessExit` 的「超时则 detach」策略一致，避免退出阻塞在网络上）。`Status` 可加 `forward_thread_active` 便于诊断（可选）。
+
+### 6.4 `src/config.zig`
+- 新增 `weixin-notify-forward: bool = false`，与其它 `weixin-*` 键并列解析（`:806` 一带），写进 `--help`（`:1235` 一带）。语义上依赖 `weixin-direct-enabled=true` 才有意义。
+
+## 7. notify-setup skill 改动（feature #2 的延伸）
+
+- `plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh`：OSC 777 body 末尾追加 `\u{200B}` 标记。
+- `plugins/skills/wispterm-notify-setup/scripts/test-install.sh`：更新 OSC 断言——既验「body 带零宽标记」，也（用与 WispTerm 一致的剥离逻辑描述）说明剥离后内容干净；保证既有 5 项 notify 断言不破。
+- `plugins/skills/wispterm-notify-setup/SKILL.md`：新增「微信转发」一节：
+  - 前置：WispTerm 构建含本特性；`weixin-direct-enabled=true`；扫码绑定；**给 bot 发过至少一条消息**以 auto-bind owner（或配 `weixin-allowed-user`）；`weixin-notify-forward=true`。
+  - 验证：沿用既有 echo 测试触发一条通知，确认手机微信收到。
+  - 说明：仅在 WispTerm 内、绑定激活、owner 已绑、且你没盯着该 pane 时才推。
+
+## 8. 测试
+
+- **纯逻辑单测**（`notification.zig`，注册进 `test_fast.zig`，原生跑）：
+  - `makeItem`：body 带 / 不带尾部 `\u{200B}` → `forward_wechat` 置位且标记被剥离 / 不置位且 body 原样；标记 + 截断边界。
+  - controller `enqueueNotify`：入队 / 满了丢最旧 / `owner==""` 丢弃（队列逻辑可与网络解耦单测）。
+- **集成测试**（`test-full`）：把带 `\u{200B}` 标记的 OSC 777 字节喂进 VtStream / VtHandler，断言 `surface.notif_queue` 出现**干净** title/body 且 `forward_wechat==true`；不带标记则为 false。Linux 即可，不碰网络。
+- **脚本测试**：`test-install.sh` 全绿（含新的标记断言）。
+- **回归**：`zig build test` + `zig build test-full` 不破（基线绿）。
+- **手验（无 live endpoint，无法自动化）**：真实绑定下，触发完成 / 需确认 → 手机微信收到、内容干净；焦点在该 pane 时不推；窗口失焦 / 切 tab 时推；`weixin-notify-forward=false` 不推；owner 未绑时静默不崩。
+
+## 9. 风险与前置校验
+
+- **微信 direct 整条链路「UNVERIFIED AT RUNTIME」**：`src/App.zig` / `src/AppWindow.zig:2264` 注释自述「cross-compiles，但未跑过，无 live WeChat」。本特性建立其上，发送链路（含空 `context_token` 是否被服务端接受）需运行期手验。
+- **线程边界**：发送绝不能跑在主线程 / reader 线程；进程退出时发送线程要能被取消 / detach，复用 `ThreadControl` 既有策略。
+- **owner 时序**：用户从未给 bot 发过消息 → owner 为空 → 转发静默跳过（非错误）。skill 文档须强调「先发一条消息」。
+- **标记鲁棒性**：零宽标记作为布尔 flag 依赖 notify→ghostty→WispTerm 全链不被中间层吞掉；本仓自产自销（用户即 WispTerm 作者），可接受。
+
+## 10. 范围边界（YAGNI / 本期不做）
+
+- 第三方中转（ServerChan / PushPlus / 企业微信机器人）。
+- 脚本侧自行 POST iLink（方案 B）。
+- 本地 IPC 控制 socket / 私有 OSC 旁路（需 fork 固定版 ghostty）。
+- 节流策略升级——复用既有 `shouldDeliver` 去重 / 限流。
+- 「转发哪些事件」的细粒度配置——本期固定「全部」。
+- 微信消息富文本 / 点击跳转 / 多 owner / 群发。
+
+## 11. 影响文件一览（预估）
+
+- 改 `src/notification.zig`（`Item.forward_wechat` + `makeItem` 剥离 + 单测）。
+- 改 `src/AppWindow.zig`（`handleNotification` 转发分支 + 读配置 + 取 `g_app.weixin_controller`）。
+- 改 `src/weixin/controller.zig`（`enqueueNotify` + 发送线程 + 生命周期 + 单测）。
+- 改 `src/config.zig`（`weixin-notify-forward` 开关 + `--help`）。
+- 改 `src/test_fast.zig` / `src/test_main.zig`（注册新单测 / 集成测试）。
+- 改 `plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh`（追加标记）。
+- 改 `plugins/skills/wispterm-notify-setup/scripts/test-install.sh`（标记断言）。
+- 改 `plugins/skills/wispterm-notify-setup/SKILL.md`（微信转发文档）。

--- a/plugins/skills/wispterm-notify-setup/SKILL.md
+++ b/plugins/skills/wispterm-notify-setup/SKILL.md
@@ -38,6 +38,32 @@ supported.
      | ~/.config/wispterm/wispterm-notify.sh
    ```
 
+## WeChat forwarding (optional)
+
+In addition to the in-terminal toast/bell, WispTerm can forward each agent
+finish / confirmation notification to a WeChat account you've already bound to
+WispTerm's built-in iLink direct connection — no third-party relay.
+
+**Prerequisites (all required):**
+1. A WispTerm build that includes notification → WeChat forwarding.
+2. `weixin-direct-enabled = true` in your WispTerm config.
+3. Scan the QR (WispTerm's WeChat panel) to bind your WeChat account.
+4. Set `weixin-allowed-user = <your iLink user id>` — forwarding needs a bound
+   owner as the push destination. The "auto-bind the first sender as owner" path
+   is not yet wired, so the owner must be set explicitly here; while it is empty,
+   pushes are silently skipped.
+5. `weixin-notify-forward = true` in your WispTerm config.
+6. Keep `desktop-notifications = on` (default) — forwarding rides the same
+   notification pipeline and is skipped when desktop notifications are off.
+
+**Behavior:** a push is sent only when the notification is from this notifier,
+the binding is live with a bound owner, and you are **not** actively viewing
+that pane (window unfocused, or a different tab/split). The phone message is
+`<title>\n<body>`, e.g. `Claude Code` / `完成，轮到你了`.
+
+**Verify:** run the test command below to trigger one notification while the
+WispTerm window is unfocused, and confirm the message arrives in WeChat.
+
 ## Notes
 
 - **Where it shows:** only when Claude Code / Codex run *inside* WispTerm. The

--- a/plugins/skills/wispterm-notify-setup/scripts/test-install.sh
+++ b/plugins/skills/wispterm-notify-setup/scripts/test-install.sh
@@ -7,6 +7,7 @@ INSTALL="$HERE/install-wispterm-notify.sh"
 FAILS=0
 ESC="$(printf '\033')"
 BEL="$(printf '\007')"
+MARKER="$(printf '\342\200\213')"
 
 ok()   { printf 'ok   - %s\n' "$1"; }
 fail() { printf 'FAIL - %s\n' "$1"; FAILS=$((FAILS+1)); }
@@ -21,30 +22,30 @@ assert_not_contains() {
 t="$(mktemp)"
 printf '%s' '{"hook_event_name":"Notification","title":"WispTerm","message":"hi"}' \
   | WISPTERM_NOTIFY_TTY="$t" sh "$NOTIFY"
-assert_contains "$t" "${ESC}]777;notify;WispTerm;hi${BEL}" "CC Notification -> OSC777 title+body"
+assert_contains "$t" "${ESC}]777;notify;WispTerm;hi${MARKER}${BEL}" "CC Notification -> OSC777 title+body"
 assert_contains "$t" "$BEL" "CC Notification -> emits BEL"
 
 # ---- notify: Claude Code Stop on stdin ----
 t="$(mktemp)"
 printf '%s' '{"hook_event_name":"Stop"}' | WISPTERM_NOTIFY_TTY="$t" sh "$NOTIFY"
-assert_contains "$t" "${ESC}]777;notify;Claude Code;完成，轮到你了${BEL}" "CC Stop -> OSC777 Claude Code title+body"
+assert_contains "$t" "${ESC}]777;notify;Claude Code;完成，轮到你了${MARKER}${BEL}" "CC Stop -> OSC777 Claude Code title+body"
 
 # ---- notify: Codex event as LAST argv ----
 t="$(mktemp)"
 WISPTERM_NOTIFY_TTY="$t" sh "$NOTIFY" '{"type":"agent-turn-complete","last-assistant-message":"done deal"}'
-assert_contains "$t" "${ESC}]777;notify;Codex;done deal${BEL}" "Codex argv -> OSC777 Codex/body"
+assert_contains "$t" "${ESC}]777;notify;Codex;done deal${MARKER}${BEL}" "Codex argv -> OSC777 Codex/body"
 
 # ---- notify: sanitization (strip ';' delimiter from title and body) ----
 t="$(mktemp)"
 printf '%s' '{"hook_event_name":"Notification","title":"a;b","message":"x;y"}' \
   | WISPTERM_NOTIFY_TTY="$t" sh "$NOTIFY"
-assert_contains "$t" "${ESC}]777;notify;ab;xy${BEL}" "sanitize strips ';' from title and body"
+assert_contains "$t" "${ESC}]777;notify;ab;xy${MARKER}${BEL}" "sanitize strips ';' from title and body"
 
 # ---- notify: sanitization strips control bytes (ESC/BEL) decoded by jq ----
 t="$(mktemp)"
 printf '%s' '{"hook_event_name":"Notification","title":"a","message":"b\u001bc\u0007d"}' \
   | WISPTERM_NOTIFY_TTY="$t" sh "$NOTIFY"
-assert_contains "$t" "${ESC}]777;notify;a;bcd${BEL}" "sanitize strips ESC/BEL control bytes from body"
+assert_contains "$t" "${ESC}]777;notify;a;bcd${MARKER}${BEL}" "sanitize strips ESC/BEL control bytes from body"
 
 # ---- notify: empty payload -> no output, exit 0 ----
 t="$(mktemp)"

--- a/plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh
+++ b/plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.sh
@@ -73,9 +73,12 @@ fi
 [ -z "$notify_tty" ] && exit 0
 
 # --- 5. Emit one OSC 777 (title+body) + BEL. Only OSC 777 (not OSC 9) to avoid
-#        double-notifying terminals that support both. ---
+#        double-notifying terminals that support both.
+# A trailing zero-width space (U+200B) in the body marks the notification for
+# WeChat forwarding; WispTerm strips it (notification.zig). Other terminals show
+# nothing extra. The bare BEL after is the bell-badge fallback. ---
 {
-  printf '\033]777;notify;%s;%s\007' "$title" "$body"
+  printf '\033]777;notify;%s;%s\342\200\213\007' "$title" "$body"
   printf '\a'
 } >"$notify_tty" 2>/dev/null || true
 exit 0

--- a/src/App.zig
+++ b/src/App.zig
@@ -74,6 +74,7 @@ copy_on_select: bool,
 right_click_action: Config.RightClickAction,
 url_open_mode: Config.UrlOpenMode,
 ssh_legacy_algorithms: bool,
+weixin_notify_forward: bool,
 
 // Background image
 background_image: ?[]const u8,
@@ -215,6 +216,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .right_click_action = cfg.@"right-click-action",
         .url_open_mode = cfg.@"url-open-mode",
         .ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms",
+        .weixin_notify_forward = cfg.@"weixin-notify-forward",
         .background_image = background_image,
         .background_opacity = cfg.@"background-opacity",
         .background_image_mode = cfg.@"background-image-mode",
@@ -380,6 +382,7 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.right_click_action = cfg.@"right-click-action";
     self.url_open_mode = cfg.@"url-open-mode";
     self.ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
+    self.weixin_notify_forward = cfg.@"weixin-notify-forward";
     self.replaceOptStr(&self.background_image, cfg.@"background-image");
     self.background_opacity = cfg.@"background-opacity";
     self.background_image_mode = cfg.@"background-image-mode";

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -132,6 +132,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     input.g_url_open_mode = app.url_open_mode;
     g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     tab.g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
+    g_weixin_notify_forward = app.weixin_notify_forward;
     overlays.g_split_divider_color = app.split_divider_color;
 
     // Apply window size from config

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3534,6 +3534,19 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
                 surface.last_notif_time = now;
             },
         }
+
+        // Forward to the bound WeChat owner when the notifier marked it, the
+        // opt-in is on, and you are not looking right at this surface. The
+        // controller self-guards on an active binding + bound owner and sends
+        // off-thread, so this never blocks. (Reaches here only after the
+        // shouldDeliver gate above, so it inherits rate-limit/dedup.)
+        if (item.forward_wechat and g_weixin_notify_forward and
+            !(window_focused and is_active_surface))
+        {
+            if (g_app) |app| {
+                if (app.weixin_controller) |ctrl| ctrl.enqueueNotify(item.title(), item.body());
+            }
+        }
     }
 }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1369,6 +1369,7 @@ pub threadlocal var g_copy_on_select: bool = false;
 pub threadlocal var g_right_click_action: Config.RightClickAction = .copy;
 pub threadlocal var g_ssh_legacy_algorithms: bool = false;
 pub threadlocal var g_desktop_notifications: bool = true;
+pub threadlocal var g_weixin_notify_forward: bool = false;
 threadlocal var g_notif_auth_requested: bool = false;
 
 /// Update cursor blink state based on time (call once per frame)
@@ -1713,6 +1714,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     input.g_url_open_mode = cfg.@"url-open-mode";
     g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     g_desktop_notifications = cfg.@"desktop-notifications";
+    g_weixin_notify_forward = cfg.@"weixin-notify-forward";
     tab.g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     overlays.g_split_divider_color = cfg.@"split-divider-color";
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -342,6 +342,10 @@ shell: []const u8 = platform_pty_command.default_shell_name,
 /// the first 1:1 sender after login is auto-bound as owner.
 @"weixin-allowed-user": ?[]const u8 = null,
 
+/// When true (with weixin-direct-enabled and a bound owner), also forward agent
+/// finish/confirm notifications to the bound WeChat owner. Opt-in; default off.
+@"weixin-notify-forward": bool = false,
+
 /// Show a debug FPS overlay in the bottom-right corner.
 @"wispterm-debug-fps": bool = false,
 @"wispterm-debug-draw-calls": bool = false,
@@ -820,6 +824,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         };
     } else if (std.mem.eql(u8, key, "weixin-allowed-user")) {
         self.@"weixin-allowed-user" = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "weixin-notify-forward")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"weixin-notify-forward" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"weixin-notify-forward" = false;
+        } else {
+            log.warn("invalid weixin-notify-forward: {s}", .{value});
+        }
     } else if (std.mem.eql(u8, key, "wispterm-debug-fps")) {
         if (std.mem.eql(u8, value, "true")) {
             self.@"wispterm-debug-fps" = true;
@@ -1236,6 +1248,7 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --weixin-base-url <url>      Override ilink API base URL
         \\  --weixin-reply-timeout-ms <n> AI-reply streaming window in ms
         \\  --weixin-allowed-user <id>   Restrict control to one ilink user_id
+        \\  --weixin-notify-forward <bool> Forward agent notifications to the bound WeChat owner
         \\  --quake-mode <bool>          Enable Quake-style drop-down mode (default: true)
         \\
         \\Color Options (override theme):

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -19,6 +19,9 @@ pub const Item = struct {
     title_len: usize = 0,
     body_buf: [max_body]u8 = undefined,
     body_len: usize = 0,
+    /// True when the body carried the WispTerm notifier's WeChat-forward marker
+    /// (stripped before storage). Read by AppWindow.handleNotification.
+    forward_wechat: bool = false,
 
     pub fn title(self: *const Item) []const u8 {
         return self.title_buf[0..self.title_len];
@@ -28,13 +31,25 @@ pub const Item = struct {
     }
 };
 
+/// Zero-width space (U+200B) the WispTerm notifier appends to a notification's
+/// OSC 777 body to mark it for forwarding to the bound WeChat owner. It is
+/// invisible in every renderer, so a build that does not strip it still shows a
+/// clean toast. We strip it here so the stored/hashed/displayed body is clean.
+pub const wechat_marker = "\u{200b}"; // bytes E2 80 8B
+
 /// Copy + truncate raw (transient) title/body slices into an owned Item.
 pub fn makeItem(title_in: []const u8, body_in: []const u8) Item {
     var item: Item = .{};
     item.title_len = @min(title_in.len, max_title);
     @memcpy(item.title_buf[0..item.title_len], title_in[0..item.title_len]);
-    item.body_len = @min(body_in.len, max_body);
-    @memcpy(item.body_buf[0..item.body_len], body_in[0..item.body_len]);
+
+    var body = body_in;
+    if (std.mem.endsWith(u8, body, wechat_marker)) {
+        item.forward_wechat = true;
+        body = body[0 .. body.len - wechat_marker.len];
+    }
+    item.body_len = @min(body.len, max_body);
+    @memcpy(item.body_buf[0..item.body_len], body[0..item.body_len]);
     return item;
 }
 
@@ -181,4 +196,18 @@ test "decideRoute matrix" {
     try std.testing.expectEqual(Route.badge, decideRoute(true, true, .denied, false, false));
     try std.testing.expectEqual(Route.badge, decideRoute(true, true, .unavailable, false, false));
     try std.testing.expectEqual(Route.badge, decideRoute(true, false, A, false, false));
+}
+
+test "makeItem strips the trailing wechat marker and sets forward_wechat" {
+    const marked = "完成，轮到你了" ++ wechat_marker;
+    const item = makeItem("Claude Code", marked);
+    try std.testing.expect(item.forward_wechat);
+    try std.testing.expectEqualStrings("完成，轮到你了", item.body());
+    try std.testing.expectEqualStrings("Claude Code", item.title());
+}
+
+test "makeItem without the marker keeps body intact and forward_wechat false" {
+    const item = makeItem("t", "完成，轮到你了");
+    try std.testing.expect(!item.forward_wechat);
+    try std.testing.expectEqualStrings("完成，轮到你了", item.body());
 }

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -10,6 +10,7 @@ const poller = @import("poller.zig");
 const control_mod = @import("control.zig");
 
 const SHUTDOWN_JOIN_TIMEOUT_MS: u32 = 1500;
+const NOTIFY_TEXT_MAX: usize = 2000;
 pub const ThreadControl = poller.ThreadControl;
 
 pub const Controller = struct {
@@ -260,6 +261,24 @@ pub const Controller = struct {
         try self.persistBinding(.{});
     }
 
+    /// Forward one notification to the bound owner's WeChat. No-op unless a
+    /// binding is live with a bound owner. The network send runs on a detached
+    /// one-shot thread so this never blocks the caller (the UI thread).
+    /// Best-effort: allocation/spawn/send failures only log.
+    pub fn enqueueNotify(self: *Controller, title: []const u8, body: []const u8) void {
+        if (!self.running or self.owner.len == 0 or self.token.len == 0) return;
+
+        var text_buf: [NOTIFY_TEXT_MAX]u8 = undefined;
+        const text = buildNotifyText(title, body, &text_buf);
+
+        const job = PushJob.create(self.allocator, self.base_url, self.token, self.owner, text) catch return;
+        const th = std.Thread.spawn(.{}, PushJob.run, .{job}) catch {
+            job.destroy();
+            return;
+        };
+        th.detach();
+    }
+
     // --- login (driven by the QR panel) ---
 
     /// Step 1 of login: fetch a QR code. The returned value borrows from `arena`.
@@ -386,6 +405,69 @@ pub const Controller = struct {
     }
 };
 
+/// Builds the WeChat push text "<title>\n<body>" into `out`, truncating to fit.
+/// Pure (no allocation/IO) so it is unit-tested directly.
+fn buildNotifyText(title: []const u8, body: []const u8, out: []u8) []const u8 {
+    var n: usize = 0;
+    const tcopy = title[0..@min(title.len, out.len)];
+    @memcpy(out[0..tcopy.len], tcopy);
+    n = tcopy.len;
+    if (body.len != 0 and n < out.len) {
+        out[n] = '\n';
+        n += 1;
+        const bcopy = body[0..@min(body.len, out.len - n)];
+        @memcpy(out[n..][0..bcopy.len], bcopy);
+        n += bcopy.len;
+    }
+    return out[0..n];
+}
+
+/// A self-contained, owned copy of everything one push needs, so the send can
+/// run on a detached thread without touching mutable Controller state.
+const PushJob = struct {
+    allocator: std.mem.Allocator,
+    base_url: []u8,
+    token: []u8,
+    owner: []u8,
+    text: []u8,
+
+    fn create(
+        allocator: std.mem.Allocator,
+        base_url: []const u8,
+        token: []const u8,
+        owner: []const u8,
+        text: []const u8,
+    ) !*PushJob {
+        const self = try allocator.create(PushJob);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.base_url = try allocator.dupe(u8, base_url);
+        errdefer allocator.free(self.base_url);
+        self.token = try allocator.dupe(u8, token);
+        errdefer allocator.free(self.token);
+        self.owner = try allocator.dupe(u8, owner);
+        errdefer allocator.free(self.owner);
+        self.text = try allocator.dupe(u8, text);
+        return self;
+    }
+
+    fn destroy(self: *PushJob) void {
+        self.allocator.free(self.base_url);
+        self.allocator.free(self.token);
+        self.allocator.free(self.owner);
+        self.allocator.free(self.text);
+        self.allocator.destroy(self);
+    }
+
+    fn run(self: *PushJob) void {
+        var client = ilink.Client.init(self.allocator, self.base_url, self.token);
+        client.sendText(self.owner, self.text, "") catch |err| {
+            std.debug.print("weixin notify forward failed: {}\n", .{err});
+        };
+        self.destroy();
+    }
+};
+
 const ilink_default_base_url = @import("ilink_codec.zig").DEFAULT_BASE_URL;
 
 fn freeOwned(allocator: std.mem.Allocator, slot: *[]u8) void {
@@ -486,4 +568,31 @@ test "cancelled login cannot later confirm and persist a binding" {
         .bot_id = "bot",
     }));
     try t.expect(!ctrl.statusSnapshot().has_token);
+}
+
+test "buildNotifyText joins title and body with a newline" {
+    var buf: [64]u8 = undefined;
+    try t.expectEqualStrings("Claude Code\n完成", buildNotifyText("Claude Code", "完成", &buf));
+}
+
+test "buildNotifyText omits the newline when body is empty" {
+    var buf: [64]u8 = undefined;
+    try t.expectEqualStrings("Codex", buildNotifyText("Codex", "", &buf));
+}
+
+test "buildNotifyText truncates to fit the output buffer" {
+    var buf: [5]u8 = undefined;
+    try t.expectEqualStrings("Title", buildNotifyText("Title", "body", &buf));
+}
+
+test "enqueueNotify is a no-op when no binding is active (owner unbound)" {
+    const path = "zig-cache-tmp-weixin-ctrl-enqueue.json";
+    defer std.fs.cwd().deleteFile(path) catch {};
+
+    const ctrl = try Controller.create(t.allocator, path, NoopControl.iface(), .{});
+    defer ctrl.destroy();
+
+    // Never started → running=false, owner empty: must not spawn a thread or crash.
+    ctrl.enqueueNotify("Claude Code", "完成");
+    try t.expect(!ctrl.running);
 }

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -265,6 +265,9 @@ pub const Controller = struct {
     /// binding is live with a bound owner. The network send runs on a detached
     /// one-shot thread so this never blocks the caller (the UI thread).
     /// Best-effort: allocation/spawn/send failures only log.
+    /// Reads the live binding fields (owner/token/base_url) without locking;
+    /// safe because callers are on the UI thread and the only background mutator
+    /// is the one-time QR login.
     pub fn enqueueNotify(self: *Controller, title: []const u8, body: []const u8) void {
         if (!self.running or self.owner.len == 0 or self.token.len == 0) return;
 
@@ -300,8 +303,9 @@ pub const Controller = struct {
         const binding = types.Binding{
             .bot_token = status.bot_token,
             .base_url = if (status.base_url.len != 0) status.base_url else self.configuredBaseUrl(),
-            // owner is auto-bound from the first inbound 1:1 message, unless the
-            // config pins an allowed user (settings.allowed_user).
+            // owner comes from settings.allowed_user (weixin-allowed-user). The
+            // first-sender auto-bind described by ownerForBind is not yet wired,
+            // so owner stays empty unless allowed_user is configured.
             .owner_user_id = self.settings.allowed_user,
             .bot_id = status.bot_id,
             .sync_buf = "",


### PR DESCRIPTION
## Summary

Forward Claude Code / Codex finish & confirmation notifications to the WeChat account already bound to WispTerm's built-in iLink direct connection — no third-party relay (ServerChan/PushPlus), no token in the shell.

- **notify.sh** appends a zero-width-space marker (U+200B) to its OSC 777 body to tag agent notifications.
- **`notification.zig`** strips that marker in `makeItem` and sets `Item.forward_wechat` (body stays clean for the toast).
- **`AppWindow.handleNotification`** forwards a marked notification to the bound owner when the `weixin-notify-forward` opt-in is on and you're *not* actively viewing that pane (mirrors the existing toast-suppression gate; inherits the existing dedup/rate-limit).
- **`weixin.Controller.enqueueNotify`** copies the message into an owned `PushJob` and sends via the existing `ilink.Client.sendText(owner, "<title>\n<body>", "")` on a detached one-shot thread — never blocks the UI thread; safe no-op unless a binding is live with a bound owner.
- New config opt-in **`weixin-notify-forward`** (default off), applied at startup and on hot-reload.

### Notes / limitations
- Owner must be set via `weixin-allowed-user` — the first-message auto-bind (`ownerForBind`) is not yet wired in this codebase. Documented in the skill.
- Forwarding rides the notification pipeline, so it's skipped when `desktop-notifications` is off (default on).
- The underlying `src/weixin/` iLink path is "unverified at runtime" per its own comments; real WeChat delivery needs manual verification (see manual checklist in the plan).

Spec: `docs/superpowers/specs/2026-05-31-wispterm-wechat-notify-forward-design.md`
Plan: `docs/superpowers/plans/2026-05-31-wispterm-wechat-notify-forward.md`

## Test Plan
- [x] `zig build` clean
- [x] `zig build test` (fast suite, incl. `notification.zig` marker strip)
- [x] `zig build test-full` (incl. `weixin/controller.zig` `buildNotifyText` + `enqueueNotify` no-op guard)
- [x] `sh plugins/skills/wispterm-notify-setup/scripts/test-install.sh` (OSC 777 marker assertions)
- [ ] Manual: with a live binding + `weixin-allowed-user` + `weixin-notify-forward=true`, trigger a finish/confirm while WispTerm is unfocused → confirm WeChat receives a clean `Claude Code` / `完成，轮到你了`; confirm no push while actively viewing the pane; confirm silent no-op when owner unbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)