### PR TITLE
feat: add AI history sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Select AI Chat input; select transcript when input is empty | **Ctrl+A** in AI Chat | **Cmd+A** in AI Chat |
 | Copy AI Chat selection or full transcript | **Ctrl+C** in AI Chat | **Cmd+C** in AI Chat |
 | Delete the selected saved Agent session | **D** / **Delete** in Agent History | **D** / **Delete** in Agent History |
+| Edit AI History filter | Type / Backspace in AI History | Type / Backspace in AI History |
+| Move selected AI History session | Up / Down in AI History | Up / Down in AI History |
+| Preview selected AI History transcript | Enter in AI History | Enter in AI History |
+| Refresh local AI History scan | **R** in local AI History | **R** in local AI History |
 | Edit AI Chat input cursor | Left/Right/Home/End/Delete/Backspace | Left/Right/Home/End/Delete/Backspace |
 | Stop in-flight AI Chat or Agent request | **Esc** in AI Chat while working | **Esc** in AI Chat while working |
 | Copy selection (right-click) | Right-click a selection | Right-click a selection |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ English | [简体中文](README.zh-CN.md)
 - **File Explorer and previews** - browse local, WSL, and SSH files; preview Markdown/text/tables/images without leaving the terminal
 - **Embedded browser panel** - open web URLs in a side WebView2 panel or the default browser, with persistent SSH loopback port forwarding for profile sessions
 - **AI Agent sessions** - launch OpenAI-compatible Agent tabs, configure profiles, restore history, and export full or clean Markdown transcripts
+- **AI history browser** - browse local, WSL, and SSH Codex / Claude Code history and resume sessions from their original project directories
 - **Kitty Graphics protocol** - display inline images and PDFs from remote shells via `imgcat.py` / `pdfcat.py`
 - **Opt-in remote access** - share a session key over a Cloudflare-hosted relay (disabled by default)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Delete the selected saved Agent session | **D** / **Delete** in Agent History | **D** / **Delete** in Agent History |
 | Edit AI History filter | Type / Backspace in AI History | Type / Backspace in AI History |
 | Move selected AI History session | Up / Down in AI History | Up / Down in AI History |
-| Preview selected AI History transcript | Enter in AI History | Enter in AI History |
+| Resume selected AI History session | Enter in AI History | Enter in AI History |
+| Preview selected AI History transcript | Space in AI History | Space in AI History |
 | Refresh local AI History scan | **R** in local AI History | **R** in local AI History |
 | Edit AI Chat input cursor | Left/Right/Home/End/Delete/Backspace | Left/Right/Home/End/Delete/Backspace |
 | Stop in-flight AI Chat or Agent request | **Esc** in AI Chat while working | **Esc** in AI Chat while working |

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -46,6 +46,17 @@ the assistant reply. This follows DeepSeek's
 Completed requests show elapsed time in the AI Chat status area, and token usage
 when the provider returns OpenAI-compatible `usage` fields.
 
+## AI History Sessions
+
+Open the session launcher with `Ctrl+Shift+T` and choose `AI History` to browse
+Codex and Claude Code transcripts stored on a Local, WSL, or SSH target. WispTerm
+connects to the selected target, scans `$HOME/.codex` and `$HOME/.claude` for
+metadata, and loads a transcript only when you open that row.
+
+Use `Resume` to open a real terminal tab on the same target. WispTerm first
+checks the original project directory recorded in the history file; if that
+directory is missing, resume stops instead of falling back to `$HOME`.
+
 ## In-context Copilot Sidebar
 
 Press `Ctrl+Shift+A` (`Cmd+Shift+A` on macOS) on a terminal tab to toggle a

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -40,6 +40,7 @@ const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
+pub const ai_history_session = @import("ai_history_session.zig");
 pub const ai_history_source = @import("ai_history_source.zig");
 pub const tab = @import("appwindow/tab.zig");
 const active_tab_state = @import("appwindow/active_tab.zig");
@@ -601,7 +602,17 @@ fn renderAiHistoryFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int
     markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
     file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     if (active_tab.ai_history_session) |session| {
+        const draw: ai_history_renderer.DrawContext = .{
+            .bg = g_theme.background,
+            .fg = g_theme.foreground,
+            .accent = g_theme.cursor_color,
+            .cell_h = font.g_titlebar_cell_height,
+            .fillQuad = ui_pipeline.fillQuad,
+            .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
+            .renderTextLimited = titlebar.renderTextLimited,
+        };
         ai_history_renderer.render(
+            draw,
             session,
             @floatFromInt(fb_width),
             @floatFromInt(fb_height),
@@ -632,6 +643,145 @@ pub fn activeSurface() ?*Surface {
 
 pub fn activeAiChat() ?*ai_chat.Session {
     return tab.activeAiChat();
+}
+
+pub fn activeAiHistory() ?*ai_history_session.Session {
+    const active = activeTab() orelse return null;
+    if (active.kind != .ai_history) return null;
+    return active.ai_history_session;
+}
+
+pub fn aiHistoryInsertCodepoint(codepoint: u21) bool {
+    const session = activeAiHistory() orelse return false;
+    if (codepoint < 0x20 or codepoint == 0x7f) return false;
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(codepoint, &buf) catch return false;
+    session.appendFilterBytes(buf[0..len]);
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryBackspaceFilter() bool {
+    const session = activeAiHistory() orelse return false;
+    session.backspaceFilter();
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryMoveSelection(delta: isize) bool {
+    const session = activeAiHistory() orelse return false;
+    session.moveSelection(delta);
+    session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryLoadSelectedTranscript() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    const home = localHomeForAiHistory(allocator) catch |err| {
+        log.warn("failed to resolve local home for AI History transcript load: {}", .{err});
+        session.transcript_state = .failed;
+        session.transcript_status = "Home unavailable";
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(home);
+
+    var host_state = ai_history_session.LocalScannerHost{ .home = home };
+    const host = host_state.scannerHost();
+    session.loadSelectedTranscript(host) catch |err| {
+        log.warn("failed to load AI History transcript: {}", .{err});
+    };
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryScanLocalNow() bool {
+    const session = activeAiHistory() orelse return false;
+    if (session.source.target != .local) return false;
+    const allocator = g_allocator orelse return false;
+    const home = localHomeForAiHistory(allocator) catch |err| {
+        log.warn("failed to resolve local home for AI History scan: {}", .{err});
+        session.state = .failed;
+        session.status = "Home unavailable";
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(home);
+
+    var host_state = ai_history_session.LocalScannerHost{ .home = home };
+    const host = host_state.scannerHost();
+    session.scanNow(host) catch |err| {
+        log.warn("failed to scan local AI History: {}", .{err});
+    };
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
+    const session = activeAiHistory() orelse return false;
+    const win = g_window orelse return true;
+    const fb = window_backend.framebufferSize(win);
+    const left = leftPanelsWidth();
+    const right = rightPanelsWidthForWindow(fb.width);
+    const width = @as(f32, @floatFromInt(fb.width)) - left - right;
+    const visible_rows = ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight());
+    const hit = ai_history_renderer.interactionHitTest(
+        session,
+        @floatFromInt(fb.width),
+        @floatFromInt(fb.height),
+        currentTitlebarHeight(),
+        left,
+        width,
+        font.g_titlebar_cell_height,
+        xpos,
+        ypos,
+    );
+    switch (hit) {
+        .none => {},
+        .refresh => {
+            _ = aiHistoryScanLocalNow();
+            return true;
+        },
+        .@"resume" => {
+            // Resume is wired in the next task; consume the click so AI History
+            // tabs never fall through to terminal mouse handling.
+            markUiDirty();
+            return true;
+        },
+        .row => |visible_index| {
+            session.selectVisibleIndex(visible_index);
+            session.ensureSelectionVisible(visible_rows);
+            markUiDirty();
+            return true;
+        },
+    }
+    markUiDirty();
+    return true;
+}
+
+fn markUiDirty() void {
+    g_force_rebuild = true;
+    g_cells_valid = false;
+}
+
+fn aiHistoryListVisibleRowsForWindow() usize {
+    const win = g_window orelse return 1;
+    const fb = window_backend.framebufferSize(win);
+    return ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight());
+}
+
+fn localHomeForAiHistory(allocator: std.mem.Allocator) ![]u8 {
+    if (std.process.getEnvVarOwned(allocator, "USERPROFILE")) |value| {
+        if (value.len > 0) return value;
+        allocator.free(value);
+    } else |_| {}
+    if (std.process.getEnvVarOwned(allocator, "HOME")) |value| {
+        if (value.len > 0) return value;
+        allocator.free(value);
+    } else |_| {}
+    return error.NoHomeDirectory;
 }
 
 pub fn exportActiveAiChatMarkdown(mode: ai_chat.MarkdownExportMode) void {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -40,6 +40,7 @@ const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
+pub const ai_history_source = @import("ai_history_source.zig");
 pub const tab = @import("appwindow/tab.zig");
 const active_tab_state = @import("appwindow/active_tab.zig");
 pub const font = @import("font/manager.zig");
@@ -66,6 +67,7 @@ pub const browser_panel = if (build_options.webview)
 else
     @import("browser_panel_stub.zig");
 pub const ai_chat_renderer = @import("renderer/ai_chat_renderer.zig");
+pub const ai_history_renderer = @import("renderer/ai_history_renderer.zig");
 const ai_sidebar = @import("ai_sidebar.zig");
 pub const ui_perf = @import("ui_perf.zig");
 const log = std.log.scoped(.app_window);
@@ -586,6 +588,30 @@ fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, le
     }
 }
 
+fn aiHistoryContentWidth(fb_width: c_int, left_panels_w: f32, right_panels_w: f32) f32 {
+    return @max(0, @as(f32, @floatFromInt(fb_width)) - left_panels_w - right_panels_w);
+}
+
+fn renderAiHistoryFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
+    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
+    gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    clearWithBackground(fb_width, fb_height);
+    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
+    file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    if (active_tab.ai_history_session) |session| {
+        ai_history_renderer.render(
+            session,
+            @floatFromInt(fb_width),
+            @floatFromInt(fb_height),
+            titlebar_offset,
+            left_panels_w,
+            aiHistoryContentWidth(fb_width, left_panels_w, right_panels_w),
+        );
+    }
+}
+
 fn renderAiCopilotPanel(fb_width: c_int, fb_height: c_int, titlebar_offset: f32) void {
     if (!aiCopilotVisible()) return;
     const session = ensureActiveCopilotSession() orelse return;
@@ -1088,6 +1114,13 @@ pub fn spawnAiChatTab(
     return true;
 }
 
+pub fn spawnAiHistoryTab(source: ai_history_source.Source) bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.spawnAiHistoryTab(allocator, source)) return false;
+    clearUiStateOnTabChange();
+    return true;
+}
+
 pub fn reopenAiChatTabFromHistorySessionId(session_id: []const u8) bool {
     if (tab.switchToAiTabBySessionId(session_id)) {
         clearUiStateOnTabChange();
@@ -1517,6 +1550,8 @@ fn onPlatformResize(width: i32, height: i32) void {
         if (split_count <= 1) {
             if (active_tab.kind == .ai_chat) {
                 renderAiChatFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .ai_history) {
+                renderAiHistoryFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (activeSurface()) |surface| {
                 // Single surface: simple render path
                 const rend = &surface.surface_renderer;
@@ -2041,6 +2076,10 @@ fn buildRemoteLayoutJson(allocator: std.mem.Allocator, out: *std.ArrayListUnmana
             try appendRemoteAiChatTabJson(allocator, out, tab_state, tab_index);
             continue;
         }
+        if (tab_state.kind == .ai_history) {
+            try appendRemoteAiHistoryTabJson(allocator, out, tab_state, tab_index);
+            continue;
+        }
 
         try out.appendSlice(allocator, "{\"index\":");
         try out.print(allocator, "{d}", .{tab_index});
@@ -2120,6 +2159,12 @@ fn buildRemoteLayoutJson(allocator: std.mem.Allocator, out: *std.ArrayListUnmana
 fn remoteAiSurfaceId(tab_index: usize) [16]u8 {
     var id: [16]u8 = undefined;
     _ = std.fmt.bufPrint(&id, "aichat{d:0>10}", .{tab_index}) catch unreachable;
+    return id;
+}
+
+fn remoteAiHistorySurfaceId(tab_index: usize) [16]u8 {
+    var id: [16]u8 = undefined;
+    _ = std.fmt.bufPrint(&id, "aihist{d:0>10}", .{tab_index}) catch unreachable;
     return id;
 }
 
@@ -2229,6 +2274,36 @@ fn appendRemoteAiChatTabJson(
     try out.appendSlice(allocator, ",\"requestStopping\":");
     try out.appendSlice(allocator, if (request_state.stopping) "true" else "false");
     try out.appendSlice(allocator, ",\"x\":0,\"y\":0,\"w\":1,\"h\":1}]}");
+}
+
+fn appendRemoteAiHistoryTabJson(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    tab_state: *tab.TabState,
+    tab_index: usize,
+) !void {
+    const surface_id = remoteAiHistorySurfaceId(tab_index);
+    const title_text = tab_state.getTitle();
+
+    try out.appendSlice(allocator, "{\"index\":");
+    try out.print(allocator, "{d}", .{tab_index});
+    try out.appendSlice(allocator, ",\"title\":\"");
+    try remote.appendJsonString(out, allocator, title_text);
+    try out.appendSlice(allocator, "\",\"focusedSurfaceId\":\"");
+    try remote.appendJsonString(out, allocator, surface_id[0..]);
+    try out.append(allocator, '"');
+    try appendAgentDetectionJson(allocator, out, null);
+    try out.appendSlice(allocator, ",\"surfaces\":[{\"id\":\"");
+    try remote.appendJsonString(out, allocator, surface_id[0..]);
+    try out.appendSlice(allocator, "\",\"title\":\"");
+    try remote.appendJsonString(out, allocator, title_text);
+    try out.appendSlice(allocator, "\",\"focused\":true");
+    try appendAgentDetectionJson(allocator, out, null);
+    // AI History is read-only in remote layouts. Keep it terminal-style so the
+    // remote client does not show AI Chat composer/input affordances.
+    try out.appendSlice(allocator, ",\"kind\":\"terminal\",\"readOnly\":true,\"cols\":120,\"rows\":30,\"cursorX\":0,\"cursorY\":0,\"snapshot\":\"AI History\\n");
+    try remote.appendJsonString(out, allocator, title_text);
+    try out.appendSlice(allocator, "\",\"x\":0,\"y\":0,\"w\":1,\"h\":1}]}");
 }
 
 fn handleRemoteAiInputRequest(request: *RemoteAiInputRequest) void {
@@ -4156,7 +4231,7 @@ fn runMainLoop(self: *AppWindow) !void {
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
             syncRemoteLayout(allocator);
             syncImeCaretPosition(win, split_count);
-            if (active_tab.kind != .ai_chat and synchronizedOutputPendingForVisibleSplits(split_count)) {
+            if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and synchronizedOutputPendingForVisibleSplits(split_count)) {
                 std.Thread.sleep(std.time.ns_per_ms);
                 continue;
             }
@@ -4165,6 +4240,8 @@ fn runMainLoop(self: *AppWindow) !void {
             // GL rendering
             if (active_tab.kind == .ai_chat) {
                 renderAiChatFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .ai_history) {
+                renderAiHistoryFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (post_process.g_post_enabled) {
                 // Post-processing path: only render focused surface for now
                 if (activeSurface()) |surface| {
@@ -4370,4 +4447,47 @@ test "appwindow: syncDefaultShellCommandFromConfig refreshes tab default shell" 
     const expected_len = platform_pty_command.resolveShellCommandLine(&expected_buf, test_shell);
     const CommandUnit = @TypeOf(expected_buf[0]);
     try testing.expectEqualSlices(CommandUnit, expected_buf[0..expected_len], tab.getShellCmd());
+}
+
+test "appwindow: ai history content width accounts for right panels" {
+    try std.testing.expectEqual(@as(f32, 700), aiHistoryContentWidth(1000, 200, 100));
+    try std.testing.expectEqual(@as(f32, 0), aiHistoryContentWidth(250, 200, 100));
+}
+
+test "appwindow: remote layout serializes ai_history as non-terminal surface" {
+    const allocator = std.testing.allocator;
+    for (0..tab.MAX_TABS) |idx| tab.g_tabs[idx] = null;
+    tab.g_tab_count = 0;
+    active_tab_state.g_active_tab = 0;
+    defer {
+        for (0..tab.MAX_TABS) |idx| tab.g_tabs[idx] = null;
+        tab.g_tab_count = 0;
+        active_tab_state.g_active_tab = 0;
+    }
+
+    var session = @import("ai_history_session.zig").Session.init(allocator, .{
+        .id = "local-history",
+        .name = "Local History",
+        .target = .local,
+    });
+    defer session.deinit();
+    var tab_state = tab.TabState{
+        .kind = .ai_history,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = &session,
+        .copilot_session = null,
+    };
+    tab.g_tabs[0] = &tab_state;
+    tab.g_tab_count = 1;
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    try buildRemoteLayoutJson(allocator, &out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"kind\":\"terminal\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"kind\":\"ai_chat\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"readOnly\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"surfaces\":[]") == null);
 }

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -682,22 +682,7 @@ pub fn aiHistoryMoveSelection(delta: isize) bool {
 pub fn aiHistoryPreviewSelectedTranscript() bool {
     const session = activeAiHistory() orelse return false;
     const allocator = g_allocator orelse return false;
-    const home = localHomeForAiHistory(allocator) catch |err| {
-        log.warn("failed to resolve local home for AI History transcript load: {}", .{err});
-        session.transcript_state = .failed;
-        session.transcript_status = "Home unavailable";
-        markUiDirty();
-        return true;
-    };
-    defer allocator.free(home);
-
-    var host_state = ai_history_session.LocalScannerHost{ .home = home };
-    const host = host_state.scannerHost();
-    session.loadSelectedTranscript(host) catch |err| {
-        log.warn("failed to load AI History transcript: {}", .{err});
-    };
-    markUiDirty();
-    return true;
+    return withAiHistoryScannerHost(allocator, session, .preview, PreviewTranscriptRunner.run);
 }
 
 pub fn aiHistoryLoadSelectedTranscript() bool {
@@ -771,24 +756,79 @@ fn failAiHistoryResumePathUnavailable() bool {
 
 pub fn aiHistoryScanLocalNow() bool {
     const session = activeAiHistory() orelse return false;
-    if (session.source.target != .local) return false;
     const allocator = g_allocator orelse return false;
-    const home = localHomeForAiHistory(allocator) catch |err| {
-        log.warn("failed to resolve local home for AI History scan: {}", .{err});
-        session.state = .failed;
-        session.status = "Home unavailable";
+    return withAiHistoryScannerHost(allocator, session, .scan, ScanRunner.run);
+}
+
+const AiHistoryHostAction = enum { scan, preview };
+const AiHistoryHostRunner = *const fn (*ai_history_session.Session, ai_history_session.ScannerHost) bool;
+
+const PreviewTranscriptRunner = struct {
+    fn run(session: *ai_history_session.Session, host: ai_history_session.ScannerHost) bool {
+        session.loadSelectedTranscript(host) catch |err| {
+            log.warn("failed to load AI History transcript: {}", .{err});
+            session.transcript_state = .failed;
+            session.transcript_status = "Transcript failed";
+            markUiDirty();
+            return true;
+        };
         markUiDirty();
         return true;
-    };
-    defer allocator.free(home);
+    }
+};
 
-    var host_state = ai_history_session.LocalScannerHost{ .home = home };
-    const host = host_state.scannerHost();
-    session.scanNow(host) catch |err| {
-        log.warn("failed to scan local AI History: {}", .{err});
-    };
-    markUiDirty();
-    return true;
+const ScanRunner = struct {
+    fn run(session: *ai_history_session.Session, host: ai_history_session.ScannerHost) bool {
+        session.scanNow(host) catch |err| {
+            log.warn("failed to scan AI History: {}", .{err});
+            markUiDirty();
+            return true;
+        };
+        markUiDirty();
+        return true;
+    }
+};
+
+fn withAiHistoryScannerHost(allocator: std.mem.Allocator, session: *ai_history_session.Session, action: AiHistoryHostAction, runner: AiHistoryHostRunner) bool {
+    switch (session.source.target) {
+        .local => {
+            const home = localHomeForAiHistory(allocator) catch |err| {
+                log.warn("failed to resolve local home for AI History scan: {}", .{err});
+                failAiHistoryHostUnavailable(session, action, "Home unavailable");
+                markUiDirty();
+                return true;
+            };
+            defer allocator.free(home);
+            var host_state = ai_history_session.LocalScannerHost{ .home = home };
+            return runner(session, host_state.scannerHost());
+        },
+        .wsl => {
+            var host_state = ai_history_session.WslScannerHost{};
+            return runner(session, host_state.scannerHost());
+        },
+        .ssh => |ssh| {
+            const conn = overlays.aiHistorySshConnection(ssh.profile_name) orelse {
+                failAiHistoryHostUnavailable(session, action, "SSH profile unavailable");
+                markUiDirty();
+                return true;
+            };
+            var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+            return runner(session, host_state.scannerHost());
+        },
+    }
+}
+
+fn failAiHistoryHostUnavailable(session: *ai_history_session.Session, action: AiHistoryHostAction, status: []const u8) void {
+    switch (action) {
+        .scan => {
+            session.state = .failed;
+            session.status = status;
+        },
+        .preview => {
+            session.transcript_state = .failed;
+            session.transcript_status = status;
+        },
+    }
 }
 
 pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -40,6 +40,8 @@ const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
+const ai_history_resume = @import("ai_history_resume.zig");
+const ai_history_types = @import("ai_history_types.zig");
 pub const ai_history_session = @import("ai_history_session.zig");
 pub const ai_history_source = @import("ai_history_source.zig");
 pub const tab = @import("appwindow/tab.zig");
@@ -653,6 +655,7 @@ pub fn activeAiHistory() ?*ai_history_session.Session {
 
 pub fn aiHistoryInsertCodepoint(codepoint: u21) bool {
     const session = activeAiHistory() orelse return false;
+    if (codepoint == ' ') return aiHistoryPreviewSelectedTranscript();
     if (codepoint < 0x20 or codepoint == 0x7f) return false;
     var buf: [4]u8 = undefined;
     const len = std.unicode.utf8Encode(codepoint, &buf) catch return false;
@@ -676,7 +679,7 @@ pub fn aiHistoryMoveSelection(delta: isize) bool {
     return true;
 }
 
-pub fn aiHistoryLoadSelectedTranscript() bool {
+pub fn aiHistoryPreviewSelectedTranscript() bool {
     const session = activeAiHistory() orelse return false;
     const allocator = g_allocator orelse return false;
     const home = localHomeForAiHistory(allocator) catch |err| {
@@ -695,6 +698,75 @@ pub fn aiHistoryLoadSelectedTranscript() bool {
     };
     markUiDirty();
     return true;
+}
+
+pub fn aiHistoryLoadSelectedTranscript() bool {
+    return resumeAiHistorySelection();
+}
+
+pub fn resumeAiHistorySelection() bool {
+    const active = tab.activeTab() orelse return false;
+    if (active.kind != .ai_history) return false;
+    const session = active.ai_history_session orelse return false;
+    const meta = session.selectedVisible() orelse return false;
+    return spawnResumeTerminal(session.source.target, meta);
+}
+
+pub fn spawnResumeTerminal(target: ai_history_source.Target, meta: ai_history_types.SessionMeta) bool {
+    var resume_buf: [512]u8 = undefined;
+    const resume_cmd = ai_history_resume.resumeCommand(meta, &resume_buf) catch |err| {
+        log.warn("failed to build AI History provider resume command for {s}: {}", .{ meta.session_id, err });
+        return failAiHistoryResumePathUnavailable();
+    };
+
+    var checked_buf: [2048]u8 = undefined;
+    const checked_cmd = ai_history_resume.checkedPosixResume(resume_cmd, meta.project_dir, &checked_buf) catch |err| {
+        log.warn("failed to build AI History checked resume command for {s}: {}", .{ meta.session_id, err });
+        return failAiHistoryResumePathUnavailable();
+    };
+
+    var command_buf: [4096]u8 = undefined;
+    switch (target) {
+        .local => {
+            var native_checked_buf: [2048]u8 = undefined;
+            const local_checked_cmd = switch (platform_pty_command.backend()) {
+                .windows => ai_history_resume.checkedPowerShellResume(meta, &native_checked_buf) catch |err| {
+                    log.warn("failed to build AI History PowerShell resume command for {s}: {}", .{ meta.session_id, err });
+                    return failAiHistoryResumePathUnavailable();
+                },
+                .unsupported => checked_cmd,
+            };
+            const command = platform_pty_command.localShellInitialCommand(command_buf[0..], tab.getShellCmd(), local_checked_cmd) orelse return failAiHistoryResumePathUnavailable();
+            if (spawnTabWithCommandUtf8(command)) return true;
+            overlays.showStatusToast("AI History resume failed");
+            return false;
+        },
+        .wsl => {
+            const command = platform_pty_command.wslShellCommand(command_buf[0..], checked_cmd) orelse return failAiHistoryResumePathUnavailable();
+            if (spawnTabWithCommandUtf8(command)) return true;
+            overlays.showStatusToast("AI History resume failed");
+            return false;
+        },
+        .ssh => |ssh| {
+            return switch (overlays.aiHistoryConnectSshProfile(ssh.profile_name, checked_cmd)) {
+                .connected => true,
+                .not_found => {
+                    overlays.showStatusToast("AI History resume failed: SSH profile unavailable");
+                    return false;
+                },
+                .failed => {
+                    overlays.showStatusToast("AI History resume failed");
+                    return false;
+                },
+            };
+        },
+    }
+}
+
+fn failAiHistoryResumePathUnavailable() bool {
+    overlays.showStatusToast("AI History resume failed: project path unavailable");
+    markUiDirty();
+    return false;
 }
 
 pub fn aiHistoryScanLocalNow() bool {
@@ -745,8 +817,7 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
             return true;
         },
         .@"resume" => {
-            // Resume is wired in the next task; consume the click so AI History
-            // tabs never fall through to terminal mouse handling.
+            _ = resumeAiHistorySelection();
             markUiDirty();
             return true;
         },

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -40,6 +40,7 @@ const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 pub const ai_chat = @import("ai_chat.zig");
+const ai_history_cache = @import("ai_history_cache.zig");
 const ai_history_resume = @import("ai_history_resume.zig");
 const ai_history_types = @import("ai_history_types.zig");
 pub const ai_history_session = @import("ai_history_session.zig");
@@ -779,11 +780,13 @@ const PreviewTranscriptRunner = struct {
 
 const ScanRunner = struct {
     fn run(session: *ai_history_session.Session, host: ai_history_session.ScannerHost) bool {
-        session.scanNow(host) catch |err| {
+        const result = session.scanNowReturningResult(host) catch |err| {
             log.warn("failed to scan AI History: {}", .{err});
             markUiDirty();
             return true;
         };
+        defer ai_history_session.freeScanResult(session.allocator, result);
+        saveAiHistoryMetadataCache(session.allocator, result.cache_update);
         markUiDirty();
         return true;
     }
@@ -799,7 +802,18 @@ fn withAiHistoryScannerHost(allocator: std.mem.Allocator, session: *ai_history_s
                 return true;
             };
             defer allocator.free(home);
-            var host_state = ai_history_session.LocalScannerHost{ .home = home };
+            var parsed_cache: ?std.json.Parsed(ai_history_cache.CacheFile) = null;
+            if (action == .scan) {
+                parsed_cache = ai_history_cache.loadDefault(allocator) catch |err| blk: {
+                    log.warn("failed to load AI History metadata cache: {}", .{err});
+                    break :blk null;
+                };
+            }
+            defer if (parsed_cache) |*cache| cache.deinit();
+            var host_state = ai_history_session.LocalScannerHost{
+                .home = home,
+                .cache = if (parsed_cache) |cache| cache.value else null,
+            };
             return runner(session, host_state.scannerHost());
         },
         .wsl => {
@@ -816,6 +830,13 @@ fn withAiHistoryScannerHost(allocator: std.mem.Allocator, session: *ai_history_s
             return runner(session, host_state.scannerHost());
         },
     }
+}
+
+fn saveAiHistoryMetadataCache(allocator: std.mem.Allocator, cache_update: ai_history_session.CacheUpdate) void {
+    if (cache_update.records.len == 0) return;
+    ai_history_cache.saveDefault(allocator, .{ .records = cache_update.records }) catch |err| {
+        log.warn("failed to save AI History metadata cache: {}", .{err});
+    };
 }
 
 fn failAiHistoryHostUnavailable(session: *ai_history_session.Session, action: AiHistoryHostAction, status: []const u8) void {

--- a/src/ai_history_cache.zig
+++ b/src/ai_history_cache.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const FileStamp = struct {
+    size: u64,
+    mtime_ns: i128,
+};
+
+pub const CacheRecord = struct {
+    source_id: []const u8,
+    provider: types.ProviderId,
+    root_path: []const u8,
+    source_path: []const u8,
+    stamp: FileStamp,
+    meta: types.SessionMeta,
+};
+
+pub fn stampMatches(record: CacheRecord, stamp: FileStamp) bool {
+    return record.stamp.size == stamp.size and record.stamp.mtime_ns == stamp.mtime_ns;
+}
+
+test "ai_history_cache: cache stamp matches only exact size and mtime" {
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const record: CacheRecord = .{
+        .source_id = "local",
+        .provider = .codex,
+        .root_path = "/home/me/.codex",
+        .source_path = "/home/me/.codex/sessions/a.jsonl",
+        .stamp = .{ .size = 10, .mtime_ns = 20 },
+        .meta = meta,
+    };
+    try std.testing.expect(stampMatches(record, .{ .size = 10, .mtime_ns = 20 }));
+    try std.testing.expect(!stampMatches(record, .{ .size = 11, .mtime_ns = 20 }));
+    try std.testing.expect(!stampMatches(record, .{ .size = 10, .mtime_ns = 21 }));
+}

--- a/src/ai_history_cache.zig
+++ b/src/ai_history_cache.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const types = @import("ai_history_types.zig");
+const platform_dirs = @import("platform/dirs.zig");
+
+const MAX_CACHE_BYTES = 16 * 1024 * 1024;
 
 pub const FileStamp = struct {
     size: u64,
@@ -15,8 +18,122 @@ pub const CacheRecord = struct {
     meta: types.SessionMeta,
 };
 
+pub const CacheFile = struct {
+    version: u32 = 1,
+    records: []CacheRecord = &.{},
+};
+
 pub fn stampMatches(record: CacheRecord, stamp: FileStamp) bool {
     return record.stamp.size == stamp.size and record.stamp.mtime_ns == stamp.mtime_ns;
+}
+
+pub fn dump(allocator: std.mem.Allocator, cache: CacheFile) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, cache, .{});
+}
+
+pub fn load(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(CacheFile) {
+    return std.json.parseFromSlice(CacheFile, allocator, bytes, .{ .ignore_unknown_fields = true });
+}
+
+pub fn defaultPath(allocator: std.mem.Allocator) ![]const u8 {
+    return platform_dirs.aiHistoryCachePath(allocator);
+}
+
+pub fn loadDefault(allocator: std.mem.Allocator) !std.json.Parsed(CacheFile) {
+    const path = try defaultPath(allocator);
+    defer allocator.free(path);
+    return loadFromPath(allocator, path);
+}
+
+pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) !std.json.Parsed(CacheFile) {
+    const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_CACHE_BYTES) catch |err| switch (err) {
+        error.FileNotFound => return try load(allocator, "{\"version\":1,\"records\":[]}"),
+        else => return err,
+    };
+    defer allocator.free(bytes);
+    return try load(allocator, bytes);
+}
+
+pub fn saveToPath(allocator: std.mem.Allocator, path: []const u8, cache: CacheFile) !void {
+    const json = try dump(allocator, cache);
+    defer allocator.free(json);
+
+    if (std.fs.path.dirname(path)) |dir| try std.fs.cwd().makePath(dir);
+    var write_buffer: [0]u8 = .{};
+    var atomic = try std.fs.cwd().atomicFile(path, .{ .write_buffer = &write_buffer });
+    defer atomic.deinit();
+    try atomic.file_writer.file.writeAll(json);
+    try atomic.finish();
+}
+
+pub fn saveDefault(allocator: std.mem.Allocator, cache: CacheFile) !void {
+    const path = try defaultPath(allocator);
+    defer allocator.free(path);
+    try saveToPath(allocator, path, cache);
+}
+
+pub fn findRecord(cache: CacheFile, source_id: []const u8, provider: types.ProviderId, source_path: []const u8, stamp: FileStamp) ?CacheRecord {
+    for (cache.records) |record| {
+        if (record.provider == provider and
+            std.mem.eql(u8, record.source_id, source_id) and
+            std.mem.eql(u8, record.source_path, source_path) and
+            stampMatches(record, stamp))
+        {
+            return record;
+        }
+    }
+    return null;
+}
+
+pub fn cloneRecord(allocator: std.mem.Allocator, record: CacheRecord) !CacheRecord {
+    var cloned: CacheRecord = .{
+        .source_id = "",
+        .provider = record.provider,
+        .root_path = "",
+        .source_path = "",
+        .stamp = record.stamp,
+        .meta = .{
+            .provider = record.meta.provider,
+            .session_id = "",
+            .title = "",
+            .summary = "",
+            .project_dir = "",
+            .created_at_ms = record.meta.created_at_ms,
+            .last_active_at_ms = record.meta.last_active_at_ms,
+            .source_path = "",
+            .resume_kind = record.meta.resume_kind,
+            .message_count = record.meta.message_count,
+            .scan_status = record.meta.scan_status,
+        },
+    };
+    errdefer freeRecord(allocator, &cloned);
+
+    cloned.source_id = try allocator.dupe(u8, record.source_id);
+    cloned.root_path = try allocator.dupe(u8, record.root_path);
+    cloned.source_path = try allocator.dupe(u8, record.source_path);
+    cloned.meta.session_id = try allocator.dupe(u8, record.meta.session_id);
+    cloned.meta.title = try allocator.dupe(u8, record.meta.title);
+    cloned.meta.summary = try allocator.dupe(u8, record.meta.summary);
+    cloned.meta.project_dir = try allocator.dupe(u8, record.meta.project_dir);
+    cloned.meta.source_path = try allocator.dupe(u8, record.meta.source_path);
+    return cloned;
+}
+
+pub fn freeRecord(allocator: std.mem.Allocator, record: *CacheRecord) void {
+    if (record.source_id.len > 0) allocator.free(record.source_id);
+    if (record.root_path.len > 0) allocator.free(record.root_path);
+    if (record.source_path.len > 0) allocator.free(record.source_path);
+    if (record.meta.session_id.len > 0) allocator.free(record.meta.session_id);
+    if (record.meta.title.len > 0) allocator.free(record.meta.title);
+    if (record.meta.summary.len > 0) allocator.free(record.meta.summary);
+    if (record.meta.project_dir.len > 0) allocator.free(record.meta.project_dir);
+    if (record.meta.source_path.len > 0) allocator.free(record.meta.source_path);
+    record.* = undefined;
+}
+
+pub fn freeRecords(allocator: std.mem.Allocator, records: []CacheRecord) void {
+    for (records) |*record| freeRecord(allocator, record);
+    allocator.free(records);
 }
 
 test "ai_history_cache: cache stamp matches only exact size and mtime" {
@@ -38,4 +155,50 @@ test "ai_history_cache: cache stamp matches only exact size and mtime" {
     try std.testing.expect(stampMatches(record, .{ .size = 10, .mtime_ns = 20 }));
     try std.testing.expect(!stampMatches(record, .{ .size = 11, .mtime_ns = 20 }));
     try std.testing.expect(!stampMatches(record, .{ .size = 10, .mtime_ns = 21 }));
+}
+
+test "ai_history_cache: json round trip keeps metadata only" {
+    const allocator = std.testing.allocator;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const records = [_]CacheRecord{.{
+        .source_id = "local",
+        .provider = .codex,
+        .root_path = "/home/me/.codex",
+        .source_path = "/home/me/.codex/sessions/a.jsonl",
+        .stamp = .{ .size = 10, .mtime_ns = 20 },
+        .meta = meta,
+    }};
+    const json = try dump(allocator, .{ .records = @constCast(&records) });
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "transcript") == null);
+    var parsed = try load(allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("abc", parsed.value.records[0].meta.session_id);
+}
+
+test "ai_history_cache: finds records by source path and stamp" {
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "/home/me/.codex/sessions/a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const records = [_]CacheRecord{.{
+        .source_id = "local",
+        .provider = .codex,
+        .root_path = "/home/me/.codex",
+        .source_path = "/home/me/.codex/sessions/a.jsonl",
+        .stamp = .{ .size = 10, .mtime_ns = 20 },
+        .meta = meta,
+    }};
+    const cache: CacheFile = .{ .records = @constCast(&records) };
+    try std.testing.expect(findRecord(cache, "local", .codex, "/home/me/.codex/sessions/a.jsonl", .{ .size = 10, .mtime_ns = 20 }) != null);
+    try std.testing.expect(findRecord(cache, "local", .codex, "/home/me/.codex/sessions/a.jsonl", .{ .size = 11, .mtime_ns = 20 }) == null);
 }

--- a/src/ai_history_provider_claude.zig
+++ b/src/ai_history_provider_claude.zig
@@ -1,0 +1,623 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const ParseError = error{OutOfMemory};
+
+pub fn parseMetadata(
+    allocator: std.mem.Allocator,
+    source_path: []const u8,
+    jsonl: []const u8,
+) ParseError!types.SessionMeta {
+    var meta = try initMetadata(allocator, source_path);
+    errdefer freeMetadata(allocator, meta);
+
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        if (objectBool(obj, "isMeta") == true) continue;
+
+        if (meta.session_id.len == 0) {
+            if (objectString(obj, "sessionId")) |session_id| try replaceOwned(allocator, &meta.session_id, session_id);
+        }
+        if (meta.project_dir.len == 0) {
+            if (objectString(obj, "cwd")) |cwd| try replaceOwned(allocator, &meta.project_dir, cwd);
+        }
+
+        const message = messageObject(obj) orelse continue;
+        const timestamp_ms = if (objectString(obj, "timestamp")) |timestamp|
+            parseTimestampMs(timestamp)
+        else
+            0;
+
+        var events = metadataMessageEvents(message) orelse continue;
+        while (events.next()) |event| {
+            meta.message_count += 1;
+            if (meta.title.len == 0 and event.role == .user and event.kind == .normal) {
+                if (event.title_text) |title_text| try replaceOwned(allocator, &meta.title, title_text);
+            }
+            if (timestamp_ms > 0) {
+                if (meta.created_at_ms == 0) meta.created_at_ms = timestamp_ms;
+                if (timestamp_ms > meta.last_active_at_ms) meta.last_active_at_ms = timestamp_ms;
+            }
+        }
+    }
+
+    if (meta.title.len == 0) {
+        try replaceOwned(allocator, &meta.title, fallbackTitle(meta.project_dir));
+    }
+
+    return meta;
+}
+
+pub fn parseTranscript(
+    allocator: std.mem.Allocator,
+    jsonl: []const u8,
+) ParseError![]types.TranscriptMessage {
+    var messages: std.ArrayListUnmanaged(types.TranscriptMessage) = .empty;
+    errdefer {
+        freeTranscriptList(allocator, messages.items);
+        messages.deinit(allocator);
+    }
+
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        if (objectBool(obj, "isMeta") == true) continue;
+
+        const message = messageObject(obj) orelse continue;
+        const timestamp_ms = if (objectString(obj, "timestamp")) |timestamp|
+            parseTimestampMs(timestamp)
+        else
+            0;
+
+        var events = messageEvents(allocator, message) orelse continue;
+        while (try events.next()) |event| {
+            defer event.deinit(allocator);
+
+            const content_owned = try allocator.dupe(u8, event.content.slice());
+            errdefer allocator.free(content_owned);
+            try messages.append(allocator, .{
+                .role = event.role,
+                .kind = event.kind,
+                .content = content_owned,
+                .timestamp_ms = timestamp_ms,
+            });
+        }
+    }
+
+    return try messages.toOwnedSlice(allocator);
+}
+
+/// Frees metadata returned by parseMetadata in this provider.
+pub fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
+    allocator.free(meta.session_id);
+    allocator.free(meta.title);
+    allocator.free(meta.project_dir);
+    allocator.free(meta.source_path);
+}
+
+pub fn freeTranscript(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    freeTranscriptList(allocator, messages);
+    allocator.free(messages);
+}
+
+fn initMetadata(allocator: std.mem.Allocator, source_path: []const u8) ParseError!types.SessionMeta {
+    const session_id = try allocator.dupe(u8, "");
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, "");
+    errdefer allocator.free(title);
+    const project_dir = try allocator.dupe(u8, "");
+    errdefer allocator.free(project_dir);
+    const source_path_owned = try allocator.dupe(u8, source_path);
+
+    return .{
+        .provider = .claude,
+        .session_id = session_id,
+        .title = title,
+        .project_dir = project_dir,
+        .source_path = source_path_owned,
+        .resume_kind = .claude_resume,
+    };
+}
+
+fn freeTranscriptList(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    for (messages) |message| {
+        allocator.free(message.content);
+    }
+}
+
+fn parseLine(allocator: std.mem.Allocator, line: []const u8) ParseError!?std.json.Parsed(std.json.Value) {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+}
+
+fn objectString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn objectBool(obj: std.json.ObjectMap, key: []const u8) ?bool {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .bool => |b| b,
+        else => null,
+    };
+}
+
+fn messageObject(obj: std.json.ObjectMap) ?std.json.ObjectMap {
+    const message = obj.get("message") orelse return null;
+    return switch (message) {
+        .object => |message_obj| message_obj,
+        else => null,
+    };
+}
+
+const MessageEvent = struct {
+    role: types.MessageRole,
+    kind: types.MessageKind,
+    content: ContentText,
+
+    fn deinit(self: MessageEvent, allocator: std.mem.Allocator) void {
+        self.content.deinit(allocator);
+    }
+};
+
+const MetadataEvent = struct {
+    role: types.MessageRole,
+    kind: types.MessageKind,
+    title_text: ?[]const u8 = null,
+};
+
+const MetadataMessageEvents = struct {
+    role: types.MessageRole,
+    content: std.json.Value,
+    index: usize = 0,
+
+    fn next(self: *MetadataMessageEvents) ?MetadataEvent {
+        switch (self.content) {
+            .string => |text| {
+                if (self.index > 0) return null;
+                self.index += 1;
+                return .{ .role = self.role, .kind = .normal, .title_text = text };
+            },
+            .array => |items| {
+                while (self.index < items.items.len) {
+                    const item = items.items[self.index];
+                    self.index += 1;
+                    if (item != .object) continue;
+                    const item_type = objectString(item.object, "type") orelse continue;
+                    if (std.mem.eql(u8, item_type, "text")) {
+                        return .{
+                            .role = self.role,
+                            .kind = .normal,
+                            .title_text = objectString(item.object, "text"),
+                        };
+                    }
+                    if (std.mem.eql(u8, item_type, "tool_result")) {
+                        return .{ .role = .tool, .kind = .tool_result };
+                    }
+                }
+            },
+            else => {},
+        }
+        return null;
+    }
+};
+
+const ContentText = union(enum) {
+    borrowed: []const u8,
+    owned: []const u8,
+
+    fn slice(self: ContentText) []const u8 {
+        return switch (self) {
+            .borrowed => |text| text,
+            .owned => |text| text,
+        };
+    }
+
+    fn deinit(self: ContentText, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .borrowed => {},
+            .owned => |text| allocator.free(text),
+        }
+    }
+};
+
+fn metadataMessageEvents(message: std.json.ObjectMap) ?MetadataMessageEvents {
+    const role = messageRole(objectString(message, "role") orelse "") orelse return null;
+    return .{
+        .role = role,
+        .content = message.get("content") orelse .{ .null = {} },
+    };
+}
+
+const MessageEvents = struct {
+    allocator: std.mem.Allocator,
+    role: types.MessageRole,
+    content: std.json.Value,
+    index: usize = 0,
+
+    fn next(self: *MessageEvents) ParseError!?MessageEvent {
+        switch (self.content) {
+            .string => |text| {
+                if (self.index > 0) return null;
+                self.index += 1;
+                return .{ .role = self.role, .kind = .normal, .content = .{ .borrowed = text } };
+            },
+            .array => |items| {
+                while (self.index < items.items.len) {
+                    const item = items.items[self.index];
+                    self.index += 1;
+                    if (item != .object) continue;
+                    const item_type = objectString(item.object, "type") orelse continue;
+                    if (std.mem.eql(u8, item_type, "text")) {
+                        const text = objectString(item.object, "text") orelse continue;
+                        return .{ .role = self.role, .kind = .normal, .content = .{ .borrowed = text } };
+                    }
+                    if (std.mem.eql(u8, item_type, "tool_result")) {
+                        const content_value = item.object.get("content") orelse continue;
+                        const content = (try normalizeToolResultContent(self.allocator, content_value)) orelse continue;
+                        return .{ .role = .tool, .kind = .tool_result, .content = content };
+                    }
+                }
+            },
+            else => {},
+        }
+        return null;
+    }
+};
+
+fn messageEvents(allocator: std.mem.Allocator, message: std.json.ObjectMap) ?MessageEvents {
+    const role = messageRole(objectString(message, "role") orelse "") orelse return null;
+    return .{
+        .allocator = allocator,
+        .role = role,
+        .content = message.get("content") orelse .{ .null = {} },
+    };
+}
+
+// Claude tool_result content may be a string or an array of text blocks. Arrays
+// without extractable text are skipped rather than serialized into transcript UI.
+fn normalizeToolResultContent(allocator: std.mem.Allocator, value: std.json.Value) ParseError!?ContentText {
+    return switch (value) {
+        .string => |text| .{ .borrowed = text },
+        .array => |items| try joinTextBlocks(allocator, items.items),
+        else => null,
+    };
+}
+
+fn joinTextBlocks(allocator: std.mem.Allocator, items: []const std.json.Value) ParseError!?ContentText {
+    var joined: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer joined.deinit(allocator);
+
+    var found_text = false;
+    for (items) |item| {
+        if (item != .object) continue;
+        if (!std.mem.eql(u8, objectString(item.object, "type") orelse "", "text")) continue;
+        const text = objectString(item.object, "text") orelse continue;
+
+        if (found_text) try joined.append(allocator, '\n');
+        try joined.appendSlice(allocator, text);
+        found_text = true;
+    }
+
+    if (!found_text) return null;
+    return .{ .owned = try joined.toOwnedSlice(allocator) };
+}
+
+fn fallbackTitle(project_dir: []const u8) []const u8 {
+    if (project_dir.len > 0) {
+        const basename = std.fs.path.basename(project_dir);
+        if (basename.len > 0) return basename;
+    }
+    return "Claude Code Session";
+}
+
+fn messageRole(role: []const u8) ?types.MessageRole {
+    if (std.mem.eql(u8, role, "user")) return .user;
+    if (std.mem.eql(u8, role, "assistant")) return .assistant;
+    return null;
+}
+
+fn replaceOwned(allocator: std.mem.Allocator, field: *[]const u8, value: []const u8) ParseError!void {
+    const owned = try allocator.dupe(u8, value);
+    allocator.free(field.*);
+    field.* = owned;
+}
+
+fn parseTimestampMs(timestamp: []const u8) i64 {
+    if (timestamp.len < "0000-00-00T00:00:00Z".len) return 0;
+    if (timestamp[4] != '-' or timestamp[7] != '-' or timestamp[10] != 'T' or
+        timestamp[13] != ':' or timestamp[16] != ':')
+    {
+        return 0;
+    }
+
+    const year: i64 = parseDigits(timestamp[0..4]) orelse return 0;
+    const month: i64 = parseDigits(timestamp[5..7]) orelse return 0;
+    const day: i64 = parseDigits(timestamp[8..10]) orelse return 0;
+    const hour: i64 = parseDigits(timestamp[11..13]) orelse return 0;
+    const minute: i64 = parseDigits(timestamp[14..16]) orelse return 0;
+    const second: i64 = parseDigits(timestamp[17..19]) orelse return 0;
+    if (month < 1 or month > 12 or day < 1 or day > daysInMonth(year, month) or
+        hour > 23 or minute > 59 or second > 59)
+    {
+        return 0;
+    }
+
+    var index: usize = 19;
+    var millisecond: i64 = 0;
+    if (index < timestamp.len and timestamp[index] == '.') {
+        index += 1;
+        const start = index;
+        var scale: i64 = 100;
+        while (index < timestamp.len and std.ascii.isDigit(timestamp[index])) : (index += 1) {
+            if (scale > 0) {
+                millisecond += @as(i64, timestamp[index] - '0') * scale;
+                scale = @divTrunc(scale, 10);
+            }
+        }
+        if (index == start) return 0;
+    }
+
+    const offset_seconds = parseTimezoneOffsetSeconds(timestamp[index..]) orelse return 0;
+    const local_seconds = daysFromCivil(year, month, day) * std.time.s_per_day +
+        hour * std.time.s_per_hour + minute * std.time.s_per_min + second;
+    return (local_seconds - offset_seconds) * std.time.ms_per_s + millisecond;
+}
+
+fn parseDigits(bytes: []const u8) ?i64 {
+    var value: i64 = 0;
+    for (bytes) |byte| {
+        if (byte < '0' or byte > '9') return null;
+        value = value * 10 + byte - '0';
+    }
+    return value;
+}
+
+fn parseTimezoneOffsetSeconds(value: []const u8) ?i64 {
+    if (std.mem.eql(u8, value, "Z")) return 0;
+    if (value.len != 6 or value[3] != ':') return null;
+    if (value[0] != '+' and value[0] != '-') return null;
+
+    const hours = parseDigits(value[1..3]) orelse return null;
+    const minutes = parseDigits(value[4..6]) orelse return null;
+    if (hours > 23 or minutes > 59) return null;
+
+    const offset = hours * std.time.s_per_hour + minutes * std.time.s_per_min;
+    return if (value[0] == '+') offset else -offset;
+}
+
+fn daysInMonth(year: i64, month: i64) i64 {
+    return switch (month) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(year)) 29 else 28,
+        else => 0,
+    };
+}
+
+fn isLeapYear(year: i64) bool {
+    return @mod(year, 4) == 0 and (@mod(year, 100) != 0 or @mod(year, 400) == 0);
+}
+
+fn daysFromCivil(year_in: i64, month: i64, day: i64) i64 {
+    var year = year_in;
+    if (month <= 2) year -= 1;
+    const era = @divFloor(year, 400);
+    const yoe = year - era * 400;
+    const month_adjusted = if (month > 2) month - 3 else month + 9;
+    const doy = @divTrunc(153 * month_adjusted + 2, 5) + day - 1;
+    const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy;
+    return era * 146097 + doe - 719468;
+}
+
+const MaxAllocAllocator = struct {
+    child: std.mem.Allocator,
+    max_alloc_len: usize,
+    allowed_large_allocs: usize = 0,
+
+    fn allocator(self: *MaxAllocAllocator) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .remap = remap,
+                .free = free,
+            },
+        };
+    }
+
+    fn alloc(ctx: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *MaxAllocAllocator = @ptrCast(@alignCast(ctx));
+        if (n > self.max_alloc_len and !self.consumeLargeAllocBudget()) return null;
+        return self.child.rawAlloc(n, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *MaxAllocAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > self.max_alloc_len and !self.consumeLargeAllocBudget()) return false;
+        return self.child.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *MaxAllocAllocator = @ptrCast(@alignCast(ctx));
+        if (new_len > self.max_alloc_len and !self.consumeLargeAllocBudget()) return null;
+        return self.child.rawRemap(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *MaxAllocAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(buf, alignment, ra);
+    }
+
+    fn consumeLargeAllocBudget(self: *MaxAllocAllocator) bool {
+        if (self.allowed_large_allocs == 0) return false;
+        self.allowed_large_allocs -= 1;
+        return true;
+    }
+};
+
+test "ai_history_provider_claude: parses metadata from project transcript" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00.000Z","type":"user","message":{"role":"user","content":"Fix tests"}}
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:01:00.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I will inspect the failure."}]}}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.claude/projects/project/claude-abc.jsonl", jsonl);
+    defer freeMetadata(allocator, meta);
+    try std.testing.expectEqual(types.ProviderId.claude, meta.provider);
+    try std.testing.expectEqualStrings("claude-abc", meta.session_id);
+    try std.testing.expectEqualStrings("Fix tests", meta.title);
+    try std.testing.expectEqualStrings("/home/me/project", meta.project_dir);
+    try std.testing.expectEqualStrings("/home/me/.claude/projects/project/claude-abc.jsonl", meta.source_path);
+    try std.testing.expectEqual(types.ResumeKind.claude_resume, meta.resume_kind);
+    try std.testing.expectEqual(@as(u32, 2), meta.message_count);
+}
+
+test "ai_history_provider_claude: skips isMeta and folds tool result messages" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"sessionId":"claude-abc","isMeta":true,"timestamp":"2026-05-31T10:00:00.000Z","type":"user","message":{"role":"user","content":"meta"}}
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:01:00.000Z","type":"user","message":{"role":"user","content":"Inspect repo"}}
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:02:00.000Z","type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ls output"}]}}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
+    try std.testing.expectEqualStrings("Inspect repo", messages[0].content);
+    try std.testing.expectEqual(types.MessageRole.tool, messages[1].role);
+    try std.testing.expectEqual(types.MessageKind.tool_result, messages[1].kind);
+    try std.testing.expectEqualStrings("ls output", messages[1].content);
+}
+
+test "ai_history_provider_claude: metadata counts array tool results without joining content" {
+    var guarded = MaxAllocAllocator{
+        .child = std.testing.allocator,
+        .max_alloc_len = 2048,
+        .allowed_large_allocs = 12,
+    };
+    const allocator = guarded.allocator();
+    const block = "x" ** 512;
+    const jsonl =
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00.000Z","type":"user","message":{"role":"user","content":"Title text"}}
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:01:00.000Z","type":"user","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"
+    ++ block ++
+        \\"},{"type":"text","text":"
+    ++ block ++
+        \\"},{"type":"text","text":"
+    ++ block ++
+        \\"},{"type":"text","text":"
+    ++ block ++
+        \\"},{"type":"text","text":"
+    ++ block ++
+        \\"},{"type":"text","text":"
+    ++ block ++
+        \\"}]}]}}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.claude/projects/project/claude-abc.jsonl", jsonl);
+    defer freeMetadata(allocator, meta);
+    try std.testing.expectEqualStrings("Title text", meta.title);
+    try std.testing.expectEqual(@as(u32, 2), meta.message_count);
+    try std.testing.expectEqual(@as(usize, 0), guarded.allowed_large_allocs);
+}
+
+test "ai_history_provider_claude: joins text blocks from tool result arrays" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:02:00.000Z","type":"user","message":{"role":"user","content":[{"type":"tool_result","content":[{"type":"text","text":"first line"},{"type":"text","text":"second line"}]}]}}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 1), messages.len);
+    try std.testing.expectEqual(types.MessageRole.tool, messages[0].role);
+    try std.testing.expectEqual(types.MessageKind.tool_result, messages[0].kind);
+    try std.testing.expectEqualStrings("first line\nsecond line", messages[0].content);
+}
+
+test "ai_history_provider_claude: falls back to cwd basename for title" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:01:00.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"No user text yet."}]}}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.claude/projects/project/claude-abc.jsonl", jsonl);
+    defer freeMetadata(allocator, meta);
+    try std.testing.expectEqualStrings("project", meta.title);
+}
+
+test "ai_history_provider_claude: falls back to default title without cwd or basename" {
+    const allocator = std.testing.allocator;
+    const root_jsonl =
+        \\{"sessionId":"claude-root","cwd":"/","timestamp":"2026-05-31T10:01:00.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"No user text yet."}]}}
+        \\
+    ;
+    const no_cwd_jsonl =
+        \\{"sessionId":"claude-empty","timestamp":"2026-05-31T10:01:00.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"No cwd."}]}}
+        \\
+    ;
+
+    const root_meta = try parseMetadata(allocator, "/home/me/.claude/projects/root/claude-root.jsonl", root_jsonl);
+    defer freeMetadata(allocator, root_meta);
+    try std.testing.expectEqualStrings("Claude Code Session", root_meta.title);
+
+    const no_cwd_meta = try parseMetadata(allocator, "/home/me/.claude/projects/empty/claude-empty.jsonl", no_cwd_jsonl);
+    defer freeMetadata(allocator, no_cwd_meta);
+    try std.testing.expectEqualStrings("Claude Code Session", no_cwd_meta.title);
+}
+
+test "ai_history_provider_claude: malformed json is skipped while parsing continues" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:01:00.000Z","type":"user","message":{"role":"user","content":"Before malformed"}}
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:01:30.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"missing close"}]}
+        \\{"sessionId":"claude-abc","timestamp":"2026-05-31T10:02:00.000Z","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"After malformed"}]}}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqualStrings("Before malformed", messages[0].content);
+    try std.testing.expectEqualStrings("After malformed", messages[1].content);
+}
+
+test "ai_history_provider_claude: allocation failures propagate" {
+    var metadata_failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(
+        error.OutOfMemory,
+        parseMetadata(metadata_failing.allocator(), "/home/me/.claude/projects/project/claude-abc.jsonl", "{}\n"),
+    );
+
+    var transcript_failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(
+        error.OutOfMemory,
+        parseTranscript(transcript_failing.allocator(), "{\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n"),
+    );
+}

--- a/src/ai_history_provider_codex.zig
+++ b/src/ai_history_provider_codex.zig
@@ -1,0 +1,391 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const ParseError = error{OutOfMemory};
+
+pub fn parseMetadata(
+    allocator: std.mem.Allocator,
+    source_path: []const u8,
+    jsonl: []const u8,
+) ParseError!types.SessionMeta {
+    var meta = try initMetadata(allocator, source_path);
+    errdefer freeMetadata(allocator, meta);
+
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        const event_type = objectString(obj, "type") orelse continue;
+        const timestamp_ms = if (objectString(obj, "timestamp")) |timestamp|
+            parseTimestampMs(timestamp)
+        else
+            0;
+
+        if (std.mem.eql(u8, event_type, "session_meta")) {
+            const body = sessionBody(obj);
+            if (objectString(body, "id")) |session_id| try replaceOwned(allocator, &meta.session_id, session_id);
+            if (objectString(body, "cwd")) |cwd| try replaceOwned(allocator, &meta.project_dir, cwd);
+            if (timestamp_ms > 0) {
+                if (meta.created_at_ms == 0) meta.created_at_ms = timestamp_ms;
+                if (timestamp_ms > meta.last_active_at_ms) meta.last_active_at_ms = timestamp_ms;
+            }
+            continue;
+        }
+
+        if (!std.mem.eql(u8, event_type, "response_item")) continue;
+        const body = responseBody(obj) orelse continue;
+        const role = messageRole(objectString(body, "role") orelse "") orelse continue;
+        if (role != .user and role != .assistant) continue;
+        const content = contentText(body.get("content") orelse continue) orelse continue;
+        if (role == .user and isNoiseUserText(content)) continue;
+
+        meta.message_count += 1;
+        if (meta.title.len == 0 and role == .user) try replaceOwned(allocator, &meta.title, content);
+        if (timestamp_ms > 0) {
+            if (meta.created_at_ms == 0) meta.created_at_ms = timestamp_ms;
+            if (timestamp_ms > meta.last_active_at_ms) meta.last_active_at_ms = timestamp_ms;
+        }
+    }
+
+    return meta;
+}
+
+pub fn parseTranscript(
+    allocator: std.mem.Allocator,
+    jsonl: []const u8,
+) ParseError![]types.TranscriptMessage {
+    var messages: std.ArrayListUnmanaged(types.TranscriptMessage) = .empty;
+    errdefer {
+        freeTranscriptList(allocator, messages.items);
+        messages.deinit(allocator);
+    }
+
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        if (!std.mem.eql(u8, objectString(obj, "type") orelse "", "response_item")) continue;
+
+        const body = responseBody(obj) orelse continue;
+        const role = messageRole(objectString(body, "role") orelse "") orelse continue;
+        if (role != .user and role != .assistant) continue;
+        const content = contentText(body.get("content") orelse continue) orelse continue;
+        if (role == .user and isNoiseUserText(content)) continue;
+        const timestamp_ms = if (objectString(obj, "timestamp")) |timestamp|
+            parseTimestampMs(timestamp)
+        else
+            0;
+
+        const content_owned = try allocator.dupe(u8, content);
+        errdefer allocator.free(content_owned);
+        try messages.append(allocator, .{
+            .role = role,
+            .content = content_owned,
+            .timestamp_ms = timestamp_ms,
+        });
+    }
+
+    return try messages.toOwnedSlice(allocator);
+}
+
+/// Frees metadata returned by parseMetadata in this provider.
+pub fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
+    allocator.free(meta.session_id);
+    allocator.free(meta.title);
+    allocator.free(meta.project_dir);
+    allocator.free(meta.source_path);
+}
+
+pub fn freeTranscript(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    freeTranscriptList(allocator, messages);
+    allocator.free(messages);
+}
+
+fn initMetadata(allocator: std.mem.Allocator, source_path: []const u8) ParseError!types.SessionMeta {
+    const session_id = try allocator.dupe(u8, "");
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, "");
+    errdefer allocator.free(title);
+    const project_dir = try allocator.dupe(u8, "");
+    errdefer allocator.free(project_dir);
+    const source_path_owned = try allocator.dupe(u8, source_path);
+
+    return .{
+        .provider = .codex,
+        .session_id = session_id,
+        .title = title,
+        .project_dir = project_dir,
+        .source_path = source_path_owned,
+        .resume_kind = .codex_resume,
+    };
+}
+
+fn freeTranscriptList(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    for (messages) |message| {
+        allocator.free(message.content);
+    }
+}
+
+fn parseLine(allocator: std.mem.Allocator, line: []const u8) ParseError!?std.json.Parsed(std.json.Value) {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+}
+
+fn objectString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn sessionBody(obj: std.json.ObjectMap) std.json.ObjectMap {
+    const payload = obj.get("payload") orelse return obj;
+    return if (payload == .object) payload.object else obj;
+}
+
+fn responseBody(obj: std.json.ObjectMap) ?std.json.ObjectMap {
+    const payload = obj.get("payload") orelse return obj;
+    if (payload != .object) return obj;
+    if (!std.mem.eql(u8, objectString(payload.object, "type") orelse "", "message")) return null;
+    return payload.object;
+}
+
+fn contentText(value: std.json.Value) ?[]const u8 {
+    switch (value) {
+        .string => |s| return s,
+        .array => |items| {
+            for (items.items) |item| {
+                if (item != .object) continue;
+                if (objectString(item.object, "text")) |text| return text;
+            }
+        },
+        else => {},
+    }
+    return null;
+}
+
+fn isNoiseUserText(text: []const u8) bool {
+    return std.mem.indexOf(u8, text, "<environment_context>") != null or
+        std.mem.indexOf(u8, text, "AGENTS.md instructions") != null;
+}
+
+fn messageRole(role: []const u8) ?types.MessageRole {
+    if (std.mem.eql(u8, role, "user")) return .user;
+    if (std.mem.eql(u8, role, "assistant")) return .assistant;
+    return null;
+}
+
+fn replaceOwned(allocator: std.mem.Allocator, field: *[]const u8, value: []const u8) ParseError!void {
+    const owned = try allocator.dupe(u8, value);
+    allocator.free(field.*);
+    field.* = owned;
+}
+
+fn parseTimestampMs(timestamp: []const u8) i64 {
+    if (timestamp.len < "0000-00-00T00:00:00Z".len) return 0;
+    if (timestamp[4] != '-' or timestamp[7] != '-' or timestamp[10] != 'T' or
+        timestamp[13] != ':' or timestamp[16] != ':')
+    {
+        return 0;
+    }
+
+    const year: i64 = parseDigits(timestamp[0..4]) orelse return 0;
+    const month: i64 = parseDigits(timestamp[5..7]) orelse return 0;
+    const day: i64 = parseDigits(timestamp[8..10]) orelse return 0;
+    const hour: i64 = parseDigits(timestamp[11..13]) orelse return 0;
+    const minute: i64 = parseDigits(timestamp[14..16]) orelse return 0;
+    const second: i64 = parseDigits(timestamp[17..19]) orelse return 0;
+    if (month < 1 or month > 12 or day < 1 or day > daysInMonth(year, month) or
+        hour > 23 or minute > 59 or second > 59)
+    {
+        return 0;
+    }
+
+    var index: usize = 19;
+    var millisecond: i64 = 0;
+    if (index < timestamp.len and timestamp[index] == '.') {
+        index += 1;
+        const start = index;
+        var scale: i64 = 100;
+        while (index < timestamp.len and std.ascii.isDigit(timestamp[index])) : (index += 1) {
+            if (scale > 0) {
+                millisecond += @as(i64, timestamp[index] - '0') * scale;
+                scale = @divTrunc(scale, 10);
+            }
+        }
+        if (index == start) return 0;
+    }
+
+    const offset_seconds = parseTimezoneOffsetSeconds(timestamp[index..]) orelse return 0;
+    const local_seconds = daysFromCivil(year, month, day) * std.time.s_per_day +
+        hour * std.time.s_per_hour + minute * std.time.s_per_min + second;
+    return (local_seconds - offset_seconds) * std.time.ms_per_s + millisecond;
+}
+
+fn parseDigits(bytes: []const u8) ?i64 {
+    var value: i64 = 0;
+    for (bytes) |byte| {
+        if (byte < '0' or byte > '9') return null;
+        value = value * 10 + byte - '0';
+    }
+    return value;
+}
+
+fn parseTimezoneOffsetSeconds(value: []const u8) ?i64 {
+    if (std.mem.eql(u8, value, "Z")) return 0;
+    if (value.len != 6 or value[3] != ':') return null;
+    if (value[0] != '+' and value[0] != '-') return null;
+
+    const hours = parseDigits(value[1..3]) orelse return null;
+    const minutes = parseDigits(value[4..6]) orelse return null;
+    if (hours > 23 or minutes > 59) return null;
+
+    const offset = hours * std.time.s_per_hour + minutes * std.time.s_per_min;
+    return if (value[0] == '+') offset else -offset;
+}
+
+fn daysInMonth(year: i64, month: i64) i64 {
+    return switch (month) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(year)) 29 else 28,
+        else => 0,
+    };
+}
+
+fn isLeapYear(year: i64) bool {
+    return @mod(year, 4) == 0 and (@mod(year, 100) != 0 or @mod(year, 400) == 0);
+}
+
+fn daysFromCivil(year_in: i64, month: i64, day: i64) i64 {
+    var year = year_in;
+    if (month <= 2) year -= 1;
+    const era = @divFloor(year, 400);
+    const yoe = year - era * 400;
+    const month_adjusted = if (month > 2) month - 3 else month + 9;
+    const doy = @divTrunc(153 * month_adjusted + 2, 5) + day - 1;
+    const doe = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy;
+    return era * 146097 + doe - 719468;
+}
+
+test "ai_history_provider_codex: parses metadata from session_meta and response items" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"session_meta","id":"codex-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00Z"}
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"Fix the renderer crash"}],"timestamp":"2026-05-31T10:01:00Z"}
+        \\{"type":"response_item","role":"assistant","content":[{"type":"output_text","text":"I found the issue."}],"timestamp":"2026-05-31T10:02:00Z"}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.codex/sessions/codex-abc.jsonl", jsonl);
+    defer freeMetadata(allocator, meta);
+    try std.testing.expectEqual(types.ProviderId.codex, meta.provider);
+    try std.testing.expectEqualStrings("codex-abc", meta.session_id);
+    try std.testing.expectEqualStrings("Fix the renderer crash", meta.title);
+    try std.testing.expectEqualStrings("/home/me/project", meta.project_dir);
+    try std.testing.expectEqualStrings("/home/me/.codex/sessions/codex-abc.jsonl", meta.source_path);
+    try std.testing.expectEqual(types.ResumeKind.codex_resume, meta.resume_kind);
+    try std.testing.expectEqual(@as(u32, 2), meta.message_count);
+    try std.testing.expect(meta.created_at_ms > 0);
+    try std.testing.expect(meta.last_active_at_ms >= meta.created_at_ms);
+}
+
+test "ai_history_provider_codex: parses real codex envelope metadata and transcript" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"session_meta","timestamp":"2026-05-31T10:00:00Z","payload":{"id":"codex-abc","cwd":"/home/me/project"}}
+        \\{"type":"response_item","timestamp":"2026-05-31T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix the renderer crash"}]}}
+        \\{"type":"response_item","timestamp":"2026-05-31T10:02:00Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I found the issue."}]}}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.codex/sessions/codex-abc.jsonl", jsonl);
+    defer freeMetadata(allocator, meta);
+    try std.testing.expectEqualStrings("codex-abc", meta.session_id);
+    try std.testing.expectEqualStrings("/home/me/project", meta.project_dir);
+    try std.testing.expectEqualStrings("Fix the renderer crash", meta.title);
+    try std.testing.expectEqual(@as(u32, 2), meta.message_count);
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
+    try std.testing.expectEqualStrings("Fix the renderer crash", messages[0].content);
+    try std.testing.expectEqual(types.MessageRole.assistant, messages[1].role);
+    try std.testing.expectEqualStrings("I found the issue.", messages[1].content);
+}
+
+test "ai_history_provider_codex: parses fractional seconds and timezone offsets" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"response_item","timestamp":"2026-05-31T10:01:00.250Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"First"}]}}
+        \\{"type":"response_item","timestamp":"2026-05-31T18:02:00+08:00","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Second"}]}}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqual(@as(i64, 1780221660250), messages[0].timestamp_ms);
+    try std.testing.expectEqual(@as(i64, 1780221720000), messages[1].timestamp_ms);
+}
+
+test "ai_history_provider_codex: invalid timestamp dates are ignored" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"response_item","timestamp":"2026-02-31T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Bad date"}]}}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 1), messages.len);
+    try std.testing.expectEqual(@as(i64, 0), messages[0].timestamp_ms);
+}
+
+test "ai_history_provider_codex: malformed json is skipped but oom propagates" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"Skipped malformed"}],"timestamp":"2026-05-31T10:00:00Z"
+        \\{"type":"response_item","role":"assistant","content":[{"type":"output_text","text":"Also kept"}],"timestamp":"2026-05-31T10:00:01Z"}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 1), messages.len);
+    try std.testing.expectEqualStrings("Also kept", messages[0].content);
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, parseTranscript(failing.allocator(), jsonl));
+}
+
+test "ai_history_provider_codex: transcript skips environment and AGENTS noise" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"<environment_context>cwd</environment_context>"}],"timestamp":"2026-05-31T10:00:00Z"}
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /tmp/project"}],"timestamp":"2026-05-31T10:00:01Z"}
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"Summarize this repo"}],"timestamp":"2026-05-31T10:01:00Z"}
+        \\{"type":"response_item","role":"assistant","content":[{"type":"output_text","text":"It is a terminal emulator."}],"timestamp":"2026-05-31T10:02:00Z"}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
+    try std.testing.expectEqualStrings("Summarize this repo", messages[0].content);
+    try std.testing.expectEqual(types.MessageRole.assistant, messages[1].role);
+    try std.testing.expectEqualStrings("It is a terminal emulator.", messages[1].content);
+}

--- a/src/ai_history_resume.zig
+++ b/src/ai_history_resume.zig
@@ -1,0 +1,269 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const ResumeError = error{ MissingProjectDir, UnsupportedProvider, CommandTooLong };
+
+pub fn resumeCommand(meta: types.SessionMeta, out: []u8) ResumeError![]const u8 {
+    if (meta.project_dir.len == 0) return error.MissingProjectDir;
+    const prefix = switch (meta.resume_kind) {
+        .codex_resume => "codex resume ",
+        .claude_resume => "claude --resume ",
+        .unavailable => return error.UnsupportedProvider,
+    };
+
+    var pos: usize = 0;
+    try append(out, &pos, prefix);
+    if (isShellSafeBareWord(meta.session_id)) {
+        try append(out, &pos, meta.session_id);
+    } else {
+        try appendShellSingleQuote(out, &pos, meta.session_id);
+    }
+    return out[0..pos];
+}
+
+pub fn posixCdThen(command: []const u8, project_dir: []const u8, out: []u8) ResumeError![]const u8 {
+    if (project_dir.len == 0) return error.MissingProjectDir;
+    var prefix_len: usize = 0;
+    try addLen(&prefix_len, "cd ".len);
+    try addLen(&prefix_len, try shellSingleQuoteLen(project_dir));
+    try addLen(&prefix_len, " && ".len);
+    if (prefix_len > out.len or command.len > out.len - prefix_len) return error.CommandTooLong;
+
+    copyPossiblyOverlapping(out[prefix_len..][0..command.len], command);
+
+    var pos: usize = 0;
+    try append(out, &pos, "cd ");
+    try appendShellSingleQuote(out, &pos, project_dir);
+    try append(out, &pos, " && ");
+    return out[0 .. pos + command.len];
+}
+
+pub fn posixDirectoryTest(project_dir: []const u8, out: []u8) ResumeError![]const u8 {
+    if (project_dir.len == 0) return error.MissingProjectDir;
+    var pos: usize = 0;
+    try append(out, &pos, "test -d ");
+    try appendShellSingleQuote(out, &pos, project_dir);
+    return out[0..pos];
+}
+
+fn append(out: []u8, pos: *usize, value: []const u8) ResumeError!void {
+    if (value.len > out.len - pos.*) return error.CommandTooLong;
+    @memcpy(out[pos.*..][0..value.len], value);
+    pos.* += value.len;
+}
+
+fn appendByte(out: []u8, pos: *usize, byte: u8) ResumeError!void {
+    if (pos.* >= out.len) return error.CommandTooLong;
+    out[pos.*] = byte;
+    pos.* += 1;
+}
+
+fn appendShellSingleQuote(out: []u8, pos: *usize, value: []const u8) ResumeError!void {
+    try appendByte(out, pos, '\'');
+    for (value) |ch| {
+        if (ch == '\'') {
+            try append(out, pos, "'\\''");
+        } else {
+            try appendByte(out, pos, ch);
+        }
+    }
+    try appendByte(out, pos, '\'');
+}
+
+fn shellSingleQuoteLen(value: []const u8) ResumeError!usize {
+    var len: usize = 2;
+    for (value) |ch| {
+        const extra: usize = if (ch == '\'') 4 else 1;
+        try addLen(&len, extra);
+    }
+    return len;
+}
+
+fn addLen(len: *usize, extra: usize) ResumeError!void {
+    if (extra > std.math.maxInt(usize) - len.*) return error.CommandTooLong;
+    len.* += extra;
+}
+
+fn copyPossiblyOverlapping(dest: []u8, source: []const u8) void {
+    if (dest.len == 0) return;
+    if (@intFromPtr(dest.ptr) <= @intFromPtr(source.ptr)) {
+        std.mem.copyForwards(u8, dest, source);
+    } else {
+        std.mem.copyBackwards(u8, dest, source);
+    }
+}
+
+fn isShellSafeBareWord(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        switch (ch) {
+            'a'...'z', 'A'...'Z', '0'...'9', '_', '-', '.', '/', ':', '@', '%' => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+test "ai_history_resume: builds provider resume commands" {
+    var out: [128]u8 = undefined;
+    const codex: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .project_dir = "/home/me/project",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectEqualStrings("codex resume abc", try resumeCommand(codex, &out));
+
+    const claude: types.SessionMeta = .{
+        .provider = .claude,
+        .session_id = "xyz",
+        .title = "B",
+        .project_dir = "/home/me/project",
+        .source_path = "b.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    try std.testing.expectEqualStrings("claude --resume xyz", try resumeCommand(claude, &out));
+}
+
+test "ai_history_resume: quotes unsafe session ids" {
+    var out: [256]u8 = undefined;
+    const with_space: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc def",
+        .title = "A",
+        .project_dir = "/home/me/project",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectEqualStrings("codex resume 'abc def'", try resumeCommand(with_space, &out));
+
+    const with_quote: types.SessionMeta = .{
+        .provider = .claude,
+        .session_id = "it's-here",
+        .title = "B",
+        .project_dir = "/home/me/project",
+        .source_path = "b.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    try std.testing.expectEqualStrings("claude --resume 'it'\\''s-here'", try resumeCommand(with_quote, &out));
+
+    const with_metacharacters: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc;$(touch /tmp/pwn)",
+        .title = "C",
+        .project_dir = "/home/me/project",
+        .source_path = "c.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectEqualStrings("codex resume 'abc;$(touch /tmp/pwn)'", try resumeCommand(with_metacharacters, &out));
+}
+
+test "ai_history_resume: refuses missing project dir" {
+    var out: [128]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectError(error.MissingProjectDir, resumeCommand(meta, &out));
+}
+
+test "ai_history_resume: unavailable resume kind is unsupported" {
+    var out: [128]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .project_dir = "/home/me/project",
+        .source_path = "a.jsonl",
+        .resume_kind = .unavailable,
+    };
+    try std.testing.expectError(error.UnsupportedProvider, resumeCommand(meta, &out));
+}
+
+test "ai_history_resume: missing project dir takes precedence over unavailable resume kind" {
+    var out: [128]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "a.jsonl",
+        .resume_kind = .unavailable,
+    };
+    try std.testing.expectError(error.MissingProjectDir, resumeCommand(meta, &out));
+}
+
+test "ai_history_resume: reports command too long for small output buffers" {
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .project_dir = "/home/me/project",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+
+    var resume_out: [8]u8 = undefined;
+    try std.testing.expectError(error.CommandTooLong, resumeCommand(meta, &resume_out));
+
+    var dir_out: [8]u8 = undefined;
+    try std.testing.expectError(error.CommandTooLong, posixDirectoryTest("/home/me/project", &dir_out));
+    try std.testing.expectError(error.CommandTooLong, posixCdThen("codex resume abc", "/home/me/project", &dir_out));
+}
+
+test "ai_history_resume: quotes project dir before shell commands" {
+    var out: [256]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "test -d '/home/me/it'\\''s here'",
+        try posixDirectoryTest("/home/me/it's here", &out),
+    );
+    try std.testing.expectEqualStrings(
+        "cd '/home/me/space dir' && codex resume abc",
+        try posixCdThen("codex resume abc", "/home/me/space dir", &out),
+    );
+}
+
+test "ai_history_resume: cd then preserves command from same output buffer" {
+    var out: [256]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc def",
+        .title = "A",
+        .project_dir = "/home/me/space dir",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+
+    const resume_cmd = try resumeCommand(meta, &out);
+    const full = try posixCdThen(resume_cmd, meta.project_dir, &out);
+
+    try std.testing.expectEqualStrings(
+        "cd '/home/me/space dir' && codex resume 'abc def'",
+        full,
+    );
+}
+
+test "ai_history_resume: long project dir uses caller output capacity" {
+    var project_dir_buf: [600]u8 = undefined;
+    @memset(&project_dir_buf, 'a');
+    project_dir_buf[0] = '/';
+
+    var out: [700]u8 = undefined;
+    const test_command = try posixDirectoryTest(&project_dir_buf, &out);
+
+    try std.testing.expectEqual(@as(usize, "test -d ".len + project_dir_buf.len + 2), test_command.len);
+    try std.testing.expectEqualStrings("test -d '", test_command[0.."test -d '".len]);
+    try std.testing.expectEqualStrings(project_dir_buf[0..], test_command["test -d '".len .. test_command.len - 1]);
+    try std.testing.expectEqual(@as(u8, '\''), test_command[test_command.len - 1]);
+
+    const cd_command = try posixCdThen("codex resume abc", &project_dir_buf, &out);
+
+    try std.testing.expectEqual(@as(usize, "cd ".len + project_dir_buf.len + 2 + " && codex resume abc".len), cd_command.len);
+    try std.testing.expectEqualStrings("cd '", cd_command[0.."cd '".len]);
+    try std.testing.expectEqualStrings(project_dir_buf[0..], cd_command["cd '".len .. cd_command.len - " && codex resume abc".len - 1]);
+    try std.testing.expectEqualStrings("' && codex resume abc", cd_command[cd_command.len - "' && codex resume abc".len ..]);
+}

--- a/src/ai_history_resume.zig
+++ b/src/ai_history_resume.zig
@@ -46,6 +46,38 @@ pub fn posixDirectoryTest(project_dir: []const u8, out: []u8) ResumeError![]cons
     return out[0..pos];
 }
 
+pub fn checkedPosixResume(command: []const u8, project_dir: []const u8, out: []u8) ResumeError![]const u8 {
+    if (project_dir.len == 0) return error.MissingProjectDir;
+    var pos: usize = 0;
+    try append(out, &pos, "test -d ");
+    try appendShellSingleQuote(out, &pos, project_dir);
+    try append(out, &pos, " && cd ");
+    try appendShellSingleQuote(out, &pos, project_dir);
+    try append(out, &pos, " && ");
+    try append(out, &pos, command);
+    return out[0..pos];
+}
+
+pub fn checkedPowerShellResume(meta: types.SessionMeta, out: []u8) ResumeError![]const u8 {
+    if (meta.project_dir.len == 0) return error.MissingProjectDir;
+    var pos: usize = 0;
+    try append(out, &pos, "if (Test-Path -LiteralPath ");
+    try appendPowerShellSingleQuote(out, &pos, meta.project_dir);
+    try append(out, &pos, " -PathType Container) { Set-Location -LiteralPath ");
+    try appendPowerShellSingleQuote(out, &pos, meta.project_dir);
+    try append(out, &pos, "; ");
+    switch (meta.resume_kind) {
+        .codex_resume => try append(out, &pos, "codex resume "),
+        .claude_resume => try append(out, &pos, "claude --resume "),
+        .unavailable => return error.UnsupportedProvider,
+    }
+    try appendPowerShellSingleQuote(out, &pos, meta.session_id);
+    try append(out, &pos, " } else { Write-Error ");
+    try appendPowerShellSingleQuote(out, &pos, "AI History resume failed: project path unavailable");
+    try append(out, &pos, " }");
+    return out[0..pos];
+}
+
 fn append(out: []u8, pos: *usize, value: []const u8) ResumeError!void {
     if (value.len > out.len - pos.*) return error.CommandTooLong;
     @memcpy(out[pos.*..][0..value.len], value);
@@ -63,6 +95,18 @@ fn appendShellSingleQuote(out: []u8, pos: *usize, value: []const u8) ResumeError
     for (value) |ch| {
         if (ch == '\'') {
             try append(out, pos, "'\\''");
+        } else {
+            try appendByte(out, pos, ch);
+        }
+    }
+    try appendByte(out, pos, '\'');
+}
+
+fn appendPowerShellSingleQuote(out: []u8, pos: *usize, value: []const u8) ResumeError!void {
+    try appendByte(out, pos, '\'');
+    for (value) |ch| {
+        if (ch == '\'') {
+            try append(out, pos, "''");
         } else {
             try appendByte(out, pos, ch);
         }
@@ -225,6 +269,78 @@ test "ai_history_resume: quotes project dir before shell commands" {
         "cd '/home/me/space dir' && codex resume abc",
         try posixCdThen("codex resume abc", "/home/me/space dir", &out),
     );
+}
+
+test "ai_history_resume: local shell command checks directory before resume" {
+    var resume_buf: [128]u8 = undefined;
+    var out: [512]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .project_dir = "/home/me/project",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const resume_cmd = try resumeCommand(meta, &resume_buf);
+    try std.testing.expectEqualStrings(
+        "test -d '/home/me/project' && cd '/home/me/project' && codex resume abc",
+        try checkedPosixResume(resume_cmd, meta.project_dir, &out),
+    );
+}
+
+test "ai_history_resume: checked POSIX resume quotes single quotes and reports missing or long commands" {
+    var out: [512]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "test -d '/home/me/it'\\''s/project' && cd '/home/me/it'\\''s/project' && codex resume 'abc def'",
+        try checkedPosixResume("codex resume 'abc def'", "/home/me/it's/project", &out),
+    );
+
+    try std.testing.expectError(error.MissingProjectDir, checkedPosixResume("codex resume abc", "", &out));
+
+    var tiny: [16]u8 = undefined;
+    try std.testing.expectError(error.CommandTooLong, checkedPosixResume("codex resume abc", "/home/me/project", &tiny));
+}
+
+test "ai_history_resume: checked PowerShell resume checks directory before resume" {
+    var out: [512]u8 = undefined;
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc def",
+        .title = "A",
+        .project_dir = "C:\\Users\\me\\it's project",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectEqualStrings(
+        "if (Test-Path -LiteralPath 'C:\\Users\\me\\it''s project' -PathType Container) { Set-Location -LiteralPath 'C:\\Users\\me\\it''s project'; codex resume 'abc def' } else { Write-Error 'AI History resume failed: project path unavailable' }",
+        try checkedPowerShellResume(meta, &out),
+    );
+}
+
+test "ai_history_resume: checked PowerShell resume reports missing unsupported and long commands" {
+    var out: [512]u8 = undefined;
+    const missing: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .source_path = "a.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    try std.testing.expectError(error.MissingProjectDir, checkedPowerShellResume(missing, &out));
+
+    const unsupported: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "abc",
+        .title = "A",
+        .project_dir = "C:\\Project",
+        .source_path = "a.jsonl",
+        .resume_kind = .unavailable,
+    };
+    try std.testing.expectError(error.UnsupportedProvider, checkedPowerShellResume(unsupported, &out));
+
+    var tiny: [16]u8 = undefined;
+    try std.testing.expectError(error.CommandTooLong, checkedPowerShellResume(unsupported, &tiny));
 }
 
 test "ai_history_resume: cd then preserves command from same output buffer" {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -1661,26 +1661,34 @@ test "ai_history_session: scanLocalFilesystem reuses unchanged cached metadata" 
         ,
     });
 
-    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const home = try tmp.dir.realpath(".", &home_buf);
-    const path = try std.fs.path.join(allocator, &.{ home, ".codex", "sessions", "a.jsonl" });
-    defer allocator.free(path);
-    const stat = try tmp.dir.statFile(".codex/sessions/a.jsonl");
     const cached_meta: types.SessionMeta = .{
         .provider = .codex,
         .session_id = "codex-cached",
         .title = "Cached title",
         .project_dir = "/tmp/cached",
-        .source_path = path,
+        .source_path = "cached.jsonl",
         .resume_kind = .codex_resume,
         .message_count = 1,
     };
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const first = try scanLocalFilesystemWithCache(allocator, .{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+        .providers = .{ .codex = true, .claude = false },
+    }, home, .{}, null);
+    defer freeScanResult(allocator, first);
+    try std.testing.expectEqual(@as(usize, 1), first.cache_update.records.len);
+    const first_record = first.cache_update.records[0];
+
     const records = [_]ai_history_cache.CacheRecord{.{
-        .source_id = "local",
-        .provider = .codex,
-        .root_path = "",
-        .source_path = path,
-        .stamp = .{ .size = stat.size, .mtime_ns = stat.mtime },
+        .source_id = first_record.source_id,
+        .provider = first_record.provider,
+        .root_path = first_record.root_path,
+        .source_path = first_record.source_path,
+        .stamp = first_record.stamp,
         .meta = cached_meta,
     }};
 

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -1,0 +1,230 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+const source_mod = @import("ai_history_source.zig");
+
+pub const LoadState = enum { idle, scanning, ready, failed };
+
+pub const Session = struct {
+    /// Allocator used for row storage. Do not change while rows are live.
+    allocator: std.mem.Allocator,
+    /// Source is stored shallowly; nested string slices must outlive Session.
+    source: source_mod.Source,
+    state: LoadState = .idle,
+    /// Rows shallow-copy SessionMeta values. All string slices inside each row
+    /// are borrowed and must outlive these rows until replacement or deinit.
+    rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
+    selected: usize = 0,
+    filter: [128]u8 = undefined,
+    filter_len: usize = 0,
+    status: []const u8 = "",
+
+    pub fn init(allocator: std.mem.Allocator, source: source_mod.Source) Session {
+        return .{
+            .allocator = allocator,
+            .source = source,
+        };
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.rows.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn beginScan(self: *Session) void {
+        self.state = .scanning;
+        self.status = "Scanning";
+    }
+
+    /// Replaces rows with shallow copies of `rows`. SessionMeta string slices
+    /// remain borrowed; callers must keep them alive until replacement/deinit.
+    pub fn replaceRows(self: *Session, rows: []const types.SessionMeta) !void {
+        var next: std.ArrayListUnmanaged(types.SessionMeta) = .empty;
+        errdefer next.deinit(self.allocator);
+
+        try next.appendSlice(self.allocator, rows);
+        std.mem.sort(types.SessionMeta, next.items, {}, types.lessRecent);
+
+        self.rows.deinit(self.allocator);
+        self.rows = next;
+        self.selected = 0;
+        self.state = .ready;
+        self.status = "Ready";
+    }
+
+    pub fn setFilter(self: *Session, text: []const u8) void {
+        self.filter_len = @min(text.len, self.filter.len);
+        @memcpy(self.filter[0..self.filter_len], text[0..self.filter_len]);
+        self.selected = 0;
+    }
+
+    pub fn visibleCount(self: *const Session) usize {
+        var count: usize = 0;
+        const query = self.filter[0..self.filter_len];
+        for (self.rows.items) |row| {
+            if (types.metadataMatches(row, query)) count += 1;
+        }
+        return count;
+    }
+
+    /// Returns a shallow SessionMeta copy. Its string slices are borrowed from
+    /// the stored rows and follow the same replacement/deinit lifetime.
+    pub fn selectedVisible(self: *const Session) ?types.SessionMeta {
+        const query = self.filter[0..self.filter_len];
+        var visible_index: usize = 0;
+        for (self.rows.items) |row| {
+            if (!types.metadataMatches(row, query)) continue;
+            if (visible_index == self.selected) return row;
+            visible_index += 1;
+        }
+        return null;
+    }
+};
+
+test "ai_history_session: replacing rows sorts by last active time" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "old",
+            .title = "Old",
+            .source_path = "old.jsonl",
+            .resume_kind = .codex_resume,
+            .last_active_at_ms = 10,
+        },
+        .{
+            .provider = .codex,
+            .session_id = "new",
+            .title = "New",
+            .source_path = "new.jsonl",
+            .resume_kind = .codex_resume,
+            .last_active_at_ms = 20,
+        },
+    };
+
+    try session.replaceRows(&rows);
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqualStrings("new", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: metadata filter controls visible rows" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "a",
+            .title = "Renderer",
+            .source_path = "a.jsonl",
+            .resume_kind = .codex_resume,
+        },
+        .{
+            .provider = .claude,
+            .session_id = "b",
+            .title = "Docs",
+            .project_dir = "/repo/docs",
+            .source_path = "b.jsonl",
+            .resume_kind = .claude_resume,
+        },
+    };
+
+    try session.replaceRows(&rows);
+    session.setFilter("docs");
+
+    try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
+    const selected = session.selectedVisible() orelse return error.ExpectedSelectedSession;
+    try std.testing.expectEqualStrings("b", selected.session_id);
+}
+
+test "ai_history_session: replace rows preserves existing state on allocation failure" {
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 1,
+    });
+    var session = Session.init(failing_allocator.allocator(), .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const existing = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "kept",
+            .title = "Kept",
+            .source_path = "kept.jsonl",
+            .resume_kind = .codex_resume,
+            .last_active_at_ms = 10,
+        },
+    };
+    try session.replaceRows(&existing);
+    session.status = "Existing";
+
+    const replacement = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "new-a",
+            .title = "New A",
+            .source_path = "new-a.jsonl",
+            .resume_kind = .codex_resume,
+            .last_active_at_ms = 30,
+        },
+        .{
+            .provider = .codex,
+            .session_id = "new-b",
+            .title = "New B",
+            .source_path = "new-b.jsonl",
+            .resume_kind = .codex_resume,
+            .last_active_at_ms = 20,
+        },
+    };
+
+    try std.testing.expectError(error.OutOfMemory, session.replaceRows(&replacement));
+
+    try std.testing.expect(failing_allocator.has_induced_failure);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("kept", session.rows.items[0].session_id);
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqualStrings("Existing", session.status);
+}
+
+test "ai_history_session: selected visible returns null when selection is unavailable" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    try std.testing.expectEqual(null, session.selectedVisible());
+
+    const rows = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "a",
+            .title = "Renderer",
+            .source_path = "a.jsonl",
+            .resume_kind = .codex_resume,
+        },
+    };
+    try session.replaceRows(&rows);
+
+    session.setFilter("missing");
+    try std.testing.expectEqual(@as(usize, 0), session.visibleCount());
+    try std.testing.expectEqual(null, session.selectedVisible());
+
+    session.setFilter("");
+    session.selected = 1;
+    try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
+    try std.testing.expectEqual(null, session.selectedVisible());
+}
+
+test "ai_history_session: filter truncates to fixed buffer length" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    var long_filter: [130]u8 = undefined;
+    @memset(&long_filter, 'x');
+    long_filter[128] = 'y';
+    long_filter[129] = 'z';
+
+    session.setFilter(&long_filter);
+
+    try std.testing.expectEqual(@as(usize, 128), session.filter_len);
+    try std.testing.expectEqualSlices(u8, long_filter[0..128], session.filter[0..session.filter_len]);
+}

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("ai_history_types.zig");
 const source_mod = @import("ai_history_source.zig");
+const session_persist = @import("session_persist.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
 
@@ -28,6 +29,27 @@ pub const Session = struct {
     pub fn deinit(self: *Session) void {
         self.rows.deinit(self.allocator);
         self.* = undefined;
+    }
+
+    pub fn persistSnap(self: *const Session, allocator: std.mem.Allocator) !session_persist.AiHistorySnap {
+        const source_id = try allocator.dupe(u8, self.source.id);
+        errdefer allocator.free(source_id);
+
+        const target_kind = try allocator.dupe(u8, switch (self.source.target) {
+            .local => "local",
+            .wsl => "wsl",
+            .ssh => "ssh",
+        });
+        errdefer allocator.free(target_kind);
+
+        const target_name = try allocator.dupe(u8, self.source.name);
+        errdefer allocator.free(target_name);
+
+        return .{
+            .source_id = source_id,
+            .target_kind = target_kind,
+            .target_name = target_name,
+        };
     }
 
     pub fn beginScan(self: *Session) void {
@@ -107,6 +129,36 @@ test "ai_history_session: replacing rows sorts by last active time" {
 
     try std.testing.expectEqual(LoadState.ready, session.state);
     try std.testing.expectEqualStrings("new", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: persistSnap duplicates source identity" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local-codex", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const snap = try session.persistSnap(allocator);
+    defer {
+        allocator.free(snap.source_id);
+        allocator.free(snap.target_kind);
+        allocator.free(snap.target_name);
+    }
+
+    try std.testing.expectEqualStrings("local-codex", snap.source_id);
+    try std.testing.expectEqualStrings("local", snap.target_kind);
+    try std.testing.expectEqualStrings("Local", snap.target_name);
+    try std.testing.expect(snap.source_id.ptr != session.source.id.ptr);
+    try std.testing.expect(snap.target_name.ptr != session.source.name.ptr);
+}
+
+test "ai_history_session: persistSnap frees partial duplicates on allocation failure" {
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 1,
+    });
+    var session = Session.init(failing_allocator.allocator(), .{ .id = "local-codex", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    try std.testing.expectError(error.OutOfMemory, session.persistSnap(failing_allocator.allocator()));
+    try std.testing.expect(failing_allocator.has_induced_failure);
 }
 
 test "ai_history_session: metadata filter controls visible rows" {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -6,6 +6,7 @@ const codex_provider = @import("ai_history_provider_codex.zig");
 const claude_provider = @import("ai_history_provider_claude.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
+pub const TranscriptState = enum { idle, loading, ready, failed };
 pub const MAX_METADATA_FILE_BYTES = 2 * 1024 * 1024;
 pub const MAX_SCAN_METADATA_FILES: usize = 256;
 pub const MAX_SCAN_METADATA_BYTES: u64 = 48 * 1024 * 1024;
@@ -64,9 +65,14 @@ pub const Session = struct {
     /// Rows own duplicated SessionMeta string fields.
     rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
     selected: usize = 0,
+    list_offset: usize = 0,
     filter: [128]u8 = undefined,
     filter_len: usize = 0,
     status: []const u8 = "",
+    transcript_state: TranscriptState = .idle,
+    transcript_status: []const u8 = "",
+    transcript_provider: ?types.ProviderId = null,
+    transcript: []types.TranscriptMessage = &.{},
 
     pub fn init(allocator: std.mem.Allocator, source: source_mod.Source) Session {
         return .{
@@ -84,6 +90,7 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        self.clearTranscript();
         freeRows(self.allocator, self.rows.items);
         self.rows.deinit(self.allocator);
         if (self.source_owned) {
@@ -137,6 +144,8 @@ pub const Session = struct {
         self.rows.deinit(self.allocator);
         self.rows = next;
         self.selected = 0;
+        self.list_offset = 0;
+        self.clearTranscript();
         self.state = .ready;
         self.status = "Ready";
     }
@@ -154,15 +163,111 @@ pub const Session = struct {
         self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
     }
 
-    pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) ![]types.TranscriptMessage {
+    pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) !void {
         const selected = self.selectedVisible() orelse return error.NoSelection;
-        return try host.loadTranscript(host.ctx, self.allocator, selected);
+        self.clearTranscript();
+        self.transcript_state = .loading;
+        self.transcript_status = "Loading transcript";
+        errdefer {
+            self.transcript_state = .failed;
+            self.transcript_status = "Transcript failed";
+        }
+        self.transcript = try host.loadTranscript(host.ctx, self.allocator, selected);
+        self.transcript_provider = selected.provider;
+        self.transcript_state = .ready;
+        self.transcript_status = "Transcript ready";
     }
 
     pub fn setFilter(self: *Session, text: []const u8) void {
         self.filter_len = @min(text.len, self.filter.len);
         @memcpy(self.filter[0..self.filter_len], text[0..self.filter_len]);
         self.selected = 0;
+        self.list_offset = 0;
+        self.clearTranscript();
+    }
+
+    pub fn appendFilterBytes(self: *Session, bytes: []const u8) void {
+        if (bytes.len == 0 or bytes.len > self.filter.len - self.filter_len) return;
+        @memcpy(self.filter[self.filter_len..][0..bytes.len], bytes);
+        self.filter_len += bytes.len;
+        self.selected = 0;
+        self.list_offset = 0;
+        self.clearTranscript();
+    }
+
+    pub fn backspaceFilter(self: *Session) void {
+        if (self.filter_len == 0) return;
+        self.filter_len = previousUtf8Boundary(self.filter[0..self.filter_len], self.filter_len);
+        self.selected = 0;
+        self.list_offset = 0;
+        self.clearTranscript();
+    }
+
+    pub fn moveSelection(self: *Session, delta: isize) void {
+        const count = self.visibleCount();
+        if (count == 0) {
+            self.selected = 0;
+            self.list_offset = 0;
+            self.clearTranscript();
+            return;
+        }
+        const old = @min(self.selected, count - 1);
+        const next = if (delta < 0)
+            old - @min(old, @as(usize, @intCast(-delta)))
+        else
+            @min(count - 1, old + @as(usize, @intCast(delta)));
+        if (next != self.selected) self.clearTranscript();
+        self.selected = next;
+    }
+
+    pub fn selectVisibleIndex(self: *Session, index: usize) void {
+        const count = self.visibleCount();
+        if (count == 0) {
+            self.selected = 0;
+            self.list_offset = 0;
+            self.clearTranscript();
+            return;
+        }
+        const next = @min(index, count - 1);
+        if (next != self.selected) self.clearTranscript();
+        self.selected = next;
+        if (self.list_offset > next) self.list_offset = next;
+    }
+
+    pub fn ensureSelectionVisible(self: *Session, max_visible_rows: usize) void {
+        const count = self.visibleCount();
+        if (count == 0 or max_visible_rows == 0) {
+            self.list_offset = 0;
+            return;
+        }
+
+        self.selected = @min(self.selected, count - 1);
+        const window_rows = @min(max_visible_rows, count);
+        if (self.selected < self.list_offset) {
+            self.list_offset = self.selected;
+        } else if (self.selected >= self.list_offset + window_rows) {
+            self.list_offset = self.selected + 1 - window_rows;
+        }
+
+        const max_offset = count - window_rows;
+        self.list_offset = @min(self.list_offset, max_offset);
+    }
+
+    pub fn listWindowStart(self: *const Session, max_visible_rows: usize) usize {
+        const count = self.visibleCount();
+        if (count == 0 or max_visible_rows == 0) return 0;
+        const window_rows = @min(max_visible_rows, count);
+        return @min(self.list_offset, count - window_rows);
+    }
+
+    pub fn clearTranscript(self: *Session) void {
+        if (self.transcript_provider) |provider| {
+            freeTranscript(self.allocator, provider, self.transcript);
+        }
+        self.transcript = &.{};
+        self.transcript_provider = null;
+        self.transcript_state = .idle;
+        self.transcript_status = "";
     }
 
     pub fn visibleCount(self: *const Session) usize {
@@ -187,6 +292,13 @@ pub const Session = struct {
         return null;
     }
 };
+
+fn previousUtf8Boundary(bytes: []const u8, from: usize) usize {
+    if (from == 0) return 0;
+    var idx = from - 1;
+    while (idx > 0 and (bytes[idx] & 0b1100_0000) == 0b1000_0000) : (idx -= 1) {}
+    return idx;
+}
 
 pub fn scanLocalFilesystem(
     allocator: std.mem.Allocator,
@@ -550,6 +662,30 @@ fn freeSlice(allocator: std.mem.Allocator, value: []const u8) void {
     if (value.len > 0) allocator.free(value);
 }
 
+const TestTranscriptHost = struct {
+    pub fn scannerHost(self: *TestTranscriptHost) ScannerHost {
+        return .{
+            .ctx = self,
+            .scan = scan,
+            .loadTranscript = loadTranscript,
+        };
+    }
+
+    fn scan(_: *anyopaque, allocator: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+        return .{ .rows = try allocator.alloc(types.SessionMeta, 0) };
+    }
+
+    fn loadTranscript(_: *anyopaque, allocator: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+        const messages = try allocator.alloc(types.TranscriptMessage, 1);
+        errdefer allocator.free(messages);
+        messages[0] = .{
+            .role = .user,
+            .content = try allocator.dupe(u8, "hello"),
+        };
+        return messages;
+    }
+};
+
 test "ai_history_session: replacing rows sorts by last active time" {
     var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
     defer session.deinit();
@@ -699,6 +835,37 @@ test "ai_history_session: metadata filter controls visible rows" {
     try std.testing.expectEqualStrings("b", selected.session_id);
 }
 
+test "ai_history_session: loading selected transcript stores and clears owned messages" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{
+        .{
+            .provider = .codex,
+            .session_id = "a",
+            .title = "Renderer",
+            .source_path = "a.jsonl",
+            .resume_kind = .codex_resume,
+        },
+    };
+    try session.replaceRows(&rows);
+
+    var host_state = TestTranscriptHost{};
+    const host = host_state.scannerHost();
+    try session.loadSelectedTranscript(host);
+
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(types.ProviderId.codex, session.transcript_provider.?);
+    try std.testing.expectEqual(@as(usize, 1), session.transcript.len);
+    try std.testing.expectEqualStrings("hello", session.transcript[0].content);
+
+    try session.replaceRows(&.{});
+    try std.testing.expectEqual(TranscriptState.idle, session.transcript_state);
+    try std.testing.expectEqual(@as(?types.ProviderId, null), session.transcript_provider);
+    try std.testing.expectEqual(@as(usize, 0), session.transcript.len);
+}
+
 test "ai_history_session: replace rows preserves existing state on allocation failure" {
     var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
         .fail_index = 4,
@@ -772,6 +939,32 @@ test "ai_history_session: selected visible returns null when selection is unavai
     session.selected = 1;
     try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
     try std.testing.expectEqual(null, session.selectedVisible());
+}
+
+test "ai_history_session: list offset keeps selected row in rendered window" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{
+        .{ .provider = .codex, .session_id = "a", .title = "A", .source_path = "a.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 4 },
+        .{ .provider = .codex, .session_id = "b", .title = "B", .source_path = "b.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 3 },
+        .{ .provider = .codex, .session_id = "c", .title = "C", .source_path = "c.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 2 },
+        .{ .provider = .codex, .session_id = "d", .title = "D", .source_path = "d.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 1 },
+    };
+    try session.replaceRows(&rows);
+
+    session.moveSelection(3);
+    session.ensureSelectionVisible(2);
+    try std.testing.expectEqual(@as(usize, 3), session.selected);
+    try std.testing.expectEqual(@as(usize, 2), session.listWindowStart(2));
+
+    session.moveSelection(-2);
+    session.ensureSelectionVisible(2);
+    try std.testing.expectEqual(@as(usize, 1), session.selected);
+    try std.testing.expectEqual(@as(usize, 1), session.listWindowStart(2));
+
+    session.setFilter("A");
+    try std.testing.expectEqual(@as(usize, 0), session.listWindowStart(2));
 }
 
 test "ai_history_session: filter truncates to fixed buffer length" {
@@ -882,7 +1075,7 @@ test "ai_history_session: scan host rows are owned after provider result is free
     try std.testing.expectEqualStrings("/tmp/a.jsonl", session.rows.items[0].source_path);
 }
 
-test "ai_history_session: loadSelectedTranscript returns fake transcript for selected row" {
+test "ai_history_session: loadSelectedTranscript stores fake transcript for selected row" {
     const allocator = std.testing.allocator;
     var fake = struct {
         fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
@@ -899,7 +1092,8 @@ test "ai_history_session: loadSelectedTranscript returns fake transcript for sel
         fn load(_: *anyopaque, alloc: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
             try std.testing.expectEqualStrings("abc", meta.session_id);
             const messages = try alloc.alloc(types.TranscriptMessage, 1);
-            messages[0] = .{ .role = .user, .content = "hello" };
+            errdefer alloc.free(messages);
+            messages[0] = .{ .role = .user, .content = try alloc.dupe(u8, "hello") };
             return messages;
         }
     }{};
@@ -908,12 +1102,12 @@ test "ai_history_session: loadSelectedTranscript returns fake transcript for sel
     const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
     try session.scanNow(host);
 
-    const transcript = try session.loadSelectedTranscript(host);
-    defer allocator.free(transcript);
+    try session.loadSelectedTranscript(host);
 
-    try std.testing.expectEqual(@as(usize, 1), transcript.len);
-    try std.testing.expectEqual(types.MessageRole.user, transcript[0].role);
-    try std.testing.expectEqualStrings("hello", transcript[0].content);
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(@as(usize, 1), session.transcript.len);
+    try std.testing.expectEqual(types.MessageRole.user, session.transcript[0].role);
+    try std.testing.expectEqualStrings("hello", session.transcript[0].content);
 }
 
 test "ai_history_session: loadSelectedTranscript returns NoSelection without visible row" {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -4,6 +4,8 @@ const source_mod = @import("ai_history_source.zig");
 const session_persist = @import("session_persist.zig");
 const codex_provider = @import("ai_history_provider_codex.zig");
 const claude_provider = @import("ai_history_provider_claude.zig");
+const remote_file = @import("platform/remote_file.zig");
+const ssh_connection = @import("ssh_connection.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
 pub const TranscriptState = enum { idle, loading, ready, failed };
@@ -34,6 +36,11 @@ pub const ScannerHost = struct {
     loadTranscript: *const fn (*anyopaque, std.mem.Allocator, types.SessionMeta) anyerror![]types.TranscriptMessage,
 };
 
+pub const RemoteExecHost = struct {
+    ctx: *anyopaque,
+    exec: *const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror![]u8,
+};
+
 pub const LocalScannerHost = struct {
     home: []const u8,
 
@@ -52,6 +59,57 @@ pub const LocalScannerHost = struct {
 
     fn loadTranscript(_: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
         return try loadLocalTranscript(allocator, meta);
+    }
+};
+
+pub const WslScannerHost = struct {
+    pub fn scannerHost(self: *WslScannerHost) ScannerHost {
+        return .{
+            .ctx = self,
+            .scan = scan,
+            .loadTranscript = loadTranscript,
+        };
+    }
+
+    fn exec(_: *anyopaque, allocator: std.mem.Allocator, command: []const u8) ![]u8 {
+        return remote_file.wslExec(allocator, command) orelse error.RemoteExecFailed;
+    }
+
+    fn scan(ctx: *anyopaque, allocator: std.mem.Allocator, source: source_mod.Source) !ScanResult {
+        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
+        return try scanRemoteFilesystem(allocator, source, host);
+    }
+
+    fn loadTranscript(ctx: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
+        return try loadRemoteTranscript(allocator, host, meta);
+    }
+};
+
+pub const SshScannerHost = struct {
+    conn: ssh_connection.SshConnection,
+
+    pub fn scannerHost(self: *SshScannerHost) ScannerHost {
+        return .{
+            .ctx = self,
+            .scan = scan,
+            .loadTranscript = loadTranscript,
+        };
+    }
+
+    fn exec(ctx: *anyopaque, allocator: std.mem.Allocator, command: []const u8) ![]u8 {
+        const self: *SshScannerHost = @ptrCast(@alignCast(ctx));
+        return try remote_file.sshExecCapture(allocator, self.conn, command);
+    }
+
+    fn scan(ctx: *anyopaque, allocator: std.mem.Allocator, source: source_mod.Source) !ScanResult {
+        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
+        return try scanRemoteFilesystem(allocator, source, host);
+    }
+
+    fn loadTranscript(ctx: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
+        return try loadRemoteTranscript(allocator, host, meta);
     }
 };
 
@@ -373,6 +431,80 @@ pub fn loadLocalTranscript(allocator: std.mem.Allocator, meta: types.SessionMeta
     };
 }
 
+pub fn providerFindCommand(provider: types.ProviderId, root: []const u8, out: []u8) ![]const u8 {
+    _ = provider;
+    var quoted_buf: [1024]u8 = undefined;
+    const quoted = remote_file.shellQuote(&quoted_buf, root) orelse return error.CommandTooLong;
+    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl' -size -2048k | head -500", .{quoted}) catch error.CommandTooLong;
+}
+
+pub fn remoteCatCommand(path: []const u8, out: []u8) ![]const u8 {
+    var quoted_buf: [1024]u8 = undefined;
+    const quoted = remote_file.shellQuote(&quoted_buf, path) orelse return error.CommandTooLong;
+    return std.fmt.bufPrint(out, "cat {s}", .{quoted}) catch error.CommandTooLong;
+}
+
+pub fn scanRemoteFilesystem(allocator: std.mem.Allocator, source: source_mod.Source, host: RemoteExecHost) !ScanResult {
+    const home_raw = try host.exec(host.ctx, allocator, remote_file.wslHomeCommand());
+    defer allocator.free(home_raw);
+    const home = std.mem.trim(u8, home_raw, " \t\r\n");
+    if (home.len == 0) return error.NoHomeDirectory;
+
+    var scanner = RemoteScan{
+        .allocator = allocator,
+        .host = host,
+    };
+    errdefer scanner.deinit();
+
+    if (source.providers.codex) {
+        if (source.codex_root_override) |root| {
+            try scanner.scanProviderRoot(.codex, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.codex, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.codex, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
+    if (source.providers.claude) {
+        if (source.claude_root_override) |root| {
+            try scanner.scanProviderRoot(.claude, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.claude, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.claude, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
+    for (source.extra_roots) |root| {
+        if (!providerEnabled(source, root.provider)) continue;
+        try scanner.scanProviderRoot(root.provider, root.path);
+    }
+
+    const rows = try scanner.rows.toOwnedSlice(allocator);
+    return .{
+        .rows = rows,
+        .warning_count = scanner.warning_count,
+        .owns_row_strings = true,
+    };
+}
+
+pub fn loadRemoteTranscript(allocator: std.mem.Allocator, host: RemoteExecHost, meta: types.SessionMeta) ![]types.TranscriptMessage {
+    var command_buf: [2048]u8 = undefined;
+    const command = try remoteCatCommand(meta.source_path, command_buf[0..]);
+    const bytes = try host.exec(host.ctx, allocator, command);
+    defer allocator.free(bytes);
+
+    return switch (meta.provider) {
+        .codex => try codex_provider.parseTranscript(allocator, bytes),
+        .claude => try claude_provider.parseTranscript(allocator, bytes),
+    };
+}
+
 pub fn freeScanResult(allocator: std.mem.Allocator, result: ScanResult) void {
     if (result.owns_row_strings) freeRows(allocator, result.rows);
     allocator.free(result.rows);
@@ -535,6 +667,76 @@ const LocalScan = struct {
     }
 };
 
+const RemoteScan = struct {
+    allocator: std.mem.Allocator,
+    host: RemoteExecHost,
+    rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
+    warning_count: u32 = 0,
+
+    fn deinit(self: *RemoteScan) void {
+        freeRows(self.allocator, self.rows.items);
+        self.rows.deinit(self.allocator);
+    }
+
+    fn scanProviderRoot(self: *RemoteScan, provider: types.ProviderId, root: []const u8) !void {
+        var find_buf: [2048]u8 = undefined;
+        const find_cmd = providerFindCommand(provider, root, find_buf[0..]) catch {
+            self.warning_count += 1;
+            return;
+        };
+        const listing = self.host.exec(self.host.ctx, self.allocator, find_cmd) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                self.warning_count += 1;
+                return;
+            },
+        };
+        defer self.allocator.free(listing);
+
+        var lines = std.mem.splitScalar(u8, listing, '\n');
+        while (lines.next()) |line_raw| {
+            const path = std.mem.trim(u8, line_raw, " \t\r\n");
+            if (path.len == 0) continue;
+            try self.scanPath(provider, path);
+        }
+    }
+
+    fn scanPath(self: *RemoteScan, provider: types.ProviderId, path: []const u8) !void {
+        var cat_buf: [2048]u8 = undefined;
+        const cat_cmd = remoteCatCommand(path, cat_buf[0..]) catch {
+            self.warning_count += 1;
+            return;
+        };
+        const bytes = self.host.exec(self.host.ctx, self.allocator, cat_cmd) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                self.warning_count += 1;
+                return;
+            },
+        };
+        defer self.allocator.free(bytes);
+        if (bytes.len > MAX_METADATA_FILE_BYTES) {
+            self.warning_count += 1;
+            return;
+        }
+
+        const meta = (switch (provider) {
+            .codex => codex_provider.parseMetadata(self.allocator, path, bytes),
+            .claude => claude_provider.parseMetadata(self.allocator, path, bytes),
+        }) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        if (!metadataHasUsableSignal(meta)) {
+            freeMetadata(self.allocator, meta);
+            self.warning_count += 1;
+            return;
+        }
+        errdefer freeMetadata(self.allocator, meta);
+
+        try self.rows.append(self.allocator, meta);
+    }
+};
+
 fn providerEnabled(source: source_mod.Source, provider: types.ProviderId) bool {
     return switch (provider) {
         .codex => source.providers.codex,
@@ -683,6 +885,43 @@ const TestTranscriptHost = struct {
             .content = try allocator.dupe(u8, "hello"),
         };
         return messages;
+    }
+};
+
+const FakeRemoteHost = struct {
+    const codex_path = "/home/me/.codex/sessions/codex-abc.jsonl";
+    const claude_path = "/home/me/.claude/projects/project/claude-abc.jsonl";
+    const codex_jsonl =
+        \\{"type":"session_meta","id":"codex-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00Z"}
+        \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"Fix remote renderer"}],"timestamp":"2026-05-31T10:01:00Z"}
+        \\
+    ;
+    const claude_jsonl =
+        \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00.000Z","type":"user","message":{"role":"user","content":"Fix remote tests"}}
+        \\
+    ;
+
+    pub fn remoteExecHost(self: *FakeRemoteHost) RemoteExecHost {
+        return .{ .ctx = self, .exec = exec };
+    }
+
+    fn exec(_: *anyopaque, allocator: std.mem.Allocator, command: []const u8) ![]u8 {
+        if (std.mem.eql(u8, command, remote_file.wslHomeCommand())) {
+            return try allocator.dupe(u8, "/home/me\n");
+        }
+        if (std.mem.eql(u8, command, "find '/home/me/.codex' -type f -name '*.jsonl' -size -2048k | head -500")) {
+            return try allocator.dupe(u8, codex_path ++ "\n");
+        }
+        if (std.mem.eql(u8, command, "find '/home/me/.claude' -type f -name '*.jsonl' -size -2048k | head -500")) {
+            return try allocator.dupe(u8, claude_path ++ "\n");
+        }
+        if (std.mem.eql(u8, command, "cat '" ++ codex_path ++ "'")) {
+            return try allocator.dupe(u8, codex_jsonl);
+        }
+        if (std.mem.eql(u8, command, "cat '" ++ claude_path ++ "'")) {
+            return try allocator.dupe(u8, claude_jsonl);
+        }
+        return error.UnexpectedCommand;
     }
 };
 
@@ -864,6 +1103,52 @@ test "ai_history_session: loading selected transcript stores and clears owned me
     try std.testing.expectEqual(TranscriptState.idle, session.transcript_state);
     try std.testing.expectEqual(@as(?types.ProviderId, null), session.transcript_provider);
     try std.testing.expectEqual(@as(usize, 0), session.transcript.len);
+}
+
+test "ai_history_session: remote provider find command quotes root" {
+    var out: [512]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "find '/home/me/it'\\''s/.codex' -type f -name '*.jsonl' -size -2048k | head -500",
+        try providerFindCommand(.codex, "/home/me/it's/.codex", &out),
+    );
+}
+
+test "ai_history_session: remote scan uses fake host JSONL bytes" {
+    const allocator = std.testing.allocator;
+    var fake = FakeRemoteHost{};
+    const result = try scanRemoteFilesystem(allocator, .{
+        .id = "wsl",
+        .name = "WSL",
+        .target = .{ .wsl = .{} },
+    }, fake.remoteExecHost());
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 2), result.rows.len);
+    try std.testing.expectEqual(@as(u32, 0), result.warning_count);
+    try std.testing.expectEqual(types.ProviderId.codex, result.rows[0].provider);
+    try std.testing.expectEqualStrings("codex-abc", result.rows[0].session_id);
+    try std.testing.expectEqualStrings("/home/me/project", result.rows[0].project_dir);
+    try std.testing.expectEqual(types.ProviderId.claude, result.rows[1].provider);
+    try std.testing.expectEqualStrings("claude-abc", result.rows[1].session_id);
+}
+
+test "ai_history_session: remote transcript loads from fake host" {
+    const allocator = std.testing.allocator;
+    var fake = FakeRemoteHost{};
+    const meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "codex-abc",
+        .title = "Remote",
+        .project_dir = "/home/me/project",
+        .source_path = FakeRemoteHost.codex_path,
+        .resume_kind = .codex_resume,
+    };
+    const messages = try loadRemoteTranscript(allocator, fake.remoteExecHost(), meta);
+    defer freeTranscript(allocator, .codex, messages);
+
+    try std.testing.expectEqual(@as(usize, 1), messages.len);
+    try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
+    try std.testing.expectEqualStrings("Fix remote renderer", messages[0].content);
 }
 
 test "ai_history_session: replace rows preserves existing state on allocation failure" {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -2,8 +2,57 @@ const std = @import("std");
 const types = @import("ai_history_types.zig");
 const source_mod = @import("ai_history_source.zig");
 const session_persist = @import("session_persist.zig");
+const codex_provider = @import("ai_history_provider_codex.zig");
+const claude_provider = @import("ai_history_provider_claude.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
+pub const MAX_METADATA_FILE_BYTES = 2 * 1024 * 1024;
+pub const MAX_SCAN_METADATA_FILES: usize = 256;
+pub const MAX_SCAN_METADATA_BYTES: u64 = 48 * 1024 * 1024;
+
+pub const ScanBudget = struct {
+    max_files: usize = MAX_SCAN_METADATA_FILES,
+    max_bytes: u64 = MAX_SCAN_METADATA_BYTES,
+};
+
+pub const FileEntry = struct {
+    provider: types.ProviderId,
+    path: []const u8,
+    bytes: []const u8,
+};
+
+pub const ScanResult = struct {
+    rows: []types.SessionMeta,
+    warning_count: u32 = 0,
+    owns_row_strings: bool = false,
+};
+
+pub const ScannerHost = struct {
+    ctx: *anyopaque,
+    scan: *const fn (*anyopaque, std.mem.Allocator, source_mod.Source) anyerror!ScanResult,
+    loadTranscript: *const fn (*anyopaque, std.mem.Allocator, types.SessionMeta) anyerror![]types.TranscriptMessage,
+};
+
+pub const LocalScannerHost = struct {
+    home: []const u8,
+
+    pub fn scannerHost(self: *LocalScannerHost) ScannerHost {
+        return .{
+            .ctx = self,
+            .scan = scan,
+            .loadTranscript = loadTranscript,
+        };
+    }
+
+    fn scan(ctx: *anyopaque, allocator: std.mem.Allocator, source: source_mod.Source) !ScanResult {
+        const self: *LocalScannerHost = @ptrCast(@alignCast(ctx));
+        return try scanLocalFilesystem(allocator, source, self.home);
+    }
+
+    fn loadTranscript(_: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+        return try loadLocalTranscript(allocator, meta);
+    }
+};
 
 pub const Session = struct {
     /// Allocator used for row storage. Do not change while rows are live.
@@ -12,8 +61,7 @@ pub const Session = struct {
     source: source_mod.Source,
     source_owned: bool = false,
     state: LoadState = .idle,
-    /// Rows shallow-copy SessionMeta values. All string slices inside each row
-    /// are borrowed and must outlive these rows until replacement or deinit.
+    /// Rows own duplicated SessionMeta string fields.
     rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
     selected: usize = 0,
     filter: [128]u8 = undefined,
@@ -36,6 +84,7 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        freeRows(self.allocator, self.rows.items);
         self.rows.deinit(self.allocator);
         if (self.source_owned) {
             freeOwnedSource(self.allocator, &self.source);
@@ -69,20 +118,45 @@ pub const Session = struct {
         self.status = "Scanning";
     }
 
-    /// Replaces rows with shallow copies of `rows`. SessionMeta string slices
-    /// remain borrowed; callers must keep them alive until replacement/deinit.
+    /// Replaces rows with owned copies of `rows`. Callers may pass static or
+    /// temporary metadata; Session owns its stored strings after this returns.
     pub fn replaceRows(self: *Session, rows: []const types.SessionMeta) !void {
         var next: std.ArrayListUnmanaged(types.SessionMeta) = .empty;
-        errdefer next.deinit(self.allocator);
+        errdefer {
+            freeRows(self.allocator, next.items);
+            next.deinit(self.allocator);
+        }
 
-        try next.appendSlice(self.allocator, rows);
+        try next.ensureTotalCapacity(self.allocator, rows.len);
+        for (rows) |row| {
+            next.appendAssumeCapacity(try cloneMetadata(self.allocator, row));
+        }
         std.mem.sort(types.SessionMeta, next.items, {}, types.lessRecent);
 
+        freeRows(self.allocator, self.rows.items);
         self.rows.deinit(self.allocator);
         self.rows = next;
         self.selected = 0;
         self.state = .ready;
         self.status = "Ready";
+    }
+
+    pub fn scanNow(self: *Session, host: ScannerHost) !void {
+        self.beginScan();
+        errdefer {
+            self.state = .failed;
+            self.status = "Scan failed";
+        }
+        const result = try host.scan(host.ctx, self.allocator, self.source);
+        defer freeScanResult(self.allocator, result);
+
+        try self.replaceRows(result.rows);
+        self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
+    }
+
+    pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) ![]types.TranscriptMessage {
+        const selected = self.selectedVisible() orelse return error.NoSelection;
+        return try host.loadTranscript(host.ctx, self.allocator, selected);
     }
 
     pub fn setFilter(self: *Session, text: []const u8) void {
@@ -113,6 +187,289 @@ pub const Session = struct {
         return null;
     }
 };
+
+pub fn scanLocalFilesystem(
+    allocator: std.mem.Allocator,
+    source: source_mod.Source,
+    home: []const u8,
+) !ScanResult {
+    return scanLocalFilesystemWithBudget(allocator, source, home, .{});
+}
+
+pub fn scanLocalFilesystemWithBudget(
+    allocator: std.mem.Allocator,
+    source: source_mod.Source,
+    home: []const u8,
+    budget: ScanBudget,
+) !ScanResult {
+    var scanner = LocalScan{
+        .allocator = allocator,
+        .budget = budget,
+    };
+    errdefer scanner.deinit();
+
+    if (source.providers.codex) {
+        if (source.codex_root_override) |root| {
+            try scanner.scanProviderRoot(.codex, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.codex, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.codex, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
+    if (source.providers.claude) {
+        if (source.claude_root_override) |root| {
+            try scanner.scanProviderRoot(.claude, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.claude, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.claude, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
+    for (source.extra_roots) |root| {
+        if (!providerEnabled(source, root.provider)) continue;
+        try scanner.scanProviderRoot(root.provider, root.path);
+    }
+    try scanner.processCandidates();
+
+    const rows = try scanner.rows.toOwnedSlice(allocator);
+    scanner.freeCandidates();
+    return .{
+        .rows = rows,
+        .warning_count = scanner.warning_count,
+        .owns_row_strings = true,
+    };
+}
+
+pub fn loadLocalTranscript(allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+    const bytes = if (std.fs.path.isAbsolute(meta.source_path)) blk: {
+        const file = try std.fs.openFileAbsolute(meta.source_path, .{});
+        defer file.close();
+        break :blk try file.readToEndAlloc(allocator, MAX_METADATA_FILE_BYTES);
+    } else try std.fs.cwd().readFileAlloc(allocator, meta.source_path, MAX_METADATA_FILE_BYTES);
+    defer allocator.free(bytes);
+
+    return switch (meta.provider) {
+        .codex => try codex_provider.parseTranscript(allocator, bytes),
+        .claude => try claude_provider.parseTranscript(allocator, bytes),
+    };
+}
+
+pub fn freeScanResult(allocator: std.mem.Allocator, result: ScanResult) void {
+    if (result.owns_row_strings) freeRows(allocator, result.rows);
+    allocator.free(result.rows);
+}
+
+pub fn freeTranscript(allocator: std.mem.Allocator, provider: types.ProviderId, messages: []types.TranscriptMessage) void {
+    switch (provider) {
+        .codex => codex_provider.freeTranscript(allocator, messages),
+        .claude => claude_provider.freeTranscript(allocator, messages),
+    }
+}
+
+const LocalScan = struct {
+    const Candidate = struct {
+        provider: types.ProviderId,
+        path: []const u8,
+        size: u64,
+        mtime: i128,
+    };
+
+    allocator: std.mem.Allocator,
+    budget: ScanBudget,
+    rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
+    candidates: std.ArrayListUnmanaged(Candidate) = .empty,
+    warning_count: u32 = 0,
+
+    fn deinit(self: *LocalScan) void {
+        freeRows(self.allocator, self.rows.items);
+        self.rows.deinit(self.allocator);
+        self.freeCandidates();
+    }
+
+    fn freeCandidates(self: *LocalScan) void {
+        for (self.candidates.items) |candidate| {
+            self.allocator.free(candidate.path);
+        }
+        self.candidates.deinit(self.allocator);
+        self.candidates = .empty;
+    }
+
+    fn scanProviderRoot(self: *LocalScan, provider: types.ProviderId, root: []const u8) !void {
+        var dir = std.fs.openDirAbsolute(root, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound, error.NotDir => return,
+            else => {
+                self.warning_count += 1;
+                return;
+            },
+        };
+        defer dir.close();
+
+        try self.walkDir(provider, root, dir);
+    }
+
+    fn walkDir(self: *LocalScan, provider: types.ProviderId, abs_path: []const u8, dir: std.fs.Dir) !void {
+        var it = dir.iterate();
+        while (it.next() catch {
+            self.warning_count += 1;
+            return;
+        }) |entry| {
+            switch (entry.kind) {
+                .directory => {
+                    const child_path = try std.fs.path.join(self.allocator, &.{ abs_path, entry.name });
+                    defer self.allocator.free(child_path);
+
+                    var child = dir.openDir(entry.name, .{ .iterate = true }) catch |err| switch (err) {
+                        error.FileNotFound, error.NotDir => continue,
+                        else => {
+                            self.warning_count += 1;
+                            continue;
+                        },
+                    };
+                    defer child.close();
+                    try self.walkDir(provider, child_path, child);
+                },
+                .file => {
+                    if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+                    try self.collectFile(provider, abs_path, dir, entry.name);
+                },
+                else => {},
+            }
+        }
+    }
+
+    fn collectFile(self: *LocalScan, provider: types.ProviderId, abs_dir: []const u8, dir: std.fs.Dir, name: []const u8) !void {
+        const stat = dir.statFile(name) catch {
+            self.warning_count += 1;
+            return;
+        };
+        if (stat.size > MAX_METADATA_FILE_BYTES) {
+            self.warning_count += 1;
+            return;
+        }
+
+        const source_path = try std.fs.path.join(self.allocator, &.{ abs_dir, name });
+        errdefer self.allocator.free(source_path);
+
+        try self.candidates.append(self.allocator, .{
+            .provider = provider,
+            .path = source_path,
+            .size = stat.size,
+            .mtime = stat.mtime,
+        });
+    }
+
+    fn processCandidates(self: *LocalScan) !void {
+        std.mem.sort(Candidate, self.candidates.items, {}, candidateMoreRecent);
+
+        var parsed_files: usize = 0;
+        var parsed_bytes: u64 = 0;
+        var budget_exceeded = false;
+
+        for (self.candidates.items) |candidate| {
+            if (parsed_files >= self.budget.max_files or
+                parsed_bytes + candidate.size > self.budget.max_bytes)
+            {
+                budget_exceeded = true;
+                continue;
+            }
+
+            try self.scanCandidate(candidate);
+            parsed_files += 1;
+            parsed_bytes += candidate.size;
+        }
+
+        if (budget_exceeded) self.warning_count += 1;
+    }
+
+    fn scanCandidate(self: *LocalScan, candidate: Candidate) !void {
+        const file = std.fs.openFileAbsolute(candidate.path, .{}) catch {
+            self.warning_count += 1;
+            return;
+        };
+        defer file.close();
+
+        const bytes = file.readToEndAlloc(self.allocator, MAX_METADATA_FILE_BYTES) catch {
+            self.warning_count += 1;
+            return;
+        };
+        defer self.allocator.free(bytes);
+
+        const meta = (switch (candidate.provider) {
+            .codex => codex_provider.parseMetadata(self.allocator, candidate.path, bytes),
+            .claude => claude_provider.parseMetadata(self.allocator, candidate.path, bytes),
+        }) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        if (!metadataHasUsableSignal(meta)) {
+            freeMetadata(self.allocator, meta);
+            self.warning_count += 1;
+            return;
+        }
+        errdefer freeMetadata(self.allocator, meta);
+
+        try self.rows.append(self.allocator, meta);
+    }
+
+    fn candidateMoreRecent(_: void, lhs: Candidate, rhs: Candidate) bool {
+        if (lhs.mtime == rhs.mtime) return std.mem.lessThan(u8, lhs.path, rhs.path);
+        return lhs.mtime > rhs.mtime;
+    }
+};
+
+fn providerEnabled(source: source_mod.Source, provider: types.ProviderId) bool {
+    return switch (provider) {
+        .codex => source.providers.codex,
+        .claude => source.providers.claude,
+    };
+}
+
+fn metadataHasUsableSignal(meta: types.SessionMeta) bool {
+    return meta.session_id.len > 0 and meta.message_count > 0;
+}
+
+fn cloneMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) !types.SessionMeta {
+    var cloned = types.SessionMeta{
+        .provider = meta.provider,
+        .session_id = "",
+        .title = "",
+        .summary = "",
+        .project_dir = "",
+        .created_at_ms = meta.created_at_ms,
+        .last_active_at_ms = meta.last_active_at_ms,
+        .source_path = "",
+        .resume_kind = meta.resume_kind,
+        .message_count = meta.message_count,
+        .scan_status = meta.scan_status,
+    };
+    errdefer freeMetadata(allocator, cloned);
+
+    cloned.session_id = try cloneSlice(allocator, meta.session_id);
+    cloned.title = try cloneSlice(allocator, meta.title);
+    cloned.summary = try cloneSlice(allocator, meta.summary);
+    cloned.project_dir = try cloneSlice(allocator, meta.project_dir);
+    cloned.source_path = try cloneSlice(allocator, meta.source_path);
+
+    return cloned;
+}
+
+fn freeRows(allocator: std.mem.Allocator, rows: []types.SessionMeta) void {
+    for (rows) |row| freeMetadata(allocator, row);
+}
+
+fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
+    freeSlice(allocator, meta.session_id);
+    freeSlice(allocator, meta.title);
+    freeSlice(allocator, meta.summary);
+    freeSlice(allocator, meta.project_dir);
+    freeSlice(allocator, meta.source_path);
+}
 
 fn cloneSource(allocator: std.mem.Allocator, source: source_mod.Source) !source_mod.Source {
     var cloned = source_mod.Source{
@@ -344,7 +701,7 @@ test "ai_history_session: metadata filter controls visible rows" {
 
 test "ai_history_session: replace rows preserves existing state on allocation failure" {
     var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
-        .fail_index = 1,
+        .fail_index = 4,
     });
     var session = Session.init(failing_allocator.allocator(), .{ .id = "local", .name = "Local", .target = .local });
     defer session.deinit();
@@ -430,4 +787,290 @@ test "ai_history_session: filter truncates to fixed buffer length" {
 
     try std.testing.expectEqual(@as(usize, 128), session.filter_len);
     try std.testing.expectEqualSlices(u8, long_filter[0..128], session.filter[0..session.filter_len]);
+}
+
+test "ai_history_session: scan host replaces rows and marks ready" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = "abc",
+                .title = "A",
+                .source_path = "a.jsonl",
+                .resume_kind = .codex_resume,
+                .last_active_at_ms = 1,
+            };
+            return .{ .rows = rows };
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+            const rows = try alloc.alloc(types.TranscriptMessage, 1);
+            rows[0] = .{ .role = .user, .content = "hello" };
+            return rows;
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+
+    try session.scanNow(host);
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqualStrings("Ready", session.status);
+    try std.testing.expectEqualStrings("abc", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: scan host warning count marks ready with warnings" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = "warn",
+                .title = "Warning",
+                .source_path = "warn.jsonl",
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows, .warning_count = 1 };
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+            return try alloc.alloc(types.TranscriptMessage, 0);
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+
+    try session.scanNow(host);
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqualStrings("Ready with warnings", session.status);
+}
+
+test "ai_history_session: scan host rows are owned after provider result is freed" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            errdefer alloc.free(rows);
+
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = try alloc.dupe(u8, "owned-abc"),
+                .title = try alloc.dupe(u8, "Owned Title"),
+                .project_dir = try alloc.dupe(u8, "/tmp/project"),
+                .source_path = try alloc.dupe(u8, "/tmp/a.jsonl"),
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows, .owns_row_strings = true };
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+            return try alloc.alloc(types.TranscriptMessage, 0);
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+
+    try session.scanNow(host);
+
+    try std.testing.expectEqualStrings("owned-abc", session.rows.items[0].session_id);
+    try std.testing.expectEqualStrings("Owned Title", session.rows.items[0].title);
+    try std.testing.expectEqualStrings("/tmp/project", session.rows.items[0].project_dir);
+    try std.testing.expectEqualStrings("/tmp/a.jsonl", session.rows.items[0].source_path);
+}
+
+test "ai_history_session: loadSelectedTranscript returns fake transcript for selected row" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = "abc",
+                .title = "A",
+                .source_path = "a.jsonl",
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows };
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+            try std.testing.expectEqualStrings("abc", meta.session_id);
+            const messages = try alloc.alloc(types.TranscriptMessage, 1);
+            messages[0] = .{ .role = .user, .content = "hello" };
+            return messages;
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+    try session.scanNow(host);
+
+    const transcript = try session.loadSelectedTranscript(host);
+    defer allocator.free(transcript);
+
+    try std.testing.expectEqual(@as(usize, 1), transcript.len);
+    try std.testing.expectEqual(types.MessageRole.user, transcript[0].role);
+    try std.testing.expectEqualStrings("hello", transcript[0].content);
+}
+
+test "ai_history_session: loadSelectedTranscript returns NoSelection without visible row" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            return .{ .rows = try alloc.alloc(types.SessionMeta, 0) };
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+            return try alloc.alloc(types.TranscriptMessage, 0);
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+
+    try std.testing.expectError(error.NoSelection, session.loadSelectedTranscript(host));
+}
+
+test "ai_history_session: scanLocalFilesystem reads codex and claude jsonl files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".codex/sessions");
+    try tmp.dir.makePath(".claude/projects/demo");
+    try tmp.dir.writeFile(.{
+        .sub_path = ".codex/sessions/a.jsonl",
+        .data =
+        \\{"type":"session_meta","timestamp":"2026-05-31T10:00:00Z","payload":{"id":"codex-abc","cwd":"/tmp/project"}}
+        \\{"type":"response_item","timestamp":"2026-05-31T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix the renderer crash"}]}}
+        \\
+        ,
+    });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".claude/projects/demo/b.jsonl",
+        .data =
+        \\{"sessionId":"claude-abc","cwd":"/tmp/project","timestamp":"2026-05-31T10:00:00Z","message":{"role":"user","content":"Explain the tests"}}
+        \\{"sessionId":"claude-abc","cwd":"/tmp/project","timestamp":"2026-05-31T10:01:00Z","message":{"role":"assistant","content":"They pass."}}
+        \\
+        ,
+    });
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const result = try scanLocalFilesystem(allocator, .{ .id = "local", .name = "Local", .target = .local }, home);
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 2), result.rows.len);
+    try std.testing.expectEqual(@as(u32, 0), result.warning_count);
+    var codex_count: usize = 0;
+    var claude_count: usize = 0;
+    for (result.rows) |row| {
+        switch (row.provider) {
+            .codex => codex_count += 1,
+            .claude => claude_count += 1,
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), codex_count);
+    try std.testing.expectEqual(@as(usize, 1), claude_count);
+}
+
+test "ai_history_session: scanNow failure marks failed and preserves existing rows" {
+    const allocator = std.testing.allocator;
+    var fake = struct {
+        fn scan(_: *anyopaque, _: std.mem.Allocator, _: source_mod.Source) !ScanResult {
+            return error.Boom;
+        }
+        fn load(_: *anyopaque, alloc: std.mem.Allocator, _: types.SessionMeta) ![]types.TranscriptMessage {
+            return try alloc.alloc(types.TranscriptMessage, 0);
+        }
+    }{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const existing = [_]types.SessionMeta{.{
+        .provider = .codex,
+        .session_id = "kept",
+        .title = "Kept",
+        .source_path = "kept.jsonl",
+        .resume_kind = .codex_resume,
+    }};
+    try session.replaceRows(&existing);
+
+    const host: ScannerHost = .{ .ctx = &fake, .scan = @TypeOf(fake).scan, .loadTranscript = @TypeOf(fake).load };
+    try std.testing.expectError(error.Boom, session.scanNow(host));
+
+    try std.testing.expectEqual(LoadState.failed, session.state);
+    try std.testing.expectEqualStrings("Scan failed", session.status);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("kept", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: scanLocalFilesystem skips unusable metadata with warning" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".codex/sessions");
+    try tmp.dir.writeFile(.{
+        .sub_path = ".codex/sessions/good.jsonl",
+        .data =
+        \\{"type":"session_meta","timestamp":"2026-05-31T10:00:00Z","payload":{"id":"codex-good","cwd":"/tmp/project"}}
+        \\{"type":"response_item","timestamp":"2026-05-31T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Keep this"}]}}
+        \\
+        ,
+    });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".codex/sessions/bad.jsonl",
+        .data =
+        \\{"type":"unrelated","value":1}
+        \\
+        ,
+    });
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const result = try scanLocalFilesystem(allocator, .{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+        .providers = .{ .codex = true, .claude = false },
+    }, home);
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 1), result.rows.len);
+    try std.testing.expectEqual(@as(u32, 1), result.warning_count);
+    try std.testing.expectEqualStrings("codex-good", result.rows[0].session_id);
+}
+
+test "ai_history_session: scanLocalFilesystem budget returns partial rows with warning" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".codex/sessions");
+    for (0..3) |idx| {
+        var path_buf: [64]u8 = undefined;
+        const sub_path = try std.fmt.bufPrint(&path_buf, ".codex/sessions/{d}.jsonl", .{idx});
+        var data_buf: [512]u8 = undefined;
+        const data = try std.fmt.bufPrint(&data_buf,
+            \\{{"type":"session_meta","timestamp":"2026-05-31T10:00:0{d}Z","payload":{{"id":"codex-{d}","cwd":"/tmp/project"}}}}
+            \\{{"type":"response_item","timestamp":"2026-05-31T10:01:0{d}Z","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"Prompt {d}"}}]}}}}
+            \\
+        , .{ idx, idx, idx, idx });
+        try tmp.dir.writeFile(.{ .sub_path = sub_path, .data = data });
+    }
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const result = try scanLocalFilesystemWithBudget(allocator, .{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+        .providers = .{ .codex = true, .claude = false },
+    }, home, .{ .max_files = 1, .max_bytes = 1024 * 1024 });
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 1), result.rows.len);
+    try std.testing.expectEqual(@as(u32, 1), result.warning_count);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -6,6 +6,7 @@ const codex_provider = @import("ai_history_provider_codex.zig");
 const claude_provider = @import("ai_history_provider_claude.zig");
 const remote_file = @import("platform/remote_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
+const ai_history_cache = @import("ai_history_cache.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
 pub const TranscriptState = enum { idle, loading, ready, failed };
@@ -18,6 +19,11 @@ pub const ScanBudget = struct {
     max_bytes: u64 = MAX_SCAN_METADATA_BYTES,
 };
 
+pub const CacheUpdate = struct {
+    records: []ai_history_cache.CacheRecord = &.{},
+    owns_record_strings: bool = false,
+};
+
 pub const FileEntry = struct {
     provider: types.ProviderId,
     path: []const u8,
@@ -28,6 +34,7 @@ pub const ScanResult = struct {
     rows: []types.SessionMeta,
     warning_count: u32 = 0,
     owns_row_strings: bool = false,
+    cache_update: CacheUpdate = .{},
 };
 
 pub const ScannerHost = struct {
@@ -43,6 +50,7 @@ pub const RemoteExecHost = struct {
 
 pub const LocalScannerHost = struct {
     home: []const u8,
+    cache: ?ai_history_cache.CacheFile = null,
 
     pub fn scannerHost(self: *LocalScannerHost) ScannerHost {
         return .{
@@ -54,6 +62,7 @@ pub const LocalScannerHost = struct {
 
     fn scan(ctx: *anyopaque, allocator: std.mem.Allocator, source: source_mod.Source) !ScanResult {
         const self: *LocalScannerHost = @ptrCast(@alignCast(ctx));
+        if (self.cache) |cache| return try scanLocalFilesystemWithCache(allocator, source, self.home, .{}, cache);
         return try scanLocalFilesystem(allocator, source, self.home);
     }
 
@@ -221,6 +230,20 @@ pub const Session = struct {
         self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
     }
 
+    pub fn scanNowReturningResult(self: *Session, host: ScannerHost) !ScanResult {
+        self.beginScan();
+        errdefer {
+            self.state = .failed;
+            self.status = "Scan failed";
+        }
+        const result = try host.scan(host.ctx, self.allocator, self.source);
+        errdefer freeScanResult(self.allocator, result);
+
+        try self.replaceRows(result.rows);
+        self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
+        return result;
+    }
+
     pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) !void {
         const selected = self.selectedVisible() orelse return error.NoSelection;
         self.clearTranscript();
@@ -372,9 +395,21 @@ pub fn scanLocalFilesystemWithBudget(
     home: []const u8,
     budget: ScanBudget,
 ) !ScanResult {
+    return scanLocalFilesystemWithCache(allocator, source, home, budget, null);
+}
+
+pub fn scanLocalFilesystemWithCache(
+    allocator: std.mem.Allocator,
+    source: source_mod.Source,
+    home: []const u8,
+    budget: ScanBudget,
+    cache: ?ai_history_cache.CacheFile,
+) !ScanResult {
     var scanner = LocalScan{
         .allocator = allocator,
+        .source = source,
         .budget = budget,
+        .cache = cache,
     };
     errdefer scanner.deinit();
 
@@ -409,11 +444,20 @@ pub fn scanLocalFilesystemWithBudget(
     try scanner.processCandidates();
 
     const rows = try scanner.rows.toOwnedSlice(allocator);
+    errdefer {
+        freeRows(allocator, rows);
+        allocator.free(rows);
+    }
+    const cache_update = try scanner.cache_records.toOwnedSlice(allocator);
     scanner.freeCandidates();
     return .{
         .rows = rows,
         .warning_count = scanner.warning_count,
         .owns_row_strings = true,
+        .cache_update = .{
+            .records = cache_update,
+            .owns_record_strings = true,
+        },
     };
 }
 
@@ -506,6 +550,7 @@ pub fn loadRemoteTranscript(allocator: std.mem.Allocator, host: RemoteExecHost, 
 }
 
 pub fn freeScanResult(allocator: std.mem.Allocator, result: ScanResult) void {
+    if (result.cache_update.owns_record_strings) ai_history_cache.freeRecords(allocator, result.cache_update.records) else allocator.free(result.cache_update.records);
     if (result.owns_row_strings) freeRows(allocator, result.rows);
     allocator.free(result.rows);
 }
@@ -526,12 +571,17 @@ const LocalScan = struct {
     };
 
     allocator: std.mem.Allocator,
+    source: source_mod.Source,
     budget: ScanBudget,
+    cache: ?ai_history_cache.CacheFile = null,
     rows: std.ArrayListUnmanaged(types.SessionMeta) = .empty,
     candidates: std.ArrayListUnmanaged(Candidate) = .empty,
+    cache_records: std.ArrayListUnmanaged(ai_history_cache.CacheRecord) = .empty,
     warning_count: u32 = 0,
 
     fn deinit(self: *LocalScan) void {
+        ai_history_cache.freeRecords(self.allocator, self.cache_records.items);
+        self.cache_records.deinit(self.allocator);
         freeRows(self.allocator, self.rows.items);
         self.rows.deinit(self.allocator);
         self.freeCandidates();
@@ -633,6 +683,17 @@ const LocalScan = struct {
     }
 
     fn scanCandidate(self: *LocalScan, candidate: Candidate) !void {
+        const stamp: ai_history_cache.FileStamp = .{ .size = candidate.size, .mtime_ns = candidate.mtime };
+        if (self.cache) |cache| {
+            if (ai_history_cache.findRecord(cache, self.source.id, candidate.provider, candidate.path, stamp)) |record| {
+                const cached_meta = try cloneMetadata(self.allocator, record.meta);
+                errdefer freeMetadata(self.allocator, cached_meta);
+                try self.rows.append(self.allocator, cached_meta);
+                try self.appendCacheRecord(candidate, record.meta);
+                return;
+            }
+        }
+
         const file = std.fs.openFileAbsolute(candidate.path, .{}) catch {
             self.warning_count += 1;
             return;
@@ -658,7 +719,26 @@ const LocalScan = struct {
         }
         errdefer freeMetadata(self.allocator, meta);
 
+        try self.appendCacheRecord(candidate, meta);
         try self.rows.append(self.allocator, meta);
+    }
+
+    fn appendCacheRecord(self: *LocalScan, candidate: Candidate, meta: types.SessionMeta) !void {
+        const root_path = providerRootForPath(self.source, candidate.provider, candidate.path);
+        const record: ai_history_cache.CacheRecord = .{
+            .source_id = self.source.id,
+            .provider = candidate.provider,
+            .root_path = root_path,
+            .source_path = candidate.path,
+            .stamp = .{ .size = candidate.size, .mtime_ns = candidate.mtime },
+            .meta = meta,
+        };
+        const cloned = try ai_history_cache.cloneRecord(self.allocator, record);
+        errdefer {
+            var mutable = cloned;
+            ai_history_cache.freeRecord(self.allocator, &mutable);
+        }
+        try self.cache_records.append(self.allocator, cloned);
     }
 
     fn candidateMoreRecent(_: void, lhs: Candidate, rhs: Candidate) bool {
@@ -666,6 +746,18 @@ const LocalScan = struct {
         return lhs.mtime > rhs.mtime;
     }
 };
+
+fn providerRootForPath(source: source_mod.Source, provider: types.ProviderId, source_path: []const u8) []const u8 {
+    const explicit = switch (provider) {
+        .codex => source.codex_root_override,
+        .claude => source.claude_root_override,
+    };
+    if (explicit) |root| return root;
+    for (source.extra_roots) |root| {
+        if (root.provider == provider and std.mem.startsWith(u8, source_path, root.path)) return root.path;
+    }
+    return "";
+}
 
 const RemoteScan = struct {
     allocator: std.mem.Allocator,
@@ -1552,4 +1644,57 @@ test "ai_history_session: scanLocalFilesystem budget returns partial rows with w
 
     try std.testing.expectEqual(@as(usize, 1), result.rows.len);
     try std.testing.expectEqual(@as(u32, 1), result.warning_count);
+}
+
+test "ai_history_session: scanLocalFilesystem reuses unchanged cached metadata" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".codex/sessions");
+    try tmp.dir.writeFile(.{
+        .sub_path = ".codex/sessions/a.jsonl",
+        .data =
+        \\{"type":"session_meta","timestamp":"2026-05-31T10:00:00Z","payload":{"id":"codex-live","cwd":"/tmp/project"}}
+        \\{"type":"response_item","timestamp":"2026-05-31T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Live title"}]}}
+        \\
+        ,
+    });
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const path = try std.fs.path.join(allocator, &.{ home, ".codex", "sessions", "a.jsonl" });
+    defer allocator.free(path);
+    const stat = try tmp.dir.statFile(".codex/sessions/a.jsonl");
+    const cached_meta: types.SessionMeta = .{
+        .provider = .codex,
+        .session_id = "codex-cached",
+        .title = "Cached title",
+        .project_dir = "/tmp/cached",
+        .source_path = path,
+        .resume_kind = .codex_resume,
+        .message_count = 1,
+    };
+    const records = [_]ai_history_cache.CacheRecord{.{
+        .source_id = "local",
+        .provider = .codex,
+        .root_path = "",
+        .source_path = path,
+        .stamp = .{ .size = stat.size, .mtime_ns = stat.mtime },
+        .meta = cached_meta,
+    }};
+
+    const result = try scanLocalFilesystemWithCache(allocator, .{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+        .providers = .{ .codex = true, .claude = false },
+    }, home, .{}, .{ .records = @constCast(&records) });
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 1), result.rows.len);
+    try std.testing.expectEqualStrings("codex-cached", result.rows[0].session_id);
+    try std.testing.expectEqualStrings("Cached title", result.rows[0].title);
+    try std.testing.expectEqual(@as(usize, 1), result.cache_update.records.len);
+    try std.testing.expectEqualStrings("codex-cached", result.cache_update.records[0].meta.session_id);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -8,8 +8,9 @@ pub const LoadState = enum { idle, scanning, ready, failed };
 pub const Session = struct {
     /// Allocator used for row storage. Do not change while rows are live.
     allocator: std.mem.Allocator,
-    /// Source is stored shallowly; nested string slices must outlive Session.
+    /// Borrowed when initialized with init; owned when initialized with initOwned.
     source: source_mod.Source,
+    source_owned: bool = false,
     state: LoadState = .idle,
     /// Rows shallow-copy SessionMeta values. All string slices inside each row
     /// are borrowed and must outlive these rows until replacement or deinit.
@@ -26,8 +27,19 @@ pub const Session = struct {
         };
     }
 
+    pub fn initOwned(allocator: std.mem.Allocator, source: source_mod.Source) !Session {
+        return .{
+            .allocator = allocator,
+            .source = try cloneSource(allocator, source),
+            .source_owned = true,
+        };
+    }
+
     pub fn deinit(self: *Session) void {
         self.rows.deinit(self.allocator);
+        if (self.source_owned) {
+            freeOwnedSource(self.allocator, &self.source);
+        }
         self.* = undefined;
     }
 
@@ -102,6 +114,85 @@ pub const Session = struct {
     }
 };
 
+fn cloneSource(allocator: std.mem.Allocator, source: source_mod.Source) !source_mod.Source {
+    var cloned = source_mod.Source{
+        .id = "",
+        .name = "",
+        .target = .local,
+        .providers = source.providers,
+        .codex_root_override = null,
+        .claude_root_override = null,
+        .extra_roots = &.{},
+    };
+    errdefer freeOwnedSource(allocator, &cloned);
+
+    cloned.id = try cloneSlice(allocator, source.id);
+    cloned.name = try cloneSlice(allocator, source.name);
+    cloned.target = switch (source.target) {
+        .local => .local,
+        .wsl => |target| .{ .wsl = .{ .distro = try cloneSlice(allocator, target.distro) } },
+        .ssh => |target| .{ .ssh = .{ .profile_name = try cloneSlice(allocator, target.profile_name) } },
+    };
+    cloned.codex_root_override = try cloneOptionalSlice(allocator, source.codex_root_override);
+    cloned.claude_root_override = try cloneOptionalSlice(allocator, source.claude_root_override);
+    cloned.extra_roots = try cloneProviderRoots(allocator, source.extra_roots);
+
+    return cloned;
+}
+
+fn cloneSlice(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    if (value.len == 0) return "";
+    return try allocator.dupe(u8, value);
+}
+
+fn cloneOptionalSlice(allocator: std.mem.Allocator, value: ?[]const u8) !?[]const u8 {
+    return if (value) |slice| try cloneSlice(allocator, slice) else null;
+}
+
+fn cloneProviderRoots(allocator: std.mem.Allocator, roots: []const source_mod.ProviderRoot) ![]const source_mod.ProviderRoot {
+    if (roots.len == 0) return &.{};
+
+    const cloned_roots = try allocator.alloc(source_mod.ProviderRoot, roots.len);
+    errdefer allocator.free(cloned_roots);
+
+    var initialized: usize = 0;
+    errdefer {
+        for (cloned_roots[0..initialized]) |root| {
+            freeSlice(allocator, root.path);
+        }
+    }
+
+    for (roots, 0..) |root, idx| {
+        cloned_roots[idx] = .{
+            .provider = root.provider,
+            .path = try cloneSlice(allocator, root.path),
+        };
+        initialized += 1;
+    }
+
+    return cloned_roots;
+}
+
+fn freeOwnedSource(allocator: std.mem.Allocator, source: *source_mod.Source) void {
+    freeSlice(allocator, source.id);
+    freeSlice(allocator, source.name);
+    switch (source.target) {
+        .local => {},
+        .wsl => |target| freeSlice(allocator, target.distro),
+        .ssh => |target| freeSlice(allocator, target.profile_name),
+    }
+    if (source.codex_root_override) |value| freeSlice(allocator, value);
+    if (source.claude_root_override) |value| freeSlice(allocator, value);
+    for (source.extra_roots) |root| {
+        freeSlice(allocator, root.path);
+    }
+    if (source.extra_roots.len > 0) allocator.free(source.extra_roots);
+}
+
+fn freeSlice(allocator: std.mem.Allocator, value: []const u8) void {
+    if (value.len > 0) allocator.free(value);
+}
+
 test "ai_history_session: replacing rows sorts by last active time" {
     var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
     defer session.deinit();
@@ -148,6 +239,66 @@ test "ai_history_session: persistSnap duplicates source identity" {
     try std.testing.expectEqualStrings("Local", snap.target_name);
     try std.testing.expect(snap.source_id.ptr != session.source.id.ptr);
     try std.testing.expect(snap.target_name.ptr != session.source.name.ptr);
+}
+
+test "ai_history_session: initOwned clones source identity and ssh roots" {
+    const allocator = std.testing.allocator;
+    var id_buf = [_]u8{ 's', 's', 'h', '-', 'h', 'i', 's', 't', 'o', 'r', 'y' };
+    var name_buf = [_]u8{ 'B', 'u', 'i', 'l', 'd', ' ', 'B', 'o', 'x' };
+    var profile_buf = [_]u8{ 'b', 'u', 'i', 'l', 'd', 'b', 'o', 'x' };
+    var codex_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'c', 'o', 'd', 'e', 'x' };
+    var claude_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'c', 'l', 'a', 'u', 'd', 'e' };
+    var extra_path_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'e', 'x', 't', 'r', 'a' };
+    const extra_roots = [_]source_mod.ProviderRoot{
+        .{ .provider = .codex, .path = extra_path_buf[0..] },
+    };
+
+    var session = try Session.initOwned(allocator, .{
+        .id = id_buf[0..],
+        .name = name_buf[0..],
+        .target = .{ .ssh = .{ .profile_name = profile_buf[0..] } },
+        .codex_root_override = codex_buf[0..],
+        .claude_root_override = claude_buf[0..],
+        .extra_roots = extra_roots[0..],
+    });
+    defer session.deinit();
+
+    @memset(&id_buf, 'x');
+    @memset(&name_buf, 'x');
+    @memset(&profile_buf, 'x');
+    @memset(&codex_buf, 'x');
+    @memset(&claude_buf, 'x');
+    @memset(&extra_path_buf, 'x');
+
+    try std.testing.expectEqualStrings("ssh-history", session.source.id);
+    try std.testing.expectEqualStrings("Build Box", session.source.name);
+    try std.testing.expectEqualStrings("buildbox", session.source.target.ssh.profile_name);
+    try std.testing.expectEqualStrings("/tmp/codex", session.source.codex_root_override.?);
+    try std.testing.expectEqualStrings("/tmp/claude", session.source.claude_root_override.?);
+    try std.testing.expectEqual(@as(usize, 1), session.source.extra_roots.len);
+    try std.testing.expectEqualStrings("/tmp/extra", session.source.extra_roots[0].path);
+    try std.testing.expect(session.source.id.ptr != id_buf[0..].ptr);
+    try std.testing.expect(session.source.name.ptr != name_buf[0..].ptr);
+    try std.testing.expect(session.source.target.ssh.profile_name.ptr != profile_buf[0..].ptr);
+    try std.testing.expect(session.source.extra_roots.ptr != extra_roots[0..].ptr);
+    try std.testing.expect(session.source.extra_roots[0].path.ptr != extra_path_buf[0..].ptr);
+}
+
+test "ai_history_session: initOwned clones wsl distro" {
+    const allocator = std.testing.allocator;
+    var distro_buf = [_]u8{ 'U', 'b', 'u', 'n', 't', 'u' };
+
+    var session = try Session.initOwned(allocator, .{
+        .id = "wsl",
+        .name = "WSL",
+        .target = .{ .wsl = .{ .distro = distro_buf[0..] } },
+    });
+    defer session.deinit();
+
+    @memset(&distro_buf, 'x');
+
+    try std.testing.expectEqualStrings("Ubuntu", session.source.target.wsl.distro);
+    try std.testing.expect(session.source.target.wsl.distro.ptr != distro_buf[0..].ptr);
 }
 
 test "ai_history_session: persistSnap frees partial duplicates on allocation failure" {

--- a/src/ai_history_source.zig
+++ b/src/ai_history_source.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const Target = union(enum) {
+    local,
+    wsl: WslTarget,
+    ssh: SshTargetRef,
+};
+
+pub const WslTarget = struct { distro: []const u8 = "" };
+pub const SshTargetRef = struct { profile_name: []const u8 };
+
+pub const ProviderFlags = packed struct {
+    codex: bool = true,
+    claude: bool = true,
+};
+
+pub const ProviderRoot = struct {
+    provider: types.ProviderId,
+    path: []const u8,
+};
+
+pub const Source = struct {
+    id: []const u8,
+    name: []const u8,
+    target: Target,
+    providers: ProviderFlags = .{},
+    codex_root_override: ?[]const u8 = null,
+    claude_root_override: ?[]const u8 = null,
+    extra_roots: []const ProviderRoot = &.{},
+};
+
+pub fn defaultRoot(provider: types.ProviderId, home: []const u8, out: []u8) ?[]const u8 {
+    const suffix = switch (provider) {
+        .codex => ".codex",
+        .claude => ".claude",
+    };
+    return std.fmt.bufPrint(out, "{s}/{s}", .{ home, suffix }) catch null;
+}
+
+test "ai_history_source: default provider roots use target home" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("/home/me/.codex", defaultRoot(.codex, "/home/me", &buf).?);
+    try std.testing.expectEqualStrings("/home/me/.claude", defaultRoot(.claude, "/home/me", &buf).?);
+}

--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+
+pub const ProviderId = enum {
+    codex,
+    claude,
+
+    pub fn label(self: ProviderId) []const u8 {
+        return switch (self) {
+            .codex => "Codex",
+            .claude => "Claude Code",
+        };
+    }
+};
+
+pub const MessageRole = enum { user, assistant, system, tool };
+pub const MessageKind = enum { normal, tool_call, tool_result, meta };
+pub const ScanStatus = enum { ok, partial, not_found, invalid };
+pub const ResumeKind = enum { codex_resume, claude_resume, unavailable };
+
+pub const SessionMeta = struct {
+    provider: ProviderId,
+    session_id: []const u8,
+    title: []const u8,
+    summary: []const u8 = "",
+    project_dir: []const u8 = "",
+    created_at_ms: i64 = 0,
+    last_active_at_ms: i64 = 0,
+    source_path: []const u8,
+    resume_kind: ResumeKind,
+    message_count: u32 = 0,
+    scan_status: ScanStatus = .ok,
+};
+
+pub const TranscriptMessage = struct {
+    role: MessageRole,
+    kind: MessageKind = .normal,
+    content: []const u8,
+    timestamp_ms: i64 = 0,
+};
+
+pub const SortDirection = enum { descending, ascending };
+
+pub fn lessRecent(_: void, lhs: SessionMeta, rhs: SessionMeta) bool {
+    if (lhs.last_active_at_ms == rhs.last_active_at_ms) {
+        return std.mem.lessThan(u8, lhs.session_id, rhs.session_id);
+    }
+    return lhs.last_active_at_ms > rhs.last_active_at_ms;
+}
+
+pub fn metadataMatches(meta: SessionMeta, query: []const u8) bool {
+    if (query.len == 0) return true;
+    return containsIgnoreCase(meta.title, query) or
+        containsIgnoreCase(meta.summary, query) or
+        containsIgnoreCase(meta.project_dir, query) or
+        containsIgnoreCase(meta.session_id, query) or
+        containsIgnoreCase(meta.source_path, query);
+}
+
+fn containsIgnoreCase(haystack: []const u8, query: []const u8) bool {
+    if (query.len == 0) return true;
+    if (query.len > haystack.len) return false;
+    var i: usize = 0;
+    while (i + query.len <= haystack.len) : (i += 1) {
+        var matched = true;
+        for (query, 0..) |qch, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(qch)) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return true;
+    }
+    return false;
+}
+
+test "ai_history_types: provider labels are stable" {
+    try std.testing.expectEqualStrings("Codex", ProviderId.codex.label());
+    try std.testing.expectEqualStrings("Claude Code", ProviderId.claude.label());
+}
+
+test "ai_history_types: metadata search covers title summary project session and path" {
+    const meta: SessionMeta = .{
+        .provider = .codex,
+        .session_id = "sess-123",
+        .title = "Fix renderer crash",
+        .summary = "OpenGL startup failure",
+        .project_dir = "/home/me/wispterm",
+        .source_path = "/home/me/.codex/sessions/one.jsonl",
+        .resume_kind = .codex_resume,
+    };
+
+    try std.testing.expect(metadataMatches(meta, "renderer"));
+    try std.testing.expect(metadataMatches(meta, "OPENGL"));
+    try std.testing.expect(metadataMatches(meta, "wispterm"));
+    try std.testing.expect(metadataMatches(meta, "sess-123"));
+    try std.testing.expect(metadataMatches(meta, "sessions/one"));
+    try std.testing.expect(!metadataMatches(meta, "missing"));
+}
+
+test "ai_history_types: metadata search considers the full query" {
+    var title_buf: [257]u8 = undefined;
+    var query_buf: [257]u8 = undefined;
+    @memset(title_buf[0..256], 'a');
+    @memset(query_buf[0..256], 'a');
+    title_buf[256] = 'c';
+    query_buf[256] = 'b';
+
+    const meta: SessionMeta = .{
+        .provider = .codex,
+        .session_id = "sess-long",
+        .title = title_buf[0..],
+        .source_path = "long.jsonl",
+        .resume_kind = .codex_resume,
+    };
+
+    try std.testing.expect(!metadataMatches(meta, query_buf[0..]));
+}
+
+test "ai_history_types: recent sort is descending with session id tie break" {
+    var rows = [_]SessionMeta{
+        .{ .provider = .claude, .session_id = "b", .title = "B", .source_path = "b.jsonl", .resume_kind = .claude_resume, .last_active_at_ms = 10 },
+        .{ .provider = .codex, .session_id = "c", .title = "C", .source_path = "c.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 20 },
+        .{ .provider = .codex, .session_id = "a", .title = "A", .source_path = "a.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = 10 },
+    };
+    std.mem.sort(SessionMeta, &rows, {}, lessRecent);
+    try std.testing.expectEqualStrings("c", rows[0].session_id);
+    try std.testing.expectEqualStrings("a", rows[1].session_id);
+    try std.testing.expectEqualStrings("b", rows[2].session_id);
+}

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -12,6 +12,8 @@ const input_key = @import("../input/key.zig");
 const remote_client = @import("../remote_client.zig");
 const session_persist = @import("../session_persist.zig");
 const ai_chat = @import("../ai_chat.zig");
+const ai_history_session = @import("../ai_history_session.zig");
+const ai_history_source = @import("../ai_history_source.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
 const active_tab_state = @import("active_tab.zig");
@@ -43,6 +45,7 @@ pub const TabState = struct {
     tree: SplitTree,
     focused: SplitTree.Node.Handle = .root,
     ai_chat_session: ?*ai_chat.Session = null,
+    ai_history_session: ?*ai_history_session.Session = null,
     /// Copilot conversation for a terminal tab (Issue #98). Distinct from
     /// `ai_chat_session`, which backs a dedicated AI-chat tab. Lazily created
     /// the first time the copilot sidebar is opened on this tab.
@@ -51,6 +54,7 @@ pub const TabState = struct {
     pub const Kind = enum {
         terminal,
         ai_chat,
+        ai_history,
     };
 
     /// Get the focused surface in this tab, or null if tree is empty
@@ -74,12 +78,15 @@ pub const TabState = struct {
             const chat_title = chat.title();
             return if (chat_title.len > 0) chat_title else "AI Chat";
         }
+        if (self.kind == .ai_history) {
+            const session = self.ai_history_session orelse return "AI History";
+            return if (session.source.name.len > 0) session.source.name else "AI History";
+        }
         const surface = self.focusedSurface() orelse return "wispterm";
         return surface.getTitle();
     }
 
     pub fn deinit(self: *TabState, allocator: std.mem.Allocator) void {
-        _ = allocator;
         switch (self.kind) {
             .terminal => {
                 self.tree.deinit();
@@ -92,6 +99,13 @@ pub const TabState = struct {
                 if (self.ai_chat_session) |session| {
                     session.deinit();
                     self.ai_chat_session = null;
+                }
+            },
+            .ai_history => {
+                if (self.ai_history_session) |session| {
+                    session.deinit();
+                    allocator.destroy(session);
+                    self.ai_history_session = null;
                 }
             },
         }
@@ -116,6 +130,12 @@ pub threadlocal var g_ai_history_change_hook: ?ai_chat.HistoryChangeHook = null;
 // id. Registered by AppWindow (which owns the history store), so tab.zig stays
 // free of that dependency. Returns true if the tab was reopened.
 pub threadlocal var g_ai_restore_hook: ?*const fn (session_id: []const u8) bool = null;
+
+// Restore hook: rebuild an AI History tab from its persisted source snapshot.
+// The snap slices are borrowed from the parsed session JSON and are only valid
+// for the duration of the hook call; callees must duplicate any fields they
+// keep after returning. Returns true if the tab was reopened.
+pub threadlocal var g_ai_history_restore_hook: ?*const fn (session_persist.AiHistorySnap) bool = null;
 
 // Forced title from config (overrides all tab titles)
 pub threadlocal var g_forced_title: ?[]const u8 = null;
@@ -323,6 +343,7 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
     t.tree = tree;
     t.focused = .root;
     t.ai_chat_session = null;
+    t.ai_history_session = null;
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
@@ -376,6 +397,7 @@ pub fn spawnAiChatTab(
     t.tree = .empty;
     t.focused = .root;
     t.ai_chat_session = session;
+    t.ai_history_session = null;
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
@@ -404,6 +426,7 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
     t.tree = .empty;
     t.focused = .root;
     t.ai_chat_session = session;
+    t.ai_history_session = null;
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
@@ -698,7 +721,7 @@ pub const CloseResult = enum {
 /// Close the focused split. Returns what happened so the caller can handle side effects.
 pub fn closeFocusedSplit(allocator: std.mem.Allocator) CloseResult {
     const t = activeTab() orelse return .no_op;
-    if (t.kind == .ai_chat) {
+    if (t.kind != .terminal) {
         if (g_tab_count <= 1) return .close_window;
         closeTab(active_tab_state.g_active_tab, allocator);
         return .closed_tab;
@@ -817,6 +840,7 @@ pub fn commitTabRename() void {
                     .ai_chat => if (t.ai_chat_session) |session| {
                         session.setTitle(g_tab_rename_buf[0..g_tab_rename_len]);
                     },
+                    .ai_history => {},
                 }
             }
         }
@@ -980,6 +1004,17 @@ pub fn snapshotTab(arena: std.mem.Allocator, t: *const TabState) !session_persis
             .zoomed_leaf = null,
             .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
             .ai_session_id = sid,
+        };
+    }
+    if (t.kind == .ai_history) {
+        const session = t.ai_history_session orelse return error.NoAiHistorySession;
+        const snap = try session.persistSnap(arena);
+        return session_persist.TabSnap{
+            .title_override = null,
+            .focused_leaf = 0,
+            .zoomed_leaf = null,
+            .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+            .ai_history = snap,
         };
     }
     if (t.kind != .terminal) return error.NotTerminalTab;
@@ -1200,6 +1235,11 @@ pub fn restoreTab(
 ) bool {
     if (g_tab_count >= MAX_TABS) return false;
 
+    if (snap.ai_history) |history_snap| {
+        const hook = g_ai_history_restore_hook orelse return false;
+        return hook(history_snap);
+    }
+
     // AI Chat tab: rebuild from its persisted history session via the hook
     // AppWindow installed (it owns the history store). The placeholder `tree` in
     // the snapshot is ignored. If the hook isn't installed or the session is
@@ -1231,6 +1271,7 @@ pub fn restoreTab(
     // Resolve focused_leaf from pre-order index back to a Handle.
     t.focused = handleOfNthLeaf(&t.tree, snap.focused_leaf) orelse .root;
     t.ai_chat_session = null;
+    t.ai_history_session = null;
     t.copilot_session = null;
 
     g_tabs[g_tab_count] = t;
@@ -1371,6 +1412,7 @@ fn makeTestTabState() TabState {
         .tree = .empty,
         .focused = .root,
         .ai_chat_session = null,
+        .ai_history_session = null,
     };
 }
 
@@ -1414,6 +1456,144 @@ test "tab: restoreTab skips an ai tab when no restore hook is installed" {
         .ai_session_id = "sess-xyz",
     };
     try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+}
+
+test "tab: restoreTab routes ai_history through the restore hook" {
+    resetTestTabGlobals();
+    const previous_hook = g_ai_history_restore_hook;
+    defer g_ai_history_restore_hook = previous_hook;
+
+    const Captured = struct {
+        var source_id: []const u8 = "";
+        var called: bool = false;
+        fn hook(snap: session_persist.AiHistorySnap) bool {
+            source_id = snap.source_id;
+            called = true;
+            return true;
+        }
+    };
+    Captured.called = false;
+    Captured.source_id = "";
+    g_ai_history_restore_hook = Captured.hook;
+
+    const snap = session_persist.TabSnap{
+        .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+        .ai_history = .{
+            .source_id = "local-history",
+            .target_kind = "local",
+            .target_name = "Local",
+        },
+    };
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(Captured.called);
+    try std.testing.expectEqualStrings("local-history", Captured.source_id);
+    try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+}
+
+test "tab: restoreTab skips an ai_history tab when no restore hook is installed" {
+    resetTestTabGlobals();
+    const previous_hook = g_ai_history_restore_hook;
+    defer g_ai_history_restore_hook = previous_hook;
+    g_ai_history_restore_hook = null;
+
+    const snap = session_persist.TabSnap{
+        .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+        .ai_history = .{
+            .source_id = "local-history",
+            .target_kind = "local",
+            .target_name = "Local",
+        },
+    };
+    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+}
+
+test "tab: snapshotTab persists a live ai_history tab" {
+    const allocator = std.testing.allocator;
+    const source: ai_history_source.Source = .{
+        .id = "local-history",
+        .name = "Local History",
+        .target = .local,
+    };
+    const session = try allocator.create(ai_history_session.Session);
+    session.* = ai_history_session.Session.init(allocator, source);
+    defer {
+        session.deinit();
+        allocator.destroy(session);
+    }
+
+    const tab = TabState{
+        .kind = .ai_history,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = session,
+        .copilot_session = null,
+    };
+
+    const snap = try snapshotTab(allocator, &tab);
+    defer if (snap.ai_history) |history| {
+        allocator.free(history.source_id);
+        allocator.free(history.target_kind);
+        allocator.free(history.target_name);
+    };
+
+    try std.testing.expect(snap.ai_session_id == null);
+    const history = snap.ai_history orelse return error.ExpectedAiHistorySnap;
+    try std.testing.expectEqualStrings("local-history", history.source_id);
+    try std.testing.expectEqualStrings("local", history.target_kind);
+    try std.testing.expectEqualStrings("Local History", history.target_name);
+
+    const leaf = switch (snap.tree) {
+        .leaf => |leaf| leaf,
+        .split => return error.UnexpectedSplit,
+    };
+    switch (leaf.surface) {
+        .local_shell => {},
+        .ssh => return error.UnexpectedSsh,
+    }
+}
+
+test "tab: restoreTab prioritizes ai_history over ai_session_id" {
+    resetTestTabGlobals();
+    const previous_history_hook = g_ai_history_restore_hook;
+    const previous_chat_hook = g_ai_restore_hook;
+    defer {
+        g_ai_history_restore_hook = previous_history_hook;
+        g_ai_restore_hook = previous_chat_hook;
+    }
+
+    const Captured = struct {
+        var history_called: bool = false;
+        var chat_called: bool = false;
+        fn historyHook(_: session_persist.AiHistorySnap) bool {
+            history_called = true;
+            return true;
+        }
+        fn chatHook(_: []const u8) bool {
+            chat_called = true;
+            return true;
+        }
+    };
+    Captured.history_called = false;
+    Captured.chat_called = false;
+    g_ai_history_restore_hook = Captured.historyHook;
+    g_ai_restore_hook = Captured.chatHook;
+
+    const snap = session_persist.TabSnap{
+        .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
+        .ai_session_id = "chat-session",
+        .ai_history = .{
+            .source_id = "local-history",
+            .target_kind = "local",
+            .target_name = "Local",
+        },
+    };
+
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(Captured.history_called);
+    try std.testing.expect(!Captured.chat_called);
+    try std.testing.expectEqual(@as(usize, 0), g_tab_count);
 }
 
 test "tab: reorder moves active tab forward" {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -440,7 +440,10 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
 pub fn spawnAiHistoryTab(allocator: std.mem.Allocator, source: ai_history_source.Source) bool {
     if (g_tab_count >= MAX_TABS) return false;
     const session_ptr = allocator.create(ai_history_session.Session) catch return false;
-    session_ptr.* = ai_history_session.Session.init(allocator, source);
+    session_ptr.* = ai_history_session.Session.initOwned(allocator, source) catch {
+        allocator.destroy(session_ptr);
+        return false;
+    };
 
     const t = allocator.create(TabState) catch {
         session_ptr.deinit();
@@ -1559,10 +1562,46 @@ test "tab: spawnAiHistoryTab creates active ai_history tab" {
     try std.testing.expectEqualStrings("local-history", session.source.id);
 }
 
+test "tab: spawnAiHistoryTab owns mutable ssh source buffers" {
+    resetTestTabGlobals();
+    const allocator = std.testing.allocator;
+    defer {
+        for (0..g_tab_count) |idx| {
+            if (g_tabs[idx]) |tab_state| {
+                tab_state.deinit(allocator);
+                allocator.destroy(tab_state);
+                g_tabs[idx] = null;
+            }
+        }
+        resetTestTabGlobals();
+    }
+
+    var id_buf = [_]u8{ 's', 's', 'h', '-', 'h', 'i', 's', 't', 'o', 'r', 'y' };
+    var name_buf = [_]u8{ 'B', 'u', 'i', 'l', 'd', ' ', 'B', 'o', 'x' };
+    var profile_buf = [_]u8{ 'b', 'u', 'i', 'l', 'd', 'b', 'o', 'x' };
+
+    try std.testing.expect(spawnAiHistoryTab(allocator, .{
+        .id = id_buf[0..],
+        .name = name_buf[0..],
+        .target = .{ .ssh = .{ .profile_name = profile_buf[0..] } },
+    }));
+
+    @memset(&id_buf, 'x');
+    @memset(&name_buf, 'x');
+    @memset(&profile_buf, 'x');
+
+    const active = activeTab() orelse return error.ExpectedActiveTab;
+    const session = active.ai_history_session orelse return error.ExpectedAiHistorySession;
+    try std.testing.expectEqualStrings("ssh-history", session.source.id);
+    try std.testing.expectEqualStrings("Build Box", session.source.name);
+    try std.testing.expectEqualStrings("buildbox", session.source.target.ssh.profile_name);
+    try std.testing.expectEqualStrings("Build Box", active.getTitle());
+}
+
 test "tab: spawnAiHistoryTab rolls back when tab allocation fails" {
     resetTestTabGlobals();
     var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
-        .fail_index = 1,
+        .fail_index = 3,
     });
 
     try std.testing.expect(!spawnAiHistoryTab(failing_allocator.allocator(), .{

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -437,6 +437,29 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
     return true;
 }
 
+pub fn spawnAiHistoryTab(allocator: std.mem.Allocator, source: ai_history_source.Source) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+    const session_ptr = allocator.create(ai_history_session.Session) catch return false;
+    session_ptr.* = ai_history_session.Session.init(allocator, source);
+
+    const t = allocator.create(TabState) catch {
+        session_ptr.deinit();
+        allocator.destroy(session_ptr);
+        return false;
+    };
+    t.kind = .ai_history;
+    t.tree = .empty;
+    t.focused = .root;
+    t.ai_chat_session = null;
+    t.copilot_session = null;
+    t.ai_history_session = session_ptr;
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+    return true;
+}
+
 /// Close the tab at the given index.
 /// The caller is responsible for clearing selection state and setting rebuild flags.
 pub fn closeTab(idx: usize, allocator: std.mem.Allocator) void {
@@ -1506,6 +1529,51 @@ test "tab: restoreTab skips an ai_history tab when no restore hook is installed"
     };
     try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
     try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+}
+
+test "tab: spawnAiHistoryTab creates active ai_history tab" {
+    resetTestTabGlobals();
+    const allocator = std.testing.allocator;
+    defer {
+        for (0..g_tab_count) |idx| {
+            if (g_tabs[idx]) |tab_state| {
+                tab_state.deinit(allocator);
+                allocator.destroy(tab_state);
+                g_tabs[idx] = null;
+            }
+        }
+        resetTestTabGlobals();
+    }
+
+    try std.testing.expect(spawnAiHistoryTab(allocator, .{
+        .id = "local-history",
+        .name = "Local History",
+        .target = .local,
+    }));
+
+    try std.testing.expectEqual(@as(usize, 1), g_tab_count);
+    try std.testing.expectEqual(@as(usize, 0), active_tab_state.g_active_tab);
+    const active = activeTab() orelse return error.ExpectedActiveTab;
+    try std.testing.expectEqual(TabState.Kind.ai_history, active.kind);
+    const session = active.ai_history_session orelse return error.ExpectedAiHistorySession;
+    try std.testing.expectEqualStrings("local-history", session.source.id);
+}
+
+test "tab: spawnAiHistoryTab rolls back when tab allocation fails" {
+    resetTestTabGlobals();
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 1,
+    });
+
+    try std.testing.expect(!spawnAiHistoryTab(failing_allocator.allocator(), .{
+        .id = "local-history",
+        .name = "Local History",
+        .target = .local,
+    }));
+
+    try std.testing.expect(failing_allocator.has_induced_failure);
+    try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+    try std.testing.expect(g_tabs[0] == null);
 }
 
 test "tab: snapshotTab persists a live ai_history tab" {

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -97,6 +97,7 @@ pub const NewAgentLaunchAction = enum {
 
 pub const SESSION_LAUNCHER_ROW_COUNT: usize = platform_pty_command.session_launcher_row_count;
 pub const SESSION_LAUNCHER_ROW_AI_AGENT: usize = platform_pty_command.session_launcher_ai_agent_row;
+pub const SESSION_LAUNCHER_ROW_AI_HISTORY: usize = platform_pty_command.session_launcher_ai_history_row;
 
 pub const State = struct {
     command_palette_visible: bool = false,
@@ -111,10 +112,11 @@ pub const State = struct {
     ssh_form_visible: bool = false,
     ai_list_visible: bool = false,
     ai_form_visible: bool = false,
+    ai_history_source_visible: bool = false,
     settings_visible: bool = false,
 
     pub fn sessionLauncherVisible(self: *const State) bool {
-        return self.session_launcher_visible or self.ssh_list_visible or self.ssh_form_visible or self.ai_list_visible or self.ai_form_visible;
+        return self.session_launcher_visible or self.ssh_list_visible or self.ssh_form_visible or self.ai_list_visible or self.ai_form_visible or self.ai_history_source_visible;
     }
 
     pub fn commandPaletteIsHistoryMode(self: *const State) bool {
@@ -155,6 +157,7 @@ pub const State = struct {
         self.ssh_form_visible = false;
         self.ai_list_visible = false;
         self.ai_form_visible = false;
+        self.ai_history_source_visible = false;
     }
 
     pub fn commandPaletteLeaveAgentHistory(self: *State) void {
@@ -210,6 +213,7 @@ pub const State = struct {
         self.ssh_form_visible = false;
         self.ai_list_visible = false;
         self.ai_form_visible = false;
+        self.ai_history_source_visible = false;
         self.command_palette_visible = false;
         self.settings_visible = false;
         self.startup_shortcuts_visible = false;
@@ -221,6 +225,7 @@ pub const State = struct {
         self.ssh_form_visible = false;
         self.ai_list_visible = false;
         self.ai_form_visible = false;
+        self.ai_history_source_visible = false;
     }
 
     pub fn settingsPageOpen(self: *State) void {

--- a/src/input.zig
+++ b/src/input.zig
@@ -224,6 +224,7 @@ threadlocal var g_ai_transcript_scroll_drag_offset: f32 = 0;
 threadlocal var g_ai_transcript_selecting: bool = false;
 threadlocal var g_ai_transcript_select_chat: ?*AppWindow.ai_chat.Session = null;
 threadlocal var g_ai_transcript_select_auto_copy: bool = false;
+threadlocal var g_ai_history_suppress_refresh_char: bool = false;
 pub threadlocal var g_sidebar_resize_hover: bool = false; // Mouse is over the sidebar resize edge
 pub threadlocal var g_sidebar_resize_dragging: bool = false; // Currently dragging the sidebar edge
 pub threadlocal var g_explorer_resize_hover: bool = false; // Mouse is over the file explorer resize edge
@@ -691,13 +692,17 @@ pub fn processEvents(win: anytype) void {
 fn processKeyAndCharEvents(win: anytype) void {
     while (true) {
         var did_anything = false;
+        var handled_key = false;
         if (window_backend.popKeyEvent(win)) |ev| {
             handleKey(ev);
             did_anything = true;
+            handled_key = true;
         }
         if (window_backend.popCharEvent(win)) |ev| {
             handleChar(ev);
             did_anything = true;
+        } else if (handled_key) {
+            g_ai_history_suppress_refresh_char = false;
         }
         if (!did_anything) break;
     }
@@ -779,6 +784,17 @@ fn handleChar(ev: platform_input.CharEvent) void {
             chat.handleChar(ev.codepoint);
             AppWindow.g_force_rebuild = true;
             AppWindow.g_cells_valid = false;
+        }
+        return;
+    }
+    if (AppWindow.activeAiHistory() != null) {
+        if (g_ai_history_suppress_refresh_char) {
+            const suppress = !ev.ctrl and !ev.alt and !ev.super and ev.codepoint == 'r';
+            g_ai_history_suppress_refresh_char = false;
+            if (suppress) return;
+        }
+        if (!ev.ctrl and !ev.alt and !ev.super) {
+            _ = AppWindow.aiHistoryInsertCodepoint(ev.codepoint);
         }
         return;
     }
@@ -1125,6 +1141,34 @@ fn handleKey(ev: platform_input.KeyEvent) void {
             AppWindow.g_cells_valid = false;
             return;
         }
+    }
+
+    if (AppWindow.activeAiHistory() != null) {
+        const plain = !ev.ctrl and !ev.alt and !ev.super;
+        switch (ev.key_code) {
+            platform_input.key_backspace => {
+                _ = AppWindow.aiHistoryBackspaceFilter();
+                return;
+            },
+            platform_input.key_up => {
+                _ = AppWindow.aiHistoryMoveSelection(-1);
+                return;
+            },
+            platform_input.key_down => {
+                _ = AppWindow.aiHistoryMoveSelection(1);
+                return;
+            },
+            platform_input.key_enter => {
+                _ = AppWindow.aiHistoryLoadSelectedTranscript();
+                return;
+            },
+            0x52 => if (plain and !ev.shift) {
+                g_ai_history_suppress_refresh_char = AppWindow.aiHistoryScanLocalNow();
+                return;
+            },
+            else => {},
+        }
+        return;
     }
 
     // AI copilot sidebar (terminal tabs): route editing/navigation keys to the
@@ -2646,6 +2690,10 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             // Clicking outside file explorer unfocuses it
             file_explorer.g_focused = false;
             if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+
+            if (AppWindow.activeAiHistory() != null) {
+                if (AppWindow.aiHistoryHandleMousePress(xpos, ypos)) return;
+            }
 
             // AI copilot sidebar (terminal tabs). When the panel is visible,
             // a click inside its rect focuses the copilot and routes one-shot

--- a/src/input.zig
+++ b/src/input.zig
@@ -859,6 +859,7 @@ fn logicalKeyFromCode(key_code: platform_input.KeyCode) input_key.Key {
         0x41 => .key_a,
         0x43 => .key_c,
         0x45 => .key_e,
+        0x48 => .key_h,
         0x4B => .key_k,
         0x4C => .key_l,
         0x4E => .key_n,
@@ -870,6 +871,10 @@ fn logicalKeyFromCode(key_code: platform_input.KeyCode) input_key.Key {
         0x59 => .key_y,
         else => .unidentified,
     };
+}
+
+test "input: logical key mapping includes session launcher H mnemonic" {
+    try std.testing.expectEqual(input_key.Key.key_h, logicalKeyFromCode(0x48));
 }
 
 fn actionIs(action: ?keybind.Action, expected: keybind.Action) bool {

--- a/src/input.zig
+++ b/src/input.zig
@@ -1162,6 +1162,10 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 _ = AppWindow.aiHistoryLoadSelectedTranscript();
                 return;
             },
+            0x20 => if (plain) {
+                _ = AppWindow.aiHistoryPreviewSelectedTranscript();
+                return;
+            },
             0x52 => if (plain and !ev.shift) {
                 g_ai_history_suppress_refresh_char = AppWindow.aiHistoryScanLocalNow();
                 return;

--- a/src/input/key.zig
+++ b/src/input/key.zig
@@ -19,6 +19,7 @@ pub const Key = enum {
     key_a,
     key_c,
     key_e,
+    key_h,
     key_k,
     key_l,
     key_u,

--- a/src/platform/dirs.zig
+++ b/src/platform/dirs.zig
@@ -163,6 +163,18 @@ pub fn agentHistoryPathFromEnvForOs(
     return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "agent-history.json");
 }
 
+pub fn aiHistoryCachePath(allocator: std.mem.Allocator) ![]const u8 {
+    return pathInConfigDir(allocator, "ai_history_cache.json");
+}
+
+pub fn aiHistoryCachePathFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "ai_history_cache.json");
+}
+
 pub fn skillsDir(allocator: std.mem.Allocator) ![]const u8 {
     return pathInConfigDir(allocator, "skills");
 }
@@ -478,6 +490,12 @@ test "platform dirs expose app data paths for shared features" {
     const expected_history = try std.fs.path.join(allocator, &.{ "/home/alice", ".config", app_dir_name, "agent-history.json" });
     defer allocator.free(expected_history);
     try std.testing.expectEqualStrings(expected_history, history);
+
+    const ai_history_cache = try aiHistoryCachePathFromEnvForOs(allocator, .linux, env);
+    defer allocator.free(ai_history_cache);
+    const expected_ai_history_cache = try std.fs.path.join(allocator, &.{ "/home/alice", ".config", app_dir_name, "ai_history_cache.json" });
+    defer allocator.free(expected_ai_history_cache);
+    try std.testing.expectEqualStrings(expected_ai_history_cache, ai_history_cache);
 }
 
 test "platform dirs expose app skill roots" {

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -358,8 +358,16 @@ pub fn wslInteractiveCommand(buf: []u8, cwd: ?[]const u8) ?[]const u8 {
     return impl.wslInteractiveCommand(buf, cwd);
 }
 
+pub fn wslShellCommand(buf: []u8, command: []const u8) ?[]const u8 {
+    return impl.wslShellCommand(buf, command);
+}
+
 pub fn wslExecArgv(command: []const u8) [5][]const u8 {
     return impl.wslExecArgv(command);
+}
+
+pub fn localShellInitialCommand(buf: []u8, current_shell: CommandLine, command: []const u8) ?[]const u8 {
+    return impl.localShellInitialCommand(buf, current_shell, command);
 }
 
 pub fn sshLauncherDetail() []const u8 {
@@ -635,6 +643,50 @@ test "platform pty command exposes session launcher layout by target OS" {
 test "platform pty command exposes OpenSSH helper executable names" {
     try std.testing.expect(sshExecutableName().len > 0);
     try std.testing.expect(scpExecutableName().len > 0);
+}
+
+test "platform pty command builds shell command lines for AI History resume" {
+    var buf: [1024]u8 = undefined;
+    const checked_resume = "test -d '/home/me/project' && cd '/home/me/project' && codex resume abc";
+
+    const current_shell_owned = try allocCommandLineFromUtf8(std.testing.allocator, "pwsh.exe");
+    defer freeCommandLine(std.testing.allocator, current_shell_owned);
+    const local_command = localShellInitialCommand(&buf, commandLineFromOwned(current_shell_owned), checked_resume) orelse return error.ExpectedCommand;
+    switch (backendForOs(builtin.os.tag)) {
+        .windows => {
+            try std.testing.expect(std.mem.startsWith(u8, local_command, "pwsh.exe -NoLogo -NoExit -Command "));
+            try std.testing.expect(std.mem.indexOf(u8, local_command, checked_resume) != null);
+        },
+        .unsupported => {
+            try std.testing.expect(std.mem.indexOf(u8, local_command, " -lc ") != null);
+            try std.testing.expect(std.mem.indexOf(u8, local_command, "codex resume abc") != null);
+        },
+    }
+
+    if (builtin.os.tag == .windows) {
+        const cmd_owned = try allocCommandLineFromUtf8(std.testing.allocator, "cmd.exe");
+        defer freeCommandLine(std.testing.allocator, cmd_owned);
+        try std.testing.expect(localShellInitialCommand(&buf, commandLineFromOwned(cmd_owned), checked_resume) == null);
+    }
+
+    const wsl_command = wslShellCommand(&buf, checked_resume);
+    switch (backendForOs(builtin.os.tag)) {
+        .windows => {
+            try std.testing.expect(wsl_command != null);
+            try std.testing.expect(std.mem.startsWith(u8, wsl_command.?, "wsl.exe --exec sh -lc "));
+            try std.testing.expect(std.mem.indexOf(u8, wsl_command.?, checked_resume) != null);
+        },
+        .unsupported => try std.testing.expect(wsl_command == null),
+    }
+
+    const ssh_command = sshInteractiveCommand(&buf, .{
+        .user = "user",
+        .host = "example.test",
+        .remote_command = checked_resume,
+    }) orelse return error.ExpectedCommand;
+    try std.testing.expect(std.mem.indexOf(u8, ssh_command, "ssh") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ssh_command, "user@example.test") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ssh_command, "codex resume abc") != null);
 }
 
 test "platform pty command selects backend by target OS" {

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -102,8 +102,8 @@ pub const session_launcher_detail = sessionLauncherDetailForOs(builtin.os.tag);
 
 pub fn sessionLauncherDetailForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
-        .windows => "Choose PowerShell, SSH, WSL, or AI Agent",
-        .unsupported => "Choose Shell, SSH, or AI Agent",
+        .windows => "Choose PowerShell, SSH, WSL, AI Agent, or AI History",
+        .unsupported => "Choose Shell, SSH, AI Agent, or AI History",
     };
 }
 
@@ -115,8 +115,8 @@ pub const session_launcher_row_count = sessionLauncherRowCountForOs(builtin.os.t
 
 pub fn sessionLauncherRowCountForOs(os_tag: std.Target.Os.Tag) usize {
     return switch (backendForOs(os_tag)) {
-        .windows => 4,
-        .unsupported => 3,
+        .windows => 5,
+        .unsupported => 4,
     };
 }
 
@@ -130,6 +130,19 @@ pub fn sessionLauncherAiAgentRowForOs(os_tag: std.Target.Os.Tag) usize {
     return switch (backendForOs(os_tag)) {
         .windows => 3,
         .unsupported => 2,
+    };
+}
+
+pub fn sessionLauncherAiHistoryRow() usize {
+    return session_launcher_ai_history_row;
+}
+
+pub const session_launcher_ai_history_row = sessionLauncherAiHistoryRowForOs(builtin.os.tag);
+
+pub fn sessionLauncherAiHistoryRowForOs(os_tag: std.Target.Os.Tag) usize {
+    return switch (backendForOs(os_tag)) {
+        .windows => 4,
+        .unsupported => 3,
     };
 }
 
@@ -597,16 +610,19 @@ test "platform pty command maps native shell titles to friendly display labels" 
 }
 
 test "platform pty command exposes session launcher layout by target OS" {
-    try std.testing.expectEqual(@as(usize, 4), sessionLauncherRowCountForOs(.windows));
-    try std.testing.expectEqual(@as(usize, 3), sessionLauncherRowCountForOs(.linux));
-    try std.testing.expectEqual(@as(usize, 3), sessionLauncherRowCountForOs(.macos));
+    try std.testing.expectEqual(@as(usize, 5), sessionLauncherRowCountForOs(.windows));
+    try std.testing.expectEqual(@as(usize, 4), sessionLauncherRowCountForOs(.linux));
+    try std.testing.expectEqual(@as(usize, 4), sessionLauncherRowCountForOs(.macos));
 
     try std.testing.expectEqual(@as(usize, 3), sessionLauncherAiAgentRowForOs(.windows));
     try std.testing.expectEqual(@as(usize, 2), sessionLauncherAiAgentRowForOs(.linux));
+    try std.testing.expectEqual(@as(usize, 4), sessionLauncherAiHistoryRowForOs(.windows));
+    try std.testing.expectEqual(@as(usize, 3), sessionLauncherAiHistoryRowForOs(.linux));
     try std.testing.expectEqual(@as(?usize, 2), sessionLauncherWslRowForOs(.windows));
     try std.testing.expectEqual(@as(?usize, null), sessionLauncherWslRowForOs(.linux));
 
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.windows), "WSL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.windows), "AI History") != null);
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.linux), "WSL") == null);
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.macos), "Shell") != null);
 

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -25,6 +25,7 @@ pub const SshCommandOptions = struct {
     password_auth: bool = false,
     legacy_algorithms: bool = false,
     proxy_jump: []const u8 = "",
+    remote_command: []const u8 = "",
 };
 
 pub fn resolveShellCommandLine(out_buf: *CommandLineBuffer, cmd: []const u8) usize {
@@ -156,8 +157,43 @@ pub fn wslInteractiveCommand(buf: []u8, cwd: ?[]const u8) ?[]const u8 {
     return null;
 }
 
+pub fn wslShellCommand(buf: []u8, command: []const u8) ?[]const u8 {
+    _ = buf;
+    _ = command;
+    return null;
+}
+
 pub fn wslExecArgv(command: []const u8) [5][]const u8 {
     return .{ "sh", "-lc", command, "", "" };
+}
+
+fn appendAscii(buf: []u8, pos: *usize, text: []const u8) bool {
+    if (pos.* + text.len > buf.len) return false;
+    @memcpy(buf[pos.*..][0..text.len], text);
+    pos.* += text.len;
+    return true;
+}
+
+fn appendPosixSingleQuotedArg(buf: []u8, pos: *usize, value: []const u8) bool {
+    if (!appendAscii(buf, pos, "'")) return false;
+    for (value) |ch| {
+        if (ch == '\'') {
+            if (!appendAscii(buf, pos, "'\\''")) return false;
+        } else {
+            if (pos.* >= buf.len) return false;
+            buf[pos.*] = ch;
+            pos.* += 1;
+        }
+    }
+    return appendAscii(buf, pos, "'");
+}
+
+pub fn localShellInitialCommand(buf: []u8, current_shell: CommandLine, command: []const u8) ?[]const u8 {
+    var pos: usize = 0;
+    if (!appendAscii(buf, &pos, configuredLocalShellCommandForShell(current_shell))) return null;
+    if (!appendAscii(buf, &pos, " -lc ")) return null;
+    if (!appendPosixSingleQuotedArg(buf, &pos, command)) return null;
+    return buf[0..pos];
 }
 
 pub fn sshLauncherDetail() []const u8 {
@@ -183,10 +219,16 @@ pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 
     else
         "";
 
-    return if (options.port.len > 0)
+    const base = (if (options.port.len > 0)
         std.fmt.bufPrint(buf, "ssh -tt {s}-p {s} {s}@{s}", .{ proxy, options.port, options.user, options.host }) catch null
     else
-        std.fmt.bufPrint(buf, "ssh -tt {s}{s}@{s}", .{ proxy, options.user, options.host }) catch null;
+        std.fmt.bufPrint(buf, "ssh -tt {s}{s}@{s}", .{ proxy, options.user, options.host }) catch null) orelse return null;
+    var pos = base.len;
+    if (options.remote_command.len > 0) {
+        if (!appendAscii(buf, &pos, " ")) return null;
+        if (!appendPosixSingleQuotedArg(buf, &pos, options.remote_command)) return null;
+    }
+    return buf[0..pos];
 }
 
 pub fn launchKindForCommand(command: CommandLine) LaunchKind {

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -25,6 +25,7 @@ pub const SshCommandOptions = struct {
     password_auth: bool = false,
     legacy_algorithms: bool = false,
     proxy_jump: []const u8 = "",
+    remote_command: []const u8 = "",
 };
 
 const HANDLE = windows.HANDLE;
@@ -276,8 +277,24 @@ pub fn wslInteractiveCommand(buf: []u8, cwd: ?[]const u8) ?[]const u8 {
     return buf[0..pos];
 }
 
+pub fn wslShellCommand(buf: []u8, command: []const u8) ?[]const u8 {
+    var pos: usize = 0;
+    if (!appendAscii(buf, &pos, "wsl.exe --exec sh -lc ")) return null;
+    if (!appendCommandLineQuotedArg(buf, &pos, command)) return null;
+    return buf[0..pos];
+}
+
 pub fn wslExecArgv(command: []const u8) [5][]const u8 {
     return .{ "wsl.exe", "--exec", "sh", "-lc", command };
+}
+
+pub fn localShellInitialCommand(buf: []u8, current_shell: CommandLine, command: []const u8) ?[]const u8 {
+    if (!shellCommandLooksLikeConfiguredLocalShell(current_shell)) return null;
+    var pos: usize = 0;
+    if (!appendAscii(buf, &pos, configuredLocalShellCommandForShell(current_shell))) return null;
+    if (!appendAscii(buf, &pos, " -NoLogo -NoExit -Command ")) return null;
+    if (!appendCommandLineQuotedArg(buf, &pos, command)) return null;
+    return buf[0..pos];
 }
 
 pub fn sshLauncherDetail() []const u8 {
@@ -313,10 +330,16 @@ pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 
     else
         "";
 
-    return if (options.port.len > 0)
+    const base = (if (options.port.len > 0)
         std.fmt.bufPrint(buf, "cmd.exe /k ssh.exe -tt {s}{s}{s}-p {s} {s}@{s}", .{ auth_flags, legacy_flags, proxy_flags, options.port, options.user, options.host }) catch null
     else
-        std.fmt.bufPrint(buf, "cmd.exe /k ssh.exe -tt {s}{s}{s}{s}@{s}", .{ auth_flags, legacy_flags, proxy_flags, options.user, options.host }) catch null;
+        std.fmt.bufPrint(buf, "cmd.exe /k ssh.exe -tt {s}{s}{s}{s}@{s}", .{ auth_flags, legacy_flags, proxy_flags, options.user, options.host }) catch null) orelse return null;
+    var pos = base.len;
+    if (options.remote_command.len > 0) {
+        if (!appendAscii(buf, &pos, " ")) return null;
+        if (!appendCommandLineQuotedArg(buf, &pos, options.remote_command)) return null;
+    }
+    return buf[0..pos];
 }
 
 pub fn launchKindForCommand(command: CommandLine) LaunchKind {

--- a/src/platform/remote_file.zig
+++ b/src/platform/remote_file.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const pty_command = @import("pty_command.zig");
 const platform_wsl = @import("wsl.zig");
+const platform_process = @import("process.zig");
 
 pub fn wslHomeCommand() []const u8 {
     return "printf %s \"$HOME\"";
@@ -37,6 +38,117 @@ pub fn wslExec(allocator: std.mem.Allocator, command: []const u8) ?[]u8 {
     if (!ok) return null;
 
     return output.toOwnedSlice(allocator) catch null;
+}
+
+pub fn sshExecCapture(allocator: std.mem.Allocator, conn: anytype, command: []const u8) ![]u8 {
+    var askpass_path: ?[]const u8 = null;
+    defer if (askpass_path) |p| allocator.free(p);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return error.SpawnFailed;
+        env_map = try std.process.getEnvMap(allocator);
+        if (env_map) |*map| {
+            try map.put("SSH_ASKPASS", askpass_path.?);
+            try map.put("SSH_ASKPASS_REQUIRE", "force");
+            try map.put("DISPLAY", "wispterm");
+            try map.put("WISPTERM_SSH_PASSWORD", conn.password());
+        }
+    }
+
+    var destination_buf: [272]u8 = undefined;
+    const destination = std.fmt.bufPrint(destination_buf[0..], "{s}@{s}", .{ conn.user(), conn.host() }) catch return error.CommandTooLong;
+
+    var argv_buf: [32][]const u8 = undefined;
+    var argc: usize = 0;
+    argv_buf[argc] = pty_command.sshExecutableName();
+    argc += 1;
+    argv_buf[argc] = "-o";
+    argc += 1;
+    argv_buf[argc] = "StrictHostKeyChecking=accept-new";
+    argc += 1;
+    argv_buf[argc] = "-o";
+    argc += 1;
+    argv_buf[argc] = "ConnectTimeout=8";
+    argc += 1;
+    if (conn.password_auth) {
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "PreferredAuthentications=publickey,password,keyboard-interactive";
+        argc += 1;
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "NumberOfPasswordPrompts=1";
+        argc += 1;
+    } else {
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "BatchMode=yes";
+        argc += 1;
+    }
+    if (conn.legacy_algorithms) {
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "HostkeyAlgorithms=+ssh-rsa,ssh-dss";
+        argc += 1;
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss";
+        argc += 1;
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1";
+        argc += 1;
+        argv_buf[argc] = "-o";
+        argc += 1;
+        argv_buf[argc] = "Ciphers=+aes128-cbc,3des-cbc";
+        argc += 1;
+    }
+    var proxy_buf: [272]u8 = undefined;
+    if (conn.proxyJump().len > 0) {
+        argv_buf[argc] = "-o";
+        argc += 1;
+        const proxy = std.fmt.bufPrint(proxy_buf[0..], "ProxyJump={s}", .{conn.proxyJump()}) catch return error.CommandTooLong;
+        argv_buf[argc] = proxy;
+        argc += 1;
+    }
+    if (conn.port().len > 0) {
+        argv_buf[argc] = "-p";
+        argc += 1;
+        argv_buf[argc] = conn.port();
+        argc += 1;
+    }
+    argv_buf[argc] = destination;
+    argc += 1;
+    argv_buf[argc] = command;
+    argc += 1;
+
+    var child = std.process.Child.init(argv_buf[0..argc], allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.create_no_window = true;
+    if (env_map) |*map| child.env_map = map;
+    try child.spawn();
+
+    const stdout = child.stdout orelse return error.SpawnFailed;
+    const stderr = child.stderr orelse return error.SpawnFailed;
+    const stdout_output = try stdout.readToEndAlloc(allocator, 2 * 1024 * 1024);
+    errdefer allocator.free(stdout_output);
+    const stderr_output = stderr.readToEndAlloc(allocator, 16 * 1024) catch null;
+    defer if (stderr_output) |bytes| allocator.free(bytes);
+
+    const term = try child.wait();
+    const ok = switch (term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+    if (!ok) {
+        logSshFailure(stderr_output);
+        return error.RemoteExecFailed;
+    }
+    return stdout_output;
 }
 
 pub fn wslPathExpr(buf: *[1024]u8, path: []const u8) ?[]const u8 {
@@ -103,6 +215,17 @@ fn appendShellQuoted(buf: *[1024]u8, pos: *usize, arg: []const u8) bool {
     buf[pos.*] = '\'';
     pos.* += 1;
     return true;
+}
+
+fn logSshFailure(stderr_output: ?[]const u8) void {
+    if (stderr_output) |stderr| {
+        const trimmed = std.mem.trim(u8, stderr, " \t\r\n");
+        if (trimmed.len > 0) {
+            std.debug.print("SSH command failed: {s}\n", .{trimmed});
+            return;
+        }
+    }
+    std.debug.print("SSH command failed\n", .{});
 }
 
 test "platform remote file shell paths keep home expandable and quote literals" {

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -194,7 +194,7 @@ fn renderLeftColumn(
     y += draw.cell_h + 5;
     _ = draw.renderTextLimited(statusText(session), layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.left_w - PAD_X * 2);
     y += draw.cell_h + 18;
-    _ = draw.renderTextLimited("r  Refresh local", layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited("r  Retry scan", layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
 
     const footer = "Enter resumes  Space previews";
     _ = draw.renderTextLimited(footer, layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
@@ -257,7 +257,12 @@ fn renderList(
     }
 
     if (session.visibleCount() == 0) {
-        const empty = if (session.rows.items.len == 0) "No sessions scanned" else "No sessions match filter";
+        const empty = if (session.state == .scanning)
+            "Scanning AI history..."
+        else if (session.rows.items.len == 0)
+            "No Codex or Claude Code history found"
+        else
+            "No sessions match filter";
         _ = draw.renderTextLimited(empty, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top + 24), muted, layout.list_w - PAD_X * 2);
     }
 }
@@ -294,8 +299,9 @@ fn renderDetail(
     _ = draw.renderTextLimited(selected.source_path, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2);
     y += draw.cell_h + 16;
     const resume_top = resumeButtonTop(top, draw.cell_h);
+    const can_resume = selected.project_dir.len > 0;
     draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, resume_top, buttonHeight(draw.cell_h)), RESUME_BUTTON_W, buttonHeight(draw.cell_h), panel_strong, 0.72);
-    _ = draw.renderTextLimited("Resume", layout.detail_x + PAD_X + 12, yTextFromTop(draw, window_height, y), accent, RESUME_BUTTON_W - 24);
+    _ = draw.renderTextLimited(if (can_resume) "Resume" else "Resume unavailable", layout.detail_x + PAD_X + 12, yTextFromTop(draw, window_height, y), if (can_resume) accent else muted, RESUME_BUTTON_W - 24);
 
     y += draw.cell_h + 20;
     draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, y, 1), layout.detail_w - PAD_X * 2, 1, line, 0.78);
@@ -304,7 +310,7 @@ fn renderDetail(
     switch (session.transcript_state) {
         .idle => _ = draw.renderTextLimited("Press Space to load transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
         .loading => _ = draw.renderTextLimited("Loading transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
-        .failed => _ = draw.renderTextLimited("Transcript failed to load", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2),
+        .failed => _ = draw.renderTextLimited("Transcript failed to load - press Space to retry", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2),
         .ready => renderTranscriptMessages(draw, session.transcript, layout, window_height, y, content_h, fg, muted, accent),
     }
 }
@@ -347,12 +353,15 @@ fn displayTitle(row: anytype) []const u8 {
 }
 
 fn statusText(session: anytype) []const u8 {
-    if (session.status.len > 0) return session.status;
+    if (session.status.len > 0) {
+        if (std.mem.eql(u8, session.status, "Ready with warnings")) return "Scan completed with warnings";
+        return session.status;
+    }
     return switch (session.state) {
         .idle => "Idle",
-        .scanning => "Scanning",
+        .scanning => "Scanning AI history...",
         .ready => "Ready",
-        .failed => "Scan failed",
+        .failed => "Connection failed - press r to retry",
     };
 }
 

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -1,5 +1,24 @@
 const std = @import("std");
 
+const HEADER_H: f32 = 54;
+const FILTER_H: f32 = 42;
+const ROW_H: f32 = 54;
+const PAD_X: f32 = 16;
+const SMALL_GAP: f32 = 6;
+const BUTTON_PAD_Y: f32 = 4;
+const BUTTON_EXTRA_H: f32 = 10;
+const RESUME_BUTTON_W: f32 = 104;
+
+pub const DrawContext = struct {
+    bg: [3]f32,
+    fg: [3]f32,
+    accent: [3]f32,
+    cell_h: f32,
+    fillQuad: *const fn (f32, f32, f32, f32, [3]f32) void,
+    fillQuadAlpha: *const fn (f32, f32, f32, f32, [3]f32, f32) void,
+    renderTextLimited: *const fn ([]const u8, f32, f32, [3]f32, f32) f32,
+};
+
 pub const Layout = struct {
     left_x: f32,
     left_w: f32,
@@ -7,6 +26,13 @@ pub const Layout = struct {
     list_w: f32,
     detail_x: f32,
     detail_w: f32,
+};
+
+pub const Hit = union(enum) {
+    none,
+    refresh,
+    @"resume",
+    row: usize,
 };
 
 pub fn computeLayout(x: f32, width: f32) Layout {
@@ -45,13 +71,386 @@ pub fn computeLayout(x: f32, width: f32) Layout {
     };
 }
 
-pub fn render(session: anytype, window_width: f32, window_height: f32, titlebar_offset: f32, x: f32, width: f32) void {
-    _ = session;
+pub fn hitTest(layout: Layout, x: f32, y_from_top: f32, row_top: f32, row_h: f32, row_count: usize) Hit {
+    if (x >= layout.list_x and x < layout.list_x + layout.list_w and y_from_top >= row_top) {
+        const idx_float = (y_from_top - row_top) / row_h;
+        if (idx_float >= 0) {
+            const idx: usize = @intFromFloat(@floor(idx_float));
+            if (idx < row_count) return .{ .row = idx };
+        }
+    }
+    return .none;
+}
+
+pub fn listVisibleCapacity(window_height: f32, titlebar_offset: f32) usize {
+    const top = @round(titlebar_offset);
+    const content_h = @round(@max(1.0, window_height - top));
+    const visible_h = @max(0, content_h - FILTER_H);
+    return @intFromFloat(@max(0, @floor(visible_h / ROW_H)));
+}
+
+pub fn interactionHitTest(
+    session: anytype,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    x: f32,
+    width: f32,
+    cell_h: f32,
+    mouse_x: f64,
+    mouse_y: f64,
+) Hit {
     _ = window_width;
-    _ = window_height;
-    _ = titlebar_offset;
-    _ = computeLayout(x, width);
-    // Placeholder in this task. Later tasks draw actual rows and transcript.
+    const content_x = @round(x);
+    const content_w = @round(@max(1.0, width));
+    const top = @round(titlebar_offset);
+    const layout = computeLayout(content_x, content_w);
+    const mx: f32 = @floatCast(mouse_x);
+    const my: f32 = @floatCast(mouse_y);
+
+    const refresh_top = refreshButtonTop(top, cell_h);
+    if (rectContains(mx, my, layout.left_x + PAD_X, refresh_top, @max(0, layout.left_w - PAD_X * 2), buttonHeight(cell_h))) {
+        return .refresh;
+    }
+
+    const visible_count = session.visibleCount();
+    if (visible_count > 0) {
+        const resume_top = resumeButtonTop(top, cell_h);
+        if (rectContains(mx, my, layout.detail_x + PAD_X, resume_top, RESUME_BUTTON_W, buttonHeight(cell_h))) {
+            return .@"resume";
+        }
+    }
+
+    const max_rows = listVisibleCapacity(window_height, top);
+    const start = session.listWindowStart(max_rows);
+    const row_count = if (visible_count > start) @min(max_rows, visible_count - start) else 0;
+    return switch (hitTest(layout, mx, my, top + FILTER_H, ROW_H, row_count)) {
+        .row => |idx| .{ .row = start + idx },
+        else => .none,
+    };
+}
+
+pub fn render(
+    draw: DrawContext,
+    session: anytype,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    x: f32,
+    width: f32,
+) void {
+    _ = window_width;
+    const content_x = @round(x);
+    const content_w = @round(@max(1.0, width));
+    const top = @round(titlebar_offset);
+    const content_h = @round(@max(1.0, window_height - top));
+    if (content_w <= 1 or content_h <= 1) return;
+
+    const bg = draw.bg;
+    const fg = draw.fg;
+    const accent = draw.accent;
+    const panel = mixColor(bg, fg, 0.045);
+    const panel_strong = mixColor(bg, fg, 0.075);
+    const line = mixColor(bg, fg, 0.18);
+    const muted = mixColor(bg, fg, 0.58);
+    const selected_bg = mixColor(bg, accent, 0.18);
+
+    const layout = computeLayout(content_x, content_w);
+    draw.fillQuad(content_x, 0, content_w, content_h, bg);
+    draw.fillQuadAlpha(layout.left_x, 0, layout.left_w, content_h, panel, 0.96);
+    draw.fillQuadAlpha(layout.list_x, 0, layout.list_w, content_h, mixColor(bg, fg, 0.025), 0.98);
+    draw.fillQuadAlpha(layout.detail_x, 0, layout.detail_w, content_h, bg, 1.0);
+    draw.fillQuad(layout.list_x, 0, 1, content_h, line);
+    draw.fillQuad(layout.detail_x, 0, 1, content_h, line);
+
+    renderLeftColumn(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line);
+    renderList(draw, session, layout, window_height, top, content_h, fg, muted, accent, selected_bg, line);
+    renderDetail(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line);
+}
+
+fn renderLeftColumn(
+    draw: DrawContext,
+    session: anytype,
+    layout: Layout,
+    window_height: f32,
+    top: f32,
+    content_h: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+    panel_strong: [3]f32,
+    line: [3]f32,
+) void {
+    draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, top, HEADER_H), layout.left_w, HEADER_H, panel_strong, 0.9);
+    draw.fillQuad(layout.left_x, yFromTop(window_height, top + HEADER_H, 1), layout.left_w, 1, line);
+    _ = draw.renderTextLimited("AI History", layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
+
+    var y = top + HEADER_H + 18;
+    _ = draw.renderTextLimited(session.source.name, layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), fg, layout.left_w - PAD_X * 2);
+    y += draw.cell_h + 8;
+    _ = draw.renderTextLimited(targetLabel(session.source.target), layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
+    y += draw.cell_h + 18;
+    _ = draw.renderTextLimited("Status", layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
+    y += draw.cell_h + 5;
+    _ = draw.renderTextLimited(statusText(session), layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.left_w - PAD_X * 2);
+    y += draw.cell_h + 18;
+    _ = draw.renderTextLimited("r  Refresh local", layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
+
+    const footer = "Enter previews transcript";
+    _ = draw.renderTextLimited(footer, layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
+    _ = content_h;
+}
+
+fn renderList(
+    draw: DrawContext,
+    session: anytype,
+    layout: Layout,
+    window_height: f32,
+    top: f32,
+    content_h: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+    selected_bg: [3]f32,
+    line: [3]f32,
+) void {
+    const filter_y = yFromTop(window_height, top, FILTER_H);
+    draw.fillQuadAlpha(layout.list_x, filter_y, layout.list_w, FILTER_H, mixColor(draw.bg, fg, 0.055), 0.98);
+    draw.fillQuad(layout.list_x, yFromTop(window_height, top + FILTER_H, 1), layout.list_w, 1, line);
+
+    const query = session.filter[0..session.filter_len];
+    const filter_label = if (query.len == 0) "Search sessions" else query;
+    const filter_color = if (query.len == 0) muted else fg;
+    _ = draw.renderTextLimited(filter_label, layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + 11), filter_color, layout.list_w - PAD_X * 2);
+
+    const row_top = top + FILTER_H;
+    _ = content_h;
+    const max_rows = listVisibleCapacity(window_height, top);
+    const start = session.listWindowStart(max_rows);
+    var visible_index: usize = 0;
+    var rendered: usize = 0;
+    for (session.rows.items) |row| {
+        if (!metadataMatches(row, query)) continue;
+        if (visible_index < start) {
+            visible_index += 1;
+            continue;
+        }
+        if (rendered >= max_rows) break;
+
+        const row_top_px = row_top + @as(f32, @floatFromInt(rendered)) * ROW_H;
+        const row_y = yFromTop(window_height, row_top_px, ROW_H);
+        const selected = visible_index == session.selected;
+        if (selected) {
+            draw.fillQuadAlpha(layout.list_x, row_y, layout.list_w, ROW_H, selected_bg, 0.92);
+            draw.fillQuad(layout.list_x, row_y, 3, ROW_H, accent);
+        }
+        draw.fillQuadAlpha(layout.list_x, row_y, layout.list_w, 1, line, 0.55);
+
+        const title = displayTitle(row);
+        const provider_end = draw.renderTextLimited(row.provider.label(), layout.list_x + PAD_X, row_y + ROW_H - draw.cell_h - 8, accent, 86);
+        _ = draw.renderTextLimited(title, provider_end + 8, row_y + ROW_H - draw.cell_h - 8, fg, layout.list_w - (provider_end - layout.list_x) - PAD_X - 8);
+        const detail = if (row.project_dir.len > 0) row.project_dir else row.source_path;
+        _ = draw.renderTextLimited(detail, layout.list_x + PAD_X, row_y + 9, muted, layout.list_w - PAD_X * 2);
+
+        rendered += 1;
+        visible_index += 1;
+    }
+
+    if (session.visibleCount() == 0) {
+        const empty = if (session.rows.items.len == 0) "No sessions scanned" else "No sessions match filter";
+        _ = draw.renderTextLimited(empty, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top + 24), muted, layout.list_w - PAD_X * 2);
+    }
+}
+
+fn renderDetail(
+    draw: DrawContext,
+    session: anytype,
+    layout: Layout,
+    window_height: f32,
+    top: f32,
+    content_h: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+    panel_strong: [3]f32,
+    line: [3]f32,
+) void {
+    draw.fillQuadAlpha(layout.detail_x, yFromTop(window_height, top, HEADER_H), layout.detail_w, HEADER_H, panel_strong, 0.82);
+    draw.fillQuad(layout.detail_x, yFromTop(window_height, top + HEADER_H, 1), layout.detail_w, 1, line);
+    _ = draw.renderTextLimited("Transcript Preview", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.detail_w - PAD_X * 2);
+
+    const selected = session.selectedVisible() orelse {
+        _ = draw.renderTextLimited("Select a session", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + HEADER_H + 24), muted, layout.detail_w - PAD_X * 2);
+        return;
+    };
+
+    var y = top + HEADER_H + 18;
+    _ = draw.renderTextLimited(displayTitle(selected), layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), fg, layout.detail_w - PAD_X * 2);
+    y += draw.cell_h + 8;
+    _ = draw.renderTextLimited(selected.provider.label(), layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2);
+    y += draw.cell_h + 8;
+    _ = draw.renderTextLimited(if (selected.project_dir.len > 0) selected.project_dir else "Project dir unavailable", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2);
+    y += draw.cell_h + 8;
+    _ = draw.renderTextLimited(selected.source_path, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2);
+    y += draw.cell_h + 16;
+    const resume_top = resumeButtonTop(top, draw.cell_h);
+    draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, resume_top, buttonHeight(draw.cell_h)), RESUME_BUTTON_W, buttonHeight(draw.cell_h), panel_strong, 0.72);
+    _ = draw.renderTextLimited("Resume", layout.detail_x + PAD_X + 12, yTextFromTop(draw, window_height, y), accent, RESUME_BUTTON_W - 24);
+
+    y += draw.cell_h + 20;
+    draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, y, 1), layout.detail_w - PAD_X * 2, 1, line, 0.78);
+    y += 14;
+
+    switch (session.transcript_state) {
+        .idle => _ = draw.renderTextLimited("Press Enter to load transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
+        .loading => _ = draw.renderTextLimited("Loading transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
+        .failed => _ = draw.renderTextLimited("Transcript failed to load", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2),
+        .ready => renderTranscriptMessages(draw, session.transcript, layout, window_height, y, content_h, fg, muted, accent),
+    }
+}
+
+fn renderTranscriptMessages(
+    draw: DrawContext,
+    messages: anytype,
+    layout: Layout,
+    window_height: f32,
+    start_top: f32,
+    content_h: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+) void {
+    if (messages.len == 0) {
+        _ = draw.renderTextLimited("Transcript is empty", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, start_top), muted, layout.detail_w - PAD_X * 2);
+        return;
+    }
+
+    const row_h = draw.cell_h + 8;
+    _ = content_h;
+    const max_rows = transcriptPreviewRowCapacity(window_height, start_top, row_h);
+    const count = @min(messages.len, max_rows);
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const msg = messages[i];
+        const y = yTextFromTop(draw, window_height, start_top + @as(f32, @floatFromInt(i)) * row_h);
+        const role_text = roleLabel(msg.role);
+        const role_color = if (msg.role == .assistant) accent else muted;
+        const role_end = draw.renderTextLimited(role_text, layout.detail_x + PAD_X, y, role_color, 78);
+        _ = draw.renderTextLimited(msg.content, role_end + SMALL_GAP, y, fg, layout.detail_w - (role_end - layout.detail_x) - PAD_X - SMALL_GAP);
+    }
+}
+
+fn displayTitle(row: anytype) []const u8 {
+    if (row.title.len > 0) return row.title;
+    if (row.summary.len > 0) return row.summary;
+    return row.session_id;
+}
+
+fn statusText(session: anytype) []const u8 {
+    if (session.status.len > 0) return session.status;
+    return switch (session.state) {
+        .idle => "Idle",
+        .scanning => "Scanning",
+        .ready => "Ready",
+        .failed => "Scan failed",
+    };
+}
+
+fn targetLabel(target: anytype) []const u8 {
+    return switch (target) {
+        .local => "Local",
+        .wsl => "WSL",
+        .ssh => "SSH",
+    };
+}
+
+fn roleLabel(role: anytype) []const u8 {
+    return switch (role) {
+        .user => "user:",
+        .assistant => "assistant:",
+        .system => "system:",
+        .tool => "tool:",
+    };
+}
+
+fn yFromTop(window_height: f32, top_px: f32, h: f32) f32 {
+    return window_height - top_px - h;
+}
+
+fn yTextFromTop(draw: DrawContext, window_height: f32, top_px: f32) f32 {
+    return window_height - top_px - draw.cell_h;
+}
+
+fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const clamped = @max(0.0, @min(1.0, t));
+    return .{
+        a[0] + (b[0] - a[0]) * clamped,
+        a[1] + (b[1] - a[1]) * clamped,
+        a[2] + (b[2] - a[2]) * clamped,
+    };
+}
+
+fn metadataMatches(meta: anytype, query: []const u8) bool {
+    if (query.len == 0) return true;
+    return containsIgnoreCase(meta.title, query) or
+        containsIgnoreCase(meta.summary, query) or
+        containsIgnoreCase(meta.project_dir, query) or
+        containsIgnoreCase(meta.session_id, query) or
+        containsIgnoreCase(meta.source_path, query);
+}
+
+fn containsIgnoreCase(haystack: []const u8, query: []const u8) bool {
+    if (query.len == 0) return true;
+    if (query.len > haystack.len) return false;
+    var i: usize = 0;
+    while (i + query.len <= haystack.len) : (i += 1) {
+        var matched = true;
+        for (query, 0..) |qch, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(qch)) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return true;
+    }
+    return false;
+}
+
+fn buttonHeight(cell_h: f32) f32 {
+    return cell_h + BUTTON_EXTRA_H;
+}
+
+fn refreshButtonTop(top: f32, cell_h: f32) f32 {
+    return top + HEADER_H + 18 +
+        (cell_h + 8) +
+        (cell_h + 18) +
+        (cell_h + 5) +
+        (cell_h + 18) - BUTTON_PAD_Y;
+}
+
+fn resumeButtonTop(top: f32, cell_h: f32) f32 {
+    return top + HEADER_H + 18 +
+        (cell_h + 8) +
+        (cell_h + 8) +
+        (cell_h + 8) +
+        (cell_h + 16) - BUTTON_PAD_Y;
+}
+
+fn rectContains(x: f32, y: f32, left: f32, top: f32, width: f32, height: f32) bool {
+    return width > 0 and height > 0 and
+        x >= left and x < left + width and
+        y >= top and y < top + height;
+}
+
+fn transcriptPreviewRowCapacity(window_height: f32, start_top: f32, row_h: f32) usize {
+    if (row_h <= 0) return 0;
+    return @intFromFloat(@max(0, @floor(@max(0, window_height - start_top) / row_h)));
+}
+
+test "ai_history_renderer: hit test maps list rows" {
+    const layout = computeLayout(0, 1000);
+    const hit = hitTest(layout, layout.list_x + 10, 120, 100, 24, 5);
+    try std.testing.expectEqual(@as(usize, 0), hit.row);
 }
 
 test "ai_history_renderer: layout keeps a readable detail column" {
@@ -81,4 +480,37 @@ test "ai_history_renderer: zero width layout has no columns" {
     try std.testing.expectEqual(@as(f32, 20), layout.left_x);
     try std.testing.expectEqual(@as(f32, 20), layout.list_x);
     try std.testing.expectEqual(@as(f32, 20), layout.detail_x);
+}
+
+test "ai_history_renderer: transcript row capacity uses absolute window bottom" {
+    try std.testing.expectEqual(@as(usize, 10), transcriptPreviewRowCapacity(600, 300, 30));
+    try std.testing.expectEqual(@as(usize, 0), transcriptPreviewRowCapacity(300, 300, 30));
+}
+
+test "ai_history_renderer: interaction hit test maps buttons and row offset" {
+    const FakeSession = struct {
+        fn visibleCount(_: @This()) usize {
+            return 8;
+        }
+
+        fn listWindowStart(_: @This(), _: usize) usize {
+            return 3;
+        }
+    };
+
+    const session = FakeSession{};
+    const layout = computeLayout(0, 1000);
+    const cell_h: f32 = 16;
+    const top: f32 = 40;
+
+    try std.testing.expectEqual(
+        Hit.refresh,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + PAD_X + 4, refreshButtonTop(top, cell_h) + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.@"resume",
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, resumeButtonTop(top, cell_h) + 2),
+    );
+    const row_hit = interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.list_x + 8, top + FILTER_H + ROW_H + 2);
+    try std.testing.expectEqual(@as(usize, 4), row_hit.row);
 }

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+
+pub const Layout = struct {
+    left_x: f32,
+    left_w: f32,
+    list_x: f32,
+    list_w: f32,
+    detail_x: f32,
+    detail_w: f32,
+};
+
+pub fn computeLayout(x: f32, width: f32) Layout {
+    const available = @max(0, width);
+    if (available == 0) {
+        return .{
+            .left_x = x,
+            .left_w = 0,
+            .list_x = x,
+            .list_w = 0,
+            .detail_x = x,
+            .detail_w = 0,
+        };
+    }
+
+    const min_left_w: f32 = 180;
+    const min_list_w: f32 = 260;
+    const min_detail_w: f32 = 120;
+    const min_total = min_left_w + min_list_w + min_detail_w;
+    const left_w = if (available < min_total)
+        available * (min_left_w / min_total)
+    else
+        @min(@max(available * 0.20, min_left_w), 260);
+    const list_w = if (available < min_total)
+        available * (min_list_w / min_total)
+    else
+        @min(@max(available * 0.32, min_list_w), 420);
+    const detail_w = available - left_w - list_w;
+    return .{
+        .left_x = x,
+        .left_w = left_w,
+        .list_x = x + left_w,
+        .list_w = list_w,
+        .detail_x = x + left_w + list_w,
+        .detail_w = detail_w,
+    };
+}
+
+pub fn render(session: anytype, window_width: f32, window_height: f32, titlebar_offset: f32, x: f32, width: f32) void {
+    _ = session;
+    _ = window_width;
+    _ = window_height;
+    _ = titlebar_offset;
+    _ = computeLayout(x, width);
+    // Placeholder in this task. Later tasks draw actual rows and transcript.
+}
+
+test "ai_history_renderer: layout keeps a readable detail column" {
+    const layout = computeLayout(0, 1200);
+    try std.testing.expect(layout.left_w >= 180);
+    try std.testing.expect(layout.list_w >= 260);
+    try std.testing.expect(layout.detail_w >= 120);
+    try std.testing.expectEqual(layout.left_x + layout.left_w, layout.list_x);
+    try std.testing.expectEqual(layout.list_x + layout.list_w, layout.detail_x);
+}
+
+test "ai_history_renderer: narrow layout stays inside available width" {
+    const layout = computeLayout(10, 300);
+    try std.testing.expect(layout.left_w >= 0);
+    try std.testing.expect(layout.list_w >= 0);
+    try std.testing.expect(layout.detail_w >= 0);
+    try std.testing.expectEqual(layout.left_x + layout.left_w, layout.list_x);
+    try std.testing.expectEqual(layout.list_x + layout.list_w, layout.detail_x);
+    try std.testing.expect(layout.detail_x + layout.detail_w <= 310.001);
+}
+
+test "ai_history_renderer: zero width layout has no columns" {
+    const layout = computeLayout(20, 0);
+    try std.testing.expectEqual(@as(f32, 0), layout.left_w);
+    try std.testing.expectEqual(@as(f32, 0), layout.list_w);
+    try std.testing.expectEqual(@as(f32, 0), layout.detail_w);
+    try std.testing.expectEqual(@as(f32, 20), layout.left_x);
+    try std.testing.expectEqual(@as(f32, 20), layout.list_x);
+    try std.testing.expectEqual(@as(f32, 20), layout.detail_x);
+}

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -196,7 +196,7 @@ fn renderLeftColumn(
     y += draw.cell_h + 18;
     _ = draw.renderTextLimited("r  Refresh local", layout.left_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.left_w - PAD_X * 2);
 
-    const footer = "Enter previews transcript";
+    const footer = "Enter resumes  Space previews";
     _ = draw.renderTextLimited(footer, layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
     _ = content_h;
 }
@@ -302,7 +302,7 @@ fn renderDetail(
     y += 14;
 
     switch (session.transcript_state) {
-        .idle => _ = draw.renderTextLimited("Press Enter to load transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
+        .idle => _ = draw.renderTextLimited("Press Space to load transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
         .loading => _ = draw.renderTextLimited("Loading transcript", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), muted, layout.detail_w - PAD_X * 2),
         .failed => _ = draw.renderTextLimited("Transcript failed to load", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2),
         .ready => renderTranscriptMessages(draw, session.transcript, layout, window_height, y, content_h, fg, muted, accent),

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2096,6 +2096,12 @@ pub fn agentConnectSshProfile(identifier: []const u8) AgentSshConnectResult {
     return .{ .connected = surface };
 }
 
+pub fn aiHistoryConnectSshProfile(identifier: []const u8, remote_command: []const u8) AgentSshConnectResult {
+    const idx = findSshProfileIndex(identifier) orelse return .not_found;
+    const surface = connectSshProfileReturningSurfaceWithCommand(idx, remote_command) orelse return .failed;
+    return .{ .connected = surface };
+}
+
 const copySshProfileField = profile_codec.copySshProfileField;
 
 const makeSshProfile = profile_codec.makeSshProfile;
@@ -2286,6 +2292,10 @@ fn connectSshProfile(idx: usize) void {
 }
 
 fn connectSshProfileReturningSurface(idx: usize) ?*Surface {
+    return connectSshProfileReturningSurfaceWithCommand(idx, "");
+}
+
+fn connectSshProfileReturningSurfaceWithCommand(idx: usize, remote_command: []const u8) ?*Surface {
     if (idx >= g_ssh_profile_count) return null;
     const profile = &g_ssh_profiles[idx];
     const ip = profileField(profile, .ip);
@@ -2299,7 +2309,7 @@ fn connectSshProfileReturningSurface(idx: usize) ?*Surface {
     if (port.len > 0 and !isPortTokenSafe(port)) return null;
     if (!command_palette_model.isProxyJumpSafe(proxy_jump)) return null;
 
-    var command_buf: [512]u8 = undefined;
+    var command_buf: [4096]u8 = undefined;
     const command = platform_pty_command.sshInteractiveCommand(command_buf[0..], .{
         .user = user,
         .host = ip,
@@ -2307,6 +2317,7 @@ fn connectSshProfileReturningSurface(idx: usize) ?*Surface {
         .password_auth = password.len > 0,
         .legacy_algorithms = AppWindow.g_ssh_legacy_algorithms,
         .proxy_jump = proxy_jump,
+        .remote_command = remote_command,
     }) orelse return null;
 
     sessionLauncherClose();

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1452,6 +1452,10 @@ const SessionAction = enum {
     ssh,
     wsl,
     ai_chat,
+    ai_history,
+    ai_history_local,
+    ai_history_wsl,
+    ai_history_ssh,
     connect_selected,
     new_ssh,
     edit_selected,
@@ -1471,6 +1475,7 @@ const SshListMode = enum {
     manage,
     edit_select,
     delete_select,
+    ai_history_select,
 };
 
 const AiListMode = enum {
@@ -1478,6 +1483,8 @@ const AiListMode = enum {
     edit_select,
     delete_select,
 };
+
+const AiHistorySourceChoice = enum { local, wsl, ssh };
 
 const SshProfile = profile_codec.SshProfile;
 pub const AgentSshConnectResult = union(enum) {
@@ -1510,6 +1517,8 @@ threadlocal var g_ssh_list_visible: bool = false;
 threadlocal var g_ssh_form_visible: bool = false;
 threadlocal var g_ai_list_visible: bool = false;
 threadlocal var g_ai_form_visible: bool = false;
+threadlocal var g_ai_history_source_visible: bool = false;
+threadlocal var g_ai_history_source_selected: usize = 0;
 threadlocal var g_ssh_focus: usize = @intFromEnum(SshField.name);
 threadlocal var g_ssh_bufs: [SSH_FIELD_COUNT][SSH_FIELD_MAX]u8 = undefined;
 threadlocal var g_ssh_lens: [SSH_FIELD_COUNT]usize = .{0} ** SSH_FIELD_COUNT;
@@ -1565,6 +1574,7 @@ fn commandCenterStateSnapshot() command_center_state.State {
         .ssh_form_visible = g_ssh_form_visible,
         .ai_list_visible = g_ai_list_visible,
         .ai_form_visible = g_ai_form_visible,
+        .ai_history_source_visible = g_ai_history_source_visible,
         .settings_visible = g_settings_visible,
     };
 }
@@ -1590,6 +1600,7 @@ fn commandCenterStateApply(state: command_center_state.State) void {
     g_ssh_form_visible = state.ssh_form_visible;
     g_ai_list_visible = state.ai_list_visible;
     g_ai_form_visible = state.ai_form_visible;
+    g_ai_history_source_visible = state.ai_history_source_visible;
     g_settings_visible = state.settings_visible;
 }
 
@@ -1599,6 +1610,7 @@ pub fn sessionLauncherOpen() void {
     commandCenterStateCommit(state);
     g_ssh_list_mode = .manage;
     g_ai_list_mode = .manage;
+    g_ai_history_source_selected = 0;
 }
 
 pub fn sessionLauncherClose() void {
@@ -1607,6 +1619,7 @@ pub fn sessionLauncherClose() void {
     commandCenterStateCommit(state);
     g_ssh_list_mode = .manage;
     g_ai_list_mode = .manage;
+    g_ai_history_source_selected = 0;
 }
 
 pub fn sessionLauncherInsertChar(codepoint: u21) void {
@@ -1648,10 +1661,50 @@ pub fn sessionLauncherPasteText(text: []const u8) bool {
     return false;
 }
 
+fn aiHistorySourceSshRow() usize {
+    return if (platform_pty_command.sessionLauncherWslRow() != null) 2 else 1;
+}
+
+fn aiHistorySourceCancelRow() usize {
+    return aiHistorySourceSshRow() + 1;
+}
+
+fn aiHistorySourceRowCount() usize {
+    return aiHistorySourceCancelRow() + 1;
+}
+
+fn aiHistorySourceChoiceForRow(row: usize) ?AiHistorySourceChoice {
+    if (row == 0) return .local;
+    if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
+        if (row == wsl_row - 1) return .wsl;
+    }
+    if (row == aiHistorySourceSshRow()) return .ssh;
+    return null;
+}
+
+fn handleAiHistorySourceKey(ev: input_key.KeyEvent) void {
+    const row_count = aiHistorySourceRowCount();
+    switch (ev.key) {
+        .arrow_down, .tab => g_ai_history_source_selected = (g_ai_history_source_selected + 1) % row_count,
+        .arrow_up => g_ai_history_source_selected = if (g_ai_history_source_selected == 0) row_count - 1 else g_ai_history_source_selected - 1,
+        .enter => runAiHistorySourceRow(g_ai_history_source_selected),
+        .key_l => runAiHistorySourceRow(0),
+        .key_w => {
+            if (platform_pty_command.sessionLauncherWslRow() != null) runAiHistorySourceRow(1);
+        },
+        .key_s => runAiHistorySourceRow(aiHistorySourceSshRow()),
+        else => {},
+    }
+}
+
 pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
     if (ev.key == .escape) {
         if (g_ssh_list_visible and g_ssh_list_filter_len > 0) {
             clearSshListFilter();
+            return;
+        }
+        if (g_ssh_list_visible and g_ssh_list_mode == .ai_history_select) {
+            openAiHistorySourcePicker();
             return;
         }
         cancelAiFormOrLauncher();
@@ -1659,6 +1712,10 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
     }
 
     if (!g_ssh_form_visible and !g_ai_form_visible) {
+        if (g_ai_history_source_visible) {
+            handleAiHistorySourceKey(ev);
+            return;
+        }
         if (g_ssh_list_visible) {
             handleSshListKey(ev);
             return;
@@ -1680,11 +1737,17 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
                 runSessionLauncherRow(g_session_launcher_selected);
             },
             .key_w => {
-                g_session_launcher_selected = 2;
-                runSessionLauncherRow(g_session_launcher_selected);
+                if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
+                    g_session_launcher_selected = wsl_row;
+                    runSessionLauncherRow(g_session_launcher_selected);
+                }
             },
             .key_a => {
-                g_session_launcher_selected = 3;
+                g_session_launcher_selected = command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT;
+                runSessionLauncherRow(g_session_launcher_selected);
+            },
+            .key_h => {
+                g_session_launcher_selected = command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY;
                 runSessionLauncherRow(g_session_launcher_selected);
             },
             else => {},
@@ -1737,6 +1800,10 @@ pub fn sessionLauncherExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_
         .ssh => openSshList(),
         .wsl => openWslSession(),
         .ai_chat => openDefaultAiSession(),
+        .ai_history => openAiHistorySourcePicker(),
+        .ai_history_local => openLocalAiHistorySession(),
+        .ai_history_wsl => openWslAiHistorySession(),
+        .ai_history_ssh => openAiHistorySshPicker(),
         .connect_selected => runSshListRow(g_ssh_list_selected),
         .new_ssh => openSshFormNew(),
         .edit_selected => openSshEditPicker(),
@@ -1766,6 +1833,63 @@ fn openWslSession() void {
     _ = AppWindow.spawnTabWithCommandUtf8(command);
 }
 
+fn openAiHistorySourcePicker() void {
+    g_session_launcher_visible = false;
+    g_ssh_list_visible = false;
+    g_ssh_form_visible = false;
+    g_ai_list_visible = false;
+    g_ai_form_visible = false;
+    g_ai_history_source_visible = true;
+    g_ai_history_source_selected = 0;
+}
+
+fn openLocalAiHistorySession() void {
+    sessionLauncherClose();
+    _ = AppWindow.spawnAiHistoryTab(.{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+    });
+}
+
+fn openWslAiHistorySession() void {
+    sessionLauncherClose();
+    _ = AppWindow.spawnAiHistoryTab(.{
+        .id = "wsl-default",
+        .name = "WSL",
+        .target = .{ .wsl = .{} },
+    });
+}
+
+fn openAiHistorySshPicker() void {
+    loadSshProfiles();
+    openSshProfilePicker(.ai_history_select);
+}
+
+fn openSshAiHistorySession(profile_idx: usize) void {
+    if (profile_idx >= g_ssh_profile_count) return;
+    const profile = &g_ssh_profiles[profile_idx];
+    const name = profileField(profile, .name);
+    sessionLauncherClose();
+    _ = AppWindow.spawnAiHistoryTab(.{
+        .id = name,
+        .name = name,
+        .target = .{ .ssh = .{ .profile_name = name } },
+    });
+}
+
+fn runAiHistorySourceRow(row: usize) void {
+    if (aiHistorySourceChoiceForRow(row)) |choice| {
+        switch (choice) {
+            .local => openLocalAiHistorySession(),
+            .wsl => openWslAiHistorySession(),
+            .ssh => openAiHistorySshPicker(),
+        }
+    } else {
+        sessionLauncherClose();
+    }
+}
+
 fn runSessionLauncherRow(row: usize) void {
     if (row == 0) {
         openLocalShellSession();
@@ -1779,12 +1903,15 @@ fn runSessionLauncherRow(row: usize) void {
     }
     if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT) {
         openDefaultAiSession();
+    } else if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY) {
+        openAiHistorySourcePicker();
     }
 }
 
 fn openSshList() void {
     loadSshProfiles();
     g_session_launcher_visible = false;
+    g_ai_history_source_visible = false;
     g_ssh_list_visible = true;
     g_ssh_form_visible = false;
     g_ssh_list_mode = .manage;
@@ -1801,8 +1928,9 @@ fn openSshDeletePicker() void {
 }
 
 fn openSshProfilePicker(mode: SshListMode) void {
-    if (g_ssh_profile_count == 0) return;
+    if (g_ssh_profile_count == 0 and mode != .ai_history_select) return;
     g_session_launcher_visible = false;
+    g_ai_history_source_visible = false;
     g_ssh_list_visible = true;
     g_ssh_form_visible = false;
     g_ssh_list_mode = mode;
@@ -1830,6 +1958,7 @@ fn openSshFormEdit(index: usize) void {
 fn openSshForm() void {
     g_ssh_list_visible = false;
     g_session_launcher_visible = false;
+    g_ai_history_source_visible = false;
     g_ssh_form_visible = true;
     g_ssh_focus = @intFromEnum(SshField.name);
     if (g_ssh_lens[@intFromEnum(SshField.port)] == 0) {
@@ -1860,7 +1989,7 @@ fn handleSshListKey(ev: input_key.KeyEvent) void {
 fn sshListRowCount() usize {
     return switch (g_ssh_list_mode) {
         .manage => sshVisibleProfileCount() + 4,
-        .edit_select, .delete_select => sshVisibleProfileCount() + 1,
+        .edit_select, .delete_select, .ai_history_select => sshVisibleProfileCount() + 1,
     };
 }
 
@@ -2070,6 +2199,14 @@ fn runSshListRow(row: usize) void {
                 openSshList();
             } else {
                 openSshList();
+            }
+        },
+        .ai_history_select => {
+            if (row < visible_profile_count) {
+                const profile_idx = sshVisibleProfileIndexAt(row) orelse return;
+                openSshAiHistorySession(profile_idx);
+            } else {
+                openAiHistorySourcePicker();
             }
         },
     }
@@ -2318,6 +2455,7 @@ fn openAiList() void {
     g_session_launcher_visible = false;
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;
+    g_ai_history_source_visible = false;
     g_ai_list_visible = true;
     g_ai_form_visible = false;
     g_ai_list_mode = .manage;
@@ -2949,6 +3087,7 @@ fn sessionTwoColumnWidth(left: []const u8, right: []const u8) f32 {
 }
 
 fn sessionLauncherTitle() []const u8 {
+    if (g_ai_history_source_visible) return "AI History";
     if (g_ai_form_visible) {
         return i18n.s().sl_ai_agent;
     }
@@ -2965,12 +3104,14 @@ fn sessionLauncherTitle() []const u8 {
             .manage => i18n.s().sl_ssh_servers,
             .edit_select => i18n.s().sl_edit_ssh_server,
             .delete_select => i18n.s().sl_delete_ssh_server,
+            .ai_history_select => "AI History SSH Profile",
         };
     }
     return i18n.s().sl_new_session;
 }
 
 fn sessionLauncherHint() []const u8 {
+    if (g_ai_history_source_visible) return "Choose a source";
     if (g_ai_form_visible) {
         return i18n.s().sl_hint_ai_form;
     }
@@ -2988,6 +3129,7 @@ fn sessionLauncherHint() []const u8 {
             .manage => if (has_filter) i18n.s().sl_hint_ssh_filter_edits else i18n.s().sl_hint_ssh_filter_manage,
             .edit_select => if (has_filter) i18n.s().sl_hint_ssh_filter_choose_edit else i18n.s().sl_hint_choose_server_edit,
             .delete_select => if (has_filter) i18n.s().sl_hint_ssh_filter_choose_delete else i18n.s().sl_hint_choose_server_delete,
+            .ai_history_select => if (has_filter) "Filter profiles" else "Choose a profile or go back",
         };
     }
     return i18n.s().sl_hint_main;
@@ -3080,7 +3222,20 @@ fn sessionDesiredBoxWidth() f32 {
             .edit_select, .delete_select => {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, i18n.s().sl_v_manage));
             },
+            .ai_history_select => {
+                desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, "AI History"));
+            },
         }
+        return desired;
+    }
+
+    if (g_ai_history_source_visible) {
+        desired = @max(desired, sessionTwoColumnWidth("Local", "This computer"));
+        if (platform_pty_command.sessionLauncherWslRow() != null) {
+            desired = @max(desired, sessionTwoColumnWidth("WSL", "Default distro"));
+        }
+        desired = @max(desired, sessionTwoColumnWidth("SSH Profile...", "Choose server"));
+        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
         return desired;
     }
 
@@ -3090,6 +3245,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("WSL", platform_pty_command.wslLauncherDetail()));
     }
     desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ai_agent, defaultAiModeLabel()));
+    desired = @max(desired, sessionTwoColumnWidth("AI History", "Browse Codex / Claude Code"));
     return desired;
 }
 
@@ -3105,6 +3261,8 @@ fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) Session
         AI_FIELD_COUNT + 3
     else if (g_ai_list_visible)
         aiListRowCount()
+    else if (g_ai_history_source_visible)
+        aiHistorySourceRowCount()
     else if (g_ssh_form_visible)
         SSH_FIELD_COUNT + 3
     else if (g_ssh_list_visible)
@@ -3132,6 +3290,16 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
     if (x < layout.box_x or x > layout.box_x + layout.box_w) return null;
     if (y < layout.first_row_top_px) return null;
     const row: usize = @intFromFloat(@floor((y - layout.first_row_top_px) / layout.row_h));
+
+    if (g_ai_history_source_visible) {
+        if (row >= aiHistorySourceRowCount()) return null;
+        g_ai_history_source_selected = row;
+        return switch (aiHistorySourceChoiceForRow(row) orelse return .cancel) {
+            .local => .ai_history_local,
+            .wsl => .ai_history_wsl,
+            .ssh => .ai_history_ssh,
+        };
+    }
 
     if (g_ssh_list_visible) {
         if (row >= sshListRowCount()) return null;
@@ -3168,6 +3336,7 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
             if (row == wsl_row) return .wsl;
         }
         if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT) return .ai_chat;
+        if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY) return .ai_history;
         return null;
     }
 
@@ -3312,6 +3481,19 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     renderTitlebarTextStrongLimited(hint, layout.box_x + 24, hint_y, muted_color, layout.box_w - 48);
 
     if (!g_ssh_form_visible and !g_ai_form_visible) {
+        if (g_ai_history_source_visible) {
+            var row: usize = 0;
+            renderSessionRow(layout, window_height, row, "Local", "This computer", g_ai_history_source_selected == row);
+            row += 1;
+            if (platform_pty_command.sessionLauncherWslRow() != null) {
+                renderSessionRow(layout, window_height, row, "WSL", "Default distro", g_ai_history_source_selected == row);
+                row += 1;
+            }
+            renderSessionRow(layout, window_height, row, "SSH Profile...", "Choose server", g_ai_history_source_selected == row);
+            row += 1;
+            renderSessionRow(layout, window_height, row, i18n.s().sl_cancel, "Esc", g_ai_history_source_selected == row);
+            return;
+        }
         if (g_ai_list_visible) {
             var row: usize = 0;
             while (row < g_ai_profile_count) : (row += 1) {
@@ -3355,6 +3537,9 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
                 .edit_select, .delete_select => {
                     renderSessionRow(layout, window_height, row, i18n.s().sl_back, i18n.s().sl_v_manage, g_ssh_list_selected == row);
                 },
+                .ai_history_select => {
+                    renderSessionRow(layout, window_height, row, i18n.s().sl_back, "AI History", g_ssh_list_selected == row);
+                },
             }
             return;
         }
@@ -3369,6 +3554,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             row += 1;
         }
         renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT, i18n.s().sl_ai_agent, defaultAiModeLabel(), g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT);
+        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, "AI History", "Browse Codex / Claude Code", g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
         return;
     }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -18,6 +18,7 @@ const Config = @import("../config.zig");
 const themes_embed = @import("../themes.zig");
 const input_key = @import("../input/key.zig");
 const ssh_prompt = @import("../ssh_prompt.zig");
+const ssh_connection = @import("../ssh_connection.zig");
 const app_metadata = @import("../app_metadata.zig");
 const command_center_state = @import("../command_center_state.zig");
 const command_palette_model = @import("../command_palette_model.zig");
@@ -2100,6 +2101,36 @@ pub fn aiHistoryConnectSshProfile(identifier: []const u8, remote_command: []cons
     const idx = findSshProfileIndex(identifier) orelse return .not_found;
     const surface = connectSshProfileReturningSurfaceWithCommand(idx, remote_command) orelse return .failed;
     return .{ .connected = surface };
+}
+
+pub fn aiHistorySshConnection(identifier: []const u8) ?ssh_connection.SshConnection {
+    const idx = findSshProfileIndex(identifier) orelse return null;
+    if (idx >= g_ssh_profile_count) return null;
+    const profile = &g_ssh_profiles[idx];
+    const ip = profileField(profile, .ip);
+    const user = profileField(profile, .user);
+    const port = profileField(profile, .port);
+    const password = profileField(profile, .password);
+    const proxy_jump = profileField(profile, .proxy_jump);
+    if (ip.len == 0 or user.len == 0) return null;
+    if (!isSshTokenSafe(ip) or !isSshTokenSafe(user)) return null;
+    if (port.len > 0 and !isPortTokenSafe(port)) return null;
+    if (!command_palette_model.isProxyJumpSafe(proxy_jump)) return null;
+
+    var conn: ssh_connection.SshConnection = .{};
+    conn.user_len = @min(user.len, conn.user_buf.len);
+    conn.host_len = @min(ip.len, conn.host_buf.len);
+    conn.port_len = @min(port.len, conn.port_buf.len);
+    conn.password_len = @min(password.len, conn.password_buf.len);
+    conn.proxy_jump_len = @min(proxy_jump.len, conn.proxy_jump_buf.len);
+    @memcpy(conn.user_buf[0..conn.user_len], user[0..conn.user_len]);
+    @memcpy(conn.host_buf[0..conn.host_len], ip[0..conn.host_len]);
+    @memcpy(conn.port_buf[0..conn.port_len], port[0..conn.port_len]);
+    @memcpy(conn.password_buf[0..conn.password_len], password[0..conn.password_len]);
+    @memcpy(conn.proxy_jump_buf[0..conn.proxy_jump_len], proxy_jump[0..conn.proxy_jump_len]);
+    conn.password_auth = password.len > 0;
+    conn.legacy_algorithms = AppWindow.g_ssh_legacy_algorithms;
+    return conn;
 }
 
 const copySshProfileField = profile_codec.copySshProfileField;

--- a/src/session_persist.zig
+++ b/src/session_persist.zig
@@ -52,6 +52,12 @@ pub const NodeSnap = union(enum) {
     };
 };
 
+pub const AiHistorySnap = struct {
+    source_id: []const u8,
+    target_kind: []const u8,
+    target_name: []const u8 = "",
+};
+
 pub const TabSnap = struct {
     title_override: ?[]const u8 = null,
     focused_leaf: u32 = 0,
@@ -62,6 +68,7 @@ pub const TabSnap = struct {
     // agent history store, not in this snapshot), and `tree` is an ignored
     // placeholder. Absent in older snapshots → null → ordinary terminal tab.
     ai_session_id: ?[]const u8 = null,
+    ai_history: ?AiHistorySnap = null,
 };
 
 pub const Session = struct {
@@ -231,6 +238,33 @@ test "session_persist: AI chat tab round-trips its ai_session_id" {
     try std.testing.expectEqualStrings("sess-abc-123", parsed.value.tabs[0].ai_session_id.?);
 }
 
+test "session_persist: AI history tab round-trips its source snapshot" {
+    const allocator = std.testing.allocator;
+
+    const placeholder = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    const tabs = [_]TabSnap{.{
+        .tree = placeholder,
+        .ai_history = .{
+            .source_id = "local-codex",
+            .target_kind = "local",
+            .target_name = "Local",
+        },
+    }};
+    const original: Session = .{ .active_tab = 0, .tabs = @constCast(&tabs) };
+
+    const json = try dumpSessionToString(allocator, original);
+    defer allocator.free(json);
+
+    var parsed = try loadSessionFromString(allocator, json);
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.tabs.len);
+    try std.testing.expect(parsed.value.tabs[0].ai_history != null);
+    const history = parsed.value.tabs[0].ai_history.?;
+    try std.testing.expectEqualStrings("local-codex", history.source_id);
+    try std.testing.expectEqualStrings("local", history.target_kind);
+}
+
 test "session_persist: tab without ai_session_id defaults to null (back-compat)" {
     const allocator = std.testing.allocator;
 
@@ -246,6 +280,19 @@ test "session_persist: tab without ai_session_id defaults to null (back-compat)"
 
     try std.testing.expectEqual(@as(usize, 1), parsed.value.tabs.len);
     try std.testing.expect(parsed.value.tabs[0].ai_session_id == null);
+}
+
+test "session_persist: old tab without ai_history defaults to null" {
+    const allocator = std.testing.allocator;
+
+    const json =
+        \\{"version":1,"active_tab":0,"tabs":[{"tree":{"leaf":{"surface":{"local_shell":{}}}}}]}
+    ;
+    var parsed = try loadSessionFromString(allocator, json);
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.tabs.len);
+    try std.testing.expect(parsed.value.tabs[0].ai_history == null);
 }
 
 test "session_persist: round-trip nested split with SSH leaf" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -51,6 +51,7 @@ test {
     _ = @import("ai_history_source.zig");
     _ = @import("ai_history_cache.zig");
     _ = @import("ai_history_resume.zig");
+    _ = @import("ai_history_session.zig");
     _ = @import("browser_url.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -45,6 +45,7 @@ test {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("ai_history_types.zig");
     _ = @import("browser_url.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -46,6 +46,7 @@ test {
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
     _ = @import("ai_history_types.zig");
+    _ = @import("ai_history_provider_codex.zig");
     _ = @import("browser_url.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -47,6 +47,7 @@ test {
     _ = @import("ai_chat_composer.zig");
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
+    _ = @import("ai_history_provider_claude.zig");
     _ = @import("browser_url.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -48,6 +48,9 @@ test {
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");
+    _ = @import("ai_history_source.zig");
+    _ = @import("ai_history_cache.zig");
+    _ = @import("ai_history_resume.zig");
     _ = @import("browser_url.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -606,6 +606,7 @@ comptime {
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
     _ = @import("ai_history_types.zig");
+    _ = @import("ai_history_provider_codex.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -605,6 +605,7 @@ comptime {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("ai_history_types.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -611,6 +611,7 @@ comptime {
     _ = @import("ai_history_source.zig");
     _ = @import("ai_history_cache.zig");
     _ = @import("ai_history_resume.zig");
+    _ = @import("ai_history_session.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -608,6 +608,9 @@ comptime {
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");
+    _ = @import("ai_history_source.zig");
+    _ = @import("ai_history_cache.zig");
+    _ = @import("ai_history_resume.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -612,6 +612,7 @@ comptime {
     _ = @import("ai_history_cache.zig");
     _ = @import("ai_history_resume.zig");
     _ = @import("ai_history_session.zig");
+    _ = @import("renderer/ai_history_renderer.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -607,6 +607,7 @@ comptime {
     _ = @import("ai_chat_composer.zig");
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
+    _ = @import("ai_history_provider_claude.zig");
     _ = @import("agent_detector.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -469,6 +469,12 @@ comptime {
     {
         @compileError("renderer/overlays.zig must get optional WSL session launcher layout from platform/pty_command.zig");
     }
+    if (std.mem.indexOf(u8, overlays_source, ".codex") != null or
+        std.mem.indexOf(u8, overlays_source, ".claude") != null or
+        std.mem.indexOf(u8, overlays_source, "parseMetadata") != null)
+    {
+        @compileError("renderer/overlays.zig must only launch AI History sources; provider scanning belongs in ai_history modules");
+    }
 
     const titlebar_source = @embedFile("renderer/titlebar.zig");
     if (std.mem.indexOf(u8, titlebar_source, "Windows Terminal-style caption button") != null or


### PR DESCRIPTION
## Summary

- Add an AI History tab for browsing Codex and Claude Code history on local, WSL, and SSH targets.
- Support lazy transcript preview, metadata filtering, metadata-only caching, and resume from the original project directory.
- Wire session launcher docs, shortcuts, UI status text, and SSH/WSL scan seams without introducing SSH connection sharing.

## Validation

- `zig test src/ai_history_session.zig`
- `zig test src/ai_history_cache.zig`
- `zig test src/renderer/ai_history_renderer.zig`
- `zig build test`
- `zig build test-full`
