### PR TITLE
fix: run AI History scan & preview asynchronously (no UI freeze)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-async-ai-history-scan.md
+++ b/docs/superpowers/plans/2026-06-02-async-ai-history-scan.md
@@ -1,0 +1,962 @@
+# Async AI History Scan & Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the AI History scan and transcript-preview off the main UI thread onto a background worker so the window never freezes, and auto-start the scan when an AI History tab is created.
+
+**Architecture:** Mirror the proven `ai_chat.zig` worker model — a `std.Thread` stored on the session, a `closing` atomic, a `mutex` guarding shared state, and `deinit` that sets `closing` then `join()`s before freeing. The blocking `host.scan` / `host.loadTranscript` run *outside* the lock; only the brief result-publish takes the lock. A monotonic generation counter discards superseded results. The continuous render loop (`runMainLoop` redraws every frame) picks up published state with no explicit wakeup. UAF safety comes purely from `deinit` joining workers before freeing.
+
+**Tech Stack:** Zig, `std.Thread` / `std.Thread.Mutex` / `std.atomic.Value`, existing `ai_history_session` scanner-host abstraction.
+
+---
+
+## Design Reference
+
+Spec: `docs/superpowers/specs/2026-06-02-async-ai-history-scan-design.md`
+
+## Key Facts (verified)
+
+- `src/ai_history_session.zig` is registered in **both** `src/test_fast.zig:54` and `src/test_main.zig:620`, so Session-level tests run under `zig build test` (fast).
+- `src/AppWindow.zig` already imports `ai_history_cache`, `ai_history_types`, `overlays` — but **not** `ssh_connection`; Task 4 adds it.
+- `g_cells_valid` / `g_force_rebuild` are `threadlocal` (`AppWindow.zig:1653-1654`). **Workers must never call `markUiDirty`.** The continuous render loop reflects state changes.
+- `overlays.aiHistorySshConnection(name) ?ssh_connection.SshConnection` is a pure value builder (inline buffers, no threadlocal pointers) — safe to snapshot on the UI thread and copy into a worker job.
+- `ai_history_cache.saveDefault(allocator, .{ .records }) !void` is already imported by `ai_history_session.zig` (line 9), so the worker saves the metadata cache itself — no AppWindow dependency.
+- Resume (`Enter`) only spawns a PTY (`spawnTabWithCommandAndCwd`) that connects asynchronously; it performs no blocking UI-thread I/O and is **out of scope**.
+
+## File Structure
+
+- `src/ai_history_session.zig` — async state fields, `ScanWork`/`TranscriptWork` interfaces, `scanAsync`/`loadTranscriptAsync`, worker bodies, generation-checked publish helpers, `deinit` join, `pub` on `cloneMetadata`/`freeMetadata`, `joinForTest`. New unit tests.
+- `src/AppWindow.zig` — `ssh_connection` import; `AiHistoryTarget` union; `AiHistoryScanJob`/`AiHistoryTranscriptJob` + their `run`/`destroy`; `scanTargetSnapshot`; `startAiHistoryScan`/`startAiHistoryTranscript`; rewrite `aiHistoryScanLocalNow`/`aiHistoryPreviewSelectedTranscript`; lock render + input/mouse dispatch; auto-scan in `spawnAiHistoryTab`; delete `withAiHistoryScannerHost`/`ScanRunner`/`PreviewTranscriptRunner`/`saveAiHistoryMetadataCache`.
+
+## Locking Contract (read before coding)
+
+`Session.mutex` guards: `state`, `status`, `rows`, `selected`, `list_offset`, `transcript`, `transcript_state`, `transcript_status`, `transcript_provider`, and the generation counters. `source` is immutable after init (only freed in `deinit`, which joins first) and needs no lock. `scan_thread`/`transcript_thread` are touched only by the UI thread (`scanAsync`/`loadTranscriptAsync`/`deinit`) and need no lock.
+
+Rules:
+- The long `host.scan`/`host.loadTranscript` runs with **no** lock held.
+- The worker takes the lock only for the final publish/discard.
+- Every UI-thread access to a guarded field holds the lock.
+- **No lock nesting:** a UI handler that holds the lock must not call another function that also locks (e.g. `scanAsync`, `loadTranscriptAsync`, `aiHistoryScanLocalNow`). Compute under the lock, release, then dispatch.
+
+---
+
+## Task 1: Session async state + generation-checked publish (synchronous logic)
+
+Adds the shared-state fields and the publish-or-discard logic, tested synchronously (no threads yet).
+
+**Files:**
+- Modify: `src/ai_history_session.zig` (struct fields ~133-142; `cloneMetadata`/`freeMetadata` at 843/872)
+- Test: `src/ai_history_session.zig` (test block at end of file)
+
+- [ ] **Step 1: Add async fields to `Session`**
+
+In the `Session` struct (after the `transcript: []types.TranscriptMessage = &.{},` field near line 142) add:
+
+```zig
+    // Async scan/transcript support. `mutex` guards state/status/rows/selected/
+    // list_offset/transcript*/generation fields. Workers run host I/O without the
+    // lock and take it only to publish. `closing` + join-on-deinit give UAF safety.
+    mutex: std.Thread.Mutex = .{},
+    scan_thread: ?std.Thread = null,
+    transcript_thread: ?std.Thread = null,
+    closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    scan_generation: u64 = 0,
+    transcript_generation: u64 = 0,
+```
+
+- [ ] **Step 2: Make `cloneMetadata` and `freeMetadata` public**
+
+Change `fn cloneMetadata` (line 843) to `pub fn cloneMetadata` and `fn freeMetadata` (line 872) to `pub fn freeMetadata`.
+
+- [ ] **Step 3: Add the publish-or-discard helpers**
+
+Add these methods to `Session` (place them right after `scanNowReturningResult`, ~line 245). They assume they are called by a worker; they take the lock internally:
+
+```zig
+    /// Publish scan rows if `generation` is still current and we are not closing,
+    /// otherwise discard. Always frees `result`. Called from the scan worker.
+    pub fn publishScanResult(self: *Session, generation: u64, result: ScanResult) void {
+        var published = false;
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            if (!self.closing.load(.acquire) and generation == self.scan_generation) {
+                if (self.replaceRows(result.rows)) |_| {
+                    self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
+                    published = true;
+                } else |_| {
+                    self.state = .failed;
+                    self.status = "Scan failed";
+                }
+            }
+        }
+        if (published and result.cache_update.records.len > 0) {
+            ai_history_cache.saveDefault(self.allocator, .{ .records = result.cache_update.records }) catch {};
+        }
+        freeScanResult(self.allocator, result);
+    }
+
+    /// Mark the scan failed if `generation` is still current and not closing.
+    pub fn publishScanFailure(self: *Session, generation: u64) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.scan_generation) {
+            self.state = .failed;
+            self.status = "Scan failed";
+        }
+    }
+```
+
+Note: `replaceRows` clones rows, so freeing `result.rows` afterward (via `freeScanResult`) is correct — it mirrors the existing `defer freeScanResult` in the old sync path.
+
+- [ ] **Step 4: Write the failing tests**
+
+Add to the test section at the end of `src/ai_history_session.zig`:
+
+```zig
+test "ai_history_session: publishScanResult applies rows when generation current" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scan_generation = 7;
+
+    const rows = try allocator.alloc(types.SessionMeta, 1);
+    rows[0] = .{
+        .provider = .codex,
+        .session_id = try allocator.dupe(u8, "live"),
+        .title = try allocator.dupe(u8, "Live"),
+        .source_path = try allocator.dupe(u8, "live.jsonl"),
+        .resume_kind = .codex_resume,
+    };
+    session.publishScanResult(7, .{ .rows = rows, .owns_row_strings = true });
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("live", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: publishScanResult discards stale generation" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scan_generation = 9;
+
+    const rows = try allocator.alloc(types.SessionMeta, 1);
+    rows[0] = .{
+        .provider = .codex,
+        .session_id = try allocator.dupe(u8, "stale"),
+        .title = try allocator.dupe(u8, "Stale"),
+        .source_path = try allocator.dupe(u8, "stale.jsonl"),
+        .resume_kind = .codex_resume,
+    };
+    // generation 4 != current 9 -> discarded and freed (testing allocator checks no leak)
+    session.publishScanResult(4, .{ .rows = rows, .owns_row_strings = true });
+
+    try std.testing.expectEqual(@as(usize, 0), session.rows.items.len);
+}
+```
+
+- [ ] **Step 5: Run the tests (expect FAIL before, PASS after Steps 1-3 are in)**
+
+Run: `zig build test`
+Expected after Steps 1-3: PASS. If you wrote the tests first against an unmodified file, they fail to compile (`publishScanResult` undefined) — that is the intended red state.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai_history_session.zig
+git commit -m "feat: add generation-checked scan publish to ai history session
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Async scan worker + deinit join
+
+Adds the `ScanWork` interface, `scanAsync`, the worker body, the `deinit` join, and a test helper.
+
+**Files:**
+- Modify: `src/ai_history_session.zig` (`deinit` ~159-167; add interface + methods near `scanNowReturningResult`)
+- Test: `src/ai_history_session.zig`
+
+- [ ] **Step 1: Add the `ScanWork` interface**
+
+Add near the other top-level public types (after `ScannerHost`, ~line 44):
+
+```zig
+/// Owned unit of background scan work. `run` performs the blocking scan; `destroy`
+/// frees the context (`ctx`). Both run on the worker thread. `ctx` must own
+/// everything `run` needs and contain no pointers into threadlocal UI state.
+pub const ScanWork = struct {
+    ctx: *anyopaque,
+    run: *const fn (*anyopaque, std.mem.Allocator, source_mod.Source) anyerror!ScanResult,
+    destroy: *const fn (*anyopaque, std.mem.Allocator) void,
+};
+```
+
+- [ ] **Step 2: Add `scanAsync`, the worker, and a test-join helper**
+
+Add to `Session` (after the publish helpers from Task 1):
+
+```zig
+    /// Start a background scan. UI-thread only. Joins any prior scan worker first
+    /// (at most one in flight per session), flips to `.scanning`, bumps the
+    /// generation, and spawns the worker. Returns immediately.
+    pub fn scanAsync(self: *Session, work: ScanWork) void {
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        self.mutex.lock();
+        self.state = .scanning;
+        self.status = "Scanning";
+        self.scan_generation +%= 1;
+        const generation = self.scan_generation;
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, scanWorkerMain, .{ self, work, generation }) catch {
+            self.mutex.lock();
+            if (generation == self.scan_generation) {
+                self.state = .failed;
+                self.status = "Scan failed";
+            }
+            self.mutex.unlock();
+            work.destroy(work.ctx, self.allocator);
+            return;
+        };
+        self.scan_thread = thread;
+    }
+
+    /// Test-only: wait for in-flight workers to finish so results can be asserted
+    /// deterministically. Not called in production (deinit joins instead).
+    pub fn joinForTest(self: *Session) void {
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
+    }
+```
+
+And the free worker function (top-level, not a method — place after the `Session` struct, near `scanRemoteFilesystem`):
+
+```zig
+fn scanWorkerMain(session: *Session, work: ScanWork, generation: u64) void {
+    defer work.destroy(work.ctx, session.allocator);
+    const result = work.run(work.ctx, session.allocator, session.source) catch {
+        session.publishScanFailure(generation);
+        return;
+    };
+    session.publishScanResult(generation, result);
+}
+```
+
+- [ ] **Step 3: Add the `deinit` join**
+
+In `Session.deinit` (line 159), make it the first thing — before any frees:
+
+```zig
+    pub fn deinit(self: *Session) void {
+        self.closing.store(.release, true);
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
+        self.clearTranscript();
+        freeRows(self.allocator, self.rows.items);
+        self.rows.deinit(self.allocator);
+        if (self.source_owned) {
+            freeOwnedSource(self.allocator, &self.source);
+        }
+        self.* = undefined;
+    }
+```
+
+Note: `std.atomic.Value(bool).store` signature is `store(self, value, ordering)`, so it is `self.closing.store(true, .release);` — write it that way:
+
+```zig
+        self.closing.store(true, .release);
+```
+
+- [ ] **Step 4: Write the failing test**
+
+```zig
+test "ai_history_session: scanAsync publishes rows then joins clean" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        destroyed: bool = false,
+        fn run(ptr: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) anyerror!ScanResult {
+            _ = ptr;
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = try alloc.dupe(u8, "async-id"),
+                .title = try alloc.dupe(u8, "Async"),
+                .source_path = try alloc.dupe(u8, "async.jsonl"),
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows, .owns_row_strings = true };
+        }
+        fn destroy(ptr: *anyopaque, _: std.mem.Allocator) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.destroyed = true;
+        }
+    };
+
+    var ctx = Ctx{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    session.scanAsync(.{ .ctx = &ctx, .run = Ctx.run, .destroy = Ctx.destroy });
+    session.joinForTest();
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("async-id", session.rows.items[0].session_id);
+    try std.testing.expect(ctx.destroyed);
+}
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `zig build test`
+Expected: PASS (and no leak report from the testing allocator).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai_history_session.zig
+git commit -m "feat: run ai history scan on a background worker thread
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Async transcript worker + deinit join
+
+**Files:**
+- Modify: `src/ai_history_session.zig`
+- Test: `src/ai_history_session.zig`
+
+- [ ] **Step 1: Add the `TranscriptWork` interface**
+
+After `ScanWork`:
+
+```zig
+/// Owned unit of background transcript-load work. `run` performs the blocking
+/// load; `provider` is used to publish; `destroy` frees `ctx` (which owns the
+/// selected metadata copy). All run on the worker thread.
+pub const TranscriptWork = struct {
+    ctx: *anyopaque,
+    provider: types.ProviderId,
+    run: *const fn (*anyopaque, std.mem.Allocator) anyerror![]types.TranscriptMessage,
+    destroy: *const fn (*anyopaque, std.mem.Allocator) void,
+};
+```
+
+- [ ] **Step 2: Add publish helpers, `loadTranscriptAsync`, and the worker**
+
+Add to `Session` (after `loadSelectedTranscript`, ~line 260):
+
+```zig
+    /// Start a background transcript load for the currently-selected row's data,
+    /// captured by the caller into `work.ctx`. UI-thread only. Clears any current
+    /// transcript, flips to `.loading`, bumps the generation, spawns the worker.
+    pub fn loadTranscriptAsync(self: *Session, work: TranscriptWork) void {
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
+        self.mutex.lock();
+        self.clearTranscript();
+        self.transcript_state = .loading;
+        self.transcript_status = "Loading transcript";
+        self.transcript_generation +%= 1;
+        const generation = self.transcript_generation;
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, transcriptWorkerMain, .{ self, work, generation }) catch {
+            self.mutex.lock();
+            if (generation == self.transcript_generation) {
+                self.transcript_state = .failed;
+                self.transcript_status = "Transcript failed";
+            }
+            self.mutex.unlock();
+            work.destroy(work.ctx, self.allocator);
+            return;
+        };
+        self.transcript_thread = thread;
+    }
+
+    /// Publish transcript messages if `generation`/`provider` still current and not
+    /// closing, otherwise free them. Worker-thread only.
+    pub fn publishTranscript(self: *Session, generation: u64, provider: types.ProviderId, messages: []types.TranscriptMessage) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.transcript_generation) {
+            self.transcript = messages;
+            self.transcript_provider = provider;
+            self.transcript_state = .ready;
+            self.transcript_status = "Transcript ready";
+        } else {
+            freeTranscript(self.allocator, provider, messages);
+        }
+    }
+
+    pub fn publishTranscriptFailure(self: *Session, generation: u64) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.transcript_generation) {
+            self.transcript_state = .failed;
+            self.transcript_status = "Transcript failed";
+        }
+    }
+```
+
+And the worker (top-level, near `scanWorkerMain`):
+
+```zig
+fn transcriptWorkerMain(session: *Session, work: TranscriptWork, generation: u64) void {
+    defer work.destroy(work.ctx, session.allocator);
+    const messages = work.run(work.ctx, session.allocator) catch {
+        session.publishTranscriptFailure(generation);
+        return;
+    };
+    session.publishTranscript(generation, work.provider, messages);
+}
+```
+
+- [ ] **Step 3: Write the failing test**
+
+```zig
+test "ai_history_session: loadTranscriptAsync publishes messages then joins clean" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        fn run(_: *anyopaque, alloc: std.mem.Allocator) anyerror![]types.TranscriptMessage {
+            const messages = try alloc.alloc(types.TranscriptMessage, 1);
+            errdefer alloc.free(messages);
+            messages[0] = .{ .role = .user, .content = try alloc.dupe(u8, "async-hello") };
+            return messages;
+        }
+        fn destroy(_: *anyopaque, _: std.mem.Allocator) void {}
+    };
+
+    var ctx_byte: u8 = 0;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    session.loadTranscriptAsync(.{
+        .ctx = &ctx_byte,
+        .provider = .codex,
+        .run = Ctx.run,
+        .destroy = Ctx.destroy,
+    });
+    session.joinForTest();
+
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(@as(usize, 1), session.transcript.len);
+    try std.testing.expectEqualStrings("async-hello", session.transcript[0].content);
+}
+
+test "ai_history_session: publishTranscript discards stale generation" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.transcript_generation = 3;
+
+    const messages = try allocator.alloc(types.TranscriptMessage, 1);
+    messages[0] = .{ .role = .user, .content = try allocator.dupe(u8, "stale") };
+    // generation 1 != current 3 -> freed, not published (testing allocator checks no leak)
+    session.publishTranscript(1, .codex, messages);
+
+    try std.testing.expectEqual(@as(usize, 0), session.transcript.len);
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `zig build test`
+Expected: PASS, no leaks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_history_session.zig
+git commit -m "feat: run ai history transcript load on a background worker thread
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: AppWindow async entry points + worker jobs
+
+Wire the new Session API into AppWindow with owned jobs. AppWindow GUI globals are not unit-tested here; verification is compile + full suite green.
+
+**Files:**
+- Modify: `src/AppWindow.zig` (imports ~43; `aiHistoryScanLocalNow` 768-772; `aiHistoryPreviewSelectedTranscript` 693-697; `ScanRunner`/`PreviewTranscriptRunner`/`withAiHistoryScannerHost`/`saveAiHistoryMetadataCache` 774-863)
+
+- [ ] **Step 1: Add the `ssh_connection` import**
+
+Near the other `ai_history_*` imports (~line 45):
+
+```zig
+const ssh_connection = @import("ssh_connection.zig");
+```
+
+- [ ] **Step 2: Add the target snapshot type and job structs**
+
+Add (place near the existing `AiHistoryHostAction` definition, ~line 774, replacing the old runner machinery you will delete in Step 4):
+
+```zig
+/// Everything a background AI History worker needs, snapshotted on the UI thread.
+/// `ssh` carries a copied `SshConnection` value (inline buffers, no threadlocal
+/// pointers). `local`/`wsl` resolve their inputs inside the worker.
+const AiHistoryTarget = union(enum) {
+    local,
+    wsl,
+    ssh: ssh_connection.SshConnection,
+};
+
+const AiHistoryScanJob = struct {
+    target: AiHistoryTarget,
+
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator, source: ai_history_source.Source) anyerror!ai_history_session.ScanResult {
+        const job: *AiHistoryScanJob = @ptrCast(@alignCast(ctx));
+        switch (job.target) {
+            .local => {
+                const home = try localHomeForAiHistory(allocator);
+                defer allocator.free(home);
+                var parsed_cache = ai_history_cache.loadDefault(allocator) catch null;
+                defer if (parsed_cache) |*cache| cache.deinit();
+                var host_state = ai_history_session.LocalScannerHost{
+                    .home = home,
+                    .cache = if (parsed_cache) |cache| cache.value else null,
+                };
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+            .wsl => {
+                var host_state = ai_history_session.WslScannerHost{};
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+            .ssh => |conn| {
+                var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+        }
+    }
+
+    fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        const job: *AiHistoryScanJob = @ptrCast(@alignCast(ctx));
+        allocator.destroy(job);
+    }
+};
+
+const AiHistoryTranscriptJob = struct {
+    target: AiHistoryTarget,
+    meta: ai_history_types.SessionMeta, // owned clone
+
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror![]ai_history_types.TranscriptMessage {
+        const job: *AiHistoryTranscriptJob = @ptrCast(@alignCast(ctx));
+        switch (job.target) {
+            .local => {
+                var host_state = ai_history_session.LocalScannerHost{ .home = "" };
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+            .wsl => {
+                var host_state = ai_history_session.WslScannerHost{};
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+            .ssh => |conn| {
+                var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+        }
+    }
+
+    fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        const job: *AiHistoryTranscriptJob = @ptrCast(@alignCast(ctx));
+        ai_history_session.freeMetadata(allocator, job.meta);
+        allocator.destroy(job);
+    }
+};
+
+/// Snapshot the source's target into a worker-safe value (UI thread). Returns
+/// null only when an SSH profile cannot be resolved.
+fn aiHistoryTargetSnapshot(target: ai_history_source.Target) ?AiHistoryTarget {
+    return switch (target) {
+        .local => .local,
+        .wsl => .wsl,
+        .ssh => |ssh| .{ .ssh = overlays.aiHistorySshConnection(ssh.profile_name) orelse return null },
+    };
+}
+
+/// Kick off an async scan for `session`. UI thread. On setup failure marks the
+/// session failed instead of spawning a doomed worker.
+fn startAiHistoryScan(allocator: std.mem.Allocator, session: *ai_history_session.Session) void {
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse {
+        session.mutex.lock();
+        session.state = .failed;
+        session.status = "SSH profile unavailable";
+        session.mutex.unlock();
+        return;
+    };
+    const job = allocator.create(AiHistoryScanJob) catch {
+        session.mutex.lock();
+        session.state = .failed;
+        session.status = "Scan failed";
+        session.mutex.unlock();
+        return;
+    };
+    job.* = .{ .target = target };
+    session.scanAsync(.{ .ctx = job, .run = AiHistoryScanJob.run, .destroy = AiHistoryScanJob.destroy });
+}
+
+/// Kick off an async transcript load for the selected row. UI thread.
+fn startAiHistoryTranscript(allocator: std.mem.Allocator, session: *ai_history_session.Session) void {
+    session.mutex.lock();
+    const selected = session.selectedVisible();
+    const meta_clone: ?ai_history_types.SessionMeta = if (selected) |m|
+        (ai_history_session.cloneMetadata(allocator, m) catch null)
+    else
+        null;
+    session.mutex.unlock();
+
+    const meta = meta_clone orelse return;
+
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse {
+        ai_history_session.freeMetadata(allocator, meta);
+        session.mutex.lock();
+        session.transcript_state = .failed;
+        session.transcript_status = "SSH profile unavailable";
+        session.mutex.unlock();
+        return;
+    };
+    const job = allocator.create(AiHistoryTranscriptJob) catch {
+        ai_history_session.freeMetadata(allocator, meta);
+        return;
+    };
+    job.* = .{ .target = target, .meta = meta };
+    session.loadTranscriptAsync(.{
+        .ctx = job,
+        .provider = meta.provider,
+        .run = AiHistoryTranscriptJob.run,
+        .destroy = AiHistoryTranscriptJob.destroy,
+    });
+}
+```
+
+Note: `AiHistoryScanJob.run`'s `source` parameter uses `ai_history_source.Source` (AppWindow already imports the source module as `ai_history_source` at line 47). This is the same type as `ai_history_session`'s private `source_mod.Source` (both `@import("ai_history_source.zig")`), so the `ScanWork.run` function-pointer type matches.
+
+- [ ] **Step 3: Rewrite the two entry points**
+
+Replace `aiHistoryScanLocalNow` (768-772):
+
+```zig
+pub fn aiHistoryScanLocalNow() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    startAiHistoryScan(allocator, session);
+    return true;
+}
+```
+
+Replace `aiHistoryPreviewSelectedTranscript` (693-697):
+
+```zig
+pub fn aiHistoryPreviewSelectedTranscript() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    startAiHistoryTranscript(allocator, session);
+    return true;
+}
+```
+
+- [ ] **Step 4: Delete the obsolete synchronous machinery**
+
+Delete these now-unused items from `src/AppWindow.zig`:
+- `const AiHistoryHostAction` and `const AiHistoryHostRunner` (~774-775)
+- `const PreviewTranscriptRunner` (~777-789)
+- `const ScanRunner` (~791-803)
+- `fn withAiHistoryScannerHost` (~805-843)
+- `fn saveAiHistoryMetadataCache` (~845-850)
+- `fn failAiHistoryHostUnavailable` (~852-863)
+
+Keep `localHomeForAiHistory` (now called by `AiHistoryScanJob.run`).
+
+- [ ] **Step 5: Build and run the full suite**
+
+Run: `zig build test && zig build test-full`
+Expected: both exit 0; no references to the deleted symbols remain. If the build reports `withAiHistoryScannerHost`/`ScanRunner`/etc. still referenced, find and update that caller (e.g. the mouse `.refresh` branch already calls `aiHistoryScanLocalNow`, which is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "feat: drive ai history scan/preview through async worker jobs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Lock the render and input/mouse dispatch
+
+Guard every UI-thread access to the session's shared fields. No lock nesting (see Locking Contract).
+
+**Files:**
+- Modify: `src/AppWindow.zig` — `renderAiHistoryFrame` (617-636); `aiHistoryInsertCodepoint` (667-676); `aiHistoryBackspaceFilter` (678-683); `aiHistoryMoveSelection` (685-691); `aiHistoryHandleMousePress` (865-904); `resumeAiHistorySelection` (703-709)
+
+- [ ] **Step 1: Lock around the render call**
+
+In `renderAiHistoryFrame`, wrap the `ai_history_renderer.render(...)` call:
+
+```zig
+    if (active_tab.ai_history_session) |session| {
+        const draw: ai_history_renderer.DrawContext = .{
+            .bg = g_theme.background,
+            .fg = g_theme.foreground,
+            .accent = g_theme.cursor_color,
+            .cell_h = font.g_titlebar_cell_height,
+            .fillQuad = ui_pipeline.fillQuad,
+            .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
+            .renderTextLimited = titlebar.renderTextLimited,
+        };
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        ai_history_renderer.render(
+            draw,
+            session,
+            @floatFromInt(fb_width),
+            @floatFromInt(fb_height),
+            titlebar_offset,
+            left_panels_w,
+            aiHistoryContentWidth(fb_width, left_panels_w, right_panels_w),
+        );
+    }
+```
+
+- [ ] **Step 2: Lock the filter/selection handlers**
+
+`aiHistoryInsertCodepoint` — keep the space-key early return *before* taking the lock (it calls preview, which locks), then lock only around `appendFilterBytes`:
+
+```zig
+pub fn aiHistoryInsertCodepoint(codepoint: u21) bool {
+    const session = activeAiHistory() orelse return false;
+    if (codepoint == ' ') return aiHistoryPreviewSelectedTranscript();
+    if (codepoint < 0x20 or codepoint == 0x7f) return false;
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(codepoint, &buf) catch return false;
+    session.mutex.lock();
+    session.appendFilterBytes(buf[0..len]);
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+```
+
+`aiHistoryBackspaceFilter`:
+
+```zig
+pub fn aiHistoryBackspaceFilter() bool {
+    const session = activeAiHistory() orelse return false;
+    session.mutex.lock();
+    session.backspaceFilter();
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+```
+
+`aiHistoryMoveSelection`:
+
+```zig
+pub fn aiHistoryMoveSelection(delta: isize) bool {
+    const session = activeAiHistory() orelse return false;
+    session.mutex.lock();
+    session.moveSelection(delta);
+    session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+```
+
+Note: `aiHistoryListVisibleRowsForWindow()` reads only window/framebuffer size, not session state, so calling it inside the lock is safe and introduces no nesting.
+
+- [ ] **Step 3: Lock the mouse handler's hit-test, then dispatch unlocked**
+
+Rewrite the body of `aiHistoryHandleMousePress` (865-904) so the lock covers only `interactionHitTest`, then dispatch after releasing:
+
+```zig
+pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
+    const session = activeAiHistory() orelse return false;
+    const win = g_window orelse return true;
+    const fb = window_backend.framebufferSize(win);
+    const left = leftPanelsWidth();
+    const right = rightPanelsWidthForWindow(fb.width);
+    const width = @as(f32, @floatFromInt(fb.width)) - left - right;
+    const visible_rows = ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight());
+
+    session.mutex.lock();
+    const hit = ai_history_renderer.interactionHitTest(
+        session,
+        @floatFromInt(fb.width),
+        @floatFromInt(fb.height),
+        currentTitlebarHeight(),
+        left,
+        width,
+        font.g_titlebar_cell_height,
+        xpos,
+        ypos,
+    );
+    session.mutex.unlock();
+
+    switch (hit) {
+        .none => {},
+        .refresh => {
+            _ = aiHistoryScanLocalNow();
+            return true;
+        },
+        .@"resume" => {
+            _ = resumeAiHistorySelection();
+            markUiDirty();
+            return true;
+        },
+        .row => |visible_index| {
+            session.mutex.lock();
+            session.selectVisibleIndex(visible_index);
+            session.ensureSelectionVisible(visible_rows);
+            session.mutex.unlock();
+            markUiDirty();
+            return true;
+        },
+    }
+    markUiDirty();
+    return true;
+}
+```
+
+- [ ] **Step 4: Clone the resume meta under the lock**
+
+Rewrite `resumeAiHistorySelection` (703-709) so the selected metadata is cloned under the lock and freed after the spawn (its strings would otherwise dangle if a concurrent scan replaced rows):
+
+```zig
+pub fn resumeAiHistorySelection() bool {
+    const active = tab.activeTab() orelse return false;
+    if (active.kind != .ai_history) return false;
+    const session = active.ai_history_session orelse return false;
+    const allocator = g_allocator orelse return false;
+
+    session.mutex.lock();
+    const selected = session.selectedVisible();
+    const meta_clone: ?ai_history_types.SessionMeta = if (selected) |m|
+        (ai_history_session.cloneMetadata(allocator, m) catch null)
+    else
+        null;
+    session.mutex.unlock();
+
+    const meta = meta_clone orelse return false;
+    defer ai_history_session.freeMetadata(allocator, meta);
+    return spawnResumeTerminal(session.source.target, meta);
+}
+```
+
+- [ ] **Step 5: Build and run the full suite**
+
+Run: `zig build test && zig build test-full`
+Expected: both exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "fix: guard ai history shared state with the session mutex
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Auto-scan on tab create
+
+**Files:**
+- Modify: `src/AppWindow.zig` — `spawnAiHistoryTab` (1409-1414)
+
+- [ ] **Step 1: Kick off the scan after creating the tab**
+
+```zig
+pub fn spawnAiHistoryTab(source: ai_history_source.Source) bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.spawnAiHistoryTab(allocator, source)) return false;
+    clearUiStateOnTabChange();
+    if (activeAiHistory()) |session| startAiHistoryScan(allocator, session);
+    return true;
+}
+```
+
+- [ ] **Step 2: Build and run the full suite**
+
+Run: `zig build test && zig build test-full`
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "feat: auto-scan ai history when a new tab is created
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full clean test run**
+
+Run: `zig build test && zig build test-full`
+Expected: both exit 0; failed count 0 (baseline ~673/677 passed, 4 skipped, 0 failed — count may be higher with the new tests).
+
+- [ ] **Step 2: Confirm no dead references**
+
+Run: `grep -rn "withAiHistoryScannerHost\|ScanRunner\|PreviewTranscriptRunner\|saveAiHistoryMetadataCache\|scanNowReturningResult" src/`
+Expected: no matches in `src/AppWindow.zig`. (`scanNow`/`scanNowReturningResult`/`loadSelectedTranscript` may still exist in `ai_history_session.zig` if its own tests use them — that is fine; they are just no longer called from the UI.)
+
+- [ ] **Step 3: Manual GUI verification (record outcome)**
+
+Build and run the app (`zig build run` or the project's run skill). Verify:
+1. New AI History tab (WSL): opens showing "Scanning AI history…" immediately, then populates without pressing `r`; the window stays responsive (can switch tabs, type) during the scan.
+2. New AI History tab (SSH profile): same — UI never freezes during the (slow) SSH scan.
+3. Press `r` on a populated list: re-scans async, no freeze.
+4. Select a row and press `space`: transcript preview loads without freezing.
+5. Close the AI History tab during a scan: app does not crash (brief pause up to the SSH round-trip is expected and acceptable).
+
+Note: GUI verification is manual — there is no Linux GUI backend in CI; record the result in the commit/PR description.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** scan async (Tasks 1-2, 4), transcript async (Task 3, 4), locking render+input (Task 5), auto-scan on create (Task 6), deinit-join lifetime option A (Task 2/3), cache save moved into worker (Task 1 `publishScanResult`), resume out of scope (not implemented, by design). All covered.
+- **Generation/closing:** publish helpers check both; deinit sets closing then joins → UAF-safe by construction.
+- **No lock nesting:** verified for the space-key→preview path, the mouse refresh/resume/row paths, and move/backspace/insert handlers.
+- **Type consistency:** `AiHistoryTarget`, `AiHistoryScanJob`, `AiHistoryTranscriptJob`, `ScanWork`, `TranscriptWork`, `publishScanResult`, `publishTranscript`, `cloneMetadata`, `freeMetadata`, `joinForTest`, `startAiHistoryScan`, `startAiHistoryTranscript`, `aiHistoryTargetSnapshot` used consistently across tasks.
+- **Source type resolved:** AppWindow's job `run` uses `ai_history_source.Source` (AppWindow import at line 47); identical underlying type to the session's private `source_mod.Source`, so the `ScanWork.run` function-pointer type matches.

--- a/docs/superpowers/specs/2026-06-02-async-ai-history-scan-design.md
+++ b/docs/superpowers/specs/2026-06-02-async-ai-history-scan-design.md
@@ -1,0 +1,233 @@
+# Async AI History Scan & Preview Design
+
+## Goal
+
+Stop the AI History browser from freezing the UI. Today, scanning a source
+(local/WSL/SSH) and loading a transcript preview both run **synchronously on the
+main render+input thread**. For WSL and SSH sources these perform blocking
+subprocess / network I/O, so the entire window stops responding until the work
+completes.
+
+Move the blocking work to a background worker thread, following the existing
+`ai_chat.zig` worker model, and auto-start the scan when an AI History tab is
+created so the user never has to press `r` to populate it.
+
+## Problem (Root Cause)
+
+The blocking call chain on the UI thread:
+
+- `r` key (`input.zig:1170`) or refresh click (`AppWindow.zig:887`)
+  → `aiHistoryScanLocalNow` → `withAiHistoryScannerHost` → `ScanRunner.run`
+  → `Session.scanNowReturningResult` → `host.scan` → `scanRemoteFilesystem`.
+- WSL: `wslExec` spawns `wsl.exe` and drains stdout to completion (blocking).
+- SSH: `sshExecCapture` spawns `ssh` with `ConnectTimeout=8`, **once per remote
+  round-trip**. A scan does a home lookup plus per-provider-root listing plus a
+  metadata read per file, so a single scan can be dozens of blocking SSH
+  handshakes → tens of seconds of frozen render+input.
+- Transcript preview (`space` → `aiHistoryPreviewSelectedTranscript`
+  → `loadSelectedTranscript` → `host.loadTranscript`) hits the same blocking
+  remote I/O path.
+
+The main loop (`runMainLoop`) renders continuously via non-blocking
+`window_backend.pollEvents`, redrawing every frame. So a background worker only
+needs to update shared `Session` state under a lock; the next frame reflects it.
+This is the same mechanism that lets `ai_chat` streaming updates appear.
+
+## Scope
+
+In scope (the operations that actually block the UI thread):
+
+- **Scan** — `Session.scanNowReturningResult` / `aiHistoryScanLocalNow`.
+- **Transcript preview** — `Session.loadSelectedTranscript` /
+  `aiHistoryPreviewSelectedTranscript`.
+
+Out of scope:
+
+- **Resume (`Enter`)** — `spawnResumeTerminal` only builds command strings and
+  calls `spawnTabWithCommandAndCwd`, which spawns a PTY child (ssh/wsl/shell)
+  that connects asynchronously in its own reader thread. It does **no**
+  synchronous network I/O on the UI thread, so it is already non-blocking.
+  Adding async machinery here would be a no-op; leave it as is.
+
+## Reference Pattern
+
+`ai_chat.zig` already solves the "blocking work off the UI thread" problem:
+
+- `request_thread: ?std.Thread` stored on the session.
+- `closing: std.atomic.Value(bool)` set in `deinit`.
+- `deinit` does `closing.store(true)` then `thread.join()` before freeing.
+- The worker periodically checks `closing.load(.acquire)` and bails early.
+
+The AI History fix mirrors this exactly.
+
+## Design
+
+### 1. Session async state (`ai_history_session.zig`)
+
+Add to `Session`:
+
+- `mutex: std.Thread.Mutex = .{}` — guards the worker-shared fields: `state`,
+  `status`, `rows`, `selected`, `list_offset`, and the `transcript*` fields.
+- `scan_thread: ?std.Thread = null`
+- `transcript_thread: ?std.Thread = null`
+- `closing: std.atomic.Value(bool) = .init(false)`
+- `scan_generation: u64 = 0`
+- `transcript_generation: u64 = 0`
+
+The generation counters let a newer request supersede an older in-flight one:
+a re-scan, or selecting a different transcript before the previous load
+finished. When a worker finishes it compares the generation it was launched
+with against the current value under the lock; if they differ (or `closing` is
+set) it discards its result instead of writing it.
+
+### 2. Worker job context
+
+Blocking work must not read threadlocal UI state. Each worker gets a
+heap-allocated, owned job:
+
+```
+ScanJob = struct {
+    session: *Session,
+    generation: u64,
+    target: TargetSnapshot,   // local | wsl | ssh(SshConnection value)
+};
+TranscriptJob = struct {
+    session: *Session,
+    generation: u64,
+    target: TargetSnapshot,
+    meta: SessionMeta,        // owned copy of the selected row
+};
+```
+
+`TargetSnapshot` carries everything the blocking call needs:
+
+- **local** — nothing; the worker resolves `home` (env `USERPROFILE`/`HOME`,
+  process-global) and loads the metadata cache from disk inside the worker.
+- **wsl** — nothing; `WslScannerHost` is stateless.
+- **ssh** — a **snapshotted `SshConnection` value**. `aiHistorySshConnection`
+  is a pure builder that copies profile fields into a self-contained struct with
+  inline buffers (no pointers into threadlocal `g_ssh_profiles`), so the value is
+  safe to copy to the worker. The snapshot is taken on the UI thread at spawn
+  time.
+
+The job is allocated with the app allocator and freed by the worker when it
+exits.
+
+### 3. UI entry points become non-blocking (`AppWindow.zig`)
+
+- `aiHistoryScanLocalNow`: under the session lock, set `state = .scanning`,
+  `status = "Scanning"`, bump `scan_generation`; build the `TargetSnapshot`
+  (snapshot SSH conn on the UI thread); join any prior `scan_thread`; spawn the
+  scan worker; return immediately.
+- `aiHistoryPreviewSelectedTranscript`: same shape with `transcript_state`,
+  `transcript_generation`, an owned copy of the selected `SessionMeta`, and the
+  transcript worker.
+
+Joining the prior thread of the *same kind* before spawning a new one keeps at
+most one scan worker and one transcript worker per session, and bounds thread
+lifetime. (A fresh request's blocking predecessor is rare; if it happens the
+join waits for the predecessor's current round-trip, same bound as close.)
+
+### 4. Worker bodies
+
+```
+scanWorkerMain(job):
+    result = run host.scan(...)   // long, blocking, NO lock held
+    lock session.mutex
+        if session.closing or job.generation != session.scan_generation:
+            unlock; free result; free job; return
+        replaceRows(result.rows)      // swaps rows, resets selected/offset, state=.ready
+        status = warning ? "Ready with warnings" : "Ready"
+    unlock
+    saveAiHistoryMetadataCache(result.cache_update)   // disk I/O, off UI thread
+    free result; free job
+on error: lock; if current generation && !closing -> state=.failed, status set; unlock
+```
+
+`transcriptWorkerMain` is the analogue for `host.loadTranscript`, writing
+`transcript`, `transcript_provider`, `transcript_state`.
+
+The long `host.scan` / `host.loadTranscript` call runs **outside** the lock.
+Only the brief final swap takes the lock.
+
+### 5. Render + input take the lock
+
+`ai_history_renderer.render` and the AI-history key/mouse handlers read/mutate
+the shared fields, so they must hold `session.mutex` while doing so. These are
+short (per-frame render; occasional input), and the worker holds the lock only
+for the brief swap, so contention is negligible. Selection/filter mutations
+(UI-thread-only) are also wrapped because `replaceRows` (worker) resets
+`selected`/`list_offset`.
+
+Implementation note: wrap the render and the input dispatch for AI-history at a
+single coarse point each, rather than sprinkling locks through every helper, to
+keep the locking obvious and avoid double-lock/recursion.
+
+### 6. Auto-scan on create
+
+The `AppWindow.spawnAiHistoryTab` wrapper (UI thread) snapshots the SSH conn (if
+the source is SSH) and kicks off the async scan immediately after the tab is
+created, so the tab shows "Scanning AI history…" and then populates without the
+user pressing `r`. Manual `r` / refresh re-scan still works (async).
+
+### 7. Lifetime on tab close — option (A), join on deinit
+
+`Session.deinit` (called when the tab closes):
+
+```
+closing.store(true, .release)
+if scan_thread: join; scan_thread = null
+if transcript_thread: join; transcript_thread = null
+... existing free of rows/transcript/source ...
+```
+
+This mirrors `ai_chat` exactly and eliminates use-after-free: the worker's
+`*Session` stays valid because `deinit` waits for the worker to return before
+freeing. Accepted tradeoff: closing a tab *during* an in-flight SSH scan blocks
+the UI for up to the current round-trip (≤ ~8s connect timeout) until the worker
+returns. The window for this is small (close must land mid-scan) and the worker
+bails as soon as the current `exec` returns, so the cost is bounded and matches
+the proven `ai_chat` model. Option (B) (detach + orphan) was rejected for the
+extra refcounting / UAF surface.
+
+## Error Handling
+
+- Worker scan/transcript failure → under lock, if still current and not closing,
+  set `state=.failed` / `transcript_state=.failed` with a status string; the
+  renderer already shows the failed states.
+- Host unavailable (SSH profile gone, home unresolvable) is detected on the UI
+  thread before spawning (or in the worker for local home) and sets the failed
+  state without spawning a doomed worker where possible.
+- Stale results (superseded generation or `closing`) are silently discarded and
+  freed.
+
+## Testing
+
+`ai_history_session.zig` already has unit tests using fake scanner hosts
+(`scan` fns returning canned `ScanResult`). Add tests for:
+
+- A scan worker writes rows and flips `.scanning` → `.ready` (drive the worker
+  function directly, or `join` the spawned thread, then assert state/rows).
+- A superseded generation result is discarded (bump generation before the worker
+  swaps; assert rows unchanged).
+- `closing` set before swap discards the result and frees cleanly (no leak under
+  the testing allocator).
+- `deinit` while a worker is "in flight" joins without UAF/leak (use a fake host
+  whose `scan` blocks on a signal the test releases).
+- Transcript worker analogues for the above.
+
+Full suite: `zig build test` (fast) and `zig build test-full` must stay green
+(current baseline ~673/677 passed, 4 skipped, 0 failed).
+
+## Files Touched
+
+- `src/ai_history_session.zig` — async state, worker bodies, generation/closing
+  logic, `deinit` join, locking helpers, tests.
+- `src/AppWindow.zig` — non-blocking entry points, `TargetSnapshot` build + SSH
+  snapshot, auto-scan on create, lock around render/input dispatch, move cache
+  save into worker.
+- `src/renderer/ai_history_renderer.zig` — read under lock (or via a locked
+  snapshot helper).
+- `src/input.zig` — AI-history input dispatch under lock (coarse).
+- Possibly `src/appwindow/tab.zig` — auto-scan hook point if `spawnAiHistoryTab`
+  is the chosen kickoff site.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1499,6 +1499,7 @@ pub fn spawnAiHistoryTab(source: ai_history_source.Source) bool {
     const allocator = g_allocator orelse return false;
     if (!tab.spawnAiHistoryTab(allocator, source)) return false;
     clearUiStateOnTabChange();
+    if (activeAiHistory()) |session| startAiHistoryScan(allocator, session);
     return true;
 }
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -977,6 +977,9 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
             return true;
         },
         .row => |visible_index| {
+            // Re-lock independently of the hit-test above: a worker may have
+            // replaced rows in between, but selectVisibleIndex clamps to the
+            // current visible count, so a now-stale index is safe.
             session.mutex.lock();
             session.selectVisibleIndex(visible_index);
             session.ensureSelectionVisible(visible_rows);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -888,7 +888,10 @@ fn startAiHistoryTranscript(allocator: std.mem.Allocator, session: *ai_history_s
     session.mutex.lock();
     const selected = session.selectedVisible();
     const meta_clone: ?ai_history_types.SessionMeta = if (selected) |m|
-        (ai_history_session.cloneMetadata(allocator, m) catch null)
+        (ai_history_session.cloneMetadata(allocator, m) catch |err| blk: {
+            log.warn("failed to clone ai history metadata for transcript: {}", .{err});
+            break :blk null;
+        })
     else
         null;
     session.mutex.unlock();
@@ -905,12 +908,16 @@ fn startAiHistoryTranscript(allocator: std.mem.Allocator, session: *ai_history_s
     };
     const job = allocator.create(AiHistoryTranscriptJob) catch {
         ai_history_session.freeMetadata(allocator, meta);
+        session.mutex.lock();
+        session.transcript_state = .failed;
+        session.transcript_status = "Transcript failed";
+        session.mutex.unlock();
         return;
     };
     job.* = .{ .target = target, .meta = meta };
     session.loadTranscriptAsync(.{
         .ctx = job,
-        .provider = meta.provider,
+        .provider = job.meta.provider,
         .run = AiHistoryTranscriptJob.run,
         .destroy = AiHistoryTranscriptJob.destroy,
     });

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -45,6 +45,7 @@ const ai_history_resume = @import("ai_history_resume.zig");
 const ai_history_types = @import("ai_history_types.zig");
 pub const ai_history_session = @import("ai_history_session.zig");
 pub const ai_history_source = @import("ai_history_source.zig");
+const ssh_connection = @import("ssh_connection.zig");
 pub const tab = @import("appwindow/tab.zig");
 const active_tab_state = @import("appwindow/active_tab.zig");
 pub const font = @import("font/manager.zig");
@@ -693,7 +694,8 @@ pub fn aiHistoryMoveSelection(delta: isize) bool {
 pub fn aiHistoryPreviewSelectedTranscript() bool {
     const session = activeAiHistory() orelse return false;
     const allocator = g_allocator orelse return false;
-    return withAiHistoryScannerHost(allocator, session, .preview, PreviewTranscriptRunner.run);
+    startAiHistoryTranscript(allocator, session);
+    return true;
 }
 
 pub fn aiHistoryLoadSelectedTranscript() bool {
@@ -768,98 +770,150 @@ fn failAiHistoryResumePathUnavailable() bool {
 pub fn aiHistoryScanLocalNow() bool {
     const session = activeAiHistory() orelse return false;
     const allocator = g_allocator orelse return false;
-    return withAiHistoryScannerHost(allocator, session, .scan, ScanRunner.run);
+    startAiHistoryScan(allocator, session);
+    return true;
 }
 
-const AiHistoryHostAction = enum { scan, preview };
-const AiHistoryHostRunner = *const fn (*ai_history_session.Session, ai_history_session.ScannerHost) bool;
-
-const PreviewTranscriptRunner = struct {
-    fn run(session: *ai_history_session.Session, host: ai_history_session.ScannerHost) bool {
-        session.loadSelectedTranscript(host) catch |err| {
-            log.warn("failed to load AI History transcript: {}", .{err});
-            session.transcript_state = .failed;
-            session.transcript_status = "Transcript failed";
-            markUiDirty();
-            return true;
-        };
-        markUiDirty();
-        return true;
-    }
+/// Everything a background AI History worker needs, snapshotted on the UI thread.
+/// `ssh` carries a copied `SshConnection` value (inline buffers, no threadlocal
+/// pointers). `local`/`wsl` resolve their inputs inside the worker.
+const AiHistoryTarget = union(enum) {
+    local,
+    wsl,
+    ssh: ssh_connection.SshConnection,
 };
 
-const ScanRunner = struct {
-    fn run(session: *ai_history_session.Session, host: ai_history_session.ScannerHost) bool {
-        const result = session.scanNowReturningResult(host) catch |err| {
-            log.warn("failed to scan AI History: {}", .{err});
-            markUiDirty();
-            return true;
-        };
-        defer ai_history_session.freeScanResult(session.allocator, result);
-        saveAiHistoryMetadataCache(session.allocator, result.cache_update);
-        markUiDirty();
-        return true;
-    }
-};
+const AiHistoryScanJob = struct {
+    target: AiHistoryTarget,
 
-fn withAiHistoryScannerHost(allocator: std.mem.Allocator, session: *ai_history_session.Session, action: AiHistoryHostAction, runner: AiHistoryHostRunner) bool {
-    switch (session.source.target) {
-        .local => {
-            const home = localHomeForAiHistory(allocator) catch |err| {
-                log.warn("failed to resolve local home for AI History scan: {}", .{err});
-                failAiHistoryHostUnavailable(session, action, "Home unavailable");
-                markUiDirty();
-                return true;
-            };
-            defer allocator.free(home);
-            var parsed_cache: ?std.json.Parsed(ai_history_cache.CacheFile) = null;
-            if (action == .scan) {
-                parsed_cache = ai_history_cache.loadDefault(allocator) catch |err| blk: {
-                    log.warn("failed to load AI History metadata cache: {}", .{err});
-                    break :blk null;
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator, source: ai_history_source.Source) anyerror!ai_history_session.ScanResult {
+        const job: *AiHistoryScanJob = @ptrCast(@alignCast(ctx));
+        switch (job.target) {
+            .local => {
+                const home = try localHomeForAiHistory(allocator);
+                defer allocator.free(home);
+                var parsed_cache = ai_history_cache.loadDefault(allocator) catch null;
+                defer if (parsed_cache) |*cache| cache.deinit();
+                var host_state = ai_history_session.LocalScannerHost{
+                    .home = home,
+                    .cache = if (parsed_cache) |cache| cache.value else null,
                 };
-            }
-            defer if (parsed_cache) |*cache| cache.deinit();
-            var host_state = ai_history_session.LocalScannerHost{
-                .home = home,
-                .cache = if (parsed_cache) |cache| cache.value else null,
-            };
-            return runner(session, host_state.scannerHost());
-        },
-        .wsl => {
-            var host_state = ai_history_session.WslScannerHost{};
-            return runner(session, host_state.scannerHost());
-        },
-        .ssh => |ssh| {
-            const conn = overlays.aiHistorySshConnection(ssh.profile_name) orelse {
-                failAiHistoryHostUnavailable(session, action, "SSH profile unavailable");
-                markUiDirty();
-                return true;
-            };
-            var host_state = ai_history_session.SshScannerHost{ .conn = conn };
-            return runner(session, host_state.scannerHost());
-        },
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+            .wsl => {
+                var host_state = ai_history_session.WslScannerHost{};
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+            .ssh => |conn| {
+                var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+                const host = host_state.scannerHost();
+                return host.scan(host.ctx, allocator, source);
+            },
+        }
     }
-}
 
-fn saveAiHistoryMetadataCache(allocator: std.mem.Allocator, cache_update: ai_history_session.CacheUpdate) void {
-    if (cache_update.records.len == 0) return;
-    ai_history_cache.saveDefault(allocator, .{ .records = cache_update.records }) catch |err| {
-        log.warn("failed to save AI History metadata cache: {}", .{err});
+    fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        const job: *AiHistoryScanJob = @ptrCast(@alignCast(ctx));
+        allocator.destroy(job);
+    }
+};
+
+const AiHistoryTranscriptJob = struct {
+    target: AiHistoryTarget,
+    meta: ai_history_types.SessionMeta, // owned clone
+
+    fn run(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror![]ai_history_types.TranscriptMessage {
+        const job: *AiHistoryTranscriptJob = @ptrCast(@alignCast(ctx));
+        switch (job.target) {
+            .local => {
+                var host_state = ai_history_session.LocalScannerHost{ .home = "" };
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+            .wsl => {
+                var host_state = ai_history_session.WslScannerHost{};
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+            .ssh => |conn| {
+                var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+                const host = host_state.scannerHost();
+                return host.loadTranscript(host.ctx, allocator, job.meta);
+            },
+        }
+    }
+
+    fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+        const job: *AiHistoryTranscriptJob = @ptrCast(@alignCast(ctx));
+        ai_history_session.freeMetadata(allocator, job.meta);
+        allocator.destroy(job);
+    }
+};
+
+/// Snapshot the source's target into a worker-safe value (UI thread). Returns
+/// null only when an SSH profile cannot be resolved.
+fn aiHistoryTargetSnapshot(target: ai_history_source.Target) ?AiHistoryTarget {
+    return switch (target) {
+        .local => .local,
+        .wsl => .wsl,
+        .ssh => |ssh| .{ .ssh = overlays.aiHistorySshConnection(ssh.profile_name) orelse return null },
     };
 }
 
-fn failAiHistoryHostUnavailable(session: *ai_history_session.Session, action: AiHistoryHostAction, status: []const u8) void {
-    switch (action) {
-        .scan => {
-            session.state = .failed;
-            session.status = status;
-        },
-        .preview => {
-            session.transcript_state = .failed;
-            session.transcript_status = status;
-        },
-    }
+/// Kick off an async scan for `session`. UI thread. On setup failure marks the
+/// session failed instead of spawning a doomed worker.
+fn startAiHistoryScan(allocator: std.mem.Allocator, session: *ai_history_session.Session) void {
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse {
+        session.mutex.lock();
+        session.state = .failed;
+        session.status = "SSH profile unavailable";
+        session.mutex.unlock();
+        return;
+    };
+    const job = allocator.create(AiHistoryScanJob) catch {
+        session.mutex.lock();
+        session.state = .failed;
+        session.status = "Scan failed";
+        session.mutex.unlock();
+        return;
+    };
+    job.* = .{ .target = target };
+    session.scanAsync(.{ .ctx = job, .run = AiHistoryScanJob.run, .destroy = AiHistoryScanJob.destroy });
+}
+
+/// Kick off an async transcript load for the selected row. UI thread.
+fn startAiHistoryTranscript(allocator: std.mem.Allocator, session: *ai_history_session.Session) void {
+    session.mutex.lock();
+    const selected = session.selectedVisible();
+    const meta_clone: ?ai_history_types.SessionMeta = if (selected) |m|
+        (ai_history_session.cloneMetadata(allocator, m) catch null)
+    else
+        null;
+    session.mutex.unlock();
+
+    const meta = meta_clone orelse return;
+
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse {
+        ai_history_session.freeMetadata(allocator, meta);
+        session.mutex.lock();
+        session.transcript_state = .failed;
+        session.transcript_status = "SSH profile unavailable";
+        session.mutex.unlock();
+        return;
+    };
+    const job = allocator.create(AiHistoryTranscriptJob) catch {
+        ai_history_session.freeMetadata(allocator, meta);
+        return;
+    };
+    job.* = .{ .target = target, .meta = meta };
+    session.loadTranscriptAsync(.{
+        .ctx = job,
+        .provider = meta.provider,
+        .run = AiHistoryTranscriptJob.run,
+        .destroy = AiHistoryTranscriptJob.destroy,
+    });
 }
 
 pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -625,6 +625,8 @@ fn renderAiHistoryFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int
             .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
             .renderTextLimited = titlebar.renderTextLimited,
         };
+        session.mutex.lock();
+        defer session.mutex.unlock();
         ai_history_renderer.render(
             draw,
             session,
@@ -671,22 +673,28 @@ pub fn aiHistoryInsertCodepoint(codepoint: u21) bool {
     if (codepoint < 0x20 or codepoint == 0x7f) return false;
     var buf: [4]u8 = undefined;
     const len = std.unicode.utf8Encode(codepoint, &buf) catch return false;
+    session.mutex.lock();
     session.appendFilterBytes(buf[0..len]);
+    session.mutex.unlock();
     markUiDirty();
     return true;
 }
 
 pub fn aiHistoryBackspaceFilter() bool {
     const session = activeAiHistory() orelse return false;
+    session.mutex.lock();
     session.backspaceFilter();
+    session.mutex.unlock();
     markUiDirty();
     return true;
 }
 
 pub fn aiHistoryMoveSelection(delta: isize) bool {
     const session = activeAiHistory() orelse return false;
+    session.mutex.lock();
     session.moveSelection(delta);
     session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+    session.mutex.unlock();
     markUiDirty();
     return true;
 }
@@ -706,7 +714,18 @@ pub fn resumeAiHistorySelection() bool {
     const active = tab.activeTab() orelse return false;
     if (active.kind != .ai_history) return false;
     const session = active.ai_history_session orelse return false;
-    const meta = session.selectedVisible() orelse return false;
+    const allocator = g_allocator orelse return false;
+
+    session.mutex.lock();
+    const selected = session.selectedVisible();
+    const meta_clone: ?ai_history_types.SessionMeta = if (selected) |m|
+        (ai_history_session.cloneMetadata(allocator, m) catch null)
+    else
+        null;
+    session.mutex.unlock();
+
+    const meta = meta_clone orelse return false;
+    defer ai_history_session.freeMetadata(allocator, meta);
     return spawnResumeTerminal(session.source.target, meta);
 }
 
@@ -931,6 +950,8 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
     const right = rightPanelsWidthForWindow(fb.width);
     const width = @as(f32, @floatFromInt(fb.width)) - left - right;
     const visible_rows = ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight());
+
+    session.mutex.lock();
     const hit = ai_history_renderer.interactionHitTest(
         session,
         @floatFromInt(fb.width),
@@ -942,6 +963,8 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
         xpos,
         ypos,
     );
+    session.mutex.unlock();
+
     switch (hit) {
         .none => {},
         .refresh => {
@@ -954,8 +977,10 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
             return true;
         },
         .row => |visible_index| {
+            session.mutex.lock();
             session.selectVisibleIndex(visible_index);
             session.ensureSelectionVisible(visible_rows);
+            session.mutex.unlock();
             markUiDirty();
             return true;
         },

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -161,8 +161,9 @@ pub const Session = struct {
     transcript: []types.TranscriptMessage = &.{},
 
     // Async scan/transcript support. `mutex` guards state/status/rows/selected/
-    // list_offset/transcript*/generation fields. Workers run host I/O without the
-    // lock and take it only to publish. `closing` + join-on-deinit give UAF safety.
+    // list_offset/filter/filter_len/transcript*/generation fields. Workers run host
+    // I/O without the lock and take it only to publish. `closing` + join-on-deinit
+    // give UAF safety.
     mutex: std.Thread.Mutex = .{},
     scan_thread: ?std.Thread = null,
     transcript_thread: ?std.Thread = null,

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -252,6 +252,7 @@ pub const Session = struct {
         self.selected = 0;
         self.list_offset = 0;
         self.clearTranscript();
+        self.transcript_generation +%= 1;
         self.state = .ready;
         self.status = "Ready";
     }
@@ -267,20 +268,6 @@ pub const Session = struct {
 
         try self.replaceRows(result.rows);
         self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
-    }
-
-    pub fn scanNowReturningResult(self: *Session, host: ScannerHost) !ScanResult {
-        self.beginScan();
-        errdefer {
-            self.state = .failed;
-            self.status = "Scan failed";
-        }
-        const result = try host.scan(host.ctx, self.allocator, self.source);
-        errdefer freeScanResult(self.allocator, result);
-
-        try self.replaceRows(result.rows);
-        self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
-        return result;
     }
 
     /// Publish scan rows if `generation` is still current and we are not closing,
@@ -2054,4 +2041,64 @@ test "ai_history_session: publishTranscript discards stale generation" {
     session.publishTranscript(1, .codex, messages);
 
     try std.testing.expectEqual(@as(usize, 0), session.transcript.len);
+}
+
+test "ai_history_session: publishScanResult discards when closing" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scan_generation = 2;
+    session.closing.store(true, .release);
+
+    const rows = try allocator.alloc(types.SessionMeta, 1);
+    rows[0] = .{
+        .provider = .codex,
+        .session_id = try allocator.dupe(u8, "closing"),
+        .title = try allocator.dupe(u8, "Closing"),
+        .source_path = try allocator.dupe(u8, "closing.jsonl"),
+        .resume_kind = .codex_resume,
+    };
+    // closing is set -> result is discarded and freed (testing allocator checks no leak)
+    session.publishScanResult(2, .{ .rows = rows, .owns_row_strings = true });
+
+    try std.testing.expectEqual(@as(usize, 0), session.rows.items.len);
+}
+
+test "ai_history_session: deinit joins an in-flight scan worker" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        gate: std.Thread.ResetEvent = .{},
+        fn run(ptr: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) anyerror!ScanResult {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.gate.wait(); // block until the test releases us
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = try alloc.dupe(u8, "inflight"),
+                .title = try alloc.dupe(u8, "Inflight"),
+                .source_path = try alloc.dupe(u8, "inflight.jsonl"),
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows, .owns_row_strings = true };
+        }
+        fn destroy(_: *anyopaque, _: std.mem.Allocator) void {}
+    };
+
+    var ctx = Ctx{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+
+    session.scanAsync(.{ .ctx = &ctx, .run = Ctx.run, .destroy = Ctx.destroy });
+
+    // Release the worker from a helper thread so deinit can join it while it is
+    // genuinely in flight (deinit sets closing, then blocks in join until the
+    // worker returns; the worker discards its result because closing is set).
+    const releaser = try std.Thread.spawn(.{}, struct {
+        fn f(c: *Ctx) void {
+            c.gate.set();
+        }
+    }.f, .{&ctx});
+
+    session.deinit(); // sets closing, joins the worker — must not leak or crash
+    releaser.join();
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -52,6 +52,16 @@ pub const ScanWork = struct {
     destroy: *const fn (*anyopaque, std.mem.Allocator) void,
 };
 
+/// Owned unit of background transcript-load work. `run` performs the blocking
+/// load; `provider` is used to publish; `destroy` frees `ctx` (which owns the
+/// selected metadata copy). All run on the worker thread.
+pub const TranscriptWork = struct {
+    ctx: *anyopaque,
+    provider: types.ProviderId,
+    run: *const fn (*anyopaque, std.mem.Allocator) anyerror![]types.TranscriptMessage,
+    destroy: *const fn (*anyopaque, std.mem.Allocator) void,
+};
+
 pub const RemoteExecHost = struct {
     ctx: *anyopaque,
     exec: *const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror![]u8,
@@ -361,6 +371,59 @@ pub const Session = struct {
         self.transcript_status = "Transcript ready";
     }
 
+    /// Start a background transcript load for the currently-selected row's data,
+    /// captured by the caller into `work.ctx`. UI-thread only. Clears any current
+    /// transcript, flips to `.loading`, bumps the generation, spawns the worker.
+    pub fn loadTranscriptAsync(self: *Session, work: TranscriptWork) void {
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
+        self.mutex.lock();
+        self.clearTranscript();
+        self.transcript_state = .loading;
+        self.transcript_status = "Loading transcript";
+        self.transcript_generation +%= 1;
+        const generation = self.transcript_generation;
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, transcriptThreadMain, .{ self, work, generation }) catch {
+            self.mutex.lock();
+            if (generation == self.transcript_generation) {
+                self.transcript_state = .failed;
+                self.transcript_status = "Transcript failed";
+            }
+            self.mutex.unlock();
+            work.destroy(work.ctx, self.allocator);
+            return;
+        };
+        self.transcript_thread = thread;
+    }
+
+    /// Publish transcript messages if `generation`/`provider` still current and not
+    /// closing, otherwise free them. Worker-thread only.
+    pub fn publishTranscript(self: *Session, generation: u64, provider: types.ProviderId, messages: []types.TranscriptMessage) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.transcript_generation) {
+            self.transcript = messages;
+            self.transcript_provider = provider;
+            self.transcript_state = .ready;
+            self.transcript_status = "Transcript ready";
+        } else {
+            freeTranscript(self.allocator, provider, messages);
+        }
+    }
+
+    pub fn publishTranscriptFailure(self: *Session, generation: u64) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.transcript_generation) {
+            self.transcript_state = .failed;
+            self.transcript_status = "Transcript failed";
+        }
+    }
+
     pub fn setFilter(self: *Session, text: []const u8) void {
         self.filter_len = @min(text.len, self.filter.len);
         @memcpy(self.filter[0..self.filter_len], text[0..self.filter_len]);
@@ -483,6 +546,15 @@ fn scanThreadMain(session: *Session, work: ScanWork, generation: u64) void {
         return;
     };
     session.publishScanResult(generation, result);
+}
+
+fn transcriptThreadMain(session: *Session, work: TranscriptWork, generation: u64) void {
+    defer work.destroy(work.ctx, session.allocator);
+    const messages = work.run(work.ctx, session.allocator) catch {
+        session.publishTranscriptFailure(generation);
+        return;
+    };
+    session.publishTranscript(generation, work.provider, messages);
 }
 
 fn previousUtf8Boundary(bytes: []const u8, from: usize) usize {
@@ -1915,4 +1987,48 @@ test "ai_history_session: scanAsync marks failed when run errors" {
     session.joinForTest();
     try std.testing.expectEqual(LoadState.failed, session.state);
     try std.testing.expect(ctx.destroyed);
+}
+
+test "ai_history_session: loadTranscriptAsync publishes messages then joins clean" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        fn run(_: *anyopaque, alloc: std.mem.Allocator) anyerror![]types.TranscriptMessage {
+            const messages = try alloc.alloc(types.TranscriptMessage, 1);
+            errdefer alloc.free(messages);
+            messages[0] = .{ .role = .user, .content = try alloc.dupe(u8, "async-hello") };
+            return messages;
+        }
+        fn destroy(_: *anyopaque, _: std.mem.Allocator) void {}
+    };
+
+    var ctx_byte: u8 = 0;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    session.loadTranscriptAsync(.{
+        .ctx = &ctx_byte,
+        .provider = .codex,
+        .run = Ctx.run,
+        .destroy = Ctx.destroy,
+    });
+    session.joinForTest();
+
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(@as(usize, 1), session.transcript.len);
+    try std.testing.expectEqualStrings("async-hello", session.transcript[0].content);
+}
+
+test "ai_history_session: publishTranscript discards stale generation" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.transcript_generation = 3;
+
+    const messages = try allocator.alloc(types.TranscriptMessage, 1);
+    messages[0] = .{ .role = .user, .content = try allocator.dupe(u8, "stale") };
+    // generation 1 != current 3 -> freed, not published (testing allocator checks no leak)
+    session.publishTranscript(1, .codex, messages);
+
+    try std.testing.expectEqual(@as(usize, 0), session.transcript.len);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -167,6 +167,15 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        self.closing.store(true, .release);
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
         self.clearTranscript();
         freeRows(self.allocator, self.rows.items);
         self.rows.deinit(self.allocator);
@@ -1767,6 +1776,7 @@ test "ai_history_session: publishScanResult applies rows when generation current
     session.publishScanResult(7, .{ .rows = rows, .owns_row_strings = true });
 
     try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqualStrings("Ready", session.status);
     try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
     try std.testing.expectEqualStrings("live", session.rows.items[0].session_id);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -320,7 +320,7 @@ pub const Session = struct {
         const generation = self.scan_generation;
         self.mutex.unlock();
 
-        const thread = std.Thread.spawn(.{}, scanWorkerMain, .{ self, work, generation }) catch {
+        const thread = std.Thread.spawn(.{}, scanThreadMain, .{ self, work, generation }) catch {
             self.mutex.lock();
             if (generation == self.scan_generation) {
                 self.state = .failed;
@@ -476,7 +476,7 @@ pub const Session = struct {
     }
 };
 
-fn scanWorkerMain(session: *Session, work: ScanWork, generation: u64) void {
+fn scanThreadMain(session: *Session, work: ScanWork, generation: u64) void {
     defer work.destroy(work.ctx, session.allocator);
     const result = work.run(work.ctx, session.allocator, session.source) catch {
         session.publishScanFailure(generation);
@@ -1893,5 +1893,26 @@ test "ai_history_session: scanAsync publishes rows then joins clean" {
     try std.testing.expectEqual(LoadState.ready, session.state);
     try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
     try std.testing.expectEqualStrings("async-id", session.rows.items[0].session_id);
+    try std.testing.expect(ctx.destroyed);
+}
+
+test "ai_history_session: scanAsync marks failed when run errors" {
+    const allocator = std.testing.allocator;
+    const Ctx = struct {
+        destroyed: bool = false,
+        fn run(_: *anyopaque, _: std.mem.Allocator, _: source_mod.Source) anyerror!ScanResult {
+            return error.ScanFailed;
+        }
+        fn destroy(ptr: *anyopaque, _: std.mem.Allocator) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.destroyed = true;
+        }
+    };
+    var ctx = Ctx{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scanAsync(.{ .ctx = &ctx, .run = Ctx.run, .destroy = Ctx.destroy });
+    session.joinForTest();
+    try std.testing.expectEqual(LoadState.failed, session.state);
     try std.testing.expect(ctx.destroyed);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -2017,6 +2017,28 @@ test "ai_history_session: loadTranscriptAsync publishes messages then joins clea
     try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
     try std.testing.expectEqual(@as(usize, 1), session.transcript.len);
     try std.testing.expectEqualStrings("async-hello", session.transcript[0].content);
+    try std.testing.expectEqual(@as(?types.ProviderId, .codex), session.transcript_provider);
+}
+
+test "ai_history_session: loadTranscriptAsync marks failed when run errors" {
+    const allocator = std.testing.allocator;
+    const Ctx = struct {
+        destroyed: bool = false,
+        fn run(_: *anyopaque, _: std.mem.Allocator) anyerror![]types.TranscriptMessage {
+            return error.TranscriptFailed;
+        }
+        fn destroy(ptr: *anyopaque, _: std.mem.Allocator) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.destroyed = true;
+        }
+    };
+    var ctx = Ctx{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.loadTranscriptAsync(.{ .ctx = &ctx, .provider = .codex, .run = Ctx.run, .destroy = Ctx.destroy });
+    session.joinForTest();
+    try std.testing.expectEqual(TranscriptState.failed, session.transcript_state);
+    try std.testing.expect(ctx.destroyed);
 }
 
 test "ai_history_session: publishTranscript discards stale generation" {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -141,6 +141,16 @@ pub const Session = struct {
     transcript_provider: ?types.ProviderId = null,
     transcript: []types.TranscriptMessage = &.{},
 
+    // Async scan/transcript support. `mutex` guards state/status/rows/selected/
+    // list_offset/transcript*/generation fields. Workers run host I/O without the
+    // lock and take it only to publish. `closing` + join-on-deinit give UAF safety.
+    mutex: std.Thread.Mutex = .{},
+    scan_thread: ?std.Thread = null,
+    transcript_thread: ?std.Thread = null,
+    closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    scan_generation: u64 = 0,
+    transcript_generation: u64 = 0,
+
     pub fn init(allocator: std.mem.Allocator, source: source_mod.Source) Session {
         return .{
             .allocator = allocator,
@@ -242,6 +252,39 @@ pub const Session = struct {
         try self.replaceRows(result.rows);
         self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
         return result;
+    }
+
+    /// Publish scan rows if `generation` is still current and we are not closing,
+    /// otherwise discard. Always frees `result`. Called from the scan worker.
+    pub fn publishScanResult(self: *Session, generation: u64, result: ScanResult) void {
+        var published = false;
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            if (!self.closing.load(.acquire) and generation == self.scan_generation) {
+                if (self.replaceRows(result.rows)) |_| {
+                    self.status = if (result.warning_count == 0) "Ready" else "Ready with warnings";
+                    published = true;
+                } else |_| {
+                    self.state = .failed;
+                    self.status = "Scan failed";
+                }
+            }
+        }
+        if (published and result.cache_update.records.len > 0) {
+            ai_history_cache.saveDefault(self.allocator, .{ .records = result.cache_update.records }) catch {};
+        }
+        freeScanResult(self.allocator, result);
+    }
+
+    /// Mark the scan failed if `generation` is still current and not closing.
+    pub fn publishScanFailure(self: *Session, generation: u64) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.closing.load(.acquire) and generation == self.scan_generation) {
+            self.state = .failed;
+            self.status = "Scan failed";
+        }
     }
 
     pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) !void {
@@ -840,7 +883,7 @@ fn metadataHasUsableSignal(meta: types.SessionMeta) bool {
     return meta.session_id.len > 0 and meta.message_count > 0;
 }
 
-fn cloneMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) !types.SessionMeta {
+pub fn cloneMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) !types.SessionMeta {
     var cloned = types.SessionMeta{
         .provider = meta.provider,
         .session_id = "",
@@ -869,7 +912,7 @@ fn freeRows(allocator: std.mem.Allocator, rows: []types.SessionMeta) void {
     for (rows) |row| freeMetadata(allocator, row);
 }
 
-fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
+pub fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
     freeSlice(allocator, meta.session_id);
     freeSlice(allocator, meta.title);
     freeSlice(allocator, meta.summary);
@@ -1705,4 +1748,45 @@ test "ai_history_session: scanLocalFilesystem reuses unchanged cached metadata" 
     try std.testing.expectEqualStrings("Cached title", result.rows[0].title);
     try std.testing.expectEqual(@as(usize, 1), result.cache_update.records.len);
     try std.testing.expectEqualStrings("codex-cached", result.cache_update.records[0].meta.session_id);
+}
+
+test "ai_history_session: publishScanResult applies rows when generation current" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scan_generation = 7;
+
+    const rows = try allocator.alloc(types.SessionMeta, 1);
+    rows[0] = .{
+        .provider = .codex,
+        .session_id = try allocator.dupe(u8, "live"),
+        .title = try allocator.dupe(u8, "Live"),
+        .source_path = try allocator.dupe(u8, "live.jsonl"),
+        .resume_kind = .codex_resume,
+    };
+    session.publishScanResult(7, .{ .rows = rows, .owns_row_strings = true });
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("live", session.rows.items[0].session_id);
+}
+
+test "ai_history_session: publishScanResult discards stale generation" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    session.scan_generation = 9;
+
+    const rows = try allocator.alloc(types.SessionMeta, 1);
+    rows[0] = .{
+        .provider = .codex,
+        .session_id = try allocator.dupe(u8, "stale"),
+        .title = try allocator.dupe(u8, "Stale"),
+        .source_path = try allocator.dupe(u8, "stale.jsonl"),
+        .resume_kind = .codex_resume,
+    };
+    // generation 4 != current 9 -> discarded and freed (testing allocator checks no leak)
+    session.publishScanResult(4, .{ .rows = rows, .owns_row_strings = true });
+
+    try std.testing.expectEqual(@as(usize, 0), session.rows.items.len);
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -43,6 +43,15 @@ pub const ScannerHost = struct {
     loadTranscript: *const fn (*anyopaque, std.mem.Allocator, types.SessionMeta) anyerror![]types.TranscriptMessage,
 };
 
+/// Owned unit of background scan work. `run` performs the blocking scan; `destroy`
+/// frees the context (`ctx`). Both run on the worker thread. `ctx` must own
+/// everything `run` needs and contain no pointers into threadlocal UI state.
+pub const ScanWork = struct {
+    ctx: *anyopaque,
+    run: *const fn (*anyopaque, std.mem.Allocator, source_mod.Source) anyerror!ScanResult,
+    destroy: *const fn (*anyopaque, std.mem.Allocator) void,
+};
+
 pub const RemoteExecHost = struct {
     ctx: *anyopaque,
     exec: *const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror![]u8,
@@ -296,6 +305,47 @@ pub const Session = struct {
         }
     }
 
+    /// Start a background scan. UI-thread only. Joins any prior scan worker first
+    /// (at most one in flight per session), flips to `.scanning`, bumps the
+    /// generation, and spawns the worker. Returns immediately.
+    pub fn scanAsync(self: *Session, work: ScanWork) void {
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        self.mutex.lock();
+        self.state = .scanning;
+        self.status = "Scanning";
+        self.scan_generation +%= 1;
+        const generation = self.scan_generation;
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, scanWorkerMain, .{ self, work, generation }) catch {
+            self.mutex.lock();
+            if (generation == self.scan_generation) {
+                self.state = .failed;
+                self.status = "Scan failed";
+            }
+            self.mutex.unlock();
+            work.destroy(work.ctx, self.allocator);
+            return;
+        };
+        self.scan_thread = thread;
+    }
+
+    /// Test-only: wait for in-flight workers to finish so results can be asserted
+    /// deterministically. Not called in production (deinit joins instead).
+    pub fn joinForTest(self: *Session) void {
+        if (self.scan_thread) |t| {
+            t.join();
+            self.scan_thread = null;
+        }
+        if (self.transcript_thread) |t| {
+            t.join();
+            self.transcript_thread = null;
+        }
+    }
+
     pub fn loadSelectedTranscript(self: *Session, host: ScannerHost) !void {
         const selected = self.selectedVisible() orelse return error.NoSelection;
         self.clearTranscript();
@@ -425,6 +475,15 @@ pub const Session = struct {
         return null;
     }
 };
+
+fn scanWorkerMain(session: *Session, work: ScanWork, generation: u64) void {
+    defer work.destroy(work.ctx, session.allocator);
+    const result = work.run(work.ctx, session.allocator, session.source) catch {
+        session.publishScanFailure(generation);
+        return;
+    };
+    session.publishScanResult(generation, result);
+}
 
 fn previousUtf8Boundary(bytes: []const u8, from: usize) usize {
     if (from == 0) return 0;
@@ -1799,4 +1858,40 @@ test "ai_history_session: publishScanResult discards stale generation" {
     session.publishScanResult(4, .{ .rows = rows, .owns_row_strings = true });
 
     try std.testing.expectEqual(@as(usize, 0), session.rows.items.len);
+}
+
+test "ai_history_session: scanAsync publishes rows then joins clean" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        destroyed: bool = false,
+        fn run(ptr: *anyopaque, alloc: std.mem.Allocator, _: source_mod.Source) anyerror!ScanResult {
+            _ = ptr;
+            const rows = try alloc.alloc(types.SessionMeta, 1);
+            rows[0] = .{
+                .provider = .codex,
+                .session_id = try alloc.dupe(u8, "async-id"),
+                .title = try alloc.dupe(u8, "Async"),
+                .source_path = try alloc.dupe(u8, "async.jsonl"),
+                .resume_kind = .codex_resume,
+            };
+            return .{ .rows = rows, .owns_row_strings = true };
+        }
+        fn destroy(ptr: *anyopaque, _: std.mem.Allocator) void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.destroyed = true;
+        }
+    };
+
+    var ctx = Ctx{};
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    session.scanAsync(.{ .ctx = &ctx, .run = Ctx.run, .destroy = Ctx.destroy });
+    session.joinForTest();
+
+    try std.testing.expectEqual(LoadState.ready, session.state);
+    try std.testing.expectEqual(@as(usize, 1), session.rows.items.len);
+    try std.testing.expectEqualStrings("async-id", session.rows.items[0].session_id);
+    try std.testing.expect(ctx.destroyed);
 }


### PR DESCRIPTION
## Summary

AI History scanning and transcript preview ran **synchronously on the UI thread**, freezing the whole app — for WSL/SSH sources each scan does many blocking subprocess/network round-trips (SSH up to ~8s connect + one round-trip per file). Creating a new AI History session (`新建之后`) and then scanning would lock up the window.

This moves that blocking work onto background worker threads, mirroring `src/ai_chat.zig`'s proven worker model, and auto-starts the scan when an AI History tab is created.

### What changed
- **`src/ai_history_session.zig`** — `Session` gained a `mutex`, `closing` atomic, `scan_thread`/`transcript_thread`, and `scan_generation`/`transcript_generation`. New `ScanWork`/`TranscriptWork` interfaces + `scanAsync`/`loadTranscriptAsync` spawn workers that run the blocking I/O **without** the lock and publish results under a brief lock, discarding stale/superseded results (generation + `closing` checks). `deinit` sets `closing` then **joins** both workers before freeing → use-after-free safe. The metadata-cache write moved into the worker.
- **`src/AppWindow.zig`** — owned `AiHistoryScanJob`/`AiHistoryTranscriptJob` carry a worker-safe snapshot (SSH `SshConnection` is a copyable value; local home/cache resolved inside the worker). Entry points are now non-blocking. Render + input/mouse handlers are guarded by the session mutex (coarse, no lock nesting). New AI History tabs **auto-scan on create**. Old synchronous machinery deleted.
- **Resume (`Enter`) left as-is** — it only spawns a PTY that connects asynchronously, so it never blocked the UI thread.

### Notes
- Lifetime model: join-on-`deinit` (option A). Closing a tab mid-SSH-scan can briefly block the UI up to the current round-trip — same bounded tradeoff as the existing `ai_chat` worker.
- Spec + plan: `docs/superpowers/specs/2026-06-02-async-ai-history-scan-design.md`, `docs/superpowers/plans/2026-06-02-async-ai-history-scan.md`.

## Test Plan
- [x] `zig build test` — exit 0
- [x] `zig build test-full` — exit 0
- [x] 6 new unit tests: scan/transcript publish + join-clean, run-failure, stale-generation discard, `closing` discard, deinit-joins-in-flight-worker
- [ ] **Manual GUI (pending — no Linux GUI backend in dev env):**
  - [ ] New WSL AI History tab shows "Scanning…" immediately and stays responsive while populating
  - [ ] New SSH AI History tab does not freeze during the slow scan
  - [ ] `r` / refresh re-scans without freezing
  - [ ] `space` transcript preview loads without freezing
  - [ ] Closing the tab during a scan does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)