### PR TITLE
fix(macos/weixin): AI Agent open + /stop on macOS

### DIFF
--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const platform_input = @import("input_events.zig");
 const platform_window = @import("window.zig");
+const window_macos = @import("window_macos.zig");
 
 pub const FileDropHandler = *const fn (path: []const u8, x: i32, y: i32) bool;
 const MessageCallback = *const fn (
@@ -145,6 +146,8 @@ var test_message_value: platform_window.WordParam = 0;
 var test_drop_seen: bool = false;
 var test_drop_x: i32 = 0;
 var test_drop_y: i32 = 0;
+var sync_test_message: platform_window.MessageId = 0;
+var sync_test_wparam: platform_window.WordParam = 0;
 
 pub const Window = struct {
     pub const FramebufferSize = struct {
@@ -348,6 +351,20 @@ pub const Window = struct {
     fn drainMessageEvents(self: *Window) void {
         var msg: RawMessageEvent = undefined;
         while (wispterm_macos_window_pop_message_event(self.hwnd, &msg)) {
+            // Synchronous cross-thread sends (window_macos.sendMessage) arrive
+            // tagged as sync_message and carry a *SyncCall in lparam. Run the
+            // real handler here — on the event-loop thread that owns the
+            // threadlocal UI state — then hand the result back to the blocked
+            // caller, emulating Win32's synchronous SendMessage.
+            if (msg.message == window_macos.sync_message) {
+                const call = window_macos.syncCallFromLparam(msg.lparam);
+                var result: platform_window.MessageResult = 0;
+                if (self.on_message) |callback| {
+                    result = callback(call.message, call.wparam, call.lparam) orelse 0;
+                }
+                window_macos.completeSyncCall(call, result);
+                continue;
+            }
             if (self.on_message) |callback| {
                 _ = callback(msg.message, msg.wparam, msg.lparam);
             }
@@ -491,6 +508,56 @@ test "macOS backend drains posted platform messages" {
 
     try std.testing.expect(test_message_seen);
     try std.testing.expectEqual(@as(platform_window.WordParam, 42), test_message_value);
+}
+
+fn syncTestCallback(
+    message: platform_window.MessageId,
+    wparam: platform_window.WordParam,
+    lparam: platform_window.LongParam,
+) ?platform_window.MessageResult {
+    _ = lparam;
+    sync_test_message = message;
+    sync_test_wparam = wparam;
+    return @as(platform_window.MessageResult, @intCast(wparam)) + 1000;
+}
+
+const SyncSendProbe = struct {
+    hwnd: NativeHandle,
+    result: platform_window.MessageResult = 0,
+    finished: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    fn run(self: *SyncSendProbe) void {
+        self.result = platform_window.sendMessage(self.hwnd, platform_window.appMessage(0x10), 7, 0);
+        self.finished.store(true, .release);
+    }
+};
+
+test "macOS backend sendMessage runs the handler on the event-loop thread and returns its result" {
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Sync Send Smoke");
+    var window = try Window.init(320, 180, title, null, null, false);
+    defer window.deinit();
+
+    sync_test_message = 0;
+    sync_test_wparam = 0;
+    window.on_message = syncTestCallback;
+
+    // sendMessage must block the caller until the event-loop thread drains the
+    // queue and runs the handler, so the call has to come from a worker thread
+    // while this thread plays the role of the event loop and pumps.
+    var probe = SyncSendProbe{ .hwnd = window.hwnd };
+    const sender = try std.Thread.spawn(.{}, SyncSendProbe.run, .{&probe});
+    defer sender.join();
+
+    var spins: usize = 0;
+    while (!probe.finished.load(.acquire) and spins < 2000) : (spins += 1) {
+        _ = window.pollEvents();
+        std.Thread.sleep(std.time.ns_per_ms);
+    }
+
+    try std.testing.expect(probe.finished.load(.acquire));
+    try std.testing.expectEqual(platform_window.appMessage(0x10), sync_test_message);
+    try std.testing.expectEqual(@as(platform_window.WordParam, 7), sync_test_wparam);
+    try std.testing.expectEqual(@as(platform_window.MessageResult, 1007), probe.result);
 }
 
 fn testFileDropCallback(path: []const u8, x: i32, y: i32) bool {

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -28,6 +28,11 @@ pub const hotkey_message: MessageId = 0x0312;
 const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 
+/// Reserved message id for the synchronous-send shim (see `sendMessage`).
+/// Distinct from the app-message range thread_message uses (wm_app + 0x51..0x57)
+/// and from `hotkey_message`, so it never collides with a real posted message.
+pub const sync_message: MessageId = wm_app + 0x7e;
+
 extern fn wispterm_macos_window_request_close(handle: NativeHandle) void;
 extern fn wispterm_macos_window_post_message(handle: NativeHandle, message: MessageId, wparam: WordParam, lparam: LongParam) bool;
 extern fn wispterm_macos_window_get_frame(handle: NativeHandle, rect: *Rect) bool;
@@ -85,12 +90,75 @@ pub fn postMessage(hwnd: NativeHandle, message: MessageId, wparam: WordParam, lp
     return wispterm_macos_window_post_message(hwnd, message, wparam, lparam);
 }
 
+/// Wall-clock cap for a blocked `sendMessage` caller. A backstop only: the
+/// window's event loop drains its message queue every frame, so a live window
+/// answers within ~1 frame. The cap bounds the wait if the target window is
+/// tearing down (its native handle is published as 0 first, so callers normally
+/// skip this path) or if the bounded message queue ever overflowed the request.
+const send_message_timeout_ns: u64 = 5 * std.time.ns_per_s;
+
+/// Cross-thread synchronous-call envelope used to emulate Win32 `SendMessage`
+/// on macOS. `sendMessage` posts one of these through the normal async message
+/// queue and blocks until the window's event-loop thread drains it, runs the
+/// real handler on that thread (where the threadlocal UI state lives), records
+/// the result, and signals `done`.
+///
+/// Heap-owned and reference counted (init 2: caller + worker) so that a
+/// timed-out caller and the later-draining worker never use-after-free: each
+/// side releases its reference once and the last release frees the envelope.
+pub const SyncCall = struct {
+    message: MessageId,
+    wparam: WordParam,
+    lparam: LongParam,
+    result: MessageResult = 0,
+    done: std.Thread.ResetEvent = .{},
+    refs: std.atomic.Value(u8) = std.atomic.Value(u8).init(2),
+};
+
+pub fn syncCallFromLparam(lparam: LongParam) *SyncCall {
+    return @ptrFromInt(ptrValueFromLongParam(lparam));
+}
+
+fn releaseSyncCall(call: *SyncCall) void {
+    if (call.refs.fetchSub(1, .acq_rel) == 1) {
+        std.heap.page_allocator.destroy(call);
+    }
+}
+
+/// Event-loop side: called by the window backend's message drain when it pops a
+/// `sync_message`. Records the handler's result, wakes the blocked caller, and
+/// drops the worker's reference.
+pub fn completeSyncCall(call: *SyncCall, result: MessageResult) void {
+    call.result = result;
+    call.done.set();
+    releaseSyncCall(call);
+}
+
+/// Synchronous cross-thread message dispatch. AppKit has no Win32-style
+/// `SendMessage`, so this marshals the message onto the window's event-loop
+/// thread (via the async queue) and blocks until that thread runs the handler
+/// and reports back. Must be called from another thread than the event loop;
+/// every in-tree caller does (weixin poller, remote client, AI tool host's
+/// cross-window path), guarded by the same-thread checks at their call sites.
 pub fn sendMessage(hwnd: NativeHandle, message: MessageId, wparam: WordParam, lparam: LongParam) MessageResult {
-    _ = hwnd;
-    _ = message;
-    _ = wparam;
-    _ = lparam;
-    return 0;
+    if (message == wm_close) {
+        _ = postCloseMessage(hwnd);
+        return 0;
+    }
+    const call = std.heap.page_allocator.create(SyncCall) catch return 0;
+    call.* = .{ .message = message, .wparam = wparam, .lparam = lparam };
+    if (!wispterm_macos_window_post_message(hwnd, sync_message, 0, longParamFromPtrValue(@intFromPtr(call)))) {
+        // Never queued, so the event loop will never touch it: drop both refs.
+        releaseSyncCall(call);
+        releaseSyncCall(call);
+        return 0;
+    }
+    const result: MessageResult = if (call.done.timedWait(send_message_timeout_ns)) |_|
+        call.result
+    else |_|
+        0;
+    releaseSyncCall(call);
+    return result;
 }
 
 pub fn dpiForWindow(hwnd: NativeHandle) u32 {

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -13,6 +13,9 @@ pub const Reply = struct {
     text: std.ArrayListUnmanaged(u8) = .empty,
     /// true ⇒ caller should start AI-reply progress streaming.
     expect_ai_progress: bool = false,
+    /// true ⇒ caller should cancel any active AI-reply progress streaming
+    /// (set by /stop), so no further progress/final replies are sent.
+    stop_followup: bool = false,
 
     pub fn init(allocator: std.mem.Allocator) Reply {
         return .{ .allocator = allocator };
@@ -105,6 +108,10 @@ fn sendAi(ctrl: control.Control, text: []const u8, reply_context: ?types.ReplyCo
 }
 
 fn stopAi(ctrl: control.Control, out: *Reply) !void {
+    // /stop halts the active AI run; also tell the poller to cancel any
+    // in-flight weixin reply streaming so no further progress/final reply is
+    // sent after the stop (otherwise a trailing reply looks like /stop failed).
+    out.stop_followup = true;
     const ai = ctrl.findAiSurface() orelse return out.set("当前没有 AI Agent 可停止。");
     if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止 AI Agent。");
     return out.set("已发送停止指令。");
@@ -265,4 +272,14 @@ test "offline control yields an offline message and no progress" {
     try route(t.allocator, fake.control_iface(), defaultSettings(), "do a thing", null, &out);
     try t.expect(!out.expect_ai_progress);
     try t.expect(std.mem.indexOf(u8, out.text.items, "离线") != null);
+}
+
+test "/stop sends ESC to the AI surface and requests followup cancellation" {
+    var fake = FakeControl{};
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/stop", null, &out);
+    try t.expectEqualStrings(ESC, fake.lastInput());
+    try t.expect(out.stop_followup);
+    try t.expect(!out.expect_ai_progress);
 }

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -33,6 +33,8 @@ const AI_REPLY_WINDOW_EXPIRED_NOTICE = "AI 处理已超过 30 分钟仍未完成
 
 pub const RouteResult = struct {
     expect_ai_progress: bool = false,
+    /// true ⇒ cancel any active AI-reply progress streaming (set by /stop).
+    stop_followup: bool = false,
     /// Heap-owned by ProcessInput. Freed after start_progress_fn returns.
     baseline_transcript: []u8 = &.{},
 };
@@ -67,6 +69,9 @@ pub const ProcessInput = struct {
     send_fn: *const fn (ctx: *anyopaque, to_user_id: []const u8, text: []const u8, context_token: []const u8) anyerror!void,
     progress_ctx: ?*anyopaque = null,
     start_progress_fn: ?*const fn (ctx: *anyopaque, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void = null,
+    /// Cancels any active AI-reply progress streaming. Invoked (with progress_ctx)
+    /// when a routed message reports stop_followup (e.g. /stop).
+    stop_progress_fn: ?*const fn (ctx: *anyopaque) void = null,
 };
 
 /// Mirror of processWeixinUpdates: filter, extract, route, reply.
@@ -109,6 +114,18 @@ pub fn processUpdates(input: ProcessInput) !void {
             "weixin process({d}): index={d} route=done reply_bytes={d} ai_followup={} baseline_bytes={d}\n",
             .{ debugNowMs(), i, reply.items.len, route_result.expect_ai_progress, route_result.baseline_transcript.len },
         );
+
+        // /stop (and any stop_followup route) cancels active reply streaming
+        // before the confirmation reply is sent, so no stale progress/final
+        // reply trails the stop.
+        if (route_result.stop_followup) {
+            if (input.progress_ctx) |ctx| {
+                if (input.stop_progress_fn) |stop| {
+                    std.debug.print("weixin process({d}): index={d} ai_followup=cancel\n", .{ debugNowMs(), i });
+                    stop(ctx);
+                }
+            }
+        }
 
         const trimmed = std.mem.trim(u8, reply.items, " \t\r\n");
         if (trimmed.len != 0) {
@@ -248,6 +265,7 @@ pub const Poller = struct {
             .send_fn = sendAdapter,
             .progress_ctx = self,
             .start_progress_fn = startProgressAdapter,
+            .stop_progress_fn = stopProgressAdapter,
         });
     }
 
@@ -275,7 +293,7 @@ pub const Poller = struct {
         try reply.appendSlice(allocator, r.text.items);
         if (!r.expect_ai_progress) {
             if (baseline.len != 0) allocator.free(baseline);
-            return .{};
+            return .{ .stop_followup = r.stop_followup };
         }
         return .{
             .expect_ai_progress = true,
@@ -305,6 +323,11 @@ pub const Poller = struct {
     fn startProgressAdapter(ctx: *anyopaque, baseline_transcript: []const u8, to_user_id: []const u8, context_token: []const u8) anyerror!void {
         const self: *Poller = @ptrCast(@alignCast(ctx));
         try self.startAiFollowup(baseline_transcript, to_user_id, context_token);
+    }
+
+    fn stopProgressAdapter(ctx: *anyopaque) void {
+        const self: *Poller = @ptrCast(@alignCast(ctx));
+        self.cancelAiFollowup();
     }
 
     fn getUpdatesLocked(self: *Poller, sync_buf_value: []const u8) !@import("ilink_codec.zig").ParsedUpdates {
@@ -565,6 +588,7 @@ const SendCtx = struct {
 
 const ProgressCtx = struct {
     started: bool = false,
+    stopped: bool = false,
     baseline: std.ArrayListUnmanaged(u8) = .empty,
     to_user_id: std.ArrayListUnmanaged(u8) = .empty,
     context_token: std.ArrayListUnmanaged(u8) = .empty,
@@ -581,6 +605,11 @@ const ProgressCtx = struct {
         try self.baseline.appendSlice(t.allocator, baseline_transcript);
         try self.to_user_id.appendSlice(t.allocator, to_user_id);
         try self.context_token.appendSlice(t.allocator, context_token);
+    }
+
+    fn stop(ctx: *anyopaque) void {
+        const self: *ProgressCtx = @ptrCast(@alignCast(ctx));
+        self.stopped = true;
     }
 };
 
@@ -765,6 +794,43 @@ test "processUpdates routes inbound voice transcript as message text" {
     try t.expectEqualStrings("transcribed command", cap.routed.items[0]);
     try t.expectEqualStrings("u1", cap.routed_to.items[0]);
     try t.expectEqualStrings("voice-ctx", cap.routed_context.items[0]);
+}
+
+test "processUpdates cancels AI followup when a routed message reports stop_followup" {
+    const Route = struct {
+        fn route(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8, allocator: std.mem.Allocator, reply: *std.ArrayListUnmanaged(u8)) anyerror!RouteResult {
+            try reply.appendSlice(allocator, "已发送停止指令。");
+            return .{ .stop_followup = true };
+        }
+    };
+    var cap = Captured{};
+    defer cap.deinit();
+    var sctx = SendCtx{ .cap = &cap };
+    var pctx = ProgressCtx{};
+    defer pctx.deinit();
+    var route_ctx: u8 = 0;
+
+    const msgs = [_]types.Message{
+        .{ .from_user_id = "u1", .context_token = "ctx", .item_list = &.{.{ .type = 1, .text = "/stop" }} },
+    };
+
+    try processUpdates(.{
+        .allocator = t.allocator,
+        .owner = "u1",
+        .account_id = "",
+        .messages = &msgs,
+        .route_ctx = &route_ctx,
+        .route_fn = Route.route,
+        .send_ctx = &sctx,
+        .send_fn = SendCtx.send,
+        .progress_ctx = &pctx,
+        .start_progress_fn = ProgressCtx.start,
+        .stop_progress_fn = ProgressCtx.stop,
+    });
+
+    try t.expect(pctx.stopped);
+    try t.expect(!pctx.started);
+    try t.expectEqualStrings("已发送停止指令。", cap.sent.items[0]);
 }
 
 test "poller bootstrap advances cursor without replying to historical messages" {


### PR DESCRIPTION
## 背景

macOS 上微信直连（weixin-direct）收到普通文本时回复 “WispTerm 无法打开 AI Agent。”，且 `/stop` 不能停止 AI Agent。本 PR 修复这两个问题。

## 根因与修复

### 1. macOS 同步 sendMessage 是空壳（`daa3590`）
`window_macos.sendMessage` 在 macOS 上是 no-op stub（直接 `return 0`），导致 weixin 的 UI 控制（`find_ai` / `open_ai` / `send_input` / `transcript`）全部失效：`WeixinRequest.open_result` 保持默认 `.failed`，于是回退 “WispTerm 无法打开 AI Agent。”。同样的缺口也让 remote 自动 AI Agent 在 macOS 失效。

修复：在 macOS 上实现 Win32 风格的同步 `SendMessage` —— 通过既有异步消息队列把消息 marshal 到窗口事件循环 worker 线程（threadlocal tab 状态所在线程，**非主线程**），阻塞等待该线程执行 handler 并回填结果。引用计数的 `SyncCall` 信封 + 5s 超时兜底，避免超时/队列溢出导致 use-after-free。

### 2. `/stop` 不取消在途的 AI 回复流（`3b856e9`）
`/stop` 已经会给 AI 会话发 ESC（修复 1 之后能真正到达 `stopRequest()`，停止生成），但 weixin 的 AI 回复 follow-up 线程不会因 `/stop` 被取消，仍会补发进度/最终回复 —— 看起来像 “没停”。

修复：`agent.route` 的 `/stop` 处理通过 `RouteResult.stop_followup` 传出信号，`processUpdates` 在发送确认回复前调用新的 `stop_progress_fn`（接到 `Poller.cancelAiFollowup`）取消 follow-up，使 `/stop` 后不再有滞后回复。

## 验证
- TDD：每处改动先写失败测试再实现。
- `zig build`（默认 Windows target）、`zig build test-full`（合并前关卡）、`zig build test-macos-window`（35/35）、weixin 模块测试（agent 8/8、poller 47/47）全部通过。
- ⚠️ 未做真实微信端到端回路验证（无登录会话）。建议合并后实测：普通文本应正常进入 AI Agent；AI 回复中途发 `/stop` 应立即收到 “已发送停止指令。” 且不再有后续回复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)