### PR TITLE
[codex] add Reasonix AI History support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ English | [简体中文](README.zh-CN.md)
 - **File Explorer and previews** - browse local, WSL, and SSH files; preview Markdown/text/tables/images without leaving the terminal
 - **Embedded browser panel** - open web URLs in a side WebView2 panel or the default browser, with persistent SSH loopback port forwarding for profile sessions
 - **AI Agent sessions** - launch OpenAI-compatible Agent tabs, configure profiles, restore history, and export full or clean Markdown transcripts
-- **AI history browser** - browse local, WSL, and SSH Codex / Claude Code history and resume sessions from their original project directories
+- **AI history browser** - browse local, WSL, and SSH Codex / Claude Code / Reasonix history and resume sessions from their original project directories
 - **Kitty Graphics protocol** - display inline images and PDFs from remote shells via `imgcat.py` / `pdfcat.py`
 - **Opt-in remote access** - share a session key over a Cloudflare-hosted relay (disabled by default)
 

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -49,9 +49,10 @@ when the provider returns OpenAI-compatible `usage` fields.
 ## AI History Sessions
 
 Open the session launcher with `Ctrl+Shift+T` and choose `AI History` to browse
-Codex and Claude Code transcripts stored on a Local, WSL, or SSH target. WispTerm
-connects to the selected target, scans `$HOME/.codex` and `$HOME/.claude` for
-metadata, and loads a transcript only when you open that row.
+Codex, Claude Code, and Reasonix transcripts stored on a Local, WSL, or SSH
+target. WispTerm connects to the selected target, scans `$HOME/.codex`,
+`$HOME/.claude`, and `$HOME/.reasonix` for metadata, and loads a transcript
+only when you open that row.
 
 Use `Resume` to open a real terminal tab on the same target. WispTerm first
 checks the original project directory recorded in the history file; if that

--- a/src/ai_history_provider_reasonix.zig
+++ b/src/ai_history_provider_reasonix.zig
@@ -1,0 +1,377 @@
+const std = @import("std");
+const types = @import("ai_history_types.zig");
+
+pub const ParseError = error{OutOfMemory};
+
+pub fn parseMetadata(
+    allocator: std.mem.Allocator,
+    source_path: []const u8,
+    transcript_jsonl: []const u8,
+    meta_json: []const u8,
+    events_jsonl: []const u8,
+) ParseError!types.SessionMeta {
+    var meta = try initMetadata(allocator, source_path);
+    errdefer freeMetadata(allocator, meta);
+
+    try replaceOwned(allocator, &meta.session_id, sessionIdFromPath(source_path));
+
+    if (try parseMetaJson(allocator, meta_json)) |sidecar| {
+        defer sidecar.deinit(allocator);
+        if (sidecar.summary.len > 0) {
+            try replaceOwned(allocator, &meta.summary, sidecar.summary);
+            try replaceOwned(allocator, &meta.title, sidecar.summary);
+        }
+        if (sidecar.workspace.len > 0) try replaceOwned(allocator, &meta.project_dir, sidecar.workspace);
+    }
+
+    try parseTranscriptMetadata(allocator, transcript_jsonl, &meta);
+    try parseEventTimestamps(allocator, events_jsonl, &meta);
+
+    if (meta.title.len == 0) try replaceOwned(allocator, &meta.title, meta.session_id);
+    return meta;
+}
+
+pub fn parseTranscript(
+    allocator: std.mem.Allocator,
+    jsonl: []const u8,
+) ParseError![]types.TranscriptMessage {
+    var messages: std.ArrayListUnmanaged(types.TranscriptMessage) = .empty;
+    errdefer {
+        freeTranscriptList(allocator, messages.items);
+        messages.deinit(allocator);
+    }
+
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        const role_text = objectString(obj, "role") orelse continue;
+        const role = messageRole(role_text) orelse continue;
+        const event = try transcriptEvent(allocator, obj, role) orelse continue;
+        errdefer allocator.free(event.content);
+        try messages.append(allocator, event);
+    }
+
+    return try messages.toOwnedSlice(allocator);
+}
+
+pub fn freeMetadata(allocator: std.mem.Allocator, meta: types.SessionMeta) void {
+    allocator.free(meta.session_id);
+    allocator.free(meta.title);
+    allocator.free(meta.summary);
+    allocator.free(meta.project_dir);
+    allocator.free(meta.source_path);
+}
+
+pub fn freeTranscript(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    freeTranscriptList(allocator, messages);
+    allocator.free(messages);
+}
+
+fn initMetadata(allocator: std.mem.Allocator, source_path: []const u8) ParseError!types.SessionMeta {
+    const session_id = try allocator.dupe(u8, "");
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, "");
+    errdefer allocator.free(title);
+    const summary = try allocator.dupe(u8, "");
+    errdefer allocator.free(summary);
+    const project_dir = try allocator.dupe(u8, "");
+    errdefer allocator.free(project_dir);
+    const source_path_owned = try allocator.dupe(u8, source_path);
+
+    return .{
+        .provider = .reasonix,
+        .session_id = session_id,
+        .title = title,
+        .summary = summary,
+        .project_dir = project_dir,
+        .source_path = source_path_owned,
+        .resume_kind = .reasonix_resume,
+    };
+}
+
+fn freeTranscriptList(allocator: std.mem.Allocator, messages: []types.TranscriptMessage) void {
+    for (messages) |message| allocator.free(message.content);
+}
+
+fn parseLine(allocator: std.mem.Allocator, line: []const u8) ParseError!?std.json.Parsed(std.json.Value) {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    return std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+}
+
+fn objectString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn sessionIdFromPath(source_path: []const u8) []const u8 {
+    const base = std.fs.path.basename(source_path);
+    return if (std.mem.endsWith(u8, base, ".jsonl")) base[0 .. base.len - ".jsonl".len] else base;
+}
+
+const ReasonixMetaSidecar = struct {
+    summary: []const u8 = "",
+    workspace: []const u8 = "",
+
+    fn deinit(self: ReasonixMetaSidecar, allocator: std.mem.Allocator) void {
+        if (self.summary.len > 0) allocator.free(self.summary);
+        if (self.workspace.len > 0) allocator.free(self.workspace);
+    }
+};
+
+fn parseMetaJson(allocator: std.mem.Allocator, meta_json: []const u8) ParseError!?ReasonixMetaSidecar {
+    const trimmed = std.mem.trim(u8, meta_json, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return null;
+    var sidecar = ReasonixMetaSidecar{};
+    errdefer sidecar.deinit(allocator);
+    if (objectString(parsed.value.object, "summary")) |summary| {
+        sidecar.summary = try allocator.dupe(u8, summary);
+    }
+    if (objectString(parsed.value.object, "workspace")) |workspace| {
+        sidecar.workspace = try allocator.dupe(u8, workspace);
+    }
+    return sidecar;
+}
+
+fn parseTranscriptMetadata(allocator: std.mem.Allocator, jsonl: []const u8, meta: *types.SessionMeta) ParseError!void {
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        var parsed = (try parseLine(allocator, line)) orelse continue;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) continue;
+        const obj = parsed.value.object;
+        const role = messageRole(objectString(obj, "role") orelse "") orelse continue;
+        const content = objectString(obj, "content") orelse "";
+        if (content.len == 0 and role != .assistant) continue;
+        if (meta.title.len == 0 and role == .user and content.len > 0) {
+            try replaceOwned(allocator, &meta.title, content);
+        }
+        meta.message_count += 1;
+    }
+}
+
+fn parseEventTimestamps(allocator: std.mem.Allocator, events_jsonl: []const u8, meta: *types.SessionMeta) ParseError!void {
+    var lines = std.mem.splitScalar(u8, events_jsonl, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r\n");
+        if (trimmed.len == 0) continue;
+        var parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => continue,
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        const timestamp = objectString(parsed.value.object, "ts") orelse continue;
+        const ms = parseTimestampMs(timestamp);
+        if (ms <= 0) continue;
+        if (meta.created_at_ms == 0) meta.created_at_ms = ms;
+        if (ms > meta.last_active_at_ms) meta.last_active_at_ms = ms;
+    }
+}
+
+fn transcriptEvent(allocator: std.mem.Allocator, obj: std.json.ObjectMap, role: types.MessageRole) ParseError!?types.TranscriptMessage {
+    if (role == .tool) {
+        const content = objectString(obj, "content") orelse return null;
+        return .{
+            .role = .tool,
+            .kind = .tool_result,
+            .content = try allocator.dupe(u8, content),
+        };
+    }
+
+    const content = objectString(obj, "content") orelse "";
+    if (content.len > 0) {
+        return .{
+            .role = role,
+            .content = try allocator.dupe(u8, content),
+        };
+    }
+
+    if (role == .assistant) {
+        if (toolCallName(obj)) |name| {
+            return .{
+                .role = .assistant,
+                .kind = .tool_call,
+                .content = try allocator.dupe(u8, name),
+            };
+        }
+    }
+
+    return null;
+}
+
+fn toolCallName(obj: std.json.ObjectMap) ?[]const u8 {
+    const calls = obj.get("tool_calls") orelse return null;
+    if (calls != .array or calls.array.items.len == 0) return null;
+    const first = calls.array.items[0];
+    if (first != .object) return null;
+    const function = first.object.get("function") orelse return null;
+    if (function != .object) return null;
+    return objectString(function.object, "name");
+}
+
+fn messageRole(role: []const u8) ?types.MessageRole {
+    if (std.mem.eql(u8, role, "user")) return .user;
+    if (std.mem.eql(u8, role, "assistant")) return .assistant;
+    if (std.mem.eql(u8, role, "tool")) return .tool;
+    if (std.mem.eql(u8, role, "system")) return .system;
+    return null;
+}
+
+fn replaceOwned(allocator: std.mem.Allocator, field: *[]const u8, value: []const u8) ParseError!void {
+    const owned = try allocator.dupe(u8, value);
+    allocator.free(field.*);
+    field.* = owned;
+}
+
+fn parseTimestampMs(timestamp: []const u8) i64 {
+    if (timestamp.len < "0000-00-00T00:00:00Z".len) return 0;
+    if (timestamp[4] != '-' or timestamp[7] != '-' or timestamp[10] != 'T' or
+        timestamp[13] != ':' or timestamp[16] != ':')
+    {
+        return 0;
+    }
+
+    const year: i64 = parseDigits(timestamp[0..4]) orelse return 0;
+    const month: i64 = parseDigits(timestamp[5..7]) orelse return 0;
+    const day: i64 = parseDigits(timestamp[8..10]) orelse return 0;
+    const hour: i64 = parseDigits(timestamp[11..13]) orelse return 0;
+    const minute: i64 = parseDigits(timestamp[14..16]) orelse return 0;
+    const second: i64 = parseDigits(timestamp[17..19]) orelse return 0;
+    if (month < 1 or month > 12 or day < 1 or day > daysInMonth(year, month) or
+        hour > 23 or minute > 59 or second > 59)
+    {
+        return 0;
+    }
+
+    var index: usize = 19;
+    var millisecond: i64 = 0;
+    if (index < timestamp.len and timestamp[index] == '.') {
+        index += 1;
+        const start = index;
+        var scale: i64 = 100;
+        while (index < timestamp.len and std.ascii.isDigit(timestamp[index])) : (index += 1) {
+            if (index - start < 3) {
+                millisecond += @as(i64, timestamp[index] - '0') * scale;
+                scale = @divFloor(scale, 10);
+            }
+        }
+    }
+
+    if (index >= timestamp.len or timestamp[index] != 'Z') return 0;
+
+    const days = daysBeforeYear(year) + daysBeforeMonth(year, month) + (day - 1);
+    const seconds = (((days * 24) + hour) * 60 + minute) * 60 + second;
+    return seconds * 1000 + millisecond;
+}
+
+fn parseDigits(bytes: []const u8) ?i64 {
+    var value: i64 = 0;
+    for (bytes) |ch| {
+        if (!std.ascii.isDigit(ch)) return null;
+        value = value * 10 + @as(i64, ch - '0');
+    }
+    return value;
+}
+
+fn daysBeforeYear(year: i64) i64 {
+    const y = year - 1970;
+    return y * 365 + @divFloor(year - 1969, 4) - @divFloor(year - 1901, 100) + @divFloor(year - 1601, 400);
+}
+
+fn daysBeforeMonth(year: i64, month: i64) i64 {
+    var days: i64 = 0;
+    var m: i64 = 1;
+    while (m < month) : (m += 1) days += daysInMonth(year, m);
+    return days;
+}
+
+fn daysInMonth(year: i64, month: i64) i64 {
+    return switch (month) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(year)) 29 else 28,
+        else => 0,
+    };
+}
+
+fn isLeapYear(year: i64) bool {
+    return @mod(year, 4) == 0 and (@mod(year, 100) != 0 or @mod(year, 400) == 0);
+}
+
+test "ai_history_provider_reasonix: parses metadata from transcript meta and events" {
+    const allocator = std.testing.allocator;
+    const transcript =
+        \\{"role":"user","content":"hello"}
+        \\{"role":"assistant","content":"Hi there"}
+        \\{"role":"tool","name":"read_file","content":"file contents","tool_call_id":"tc-1"}
+        \\
+    ;
+    const meta_json =
+        \\{"workspace":"/home/me/project","summary":"Investigate startup","turnCount":2,"branch":"main"}
+    ;
+    const events =
+        \\{"type":"session.opened","id":1,"name":"code-project","turn":0,"ts":"2026-05-26T13:53:34.400Z"}
+        \\{"type":"model.final","id":2,"turn":1,"ts":"2026-05-26T13:54:59.393Z"}
+        \\
+    ;
+
+    const meta = try parseMetadata(allocator, "/home/me/.reasonix/sessions/code-project.jsonl", transcript, meta_json, events);
+    defer freeMetadata(allocator, meta);
+
+    try std.testing.expectEqual(types.ProviderId.reasonix, meta.provider);
+    try std.testing.expectEqualStrings("code-project", meta.session_id);
+    try std.testing.expectEqualStrings("Investigate startup", meta.title);
+    try std.testing.expectEqualStrings("Investigate startup", meta.summary);
+    try std.testing.expectEqualStrings("/home/me/project", meta.project_dir);
+    try std.testing.expectEqualStrings("/home/me/.reasonix/sessions/code-project.jsonl", meta.source_path);
+    try std.testing.expectEqual(types.ResumeKind.reasonix_resume, meta.resume_kind);
+    try std.testing.expectEqual(@as(u32, 3), meta.message_count);
+    try std.testing.expectEqual(@as(i64, 1779803614400), meta.created_at_ms);
+    try std.testing.expectEqual(@as(i64, 1779803699393), meta.last_active_at_ms);
+}
+
+test "ai_history_provider_reasonix: transcript keeps user assistant and tool messages" {
+    const allocator = std.testing.allocator;
+    const jsonl =
+        \\{"role":"user","content":"inspect"}
+        \\{"role":"assistant","reasoning_content":"thinking","content":"","tool_calls":[{"id":"tc-1","function":{"name":"list_directory"}}]}
+        \\{"role":"tool","name":"list_directory","content":"README.md","tool_call_id":"tc-1"}
+        \\{"role":"assistant","content":"Done"}
+        \\
+    ;
+
+    const messages = try parseTranscript(allocator, jsonl);
+    defer freeTranscript(allocator, messages);
+
+    try std.testing.expectEqual(@as(usize, 4), messages.len);
+    try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
+    try std.testing.expectEqual(types.MessageKind.normal, messages[0].kind);
+    try std.testing.expectEqualStrings("inspect", messages[0].content);
+    try std.testing.expectEqual(types.MessageRole.assistant, messages[1].role);
+    try std.testing.expectEqual(types.MessageKind.tool_call, messages[1].kind);
+    try std.testing.expectEqualStrings("list_directory", messages[1].content);
+    try std.testing.expectEqual(types.MessageRole.tool, messages[2].role);
+    try std.testing.expectEqual(types.MessageKind.tool_result, messages[2].kind);
+    try std.testing.expectEqualStrings("README.md", messages[2].content);
+    try std.testing.expectEqual(types.MessageRole.assistant, messages[3].role);
+    try std.testing.expectEqualStrings("Done", messages[3].content);
+}

--- a/src/ai_history_resume.zig
+++ b/src/ai_history_resume.zig
@@ -3,21 +3,28 @@ const types = @import("ai_history_types.zig");
 
 pub const ResumeError = error{ MissingProjectDir, UnsupportedProvider, CommandTooLong };
 
+const ResumeCommandParts = struct {
+    prefix: []const u8,
+    suffix: []const u8,
+};
+
 pub fn resumeCommand(meta: types.SessionMeta, out: []u8) ResumeError![]const u8 {
     if (meta.project_dir.len == 0) return error.MissingProjectDir;
-    const prefix = switch (meta.resume_kind) {
-        .codex_resume => "codex resume ",
-        .claude_resume => "claude --resume ",
+    const parts: ResumeCommandParts = switch (meta.resume_kind) {
+        .codex_resume => .{ .prefix = "codex resume ", .suffix = "" },
+        .claude_resume => .{ .prefix = "claude --resume ", .suffix = "" },
+        .reasonix_resume => .{ .prefix = "reasonix chat --session ", .suffix = " --resume" },
         .unavailable => return error.UnsupportedProvider,
     };
 
     var pos: usize = 0;
-    try append(out, &pos, prefix);
+    try append(out, &pos, parts.prefix);
     if (isShellSafeBareWord(meta.session_id)) {
         try append(out, &pos, meta.session_id);
     } else {
         try appendShellSingleQuote(out, &pos, meta.session_id);
     }
+    try append(out, &pos, parts.suffix);
     return out[0..pos];
 }
 
@@ -77,9 +84,11 @@ pub fn checkedPowerShellResume(meta: types.SessionMeta, out: []u8) ResumeError![
     switch (meta.resume_kind) {
         .codex_resume => try append(out, &pos, "codex resume "),
         .claude_resume => try append(out, &pos, "claude --resume "),
+        .reasonix_resume => try append(out, &pos, "reasonix chat --session "),
         .unavailable => return error.UnsupportedProvider,
     }
     try appendPowerShellSingleQuote(out, &pos, meta.session_id);
+    if (meta.resume_kind == .reasonix_resume) try append(out, &pos, " --resume");
     try append(out, &pos, " } else { Write-Error ");
     try appendPowerShellSingleQuote(out, &pos, "AI History resume failed: project path unavailable");
     try append(out, &pos, " }");
@@ -177,6 +186,16 @@ test "ai_history_resume: builds provider resume commands" {
         .resume_kind = .claude_resume,
     };
     try std.testing.expectEqualStrings("claude --resume xyz", try resumeCommand(claude, &out));
+
+    const reasonix: types.SessionMeta = .{
+        .provider = .reasonix,
+        .session_id = "code-project",
+        .title = "C",
+        .project_dir = "/home/me/project",
+        .source_path = "c.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    try std.testing.expectEqualStrings("reasonix chat --session code-project --resume", try resumeCommand(reasonix, &out));
 }
 
 test "ai_history_resume: quotes unsafe session ids" {
@@ -200,6 +219,16 @@ test "ai_history_resume: quotes unsafe session ids" {
         .resume_kind = .claude_resume,
     };
     try std.testing.expectEqualStrings("claude --resume 'it'\\''s-here'", try resumeCommand(with_quote, &out));
+
+    const reasonix_with_quote: types.SessionMeta = .{
+        .provider = .reasonix,
+        .session_id = "it'has space",
+        .title = "R",
+        .project_dir = "/home/me/project",
+        .source_path = "r.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    try std.testing.expectEqualStrings("reasonix chat --session 'it'\\''has space' --resume", try resumeCommand(reasonix_with_quote, &out));
 
     const with_metacharacters: types.SessionMeta = .{
         .provider = .codex,
@@ -336,6 +365,19 @@ test "ai_history_resume: checked PowerShell resume checks directory before resum
     try std.testing.expectEqualStrings(
         "if (Test-Path -LiteralPath 'C:\\Users\\me\\it''s project' -PathType Container) { Set-Location -LiteralPath 'C:\\Users\\me\\it''s project'; codex resume 'abc def' } else { Write-Error 'AI History resume failed: project path unavailable' }",
         try checkedPowerShellResume(meta, &out),
+    );
+
+    const reasonix: types.SessionMeta = .{
+        .provider = .reasonix,
+        .session_id = "code-project",
+        .title = "R",
+        .project_dir = "C:\\Project",
+        .source_path = "r.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    try std.testing.expectEqualStrings(
+        "if (Test-Path -LiteralPath 'C:\\Project' -PathType Container) { Set-Location -LiteralPath 'C:\\Project'; reasonix chat --session 'code-project' --resume } else { Write-Error 'AI History resume failed: project path unavailable' }",
+        try checkedPowerShellResume(reasonix, &out),
     );
 }
 

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -4,6 +4,7 @@ const source_mod = @import("ai_history_source.zig");
 const session_persist = @import("session_persist.zig");
 const codex_provider = @import("ai_history_provider_codex.zig");
 const claude_provider = @import("ai_history_provider_claude.zig");
+const reasonix_provider = @import("ai_history_provider_reasonix.zig");
 const remote_file = @import("platform/remote_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
 const ai_history_cache = @import("ai_history_cache.zig");
@@ -655,7 +656,7 @@ pub const Session = struct {
     }
 
     pub fn cycleCategory(self: *Session, delta: isize) void {
-        const count: isize = 3;
+        const count: isize = 4;
         const cur: isize = @intFromEnum(self.category);
         const next: usize = @intCast(@mod(cur + delta, count));
         self.setCategory(@enumFromInt(next));
@@ -677,10 +678,11 @@ pub const Session = struct {
         }
     }
 
-    pub fn categoryCounts(self: *const Session, query: []const u8) struct { all: usize, codex: usize, claude: usize } {
+    pub fn categoryCounts(self: *const Session, query: []const u8) struct { all: usize, codex: usize, claude: usize, reasonix: usize } {
         var all: usize = 0;
         var codex: usize = 0;
         var claude: usize = 0;
+        var reasonix: usize = 0;
         for (self.rows.items) |row| {
             if (!types.metadataMatches(row, query)) continue;
             const key = types.dateKeyFromMs(row.last_active_at_ms, self.tz_offset_seconds);
@@ -689,9 +691,10 @@ pub const Session = struct {
             switch (row.provider) {
                 .codex => codex += 1,
                 .claude => claude += 1,
+                .reasonix => reasonix += 1,
             }
         }
-        return .{ .all = all, .codex = codex, .claude = claude };
+        return .{ .all = all, .codex = codex, .claude = claude, .reasonix = reasonix };
     }
 
     /// Fill `buf` with the distinct local days present under the current
@@ -850,6 +853,18 @@ pub fn scanLocalFilesystemWithCacheSink(
             }
         }
     }
+    if (source.providers.reasonix) {
+        if (source.reasonix_root_override) |root| {
+            try scanner.scanProviderRoot(.reasonix, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.reasonix, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.reasonix, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
     for (source.extra_roots) |root| {
         if (!providerEnabled(source, root.provider)) continue;
         try scanner.scanProviderRoot(root.provider, root.path);
@@ -891,25 +906,40 @@ pub fn loadLocalTranscript(allocator: std.mem.Allocator, meta: types.SessionMeta
     return switch (meta.provider) {
         .codex => try codex_provider.parseTranscript(allocator, bytes),
         .claude => try claude_provider.parseTranscript(allocator, bytes),
+        .reasonix => try reasonix_provider.parseTranscript(allocator, bytes),
     };
 }
 
 pub fn providerFindCommand(provider: types.ProviderId, root: []const u8, out: []u8) ![]const u8 {
-    _ = provider;
+    var reasonix_root_buf: [1024]u8 = undefined;
+    const find_root = providerFindRoot(provider, root, &reasonix_root_buf) catch return error.CommandTooLong;
     var quoted_buf: [1024]u8 = undefined;
-    const quoted = remote_file.shellQuote(&quoted_buf, root) orelse return error.CommandTooLong;
+    const quoted = remote_file.shellQuote(&quoted_buf, find_root) orelse return error.CommandTooLong;
+    const reasonix_filter = if (provider == .reasonix) " ! -name '*.events.jsonl'" else "";
     // GNU find: emit "mtime<TAB>size<TAB>path", newest first, capped. The \t and \n
     // are literal escapes for find -printf (single-quoted so the shell preserves them).
-    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl' -size -2048k -printf '%T@\\t%s\\t%p\\n' 2>/dev/null | sort -rn | head -500", .{quoted}) catch error.CommandTooLong;
+    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl'{s} -size -2048k -printf '%T@\\t%s\\t%p\\n' 2>/dev/null | sort -rn | head -500", .{ quoted, reasonix_filter }) catch error.CommandTooLong;
 }
 
 /// Fallback for environments without GNU `find -printf` (e.g. BSD): path-only,
 /// no stamps. Used when the primary command returns nothing.
 pub fn providerFindCommandPlain(provider: types.ProviderId, root: []const u8, out: []u8) ![]const u8 {
-    _ = provider;
+    var reasonix_root_buf: [1024]u8 = undefined;
+    const find_root = providerFindRoot(provider, root, &reasonix_root_buf) catch return error.CommandTooLong;
     var quoted_buf: [1024]u8 = undefined;
-    const quoted = remote_file.shellQuote(&quoted_buf, root) orelse return error.CommandTooLong;
-    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl' -size -2048k | head -500", .{quoted}) catch error.CommandTooLong;
+    const quoted = remote_file.shellQuote(&quoted_buf, find_root) orelse return error.CommandTooLong;
+    const reasonix_filter = if (provider == .reasonix) " ! -name '*.events.jsonl'" else "";
+    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl'{s} -size -2048k | head -500", .{ quoted, reasonix_filter }) catch error.CommandTooLong;
+}
+
+fn providerFindRoot(provider: types.ProviderId, root: []const u8, out: []u8) ![]const u8 {
+    return switch (provider) {
+        .codex, .claude => root,
+        .reasonix => if (std.mem.eql(u8, std.fs.path.basename(root), "sessions"))
+            root
+        else
+            std.fmt.bufPrint(out, "{s}/sessions", .{root}) catch error.CommandTooLong,
+    };
 }
 
 const RemoteCandidate = struct {
@@ -942,6 +972,12 @@ pub fn remoteCatCommand(path: []const u8, out: []u8) ![]const u8 {
     var quoted_buf: [1024]u8 = undefined;
     const quoted = remote_file.shellQuote(&quoted_buf, path) orelse return error.CommandTooLong;
     return std.fmt.bufPrint(out, "cat {s}", .{quoted}) catch error.CommandTooLong;
+}
+
+pub fn remoteOptionalCatCommand(path: []const u8, out: []u8) ![]const u8 {
+    var quoted_buf: [1024]u8 = undefined;
+    const quoted = remote_file.shellQuote(&quoted_buf, path) orelse return error.CommandTooLong;
+    return std.fmt.bufPrint(out, "cat {s} 2>/dev/null || true", .{quoted}) catch error.CommandTooLong;
 }
 
 pub fn scanRemoteFilesystem(allocator: std.mem.Allocator, source: source_mod.Source, host: RemoteExecHost) !ScanResult {
@@ -990,6 +1026,18 @@ pub fn scanRemoteFilesystemSink(allocator: std.mem.Allocator, source: source_mod
             }
         }
     }
+    if (source.providers.reasonix) {
+        if (source.reasonix_root_override) |root| {
+            try scanner.scanProviderRoot(.reasonix, root);
+        } else {
+            var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (source_mod.defaultRoot(.reasonix, home, &root_buf)) |root| {
+                try scanner.scanProviderRoot(.reasonix, root);
+            } else {
+                scanner.warning_count += 1;
+            }
+        }
+    }
     for (source.extra_roots) |root| {
         if (!providerEnabled(source, root.provider)) continue;
         try scanner.scanProviderRoot(root.provider, root.path);
@@ -1027,6 +1075,7 @@ pub fn loadRemoteTranscript(allocator: std.mem.Allocator, host: RemoteExecHost, 
     return switch (meta.provider) {
         .codex => try codex_provider.parseTranscript(allocator, bytes),
         .claude => try claude_provider.parseTranscript(allocator, bytes),
+        .reasonix => try reasonix_provider.parseTranscript(allocator, bytes),
     };
 }
 
@@ -1040,6 +1089,7 @@ pub fn freeTranscript(allocator: std.mem.Allocator, provider: types.ProviderId, 
     switch (provider) {
         .codex => codex_provider.freeTranscript(allocator, messages),
         .claude => claude_provider.freeTranscript(allocator, messages),
+        .reasonix => reasonix_provider.freeTranscript(allocator, messages),
     }
 }
 
@@ -1197,7 +1247,7 @@ const LocalScan = struct {
                     try self.walkDir(provider, child_path, child);
                 },
                 .file => {
-                    if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+                    if (!providerAcceptsJsonl(provider, abs_path, entry.name)) continue;
                     try self.collectFile(provider, abs_path, dir, entry.name);
                 },
                 else => {},
@@ -1279,6 +1329,7 @@ const LocalScan = struct {
         const meta = (switch (candidate.provider) {
             .codex => codex_provider.parseMetadata(self.allocator, candidate.path, bytes),
             .claude => claude_provider.parseMetadata(self.allocator, candidate.path, bytes),
+            .reasonix => self.parseReasonixMetadata(candidate, bytes),
         }) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
         };
@@ -1312,6 +1363,35 @@ const LocalScan = struct {
         try self.cache_records.append(self.allocator, cloned);
     }
 
+    fn parseReasonixMetadata(self: *LocalScan, candidate: Candidate, transcript_bytes: []const u8) !types.SessionMeta {
+        const meta_bytes = try self.readReasonixSidecar(candidate.path, ".meta.json");
+        defer self.allocator.free(meta_bytes);
+        const events_bytes = try self.readReasonixSidecar(candidate.path, ".events.jsonl");
+        defer self.allocator.free(events_bytes);
+        return try reasonix_provider.parseMetadata(self.allocator, candidate.path, transcript_bytes, meta_bytes, events_bytes);
+    }
+
+    fn readReasonixSidecar(self: *LocalScan, source_path: []const u8, suffix: []const u8) ![]u8 {
+        const sidecar_path = try reasonixSidecarPath(self.allocator, source_path, suffix);
+        defer self.allocator.free(sidecar_path);
+
+        const file = std.fs.openFileAbsolute(sidecar_path, .{}) catch |err| switch (err) {
+            error.FileNotFound => return try self.allocator.alloc(u8, 0),
+            else => {
+                self.warning_count += 1;
+                return try self.allocator.alloc(u8, 0);
+            },
+        };
+        defer file.close();
+        return file.readToEndAlloc(self.allocator, MAX_METADATA_FILE_BYTES) catch |err| switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => {
+                self.warning_count += 1;
+                return try self.allocator.alloc(u8, 0);
+            },
+        };
+    }
+
     fn candidateMoreRecent(_: void, lhs: Candidate, rhs: Candidate) bool {
         if (lhs.mtime == rhs.mtime) return std.mem.lessThan(u8, lhs.path, rhs.path);
         return lhs.mtime > rhs.mtime;
@@ -1322,6 +1402,7 @@ fn providerRootForPath(source: source_mod.Source, provider: types.ProviderId, so
     const explicit = switch (provider) {
         .codex => source.codex_root_override,
         .claude => source.claude_root_override,
+        .reasonix => source.reasonix_root_override,
     };
     if (explicit) |root| return root;
     for (source.extra_roots) |root| {
@@ -1421,6 +1502,7 @@ const RemoteScan = struct {
         const meta = (switch (provider) {
             .codex => codex_provider.parseMetadata(self.allocator, path, bytes),
             .claude => claude_provider.parseMetadata(self.allocator, path, bytes),
+            .reasonix => self.parseReasonixMetadata(path, bytes),
         }) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
         };
@@ -1453,13 +1535,59 @@ const RemoteScan = struct {
         }
         try self.cache_records.append(self.allocator, cloned);
     }
+
+    fn parseReasonixMetadata(self: *RemoteScan, path: []const u8, transcript_bytes: []const u8) !types.SessionMeta {
+        const meta_bytes = try self.readReasonixSidecar(path, ".meta.json");
+        defer self.allocator.free(meta_bytes);
+        const events_bytes = try self.readReasonixSidecar(path, ".events.jsonl");
+        defer self.allocator.free(events_bytes);
+        return try reasonix_provider.parseMetadata(self.allocator, path, transcript_bytes, meta_bytes, events_bytes);
+    }
+
+    fn readReasonixSidecar(self: *RemoteScan, source_path: []const u8, suffix: []const u8) ![]u8 {
+        const sidecar_path = try reasonixSidecarPath(self.allocator, source_path, suffix);
+        defer self.allocator.free(sidecar_path);
+        var command_buf: [2048]u8 = undefined;
+        const command = remoteOptionalCatCommand(sidecar_path, &command_buf) catch {
+            self.warning_count += 1;
+            return try self.allocator.alloc(u8, 0);
+        };
+        return self.host.exec(self.host.ctx, self.allocator, command) catch |err| switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => {
+                self.warning_count += 1;
+                return try self.allocator.alloc(u8, 0);
+            },
+        };
+    }
 };
 
 fn providerEnabled(source: source_mod.Source, provider: types.ProviderId) bool {
     return switch (provider) {
         .codex => source.providers.codex,
         .claude => source.providers.claude,
+        .reasonix => source.providers.reasonix,
     };
+}
+
+fn providerAcceptsJsonl(provider: types.ProviderId, abs_dir: []const u8, name: []const u8) bool {
+    if (!std.mem.endsWith(u8, name, ".jsonl")) return false;
+    return switch (provider) {
+        .codex, .claude => true,
+        .reasonix => std.mem.eql(u8, std.fs.path.basename(abs_dir), "sessions") and
+            !std.mem.endsWith(u8, name, ".events.jsonl"),
+    };
+}
+
+fn reasonixSidecarPath(allocator: std.mem.Allocator, source_path: []const u8, suffix: []const u8) ![]u8 {
+    const stem = if (std.mem.endsWith(u8, source_path, ".jsonl"))
+        source_path[0 .. source_path.len - ".jsonl".len]
+    else
+        source_path;
+    const path = try allocator.alloc(u8, stem.len + suffix.len);
+    @memcpy(path[0..stem.len], stem);
+    @memcpy(path[stem.len..], suffix);
+    return path;
 }
 
 fn metadataHasUsableSignal(meta: types.SessionMeta) bool {
@@ -1511,6 +1639,7 @@ fn cloneSource(allocator: std.mem.Allocator, source: source_mod.Source) !source_
         .providers = source.providers,
         .codex_root_override = null,
         .claude_root_override = null,
+        .reasonix_root_override = null,
         .extra_roots = &.{},
     };
     errdefer freeOwnedSource(allocator, &cloned);
@@ -1524,6 +1653,7 @@ fn cloneSource(allocator: std.mem.Allocator, source: source_mod.Source) !source_
     };
     cloned.codex_root_override = try cloneOptionalSlice(allocator, source.codex_root_override);
     cloned.claude_root_override = try cloneOptionalSlice(allocator, source.claude_root_override);
+    cloned.reasonix_root_override = try cloneOptionalSlice(allocator, source.reasonix_root_override);
     cloned.extra_roots = try cloneProviderRoots(allocator, source.extra_roots);
 
     return cloned;
@@ -1572,6 +1702,7 @@ fn freeOwnedSource(allocator: std.mem.Allocator, source: *source_mod.Source) voi
     }
     if (source.codex_root_override) |value| freeSlice(allocator, value);
     if (source.claude_root_override) |value| freeSlice(allocator, value);
+    if (source.reasonix_root_override) |value| freeSlice(allocator, value);
     for (source.extra_roots) |root| {
         freeSlice(allocator, root.path);
     }
@@ -1609,6 +1740,9 @@ const TestTranscriptHost = struct {
 const FakeRemoteHost = struct {
     const codex_path = "/home/me/.codex/sessions/codex-abc.jsonl";
     const claude_path = "/home/me/.claude/projects/project/claude-abc.jsonl";
+    const reasonix_path = "/home/me/.reasonix/sessions/code-remote.jsonl";
+    const reasonix_meta_path = "/home/me/.reasonix/sessions/code-remote.meta.json";
+    const reasonix_events_path = "/home/me/.reasonix/sessions/code-remote.events.jsonl";
     const codex_jsonl =
         \\{"type":"session_meta","id":"codex-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00Z"}
         \\{"type":"response_item","role":"user","content":[{"type":"input_text","text":"Fix remote renderer"}],"timestamp":"2026-05-31T10:01:00Z"}
@@ -1616,6 +1750,19 @@ const FakeRemoteHost = struct {
     ;
     const claude_jsonl =
         \\{"sessionId":"claude-abc","cwd":"/home/me/project","timestamp":"2026-05-31T10:00:00.000Z","type":"user","message":{"role":"user","content":"Fix remote tests"}}
+        \\
+    ;
+    const reasonix_jsonl =
+        \\{"role":"user","content":"remote reasonix"}
+        \\{"role":"assistant","content":"ok"}
+        \\
+    ;
+    const reasonix_meta_json =
+        \\{"workspace":"/home/me/reasonix-project","summary":"Remote Reasonix","turnCount":1}
+    ;
+    const reasonix_events_jsonl =
+        \\{"type":"session.opened","name":"code-remote","ts":"2026-05-31T10:00:00.000Z"}
+        \\{"type":"model.final","ts":"2026-05-31T10:01:00.000Z"}
         \\
     ;
 
@@ -1635,6 +1782,9 @@ const FakeRemoteHost = struct {
             if (std.mem.indexOf(u8, command, "/home/me/.claude") != null) {
                 return try allocator.dupe(u8, "1700000001\t100\t" ++ claude_path ++ "\n");
             }
+            if (std.mem.indexOf(u8, command, "/home/me/.reasonix") != null) {
+                return try allocator.dupe(u8, "1700000002\t100\t" ++ reasonix_path ++ "\n");
+            }
             return try allocator.dupe(u8, "");
         }
         if (std.mem.eql(u8, command, "cat '" ++ codex_path ++ "'")) {
@@ -1642,6 +1792,15 @@ const FakeRemoteHost = struct {
         }
         if (std.mem.eql(u8, command, "cat '" ++ claude_path ++ "'")) {
             return try allocator.dupe(u8, claude_jsonl);
+        }
+        if (std.mem.eql(u8, command, "cat '" ++ reasonix_path ++ "'")) {
+            return try allocator.dupe(u8, reasonix_jsonl);
+        }
+        if (std.mem.eql(u8, command, "cat '" ++ reasonix_meta_path ++ "' 2>/dev/null || true")) {
+            return try allocator.dupe(u8, reasonix_meta_json);
+        }
+        if (std.mem.eql(u8, command, "cat '" ++ reasonix_events_path ++ "' 2>/dev/null || true")) {
+            return try allocator.dupe(u8, reasonix_events_jsonl);
         }
         return error.UnexpectedCommand;
     }
@@ -1702,6 +1861,7 @@ test "ai_history_session: initOwned clones source identity and ssh roots" {
     var profile_buf = [_]u8{ 'b', 'u', 'i', 'l', 'd', 'b', 'o', 'x' };
     var codex_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'c', 'o', 'd', 'e', 'x' };
     var claude_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'c', 'l', 'a', 'u', 'd', 'e' };
+    var reasonix_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'r', 'e', 'a', 's', 'o', 'n', 'i', 'x' };
     var extra_path_buf = [_]u8{ '/', 't', 'm', 'p', '/', 'e', 'x', 't', 'r', 'a' };
     const extra_roots = [_]source_mod.ProviderRoot{
         .{ .provider = .codex, .path = extra_path_buf[0..] },
@@ -1713,6 +1873,7 @@ test "ai_history_session: initOwned clones source identity and ssh roots" {
         .target = .{ .ssh = .{ .profile_name = profile_buf[0..] } },
         .codex_root_override = codex_buf[0..],
         .claude_root_override = claude_buf[0..],
+        .reasonix_root_override = reasonix_buf[0..],
         .extra_roots = extra_roots[0..],
     });
     defer session.deinit();
@@ -1722,6 +1883,7 @@ test "ai_history_session: initOwned clones source identity and ssh roots" {
     @memset(&profile_buf, 'x');
     @memset(&codex_buf, 'x');
     @memset(&claude_buf, 'x');
+    @memset(&reasonix_buf, 'x');
     @memset(&extra_path_buf, 'x');
 
     try std.testing.expectEqualStrings("ssh-history", session.source.id);
@@ -1729,11 +1891,13 @@ test "ai_history_session: initOwned clones source identity and ssh roots" {
     try std.testing.expectEqualStrings("buildbox", session.source.target.ssh.profile_name);
     try std.testing.expectEqualStrings("/tmp/codex", session.source.codex_root_override.?);
     try std.testing.expectEqualStrings("/tmp/claude", session.source.claude_root_override.?);
+    try std.testing.expectEqualStrings("/tmp/reasonix", session.source.reasonix_root_override.?);
     try std.testing.expectEqual(@as(usize, 1), session.source.extra_roots.len);
     try std.testing.expectEqualStrings("/tmp/extra", session.source.extra_roots[0].path);
     try std.testing.expect(session.source.id.ptr != id_buf[0..].ptr);
     try std.testing.expect(session.source.name.ptr != name_buf[0..].ptr);
     try std.testing.expect(session.source.target.ssh.profile_name.ptr != profile_buf[0..].ptr);
+    try std.testing.expect(session.source.reasonix_root_override.?.ptr != reasonix_buf[0..].ptr);
     try std.testing.expect(session.source.extra_roots.ptr != extra_roots[0..].ptr);
     try std.testing.expect(session.source.extra_roots[0].path.ptr != extra_path_buf[0..].ptr);
 }
@@ -1849,13 +2013,17 @@ test "ai_history_session: remote scan uses fake host JSONL bytes" {
     }, fake.remoteExecHost());
     defer freeScanResult(allocator, result);
 
-    try std.testing.expectEqual(@as(usize, 2), result.rows.len);
+    try std.testing.expectEqual(@as(usize, 3), result.rows.len);
     try std.testing.expectEqual(@as(u32, 0), result.warning_count);
     try std.testing.expectEqual(types.ProviderId.codex, result.rows[0].provider);
     try std.testing.expectEqualStrings("codex-abc", result.rows[0].session_id);
     try std.testing.expectEqualStrings("/home/me/project", result.rows[0].project_dir);
     try std.testing.expectEqual(types.ProviderId.claude, result.rows[1].provider);
     try std.testing.expectEqualStrings("claude-abc", result.rows[1].session_id);
+    try std.testing.expectEqual(types.ProviderId.reasonix, result.rows[2].provider);
+    try std.testing.expectEqualStrings("code-remote", result.rows[2].session_id);
+    try std.testing.expectEqualStrings("/home/me/reasonix-project", result.rows[2].project_dir);
+    try std.testing.expectEqualStrings("Remote Reasonix", result.rows[2].summary);
 }
 
 test "ai_history_session: remote transcript loads from fake host" {
@@ -2175,10 +2343,69 @@ test "ai_history_session: scanLocalFilesystem reads codex and claude jsonl files
         switch (row.provider) {
             .codex => codex_count += 1,
             .claude => claude_count += 1,
+            .reasonix => {},
         }
     }
     try std.testing.expectEqual(@as(usize, 1), codex_count);
     try std.testing.expectEqual(@as(usize, 1), claude_count);
+}
+
+test "ai_history_session: scanLocalFilesystem reads reasonix sessions with sidecars" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".reasonix/sessions");
+    try tmp.dir.writeFile(.{
+        .sub_path = ".reasonix/sessions/code-demo.jsonl",
+        .data =
+        \\{"role":"user","content":"hello"}
+        \\{"role":"assistant","content":"Hi"}
+        \\
+        ,
+    });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".reasonix/sessions/code-demo.meta.json",
+        .data =
+        \\{"workspace":"/tmp/reasonix-project","summary":"Reasonix summary","turnCount":1}
+        ,
+    });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".reasonix/sessions/code-demo.events.jsonl",
+        .data =
+        \\{"type":"session.opened","name":"code-demo","ts":"2026-05-26T13:53:34.400Z"}
+        \\{"type":"model.final","ts":"2026-05-26T13:54:59.393Z"}
+        \\
+        ,
+    });
+    try tmp.dir.writeFile(.{
+        .sub_path = ".reasonix/usage.jsonl",
+        .data =
+        \\{"not":"a session"}
+        ,
+    });
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const result = try scanLocalFilesystem(allocator, .{
+        .id = "local",
+        .name = "Local",
+        .target = .local,
+        .providers = .{ .codex = false, .claude = false, .reasonix = true },
+    }, home);
+    defer freeScanResult(allocator, result);
+
+    try std.testing.expectEqual(@as(usize, 1), result.rows.len);
+    try std.testing.expectEqual(@as(u32, 0), result.warning_count);
+    const row = result.rows[0];
+    try std.testing.expectEqual(types.ProviderId.reasonix, row.provider);
+    try std.testing.expectEqualStrings("code-demo", row.session_id);
+    try std.testing.expectEqualStrings("Reasonix summary", row.title);
+    try std.testing.expectEqualStrings("Reasonix summary", row.summary);
+    try std.testing.expectEqualStrings("/tmp/reasonix-project", row.project_dir);
+    try std.testing.expectEqual(types.ResumeKind.reasonix_resume, row.resume_kind);
+    try std.testing.expectEqual(@as(u32, 2), row.message_count);
+    try std.testing.expect(row.last_active_at_ms > row.created_at_ms);
 }
 
 test "ai_history_session: scanNow failure marks failed and preserves existing rows" {
@@ -2239,7 +2466,7 @@ test "ai_history_session: scanLocalFilesystem skips unusable metadata with warni
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home);
     defer freeScanResult(allocator, result);
 
@@ -2272,7 +2499,7 @@ test "ai_history_session: scanLocalFilesystem budget returns partial rows with w
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home, .{ .max_files = 1, .max_bytes = 1024 * 1024 });
     defer freeScanResult(allocator, result);
 
@@ -2311,7 +2538,7 @@ test "ai_history_session: scanLocalFilesystem reuses unchanged cached metadata" 
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home, .{}, null);
     defer freeScanResult(allocator, first);
     try std.testing.expectEqual(@as(usize, 1), first.cache_update.records.len);
@@ -2330,7 +2557,7 @@ test "ai_history_session: scanLocalFilesystem reuses unchanged cached metadata" 
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home, .{}, .{ .records = @constCast(&records) });
     defer freeScanResult(allocator, result);
 
@@ -2413,9 +2640,11 @@ test "ai_history_session: cycleCategory wraps forward and backward" {
     session.cycleCategory(1);
     try std.testing.expectEqual(types.CategoryFilter.claude, session.category);
     session.cycleCategory(1);
+    try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
+    session.cycleCategory(1);
     try std.testing.expectEqual(types.CategoryFilter.all, session.category);
     session.cycleCategory(-1);
-    try std.testing.expectEqual(types.CategoryFilter.claude, session.category);
+    try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
 }
 
 test "ai_history_session: finishScan applies rows when generation current" {
@@ -2909,7 +3138,7 @@ test "ai_history_session: local scan with sink streams rows and returns empty no
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home, .{}, null, collect.sink());
     defer freeScanResult(allocator, result);
 
@@ -2932,7 +3161,7 @@ test "ai_history_session: remote scan with sink streams rows and returns empty n
         .id = "wsl",
         .name = "WSL",
         .target = .{ .wsl = .{} },
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, host, null, collect.sink());
     defer freeScanResult(allocator, result);
 
@@ -3034,7 +3263,7 @@ test "ai_history_session: local scan warm cache publishes provisional batch then
         .id = "local",
         .name = "Local",
         .target = .local,
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, home, .{}, cache, collect.sink());
     defer freeScanResult(allocator, result);
 
@@ -3053,6 +3282,14 @@ test "ai_history_session: providerFindCommand emits sorted mtime/size/path" {
     try std.testing.expect(std.mem.indexOf(u8, cmd, "-printf '%T@\\t%s\\t%p\\n'") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "sort -rn") != null);
     try std.testing.expect(std.mem.indexOf(u8, cmd, "'/home/me/.codex'") != null);
+
+    const reasonix_cmd = try providerFindCommand(.reasonix, "/home/me/.reasonix", &buf);
+    try std.testing.expect(std.mem.indexOf(u8, reasonix_cmd, "'/home/me/.reasonix/sessions'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, reasonix_cmd, "! -name '*.events.jsonl'") != null);
+
+    const reasonix_sessions_cmd = try providerFindCommand(.reasonix, "/home/me/.reasonix/sessions", &buf);
+    try std.testing.expect(std.mem.indexOf(u8, reasonix_sessions_cmd, "'/home/me/.reasonix/sessions/sessions'") == null);
+    try std.testing.expect(std.mem.indexOf(u8, reasonix_sessions_cmd, "'/home/me/.reasonix/sessions'") != null);
 }
 
 test "ai_history_session: parseRemoteStamp parses tab fields and tolerates plain paths" {
@@ -3096,7 +3333,7 @@ test "ai_history_session: remote scan skips cat on cache hit" {
         .id = "wsl",
         .name = "WSL",
         .target = .{ .wsl = .{} },
-        .providers = .{ .codex = true, .claude = false },
+        .providers = .{ .codex = true, .claude = false, .reasonix = false },
     }, host, cache, null);
     defer freeScanResult(allocator, result);
 

--- a/src/ai_history_source.zig
+++ b/src/ai_history_source.zig
@@ -13,6 +13,7 @@ pub const SshTargetRef = struct { profile_name: []const u8 };
 pub const ProviderFlags = packed struct {
     codex: bool = true,
     claude: bool = true,
+    reasonix: bool = true,
 };
 
 pub const ProviderRoot = struct {
@@ -27,6 +28,7 @@ pub const Source = struct {
     providers: ProviderFlags = .{},
     codex_root_override: ?[]const u8 = null,
     claude_root_override: ?[]const u8 = null,
+    reasonix_root_override: ?[]const u8 = null,
     extra_roots: []const ProviderRoot = &.{},
 };
 
@@ -34,6 +36,7 @@ pub fn defaultRoot(provider: types.ProviderId, home: []const u8, out: []u8) ?[]c
     const suffix = switch (provider) {
         .codex => ".codex",
         .claude => ".claude",
+        .reasonix => ".reasonix",
     };
     return std.fmt.bufPrint(out, "{s}/{s}", .{ home, suffix }) catch null;
 }
@@ -42,4 +45,5 @@ test "ai_history_source: default provider roots use target home" {
     var buf: [128]u8 = undefined;
     try std.testing.expectEqualStrings("/home/me/.codex", defaultRoot(.codex, "/home/me", &buf).?);
     try std.testing.expectEqualStrings("/home/me/.claude", defaultRoot(.claude, "/home/me", &buf).?);
+    try std.testing.expectEqualStrings("/home/me/.reasonix", defaultRoot(.reasonix, "/home/me", &buf).?);
 }

--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -3,11 +3,13 @@ const std = @import("std");
 pub const ProviderId = enum {
     codex,
     claude,
+    reasonix,
 
     pub fn label(self: ProviderId) []const u8 {
         return switch (self) {
             .codex => "Codex",
             .claude => "Claude Code",
+            .reasonix => "Reasonix",
         };
     }
 };
@@ -16,6 +18,7 @@ pub const CategoryFilter = enum {
     all,
     codex,
     claude,
+    reasonix,
 };
 
 pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
@@ -23,6 +26,7 @@ pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
         .all => true,
         .codex => provider == .codex,
         .claude => provider == .claude,
+        .reasonix => provider == .reasonix,
     };
 }
 
@@ -31,6 +35,7 @@ pub fn categoryLabel(category: CategoryFilter) []const u8 {
         .all => "All",
         .codex => "Codex",
         .claude => "Claude Code",
+        .reasonix => "Reasonix",
     };
 }
 
@@ -76,7 +81,7 @@ pub fn formatDateKey(key: DateKey, buf: []u8) []const u8 {
 pub const MessageRole = enum { user, assistant, system, tool };
 pub const MessageKind = enum { normal, tool_call, tool_result, meta };
 pub const ScanStatus = enum { ok, partial, not_found, invalid };
-pub const ResumeKind = enum { codex_resume, claude_resume, unavailable };
+pub const ResumeKind = enum { codex_resume, claude_resume, reasonix_resume, unavailable };
 
 pub const SessionMeta = struct {
     provider: ProviderId,
@@ -137,6 +142,7 @@ fn containsIgnoreCase(haystack: []const u8, query: []const u8) bool {
 test "ai_history_types: provider labels are stable" {
     try std.testing.expectEqualStrings("Codex", ProviderId.codex.label());
     try std.testing.expectEqualStrings("Claude Code", ProviderId.claude.label());
+    try std.testing.expectEqualStrings("Reasonix", ProviderId.reasonix.label());
 }
 
 test "ai_history_types: metadata search covers title summary project session and path" {
@@ -196,12 +202,15 @@ test "ai_history_types: categoryMatches respects provider" {
     try std.testing.expect(!categoryMatches(.codex, .claude));
     try std.testing.expect(categoryMatches(.claude, .claude));
     try std.testing.expect(!categoryMatches(.claude, .codex));
+    try std.testing.expect(categoryMatches(.reasonix, .reasonix));
+    try std.testing.expect(!categoryMatches(.reasonix, .codex));
 }
 
 test "ai_history_types: categoryLabel is stable" {
     try std.testing.expectEqualStrings("All", categoryLabel(.all));
     try std.testing.expectEqualStrings("Codex", categoryLabel(.codex));
     try std.testing.expectEqualStrings("Claude Code", categoryLabel(.claude));
+    try std.testing.expectEqualStrings("Reasonix", categoryLabel(.reasonix));
 }
 
 test "ai_history_types: dateKeyFromMs packs local civil date and handles sentinels" {

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -71,7 +71,7 @@ pub fn leftColumnLayout(top: f32, cell_h: f32) LeftColumnLayout {
     y += cell_h + 8;
     const category_rows_top = y;
     const category_row_h = cell_h + 10;
-    y += category_row_h * 3;
+    y += category_row_h * 4;
     y += 12;
     const retry_text_top = y;
     // DATE navigator: below the Refresh button, filling the rest of the column.
@@ -202,7 +202,7 @@ pub fn interactionHitTest(
     const my: f32 = @floatCast(mouse_y);
 
     const lc = leftColumnLayout(top, cell_h);
-    const categories = [_]types.CategoryFilter{ .all, .codex, .claude };
+    const categories = [_]types.CategoryFilter{ .all, .codex, .claude, .reasonix };
     for (categories, 0..) |cat, i| {
         const cat_top = lc.category_rows_top + @as(f32, @floatFromInt(i)) * lc.category_row_h;
         if (rectContains(mx, my, layout.left_x, cat_top, layout.left_w, lc.category_row_h)) {
@@ -355,7 +355,7 @@ fn renderLeftColumn(
     const query = session.filter[0..session.filter_len];
     const counts = session.categoryCounts(query);
     const selected_bg = mixColor(draw.bg, accent, 0.18);
-    const categories = [_]types.CategoryFilter{ .all, .codex, .claude };
+    const categories = [_]types.CategoryFilter{ .all, .codex, .claude, .reasonix };
     for (categories, 0..) |cat, i| {
         const row_top = lc.category_rows_top + @as(f32, @floatFromInt(i)) * lc.category_row_h;
         const active = session.category == cat;
@@ -370,6 +370,7 @@ fn renderLeftColumn(
             .all => counts.all,
             .codex => counts.codex,
             .claude => counts.claude,
+            .reasonix => counts.reasonix,
         };
         var num_buf: [16]u8 = undefined;
         const num_text = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch "";
@@ -473,11 +474,12 @@ fn renderList(
         const empty = if (session.state == .scanning)
             "Scanning AI history..."
         else if (session.rows.items.len == 0)
-            "No Codex or Claude Code history found"
+            "No AI history found"
         else switch (session.category) {
             .all => "No sessions match filter",
             .codex => "No Codex sessions",
             .claude => "No Claude Code sessions",
+            .reasonix => "No Reasonix sessions",
         };
         _ = draw.renderTextLimited(empty, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top + 24), muted, layout.list_w - PAD_X * 2);
     }
@@ -996,6 +998,12 @@ test "ai_history_renderer: interaction hit test maps category rows" {
     try std.testing.expectEqual(
         Hit{ .category = .claude },
         interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + 10, claude_y),
+    );
+
+    const reasonix_y = lc.category_rows_top + lc.category_row_h * 3.5;
+    try std.testing.expectEqual(
+        Hit{ .category = .reasonix },
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + 10, reasonix_y),
     );
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3379,7 +3379,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("WSL", platform_pty_command.wslLauncherDetail()));
     }
     desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ai_agent, defaultAiModeLabel()));
-    desired = @max(desired, sessionTwoColumnWidth("AI History", "Browse Codex / Claude Code"));
+    desired = @max(desired, sessionTwoColumnWidth("AI History", "Browse AI agent history"));
     return desired;
 }
 
@@ -3688,7 +3688,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             row += 1;
         }
         renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT, i18n.s().sl_ai_agent, defaultAiModeLabel(), g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT);
-        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, "AI History", "Browse Codex / Claude Code", g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
+        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, "AI History", "Browse AI agent history", g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
         return;
     }
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -49,6 +49,7 @@ test {
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");
+    _ = @import("ai_history_provider_reasonix.zig");
     _ = @import("ai_history_source.zig");
     _ = @import("ai_history_cache.zig");
     _ = @import("ai_history_resume.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -471,6 +471,7 @@ comptime {
     }
     if (std.mem.indexOf(u8, overlays_source, ".codex") != null or
         std.mem.indexOf(u8, overlays_source, ".claude") != null or
+        std.mem.indexOf(u8, overlays_source, ".reasonix") != null or
         std.mem.indexOf(u8, overlays_source, "parseMetadata") != null)
     {
         @compileError("renderer/overlays.zig must only launch AI History sources; provider scanning belongs in ai_history modules");
@@ -614,6 +615,7 @@ comptime {
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");
+    _ = @import("ai_history_provider_reasonix.zig");
     _ = @import("ai_history_source.zig");
     _ = @import("ai_history_cache.zig");
     _ = @import("ai_history_resume.zig");


### PR DESCRIPTION
## Summary

Adds Reasonix as a third AI History provider alongside Codex and Claude Code.

- scans $HOME/.reasonix/sessions for Reasonix transcripts and sidecar metadata
- parses Reasonix transcript, meta, and events files into AI History rows and previews
- resumes Reasonix sessions with reasonix chat --session <name> --resume
- adds the Reasonix category to the AI History sidebar and updates user-visible docs

## Validation

- zig build test
- zig build test-full
- git diff --check
- Windows checkout path-safety equivalent check: 0 name violations, 0 casefold collisions, no tracked symlinks
