### PR TITLE
feat(splits): Alt-drag to swap panels within a tab

### DIFF
--- a/docs/superpowers/specs/2026-06-03-panel-swap-design.md
+++ b/docs/superpowers/specs/2026-06-03-panel-swap-design.md
@@ -1,0 +1,179 @@
+# Panel Swap via Alt-Drag — Design
+
+Date: 2026-06-03
+Status: Approved, ready for implementation
+Branch: `worktree-feat-enhancer-panel-control`
+
+## Problem
+
+Within a single tab, panels (terminal surfaces in the `SplitTree`) can today only
+be **created** (`splitFocused` → `tree.split`) and **closed**
+(`closeFocusedSplit` → `tree.remove`). There is no way to **rearrange** them. Users
+want to swap two panels' positions, driven by the mouse.
+
+## Goal
+
+Add a mouse gesture that swaps the contents of two panels within a tab:
+
+- **Gesture:** hold **Alt** and left-drag from a source panel, drop onto a target
+  panel; on release the two panels' contents are swapped.
+- **Semantics:** swap the two leaves' `*Surface` only. The split-tree topology,
+  layout, and ratios are **unchanged**. Any two panels in the tab can be swapped,
+  not just adjacent ones.
+- **Feedback:** during the drag the source panel dims, the hovered target panel
+  gets a highlight border, and the cursor becomes the `size_all` (4-way move) shape.
+
+Non-goals (YAGNI for v1):
+
+- Keyboard shortcut / command-palette entry (the request is mouse-driven).
+- Topology-changing "move panel to a new edge" (re-parenting subtrees).
+- A floating thumbnail/ghost of the dragged panel.
+
+## Why "swap leaves" (chosen approach)
+
+Three options were considered for the core operation:
+
+| Option | Approach | Trade-off |
+|--------|----------|-----------|
+| **A. In-place leaf-surface swap (CHOSEN)** | Swap the two `*Surface` pointers at the two leaf nodes. Topology/ratio unchanged, no ref-count change, O(1), no allocation. Same mutable pattern as `resizeInPlace`/`zoom`. | Simplest and most predictable. No undo support — but the project has no split undo anyway. |
+| B. Clone-and-swap into a new tree | Honors the "immutable tree" doc comment; leaves room for future undo/redo. | Extra allocation + `refNodes` for no current benefit (no undo system, topology unchanged). |
+| C. `remove` + `split` to physically move the node | Truly mutates topology. | Overkill; changes ratios/layout; error-prone; it is a "move", not a "swap". |
+
+Option A is chosen.
+
+## Components
+
+### 1. `src/split_tree.zig` — new operation
+
+```zig
+/// Swap the surfaces held by two leaf nodes in place. Both handles MUST refer
+/// to leaf nodes (asserted). Topology, layout, ratios, zoom state, and
+/// reference counts are all unchanged — only the two *Surface pointers swap.
+pub fn swapLeaves(self: *SplitTree, a: Node.Handle, b: Node.Handle) void
+```
+
+- Asserts `a.idx()` and `b.idx()` are in range and both nodes are `.leaf`.
+- Uses the same `@constCast` pattern as `resizeInPlace` to mutate the owned nodes.
+- `a == b` is a harmless no-op (still valid).
+- Does **not** touch `zoomed`: the zoomed handle refers to a slot, and swapping the
+  surface in a slot keeps the zoom on that slot. (Dragging while a panel is zoomed
+  is practically impossible since the other panels aren't visible.)
+
+### 2. `src/appwindow/tab.zig` — wrapper
+
+```zig
+/// Swap the panels at handles `a` (drag source) and `b` (drop target).
+/// Focus follows the dragged surface to the target slot. Returns true on success.
+pub fn swapPanels(a: SplitTree.Node.Handle, b: SplitTree.Node.Handle) bool
+```
+
+- Returns `false` if: no active tab, tab is not `.terminal`, either handle is out of
+  range, either node is not a leaf, or `a == b`. (Defensive: a shell may have exited
+  mid-drag and changed the tree.)
+- Calls `t.tree.swapLeaves(a, b)`.
+- Sets `t.focused = b` so focus follows the dragged surface to its new slot.
+- Returns `true`. The caller (input layer) is responsible for
+  `split_layout.invalidateCachedRects()`, `AppWindow.g_force_rebuild = true`, and
+  `AppWindow.handleActiveSurfaceChangeWithinTab()`.
+
+### 3. `src/input.zig` — Alt-drag state machine
+
+Modeled on the existing `g_divider_drag*` and sidebar-tab-drag patterns.
+
+New thread-local state:
+- `g_panel_swap_source: ?SplitTree.Node.Handle`
+- `g_panel_swap_target: ?SplitTree.Node.Handle`
+- `g_panel_swap_start_x: f64`, `g_panel_swap_start_y: f64`
+- `g_panel_swap_active: bool`
+
+New helper:
+- `panelHandleAtPoint(x, y) ?SplitTree.Node.Handle` — scans `split_layout.g_split_rects`
+  (skipping non-live rects), returns the handle of the panel containing the point.
+
+New constant: `PANEL_SWAP_DRAG_THRESHOLD_PX` (~6px).
+
+Flow:
+- **Mouse press** (left button + `ev.alt`, active tab is terminal, `tree.isSplit()`):
+  record `g_panel_swap_source = panelHandleAtPoint(...)`, save start coords, focus the
+  source panel, set cursor to `size_all`, and `return` (do **not** enter selection).
+  If `tree.isSplit()` is false (single panel) the gesture is not engaged and input
+  falls through to default behavior.
+- **Mouse move** while a source is recorded: if not yet `active`, engage `active`
+  once the move distance exceeds `PANEL_SWAP_DRAG_THRESHOLD_PX` (and clear
+  `g_selecting`). Once active, compute `g_panel_swap_target = panelHandleAtPoint(...)`,
+  but set it to `null` when the point is over the source itself, over a divider, or
+  outside any panel. Trigger a rebuild so the highlight updates.
+- **Mouse release** while a source is recorded: if `g_panel_swap_active` and the
+  target is non-null and `!= source`, call `tab.swapPanels(source, target)` and (on
+  success) invalidate rects + force rebuild + `handleActiveSurfaceChangeWithinTab`.
+  Otherwise cancel. Always reset swap state and restore the cursor. Consume the event.
+- `cancelTransientMouseState` resets all swap state too.
+
+The press-time check is added **before** the existing divider / selection / URL-open
+logic so Alt-drag is intercepted cleanly.
+
+### 4. `src/AppWindow.zig` per-panel render loop + `src/renderer/overlays.zig` — feedback
+
+In the per-split render loop (`for (0..split_count)`), when `input.g_panel_swap_active`:
+- If `rect.handle == g_panel_swap_source`: dim it via the existing
+  `overlays.renderUnfocusedOverlaySimple(width, height)` (even if it is the focused
+  panel).
+- Else if `rect.handle == g_panel_swap_target`: draw
+  `overlays.renderSwapTargetHighlight(width, height)`.
+- Else: existing non-focused dim logic applies unchanged.
+
+New overlay helper in `overlays.zig`:
+```zig
+/// Accent-colored highlight for a panel that is the current swap drop target:
+/// a faint accent fill plus an accent border, drawn in the panel's own viewport.
+pub fn renderSwapTargetHighlight(width: f32, height: f32) void
+```
+Implemented with `ui_pipeline.fillQuadAlpha` (faint `mixColor(bg, accent, …)` fill +
+four thin border quads in `accent = AppWindow.g_theme.cursor_color`).
+
+## Data flow
+
+```
+Alt + left press in panel P (tab is split)
+  → input: g_panel_swap_source = handle(P), focus P, cursor = size_all
+move (> threshold)
+  → input: g_panel_swap_active = true; g_panel_swap_target = handle under cursor
+  → render: source dimmed, target highlighted
+release over target T (T != P)
+  → input: tab.swapPanels(handle(P), handle(T))
+      → split_tree.swapLeaves: swap *Surface at the two leaves
+      → tab: focus follows to T's slot
+  → input: invalidate rects + force rebuild + active-surface-change
+  → reset swap state, restore cursor
+```
+
+## Edge cases
+
+- **Single panel (not split):** gesture not engaged; default behavior (Alt-drag is
+  not otherwise used for selection).
+- **Release over source / divider / outside any panel:** cancel, no swap.
+- **Drag never crosses threshold (Alt-click):** treated as a focus click on the
+  source panel; no swap, no selection.
+- **Shell exits mid-drag and mutates the tree:** stored handles may be stale;
+  `swapPanels` validates range + leaf-ness and returns `false`, so nothing happens.
+- **Zoomed panel:** zoom is left untouched; in practice the other panels aren't
+  visible to drop onto.
+
+## Testing
+
+- `src/split_tree.zig`: unit test for `swapLeaves` using the existing sentinel-surface
+  pattern (see `fromSnapshot` tests):
+  - After swapping two leaves, the two slots' surface pointers are exchanged.
+  - `layout`, `ratio`, and all `Node.Handle`s are unchanged.
+  - Swapping the same pair twice restores the original arrangement.
+- Register the new test file usage if needed (split_tree tests already run; confirm
+  via `test_fast.zig` / `test_main.zig` wiring).
+- Input/render glue follows the project's GUI-verify convention (not unit-tested);
+  verify manually on macOS/Windows.
+
+## Out of scope / future
+
+- Keyboard `swap_panel_*` keybind and command-palette entry.
+- Topology-changing move (drop on a panel edge to re-split).
+- Floating ghost thumbnail of the dragged panel.
+- Optional: a one-line mention of the gesture in the help/shortcuts overlay.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2086,6 +2086,19 @@ pub fn equalizeSplits() void {
     }
 }
 
+/// Swap the contents of two panels (drag source `a`, drop target `b`) within
+/// the active tab. Returns whether a swap happened so the input layer can avoid
+/// redundant work on a no-op. Topology is unchanged, so cached rects only need
+/// to be re-pointed at their (swapped) surfaces — invalidate and rebuild.
+pub fn swapPanels(a: SplitTree.Node.Handle, b: SplitTree.Node.Handle) bool {
+    if (!tab.swapPanels(a, b)) return false;
+    split_layout.invalidateCachedRects();
+    handleActiveSurfaceChangeWithinTab();
+    g_force_rebuild = true;
+    g_cells_valid = false;
+    return true;
+}
+
 // Embed the font
 // Embedded fallback font (JetBrains Mono, like Ghostty)
 const embedded = @import("font/embedded.zig");
@@ -5105,8 +5118,17 @@ fn runMainLoop(self: *AppWindow) !void {
                         // Render scrollbar for this surface within its viewport
                         overlays.renderScrollbarForSurface(rect.surface, @floatFromInt(rect.width), @floatFromInt(rect.height), @floatFromInt(pad.top));
 
-                        // Draw unfocused overlay if not focused
-                        if (!is_focused) {
+                        // Alt-drag panel swap feedback: highlight the drop target,
+                        // dim the grabbed source. Otherwise dim any unfocused panel.
+                        const is_swap_target = input.g_panel_swap_active and
+                            input.g_panel_swap_target != null and
+                            rect.handle == input.g_panel_swap_target.?;
+                        const is_swap_source = input.g_panel_swap_active and
+                            input.g_panel_swap_source != null and
+                            rect.handle == input.g_panel_swap_source.?;
+                        if (is_swap_target) {
+                            overlays.renderSwapTargetHighlight(@floatFromInt(rect.width), @floatFromInt(rect.height));
+                        } else if (is_swap_source or !is_focused) {
                             overlays.renderUnfocusedOverlaySimple(@floatFromInt(rect.width), @floatFromInt(rect.height));
                         }
 

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -835,6 +835,27 @@ pub fn equalizeSplits(allocator: std.mem.Allocator) bool {
     return true;
 }
 
+/// Swap the panels at handles `a` (drag source) and `b` (drop target). The two
+/// leaves exchange their surfaces; the split-tree topology and ratios are
+/// unchanged. Focus follows the dragged surface to the target slot.
+///
+/// Returns false (no-op) if there is no terminal tab, either handle is out of
+/// range, either node is not a leaf, or `a == b`. The leaf/range checks are
+/// defensive: a shell may have exited mid-drag and reshaped the tree, leaving
+/// the caller holding stale handles.
+pub fn swapPanels(a: SplitTree.Node.Handle, b: SplitTree.Node.Handle) bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    if (a == b) return false;
+    if (a.idx() >= t.tree.nodes.len or b.idx() >= t.tree.nodes.len) return false;
+    if (t.tree.nodes[a.idx()] != .leaf or t.tree.nodes[b.idx()] != .leaf) return false;
+
+    t.tree.swapLeaves(a, b);
+    // The dragged surface (was at `a`) now lives at `b`; keep it focused.
+    t.focused = b;
+    return true;
+}
+
 // ============================================================================
 // Tab rename
 // ============================================================================

--- a/src/input.zig
+++ b/src/input.zig
@@ -212,6 +212,18 @@ pub threadlocal var g_divider_hover: bool = false; // Mouse is over a divider
 pub threadlocal var g_divider_dragging: bool = false; // Currently dragging a divider
 pub threadlocal var g_divider_drag_handle: ?SplitTree.Node.Handle = null; // Handle of the split node being resized
 pub threadlocal var g_divider_drag_layout: ?SplitTree.Split.Layout = null; // horizontal or vertical
+
+// Alt + left-drag panel swap. `source` is the grabbed panel (recorded on press),
+// `target` is the panel under the cursor while dragging (drives the highlight),
+// `active` flips true once the drag passes PANEL_SWAP_DRAG_THRESHOLD_PX. The
+// renderer reads `g_panel_swap_active`/`source`/`target` to dim the source and
+// highlight the drop target.
+const PANEL_SWAP_DRAG_THRESHOLD_PX: f64 = 6.0;
+pub threadlocal var g_panel_swap_active: bool = false;
+pub threadlocal var g_panel_swap_source: ?SplitTree.Node.Handle = null;
+pub threadlocal var g_panel_swap_target: ?SplitTree.Node.Handle = null;
+threadlocal var g_panel_swap_start_x: f64 = 0;
+threadlocal var g_panel_swap_start_y: f64 = 0;
 threadlocal var g_scrollbar_drag_surface: ?*Surface = null;
 threadlocal var g_scrollbar_drag_view_y: f32 = 0;
 threadlocal var g_scrollbar_drag_view_h: f32 = 0;
@@ -375,6 +387,7 @@ pub fn cancelTransientMouseState(win: anytype) void {
     g_selecting = false;
     plus_btn_pressed = false;
     tab.g_tab_close_pressed = null;
+    resetPanelSwapState();
     resetSidebarTabDragState();
     overlays.scrollbar.g_scrollbar_dragging = false;
     g_scrollbar_drag_surface = null;
@@ -723,6 +736,90 @@ pub fn updateFocusFromMouse(mouse_x: i32, mouse_y: i32) void {
             return;
         }
     }
+}
+
+/// Return the split-tree handle of the panel containing the given window point,
+/// or null if the point is not inside any (live) panel rect — e.g. it is over a
+/// divider gap or outside the content area.
+fn panelHandleAtPoint(x: i32, y: i32) ?SplitTree.Node.Handle {
+    for (0..split_layout.g_split_rect_count) |i| {
+        const rect = split_layout.g_split_rects[i];
+        if (!split_layout.cachedRectIsLive(rect)) continue;
+        if (x >= rect.x and x < rect.x + rect.width and
+            y >= rect.y and y < rect.y + rect.height)
+        {
+            return rect.handle;
+        }
+    }
+    return null;
+}
+
+fn resetPanelSwapState() void {
+    g_panel_swap_active = false;
+    g_panel_swap_source = null;
+    g_panel_swap_target = null;
+    g_panel_swap_start_x = 0;
+    g_panel_swap_start_y = 0;
+}
+
+/// Begin a potential Alt-drag panel swap if the active terminal tab is split and
+/// the press landed inside a panel. Returns true if the gesture was engaged (the
+/// caller should consume the event). Single-panel tabs are left alone so default
+/// click/selection behavior is unchanged.
+fn beginPanelSwapIfSplit(x: i32, y: i32) bool {
+    const t = tab.activeTab() orelse return false;
+    if (t.kind != .terminal or !t.tree.isSplit()) return false;
+    const source = panelHandleAtPoint(x, y) orelse return false;
+    g_panel_swap_source = source;
+    g_panel_swap_target = null;
+    g_panel_swap_active = false;
+    g_panel_swap_start_x = @floatFromInt(x);
+    g_panel_swap_start_y = @floatFromInt(y);
+    platform_cursor.set(.size_all);
+    return true;
+}
+
+/// Drive an in-progress panel swap from a mouse-move. Returns true while the
+/// gesture owns the move (caller should return early). Engages `active` once the
+/// drag passes the threshold, then tracks the hovered drop target for highlight.
+fn updatePanelSwapDrag(x: i32, y: i32) bool {
+    const source = g_panel_swap_source orelse return false;
+
+    if (!g_panel_swap_active) {
+        const dx = @as(f64, @floatFromInt(x)) - g_panel_swap_start_x;
+        const dy = @as(f64, @floatFromInt(y)) - g_panel_swap_start_y;
+        if (@sqrt(dx * dx + dy * dy) < PANEL_SWAP_DRAG_THRESHOLD_PX) return true;
+        g_panel_swap_active = true;
+        g_selecting = false;
+    }
+
+    // The drop target is the hovered panel, but never the source itself.
+    const hovered = panelHandleAtPoint(x, y);
+    const target: ?SplitTree.Node.Handle = if (hovered) |h| (if (h == source) null else h) else null;
+    if (target != g_panel_swap_target) {
+        g_panel_swap_target = target;
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+    }
+    platform_cursor.set(.size_all);
+    return true;
+}
+
+/// Finish a panel swap on mouse-up. Returns true if a swap gesture was in
+/// progress (caller should consume the event). Performs the swap only when the
+/// drag was active and dropped on a valid, different panel.
+fn finishPanelSwapDrag() bool {
+    const source = g_panel_swap_source orelse return false;
+    const did_swap = g_panel_swap_active;
+    const target = g_panel_swap_target;
+    resetPanelSwapState();
+    if (did_swap) {
+        if (target) |t| _ = AppWindow.swapPanels(source, t);
+    }
+    // The press set the size_all cursor; restore it whether or not a swap
+    // happened (a bare Alt-click never crossed the drag threshold).
+    platform_cursor.set(.arrow);
+    return true;
 }
 
 /// Process all queued platform input events. Called once per frame from the main loop.
@@ -2705,6 +2802,18 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         }
     }
 
+    // Alt + left-press begins a panel swap when the active terminal tab is
+    // split. Intercept here — before terminal mouse-reporting — so the gesture
+    // works even when the panel runs a full-screen mouse-tracking program. Only
+    // engages when the press lands inside a panel of a split tab; otherwise it
+    // falls through to the normal handling below.
+    if (ev.button == .left and ev.action == .press and ev.alt) {
+        if (beginPanelSwapIfSplit(ev.x, ev.y)) {
+            updateFocusFromMouse(ev.x, ev.y);
+            return;
+        }
+    }
+
     // Terminal mouse reporting (xterm 1000/1002/1003). When the focused
     // program has enabled mouse tracking, deliver button events to the PTY
     // instead of driving local selection / paste / context-menu. A release
@@ -3299,6 +3408,9 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 return;
             }
 
+            // Handle Alt-drag panel swap release (performs the swap if valid).
+            if (finishPanelSwapDrag()) return;
+
             // Handle divider drag release
             if (g_divider_dragging) {
                 g_divider_dragging = false;
@@ -3558,6 +3670,11 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
         platform_cursor.set(.size_all);
         return;
     }
+
+    // Alt-drag panel swap: track the drop target / dim the source. Owns the move
+    // while a swap source is recorded, so it must precede PTY mouse-report and
+    // selection handling below.
+    if (updatePanelSwapDrag(ev.x, ev.y)) return;
 
     // Reported mouse drag: stream motion to the PTY (button/any tracking
     // modes) and suppress local hover/selection while the button is held.

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -4241,6 +4241,39 @@ pub fn renderUnfocusedOverlaySimple(width: f32, height: f32) void {
     });
 }
 
+/// Highlight a panel that is the current Alt-drag swap drop target. Drawn inside
+/// the panel's own viewport (coords 0..width / 0..height), like the unfocused
+/// overlay: a faint accent wash plus an accent border. Uses real alpha blending
+/// (fillOverlay) so the underlying terminal content stays visible.
+pub fn renderSwapTargetHighlight(width: f32, height: f32) void {
+    const accent = AppWindow.g_theme.cursor_color;
+    const border: f32 = 2.0;
+
+    const fillRectOverlay = struct {
+        fn call(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) void {
+            if (w <= 0 or h <= 0) return;
+            const verts = [6][4]f32{
+                .{ x, y + h, 0.0, 0.0 },
+                .{ x, y, 0.0, 1.0 },
+                .{ x + w, y, 1.0, 1.0 },
+                .{ x, y + h, 0.0, 0.0 },
+                .{ x + w, y, 1.0, 1.0 },
+                .{ x + w, y + h, 1.0, 0.0 },
+            };
+            ui_pipeline.fillOverlay(verts, .{ color[0], color[1], color[2], alpha });
+        }
+    }.call;
+
+    // Faint accent wash over the whole panel.
+    fillRectOverlay(0, 0, width, height, accent, 0.14);
+
+    // Accent border on all four edges.
+    fillRectOverlay(0, 0, width, border, accent, 0.85); // bottom
+    fillRectOverlay(0, height - border, width, border, accent, 0.85); // top
+    fillRectOverlay(0, 0, border, height, accent, 0.85); // left
+    fillRectOverlay(width - border, 0, border, height, accent, 0.85); // right
+}
+
 /// Render split dividers between panes in the active tab.
 /// If split-divider-color is configured, uses that color (solid).
 /// Otherwise uses scrollbar-style rendering: black with alpha transparency.

--- a/src/split_tree.zig
+++ b/src/split_tree.zig
@@ -416,6 +416,31 @@ pub fn resizeInPlace(
     s.ratio = ratio;
 }
 
+/// Swap the surfaces held by two leaf nodes in place. Both handles MUST refer
+/// to leaf nodes (asserted). Topology, layout, ratios, zoom state, and
+/// reference counts are all unchanged — only the two *Surface pointers swap.
+/// Swapping a node with itself is a harmless no-op.
+///
+/// Like `resizeInPlace`, this mutates the otherwise-immutable nodes via the
+/// constCast escape hatch: we own the memory and a swap touches no handles.
+pub fn swapLeaves(self: *SplitTree, a: Node.Handle, b: Node.Handle) void {
+    assert(a.idx() < self.nodes.len);
+    assert(b.idx() < self.nodes.len);
+    if (a == b) return;
+
+    const nodes: []Node = @constCast(self.nodes);
+    const surf_a = switch (nodes[a.idx()]) {
+        .leaf => |s| s,
+        .split => unreachable,
+    };
+    const surf_b = switch (nodes[b.idx()]) {
+        .leaf => |s| s,
+        .split => unreachable,
+    };
+    nodes[a.idx()] = .{ .leaf = surf_b };
+    nodes[b.idx()] = .{ .leaf = surf_a };
+}
+
 /// Insert another tree into this tree at the given node in the
 /// specified direction. The other tree will be inserted in the
 /// new direction. For example, if the direction is "right" then
@@ -1199,4 +1224,60 @@ test "SplitTree: fromSnapshot clamps ratios" {
     }
 
     try std.testing.expect(tree.nodes[0].split.ratio <= 0.95);
+}
+
+test "SplitTree: swapLeaves exchanges leaf surfaces and preserves topology" {
+    const session_persist = @import("session_persist.zig");
+
+    var leaf_a = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var leaf_b = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.6, .left = &leaf_a, .right = &leaf_b } };
+
+    const Stub = struct {
+        var counter: usize = 0;
+        var sentinels: [16]usize = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: Allocator) ?*Surface {
+            const ptr = &sentinels[counter];
+            counter += 1;
+            return @ptrCast(@alignCast(ptr));
+        }
+    };
+    Stub.counter = 0;
+
+    var tree = try fromSnapshot(std.testing.allocator, &root, Stub.make);
+    defer {
+        // Sentinel leaves can't be unref'd; free the arena directly.
+        if (tree.nodes.len > 0) tree.arena.deinit();
+        tree = undefined;
+    }
+
+    // Pre-order layout: [root_split@0, leaf_a@1, leaf_b@2]
+    const a: Node.Handle = @enumFromInt(1);
+    const b: Node.Handle = @enumFromInt(2);
+    const surf_a = tree.nodes[1].leaf;
+    const surf_b = tree.nodes[2].leaf;
+    try std.testing.expect(surf_a != surf_b);
+
+    // Capture topology before the swap.
+    const layout_before = tree.nodes[0].split.layout;
+    const ratio_before = tree.nodes[0].split.ratio;
+    const left_before = tree.nodes[0].split.left;
+    const right_before = tree.nodes[0].split.right;
+
+    tree.swapLeaves(a, b);
+
+    // Surfaces exchanged.
+    try std.testing.expectEqual(surf_b, tree.nodes[1].leaf);
+    try std.testing.expectEqual(surf_a, tree.nodes[2].leaf);
+
+    // Topology untouched: layout, ratio, and child handles unchanged.
+    try std.testing.expectEqual(layout_before, tree.nodes[0].split.layout);
+    try std.testing.expectEqual(ratio_before, tree.nodes[0].split.ratio);
+    try std.testing.expectEqual(left_before, tree.nodes[0].split.left);
+    try std.testing.expectEqual(right_before, tree.nodes[0].split.right);
+
+    // Swapping the same pair again restores the original arrangement.
+    tree.swapLeaves(a, b);
+    try std.testing.expectEqual(surf_a, tree.nodes[1].leaf);
+    try std.testing.expectEqual(surf_b, tree.nodes[2].leaf);
 }


### PR DESCRIPTION
## What

Adds a mouse gesture to **swap two panels' contents within a tab**. Hold **Alt** and left-drag from a source panel onto a target panel; on release the two leaves exchange their `*Surface`. The split-tree topology and ratios are unchanged, so **any** two panels can be swapped — not just adjacent ones.

Previously panels could only be created (split) and closed; there was no way to rearrange them.

## How

- **`split_tree.swapLeaves(a, b)`** — in-place swap of the two leaf `*Surface` pointers via the same `@constCast` escape hatch as `resizeInPlace`/`zoom`. Topology, layout, ratios, zoom state, and reference counts are all untouched.
- **`tab.swapPanels` / `AppWindow.swapPanels`** — validate both handles (defensive against a shell exiting mid-drag and reshaping the tree), perform the swap, move focus to follow the dragged surface to the target slot, then invalidate cached rects + force a rebuild.
- **`input.zig`** — Alt + left-press state machine, intercepted **before** terminal mouse-reporting so the gesture works even over a full-screen mouse-tracking TUI (vim/htop). 6px drag threshold, `size_all` cursor, tracks the hovered drop target. Single-panel tabs fall through unchanged (Alt+click still reaches the PTY there).
- **`overlays.renderSwapTargetHighlight` + render loop** — dim the grabbed source, draw an accent border + faint accent wash on the drop target (real alpha blend via `fillOverlay`).

## Design choices

- **Swap leaf surfaces** (topology unchanged) over clone-and-swap or a topology-changing "move" — simplest and most predictable; no undo system exists to benefit from immutability here.
- In a **split** tab, Alt+left-press is reserved for swap and no longer sent to the PTY. Alt+drag on a divider still resizes (press on the gap → no panel hit → falls through).
- YAGNI'd out of v1: keyboard / command-palette entry, topology-changing move, floating ghost thumbnail.

Spec: `docs/superpowers/specs/2026-06-03-panel-swap-design.md`

## Testing

- `zig build test` → exit 0
- `zig build test-full` → exit 0 (includes a new TDD unit test for `swapLeaves`: surfaces exchanged, topology/ratios/handles preserved, double-swap restores).
- ⚠️ Interactive GUI behavior (drag gesture, highlight, cursor) **pending manual verify on macOS/Windows** — no Linux GUI backend in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
