### PR TITLE
[codex] add Weixin agent attachments

### DIFF
--- a/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
+++ b/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
@@ -1,0 +1,2159 @@
+# Weixin Agent Attachments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the desktop direct Weixin bridge route inbound text and voice transcripts into AI Chat, and let AI Chat call `weixin_send_attachment` to send local `file`, `image`, or `voice` attachments back to the active Weixin conversation.
+
+**Architecture:** Keep iLink upload protocol code inside `src/weixin/`, keep terminal/VT/rendering unaware of Weixin, and pass a short-lived reply context from the poller through the app control boundary into the AI Chat request. The Agent tool dispatch uses that context only when the current request came from Weixin; normal local AI Chat requests return a clear no-context tool result.
+
+**Tech Stack:** Zig 0.15.2, `std.json`, `std.http.Client`, `std.crypto.core.aes.Aes128`, `std.crypto.hash.Md5`, existing AI Chat tool protocol, existing Weixin direct poller.
+
+---
+
+## Reference Notes
+
+Ghostty has no Weixin bridge and no Agent tool layer. Its closest comparable feature is host-layer automation on macOS: App Intents and AppleScript commands call app/surface APIs such as `surface.sendText`, while VT parsing, terminal state, rendering, and fonts stay independent. Match that boundary here: Weixin tokens, upload URLs, CDN encryption, and reply context stay in `src/weixin/`, `src/AppWindow.zig`, and `src/ai_chat.zig`.
+
+CiteBox reference mapping:
+
+- `internal/weixin/types.go`: item types, upload URL request and CDN media structs.
+- `internal/weixin/media.go`: upload URL flow, AES-ECB with PKCS7 padding, CDN upload, file/image/voice send bodies, voice codec mapping.
+- `internal/weixin/cdn.go`: confirms `media.aes_key` is base64 of the hex-encoded AES key.
+- `internal/service/weixin_im_bridge.go`: confirms inbound `voice_item.text` is the transcript used as ordinary text.
+
+## File Structure
+
+- Create `src/weixin/media.zig`: pure media helpers plus narrow `ffprobe` parsing helpers. No bot token storage.
+- Modify `src/weixin/types.zig`: attachment kinds, upload URL response, CDN media structs, uploaded media structs, sender and reply context structs.
+- Modify `src/weixin/ilink_codec.zig`: JSON builders for upload URL and typed sendmessage bodies; parser for upload URL response.
+- Modify `src/weixin/ilink_client.zig`: high-level attachment send flow and `ClientApi.send_attachment`.
+- Modify `src/weixin/control.zig`: pass optional Weixin reply context through `sendInput`.
+- Modify `src/weixin/agent.zig`: route normal Weixin text into AI with reply context; keep `/term`, `/keys`, and `/stop` context-free.
+- Modify `src/weixin/poller.zig`: route callback receives current `from_user_id` and `context_token`; build a reply context around the active iLink client.
+- Modify `src/AppWindow.zig`: marshal reply context to the UI thread and call `Session.applyWeixinInput` for AI chat surfaces.
+- Modify `src/ai_chat.zig`: own request-time Weixin reply context, tool dispatch, no-context behavior, fake sender tests.
+- Modify `src/ai_chat_protocol.zig`: expose `weixin_send_attachment` in all tool schema builders.
+- Modify `src/platform/agent_prompt.zig`: tell the Agent when to use the tool.
+- Modify `src/test_fast.zig`: include pure Weixin modules in fast tests.
+
+## Task 1: Add Attachment Types
+
+**Files:**
+- Modify: `src/weixin/types.zig`
+- Test: `src/weixin/types.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Write failing type tests**
+
+Add this import and tests to `src/weixin/types.zig`. The import goes immediately after the file-level `//!` module comment.
+
+```zig
+const std = @import("std");
+```
+
+Append these tests at the end of `src/weixin/types.zig`.
+
+```zig
+const t = std.testing;
+
+test "AttachmentKind parses accepted tool values" {
+    try t.expectEqual(AttachmentKind.file, AttachmentKind.parse("file").?);
+    try t.expectEqual(AttachmentKind.image, AttachmentKind.parse("image").?);
+    try t.expectEqual(AttachmentKind.voice, AttachmentKind.parse("voice").?);
+    try t.expect(AttachmentKind.parse("video") == null);
+    try t.expectEqualStrings("file", AttachmentKind.file.name());
+    try t.expectEqualStrings("image", AttachmentKind.image.name());
+    try t.expectEqualStrings("voice", AttachmentKind.voice.name());
+}
+
+test "AttachmentSender forwards typed send calls" {
+    const Capture = struct {
+        called: bool = false,
+        kind: AttachmentKind = .file,
+        path: []const u8 = "",
+        display_name: []const u8 = "",
+        to_user_id: []const u8 = "",
+        context_token: []const u8 = "",
+
+        fn send(
+            ctx: *anyopaque,
+            kind: AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void {
+            const self: *Capture = @ptrCast(@alignCast(ctx));
+            self.called = true;
+            self.kind = kind;
+            self.path = path;
+            self.display_name = display_name;
+            self.to_user_id = to_user_id;
+            self.context_token = context_token;
+        }
+    };
+
+    var capture = Capture{};
+    const sender = AttachmentSender{ .ctx = &capture, .send_attachment = Capture.send };
+    try sender.sendAttachment(.image, "C:\\tmp\\plot.png", "plot.png", "wx-user", "ctx-1");
+
+    try t.expect(capture.called);
+    try t.expectEqual(AttachmentKind.image, capture.kind);
+    try t.expectEqualStrings("C:\\tmp\\plot.png", capture.path);
+    try t.expectEqualStrings("plot.png", capture.display_name);
+    try t.expectEqualStrings("wx-user", capture.to_user_id);
+    try t.expectEqualStrings("ctx-1", capture.context_token);
+}
+```
+
+- [ ] **Step 2: Run the new module test and verify it fails**
+
+Run:
+
+```bash
+zig test src/weixin/types.zig
+```
+
+Expected: FAIL with errors for `AttachmentKind` and `AttachmentSender` not existing.
+
+- [ ] **Step 3: Add attachment structs and helpers**
+
+Add these definitions after `pub const Message` in `src/weixin/types.zig`.
+
+```zig
+pub const AttachmentKind = enum {
+    file,
+    image,
+    voice,
+
+    pub fn parse(value: []const u8) ?AttachmentKind {
+        const trimmed = std.mem.trim(u8, value, " \t\r\n");
+        if (std.ascii.eqlIgnoreCase(trimmed, "file")) return .file;
+        if (std.ascii.eqlIgnoreCase(trimmed, "image")) return .image;
+        if (std.ascii.eqlIgnoreCase(trimmed, "voice")) return .voice;
+        return null;
+    }
+
+    pub fn name(self: AttachmentKind) []const u8 {
+        return switch (self) {
+            .file => "file",
+            .image => "image",
+            .voice => "voice",
+        };
+    }
+
+    pub fn uploadMediaType(self: AttachmentKind) i64 {
+        return switch (self) {
+            .image => 1,
+            .file => 3,
+            .voice => 4,
+        };
+    }
+};
+
+pub const UploadUrl = struct {
+    url: []const u8 = "",
+    ticket: []const u8 = "",
+    file_key: []const u8 = "",
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    message: []const u8 = "",
+};
+
+pub const CdnMedia = struct {
+    encrypt_query_param: []const u8,
+    aes_key: []const u8,
+    encrypt_type: i64 = 1,
+    md5: []const u8 = "",
+    size: u64 = 0,
+    file_key: []const u8 = "",
+};
+
+pub const VoiceMetadata = struct {
+    encode_type: i64,
+    sample_rate: i64,
+    playtime: i64,
+    codec: []const u8 = "",
+};
+
+pub const UploadedFileAttachment = struct {
+    media: CdnMedia,
+    file_name: []const u8,
+    len: u64,
+};
+
+pub const UploadedImage = struct {
+    media: CdnMedia,
+    mid_size: u64,
+};
+
+pub const UploadedVoice = struct {
+    media: CdnMedia,
+    encode_type: i64,
+    sample_rate: i64,
+    playtime: i64,
+};
+
+pub const AttachmentSender = struct {
+    ctx: *anyopaque,
+    send_attachment: *const fn (
+        ctx: *anyopaque,
+        kind: AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void,
+
+    pub fn sendAttachment(
+        self: AttachmentSender,
+        kind: AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return self.send_attachment(self.ctx, kind, path, display_name, to_user_id, context_token);
+    }
+};
+
+pub const ReplyContext = struct {
+    sender: AttachmentSender,
+    to_user_id: []const u8,
+    context_token: []const u8,
+};
+```
+
+- [ ] **Step 4: Add Weixin modules to fast tests**
+
+Append these imports inside the `test { ... }` block in `src/test_fast.zig`, near the existing `ai_chat_protocol.zig` import.
+
+```zig
+    _ = @import("weixin/types.zig");
+    _ = @import("weixin/ilink_codec.zig");
+    _ = @import("weixin/binding.zig");
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/weixin/types.zig
+zig build test
+```
+
+Expected: both commands PASS.
+
+Commit:
+
+```bash
+git add src/weixin/types.zig src/test_fast.zig
+git commit -m "feat: add weixin attachment types"
+```
+
+## Task 2: Add Pure Media Helpers
+
+**Files:**
+- Create: `src/weixin/media.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Create failing tests in `src/weixin/media.zig`**
+
+Create `src/weixin/media.zig` with this test-first skeleton.
+
+```zig
+//! Pure helpers for Weixin iLink media uploads.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const AesKey = [16]u8;
+
+pub fn pkcs7PaddedLen(input_len: usize) usize {
+    _ = input_len;
+    @compileError("pkcs7PaddedLen is not implemented");
+}
+
+pub fn aes128EcbPkcs7Encrypt(allocator: std.mem.Allocator, key: AesKey, plain: []const u8) ![]u8 {
+    _ = allocator;
+    _ = key;
+    _ = plain;
+    @compileError("aes128EcbPkcs7Encrypt is not implemented");
+}
+
+pub fn aes128EcbPkcs7DecryptForTest(allocator: std.mem.Allocator, key: AesKey, encrypted: []const u8) ![]u8 {
+    _ = allocator;
+    _ = key;
+    _ = encrypted;
+    @compileError("aes128EcbPkcs7DecryptForTest is not implemented");
+}
+
+pub fn encodeIlinkAesKey(allocator: std.mem.Allocator, key: AesKey) ![]u8 {
+    _ = allocator;
+    _ = key;
+    @compileError("encodeIlinkAesKey is not implemented");
+}
+
+pub fn md5Hex(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    _ = allocator;
+    _ = data;
+    @compileError("md5Hex is not implemented");
+}
+
+pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, ticket: []const u8) ![]u8 {
+    _ = allocator;
+    _ = base_url;
+    _ = ticket;
+    @compileError("uploadUrlWithTicket is not implemented");
+}
+
+pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
+    _ = codec;
+    _ = path;
+    @compileError("voiceEncodeType is not implemented");
+}
+
+pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
+    _ = allocator;
+    _ = json;
+    _ = path;
+    @compileError("parseFfprobeVoiceMetadata is not implemented");
+}
+
+const t = std.testing;
+
+test "pkcs7 padding always adds at least one AES block" {
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(0));
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(1));
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(15));
+    try t.expectEqual(@as(usize, 32), pkcs7PaddedLen(16));
+}
+
+test "AES ECB PKCS7 encrypts and decrypts a short buffer" {
+    const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    const encrypted = try aes128EcbPkcs7Encrypt(t.allocator, key, "hello");
+    defer t.allocator.free(encrypted);
+    try t.expectEqual(@as(usize, 16), encrypted.len);
+
+    const decrypted = try aes128EcbPkcs7DecryptForTest(t.allocator, key, encrypted);
+    defer t.allocator.free(decrypted);
+    try t.expectEqualStrings("hello", decrypted);
+}
+
+test "AES key is encoded as base64 of hex bytes" {
+    const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    const encoded = try encodeIlinkAesKey(t.allocator, key);
+    defer t.allocator.free(encoded);
+    try t.expectEqualStrings("MDAwMTAyMDMwNDA1MDYwNzA4MDkwYTBiMGMwZDBlMGY=", encoded);
+}
+
+test "md5Hex returns lowercase hex digest" {
+    const digest = try md5Hex(t.allocator, "abc");
+    defer t.allocator.free(digest);
+    try t.expectEqualStrings("900150983cd24fb0d6963f7d28e17f72", digest);
+}
+
+test "uploadUrlWithTicket appends ticket query using question mark or ampersand" {
+    const a = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload", "ticket=abc");
+    defer t.allocator.free(a);
+    try t.expectEqualStrings("https://cdn.example/upload?ticket=abc", a);
+
+    const b = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload?x=1", "ticket=abc");
+    defer t.allocator.free(b);
+    try t.expectEqualStrings("https://cdn.example/upload?x=1&ticket=abc", b);
+}
+
+test "voiceEncodeType maps codec and extension values" {
+    try t.expectEqual(@as(i64, 1), try voiceEncodeType("pcm_s16le", "note.wav"));
+    try t.expectEqual(@as(i64, 5), try voiceEncodeType("amr_nb", "note.amr"));
+    try t.expectEqual(@as(i64, 6), try voiceEncodeType("silk", "note.silk"));
+    try t.expectEqual(@as(i64, 7), try voiceEncodeType("mp3", "note.mp3"));
+    try t.expectEqual(@as(i64, 8), try voiceEncodeType("speex", "note.ogg"));
+    try t.expectError(error.UnsupportedVoiceCodec, voiceEncodeType("aac", "note.m4a"));
+}
+
+test "parseFfprobeVoiceMetadata reads codec sample rate and duration" {
+    const json =
+        \\{"streams":[{"codec_type":"audio","codec_name":"mp3","sample_rate":"44100","duration":"2.700000"}],
+        \\"format":{"duration":"2.700000"}}
+    ;
+    const meta = try parseFfprobeVoiceMetadata(t.allocator, json, "voice.mp3");
+    try t.expectEqual(@as(i64, 7), meta.encode_type);
+    try t.expectEqual(@as(i64, 44100), meta.sample_rate);
+    try t.expectEqual(@as(i64, 2700), meta.playtime);
+    try t.expectEqualStrings("mp3", meta.codec);
+}
+```
+
+- [ ] **Step 2: Run the new module test and verify it fails**
+
+Run:
+
+```bash
+zig test src/weixin/media.zig
+```
+
+Expected: FAIL at compile time because the helper bodies are compile errors.
+
+- [ ] **Step 3: Implement pure helpers**
+
+Replace the compile-error bodies in `src/weixin/media.zig` with this code.
+
+```zig
+pub fn pkcs7PaddedLen(input_len: usize) usize {
+    const block = 16;
+    return input_len + (block - (input_len % block));
+}
+
+pub fn aes128EcbPkcs7Encrypt(allocator: std.mem.Allocator, key: AesKey, plain: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, pkcs7PaddedLen(plain.len));
+    errdefer allocator.free(out);
+    @memcpy(out[0..plain.len], plain);
+    const pad: u8 = @intCast(out.len - plain.len);
+    @memset(out[plain.len..], pad);
+
+    var ctx = std.crypto.core.aes.Aes128.initEnc(key);
+    var offset: usize = 0;
+    while (offset < out.len) : (offset += 16) {
+        ctx.encrypt(out[offset .. offset + 16], out[offset .. offset + 16]);
+    }
+    return out;
+}
+
+pub fn aes128EcbPkcs7DecryptForTest(allocator: std.mem.Allocator, key: AesKey, encrypted: []const u8) ![]u8 {
+    if (encrypted.len == 0 or encrypted.len % 16 != 0) return error.InvalidCiphertext;
+    const padded = try allocator.dupe(u8, encrypted);
+    errdefer allocator.free(padded);
+
+    var ctx = std.crypto.core.aes.Aes128.initDec(key);
+    var offset: usize = 0;
+    while (offset < padded.len) : (offset += 16) {
+        ctx.decrypt(padded[offset .. offset + 16], padded[offset .. offset + 16]);
+    }
+    const pad = padded[padded.len - 1];
+    const pad_len: usize = pad;
+    if (pad == 0 or pad > 16 or pad_len > padded.len) return error.InvalidPadding;
+    for (padded[padded.len - pad_len ..]) |b| {
+        if (b != pad) return error.InvalidPadding;
+    }
+    return allocator.realloc(padded, padded.len - pad_len);
+}
+
+pub fn encodeIlinkAesKey(allocator: std.mem.Allocator, key: AesKey) ![]u8 {
+    const hex = try allocator.alloc(u8, key.len * 2);
+    defer allocator.free(hex);
+    _ = std.fmt.bufPrint(hex, "{}", .{std.fmt.fmtSliceHexLower(&key)}) catch unreachable;
+    const out = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(hex.len));
+    _ = std.base64.standard.Encoder.encode(out, hex);
+    return out;
+}
+
+pub fn md5Hex(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    var digest: [std.crypto.hash.Md5.digest_length]u8 = undefined;
+    std.crypto.hash.Md5.hash(data, &digest, .{});
+    const out = try allocator.alloc(u8, digest.len * 2);
+    _ = std.fmt.bufPrint(out, "{}", .{std.fmt.fmtSliceHexLower(&digest)}) catch unreachable;
+    return out;
+}
+
+pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, ticket: []const u8) ![]u8 {
+    const sep: []const u8 = if (std.mem.indexOfScalar(u8, base_url, '?') == null) "?" else "&";
+    return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ base_url, sep, ticket });
+}
+
+pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
+    const ext = std.fs.path.extension(path);
+    if (std.ascii.eqlIgnoreCase(codec, "pcm_s16le") or std.ascii.eqlIgnoreCase(codec, "pcm_u8") or std.ascii.eqlIgnoreCase(ext, ".wav")) return 1;
+    if (std.ascii.eqlIgnoreCase(codec, "amr_nb") or std.ascii.eqlIgnoreCase(codec, "amr_wb") or std.ascii.eqlIgnoreCase(ext, ".amr")) return 5;
+    if (std.ascii.eqlIgnoreCase(codec, "silk") or std.ascii.eqlIgnoreCase(ext, ".silk")) return 6;
+    if (std.ascii.eqlIgnoreCase(codec, "mp3") or std.ascii.eqlIgnoreCase(ext, ".mp3")) return 7;
+    if (std.ascii.eqlIgnoreCase(codec, "speex") or std.ascii.eqlIgnoreCase(codec, "opus") or std.ascii.eqlIgnoreCase(codec, "vorbis") or std.ascii.eqlIgnoreCase(ext, ".ogg")) return 8;
+    return error.UnsupportedVoiceCodec;
+}
+
+fn voiceCodecLabel(encode_type: i64) []const u8 {
+    return switch (encode_type) {
+        1 => "pcm",
+        5 => "amr",
+        6 => "silk",
+        7 => "mp3",
+        8 => "ogg",
+        else => "unknown",
+    };
+}
+
+pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
+    const Probe = struct {
+        streams: []struct {
+            codec_type: []const u8 = "",
+            codec_name: []const u8 = "",
+            sample_rate: []const u8 = "",
+            duration: []const u8 = "",
+        } = &.{},
+        format: struct { duration: []const u8 = "" } = .{},
+    };
+    var parsed = try std.json.parseFromSlice(Probe, allocator, json, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    for (parsed.value.streams) |stream| {
+        if (!std.mem.eql(u8, stream.codec_type, "audio")) continue;
+        const sample_rate = std.fmt.parseInt(i64, stream.sample_rate, 10) catch 0;
+        const duration_text = if (stream.duration.len != 0) stream.duration else parsed.value.format.duration;
+        const seconds = std.fmt.parseFloat(f64, duration_text) catch 0;
+        const encode_type = try voiceEncodeType(stream.codec_name, path);
+        return .{
+            .encode_type = encode_type,
+            .sample_rate = sample_rate,
+            .playtime = @as(i64, @intFromFloat(@round(seconds * 1000.0))),
+            .codec = voiceCodecLabel(encode_type),
+        };
+    }
+    return error.NoAudioStream;
+}
+```
+
+- [ ] **Step 4: Add `media.zig` to fast tests**
+
+Add this import inside the `test { ... }` block in `src/test_fast.zig` next to the other Weixin imports.
+
+```zig
+    _ = @import("weixin/media.zig");
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/weixin/media.zig
+zig build test
+```
+
+Expected: both commands PASS.
+
+Commit:
+
+```bash
+git add src/weixin/media.zig src/test_fast.zig
+git commit -m "feat: add weixin media helpers"
+```
+
+## Task 3: Add iLink Attachment JSON Codecs
+
+**Files:**
+- Modify: `src/weixin/ilink_codec.zig`
+
+- [ ] **Step 1: Write failing codec tests**
+
+Append these tests to `src/weixin/ilink_codec.zig`.
+
+```zig
+test "builds getuploadurl body for file media" {
+    const body = try buildGetUploadUrlBody(t.allocator, .file, 123, "900150983cd24fb0d6963f7d28e17f72", "file-key");
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"media_type\":3") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"size\":123") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"md5\":\"900150983cd24fb0d6963f7d28e17f72\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"file_key\":\"file-key\"") != null);
+}
+
+test "parses getuploadurl response" {
+    var parsed = try parseGetUploadUrl(t.allocator,
+        \\{"ret":0,"errcode":0,"url":"https://cdn.example/upload","ticket":"ticket=abc","file_key":"file-key"}
+    );
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 0), parsed.value.ret);
+    try t.expectEqualStrings("https://cdn.example/upload", parsed.value.url);
+    try t.expectEqualStrings("ticket=abc", parsed.value.ticket);
+    try t.expectEqualStrings("file-key", parsed.value.file_key);
+}
+
+test "builds uploaded file sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedFileBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .file_name = "report.pdf",
+        .len = 123,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":4") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"file_name\":\"report.pdf\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"len\":\"123\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"encrypt_query_param\":\"encrypted-param\"") != null);
+}
+
+test "builds uploaded image sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedImageBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .mid_size = 64,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"image_item\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"mid_size\":64") != null);
+}
+
+test "builds uploaded voice sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedVoiceBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .encode_type = 7,
+        .sample_rate = 44100,
+        .playtime = 2700,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":3") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"voice_item\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"encode_type\":7") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"sample_rate\":44100") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"playtime\":2700") != null);
+}
+
+test "parses inbound voice transcription into message item" {
+    const json =
+        \\{"ret":0,"msgs":[{"from_user_id":"u1","context_token":"ctx",
+        \\"item_list":[{"type":3,"voice_item":{"text":"transcribed voice"}}]}]}
+    ;
+    var parsed = try parseGetUpdates(t.allocator, json);
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 3), parsed.value.msgs[0].item_list[0].type);
+    try t.expectEqualStrings("transcribed voice", parsed.value.msgs[0].item_list[0].voice_text);
+}
+```
+
+- [ ] **Step 2: Run codec tests and verify they fail**
+
+Run:
+
+```bash
+zig test src/weixin/ilink_codec.zig
+```
+
+Expected: FAIL with missing `buildGetUploadUrlBody`, `parseGetUploadUrl`, and typed send builders.
+
+- [ ] **Step 3: Add upload URL codecs**
+
+Add this parsed wrapper near `ParsedUpdates` in `src/weixin/ilink_codec.zig`.
+
+```zig
+const WireUploadUrl = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    message: []const u8 = "",
+    url: []const u8 = "",
+    ticket: []const u8 = "",
+    file_key: []const u8 = "",
+};
+
+pub const ParsedUploadUrl = struct {
+    parsed: std.json.Parsed(WireUploadUrl),
+    value: types.UploadUrl,
+
+    pub fn deinit(self: *ParsedUploadUrl) void {
+        self.parsed.deinit();
+    }
+};
+
+pub fn parseGetUploadUrl(allocator: std.mem.Allocator, json: []const u8) !ParsedUploadUrl {
+    const parsed = try std.json.parseFromSlice(WireUploadUrl, allocator, json, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    errdefer parsed.deinit();
+    const wire = parsed.value;
+    return .{
+        .parsed = parsed,
+        .value = .{
+            .ret = wire.ret,
+            .errcode = wire.errcode,
+            .message = wire.message,
+            .url = wire.url,
+            .ticket = wire.ticket,
+            .file_key = wire.file_key,
+        },
+    };
+}
+
+pub fn buildGetUploadUrlBody(
+    allocator: std.mem.Allocator,
+    kind: types.AttachmentKind,
+    size: u64,
+    md5: []const u8,
+    file_key: []const u8,
+) ![]u8 {
+    const Body = struct {
+        media_type: i64,
+        size: u64,
+        md5: []const u8,
+        file_key: []const u8,
+        base_info: BaseInfo,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .media_type = kind.uploadMediaType(),
+        .size = size,
+        .md5 = md5,
+        .file_key = file_key,
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+```
+
+- [ ] **Step 4: Add typed sendmessage builders**
+
+Add these structs and functions after `buildSendTextBody` in `src/weixin/ilink_codec.zig`.
+
+```zig
+const WireCdnMedia = struct {
+    encrypt_query_param: []const u8,
+    aes_key: []const u8,
+    encrypt_type: i64 = 1,
+};
+
+fn wireMedia(media: types.CdnMedia) WireCdnMedia {
+    return .{
+        .encrypt_query_param = media.encrypt_query_param,
+        .aes_key = media.aes_key,
+        .encrypt_type = media.encrypt_type,
+    };
+}
+
+pub fn buildSendUploadedFileBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    file: types.UploadedFileAttachment,
+) ![]u8 {
+    const FileItem = struct {
+        media: WireCdnMedia,
+        file_name: []const u8,
+        len: []const u8,
+    };
+    const Item = struct { type: i64 = 4, file_item: FileItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const len_text = try std.fmt.allocPrint(allocator, "{d}", .{file.len});
+    const items = [_]Item{.{ .file_item = .{
+        .media = wireMedia(file.media),
+        .file_name = file.file_name,
+        .len = len_text,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildSendUploadedImageBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    image: types.UploadedImage,
+) ![]u8 {
+    const ImageItem = struct {
+        media: WireCdnMedia,
+        mid_size: u64,
+    };
+    const Item = struct { type: i64 = 2, image_item: ImageItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const items = [_]Item{.{ .image_item = .{
+        .media = wireMedia(image.media),
+        .mid_size = image.mid_size,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildSendUploadedVoiceBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    voice: types.UploadedVoice,
+) ![]u8 {
+    const VoiceItem = struct {
+        media: WireCdnMedia,
+        encode_type: i64,
+        sample_rate: i64,
+        playtime: i64,
+    };
+    const Item = struct { type: i64 = 3, voice_item: VoiceItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const items = [_]Item{.{ .voice_item = .{
+        .media = wireMedia(voice.media),
+        .encode_type = voice.encode_type,
+        .sample_rate = voice.sample_rate,
+        .playtime = voice.playtime,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/weixin/ilink_codec.zig
+zig build test
+```
+
+Expected: both commands PASS.
+
+Commit:
+
+```bash
+git add src/weixin/ilink_codec.zig
+git commit -m "feat: build weixin attachment payloads"
+```
+
+## Task 4: Implement iLink Client Attachment Sending
+
+**Files:**
+- Modify: `src/weixin/ilink_client.zig`
+
+- [ ] **Step 1: Write failing ClientApi and helper tests**
+
+Append these tests to `src/weixin/ilink_client.zig`.
+
+```zig
+test "ClientApi forwards sendAttachment to the vtable" {
+    const Capture = struct {
+        called: bool = false,
+        kind: types.AttachmentKind = .file,
+        path: []const u8 = "",
+        display_name: []const u8 = "",
+        to_user_id: []const u8 = "",
+        context_token: []const u8 = "",
+
+        fn sendAttachment(
+            ctx: *anyopaque,
+            kind: types.AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void {
+            const self: *Capture = @ptrCast(@alignCast(ctx));
+            self.called = true;
+            self.kind = kind;
+            self.path = path;
+            self.display_name = display_name;
+            self.to_user_id = to_user_id;
+            self.context_token = context_token;
+        }
+
+        fn getUpdates(ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates {
+            _ = ctx;
+            _ = buf;
+            return error.NotUsed;
+        }
+
+        fn sendText(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
+            _ = ctx;
+            _ = to_user_id;
+            _ = text;
+            _ = context_token;
+        }
+    };
+
+    var capture = Capture{};
+    const api = ClientApi{ .ctx = &capture, .vtable = &.{
+        .get_updates = Capture.getUpdates,
+        .send_text = Capture.sendText,
+        .send_attachment = Capture.sendAttachment,
+    } };
+    try api.sendAttachment(.voice, "C:\\tmp\\a.mp3", "a.mp3", "wx-user", "ctx");
+    try std.testing.expect(capture.called);
+    try std.testing.expectEqual(types.AttachmentKind.voice, capture.kind);
+    try std.testing.expectEqualStrings("C:\\tmp\\a.mp3", capture.path);
+    try std.testing.expectEqualStrings("a.mp3", capture.display_name);
+    try std.testing.expectEqualStrings("wx-user", capture.to_user_id);
+    try std.testing.expectEqualStrings("ctx", capture.context_token);
+}
+
+test "client ids are generated with the wispterm weixin prefix" {
+    var c = Client.init(std.testing.allocator, "https://x.test", "tok");
+    const id = try c.clientId(std.testing.allocator);
+    defer std.testing.allocator.free(id);
+    try std.testing.expect(std.mem.startsWith(u8, id, "wispterm-weixin-"));
+}
+```
+
+- [ ] **Step 2: Run client tests and verify they fail**
+
+Run:
+
+```bash
+zig test src/weixin/ilink_client.zig
+```
+
+Expected: FAIL because `ClientApi.VTable.send_attachment`, `ClientApi.sendAttachment`, and `Client.clientId` do not exist.
+
+- [ ] **Step 3: Extend `ClientApi`**
+
+In `src/weixin/ilink_client.zig`, extend `ClientApi.VTable` and methods to this shape.
+
+```zig
+    pub const VTable = struct {
+        /// Returned value owns its own arena; caller must call `.deinit()`.
+        get_updates: *const fn (ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates,
+        send_text: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+        send_attachment: *const fn (
+            ctx: *anyopaque,
+            kind: types.AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void,
+    };
+
+    pub fn getUpdates(self: ClientApi, buf: []const u8) !codec.ParsedUpdates {
+        return self.vtable.get_updates(self.ctx, buf);
+    }
+    pub fn sendText(self: ClientApi, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
+        return self.vtable.send_text(self.ctx, to_user_id, text, context_token);
+    }
+    pub fn sendAttachment(
+        self: ClientApi,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return self.vtable.send_attachment(self.ctx, kind, path, display_name, to_user_id, context_token);
+    }
+```
+
+- [ ] **Step 4: Factor client ID creation**
+
+In `src/weixin/ilink_client.zig`, add this public helper inside `Client`.
+
+```zig
+    pub fn clientId(self: *Client, allocator: std.mem.Allocator) ![]u8 {
+        return std.fmt.allocPrint(allocator, "wispterm-weixin-{d}-{d}", .{
+            std.time.milliTimestamp(), self.nextRandomU32(),
+        });
+    }
+```
+
+Update `sendText` to use it:
+
+```zig
+        const client_id = try self.clientId(a);
+```
+
+- [ ] **Step 5: Add high-level upload and send flow**
+
+Add `const media = @import("media.zig");` near the imports in `src/weixin/ilink_client.zig`.
+
+Add these functions inside `Client`.
+
+```zig
+    pub fn sendAttachment(
+        self: *Client,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return switch (kind) {
+            .file => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
+            .image => self.sendImageFile(path, to_user_id, context_token),
+            .voice => self.sendVoiceFile(path, to_user_id, context_token),
+        };
+    }
+
+    fn sendFileAttachment(self: *Client, path: []const u8, file_name: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+
+        const uploaded = try self.uploadLocalFile(a, .file, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedFileBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .file_name = file_name,
+            .len = uploaded.raw_len,
+        });
+        try self.postSendMessage(a, body);
+    }
+
+    fn sendImageFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+
+        const uploaded = try self.uploadLocalFile(a, .image, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedImageBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .mid_size = uploaded.encrypted_len,
+        });
+        try self.postSendMessage(a, body);
+    }
+
+    fn sendVoiceFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+
+        const uploaded = try self.uploadLocalFile(a, .voice, path);
+        const meta = try self.probeVoiceFile(a, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedVoiceBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .encode_type = meta.encode_type,
+            .sample_rate = meta.sample_rate,
+            .playtime = meta.playtime,
+        });
+        try self.postSendMessage(a, body);
+    }
+```
+
+Add these helper functions inside `Client`.
+
+```zig
+    const UploadedLocalFile = struct {
+        media: types.CdnMedia,
+        raw_len: u64,
+        encrypted_len: u64,
+    };
+
+    fn uploadLocalFile(self: *Client, arena: std.mem.Allocator, kind: types.AttachmentKind, path: []const u8) !UploadedLocalFile {
+        const file_bytes = readLocalFileAlloc(arena, path) catch |err| switch (err) {
+            error.FileNotFound => return error.WeixinAttachmentFileNotFound,
+            error.IsDir => return error.WeixinAttachmentPathIsDirectory,
+            else => return err,
+        };
+        const md5 = try media.md5Hex(arena, file_bytes);
+
+        var file_key_bytes: [16]u8 = undefined;
+        self.randomBytes(&file_key_bytes);
+        const file_key = try std.fmt.allocPrint(arena, "{}", .{std.fmt.fmtSliceHexLower(&file_key_bytes)});
+
+        var aes_key: media.AesKey = undefined;
+        self.randomBytes(&aes_key);
+        const encoded_key = try media.encodeIlinkAesKey(arena, aes_key);
+
+        const upload = try self.getUploadUrl(arena, kind, file_bytes.len, md5, file_key);
+        if (upload.ret != 0) return error.IlinkGetUploadUrlFailed;
+        if (upload.url.len == 0 or upload.ticket.len == 0) return error.IlinkGetUploadUrlMalformed;
+
+        const encrypted = try media.aes128EcbPkcs7Encrypt(arena, aes_key, file_bytes);
+        const encrypted_param = try self.uploadBufferToCdn(arena, upload.url, upload.ticket, encrypted);
+
+        return .{
+            .media = .{
+                .encrypt_query_param = encrypted_param,
+                .aes_key = encoded_key,
+                .encrypt_type = 1,
+                .md5 = md5,
+                .size = file_bytes.len,
+                .file_key = file_key,
+            },
+            .raw_len = file_bytes.len,
+            .encrypted_len = encrypted.len,
+        };
+    }
+
+    fn getUploadUrl(self: *Client, arena: std.mem.Allocator, kind: types.AttachmentKind, size: u64, md5: []const u8, file_key: []const u8) !types.UploadUrl {
+        const body = try codec.buildGetUploadUrlBody(arena, kind, size, md5, file_key);
+        const resp = try self.fetch(arena, .POST, "/ilink/bot/getuploadurl", body, null);
+        var parsed = try codec.parseGetUploadUrl(arena, resp);
+        defer parsed.deinit();
+        const value = parsed.value;
+        if (value.ret != 0) {
+            std.debug.print("weixin upload({d}): getuploadurl failed ret={} errcode={} message={s}\n", .{
+                std.time.milliTimestamp(), value.ret, value.errcode, value.message,
+            });
+        }
+        return .{
+            .ret = value.ret,
+            .errcode = value.errcode,
+            .message = try arena.dupe(u8, value.message),
+            .url = try arena.dupe(u8, value.url),
+            .ticket = try arena.dupe(u8, value.ticket),
+            .file_key = try arena.dupe(u8, value.file_key),
+        };
+    }
+
+    fn uploadBufferToCdn(self: *Client, arena: std.mem.Allocator, upload_url: []const u8, ticket: []const u8, encrypted: []const u8) ![]const u8 {
+        var client: std.http.Client = .{ .allocator = self.allocator };
+        defer client.deinit();
+
+        const url = try media.uploadUrlWithTicket(arena, upload_url, ticket);
+        const uri = try std.Uri.parse(url);
+        var req = try client.request(.POST, uri, .{
+            .keep_alive = false,
+            .headers = .{ .content_type = .{ .override = "application/octet-stream" } },
+        });
+        defer req.deinit();
+
+        req.transfer_encoding = .{ .content_length = encrypted.len };
+        var body = try req.sendBodyUnflushed(&.{});
+        try body.writer.writeAll(encrypted);
+        try body.end();
+        try req.connection.?.flush();
+
+        var response = try req.receiveHead(&.{});
+        if (response.head.status != .ok) {
+            std.debug.print("weixin upload({d}): cdn failed status={}\n", .{ std.time.milliTimestamp(), response.head.status });
+            return error.WeixinCdnUploadFailed;
+        }
+        var encrypted_param: ?[]u8 = null;
+        var it = response.head.iterateHeaders();
+        while (it.next()) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, "x-encrypted-param")) {
+                encrypted_param = try arena.dupe(u8, header.value);
+                break;
+            }
+        }
+
+        const reader = response.reader(&.{});
+        _ = reader.discardRemaining() catch {};
+        return encrypted_param orelse error.WeixinCdnMissingEncryptedParam;
+    }
+
+    fn postSendMessage(self: *Client, arena: std.mem.Allocator, body: []const u8) !void {
+        const resp = try self.fetch(arena, .POST, "/ilink/bot/sendmessage", body, null);
+        const W = struct { ret: ?i64 = null, errcode: i64 = 0, message: []const u8 = "" };
+        const w = try std.json.parseFromSliceLeaky(W, arena, resp, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        });
+        if (w.ret) |ret| {
+            if (ret != 0) {
+                std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{
+                    std.time.milliTimestamp(), ret, w.errcode, w.message,
+                });
+                return error.IlinkSendMessageFailed;
+            }
+        }
+    }
+
+    fn probeVoiceFile(self: *Client, arena: std.mem.Allocator, path: []const u8) !types.VoiceMetadata {
+        _ = self;
+        var child = std.process.Child.init(&.{
+            "ffprobe",
+            "-v", "error",
+            "-show_entries", "stream=codec_type,codec_name,sample_rate,duration:format=duration",
+            "-of", "json",
+            path,
+        }, arena);
+        child.stdin_behavior = .Ignore;
+        child.stderr_behavior = .Pipe;
+        child.stdout_behavior = .Pipe;
+        const result = child.run() catch |err| switch (err) {
+            error.FileNotFound => return error.FfprobeNotFound,
+            else => return err,
+        };
+        defer arena.free(result.stdout);
+        defer arena.free(result.stderr);
+        if (result.term != .Exited or result.term.Exited != 0) return error.FfprobeFailed;
+        return media.parseFfprobeVoiceMetadata(arena, result.stdout, path);
+    }
+
+    fn randomBytes(self: *Client, out: []u8) void {
+        self.rng_mutex.lock();
+        defer self.rng_mutex.unlock();
+        self.rng.random().bytes(out);
+    }
+```
+
+Add this file-level helper after `appendQueryEscaped`.
+
+```zig
+fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    }
+    return std.fs.cwd().readFileAlloc(allocator, path, std.math.maxInt(usize));
+}
+
+fn displayNameOrBasename(display_name: []const u8, path: []const u8) []const u8 {
+    if (display_name.len != 0) return display_name;
+    return std.fs.path.basename(path);
+}
+```
+
+- [ ] **Step 6: Wire the real adapter and fakes**
+
+Update `Client.api()` in `src/weixin/ilink_client.zig`.
+
+```zig
+    pub fn api(self: *Client) ClientApi {
+        return .{ .ctx = self, .vtable = &.{
+            .get_updates = apiGetUpdates,
+            .send_text = apiSendText,
+            .send_attachment = apiSendAttachment,
+        } };
+    }
+```
+
+Add this adapter.
+
+```zig
+    fn apiSendAttachment(
+        ctx: *anyopaque,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).sendAttachment(kind, path, display_name, to_user_id, context_token);
+    }
+```
+
+Any test fake that constructs `ClientApi.VTable` must add:
+
+```zig
+            .send_attachment = sendAttachment,
+```
+
+and this no-op or capture function:
+
+```zig
+    fn sendAttachment(ctx: *anyopaque, kind: types.AttachmentKind, path: []const u8, display_name: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
+        _ = ctx;
+        _ = kind;
+        _ = path;
+        _ = display_name;
+        _ = to_user_id;
+        _ = context_token;
+    }
+```
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/weixin/ilink_client.zig
+zig build test
+```
+
+Expected: both commands PASS.
+
+Commit:
+
+```bash
+git add src/weixin/ilink_client.zig
+git commit -m "feat: send weixin attachments through ilink"
+```
+
+## Task 5: Expose the Agent Tool Schema and Prompt
+
+**Files:**
+- Modify: `src/ai_chat_protocol.zig`
+- Modify: `src/platform/agent_prompt.zig`
+
+- [ ] **Step 1: Write failing schema and prompt tests**
+
+Append this test to `src/ai_chat_protocol.zig`.
+
+```zig
+test "tool schemas include weixin_send_attachment" {
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("send the report") }};
+    const params = RequestParams{
+        .model = "m",
+        .system_prompt = "",
+        .protocol = .chat_completions,
+        .thinking_enabled = false,
+        .reasoning_effort = "",
+        .stream = false,
+    };
+    const json = try buildRequestJson(std.testing.allocator, params, &msgs, true);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"weixin_send_attachment\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"kind\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"path\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"display_name\"") != null);
+}
+```
+
+Append this test to `src/platform/agent_prompt.zig`.
+
+```zig
+test "platform agent prompt describes the Weixin attachment tool" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "weixin_send_attachment") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "kind=image") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "kind=voice") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "kind=file") != null);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+zig test src/ai_chat_protocol.zig
+zig test src/platform/agent_prompt.zig
+```
+
+Expected: both fail because the schema and prompt do not mention `weixin_send_attachment`.
+
+- [ ] **Step 3: Add tool schema**
+
+In `src/ai_chat_protocol.zig`, add this `emit` call inside `forEachToolSpec`, after `wispterm_docs`.
+
+```zig
+    try emit(ctx, "weixin_send_attachment", "Send a local file back to the active Weixin conversation that triggered this agent request. Use only when the current request came from Weixin; normal local chat requests have no Weixin reply context.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in Weixin for file attachments; defaults to the path basename.\"}}");
+```
+
+- [ ] **Step 4: Add prompt guidance**
+
+In `src/platform/agent_prompt.zig`, insert these lines in `common_tools_after_wsl`, after the `wispterm_docs` bullet and before the blank line that precedes `Python:`.
+
+```zig
+    \\- When the request came from Weixin and the user asks you to send a generated or local artifact, call `weixin_send_attachment`.
+    \\- Use `kind=image` for image previews, `kind=voice` only for playable voice messages, and `kind=file` for ordinary attachments.
+    \\- If voice metadata probing fails or playback as an in-chat voice message is not required, send the same path with `kind=file`.
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/ai_chat_protocol.zig
+zig test src/platform/agent_prompt.zig
+zig build test
+```
+
+Expected: all commands PASS.
+
+Commit:
+
+```bash
+git add src/ai_chat_protocol.zig src/platform/agent_prompt.zig
+git commit -m "feat: expose weixin attachment tool"
+```
+
+## Task 6: Add Weixin Context and Tool Dispatch in AI Chat
+
+**Files:**
+- Modify: `src/ai_chat.zig`
+
+- [ ] **Step 1: Add failing tool dispatch tests**
+
+Add `const weixin_types = @import("weixin/types.zig");` near the imports in `src/ai_chat.zig`.
+
+Append these tests near the other `executeToolCall` tests in `src/ai_chat.zig`.
+
+```zig
+const WeixinAttachmentCapture = struct {
+    called: bool = false,
+    kind: weixin_types.AttachmentKind = .file,
+    path: []const u8 = "",
+    display_name: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+
+    fn send(
+        ctx: *anyopaque,
+        kind: weixin_types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        const self: *WeixinAttachmentCapture = @ptrCast(@alignCast(ctx));
+        self.called = true;
+        self.kind = kind;
+        self.path = path;
+        self.display_name = display_name;
+        self.to_user_id = to_user_id;
+        self.context_token = context_token;
+    }
+};
+
+fn testWeixinSender(capture: *WeixinAttachmentCapture) weixin_types.AttachmentSender {
+    return .{ .ctx = capture, .send_attachment = WeixinAttachmentCapture.send };
+}
+
+test "weixin_send_attachment without reply context returns a clear tool result" {
+    var session = try Session.init(
+        std.testing.allocator,
+        "test",
+        "https://api.example",
+        "key",
+        "model",
+        "prompt",
+        "enabled",
+        "medium",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    const request = try std.testing.allocator.create(ChatRequest);
+    request.* = .{
+        .allocator = std.testing.allocator,
+        .session = session,
+        .base_url = try std.testing.allocator.dupe(u8, "https://api.example"),
+        .api_key = try std.testing.allocator.dupe(u8, "key"),
+        .model = try std.testing.allocator.dupe(u8, "model"),
+        .system_prompt = try std.testing.allocator.dupe(u8, "prompt"),
+        .messages = &.{},
+        .thinking_enabled = false,
+        .reasoning_effort = try std.testing.allocator.dupe(u8, "medium"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .started_ms = 0,
+    };
+    defer request.deinit();
+
+    var call = ToolCall{
+        .id = try std.testing.allocator.dupe(u8, "call_1"),
+        .name = try std.testing.allocator.dupe(u8, "weixin_send_attachment"),
+        .arguments = try std.testing.allocator.dupe(u8, "{\"kind\":\"image\",\"path\":\"C:\\\\tmp\\\\plot.png\"}"),
+    };
+    defer call.deinit(std.testing.allocator);
+
+    const result = try executeToolCall(request, call);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("No active Weixin reply context; cannot send attachment.", result);
+}
+
+test "weixin_send_attachment calls the active Weixin sender" {
+    var capture = WeixinAttachmentCapture{};
+    var session = try Session.init(
+        std.testing.allocator,
+        "test",
+        "https://api.example",
+        "key",
+        "model",
+        "prompt",
+        "enabled",
+        "medium",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    const request = try std.testing.allocator.create(ChatRequest);
+    request.* = .{
+        .allocator = std.testing.allocator,
+        .session = session,
+        .base_url = try std.testing.allocator.dupe(u8, "https://api.example"),
+        .api_key = try std.testing.allocator.dupe(u8, "key"),
+        .model = try std.testing.allocator.dupe(u8, "model"),
+        .system_prompt = try std.testing.allocator.dupe(u8, "prompt"),
+        .messages = &.{},
+        .thinking_enabled = false,
+        .reasoning_effort = try std.testing.allocator.dupe(u8, "medium"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .started_ms = 0,
+        .weixin_reply_context = try WeixinReplyContext.init(std.testing.allocator, .{
+            .sender = testWeixinSender(&capture),
+            .to_user_id = "wx-user",
+            .context_token = "ctx-1",
+        }),
+    };
+    defer request.deinit();
+
+    var call = ToolCall{
+        .id = try std.testing.allocator.dupe(u8, "call_1"),
+        .name = try std.testing.allocator.dupe(u8, "weixin_send_attachment"),
+        .arguments = try std.testing.allocator.dupe(u8, "{\"kind\":\"file\",\"path\":\"C:\\\\tmp\\\\report.pdf\",\"display_name\":\"report.pdf\"}"),
+    };
+    defer call.deinit(std.testing.allocator);
+
+    const result = try executeToolCall(request, call);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expect(capture.called);
+    try std.testing.expectEqual(weixin_types.AttachmentKind.file, capture.kind);
+    try std.testing.expectEqualStrings("C:\\tmp\\report.pdf", capture.path);
+    try std.testing.expectEqualStrings("report.pdf", capture.display_name);
+    try std.testing.expectEqualStrings("wx-user", capture.to_user_id);
+    try std.testing.expectEqualStrings("ctx-1", capture.context_token);
+    try std.testing.expectEqualStrings("Sent file to Weixin: report.pdf", result);
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+zig test src/ai_chat.zig
+```
+
+Expected: FAIL because `WeixinReplyContext`, `weixin_reply_context`, and tool dispatch do not exist.
+
+- [ ] **Step 3: Add owned request context**
+
+Add this struct near `ChatRequest` in `src/ai_chat.zig`.
+
+```zig
+const WeixinReplyContext = struct {
+    sender: weixin_types.AttachmentSender,
+    to_user_id: []u8,
+    context_token: []u8,
+
+    fn init(allocator: std.mem.Allocator, ctx: weixin_types.ReplyContext) !WeixinReplyContext {
+        return .{
+            .sender = ctx.sender,
+            .to_user_id = try allocator.dupe(u8, ctx.to_user_id),
+            .context_token = try allocator.dupe(u8, ctx.context_token),
+        };
+    }
+
+    fn clone(self: WeixinReplyContext, allocator: std.mem.Allocator) !WeixinReplyContext {
+        return .{
+            .sender = self.sender,
+            .to_user_id = try allocator.dupe(u8, self.to_user_id),
+            .context_token = try allocator.dupe(u8, self.context_token),
+        };
+    }
+
+    fn deinit(self: *WeixinReplyContext, allocator: std.mem.Allocator) void {
+        allocator.free(self.to_user_id);
+        allocator.free(self.context_token);
+        self.* = undefined;
+    }
+};
+```
+
+Add this field to `ChatRequest`.
+
+```zig
+    weixin_reply_context: ?WeixinReplyContext = null,
+```
+
+Add this deinit block before `self.allocator.destroy(self);`.
+
+```zig
+        if (self.weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
+```
+
+- [ ] **Step 4: Store pending context on Session and apply Weixin input**
+
+Add this field to `Session`.
+
+```zig
+    pending_weixin_reply_context: ?WeixinReplyContext = null,
+```
+
+In `Session.deinit`, before `self.allocator.destroy(self);`, add:
+
+```zig
+        if (self.pending_weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
+```
+
+Add these methods near `applyRemoteInput`.
+
+```zig
+    pub fn applyWeixinInput(self: *Session, data: []const u8, ctx: weixin_types.ReplyContext) void {
+        self.mutex.lock();
+        if (self.pending_weixin_reply_context) |*old| old.deinit(self.allocator);
+        self.pending_weixin_reply_context = WeixinReplyContext.init(self.allocator, ctx) catch null;
+        self.mutex.unlock();
+        self.applyRemoteInput(data);
+    }
+
+    fn clearPendingWeixinReplyContextLocked(self: *Session) void {
+        if (self.pending_weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
+        self.pending_weixin_reply_context = null;
+    }
+```
+
+In `submit`, when `prompt_raw.len == 0`, clear the pending context before unlocking:
+
+```zig
+        if (prompt_raw.len == 0) {
+            self.clearPendingWeixinReplyContextLocked();
+            self.mutex.unlock();
+            return;
+        }
+```
+
+In `submit`, when an existing request is still inflight, clear the pending context before returning:
+
+```zig
+            if (self.request_inflight) {
+                self.clearPendingWeixinReplyContextLocked();
+                self.mutex.unlock();
+                return;
+            }
+```
+
+Before each built-in command or custom-command early return in `submit`, add:
+
+```zig
+            self.clearPendingWeixinReplyContextLocked();
+```
+
+This keeps Weixin reply context attached only to model requests, not to local slash commands.
+
+- [ ] **Step 5: Clone pending context into ChatRequest**
+
+In `buildRequestLocked`, add:
+
+```zig
+        var weixin_ctx: ?WeixinReplyContext = null;
+        errdefer if (weixin_ctx) |*ctx| ctx.deinit(self.allocator);
+        if (self.pending_weixin_reply_context) |ctx| {
+            weixin_ctx = try ctx.clone(self.allocator);
+            self.clearPendingWeixinReplyContextLocked();
+        }
+```
+
+Add this field to `req.* = .{ ... }`:
+
+```zig
+            .weixin_reply_context = weixin_ctx,
+```
+
+After ownership transfers, set:
+
+```zig
+        weixin_ctx = null;
+```
+
+- [ ] **Step 6: Add tool dispatch**
+
+Add this branch to `executeToolCall` before the final unknown-tool return.
+
+```zig
+    if (std.mem.eql(u8, call.name, "weixin_send_attachment")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const kind_text = jsonStringArg(args.value, "kind") orelse return request.allocator.dupe(u8, "Missing kind");
+        const kind = weixin_types.AttachmentKind.parse(kind_text) orelse return request.allocator.dupe(u8, "Invalid kind; expected file, image, or voice");
+        const path = jsonStringArg(args.value, "path") orelse return request.allocator.dupe(u8, "Missing path");
+        const display_name = jsonStringArg(args.value, "display_name") orelse "";
+        return weixinSendAttachmentTool(request, kind, path, display_name);
+    }
+```
+
+Add this function near other tool functions.
+
+```zig
+fn weixinSendAttachmentTool(
+    request: *ChatRequest,
+    kind: weixin_types.AttachmentKind,
+    path: []const u8,
+    display_name: []const u8,
+) ![]u8 {
+    const ctx = request.weixin_reply_context orelse {
+        return request.allocator.dupe(u8, "No active Weixin reply context; cannot send attachment.");
+    };
+    ctx.sender.sendAttachment(kind, path, display_name, ctx.to_user_id, ctx.context_token) catch |err| {
+        return std.fmt.allocPrint(request.allocator, "Failed to send {s} to Weixin: {}", .{ kind.name(), err });
+    };
+    const shown = if (display_name.len != 0) display_name else std.fs.path.basename(path);
+    return std.fmt.allocPrint(request.allocator, "Sent {s} to Weixin: {s}", .{ kind.name(), shown });
+}
+```
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/ai_chat.zig
+zig build test
+```
+
+Expected: both commands PASS.
+
+Commit:
+
+```bash
+git add src/ai_chat.zig
+git commit -m "feat: handle weixin attachment tool calls"
+```
+
+## Task 7: Wire Weixin Reply Context Through Poller and AppWindow
+
+**Files:**
+- Modify: `src/weixin/control.zig`
+- Modify: `src/weixin/agent.zig`
+- Modify: `src/weixin/poller.zig`
+- Modify: `src/AppWindow.zig`
+- Modify: `src/weixin/controller.zig`
+
+- [ ] **Step 1: Update control contract with failing tests**
+
+In `src/weixin/control.zig`, add `const types = @import("types.zig");` near the top.
+
+Change the vtable signature to:
+
+```zig
+        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool,
+```
+
+Change the method to:
+
+```zig
+    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
+        return self.vtable.send_input(self.ctx, surface_id, bytes, reply_context);
+    }
+```
+
+Run:
+
+```bash
+zig test src/weixin/agent.zig
+```
+
+Expected: FAIL at fake control implementations and call sites that still use the three-argument `sendInput`.
+
+- [ ] **Step 2: Update agent routing**
+
+Change `agent.route` in `src/weixin/agent.zig` to accept reply context.
+
+```zig
+pub fn route(
+    allocator: std.mem.Allocator,
+    ctrl: control.Control,
+    settings: types.Settings,
+    raw_text: []const u8,
+    reply_context: ?types.ReplyContext,
+    out: *Reply,
+) !void {
+```
+
+Update the default and `/ai` calls to pass context:
+
+```zig
+    if (eqIgnoreCase(cmd, "/ai")) return sendAi(ctrl, parts.arg, reply_context, out);
+    return sendAi(ctrl, text, reply_context, out);
+```
+
+Change `sendAi` signature and call:
+
+```zig
+fn sendAi(ctrl: control.Control, text: []const u8, reply_context: ?types.ReplyContext, out: *Reply) !void {
+```
+
+```zig
+    if (!ctrl.sendInput(ai.id, buf.items, reply_context)) return out.set("WispTerm 当前离线，无法发送给 AI Agent。");
+```
+
+Keep `/term`, `/keys`, and `/stop` context-free:
+
+```zig
+    if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止 AI Agent。");
+```
+
+```zig
+    if (!ctrl.sendInput(term.id, buf.items, null)) return out.set("WispTerm 当前离线，无法发送到终端。");
+```
+
+Update every test call to `route` by passing `null` before `&out`, except the new context test in the next step.
+
+- [ ] **Step 3: Add agent context forwarding test**
+
+Append this test to `src/weixin/agent.zig`.
+
+```zig
+test "default AI route forwards Weixin reply context only to AI surface" {
+    const Sender = struct {
+        fn sendAttachment(ctx: *anyopaque, kind: types.AttachmentKind, path: []const u8, display_name: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
+            _ = ctx;
+            _ = kind;
+            _ = path;
+            _ = display_name;
+            _ = to_user_id;
+            _ = context_token;
+        }
+    };
+
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    const reply_ctx = types.ReplyContext{
+        .sender = .{ .ctx = &fake, .send_attachment = Sender.sendAttachment },
+        .to_user_id = "wx-user",
+        .context_token = "ctx-1",
+    };
+
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "make a chart", reply_ctx, &out);
+    try t.expect(fake.last_reply_context != null);
+    try t.expectEqualStrings("wx-user", fake.last_reply_context.?.to_user_id);
+    try t.expectEqualStrings("ctx-1", fake.last_reply_context.?.context_token);
+}
+```
+
+Extend `FakeControl` with:
+
+```zig
+    last_reply_context: ?types.ReplyContext = null,
+```
+
+Change fake `send_input` signature and body:
+
+```zig
+    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
+        const self = cast(ctx);
+        if (!self.connected) return false;
+        self.last_surface = surface_id;
+        self.last_reply_context = reply_context;
+        const n = @min(bytes.len, self.buf.len);
+        @memcpy(self.buf[0..n], bytes[0..n]);
+        self.len = n;
+        return true;
+    }
+```
+
+- [ ] **Step 4: Update poller route callback and tests**
+
+Change `ProcessInput.route_fn` in `src/weixin/poller.zig` to:
+
+```zig
+    route_fn: *const fn (
+        ctx: *anyopaque,
+        text: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+        allocator: std.mem.Allocator,
+        reply: *std.ArrayListUnmanaged(u8),
+    ) anyerror!RouteResult,
+```
+
+Change the call in `processUpdates` to:
+
+```zig
+        const route_result = input.route_fn(input.route_ctx, text, msg.from_user_id, msg.context_token, input.allocator, &reply) catch |err| {
+```
+
+Change `Poller.routeAdapter` signature:
+
+```zig
+    fn routeAdapter(
+        ctx: *anyopaque,
+        text: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+        allocator: std.mem.Allocator,
+        reply: *std.ArrayListUnmanaged(u8),
+    ) anyerror!RouteResult {
+```
+
+Inside `routeAdapter`, create the context:
+
+```zig
+        const reply_context = types.ReplyContext{
+            .sender = .{ .ctx = self, .send_attachment = pollerSendAttachment },
+            .to_user_id = to_user_id,
+            .context_token = context_token,
+        };
+```
+
+Change `agent.route` call:
+
+```zig
+        try agent.route(allocator, self.control, self.settings, text, reply_context, &r);
+```
+
+Add this adapter inside `Poller`.
+
+```zig
+    fn pollerSendAttachment(
+        ctx: *anyopaque,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        if (self.stop_requested.load(.acquire)) return error.PollerStopped;
+        try self.client.sendAttachment(kind, path, display_name, to_user_id, context_token);
+    }
+```
+
+Update test route callback signatures. For `RouteCtx`, capture to/context:
+
+```zig
+const Captured = struct {
+    sent: std.ArrayListUnmanaged([]u8) = .empty,
+    routed: std.ArrayListUnmanaged([]u8) = .empty,
+    routed_to: std.ArrayListUnmanaged([]u8) = .empty,
+    routed_context: std.ArrayListUnmanaged([]u8) = .empty,
+    fn deinit(self: *Captured) void {
+        for (self.sent.items) |s| t.allocator.free(s);
+        for (self.routed.items) |s| t.allocator.free(s);
+        for (self.routed_to.items) |s| t.allocator.free(s);
+        for (self.routed_context.items) |s| t.allocator.free(s);
+        self.sent.deinit(t.allocator);
+        self.routed.deinit(t.allocator);
+        self.routed_to.deinit(t.allocator);
+        self.routed_context.deinit(t.allocator);
+    }
+};
+```
+
+```zig
+    fn route(ctx: *anyopaque, text: []const u8, to_user_id: []const u8, context_token: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+        const self: *RouteCtx = @ptrCast(@alignCast(ctx));
+        try self.cap.routed.append(t.allocator, try t.allocator.dupe(u8, text));
+        try self.cap.routed_to.append(t.allocator, try t.allocator.dupe(u8, to_user_id));
+        try self.cap.routed_context.append(t.allocator, try t.allocator.dupe(u8, context_token));
+        try reply.appendSlice(allocator, "ok");
+        return .{};
+    }
+```
+
+In `processUpdates routes accepted text and sends replies`, add:
+
+```zig
+    try t.expectEqualStrings("u1", cap.routed_to.items[0]);
+    try t.expectEqualStrings("c", cap.routed_context.items[0]);
+```
+
+Add this test for inbound voice routing:
+
+```zig
+test "processUpdates routes inbound voice transcript as message text" {
+    var cap = Captured{};
+    defer cap.deinit();
+    var rctx = RouteCtx{ .cap = &cap };
+    var sctx = SendCtx{ .cap = &cap };
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "voice-ctx", .item_list = &.{.{ .type = 3, .voice_text = "transcribed command" }} },
+    };
+
+    try processUpdates(.{
+        .allocator = t.allocator,
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &rctx,
+        .route_fn = RouteCtx.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+    });
+
+    try t.expectEqual(@as(usize, 1), cap.routed.items.len);
+    try t.expectEqualStrings("transcribed command", cap.routed.items[0]);
+    try t.expectEqualStrings("u1", cap.routed_to.items[0]);
+    try t.expectEqualStrings("voice-ctx", cap.routed_context.items[0]);
+}
+```
+
+- [ ] **Step 5: Update AppWindow UI-thread marshal**
+
+In `src/AppWindow.zig`, make sure the import list includes the Weixin types module. Use the local import style already present in the file; the resulting alias must be:
+
+```zig
+const weixin_types = @import("weixin/types.zig");
+```
+
+Add this field to `WeixinRequest`.
+
+```zig
+    reply_context: ?weixin_types.ReplyContext = null,
+```
+
+In `handleWeixinControlRequest`, change the AI send path:
+
+```zig
+                if (req.reply_context) |ctx| {
+                    session.applyWeixinInput(req.bytes, ctx);
+                } else {
+                    session.applyRemoteInput(req.bytes);
+                }
+```
+
+Change `wxSendInput` signature and request construction:
+
+```zig
+fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?weixin_types.ReplyContext) bool {
+    var req = WeixinRequest{ .op = .send_input, .surface_id = surface_id, .bytes = bytes, .reply_context = reply_context };
+    if (!weixinDispatch(&req)) return false;
+    return req.sent;
+}
+```
+
+- [ ] **Step 6: Update control fakes**
+
+In `src/weixin/poller.zig` and `src/weixin/controller.zig`, update every `NoopControl.sendInput` fake to:
+
+```zig
+    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
+        return false;
+    }
+```
+
+If the fake file imports `control_mod` but not `types`, use the existing `types` alias in `poller.zig`; `controller.zig` already imports `types.zig`.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+zig test src/weixin/agent.zig
+zig test src/weixin/poller.zig
+zig build test
+```
+
+Expected: all commands PASS.
+
+Commit:
+
+```bash
+git add src/weixin/control.zig src/weixin/agent.zig src/weixin/poller.zig src/AppWindow.zig src/weixin/controller.zig
+git commit -m "feat: pass weixin reply context to agent"
+```
+
+## Task 8: Final Verification and Cleanup
+
+**Files:**
+- Modify only if tests reveal compile errors in files changed by earlier tasks.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+zig test src/weixin/types.zig
+zig test src/weixin/media.zig
+zig test src/weixin/ilink_codec.zig
+zig test src/weixin/ilink_client.zig
+zig test src/weixin/binding.zig
+zig test src/weixin/agent.zig
+zig test src/weixin/poller.zig
+zig test src/ai_chat_protocol.zig
+zig test src/platform/agent_prompt.zig
+zig test src/ai_chat.zig
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 2: Run fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full suite before merge on Windows**
+
+On the Windows development host, run:
+
+```powershell
+zig build test-full
+```
+
+Expected: PASS. If this environment is not Windows, record that `test-full` still needs to be run on Windows before merge because this repository targets `x86_64-windows-gnu` by default.
+
+- [ ] **Step 4: Run Windows checkout-safety checks if files were added**
+
+Because this plan adds `src/weixin/media.zig`, run the path-safety check documented in `docs/development.md#windows-checkout-safety`.
+
+Expected: no reserved names, illegal characters, case-fold collisions, symlinks, or excessive paths.
+
+- [ ] **Step 5: Review secrets and logging**
+
+Inspect changed files:
+
+```bash
+git diff -- src/weixin src/ai_chat.zig src/ai_chat_protocol.zig src/platform/agent_prompt.zig src/AppWindow.zig src/test_fast.zig
+```
+
+Expected:
+
+- No bot token, `context_token`, AES key, or raw file contents are printed.
+- Debug logs may print lengths, hashes, status codes, `ret`, `errcode`, and non-secret API messages.
+- The tool success message prints only kind and display filename.
+
+- [ ] **Step 6: Commit final fixes if any**
+
+If Step 1 through Step 5 required fixes, commit only those tracked changes:
+
+```bash
+git add src/weixin src/ai_chat.zig src/ai_chat_protocol.zig src/platform/agent_prompt.zig src/AppWindow.zig src/test_fast.zig
+git commit -m "fix: stabilize weixin attachment support"
+```
+
+If there were no final fixes, do not create an empty commit.

--- a/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
+++ b/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
@@ -32,6 +32,8 @@ it through the generic `file_item` path:
 - Use media type `3` and `file_item` for both `kind=file` and `kind=voice`.
 - Inbound Weixin voice transcription remains unchanged: continue extracting
   `voice_item.text` as ordinary message text.
+- Do not pre-block oversized files in v1. If iLink rejects the file, surface
+  that API error.
 
 ## File Structure
 

--- a/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
+++ b/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
@@ -181,13 +181,6 @@ pub const CdnMedia = struct {
     file_key: []const u8 = "",
 };
 
-pub const VoiceMetadata = struct {
-    encode_type: i64,
-    sample_rate: i64,
-    playtime: i64,
-    codec: []const u8 = "",
-};
-
 pub const UploadedFileAttachment = struct {
     media: CdnMedia,
     file_name: []const u8,
@@ -197,13 +190,6 @@ pub const UploadedFileAttachment = struct {
 pub const UploadedImage = struct {
     media: CdnMedia,
     mid_size: u64,
-};
-
-pub const UploadedVoice = struct {
-    media: CdnMedia,
-    encode_type: i64,
-    sample_rate: i64,
-    playtime: i64,
 };
 
 pub const AttachmentSender = struct {
@@ -319,19 +305,6 @@ pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, t
     @compileError("uploadUrlWithTicket is not implemented");
 }
 
-pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
-    _ = codec;
-    _ = path;
-    @compileError("voiceEncodeType is not implemented");
-}
-
-pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
-    _ = allocator;
-    _ = json;
-    _ = path;
-    @compileError("parseFfprobeVoiceMetadata is not implemented");
-}
-
 const t = std.testing;
 
 test "pkcs7 padding always adds at least one AES block" {
@@ -373,27 +346,6 @@ test "uploadUrlWithTicket appends ticket query using question mark or ampersand"
     const b = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload?x=1", "ticket=abc");
     defer t.allocator.free(b);
     try t.expectEqualStrings("https://cdn.example/upload?x=1&ticket=abc", b);
-}
-
-test "voiceEncodeType maps codec and extension values" {
-    try t.expectEqual(@as(i64, 1), try voiceEncodeType("pcm_s16le", "note.wav"));
-    try t.expectEqual(@as(i64, 5), try voiceEncodeType("amr_nb", "note.amr"));
-    try t.expectEqual(@as(i64, 6), try voiceEncodeType("silk", "note.silk"));
-    try t.expectEqual(@as(i64, 7), try voiceEncodeType("mp3", "note.mp3"));
-    try t.expectEqual(@as(i64, 8), try voiceEncodeType("speex", "note.ogg"));
-    try t.expectError(error.UnsupportedVoiceCodec, voiceEncodeType("aac", "note.m4a"));
-}
-
-test "parseFfprobeVoiceMetadata reads codec sample rate and duration" {
-    const json =
-        \\{"streams":[{"codec_type":"audio","codec_name":"mp3","sample_rate":"44100","duration":"2.700000"}],
-        \\"format":{"duration":"2.700000"}}
-    ;
-    const meta = try parseFfprobeVoiceMetadata(t.allocator, json, "voice.mp3");
-    try t.expectEqual(@as(i64, 7), meta.encode_type);
-    try t.expectEqual(@as(i64, 44100), meta.sample_rate);
-    try t.expectEqual(@as(i64, 2700), meta.playtime);
-    try t.expectEqualStrings("mp3", meta.codec);
 }
 ```
 
@@ -471,59 +423,6 @@ pub fn md5Hex(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
 pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, ticket: []const u8) ![]u8 {
     const sep: []const u8 = if (std.mem.indexOfScalar(u8, base_url, '?') == null) "?" else "&";
     return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ base_url, sep, ticket });
-}
-
-pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
-    const ext = std.fs.path.extension(path);
-    if (std.ascii.eqlIgnoreCase(codec, "pcm_s16le") or std.ascii.eqlIgnoreCase(codec, "pcm_u8") or std.ascii.eqlIgnoreCase(ext, ".wav")) return 1;
-    if (std.ascii.eqlIgnoreCase(codec, "amr_nb") or std.ascii.eqlIgnoreCase(codec, "amr_wb") or std.ascii.eqlIgnoreCase(ext, ".amr")) return 5;
-    if (std.ascii.eqlIgnoreCase(codec, "silk") or std.ascii.eqlIgnoreCase(ext, ".silk")) return 6;
-    if (std.ascii.eqlIgnoreCase(codec, "mp3") or std.ascii.eqlIgnoreCase(ext, ".mp3")) return 7;
-    if (std.ascii.eqlIgnoreCase(codec, "speex") or std.ascii.eqlIgnoreCase(codec, "opus") or std.ascii.eqlIgnoreCase(codec, "vorbis") or std.ascii.eqlIgnoreCase(ext, ".ogg")) return 8;
-    return error.UnsupportedVoiceCodec;
-}
-
-fn voiceCodecLabel(encode_type: i64) []const u8 {
-    return switch (encode_type) {
-        1 => "pcm",
-        5 => "amr",
-        6 => "silk",
-        7 => "mp3",
-        8 => "ogg",
-        else => "unknown",
-    };
-}
-
-pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
-    const Probe = struct {
-        streams: []struct {
-            codec_type: []const u8 = "",
-            codec_name: []const u8 = "",
-            sample_rate: []const u8 = "",
-            duration: []const u8 = "",
-        } = &.{},
-        format: struct { duration: []const u8 = "" } = .{},
-    };
-    var parsed = try std.json.parseFromSlice(Probe, allocator, json, .{
-        .ignore_unknown_fields = true,
-        .allocate = .alloc_always,
-    });
-    defer parsed.deinit();
-
-    for (parsed.value.streams) |stream| {
-        if (!std.mem.eql(u8, stream.codec_type, "audio")) continue;
-        const sample_rate = std.fmt.parseInt(i64, stream.sample_rate, 10) catch 0;
-        const duration_text = if (stream.duration.len != 0) stream.duration else parsed.value.format.duration;
-        const seconds = std.fmt.parseFloat(f64, duration_text) catch 0;
-        const encode_type = try voiceEncodeType(stream.codec_name, path);
-        return .{
-            .encode_type = encode_type,
-            .sample_rate = sample_rate,
-            .playtime = @as(i64, @intFromFloat(@round(seconds * 1000.0))),
-            .codec = voiceCodecLabel(encode_type),
-        };
-    }
-    return error.NoAudioStream;
 }
 ```
 
@@ -619,28 +518,6 @@ test "builds uploaded image sendmessage body" {
     try t.expect(std.mem.indexOf(u8, body, "\"type\":2") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"image_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"mid_size\":64") != null);
-}
-
-test "builds uploaded voice sendmessage body" {
-    const media = types.CdnMedia{
-        .encrypt_query_param = "encrypted-param",
-        .aes_key = "encoded-key",
-        .md5 = "md5",
-        .size = 64,
-        .file_key = "file-key",
-    };
-    const body = try buildSendUploadedVoiceBody(t.allocator, "u1", "ctx", "cid", .{
-        .media = media,
-        .encode_type = 7,
-        .sample_rate = 44100,
-        .playtime = 2700,
-    });
-    defer t.allocator.free(body);
-    try t.expect(std.mem.indexOf(u8, body, "\"type\":3") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"voice_item\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"encode_type\":7") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"sample_rate\":44100") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"playtime\":2700") != null);
 }
 
 test "parses inbound voice transcription into message item" {
@@ -814,46 +691,6 @@ pub fn buildSendUploadedImageBody(
     const items = [_]Item{.{ .image_item = .{
         .media = wireMedia(image.media),
         .mid_size = image.mid_size,
-    } }};
-    return std.json.Stringify.valueAlloc(allocator, Body{
-        .msg = .{
-            .to_user_id = to_user_id,
-            .client_id = client_id,
-            .context_token = context_token,
-            .item_list = &items,
-        },
-        .base_info = .{ .channel_version = CHANNEL_VERSION },
-    }, .{});
-}
-
-pub fn buildSendUploadedVoiceBody(
-    allocator: std.mem.Allocator,
-    to_user_id: []const u8,
-    context_token: []const u8,
-    client_id: []const u8,
-    voice: types.UploadedVoice,
-) ![]u8 {
-    const VoiceItem = struct {
-        media: WireCdnMedia,
-        encode_type: i64,
-        sample_rate: i64,
-        playtime: i64,
-    };
-    const Item = struct { type: i64 = 3, voice_item: VoiceItem };
-    const Msg = struct {
-        to_user_id: []const u8,
-        client_id: []const u8,
-        message_type: i64 = 2,
-        message_state: i64 = 2,
-        context_token: []const u8,
-        item_list: []const Item,
-    };
-    const Body = struct { msg: Msg, base_info: BaseInfo };
-    const items = [_]Item{.{ .voice_item = .{
-        .media = wireMedia(voice.media),
-        .encode_type = voice.encode_type,
-        .sample_rate = voice.sample_rate,
-        .playtime = voice.playtime,
     } }};
     return std.json.Stringify.valueAlloc(allocator, Body{
         .msg = .{

--- a/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
+++ b/docs/superpowers/plans/2026-05-31-weixin-agent-attachments.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Let the desktop direct Weixin bridge route inbound text and voice transcripts into AI Chat, and let AI Chat call `weixin_send_attachment` to send local `file`, `image`, or `voice` attachments back to the active Weixin conversation.
+**Goal:** Let the desktop direct Weixin bridge route inbound text and voice transcripts into AI Chat, and let AI Chat call `weixin_send_attachment` to send local `file`, `image`, or `voice` inputs back to the active Weixin conversation. Outbound `voice` is sent as a normal file attachment in v1.
 
 **Architecture:** Keep iLink upload protocol code inside `src/weixin/`, keep terminal/VT/rendering unaware of Weixin, and pass a short-lived reply context from the poller through the app control boundary into the AI Chat request. The Agent tool dispatch uses that context only when the current request came from Weixin; normal local AI Chat requests return a clear no-context tool result.
 
@@ -21,9 +21,21 @@ CiteBox reference mapping:
 - `internal/weixin/cdn.go`: confirms `media.aes_key` is base64 of the hex-encoded AES key.
 - `internal/service/weixin_im_bridge.go`: confirms inbound `voice_item.text` is the transcript used as ordinary text.
 
+## Approved Change: Outbound Voice As File
+
+After Task 4 review, the user clarified that outbound `voice` should be treated
+as `file`. Keep accepting `kind=voice` as a tool input for convenience, but send
+it through the generic `file_item` path:
+
+- Do not call `ffprobe` from the iLink client.
+- Do not send outbound iLink `voice_item` messages in v1.
+- Use media type `3` and `file_item` for both `kind=file` and `kind=voice`.
+- Inbound Weixin voice transcription remains unchanged: continue extracting
+  `voice_item.text` as ordinary message text.
+
 ## File Structure
 
-- Create `src/weixin/media.zig`: pure media helpers plus narrow `ffprobe` parsing helpers. No bot token storage.
+- Create `src/weixin/media.zig`: pure media helpers. No bot token storage.
 - Modify `src/weixin/types.zig`: attachment kinds, upload URL response, CDN media structs, uploaded media structs, sender and reply context structs.
 - Modify `src/weixin/ilink_codec.zig`: JSON builders for upload URL and typed sendmessage bodies; parser for upload URL response.
 - Modify `src/weixin/ilink_client.zig`: high-level attachment send flow and `ClientApi.send_attachment`.
@@ -146,7 +158,7 @@ pub const AttachmentKind = enum {
         return switch (self) {
             .image => 1,
             .file => 3,
-            .voice => 4,
+            .voice => 3,
         };
     }
 };
@@ -1029,7 +1041,7 @@ Add these functions inside `Client`.
         return switch (kind) {
             .file => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
             .image => self.sendImageFile(path, to_user_id, context_token),
-            .voice => self.sendVoiceFile(path, to_user_id, context_token),
+            .voice => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
         };
     }
 
@@ -1062,22 +1074,6 @@ Add these functions inside `Client`.
         try self.postSendMessage(a, body);
     }
 
-    fn sendVoiceFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
-        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
-        defer req_arena.deinit();
-        const a = req_arena.allocator();
-
-        const uploaded = try self.uploadLocalFile(a, .voice, path);
-        const meta = try self.probeVoiceFile(a, path);
-        const client_id = try self.clientId(a);
-        const body = try codec.buildSendUploadedVoiceBody(a, to_user_id, context_token, client_id, .{
-            .media = uploaded.media,
-            .encode_type = meta.encode_type,
-            .sample_rate = meta.sample_rate,
-            .playtime = meta.playtime,
-        });
-        try self.postSendMessage(a, body);
-    }
 ```
 
 Add these helper functions inside `Client`.
@@ -1199,28 +1195,6 @@ Add these helper functions inside `Client`.
                 return error.IlinkSendMessageFailed;
             }
         }
-    }
-
-    fn probeVoiceFile(self: *Client, arena: std.mem.Allocator, path: []const u8) !types.VoiceMetadata {
-        _ = self;
-        var child = std.process.Child.init(&.{
-            "ffprobe",
-            "-v", "error",
-            "-show_entries", "stream=codec_type,codec_name,sample_rate,duration:format=duration",
-            "-of", "json",
-            path,
-        }, arena);
-        child.stdin_behavior = .Ignore;
-        child.stderr_behavior = .Pipe;
-        child.stdout_behavior = .Pipe;
-        const result = child.run() catch |err| switch (err) {
-            error.FileNotFound => return error.FfprobeNotFound,
-            else => return err,
-        };
-        defer arena.free(result.stdout);
-        defer arena.free(result.stderr);
-        if (result.term != .Exited or result.term.Exited != 0) return error.FfprobeFailed;
-        return media.parseFfprobeVoiceMetadata(arena, result.stdout, path);
     }
 
     fn randomBytes(self: *Client, out: []u8) void {
@@ -1352,7 +1326,7 @@ test "platform agent prompt describes the Weixin attachment tool" {
         const p = defaultSystemPromptForOs(os);
         try std.testing.expect(std.mem.indexOf(u8, p, "weixin_send_attachment") != null);
         try std.testing.expect(std.mem.indexOf(u8, p, "kind=image") != null);
-        try std.testing.expect(std.mem.indexOf(u8, p, "kind=voice") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "voice files are sent as file attachments") != null);
         try std.testing.expect(std.mem.indexOf(u8, p, "kind=file") != null);
     }
 }
@@ -1374,7 +1348,7 @@ Expected: both fail because the schema and prompt do not mention `weixin_send_at
 In `src/ai_chat_protocol.zig`, add this `emit` call inside `forEachToolSpec`, after `wispterm_docs`.
 
 ```zig
-    try emit(ctx, "weixin_send_attachment", "Send a local file back to the active Weixin conversation that triggered this agent request. Use only when the current request came from Weixin; normal local chat requests have no Weixin reply context.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in Weixin for file attachments; defaults to the path basename.\"}}");
+    try emit(ctx, "weixin_send_attachment", "Send a local file back to the active Weixin conversation that triggered this agent request. Use only when the current request came from Weixin; normal local chat requests have no Weixin reply context. Audio and voice files are sent as ordinary file attachments.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice. Voice is accepted as an alias for file.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in Weixin for file attachments; defaults to the path basename.\"}}");
 ```
 
 - [ ] **Step 4: Add prompt guidance**
@@ -1383,8 +1357,8 @@ In `src/platform/agent_prompt.zig`, insert these lines in `common_tools_after_ws
 
 ```zig
     \\- When the request came from Weixin and the user asks you to send a generated or local artifact, call `weixin_send_attachment`.
-    \\- Use `kind=image` for image previews, `kind=voice` only for playable voice messages, and `kind=file` for ordinary attachments.
-    \\- If voice metadata probing fails or playback as an in-chat voice message is not required, send the same path with `kind=file`.
+    \\- Use `kind=image` for image previews and `kind=file` for ordinary attachments; voice files are sent as file attachments.
+    \\- `kind=voice` is accepted for Weixin, but it behaves like `kind=file` and does not create an in-chat voice message.
 ```
 
 - [ ] **Step 5: Run tests and commit**

--- a/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
+++ b/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
@@ -130,13 +130,11 @@ New media helper module.
 
 Responsibilities:
 
-- Build `getuploadurl` request bodies.
 - Build CDN upload URLs.
 - AES-ECB encrypt with PKCS7 padding.
 - Encode AES keys in the iLink-compatible form.
-- Build typed `sendmessage` payloads for file and image.
-- Keep inbound `voice_item.text` parsing. Outbound `kind=voice` does not use
-  `ffprobe` in v1.
+- Keep upload crypto and URL helpers pure; JSON request/response shapes stay in
+  `ilink_codec.zig`.
 
 ### `src/weixin/types.zig`
 
@@ -157,6 +155,8 @@ Extend JSON builders/parsers:
 - `buildSendUploadedImageBody(...)`
 - keep existing `voice_item.text` parsing for inbound messages and add direct
   tests for it.
+- do not add outbound `voice_item` builders in v1; `kind=voice` is sent with
+  the file payload path.
 
 ### `src/weixin/ilink_client.zig`
 

--- a/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
+++ b/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
@@ -1,0 +1,316 @@
+# Weixin Agent Attachments Design
+
+**Date:** 2026-05-31
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Add typed attachment sending to the desktop direct Weixin path in `src/weixin/`.
+The AI Agent should be able to send local files back to the active Weixin
+conversation by calling a tool, rather than relying on a manual `/file` command.
+
+This design applies only to the Zig desktop direct bridge. The `remote/` Node
+bridge remains out of scope for this change.
+
+## Context
+
+WispTerm currently has two Weixin paths:
+
+- `remote/src/server/bridge/weixin/`: Node Remote bridge.
+- `src/weixin/`: embedded desktop direct iLink client and poller.
+
+Both paths currently send text replies. Both already extract text from inbound
+voice messages by reading the iLink `voice_item.text` transcription:
+
+- TypeScript Remote bridge: `extractWeixinText()` in
+  `remote/src/server/bridge/weixin/poller.ts`.
+- Zig direct bridge: `binding.extractText()` in `src/weixin/binding.zig`.
+
+The missing capability is outbound media. CiteBox provides a working reference:
+
+- `internal/weixin/types.go`: iLink media item types and upload request shapes.
+- `internal/weixin/media.go`: upload URL, AES-ECB encryption, CDN upload,
+  and typed `sendmessage` payloads.
+- `internal/weixin/cdn.go`: CDN download/decrypt helpers.
+- `internal/service/weixin_im_bridge.go`: higher-level bridge behavior around
+  text, image, file, and voice sends.
+
+## Ghostty Comparison
+
+Ghostty has no Weixin bridge or AI Agent tool system. The closest relevant
+reference is its host-level automation on macOS:
+
+- App Intents expose terminal input and terminal details through host-layer
+  APIs such as `InputTextIntent` and `GetTerminalDetailsIntent`.
+- AppleScript commands also live in the app/host layer and ultimately call
+  surface APIs such as `surface.sendText`.
+
+The same boundary should hold here: iLink upload, CDN encryption, bot tokens,
+and Weixin reply context stay in `src/weixin/` and the app/Agent host layer.
+Terminal emulation, VT parsing, PTY state, and rendering do not know about
+Weixin attachments.
+
+## User-Approved Decisions
+
+- Scope is `src/weixin/` desktop direct only.
+- Expose attachment sending as an Agent tool.
+- Tool name: `weixin_send_attachment`.
+- Support typed attachments in v1: `file`, `image`, and `voice`.
+- Do not add extra local path restrictions. The tool may send any readable
+  local file path.
+- Do not add a separate manual `/file` command in v1.
+- Inbound voice transcription is not a tool; it remains ordinary message text
+  extraction from `voice_item.text`.
+
+## Tool Contract
+
+`weixin_send_attachment` accepts:
+
+```json
+{
+  "kind": "file | image | voice",
+  "path": "C:\\path\\to\\artifact",
+  "display_name": "optional-name.ext"
+}
+```
+
+Semantics:
+
+- `kind=file` sends a generic iLink `file_item`.
+- `kind=image` sends an iLink `image_item`.
+- `kind=voice` sends an iLink `voice_item` and probes audio metadata.
+- `display_name` is optional. If omitted, the basename of `path` is used where
+  the iLink item supports a filename.
+- The tool is usable only while handling a Weixin-triggered Agent request. A
+  normal local AI Chat request has no Weixin reply context and returns a clear
+  tool error.
+
+## Protocol Flow
+
+For all attachment kinds:
+
+1. Read the local file.
+2. Compute raw size and MD5.
+3. Generate a random file key and random AES-128 key.
+4. Request `/ilink/bot/getuploadurl`.
+5. AES-ECB encrypt the file with PKCS7 padding.
+6. Upload encrypted bytes to the Weixin CDN upload URL.
+7. Read the CDN response `x-encrypted-param`.
+8. Send `/ilink/bot/sendmessage` with the matching typed item.
+
+Mapping:
+
+| Tool kind | iLink media_type | sendmessage item |
+| --- | ---: | --- |
+| `image` | `1` | `image_item` |
+| `file` | `3` | `file_item` |
+| `voice` | `4` | `voice_item` |
+
+The media metadata follows the CiteBox wire shape:
+
+- `media.encrypt_query_param`: CDN download token from `x-encrypted-param`.
+- `media.aes_key`: base64 encoding of the hex-encoded AES key.
+- `media.encrypt_type`: bundle encryption type `1`.
+- `file_item.file_name`: display name or path basename.
+- `file_item.len`: raw file size as a decimal string.
+- `image_item.mid_size`: encrypted file size.
+- `voice_item.encode_type`, `sample_rate`, and `playtime`: probed audio
+  metadata.
+
+## Architecture
+
+### `src/weixin/media.zig`
+
+New media helper module.
+
+Responsibilities:
+
+- Build `getuploadurl` request bodies.
+- Build CDN upload URLs.
+- AES-ECB encrypt with PKCS7 padding.
+- Encode AES keys in the iLink-compatible form.
+- Build typed `sendmessage` payloads for file, image, and voice.
+- Parse `ffprobe` JSON output into voice metadata.
+- Map voice codecs/extensions to iLink encode types:
+  - PCM/WAV -> `1`
+  - AMR -> `5`
+  - SILK -> `6`
+  - MP3 -> `7`
+  - OGG/Speex -> `8`
+
+The pure parts should be unit-tested without network access. The `ffprobe`
+process execution wrapper can stay in `ilink_client.zig` or a small helper, but
+the JSON parsing and codec mapping should be pure.
+
+### `src/weixin/types.zig`
+
+Extend the in-memory iLink model with:
+
+- `AttachmentKind = enum { file, image, voice }`
+- upload URL request/response structs
+- CDN media struct
+- typed uploaded media structs for file/image/voice
+
+### `src/weixin/ilink_codec.zig`
+
+Extend JSON builders/parsers:
+
+- `buildGetUploadUrlBody(...)`
+- `buildSendUploadedFileBody(...)`
+- `buildSendUploadedImageBody(...)`
+- `buildSendUploadedVoiceBody(...)`
+- keep existing `voice_item.text` parsing for inbound messages and add direct
+  tests for it.
+
+### `src/weixin/ilink_client.zig`
+
+Extend `ClientApi` so Agent code can use a fake in tests:
+
+```zig
+send_attachment(
+    ctx: *anyopaque,
+    kind: types.AttachmentKind,
+    path: []const u8,
+    display_name: []const u8,
+    to_user_id: []const u8,
+    context_token: []const u8,
+) anyerror!void
+```
+
+The real `Client` implements:
+
+- `getUploadUrl`
+- `uploadBufferToCDN`
+- `sendUploadedFileAttachment`
+- `sendUploadedImage`
+- `sendUploadedVoice`
+- `sendAttachment`
+
+`sendAttachment` is the high-level entry point used by the Agent tool.
+
+### `src/ai_chat.zig`
+
+Add optional Weixin reply context to `ChatRequest`.
+
+The context carries only what the tool needs:
+
+- `to_user_id`
+- `context_token`
+- a `send_attachment` callback or `weixin.ClientApi`
+
+Add tool dispatch:
+
+- Parse `kind`, `path`, and optional `display_name`.
+- Return `Invalid tool arguments`, `Missing kind`, or `Missing path` for invalid
+  calls.
+- Return a clear no-context message for normal AI Chat requests.
+- Call the Weixin attachment sender for Weixin-triggered requests.
+- Return a concise success message to the transcript, for example
+  `Sent image to Weixin: chart.png`.
+
+### `src/ai_chat_protocol.zig`
+
+Add `weixin_send_attachment` to the single tool schema list.
+
+Properties:
+
+- `kind`: string, described as `file`, `image`, or `voice`.
+- `path`: string, local file path.
+- `display_name`: string, optional filename shown in Weixin for file-like
+  attachments.
+
+### `src/platform/agent_prompt.zig`
+
+Add guidance to the Agent prompt:
+
+- If the request came from Weixin and the user asks for a generated or local
+  artifact, call `weixin_send_attachment`.
+- Use `kind=image` for image previews, `kind=voice` for playable voice files,
+  and `kind=file` for ordinary attachments.
+- If voice metadata probing fails, use `kind=file` when the user's intent is to
+  receive the bytes rather than play an in-chat voice message.
+
+### `src/weixin/poller.zig`
+
+When routing a Weixin message into AI:
+
+- Carry the current message sender as `to_user_id`.
+- Carry the current message `context_token`.
+- Carry an attachment-sending capability tied to the same iLink client used for
+  text replies.
+
+This is the only place where a normal Agent request becomes a
+Weixin-triggered request.
+
+## Error Handling
+
+- Missing file, non-regular file, or read failure: return a clear tool error.
+- `kind=voice` and `ffprobe` is missing: return a clear tool error suggesting
+  `kind=file` if playback as a voice message is not required.
+- Unsupported voice codec: return a clear tool error with the detected codec.
+- `getuploadurl` failure: return `ret`, `errcode`, and message when available.
+- CDN upload failure: return HTTP status and a short response body excerpt.
+- Missing `x-encrypted-param`: return a specific CDN protocol error.
+- `sendmessage` failure: return `ret`, `errcode`, and message when available.
+- No Weixin reply context: return `No active Weixin reply context; cannot send attachment.`
+- Oversized files are not pre-blocked in v1. If iLink rejects the file, surface
+  that API error.
+
+Never log bot tokens, `context_token`, AES keys, or raw file contents.
+
+## Testing
+
+Use TDD for implementation. Add tests before production code.
+
+Pure tests:
+
+- `media.zig`
+  - AES-ECB/PKCS7 encrypted size and round-trip decrypt helper in test code.
+  - CDN upload URL construction.
+  - AES key iLink encoding.
+  - voice metadata JSON parsing.
+  - codec/extension to voice encode type mapping.
+- `ilink_codec.zig`
+  - build `getuploadurl` JSON.
+  - build `file_item`, `image_item`, and `voice_item` sendmessage JSON.
+  - parse inbound `voice_item.text` into `MessageItem.voice_text`.
+- `binding.zig`
+  - keep/extend voice transcript extraction test.
+- `ai_chat_protocol.zig`
+  - tool schema includes `weixin_send_attachment`.
+- `ai_chat.zig`
+  - no Weixin context returns the no-context tool result.
+  - valid context calls the fake attachment sender with kind, path,
+    display_name, to_user_id, and context_token.
+- `poller.zig`
+  - Weixin-triggered AI routing carries the reply context into the request.
+  - voice transcript messages route the same way as text messages.
+
+Integration-style compile/build checks:
+
+- `zig test src/weixin/media.zig`
+- `zig test src/weixin/ilink_codec.zig`
+- `zig test src/weixin/binding.zig`
+- `zig test src/ai_chat_protocol.zig`
+- `zig build test`
+
+Before merging a completed implementation, run `zig build test-full` on Windows
+per the repository development rules.
+
+## Implementation Order
+
+1. Add media types, pure codec/media tests, and pure implementation.
+2. Extend `ClientApi` and real iLink client upload/send implementation.
+3. Add Agent tool schema and prompt guidance.
+4. Add `ChatRequest` Weixin reply context and tool dispatch.
+5. Wire `poller.zig` so Weixin-triggered Agent requests carry reply context.
+6. Verify with focused Zig tests and `zig build test`.
+
+## Non-Goals
+
+- No `remote/` bridge changes.
+- No manual `/file` command.
+- No inbound file download/import.
+- No file path allowlist or extra permission prompt.
+- No UI for selecting files.
+- No changes to keyboard shortcuts or desktop version surfaces.

--- a/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
+++ b/docs/superpowers/specs/2026-05-31-weixin-agent-attachments-design.md
@@ -8,6 +8,8 @@
 Add typed attachment sending to the desktop direct Weixin path in `src/weixin/`.
 The AI Agent should be able to send local files back to the active Weixin
 conversation by calling a tool, rather than relying on a manual `/file` command.
+Outbound audio/voice paths are sent as ordinary file attachments in v1, not as
+Weixin `voice_item` messages.
 
 This design applies only to the Zig desktop direct bridge. The `remote/` Node
 bridge remains out of scope for this change.
@@ -55,7 +57,9 @@ Weixin attachments.
 - Scope is `src/weixin/` desktop direct only.
 - Expose attachment sending as an Agent tool.
 - Tool name: `weixin_send_attachment`.
-- Support typed attachments in v1: `file`, `image`, and `voice`.
+- Support typed attachment inputs in v1: `file`, `image`, and `voice`.
+- Treat outbound `kind=voice` as a file attachment alias. Do not probe audio
+  metadata or send iLink `voice_item` messages in v1.
 - Do not add extra local path restrictions. The tool may send any readable
   local file path.
 - Do not add a separate manual `/file` command in v1.
@@ -78,7 +82,8 @@ Semantics:
 
 - `kind=file` sends a generic iLink `file_item`.
 - `kind=image` sends an iLink `image_item`.
-- `kind=voice` sends an iLink `voice_item` and probes audio metadata.
+- `kind=voice` sends the bytes as a generic iLink `file_item`, same as
+  `kind=file`.
 - `display_name` is optional. If omitted, the basename of `path` is used where
   the iLink item supports a filename.
 - The tool is usable only while handling a Weixin-triggered Agent request. A
@@ -104,7 +109,7 @@ Mapping:
 | --- | ---: | --- |
 | `image` | `1` | `image_item` |
 | `file` | `3` | `file_item` |
-| `voice` | `4` | `voice_item` |
+| `voice` | `3` | `file_item` |
 
 The media metadata follows the CiteBox wire shape:
 
@@ -114,8 +119,8 @@ The media metadata follows the CiteBox wire shape:
 - `file_item.file_name`: display name or path basename.
 - `file_item.len`: raw file size as a decimal string.
 - `image_item.mid_size`: encrypted file size.
-- `voice_item.encode_type`, `sample_rate`, and `playtime`: probed audio
-  metadata.
+No outbound voice metadata is required in v1 because audio/voice paths are sent
+as files.
 
 ## Architecture
 
@@ -129,18 +134,9 @@ Responsibilities:
 - Build CDN upload URLs.
 - AES-ECB encrypt with PKCS7 padding.
 - Encode AES keys in the iLink-compatible form.
-- Build typed `sendmessage` payloads for file, image, and voice.
-- Parse `ffprobe` JSON output into voice metadata.
-- Map voice codecs/extensions to iLink encode types:
-  - PCM/WAV -> `1`
-  - AMR -> `5`
-  - SILK -> `6`
-  - MP3 -> `7`
-  - OGG/Speex -> `8`
-
-The pure parts should be unit-tested without network access. The `ffprobe`
-process execution wrapper can stay in `ilink_client.zig` or a small helper, but
-the JSON parsing and codec mapping should be pure.
+- Build typed `sendmessage` payloads for file and image.
+- Keep inbound `voice_item.text` parsing. Outbound `kind=voice` does not use
+  `ffprobe` in v1.
 
 ### `src/weixin/types.zig`
 
@@ -149,7 +145,8 @@ Extend the in-memory iLink model with:
 - `AttachmentKind = enum { file, image, voice }`
 - upload URL request/response structs
 - CDN media struct
-- typed uploaded media structs for file/image/voice
+- typed uploaded media structs for file/image; voice input is sent with the file
+  attachment path.
 
 ### `src/weixin/ilink_codec.zig`
 
@@ -158,7 +155,6 @@ Extend JSON builders/parsers:
 - `buildGetUploadUrlBody(...)`
 - `buildSendUploadedFileBody(...)`
 - `buildSendUploadedImageBody(...)`
-- `buildSendUploadedVoiceBody(...)`
 - keep existing `voice_item.text` parsing for inbound messages and add direct
   tests for it.
 
@@ -183,10 +179,11 @@ The real `Client` implements:
 - `uploadBufferToCDN`
 - `sendUploadedFileAttachment`
 - `sendUploadedImage`
-- `sendUploadedVoice`
 - `sendAttachment`
 
 `sendAttachment` is the high-level entry point used by the Agent tool.
+It maps `AttachmentKind.voice` to the same generic file attachment flow as
+`AttachmentKind.file`.
 
 ### `src/ai_chat.zig`
 
@@ -225,10 +222,9 @@ Add guidance to the Agent prompt:
 
 - If the request came from Weixin and the user asks for a generated or local
   artifact, call `weixin_send_attachment`.
-- Use `kind=image` for image previews, `kind=voice` for playable voice files,
-  and `kind=file` for ordinary attachments.
-- If voice metadata probing fails, use `kind=file` when the user's intent is to
-  receive the bytes rather than play an in-chat voice message.
+- Use `kind=image` for image previews and `kind=file` for ordinary attachments,
+  including audio/voice files. `kind=voice` is accepted as an alias that still
+  sends a file attachment.
 
 ### `src/weixin/poller.zig`
 
@@ -245,9 +241,6 @@ Weixin-triggered request.
 ## Error Handling
 
 - Missing file, non-regular file, or read failure: return a clear tool error.
-- `kind=voice` and `ffprobe` is missing: return a clear tool error suggesting
-  `kind=file` if playback as a voice message is not required.
-- Unsupported voice codec: return a clear tool error with the detected codec.
 - `getuploadurl` failure: return `ret`, `errcode`, and message when available.
 - CDN upload failure: return HTTP status and a short response body excerpt.
 - Missing `x-encrypted-param`: return a specific CDN protocol error.
@@ -268,11 +261,9 @@ Pure tests:
   - AES-ECB/PKCS7 encrypted size and round-trip decrypt helper in test code.
   - CDN upload URL construction.
   - AES key iLink encoding.
-  - voice metadata JSON parsing.
-  - codec/extension to voice encode type mapping.
 - `ilink_codec.zig`
   - build `getuploadurl` JSON.
-  - build `file_item`, `image_item`, and `voice_item` sendmessage JSON.
+  - build `file_item` and `image_item` sendmessage JSON.
   - parse inbound `voice_item.text` into `MessageItem.voice_text`.
 - `binding.zig`
   - keep/extend voice transcript extraction test.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -18,6 +18,7 @@ const Renderer = @import("renderer/Renderer.zig");
 const remote = @import("remote_client.zig");
 const remote_snapshot = @import("remote_snapshot.zig");
 const weixin_control = @import("weixin/control.zig");
+const weixin_types = @import("weixin/types.zig");
 const memory_debug = @import("memory_debug.zig");
 const agent_detector = @import("agent_detector.zig");
 const agent_history = @import("agent_history.zig");
@@ -2277,6 +2278,7 @@ const WeixinRequest = struct {
     // send_input input (valid for the duration of the synchronous call):
     surface_id: [16]u8 = [_]u8{0} ** 16,
     bytes: []const u8 = "",
+    reply_context: ?weixin_types.ReplyContext = null,
     // outputs filled by the UI-thread handler:
     found: bool = false,
     out_surface_id: [16]u8 = [_]u8{0} ** 16,
@@ -2365,7 +2367,11 @@ fn handleWeixinControlRequest(req: *WeixinRequest) void {
                 const tab_state = tab.g_tabs[idx] orelse return;
                 if (tab_state.kind != .ai_chat) return;
                 const session = tab_state.ai_chat_session orelse return;
-                session.applyRemoteInput(req.bytes);
+                if (req.reply_context) |ctx| {
+                    session.applyWeixinInput(req.bytes, ctx);
+                } else {
+                    session.applyRemoteInput(req.bytes);
+                }
                 g_force_rebuild = true;
                 req.sent = true;
                 return;
@@ -2417,8 +2423,8 @@ fn wxOpenAiAgent(_: *anyopaque, _: u32) weixin_control.OpenResult {
     return req.open_result;
 }
 
-fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
-    var req = WeixinRequest{ .op = .send_input, .surface_id = surface_id, .bytes = bytes };
+fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?weixin_types.ReplyContext) bool {
+    var req = WeixinRequest{ .op = .send_input, .surface_id = surface_id, .bytes = bytes, .reply_context = reply_context };
     if (!weixinDispatch(&req)) return false;
     return req.sent;
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -20,6 +20,7 @@ const wispterm_docs = @import("wispterm_docs.zig");
 const markdown_text = @import("markdown_text.zig");
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
 const ai_chat_composer = @import("ai_chat_composer.zig");
+const weixin_types = @import("weixin/types.zig");
 
 pub const DEFAULT_NAME = "DeepSeek";
 pub const DEFAULT_BASE_URL = "https://api.deepseek.com";
@@ -247,6 +248,34 @@ pub const ToolHost = struct {
     connectSshProfile: *const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror!ToolSurface,
 };
 
+const WeixinReplyContext = struct {
+    sender: weixin_types.AttachmentSender,
+    to_user_id: []u8,
+    context_token: []u8,
+
+    fn init(allocator: std.mem.Allocator, ctx: weixin_types.ReplyContext) !WeixinReplyContext {
+        return .{
+            .sender = ctx.sender,
+            .to_user_id = try allocator.dupe(u8, ctx.to_user_id),
+            .context_token = try allocator.dupe(u8, ctx.context_token),
+        };
+    }
+
+    fn clone(self: WeixinReplyContext, allocator: std.mem.Allocator) !WeixinReplyContext {
+        return .{
+            .sender = self.sender,
+            .to_user_id = try allocator.dupe(u8, self.to_user_id),
+            .context_token = try allocator.dupe(u8, self.context_token),
+        };
+    }
+
+    fn deinit(self: *WeixinReplyContext, allocator: std.mem.Allocator) void {
+        allocator.free(self.to_user_id);
+        allocator.free(self.context_token);
+        self.* = undefined;
+    }
+};
+
 const ChatRequest = struct {
     allocator: std.mem.Allocator,
     session: *Session,
@@ -264,6 +293,7 @@ const ChatRequest = struct {
     copilot: bool = false,
     tool_host: ?ToolHost,
     tool_snapshot: ?ToolSnapshot,
+    weixin_reply_context: ?WeixinReplyContext = null,
     started_ms: i64,
     write_context_surface_id: [64]u8 = undefined,
     write_context_surface_id_len: usize = 0,
@@ -277,6 +307,7 @@ const ChatRequest = struct {
         for (self.messages) |msg| msg.deinit(self.allocator);
         self.allocator.free(self.messages);
         if (self.tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
+        if (self.weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
         self.allocator.destroy(self);
     }
 
@@ -771,6 +802,7 @@ pub const Session = struct {
     request_stopping: bool = false,
     request_thread: ?std.Thread = null,
     title_thread: ?std.Thread = null,
+    pending_weixin_reply_context: ?WeixinReplyContext = null,
     auto_title_attempted: bool = false,
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -971,6 +1003,7 @@ pub const Session = struct {
         self.freeSkillSuggestions();
         self.freeCustomCommandSuggestions();
         command_registry.freeCommandList(self.allocator, self.custom_commands);
+        if (self.pending_weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
         self.allocator.destroy(self);
     }
 
@@ -1339,6 +1372,19 @@ pub const Session = struct {
         if (text_start < data.len) self.appendInputText(data[text_start..]);
     }
 
+    pub fn applyWeixinInput(self: *Session, data: []const u8, ctx: weixin_types.ReplyContext) void {
+        self.mutex.lock();
+        if (self.pending_weixin_reply_context) |*old| old.deinit(self.allocator);
+        self.pending_weixin_reply_context = WeixinReplyContext.init(self.allocator, ctx) catch null;
+        self.mutex.unlock();
+        self.applyRemoteInput(data);
+    }
+
+    fn clearPendingWeixinReplyContextLocked(self: *Session) void {
+        if (self.pending_weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
+        self.pending_weixin_reply_context = null;
+    }
+
     pub fn handleKey(self: *Session, ev: input_key.KeyEvent) void {
         self.handleKeyWithWrapCols(ev, std.math.maxInt(usize));
     }
@@ -1667,6 +1713,7 @@ pub const Session = struct {
         self.mutex.lock();
         if (self.request_thread) |thread| {
             if (self.request_inflight) {
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             }
@@ -1678,6 +1725,7 @@ pub const Session = struct {
 
         var prompt_raw = std.mem.trim(u8, self.input(), " \t\r\n");
         if (prompt_raw.len == 0) {
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             return;
         }
@@ -1689,6 +1737,7 @@ pub const Session = struct {
         // 1) Built-in command (with optional argument), exact first-token match.
         if (ai_chat_composer.exactBuiltinCommand(first_tok)) |command| {
             const r = self.runBuiltinCommandLocked(command, arg);
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             self.notifyHistoryChange(r.history_change);
             fireDeferredAction(r.deferred);
@@ -1700,6 +1749,7 @@ pub const Session = struct {
             if (cmd.action) |av| {
                 if (knownActionFromName(av)) |builtin_command| {
                     const r = self.runBuiltinCommandLocked(builtin_command, arg);
+                    self.clearPendingWeixinReplyContextLocked();
                     self.mutex.unlock();
                     self.notifyHistoryChange(r.history_change);
                     fireDeferredAction(r.deferred);
@@ -1713,6 +1763,7 @@ pub const Session = struct {
             // legacy: a no-arg unknown slash like "/help" still shows "Unknown command".
             if (parseSlashCommand(prompt_raw)) |command| {
                 const r = self.runBuiltinCommandLocked(command, "");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 self.notifyHistoryChange(r.history_change);
                 fireDeferredAction(r.deferred);
@@ -1723,6 +1774,7 @@ pub const Session = struct {
 
         if (self.api_key_len == 0) {
             self.setStatusLocked("Missing API key. Edit the AI Chat profile or set DEEPSEEK_API_KEY.");
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             return;
         }
@@ -1733,6 +1785,7 @@ pub const Session = struct {
         if (invocation) |parsed| {
             skill_preload_content = loadSkillPreloadContent(self.allocator, parsed.skill_name) catch {
                 self.setStatusLocked("Could not load skill");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             };
@@ -1745,6 +1798,7 @@ pub const Session = struct {
         const prompt = self.allocator.dupe(u8, prompt_for_history) catch {
             if (skill_preload_content) |content| self.allocator.free(content);
             self.setStatusLocked("Out of memory");
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             return;
         };
@@ -1752,6 +1806,7 @@ pub const Session = struct {
             if (skill_preload_content) |content| self.allocator.free(content);
             self.allocator.free(prompt);
             self.setStatusLocked("Out of memory");
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             return;
         };
@@ -1763,6 +1818,7 @@ pub const Session = struct {
                 var user_msg = self.messages.pop().?;
                 user_msg.deinit(self.allocator);
                 self.setStatusLocked("Out of memory");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             };
@@ -1772,6 +1828,7 @@ pub const Session = struct {
                 var user_msg = self.messages.pop().?;
                 user_msg.deinit(self.allocator);
                 self.setStatusLocked("Out of memory");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             };
@@ -1791,6 +1848,7 @@ pub const Session = struct {
                 var user_msg = self.messages.pop().?;
                 user_msg.deinit(self.allocator);
                 self.setStatusLocked("Out of memory");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             };
@@ -1807,10 +1865,12 @@ pub const Session = struct {
             if (skill_preload_appended) {
                 self.rollbackMessagesFromLocked(message_start);
                 self.setStatusLocked("Could not prepare request");
+                self.clearPendingWeixinReplyContextLocked();
                 self.mutex.unlock();
                 return;
             }
             self.setStatusLocked("Could not prepare request");
+            self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             self.notifyHistoryChange(history_change);
             return;
@@ -2430,6 +2490,13 @@ pub const Session = struct {
             tool_snapshot = host.collectSnapshot(host.ctx, self.allocator) catch null;
         }
 
+        var weixin_ctx: ?WeixinReplyContext = null;
+        errdefer if (weixin_ctx) |*ctx| ctx.deinit(self.allocator);
+        if (self.pending_weixin_reply_context) |ctx| {
+            weixin_ctx = try ctx.clone(self.allocator);
+            self.clearPendingWeixinReplyContextLocked();
+        }
+
         // Each copilot user message carries a lightweight snapshot of the bound
         // terminal (cwd + recent output). Append it to the latest user message
         // rather than emitting a separate trailing message, which would break the
@@ -2533,6 +2600,7 @@ pub const Session = struct {
             .copilot = self.copilot,
             .tool_host = tool_host,
             .tool_snapshot = tool_snapshot,
+            .weixin_reply_context = weixin_ctx,
             .started_ms = std.time.milliTimestamp(),
         };
         base_url_owned = false;
@@ -2540,6 +2608,7 @@ pub const Session = struct {
         model_owned = false;
         system_prompt_owned = false;
         reasoning_effort_owned = false;
+        weixin_ctx = null;
         if (self.copilot and self.bound_surface_id_len > 0) {
             setWriteContext(req, self.boundSurfaceId());
         }
@@ -3810,6 +3879,15 @@ fn executeToolCall(request: *ChatRequest, call: ToolCall) ![]u8 {
         const topic = if (args) |parsed| jsonStringArg(parsed.value, "topic") else null;
         return wisptermDocsTool(request.allocator, topic);
     }
+    if (std.mem.eql(u8, call.name, "weixin_send_attachment")) {
+        const args = parseArgs(request.allocator, call.arguments) orelse return request.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const kind_text = jsonStringArg(args.value, "kind") orelse return request.allocator.dupe(u8, "Missing kind");
+        const kind = weixin_types.AttachmentKind.parse(kind_text) orelse return request.allocator.dupe(u8, "Invalid kind; expected file, image, or voice");
+        const path = jsonStringArg(args.value, "path") orelse return request.allocator.dupe(u8, "Missing path");
+        const display_name = jsonStringArg(args.value, "display_name") orelse "";
+        return weixinSendAttachmentTool(request, kind, path, display_name);
+    }
     return std.fmt.allocPrint(request.allocator, "Unknown tool: {s}", .{call.name});
 }
 
@@ -3878,6 +3956,22 @@ fn wisptermDocsTool(allocator: std.mem.Allocator, topic: ?[]const u8) ![]u8 {
         return out.toOwnedSlice(allocator);
     }
     return wispterm_docs.listTopics(allocator);
+}
+
+fn weixinSendAttachmentTool(
+    request: *ChatRequest,
+    kind: weixin_types.AttachmentKind,
+    path: []const u8,
+    display_name: []const u8,
+) ![]u8 {
+    const ctx = request.weixin_reply_context orelse {
+        return request.allocator.dupe(u8, "No active Weixin reply context; cannot send attachment.");
+    };
+    ctx.sender.sendAttachment(kind, path, display_name, ctx.to_user_id, ctx.context_token) catch |err| {
+        return std.fmt.allocPrint(request.allocator, "Failed to send {s} to Weixin: {}", .{ kind.name(), err });
+    };
+    const shown = if (display_name.len != 0) display_name else std.fs.path.basename(path);
+    return std.fmt.allocPrint(request.allocator, "Sent {s} to Weixin: {s}", .{ kind.name(), shown });
 }
 
 fn toolSurfaceKind(surface: ToolSurface) []const u8 {
@@ -5343,6 +5437,151 @@ test "wispterm_docs tool reports unknown topic with the topic list" {
     defer a.free(text);
     try std.testing.expect(std.mem.indexOf(u8, text, "Unknown topic") != null);
     try std.testing.expect(std.mem.indexOf(u8, text, "faq") != null);
+}
+
+const WeixinAttachmentCapture = struct {
+    called: bool = false,
+    kind: weixin_types.AttachmentKind = .file,
+    path: []const u8 = "",
+    display_name: []const u8 = "",
+    to_user_id: []const u8 = "",
+    context_token: []const u8 = "",
+    path_buf: [512]u8 = undefined,
+    display_name_buf: [256]u8 = undefined,
+    to_user_id_buf: [256]u8 = undefined,
+    context_token_buf: [256]u8 = undefined,
+
+    fn copyField(buf: []u8, value: []const u8) []const u8 {
+        const n = @min(buf.len, value.len);
+        @memcpy(buf[0..n], value[0..n]);
+        return buf[0..n];
+    }
+
+    fn send(
+        ctx: *anyopaque,
+        kind: weixin_types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        const self: *WeixinAttachmentCapture = @ptrCast(@alignCast(ctx));
+        self.called = true;
+        self.kind = kind;
+        self.path = copyField(&self.path_buf, path);
+        self.display_name = copyField(&self.display_name_buf, display_name);
+        self.to_user_id = copyField(&self.to_user_id_buf, to_user_id);
+        self.context_token = copyField(&self.context_token_buf, context_token);
+    }
+};
+
+fn testWeixinSender(capture: *WeixinAttachmentCapture) weixin_types.AttachmentSender {
+    return .{ .ctx = capture, .send_attachment = WeixinAttachmentCapture.send };
+}
+
+test "weixin_send_attachment without reply context returns a clear tool result" {
+    var session = try Session.init(
+        std.testing.allocator,
+        "test",
+        "https://api.example",
+        "key",
+        "model",
+        "prompt",
+        "enabled",
+        "medium",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    const request = try std.testing.allocator.create(ChatRequest);
+    request.* = .{
+        .allocator = std.testing.allocator,
+        .session = session,
+        .base_url = try std.testing.allocator.dupe(u8, "https://api.example"),
+        .api_key = try std.testing.allocator.dupe(u8, "key"),
+        .model = try std.testing.allocator.dupe(u8, "model"),
+        .system_prompt = try std.testing.allocator.dupe(u8, "prompt"),
+        .messages = &.{},
+        .thinking_enabled = false,
+        .reasoning_effort = try std.testing.allocator.dupe(u8, "medium"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .started_ms = 0,
+    };
+    defer request.deinit();
+
+    var call = ToolCall{
+        .id = try std.testing.allocator.dupe(u8, "call_1"),
+        .name = try std.testing.allocator.dupe(u8, "weixin_send_attachment"),
+        .arguments = try std.testing.allocator.dupe(u8, "{\"kind\":\"image\",\"path\":\"C:\\\\tmp\\\\plot.png\"}"),
+    };
+    defer call.deinit(std.testing.allocator);
+
+    const result = try executeToolCall(request, call);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("No active Weixin reply context; cannot send attachment.", result);
+}
+
+test "weixin_send_attachment calls the active Weixin sender" {
+    var capture = WeixinAttachmentCapture{};
+    var session = try Session.init(
+        std.testing.allocator,
+        "test",
+        "https://api.example",
+        "key",
+        "model",
+        "prompt",
+        "enabled",
+        "medium",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    const request = try std.testing.allocator.create(ChatRequest);
+    request.* = .{
+        .allocator = std.testing.allocator,
+        .session = session,
+        .base_url = try std.testing.allocator.dupe(u8, "https://api.example"),
+        .api_key = try std.testing.allocator.dupe(u8, "key"),
+        .model = try std.testing.allocator.dupe(u8, "model"),
+        .system_prompt = try std.testing.allocator.dupe(u8, "prompt"),
+        .messages = &.{},
+        .thinking_enabled = false,
+        .reasoning_effort = try std.testing.allocator.dupe(u8, "medium"),
+        .stream = false,
+        .agent_enabled = true,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .started_ms = 0,
+        .weixin_reply_context = try WeixinReplyContext.init(std.testing.allocator, .{
+            .sender = testWeixinSender(&capture),
+            .to_user_id = "wx-user",
+            .context_token = "ctx-1",
+        }),
+    };
+    defer request.deinit();
+
+    var call = ToolCall{
+        .id = try std.testing.allocator.dupe(u8, "call_1"),
+        .name = try std.testing.allocator.dupe(u8, "weixin_send_attachment"),
+        .arguments = try std.testing.allocator.dupe(u8, "{\"kind\":\"file\",\"path\":\"C:\\\\tmp\\\\report.pdf\",\"display_name\":\"report.pdf\"}"),
+    };
+    defer call.deinit(std.testing.allocator);
+
+    const result = try executeToolCall(request, call);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expect(capture.called);
+    try std.testing.expectEqual(weixin_types.AttachmentKind.file, capture.kind);
+    try std.testing.expectEqualStrings("C:\\tmp\\report.pdf", capture.path);
+    try std.testing.expectEqualStrings("report.pdf", capture.display_name);
+    try std.testing.expectEqualStrings("wx-user", capture.to_user_id);
+    try std.testing.expectEqualStrings("ctx-1", capture.context_token);
+    try std.testing.expectEqualStrings("Sent file to Weixin: report.pdf", result);
 }
 
 test "ai chat skill_info loads from explicit root paths" {

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -554,6 +554,7 @@ fn forEachToolSpec(
     try emit(ctx, "tab_close", "Close a terminal tab by zero-based tab_index, surface_id, title, or the active terminal tab when no selector is provided. Cannot close the AI chat tab running the agent.", "{\"tab_index\":{\"type\":\"integer\",\"description\":\"Zero-based tab index from terminal_list.\"},\"tab_number\":{\"type\":\"integer\",\"description\":\"One-based UI tab number, accepted as a convenience.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list.\"},\"title\":{\"type\":\"string\",\"description\":\"Terminal tab title to close, such as CPU2.\"}}");
     try emit(ctx, "skill_info", "Load a WispTerm skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}");
     try emit(ctx, "wispterm_docs", "Read WispTerm's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}");
+    try emit(ctx, "weixin_send_attachment", "Send a local file back to the active Weixin conversation that triggered this agent request. Use only when the current request came from Weixin; normal local chat requests have no Weixin reply context. Audio and voice files are sent as ordinary file attachments.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice. Voice is accepted as an alias for file.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in Weixin for file attachments; defaults to the path basename.\"}}");
 }
 
 const ToolSchemaEmitter = struct {
@@ -1111,6 +1112,24 @@ test "buildRequestJson includes wispterm_docs tool for both protocols" {
     const resp_json = try buildRequestJson(a, resp, &msgs, true);
     defer a.free(resp_json);
     try std.testing.expect(std.mem.indexOf(u8, resp_json, "\"wispterm_docs\"") != null);
+}
+
+test "tool schemas include weixin_send_attachment" {
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("send the report") }};
+    const params = RequestParams{
+        .model = "m",
+        .system_prompt = "",
+        .protocol = .chat_completions,
+        .thinking_enabled = false,
+        .reasoning_effort = "",
+        .stream = false,
+    };
+    const json = try buildRequestJson(std.testing.allocator, params, &msgs, true);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"weixin_send_attachment\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"kind\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"path\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"display_name\"") != null);
 }
 
 test "parseApiResponse reads responses-protocol output text" {

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -31,14 +31,14 @@ const macos_copilot_prompt = macos_prompt ++ copilot_binding_clause;
 const windows_copilot_prompt = windows_prompt ++ copilot_binding_clause;
 
 const common_tools_before_wsl =
-    \\- Be direct and concise. Inspect the current directory before making changes.
-    \\- Preserve user work. Do not overwrite files, reset Git state, or delete data unless the user asks.
+    \\- Be direct. Inspect the current directory before changes.
+    \\- Preserve user work; do not overwrite, reset, or delete unless asked.
     \\
     \\Terminal tools:
-    \\- Use `terminal_list` to inspect open WispTerm terminals before writing to one.
-    \\- Use `terminal_select` before any selected-terminal write.
-    \\- Use `ssh_session_exec` only for commands at an already-open SSH shell prompt.
-    \\- Use `ssh_profile_save` to create/update a saved WispTerm SSH profile when the user gives SSH details; use `ssh_profile_connect` to open it.
+    \\- Use `terminal_list` before terminal writes.
+    \\- Use `terminal_select` before selected-terminal writes.
+    \\- Use `ssh_session_exec` only at an already-open SSH shell prompt.
+    \\- Use `ssh_profile_save` for saved SSH details; use `ssh_profile_connect` to open them.
 ;
 
 const wsl_tool_guidance =
@@ -46,19 +46,20 @@ const wsl_tool_guidance =
 ;
 
 const common_tools_after_wsl =
-    \\- If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use `terminal_repl_exec`.
-    \\- Do not paste shell commands into Codex or Claude Code; send user-facing text there, not shell commands.
-    \\- Open a new local terminal with `tab_new` only when no suitable terminal exists.
-    \\- For questions about WispTerm itself (features, config, shortcuts), call `wispterm_docs` to list and read the built-in docs.
+    \\- Use `terminal_repl_exec` for Codex, Claude Code, Python, R, or other REPL/app terminals.
+    \\- Do not paste shell commands into Codex or Claude Code; send user-facing text.
+    \\- Use `tab_new` only when no suitable terminal exists.
+    \\- For WispTerm questions, call `wispterm_docs` to list and read built-in docs.
+    \\- When the request came from Weixin and the user asks you to send a generated or local artifact, call `weixin_send_attachment`.
+    \\- Use `kind=image` for image previews and `kind=file` for ordinary attachments; voice files are sent as file attachments.
+    \\- `kind=voice` is accepted for Weixin, but it behaves like `kind=file` and does not create an in-chat voice message.
     \\
     \\Python:
-    \\- Use uv for Python environments and dependencies.
-    \\- Before Python work, run `uv --version`.
-    \\- Verify installation with `uv --version`.
+    \\- Use uv for Python environments; run `uv --version` first.
     \\- Prefer `uv sync`, `uv run`, `uv add`, `uv remove`, and `uvx`.
     \\- Do not use global `pip install` unless the user explicitly asks.
     \\
-    \\After changes, run the smallest useful verification command and report what changed.
+    \\After changes, run focused verification and report what changed.
 ;
 
 const common_tools = common_tools_before_wsl ++ common_tools_after_wsl;
@@ -127,5 +128,15 @@ test "platform agent prompt points at the wispterm_docs tool on every OS" {
     for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
         const p = defaultSystemPromptForOs(os);
         try std.testing.expect(std.mem.indexOf(u8, p, "wispterm_docs") != null);
+    }
+}
+
+test "platform agent prompt describes the Weixin attachment tool" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "weixin_send_attachment") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "kind=image") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "voice files are sent as file attachments") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "kind=file") != null);
     }
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("ai_chat_protocol.zig");
     _ = @import("weixin/types.zig");
     _ = @import("weixin/ilink_codec.zig");
+    _ = @import("weixin/media.zig");
     _ = @import("weixin/binding.zig");
     _ = @import("ai_chat_title.zig");
     _ = @import("command_registry.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -48,6 +48,9 @@ test {
     _ = @import("ai_sidebar.zig");
     _ = @import("appwindow/flush_scheduler.zig");
     _ = @import("ai_chat_protocol.zig");
+    _ = @import("weixin/types.zig");
+    _ = @import("weixin/ilink_codec.zig");
+    _ = @import("weixin/binding.zig");
     _ = @import("ai_chat_title.zig");
     _ = @import("command_registry.zig");
     // Generic POSIX SSH/WSL command builder: asserts native (non-Windows)

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -51,6 +51,7 @@ pub fn route(
     ctrl: control.Control,
     settings: types.Settings,
     raw_text: []const u8,
+    reply_context: ?types.ReplyContext,
     out: *Reply,
 ) !void {
     _ = allocator;
@@ -78,11 +79,11 @@ pub fn route(
     if (eqIgnoreCase(cmd, "/stop")) return stopAi(ctrl, out);
     if (eqIgnoreCase(cmd, "/term")) return sendTerminal(ctrl, parts.arg, true, out);
     if (eqIgnoreCase(cmd, "/keys")) return sendTerminal(ctrl, parts.arg, false, out);
-    if (eqIgnoreCase(cmd, "/ai")) return sendAi(ctrl, parts.arg, out);
-    return sendAi(ctrl, text, out);
+    if (eqIgnoreCase(cmd, "/ai")) return sendAi(ctrl, parts.arg, reply_context, out);
+    return sendAi(ctrl, text, reply_context, out);
 }
 
-fn sendAi(ctrl: control.Control, text: []const u8, out: *Reply) !void {
+fn sendAi(ctrl: control.Control, text: []const u8, reply_context: ?types.ReplyContext, out: *Reply) !void {
     const ai = ctrl.findAiSurface() orelse blk: {
         switch (ctrl.openAiAgent(AI_OPEN_TIMEOUT_MS)) {
             .no_profile => return out.set("WispTerm 尚未配置 AI Chat profile。"),
@@ -98,14 +99,14 @@ fn sendAi(ctrl: control.Control, text: []const u8, out: *Reply) !void {
     defer buf.deinit(out.allocator);
     try buf.appendSlice(out.allocator, text);
     try buf.append(out.allocator, '\r');
-    if (!ctrl.sendInput(ai.id, buf.items)) return out.set("WispTerm 当前离线，无法发送给 AI Agent。");
+    if (!ctrl.sendInput(ai.id, buf.items, reply_context)) return out.set("WispTerm 当前离线，无法发送给 AI Agent。");
     try out.set(AI_ACK);
     out.expect_ai_progress = true;
 }
 
 fn stopAi(ctrl: control.Control, out: *Reply) !void {
     const ai = ctrl.findAiSurface() orelse return out.set("当前没有 AI Agent 可停止。");
-    if (!ctrl.sendInput(ai.id, ESC)) return out.set("WispTerm 当前离线，无法停止 AI Agent。");
+    if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止 AI Agent。");
     return out.set("已发送停止指令。");
 }
 
@@ -115,7 +116,7 @@ fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Repl
     defer buf.deinit(out.allocator);
     try buf.appendSlice(out.allocator, text);
     if (enter) try buf.append(out.allocator, '\r');
-    if (!ctrl.sendInput(term.id, buf.items)) return out.set("WispTerm 当前离线，无法发送到终端。");
+    if (!ctrl.sendInput(term.id, buf.items, null)) return out.set("WispTerm 当前离线，无法发送到终端。");
     return out.set("已发送到终端。");
 }
 
@@ -144,6 +145,7 @@ const FakeControl = struct {
     buf: [256]u8 = undefined,
     len: usize = 0,
     last_surface: [16]u8 = [_]u8{0} ** 16,
+    last_reply_context: ?types.ReplyContext = null,
 
     /// Bytes captured from the last send_input. send_input borrows its argument
     /// (production consumes it synchronously), so the fake copies for inspection.
@@ -163,10 +165,11 @@ const FakeControl = struct {
     fn open_ai_agent(_: *anyopaque, _: u32) control.OpenResult {
         return .opened;
     }
-    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool {
+    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
         const self = cast(ctx);
         if (!self.connected) return false;
         self.last_surface = surface_id;
+        self.last_reply_context = reply_context;
         const n = @min(bytes.len, self.buf.len);
         @memcpy(self.buf[0..n], bytes[0..n]);
         self.len = n;
@@ -200,7 +203,7 @@ test "ping returns pong without touching surfaces" {
     var fake = FakeControl{};
     var out = Reply.init(t.allocator);
     defer out.deinit();
-    try route(t.allocator, fake.control_iface(), defaultSettings(), "ping", &out);
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "ping", null, &out);
     try t.expectEqualStrings("pong", out.text.items);
     try t.expect(!out.expect_ai_progress);
 }
@@ -209,22 +212,49 @@ test "default text goes to the AI surface with a carriage return" {
     var fake = FakeControl{};
     var out = Reply.init(t.allocator);
     defer out.deinit();
-    try route(t.allocator, fake.control_iface(), defaultSettings(), "hello world", &out);
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "hello world", null, &out);
     try t.expectEqualStrings("hello world\r", fake.lastInput());
     try t.expectEqualSlices(u8, &FakeControl.aiId(), &fake.last_surface);
     try t.expect(out.expect_ai_progress);
+}
+
+test "default AI route forwards Weixin reply context only to AI surface" {
+    const Sender = struct {
+        fn sendAttachment(ctx: *anyopaque, kind: types.AttachmentKind, path: []const u8, display_name: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
+            _ = ctx;
+            _ = kind;
+            _ = path;
+            _ = display_name;
+            _ = to_user_id;
+            _ = context_token;
+        }
+    };
+
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    const reply_ctx = types.ReplyContext{
+        .sender = .{ .ctx = &fake, .send_attachment = Sender.sendAttachment },
+        .to_user_id = "wx-user",
+        .context_token = "ctx-1",
+    };
+
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "make a chart", reply_ctx, &out);
+    try t.expect(fake.last_reply_context != null);
+    try t.expectEqualStrings("wx-user", fake.last_reply_context.?.to_user_id);
+    try t.expectEqualStrings("ctx-1", fake.last_reply_context.?.context_token);
 }
 
 test "/term sends to terminal with enter, /keys without" {
     var fake = FakeControl{};
     var out = Reply.init(t.allocator);
     defer out.deinit();
-    try route(t.allocator, fake.control_iface(), defaultSettings(), "/term ls", &out);
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/term ls", null, &out);
     try t.expectEqualStrings("ls\r", fake.lastInput());
 
     var out2 = Reply.init(t.allocator);
     defer out2.deinit();
-    try route(t.allocator, fake.control_iface(), defaultSettings(), "/keys abc", &out2);
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/keys abc", null, &out2);
     try t.expectEqualStrings("abc", fake.lastInput());
 }
 
@@ -232,7 +262,7 @@ test "offline control yields an offline message and no progress" {
     var fake = FakeControl{ .connected = false };
     var out = Reply.init(t.allocator);
     defer out.deinit();
-    try route(t.allocator, fake.control_iface(), defaultSettings(), "do a thing", &out);
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "do a thing", null, &out);
     try t.expect(!out.expect_ai_progress);
     try t.expect(std.mem.indexOf(u8, out.text.items, "离线") != null);
 }

--- a/src/weixin/control.zig
+++ b/src/weixin/control.zig
@@ -1,6 +1,7 @@
 //! Boundary between WeChat routing and the live WispTerm surfaces. The real
 //! vtable is supplied by controller.zig; tests supply a fake.
 const std = @import("std");
+const types = @import("types.zig");
 
 pub const Surface = struct { id: [16]u8, title: []const u8 };
 
@@ -15,7 +16,7 @@ pub const Control = struct {
         find_ai_surface: *const fn (ctx: *anyopaque) ?Surface,
         find_terminal_surface: *const fn (ctx: *anyopaque) ?Surface,
         open_ai_agent: *const fn (ctx: *anyopaque, timeout_ms: u32) OpenResult,
-        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8) bool,
+        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool,
         latest_transcript: *const fn (ctx: *anyopaque) []const u8,
     };
 
@@ -31,8 +32,8 @@ pub const Control = struct {
     pub fn openAiAgent(self: Control, timeout_ms: u32) OpenResult {
         return self.vtable.open_ai_agent(self.ctx, timeout_ms);
     }
-    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8) bool {
-        return self.vtable.send_input(self.ctx, surface_id, bytes);
+    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
+        return self.vtable.send_input(self.ctx, surface_id, bytes, reply_context);
     }
     pub fn latestTranscript(self: Control) []const u8 {
         return self.vtable.latest_transcript(self.ctx);

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -409,7 +409,7 @@ const NoopControl = struct {
     fn open_ai_agent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8) bool {
+    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
         return false;
     }
     fn latest_transcript(_: *anyopaque) []const u8 {

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -3,6 +3,7 @@
 //! ClientApi so the poller can be tested with a fake.
 const std = @import("std");
 const codec = @import("ilink_codec.zig");
+const media = @import("media.zig");
 const types = @import("types.zig");
 
 /// Abstract transport the poller depends on, so it can be faked in tests.
@@ -14,6 +15,14 @@ pub const ClientApi = struct {
         /// Returned value owns its own arena; caller must call `.deinit()`.
         get_updates: *const fn (ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates,
         send_text: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
+        send_attachment: *const fn (
+            ctx: *anyopaque,
+            kind: types.AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void,
     };
 
     pub fn getUpdates(self: ClientApi, buf: []const u8) !codec.ParsedUpdates {
@@ -21,6 +30,16 @@ pub const ClientApi = struct {
     }
     pub fn sendText(self: ClientApi, to_user_id: []const u8, text: []const u8, context_token: []const u8) !void {
         return self.vtable.send_text(self.ctx, to_user_id, text, context_token);
+    }
+    pub fn sendAttachment(
+        self: ClientApi,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return self.vtable.send_attachment(self.ctx, kind, path, display_name, to_user_id, context_token);
     }
 };
 
@@ -30,6 +49,12 @@ pub const Client = struct {
     token: []const u8,
     rng: std.Random.DefaultPrng,
     rng_mutex: std.Thread.Mutex = .{},
+
+    const UploadedLocalFile = struct {
+        media: types.CdnMedia,
+        raw_len: u64,
+        encrypted_len: u64,
+    };
 
     pub fn init(allocator: std.mem.Allocator, base_url: []const u8, token: []const u8) Client {
         return .{
@@ -88,9 +113,7 @@ pub const Client = struct {
         var req_arena = std.heap.ArenaAllocator.init(self.allocator);
         defer req_arena.deinit();
         const a = req_arena.allocator();
-        const client_id = try std.fmt.allocPrint(a, "wispterm-weixin-{d}-{d}", .{
-            std.time.milliTimestamp(), self.nextRandomU32(),
-        });
+        const client_id = try self.clientId(a);
         const body = try codec.buildSendTextBody(a, to_user_id, text, context_token, client_id);
         const resp = try self.fetch(a, .POST, "/ilink/bot/sendmessage", body, null);
         const W = struct { ret: ?i64 = null, errcode: i64 = 0, message: []const u8 = "" };
@@ -104,6 +127,229 @@ pub const Client = struct {
                 return error.IlinkSendMessageFailed;
             }
         }
+    }
+
+    pub fn clientId(self: *Client, allocator: std.mem.Allocator) ![]u8 {
+        return std.fmt.allocPrint(allocator, "wispterm-weixin-{d}-{d}", .{
+            std.time.milliTimestamp(), self.nextRandomU32(),
+        });
+    }
+
+    pub fn sendAttachment(
+        self: *Client,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return switch (kind) {
+            .file => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
+            .image => self.sendImageFile(path, to_user_id, context_token),
+            .voice => self.sendVoiceFile(path, to_user_id, context_token),
+        };
+    }
+
+    fn sendFileAttachment(self: *Client, path: []const u8, file_name: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+        const uploaded = try self.uploadLocalFile(a, .file, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedFileBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .file_name = file_name,
+            .len = uploaded.raw_len,
+        });
+        try self.postSendMessage(a, body);
+    }
+
+    fn sendImageFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+        const uploaded = try self.uploadLocalFile(a, .image, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedImageBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .mid_size = uploaded.encrypted_len,
+        });
+        try self.postSendMessage(a, body);
+    }
+
+    fn sendVoiceFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
+        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer req_arena.deinit();
+        const a = req_arena.allocator();
+        const metadata = try self.probeVoiceFile(a, path);
+        const uploaded = try self.uploadLocalFile(a, .voice, path);
+        const client_id = try self.clientId(a);
+        const body = try codec.buildSendUploadedVoiceBody(a, to_user_id, context_token, client_id, .{
+            .media = uploaded.media,
+            .encode_type = metadata.encode_type,
+            .sample_rate = metadata.sample_rate,
+            .playtime = metadata.playtime,
+        });
+        try self.postSendMessage(a, body);
+    }
+
+    fn uploadLocalFile(self: *Client, arena: std.mem.Allocator, kind: types.AttachmentKind, path: []const u8) !UploadedLocalFile {
+        const plain = readLocalFileAlloc(arena, path) catch |err| switch (err) {
+            error.FileNotFound => return error.WeixinAttachmentFileNotFound,
+            error.IsDir => return error.WeixinAttachmentPathIsDirectory,
+            else => return err,
+        };
+        const md5 = try media.md5Hex(arena, plain);
+
+        var file_key_bytes: [16]u8 = undefined;
+        self.randomBytes(file_key_bytes[0..]);
+        const file_key_hex = std.fmt.bytesToHex(file_key_bytes, .lower);
+        const file_key = try arena.dupe(u8, &file_key_hex);
+
+        var aes_key: media.AesKey = undefined;
+        self.randomBytes(aes_key[0..]);
+        const encoded_aes_key = try media.encodeIlinkAesKey(arena, aes_key);
+
+        const upload = try self.getUploadUrl(arena, kind, plain.len, md5, file_key);
+        const encrypted = try media.aes128EcbPkcs7Encrypt(arena, aes_key, plain);
+        const encrypted_param = try self.uploadBufferToCdn(arena, upload.url, upload.ticket, encrypted);
+
+        return .{
+            .media = .{
+                .encrypt_query_param = encrypted_param,
+                .aes_key = encoded_aes_key,
+                .md5 = md5,
+                .size = plain.len,
+                .file_key = if (upload.file_key.len != 0) upload.file_key else file_key,
+            },
+            .raw_len = plain.len,
+            .encrypted_len = encrypted.len,
+        };
+    }
+
+    fn getUploadUrl(
+        self: *Client,
+        arena: std.mem.Allocator,
+        kind: types.AttachmentKind,
+        size: u64,
+        md5: []const u8,
+        file_key: []const u8,
+    ) !types.UploadUrl {
+        const body = try codec.buildGetUploadUrlBody(arena, kind, size, md5, file_key);
+        const resp = try self.fetch(arena, .POST, "/ilink/bot/getuploadurl", body, null);
+        var parsed = try codec.parseGetUploadUrl(self.allocator, resp);
+        defer parsed.deinit();
+        const upload = parsed.value;
+        if (upload.ret != 0) {
+            std.debug.print("weixin upload-url({d}): kind={s} status=failed ret={} errcode={} message={s}\n", .{
+                std.time.milliTimestamp(),
+                kind.name(),
+                upload.ret,
+                upload.errcode,
+                upload.message,
+            });
+            return error.WeixinGetUploadUrlFailed;
+        }
+        if (upload.url.len == 0 or upload.ticket.len == 0) {
+            std.debug.print("weixin upload-url({d}): kind={s} status=missing-url ret={} errcode={} message={s}\n", .{
+                std.time.milliTimestamp(),
+                kind.name(),
+                upload.ret,
+                upload.errcode,
+                upload.message,
+            });
+            return error.WeixinGetUploadUrlMissingUrl;
+        }
+        return .{
+            .url = try arena.dupe(u8, upload.url),
+            .ticket = try arena.dupe(u8, upload.ticket),
+            .file_key = try arena.dupe(u8, upload.file_key),
+            .ret = upload.ret,
+            .errcode = upload.errcode,
+            .message = try arena.dupe(u8, upload.message),
+        };
+    }
+
+    fn uploadBufferToCdn(self: *Client, arena: std.mem.Allocator, upload_url: []const u8, ticket: []const u8, encrypted: []const u8) ![]u8 {
+        var client: std.http.Client = .{ .allocator = self.allocator };
+        defer client.deinit();
+
+        const ticket_url = try media.uploadUrlWithTicket(arena, upload_url, ticket);
+        const uri = try std.Uri.parse(ticket_url);
+        var req = try client.request(.POST, uri, .{
+            .headers = .{ .content_type = .{ .override = "application/octet-stream" } },
+            .keep_alive = false,
+        });
+        defer req.deinit();
+
+        try req.sendBodyComplete(encrypted);
+
+        var redirect_buffer: [8 * 1024]u8 = undefined;
+        var response = try req.receiveHead(&redirect_buffer);
+
+        var encrypted_param: ?[]u8 = null;
+        var header_it = response.head.iterateHeaders();
+        while (header_it.next()) |header| {
+            if (std.ascii.eqlIgnoreCase(header.name, "x-encrypted-param")) {
+                encrypted_param = try arena.dupe(u8, header.value);
+                break;
+            }
+        }
+
+        var transfer_buffer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer_buffer);
+        var discard_buffer: [1024]u8 = undefined;
+        var discarding: std.Io.Writer.Discarding = .init(&discard_buffer);
+        _ = reader.streamRemaining(&discarding.writer) catch {};
+
+        if (response.head.status != .ok) return error.WeixinCdnUploadFailed;
+        return encrypted_param orelse error.WeixinCdnMissingEncryptedParam;
+    }
+
+    fn postSendMessage(self: *Client, arena: std.mem.Allocator, body: []const u8) !void {
+        const resp = try self.fetch(arena, .POST, "/ilink/bot/sendmessage", body, null);
+        const W = struct { ret: ?i64 = null, errcode: i64 = 0, message: []const u8 = "" };
+        const w = try std.json.parseFromSliceLeaky(W, arena, resp, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        });
+        if (w.ret) |ret| {
+            if (ret != 0) {
+                std.debug.print("weixin send({d}): kind=sendmessage status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
+                return error.IlinkSendMessageFailed;
+            }
+        }
+    }
+
+    fn probeVoiceFile(self: *Client, arena: std.mem.Allocator, path: []const u8) !types.VoiceMetadata {
+        _ = self;
+        const argv = [_][]const u8{
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type,codec_name,sample_rate,duration:format=duration",
+            "-of",
+            "json",
+            path,
+        };
+        var child = std.process.Child.init(&argv, arena);
+        child.stdin_behavior = .Ignore;
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Ignore;
+        child.create_no_window = true;
+        child.spawn() catch |err| switch (err) {
+            error.FileNotFound => return error.FfprobeNotFound,
+            else => return error.FfprobeFailed,
+        };
+
+        const stdout = if (child.stdout) |out| try out.readToEndAlloc(arena, 64 * 1024) else "";
+        const term = child.wait() catch return error.FfprobeFailed;
+        switch (term) {
+            .Exited => |code| if (code != 0) return error.FfprobeFailed,
+            else => return error.FfprobeFailed,
+        }
+        return media.parseFfprobeVoiceMetadata(arena, stdout, path);
     }
 
     /// Performs one HTTP request, returning the response body bytes allocated in
@@ -163,12 +409,19 @@ pub const Client = struct {
         return self.rng.random().int(u32);
     }
 
+    fn randomBytes(self: *Client, out: []u8) void {
+        self.rng_mutex.lock();
+        defer self.rng_mutex.unlock();
+        self.rng.random().bytes(out);
+    }
+
     // --- ClientApi adapter ---
 
     pub fn api(self: *Client) ClientApi {
         return .{ .ctx = self, .vtable = &.{
             .get_updates = apiGetUpdates,
             .send_text = apiSendText,
+            .send_attachment = apiSendAttachment,
         } };
     }
     fn apiGetUpdates(ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates {
@@ -176,6 +429,16 @@ pub const Client = struct {
     }
     fn apiSendText(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
         return @as(*Client, @ptrCast(@alignCast(ctx))).sendText(to_user_id, text, context_token);
+    }
+    fn apiSendAttachment(
+        ctx: *anyopaque,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        return @as(*Client, @ptrCast(@alignCast(ctx))).sendAttachment(kind, path, display_name, to_user_id, context_token);
     }
 };
 
@@ -201,6 +464,20 @@ fn appendQueryEscaped(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Alloc
     }
 }
 
+fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    }
+    return std.fs.cwd().readFileAlloc(allocator, path, std.math.maxInt(usize));
+}
+
+fn displayNameOrBasename(display_name: []const u8, path: []const u8) []const u8 {
+    if (display_name.len != 0) return display_name;
+    return std.fs.path.basename(path);
+}
+
 test "client init defaults the base url" {
     const c = Client.init(std.testing.allocator, "", "tok");
     try std.testing.expectEqualStrings(codec.DEFAULT_BASE_URL, c.base_url);
@@ -216,4 +493,66 @@ test "client qrcode status path percent-encodes the qrcode query value" {
         "/ilink/bot/get_qrcode_status?qrcode=qr%20session%2B%26%3D%25",
         path,
     );
+}
+
+test "ClientApi forwards sendAttachment to the vtable" {
+    const Capture = struct {
+        called: bool = false,
+        kind: types.AttachmentKind = .file,
+        path: []const u8 = "",
+        display_name: []const u8 = "",
+        to_user_id: []const u8 = "",
+        context_token: []const u8 = "",
+
+        fn sendAttachment(
+            ctx: *anyopaque,
+            kind: types.AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.called = true;
+            self.kind = kind;
+            self.path = path;
+            self.display_name = display_name;
+            self.to_user_id = to_user_id;
+            self.context_token = context_token;
+        }
+
+        fn getUpdates(ctx: *anyopaque, buf: []const u8) anyerror!codec.ParsedUpdates {
+            _ = ctx;
+            _ = buf;
+            return error.NotUsed;
+        }
+
+        fn sendText(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
+            _ = ctx;
+            _ = to_user_id;
+            _ = text;
+            _ = context_token;
+        }
+    };
+
+    var capture = Capture{};
+    const api = ClientApi{ .ctx = &capture, .vtable = &.{
+        .get_updates = Capture.getUpdates,
+        .send_text = Capture.sendText,
+        .send_attachment = Capture.sendAttachment,
+    } };
+    try api.sendAttachment(.voice, "C:\\tmp\\a.mp3", "a.mp3", "wx-user", "ctx");
+    try std.testing.expect(capture.called);
+    try std.testing.expectEqual(types.AttachmentKind.voice, capture.kind);
+    try std.testing.expectEqualStrings("C:\\tmp\\a.mp3", capture.path);
+    try std.testing.expectEqualStrings("a.mp3", capture.display_name);
+    try std.testing.expectEqualStrings("wx-user", capture.to_user_id);
+    try std.testing.expectEqualStrings("ctx", capture.context_token);
+}
+
+test "client ids are generated with the wispterm weixin prefix" {
+    var c = Client.init(std.testing.allocator, "https://x.test", "tok");
+    const id = try c.clientId(std.testing.allocator);
+    defer std.testing.allocator.free(id);
+    try std.testing.expect(std.mem.startsWith(u8, id, "wispterm-weixin-"));
 }

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -146,7 +146,12 @@ pub const Client = struct {
         });
         if (w.ret) |ret| {
             if (ret != 0) {
-                std.debug.print("weixin send({d}): kind=sendmessage status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
+                std.debug.print("weixin send({d}): kind=sendmessage status=failed ret={} errcode={} message={s}\n", .{
+                    std.time.milliTimestamp(),
+                    ret,
+                    w.errcode,
+                    logSafeDiagnosticText(a, w.message),
+                });
                 return error.IlinkSendMessageFailed;
             }
         }
@@ -253,7 +258,7 @@ pub const Client = struct {
                 kind.name(),
                 upload.ret,
                 upload.errcode,
-                upload.message,
+                logSafeDiagnosticText(arena, upload.message),
             });
             return error.WeixinGetUploadUrlFailed;
         }
@@ -263,7 +268,7 @@ pub const Client = struct {
                 kind.name(),
                 upload.ret,
                 upload.errcode,
-                upload.message,
+                logSafeDiagnosticText(arena, upload.message),
             });
             return error.WeixinGetUploadUrlMissingUrl;
         }
@@ -352,7 +357,12 @@ pub const Client = struct {
             return error.IlinkSendMessageMalformed;
         };
         if (ret != 0) {
-            std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
+            std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{
+                std.time.milliTimestamp(),
+                ret,
+                w.errcode,
+                logSafeDiagnosticText(arena, w.message),
+            });
             return error.IlinkSendMessageFailed;
         }
     }
@@ -556,10 +566,14 @@ fn readResponseBodyExcerpt(allocator: std.mem.Allocator, reader: *std.Io.Reader)
 }
 
 fn logSafeResponseExcerpt(allocator: std.mem.Allocator, body: []const u8) []const u8 {
-    return safeResponseExcerptAlloc(allocator, body) catch "[response excerpt unavailable]";
+    return logSafeDiagnosticText(allocator, body);
 }
 
-fn safeResponseExcerptAlloc(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
+fn logSafeDiagnosticText(allocator: std.mem.Allocator, text: []const u8) []const u8 {
+    return safeDiagnosticTextAlloc(allocator, text) catch "[diagnostic text unavailable]";
+}
+
+fn safeDiagnosticTextAlloc(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
     const capped = body[0..@min(body.len, Client.ERROR_BODY_EXCERPT_BYTES)];
     if (looksBinary(capped)) return allocator.dupe(u8, "[binary body omitted]");
 
@@ -575,6 +589,7 @@ fn safeResponseExcerptAlloc(allocator: std.mem.Allocator, body: []const u8) ![]u
 }
 
 fn looksBinary(bytes: []const u8) bool {
+    if (!std.unicode.utf8ValidateSlice(bytes)) return true;
     for (bytes) |b| {
         if (b == 0 or b == 0x7f) return true;
         if (b < 0x20 and b != '\n' and b != '\r' and b != '\t') return true;
@@ -588,42 +603,43 @@ fn appendRedactedJsonField(
     input: []const u8,
     index: *usize,
 ) !bool {
-    const fields = [_][]const u8{
-        "context_token",
-        "aes_key",
-        "encrypt_query_param",
-        "token",
-        "bot_token",
-        "access_token",
-        "authorization",
-        "Authorization",
-        "ticket",
-    };
-    for (fields) |field| {
-        if (jsonStringValueStart(input, index.*, field)) |value_quote| {
-            try out.appendSlice(allocator, input[index.* .. value_quote + 1]);
+    if (jsonStringValueStart(input, index.*)) |field| {
+        if (isSensitiveDiagnosticField(field.key)) {
+            try out.appendSlice(allocator, input[index.* .. field.value_quote + 1]);
             try out.appendSlice(allocator, "[redacted]");
             try out.append(allocator, '"');
-            index.* = skipJsonString(input, value_quote + 1);
+            index.* = skipJsonString(input, field.value_quote + 1);
+            return true;
+        }
+    }
+    if (plainValueStart(input, index.*)) |field| {
+        if (isSensitiveDiagnosticField(field.key)) {
+            try out.appendSlice(allocator, input[index.*..field.value_start]);
+            try out.appendSlice(allocator, "[redacted]");
+            index.* = skipPlainValue(input, field.value_start);
             return true;
         }
     }
     return false;
 }
 
-fn jsonStringValueStart(input: []const u8, start: usize, field: []const u8) ?usize {
+const JsonDiagnosticField = struct {
+    key: []const u8,
+    value_quote: usize,
+};
+
+fn jsonStringValueStart(input: []const u8, start: usize) ?JsonDiagnosticField {
     if (start >= input.len or input[start] != '"') return null;
-    const key_end = start + 1 + field.len;
-    if (key_end >= input.len) return null;
-    if (!std.mem.eql(u8, input[start + 1 .. key_end], field)) return null;
-    if (input[key_end] != '"') return null;
-    var i = key_end + 1;
+    const key_quote_end = skipJsonString(input, start + 1);
+    if (key_quote_end <= start + 1 or key_quote_end > input.len or input[key_quote_end - 1] != '"') return null;
+    const key = input[start + 1 .. key_quote_end - 1];
+    var i = key_quote_end;
     while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
     if (i >= input.len or input[i] != ':') return null;
     i += 1;
     while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
     if (i >= input.len or input[i] != '"') return null;
-    return i;
+    return .{ .key = key, .value_quote = i };
 }
 
 fn skipJsonString(input: []const u8, start: usize) usize {
@@ -636,6 +652,69 @@ fn skipJsonString(input: []const u8, start: usize) usize {
         if (input[i] == '"') return i + 1;
     }
     return input.len;
+}
+
+const PlainDiagnosticField = struct {
+    key: []const u8,
+    value_start: usize,
+};
+
+fn plainValueStart(input: []const u8, start: usize) ?PlainDiagnosticField {
+    if (start >= input.len or !isDiagnosticKeyChar(input[start])) return null;
+    var key_end = start + 1;
+    while (key_end < input.len and isDiagnosticKeyChar(input[key_end])) : (key_end += 1) {}
+    var i = key_end;
+    while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
+    if (i >= input.len or (input[i] != ':' and input[i] != '=')) return null;
+    i += 1;
+    while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
+    return .{ .key = input[start..key_end], .value_start = i };
+}
+
+fn isDiagnosticKeyChar(b: u8) bool {
+    return std.ascii.isAlphanumeric(b) or b == '_' or b == '-' or b == '.';
+}
+
+fn skipPlainValue(input: []const u8, start: usize) usize {
+    if (start < input.len and input[start] == '"') return skipJsonString(input, start + 1);
+    var i = start;
+    while (i < input.len) : (i += 1) {
+        switch (input[i]) {
+            ' ', '\t', '\r', '\n', ',', ';', '&', '}' => return i,
+            else => {},
+        }
+    }
+    return input.len;
+}
+
+fn isSensitiveDiagnosticField(field: []const u8) bool {
+    const sensitive = [_][]const u8{
+        "contexttoken",
+        "aeskey",
+        "encryptqueryparam",
+        "encryptedparam",
+        "xencryptedparam",
+        "token",
+        "bottoken",
+        "accesstoken",
+        "authorization",
+        "ticket",
+    };
+    for (sensitive) |canonical| {
+        if (normalizedDiagnosticFieldEquals(field, canonical)) return true;
+    }
+    return false;
+}
+
+fn normalizedDiagnosticFieldEquals(field: []const u8, canonical: []const u8) bool {
+    var j: usize = 0;
+    for (field) |raw| {
+        if (raw == '_' or raw == '-' or raw == '.') continue;
+        if (j >= canonical.len) return false;
+        if (std.ascii.toLower(raw) != canonical[j]) return false;
+        j += 1;
+    }
+    return j == canonical.len;
 }
 
 fn appendLogEscapedByte(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, b: u8) !void {
@@ -755,18 +834,30 @@ test "readLocalFileAlloc rejects directories" {
 }
 
 test "safe response excerpts redact sensitive fields and omit binary bodies" {
-    const redacted = try safeResponseExcerptAlloc(std.testing.allocator, "{\"context_token\":\"ctx-1\",\"aes_key\":\"secret\",\"encrypt_query_param\":\"param\",\"bot_token\":\"bot\",\"message\":\"line\nnext\"}");
+    const redacted = try safeDiagnosticTextAlloc(std.testing.allocator, "{\"context_token\":\"ctx-1\",\"aesKey\":\"secret\",\"encryptQueryParam\":\"param\",\"x-encrypted-param\":\"header-param\",\"accessToken\":\"access\",\"bot_token\":\"bot\",\"message\":\"line\nnext\"}");
     defer std.testing.allocator.free(redacted);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "ctx-1") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "secret") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"param\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "header-param") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"access\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"bot\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "[redacted]") != null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\\n") != null);
 
-    const binary = try safeResponseExcerptAlloc(std.testing.allocator, "abc\x00def");
+    const message = try safeDiagnosticTextAlloc(std.testing.allocator, "failed contextToken=ctx-2 aes_key=key-2 encrypted_param=param-2");
+    defer std.testing.allocator.free(message);
+    try std.testing.expect(std.mem.indexOf(u8, message, "ctx-2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "key-2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "param-2") == null);
+
+    const binary = try safeDiagnosticTextAlloc(std.testing.allocator, "abc\x00def");
     defer std.testing.allocator.free(binary);
     try std.testing.expectEqualStrings("[binary body omitted]", binary);
+
+    const invalid_utf8 = try safeDiagnosticTextAlloc(std.testing.allocator, "abc\xffdef");
+    defer std.testing.allocator.free(invalid_utf8);
+    try std.testing.expectEqualStrings("[binary body omitted]", invalid_utf8);
 }
 
 test "readResponseBodyExcerpt caps diagnostic body reads" {
@@ -776,6 +867,7 @@ test "readResponseBodyExcerpt caps diagnostic body reads" {
     const excerpt = try readResponseBodyExcerpt(std.testing.allocator, &reader);
     defer std.testing.allocator.free(excerpt);
     try std.testing.expectEqual(@as(usize, Client.ERROR_BODY_EXCERPT_BYTES), excerpt.len);
+    try std.testing.expectError(error.EndOfStream, reader.takeByte());
 }
 
 test "voice attachment uploads as a file item through injected transport" {

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -694,6 +694,7 @@ fn isSensitiveDiagnosticField(field: []const u8) bool {
         "encryptqueryparam",
         "encryptedparam",
         "xencryptedparam",
+        "filekey",
         "token",
         "bottoken",
         "accesstoken",
@@ -834,22 +835,25 @@ test "readLocalFileAlloc rejects directories" {
 }
 
 test "safe response excerpts redact sensitive fields and omit binary bodies" {
-    const redacted = try safeDiagnosticTextAlloc(std.testing.allocator, "{\"context_token\":\"ctx-1\",\"aesKey\":\"secret\",\"encryptQueryParam\":\"param\",\"x-encrypted-param\":\"header-param\",\"accessToken\":\"access\",\"bot_token\":\"bot\",\"message\":\"line\nnext\"}");
+    const redacted = try safeDiagnosticTextAlloc(std.testing.allocator, "{\"context_token\":\"ctx-1\",\"aesKey\":\"secret\",\"encryptQueryParam\":\"param\",\"x-encrypted-param\":\"header-param\",\"accessToken\":\"access\",\"file_key\":\"file-secret\",\"fileKey\":\"camel-file-secret\",\"bot_token\":\"bot\",\"message\":\"line\nnext\"}");
     defer std.testing.allocator.free(redacted);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "ctx-1") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "secret") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"param\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "header-param") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"access\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "file-secret") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "camel-file-secret") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"bot\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "[redacted]") != null);
     try std.testing.expect(std.mem.indexOf(u8, redacted, "\\n") != null);
 
-    const message = try safeDiagnosticTextAlloc(std.testing.allocator, "failed contextToken=ctx-2 aes_key=key-2 encrypted_param=param-2");
+    const message = try safeDiagnosticTextAlloc(std.testing.allocator, "failed contextToken=ctx-2 aes_key=key-2 encrypted_param=param-2 fileKey=file-2");
     defer std.testing.allocator.free(message);
     try std.testing.expect(std.mem.indexOf(u8, message, "ctx-2") == null);
     try std.testing.expect(std.mem.indexOf(u8, message, "key-2") == null);
     try std.testing.expect(std.mem.indexOf(u8, message, "param-2") == null);
+    try std.testing.expect(std.mem.indexOf(u8, message, "file-2") == null);
 
     const binary = try safeDiagnosticTextAlloc(std.testing.allocator, "abc\x00def");
     defer std.testing.allocator.free(binary);

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -2,6 +2,7 @@
 //! the dev host (no live WeChat endpoint); logic that consumes this goes through
 //! ClientApi so the poller can be tested with a fake.
 const std = @import("std");
+const builtin = @import("builtin");
 const codec = @import("ilink_codec.zig");
 const media = @import("media.zig");
 const types = @import("types.zig");
@@ -49,6 +50,28 @@ pub const Client = struct {
     token: []const u8,
     rng: std.Random.DefaultPrng,
     rng_mutex: std.Thread.Mutex = .{},
+    transport_ctx: ?*anyopaque = null,
+    fetch_impl: FetchImpl = httpFetch,
+    cdn_upload_impl: CdnUploadImpl = httpUploadBufferToCdn,
+
+    const ERROR_BODY_EXCERPT_BYTES = 256;
+    const FetchImpl = *const fn (
+        ctx: ?*anyopaque,
+        client: *Client,
+        arena: std.mem.Allocator,
+        method: std.http.Method,
+        path: []const u8,
+        payload: ?[]const u8,
+        client_version: ?[]const u8,
+    ) anyerror![]u8;
+    const CdnUploadImpl = *const fn (
+        ctx: ?*anyopaque,
+        client: *Client,
+        arena: std.mem.Allocator,
+        upload_url: []const u8,
+        ticket: []const u8,
+        encrypted: []u8,
+    ) anyerror![]u8;
 
     const UploadedLocalFile = struct {
         media: types.CdnMedia,
@@ -180,6 +203,7 @@ pub const Client = struct {
         const plain = readLocalFileAlloc(arena, path) catch |err| switch (err) {
             error.FileNotFound => return error.WeixinAttachmentFileNotFound,
             error.IsDir => return error.WeixinAttachmentPathIsDirectory,
+            error.WeixinAttachmentNotRegularFile => return error.WeixinAttachmentNotRegularFile,
             else => return err,
         };
         const md5 = try media.md5Hex(arena, plain);
@@ -254,6 +278,17 @@ pub const Client = struct {
     }
 
     fn uploadBufferToCdn(self: *Client, arena: std.mem.Allocator, upload_url: []const u8, ticket: []const u8, encrypted: []u8) ![]u8 {
+        return self.cdn_upload_impl(self.transport_ctx, self, arena, upload_url, ticket, encrypted);
+    }
+
+    fn httpUploadBufferToCdn(
+        _: ?*anyopaque,
+        self: *Client,
+        arena: std.mem.Allocator,
+        upload_url: []const u8,
+        ticket: []const u8,
+        encrypted: []u8,
+    ) ![]u8 {
         var client: std.http.Client = .{ .allocator = self.allocator };
         defer client.deinit();
 
@@ -281,12 +316,27 @@ pub const Client = struct {
 
         var transfer_buffer: [16 * 1024]u8 = undefined;
         const reader = response.reader(&transfer_buffer);
-        var discard_buffer: [1024]u8 = undefined;
-        var discarding: std.Io.Writer.Discarding = .init(&discard_buffer);
-        _ = reader.streamRemaining(&discarding.writer) catch return error.WeixinCdnUploadFailed;
+        var response_body: std.Io.Writer.Allocating = .init(arena);
+        _ = reader.streamRemaining(&response_body.writer) catch |err| {
+            std.debug.print("weixin upload-cdn({d}): status=read_failed err={}\n", .{ std.time.milliTimestamp(), err });
+            return error.WeixinCdnUploadFailed;
+        };
+        const response_items = response_body.toArrayList().items;
 
-        if (response.head.status != .ok) return error.WeixinCdnUploadFailed;
-        return encrypted_param orelse error.WeixinCdnMissingEncryptedParam;
+        if (response.head.status != .ok) {
+            std.debug.print("weixin upload-cdn({d}): status=failed http_status={} body_excerpt={s}\n", .{
+                std.time.milliTimestamp(),
+                response.head.status,
+                responseExcerpt(response_items),
+            });
+            return error.WeixinCdnUploadFailed;
+        }
+        if (encrypted_param) |param| return param;
+        std.debug.print("weixin upload-cdn({d}): status=missing-encrypted-param body_excerpt={s}\n", .{
+            std.time.milliTimestamp(),
+            responseExcerpt(response_items),
+        });
+        return error.WeixinCdnMissingEncryptedParam;
     }
 
     fn postSendMessage(self: *Client, arena: std.mem.Allocator, body: []const u8) !void {
@@ -296,17 +346,34 @@ pub const Client = struct {
             .ignore_unknown_fields = true,
             .allocate = .alloc_always,
         });
-        if (w.ret) |ret| {
-            if (ret != 0) {
-                std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
-                return error.IlinkSendMessageFailed;
-            }
+        const ret = w.ret orelse {
+            std.debug.print("weixin send({d}): kind=attachment status=malformed body_excerpt={s}\n", .{
+                std.time.milliTimestamp(),
+                responseExcerpt(resp),
+            });
+            return error.IlinkSendMessageMalformed;
+        };
+        if (ret != 0) {
+            std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
+            return error.IlinkSendMessageFailed;
         }
     }
 
     /// Performs one HTTP request, returning the response body bytes allocated in
     /// `arena`. `client_version`, when set, adds the iLink-App-ClientVersion header.
     fn fetch(
+        self: *Client,
+        arena: std.mem.Allocator,
+        method: std.http.Method,
+        path: []const u8,
+        payload: ?[]const u8,
+        client_version: ?[]const u8,
+    ) ![]u8 {
+        return self.fetch_impl(self.transport_ctx, self, arena, method, path, payload, client_version);
+    }
+
+    fn httpFetch(
+        _: ?*anyopaque,
         self: *Client,
         arena: std.mem.Allocator,
         method: std.http.Method,
@@ -351,8 +418,17 @@ pub const Client = struct {
             .extra_headers = headers_buf[0..header_count],
             .response_writer = &body.writer,
         });
-        if (response.status != .ok) return error.IlinkHttpStatus;
-        return body.toArrayList().items;
+        const response_items = body.toArrayList().items;
+        if (response.status != .ok) {
+            std.debug.print("weixin http({d}): endpoint={s} status=failed http_status={} body_excerpt={s}\n", .{
+                std.time.milliTimestamp(),
+                endpointForLog(path),
+                response.status,
+                responseExcerpt(response_items),
+            });
+            return error.IlinkHttpStatus;
+        }
+        return response_items;
     }
 
     fn nextRandomU32(self: *Client) u32 {
@@ -415,17 +491,32 @@ fn appendQueryEscaped(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Alloc
 }
 
 fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    if (std.fs.path.isAbsolute(path)) {
-        const file = try std.fs.openFileAbsolute(path, .{});
-        defer file.close();
-        return file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.fs.openFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+
+    const stat = try file.stat();
+    switch (stat.kind) {
+        .file => return file.readToEndAlloc(allocator, std.math.maxInt(usize)),
+        .directory => return error.IsDir,
+        else => return error.WeixinAttachmentNotRegularFile,
     }
-    return std.fs.cwd().readFileAlloc(allocator, path, std.math.maxInt(usize));
 }
 
 fn displayNameOrBasename(display_name: []const u8, path: []const u8) []const u8 {
     if (display_name.len != 0) return display_name;
     return std.fs.path.basename(path);
+}
+
+fn endpointForLog(path: []const u8) []const u8 {
+    const query_index = std.mem.indexOfScalar(u8, path, '?') orelse return path;
+    return path[0..query_index];
+}
+
+fn responseExcerpt(body: []const u8) []const u8 {
+    return body[0..@min(body.len, Client.ERROR_BODY_EXCERPT_BYTES)];
 }
 
 test "client init defaults the base url" {
@@ -513,4 +604,103 @@ test "voice attachment uses file path handling before network access" {
         error.WeixinAttachmentFileNotFound,
         c.sendAttachment(.voice, "definitely-missing-file.mp3", "", "u", "ctx"),
     );
+}
+
+test "readLocalFileAlloc rejects non-regular files" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    if (readLocalFileAlloc(std.testing.allocator, "/dev/null")) |bytes| {
+        defer std.testing.allocator.free(bytes);
+        return error.TestUnexpectedResult;
+    } else |err| {
+        try std.testing.expectEqual(error.WeixinAttachmentNotRegularFile, err);
+    }
+}
+
+test "voice attachment uploads as a file item through injected transport" {
+    const Capture = struct {
+        getuploadurl_body: std.ArrayListUnmanaged(u8) = .empty,
+        sendmessage_body: std.ArrayListUnmanaged(u8) = .empty,
+        cdn_url: std.ArrayListUnmanaged(u8) = .empty,
+        cdn_ticket: std.ArrayListUnmanaged(u8) = .empty,
+        encrypted_len: usize = 0,
+
+        fn deinit(self: *@This()) void {
+            self.getuploadurl_body.deinit(std.testing.allocator);
+            self.sendmessage_body.deinit(std.testing.allocator);
+            self.cdn_url.deinit(std.testing.allocator);
+            self.cdn_ticket.deinit(std.testing.allocator);
+        }
+
+        fn fetch(
+            ctx: ?*anyopaque,
+            client: *Client,
+            arena: std.mem.Allocator,
+            method: std.http.Method,
+            path: []const u8,
+            payload: ?[]const u8,
+            client_version: ?[]const u8,
+        ) anyerror![]u8 {
+            _ = client;
+            _ = client_version;
+            try std.testing.expectEqual(std.http.Method.POST, method);
+            const self: *@This() = @ptrCast(@alignCast(ctx.?));
+            if (std.mem.eql(u8, path, "/ilink/bot/getuploadurl")) {
+                try self.getuploadurl_body.appendSlice(std.testing.allocator, payload.?);
+                return arena.dupe(u8,
+                    \\{"ret":0,"url":"https://cdn.test/upload","ticket":"ticket=abc","file_key":"server-file-key"}
+                );
+            }
+            if (std.mem.eql(u8, path, "/ilink/bot/sendmessage")) {
+                try self.sendmessage_body.appendSlice(std.testing.allocator, payload.?);
+                return arena.dupe(u8, "{\"ret\":0}");
+            }
+            return error.UnexpectedPath;
+        }
+
+        fn uploadCdn(
+            ctx: ?*anyopaque,
+            client: *Client,
+            arena: std.mem.Allocator,
+            upload_url: []const u8,
+            ticket: []const u8,
+            encrypted: []u8,
+        ) anyerror![]u8 {
+            _ = client;
+            const self: *@This() = @ptrCast(@alignCast(ctx.?));
+            try self.cdn_url.appendSlice(std.testing.allocator, upload_url);
+            try self.cdn_ticket.appendSlice(std.testing.allocator, ticket);
+            self.encrypted_len = encrypted.len;
+            return arena.dupe(u8, "encrypted-param");
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "voice.mp3", .data = "hello" });
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ root, "voice.mp3" });
+    defer std.testing.allocator.free(path);
+
+    var capture = Capture{};
+    defer capture.deinit();
+    var c = Client.init(std.testing.allocator, "https://x.test", "tok");
+    c.transport_ctx = &capture;
+    c.fetch_impl = Capture.fetch;
+    c.cdn_upload_impl = Capture.uploadCdn;
+
+    try c.sendAttachment(.voice, path, "", "wx-user", "ctx-1");
+
+    try std.testing.expect(std.mem.indexOf(u8, capture.getuploadurl_body.items, "\"media_type\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.getuploadurl_body.items, "\"size\":5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.getuploadurl_body.items, "\"md5\":\"5d41402abc4b2a76b9719d911017c592\"") != null);
+    try std.testing.expectEqualStrings("https://cdn.test/upload", capture.cdn_url.items);
+    try std.testing.expectEqualStrings("ticket=abc", capture.cdn_ticket.items);
+    try std.testing.expectEqual(@as(usize, 16), capture.encrypted_len);
+    try std.testing.expect(std.mem.indexOf(u8, capture.sendmessage_body.items, "\"type\":4") != null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.sendmessage_body.items, "\"file_item\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.sendmessage_body.items, "\"voice_item\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.sendmessage_body.items, "\"file_name\":\"voice.mp3\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, capture.sendmessage_body.items, "\"encrypt_query_param\":\"encrypted-param\"") != null);
 }

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -316,25 +316,23 @@ pub const Client = struct {
 
         var transfer_buffer: [16 * 1024]u8 = undefined;
         const reader = response.reader(&transfer_buffer);
-        var response_body: std.Io.Writer.Allocating = .init(arena);
-        _ = reader.streamRemaining(&response_body.writer) catch |err| {
+        const response_excerpt = readResponseBodyExcerpt(arena, reader) catch |err| {
             std.debug.print("weixin upload-cdn({d}): status=read_failed err={}\n", .{ std.time.milliTimestamp(), err });
             return error.WeixinCdnUploadFailed;
         };
-        const response_items = response_body.toArrayList().items;
 
         if (response.head.status != .ok) {
             std.debug.print("weixin upload-cdn({d}): status=failed http_status={} body_excerpt={s}\n", .{
                 std.time.milliTimestamp(),
                 response.head.status,
-                responseExcerpt(response_items),
+                logSafeResponseExcerpt(arena, response_excerpt),
             });
             return error.WeixinCdnUploadFailed;
         }
         if (encrypted_param) |param| return param;
         std.debug.print("weixin upload-cdn({d}): status=missing-encrypted-param body_excerpt={s}\n", .{
             std.time.milliTimestamp(),
-            responseExcerpt(response_items),
+            logSafeResponseExcerpt(arena, response_excerpt),
         });
         return error.WeixinCdnMissingEncryptedParam;
     }
@@ -349,7 +347,7 @@ pub const Client = struct {
         const ret = w.ret orelse {
             std.debug.print("weixin send({d}): kind=attachment status=malformed body_excerpt={s}\n", .{
                 std.time.milliTimestamp(),
-                responseExcerpt(resp),
+                logSafeResponseExcerpt(arena, resp),
             });
             return error.IlinkSendMessageMalformed;
         };
@@ -424,7 +422,7 @@ pub const Client = struct {
                 std.time.milliTimestamp(),
                 endpointForLog(path),
                 response.status,
-                responseExcerpt(response_items),
+                logSafeResponseExcerpt(arena, response_items),
             });
             return error.IlinkHttpStatus;
         }
@@ -491,17 +489,51 @@ fn appendQueryEscaped(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Alloc
 }
 
 fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const path_kind = try localPathKind(path);
+    switch (path_kind) {
+        .file => {},
+        .directory => return error.IsDir,
+        else => return error.WeixinAttachmentNotRegularFile,
+    }
+
     var file = if (std.fs.path.isAbsolute(path))
         try std.fs.openFileAbsolute(path, .{})
     else
         try std.fs.cwd().openFile(path, .{});
     defer file.close();
 
+    // Re-check the opened handle so a path replaced after the initial stat is
+    // not read if it no longer resolves to a regular file.
     const stat = try file.stat();
     switch (stat.kind) {
         .file => return file.readToEndAlloc(allocator, std.math.maxInt(usize)),
         .directory => return error.IsDir,
         else => return error.WeixinAttachmentNotRegularFile,
+    }
+}
+
+fn localPathKind(path: []const u8) !std.fs.File.Kind {
+    const stat = std.fs.cwd().statFile(path) catch |err| switch (err) {
+        error.IsDir => return .directory,
+        error.AccessDenied => {
+            if (pathIsDirectory(path)) return .directory;
+            return err;
+        },
+        else => return err,
+    };
+    return stat.kind;
+}
+
+fn pathIsDirectory(path: []const u8) bool {
+    var dir = if (std.fs.path.isAbsolute(path))
+        std.fs.openDirAbsolute(path, .{})
+    else
+        std.fs.cwd().openDir(path, .{});
+    if (dir) |*d| {
+        d.close();
+        return true;
+    } else |_| {
+        return false;
     }
 }
 
@@ -515,8 +547,104 @@ fn endpointForLog(path: []const u8) []const u8 {
     return path[0..query_index];
 }
 
-fn responseExcerpt(body: []const u8) []const u8 {
-    return body[0..@min(body.len, Client.ERROR_BODY_EXCERPT_BYTES)];
+fn readResponseBodyExcerpt(allocator: std.mem.Allocator, reader: *std.Io.Reader) ![]u8 {
+    const out = try allocator.alloc(u8, Client.ERROR_BODY_EXCERPT_BYTES);
+    errdefer allocator.free(out);
+    const len = try reader.readSliceShort(out);
+    _ = try reader.discardRemaining();
+    return allocator.realloc(out, len);
+}
+
+fn logSafeResponseExcerpt(allocator: std.mem.Allocator, body: []const u8) []const u8 {
+    return safeResponseExcerptAlloc(allocator, body) catch "[response excerpt unavailable]";
+}
+
+fn safeResponseExcerptAlloc(allocator: std.mem.Allocator, body: []const u8) ![]u8 {
+    const capped = body[0..@min(body.len, Client.ERROR_BODY_EXCERPT_BYTES)];
+    if (looksBinary(capped)) return allocator.dupe(u8, "[binary body omitted]");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var i: usize = 0;
+    while (i < capped.len) {
+        if (try appendRedactedJsonField(&out, allocator, capped, &i)) continue;
+        try appendLogEscapedByte(&out, allocator, capped[i]);
+        i += 1;
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+fn looksBinary(bytes: []const u8) bool {
+    for (bytes) |b| {
+        if (b == 0 or b == 0x7f) return true;
+        if (b < 0x20 and b != '\n' and b != '\r' and b != '\t') return true;
+    }
+    return false;
+}
+
+fn appendRedactedJsonField(
+    out: *std.ArrayListUnmanaged(u8),
+    allocator: std.mem.Allocator,
+    input: []const u8,
+    index: *usize,
+) !bool {
+    const fields = [_][]const u8{
+        "context_token",
+        "aes_key",
+        "encrypt_query_param",
+        "token",
+        "bot_token",
+        "access_token",
+        "authorization",
+        "Authorization",
+        "ticket",
+    };
+    for (fields) |field| {
+        if (jsonStringValueStart(input, index.*, field)) |value_quote| {
+            try out.appendSlice(allocator, input[index.* .. value_quote + 1]);
+            try out.appendSlice(allocator, "[redacted]");
+            try out.append(allocator, '"');
+            index.* = skipJsonString(input, value_quote + 1);
+            return true;
+        }
+    }
+    return false;
+}
+
+fn jsonStringValueStart(input: []const u8, start: usize, field: []const u8) ?usize {
+    if (start >= input.len or input[start] != '"') return null;
+    const key_end = start + 1 + field.len;
+    if (key_end >= input.len) return null;
+    if (!std.mem.eql(u8, input[start + 1 .. key_end], field)) return null;
+    if (input[key_end] != '"') return null;
+    var i = key_end + 1;
+    while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
+    if (i >= input.len or input[i] != ':') return null;
+    i += 1;
+    while (i < input.len and std.ascii.isWhitespace(input[i])) : (i += 1) {}
+    if (i >= input.len or input[i] != '"') return null;
+    return i;
+}
+
+fn skipJsonString(input: []const u8, start: usize) usize {
+    var i = start;
+    while (i < input.len) : (i += 1) {
+        if (input[i] == '\\') {
+            if (i + 1 < input.len) i += 1;
+            continue;
+        }
+        if (input[i] == '"') return i + 1;
+    }
+    return input.len;
+}
+
+fn appendLogEscapedByte(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, b: u8) !void {
+    switch (b) {
+        '\n' => try out.appendSlice(allocator, "\\n"),
+        '\r' => try out.appendSlice(allocator, "\\r"),
+        '\t' => try out.appendSlice(allocator, "\\t"),
+        else => try out.append(allocator, b),
+    }
 }
 
 test "client init defaults the base url" {
@@ -615,6 +743,39 @@ test "readLocalFileAlloc rejects non-regular files" {
     } else |err| {
         try std.testing.expectEqual(error.WeixinAttachmentNotRegularFile, err);
     }
+}
+
+test "readLocalFileAlloc rejects directories" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    try std.testing.expectError(error.IsDir, readLocalFileAlloc(std.testing.allocator, root));
+}
+
+test "safe response excerpts redact sensitive fields and omit binary bodies" {
+    const redacted = try safeResponseExcerptAlloc(std.testing.allocator, "{\"context_token\":\"ctx-1\",\"aes_key\":\"secret\",\"encrypt_query_param\":\"param\",\"bot_token\":\"bot\",\"message\":\"line\nnext\"}");
+    defer std.testing.allocator.free(redacted);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "ctx-1") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "secret") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"param\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "\":\"bot\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "[redacted]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, redacted, "\\n") != null);
+
+    const binary = try safeResponseExcerptAlloc(std.testing.allocator, "abc\x00def");
+    defer std.testing.allocator.free(binary);
+    try std.testing.expectEqualStrings("[binary body omitted]", binary);
+}
+
+test "readResponseBodyExcerpt caps diagnostic body reads" {
+    var long_body: [Client.ERROR_BODY_EXCERPT_BYTES + 64]u8 = undefined;
+    @memset(long_body[0..], 'a');
+    var reader: std.Io.Reader = .fixed(&long_body);
+    const excerpt = try readResponseBodyExcerpt(std.testing.allocator, &reader);
+    defer std.testing.allocator.free(excerpt);
+    try std.testing.expectEqual(@as(usize, Client.ERROR_BODY_EXCERPT_BYTES), excerpt.len);
 }
 
 test "voice attachment uploads as a file item through injected transport" {

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -300,7 +300,7 @@ pub const Client = struct {
         const reader = response.reader(&transfer_buffer);
         var discard_buffer: [1024]u8 = undefined;
         var discarding: std.Io.Writer.Discarding = .init(&discard_buffer);
-        _ = reader.streamRemaining(&discarding.writer) catch {};
+        _ = reader.streamRemaining(&discarding.writer) catch return error.WeixinCdnUploadFailed;
 
         if (response.head.status != .ok) return error.WeixinCdnUploadFailed;
         return encrypted_param orelse error.WeixinCdnMissingEncryptedParam;
@@ -315,7 +315,7 @@ pub const Client = struct {
         });
         if (w.ret) |ret| {
             if (ret != 0) {
-                std.debug.print("weixin send({d}): kind=sendmessage status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
+                std.debug.print("weixin send({d}): kind=attachment status=failed ret={} errcode={} message={s}\n", .{ std.time.milliTimestamp(), ret, w.errcode, w.message });
                 return error.IlinkSendMessageFailed;
             }
         }
@@ -333,23 +333,19 @@ pub const Client = struct {
             "json",
             path,
         };
-        var child = std.process.Child.init(&argv, arena);
-        child.stdin_behavior = .Ignore;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Ignore;
-        child.create_no_window = true;
-        child.spawn() catch |err| switch (err) {
+        const result = std.process.Child.run(.{
+            .allocator = arena,
+            .argv = &argv,
+            .max_output_bytes = 64 * 1024,
+        }) catch |err| switch (err) {
             error.FileNotFound => return error.FfprobeNotFound,
             else => return error.FfprobeFailed,
         };
-
-        const stdout = if (child.stdout) |out| try out.readToEndAlloc(arena, 64 * 1024) else "";
-        const term = child.wait() catch return error.FfprobeFailed;
-        switch (term) {
+        switch (result.term) {
             .Exited => |code| if (code != 0) return error.FfprobeFailed,
             else => return error.FfprobeFailed,
         }
-        return media.parseFfprobeVoiceMetadata(arena, stdout, path);
+        return media.parseFfprobeVoiceMetadata(arena, result.stdout, path);
     }
 
     /// Performs one HTTP request, returning the response body bytes allocated in
@@ -409,10 +405,8 @@ pub const Client = struct {
         return self.rng.random().int(u32);
     }
 
-    fn randomBytes(self: *Client, out: []u8) void {
-        self.rng_mutex.lock();
-        defer self.rng_mutex.unlock();
-        self.rng.random().bytes(out);
+    fn randomBytes(_: *Client, out: []u8) void {
+        std.crypto.random.bytes(out);
     }
 
     // --- ClientApi adapter ---

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -144,9 +144,8 @@ pub const Client = struct {
         context_token: []const u8,
     ) !void {
         return switch (kind) {
-            .file => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
+            .file, .voice => self.sendFileAttachment(path, displayNameOrBasename(display_name, path), to_user_id, context_token),
             .image => self.sendImageFile(path, to_user_id, context_token),
-            .voice => self.sendVoiceFile(path, to_user_id, context_token),
         };
     }
 
@@ -173,22 +172,6 @@ pub const Client = struct {
         const body = try codec.buildSendUploadedImageBody(a, to_user_id, context_token, client_id, .{
             .media = uploaded.media,
             .mid_size = uploaded.encrypted_len,
-        });
-        try self.postSendMessage(a, body);
-    }
-
-    fn sendVoiceFile(self: *Client, path: []const u8, to_user_id: []const u8, context_token: []const u8) !void {
-        var req_arena = std.heap.ArenaAllocator.init(self.allocator);
-        defer req_arena.deinit();
-        const a = req_arena.allocator();
-        const metadata = try self.probeVoiceFile(a, path);
-        const uploaded = try self.uploadLocalFile(a, .voice, path);
-        const client_id = try self.clientId(a);
-        const body = try codec.buildSendUploadedVoiceBody(a, to_user_id, context_token, client_id, .{
-            .media = uploaded.media,
-            .encode_type = metadata.encode_type,
-            .sample_rate = metadata.sample_rate,
-            .playtime = metadata.playtime,
         });
         try self.postSendMessage(a, body);
     }
@@ -270,7 +253,7 @@ pub const Client = struct {
         };
     }
 
-    fn uploadBufferToCdn(self: *Client, arena: std.mem.Allocator, upload_url: []const u8, ticket: []const u8, encrypted: []const u8) ![]u8 {
+    fn uploadBufferToCdn(self: *Client, arena: std.mem.Allocator, upload_url: []const u8, ticket: []const u8, encrypted: []u8) ![]u8 {
         var client: std.http.Client = .{ .allocator = self.allocator };
         defer client.deinit();
 
@@ -319,33 +302,6 @@ pub const Client = struct {
                 return error.IlinkSendMessageFailed;
             }
         }
-    }
-
-    fn probeVoiceFile(self: *Client, arena: std.mem.Allocator, path: []const u8) !types.VoiceMetadata {
-        _ = self;
-        const argv = [_][]const u8{
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            "stream=codec_type,codec_name,sample_rate,duration:format=duration",
-            "-of",
-            "json",
-            path,
-        };
-        const result = std.process.Child.run(.{
-            .allocator = arena,
-            .argv = &argv,
-            .max_output_bytes = 64 * 1024,
-        }) catch |err| switch (err) {
-            error.FileNotFound => return error.FfprobeNotFound,
-            else => return error.FfprobeFailed,
-        };
-        switch (result.term) {
-            .Exited => |code| if (code != 0) return error.FfprobeFailed,
-            else => return error.FfprobeFailed,
-        }
-        return media.parseFfprobeVoiceMetadata(arena, result.stdout, path);
     }
 
     /// Performs one HTTP request, returning the response body bytes allocated in
@@ -549,4 +505,12 @@ test "client ids are generated with the wispterm weixin prefix" {
     const id = try c.clientId(std.testing.allocator);
     defer std.testing.allocator.free(id);
     try std.testing.expect(std.mem.startsWith(u8, id, "wispterm-weixin-"));
+}
+
+test "voice attachment uses file path handling before network access" {
+    var c = Client.init(std.testing.allocator, "https://x.test", "tok");
+    try std.testing.expectError(
+        error.WeixinAttachmentFileNotFound,
+        c.sendAttachment(.voice, "definitely-missing-file.mp3", "", "u", "ctx"),
+    );
 }

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -561,7 +561,6 @@ fn readResponseBodyExcerpt(allocator: std.mem.Allocator, reader: *std.Io.Reader)
     const out = try allocator.alloc(u8, Client.ERROR_BODY_EXCERPT_BYTES);
     errdefer allocator.free(out);
     const len = try reader.readSliceShort(out);
-    _ = try reader.discardRemaining();
     return allocator.realloc(out, len);
 }
 
@@ -680,7 +679,7 @@ fn skipPlainValue(input: []const u8, start: usize) usize {
     var i = start;
     while (i < input.len) : (i += 1) {
         switch (input[i]) {
-            ' ', '\t', '\r', '\n', ',', ';', '&', '}' => return i,
+            '\r', '\n', ',', ';', '&', '}' => return i,
             else => {},
         }
     }
@@ -855,6 +854,16 @@ test "safe response excerpts redact sensitive fields and omit binary bodies" {
     try std.testing.expect(std.mem.indexOf(u8, message, "param-2") == null);
     try std.testing.expect(std.mem.indexOf(u8, message, "file-2") == null);
 
+    const bearer = try safeDiagnosticTextAlloc(std.testing.allocator, "Authorization: Bearer secret-token\nstatus=401");
+    defer std.testing.allocator.free(bearer);
+    try std.testing.expect(std.mem.indexOf(u8, bearer, "secret-token") == null);
+    try std.testing.expect(std.mem.indexOf(u8, bearer, "status=401") != null);
+
+    const spaced = try safeDiagnosticTextAlloc(std.testing.allocator, "access_token: tok with suffix; ret=1");
+    defer std.testing.allocator.free(spaced);
+    try std.testing.expect(std.mem.indexOf(u8, spaced, "tok with suffix") == null);
+    try std.testing.expect(std.mem.indexOf(u8, spaced, "ret=1") != null);
+
     const binary = try safeDiagnosticTextAlloc(std.testing.allocator, "abc\x00def");
     defer std.testing.allocator.free(binary);
     try std.testing.expectEqualStrings("[binary body omitted]", binary);
@@ -871,7 +880,7 @@ test "readResponseBodyExcerpt caps diagnostic body reads" {
     const excerpt = try readResponseBodyExcerpt(std.testing.allocator, &reader);
     defer std.testing.allocator.free(excerpt);
     try std.testing.expectEqual(@as(usize, Client.ERROR_BODY_EXCERPT_BYTES), excerpt.len);
-    try std.testing.expectError(error.EndOfStream, reader.takeByte());
+    try std.testing.expectEqual(@as(u8, 'a'), try reader.takeByte());
 }
 
 test "voice attachment uploads as a file item through injected transport" {

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -53,6 +53,159 @@ pub fn buildSendTextBody(
     }, .{});
 }
 
+const WireCdnMedia = struct {
+    encrypt_query_param: []const u8,
+    aes_key: []const u8,
+    encrypt_type: i64 = 1,
+};
+
+fn wireMedia(media: types.CdnMedia) WireCdnMedia {
+    return .{
+        .encrypt_query_param = media.encrypt_query_param,
+        .aes_key = media.aes_key,
+        .encrypt_type = media.encrypt_type,
+    };
+}
+
+pub fn buildSendUploadedFileBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    file: types.UploadedFileAttachment,
+) ![]u8 {
+    const FileItem = struct {
+        media: WireCdnMedia,
+        file_name: []const u8,
+        len: []const u8,
+    };
+    const Item = struct { type: i64 = 4, file_item: FileItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const len_text = try std.fmt.allocPrint(allocator, "{d}", .{file.len});
+    defer allocator.free(len_text);
+    const items = [_]Item{.{ .file_item = .{
+        .media = wireMedia(file.media),
+        .file_name = file.file_name,
+        .len = len_text,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildSendUploadedImageBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    image: types.UploadedImage,
+) ![]u8 {
+    const ImageItem = struct {
+        media: WireCdnMedia,
+        mid_size: u64,
+    };
+    const Item = struct { type: i64 = 2, image_item: ImageItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const items = [_]Item{.{ .image_item = .{
+        .media = wireMedia(image.media),
+        .mid_size = image.mid_size,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildSendUploadedVoiceBody(
+    allocator: std.mem.Allocator,
+    to_user_id: []const u8,
+    context_token: []const u8,
+    client_id: []const u8,
+    voice: types.UploadedVoice,
+) ![]u8 {
+    const VoiceItem = struct {
+        media: WireCdnMedia,
+        encode_type: i64,
+        sample_rate: i64,
+        playtime: i64,
+    };
+    const Item = struct { type: i64 = 3, voice_item: VoiceItem };
+    const Msg = struct {
+        to_user_id: []const u8,
+        client_id: []const u8,
+        message_type: i64 = 2,
+        message_state: i64 = 2,
+        context_token: []const u8,
+        item_list: []const Item,
+    };
+    const Body = struct { msg: Msg, base_info: BaseInfo };
+    const items = [_]Item{.{ .voice_item = .{
+        .media = wireMedia(voice.media),
+        .encode_type = voice.encode_type,
+        .sample_rate = voice.sample_rate,
+        .playtime = voice.playtime,
+    } }};
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .msg = .{
+            .to_user_id = to_user_id,
+            .client_id = client_id,
+            .context_token = context_token,
+            .item_list = &items,
+        },
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
+pub fn buildGetUploadUrlBody(
+    allocator: std.mem.Allocator,
+    kind: types.AttachmentKind,
+    size: u64,
+    md5: []const u8,
+    file_key: []const u8,
+) ![]u8 {
+    const Body = struct {
+        media_type: i64,
+        size: u64,
+        md5: []const u8,
+        file_key: []const u8,
+        base_info: BaseInfo,
+    };
+    return std.json.Stringify.valueAlloc(allocator, Body{
+        .media_type = kind.uploadMediaType(),
+        .size = size,
+        .md5 = md5,
+        .file_key = file_key,
+        .base_info = .{ .channel_version = CHANNEL_VERSION },
+    }, .{});
+}
+
 pub fn statusKindFromString(s: []const u8) types.QrStatusKind {
     if (std.mem.eql(u8, s, "wait")) return .wait;
     if (std.mem.eql(u8, s, "scaned")) return .scaned;
@@ -92,6 +245,44 @@ pub const ParsedUpdates = struct {
         self.parsed.deinit();
     }
 };
+
+const WireUploadUrl = struct {
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    message: []const u8 = "",
+    url: []const u8 = "",
+    ticket: []const u8 = "",
+    file_key: []const u8 = "",
+};
+
+pub const ParsedUploadUrl = struct {
+    parsed: std.json.Parsed(WireUploadUrl),
+    value: types.UploadUrl,
+
+    pub fn deinit(self: *ParsedUploadUrl) void {
+        self.parsed.deinit();
+    }
+};
+
+pub fn parseGetUploadUrl(allocator: std.mem.Allocator, json: []const u8) !ParsedUploadUrl {
+    const parsed = try std.json.parseFromSlice(WireUploadUrl, allocator, json, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    errdefer parsed.deinit();
+    const wire = parsed.value;
+    return .{
+        .parsed = parsed,
+        .value = .{
+            .ret = wire.ret,
+            .errcode = wire.errcode,
+            .message = wire.message,
+            .url = wire.url,
+            .ticket = wire.ticket,
+            .file_key = wire.file_key,
+        },
+    };
+}
 
 pub fn parseGetUpdates(allocator: std.mem.Allocator, json: []const u8) !ParsedUpdates {
     const parsed = try std.json.parseFromSlice(WireUpdates, allocator, json, .{
@@ -166,4 +357,95 @@ test "maps qrcode status strings to the enum" {
     try t.expectEqual(types.QrStatusKind.scaned, statusKindFromString("scaned"));
     try t.expectEqual(types.QrStatusKind.confirmed, statusKindFromString("confirmed"));
     try t.expectEqual(types.QrStatusKind.unknown, statusKindFromString("nonsense"));
+}
+
+test "builds getuploadurl body for file media" {
+    const body = try buildGetUploadUrlBody(t.allocator, .file, 123, "900150983cd24fb0d6963f7d28e17f72", "file-key");
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"media_type\":3") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"size\":123") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"md5\":\"900150983cd24fb0d6963f7d28e17f72\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"file_key\":\"file-key\"") != null);
+}
+
+test "parses getuploadurl response" {
+    var parsed = try parseGetUploadUrl(t.allocator,
+        \\{"ret":0,"errcode":0,"url":"https://cdn.example/upload","ticket":"ticket=abc","file_key":"file-key"}
+    );
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 0), parsed.value.ret);
+    try t.expectEqualStrings("https://cdn.example/upload", parsed.value.url);
+    try t.expectEqualStrings("ticket=abc", parsed.value.ticket);
+    try t.expectEqualStrings("file-key", parsed.value.file_key);
+}
+
+test "builds uploaded file sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedFileBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .file_name = "report.pdf",
+        .len = 123,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":4") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"file_name\":\"report.pdf\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"len\":\"123\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"encrypt_query_param\":\"encrypted-param\"") != null);
+}
+
+test "builds uploaded image sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedImageBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .mid_size = 64,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"image_item\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"mid_size\":64") != null);
+}
+
+test "builds uploaded voice sendmessage body" {
+    const media = types.CdnMedia{
+        .encrypt_query_param = "encrypted-param",
+        .aes_key = "encoded-key",
+        .md5 = "md5",
+        .size = 64,
+        .file_key = "file-key",
+    };
+    const body = try buildSendUploadedVoiceBody(t.allocator, "u1", "ctx", "cid", .{
+        .media = media,
+        .encode_type = 7,
+        .sample_rate = 44100,
+        .playtime = 2700,
+    });
+    defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"type\":3") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"voice_item\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"encode_type\":7") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"sample_rate\":44100") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"playtime\":2700") != null);
+}
+
+test "parses inbound voice transcription into message item" {
+    const json =
+        \\{"ret":0,"msgs":[{"from_user_id":"u1","context_token":"ctx",
+        \\"item_list":[{"type":3,"voice_item":{"text":"transcribed voice"}}]}]}
+    ;
+    var parsed = try parseGetUpdates(t.allocator, json);
+    defer parsed.deinit();
+    try t.expectEqual(@as(i64, 3), parsed.value.msgs[0].item_list[0].type);
+    try t.expectEqualStrings("transcribed voice", parsed.value.msgs[0].item_list[0].voice_text);
 }

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -143,46 +143,6 @@ pub fn buildSendUploadedImageBody(
     }, .{});
 }
 
-pub fn buildSendUploadedVoiceBody(
-    allocator: std.mem.Allocator,
-    to_user_id: []const u8,
-    context_token: []const u8,
-    client_id: []const u8,
-    voice: types.UploadedVoice,
-) ![]u8 {
-    const VoiceItem = struct {
-        media: WireCdnMedia,
-        encode_type: i64,
-        sample_rate: i64,
-        playtime: i64,
-    };
-    const Item = struct { type: i64 = 3, voice_item: VoiceItem };
-    const Msg = struct {
-        to_user_id: []const u8,
-        client_id: []const u8,
-        message_type: i64 = 2,
-        message_state: i64 = 2,
-        context_token: []const u8,
-        item_list: []const Item,
-    };
-    const Body = struct { msg: Msg, base_info: BaseInfo };
-    const items = [_]Item{.{ .voice_item = .{
-        .media = wireMedia(voice.media),
-        .encode_type = voice.encode_type,
-        .sample_rate = voice.sample_rate,
-        .playtime = voice.playtime,
-    } }};
-    return std.json.Stringify.valueAlloc(allocator, Body{
-        .msg = .{
-            .to_user_id = to_user_id,
-            .client_id = client_id,
-            .context_token = context_token,
-            .item_list = &items,
-        },
-        .base_info = .{ .channel_version = CHANNEL_VERSION },
-    }, .{});
-}
-
 pub fn buildGetUploadUrlBody(
     allocator: std.mem.Allocator,
     kind: types.AttachmentKind,
@@ -431,35 +391,6 @@ test "builds uploaded image sendmessage body" {
     try t.expect(std.mem.indexOf(u8, body, "\"type\":2") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"image_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"mid_size\":64") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
-}
-
-test "builds uploaded voice sendmessage body" {
-    const media = types.CdnMedia{
-        .encrypt_query_param = "encrypted-param",
-        .aes_key = "encoded-key",
-        .md5 = "md5",
-        .size = 64,
-        .file_key = "file-key",
-    };
-    const body = try buildSendUploadedVoiceBody(t.allocator, "u1", "ctx", "cid", .{
-        .media = media,
-        .encode_type = 7,
-        .sample_rate = 44100,
-        .playtime = 2700,
-    });
-    defer t.allocator.free(body);
-    try t.expect(std.mem.indexOf(u8, body, "\"to_user_id\":\"u1\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"client_id\":\"cid\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"message_type\":2") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"message_state\":2") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"context_token\":\"ctx\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"item_list\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"type\":3") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"voice_item\"") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"encode_type\":7") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"sample_rate\":44100") != null);
-    try t.expect(std.mem.indexOf(u8, body, "\"playtime\":2700") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
 }
 

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -366,6 +366,7 @@ test "builds getuploadurl body for file media" {
     try t.expect(std.mem.indexOf(u8, body, "\"size\":123") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"md5\":\"900150983cd24fb0d6963f7d28e17f72\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"file_key\":\"file-key\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
 }
 
 test "parses getuploadurl response" {
@@ -394,11 +395,18 @@ test "builds uploaded file sendmessage body" {
         .len = 123,
     });
     defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"to_user_id\":\"u1\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"client_id\":\"cid\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_type\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_state\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"context_token\":\"ctx\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"item_list\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"type\":4") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"file_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"file_name\":\"report.pdf\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"len\":\"123\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"encrypt_query_param\":\"encrypted-param\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
 }
 
 test "builds uploaded image sendmessage body" {
@@ -414,9 +422,16 @@ test "builds uploaded image sendmessage body" {
         .mid_size = 64,
     });
     defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"to_user_id\":\"u1\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"client_id\":\"cid\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_type\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_state\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"context_token\":\"ctx\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"item_list\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"type\":2") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"image_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"mid_size\":64") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
 }
 
 test "builds uploaded voice sendmessage body" {
@@ -434,11 +449,18 @@ test "builds uploaded voice sendmessage body" {
         .playtime = 2700,
     });
     defer t.allocator.free(body);
+    try t.expect(std.mem.indexOf(u8, body, "\"to_user_id\":\"u1\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"client_id\":\"cid\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_type\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"message_state\":2") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"context_token\":\"ctx\"") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"item_list\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"type\":3") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"voice_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"encode_type\":7") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"sample_rate\":44100") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"playtime\":2700") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"channel_version\":\"1.0.2\"") != null);
 }
 
 test "parses inbound voice transcription into message item" {

--- a/src/weixin/ilink_codec.zig
+++ b/src/weixin/ilink_codec.zig
@@ -370,10 +370,11 @@ test "builds getuploadurl body for file media" {
 
 test "parses getuploadurl response" {
     var parsed = try parseGetUploadUrl(t.allocator,
-        \\{"ret":0,"errcode":0,"url":"https://cdn.example/upload","ticket":"ticket=abc","file_key":"file-key"}
+        \\{"ret":0,"errcode":42,"url":"https://cdn.example/upload","ticket":"ticket=abc","file_key":"file-key"}
     );
     defer parsed.deinit();
     try t.expectEqual(@as(i64, 0), parsed.value.ret);
+    try t.expectEqual(@as(i64, 42), parsed.value.errcode);
     try t.expectEqualStrings("https://cdn.example/upload", parsed.value.url);
     try t.expectEqualStrings("ticket=abc", parsed.value.ticket);
     try t.expectEqualStrings("file-key", parsed.value.file_key);
@@ -394,6 +395,7 @@ test "builds uploaded file sendmessage body" {
     });
     defer t.allocator.free(body);
     try t.expect(std.mem.indexOf(u8, body, "\"type\":4") != null);
+    try t.expect(std.mem.indexOf(u8, body, "\"file_item\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"file_name\":\"report.pdf\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"len\":\"123\"") != null);
     try t.expect(std.mem.indexOf(u8, body, "\"encrypt_query_param\":\"encrypted-param\"") != null);

--- a/src/weixin/media.zig
+++ b/src/weixin/media.zig
@@ -1,0 +1,194 @@
+//! Pure helpers for Weixin iLink media uploads.
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const AesKey = [16]u8;
+
+pub fn pkcs7PaddedLen(input_len: usize) usize {
+    const block = 16;
+    return input_len + (block - (input_len % block));
+}
+
+pub fn aes128EcbPkcs7Encrypt(allocator: std.mem.Allocator, key: AesKey, plain: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, pkcs7PaddedLen(plain.len));
+    errdefer allocator.free(out);
+    @memcpy(out[0..plain.len], plain);
+    const pad: u8 = @intCast(out.len - plain.len);
+    @memset(out[plain.len..], pad);
+
+    var ctx = std.crypto.core.aes.Aes128.initEnc(key);
+    var offset: usize = 0;
+    while (offset < out.len) : (offset += 16) {
+        const block: *[16]u8 = out[offset..][0..16];
+        ctx.encrypt(block, block);
+    }
+    return out;
+}
+
+pub fn aes128EcbPkcs7DecryptForTest(allocator: std.mem.Allocator, key: AesKey, encrypted: []const u8) ![]u8 {
+    if (encrypted.len == 0 or encrypted.len % 16 != 0) return error.InvalidCiphertext;
+    const padded = try allocator.dupe(u8, encrypted);
+    errdefer allocator.free(padded);
+
+    var ctx = std.crypto.core.aes.Aes128.initDec(key);
+    var offset: usize = 0;
+    while (offset < padded.len) : (offset += 16) {
+        const block: *[16]u8 = padded[offset..][0..16];
+        ctx.decrypt(block, block);
+    }
+    const pad = padded[padded.len - 1];
+    const pad_len: usize = pad;
+    if (pad == 0 or pad > 16 or pad_len > padded.len) return error.InvalidPadding;
+    for (padded[padded.len - pad_len ..]) |b| {
+        if (b != pad) return error.InvalidPadding;
+    }
+    return allocator.realloc(padded, padded.len - pad_len);
+}
+
+pub fn encodeIlinkAesKey(allocator: std.mem.Allocator, key: AesKey) ![]u8 {
+    const hex = try allocator.alloc(u8, key.len * 2);
+    defer allocator.free(hex);
+    writeHexLower(hex, &key);
+    const out = try allocator.alloc(u8, std.base64.standard.Encoder.calcSize(hex.len));
+    _ = std.base64.standard.Encoder.encode(out, hex);
+    return out;
+}
+
+pub fn md5Hex(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    var digest: [std.crypto.hash.Md5.digest_length]u8 = undefined;
+    std.crypto.hash.Md5.hash(data, &digest, .{});
+    const out = try allocator.alloc(u8, digest.len * 2);
+    writeHexLower(out, &digest);
+    return out;
+}
+
+fn writeHexLower(out: []u8, data: []const u8) void {
+    const hex = "0123456789abcdef";
+    std.debug.assert(out.len == data.len * 2);
+    for (data, 0..) |byte, i| {
+        out[i * 2] = hex[byte >> 4];
+        out[i * 2 + 1] = hex[byte & 0x0f];
+    }
+}
+
+pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, ticket: []const u8) ![]u8 {
+    const sep: []const u8 = if (std.mem.indexOfScalar(u8, base_url, '?') == null) "?" else "&";
+    return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ base_url, sep, ticket });
+}
+
+pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
+    const ext = std.fs.path.extension(path);
+    if (std.ascii.eqlIgnoreCase(codec, "pcm_s16le") or std.ascii.eqlIgnoreCase(codec, "pcm_u8") or std.ascii.eqlIgnoreCase(ext, ".wav")) return 1;
+    if (std.ascii.eqlIgnoreCase(codec, "amr_nb") or std.ascii.eqlIgnoreCase(codec, "amr_wb") or std.ascii.eqlIgnoreCase(ext, ".amr")) return 5;
+    if (std.ascii.eqlIgnoreCase(codec, "silk") or std.ascii.eqlIgnoreCase(ext, ".silk")) return 6;
+    if (std.ascii.eqlIgnoreCase(codec, "mp3") or std.ascii.eqlIgnoreCase(ext, ".mp3")) return 7;
+    if (std.ascii.eqlIgnoreCase(codec, "speex") or std.ascii.eqlIgnoreCase(codec, "opus") or std.ascii.eqlIgnoreCase(codec, "vorbis") or std.ascii.eqlIgnoreCase(ext, ".ogg")) return 8;
+    return error.UnsupportedVoiceCodec;
+}
+
+fn voiceCodecLabel(encode_type: i64) []const u8 {
+    return switch (encode_type) {
+        1 => "pcm",
+        5 => "amr",
+        6 => "silk",
+        7 => "mp3",
+        8 => "ogg",
+        else => "unknown",
+    };
+}
+
+pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
+    const Probe = struct {
+        streams: []struct {
+            codec_type: []const u8 = "",
+            codec_name: []const u8 = "",
+            sample_rate: []const u8 = "",
+            duration: []const u8 = "",
+        } = &.{},
+        format: struct { duration: []const u8 = "" } = .{},
+    };
+    var parsed = try std.json.parseFromSlice(Probe, allocator, json, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    for (parsed.value.streams) |stream| {
+        if (!std.mem.eql(u8, stream.codec_type, "audio")) continue;
+        const sample_rate = std.fmt.parseInt(i64, stream.sample_rate, 10) catch 0;
+        const duration_text = if (stream.duration.len != 0) stream.duration else parsed.value.format.duration;
+        const seconds = std.fmt.parseFloat(f64, duration_text) catch 0;
+        const encode_type = try voiceEncodeType(stream.codec_name, path);
+        return .{
+            .encode_type = encode_type,
+            .sample_rate = sample_rate,
+            .playtime = @as(i64, @intFromFloat(@round(seconds * 1000.0))),
+            .codec = voiceCodecLabel(encode_type),
+        };
+    }
+    return error.NoAudioStream;
+}
+
+const t = std.testing;
+
+test "pkcs7 padding always adds at least one AES block" {
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(0));
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(1));
+    try t.expectEqual(@as(usize, 16), pkcs7PaddedLen(15));
+    try t.expectEqual(@as(usize, 32), pkcs7PaddedLen(16));
+}
+
+test "AES ECB PKCS7 encrypts and decrypts a short buffer" {
+    const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    const encrypted = try aes128EcbPkcs7Encrypt(t.allocator, key, "hello");
+    defer t.allocator.free(encrypted);
+    try t.expectEqual(@as(usize, 16), encrypted.len);
+
+    const decrypted = try aes128EcbPkcs7DecryptForTest(t.allocator, key, encrypted);
+    defer t.allocator.free(decrypted);
+    try t.expectEqualStrings("hello", decrypted);
+}
+
+test "AES key is encoded as base64 of hex bytes" {
+    const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    const encoded = try encodeIlinkAesKey(t.allocator, key);
+    defer t.allocator.free(encoded);
+    try t.expectEqualStrings("MDAwMTAyMDMwNDA1MDYwNzA4MDkwYTBiMGMwZDBlMGY=", encoded);
+}
+
+test "md5Hex returns lowercase hex digest" {
+    const digest = try md5Hex(t.allocator, "abc");
+    defer t.allocator.free(digest);
+    try t.expectEqualStrings("900150983cd24fb0d6963f7d28e17f72", digest);
+}
+
+test "uploadUrlWithTicket appends ticket query using question mark or ampersand" {
+    const a = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload", "ticket=abc");
+    defer t.allocator.free(a);
+    try t.expectEqualStrings("https://cdn.example/upload?ticket=abc", a);
+
+    const b = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload?x=1", "ticket=abc");
+    defer t.allocator.free(b);
+    try t.expectEqualStrings("https://cdn.example/upload?x=1&ticket=abc", b);
+}
+
+test "voiceEncodeType maps codec and extension values" {
+    try t.expectEqual(@as(i64, 1), try voiceEncodeType("pcm_s16le", "note.wav"));
+    try t.expectEqual(@as(i64, 5), try voiceEncodeType("amr_nb", "note.amr"));
+    try t.expectEqual(@as(i64, 6), try voiceEncodeType("silk", "note.silk"));
+    try t.expectEqual(@as(i64, 7), try voiceEncodeType("mp3", "note.mp3"));
+    try t.expectEqual(@as(i64, 8), try voiceEncodeType("speex", "note.ogg"));
+    try t.expectError(error.UnsupportedVoiceCodec, voiceEncodeType("aac", "note.m4a"));
+}
+
+test "parseFfprobeVoiceMetadata reads codec sample rate and duration" {
+    const json =
+        \\{"streams":[{"codec_type":"audio","codec_name":"mp3","sample_rate":"44100","duration":"2.700000"}],
+        \\"format":{"duration":"2.700000"}}
+    ;
+    const meta = try parseFfprobeVoiceMetadata(t.allocator, json, "voice.mp3");
+    try t.expectEqual(@as(i64, 7), meta.encode_type);
+    try t.expectEqual(@as(i64, 44100), meta.sample_rate);
+    try t.expectEqual(@as(i64, 2700), meta.playtime);
+    try t.expectEqualStrings("mp3", meta.codec);
+}

--- a/src/weixin/media.zig
+++ b/src/weixin/media.zig
@@ -149,6 +149,19 @@ test "AES ECB PKCS7 encrypts and decrypts a short buffer" {
     try t.expectEqualStrings("hello", decrypted);
 }
 
+test "AES ECB PKCS7 encrypts and decrypts multiple blocks" {
+    const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
+    const plain = "0123456789abcdef0123456789abcdef!";
+    const encrypted = try aes128EcbPkcs7Encrypt(t.allocator, key, plain);
+    defer t.allocator.free(encrypted);
+    try t.expectEqual(@as(usize, 48), encrypted.len);
+    try t.expect(!std.mem.eql(u8, encrypted[0..plain.len], plain));
+
+    const decrypted = try aes128EcbPkcs7DecryptForTest(t.allocator, key, encrypted);
+    defer t.allocator.free(decrypted);
+    try t.expectEqualStrings(plain, decrypted);
+}
+
 test "AES key is encoded as base64 of hex bytes" {
     const key: AesKey = [_]u8{ 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
     const encoded = try encodeIlinkAesKey(t.allocator, key);

--- a/src/weixin/media.zig
+++ b/src/weixin/media.zig
@@ -1,6 +1,5 @@
 //! Pure helpers for Weixin iLink media uploads.
 const std = @import("std");
-const types = @import("types.zig");
 
 pub const AesKey = [16]u8;
 
@@ -76,59 +75,6 @@ pub fn uploadUrlWithTicket(allocator: std.mem.Allocator, base_url: []const u8, t
     return std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ base_url, sep, ticket });
 }
 
-pub fn voiceEncodeType(codec: []const u8, path: []const u8) !i64 {
-    const ext = std.fs.path.extension(path);
-    if (std.ascii.eqlIgnoreCase(codec, "pcm_s16le") or std.ascii.eqlIgnoreCase(codec, "pcm_u8") or std.ascii.eqlIgnoreCase(ext, ".wav")) return 1;
-    if (std.ascii.eqlIgnoreCase(codec, "amr_nb") or std.ascii.eqlIgnoreCase(codec, "amr_wb") or std.ascii.eqlIgnoreCase(ext, ".amr")) return 5;
-    if (std.ascii.eqlIgnoreCase(codec, "silk") or std.ascii.eqlIgnoreCase(ext, ".silk")) return 6;
-    if (std.ascii.eqlIgnoreCase(codec, "mp3") or std.ascii.eqlIgnoreCase(ext, ".mp3")) return 7;
-    if (std.ascii.eqlIgnoreCase(codec, "speex") or std.ascii.eqlIgnoreCase(codec, "opus") or std.ascii.eqlIgnoreCase(codec, "vorbis") or std.ascii.eqlIgnoreCase(ext, ".ogg")) return 8;
-    return error.UnsupportedVoiceCodec;
-}
-
-fn voiceCodecLabel(encode_type: i64) []const u8 {
-    return switch (encode_type) {
-        1 => "pcm",
-        5 => "amr",
-        6 => "silk",
-        7 => "mp3",
-        8 => "ogg",
-        else => "unknown",
-    };
-}
-
-pub fn parseFfprobeVoiceMetadata(allocator: std.mem.Allocator, json: []const u8, path: []const u8) !types.VoiceMetadata {
-    const Probe = struct {
-        streams: []struct {
-            codec_type: []const u8 = "",
-            codec_name: []const u8 = "",
-            sample_rate: []const u8 = "",
-            duration: []const u8 = "",
-        } = &.{},
-        format: struct { duration: []const u8 = "" } = .{},
-    };
-    var parsed = try std.json.parseFromSlice(Probe, allocator, json, .{
-        .ignore_unknown_fields = true,
-        .allocate = .alloc_always,
-    });
-    defer parsed.deinit();
-
-    for (parsed.value.streams) |stream| {
-        if (!std.mem.eql(u8, stream.codec_type, "audio")) continue;
-        const sample_rate = std.fmt.parseInt(i64, stream.sample_rate, 10) catch 0;
-        const duration_text = if (stream.duration.len != 0) stream.duration else parsed.value.format.duration;
-        const seconds = std.fmt.parseFloat(f64, duration_text) catch 0;
-        const encode_type = try voiceEncodeType(stream.codec_name, path);
-        return .{
-            .encode_type = encode_type,
-            .sample_rate = sample_rate,
-            .playtime = @as(i64, @intFromFloat(@round(seconds * 1000.0))),
-            .codec = voiceCodecLabel(encode_type),
-        };
-    }
-    return error.NoAudioStream;
-}
-
 const t = std.testing;
 
 test "pkcs7 padding always adds at least one AES block" {
@@ -183,25 +129,4 @@ test "uploadUrlWithTicket appends ticket query using question mark or ampersand"
     const b = try uploadUrlWithTicket(t.allocator, "https://cdn.example/upload?x=1", "ticket=abc");
     defer t.allocator.free(b);
     try t.expectEqualStrings("https://cdn.example/upload?x=1&ticket=abc", b);
-}
-
-test "voiceEncodeType maps codec and extension values" {
-    try t.expectEqual(@as(i64, 1), try voiceEncodeType("pcm_s16le", "note.wav"));
-    try t.expectEqual(@as(i64, 5), try voiceEncodeType("amr_nb", "note.amr"));
-    try t.expectEqual(@as(i64, 6), try voiceEncodeType("silk", "note.silk"));
-    try t.expectEqual(@as(i64, 7), try voiceEncodeType("mp3", "note.mp3"));
-    try t.expectEqual(@as(i64, 8), try voiceEncodeType("speex", "note.ogg"));
-    try t.expectError(error.UnsupportedVoiceCodec, voiceEncodeType("aac", "note.m4a"));
-}
-
-test "parseFfprobeVoiceMetadata reads codec sample rate and duration" {
-    const json =
-        \\{"streams":[{"codec_type":"audio","codec_name":"mp3","sample_rate":"44100","duration":"2.700000"}],
-        \\"format":{"duration":"2.700000"}}
-    ;
-    const meta = try parseFfprobeVoiceMetadata(t.allocator, json, "voice.mp3");
-    try t.expectEqual(@as(i64, 7), meta.encode_type);
-    try t.expectEqual(@as(i64, 44100), meta.sample_rate);
-    try t.expectEqual(@as(i64, 2700), meta.playtime);
-    try t.expectEqualStrings("mp3", meta.codec);
 }

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -503,6 +503,7 @@ const FakeClient = struct {
         return .{ .ctx = self, .vtable = &.{
             .get_updates = getUpdates,
             .send_text = sendText,
+            .send_attachment = sendAttachment,
         } };
     }
 
@@ -519,6 +520,17 @@ const FakeClient = struct {
     fn sendText(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) anyerror!void {
         const self: *FakeClient = @ptrCast(@alignCast(ctx));
         self.send_count += 1;
+    }
+
+    fn sendAttachment(
+        ctx: *anyopaque,
+        _: types.AttachmentKind,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+    ) anyerror!void {
+        _ = ctx;
     }
 };
 

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -38,7 +38,14 @@ pub const ProcessInput = struct {
     route_ctx: *anyopaque,
     /// Fills `reply` with the response text; returns true if the caller should
     /// begin AI-reply progress streaming.
-    route_fn: *const fn (ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult,
+    route_fn: *const fn (
+        ctx: *anyopaque,
+        text: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+        allocator: std.mem.Allocator,
+        reply: *std.ArrayListUnmanaged(u8),
+    ) anyerror!RouteResult,
     send_ctx: *anyopaque,
     send_fn: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
     progress_ctx: ?*anyopaque = null,
@@ -76,7 +83,7 @@ pub fn processUpdates(input: ProcessInput) !void {
 
         var reply: std.ArrayListUnmanaged(u8) = .empty;
         defer reply.deinit(input.allocator);
-        const route_result = input.route_fn(input.route_ctx, text, input.allocator, &reply) catch |err| {
+        const route_result = input.route_fn(input.route_ctx, text, msg.from_user_id, msg.context_token, input.allocator, &reply) catch |err| {
             std.debug.print("weixin process({d}): index={d} route=failed err={}\n", .{ debugNowMs(), i, err });
             continue;
         };
@@ -227,7 +234,14 @@ pub const Poller = struct {
         });
     }
 
-    fn routeAdapter(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+    fn routeAdapter(
+        ctx: *anyopaque,
+        text: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+        allocator: std.mem.Allocator,
+        reply: *std.ArrayListUnmanaged(u8),
+    ) anyerror!RouteResult {
         const self: *Poller = @ptrCast(@alignCast(ctx));
         if (self.stop_requested.load(.acquire)) return error.PollerStopped;
         const baseline = try self.allocTranscriptSnapshot(allocator);
@@ -235,7 +249,12 @@ pub const Poller = struct {
 
         var r = agent.Reply.init(allocator);
         defer r.deinit();
-        try agent.route(allocator, self.control, self.settings, text, &r);
+        const reply_context = types.ReplyContext{
+            .sender = .{ .ctx = self, .send_attachment = pollerSendAttachment },
+            .to_user_id = to_user_id,
+            .context_token = context_token,
+        };
+        try agent.route(allocator, self.control, self.settings, text, reply_context, &r);
         try reply.appendSlice(allocator, r.text.items);
         if (!r.expect_ai_progress) {
             if (baseline.len != 0) allocator.free(baseline);
@@ -245,6 +264,19 @@ pub const Poller = struct {
             .expect_ai_progress = true,
             .baseline_transcript = baseline,
         };
+    }
+
+    fn pollerSendAttachment(
+        ctx: *anyopaque,
+        kind: types.AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        if (self.stop_requested.load(.acquire)) return error.PollerStopped;
+        try self.client.sendAttachment(kind, path, display_name, to_user_id, context_token);
     }
 
     fn sendAdapter(ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void {
@@ -447,19 +479,27 @@ const codec = @import("ilink_codec.zig");
 const Captured = struct {
     sent: std.ArrayListUnmanaged([]u8) = .empty,
     routed: std.ArrayListUnmanaged([]u8) = .empty,
+    routed_to: std.ArrayListUnmanaged([]u8) = .empty,
+    routed_context: std.ArrayListUnmanaged([]u8) = .empty,
     fn deinit(self: *Captured) void {
         for (self.sent.items) |s| t.allocator.free(s);
         for (self.routed.items) |s| t.allocator.free(s);
+        for (self.routed_to.items) |s| t.allocator.free(s);
+        for (self.routed_context.items) |s| t.allocator.free(s);
         self.sent.deinit(t.allocator);
         self.routed.deinit(t.allocator);
+        self.routed_to.deinit(t.allocator);
+        self.routed_context.deinit(t.allocator);
     }
 };
 
 const RouteCtx = struct {
     cap: *Captured,
-    fn route(ctx: *anyopaque, text: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+    fn route(ctx: *anyopaque, text: []const u8, to_user_id: []const u8, context_token: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
         const self: *RouteCtx = @ptrCast(@alignCast(ctx));
         try self.cap.routed.append(t.allocator, try t.allocator.dupe(u8, text));
+        try self.cap.routed_to.append(t.allocator, try t.allocator.dupe(u8, to_user_id));
+        try self.cap.routed_context.append(t.allocator, try t.allocator.dupe(u8, context_token));
         try reply.appendSlice(allocator, "ok");
         return .{};
     }
@@ -561,7 +601,7 @@ const NoopControl = struct {
     fn openAiAgent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8) bool {
+    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
         return false;
     }
     fn latestTranscript(_: *anyopaque) []const u8 {
@@ -604,13 +644,15 @@ test "processUpdates routes accepted text and sends replies" {
 
     try t.expectEqual(@as(usize, 1), cap.routed.items.len);
     try t.expectEqualStrings("hi", cap.routed.items[0]);
+    try t.expectEqualStrings("u1", cap.routed_to.items[0]);
+    try t.expectEqualStrings("c", cap.routed_context.items[0]);
     try t.expectEqual(@as(usize, 1), cap.sent.items.len);
     try t.expectEqualStrings("ok", cap.sent.items[0]);
 }
 
 test "processUpdates starts AI followup after ack reply is sent" {
     const Route = struct {
-        fn route(_: *anyopaque, _: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+        fn route(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
             try reply.appendSlice(allocator, "ack");
             return .{
                 .expect_ai_progress = true,
@@ -647,6 +689,33 @@ test "processUpdates starts AI followup after ack reply is sent" {
     try t.expectEqualStrings("Status:\nReady\n", pctx.baseline.items);
     try t.expectEqualStrings("u1", pctx.to_user_id.items);
     try t.expectEqualStrings("ctx", pctx.context_token.items);
+}
+
+test "processUpdates routes inbound voice transcript as message text" {
+    var cap = Captured{};
+    defer cap.deinit();
+    var rctx = RouteCtx{ .cap = &cap };
+    var sctx = SendCtx{ .cap = &cap };
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "voice-ctx", .item_list = &.{.{ .type = 3, .voice_text = "transcribed command" }} },
+    };
+
+    try processUpdates(.{
+        .allocator = t.allocator,
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &rctx,
+        .route_fn = RouteCtx.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+    });
+
+    try t.expectEqual(@as(usize, 1), cap.routed.items.len);
+    try t.expectEqualStrings("transcribed command", cap.routed.items[0]);
+    try t.expectEqualStrings("u1", cap.routed_to.items[0]);
+    try t.expectEqualStrings("voice-ctx", cap.routed_context.items[0]);
 }
 
 test "poller bootstrap advances cursor without replying to historical messages" {

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -172,6 +172,9 @@ test "AttachmentKind parses accepted tool values" {
     try t.expectEqualStrings("file", AttachmentKind.file.name());
     try t.expectEqualStrings("image", AttachmentKind.image.name());
     try t.expectEqualStrings("voice", AttachmentKind.voice.name());
+    try t.expectEqual(@as(i64, 1), AttachmentKind.image.uploadMediaType());
+    try t.expectEqual(@as(i64, 3), AttachmentKind.file.uploadMediaType());
+    try t.expectEqual(@as(i64, 4), AttachmentKind.voice.uploadMediaType());
 }
 
 test "AttachmentSender forwards typed send calls" {

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -66,13 +66,6 @@ pub const CdnMedia = struct {
     file_key: []const u8 = "",
 };
 
-pub const VoiceMetadata = struct {
-    encode_type: i64,
-    sample_rate: i64,
-    playtime: i64,
-    codec: []const u8 = "",
-};
-
 pub const UploadedFileAttachment = struct {
     media: CdnMedia,
     file_name: []const u8,
@@ -82,13 +75,6 @@ pub const UploadedFileAttachment = struct {
 pub const UploadedImage = struct {
     media: CdnMedia,
     mid_size: u64,
-};
-
-pub const UploadedVoice = struct {
-    media: CdnMedia,
-    encode_type: i64,
-    sample_rate: i64,
-    playtime: i64,
 };
 
 pub const AttachmentSender = struct {

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -1,6 +1,8 @@
 //! In-memory representations of ilink protocol values. No I/O lives here;
 //! `ilink_codec.zig` converts wire JSON to/from these.
 
+const std = @import("std");
+
 pub const MessageItem = struct {
     type: i64 = 0,
     /// text from a text_item (type 1)
@@ -15,6 +17,108 @@ pub const Message = struct {
     context_token: []const u8 = "",
     group_id: []const u8 = "",
     item_list: []const MessageItem = &.{},
+};
+
+pub const AttachmentKind = enum {
+    file,
+    image,
+    voice,
+
+    pub fn parse(value: []const u8) ?AttachmentKind {
+        const trimmed = std.mem.trim(u8, value, " \t\r\n");
+        if (std.ascii.eqlIgnoreCase(trimmed, "file")) return .file;
+        if (std.ascii.eqlIgnoreCase(trimmed, "image")) return .image;
+        if (std.ascii.eqlIgnoreCase(trimmed, "voice")) return .voice;
+        return null;
+    }
+
+    pub fn name(self: AttachmentKind) []const u8 {
+        return switch (self) {
+            .file => "file",
+            .image => "image",
+            .voice => "voice",
+        };
+    }
+
+    pub fn uploadMediaType(self: AttachmentKind) i64 {
+        return switch (self) {
+            .image => 1,
+            .file => 3,
+            .voice => 4,
+        };
+    }
+};
+
+pub const UploadUrl = struct {
+    url: []const u8 = "",
+    ticket: []const u8 = "",
+    file_key: []const u8 = "",
+    ret: i64 = 0,
+    errcode: i64 = 0,
+    message: []const u8 = "",
+};
+
+pub const CdnMedia = struct {
+    encrypt_query_param: []const u8,
+    aes_key: []const u8,
+    encrypt_type: i64 = 1,
+    md5: []const u8 = "",
+    size: u64 = 0,
+    file_key: []const u8 = "",
+};
+
+pub const VoiceMetadata = struct {
+    encode_type: i64,
+    sample_rate: i64,
+    playtime: i64,
+    codec: []const u8 = "",
+};
+
+pub const UploadedFileAttachment = struct {
+    media: CdnMedia,
+    file_name: []const u8,
+    len: u64,
+};
+
+pub const UploadedImage = struct {
+    media: CdnMedia,
+    mid_size: u64,
+};
+
+pub const UploadedVoice = struct {
+    media: CdnMedia,
+    encode_type: i64,
+    sample_rate: i64,
+    playtime: i64,
+};
+
+pub const AttachmentSender = struct {
+    ctx: *anyopaque,
+    send_attachment: *const fn (
+        ctx: *anyopaque,
+        kind: AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) anyerror!void,
+
+    pub fn sendAttachment(
+        self: AttachmentSender,
+        kind: AttachmentKind,
+        path: []const u8,
+        display_name: []const u8,
+        to_user_id: []const u8,
+        context_token: []const u8,
+    ) !void {
+        return self.send_attachment(self.ctx, kind, path, display_name, to_user_id, context_token);
+    }
+};
+
+pub const ReplyContext = struct {
+    sender: AttachmentSender,
+    to_user_id: []const u8,
+    context_token: []const u8,
 };
 
 pub const GetUpdatesResult = struct {
@@ -57,3 +161,54 @@ pub const Binding = struct {
     bot_id: []const u8 = "",
     sync_buf: []const u8 = "",
 };
+
+const t = std.testing;
+
+test "AttachmentKind parses accepted tool values" {
+    try t.expectEqual(AttachmentKind.file, AttachmentKind.parse("file").?);
+    try t.expectEqual(AttachmentKind.image, AttachmentKind.parse("image").?);
+    try t.expectEqual(AttachmentKind.voice, AttachmentKind.parse("voice").?);
+    try t.expect(AttachmentKind.parse("video") == null);
+    try t.expectEqualStrings("file", AttachmentKind.file.name());
+    try t.expectEqualStrings("image", AttachmentKind.image.name());
+    try t.expectEqualStrings("voice", AttachmentKind.voice.name());
+}
+
+test "AttachmentSender forwards typed send calls" {
+    const Capture = struct {
+        called: bool = false,
+        kind: AttachmentKind = .file,
+        path: []const u8 = "",
+        display_name: []const u8 = "",
+        to_user_id: []const u8 = "",
+        context_token: []const u8 = "",
+
+        fn send(
+            ctx: *anyopaque,
+            kind: AttachmentKind,
+            path: []const u8,
+            display_name: []const u8,
+            to_user_id: []const u8,
+            context_token: []const u8,
+        ) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.called = true;
+            self.kind = kind;
+            self.path = path;
+            self.display_name = display_name;
+            self.to_user_id = to_user_id;
+            self.context_token = context_token;
+        }
+    };
+
+    var capture = Capture{};
+    const sender = AttachmentSender{ .ctx = &capture, .send_attachment = Capture.send };
+    try sender.sendAttachment(.image, "C:\\tmp\\plot.png", "plot.png", "wx-user", "ctx-1");
+
+    try t.expect(capture.called);
+    try t.expectEqual(AttachmentKind.image, capture.kind);
+    try t.expectEqualStrings("C:\\tmp\\plot.png", capture.path);
+    try t.expectEqualStrings("plot.png", capture.display_name);
+    try t.expectEqualStrings("wx-user", capture.to_user_id);
+    try t.expectEqualStrings("ctx-1", capture.context_token);
+}

--- a/src/weixin/types.zig
+++ b/src/weixin/types.zig
@@ -43,8 +43,7 @@ pub const AttachmentKind = enum {
     pub fn uploadMediaType(self: AttachmentKind) i64 {
         return switch (self) {
             .image => 1,
-            .file => 3,
-            .voice => 4,
+            .file, .voice => 3,
         };
     }
 };
@@ -174,7 +173,7 @@ test "AttachmentKind parses accepted tool values" {
     try t.expectEqualStrings("voice", AttachmentKind.voice.name());
     try t.expectEqual(@as(i64, 1), AttachmentKind.image.uploadMediaType());
     try t.expectEqual(@as(i64, 3), AttachmentKind.file.uploadMediaType());
-    try t.expectEqual(@as(i64, 4), AttachmentKind.voice.uploadMediaType());
+    try t.expectEqual(@as(i64, 3), AttachmentKind.voice.uploadMediaType());
 }
 
 test "AttachmentSender forwards typed send calls" {


### PR DESCRIPTION
## Summary
- add typed Weixin attachment upload/send support for file and image, with voice accepted as a file attachment alias
- route inbound Weixin voice transcripts as AI text input
- expose the weixin_send_attachment agent tool and pass short-lived Weixin reply context to AI Chat

## Validation
- zig test src/weixin/types.zig
- zig test src/weixin/media.zig
- zig test src/weixin/ilink_codec.zig
- zig test src/weixin/ilink_client.zig
- zig test src/weixin/binding.zig
- zig test src/weixin/agent.zig
- zig test src/weixin/poller.zig
- zig test src/ai_chat_protocol.zig
- zig test src/platform/agent_prompt.zig
- zig test src/ai_chat.zig with documented embed imports
- zig build test
- zig build test-full
- Windows path-safety checks: no name violations, no case-fold collisions, no tracked symlinks