### PR TITLE
fix(macos/window): lock event ring queues against cross-thread races

### DIFF
--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -560,6 +560,157 @@ test "macOS backend sendMessage runs the handler on the event-loop thread and re
     try std.testing.expectEqual(@as(platform_window.MessageResult, 1007), probe.result);
 }
 
+const MessageRaceContext = struct {
+    hwnd: NativeHandle,
+    total: usize,
+    inflight_cap: usize,
+    // Number of slots the consumer has popped. The producer reads this to
+    // bound in-flight messages below the ring capacity so the queue never
+    // legitimately overwrites — any lost/duplicated message is therefore a
+    // synchronization bug, not expected ring-buffer eviction.
+    consumed: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+fn messageRaceProducer(ctx: *MessageRaceContext) void {
+    var i: usize = 0;
+    while (i < ctx.total) : (i += 1) {
+        // Throttle on the consumer's own atomic counter (never the bridge's
+        // internal, racy count) so in-flight stays < ring capacity.
+        while (i -% ctx.consumed.load(.acquire) >= ctx.inflight_cap) {
+            if (ctx.stop.load(.acquire)) return;
+            std.atomic.spinLoopHint();
+        }
+        if (ctx.stop.load(.acquire)) return;
+        _ = platform_window.postMessage(ctx.hwnd, platform_window.hotkey_message, i, 0);
+    }
+}
+
+test "macOS message queue survives concurrent push and pop" {
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Message Race");
+    var window = try Window.init(320, 180, title, null, null, false);
+    defer window.deinit();
+
+    const total: usize = 200_000;
+    var ctx = MessageRaceContext{
+        .hwnd = window.hwnd,
+        .total = total,
+        .inflight_cap = 16, // < message ring capacity (32) so no legitimate eviction
+    };
+
+    const allocator = std.testing.allocator;
+    const seen = try allocator.alloc(bool, total);
+    defer allocator.free(seen);
+    @memset(seen, false);
+
+    const producer = try std.Thread.spawn(.{}, messageRaceProducer, .{&ctx});
+
+    var received: usize = 0;
+    var duplicates: usize = 0;
+    var corrupt: usize = 0;
+    var popped: usize = 0;
+    var timer = try std.time.Timer.start();
+    const timeout_ns: u64 = 30 * std.time.ns_per_s;
+
+    while (received < total) {
+        var ev: RawMessageEvent = undefined;
+        if (wispterm_macos_window_pop_message_event(window.hwnd, &ev)) {
+            popped += 1;
+            ctx.consumed.store(popped, .release);
+            if (ev.message != platform_window.hotkey_message or ev.wparam >= total) {
+                corrupt += 1;
+            } else if (seen[ev.wparam]) {
+                duplicates += 1;
+            } else {
+                seen[ev.wparam] = true;
+                received += 1;
+            }
+        } else {
+            std.atomic.spinLoopHint();
+        }
+        if (timer.read() > timeout_ns) break;
+    }
+
+    ctx.stop.store(true, .release);
+    producer.join();
+
+    try std.testing.expectEqual(@as(usize, 0), corrupt);
+    try std.testing.expectEqual(@as(usize, 0), duplicates);
+    try std.testing.expectEqual(total, received);
+}
+
+fn keyRaceProducer(ctx: *MessageRaceContext) void {
+    var i: usize = 0;
+    while (i < ctx.total) : (i += 1) {
+        while (i -% ctx.consumed.load(.acquire) >= ctx.inflight_cap) {
+            if (ctx.stop.load(.acquire)) return;
+            std.atomic.spinLoopHint();
+        }
+        if (ctx.stop.load(.acquire)) return;
+        // Encode the sequence number in the key code so the consumer can
+        // detect loss/duplication/torn reads.
+        wispterm_macos_window_test_push_key(ctx.hwnd, i, false, false, false);
+    }
+}
+
+// Mirrors the message-queue race test for an input queue: with additional
+// windows the main thread pushes input events (AppKit dispatch during
+// pumpAppEvents) while the per-window worker thread pops them, so the input
+// rings must serialize too. Uses the key ring as the representative for the
+// shared input_lock.
+test "macOS input queue survives concurrent push and pop" {
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Input Race");
+    var window = try Window.init(320, 180, title, null, null, false);
+    defer window.deinit();
+
+    const total: usize = 200_000;
+    var ctx = MessageRaceContext{
+        .hwnd = window.hwnd,
+        .total = total,
+        .inflight_cap = 32, // < key ring capacity (64) so no legitimate eviction
+    };
+
+    const allocator = std.testing.allocator;
+    const seen = try allocator.alloc(bool, total);
+    defer allocator.free(seen);
+    @memset(seen, false);
+
+    const producer = try std.Thread.spawn(.{}, keyRaceProducer, .{&ctx});
+
+    var received: usize = 0;
+    var duplicates: usize = 0;
+    var corrupt: usize = 0;
+    var popped: usize = 0;
+    var timer = try std.time.Timer.start();
+    const timeout_ns: u64 = 30 * std.time.ns_per_s;
+
+    while (received < total) {
+        var ev: RawKeyEvent = undefined;
+        if (wispterm_macos_window_pop_key_event(window.hwnd, &ev)) {
+            popped += 1;
+            ctx.consumed.store(popped, .release);
+            if (ev.key_code >= total) {
+                corrupt += 1;
+            } else if (seen[ev.key_code]) {
+                duplicates += 1;
+            } else {
+                seen[ev.key_code] = true;
+                received += 1;
+            }
+        } else {
+            std.atomic.spinLoopHint();
+        }
+        if (timer.read() > timeout_ns) break;
+    }
+
+    ctx.stop.store(true, .release);
+    producer.join();
+
+    try std.testing.expectEqual(@as(usize, 0), corrupt);
+    try std.testing.expectEqual(@as(usize, 0), duplicates);
+    try std.testing.expectEqual(total, received);
+}
+
 fn testFileDropCallback(path: []const u8, x: i32, y: i32) bool {
     test_drop_seen = std.mem.eql(u8, path, "/tmp/wispterm-drop.txt");
     test_drop_x = x;

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -1,6 +1,7 @@
 #import <AppKit/AppKit.h>
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
+#include <os/lock.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -94,6 +95,14 @@ struct WispTermMacWindowState {
     char ime_preedit[1024];
     size_t ime_preedit_len;
     NSEventModifierFlags insert_text_modifier_flags;
+    // Guards the key/char/mouse/file-drop rings below. For windows running on
+    // a worker thread (every window past the first: Dock reopen / new-window),
+    // AppKit dispatches input on the main thread while that window's worker
+    // thread drains via pollEvents, so these rings are cross-thread too. One
+    // shared lock suffices: the worker drains them sequentially and AppKit
+    // dispatch on main is itself serialized, so there is no cross-queue
+    // contention to gain from per-ring locks.
+    os_unfair_lock input_lock;
     WispTermMacKeyEvent key_events[64];
     size_t key_head;
     size_t key_count;
@@ -112,6 +121,13 @@ struct WispTermMacWindowState {
     WispTermMacMessageEvent message_events[32];
     size_t message_head;
     size_t message_count;
+    // The message ring is the one event queue written from arbitrary caller
+    // threads (remote-client / poller threads via
+    // wispterm_macos_window_post_message) and drained from the per-window
+    // worker thread (windowThreadMain -> pollEvents -> drainMessageEvents).
+    // Without a lock, the non-atomic head/count are a data race: concurrent
+    // RMW loses/duplicates messages and torn reads hand the consumer garbage.
+    os_unfair_lock message_lock;
     WispTermMacFileDropEvent file_drop_events[16];
     size_t file_drop_head;
     size_t file_drop_count;
@@ -268,6 +284,7 @@ static double wispterm_macos_scale(WispTermMacWindowState *state) {
 static void wispterm_macos_push_key_event(WispTermMacWindowState *state, WispTermMacKeyEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->key_events) / sizeof(state->key_events[0]);
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->key_head + state->key_count) % capacity;
     state->key_events[idx] = event;
     if (state->key_count < capacity) {
@@ -275,20 +292,27 @@ static void wispterm_macos_push_key_event(WispTermMacWindowState *state, WispTer
     } else {
         state->key_head = (state->key_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
 }
 
 static bool wispterm_macos_pop_key_event(WispTermMacWindowState *state, WispTermMacKeyEvent *out) {
-    if (state == NULL || out == NULL || state->key_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->key_events) / sizeof(state->key_events[0]);
-    *out = state->key_events[state->key_head];
-    state->key_head = (state->key_head + 1) % capacity;
-    state->key_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->key_count != 0;
+    if (has_event) {
+        *out = state->key_events[state->key_head];
+        state->key_head = (state->key_head + 1) % capacity;
+        state->key_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
 static void wispterm_macos_push_char_event(WispTermMacWindowState *state, WispTermMacCharEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->char_events) / sizeof(state->char_events[0]);
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->char_head + state->char_count) % capacity;
     state->char_events[idx] = event;
     if (state->char_count < capacity) {
@@ -296,20 +320,27 @@ static void wispterm_macos_push_char_event(WispTermMacWindowState *state, WispTe
     } else {
         state->char_head = (state->char_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
 }
 
 static bool wispterm_macos_pop_char_event(WispTermMacWindowState *state, WispTermMacCharEvent *out) {
-    if (state == NULL || out == NULL || state->char_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->char_events) / sizeof(state->char_events[0]);
-    *out = state->char_events[state->char_head];
-    state->char_head = (state->char_head + 1) % capacity;
-    state->char_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->char_count != 0;
+    if (has_event) {
+        *out = state->char_events[state->char_head];
+        state->char_head = (state->char_head + 1) % capacity;
+        state->char_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
 static void wispterm_macos_push_mouse_button_event(WispTermMacWindowState *state, WispTermMacMouseButtonEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->mouse_button_events) / sizeof(state->mouse_button_events[0]);
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->mouse_button_head + state->mouse_button_count) % capacity;
     state->mouse_button_events[idx] = event;
     if (state->mouse_button_count < capacity) {
@@ -317,20 +348,27 @@ static void wispterm_macos_push_mouse_button_event(WispTermMacWindowState *state
     } else {
         state->mouse_button_head = (state->mouse_button_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
 }
 
 static bool wispterm_macos_pop_mouse_button_event(WispTermMacWindowState *state, WispTermMacMouseButtonEvent *out) {
-    if (state == NULL || out == NULL || state->mouse_button_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->mouse_button_events) / sizeof(state->mouse_button_events[0]);
-    *out = state->mouse_button_events[state->mouse_button_head];
-    state->mouse_button_head = (state->mouse_button_head + 1) % capacity;
-    state->mouse_button_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->mouse_button_count != 0;
+    if (has_event) {
+        *out = state->mouse_button_events[state->mouse_button_head];
+        state->mouse_button_head = (state->mouse_button_head + 1) % capacity;
+        state->mouse_button_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
 static void wispterm_macos_push_mouse_move_event(WispTermMacWindowState *state, WispTermMacMouseMoveEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->mouse_move_events) / sizeof(state->mouse_move_events[0]);
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->mouse_move_head + state->mouse_move_count) % capacity;
     state->mouse_move_events[idx] = event;
     if (state->mouse_move_count < capacity) {
@@ -338,20 +376,27 @@ static void wispterm_macos_push_mouse_move_event(WispTermMacWindowState *state, 
     } else {
         state->mouse_move_head = (state->mouse_move_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
 }
 
 static bool wispterm_macos_pop_mouse_move_event(WispTermMacWindowState *state, WispTermMacMouseMoveEvent *out) {
-    if (state == NULL || out == NULL || state->mouse_move_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->mouse_move_events) / sizeof(state->mouse_move_events[0]);
-    *out = state->mouse_move_events[state->mouse_move_head];
-    state->mouse_move_head = (state->mouse_move_head + 1) % capacity;
-    state->mouse_move_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->mouse_move_count != 0;
+    if (has_event) {
+        *out = state->mouse_move_events[state->mouse_move_head];
+        state->mouse_move_head = (state->mouse_move_head + 1) % capacity;
+        state->mouse_move_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
 static void wispterm_macos_push_mouse_wheel_event(WispTermMacWindowState *state, WispTermMacMouseWheelEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->mouse_wheel_events) / sizeof(state->mouse_wheel_events[0]);
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->mouse_wheel_head + state->mouse_wheel_count) % capacity;
     state->mouse_wheel_events[idx] = event;
     if (state->mouse_wheel_count < capacity) {
@@ -359,20 +404,31 @@ static void wispterm_macos_push_mouse_wheel_event(WispTermMacWindowState *state,
     } else {
         state->mouse_wheel_head = (state->mouse_wheel_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
 }
 
 static bool wispterm_macos_pop_mouse_wheel_event(WispTermMacWindowState *state, WispTermMacMouseWheelEvent *out) {
-    if (state == NULL || out == NULL || state->mouse_wheel_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->mouse_wheel_events) / sizeof(state->mouse_wheel_events[0]);
-    *out = state->mouse_wheel_events[state->mouse_wheel_head];
-    state->mouse_wheel_head = (state->mouse_wheel_head + 1) % capacity;
-    state->mouse_wheel_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->mouse_wheel_count != 0;
+    if (has_event) {
+        *out = state->mouse_wheel_events[state->mouse_wheel_head];
+        state->mouse_wheel_head = (state->mouse_wheel_head + 1) % capacity;
+        state->mouse_wheel_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
+// The message ring is the only event queue with producers off the window
+// worker thread, so push/pop must serialize on state->message_lock. The lock
+// is held only for the few non-blocking ring operations below — never across
+// an AppKit call or a callback — so contention is negligible.
 static void wispterm_macos_push_message_event(WispTermMacWindowState *state, WispTermMacMessageEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->message_events) / sizeof(state->message_events[0]);
+    os_unfair_lock_lock(&state->message_lock);
     const size_t idx = (state->message_head + state->message_count) % capacity;
     state->message_events[idx] = event;
     if (state->message_count < capacity) {
@@ -380,24 +436,31 @@ static void wispterm_macos_push_message_event(WispTermMacWindowState *state, Wis
     } else {
         state->message_head = (state->message_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->message_lock);
 }
 
 static bool wispterm_macos_pop_message_event(WispTermMacWindowState *state, WispTermMacMessageEvent *out) {
-    if (state == NULL || out == NULL || state->message_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->message_events) / sizeof(state->message_events[0]);
-    *out = state->message_events[state->message_head];
-    state->message_head = (state->message_head + 1) % capacity;
-    state->message_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->message_lock);
+    bool has_event = state->message_count != 0;
+    if (has_event) {
+        *out = state->message_events[state->message_head];
+        state->message_head = (state->message_head + 1) % capacity;
+        state->message_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->message_lock);
+    return has_event;
 }
 
 static bool wispterm_macos_push_file_drop_event(WispTermMacWindowState *state, const char *path, int32_t x, int32_t y) {
     if (state == NULL || path == NULL) return false;
     const size_t capacity = sizeof(state->file_drop_events) / sizeof(state->file_drop_events[0]);
+    const size_t source_len = strlen(path);
+    const size_t len = source_len < sizeof(state->file_drop_events[0].path) ? source_len : sizeof(state->file_drop_events[0].path) - 1;
+    os_unfair_lock_lock(&state->input_lock);
     const size_t idx = (state->file_drop_head + state->file_drop_count) % capacity;
     WispTermMacFileDropEvent *event = &state->file_drop_events[idx];
-    const size_t source_len = strlen(path);
-    const size_t len = source_len < sizeof(event->path) ? source_len : sizeof(event->path) - 1;
     memcpy(event->path, path, len);
     event->path[len] = 0;
     event->path_len = len;
@@ -408,16 +471,22 @@ static bool wispterm_macos_push_file_drop_event(WispTermMacWindowState *state, c
     } else {
         state->file_drop_head = (state->file_drop_head + 1) % capacity;
     }
+    os_unfair_lock_unlock(&state->input_lock);
     return true;
 }
 
 static bool wispterm_macos_pop_file_drop_event(WispTermMacWindowState *state, WispTermMacFileDropEvent *out) {
-    if (state == NULL || out == NULL || state->file_drop_count == 0) return false;
+    if (state == NULL || out == NULL) return false;
     const size_t capacity = sizeof(state->file_drop_events) / sizeof(state->file_drop_events[0]);
-    *out = state->file_drop_events[state->file_drop_head];
-    state->file_drop_head = (state->file_drop_head + 1) % capacity;
-    state->file_drop_count -= 1;
-    return true;
+    os_unfair_lock_lock(&state->input_lock);
+    bool has_event = state->file_drop_count != 0;
+    if (has_event) {
+        *out = state->file_drop_events[state->file_drop_head];
+        state->file_drop_head = (state->file_drop_head + 1) % capacity;
+        state->file_drop_count -= 1;
+    }
+    os_unfair_lock_unlock(&state->input_lock);
+    return has_event;
 }
 
 static void wispterm_macos_mods(NSEventModifierFlags flags, bool *ctrl, bool *shift, bool *alt, bool *super) {
@@ -939,6 +1008,8 @@ void *wispterm_macos_window_create(
             state->layer = [layer retain];
             state->delegate = delegate;
             state->close_requested = false;
+            state->input_lock = OS_UNFAIR_LOCK_INIT;
+            state->message_lock = OS_UNFAIR_LOCK_INIT;
             state->ime_caret_x = 0;
             state->ime_caret_y = 0;
             state->ime_caret_height = 16;


### PR DESCRIPTION
## 问题

`src/platform/window_macos_bridge.m` 的事件环形队列用非原子 `head`/`count` 索引、无任何互斥锁，存在跨线程数据竞争（未定义行为）：

- **消息队列**：由发起方线程（remote client、weixin poller 经 `wispterm_macos_window_post_message`）push，由窗口 worker 线程（`windowThreadMain → pollEvents → drainMessageEvents`）pop。并发非原子 RMW 会丢失/重复消息，撕裂读会把垃圾交给消费者。同步 `sendMessage` 路径对丢消息尤其敏感。
- **输入/拖拽队列**（key/char/mouse/file_drop）：对**第 2+ 个窗口**有同样问题——这些窗口的事件循环跑在 worker 线程，而 AppKit 在主线程 `pumpAppEvents` 期间分发它们的输入，于是 push（主线程）与 pop（worker 线程）相竞争。首个窗口全程在主线程，不受影响。

## 修复

- `WispTermMacWindowState` 新增 `os_unfair_lock`：`message_lock` 保护消息环，共享的 `input_lock` 保护 6 个输入/拖拽环。
- 每个 push/pop 都在锁内串行；pop 改为**持锁后**判空，消除原先锁外的 check-then-act 窗口。
- 锁只覆盖少量非阻塞环操作，绝不跨 AppKit 调用或回调，竞争开销可忽略。

## 测试

新增 2 个并发 push/pop 压测（消息环 + 作为输入代表的 key 环）。生产者按消费者自己的原子计数限流，使在途消息 < 环容量、**绝无合法覆盖**——任何丢失/重复/撕裂读都只能是同步 bug。

| | 未修复 | 已修复 |
|---|---|---|
| 消息环压测 | 3/3 失败（corrupt=3/3/6） | 通过 |
| 输入环压测 | 3/3 失败（corrupt=17/40/80） | 通过 |
| `zig build test-macos-window` | — | **36/36 通过**，连跑 5 次稳定 |
| 默认 Windows target `zig build` | — | exit 0，产出 `wispterm.exe` |

## 平台影响

仅限 macOS：`window_macos_bridge.m` 只在 macOS host 编译，`window_backend_macos.zig` 只在 `.macos` target 被选用，Windows 默认构建不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)