### PR TITLE
fix(weixin): keep the final answer in the remote snapshot so slow replies deliver (#118)

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1166,17 +1166,21 @@ pub const Session = struct {
                 const summary = try allocRemoteToolSummary(allocator, msg);
                 var summary_owned = true;
                 errdefer if (summary_owned) allocator.free(summary);
-                try sections.append(allocator, .{ .label = msg.role.label(), .text = summary });
+                try sections.append(allocator, .{ .label = msg.role.label(), .text = summary, .priority = true });
                 try tool_summaries.append(allocator, summary);
                 summary_owned = false;
             } else {
-                try sections.append(allocator, .{ .label = msg.role.label(), .text = msg.content });
+                try sections.append(allocator, .{ .label = msg.role.label(), .text = msg.content, .priority = true });
             }
+            // Reasoning and the usage footer are auxiliary: useful for the web
+            // mirror, but the remote reply detector only needs the message bodies.
+            // Mark them low-priority so a huge reasoning block can never evict the
+            // latest assistant answer from the byte budget (issue #118).
             if (msg.reasoning) |reasoning| {
-                if (reasoning.len > 0) try sections.append(allocator, .{ .label = "Reasoning", .text = reasoning });
+                if (reasoning.len > 0) try sections.append(allocator, .{ .label = "Reasoning", .text = reasoning, .priority = false });
             }
             if (msg.usage_footer) |footer| {
-                if (footer.len > 0) try sections.append(allocator, .{ .label = "Usage", .text = footer });
+                if (footer.len > 0) try sections.append(allocator, .{ .label = "Usage", .text = footer, .priority = false });
             }
         }
         try appendRecentLimitedSections(allocator, &out, sections.items, REMOTE_SNAPSHOT_MAX_BYTES);
@@ -2421,8 +2425,18 @@ fn appendLimitedSection(
 const RemoteSnapshotSection = struct {
     label: []const u8,
     text: []const u8,
+    /// High-priority sections (message bodies) are budgeted before low-priority
+    /// auxiliary sections (reasoning, usage), so bulky reasoning can never push
+    /// the latest answer out of the snapshot.
+    priority: bool = true,
 };
 
+/// Appends the most recent sections that fit in `max_bytes`, in two priority
+/// passes. Pass one reserves budget for message bodies newest-first, always
+/// keeping the newest body (truncated if it alone overflows). Pass two fills any
+/// remaining budget with auxiliary sections (reasoning/usage), also newest-first.
+/// Sections are emitted in their original order. This guarantees the latest
+/// assistant answer survives even when an earlier-walked reasoning block is huge.
 fn appendRecentLimitedSections(
     allocator: std.mem.Allocator,
     out: *std.ArrayListUnmanaged(u8),
@@ -2431,30 +2445,52 @@ fn appendRecentLimitedSections(
 ) !void {
     if (sections.len == 0 or out.items.len >= max_bytes) return;
 
-    var start = sections.len;
-    var used = out.items.len;
-    while (start > 0) {
-        const section = sections[start - 1];
-        const header_len = remoteSnapshotSectionHeaderLen(used, section.label);
-        if (used + header_len >= max_bytes) break;
-        const full_len = header_len + section.text.len;
-        if (full_len <= max_bytes - used) {
-            used += full_len;
-            start -= 1;
-            continue;
-        }
+    const included = try allocator.alloc(bool, sections.len);
+    defer allocator.free(included);
+    @memset(included, false);
 
-        if (start == sections.len) start -= 1;
-        break;
+    // Model + Status are always emitted first, so every section here pays the
+    // 4-byte separator; the per-section cost is therefore position-independent.
+    var used = out.items.len;
+
+    // Pass 1: message bodies, newest-first. Always include the newest body so
+    // the reply detector and the user can always see the latest answer; if it
+    // alone overflows, appendLimitedSection truncates it.
+    var newest_body_seen = false;
+    var i = sections.len;
+    while (i > 0) : (i -= 1) {
+        const section = sections[i - 1];
+        if (!section.priority) continue;
+        const cost = remoteSnapshotSectionCost(section.label, section.text);
+        if (!newest_body_seen) {
+            included[i - 1] = true;
+            used = @min(used + cost, max_bytes);
+            newest_body_seen = true;
+        } else if (used + cost <= max_bytes) {
+            included[i - 1] = true;
+            used += cost;
+        }
     }
 
-    for (sections[start..]) |section| {
-        try appendLimitedSection(allocator, out, section.label, section.text, max_bytes);
+    // Pass 2: auxiliary sections (reasoning/usage), newest-first, best effort.
+    i = sections.len;
+    while (i > 0) : (i -= 1) {
+        const section = sections[i - 1];
+        if (section.priority) continue;
+        const cost = remoteSnapshotSectionCost(section.label, section.text);
+        if (used + cost <= max_bytes) {
+            included[i - 1] = true;
+            used += cost;
+        }
+    }
+
+    for (sections, 0..) |section, idx| {
+        if (included[idx]) try appendLimitedSection(allocator, out, section.label, section.text, max_bytes);
     }
 }
 
-fn remoteSnapshotSectionHeaderLen(current_len: usize, label: []const u8) usize {
-    return (if (current_len > 0) "\r\n\r\n".len else 0) + label.len + ":\r\n".len;
+fn remoteSnapshotSectionCost(label: []const u8, text: []const u8) usize {
+    return "\r\n\r\n".len + label.len + ":\r\n".len + text.len;
 }
 
 fn allocRemoteToolSummary(allocator: std.mem.Allocator, msg: Message) ![]u8 {
@@ -4373,6 +4409,63 @@ test "ai chat remote snapshot keeps latest messages after large tool output" {
     try std.testing.expect(std.mem.indexOf(u8, snapshot, "latest assistant reply") != null);
     try std.testing.expect(std.mem.indexOf(u8, snapshot, "terminal_repl_exec") != null);
     try std.testing.expect(std.mem.indexOf(u8, snapshot, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx") == null);
+}
+
+test "ai chat remote snapshot keeps final answer when reasoning is huge (issue 118)" {
+    // A reasoning-heavy turn (e.g. GLM thinking) on a large context once evicted
+    // the final assistant answer from the byte budget, so the weixin reply
+    // detector never saw the answer and never reported the turn done.
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+    session.setStatusLocked("Done in 280.9s");
+
+    const big_reasoning = try allocator.alloc(u8, REMOTE_SNAPSHOT_MAX_BYTES + 4096);
+    @memset(big_reasoning, 'r');
+    try session.messages.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "explain the captain model"),
+    });
+    try session.messages.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "FINAL_ANSWER_MARKER the captain model is ..."),
+        .reasoning = big_reasoning,
+    });
+
+    const snapshot = try session.allocRemoteSnapshot(allocator);
+    defer allocator.free(snapshot);
+
+    // The answer body survives; the oversized reasoning is dropped, not the answer.
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "FINAL_ANSWER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "Done in 280.9s") != null);
+}
+
+test "ai chat remote snapshot still includes reasoning when it fits" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+
+    try session.messages.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "status?"),
+    });
+    try session.messages.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "all good"),
+        .reasoning = try allocator.dupe(u8, "checked the state first"),
+    });
+
+    const snapshot = try session.allocRemoteSnapshot(allocator);
+    defer allocator.free(snapshot);
+
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "all good") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "checked the state first") != null);
 }
 
 test "ai chat clipboard text exports transcript when input is empty" {

--- a/src/weixin/reply_progress.zig
+++ b/src/weixin/reply_progress.zig
@@ -185,3 +185,25 @@ test "empty when nothing new" {
     const p = progress("You:\nhi\n", "You:\nhi\n");
     try t.expect(!p.done);
 }
+
+test "done with realistic remote snapshot shape after a tool turn (issue 118)" {
+    // Mirrors allocRemoteSnapshot: Model + Status header, then message bodies.
+    // The turn finished ("Done in ...s"), a tool ran, and a new AI answer exists.
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n\nYou:\nq\n";
+    const current =
+        "Model:\nGLM\n\nStatus:\nDone in 280.9s\n\n" ++
+        "You:\nq\n\nTool:\nterminal completed.\n\nAI:\nthe captain model is ...\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expectEqualStrings("the captain model is ...", p.text);
+}
+
+test "not done while a tool turn is still streaming" {
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n\nYou:\nq\n";
+    const current =
+        "Model:\nGLM\n\nStatus:\nRunning tools...\n\n" ++
+        "You:\nq\n\nTool:\nterminal completed.\n";
+    const p = progress(baseline, current);
+    try t.expect(!p.done);
+    try t.expect(p.text.len != 0);
+}


### PR DESCRIPTION
## Summary

Fixes #118 — the WeChat bridge stayed stuck on "还在处理中，工具调用仍在执行" while the AI agent panel already showed the finished answer.

The bridge decides an AI turn is done by diffing a 24 KB rendered transcript snapshot (`allocRemoteSnapshot`) and finding a new assistant message once the status goes idle. That snapshot budgeted each message's trailing `Reasoning:`/`Usage:` sections **before** the message body. A reasoning-heavy model (e.g. GLM-5.1) on a large context produced a reasoning block larger than the entire budget, which **evicted the final assistant answer** from the snapshot. The detector then saw `Status: Done` but no assistant message, so it never reported the turn done — the WeChat user kept getting progress pings until the 30-minute window expired.

This is distinct from the earlier slow-reply fix (`80861cc`, the 30-min window), which already shipped in v1.6.0 — the version the reporter runs. The weixin progress code is byte-identical to v1.6.0, so the bug reproduces on current `main`.

## Fix

`appendRecentLimitedSections` now budgets in two priority passes:
1. **Message bodies** (user/assistant/tool), newest-first — the newest is always kept, truncated only if it alone overflows.
2. **Auxiliary** reasoning/usage sections, in any leftover budget.

The latest assistant answer can never be evicted by a huge reasoning block. Reasoning is still mirrored to the web remote client when it fits, so there's no display regression there.

## Test Plan

- [x] New: reproduce the eviction — the final answer survives a reasoning block larger than the whole budget.
- [x] New: reasoning is still included in the snapshot when it fits.
- [x] New (weixin): the reply detector reports `done` on a realistic completed-turn snapshot (`Status: Done in 280.9s`, tool ran, new answer present), and stays not-done while `Running tools...`.
- [x] `zig build test` and `zig build test-full` both green.
- [ ] GUI verify (Windows/macOS): a long reasoning-heavy turn over WeChat delivers the final answer instead of looping on "工具调用仍在执行".

🤖 Generated with [Claude Code](https://claude.com/claude-code)