### PR TITLE
feat(ai-history): panel-focus keyboard nav + workbench styling cleanup

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -892,13 +892,39 @@ pub fn aiHistoryMoveSelection(delta: isize) bool {
     return true;
 }
 
-pub fn aiHistoryCycleCategory(delta: isize) bool {
+/// ←/→ move keyboard focus between the Filters, Sessions, and Transcript panels.
+pub fn aiHistoryFocusMove(delta: isize) bool {
     const session = activeAiHistory() orelse return false;
-    session.cycleCategory(delta);
-    session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+    session.mutex.lock();
+    session.focusMove(delta);
+    session.mutex.unlock();
     markUiDirty();
     return true;
 }
+
+/// ↑/↓ act within the focused panel: walk the combined CATEGORY+DATE filter
+/// list, change the selected session, or scroll the transcript preview.
+pub fn aiHistoryNav(delta: isize) bool {
+    const session = activeAiHistory() orelse return false;
+    session.mutex.lock();
+    switch (session.focus) {
+        .filters => {
+            session.moveFilterCursor(delta);
+            session.ensureFilterCursorVisible(aiHistoryDateDaySlotsForWindow());
+            session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+        },
+        .sessions => {
+            session.moveSelection(delta);
+            session.ensureSelectionVisible(aiHistoryListVisibleRowsForWindow());
+        },
+        .transcript => session.scrollTranscriptBy(delta * AI_HISTORY_TRANSCRIPT_KEY_STEP),
+    }
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+
+const AI_HISTORY_TRANSCRIPT_KEY_STEP: isize = 3;
 
 pub fn aiHistoryPreviewSelectedTranscript() bool {
     const session = activeAiHistory() orelse return false;
@@ -1255,6 +1281,17 @@ fn aiHistoryListVisibleRowsForWindow() usize {
     const win = g_window orelse return 1;
     const fb = window_backend.framebufferSize(win);
     return ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight(), font.g_titlebar_cell_height);
+}
+
+/// Number of day rows (excluding the pinned "All dates") visible in the DATE
+/// navigator, used to keep the Filters cursor's day in view.
+fn aiHistoryDateDaySlotsForWindow() usize {
+    const win = g_window orelse return 0;
+    const fb = window_backend.framebufferSize(win);
+    const cell_h = font.g_titlebar_cell_height;
+    const lc = ai_history_renderer.leftColumnLayout(currentTitlebarHeight(), cell_h);
+    const cap = ai_history_renderer.dateVisibleCapacity(@floatFromInt(fb.height), lc.date_rows_top, cell_h);
+    return if (cap > 1) cap - 1 else 0;
 }
 
 fn localHomeForAiHistory(allocator: std.mem.Allocator) ![]u8 {

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -159,6 +159,22 @@ pub const SshScannerHost = struct {
     }
 };
 
+/// Which of the three workbench panels keyboard ↑/↓ acts on. ←/→ moves focus
+/// between them (Filters ⟷ Sessions ⟷ Transcript).
+pub const Focus = enum(u8) {
+    filters = 0,
+    sessions = 1,
+    transcript = 2,
+};
+
+/// Max day buckets considered when walking the combined filter list by keyboard.
+const FILTER_BUCKET_CAP: usize = 256;
+/// Combined-filter cursor layout: rows 0..2 are the categories (All/Codex/
+/// Claude), row 3 is "All dates", rows 4.. are individual days.
+const FILTER_CATEGORY_ROWS: usize = 3;
+const FILTER_ALL_DATES_ROW: usize = 3;
+const FILTER_DAY_BASE: usize = 4;
+
 pub const Session = struct {
     /// Allocator used for row storage. Do not change while rows are live.
     allocator: std.mem.Allocator,
@@ -189,6 +205,16 @@ pub const Session = struct {
     /// Scroll offset into the transcript preview, in wrapped visual lines. The
     /// renderer clamps this against the actual content height each frame.
     transcript_scroll: usize = 0,
+    /// Which panel keyboard ↑/↓ acts on; ←/→ switches it. Sessions by default so
+    /// the list is immediately navigable when the workbench opens.
+    focus: Focus = .sessions,
+    /// Keyboard cursor into the combined CATEGORY+DATE list while the Filters
+    /// panel is focused. Indices follow FILTER_* constants above.
+    filter_cursor: usize = 0,
+    /// Lazily-composed tab/window title ("History · <source>"); the source is
+    /// fixed for a session's lifetime, so it is computed once.
+    tab_title_buf: [96]u8 = undefined,
+    tab_title_len: usize = 0,
 
     // Async scan/transcript support. `mutex` guards state/status/rows/selected/
     // list_offset/filter/filter_len/transcript*/generation fields. Workers run host
@@ -732,6 +758,84 @@ pub const Session = struct {
             count += 1;
         }
         return count;
+    }
+
+    /// Tab/window title for the workbench: "History · <source>", or "AI History"
+    /// when the source is unnamed. Conveys that this is the history workbench
+    /// rather than echoing the originating terminal's name. Cached after first use.
+    pub fn tabTitle(self: *Session) []const u8 {
+        if (self.tab_title_len == 0) {
+            const composed = if (self.source.name.len == 0)
+                std.fmt.bufPrint(&self.tab_title_buf, "AI History", .{}) catch "AI History"
+            else
+                std.fmt.bufPrint(&self.tab_title_buf, "History · {s}", .{self.source.name}) catch self.source.name;
+            self.tab_title_len = composed.len;
+        }
+        return self.tab_title_buf[0..self.tab_title_len];
+    }
+
+    // --- panel focus + combined-filter keyboard navigation ----------------
+
+    /// Move keyboard focus between the three panels (←/→). Clamped at the ends.
+    pub fn focusMove(self: *Session, delta: isize) void {
+        const cur: isize = @intFromEnum(self.focus);
+        const next = std.math.clamp(cur + delta, 0, 2);
+        self.focus = @enumFromInt(@as(u8, @intCast(next)));
+    }
+
+    /// Number of rows in the combined CATEGORY+DATE list the Filters cursor walks
+    /// (3 categories + "All dates" + one row per distinct day). Callers must hold
+    /// `mutex` (reads `rows`).
+    pub fn filterRowCount(self: *const Session) usize {
+        var buf: [FILTER_BUCKET_CAP]types.DateBucket = undefined;
+        const buckets = self.buildDateBuckets(&buf);
+        return FILTER_DAY_BASE + buckets.len;
+    }
+
+    /// Move the Filters-panel cursor by `delta` rows and apply the filter the
+    /// cursor lands on (category for rows 0..2, date for rows 3..). Live-applying
+    /// mirrors clicking the row. Callers must hold `mutex`.
+    pub fn moveFilterCursor(self: *Session, delta: isize) void {
+        var buf: [FILTER_BUCKET_CAP]types.DateBucket = undefined;
+        const buckets = self.buildDateBuckets(&buf);
+        const count = FILTER_DAY_BASE + buckets.len;
+        if (count == 0) return;
+        const old = @min(self.filter_cursor, count - 1);
+        const next = if (delta < 0)
+            old - @min(old, @as(usize, @intCast(-delta)))
+        else
+            @min(count - 1, old + @as(usize, @intCast(delta)));
+        self.filter_cursor = next;
+        self.applyFilterCursorLocked(buckets);
+    }
+
+    fn applyFilterCursorLocked(self: *Session, buckets: []const types.DateBucket) void {
+        const c = self.filter_cursor;
+        if (c < FILTER_CATEGORY_ROWS) {
+            self.setCategory(@enumFromInt(c));
+        } else if (c == FILTER_ALL_DATES_ROW) {
+            self.setDateFilter(null);
+        } else {
+            const day = c - FILTER_DAY_BASE;
+            if (day < buckets.len) self.setDateFilter(buckets[day].key);
+        }
+    }
+
+    /// Keep the Filters cursor's day row inside the visible DATE window of
+    /// `day_slots` rows by adjusting `date_offset`. Category and "All dates" rows
+    /// pin the list to the top. Callers must hold `mutex`.
+    pub fn ensureFilterCursorVisible(self: *Session, day_slots: usize) void {
+        if (self.filter_cursor < FILTER_DAY_BASE) {
+            self.date_offset = 0;
+            return;
+        }
+        if (day_slots == 0) return;
+        const day = self.filter_cursor - FILTER_DAY_BASE;
+        if (day < self.date_offset) {
+            self.date_offset = day;
+        } else if (day >= self.date_offset + day_slots) {
+            self.date_offset = day + 1 - day_slots;
+        }
     }
 };
 
@@ -2684,6 +2788,76 @@ test "ai_history_session: setDateFilter resets selection and is a no-op when unc
     session.selected = 1;
     session.setDateFilter(20260601);
     try std.testing.expectEqual(@as(usize, 1), session.selected);
+}
+
+test "ai_history_session: focusMove clamps across the three panels" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    try std.testing.expectEqual(Focus.sessions, session.focus); // default
+    session.focusMove(-1);
+    try std.testing.expectEqual(Focus.filters, session.focus);
+    session.focusMove(-1); // clamp at left edge
+    try std.testing.expectEqual(Focus.filters, session.focus);
+    session.focusMove(1);
+    try std.testing.expectEqual(Focus.sessions, session.focus);
+    session.focusMove(1);
+    try std.testing.expectEqual(Focus.transcript, session.focus);
+    session.focusMove(1); // clamp at right edge
+    try std.testing.expectEqual(Focus.transcript, session.focus);
+}
+
+test "ai_history_session: moveFilterCursor walks categories then dates, applying live" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    const day1: i64 = 1780315200000; // 2026-06-01
+    const day2: i64 = day1 + 86400000; // 2026-06-02
+    const rows = [_]types.SessionMeta{
+        .{ .provider = .codex, .session_id = "a", .title = "A", .source_path = "a.jsonl", .resume_kind = .codex_resume, .last_active_at_ms = day2 },
+        .{ .provider = .claude, .session_id = "b", .title = "B", .source_path = "b.jsonl", .resume_kind = .claude_resume, .last_active_at_ms = day1 },
+    };
+    try session.replaceRows(&rows);
+
+    // Combined list: All, Codex, Claude, All dates, 20260602, 20260601 => 6 rows.
+    try std.testing.expectEqual(@as(usize, 6), session.filterRowCount());
+    try std.testing.expectEqual(types.CategoryFilter.all, session.category);
+
+    session.moveFilterCursor(1); // -> Codex
+    try std.testing.expectEqual(types.CategoryFilter.codex, session.category);
+    session.moveFilterCursor(1); // -> Claude
+    try std.testing.expectEqual(types.CategoryFilter.claude, session.category);
+    session.moveFilterCursor(1); // -> All dates (date filter cleared, category kept)
+    try std.testing.expectEqual(types.CategoryFilter.claude, session.category);
+    try std.testing.expectEqual(@as(?types.DateKey, null), session.date_filter);
+
+    // Reset category so both days are present, then step onto a specific day.
+    session.setCategory(.all);
+    session.filter_cursor = FILTER_ALL_DATES_ROW;
+    session.moveFilterCursor(1); // -> 20260602 (first/most-recent day)
+    try std.testing.expectEqual(@as(?types.DateKey, 20260602), session.date_filter);
+    session.moveFilterCursor(1); // -> 20260601
+    try std.testing.expectEqual(@as(?types.DateKey, 20260601), session.date_filter);
+    session.moveFilterCursor(1); // clamp at end, stays on last day
+    try std.testing.expectEqual(@as(?types.DateKey, 20260601), session.date_filter);
+}
+
+test "ai_history_session: ensureFilterCursorVisible scrolls the day window" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+    // Category/All-dates rows pin to the top.
+    session.date_offset = 5;
+    session.filter_cursor = 1; // Codex
+    session.ensureFilterCursorVisible(3);
+    try std.testing.expectEqual(@as(usize, 0), session.date_offset);
+
+    // Day index 6 (cursor 10) with a 3-row window scrolls so it is visible.
+    session.filter_cursor = FILTER_DAY_BASE + 6;
+    session.ensureFilterCursorVisible(3);
+    try std.testing.expectEqual(@as(usize, 4), session.date_offset); // 6 + 1 - 3
+
+    // Scrolling back up to an earlier day pulls the window up.
+    session.filter_cursor = FILTER_DAY_BASE + 1;
+    session.ensureFilterCursorVisible(3);
+    try std.testing.expectEqual(@as(usize, 1), session.date_offset);
 }
 
 test "ai_history_session: scrollDateBy saturates at zero" {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -81,7 +81,7 @@ pub const TabState = struct {
         }
         if (self.kind == .ai_history) {
             const session = self.ai_history_session orelse return "AI History";
-            return if (session.source.name.len > 0) session.source.name else "AI History";
+            return session.tabTitle();
         }
         const surface = self.focusedSurface() orelse return "wispterm";
         return surface.getTitle();
@@ -1789,7 +1789,8 @@ test "tab: spawnAiHistoryTab owns mutable ssh source buffers" {
     try std.testing.expectEqualStrings("ssh-history", session.source.id);
     try std.testing.expectEqualStrings("Build Box", session.source.name);
     try std.testing.expectEqualStrings("buildbox", session.source.target.ssh.profile_name);
-    try std.testing.expectEqualStrings("Build Box", active.getTitle());
+    // The tab conveys the history workbench, not the bare source name.
+    try std.testing.expectEqualStrings("History · Build Box", active.getTitle());
 }
 
 test "tab: spawnAiHistoryTab rolls back when tab allocation fails" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -1214,19 +1214,19 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 return;
             },
             platform_input.key_up => {
-                _ = AppWindow.aiHistoryMoveSelection(-1);
+                _ = AppWindow.aiHistoryNav(-1);
                 return;
             },
             platform_input.key_down => {
-                _ = AppWindow.aiHistoryMoveSelection(1);
+                _ = AppWindow.aiHistoryNav(1);
                 return;
             },
             platform_input.key_left => {
-                _ = AppWindow.aiHistoryCycleCategory(-1);
+                _ = AppWindow.aiHistoryFocusMove(-1);
                 return;
             },
             platform_input.key_right => {
-                _ = AppWindow.aiHistoryCycleCategory(1);
+                _ = AppWindow.aiHistoryFocusMove(1);
                 return;
             },
             platform_input.key_enter => {

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -10,6 +10,8 @@ const SMALL_GAP: f32 = 6;
 const BUTTON_PAD_Y: f32 = 4;
 const BUTTON_EXTRA_H: f32 = 10;
 const RESUME_BUTTON_W: f32 = 104;
+/// Width of the "r Retry" affordance sharing the Status value line (right-aligned).
+const RETRY_LABEL_W: f32 = 70;
 const MAX_DATE_BUCKETS: usize = 256;
 
 pub const DrawContext = struct {
@@ -45,13 +47,13 @@ pub const Hit = union(enum) {
 
 pub const LeftColumnLayout = struct {
     source_name_top: f32,
-    target_top: f32,
     status_label_top: f32,
     status_value_top: f32,
+    /// Retry/rescan affordance — shares the status value line, right-aligned.
+    retry_text_top: f32,
     category_heading_top: f32,
     category_rows_top: f32,
     category_row_h: f32,
-    retry_text_top: f32,
     date_heading_top: f32,
     date_rows_top: f32,
     date_row_h: f32,
@@ -60,37 +62,32 @@ pub const LeftColumnLayout = struct {
 pub fn leftColumnLayout(top: f32, cell_h: f32) LeftColumnLayout {
     var y = top + headerHeight(cell_h) + 18;
     const source_name_top = y;
-    y += cell_h + 8;
-    const target_top = y;
-    y += cell_h + 18;
+    y += cell_h + 16; // single source line (the target type no longer duplicates it)
     const status_label_top = y;
     y += cell_h + 5;
     const status_value_top = y;
+    // Retry shares the status value line (it is scan-related), so CATEGORY and
+    // DATE become one contiguous filter group below.
+    const retry_text_top = status_value_top;
     y += cell_h + 18;
     const category_heading_top = y;
     y += cell_h + 8;
     const category_rows_top = y;
     const category_row_h = cell_h + 10;
     y += category_row_h * 3;
-    y += 12;
-    const retry_text_top = y;
-    // DATE navigator: below the Refresh button, filling the rest of the column.
-    // `cell_h + 16` clears the retry text plus the refresh button body
-    // (buttonHeight = cell_h + BUTTON_EXTRA_H, lifted by BUTTON_PAD_Y).
-    y += cell_h + 16;
+    y += 14;
     const date_heading_top = y;
     y += cell_h + 8;
     const date_rows_top = y;
     const date_row_h = category_row_h;
     return .{
         .source_name_top = source_name_top,
-        .target_top = target_top,
         .status_label_top = status_label_top,
         .status_value_top = status_value_top,
+        .retry_text_top = retry_text_top,
         .category_heading_top = category_heading_top,
         .category_rows_top = category_rows_top,
         .category_row_h = category_row_h,
-        .retry_text_top = retry_text_top,
         .date_heading_top = date_heading_top,
         .date_rows_top = date_rows_top,
         .date_row_h = date_row_h,
@@ -210,8 +207,10 @@ pub fn interactionHitTest(
         }
     }
 
+    // Retry shares the Status value line, right-aligned; only that label is clickable.
     const refresh_top = refreshButtonTop(top, cell_h);
-    if (rectContains(mx, my, layout.left_x + PAD_X, refresh_top, @max(0, layout.left_w - PAD_X * 2), buttonHeight(cell_h))) {
+    const retry_x = layout.left_x + layout.left_w - PAD_X - RETRY_LABEL_W;
+    if (rectContains(mx, my, retry_x, refresh_top, RETRY_LABEL_W, buttonHeight(cell_h))) {
         return .refresh;
     }
 
@@ -301,18 +300,20 @@ fn drawDateRow(
     label: []const u8,
     count: usize,
     active: bool,
+    cursor: bool,
     fg: [3]f32,
     muted: [3]f32,
     accent: [3]f32,
     selected_bg: [3]f32,
 ) void {
-    if (active) {
+    const highlight = active or cursor;
+    if (highlight) {
         const row_y = yFromTop(window_height, row_top, row_h);
-        draw.fillQuadAlpha(layout.left_x, row_y, layout.left_w, row_h, selected_bg, 0.92);
-        draw.fillQuad(layout.left_x, row_y, 3, row_h, accent);
+        draw.fillQuadAlpha(layout.left_x, row_y, layout.left_w, row_h, selected_bg, if (cursor) 0.98 else 0.92);
+        draw.fillQuad(layout.left_x, row_y, if (cursor) 4 else 3, row_h, accent);
     }
     const text_top = row_top + (row_h - draw.cell_h) / 2;
-    const label_color = if (active) fg else muted;
+    const label_color = if (highlight) fg else muted;
     var num_buf: [16]u8 = undefined;
     const num_text = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch "";
     const count_w: f32 = 44;
@@ -335,21 +336,28 @@ fn renderLeftColumn(
     panel_strong: [3]f32,
     line: [3]f32,
 ) void {
+    const filters_focused = session.focus == .filters;
     const header_h = headerHeight(draw.cell_h);
     draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, top, header_h), layout.left_w, header_h, panel_strong, 0.9);
     draw.fillQuad(layout.left_x, yFromTop(window_height, top + header_h, 1), layout.left_w, 1, line);
     _ = draw.renderTextLimited("AI History", layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
+    drawFocusUnderline(draw, layout.left_x, layout.left_w, window_height, top, header_h, accent, filters_focused);
 
     const lc = leftColumnLayout(top, draw.cell_h);
-    _ = draw.renderTextLimited(session.source.name, layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.source_name_top), fg, layout.left_w - PAD_X * 2);
-    _ = draw.renderTextLimited(targetLabel(session.source.target), layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.target_top), muted, layout.left_w - PAD_X * 2);
+    var source_buf: [160]u8 = undefined;
+    _ = draw.renderTextLimited(sourceDisplayText(session.source, &source_buf), layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.source_name_top), fg, layout.left_w - PAD_X * 2);
+
+    // Status label, plus the rescan affordance sharing the value line on the right.
     _ = draw.renderTextLimited("Status", layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.status_label_top), muted, layout.left_w - PAD_X * 2);
+    const retry_x = layout.left_x + layout.left_w - PAD_X - RETRY_LABEL_W;
+    _ = draw.renderTextLimited("r Retry", retry_x, yTextFromTop(draw, window_height, lc.retry_text_top), muted, RETRY_LABEL_W);
     var status_buf: [48]u8 = undefined;
     const status_label = if (session.state == .scanning)
         ai_history_session.scanningStatusLabel(&status_buf, session.rows.items.len)
     else
         statusText(session);
-    _ = draw.renderTextLimited(status_label, layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.status_value_top), accent, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited(status_label, layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.status_value_top), accent, @max(0, retry_x - (layout.left_x + PAD_X) - 8));
+
     _ = draw.renderTextLimited("CATEGORY", layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.category_heading_top), muted, layout.left_w - PAD_X * 2);
 
     const query = session.filter[0..session.filter_len];
@@ -359,13 +367,15 @@ fn renderLeftColumn(
     for (categories, 0..) |cat, i| {
         const row_top = lc.category_rows_top + @as(f32, @floatFromInt(i)) * lc.category_row_h;
         const active = session.category == cat;
-        if (active) {
+        const cursor = filters_focused and session.filter_cursor == i;
+        const highlight = active or cursor;
+        if (highlight) {
             const row_y = yFromTop(window_height, row_top, lc.category_row_h);
-            draw.fillQuadAlpha(layout.left_x, row_y, layout.left_w, lc.category_row_h, selected_bg, 0.92);
-            draw.fillQuad(layout.left_x, row_y, 3, lc.category_row_h, accent);
+            draw.fillQuadAlpha(layout.left_x, row_y, layout.left_w, lc.category_row_h, selected_bg, if (cursor) 0.98 else 0.92);
+            draw.fillQuad(layout.left_x, row_y, if (cursor) 4 else 3, lc.category_row_h, accent);
         }
         const text_top = row_top + (lc.category_row_h - draw.cell_h) / 2;
-        const label_color = if (active) fg else muted;
+        const label_color = if (highlight) fg else muted;
         const count = switch (cat) {
             .all => counts.all,
             .codex => counts.codex,
@@ -380,14 +390,13 @@ fn renderLeftColumn(
         _ = draw.renderTextLimited(num_text, count_x, yTextFromTop(draw, window_height, text_top), muted, count_w);
     }
 
-    _ = draw.renderTextLimited("r  Retry scan", layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.retry_text_top), muted, layout.left_w - PAD_X * 2);
-
     _ = draw.renderTextLimited("DATE", layout.left_x + PAD_X, yTextFromTop(draw, window_height, lc.date_heading_top), muted, layout.left_w - PAD_X * 2);
     var bucket_buf: [MAX_DATE_BUCKETS]types.DateBucket = undefined;
     const buckets = session.buildDateBuckets(&bucket_buf);
     const date_cap = dateVisibleCapacity(window_height, lc.date_rows_top, draw.cell_h);
     if (date_cap > 0) {
-        drawDateRow(draw, layout, window_height, lc.date_rows_top, lc.date_row_h, "All dates", session.dateAllCount(), session.date_filter == null, fg, muted, accent, selected_bg);
+        const all_dates_cursor = filters_focused and session.filter_cursor == 3;
+        drawDateRow(draw, layout, window_height, lc.date_rows_top, lc.date_row_h, "All dates", session.dateAllCount(), session.date_filter == null, all_dates_cursor, fg, muted, accent, selected_bg);
         const day_slots = date_cap - 1;
         const offset = clampDateOffset(session.date_offset, buckets.len, day_slots);
         var j: usize = 0;
@@ -397,7 +406,8 @@ fn renderLeftColumn(
             var label_buf: [16]u8 = undefined;
             const label = types.formatDateKey(bucket.key, &label_buf);
             const active = session.date_filter != null and session.date_filter.? == bucket.key;
-            drawDateRow(draw, layout, window_height, row_top, lc.date_row_h, label, bucket.count, active, fg, muted, accent, selected_bg);
+            const cursor = filters_focused and session.filter_cursor == 4 + offset + j;
+            drawDateRow(draw, layout, window_height, row_top, lc.date_row_h, label, bucket.count, active, cursor, fg, muted, accent, selected_bg);
         }
     }
 
@@ -423,6 +433,7 @@ fn renderList(
     const filter_y = yFromTop(window_height, top, filter_h);
     draw.fillQuadAlpha(layout.list_x, filter_y, layout.list_w, filter_h, mixColor(draw.bg, fg, 0.055), 0.98);
     draw.fillQuad(layout.list_x, yFromTop(window_height, top + filter_h, 1), layout.list_w, 1, line);
+    drawFocusUnderline(draw, layout.list_x, layout.list_w, window_height, top, filter_h, accent, session.focus == .sessions);
 
     const query = session.filter[0..session.filter_len];
     const filter_label = if (query.len == 0) "Search sessions" else query;
@@ -500,6 +511,7 @@ fn renderDetail(
     draw.fillQuadAlpha(layout.detail_x, yFromTop(window_height, top, header_h), layout.detail_w, header_h, panel_strong, 0.82);
     draw.fillQuad(layout.detail_x, yFromTop(window_height, top + header_h, 1), layout.detail_w, 1, line);
     _ = draw.renderTextLimited("Transcript Preview", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.detail_w - PAD_X * 2);
+    drawFocusUnderline(draw, layout.detail_x, layout.detail_w, window_height, top, header_h, accent, session.focus == .transcript);
 
     const selected = session.selectedVisible() orelse {
         _ = draw.renderTextLimited("Select a session", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), muted, layout.detail_w - PAD_X * 2);
@@ -696,6 +708,24 @@ fn statusText(session: anytype) []const u8 {
     };
 }
 
+/// Accent rule under a panel's header marking it as the keyboard-focused panel.
+fn drawFocusUnderline(draw: DrawContext, x: f32, w: f32, window_height: f32, top: f32, header_h: f32, accent: [3]f32, focused: bool) void {
+    if (!focused) return;
+    draw.fillQuad(x, yFromTop(window_height, top + header_h - 2, 2), w, 2, accent);
+}
+
+/// Single source line for the left column: the source name, with the target
+/// type appended only when it adds information (e.g. "panda · SSH"). When the
+/// name already equals the target type (the common "WSL"/"WSL" case) it is shown
+/// once instead of duplicated.
+fn sourceDisplayText(source: anytype, buf: []u8) []const u8 {
+    const name = source.name;
+    const tlabel = targetLabel(source.target);
+    if (name.len == 0) return tlabel;
+    if (std.ascii.eqlIgnoreCase(name, tlabel)) return name;
+    return std.fmt.bufPrint(buf, "{s} · {s}", .{ name, tlabel }) catch name;
+}
+
 fn targetLabel(target: anytype) []const u8 {
     return switch (target) {
         .local => "Local",
@@ -867,9 +897,10 @@ test "ai_history_renderer: interaction hit test maps buttons and row offset" {
     const cell_h: f32 = 16;
     const top: f32 = 40;
 
+    // Retry is right-aligned on the Status value line; click inside that label.
     try std.testing.expectEqual(
         Hit.refresh,
-        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + PAD_X + 4, refreshButtonTop(top, cell_h) + 2),
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + layout.left_w - PAD_X - RETRY_LABEL_W + 4, refreshButtonTop(top, cell_h) + 2),
     );
     try std.testing.expectEqual(
         Hit.@"resume",
@@ -953,10 +984,12 @@ test "ai_history_renderer: clampScroll keeps scroll within the scrollable range"
 
 test "ai_history_renderer: left column layout is ordered top to bottom" {
     const lc = leftColumnLayout(40, 16);
-    try std.testing.expect(lc.source_name_top < lc.target_top);
-    try std.testing.expect(lc.target_top < lc.status_label_top);
+    try std.testing.expect(lc.source_name_top < lc.status_label_top);
     try std.testing.expect(lc.status_label_top < lc.status_value_top);
-    try std.testing.expect(lc.status_value_top < lc.retry_text_top);
+    // Retry shares the status value line, then CATEGORY/DATE follow.
+    try std.testing.expectEqual(lc.status_value_top, lc.retry_text_top);
+    try std.testing.expect(lc.status_value_top < lc.category_heading_top);
+    try std.testing.expect(lc.category_heading_top < lc.date_heading_top);
     try std.testing.expectEqual(lc.retry_text_top - BUTTON_PAD_Y, refreshButtonTop(40, 16));
 }
 


### PR DESCRIPTION
## Summary

Reworks the AI History workbench per field feedback (duplicate "WSL / WSL" header, awkward "Retry scan" placement, mouse-only transcript scrolling).

- **Panel-focus keyboard navigation.** **←/→** move keyboard focus between the three panels (**Filters ⟷ Sessions ⟷ Transcript**); **↑/↓** act within the focused panel — walk the combined **CATEGORY+DATE** filter list (applying live), change the selected session, or scroll the transcript. The focused panel's header shows an accent underline. This lets you Space-preview a session, press **→** into the transcript, and read it with **↑/↓** instead of the mouse wheel. (Replaces ←/→ = category cycle; the mouse still clicks filters directly. PageUp/Down/Home/End, Enter, `r`, and typing-to-search are unchanged.)
- **Tab/window title** now reads **"History · \<source\>"** (or "AI History" when unnamed), so the tab conveys the history workbench rather than echoing the originating terminal's name.
- **Dedup'd source line** — shows the source once, appending the target type only when it adds information (e.g. `panda · SSH`) instead of two duplicate `WSL` lines.
- **"Retry scan" moved beside the Status line** (it is scan-related), so CATEGORY and DATE form one contiguous filter group below. Its click target was narrowed to just the label.

## Implementation

- `ai_history_session.zig`: new `Focus` enum + `filter_cursor`/`tab_title` state; `focusMove`, `moveFilterCursor` (live-applies category/date), `ensureFilterCursorVisible`, `tabTitle`.
- `AppWindow.zig`: `aiHistoryFocusMove` / `aiHistoryNav` (routes ↑/↓ by focus) / `aiHistoryDateDaySlotsForWindow`; removed the now-dead `aiHistoryCycleCategory`.
- `input.zig`: arrow keys rewired to focus/nav.
- `appwindow/tab.zig`: `getTitle` → `session.tabTitle()`.
- `renderer/ai_history_renderer.zig`: dropped the duplicate target line, repositioned + narrowed the retry affordance, added focus underlines and a filter-cursor highlight.

## Test Plan

- [x] New: `focusMove` clamps across the three panels.
- [x] New: `moveFilterCursor` walks categories then dates, applying live.
- [x] New: `ensureFilterCursorVisible` scrolls the day window.
- [x] Updated: left-column layout ordering + hit-test (retry beside Status) and the tab-title assertion.
- [x] `zig build`, `zig build test`, and `zig build test-full` all green.
- [ ] GUI verify (Windows/macOS): focus underline + filter cursor highlight render; ←/→ switch panels; ↑/↓ move within; Space → → → ↑/↓ reads a transcript without the mouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)