### PR TITLE
fix(macos): load CJK fallback fonts from memory to fix tofu (#139)

### DIFF
--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -120,6 +120,7 @@ pub threadlocal var g_ft_lib: ?freetype.Library = null;
 pub threadlocal var g_font_discovery: ?*font_backend.FontDiscovery = null;
 pub threadlocal var g_fallback_faces: std.AutoHashMapUnmanaged(u32, freetype.Face) = .empty; // codepoint -> fallback face
 pub threadlocal var g_no_fallback: std.AutoHashMapUnmanaged(u32, void) = .empty; // codepoints with no fallback (negative cache)
+pub threadlocal var g_fallback_font_data: std.ArrayListUnmanaged([]u8) = .empty; // backing memory for initMemoryFace fallbacks (must outlive the faces)
 pub threadlocal var g_font_size: u32 = DEFAULT_FONT_SIZE;
 pub threadlocal var g_dpi: u32 = platform_display.default_dpi;
 pub threadlocal var g_cjk_font_family: ?[]const u8 = null;
@@ -351,15 +352,17 @@ fn isCjkCodepoint(codepoint: u32) bool {
 fn preferredFallbackFamilies(codepoint: u32) []const []const u8 {
     if (isCjkCodepoint(codepoint)) {
         if (builtin.os.tag == .macos) {
-            // macOS 26 moved PingFang into PrivateFrameworks/.../Reserved as a
-            // system-reserved .ttc that FreeType cannot open (FT_New_Face fails),
-            // and CoreText's default cascade prefers exactly that reserved font —
-            // which is why CJK rendered as tofu. List the public system CJK
-            // families (all FreeType-loadable from /System/Library/Fonts) first
-            // so findOrLoadFallbackFace resolves a usable face before falling
-            // back to the broken CoreText default. Third-party families follow
-            // for users who installed them.
+            // PingFang is the only CJK font guaranteed present on a stock macOS,
+            // but macOS 26 relocated it under PrivateFrameworks/.../Reserved as a
+            // .ttc whose path FreeType cannot open (FT_New_Face fails) — which is
+            // why CJK rendered as tofu. openFallbackFreetypeFace now loads such
+            // fonts from CoreText-extracted sfnt bytes, so list PingFang first
+            // (it resolves on every machine). Public optional families and
+            // third-party installs follow as nicer monospace alternatives.
             return &.{
+                "PingFang SC",
+                "PingFang TC",
+                "PingFang HK",
                 "Hiragino Sans GB",
                 "Songti SC",
                 "Heiti SC",
@@ -1217,25 +1220,52 @@ pub fn loadBellEmoji() ?BellCache {
 
 /// Find or load a fallback font that contains the given codepoint
 /// Resolve a FallbackFont to a FreeType face, verifying FreeType can actually
-/// open the file AND that the face contains `codepoint`. Returns null (after
-/// cleaning up) if either check fails, so callers can try the next candidate.
-/// This is the crux of the macOS CJK fix: CoreText happily hands back the
-/// reserved PingFangUI.ttc which FreeType cannot open, so we must validate the
-/// load rather than trust the discovery result.
+/// load it AND that the face contains `codepoint`. Returns null (after cleaning
+/// up) if either check fails, so callers can try the next candidate.
+///
+/// This is the crux of the macOS CJK fix. CoreText happily resolves CJK to the
+/// reserved PingFang.ttc, whose file path FreeType's FT_New_Face cannot open
+/// (macOS 26 relocated it under PrivateFrameworks/.../Reserved). We first try
+/// the cheap path-based load, then — when that fails — pull the font's sfnt
+/// bytes straight from the backend (CoreText tables) and load them from memory,
+/// which works regardless of file accessibility. The memory buffer must outlive
+/// the face, so it is tracked in g_fallback_font_data and freed in
+/// clearFallbackFaces.
 fn openFallbackFreetypeFace(
     ft_lib: freetype.Library,
     font: *font_backend.FallbackFont,
     codepoint: u32,
     alloc: std.mem.Allocator,
 ) ?freetype.Face {
-    var font_path = font_backend.fontFilePathAlloc(alloc, font) orelse return null;
-    defer font_path.deinit();
+    // 1. Cheap path: open by file path (no data copy). Works for ordinary
+    //    user/system fonts that resolve to a readable file.
+    if (font_backend.fontFilePathAlloc(alloc, font)) |path_result| {
+        var font_path = path_result;
+        defer font_path.deinit();
+        if (ft_lib.initFace(font_path.path, @intCast(font_path.face_index))) |ft_face| {
+            if ((ft_face.getCharIndex(codepoint) orelse 0) != 0) return ft_face;
+            ft_face.deinit();
+        } else |_| {}
+    }
 
-    const ft_face = ft_lib.initFace(font_path.path, @intCast(font_path.face_index)) catch return null;
+    // 2. Memory path: for fonts FreeType cannot open by path (reserved system
+    //    .ttc files), reconstruct the sfnt from the backend and load it from
+    //    memory. The buffer is borrowed by FreeType, so retain it.
+    const data = font_backend.fontDataAlloc(alloc, font) orelse return null;
+    const ft_face = ft_lib.initMemoryFace(data, 0) catch {
+        alloc.free(data);
+        return null;
+    };
     if ((ft_face.getCharIndex(codepoint) orelse 0) == 0) {
         ft_face.deinit();
+        alloc.free(data);
         return null;
     }
+    g_fallback_font_data.append(alloc, data) catch {
+        ft_face.deinit();
+        alloc.free(data);
+        return null;
+    };
     return ft_face;
 }
 
@@ -1553,6 +1583,14 @@ pub fn clearFallbackFaces(allocator: std.mem.Allocator) void {
     }
     g_fallback_faces.deinit(allocator);
     g_fallback_faces = .empty;
+
+    // Free sfnt buffers backing memory-loaded fallback faces. Must happen after
+    // the faces above are deinited, since FreeType borrows these buffers.
+    for (g_fallback_font_data.items) |data| {
+        allocator.free(data);
+    }
+    g_fallback_font_data.deinit(allocator);
+    g_fallback_font_data = .empty;
 
     // Also clear negative cache
     g_no_fallback.deinit(allocator);

--- a/src/platform/font_backend.zig
+++ b/src/platform/font_backend.zig
@@ -70,12 +70,21 @@ pub fn fontFilePathAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?Fon
     return impl.fontFilePathAlloc(allocator, font);
 }
 
+/// Copy a fallback font's raw sfnt bytes into an allocator-owned buffer, for
+/// loading via FreeType's memory-face API. Returns null when the backend cannot
+/// extract data (only macOS implements this; other backends rely on path-based
+/// loading). Caller owns the returned slice.
+pub fn fontDataAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?[]u8 {
+    return impl.fontDataAlloc(allocator, font);
+}
+
 test "platform font backend exposes discovery and weight APIs" {
     _ = FontDiscovery;
     _ = LoadedFont;
     _ = FallbackFont;
     _ = FontFilePath;
     try std.testing.expect(@hasDecl(@This(), "fontFilePathAlloc"));
+    try std.testing.expect(@hasDecl(@This(), "fontDataAlloc"));
     try std.testing.expectEqual(FontWeight.BOLD, fontWeightFromValue(700));
     try std.testing.expectEqual(FontWeight.NORMAL, fontWeightFromValue(123));
 }

--- a/src/platform/font_backend_macos.zig
+++ b/src/platform/font_backend_macos.zig
@@ -37,3 +37,7 @@ pub fn fontWeightFromValue(value: u16) FontWeight {
 pub fn fontFilePathAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?FontFilePath {
     return font_discovery.fontFilePathAlloc(allocator, font);
 }
+
+pub fn fontDataAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?[]u8 {
+    return font_discovery.fontDataAlloc(allocator, font);
+}

--- a/src/platform/font_backend_unsupported.zig
+++ b/src/platform/font_backend_unsupported.zig
@@ -228,3 +228,9 @@ pub fn fontFilePathAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?Fon
     _ = font;
     return null;
 }
+
+pub fn fontDataAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?[]u8 {
+    _ = allocator;
+    _ = font;
+    return null;
+}

--- a/src/platform/font_backend_windows.zig
+++ b/src/platform/font_backend_windows.zig
@@ -73,3 +73,11 @@ pub fn fontFilePathAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?Fon
         .allocator = allocator,
     };
 }
+
+pub fn fontDataAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?[]u8 {
+    // DirectWrite fonts resolve to openable file paths, so the path-based
+    // loader in the font manager is sufficient on Windows.
+    _ = allocator;
+    _ = font;
+    return null;
+}

--- a/src/platform/font_discovery_macos.zig
+++ b/src/platform/font_discovery_macos.zig
@@ -29,6 +29,7 @@ extern fn wispterm_coretext_font_release(handle: *anyopaque) void;
 extern fn wispterm_coretext_font_has_character(handle: *anyopaque, codepoint: u32) bool;
 extern fn wispterm_coretext_font_glyph_index(handle: *anyopaque, codepoint: u32) u16;
 extern fn wispterm_coretext_font_copy_path(handle: *anyopaque) ?[*:0]u8;
+extern fn wispterm_coretext_font_copy_table_data(handle: *anyopaque, out_len: *usize) ?[*]u8;
 extern fn wispterm_coretext_family_count() usize;
 extern fn wispterm_coretext_copy_family_name(index: usize) ?[*:0]u8;
 extern fn wispterm_coretext_free(ptr: ?*anyopaque) void;
@@ -174,4 +175,18 @@ pub fn fontFilePathAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?Fon
         .face_index = 0,
         .allocator = allocator,
     };
+}
+
+/// Copy the font's sfnt bytes (reconstructed from CoreText tables) into an
+/// allocator-owned buffer. Used to load fonts whose file path FreeType cannot
+/// open (e.g. macOS 26's reserved PingFang.ttc). Caller owns the returned slice.
+pub fn fontDataAlloc(allocator: std.mem.Allocator, font: *FallbackFont) ?[]u8 {
+    var len: usize = 0;
+    const raw = wispterm_coretext_font_copy_table_data(font.handle, &len) orelse return null;
+    defer wispterm_coretext_free(raw);
+    if (len == 0) return null;
+
+    const data = allocator.alloc(u8, len) catch return null;
+    @memcpy(data, raw[0..len]);
+    return data;
 }

--- a/src/platform/font_macos_bridge.m
+++ b/src/platform/font_macos_bridge.m
@@ -183,6 +183,143 @@ char *wispterm_coretext_font_copy_path(void *handle) {
     return result;
 }
 
+static void wispterm_write_u32_be(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)(v);
+}
+
+static void wispterm_write_u16_be(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v);
+}
+
+static uint32_t wispterm_sfnt_checksum(const uint8_t *data, uint32_t len) {
+    uint32_t sum = 0;
+    uint32_t words = (len + 3u) / 4u;
+    for (uint32_t i = 0; i < words; i++) {
+        uint32_t word = 0;
+        for (uint32_t j = 0; j < 4; j++) {
+            uint32_t idx = i * 4u + j;
+            word = (word << 8) | (idx < len ? data[idx] : 0u);
+        }
+        sum += word;
+    }
+    return sum;
+}
+
+// Reconstruct a standalone sfnt (TrueType/OpenType) blob from a CTFont's
+// tables. This lets FreeType load fonts that have no FreeType-openable file
+// path — most importantly macOS 26's reserved PingFang.ttc, which CoreText can
+// read but FT_New_Face(path) cannot open, the root cause of CJK tofu. Pulling
+// one font's tables also sidesteps .ttc face-index ambiguity. Returns a malloc'd
+// buffer (free via wispterm_coretext_free) and writes its length to *out_len,
+// or NULL on failure.
+uint8_t *wispterm_coretext_font_copy_table_data(void *handle, size_t *out_len) {
+    if (out_len != NULL) *out_len = 0;
+    CTFontRef font = (CTFontRef)handle;
+    if (font == NULL) return NULL;
+
+    CFArrayRef tags = CTFontCopyAvailableTables(font, kCTFontTableOptionNoOptions);
+    if (tags == NULL) return NULL;
+    CFIndex num_tables = CFArrayGetCount(tags);
+    if (num_tables <= 0) {
+        CFRelease(tags);
+        return NULL;
+    }
+
+    typedef struct {
+        uint32_t tag;
+        CFDataRef data;
+        uint32_t length;
+        uint32_t padded;
+    } TableEntry;
+
+    TableEntry *entries = calloc((size_t)num_tables, sizeof(TableEntry));
+    if (entries == NULL) {
+        CFRelease(tags);
+        return NULL;
+    }
+
+    bool has_cff = false;
+    size_t total_data = 0;
+    CFIndex count = 0;
+    for (CFIndex i = 0; i < num_tables; i++) {
+        CTFontTableTag tag = (CTFontTableTag)(uintptr_t)CFArrayGetValueAtIndex(tags, i);
+        CFDataRef data = CTFontCopyTable(font, tag, kCTFontTableOptionNoOptions);
+        if (data == NULL) continue;
+        uint32_t len = (uint32_t)CFDataGetLength(data);
+        entries[count].tag = (uint32_t)tag;
+        entries[count].data = data;
+        entries[count].length = len;
+        entries[count].padded = (len + 3u) & ~3u;
+        if (tag == 0x43464620u /* 'CFF ' */ || tag == 0x43464632u /* 'CFF2' */) has_cff = true;
+        total_data += entries[count].padded;
+        count++;
+    }
+    CFRelease(tags);
+
+    if (count == 0) {
+        free(entries);
+        return NULL;
+    }
+
+    // sfnt requires the table directory to be sorted by tag ascending.
+    for (CFIndex a = 0; a + 1 < count; a++) {
+        for (CFIndex b = a + 1; b < count; b++) {
+            if (entries[b].tag < entries[a].tag) {
+                TableEntry tmp = entries[a];
+                entries[a] = entries[b];
+                entries[b] = tmp;
+            }
+        }
+    }
+
+    size_t header_size = 12 + (size_t)count * 16;
+    size_t total_size = header_size + total_data;
+    uint8_t *out = malloc(total_size);
+    if (out == NULL) {
+        for (CFIndex i = 0; i < count; i++) CFRelease(entries[i].data);
+        free(entries);
+        return NULL;
+    }
+    memset(out, 0, total_size);
+
+    uint16_t num = (uint16_t)count;
+    uint16_t max_pow2 = 1;
+    uint16_t entry_selector = 0;
+    while ((uint16_t)(max_pow2 << 1) <= num) {
+        max_pow2 = (uint16_t)(max_pow2 << 1);
+        entry_selector++;
+    }
+    uint16_t search_range = (uint16_t)(max_pow2 * 16);
+    uint16_t range_shift = (uint16_t)(num * 16 - search_range);
+
+    wispterm_write_u32_be(out + 0, has_cff ? 0x4F54544Fu /* 'OTTO' */ : 0x00010000u);
+    wispterm_write_u16_be(out + 4, num);
+    wispterm_write_u16_be(out + 6, search_range);
+    wispterm_write_u16_be(out + 8, entry_selector);
+    wispterm_write_u16_be(out + 10, range_shift);
+
+    size_t data_offset = header_size;
+    for (CFIndex i = 0; i < count; i++) {
+        const uint8_t *src = CFDataGetBytePtr(entries[i].data);
+        uint8_t *dir = out + 12 + (size_t)i * 16;
+        wispterm_write_u32_be(dir + 0, entries[i].tag);
+        wispterm_write_u32_be(dir + 4, wispterm_sfnt_checksum(src, entries[i].length));
+        wispterm_write_u32_be(dir + 8, (uint32_t)data_offset);
+        wispterm_write_u32_be(dir + 12, entries[i].length);
+        memcpy(out + data_offset, src, entries[i].length);
+        data_offset += entries[i].padded;
+        CFRelease(entries[i].data);
+    }
+    free(entries);
+
+    if (out_len != NULL) *out_len = total_size;
+    return out;
+}
+
 size_t wispterm_coretext_family_count(void) {
     CFArrayRef families = CTFontManagerCopyAvailableFontFamilyNames();
     if (families == NULL) return 0;

--- a/src/test_macos_font.zig
+++ b/src/test_macos_font.zig
@@ -45,6 +45,43 @@ test "CoreText backend honors preferred fallback families" {
     try std.testing.expect(path.path.len > 0);
 }
 
+test "CoreText backend reconstructs a loadable sfnt for the CJK fallback" {
+    var discovery = try font_backend.FontDiscovery.init();
+    defer discovery.deinit();
+
+    // U+4E2D 中 — a common ideograph present in every macOS CJK system font.
+    // On stock macOS this resolves (via the default cascade) to the reserved
+    // PingFang.ttc, whose file path FreeType cannot open: the bug this fixes.
+    const cjk: u32 = 0x4E2D;
+    const font = (try discovery.findFallbackFont(cjk)) orelse return error.ExpectedCjkFallbackFont;
+    defer font.release();
+    try std.testing.expect(font.hasCharacter(cjk));
+
+    const data = font_backend.fontDataAlloc(std.testing.allocator, font) orelse
+        return error.ExpectedReconstructedFontData;
+    defer std.testing.allocator.free(data);
+
+    // Validate the sfnt container: 12-byte offset table + 16 bytes per entry.
+    try std.testing.expect(data.len > 12);
+    const version = std.mem.readInt(u32, data[0..4], .big);
+    const truetype: u32 = 0x00010000;
+    const opentype: u32 = 0x4F54544F; // 'OTTO'
+    try std.testing.expect(version == truetype or version == opentype);
+
+    const num_tables = std.mem.readInt(u16, data[4..6], .big);
+    try std.testing.expect(num_tables > 0);
+    try std.testing.expect(data.len >= 12 + @as(usize, num_tables) * 16);
+
+    // Every table directory entry must reference bytes inside the buffer.
+    var i: usize = 0;
+    while (i < num_tables) : (i += 1) {
+        const dir = 12 + i * 16;
+        const offset = std.mem.readInt(u32, data[dir + 8 ..][0..4], .big);
+        const length = std.mem.readInt(u32, data[dir + 12 ..][0..4], .big);
+        try std.testing.expect(@as(usize, offset) + @as(usize, length) <= data.len);
+    }
+}
+
 test {
     _ = font_backend;
 }


### PR DESCRIPTION
Fixes #139.

## Problem

On stock macOS 26.5 with default config, CJK characters render as tofu (□).

The codebase already had a macOS CJK fallback fix (`01db0b9`, shipped in v1.7.1), but it doesn't engage on a **stock** macOS:

1. `findOrLoadFallbackFace` first tries a preferred list of *public* CJK families (Songti SC, Heiti SC, Hiragino Sans GB, …) — **these aren't installed by default**; they're download-on-demand.
2. The only CJK font guaranteed present is **PingFang**, which macOS 26 relocated under `PrivateFrameworks/.../Reserved` as a `.ttc` whose path **FreeType's `FT_New_Face` cannot open** (already documented in the code's own comment).
3. So the CoreText cascade returns PingFang, `openFallbackFreetypeFace` fails the path-load, and every CJK codepoint hits the negative cache → tofu.

This matches the reporter's note: *"PingFang SC/TC/JP/KR are available but not automatically used."*

## Fix

Load fallback fonts **from memory** when path-loading fails, by extracting the font's sfnt bytes directly from CoreText (which can read reserved system fonts):

- **`font_macos_bridge.m`**: new `wispterm_coretext_font_copy_table_data` reconstructs a standalone sfnt from `CTFontCopyAvailableTables` + `CTFontCopyTable` (sorted table directory, 4-byte padding, per-table checksums, `OTTO` vs `0x00010000`). Also resolves `.ttc` face-index ambiguity.
- **`manager.zig` `openFallbackFreetypeFace`**: tries the cheap path-load first (unchanged for ordinary fonts), then falls back to `initMemoryFace(fontDataAlloc(...))`. Backing buffers are tracked in a new threadlocal `g_fallback_font_data` and freed (after the faces) in `clearFallbackFaces`. Added `PingFang SC/TC/HK` to the front of the macOS preferred fallback list since it's now loadable.
- **`fontDataAlloc`** wired through all four backend facades (non-macOS backends return `null`, so behavior is unchanged off-Mac).
- **`test_macos_font.zig`**: new macOS-native test asserting `fontDataAlloc` of the U+4E2D fallback font yields a well-formed sfnt.

## Verification

- `zig build test` → exit 0
- `zig build test-full` → exit 0 (no error/FAIL/panic)

⚠️ The macOS-specific code (the `.m` bridge, the macOS backend, the new test) is **not compiled by the Linux suites** (`test-full` target is windows-gnu; the macOS font test only builds on a Mac). Linux confirms the cross-platform plumbing compiles and nothing regressed. **Still pending on a Mac:** `zig build test-macos-font` and GUI verification that `echo "你好世界 こんにちは 안녕하세요"` renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)