### PR TITLE
[codex] Update WispTerm notify setup skill

### DIFF
--- a/plugins/skills/wispterm-notify-setup/SKILL.md
+++ b/plugins/skills/wispterm-notify-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wispterm-notify-setup
-description: Use when the user wants to install, repair, or re-apply WispTerm notification reminders (Claude Code Stop + Notification, and Codex turn-complete) on this Unix machine, so finishes and confirmation prompts surface inside WispTerm. Linux/WSL + macOS only.
+description: Use when the user wants to install, repair, or re-apply WispTerm notification reminders (Claude Code Stop + Notification, and Codex turn-complete) in a local WSL/macOS/Linux/PowerShell shell or a saved WispTerm SSH profile, so finishes and confirmation prompts surface inside WispTerm.
 ---
 
 # WispTerm Notify Setup
@@ -9,28 +9,64 @@ description: Use when the user wants to install, repair, or re-apply WispTerm no
 
 Install a small notifier that makes Claude Code and Codex surface a WispTerm
 notification (OSC 777 toast + terminal bell badge) when a turn finishes or a
-confirmation is needed. The notifier is agent-agnostic and the installer is
-idempotent — safe to re-run. Unix only (Linux/WSL + macOS); Windows is not yet
-supported.
+confirmation is needed. The notifier is agent-agnostic and the installers are
+idempotent — safe to re-run.
 
 ## Workflow
 
-1. Run the bundled installer:
+1. Determine the target from the user's words and WispTerm state.
 
-   ```bash
-   sh "$(dirname "$0")/scripts/install-wispterm-notify.sh"
-   ```
+   - If the user names an existing WispTerm tab/server/profile (for example
+     `CPU3`), call `terminal_list` first and match by `title`/`kind`.
+   - If a saved SSH profile is named but no SSH tab is already open, call
+     `ssh_profile_connect {"profile_name":"<name>"}` and use the returned
+     `surface_id`.
+   - Never ask the user to re-provide SSH host/user/port/password when the
+     target is an existing saved WispTerm profile. Ask only if the profile is
+     missing or authentication fails.
 
-   (Invoke the `scripts/install-wispterm-notify.sh` that ships with this skill —
-   under `~/.claude/skills/wispterm-notify-setup/` or
-   `~/.codex/skills/wispterm-notify-setup/`.)
+2. Install using the target-specific transfer path.
 
-2. Relay what it changed: the notify program path (`~/.config/wispterm/wispterm-notify.sh`),
-   which Claude Code hooks were added vs already present, and whether Codex's
-   `notify` was added, already set, or left untouched (a pre-existing different
-   `notify` is never overwritten).
+   - **Local POSIX / macOS / WSL:** copy the bundled POSIX scripts directly to
+     the target shell, then run:
 
-3. Verify — run the printed test command and ask the user to confirm they saw a
+     ```bash
+     sh ./install-wispterm-notify.sh
+     ```
+
+     When targeting an already-open WSL surface, use `wsl_session_exec` to run
+     commands in that surface. Do not use `scp` for WSL.
+
+   - **Local Windows PowerShell:** copy the bundled PowerShell scripts directly
+     to the Windows profile and run `install-wispterm-notify.ps1` with
+     `powershell_exec`:
+
+     ```powershell
+     powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install-wispterm-notify.ps1
+     ```
+
+   - **Remote saved SSH profile:** use `scp`, not pasted heredocs, to transfer
+     the bundled POSIX scripts to the remote server, then run the POSIX
+     installer in that SSH session. From Windows/WispTerm, prefer the bundled
+     profile-aware helper because it reads `%APPDATA%\wispterm\ssh_hosts`,
+     decodes the saved profile, supports saved-password profiles via
+     `SSH_ASKPASS`, and uses `scp.exe`/`ssh.exe` without connection sharing:
+
+     ```powershell
+     powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install-wispterm-notify-remote.ps1 -ProfileName "CPU3"
+     ```
+
+     If you are already inside the SSH tab, you may run the final installer
+     with `ssh_session_exec` after the `scp` upload.
+
+3. Relay what it changed: the notify program path
+   (`~/.config/wispterm/wispterm-notify.sh` on POSIX/remote,
+   `%APPDATA%\wispterm\wispterm-notify.ps1` on Windows), which Claude Code hooks
+   were added vs already present, and whether Codex's `notify` was added,
+   already set, or left untouched (a pre-existing different `notify` is never
+   overwritten).
+
+4. Verify — run the printed test command and ask the user to confirm they saw a
    bell badge / toast in WispTerm:
 
    ```bash
@@ -72,5 +108,8 @@ WispTerm window is unfocused, and confirm the message arrives in WeChat.
 - **Idempotent:** re-running won't duplicate hooks; existing hooks and a
   pre-existing Codex `notify` are preserved.
 - **Backups:** `settings.json.bak` / `config.toml.bak` are written before edits.
-- **Dependencies:** prefers `python3` for the JSON merge, falls back to `jq`,
-  then to printing a manual snippet.
+- **Dependencies:** the POSIX installer prefers `python3` for the JSON merge,
+  falls back to `jq`, then to printing a manual snippet. The PowerShell
+  installers use built-in PowerShell JSON/text handling.
+- **SSH transfers:** keep OpenSSH stderr visible. Do not add
+  `ControlMaster`/`ControlPersist`/`ControlPath` to `ssh.exe`/`scp.exe`.

--- a/plugins/skills/wispterm-notify-setup/agents/openai.yaml
+++ b/plugins/skills/wispterm-notify-setup/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "WispTerm Notify Setup"
-  short_description: "Install WispTerm notify hooks for Claude Code + Codex"
-  default_prompt: "Use $wispterm-notify-setup to install WispTerm Stop/Notification reminders on this machine."
+  short_description: "Install WispTerm notify hooks locally or on SSH profiles"
+  default_prompt: "Use $wispterm-notify-setup to install WispTerm Stop/Notification reminders on this machine or a saved WispTerm SSH profile."

--- a/plugins/skills/wispterm-notify-setup/scripts/install-wispterm-notify-remote.ps1
+++ b/plugins/skills/wispterm-notify-setup/scripts/install-wispterm-notify-remote.ps1
@@ -1,0 +1,169 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ProfileName,
+    [string] $RemoteDir = ".config/wispterm/notify-setup"
+)
+
+# Install WispTerm notify into a saved WispTerm SSH profile from Windows.
+# The profile file is WispTerm's source of truth; this script never prints the
+# saved password and uses scp.exe/ssh.exe without ControlMaster options.
+
+$ErrorActionPreference = "Stop"
+
+function ConvertFrom-HexField {
+    param([string] $Hex)
+    if ([string]::IsNullOrEmpty($Hex)) { return "" }
+    if (($Hex.Length % 2) -ne 0) { return $null }
+    $bytes = New-Object byte[] ([int]($Hex.Length / 2))
+    for ($i = 0; $i -lt $bytes.Length; $i++) {
+        try {
+            $bytes[$i] = [Convert]::ToByte($Hex.Substring($i * 2, 2), 16)
+        } catch {
+            return $null
+        }
+    }
+    return [Text.Encoding]::UTF8.GetString($bytes)
+}
+
+function Read-WispTermSshProfiles {
+    param([string] $Path)
+    $profiles = @()
+    foreach ($line in [IO.File]::ReadLines($Path)) {
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.TrimStart().StartsWith("#")) {
+            continue
+        }
+        $parts = $line -split "`t"
+        if ($parts.Count -lt 3) { continue }
+        $fields = @()
+        for ($i = 0; $i -lt 6; $i++) {
+            $raw = if ($i -lt $parts.Count) { $parts[$i] } else { "" }
+            $decoded = ConvertFrom-HexField $raw
+            if ($null -eq $decoded) { $decoded = "" }
+            $fields += $decoded
+        }
+        $profiles += [pscustomobject]@{
+            Name = $fields[0]
+            Host = $fields[1]
+            User = $fields[2]
+            Password = $fields[3]
+            Port = if ([string]::IsNullOrWhiteSpace($fields[4])) { "22" } else { $fields[4] }
+            ProxyJump = $fields[5]
+        }
+    }
+    return $profiles
+}
+
+function Find-Profile {
+    param(
+        [object[]] $Profiles,
+        [string] $Name
+    )
+    foreach ($profile in $Profiles) {
+        if ([string]::Equals($profile.Name, $Name, [StringComparison]::OrdinalIgnoreCase)) {
+            return $profile
+        }
+    }
+    foreach ($profile in $Profiles) {
+        if ([string]::Equals($profile.Host, $Name, [StringComparison]::OrdinalIgnoreCase)) {
+            return $profile
+        }
+    }
+    return $null
+}
+
+function Quote-Sh {
+    param([string] $Value)
+    return [string]::Concat("'", $Value.Replace("'", "'\''"), "'")
+}
+
+function Invoke-Checked {
+    param(
+        [string] $Exe,
+        [string[]] $ArgsList,
+        [string] $Label
+    )
+    Write-Host $Label
+    & $Exe @ArgsList
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+}
+
+$ScriptDir = Split-Path -LiteralPath $MyInvocation.MyCommand.Path -Parent
+$NotifySrc = Join-Path $ScriptDir "wispterm-notify.sh"
+$InstallSrc = Join-Path $ScriptDir "install-wispterm-notify.sh"
+if (-not (Test-Path -LiteralPath $NotifySrc)) { throw "Missing notifier script: $NotifySrc" }
+if (-not (Test-Path -LiteralPath $InstallSrc)) { throw "Missing installer script: $InstallSrc" }
+
+$profilePath = if ($env:APPDATA) {
+    Join-Path $env:APPDATA "wispterm\ssh_hosts"
+} else {
+    Join-Path $HOME ".config/wispterm/ssh_hosts"
+}
+if (-not (Test-Path -LiteralPath $profilePath)) {
+    throw "WispTerm SSH profile file not found: $profilePath"
+}
+
+$profiles = @(Read-WispTermSshProfiles $profilePath)
+$profile = Find-Profile $profiles $ProfileName
+if ($null -eq $profile) {
+    $names = ($profiles | ForEach-Object { $_.Name } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ", "
+    throw "No WispTerm SSH profile matched '$ProfileName'. Available profiles: $names"
+}
+if ([string]::IsNullOrWhiteSpace($profile.Host) -or [string]::IsNullOrWhiteSpace($profile.User)) {
+    throw "Profile '$ProfileName' is missing host or user."
+}
+
+$sshExe = "ssh.exe"
+$scpExe = "scp.exe"
+$dest = "$($profile.User)@$($profile.Host)"
+$sshArgs = @()
+$scpArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($profile.Port)) {
+    $sshArgs += @("-p", $profile.Port)
+    $scpArgs += @("-P", $profile.Port)
+}
+if (-not [string]::IsNullOrWhiteSpace($profile.ProxyJump)) {
+    $sshArgs += @("-J", $profile.ProxyJump)
+    $scpArgs += @("-J", $profile.ProxyJump)
+}
+
+$oldAskpass = $env:SSH_ASKPASS
+$oldAskpassRequire = $env:SSH_ASKPASS_REQUIRE
+$oldDisplay = $env:DISPLAY
+$oldPassword = $env:WISPTERM_SSH_PASSWORD
+$askpassDir = $null
+try {
+    if (-not [string]::IsNullOrEmpty($profile.Password)) {
+        $askpassDir = Join-Path ([IO.Path]::GetTempPath()) ("wispterm-ssh-askpass-" + [guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Force -Path $askpassDir | Out-Null
+        $askpass = Join-Path $askpassDir "askpass.cmd"
+        [IO.File]::WriteAllText($askpass, "@echo off`r`necho %WISPTERM_SSH_PASSWORD%`r`n", [Text.Encoding]::ASCII)
+        $env:SSH_ASKPASS = $askpass
+        $env:SSH_ASKPASS_REQUIRE = "force"
+        $env:DISPLAY = "wispterm"
+        $env:WISPTERM_SSH_PASSWORD = $profile.Password
+    }
+
+    $remoteDirQuoted = Quote-Sh $RemoteDir
+    Invoke-Checked $sshExe (@($sshArgs + $dest + "mkdir -p $remoteDirQuoted")) "remote: create notify setup directory"
+
+    $remoteTarget = "${dest}:$RemoteDir/"
+    Invoke-Checked $scpExe (@($scpArgs + $NotifySrc + $InstallSrc + $remoteTarget)) "remote: scp notify setup scripts"
+
+    $remoteInstaller = Quote-Sh "$RemoteDir/install-wispterm-notify.sh"
+    Invoke-Checked $sshExe (@($sshArgs + $dest + "sh $remoteInstaller")) "remote: run notify installer"
+} finally {
+    $env:SSH_ASKPASS = $oldAskpass
+    $env:SSH_ASKPASS_REQUIRE = $oldAskpassRequire
+    $env:DISPLAY = $oldDisplay
+    $env:WISPTERM_SSH_PASSWORD = $oldPassword
+    if ($askpassDir -and (Test-Path -LiteralPath $askpassDir)) {
+        Remove-Item -LiteralPath $askpassDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host ""
+Write-Host "Installed WispTerm notify on SSH profile '$($profile.Name)' ($dest)."
+Write-Host "Verify from the connected SSH tab:"
+Write-Host "  echo '{`"hook_event_name`":`"Notification`",`"title`":`"WispTerm`",`"message`":`"setup ok`"}' | ~/.config/wispterm/wispterm-notify.sh"

--- a/plugins/skills/wispterm-notify-setup/scripts/install-wispterm-notify.ps1
+++ b/plugins/skills/wispterm-notify-setup/scripts/install-wispterm-notify.ps1
@@ -1,0 +1,144 @@
+param()
+
+# Idempotently install the Windows PowerShell WispTerm notifier and wire Claude
+# Code Stop/Notification hooks plus Codex config.toml notify.
+
+$ErrorActionPreference = "Stop"
+
+function Write-Utf8NoBom {
+    param(
+        [string] $Path,
+        [string] $Text
+    )
+    $encoding = New-Object System.Text.UTF8Encoding -ArgumentList $false
+    [IO.File]::WriteAllText($Path, $Text, $encoding)
+}
+
+function Read-TextOrEmpty {
+    param([string] $Path)
+    if (Test-Path -LiteralPath $Path) {
+        return [IO.File]::ReadAllText($Path)
+    }
+    return ""
+}
+
+function Ensure-Property {
+    param(
+        [object] $Object,
+        [string] $Name,
+        [object] $Value
+    )
+    if ($null -eq $Object.PSObject.Properties[$Name]) {
+        Add-Member -InputObject $Object -NotePropertyName $Name -NotePropertyValue $Value
+    }
+}
+
+function Ensure-ClaudeHook {
+    param(
+        [object] $Settings,
+        [string] $EventName,
+        [string] $Command
+    )
+    $hooks = $Settings.PSObject.Properties["hooks"].Value
+    Ensure-Property $hooks $EventName @()
+    $entries = @($hooks.PSObject.Properties[$EventName].Value)
+
+    foreach ($entry in $entries) {
+        foreach ($hook in @($entry.hooks)) {
+            if ($hook.type -eq "command" -and $hook.command -eq $Command) {
+                return "present"
+            }
+        }
+    }
+
+    $entries = @($entries + [pscustomobject]@{
+        hooks = @([pscustomobject]@{
+            type = "command"
+            command = $Command
+        })
+    })
+    $hooks.PSObject.Properties[$EventName].Value = $entries
+    return "added"
+}
+
+function ConvertTo-TomlBasicString {
+    param([string] $Value)
+    return $Value.Replace("\", "\\").Replace('"', '\"')
+}
+
+$ScriptDir = Split-Path -LiteralPath $MyInvocation.MyCommand.Path -Parent
+$NotifySrc = Join-Path $ScriptDir "wispterm-notify.ps1"
+if (-not (Test-Path -LiteralPath $NotifySrc)) {
+    throw "Missing notifier script: $NotifySrc"
+}
+
+$DestDir = if ($env:APPDATA) {
+    Join-Path $env:APPDATA "wispterm"
+} else {
+    Join-Path $HOME ".config/wispterm"
+}
+$Dest = Join-Path $DestDir "wispterm-notify.ps1"
+New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+Copy-Item -LiteralPath $NotifySrc -Destination $Dest -Force
+Write-Host "notify program -> $Dest"
+
+$HomeDir = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+
+# Claude Code settings.json
+$ClaudeDir = Join-Path $HomeDir ".claude"
+$ClaudeSettings = Join-Path $ClaudeDir "settings.json"
+New-Item -ItemType Directory -Force -Path $ClaudeDir | Out-Null
+if (-not (Test-Path -LiteralPath $ClaudeSettings)) {
+    Write-Utf8NoBom $ClaudeSettings "{}`n"
+}
+Copy-Item -LiteralPath $ClaudeSettings -Destination "$ClaudeSettings.bak" -Force
+
+try {
+    $settings = (Read-TextOrEmpty $ClaudeSettings) | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    $settings = [pscustomobject]@{}
+}
+if ($null -eq $settings -or $settings -isnot [pscustomobject]) {
+    $settings = [pscustomobject]@{}
+}
+Ensure-Property $settings "hooks" ([pscustomobject]@{})
+$hookDest = $Dest.Replace('"', '\"')
+$hookCommand = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$hookDest`""
+$stopState = Ensure-ClaudeHook $settings "Stop" $hookCommand
+$notificationState = Ensure-ClaudeHook $settings "Notification" $hookCommand
+Write-Utf8NoBom $ClaudeSettings (($settings | ConvertTo-Json -Depth 16) + "`n")
+Write-Host "claude: Stop $stopState, Notification $notificationState"
+
+# Codex config.toml top-level notify
+$CodexDir = Join-Path $HomeDir ".codex"
+$CodexConfig = Join-Path $CodexDir "config.toml"
+New-Item -ItemType Directory -Force -Path $CodexDir | Out-Null
+if (-not (Test-Path -LiteralPath $CodexConfig)) {
+    Write-Utf8NoBom $CodexConfig ""
+}
+Copy-Item -LiteralPath $CodexConfig -Destination "$CodexConfig.bak" -Force
+
+$codexContent = Read-TextOrEmpty $CodexConfig
+$firstSection = [regex]::Match($codexContent, "(?m)^\s*\[")
+$topLevel = if ($firstSection.Success) { $codexContent.Substring(0, $firstSection.Index) } else { $codexContent }
+$existingNotify = [regex]::Match($topLevel, "(?m)^\s*notify\s*=.*$")
+$tomlDest = ConvertTo-TomlBasicString $Dest
+$notifyLine = "notify = [`"powershell.exe`", `"-NoProfile`", `"-ExecutionPolicy`", `"Bypass`", `"-File`", `"$tomlDest`"]"
+
+if (-not $existingNotify.Success) {
+    $newContent = if ($codexContent.Length -gt 0) {
+        "$notifyLine`n$codexContent"
+    } else {
+        "$notifyLine`n"
+    }
+    Write-Utf8NoBom $CodexConfig $newContent
+    Write-Host "codex: notify added -> $Dest"
+} elseif ($existingNotify.Value -like "*wispterm-notify.ps1*") {
+    Write-Host "codex: notify already set to wispterm-notify"
+} else {
+    Write-Host "WARN: codex already has a different notify (left untouched): $($existingNotify.Value.Trim())"
+}
+
+Write-Host ""
+Write-Host "Verify in WispTerm:"
+Write-Host "  '{`"hook_event_name`":`"Notification`",`"title`":`"WispTerm`",`"message`":`"setup ok`"}' | powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$Dest`""

--- a/plugins/skills/wispterm-notify-setup/scripts/test-install.sh
+++ b/plugins/skills/wispterm-notify-setup/scripts/test-install.sh
@@ -17,6 +17,9 @@ assert_contains() { # file needle desc
 assert_not_contains() {
   if LC_ALL=C grep -qF -- "$2" "$1"; then fail "$3 (unexpected: $2)"; else ok "$3"; fi
 }
+assert_file_exists() {
+  if [ -f "$1" ]; then ok "$2"; else fail "$2 (missing: $1)"; fi
+}
 
 # ---- notify: Claude Code Notification on stdin ----
 t="$(mktemp)"
@@ -150,6 +153,33 @@ out5="$(HOME="$FAKE5" sh "$INSTALL" 2>/dev/null)"
 assert_contains "$FAKE5/.codex/config.toml" '/some/indented/notifier.sh' "codex: indented top-level notify preserved"
 [ "$(grep -cE '^[[:space:]]*notify[[:space:]]*=' "$FAKE5/.codex/config.toml")" -eq 1 ] \
   && ok "codex: no duplicate notify for indented top-level" || fail "codex: duplicated indented notify"
+
+# ================= skill workflow guardrails =================
+SKILL="$HERE/../SKILL.md"
+PS_NOTIFY="$HERE/wispterm-notify.ps1"
+PS_INSTALL="$HERE/install-wispterm-notify.ps1"
+PS_REMOTE_INSTALL="$HERE/install-wispterm-notify-remote.ps1"
+assert_contains "$SKILL" 'terminal_list' "skill tells agents to inspect WispTerm surfaces"
+assert_contains "$SKILL" 'ssh_profile_connect' "skill tells agents to connect saved SSH profiles"
+assert_contains "$SKILL" 'wsl_session_exec' "skill tells agents to install inside WSL surfaces"
+assert_contains "$SKILL" 'powershell_exec' "skill tells agents to install from PowerShell"
+assert_contains "$SKILL" 'scp' "skill requires scp transfer for remote SSH profiles"
+assert_contains "$SKILL" 'Never ask the user to re-provide SSH host/user/port/password' "skill forbids re-asking for saved profile credentials"
+assert_file_exists "$PS_NOTIFY" "PowerShell notifier script is bundled"
+assert_file_exists "$PS_INSTALL" "PowerShell installer script is bundled"
+assert_file_exists "$PS_REMOTE_INSTALL" "PowerShell remote profile installer is bundled"
+if [ -f "$PS_NOTIFY" ]; then
+  assert_contains "$PS_NOTIFY" 'CONOUT$' "PowerShell notifier writes to attached console"
+fi
+if [ -f "$PS_INSTALL" ]; then
+  assert_contains "$PS_INSTALL" 'settings.json' "PowerShell installer wires Claude settings"
+  assert_contains "$PS_INSTALL" 'config.toml' "PowerShell installer wires Codex config"
+fi
+if [ -f "$PS_REMOTE_INSTALL" ]; then
+  assert_contains "$PS_REMOTE_INSTALL" 'ssh_hosts' "remote installer reads WispTerm SSH profiles"
+  assert_contains "$PS_REMOTE_INSTALL" 'scp.exe' "remote installer transfers scripts with scp"
+  assert_contains "$PS_REMOTE_INSTALL" 'SSH_ASKPASS' "remote installer supports saved password profiles"
+fi
 
 printf '\n%s test(s) failed\n' "$FAILS"
 [ "$FAILS" -eq 0 ]

--- a/plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.ps1
+++ b/plugins/skills/wispterm-notify-setup/scripts/wispterm-notify.ps1
@@ -1,0 +1,112 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $EventArgs
+)
+
+# Agent-agnostic WispTerm notifier for Windows PowerShell/PowerShell Core.
+# Reads a Claude Code hook event from stdin or a Codex event JSON from the last
+# argv, then writes OSC 777 + BEL directly to the attached ConPTY console.
+
+$payload = ""
+if ($EventArgs -and $EventArgs.Count -gt 0) {
+    $payload = $EventArgs[$EventArgs.Count - 1]
+}
+if ([string]::IsNullOrWhiteSpace($payload)) {
+    try {
+        if ([Console]::IsInputRedirected) {
+            $payload = [Console]::In.ReadToEnd()
+        }
+    } catch {
+        $payload = ""
+    }
+}
+if ([string]::IsNullOrWhiteSpace($payload)) {
+    exit 0
+}
+
+function Get-JsonProperty {
+    param(
+        [object] $Object,
+        [string] $Name
+    )
+    if ($null -eq $Object) { return $null }
+    $prop = $Object.PSObject.Properties[$Name]
+    if ($null -eq $prop -or $null -eq $prop.Value) { return $null }
+    return [string] $prop.Value
+}
+
+$title = "Claude Code"
+$body = "Notification"
+$event = $null
+try {
+    $event = $payload | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    $event = $null
+}
+
+$hookEvent = Get-JsonProperty $event "hook_event_name"
+if ($hookEvent -eq "Stop") {
+    $title = "Claude Code"
+    $body = "完成，轮到你了"
+} elseif ($hookEvent -eq "Notification") {
+    $maybeTitle = Get-JsonProperty $event "title"
+    $maybeBody = Get-JsonProperty $event "message"
+    if ([string]::IsNullOrEmpty($maybeBody)) {
+        $maybeBody = Get-JsonProperty $event "notification_type"
+    }
+    if (-not [string]::IsNullOrEmpty($maybeTitle)) { $title = $maybeTitle }
+    if (-not [string]::IsNullOrEmpty($maybeBody)) { $body = $maybeBody }
+} else {
+    $codexType = Get-JsonProperty $event "type"
+    if (-not [string]::IsNullOrEmpty($codexType)) {
+        $title = "Codex"
+        $codexBody = Get-JsonProperty $event "last-assistant-message"
+        if ([string]::IsNullOrEmpty($codexBody)) { $codexBody = $codexType }
+        if ([string]::IsNullOrEmpty($codexBody)) { $codexBody = "Turn complete" }
+        $body = $codexBody
+    }
+}
+
+function Sanitize-Field {
+    param(
+        [string] $Value,
+        [int] $MaxLength
+    )
+    if ($null -eq $Value) { $Value = "" }
+    $Value = $Value.Replace([string][char]27, "")
+    $Value = $Value.Replace([string][char]7, "")
+    $Value = $Value.Replace("`r", "")
+    $Value = $Value.Replace("`n", "")
+    $Value = $Value.Replace(";", "")
+    if ($Value.Length -gt $MaxLength) {
+        return $Value.Substring(0, $MaxLength)
+    }
+    return $Value
+}
+
+$title = Sanitize-Field $title 256
+$body = Sanitize-Field $body 1024
+
+$esc = [char]27
+$bel = [char]7
+$marker = [char]0x200B
+$message = "$esc]777;notify;$title;$body$marker$bel$bel"
+$bytes = [Text.Encoding]::UTF8.GetBytes($message)
+
+try {
+    $stream = [IO.File]::OpenWrite("CONOUT$")
+    try {
+        $stream.Write($bytes, 0, $bytes.Length)
+    } finally {
+        $stream.Dispose()
+    }
+} catch {
+    try {
+        $stdout = [Console]::OpenStandardOutput()
+        $stdout.Write($bytes, 0, $bytes.Length)
+    } catch {
+        # Never block or fail the agent because notification delivery failed.
+    }
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- Add profile-aware setup guidance for WispTerm notify installs across local shells, WSL, PowerShell, and saved SSH profiles.
- Add Windows PowerShell notifier/installers, including a remote saved-profile installer that uses scp/ssh and WispTerm ssh_hosts.
- Extend the skill test harness with workflow guardrails for profile lookup, WSL/PowerShell routing, and scp-based SSH installs.

## Test Plan
- sh plugins/skills/wispterm-notify-setup/scripts/test-install.sh
- python3 /home/xzg/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/skills/wispterm-notify-setup
- git diff --check
- Windows checkout path-safety check