### PR TITLE
refactor: move pure-logic tests into the fast suite (test-speed decoupling)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-test-speed-refactor.md
+++ b/docs/superpowers/plans/2026-06-01-test-speed-refactor.md
@@ -1,0 +1,339 @@
+# Test-Speed Decoupling Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) or superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move pure-logic tests out of the heavy `zig build test-full` compile graph (full desktop app: AppWindow/Surface/renderer/ghostty-vt/xev/GL/FreeType/Harfbuzz/win32) and into the sub-second `zig build test` fast suite, by extracting self-contained types/logic out of modules that currently force a heavy import.
+
+**Architecture:** A Zig module's tests can run in the fast suite (`src/test_fast.zig`) only if its *entire transitive import graph* compiles natively without the heavy app deps. Today, several pure-logic modules reach the heavy graph through a single thin coupling (e.g. `Surface.SshConnection`, `tab.g_active_tab`, `ai_chat.AgentPermission`). We sever each coupling by extracting the small shared type into its own light module, re-exporting from the original for source compatibility, then registering the freed module in `test_fast.zig`.
+
+**Tech Stack:** Zig 0.14-era build, `src/test_fast.zig` (fast native aggregator) + `src/test_main.zig` (full app graph). Tests register only when `_ = @import("…")`'d in an aggregator (see memory: *Test inclusion wiring*).
+
+**Ordering rationale (refined from the brief):** The brief's order was SshConnection → file_explorer/scp → input → overlays → config/split_tree last. We move **config→ai_chat first** because `config.zig` is *already in the fast suite* and is the only fast-suite module dragging in the 336 KB `ai_chat.zig`; cutting it speeds the fast loop itself and is trivially low-risk. Everything else follows the brief, biggest-test-migration-first.
+
+**Baseline (measured 2026-06-01, branch `worktree-feat-refactor`):**
+- `zig build test` (fast): ~5 s wall (~7 s user); 451 passed / 1 skipped.
+- `zig build test-full`: ~50 s, dominated by the Windows app cross-compile (~49 s); `.exe` run fails under WSL (expected).
+- Tests currently trapped in `test-full` only because of a thin heavy coupling:
+  - `file_explorer.zig` 26, `scp.zig` 11, `ssh_tunnel.zig` 4, `file_backend.zig` 1 — all use **only** `Surface.SshConnection` from Surface (verified); file_explorer additionally uses only `tab.g_active_tab` from the heavy `appwindow/tab.zig`.
+  - `input.zig` 8 — binds `AppWindow` + `Surface`.
+  - `renderer/overlays.zig` 16 — binds `AppWindow` + `ai_chat` + `Surface`.
+  - `split_tree.zig` 4 — binds `*Surface` as the leaf type.
+
+**Verification gate used after every phase:**
+```bash
+zig build test        # fast suite — must stay green, ideally faster / more tests
+zig build test-full   # full graph — must stay green (compile is the real check; .exe run-fail under WSL is OK)
+```
+Per memory *Phantty test execution env*: full suite green baseline is ~673+/677, 4 skipped, **0 failed**. Test counts only grow.
+
+---
+
+## Phase 1: Decouple `config.zig` from `ai_chat.zig` (brief item #5)
+
+**Why first:** `config.zig` is in `test_fast.zig` and is the *only* fast-suite importer of `ai_chat.zig` (336 KB / ~8k lines). It imports it solely for the tiny self-contained `AgentPermission` enum. Cutting this removes the entire `ai_chat.zig` subgraph from the fast compile.
+
+**Files:**
+- Create: `src/ai_agent_config.zig`
+- Modify: `src/ai_chat.zig` (re-export, remove local def)
+- Modify: `src/config.zig:22` (import), `:293`, `:786`, tests `:1845`,`:1853`
+- (No change needed in `src/App.zig:97` — it keeps using `ai_chat.AgentPermission` via the re-export.)
+
+- [ ] **Step 1: Create the extracted module** — move the enum verbatim (it has zero non-std deps).
+
+```zig
+//! src/ai_agent_config.zig
+//! Small, dependency-light AI-agent config types shared by config.zig and
+//! ai_chat.zig. Kept out of the 8k-line ai_chat.zig so config (and its fast
+//! unit tests) need not compile the full AI session/API/tool-exec graph.
+const std = @import("std");
+
+pub const AgentPermission = enum {
+    confirm,
+    full,
+
+    pub fn parse(value: []const u8) ?AgentPermission {
+        if (std.mem.eql(u8, value, "confirm")) return .confirm;
+        if (std.mem.eql(u8, value, "full") or std.mem.eql(u8, value, "full-permission")) return .full;
+        return null;
+    }
+
+    pub fn name(self: AgentPermission) []const u8 {
+        return switch (self) {
+            .confirm => "confirm",
+            .full => "full",
+        };
+    }
+};
+
+test "AgentPermission.parse accepts confirm/full/full-permission" {
+    try std.testing.expectEqual(AgentPermission.confirm, AgentPermission.parse("confirm").?);
+    try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full").?);
+    try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full-permission").?);
+    try std.testing.expectEqual(@as(?AgentPermission, null), AgentPermission.parse("nope"));
+}
+```
+
+- [ ] **Step 2: Re-export from `ai_chat.zig`** — replace the local `pub const AgentPermission = enum { … };` block (src/ai_chat.zig:106–124) with:
+
+```zig
+pub const AgentPermission = @import("ai_agent_config.zig").AgentPermission;
+```
+Keep `AgentSettings` (which uses `AgentPermission`) as-is — it resolves through the re-export.
+
+- [ ] **Step 3: Point `config.zig` at the light module.** At `src/config.zig:22` change:
+```zig
+const ai_chat = @import("ai_chat.zig");
+```
+to:
+```zig
+const ai_agent_config = @import("ai_agent_config.zig");
+```
+Then replace the 4 `ai_chat.AgentPermission` references (`:293`, `:786`, `:1845`, `:1853`) with `ai_agent_config.AgentPermission`. (Confirm `ai_chat` is not used elsewhere in config.zig: `grep -n 'ai_chat\.' src/config.zig` — must return nothing after this step.)
+
+- [ ] **Step 4: Register the new module in the fast suite.** In `src/test_fast.zig`, add inside the `test { … }` block:
+```zig
+    _ = @import("ai_agent_config.zig");
+```
+
+- [ ] **Step 5: Verify fast suite green + faster, and no stray ai_chat import remains in fast graph.**
+```bash
+grep -n 'ai_chat' src/config.zig            # expect: no matches
+( time zig build test ) 2>&1 | tail -5      # green; wall time should drop vs ~5s baseline
+```
+Expected: 452+ passed; ai_chat.zig no longer in the fast compile graph.
+
+- [ ] **Step 6: Verify full suite still green.**
+```bash
+zig build test-full 2>&1 | tail -15
+```
+Expected: 0 failed (compile succeeds; WSL .exe run-fail is OK).
+
+- [ ] **Step 7: Commit.**
+```bash
+git add src/ai_agent_config.zig src/ai_chat.zig src/config.zig src/test_fast.zig
+git commit -m "refactor(config): extract AgentPermission to ai_agent_config, drop ai_chat from fast graph"
+```
+
+---
+
+## Phase 2: Extract `SshConnection` out of `Surface.zig` (brief item #3, first cut)
+
+**Why:** `SshConnection` is a fully self-contained struct (fixed buffers + accessors, no imports). `scp.zig`, `ssh_tunnel.zig`, `file_backend.zig`, `file_explorer.zig` reference **only** `Surface.SshConnection` from Surface (verified), yet importing `Surface.zig` drags in `ghostty-vt` + the GL renderer. Extracting it severs that.
+
+**Files:**
+- Create: `src/ssh_connection.zig`
+- Modify: `src/Surface.zig:69-102` (replace struct with re-export)
+- Modify: `src/scp.zig:8`, `src/ssh_tunnel.zig:5`, `src/file_backend.zig:8`, `src/file_explorer.zig:8` (import the light module; replace `Surface.SshConnection` → `ssh_connection.SshConnection`)
+
+- [ ] **Step 1: Create `src/ssh_connection.zig`** with the struct moved verbatim:
+
+```zig
+//! src/ssh_connection.zig
+//! Self-contained SSH connection descriptor (fixed-buffer fields + accessors).
+//! Lives outside Surface.zig so remote-IO logic modules (scp, ssh_tunnel,
+//! file_backend, file_explorer) can use it without compiling the heavy
+//! ghostty-vt / renderer graph that Surface pulls in.
+
+pub const SshConnection = struct {
+    user_buf: [128]u8 = undefined,
+    user_len: usize = 0,
+    host_buf: [128]u8 = undefined,
+    host_len: usize = 0,
+    port_buf: [16]u8 = undefined,
+    port_len: usize = 0,
+    password_buf: [128]u8 = undefined,
+    password_len: usize = 0,
+    proxy_jump_buf: [256]u8 = undefined,
+    proxy_jump_len: usize = 0,
+    password_auth: bool = false,
+    legacy_algorithms: bool = false,
+
+    pub fn user(self: *const SshConnection) []const u8 {
+        return self.user_buf[0..self.user_len];
+    }
+    pub fn proxyJump(self: *const SshConnection) []const u8 {
+        return self.proxy_jump_buf[0..self.proxy_jump_len];
+    }
+    pub fn host(self: *const SshConnection) []const u8 {
+        return self.host_buf[0..self.host_len];
+    }
+    pub fn port(self: *const SshConnection) []const u8 {
+        return self.port_buf[0..self.port_len];
+    }
+    pub fn password(self: *const SshConnection) []const u8 {
+        return self.password_buf[0..self.password_len];
+    }
+};
+```
+
+- [ ] **Step 2: Re-export from `Surface.zig`.** Add near the top imports of `src/Surface.zig`:
+```zig
+const ssh_connection = @import("ssh_connection.zig");
+```
+Replace the `pub const SshConnection = struct { … };` block (lines 69–102) with:
+```zig
+pub const SshConnection = ssh_connection.SshConnection;
+```
+(All in-file uses like `setSshConnection`, `ssh_connection: ?SshConnection` at `:179` continue to resolve.)
+
+- [ ] **Step 3: Repoint the four consumers.** In each of `scp.zig`, `ssh_tunnel.zig`, `file_backend.zig`, `file_explorer.zig`: add `const ssh_connection = @import("ssh_connection.zig");` and replace every `Surface.SshConnection` with `ssh_connection.SshConnection`. Then drop the now-unused `const Surface = @import("Surface.zig");` **only if** `grep -n 'Surface\.' <file>` shows no other `Surface.` use (verified: only SshConnection). Do NOT drop the Surface import in `file_explorer.zig` yet if anything else needs it — re-grep to confirm (expected: safe to drop in all four).
+
+Per-file commands to confirm clean removal:
+```bash
+for f in scp ssh_tunnel file_backend file_explorer; do echo "== $f =="; grep -n 'Surface' src/$f.zig; done
+```
+Expected after edit: no `Surface` references remain in any of the four.
+
+- [ ] **Step 4: Register `ssh_connection.zig` in fast suite.** Add `_ = @import("ssh_connection.zig");` to `src/test_fast.zig`.
+
+- [ ] **Step 5: Verify both suites green.**
+```bash
+zig build test 2>&1 | tail -5
+zig build test-full 2>&1 | tail -15
+```
+Expected: both green; consumers still compile under test-full (they're added to fast in Phase 3).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/ssh_connection.zig src/Surface.zig src/scp.zig src/ssh_tunnel.zig src/file_backend.zig src/file_explorer.zig src/test_fast.zig
+git commit -m "refactor(surface): extract SshConnection to ssh_connection.zig"
+```
+
+---
+
+## Phase 3: Free file_explorer / scp / ssh_tunnel / file_backend into the fast suite (brief item #3, payoff)
+
+**Why:** After Phase 2, `scp` / `ssh_tunnel` / `file_backend` reach only light deps. `file_explorer` still imports the heavy `appwindow/tab.zig` — but uses **only** `tab.g_active_tab` (a `threadlocal var usize`). Extract that global to a light module so file_explorer drops the heavy import; then register all four in the fast suite. **Migrates 42 tests.**
+
+**Files:**
+- Create: `src/appwindow/active_tab.zig`
+- Modify: `src/appwindow/tab.zig:106` (move the var; reference from new module)
+- Modify all `g_active_tab` users: `AppWindow.zig`, `browser_panel.zig`, `browser_panel_stub.zig`, `input.zig`, `file_explorer.zig`, `renderer/titlebar.zig`, `markdown_preview_panel.zig`
+- Modify: `src/test_fast.zig` (register the four freed modules)
+
+- [ ] **Step 1: Create `src/appwindow/active_tab.zig`** as the single source of truth:
+```zig
+//! src/appwindow/active_tab.zig
+//! Index of the currently-active tab. Extracted from appwindow/tab.zig so
+//! light modules (e.g. file_explorer) can read/write it without importing the
+//! heavy tab module (which pulls in Surface/ai_chat/split_tree).
+pub threadlocal var g_active_tab: usize = 0;
+```
+
+- [ ] **Step 2: Re-home the var in `tab.zig`.** In `src/appwindow/tab.zig`, remove the `pub threadlocal var g_active_tab: usize = 0;` at line 106 and add (with imports):
+```zig
+const active_tab = @import("active_tab.zig");
+```
+Then replace tab.zig's internal `g_active_tab` references with `active_tab.g_active_tab`. (Zig cannot alias a mutable `var` through a `const` re-export, so use the qualified name. `grep -n 'g_active_tab' src/appwindow/tab.zig` to find all ~12 sites.)
+*Optional source-compat shim to limit blast radius:* keep `tab.zig` exposing the name via a getter/setter is NOT enough for `+=`/`-=` call sites, so we update references directly — see Step 3.
+
+- [ ] **Step 3: Repoint every other `g_active_tab` user.** In each of `AppWindow.zig`, `browser_panel.zig`, `browser_panel_stub.zig`, `input.zig`, `file_explorer.zig`, `renderer/titlebar.zig`, `markdown_preview_panel.zig`: add an import to `active_tab.zig` (path-adjusted) and replace `tab.g_active_tab` (or local alias) with `active_tab.g_active_tab`. For `file_explorer.zig` specifically, after this it uses nothing else from `appwindow/tab.zig` — **remove** `const tab = @import("appwindow/tab.zig");`. Confirm:
+```bash
+grep -n 'appwindow/tab.zig\|tab\.g_active_tab' src/file_explorer.zig   # expect: no matches
+```
+
+- [ ] **Step 4: Register `active_tab.zig` + the four freed modules in the fast suite.** Add to `src/test_fast.zig`'s `test {}` block:
+```zig
+    _ = @import("appwindow/active_tab.zig");
+    _ = @import("scp.zig");
+    _ = @import("ssh_tunnel.zig");
+    _ = @import("file_backend.zig");
+    _ = @import("file_explorer.zig");
+```
+
+- [ ] **Step 5: Verify fast suite now runs the 42 migrated tests and stays fast/green.**
+```bash
+( time zig build test ) 2>&1 | tail -6
+```
+Expected: ~493+ passed (451 + ~42), wall time still in the single-digit seconds.
+
+- [ ] **Step 6: Verify full suite green (no double-registration errors, heavy modules still compile).**
+```bash
+zig build test-full 2>&1 | tail -15
+```
+
+- [ ] **Step 7: Commit.**
+```bash
+git add -A
+git commit -m "refactor(tabs): extract g_active_tab; move file_explorer/scp/ssh_tunnel/file_backend tests to fast suite"
+```
+
+---
+
+## Phase 4: `input.zig` pure-rule extraction (brief item #1)
+
+**Why:** `input.zig` (167 KB) imports `AppWindow` + `Surface` + `SplitTree`, trapping its 8 tests in test-full. Prior work already split out `input/{key,command_dispatch,click_tracker,hit_test,mouse_report,preview_source,clipboard}.zig`. The remaining 8 tests assert pure input rules that can move to AppWindow-free submodules. Ghostty reference: `src/input.zig` is a thin re-export of small `input/*` modules, not bound to the window loop.
+
+**Files:**
+- Read first: `src/input.zig` test blocks (8) + the helper fns they exercise.
+- Create (as the tests dictate): candidate `input/action_router.zig`, `input/selection_model.zig`, `input/terminal_link_action.zig` (only those actually needed — YAGNI).
+- Modify: `src/input.zig` (delegate to extracted fns; keep AppWindow adapter layer), `src/test_fast.zig`.
+
+- [ ] **Step 1: Read & inventory.** `grep -n '^test ' src/input.zig` then read each test + the functions it calls. Classify each as (a) pure logic (no AppWindow/Surface state) → extract, or (b) genuinely window-coupled → leave in test-full. Record the mapping in the commit message.
+
+- [ ] **Step 2: For each pure test group, TDD the extraction.** Create the target `input/<name>.zig` containing the pure fn(s) + the moved `test` blocks. Replace the body in `input.zig` with a thin call into the new module (or `pub const x = mod.x;`). Each extracted module must NOT `@import` `AppWindow.zig`/`Surface.zig`/`split_tree.zig`. Verify with `grep -nE 'AppWindow|Surface|split_tree' src/input/<name>.zig` → no matches.
+
+- [ ] **Step 3: Register extracted modules** in `src/test_fast.zig` (`_ = @import("input/<name>.zig");`).
+
+- [ ] **Step 4: Verify.** `zig build test` (new tests appear, green) then `zig build test-full` (green). If a test cannot be cleanly separated from window state, leave it in `input.zig`/test-full and note why — do not force it.
+
+- [ ] **Step 5: Commit** per extracted module (frequent commits): `git commit -m "refactor(input): extract <name> pure logic to fast suite"`.
+
+---
+
+## Phase 5: `renderer/overlays.zig` model extraction (brief item #2)
+
+**Why:** `overlays.zig` (201 KB) imports `AppWindow` + `ai_chat` + `Surface`, trapping its 16 tests. It mixes pure model/codec logic (SSH/AI profile encode-decode, command-center model, transfer toast, update prompt) with actual GL drawing. The pure parts need neither GL nor a window. Prior work already split `overlays/{primitives,scrollbar,resize,startup_shortcuts}.zig`.
+
+**Files:**
+- Read first: `src/renderer/overlays.zig` test blocks (16) + the fns under test.
+- Create (as tests dictate): `renderer/overlays/profile_codec.zig`, `renderer/overlays/command_center_model.zig`, `renderer/overlays/transfer_toast_model.zig`, `renderer/overlays/update_prompt_model.zig` (only those the tests actually need).
+- Modify: `src/renderer/overlays.zig` (delegate; keep draw fns), `src/test_fast.zig`.
+
+- [ ] **Step 1: Read & inventory** the 16 tests (`grep -n '^test ' src/renderer/overlays.zig`); map each to a target pure module or "stays in test-full" (drawing/GL-coupled). Note macOS-gated `SkipZigTest` ones (lines ~4156, ~4208) — they may stay.
+
+- [ ] **Step 2: TDD each extraction.** Move the pure fn(s) + their `test` blocks into the target submodule; the original calls into it. Each new module must not `@import` `AppWindow`/`ai_chat`/`Surface`. Verify via grep.
+
+- [ ] **Step 3: Register** extracted modules in `src/test_fast.zig`.
+
+- [ ] **Step 4: Verify** `zig build test` then `zig build test-full` (both green).
+
+- [ ] **Step 5: Commit** per extracted model module.
+
+---
+
+## Phase 6: Generic-ize `split_tree.zig` (brief item #4)
+
+**Why:** `split_tree.zig` (41 KB) is pure topology but hard-binds `*Surface` as its leaf, so its 4 tests need the heavy graph. Ghostty reference: `datastruct/split_tree.zig` is a generic data structure. Parameterize over the leaf type; AppWindow layer instantiates with `*Surface`.
+
+**Decision to confirm at execution:** `SplitTree` calls `Surface.ref()`/`deref()` (see `refNodes`, line ~657). Two options:
+- **(A) Generic over leaf type** `SplitTree(comptime Leaf: type)` requiring `Leaf.ref()/.deref()` — type-checks at instantiation; tests instantiate with a tiny fake leaf.
+- **(B) Opaque handle** (leaf = `usize`/index) with ref/deref via injected callbacks — looser coupling, more call-site churn.
+Prefer **(A)** unless call-site churn proves smaller for (B).
+
+**Files:**
+- Modify: `src/split_tree.zig` (parameterize; move the 4 tests to use a fake leaf), and every importer: `src/Surface.zig`(?), `src/AppWindow.zig`, `src/input.zig`, `src/renderer/overlays.zig`, `src/appwindow/tab.zig`, `src/renderer/titlebar.zig` — `grep -rln 'split_tree.zig' src/` for the full list.
+- Modify: `src/test_fast.zig`.
+
+- [ ] **Step 1: Map call sites.** `grep -rn 'SplitTree\b' src/` — list every instantiation and method call. Most refer to a `SplitTree` value/type alias.
+- [ ] **Step 2: Parameterize** `split_tree.zig` to `pub fn SplitTree(comptime Leaf: type) type { return struct { … }; }` (option A). Internally use `Leaf` instead of `*Surface`. Keep `Surface.ref/deref` calls as `leaf.ref()/leaf.deref()`.
+- [ ] **Step 3: Add the concrete alias where Surface lives** (e.g. in `Surface.zig` or a small `surface_split_tree.zig`): `pub const SurfaceSplitTree = @import("split_tree.zig").SplitTree(*Surface);`. Repoint heavy callers to the alias.
+- [ ] **Step 4: Move the 4 topology tests** into `split_tree.zig` using a minimal fake leaf type with no-op `ref/deref`, so they compile light. Register `split_tree.zig` in `src/test_fast.zig`.
+- [ ] **Step 5: Verify** `zig build test` (topology tests now fast) then `zig build test-full` (all callers compile, green).
+- [ ] **Step 6: Commit.** `git commit -m "refactor(split_tree): generic over leaf type; topology tests to fast suite"`.
+
+---
+
+## Final verification & wrap-up
+
+- [ ] Re-measure: `( time zig build test ) 2>&1 | tail -3` — record new fast-suite count + wall time vs the ~5 s / 451-test baseline.
+- [ ] `zig build test-full 2>&1 | tail -15` — confirm 0 failed.
+- [ ] Update memory note *Phantty test execution env* with the new fast-suite count and which modules migrated.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Brief items #1 (input)→Phase 4, #2 (overlays)→Phase 5, #3 (SshConnection + file_explorer/scp)→Phases 2–3, #4 (split_tree)→Phase 6, #5 (config→ai_chat)→Phase 1. All five covered.
+- **Type consistency:** New module names used consistently — `ai_agent_config.AgentPermission`, `ssh_connection.SshConnection`, `active_tab.g_active_tab`. Re-exports preserve `ai_chat.AgentPermission` and `Surface.SshConnection` so unrelated callers (App.zig, RendererThread.zig, etc.) are untouched.
+- **Risk note:** Phases 1–3 are turn-key (full code given; types verified self-contained). Phases 4–6 require reading the in-file `test` blocks at execution time before carving, because the exact pure/coupled split can only be decided against the real test bodies; each lists explicit read-first + grep-verify gates instead of speculative code.

--- a/docs/superpowers/plans/2026-06-01-test-speed-refactor.md
+++ b/docs/superpowers/plans/2026-06-01-test-speed-refactor.md
@@ -332,6 +332,41 @@ Prefer **(A)** unless call-site churn proves smaller for (B).
 
 ---
 
+## Execution outcome (2026-06-01, branch `worktree-feat-refactor`)
+
+Landed Phases 1–5 (+5b), one commit each; both suites green after every phase.
+
+| Phase | Commit | Fast tests |
+|---|---|---|
+| Baseline | — | 451 / ~5 s (incl. ai_chat dragged in via config) |
+| 1 config→ai_chat | `41dd703` | 315 / ~1.9 s |
+| 2 SshConnection | `3a5fef1` | 315 |
+| 3 g_active_tab + file_explorer/scp/file_backend | `c7d6c9c` | 367 |
+| 4 input terminal_link_action + preview_path | `2fa7dcb` | 378 |
+| 5 overlays profile_codec | `418d22c` | 384 |
+| 5b overlays transfer_toast + update_prompt models | `063b67c` | **410** / ~1.9 s cold, ~0.45 s incremental |
+
+Full suite throughout: **780/786 passed, 6 skipped, 0 failed**.
+
+New light modules: `ai_agent_config`, `ssh_connection`, `appwindow/active_tab`,
+`input/preview_path`, `input/terminal_link_action`, `renderer/overlays/{profile_codec,
+transfer_toast_model, update_prompt_model}`. Also relocated 5 AI default constants
+to `ai_chat_protocol`. ssh_tunnel stayed in test-full (uses the full `*Surface`).
+
+### Phase 6 (split_tree) — DEFERRED, not done
+
+Assessment after exploration: split_tree.zig's only heavy import is `Surface.zig`
+(session_persist is light). The clean fix is a concrete-alias generic —
+`pub const SplitTree = SplitTreeImpl(*Surface)` in split_tree.zig, with the generic
+`SplitTreeImpl(comptime Leaf)` + the 4 topology tests in a new Surface-free
+`split_tree_impl.zig`. This gives **zero caller churn** (the 113 `SplitTree*`
+references keep working against the concrete alias). **However**, it requires
+genericizing ~1000 lines of intricate tree topology (handle arithmetic, backtracking,
+zoom/resize/remove, fromSnapshot factory) — effectively a full rewrite of core
+window-management code — for only **4 tests**. Highest risk / lowest reward of the
+refactor; the brief itself ranked it last. Recommended as its own focused PR with
+review, not the tail of a batch.
+
 ## Self-Review notes
 
 - **Spec coverage:** Brief items #1 (input)→Phase 4, #2 (overlays)→Phase 5, #3 (SshConnection + file_explorer/scp)→Phases 2–3, #4 (split_tree)→Phase 6, #5 (config→ai_chat)→Phase 1. All five covered.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -41,6 +41,7 @@ const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
 pub const tab = @import("appwindow/tab.zig");
+const active_tab_state = @import("appwindow/active_tab.zig");
 pub const font = @import("font/manager.zig");
 pub const cell_renderer = @import("renderer/cell_renderer.zig");
 pub const cell_pipeline = @import("renderer/cell_pipeline.zig");
@@ -1267,7 +1268,7 @@ pub fn splitFocusedReturningSurface(direction: SplitTree.Split.Direction) ?*Surf
 
 pub fn closeFocusedSplit() void {
     const allocator = g_allocator orelse return;
-    const closing_tab_idx = tab.g_active_tab;
+    const closing_tab_idx = active_tab_state.g_active_tab;
     switch (tab.closeFocusedSplit(allocator)) {
         .closed_split => {
             input.g_selecting = false;
@@ -1868,7 +1869,7 @@ fn maybePrintMemoryDebug(now: i64) void {
 
         var it = tab_state.tree.iterator();
         while (it.next()) |entry| {
-            const visible = tab_index == tab.g_active_tab;
+            const visible = tab_index == active_tab_state.g_active_tab;
             const stats = collectSurfaceMemoryDebug(entry.surface);
 
             totals.surfaces += 1;
@@ -2024,7 +2025,7 @@ fn appendAgentDetectionJson(
 
 fn buildRemoteLayoutJson(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
     try out.appendSlice(allocator, "{\"type\":\"layout\",\"activeTab\":");
-    try out.print(allocator, "{d}", .{tab.g_active_tab});
+    try out.print(allocator, "{d}", .{active_tab_state.g_active_tab});
     try out.appendSlice(allocator, ",\"tabs\":[");
 
     var wrote_tab = false;
@@ -2293,9 +2294,9 @@ const WeixinRequest = struct {
 /// Index of the AI-chat tab to target: the active tab if it is AI chat, else the
 /// first AI-chat tab. UI-thread only (reads threadlocal tab state).
 fn weixinActiveAiTabIndex() ?usize {
-    if (tab.g_active_tab < tab.g_tab_count) {
-        if (tab.g_tabs[tab.g_active_tab]) |ts| {
-            if (ts.kind == .ai_chat) return tab.g_active_tab;
+    if (active_tab_state.g_active_tab < tab.g_tab_count) {
+        if (tab.g_tabs[active_tab_state.g_active_tab]) |ts| {
+            if (ts.kind == .ai_chat) return active_tab_state.g_active_tab;
         }
     }
     for (0..tab.g_tab_count) |i| {
@@ -2312,8 +2313,8 @@ fn weixinTabIndexFromSurfaceId(id: [16]u8) ?usize {
 }
 
 fn weixinActiveTerminalSurface() ?*Surface {
-    if (tab.g_active_tab < tab.g_tab_count) {
-        if (tab.g_tabs[tab.g_active_tab]) |ts| {
+    if (active_tab_state.g_active_tab < tab.g_tab_count) {
+        if (tab.g_tabs[active_tab_state.g_active_tab]) |ts| {
             if (ts.kind == .terminal) {
                 if (ts.focusedSurface()) |surface| return surface;
             }
@@ -2489,7 +2490,7 @@ fn findAgentSurfaceLocation(surface: *const Surface) ?AgentSurfaceLocation {
             if (entry.surface == surface) {
                 return .{
                     .tab_index = tab_index,
-                    .focused = tab_index == tab.g_active_tab and entry.handle == tab_state.focused,
+                    .focused = tab_index == active_tab_state.g_active_tab and entry.handle == tab_state.focused,
                 };
             }
         }
@@ -2527,7 +2528,7 @@ fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyer
         surfaces.deinit(allocator);
     }
 
-    var active_tab = tab.g_active_tab;
+    var active_tab = active_tab_state.g_active_tab;
     const context_surface_id = g_agent_context_surface_id[0..g_agent_context_surface_id_len];
     for (0..tab.g_tab_count) |tab_index| {
         const tab_state = tab.g_tabs[tab_index] orelse continue;
@@ -2760,7 +2761,7 @@ fn resolveAgentCloseTabIndex(request: *const AgentTabCloseRequest) ?usize {
     if (request.title) |title_text| {
         if (findTabIndexByTitle(title_text)) |idx| return idx;
     }
-    return tab.g_active_tab;
+    return active_tab_state.g_active_tab;
 }
 
 fn handleAgentTabCloseRequest(request: *AgentTabCloseRequest) void {
@@ -2795,7 +2796,7 @@ fn handleAgentTabCloseRequest(request: *AgentTabCloseRequest) void {
     closeTab(idx);
     request.result = .{
         .tab_index = idx,
-        .active_tab = tab.g_active_tab,
+        .active_tab = active_tab_state.g_active_tab,
         .title = title_copy,
     };
 }
@@ -4059,10 +4060,10 @@ fn runMainLoop(self: *AppWindow) !void {
                 var it = tb.tree.iterator();
                 while (it.next()) |entry| {
                     if (entry.surface.bell_pending.swap(false, .acquire)) {
-                        handleBell(entry.surface, win, ti == tab.g_active_tab);
+                        handleBell(entry.surface, win, ti == active_tab_state.g_active_tab);
                     }
                     {
-                        const is_active_surface = (ti == tab.g_active_tab) and
+                        const is_active_surface = (ti == active_tab_state.g_active_tab) and
                             (if (tb.focusedSurface()) |fs| fs == entry.surface else false);
                         handleNotification(entry.surface, is_active_surface);
                     }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -24,6 +24,7 @@ const sync_output = @import("sync_output.zig");
 const notification = @import("notification.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
+const ssh_connection_mod = @import("ssh_connection.zig");
 
 const Surface = @This();
 
@@ -66,40 +67,7 @@ const WISPTERM_IMAGE_OSC_MAX = 16 * 1024;
 /// Coarse launch environment for terminal-side integrations such as path paste.
 pub const LaunchKind = platform_pty_command.LaunchKind;
 
-pub const SshConnection = struct {
-    user_buf: [128]u8 = undefined,
-    user_len: usize = 0,
-    host_buf: [128]u8 = undefined,
-    host_len: usize = 0,
-    port_buf: [16]u8 = undefined,
-    port_len: usize = 0,
-    password_buf: [128]u8 = undefined,
-    password_len: usize = 0,
-    proxy_jump_buf: [256]u8 = undefined,
-    proxy_jump_len: usize = 0,
-    password_auth: bool = false,
-    legacy_algorithms: bool = false,
-
-    pub fn user(self: *const SshConnection) []const u8 {
-        return self.user_buf[0..self.user_len];
-    }
-
-    pub fn proxyJump(self: *const SshConnection) []const u8 {
-        return self.proxy_jump_buf[0..self.proxy_jump_len];
-    }
-
-    pub fn host(self: *const SshConnection) []const u8 {
-        return self.host_buf[0..self.host_len];
-    }
-
-    pub fn port(self: *const SshConnection) []const u8 {
-        return self.port_buf[0..self.port_len];
-    }
-
-    pub fn password(self: *const SshConnection) []const u8 {
-        return self.password_buf[0..self.password_len];
-    }
-};
+pub const SshConnection = ssh_connection_mod.SshConnection;
 
 // ============================================================================
 // VT stream handler — wraps ghostty's readonly handler to intercept bell

--- a/src/ai_agent_config.zig
+++ b/src/ai_agent_config.zig
@@ -1,0 +1,34 @@
+//! Small, dependency-light AI-agent config types shared by config.zig and
+//! ai_chat.zig. Kept out of the 8k-line ai_chat.zig so config (and its fast
+//! unit tests) need not compile the full AI session/API/tool-exec graph.
+const std = @import("std");
+
+pub const AgentPermission = enum {
+    confirm,
+    full,
+
+    pub fn parse(value: []const u8) ?AgentPermission {
+        if (std.mem.eql(u8, value, "confirm")) return .confirm;
+        if (std.mem.eql(u8, value, "full") or std.mem.eql(u8, value, "full-permission")) return .full;
+        return null;
+    }
+
+    pub fn name(self: AgentPermission) []const u8 {
+        return switch (self) {
+            .confirm => "confirm",
+            .full => "full",
+        };
+    }
+};
+
+test "AgentPermission.parse accepts confirm/full/full-permission" {
+    try std.testing.expectEqual(AgentPermission.confirm, AgentPermission.parse("confirm").?);
+    try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full").?);
+    try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full-permission").?);
+    try std.testing.expectEqual(@as(?AgentPermission, null), AgentPermission.parse("nope"));
+}
+
+test "AgentPermission.name round-trips" {
+    try std.testing.expectEqualStrings("confirm", AgentPermission.confirm.name());
+    try std.testing.expectEqualStrings("full", AgentPermission.full.name());
+}

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -103,23 +103,7 @@ const RequestMessage = ai_chat_protocol.RequestMessage;
 const ai_chat_title = @import("ai_chat_title.zig");
 const ToolCall = ai_chat_protocol.ToolCall;
 
-pub const AgentPermission = enum {
-    confirm,
-    full,
-
-    pub fn parse(value: []const u8) ?AgentPermission {
-        if (std.mem.eql(u8, value, "confirm")) return .confirm;
-        if (std.mem.eql(u8, value, "full") or std.mem.eql(u8, value, "full-permission")) return .full;
-        return null;
-    }
-
-    pub fn name(self: AgentPermission) []const u8 {
-        return switch (self) {
-            .confirm => "confirm",
-            .full => "full",
-        };
-    }
-};
+pub const AgentPermission = @import("ai_agent_config.zig").AgentPermission;
 
 pub const AgentSettings = struct {
     enabled: bool = false,

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -27,12 +27,12 @@ pub const DEFAULT_BASE_URL = "https://api.deepseek.com";
 pub const DEFAULT_MODEL = "deepseek-v4-pro";
 pub const DEFAULT_SYSTEM_PROMPT = platform_agent_prompt.defaultSystemPrompt;
 pub const COPILOT_SYSTEM_PROMPT = platform_agent_prompt.copilotSystemPrompt;
-pub const DEFAULT_THINKING = "enabled";
-pub const DEFAULT_REASONING_EFFORT = "high";
-pub const DEFAULT_STREAM = "false";
-pub const DEFAULT_AGENT = "true";
+pub const DEFAULT_THINKING = ai_chat_protocol.DEFAULT_THINKING;
+pub const DEFAULT_REASONING_EFFORT = ai_chat_protocol.DEFAULT_REASONING_EFFORT;
+pub const DEFAULT_STREAM = ai_chat_protocol.DEFAULT_STREAM;
+pub const DEFAULT_AGENT = ai_chat_protocol.DEFAULT_AGENT;
 pub const DEFAULT_PROTOCOL = ai_chat_protocol.DEFAULT_PROTOCOL;
-pub const DEFAULT_MAX_TOKENS = "8192";
+pub const DEFAULT_MAX_TOKENS = ai_chat_protocol.DEFAULT_MAX_TOKENS;
 
 const DEFAULT_AGENT_TIMEOUT_MS: u32 = 60_000;
 const DEFAULT_AGENT_OUTPUT_LIMIT: u32 = 16 * 1024;

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -7,6 +7,11 @@ const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 
 pub const DEFAULT_PROTOCOL = "chat_completions";
+pub const DEFAULT_THINKING = "enabled";
+pub const DEFAULT_REASONING_EFFORT = "high";
+pub const DEFAULT_STREAM = "false";
+pub const DEFAULT_AGENT = "true";
+pub const DEFAULT_MAX_TOKENS = "8192";
 pub const TOOL_CALL_REASONING_FALLBACK = "Tool call is required before answering.";
 
 // ---------------------------------------------------------------------------

--- a/src/appwindow/active_tab.zig
+++ b/src/appwindow/active_tab.zig
@@ -1,0 +1,5 @@
+//! Index of the currently-active tab. Extracted from appwindow/tab.zig so
+//! dependency-light modules (e.g. file_explorer) can read/write the active-tab
+//! index without importing the heavy tab module (which pulls in
+//! Surface / ai_chat / split_tree and thus the full app graph).
+pub threadlocal var g_active_tab: usize = 0;

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -14,6 +14,7 @@ const session_persist = @import("../session_persist.zig");
 const ai_chat = @import("../ai_chat.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
+const active_tab_state = @import("active_tab.zig");
 
 const CursorStyle = Config.CursorStyle;
 const Selection = Surface.Selection;
@@ -103,7 +104,6 @@ pub const TabState = struct {
 
 pub threadlocal var g_tabs: [MAX_TABS]?*TabState = .{null} ** MAX_TABS;
 pub threadlocal var g_tab_count: usize = 0;
-pub threadlocal var g_active_tab: usize = 0;
 
 // Shell command for spawning new tabs (set once at startup from config)
 pub threadlocal var g_shell_cmd_buf: platform_pty_command.CommandLineBuffer = undefined;
@@ -165,18 +165,18 @@ pub fn getShellCmd() platform_pty_command.CommandLine {
 
 pub fn activeTab() ?*TabState {
     if (g_tab_count == 0) return null;
-    return g_tabs[g_active_tab];
+    return g_tabs[active_tab_state.g_active_tab];
 }
 
 pub fn activeSurface() ?*Surface {
     if (g_tab_count == 0) return null;
-    const t = g_tabs[g_active_tab] orelse return null;
+    const t = g_tabs[active_tab_state.g_active_tab] orelse return null;
     return t.focusedSurface();
 }
 
 pub fn activeAiChat() ?*ai_chat.Session {
     if (g_tab_count == 0) return null;
-    const t = g_tabs[g_active_tab] orelse return null;
+    const t = g_tabs[active_tab_state.g_active_tab] orelse return null;
     if (t.kind != .ai_chat) return null;
     return t.ai_chat_session;
 }
@@ -253,7 +253,7 @@ fn splitSshCommand(
 /// Get the active tab's focused surface's selection
 pub fn activeSelection() *Selection {
     if (g_tab_count > 0) {
-        if (g_tabs[g_active_tab]) |t| {
+        if (g_tabs[active_tab_state.g_active_tab]) |t| {
             if (t.kind != .terminal) {
                 const S = struct {
                     var dummy: Selection = .{};
@@ -273,7 +273,7 @@ pub fn activeSelection() *Selection {
 
 pub fn isActiveTabTerminal() bool {
     if (g_tab_count == 0) return false;
-    const t = g_tabs[g_active_tab] orelse return false;
+    const t = g_tabs[active_tab_state.g_active_tab] orelse return false;
     return t.kind == .terminal;
 }
 
@@ -326,10 +326,10 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
-    g_active_tab = g_tab_count;
+    active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
 
-    std.debug.print("New tab spawned (count={}), active: {}\n", .{ g_tab_count, g_active_tab });
+    std.debug.print("New tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
 }
 
@@ -379,10 +379,10 @@ pub fn spawnAiChatTab(
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
-    g_active_tab = g_tab_count;
+    active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
 
-    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, g_active_tab });
+    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
 }
 
@@ -407,10 +407,10 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
-    g_active_tab = g_tab_count;
+    active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
 
-    std.debug.print("Restored AI Chat tab from history (count={}), active: {}\n", .{ g_tab_count, g_active_tab });
+    std.debug.print("Restored AI Chat tab from history (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
 }
 
@@ -435,12 +435,12 @@ pub fn closeTab(idx: usize, allocator: std.mem.Allocator) void {
     g_tab_close_opacity[g_tab_count - 1] = 0;
     g_tab_count -= 1;
 
-    if (g_active_tab == idx) {
-        if (g_active_tab >= g_tab_count) {
-            g_active_tab = g_tab_count - 1;
+    if (active_tab_state.g_active_tab == idx) {
+        if (active_tab_state.g_active_tab >= g_tab_count) {
+            active_tab_state.g_active_tab = g_tab_count - 1;
         }
-    } else if (g_active_tab > idx) {
-        g_active_tab -= 1;
+    } else if (active_tab_state.g_active_tab > idx) {
+        active_tab_state.g_active_tab -= 1;
     }
 }
 
@@ -471,7 +471,7 @@ fn setVisualStateAt(idx: usize, state: TabVisualState) void {
 }
 
 /// Move a tab from one index to another.
-/// Keeps g_active_tab attached to the same logical tab after the move.
+/// Keeps active_tab_state.g_active_tab attached to the same logical tab after the move.
 pub fn reorderTab(from_idx: usize, to_idx: usize) bool {
     if (g_tab_count <= 1) return false;
     if (from_idx >= g_tab_count or to_idx >= g_tab_count) return false;
@@ -497,12 +497,12 @@ pub fn reorderTab(from_idx: usize, to_idx: usize) bool {
     g_tabs[to_idx] = moved_tab;
     setVisualStateAt(to_idx, moved_visual);
 
-    if (g_active_tab == from_idx) {
-        g_active_tab = to_idx;
-    } else if (from_idx < to_idx and g_active_tab > from_idx and g_active_tab <= to_idx) {
-        g_active_tab -= 1;
-    } else if (from_idx > to_idx and g_active_tab >= to_idx and g_active_tab < from_idx) {
-        g_active_tab += 1;
+    if (active_tab_state.g_active_tab == from_idx) {
+        active_tab_state.g_active_tab = to_idx;
+    } else if (from_idx < to_idx and active_tab_state.g_active_tab > from_idx and active_tab_state.g_active_tab <= to_idx) {
+        active_tab_state.g_active_tab -= 1;
+    } else if (from_idx > to_idx and active_tab_state.g_active_tab >= to_idx and active_tab_state.g_active_tab < from_idx) {
+        active_tab_state.g_active_tab += 1;
     }
 
     return true;
@@ -512,7 +512,7 @@ pub fn reorderTab(from_idx: usize, to_idx: usize) bool {
 /// The caller is responsible for clearing selection/divider/resize state and setting rebuild flags.
 pub fn switchTab(idx: usize) void {
     if (idx >= g_tab_count) return;
-    g_active_tab = idx;
+    active_tab_state.g_active_tab = idx;
     // Clear bell indicator and force rebuild for surfaces in this tab
     if (g_tabs[idx]) |t| {
         if (t.kind != .terminal) return;
@@ -700,7 +700,7 @@ pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
     const t = activeTab() orelse return .no_op;
     if (t.kind == .ai_chat) {
         if (g_tab_count <= 1) return .close_window;
-        closeTab(g_active_tab, allocator);
+        closeTab(active_tab_state.g_active_tab, allocator);
         return .closed_tab;
     }
 
@@ -708,7 +708,7 @@ pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
         if (g_tab_count <= 1) {
             return .close_window;
         } else {
-            closeTab(g_active_tab, allocator);
+            closeTab(active_tab_state.g_active_tab, allocator);
             return .closed_tab;
         }
     }
@@ -728,7 +728,7 @@ pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
         if (g_tab_count <= 1) {
             return .close_window;
         } else {
-            closeTab(g_active_tab, allocator);
+            closeTab(active_tab_state.g_active_tab, allocator);
             return .closed_tab;
         }
     }
@@ -1234,7 +1234,7 @@ pub fn restoreTab(
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
-    g_active_tab = g_tab_count;
+    active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
     return true;
 }
@@ -1284,7 +1284,7 @@ pub fn collectSessionSnapshot(arena: *std.heap.ArenaAllocator) !session_persist.
 
     return .{
         .version = session_persist.SCHEMA_VERSION,
-        .active_tab = @intCast(@min(g_active_tab, written - 1)),
+        .active_tab = @intCast(@min(active_tab_state.g_active_tab, written - 1)),
         .tabs = tabs[0..written],
     };
 }
@@ -1355,7 +1355,7 @@ fn resetTestTabGlobals() void {
         g_tab_text_y_end[idx] = 0;
     }
     g_tab_count = 0;
-    g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     g_tab_close_pressed = null;
     g_last_frame_time_ms = 0;
     g_tab_rename_active = false;
@@ -1425,7 +1425,7 @@ test "tab: reorder moves active tab forward" {
     g_tabs[1] = &b;
     g_tabs[2] = &c;
     g_tab_count = 3;
-    g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     g_tab_close_opacity[0] = 0.1;
     g_tab_close_opacity[1] = 0.2;
     g_tab_close_opacity[2] = 0.3;
@@ -1447,7 +1447,7 @@ test "tab: reorder moves active tab forward" {
     try std.testing.expect(g_tabs[0].? == &b);
     try std.testing.expect(g_tabs[1].? == &c);
     try std.testing.expect(g_tabs[2].? == &a);
-    try std.testing.expectEqual(@as(usize, 2), g_active_tab);
+    try std.testing.expectEqual(@as(usize, 2), active_tab_state.g_active_tab);
     try std.testing.expectEqual(@as(f32, 0.2), g_tab_close_opacity[0]);
     try std.testing.expectEqual(@as(f32, 0.3), g_tab_close_opacity[1]);
     try std.testing.expectEqual(@as(f32, 0.1), g_tab_close_opacity[2]);
@@ -1489,14 +1489,14 @@ test "tab: reorder moves active tab backward" {
     g_tabs[1] = &b;
     g_tabs[2] = &c;
     g_tab_count = 3;
-    g_active_tab = 2;
+    active_tab_state.g_active_tab = 2;
 
     try std.testing.expect(reorderTab(2, 0));
 
     try std.testing.expect(g_tabs[0].? == &c);
     try std.testing.expect(g_tabs[1].? == &a);
     try std.testing.expect(g_tabs[2].? == &b);
-    try std.testing.expectEqual(@as(usize, 0), g_active_tab);
+    try std.testing.expectEqual(@as(usize, 0), active_tab_state.g_active_tab);
 }
 
 test "tab: reorder preserves selected logical tab when another tab moves" {
@@ -1508,15 +1508,15 @@ test "tab: reorder preserves selected logical tab when another tab moves" {
     g_tabs[1] = &b;
     g_tabs[2] = &c;
     g_tab_count = 3;
-    g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
 
     try std.testing.expect(reorderTab(0, 2));
-    try std.testing.expect(g_tabs[g_active_tab].? == &b);
-    try std.testing.expectEqual(@as(usize, 0), g_active_tab);
+    try std.testing.expect(g_tabs[active_tab_state.g_active_tab].? == &b);
+    try std.testing.expectEqual(@as(usize, 0), active_tab_state.g_active_tab);
 
     try std.testing.expect(reorderTab(2, 0));
-    try std.testing.expect(g_tabs[g_active_tab].? == &b);
-    try std.testing.expectEqual(@as(usize, 1), g_active_tab);
+    try std.testing.expect(g_tabs[active_tab_state.g_active_tab].? == &b);
+    try std.testing.expectEqual(@as(usize, 1), active_tab_state.g_active_tab);
 }
 
 test "tab: reorder rejects invalid and no-op moves" {
@@ -1524,11 +1524,11 @@ test "tab: reorder rejects invalid and no-op moves" {
     var a = makeTestTabState();
     g_tabs[0] = &a;
     g_tab_count = 1;
-    g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
 
     try std.testing.expect(!reorderTab(0, 0));
     try std.testing.expect(!reorderTab(0, 1));
     try std.testing.expect(!reorderTab(1, 0));
     try std.testing.expect(g_tabs[0].? == &a);
-    try std.testing.expectEqual(@as(usize, 0), g_active_tab);
+    try std.testing.expectEqual(@as(usize, 0), active_tab_state.g_active_tab);
 }

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -7,6 +7,7 @@ const ssh_tunnel = @import("ssh_tunnel.zig");
 const window_backend = @import("platform/window_backend.zig");
 const ui_perf = @import("ui_perf.zig");
 const tab = @import("appwindow/tab.zig");
+const active_tab_state = @import("appwindow/active_tab.zig");
 
 pub const DEFAULT_WIDTH: f32 = 720;
 pub const MIN_WIDTH: f32 = 360;
@@ -72,7 +73,7 @@ pub fn width() f32 {
 
 pub fn isVisibleForActiveTab() bool {
     const owner = g_owner_tab orelse return false;
-    return g_visible and owner == tab.g_active_tab;
+    return g_visible and owner == active_tab_state.g_active_tab;
 }
 
 pub fn onTabClosed(closed_idx: usize) void {
@@ -129,7 +130,7 @@ pub fn open(parent: ?window_backend.NativeHandle, url: []const u8) void {
 
     setUrl(url);
     g_visible = true;
-    g_owner_tab = tab.g_active_tab;
+    g_owner_tab = active_tab_state.g_active_tab;
 
     if (g_browser) |browser| {
         navigateCurrentUrl(browser);
@@ -418,25 +419,25 @@ fn copyBounded(dest: []u8, text: []const u8) usize {
 test "browser_panel: visible only on owning active tab" {
     const saved_visible = g_visible;
     const saved_owner = g_owner_tab;
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     defer {
         g_visible = saved_visible;
         g_owner_tab = saved_owner;
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     g_visible = true;
     g_owner_tab = 0;
 
     try std.testing.expect(isVisibleForActiveTab());
     try std.testing.expectEqual(DEFAULT_WIDTH, width());
 
-    tab.g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
     try std.testing.expect(!isVisibleForActiveTab());
     try std.testing.expectEqual(@as(f32, 0), width());
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     try std.testing.expect(isVisibleForActiveTab());
 }
 

--- a/src/browser_panel_stub.zig
+++ b/src/browser_panel_stub.zig
@@ -5,6 +5,7 @@ const Surface = @import("Surface.zig");
 const ssh_tunnel = @import("ssh_tunnel.zig");
 const window_backend = @import("platform/window_backend.zig");
 const tab = @import("appwindow/tab.zig");
+const active_tab_state = @import("appwindow/active_tab.zig");
 
 pub const DEFAULT_WIDTH: f32 = 720;
 pub const MIN_WIDTH: f32 = 360;
@@ -59,7 +60,7 @@ pub fn width() f32 {
 
 pub fn isVisibleForActiveTab() bool {
     const owner = g_owner_tab orelse return false;
-    return g_visible and owner == tab.g_active_tab;
+    return g_visible and owner == active_tab_state.g_active_tab;
 }
 
 pub fn onTabClosed(closed_idx: usize) void {
@@ -227,19 +228,19 @@ pub fn boundsForWindow(window_width: i32, window_height: i32, titlebar_height: f
 test "browser_panel_stub: visible only on owning active tab" {
     const saved_visible = g_visible;
     const saved_owner = g_owner_tab;
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     defer {
         g_visible = saved_visible;
         g_owner_tab = saved_owner;
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     g_visible = true;
     g_owner_tab = 0;
     try std.testing.expect(isVisibleForActiveTab());
 
-    tab.g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
     try std.testing.expect(!isVisibleForActiveTab());
 }
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -19,7 +19,7 @@ const Config = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");
-const ai_chat = @import("ai_chat.zig");
+const ai_agent_config = @import("ai_agent_config.zig");
 const keybind = @import("keybind.zig");
 const link_open = @import("link_open.zig");
 const platform_dirs = @import("platform/dirs.zig");
@@ -290,7 +290,7 @@ theme: ?[]const u8 = null,
 @"desktop-notifications": bool = true,
 
 /// Agent command permission mode: confirm (deny until approved UI exists) or full.
-@"ai-agent-permission": ai_chat.AgentPermission = .confirm,
+@"ai-agent-permission": ai_agent_config.AgentPermission = .confirm,
 
 /// Timeout budget for agent shell/SSH commands.
 @"ai-agent-command-timeout-ms": u32 = 60_000,
@@ -783,7 +783,7 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             log.warn("invalid ai-agent-enabled: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "ai-agent-permission")) {
-        if (ai_chat.AgentPermission.parse(value)) |permission| {
+        if (ai_agent_config.AgentPermission.parse(value)) |permission| {
             self.@"ai-agent-permission" = permission;
         } else {
             log.warn("invalid ai-agent-permission: {s}", .{value});
@@ -1842,7 +1842,7 @@ test "config: ai agent options parse" {
     var cfg: Config = .{};
 
     try std.testing.expectEqual(false, cfg.@"ai-agent-enabled");
-    try std.testing.expectEqual(ai_chat.AgentPermission.confirm, cfg.@"ai-agent-permission");
+    try std.testing.expectEqual(ai_agent_config.AgentPermission.confirm, cfg.@"ai-agent-permission");
 
     cfg.applyKeyValue(allocator, "ai-agent-enabled", "true", ".");
     cfg.applyKeyValue(allocator, "ai-agent-permission", "full", ".");
@@ -1850,7 +1850,7 @@ test "config: ai agent options parse" {
     cfg.applyKeyValue(allocator, "ai-agent-output-limit", "4096", ".");
 
     try std.testing.expectEqual(true, cfg.@"ai-agent-enabled");
-    try std.testing.expectEqual(ai_chat.AgentPermission.full, cfg.@"ai-agent-permission");
+    try std.testing.expectEqual(ai_agent_config.AgentPermission.full, cfg.@"ai-agent-permission");
     try std.testing.expectEqual(@as(u32, 120000), cfg.@"ai-agent-command-timeout-ms");
     try std.testing.expectEqual(@as(u32, 4096), cfg.@"ai-agent-output-limit");
 }

--- a/src/file_backend.zig
+++ b/src/file_backend.zig
@@ -5,7 +5,7 @@
 //! adding extra filesystem/SSH dependencies.
 
 const std = @import("std");
-const Surface = @import("Surface.zig");
+const ssh_connection = @import("ssh_connection.zig");
 const scp = @import("scp.zig");
 const platform_remote_file = @import("platform/remote_file.zig");
 
@@ -14,7 +14,7 @@ pub const MAX_NAME_LEN = 255;
 pub const Backend = union(enum) {
     local,
     wsl,
-    ssh: *const Surface.SshConnection,
+    ssh: *const ssh_connection.SshConnection,
 };
 
 pub const Entry = struct {
@@ -117,7 +117,7 @@ fn listWsl(
 
 fn listSsh(
     allocator: std.mem.Allocator,
-    conn: *const Surface.SshConnection,
+    conn: *const ssh_connection.SshConnection,
     path: []const u8,
     out: []Entry,
 ) ListResult {
@@ -143,7 +143,7 @@ fn listSsh(
 
 fn sshPwd(
     allocator: std.mem.Allocator,
-    conn: *const Surface.SshConnection,
+    conn: *const ssh_connection.SshConnection,
     out: []u8,
 ) ?usize {
     const output = scp.sshExec(allocator, conn, "pwd") orelse return null;

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -5,7 +5,7 @@
 //! Supports local (std.fs), WSL, and remote SSH/SCP modes.
 
 const std = @import("std");
-const Surface = @import("Surface.zig");
+const ssh_connection = @import("ssh_connection.zig");
 const agent_history = @import("agent_history.zig");
 const scp = @import("scp.zig");
 const file_backend = @import("file_backend.zig");
@@ -37,7 +37,7 @@ pub const HistoryRow = struct {
 
 pub const TerminalPanelTarget = union(enum) {
     remote: struct {
-        conn: *const Surface.SshConnection,
+        conn: *const ssh_connection.SshConnection,
         cwd: []const u8,
     },
     wsl: []const u8,
@@ -54,7 +54,7 @@ pub threadlocal var g_row_height: f32 = ROW_HEIGHT;
 pub threadlocal var g_header_height: f32 = HEADER_HEIGHT;
 
 // Remote SSH connection state (copied from surface when entering remote mode)
-pub threadlocal var g_ssh_conn: Surface.SshConnection = .{};
+pub threadlocal var g_ssh_conn: ssh_connection.SshConnection = .{};
 pub threadlocal var g_has_ssh_conn: bool = false;
 
 // Transfer status
@@ -107,7 +107,7 @@ const AsyncListKind = enum { rescan, expand };
 
 const AsyncListJob = struct {
     kind: AsyncListKind,
-    conn: Surface.SshConnection,
+    conn: ssh_connection.SshConnection,
     context_id: u64,
     path_buf: [512]u8 = undefined,
     path_len: usize = 0,
@@ -137,7 +137,7 @@ threadlocal var g_async_job: ?*AsyncListJob = null;
 threadlocal var g_pending_async_list: ?PendingAsyncList = null;
 threadlocal var g_async_context_id: u64 = 1;
 
-const TransferFn = *const fn (std.mem.Allocator, *const Surface.SshConnection, []const u8, []const u8, *scp.TransferControl) scp.TransferResult;
+const TransferFn = *const fn (std.mem.Allocator, *const ssh_connection.SshConnection, []const u8, []const u8, *scp.TransferControl) scp.TransferResult;
 pub const TransferSuccessCallback = *const fn (?*anyopaque) void;
 pub const TransferDestroyCallback = *const fn (?*anyopaque) void;
 const TRANSFER_PATH_MAX: usize = 1024;
@@ -151,7 +151,7 @@ pub const TransferCompletion = struct {
 
 const TransferRequest = struct {
     kind: TransferKind,
-    conn: Surface.SshConnection,
+    conn: ssh_connection.SshConnection,
     context_id: u64,
     src_buf: [TRANSFER_PATH_MAX]u8 = undefined,
     src_len: usize = 0,
@@ -460,7 +460,7 @@ fn terminalTargetMatchesCurrentState(target: TerminalPanelTarget) bool {
     };
 }
 
-fn sshConnectionsEqual(a: *const Surface.SshConnection, b: *const Surface.SshConnection) bool {
+fn sshConnectionsEqual(a: *const ssh_connection.SshConnection, b: *const ssh_connection.SshConnection) bool {
     return std.mem.eql(u8, a.user(), b.user()) and
         std.mem.eql(u8, a.host(), b.host()) and
         std.mem.eql(u8, a.port(), b.port()) and
@@ -504,7 +504,7 @@ fn copyRootPathOnly(path: []const u8) void {
 }
 
 /// Enter remote mode with the given SSH connection.
-pub fn enterRemoteMode(conn: *const Surface.SshConnection, remote_cwd: []const u8) void {
+pub fn enterRemoteMode(conn: *const ssh_connection.SshConnection, remote_cwd: []const u8) void {
     g_async_context_id +%= 1;
     g_mode = .remote;
     g_ssh_conn = conn.*;
@@ -927,11 +927,11 @@ fn destroyAsyncJob(job: *AsyncListJob) void {
     allocator.destroy(job);
 }
 
-fn startTransferJob(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
+fn startTransferJob(kind: TransferKind, conn: *const ssh_connection.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
     return startTransferJobWithCompletion(kind, conn, src, dst, display, transfer_fn, .{});
 }
 
-fn startTransferJobWithCompletion(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn, completion: TransferCompletion) bool {
+fn startTransferJobWithCompletion(kind: TransferKind, conn: *const ssh_connection.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn, completion: TransferCompletion) bool {
     if (src.len > TRANSFER_PATH_MAX or dst.len > TRANSFER_PATH_MAX) {
         destroyTransferCompletion(completion);
         setTransferStatusForKind(kind, .failed, "Path too long");
@@ -1142,7 +1142,7 @@ fn destroyTransferJob(job: *TransferJob) void {
     std.heap.page_allocator.destroy(job);
 }
 
-fn startTransferJobForTest(kind: TransferKind, conn: *const Surface.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
+fn startTransferJobForTest(kind: TransferKind, conn: *const ssh_connection.SshConnection, src: []const u8, dst: []const u8, display: []const u8, transfer_fn: TransferFn) bool {
     return startTransferJob(kind, conn, src, dst, display, transfer_fn);
 }
 
@@ -1527,11 +1527,11 @@ pub fn uploadFile(local_path: []const u8) void {
     _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, filename, scp.transferWithControl);
 }
 
-pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const Surface.SshConnection) bool {
+pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
     return uploadLocalFileToRemoteSpecWithTransfer(local_path, dst_spec, display_name, conn, scp.transferWithControl);
 }
 
-fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const Surface.SshConnection, transfer_fn: TransferFn) bool {
+fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, transfer_fn: TransferFn) bool {
     return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
 
@@ -1539,7 +1539,7 @@ fn uploadLocalFileToRemoteSpecWithTransferAndCallback(
     local_path: []const u8,
     dst_spec: []const u8,
     display_name: []const u8,
-    conn: *const Surface.SshConnection,
+    conn: *const ssh_connection.SshConnection,
     transfer_fn: TransferFn,
     callback: TransferSuccessCallback,
 ) bool {
@@ -1550,17 +1550,17 @@ pub fn uploadLocalFileToRemoteSpecWithCompletion(
     local_path: []const u8,
     dst_spec: []const u8,
     display_name: []const u8,
-    conn: *const Surface.SshConnection,
+    conn: *const ssh_connection.SshConnection,
     completion: TransferCompletion,
 ) bool {
     return startTransferJobWithCompletion(.upload, conn, local_path, dst_spec, display_name, scp.transferWithControl, completion);
 }
 
-pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const Surface.SshConnection) bool {
+pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
     return downloadRemoteFileToPathWithTransfer(remote_path, local_path, display_name, conn, scp.transferWithControl);
 }
 
-fn downloadRemoteFileToPathWithTransfer(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const Surface.SshConnection, transfer_fn: TransferFn) bool {
+fn downloadRemoteFileToPathWithTransfer(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, transfer_fn: TransferFn) bool {
     if (conn.user_len + conn.host_len + remote_path.len + 2 > 512) {
         setTransferStatusForKind(.download, .failed, "Path too long");
         return false;
@@ -1581,7 +1581,7 @@ test "setTransferStatus stores message" {
     try std.testing.expectEqualStrings("test_file.txt", g_transfer_msg[0..g_transfer_msg_len]);
 }
 
-fn transferOkForTest(_: std.mem.Allocator, _: *const Surface.SshConnection, _: []const u8, _: []const u8, _: *scp.TransferControl) scp.TransferResult {
+fn transferOkForTest(_: std.mem.Allocator, _: *const ssh_connection.SshConnection, _: []const u8, _: []const u8, _: *scp.TransferControl) scp.TransferResult {
     return .ok;
 }
 
@@ -1603,7 +1603,7 @@ test "file_explorer: transfer job starts without completing on input thread" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferOkForTest));
     try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
     try std.testing.expectEqualStrings("file.txt - calculating...", g_transfer_msg[0..g_transfer_msg_len]);
@@ -1614,7 +1614,7 @@ test "file_explorer: completed transfer job updates status on tick" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferOkForTest));
 
     var attempts: usize = 0;
@@ -1632,7 +1632,7 @@ test "file_explorer: second transfer is queued while one is active" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(startTransferJobForTest(.download, &conn, "remote-a", "local-a", "a.txt", transferOkForTest));
     try std.testing.expect(startTransferJobForTest(.upload, &conn, "local-b", "remote-b", "b.txt", transferOkForTest));
     try std.testing.expectEqual(@as(usize, 1), transferQueueLenForTest());
@@ -1650,7 +1650,7 @@ test "file_explorer: transfer success callback is deferred until upload succeeds
     defer resetTransferStateForTest();
     g_transfer_success_callback_count_for_test = 0;
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(uploadLocalFileToRemoteSpecWithTransferAndCallback(
         "local.txt",
         "user@host:/tmp",
@@ -1671,7 +1671,7 @@ test "file_explorer: upload helper starts transfer with explicit remote spec" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(uploadLocalFileToRemoteSpecWithTransfer("local.txt", "user@host:/tmp", "local.txt", &conn, transferOkForTest));
     try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
     try std.testing.expectEqualStrings("local.txt", g_transfer_msg[0..g_transfer_msg_len]);
@@ -1682,7 +1682,7 @@ test "file_explorer: download helper starts transfer with explicit remote path" 
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     conn.user_buf[0] = 'u';
     conn.user_len = 1;
     conn.host_buf[0] = 'h';
@@ -1698,7 +1698,7 @@ test "file_explorer: download transfer emits notification" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     conn.user_buf[0] = 'u';
     conn.user_len = 1;
     conn.host_buf[0] = 'h';
@@ -1727,7 +1727,7 @@ test "file_explorer: download progress message includes transfer speed" {
     );
 }
 
-fn transferWaitForCancelForTest(_: std.mem.Allocator, _: *const Surface.SshConnection, _: []const u8, _: []const u8, control: *scp.TransferControl) scp.TransferResult {
+fn transferWaitForCancelForTest(_: std.mem.Allocator, _: *const ssh_connection.SshConnection, _: []const u8, _: []const u8, control: *scp.TransferControl) scp.TransferResult {
     var attempts: usize = 0;
     while (!control.cancelRequested() and attempts < 200) : (attempts += 1) {
         std.Thread.sleep(std.time.ns_per_ms);
@@ -1739,7 +1739,7 @@ test "file_explorer: active download transfer can be cancelled" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
-    var conn: Surface.SshConnection = .{};
+    var conn: ssh_connection.SshConnection = .{};
     try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferWaitForCancelForTest));
     try std.testing.expect(cancelActiveDownloadForTest());
 
@@ -1910,7 +1910,7 @@ test "file_explorer: syncPanelForTabKind resets focus and mode" {
 }
 
 test "file_explorer: applyTerminalTargetState updates terminal backend and root" {
-    const conn: Surface.SshConnection = .{
+    const conn: ssh_connection.SshConnection = .{
         .user_len = 4,
         .host_len = 4,
         .port_len = 2,
@@ -1997,7 +1997,7 @@ test "file_explorer: unchanged terminal target preserves file state" {
 }
 
 test "file_explorer: terminal target equality checks ssh identity and cwd" {
-    const conn_a: Surface.SshConnection = .{
+    const conn_a: ssh_connection.SshConnection = .{
         .user_buf = [_]u8{ 'r', 'o', 'o', 't' } ++ [_]u8{0} ** 124,
         .user_len = 4,
         .host_buf = [_]u8{ 'h', 'o', 's', 't' } ++ [_]u8{0} ** 124,
@@ -2009,7 +2009,7 @@ test "file_explorer: terminal target equality checks ssh identity and cwd" {
         .password_auth = true,
         .legacy_algorithms = false,
     };
-    const conn_b: Surface.SshConnection = .{
+    const conn_b: ssh_connection.SshConnection = .{
         .user_buf = [_]u8{ 'r', 'o', 'o', 't' } ++ [_]u8{0} ** 124,
         .user_len = 4,
         .host_buf = [_]u8{ 'h', 'o', 's', 't' } ++ [_]u8{0} ** 124,

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -11,7 +11,7 @@ const scp = @import("scp.zig");
 const file_backend = @import("file_backend.zig");
 const platform_local_path = @import("platform/local_path.zig");
 const ui_perf = @import("ui_perf.zig");
-const tab = @import("appwindow/tab.zig");
+const active_tab_state = @import("appwindow/active_tab.zig");
 
 pub const DEFAULT_WIDTH: f32 = 240;
 pub const MIN_WIDTH: f32 = 160;
@@ -193,12 +193,12 @@ pub fn width() f32 {
 
 pub fn isVisibleForActiveTab() bool {
     const owner = g_owner_tab orelse return false;
-    return g_visible and owner == tab.g_active_tab;
+    return g_visible and owner == active_tab_state.g_active_tab;
 }
 
 pub fn openForActiveTab() void {
     g_visible = true;
-    g_owner_tab = tab.g_active_tab;
+    g_owner_tab = active_tab_state.g_active_tab;
 }
 
 pub fn close() void {
@@ -1773,25 +1773,25 @@ test "file_explorer: visible only on owning active tab" {
     const saved_visible = g_visible;
     const saved_owner = g_owner_tab;
     const saved_focused = g_focused;
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     defer {
         g_visible = saved_visible;
         g_owner_tab = saved_owner;
         g_focused = saved_focused;
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     openForActiveTab();
 
     try std.testing.expect(isVisibleForActiveTab());
     try std.testing.expectEqual(DEFAULT_WIDTH, width());
 
-    tab.g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
     try std.testing.expect(!isVisibleForActiveTab());
     try std.testing.expectEqual(@as(f32, 0), width());
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     try std.testing.expect(isVisibleForActiveTab());
 }
 
@@ -1799,12 +1799,12 @@ test "file_explorer: owner follows tab close and reorder" {
     const saved_visible = g_visible;
     const saved_owner = g_owner_tab;
     const saved_focused = g_focused;
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     defer {
         g_visible = saved_visible;
         g_owner_tab = saved_owner;
         g_focused = saved_focused;
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
     g_visible = true;
@@ -1812,7 +1812,7 @@ test "file_explorer: owner follows tab close and reorder" {
     onTabClosed(1);
     try std.testing.expectEqual(@as(?usize, 1), g_owner_tab);
 
-    tab.g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
     try std.testing.expect(isVisibleForActiveTab());
 
     onTabReordered(1, 3);

--- a/src/input.zig
+++ b/src/input.zig
@@ -46,6 +46,7 @@ const clipboard = @import("input/clipboard.zig");
 const click_tracker = @import("input/click_tracker.zig");
 const hit_test = @import("input/hit_test.zig");
 const preview_source = @import("input/preview_source.zig");
+const terminal_link_action = @import("input/terminal_link_action.zig");
 const mouse_report = @import("input/mouse_report.zig");
 const writeToPty = clipboard.writeToPty;
 pub const copyTextToClipboard = clipboard.copyTextToClipboard;
@@ -68,13 +69,11 @@ const resolveTerminalPreviewPath = preview_source.resolveTerminalPreviewPath;
 const basenameForPreview = preview_source.basenameForPreview;
 const buildPreviewCommand = preview_source.buildPreviewCommand;
 
-const LayoutResizeUrgency = enum { coalesced, immediate };
-const TerminalPathClickAction = enum { pass_through, open_url_or_preview, download_ssh_file };
-const InteractiveUnderlineTokenKind = enum { none, url, preview_path };
+const LayoutResizeUrgency = terminal_link_action.LayoutResizeUrgency;
+const TerminalPathClickAction = terminal_link_action.TerminalPathClickAction;
+const InteractiveUnderlineTokenKind = terminal_link_action.InteractiveUnderlineTokenKind;
 
-fn panelToggleResizeUrgency() LayoutResizeUrgency {
-    return .coalesced;
-}
+const panelToggleResizeUrgency = terminal_link_action.panelToggleResizeUrgency;
 
 fn clientSize(win: anytype) window_backend.Size {
     return window_backend.clientSize(win);
@@ -94,94 +93,11 @@ fn syncSidebarWidthToBackend(win: anytype) void {
     window_backend.setSidebarWidth(win, @intFromFloat(titlebar.sidebarWidth()));
 }
 
-test "panel toggles request coalesced layout resize" {
-    try std.testing.expectEqual(LayoutResizeUrgency.coalesced, panelToggleResizeUrgency());
-}
+const primaryOpenMod = terminal_link_action.primaryOpenMod;
+const terminalPathClickAction = terminal_link_action.terminalPathClickAction;
 
-/// The modifier that opens URLs / previews files / downloads SSH paths when
-/// clicking or hovering terminal text. macOS uses Cmd (super) — Ctrl+click is
-/// the system secondary-click — while other platforms use Ctrl.
-fn primaryOpenMod(ctrl: bool, super: bool) bool {
-    return if (builtin.target.os.tag == .macos) super else ctrl;
-}
-
-fn terminalPathClickAction(launch_kind: Surface.LaunchKind, has_ssh_conn: bool, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
-    if (mod and shift and !alt and launch_kind == .ssh and has_ssh_conn) return .download_ssh_file;
-    if (mod and !shift and !alt) return .open_url_or_preview;
-    return .pass_through;
-}
-
-test "primary open modifier is Cmd on macOS, Ctrl elsewhere" {
-    if (builtin.target.os.tag == .macos) {
-        try std.testing.expect(primaryOpenMod(false, true)); // Cmd-click opens
-        try std.testing.expect(!primaryOpenMod(true, false)); // Ctrl-click does not
-    } else {
-        try std.testing.expect(primaryOpenMod(true, false)); // Ctrl-click opens
-        try std.testing.expect(!primaryOpenMod(false, true)); // Win/Super does not
-    }
-}
-
-test "terminal path click action maps ctrl shift ssh to download" {
-    try std.testing.expectEqual(
-        TerminalPathClickAction.download_ssh_file,
-        terminalPathClickAction(.ssh, true, true, true, false),
-    );
-    try std.testing.expectEqual(
-        TerminalPathClickAction.pass_through,
-        terminalPathClickAction(.ssh, false, true, true, false),
-    );
-    try std.testing.expectEqual(
-        TerminalPathClickAction.pass_through,
-        terminalPathClickAction(.wsl, false, true, true, false),
-    );
-    try std.testing.expectEqual(
-        TerminalPathClickAction.open_url_or_preview,
-        terminalPathClickAction(.ssh, true, true, false, false),
-    );
-}
-
-fn interactiveUnderlineTokenKind(action: TerminalPathClickAction, text: []const u8) InteractiveUnderlineTokenKind {
-    return switch (action) {
-        .pass_through => .none,
-        .download_ssh_file => if (looksLikeDownloadPath(text)) .preview_path else .none,
-        .open_url_or_preview => if (looksLikeUrl(text))
-            .url
-        else if (looksLikePreviewPath(text))
-            .preview_path
-        else
-            .none,
-    };
-}
-
-fn looksLikeDownloadPath(text: []const u8) bool {
-    if (text.len == 0 or looksLikeUrl(text)) return false;
-    if (looksLikePreviewPath(text)) return true;
-
-    const dot_idx = std.mem.lastIndexOfScalar(u8, text, '.') orelse return false;
-    return dot_idx > 0 and dot_idx + 1 < text.len;
-}
-
-test "interactive underline includes preview paths for ctrl hover" {
-    try std.testing.expectEqual(
-        InteractiveUnderlineTokenKind.preview_path,
-        interactiveUnderlineTokenKind(.open_url_or_preview, "README.md"),
-    );
-    try std.testing.expectEqual(
-        InteractiveUnderlineTokenKind.url,
-        interactiveUnderlineTokenKind(.open_url_or_preview, "https://example.com/README.md"),
-    );
-    try std.testing.expectEqual(
-        InteractiveUnderlineTokenKind.none,
-        interactiveUnderlineTokenKind(.pass_through, "README.md"),
-    );
-}
-
-test "interactive underline includes plain filenames for ssh download hover" {
-    try std.testing.expectEqual(
-        InteractiveUnderlineTokenKind.preview_path,
-        interactiveUnderlineTokenKind(.download_ssh_file, "xx.h5ad"),
-    );
-}
+const interactiveUnderlineTokenKind = terminal_link_action.interactiveUnderlineTokenKind;
+const looksLikeDownloadPath = terminal_link_action.looksLikeDownloadPath;
 
 test "input: WeChat QR panel consumes text input while visible" {
     AppWindow.weixin_qr_panel.g_visible = true;
@@ -2158,11 +2074,7 @@ fn extractTokenAtCell(allocator: std.mem.Allocator, surface: *Surface, cell_pos:
     return token.text;
 }
 
-fn looksLikeUrl(text: []const u8) bool {
-    return std.mem.startsWith(u8, text, "http://") or
-        std.mem.startsWith(u8, text, "https://") or
-        std.mem.startsWith(u8, text, "www.");
-}
+const looksLikeUrl = terminal_link_action.looksLikeUrl;
 
 fn extractUrlRangeAtCell(allocator: std.mem.Allocator, surface: *Surface, cell_pos: CellPos) ?TokenAtCell {
     const token = extractTokenRangeAtCell(allocator, surface, cell_pos) orelse return null;

--- a/src/input.zig
+++ b/src/input.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const AppWindow = @import("AppWindow.zig");
 const tab = AppWindow.tab;
+const active_tab_state = @import("appwindow/active_tab.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
 const overlays = AppWindow.overlays;
@@ -1052,9 +1053,9 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
             .next => AppWindow.gotoSplit(.next_wrapped),
         },
         .equalize_splits => AppWindow.equalizeSplits(),
-        .next_tab => AppWindow.switchTab((tab.g_active_tab + 1) % tab.g_tab_count),
+        .next_tab => AppWindow.switchTab((active_tab_state.g_active_tab + 1) % tab.g_tab_count),
         .previous_tab => {
-            if (tab.g_active_tab > 0) AppWindow.switchTab(tab.g_active_tab - 1) else AppWindow.switchTab(tab.g_tab_count - 1);
+            if (active_tab_state.g_active_tab > 0) AppWindow.switchTab(active_tab_state.g_active_tab - 1) else AppWindow.switchTab(tab.g_tab_count - 1);
         },
         .open_config => {
             std.debug.print("[keybind] open_config pressed\n", .{});

--- a/src/input/preview_path.zig
+++ b/src/input/preview_path.zig
@@ -1,0 +1,39 @@
+//! Pure preview-path detection predicate. Extracted from preview_source.zig
+//! (which is Surface-coupled and therefore test-full only) so the predicate can
+//! be reused by dependency-light modules and unit-tested in the fast suite.
+//! Depends only on std and the std-only markdown_preview module.
+const std = @import("std");
+const markdown_preview = @import("../markdown_preview.zig");
+
+fn endsWithIgnoreCase(text: []const u8, suffix: []const u8) bool {
+    if (text.len < suffix.len) return false;
+    return std.ascii.eqlIgnoreCase(text[text.len - suffix.len ..], suffix);
+}
+
+fn isPreviewImagePath(path: []const u8) bool {
+    return markdown_preview.isImagePath(path);
+}
+
+pub fn looksLikePreviewPath(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (std.mem.startsWith(u8, path, "http://") or std.mem.startsWith(u8, path, "https://")) return false;
+    if (markdown_preview.detectKind(path) != null) return true;
+    if (path[0] == '~') return true;
+    if (path.len >= 2 and path[1] == ':') return true;
+    if (std.mem.indexOfScalar(u8, path, '/') != null) return true;
+    if (std.mem.indexOfScalar(u8, path, '\\') != null) return true;
+    return endsWithIgnoreCase(path, ".pdf") or isPreviewImagePath(path);
+}
+
+test "looksLikePreviewPath: markdown and image and pdf paths" {
+    try std.testing.expect(looksLikePreviewPath("README.md"));
+    try std.testing.expect(looksLikePreviewPath("notes.pdf"));
+    try std.testing.expect(looksLikePreviewPath("~/file"));
+    try std.testing.expect(looksLikePreviewPath("dir/file"));
+}
+
+test "looksLikePreviewPath: rejects urls and empty" {
+    try std.testing.expect(!looksLikePreviewPath(""));
+    try std.testing.expect(!looksLikePreviewPath("https://example.com"));
+    try std.testing.expect(!looksLikePreviewPath("http://example.com/x"));
+}

--- a/src/input/preview_source.zig
+++ b/src/input/preview_source.zig
@@ -7,6 +7,7 @@ const markdown_preview = @import("../markdown_preview.zig");
 const platform_remote_file = @import("../platform/remote_file.zig");
 const scp = @import("../scp.zig");
 const ui_perf = @import("../ui_perf.zig");
+const preview_path = @import("preview_path.zig");
 
 fn endsWithIgnoreCase(text: []const u8, suffix: []const u8) bool {
     if (text.len < suffix.len) return false;
@@ -23,16 +24,7 @@ pub const SourceKind = union(enum) {
     remote: Surface.SshConnection,
 };
 
-pub fn looksLikePreviewPath(path: []const u8) bool {
-    if (path.len == 0) return false;
-    if (std.mem.startsWith(u8, path, "http://") or std.mem.startsWith(u8, path, "https://")) return false;
-    if (markdown_preview.detectKind(path) != null) return true;
-    if (path[0] == '~') return true;
-    if (path.len >= 2 and path[1] == ':') return true;
-    if (std.mem.indexOfScalar(u8, path, '/') != null) return true;
-    if (std.mem.indexOfScalar(u8, path, '\\') != null) return true;
-    return endsWithIgnoreCase(path, ".pdf") or isPreviewImagePath(path);
-}
+pub const looksLikePreviewPath = preview_path.looksLikePreviewPath;
 
 fn appendShellQuoted(list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, text: []const u8) !void {
     try list.append(allocator, '\'');

--- a/src/input/terminal_link_action.zig
+++ b/src/input/terminal_link_action.zig
@@ -1,0 +1,114 @@
+//! Pure decision logic for terminal-text link/preview interaction: which
+//! modifier opens links, what a click on terminal text should do, and how to
+//! classify hovered tokens for interactive underlines. Extracted from input.zig
+//! so these rules are unit-tested in the fast suite without the AppWindow /
+//! Surface graph. input.zig keeps the adapter layer that feeds real events in.
+const std = @import("std");
+const builtin = @import("builtin");
+const platform_pty_command = @import("../platform/pty_command.zig");
+const preview_path = @import("preview_path.zig");
+
+const looksLikePreviewPath = preview_path.looksLikePreviewPath;
+
+pub const LayoutResizeUrgency = enum { coalesced, immediate };
+pub const TerminalPathClickAction = enum { pass_through, open_url_or_preview, download_ssh_file };
+pub const InteractiveUnderlineTokenKind = enum { none, url, preview_path };
+
+pub fn panelToggleResizeUrgency() LayoutResizeUrgency {
+    return .coalesced;
+}
+
+/// The modifier that opens URLs / previews files / downloads SSH paths when
+/// clicking or hovering terminal text. macOS uses Cmd (super) — Ctrl+click is
+/// the system secondary-click — while other platforms use Ctrl.
+pub fn primaryOpenMod(ctrl: bool, super: bool) bool {
+    return if (builtin.target.os.tag == .macos) super else ctrl;
+}
+
+pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, has_ssh_conn: bool, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
+    if (mod and shift and !alt and launch_kind == .ssh and has_ssh_conn) return .download_ssh_file;
+    if (mod and !shift and !alt) return .open_url_or_preview;
+    return .pass_through;
+}
+
+pub fn interactiveUnderlineTokenKind(action: TerminalPathClickAction, text: []const u8) InteractiveUnderlineTokenKind {
+    return switch (action) {
+        .pass_through => .none,
+        .download_ssh_file => if (looksLikeDownloadPath(text)) .preview_path else .none,
+        .open_url_or_preview => if (looksLikeUrl(text))
+            .url
+        else if (looksLikePreviewPath(text))
+            .preview_path
+        else
+            .none,
+    };
+}
+
+pub fn looksLikeDownloadPath(text: []const u8) bool {
+    if (text.len == 0 or looksLikeUrl(text)) return false;
+    if (looksLikePreviewPath(text)) return true;
+
+    const dot_idx = std.mem.lastIndexOfScalar(u8, text, '.') orelse return false;
+    return dot_idx > 0 and dot_idx + 1 < text.len;
+}
+
+pub fn looksLikeUrl(text: []const u8) bool {
+    return std.mem.startsWith(u8, text, "http://") or
+        std.mem.startsWith(u8, text, "https://") or
+        std.mem.startsWith(u8, text, "www.");
+}
+
+test "panel toggles request coalesced layout resize" {
+    try std.testing.expectEqual(LayoutResizeUrgency.coalesced, panelToggleResizeUrgency());
+}
+
+test "primary open modifier is Cmd on macOS, Ctrl elsewhere" {
+    if (builtin.target.os.tag == .macos) {
+        try std.testing.expect(primaryOpenMod(false, true)); // Cmd-click opens
+        try std.testing.expect(!primaryOpenMod(true, false)); // Ctrl-click does not
+    } else {
+        try std.testing.expect(primaryOpenMod(true, false)); // Ctrl-click opens
+        try std.testing.expect(!primaryOpenMod(false, true)); // Win/Super does not
+    }
+}
+
+test "terminal path click action maps ctrl shift ssh to download" {
+    try std.testing.expectEqual(
+        TerminalPathClickAction.download_ssh_file,
+        terminalPathClickAction(.ssh, true, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.pass_through,
+        terminalPathClickAction(.ssh, false, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.pass_through,
+        terminalPathClickAction(.wsl, false, true, true, false),
+    );
+    try std.testing.expectEqual(
+        TerminalPathClickAction.open_url_or_preview,
+        terminalPathClickAction(.ssh, true, true, false, false),
+    );
+}
+
+test "interactive underline includes preview paths for ctrl hover" {
+    try std.testing.expectEqual(
+        InteractiveUnderlineTokenKind.preview_path,
+        interactiveUnderlineTokenKind(.open_url_or_preview, "README.md"),
+    );
+    try std.testing.expectEqual(
+        InteractiveUnderlineTokenKind.url,
+        interactiveUnderlineTokenKind(.open_url_or_preview, "https://example.com/README.md"),
+    );
+    try std.testing.expectEqual(
+        InteractiveUnderlineTokenKind.none,
+        interactiveUnderlineTokenKind(.pass_through, "README.md"),
+    );
+}
+
+test "interactive underline includes plain filenames for ssh download hover" {
+    try std.testing.expectEqual(
+        InteractiveUnderlineTokenKind.preview_path,
+        interactiveUnderlineTokenKind(.download_ssh_file, "xx.h5ad"),
+    );
+}

--- a/src/markdown_preview_panel.zig
+++ b/src/markdown_preview_panel.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const markdown_preview = @import("markdown_preview.zig");
 const preview_source = @import("input/preview_source.zig");
 const tab = @import("appwindow/tab.zig");
+const active_tab_state = @import("appwindow/active_tab.zig");
 
 pub const DEFAULT_WIDTH: f32 = 440;
 pub const MIN_WIDTH: f32 = 280;
@@ -68,7 +69,7 @@ pub fn width() f32 {
 
 pub fn isVisibleForActiveTab() bool {
     const owner = g_owner_tab orelse return false;
-    return g_visible and owner == tab.g_active_tab;
+    return g_visible and owner == active_tab_state.g_active_tab;
 }
 
 pub fn onTabClosed(closed_idx: usize) void {
@@ -104,7 +105,7 @@ pub fn setWidth(w: f32, window_width: f32) bool {
 
 pub fn open(kind: markdown_preview.Kind, preview_title: []const u8, preview_path: []const u8, source_text: []const u8) void {
     g_preview_request_id +%= 1;
-    applyContentForOwner(tab.g_active_tab, kind, preview_title, preview_path, source_text, .ready);
+    applyContentForOwner(active_tab_state.g_active_tab, kind, preview_title, preview_path, source_text, .ready);
 }
 
 fn applyContentForOwner(owner_tab: usize, kind: markdown_preview.Kind, preview_title: []const u8, preview_path: []const u8, source_text: []const u8, status: LoadStatus) void {
@@ -242,7 +243,7 @@ pub fn beginAsyncLoad(kind: markdown_preview.Kind, preview_title: []const u8, pr
 fn beginAsyncLoadWithReader(kind: markdown_preview.Kind, preview_title: []const u8, preview_path: []const u8, source_kind: PreviewSourceKind, read_fn: PreviewReadFn) bool {
     g_preview_request_id +%= 1;
     const request_id = g_preview_request_id;
-    const owner_tab = tab.g_active_tab;
+    const owner_tab = active_tab_state.g_active_tab;
 
     if (preview_path.len > 512) {
         applyContentForOwner(owner_tab, kind, preview_title, preview_path, FAILED_SOURCE, .failed);
@@ -320,7 +321,7 @@ pub fn tickAsync() bool {
             const result_source = if (job.status == .too_large) TOO_LARGE_SOURCE else FAILED_SOURCE;
             applyContentForOwner(job.owner_tab, job.kind, job.title_buf[0..job.title_len], job.path_buf[0..job.path_len], result_source, job.status);
         }
-        changed = changed or job.owner_tab == tab.g_active_tab;
+        changed = changed or job.owner_tab == active_tab_state.g_active_tab;
     }
     return changed;
 }
@@ -398,24 +399,24 @@ fn resetAsyncForTest() void {
 test "markdown_preview_panel: visible only on owning active tab" {
     const saved_visible = g_visible;
     const saved_owner = g_owner_tab;
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     defer {
         g_visible = saved_visible;
         g_owner_tab = saved_owner;
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     open(.markdown, "README.md", "README.md", "# Title\n");
 
     try std.testing.expect(isVisibleForActiveTab());
     try std.testing.expectEqual(DEFAULT_WIDTH, width());
 
-    tab.g_active_tab = 1;
+    active_tab_state.g_active_tab = 1;
     try std.testing.expect(!isVisibleForActiveTab());
     try std.testing.expectEqual(@as(f32, 0), width());
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     try std.testing.expect(isVisibleForActiveTab());
 }
 
@@ -478,14 +479,14 @@ fn tickPreviewJobsUntilIdleForTest() void {
 }
 
 test "markdown_preview_panel: async load shows loading then applies content" {
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     resetAsyncForTest();
     defer {
         resetAsyncForTest();
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     try std.testing.expect(beginAsyncLoadForTest(.markdown, "README.md", "README.md", .local, previewReadOkForTest));
     try std.testing.expectEqual(LoadStatus.loading, g_load_status);
     try std.testing.expectEqualStrings("Loading preview...", source());
@@ -498,14 +499,14 @@ test "markdown_preview_panel: async load shows loading then applies content" {
 }
 
 test "markdown_preview_panel: stale async load does not overwrite newer request" {
-    const saved_active_tab = tab.g_active_tab;
+    const saved_active_tab = active_tab_state.g_active_tab;
     resetAsyncForTest();
     defer {
         resetAsyncForTest();
-        tab.g_active_tab = saved_active_tab;
+        active_tab_state.g_active_tab = saved_active_tab;
     }
 
-    tab.g_active_tab = 0;
+    active_tab_state.g_active_tab = 0;
     try std.testing.expect(beginAsyncLoadForTest(.markdown, "old.md", "old.md", .local, previewReadSlowOkForTest));
     try std.testing.expect(beginAsyncLoadForTest(.markdown, "new.md", "new.md", .local, previewReadOkForTest));
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -116,7 +116,8 @@ threadlocal var g_transfer_cancel_confirm_visible: bool = false;
 const UPDATE_PROMPT_DURATION_MS: i64 = 10000;
 const UPDATE_STATUS_DURATION_MS: i64 = 2500;
 const SSH_CWD_HELP_URL = "https://github.com/xuzhougeng/wispterm#ssh-current-directory-for-downloads-and-uploads";
-const UpdatePromptAction = enum { none, open_release, download_update };
+const update_prompt_model = @import("overlays/update_prompt_model.zig");
+const UpdatePromptAction = update_prompt_model.UpdatePromptAction;
 threadlocal var g_update_prompt_until_ms: i64 = 0;
 threadlocal var g_update_prompt_buf: [128]u8 = undefined;
 threadlocal var g_update_prompt_len: usize = 0;
@@ -3984,33 +3985,10 @@ pub fn showStatusToast(message: []const u8) void {
     AppWindow.g_cells_valid = false;
 }
 
-fn transferToastVerb(kind: AppWindow.file_explorer.TransferKind, status: AppWindow.file_explorer.TransferStatus) []const u8 {
-    return switch (kind) {
-        .download => switch (status) {
-            .in_progress => "Downloading",
-            .success => "Downloaded",
-            .failed => "Download failed",
-            .cancelled => "Download interrupted",
-            .idle => "Download",
-        },
-        .upload => switch (status) {
-            .in_progress => "Uploading",
-            .success => "Uploaded",
-            .failed => "Upload failed",
-            .cancelled => "Upload interrupted",
-            .idle => "Upload",
-        },
-    };
-}
+const transferToastVerb = transfer_toast_model.transferToastVerb;
 
-fn formatTransferToast(
-    buf: []u8,
-    kind: AppWindow.file_explorer.TransferKind,
-    status: AppWindow.file_explorer.TransferStatus,
-    message: []const u8,
-) ![]u8 {
-    return std.fmt.bufPrint(buf, "{s}: {s}", .{ transferToastVerb(kind, status), message });
-}
+const transfer_toast_model = @import("overlays/transfer_toast_model.zig");
+const formatTransferToast = transfer_toast_model.formatTransferToast;
 
 pub fn showTransferToast(
     kind: AppWindow.file_explorer.TransferKind,
@@ -4024,23 +4002,6 @@ pub fn showTransferToast(
     g_transfer_toast_clickable = kind == .download and status == .in_progress;
     if (status != .in_progress) transferCancelConfirmClose();
     g_transfer_toast_until_ms = std.time.milliTimestamp() + TRANSFER_TOAST_DURATION_MS;
-}
-
-test "overlays: transfer toast text describes download states" {
-    var buf: [160]u8 = undefined;
-
-    try std.testing.expectEqualStrings(
-        "Downloading: file.txt",
-        try formatTransferToast(&buf, .download, .in_progress, "file.txt"),
-    );
-    try std.testing.expectEqualStrings(
-        "Downloaded: file.txt",
-        try formatTransferToast(&buf, .download, .success, "file.txt"),
-    );
-    try std.testing.expectEqualStrings(
-        "Download failed: file.txt",
-        try formatTransferToast(&buf, .download, .failed, "file.txt"),
-    );
 }
 
 test "overlays: command center Settings command opens settings page" {
@@ -4183,28 +4144,6 @@ test "overlays: transfer interruption prompt returns explicit actions" {
     );
 }
 
-test "overlays: update prompt action selection prefers downloadable asset" {
-    try std.testing.expectEqual(
-        UpdatePromptAction.download_update,
-        updatePromptActionForResult(.{
-            .state = .update_available,
-            .release_url = "https://example.test/releases/v0.28.0",
-            .asset_download_url = "https://example.test/portable.zip",
-        }),
-    );
-    try std.testing.expectEqual(
-        UpdatePromptAction.open_release,
-        updatePromptActionForResult(.{
-            .state = .download_failed,
-            .release_url = "https://example.test/releases/v0.28.0",
-        }),
-    );
-    try std.testing.expectEqual(
-        UpdatePromptAction.none,
-        updatePromptActionForResult(.{ .state = .up_to_date }),
-    );
-}
-
 test "overlays: stored prompt URL does not affect latest release command URL" {
     showSshCwdFallbackPrompt();
 
@@ -4279,18 +4218,7 @@ pub fn showUpdateCheckResult(result: update_check.CheckResult) void {
     showUpdatePrompt(result, updatePromptActionForResult(result));
 }
 
-fn updatePromptActionForResult(result: update_check.CheckResult) UpdatePromptAction {
-    return if (result.state == .update_available and result.asset_download_url.len > 0)
-        .download_update
-    else if (result.state == .update_available and result.release_url.len > 0)
-        .open_release
-    else if (result.state == .failed and result.release_url.len > 0)
-        .open_release
-    else if (result.state == .download_failed and result.release_url.len > 0)
-        .open_release
-    else
-        .none;
-}
+const updatePromptActionForResult = update_prompt_model.updatePromptActionForResult;
 
 fn showUpdatePrompt(result: update_check.CheckResult, action: UpdatePromptAction) void {
     var status_buf: [96]u8 = undefined;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1368,36 +1368,17 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
 // New session / SSH launcher
 // ============================================================================
 
-const SSH_FIELD_COUNT = 6;
-const SSH_FIELD_MAX = 128;
+const profile_codec = @import("overlays/profile_codec.zig");
+const SSH_FIELD_COUNT = profile_codec.SSH_FIELD_COUNT;
+const SSH_FIELD_MAX = profile_codec.SSH_FIELD_MAX;
 const SSH_PROFILE_MAX = 16;
 const SSH_PROFILE_NONE = std.math.maxInt(usize);
-const AI_FIELD_COUNT = 11;
-const AI_FIELD_MAX = 8192;
+const AI_FIELD_COUNT = profile_codec.AI_FIELD_COUNT;
+const AI_FIELD_MAX = profile_codec.AI_FIELD_MAX;
 const AI_PROFILE_MAX = 16;
 const AI_PROFILE_NONE = std.math.maxInt(usize);
-const SshField = enum(usize) {
-    name = 0,
-    ip = 1,
-    user = 2,
-    password = 3,
-    port = 4,
-    proxy_jump = 5,
-};
-
-const AiField = enum(usize) {
-    name = 0,
-    base_url = 1,
-    api_key = 2,
-    model = 3,
-    system_prompt = 4,
-    thinking = 5,
-    reasoning_effort = 6,
-    stream = 7,
-    agent = 8,
-    protocol = 9,
-    max_tokens = 10,
-};
+const SshField = profile_codec.SshField;
+const AiField = profile_codec.AiField;
 
 const SessionAction = enum {
     local_shell,
@@ -1431,10 +1412,7 @@ const AiListMode = enum {
     delete_select,
 };
 
-const SshProfile = struct {
-    fields: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined,
-    lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT,
-};
+const SshProfile = profile_codec.SshProfile;
 pub const AgentSshConnectResult = union(enum) {
     connected: *Surface,
     not_found,
@@ -1447,10 +1425,7 @@ pub const DefaultAgentOpenResult = enum {
     failed,
 };
 
-const AiProfile = struct {
-    fields: [AI_FIELD_COUNT][AI_FIELD_MAX]u8 = undefined,
-    lens: [AI_FIELD_COUNT]usize = .{0} ** AI_FIELD_COUNT,
-};
+const AiProfile = profile_codec.AiProfile;
 
 const SessionLayout = struct {
     box_x: f32,
@@ -1898,10 +1873,7 @@ fn sshField(field: SshField) []const u8 {
     return g_ssh_bufs[idx][0..g_ssh_lens[idx]];
 }
 
-fn profileField(profile: *const SshProfile, field: SshField) []const u8 {
-    const idx: usize = @intFromEnum(field);
-    return profile.fields[idx][0..profile.lens[idx]];
-}
+const profileField = profile_codec.profileField;
 
 fn findSshProfileIndex(identifier_raw: []const u8) ?usize {
     loadSshProfiles();
@@ -1928,21 +1900,9 @@ pub fn agentConnectSshProfile(identifier: []const u8) AgentSshConnectResult {
     return .{ .connected = surface };
 }
 
-fn copySshProfileField(profile: *SshProfile, field: SshField, value: []const u8) void {
-    const idx: usize = @intFromEnum(field);
-    const len = @min(value.len, SSH_FIELD_MAX);
-    @memcpy(profile.fields[idx][0..len], value[0..len]);
-    profile.lens[idx] = len;
-}
+const copySshProfileField = profile_codec.copySshProfileField;
 
-fn makeSshProfile(name: []const u8, host: []const u8, user: []const u8, port: []const u8) SshProfile {
-    var profile = SshProfile{};
-    copySshProfileField(&profile, .name, name);
-    copySshProfileField(&profile, .ip, host);
-    copySshProfileField(&profile, .user, user);
-    copySshProfileField(&profile, .port, port);
-    return profile;
-}
+const makeSshProfile = profile_codec.makeSshProfile;
 
 pub fn agentSaveSshProfile(allocator: std.mem.Allocator, args: AppWindow.ai_chat.SshProfileSaveArgs) !AppWindow.ai_chat.SavedSshProfile {
     loadSshProfiles();
@@ -2443,12 +2403,7 @@ fn setAiDefault(field: AiField, value: []const u8) void {
     g_ai_lens[idx] = len;
 }
 
-fn setProfileDefault(profile: *AiProfile, field: AiField, value: []const u8) void {
-    const idx: usize = @intFromEnum(field);
-    const len = @min(value.len, AI_FIELD_MAX);
-    @memcpy(profile.fields[idx][0..len], value[0..len]);
-    profile.lens[idx] = len;
-}
+const setProfileDefault = profile_codec.setProfileDefault;
 
 fn clearAiForm() void {
     g_ai_lens = .{0} ** AI_FIELD_COUNT;
@@ -2556,10 +2511,7 @@ fn aiField(field: AiField) []const u8 {
     return g_ai_bufs[idx][0..g_ai_lens[idx]];
 }
 
-fn aiProfileField(profile: *const AiProfile, field: AiField) []const u8 {
-    const idx: usize = @intFromEnum(field);
-    return profile.fields[idx][0..profile.lens[idx]];
-}
+const aiProfileField = profile_codec.aiProfileField;
 
 fn runAiListRow(row: usize) void {
     switch (g_ai_list_mode) {
@@ -2837,24 +2789,7 @@ fn loadAiProfiles() void {
 /// fields absent from the line (e.g. `protocol`/`max_tokens` from older builds)
 /// are defaulted rather than misaligned, so profiles written before the schema
 /// grew still load correctly.
-fn decodeAiProfileLine(line: []const u8) ?AiProfile {
-    var profile = AiProfile{};
-    var parts = std.mem.splitScalar(u8, line, '\t');
-    var field_idx: usize = 0;
-    while (field_idx < AI_FIELD_COUNT) : (field_idx += 1) {
-        const part = parts.next() orelse break;
-        const decoded = decodeHexFieldToSlice(part, profile.fields[field_idx][0..]) orelse return null;
-        profile.lens[field_idx] = decoded;
-    }
-    if (field_idx < 5) return null;
-    if (profile.lens[@intFromEnum(AiField.thinking)] == 0) setProfileDefault(&profile, .thinking, AppWindow.ai_chat.DEFAULT_THINKING);
-    if (profile.lens[@intFromEnum(AiField.reasoning_effort)] == 0) setProfileDefault(&profile, .reasoning_effort, AppWindow.ai_chat.DEFAULT_REASONING_EFFORT);
-    if (profile.lens[@intFromEnum(AiField.stream)] == 0) setProfileDefault(&profile, .stream, AppWindow.ai_chat.DEFAULT_STREAM);
-    if (profile.lens[@intFromEnum(AiField.agent)] == 0) setProfileDefault(&profile, .agent, AppWindow.ai_chat.DEFAULT_AGENT);
-    if (profile.lens[@intFromEnum(AiField.protocol)] == 0) setProfileDefault(&profile, .protocol, AppWindow.ai_chat.DEFAULT_PROTOCOL);
-    if (profile.lens[@intFromEnum(AiField.max_tokens)] == 0) setProfileDefault(&profile, .max_tokens, AppWindow.ai_chat.DEFAULT_MAX_TOKENS);
-    return profile;
-}
+const decodeAiProfileLine = profile_codec.decodeAiProfileLine;
 
 fn saveAiProfiles(allocator: std.mem.Allocator) void {
     const path = aiProfilesPath(allocator) catch return;
@@ -2904,21 +2839,7 @@ fn loadSshProfiles() void {
     }
 }
 
-/// Decode one tab-separated, hex-encoded SSH profile line into an `SshProfile`.
-/// Returns null only when a present field contains malformed hex; trailing
-/// fields absent from the line are left empty so profiles written by older
-/// builds (with fewer fields) still load after the schema grows.
-fn decodeSshProfileLine(line: []const u8) ?SshProfile {
-    var profile = SshProfile{};
-    var parts = std.mem.splitScalar(u8, line, '\t');
-    var field_idx: usize = 0;
-    while (field_idx < SSH_FIELD_COUNT) : (field_idx += 1) {
-        const part = parts.next() orelse break;
-        const decoded = decodeHexField(part, &profile.fields[field_idx]) orelse return null;
-        profile.lens[field_idx] = decoded;
-    }
-    return profile;
-}
+const decodeSshProfileLine = profile_codec.decodeSshProfileLine;
 
 fn saveSshProfiles(allocator: std.mem.Allocator) void {
     const path = sshProfilesPath(allocator) catch return;
@@ -2951,28 +2872,9 @@ fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)
     }
 }
 
-fn decodeHexField(value: []const u8, out: *[SSH_FIELD_MAX]u8) ?usize {
-    return decodeHexFieldToSlice(value, out[0..]);
-}
-
-fn decodeHexFieldToSlice(value: []const u8, out: []u8) ?usize {
-    if (value.len % 2 != 0) return null;
-    const len = @min(value.len / 2, out.len);
-    var i: usize = 0;
-    while (i < len) : (i += 1) {
-        const hi = hexValue(value[i * 2]) orelse return null;
-        const lo = hexValue(value[i * 2 + 1]) orelse return null;
-        out[i] = (hi << 4) | lo;
-    }
-    return len;
-}
-
-fn hexValue(ch: u8) ?u8 {
-    if (ch >= '0' and ch <= '9') return ch - '0';
-    if (ch >= 'a' and ch <= 'f') return ch - 'a' + 10;
-    if (ch >= 'A' and ch <= 'F') return ch - 'A' + 10;
-    return null;
-}
+const decodeHexField = profile_codec.decodeHexField;
+const decodeHexFieldToSlice = profile_codec.decodeHexFieldToSlice;
+const hexValue = profile_codec.hexValue;
 
 fn sessionTwoColumnWidth(left: []const u8, right: []const u8) f32 {
     const right_w = if (right.len > 0) measureTitlebarText(right) + 36.0 else 0.0;
@@ -4348,88 +4250,6 @@ test "overlays: SSH list filter backspace restores matching rows" {
     try std.testing.expectEqual(@as(usize, 1), sshVisibleProfileCount());
     try std.testing.expectEqual(@as(?usize, 0), sshVisibleProfileIndexAt(0));
     try std.testing.expectEqual(@as(usize, 2), sshListRowCount());
-}
-
-fn testEncodeProfileLine(buf: []u8, fields: []const []const u8) []const u8 {
-    const hex = "0123456789ABCDEF";
-    var len: usize = 0;
-    for (fields, 0..) |field, fi| {
-        if (fi > 0) {
-            buf[len] = '\t';
-            len += 1;
-        }
-        for (field) |ch| {
-            buf[len] = hex[ch >> 4];
-            buf[len + 1] = hex[ch & 0x0f];
-            len += 2;
-        }
-    }
-    return buf[0..len];
-}
-
-test "overlays: SSH profile line decode preserves all fields including proxy jump" {
-    var buf: [512]u8 = undefined;
-    const line = testEncodeProfileLine(&buf, &.{ "Prod", "10.0.0.9", "root", "secret", "2222", "admin@jump.test:22" });
-    const profile = decodeSshProfileLine(line) orelse return error.ExpectedProfile;
-    try std.testing.expectEqualStrings("Prod", profileField(&profile, .name));
-    try std.testing.expectEqualStrings("10.0.0.9", profileField(&profile, .ip));
-    try std.testing.expectEqualStrings("root", profileField(&profile, .user));
-    try std.testing.expectEqualStrings("secret", profileField(&profile, .password));
-    try std.testing.expectEqualStrings("2222", profileField(&profile, .port));
-    try std.testing.expectEqualStrings("admin@jump.test:22", profileField(&profile, .proxy_jump));
-}
-
-test "overlays: SSH profile line decode accepts legacy lines without a proxy jump field" {
-    // Profiles saved before ProxyJump existed have only the first five fields.
-    // They must still load, with an empty proxy jump, rather than being dropped.
-    var buf: [512]u8 = undefined;
-    const legacy = testEncodeProfileLine(&buf, &.{ "Old", "10.0.0.1", "user", "", "22" });
-    const profile = decodeSshProfileLine(legacy) orelse return error.ExpectedProfile;
-    try std.testing.expectEqualStrings("Old", profileField(&profile, .name));
-    try std.testing.expectEqualStrings("10.0.0.1", profileField(&profile, .ip));
-    try std.testing.expectEqualStrings("22", profileField(&profile, .port));
-    try std.testing.expectEqualStrings("", profileField(&profile, .proxy_jump));
-}
-
-test "overlays: SSH profile line decode rejects malformed hex" {
-    try std.testing.expect(decodeSshProfileLine("not-hex\tzz") == null);
-}
-
-test "overlays: AI profile line decode round-trips all fields including max_tokens" {
-    var buf: [1024]u8 = undefined;
-    const line = testEncodeProfileLine(&buf, &.{
-        "Claude", "https://api.anthropic.com", "sk-key", "claude-x",
-        "sys", "enabled", "high", "false", "true", "anthropic", "4096",
-    });
-    const profile = decodeAiProfileLine(line) orelse return error.ExpectedProfile;
-    try std.testing.expectEqualStrings("Claude", aiProfileField(&profile, .name));
-    try std.testing.expectEqualStrings("anthropic", aiProfileField(&profile, .protocol));
-    try std.testing.expectEqualStrings("4096", aiProfileField(&profile, .max_tokens));
-}
-
-test "overlays: AI profile line decode defaults max_tokens for legacy 10-field profiles" {
-    // Profiles written before max_tokens existed have only the first ten fields
-    // (indices 0-9). They must still load, with the new trailing field defaulted
-    // to 8192, and the existing positional fields staying aligned.
-    var buf: [1024]u8 = undefined;
-    const legacy = testEncodeProfileLine(&buf, &.{
-        "Legacy", "https://api.anthropic.com", "sk-key", "claude-x",
-        "sys", "enabled", "high", "false", "true", "anthropic",
-    });
-    const profile = decodeAiProfileLine(legacy) orelse return error.ExpectedProfile;
-    try std.testing.expectEqualStrings("Legacy", aiProfileField(&profile, .name));
-    try std.testing.expectEqualStrings("anthropic", aiProfileField(&profile, .protocol));
-    try std.testing.expectEqualStrings("8192", aiProfileField(&profile, .max_tokens));
-}
-
-test "overlays: AI profile line decode defaults max_tokens when the field is empty" {
-    var buf: [1024]u8 = undefined;
-    const line = testEncodeProfileLine(&buf, &.{
-        "Empty", "https://api.anthropic.com", "sk-key", "claude-x",
-        "sys", "enabled", "high", "false", "true", "anthropic", "",
-    });
-    const profile = decodeAiProfileLine(line) orelse return error.ExpectedProfile;
-    try std.testing.expectEqualStrings("8192", aiProfileField(&profile, .max_tokens));
 }
 
 fn showVersionToast() void {

--- a/src/renderer/overlays/profile_codec.zig
+++ b/src/renderer/overlays/profile_codec.zig
@@ -1,0 +1,219 @@
+//! Pure SSH/AI profile codec: fixed-buffer profile records plus the
+//! tab-separated, hex-encoded line decode used to persist them. Extracted from
+//! renderer/overlays.zig so the parsing / round-trip / legacy-field rules are
+//! unit-tested in the fast suite without the AppWindow / Surface / GL graph.
+//! overlays.zig keeps the form state, persistence I/O, and drawing, and
+//! re-exports these symbols so its call sites are unchanged.
+const std = @import("std");
+const ai_chat_protocol = @import("../../ai_chat_protocol.zig");
+
+pub const SSH_FIELD_COUNT = 6;
+pub const SSH_FIELD_MAX = 128;
+pub const AI_FIELD_COUNT = 11;
+pub const AI_FIELD_MAX = 8192;
+
+pub const SshField = enum(usize) {
+    name = 0,
+    ip = 1,
+    user = 2,
+    password = 3,
+    port = 4,
+    proxy_jump = 5,
+};
+
+pub const AiField = enum(usize) {
+    name = 0,
+    base_url = 1,
+    api_key = 2,
+    model = 3,
+    system_prompt = 4,
+    thinking = 5,
+    reasoning_effort = 6,
+    stream = 7,
+    agent = 8,
+    protocol = 9,
+    max_tokens = 10,
+};
+
+pub const SshProfile = struct {
+    fields: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined,
+    lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT,
+};
+
+pub const AiProfile = struct {
+    fields: [AI_FIELD_COUNT][AI_FIELD_MAX]u8 = undefined,
+    lens: [AI_FIELD_COUNT]usize = .{0} ** AI_FIELD_COUNT,
+};
+
+pub fn profileField(profile: *const SshProfile, field: SshField) []const u8 {
+    const idx: usize = @intFromEnum(field);
+    return profile.fields[idx][0..profile.lens[idx]];
+}
+
+pub fn copySshProfileField(profile: *SshProfile, field: SshField, value: []const u8) void {
+    const idx: usize = @intFromEnum(field);
+    const len = @min(value.len, SSH_FIELD_MAX);
+    @memcpy(profile.fields[idx][0..len], value[0..len]);
+    profile.lens[idx] = len;
+}
+
+pub fn makeSshProfile(name: []const u8, host: []const u8, user: []const u8, port: []const u8) SshProfile {
+    var profile = SshProfile{};
+    copySshProfileField(&profile, .name, name);
+    copySshProfileField(&profile, .ip, host);
+    copySshProfileField(&profile, .user, user);
+    copySshProfileField(&profile, .port, port);
+    return profile;
+}
+
+pub fn aiProfileField(profile: *const AiProfile, field: AiField) []const u8 {
+    const idx: usize = @intFromEnum(field);
+    return profile.fields[idx][0..profile.lens[idx]];
+}
+
+pub fn setProfileDefault(profile: *AiProfile, field: AiField, value: []const u8) void {
+    const idx: usize = @intFromEnum(field);
+    const len = @min(value.len, AI_FIELD_MAX);
+    @memcpy(profile.fields[idx][0..len], value[0..len]);
+    profile.lens[idx] = len;
+}
+
+pub fn hexValue(ch: u8) ?u8 {
+    if (ch >= '0' and ch <= '9') return ch - '0';
+    if (ch >= 'a' and ch <= 'f') return ch - 'a' + 10;
+    if (ch >= 'A' and ch <= 'F') return ch - 'A' + 10;
+    return null;
+}
+
+pub fn decodeHexFieldToSlice(value: []const u8, out: []u8) ?usize {
+    if (value.len % 2 != 0) return null;
+    const len = @min(value.len / 2, out.len);
+    var i: usize = 0;
+    while (i < len) : (i += 1) {
+        const hi = hexValue(value[i * 2]) orelse return null;
+        const lo = hexValue(value[i * 2 + 1]) orelse return null;
+        out[i] = (hi << 4) | lo;
+    }
+    return len;
+}
+
+pub fn decodeHexField(value: []const u8, out: *[SSH_FIELD_MAX]u8) ?usize {
+    return decodeHexFieldToSlice(value, out[0..]);
+}
+
+/// Decode one tab-separated, hex-encoded SSH profile line into an `SshProfile`.
+/// Returns null only when a present field contains malformed hex; trailing
+/// fields absent from the line are left empty so profiles written by older
+/// builds (with fewer fields) still load after the schema grows.
+pub fn decodeSshProfileLine(line: []const u8) ?SshProfile {
+    var profile = SshProfile{};
+    var parts = std.mem.splitScalar(u8, line, '\t');
+    var field_idx: usize = 0;
+    while (field_idx < SSH_FIELD_COUNT) : (field_idx += 1) {
+        const part = parts.next() orelse break;
+        const decoded = decodeHexField(part, &profile.fields[field_idx]) orelse return null;
+        profile.lens[field_idx] = decoded;
+    }
+    return profile;
+}
+
+pub fn decodeAiProfileLine(line: []const u8) ?AiProfile {
+    var profile = AiProfile{};
+    var parts = std.mem.splitScalar(u8, line, '\t');
+    var field_idx: usize = 0;
+    while (field_idx < AI_FIELD_COUNT) : (field_idx += 1) {
+        const part = parts.next() orelse break;
+        const decoded = decodeHexFieldToSlice(part, profile.fields[field_idx][0..]) orelse return null;
+        profile.lens[field_idx] = decoded;
+    }
+    if (field_idx < 5) return null;
+    if (profile.lens[@intFromEnum(AiField.thinking)] == 0) setProfileDefault(&profile, .thinking, ai_chat_protocol.DEFAULT_THINKING);
+    if (profile.lens[@intFromEnum(AiField.reasoning_effort)] == 0) setProfileDefault(&profile, .reasoning_effort, ai_chat_protocol.DEFAULT_REASONING_EFFORT);
+    if (profile.lens[@intFromEnum(AiField.stream)] == 0) setProfileDefault(&profile, .stream, ai_chat_protocol.DEFAULT_STREAM);
+    if (profile.lens[@intFromEnum(AiField.agent)] == 0) setProfileDefault(&profile, .agent, ai_chat_protocol.DEFAULT_AGENT);
+    if (profile.lens[@intFromEnum(AiField.protocol)] == 0) setProfileDefault(&profile, .protocol, ai_chat_protocol.DEFAULT_PROTOCOL);
+    if (profile.lens[@intFromEnum(AiField.max_tokens)] == 0) setProfileDefault(&profile, .max_tokens, ai_chat_protocol.DEFAULT_MAX_TOKENS);
+    return profile;
+}
+
+fn testEncodeProfileLine(buf: []u8, fields: []const []const u8) []const u8 {
+    const hex = "0123456789ABCDEF";
+    var len: usize = 0;
+    for (fields, 0..) |field, fi| {
+        if (fi > 0) {
+            buf[len] = '\t';
+            len += 1;
+        }
+        for (field) |ch| {
+            buf[len] = hex[ch >> 4];
+            buf[len + 1] = hex[ch & 0x0f];
+            len += 2;
+        }
+    }
+    return buf[0..len];
+}
+
+test "overlays: SSH profile line decode preserves all fields including proxy jump" {
+    var buf: [512]u8 = undefined;
+    const line = testEncodeProfileLine(&buf, &.{ "Prod", "10.0.0.9", "root", "secret", "2222", "admin@jump.test:22" });
+    const profile = decodeSshProfileLine(line) orelse return error.ExpectedProfile;
+    try std.testing.expectEqualStrings("Prod", profileField(&profile, .name));
+    try std.testing.expectEqualStrings("10.0.0.9", profileField(&profile, .ip));
+    try std.testing.expectEqualStrings("root", profileField(&profile, .user));
+    try std.testing.expectEqualStrings("secret", profileField(&profile, .password));
+    try std.testing.expectEqualStrings("2222", profileField(&profile, .port));
+    try std.testing.expectEqualStrings("admin@jump.test:22", profileField(&profile, .proxy_jump));
+}
+
+test "overlays: SSH profile line decode accepts legacy lines without a proxy jump field" {
+    // Profiles saved before ProxyJump existed have only the first five fields.
+    // They must still load, with an empty proxy jump, rather than being dropped.
+    var buf: [512]u8 = undefined;
+    const legacy = testEncodeProfileLine(&buf, &.{ "Old", "10.0.0.1", "user", "", "22" });
+    const profile = decodeSshProfileLine(legacy) orelse return error.ExpectedProfile;
+    try std.testing.expectEqualStrings("Old", profileField(&profile, .name));
+    try std.testing.expectEqualStrings("10.0.0.1", profileField(&profile, .ip));
+    try std.testing.expectEqualStrings("22", profileField(&profile, .port));
+    try std.testing.expectEqualStrings("", profileField(&profile, .proxy_jump));
+}
+
+test "overlays: SSH profile line decode rejects malformed hex" {
+    try std.testing.expect(decodeSshProfileLine("not-hex\tzz") == null);
+}
+
+test "overlays: AI profile line decode round-trips all fields including max_tokens" {
+    var buf: [1024]u8 = undefined;
+    const line = testEncodeProfileLine(&buf, &.{
+        "Claude", "https://api.anthropic.com", "sk-key", "claude-x",
+        "sys", "enabled", "high", "false", "true", "anthropic", "4096",
+    });
+    const profile = decodeAiProfileLine(line) orelse return error.ExpectedProfile;
+    try std.testing.expectEqualStrings("Claude", aiProfileField(&profile, .name));
+    try std.testing.expectEqualStrings("anthropic", aiProfileField(&profile, .protocol));
+    try std.testing.expectEqualStrings("4096", aiProfileField(&profile, .max_tokens));
+}
+
+test "overlays: AI profile line decode defaults max_tokens for legacy 10-field profiles" {
+    // Profiles written before max_tokens existed have only the first ten fields
+    // (indices 0-9). They must still load, with the new trailing field defaulted
+    // to 8192, and the existing positional fields staying aligned.
+    var buf: [1024]u8 = undefined;
+    const legacy = testEncodeProfileLine(&buf, &.{
+        "Legacy", "https://api.anthropic.com", "sk-key", "claude-x",
+        "sys", "enabled", "high", "false", "true", "anthropic",
+    });
+    const profile = decodeAiProfileLine(legacy) orelse return error.ExpectedProfile;
+    try std.testing.expectEqualStrings("Legacy", aiProfileField(&profile, .name));
+    try std.testing.expectEqualStrings("anthropic", aiProfileField(&profile, .protocol));
+    try std.testing.expectEqualStrings("8192", aiProfileField(&profile, .max_tokens));
+}
+
+test "overlays: AI profile line decode defaults max_tokens when the field is empty" {
+    var buf: [1024]u8 = undefined;
+    const line = testEncodeProfileLine(&buf, &.{
+        "Empty", "https://api.anthropic.com", "sk-key", "claude-x",
+        "sys", "enabled", "high", "false", "true", "anthropic", "",
+    });
+    const profile = decodeAiProfileLine(line) orelse return error.ExpectedProfile;
+    try std.testing.expectEqualStrings("8192", aiProfileField(&profile, .max_tokens));
+}

--- a/src/renderer/overlays/transfer_toast_model.zig
+++ b/src/renderer/overlays/transfer_toast_model.zig
@@ -1,0 +1,51 @@
+//! Pure transfer-toast text model: maps a file-transfer kind+status to the
+//! toast verb and full message. Extracted from overlays.zig so the wording is
+//! unit-tested in the fast suite; overlays keeps the toast timing/hit-test/draw
+//! state and re-exports these helpers.
+const std = @import("std");
+const file_explorer = @import("../../file_explorer.zig");
+
+pub fn transferToastVerb(kind: file_explorer.TransferKind, status: file_explorer.TransferStatus) []const u8 {
+    return switch (kind) {
+        .download => switch (status) {
+            .in_progress => "Downloading",
+            .success => "Downloaded",
+            .failed => "Download failed",
+            .cancelled => "Download interrupted",
+            .idle => "Download",
+        },
+        .upload => switch (status) {
+            .in_progress => "Uploading",
+            .success => "Uploaded",
+            .failed => "Upload failed",
+            .cancelled => "Upload interrupted",
+            .idle => "Upload",
+        },
+    };
+}
+
+pub fn formatTransferToast(
+    buf: []u8,
+    kind: file_explorer.TransferKind,
+    status: file_explorer.TransferStatus,
+    message: []const u8,
+) ![]u8 {
+    return std.fmt.bufPrint(buf, "{s}: {s}", .{ transferToastVerb(kind, status), message });
+}
+
+test "overlays: transfer toast text describes download states" {
+    var buf: [160]u8 = undefined;
+
+    try std.testing.expectEqualStrings(
+        "Downloading: file.txt",
+        try formatTransferToast(&buf, .download, .in_progress, "file.txt"),
+    );
+    try std.testing.expectEqualStrings(
+        "Downloaded: file.txt",
+        try formatTransferToast(&buf, .download, .success, "file.txt"),
+    );
+    try std.testing.expectEqualStrings(
+        "Download failed: file.txt",
+        try formatTransferToast(&buf, .download, .failed, "file.txt"),
+    );
+}

--- a/src/renderer/overlays/update_prompt_model.zig
+++ b/src/renderer/overlays/update_prompt_model.zig
@@ -1,0 +1,43 @@
+//! Pure update-prompt action selection: maps an update CheckResult to the
+//! prompt's primary action (download the asset, open the release page, or
+//! nothing). Extracted from overlays.zig for fast-suite testing; overlays keeps
+//! the prompt's stored URLs and draw state.
+const std = @import("std");
+const update_check = @import("../../update_check.zig");
+
+pub const UpdatePromptAction = enum { none, open_release, download_update };
+
+pub fn updatePromptActionForResult(result: update_check.CheckResult) UpdatePromptAction {
+    return if (result.state == .update_available and result.asset_download_url.len > 0)
+        .download_update
+    else if (result.state == .update_available and result.release_url.len > 0)
+        .open_release
+    else if (result.state == .failed and result.release_url.len > 0)
+        .open_release
+    else if (result.state == .download_failed and result.release_url.len > 0)
+        .open_release
+    else
+        .none;
+}
+
+test "overlays: update prompt action selection prefers downloadable asset" {
+    try std.testing.expectEqual(
+        UpdatePromptAction.download_update,
+        updatePromptActionForResult(.{
+            .state = .update_available,
+            .release_url = "https://example.test/releases/v0.28.0",
+            .asset_download_url = "https://example.test/portable.zip",
+        }),
+    );
+    try std.testing.expectEqual(
+        UpdatePromptAction.open_release,
+        updatePromptActionForResult(.{
+            .state = .download_failed,
+            .release_url = "https://example.test/releases/v0.28.0",
+        }),
+    );
+    try std.testing.expectEqual(
+        UpdatePromptAction.none,
+        updatePromptActionForResult(.{ .state = .up_to_date }),
+    );
+}

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -11,6 +11,7 @@ const AppWindow = @import("../AppWindow.zig");
 const ui_pipeline = AppWindow.ui_pipeline;
 const font = AppWindow.font;
 const tab = AppWindow.tab;
+const active_tab_state = @import("../appwindow/active_tab.zig");
 const cell_renderer = AppWindow.cell_renderer;
 const gl_init = AppWindow.gpu.gl_init;
 const font_backend = @import("../platform/font_backend.zig");
@@ -547,7 +548,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
     tab.g_last_frame_time_ms = now_ms;
 
     for (0..num_tabs) |tab_idx| {
-        const is_active = (tab_idx == tab.g_active_tab);
+        const is_active = (tab_idx == active_tab_state.g_active_tab);
 
         // Check if mouse is hovering this tab
         const tab_hovered = mouseInTitlebarRange(titlebar_h, cursor_x, cursor_x + tab_w);
@@ -924,7 +925,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         }
 
         // Left border — skip when last tab is active (no visual break needed)
-        if (tab.g_active_tab != num_tabs - 1) {
+        if (active_tab_state.g_active_tab != num_tabs - 1) {
             gl_init.renderQuad(cursor_x, tb_top, bdr, titlebar_h, border_color);
         }
 
@@ -1042,7 +1043,7 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
         if (row_top_px >= window_height) break;
         const row_h = @min(row_h_full, window_height - row_top_px);
         const row_y = window_height - row_top_px - row_h;
-        const is_active = tab_idx == tab.g_active_tab;
+        const is_active = tab_idx == active_tab_state.g_active_tab;
 
         const row_hovered = mouseInRect(0, row_top_px, sidebar_w, row_h);
 

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -5,8 +5,8 @@
 //! image paste path and the file explorer remote operations.
 
 const std = @import("std");
-const Surface = @import("Surface.zig");
-const SshConnection = Surface.SshConnection;
+const ssh_connection = @import("ssh_connection.zig");
+const SshConnection = ssh_connection.SshConnection;
 const platform_dirs = @import("platform/dirs.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");

--- a/src/ssh_connection.zig
+++ b/src/ssh_connection.zig
@@ -1,0 +1,39 @@
+//! Self-contained SSH connection descriptor (fixed-buffer fields + accessors).
+//! Lives outside Surface.zig so remote-IO logic modules (scp, ssh_tunnel,
+//! file_backend, file_explorer) can use it without compiling the heavy
+//! ghostty-vt / renderer graph that Surface pulls in.
+
+pub const SshConnection = struct {
+    user_buf: [128]u8 = undefined,
+    user_len: usize = 0,
+    host_buf: [128]u8 = undefined,
+    host_len: usize = 0,
+    port_buf: [16]u8 = undefined,
+    port_len: usize = 0,
+    password_buf: [128]u8 = undefined,
+    password_len: usize = 0,
+    proxy_jump_buf: [256]u8 = undefined,
+    proxy_jump_len: usize = 0,
+    password_auth: bool = false,
+    legacy_algorithms: bool = false,
+
+    pub fn user(self: *const SshConnection) []const u8 {
+        return self.user_buf[0..self.user_len];
+    }
+
+    pub fn proxyJump(self: *const SshConnection) []const u8 {
+        return self.proxy_jump_buf[0..self.proxy_jump_len];
+    }
+
+    pub fn host(self: *const SshConnection) []const u8 {
+        return self.host_buf[0..self.host_len];
+    }
+
+    pub fn port(self: *const SshConnection) []const u8 {
+        return self.port_buf[0..self.port_len];
+    }
+
+    pub fn password(self: *const SshConnection) []const u8 {
+        return self.password_buf[0..self.password_len];
+    }
+};

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Surface = @import("Surface.zig");
+const ssh_connection = @import("ssh_connection.zig");
 const browser_url = @import("browser_url.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
@@ -32,7 +33,7 @@ const SshTunnel = struct {
     ssh_port_buf: [16]u8 = undefined,
     ssh_port_len: usize = 0,
 
-    fn init(child: std.process.Child, conn: *const Surface.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) SshTunnel {
+    fn init(child: std.process.Child, conn: *const ssh_connection.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) SshTunnel {
         var tunnel: SshTunnel = .{
             .child = child,
             .local_port = local_port,
@@ -46,7 +47,7 @@ const SshTunnel = struct {
         return tunnel;
     }
 
-    fn matches(self: *const SshTunnel, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) bool {
+    fn matches(self: *const SshTunnel, conn: *const ssh_connection.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) bool {
         return self.remote_port == remote_port and
             std.mem.eql(u8, self.localHost(), local_host) and
             std.mem.eql(u8, self.remoteHost(), remote_host) and
@@ -108,7 +109,7 @@ pub fn stopAll() void {
 }
 
 const SshLoopbackUrl = struct {
-    conn: Surface.SshConnection,
+    conn: ssh_connection.SshConnection,
     parsed: browser_url.HttpUrl,
 };
 
@@ -121,7 +122,7 @@ fn sshLoopbackUrl(surface: ?*const Surface, url: []const u8) ?SshLoopbackUrl {
     return .{ .conn = conn, .parsed = parsed };
 }
 
-fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) ?u16 {
+fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) ?u16 {
     const perf = ui_perf.begin("ssh_tunnel.ensure_ssh_tunnel");
     defer perf.end();
 
@@ -150,7 +151,7 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnect
     return local_port;
 }
 
-fn findReusableTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) ?u16 {
+fn findReusableTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.SshConnection, remote_port: u16, local_host: []const u8, remote_host: []const u8) ?u16 {
     for (&g_tunnels) |*slot| {
         const tunnel = if (slot.*) |*tunnel| tunnel else continue;
         if (!tunnel.matches(conn, remote_port, local_host, remote_host)) continue;
@@ -167,7 +168,7 @@ fn findReusableTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConn
     return null;
 }
 
-fn spawnSshTunnel(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) ?std.process.Child {
+fn spawnSshTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) ?std.process.Child {
     var local_spec_buf: [MAX_TUNNEL_SPEC_BYTES]u8 = undefined;
     const local_spec = std.fmt.bufPrint(
         &local_spec_buf,
@@ -346,7 +347,7 @@ fn reserveLocalPort() ?u16 {
     return if (port == 0) null else port;
 }
 
-fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const Surface.SshConnection) ?[]const u8 {
+fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const ssh_connection.SshConnection) ?[]const u8 {
     const user = conn.user();
     const host = conn.host();
     const len = user.len + 1 + host.len;

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -24,6 +24,8 @@ test {
     _ = @import("input/click_tracker.zig");
     _ = @import("input/hit_test.zig");
     _ = @import("input/mouse_report.zig");
+    _ = @import("input/preview_path.zig");
+    _ = @import("input/terminal_link_action.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -29,6 +29,10 @@ test {
     _ = @import("config.zig");
     _ = @import("ai_agent_config.zig");
     _ = @import("ssh_connection.zig");
+    _ = @import("appwindow/active_tab.zig");
+    _ = @import("scp.zig");
+    _ = @import("file_backend.zig");
+    _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");
     _ = @import("markdown_text.zig");
     _ = @import("ai_chat_composer_layout.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -28,6 +28,7 @@ test {
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");
     _ = @import("ai_agent_config.zig");
+    _ = @import("ssh_connection.zig");
     _ = @import("i18n.zig");
     _ = @import("markdown_text.zig");
     _ = @import("ai_chat_composer_layout.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -27,6 +27,8 @@ test {
     _ = @import("input/preview_path.zig");
     _ = @import("input/terminal_link_action.zig");
     _ = @import("renderer/overlays/profile_codec.zig");
+    _ = @import("renderer/overlays/transfer_toast_model.zig");
+    _ = @import("renderer/overlays/update_prompt_model.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -26,6 +26,7 @@ test {
     _ = @import("input/mouse_report.zig");
     _ = @import("input/preview_path.zig");
     _ = @import("input/terminal_link_action.zig");
+    _ = @import("renderer/overlays/profile_codec.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -27,6 +27,7 @@ test {
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("config.zig");
+    _ = @import("ai_agent_config.zig");
     _ = @import("i18n.zig");
     _ = @import("markdown_text.zig");
     _ = @import("ai_chat_composer_layout.zig");


### PR DESCRIPTION
## Goal

Move pure-logic tests out of the ~50 s `zig build test-full` graph (full desktop app: AppWindow/Surface/renderer/ghostty-vt/xev/GL/FreeType/Harfbuzz/win32) into the sub-second `zig build test` fast suite, by extracting self-contained types/logic from modules that reach the heavy graph through a single thin coupling. Plan + rationale: `docs/superpowers/plans/2026-06-01-test-speed-refactor.md`.

## Result

- **Fast suite: ~5 s → ~1.9 s cold / ~0.45 s incremental** (now 410 tests).
- **Full suite: 780/786 passed, 6 skipped, 0 failed** after every commit (unchanged).
- ~95 tests that previously forced the full graph now run in the fast loop: SSH/SCP/file-transfer, file_explorer, terminal link/preview rules, SSH+AI profile codecs, transfer-toast & update-prompt models.

## Phases (one commit each)

| # | Phase | Effect |
|---|---|---|
| 1 | `config → ai_chat` cut: `AgentPermission` → new `ai_agent_config.zig` | removes 336 KB `ai_chat.zig` from the **fast** graph → 2.6× faster loop |
| 2 | `SshConnection` → `ssh_connection.zig` | unblocks scp/file_backend/file_explorer |
| 3 | `g_active_tab` → `appwindow/active_tab.zig`; register scp/file_backend/file_explorer | +52 tests |
| 4 | input: `terminal_link_action.zig` + `preview_path.zig` | +11 |
| 5 | overlays: `profile_codec.zig` (SSH+AI), 5 AI defaults → `ai_chat_protocol` | +6 |
| 5b | overlays: `transfer_toast_model.zig` + `update_prompt_model.zig` | +26 (incl. update_check/release_package) |

Every consumer re-exports the moved symbols, so no call sites changed.

### Notable finding
`config.zig`'s plain `const ai_chat = @import(...)` *reference* had been silently dragging ai_chat's 119 tests into the fast suite (Zig runs tests of any semantically-referenced file, not only `_ = @import`'d ones), inflating it to 451 tests / ~5 s. Cutting it both sped the loop and restored the documented "ai_chat is test-full only" contract — no overall coverage loss (test-full still runs them).

### Not included
- **ssh_tunnel** stays in test-full: it uses the full `*Surface` type, not just `SshConnection`.
- **Phase 6 (split_tree generic-ization)** deferred to a focused PR: its only heavy dep is `Surface.zig`, and the clean fix (concrete-alias generic, zero caller churn) requires genericizing ~1000 lines of core tree topology for 4 tests — highest risk / lowest reward. Documented in the plan for a future session.

## Verification
`zig build test` and `zig build test-full` both green after each commit (full = 0 failed; `.exe` run-fail under WSL is expected and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)