### PR TITLE
feat: private file-access guard for the AI agent (allow/deny lists)

### DIFF
--- a/docs/agent-access.local.example
+++ b/docs/agent-access.local.example
@@ -1,0 +1,16 @@
+# WispTerm agent file-access rules (private, machine-local).
+# Copy to ~/.config/wispterm/agent-access.local and edit.
+#
+#   allow <path>   folders the agent may read freely (read-only commands skip the prompt)
+#   deny  <path>   paths/files the agent must never read without your per-command approval
+#
+# '~' and $HOME expand. An entry without '/' is a basename glob (e.g. *.pem, .env).
+# Built-in deny defaults are ALWAYS on (~/.ssh, ~/.aws, ~/.gnupg, ~/.config/gh,
+# ~/.config/wispterm, ~/.kube, ~/.netrc, ~/.docker/config.json, *.pem, *.key, .env);
+# the lines below extend them. deny always wins over allow.
+
+# allow ~/project
+# allow ~/work
+
+# deny ~/Documents/finance
+# deny *.kdbx

--- a/docs/superpowers/plans/2026-06-03-agent-file-access-guard.md
+++ b/docs/superpowers/plans/2026-06-03-agent-file-access-guard.md
@@ -1,0 +1,1274 @@
+# Agent File-Access Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a private, machine-local allow/deny file-access guard so WispTerm's AI agent forces per-command approval before reading protected paths (even in full-permission mode) and auto-approves safe reads confined to trusted folders.
+
+**Architecture:** A new pure, Session-free leaf module `src/ai_agent_access.zig` parses a private rules file and lexically classifies each exec command's path references into `neutral | blacklisted | whitelisted_safe`. The verdict is folded into the existing approval gate (`isDangerousCommand` → `ctx.requestApproval`) in all three exec tools (`localCommandExecTool`, `unixSessionExecTool`, `terminalReplExecTool`) via one shared `accessGate` helper. Rules are loaded once at startup and reach the tool layer as a `?*const AccessRules` pointer stamped into `AgentSettings`.
+
+**Tech Stack:** Zig (0.15 idioms: `std.ArrayListUnmanaged(T) = .empty`, `std.heap.ArenaAllocator`, `std.mem.tokenizeAny`). Tests: `zig build test` (fast native suite) for the pure module; `zig build test-full` for the tool-layer wiring.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md`
+
+---
+
+## Precedence (the rule every task serves)
+
+`deny > allow > base permission mode`. For each exec command:
+
+| Condition | Result |
+|---|---|
+| References a **deny** path/name | `blacklisted` → force approval even in `full` mode |
+| Else read-only command, ≥1 path token, **all** under an **allow** root, no deny hit | `whitelisted_safe` → auto-approve even in `confirm` mode |
+| Else | `neutral` → existing behavior |
+
+Deny matching is **generous** (over-trigger = safe). Allow auto-approve is **strict** (any uncertainty → not safe).
+
+---
+
+## Fixed public interface (defined in Task 1, used everywhere — do not rename)
+
+```zig
+pub const Decision = enum { neutral, blacklisted, whitelisted_safe };
+pub const EvalResult = struct { decision: Decision = .neutral, matched: []const u8 = "" };
+pub const AccessRules = struct {
+    arena: std.heap.ArenaAllocator,
+    home: []const u8,
+    allow_roots: [][]const u8,
+    deny_roots: [][]const u8,
+    deny_names: [][]const u8,
+    pub fn deinit(self: *AccessRules) void { self.arena.deinit(); }
+};
+pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []const u8) !AccessRules;
+pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules;
+pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult;
+pub fn isReadOnlyCommand(command: []const u8) bool;
+```
+
+---
+
+### Task 1: Scaffold the module + register it in both test suites
+
+**Files:**
+- Create: `src/ai_agent_access.zig`
+- Modify: `src/test_fast.zig` (after line 39 `_ = @import("ai_agent_config.zig");`)
+- Modify: `src/test_main.zig` (near the other `ai_*` imports, e.g. after line 608 `_ = @import("ai_chat_types.zig");`)
+
+- [ ] **Step 1: Create the module with the fixed interface + safe stubs**
+
+```zig
+//! Private file-access guard for the AI agent. Pure + Session-free so it lives
+//! in the fast test suite. Reads ride on arbitrary shell commands, so this is a
+//! heuristic command-string gate (bias: over-trigger deny, under-trigger allow),
+//! not an OS sandbox.
+//! Spec: docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md
+const std = @import("std");
+
+const MAX_RULES_BYTES = 64 * 1024;
+const List = std.ArrayListUnmanaged([]const u8);
+
+pub const Decision = enum { neutral, blacklisted, whitelisted_safe };
+
+pub const EvalResult = struct {
+    decision: Decision = .neutral,
+    /// Borrowed slice into the input command: the token that tripped the deny list.
+    matched: []const u8 = "",
+};
+
+/// Compiled-in secure-by-default deny entries. Entries containing '/' (or a
+/// leading '~') are directory/file path prefixes; bare names are basename globs.
+pub const BUILTIN_DENY = [_][]const u8{
+    "~/.ssh",
+    "~/.aws",
+    "~/.gnupg",
+    "~/.config/gh",
+    "~/.config/wispterm",
+    "~/.kube",
+    "~/.netrc",
+    "~/.docker/config.json",
+    "*.pem",
+    "*.key",
+    ".env",
+};
+
+const READ_ONLY_VERBS = [_][]const u8{
+    "cat",      "bat",  "head",   "tail",     "less",     "more", "grep",
+    "egrep",    "fgrep", "rg",    "ag",       "ls",       "ll",   "find",
+    "stat",     "file", "wc",     "nl",       "od",       "xxd",  "hexdump",
+    "strings",  "cut",  "sort",   "uniq",     "diff",     "tree", "readlink",
+    "realpath", "dirname", "basename", "pwd",
+};
+
+pub const AccessRules = struct {
+    arena: std.heap.ArenaAllocator,
+    home: []const u8,
+    allow_roots: [][]const u8,
+    deny_roots: [][]const u8,
+    deny_names: [][]const u8,
+
+    pub fn deinit(self: *AccessRules) void {
+        self.arena.deinit();
+    }
+};
+
+pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []const u8) !AccessRules {
+    _ = contents;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+    return .{
+        .arena = arena,
+        .home = try a.dupe(u8, home),
+        .allow_roots = &.{},
+        .deny_roots = &.{},
+        .deny_names = &.{},
+    };
+}
+
+pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules {
+    _ = file_path;
+    return parseRules(allocator, "", home);
+}
+
+pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult {
+    _ = allocator;
+    _ = rules;
+    _ = command;
+    _ = cwd;
+    return .{};
+}
+
+pub fn isReadOnlyCommand(command: []const u8) bool {
+    _ = command;
+    return false;
+}
+
+test "module scaffold compiles and parseRules yields a valid struct" {
+    var rules = try parseRules(std.testing.allocator, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqualStrings("/home/u", rules.home);
+    try std.testing.expectEqual(@as(usize, 0), rules.deny_roots.len);
+}
+```
+
+- [ ] **Step 2: Register in the fast suite**
+
+In `src/test_fast.zig`, immediately after the line `_ = @import("ai_agent_config.zig");` add:
+
+```zig
+    _ = @import("ai_agent_access.zig");
+```
+
+- [ ] **Step 3: Register in the full suite**
+
+In `src/test_main.zig`, immediately after the line `_ = @import("ai_chat_types.zig");` add:
+
+```zig
+    _ = @import("ai_agent_access.zig");
+```
+
+- [ ] **Step 4: Run the fast suite**
+
+Run: `zig build test`
+Expected: build succeeds, no test failures (the scaffold test passes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig src/test_fast.zig src/test_main.zig
+git commit -m "feat(agent-access): scaffold file-access guard module"
+```
+
+---
+
+### Task 2: Glob matcher (`globMatch`)
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing test** (append to the test section)
+
+```zig
+test "globMatch handles wildcards and exact names" {
+    try std.testing.expect(globMatch("*.pem", "server.pem"));
+    try std.testing.expect(globMatch(".env", ".env"));
+    try std.testing.expect(globMatch("id_*", "id_rsa"));
+    try std.testing.expect(globMatch("*", "anything"));
+    try std.testing.expect(!globMatch("*.pem", "notes.txt"));
+    try std.testing.expect(!globMatch(".env", "env"));
+    try std.testing.expect(!globMatch("a?c", "ac"));
+    try std.testing.expect(globMatch("a?c", "abc"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test`
+Expected: FAIL — `globMatch` is not defined.
+
+- [ ] **Step 3: Implement `globMatch`** (add above the test section)
+
+```zig
+fn globMatch(pat: []const u8, str: []const u8) bool {
+    var pi: usize = 0;
+    var si: usize = 0;
+    var star_pi: ?usize = null;
+    var star_si: usize = 0;
+    while (si < str.len) {
+        if (pi < pat.len and (pat[pi] == '?' or pat[pi] == str[si])) {
+            pi += 1;
+            si += 1;
+        } else if (pi < pat.len and pat[pi] == '*') {
+            star_pi = pi;
+            star_si = si;
+            pi += 1;
+        } else if (star_pi) |sp| {
+            pi = sp + 1;
+            star_si += 1;
+            si = star_si;
+        } else return false;
+    }
+    while (pi < pat.len and pat[pi] == '*') pi += 1;
+    return pi == pat.len;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): add glob matcher"
+```
+
+---
+
+### Task 3: Path helpers (`expandHome`, `lexicalNormalize`, `resolveToken`, `matchesRoot`, `looksLikePath`)
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "expandHome expands ~ and $HOME prefixes" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh", try expandHome(z, "~/.ssh", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u", try expandHome(z, "~", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u/.aws", try expandHome(z, "$HOME/.aws", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u/x", try expandHome(z, "${HOME}/x", "/home/u"));
+    try std.testing.expectEqualStrings("/etc/passwd", try expandHome(z, "/etc/passwd", "/home/u"));
+}
+
+test "lexicalNormalize collapses . and .. and trailing slashes" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh", try lexicalNormalize(z, "/home/u/./.ssh/"));
+    try std.testing.expectEqualStrings("/home/.ssh", try lexicalNormalize(z, "/home/u/../.ssh"));
+    try std.testing.expectEqualStrings("/", try lexicalNormalize(z, "/"));
+    try std.testing.expectEqualStrings("a/b", try lexicalNormalize(z, "a/./b"));
+}
+
+test "resolveToken expands, strips quotes, and resolves against cwd" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh/id_rsa", (try resolveToken(z, "~/.ssh/id_rsa", "/home/u", null)).?);
+    try std.testing.expectEqualStrings("/home/u/.ssh/cfg", (try resolveToken(z, "\"$HOME/.ssh/cfg\"", "/home/u", "/tmp")).?);
+    try std.testing.expectEqualStrings("/work/a.txt", (try resolveToken(z, "a.txt", "/home/u", "/work")).?);
+    try std.testing.expect((try resolveToken(z, "-rf", "/home/u", "/work")) == null);
+}
+
+test "matchesRoot is a path-component prefix match" {
+    try std.testing.expect(matchesRoot("/home/u/.ssh", "/home/u/.ssh"));
+    try std.testing.expect(matchesRoot("/home/u/.ssh/id_rsa", "/home/u/.ssh"));
+    try std.testing.expect(!matchesRoot("/home/u/.sshconfig", "/home/u/.ssh"));
+    try std.testing.expect(!matchesRoot("/home/u", "/home/u/.ssh"));
+}
+
+test "looksLikePath recognizes path-shaped tokens" {
+    try std.testing.expect(looksLikePath("~/.ssh"));
+    try std.testing.expect(looksLikePath("/etc/passwd"));
+    try std.testing.expect(looksLikePath("./rel"));
+    try std.testing.expect(looksLikePath("a/b"));
+    try std.testing.expect(looksLikePath(".env"));
+    try std.testing.expect(!looksLikePath("grep"));
+    try std.testing.expect(!looksLikePath("-rf"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — helper functions not defined.
+
+- [ ] **Step 3: Implement the helpers** (add above the test section)
+
+```zig
+fn expandHome(a: std.mem.Allocator, raw: []const u8, home: []const u8) ![]const u8 {
+    if (std.mem.eql(u8, raw, "~")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "~/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[1..] });
+    if (std.mem.eql(u8, raw, "$HOME")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "$HOME/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[5..] });
+    if (std.mem.eql(u8, raw, "${HOME}")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "${HOME}/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[7..] });
+    return a.dupe(u8, raw);
+}
+
+fn lexicalNormalize(a: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const absolute = path.len > 0 and path[0] == '/';
+    var stack: List = .empty;
+    defer stack.deinit(a);
+    var it = std.mem.tokenizeScalar(u8, path, '/');
+    while (it.next()) |comp| {
+        if (std.mem.eql(u8, comp, ".")) continue;
+        if (std.mem.eql(u8, comp, "..")) {
+            if (stack.items.len > 0 and !std.mem.eql(u8, stack.items[stack.items.len - 1], "..")) {
+                _ = stack.pop();
+            } else if (!absolute) {
+                try stack.append(a, "..");
+            }
+            continue;
+        }
+        try stack.append(a, comp);
+    }
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(a);
+    if (absolute) try out.append(a, '/');
+    for (stack.items, 0..) |comp, i| {
+        if (i != 0) try out.append(a, '/');
+        try out.appendSlice(a, comp);
+    }
+    if (out.items.len == 0) try out.append(a, '.');
+    return out.toOwnedSlice(a);
+}
+
+fn stripQuotes(token: []const u8) []const u8 {
+    if (token.len >= 2 and (token[0] == '"' or token[0] == '\'') and token[token.len - 1] == token[0]) {
+        return token[1 .. token.len - 1];
+    }
+    return token;
+}
+
+fn resolveToken(a: std.mem.Allocator, token: []const u8, home: []const u8, cwd: ?[]const u8) !?[]const u8 {
+    const t = stripQuotes(token);
+    if (t.len == 0 or t[0] == '-') return null;
+    const expanded = try expandHome(a, t, home);
+    if (expanded.len > 0 and expanded[0] == '/') return try lexicalNormalize(a, expanded);
+    if (cwd) |c| {
+        const joined = try std.fmt.allocPrint(a, "{s}/{s}", .{ c, expanded });
+        return try lexicalNormalize(a, joined);
+    }
+    return try lexicalNormalize(a, expanded);
+}
+
+fn matchesRoot(path: []const u8, root: []const u8) bool {
+    if (root.len == 0) return false;
+    if (std.mem.eql(u8, path, root)) return true;
+    if (path.len > root.len and std.mem.startsWith(u8, path, root) and path[root.len] == '/') return true;
+    return false;
+}
+
+fn looksLikePath(token: []const u8) bool {
+    const t = stripQuotes(token);
+    if (t.len == 0 or t[0] == '-') return false;
+    if (std.mem.indexOfScalar(u8, t, '/') != null) return true;
+    if (t[0] == '~' or t[0] == '.' or t[0] == '/') return true;
+    if (std.mem.startsWith(u8, t, "$HOME") or std.mem.startsWith(u8, t, "${HOME}")) return true;
+    return false;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): add path normalization helpers"
+```
+
+---
+
+### Task 4: Real `parseRules` (built-ins + private-file lines)
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "parseRules loads built-in deny defaults" {
+    var rules = try parseRules(std.testing.allocator, "", "/home/u");
+    defer rules.deinit();
+    var found_ssh = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/.ssh")) found_ssh = true;
+    }
+    try std.testing.expect(found_ssh);
+    var found_pem = false;
+    for (rules.deny_names) |n| {
+        if (std.mem.eql(u8, n, "*.pem")) found_pem = true;
+    }
+    try std.testing.expect(found_pem);
+}
+
+test "parseRules reads allow/deny lines and ignores comments" {
+    const contents =
+        \\# private rules
+        \\allow ~/project
+        \\deny  ~/secrets
+        \\deny  *.key
+        \\garbage line
+        \\
+    ;
+    var rules = try parseRules(std.testing.allocator, contents, "/home/u");
+    defer rules.deinit();
+    var found_allow = false;
+    for (rules.allow_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/project")) found_allow = true;
+    }
+    try std.testing.expect(found_allow);
+    var found_secrets = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/secrets")) found_secrets = true;
+    }
+    try std.testing.expect(found_secrets);
+    var found_key = false;
+    for (rules.deny_names) |n| {
+        if (std.mem.eql(u8, n, "*.key")) found_key = true;
+    }
+    try std.testing.expect(found_key);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — current `parseRules` returns empty lists.
+
+- [ ] **Step 3: Replace `parseRules` and add its helpers**
+
+Replace the entire `parseRules` stub with:
+
+```zig
+pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []const u8) !AccessRules {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var allow: List = .empty;
+    var deny: List = .empty;
+    var names: List = .empty;
+
+    const home_copy = try a.dupe(u8, home);
+
+    for (BUILTIN_DENY) |entry| {
+        try addDenyEntry(a, &deny, &names, entry, home_copy);
+    }
+
+    var lines = std.mem.tokenizeAny(u8, contents, "\r\n");
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (parseKeyword(line, "allow")) |rest| {
+            const norm = try normalizeEntry(a, rest, home_copy);
+            if (norm.len != 0) try allow.append(a, norm);
+        } else if (parseKeyword(line, "deny")) |rest| {
+            try addDenyEntry(a, &deny, &names, rest, home_copy);
+        } else {
+            std.log.warn("agent-access: ignoring malformed rule line: {s}", .{line});
+        }
+    }
+
+    return .{
+        .arena = arena,
+        .home = home_copy,
+        .allow_roots = try allow.toOwnedSlice(a),
+        .deny_roots = try deny.toOwnedSlice(a),
+        .deny_names = try names.toOwnedSlice(a),
+    };
+}
+
+fn parseKeyword(line: []const u8, kw: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, line, kw)) return null;
+    if (line.len == kw.len) return "";
+    if (line[kw.len] != ' ' and line[kw.len] != '\t') return null;
+    return std.mem.trim(u8, line[kw.len..], " \t");
+}
+
+fn addDenyEntry(a: std.mem.Allocator, deny: *List, names: *List, entry: []const u8, home: []const u8) !void {
+    const e = std.mem.trim(u8, entry, " \t");
+    if (e.len == 0) return;
+    if (std.mem.indexOfScalar(u8, e, '/') == null and e[0] != '~') {
+        try names.append(a, try a.dupe(u8, e));
+    } else {
+        const norm = try normalizeEntry(a, e, home);
+        if (norm.len != 0) try deny.append(a, norm);
+    }
+}
+
+fn normalizeEntry(a: std.mem.Allocator, raw: []const u8, home: []const u8) ![]const u8 {
+    const expanded = try expandHome(a, raw, home);
+    return lexicalNormalize(a, expanded);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): parse built-in and private allow/deny rules"
+```
+
+---
+
+### Task 5: Real `isReadOnlyCommand`
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "isReadOnlyCommand accepts read verbs and pipelines" {
+    try std.testing.expect(isReadOnlyCommand("cat foo.txt"));
+    try std.testing.expect(isReadOnlyCommand("cat a | grep b"));
+    try std.testing.expect(isReadOnlyCommand("FOO=1 ls -la"));
+    try std.testing.expect(isReadOnlyCommand("/bin/cat foo"));
+    try std.testing.expect(isReadOnlyCommand("grep x a && head b"));
+}
+
+test "isReadOnlyCommand rejects writes and unknown verbs" {
+    try std.testing.expect(!isReadOnlyCommand("rm foo"));
+    try std.testing.expect(!isReadOnlyCommand("cat foo > bar"));
+    try std.testing.expect(!isReadOnlyCommand("cat a | tee b"));
+    try std.testing.expect(!isReadOnlyCommand("echo `cat secret`"));
+    try std.testing.expect(!isReadOnlyCommand("cat $(find / -name id_rsa)"));
+    try std.testing.expect(!isReadOnlyCommand(""));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — current `isReadOnlyCommand` always returns false.
+
+- [ ] **Step 3: Replace the stub and add helpers**
+
+Replace the `isReadOnlyCommand` stub with:
+
+```zig
+pub fn isReadOnlyCommand(command: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, command, '>') != null) return false; // output redirect
+    if (std.mem.indexOf(u8, command, "$(") != null) return false; // command substitution
+    if (std.mem.indexOfScalar(u8, command, '`') != null) return false; // command substitution
+    var segs = std.mem.tokenizeAny(u8, command, ";|&");
+    var any = false;
+    while (segs.next()) |seg| {
+        const verb = firstVerb(seg) orelse return false;
+        any = true;
+        if (!isReadVerb(verb)) return false;
+    }
+    return any;
+}
+
+fn firstVerb(seg: []const u8) ?[]const u8 {
+    var words = std.mem.tokenizeAny(u8, seg, " \t");
+    while (words.next()) |w| {
+        if (isAssignment(w)) continue;
+        if (std.mem.eql(u8, w, "sudo") or std.mem.eql(u8, w, "command") or std.mem.eql(u8, w, "\\")) continue;
+        if (w[0] == '(' or w[0] == '{') {
+            if (w.len == 1) continue;
+            return std.fs.path.basename(w[1..]);
+        }
+        return std.fs.path.basename(w);
+    }
+    return null;
+}
+
+fn isAssignment(w: []const u8) bool {
+    const eq = std.mem.indexOfScalar(u8, w, '=') orelse return false;
+    const slash = std.mem.indexOfScalar(u8, w, '/') orelse w.len;
+    return eq > 0 and eq < slash;
+}
+
+fn isReadVerb(verb: []const u8) bool {
+    for (READ_ONLY_VERBS) |v| {
+        if (std.mem.eql(u8, v, verb)) return true;
+    }
+    return false;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): classify read-only commands"
+```
+
+---
+
+### Task 6: `evaluate` — deny pass
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "evaluate flags reads of denied paths (generous)" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ~/.ssh/id_rsa", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat \"$HOME/.ssh/config\"", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat /home/u/.ssh/id_rsa", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ../.ssh/id_rsa", "/home/u/project").decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat server.pem", "/work").decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat < .env", "/work").decision);
+}
+
+test "evaluate leaves unrelated reads neutral" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "cat /work/readme.txt", null).decision);
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "ls -la", null).decision);
+}
+
+test "evaluate matched names the triggering token" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    const r = evaluate(a, &rules, "cat ~/.ssh/id_rsa", null);
+    try std.testing.expectEqualStrings("~/.ssh/id_rsa", r.matched);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — current `evaluate` returns neutral.
+
+- [ ] **Step 3: Replace `evaluate` with the deny pass**
+
+```zig
+pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Deny pass: generous, first hit wins.
+    var tokens = std.mem.tokenizeAny(u8, command, " \t\r\n|&;<>()");
+    while (tokens.next()) |tok| {
+        const t = stripQuotes(tok);
+        if (t.len == 0) continue;
+        const base = std.fs.path.basename(t);
+        for (rules.deny_names) |pat| {
+            if (globMatch(pat, base)) return .{ .decision = .blacklisted, .matched = tok };
+        }
+        if (looksLikePath(tok)) {
+            const resolved = (resolveToken(a, tok, rules.home, cwd) catch null) orelse continue;
+            for (rules.deny_roots) |root| {
+                if (matchesRoot(resolved, root)) return .{ .decision = .blacklisted, .matched = tok };
+            }
+        }
+    }
+    return .{};
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): evaluate deny list against commands"
+```
+
+---
+
+### Task 7: `evaluate` — allow (whitelist) pass
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "evaluate auto-approves read-only commands confined to allow roots" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "allow ~/project\n", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "cat ~/project/readme.md", null).decision);
+    try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "cat a.txt", "/home/u/project").decision);
+    // A path outside the allow root → not safe.
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "cat ~/project/a /etc/hosts", null).decision);
+    // Not read-only → not safe.
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "rm ~/project/a", null).decision);
+    // No path argument → not safe (avoid blanket auto-approve).
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "ls", "/home/u/project").decision);
+}
+
+test "evaluate: deny beats allow even when nested" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "allow ~/project\ndeny ~/project/.git\n", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ~/project/.git/config", null).decision);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — `evaluate` never returns `whitelisted_safe`.
+
+- [ ] **Step 3: Extend `evaluate` with the allow pass**
+
+In `evaluate`, replace the final `return .{};` with:
+
+```zig
+    // Allow pass: strict. Read-only, ≥1 path token, every path token confined.
+    if (!isReadOnlyCommand(command)) return .{};
+    var any_path = false;
+    var toks2 = std.mem.tokenizeAny(u8, command, " \t\r\n|&;<>()");
+    while (toks2.next()) |tok| {
+        if (!looksLikePath(tok)) continue;
+        const resolved = (resolveToken(a, tok, rules.home, cwd) catch null) orelse continue;
+        any_path = true;
+        var confined = false;
+        for (rules.allow_roots) |root| {
+            if (matchesRoot(resolved, root)) {
+                confined = true;
+                break;
+            }
+        }
+        if (!confined) return .{};
+    }
+    if (any_path) return .{ .decision = .whitelisted_safe };
+    return .{};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS (including the deny-beats-allow test, since the deny pass returns before the allow pass runs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): auto-approve reads confined to allow roots"
+```
+
+---
+
+### Task 8: Real `loadRules` (read the private file, merge with built-ins)
+
+**Files:**
+- Modify: `src/ai_agent_access.zig`
+
+- [ ] **Step 1: Write the failing tests**
+
+```zig
+test "loadRules reads a private file and merges built-ins" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "agent-access.local", .data = "allow ~/project\ndeny ~/private\n" });
+    const path = try tmp.dir.realpathAlloc(a, "agent-access.local");
+    defer a.free(path);
+
+    var rules = try loadRules(a, path, "/home/u");
+    defer rules.deinit();
+
+    var found_allow = false;
+    for (rules.allow_roots) |r| if (std.mem.eql(u8, r, "/home/u/project")) {
+        found_allow = true;
+    };
+    try std.testing.expect(found_allow);
+    var found_private = false;
+    var found_builtin = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/private")) found_private = true;
+        if (std.mem.eql(u8, r, "/home/u/.ssh")) found_builtin = true;
+    }
+    try std.testing.expect(found_private);
+    try std.testing.expect(found_builtin);
+}
+
+test "loadRules with a missing file falls back to built-ins" {
+    const a = std.testing.allocator;
+    var rules = try loadRules(a, "/nonexistent/path/agent-access.local", "/home/u");
+    defer rules.deinit();
+    var found_builtin = false;
+    for (rules.deny_roots) |r| if (std.mem.eql(u8, r, "/home/u/.ssh")) {
+        found_builtin = true;
+    };
+    try std.testing.expect(found_builtin);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test`
+Expected: FAIL — current `loadRules` ignores the file (always parses `""`), so the allow/deny-from-file assertions fail.
+
+- [ ] **Step 3: Replace the `loadRules` stub**
+
+```zig
+pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules {
+    const contents = std.fs.cwd().readFileAlloc(allocator, file_path, MAX_RULES_BYTES) catch |err| switch (err) {
+        error.FileNotFound, error.NotDir => return parseRules(allocator, "", home),
+        else => return err,
+    };
+    defer allocator.free(contents);
+    return parseRules(allocator, contents, home);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_agent_access.zig
+git commit -m "feat(agent-access): load rules from the private file"
+```
+
+---
+
+### Task 9: Wire `AccessRules` into settings and load at startup
+
+**Files:**
+- Modify: `src/ai_chat_types.zig` (add import + `access_rules` field on `AgentSettings`)
+- Modify: `src/ai_chat.zig` (rules global, setter, loader, stamp into `currentAgentSettings`)
+- Modify: `src/main.zig` (call the loader once at startup)
+
+- [ ] **Step 1: Add the `access_rules` field to `AgentSettings`**
+
+In `src/ai_chat_types.zig`, after the existing imports (around line 6, after `const agent_detector = @import("agent_detector.zig");`) add:
+
+```zig
+const ai_agent_access = @import("ai_agent_access.zig");
+```
+
+Then change the `AgentSettings` struct (lines 11-16) to:
+
+```zig
+pub const AgentSettings = struct {
+    enabled: bool = false,
+    permission: AgentPermission = .confirm,
+    command_timeout_ms: u32 = DEFAULT_AGENT_TIMEOUT_MS,
+    output_limit: u32 = DEFAULT_AGENT_OUTPUT_LIMIT,
+    /// Private file-access rules (owned by the app layer; null = guard inactive).
+    access_rules: ?*const ai_agent_access.AccessRules = null,
+};
+```
+
+- [ ] **Step 2: Add the rules global, setter, loader, and stamping in `ai_chat.zig`**
+
+In `src/ai_chat.zig`, ensure these imports exist near the top (add any that are missing — check with `grep -n 'ai_agent_access\|platform/dirs' src/ai_chat.zig`):
+
+```zig
+const ai_agent_access = @import("ai_agent_access.zig");
+const platform_dirs = @import("platform/dirs.zig");
+```
+
+After the line `var g_agent_settings: AgentSettings = .{};` (line 236) add:
+
+```zig
+var g_access_rules_storage: ?ai_agent_access.AccessRules = null;
+var g_access_rules: ?*const ai_agent_access.AccessRules = null;
+
+/// Load the private agent-access rules once at startup. Safe to call repeatedly
+/// (loads only the first time). Never fails the app: on any error the guard
+/// simply stays inactive (built-ins still apply once rules load successfully).
+pub fn loadAccessRules(allocator: std.mem.Allocator) void {
+    g_agent_mutex.lock();
+    const already = g_access_rules_storage != null;
+    g_agent_mutex.unlock();
+    if (already) return;
+
+    const home = resolveHomeDir(allocator) orelse "";
+    defer if (home.len != 0) allocator.free(home);
+    const path = platform_dirs.pathInConfigDir(allocator, "agent-access.local") catch return;
+    defer allocator.free(path);
+    const rules = ai_agent_access.loadRules(allocator, path, home) catch return;
+
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    g_access_rules_storage = rules;
+    g_access_rules = &g_access_rules_storage.?;
+}
+
+fn resolveHomeDir(allocator: std.mem.Allocator) ?[]u8 {
+    if (std.process.getEnvVarOwned(allocator, "HOME")) |v| {
+        return v;
+    } else |_| {}
+    if (std.process.getEnvVarOwned(allocator, "USERPROFILE")) |v| {
+        return v;
+    } else |_| {}
+    return null;
+}
+```
+
+Then change `currentAgentSettings` (lines 272-275) to stamp the rules pointer:
+
+```zig
+pub fn currentAgentSettings() AgentSettings {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    var s = g_agent_settings;
+    s.access_rules = g_access_rules;
+    return s;
+}
+```
+
+- [ ] **Step 3: Call the loader at startup**
+
+In `src/main.zig`, confirm `ai_chat` is imported (add `const ai_chat = @import("ai_chat.zig");` near the other imports if `grep -n 'ai_chat' src/main.zig` finds none). Then, immediately after `var app = try App.init(allocator, cfg);` (line 171) add:
+
+```zig
+    ai_chat.loadAccessRules(allocator);
+```
+
+- [ ] **Step 4: Build the app and run the full suite**
+
+Run: `zig build test-full`
+Expected: build succeeds, no test failures (existing `AgentSettings`-related tests still pass; the new field has a default).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_types.zig src/ai_chat.zig src/main.zig
+git commit -m "feat(agent-access): wire access rules into agent settings + startup load"
+```
+
+---
+
+### Task 10: Enforce the guard in the three exec gates
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig` (import, `accessGate` helper, refactor `localCommandExecTool`, `unixSessionExecTool`, `terminalReplExecTool`, add tests)
+
+- [ ] **Step 1: Write the failing tests** (append to the existing test section near the bottom of the file)
+
+```zig
+test "accessGate forces approval for denied paths and skips safe allowed reads" {
+    const a = std.testing.allocator;
+    var rules = try ai_agent_access.parseRules(a, "allow /work/ok\n", "/home/u");
+    defer rules.deinit();
+
+    var session_dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &session_dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = &rules },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    // Denied path → force approval even in full mode.
+    const denied = accessGate(&ctx, "cat ~/.ssh/id_rsa", null);
+    try std.testing.expect(denied.force);
+    try std.testing.expect(denied.blacklisted);
+
+    // Safe read confined to an allow root → skip even in confirm mode.
+    ctx.settings.permission = .confirm;
+    const safe = accessGate(&ctx, "cat /work/ok/readme.md", null);
+    try std.testing.expect(safe.skip);
+    try std.testing.expect(!safe.force);
+
+    // Unrelated read → neutral (no force, no skip).
+    const neutral = accessGate(&ctx, "cat /work/other.txt", null);
+    try std.testing.expect(!neutral.force);
+    try std.testing.expect(!neutral.skip);
+}
+
+test "accessGate with no rules degrades to dangerous-only behavior" {
+    const a = std.testing.allocator;
+    var session_dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &session_dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    try std.testing.expect(!accessGate(&ctx, "cat foo.txt", null).force);
+    try std.testing.expect(accessGate(&ctx, "rm foo.txt", null).force); // dangerous still forces
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test-full`
+Expected: FAIL — `accessGate` and `ai_agent_access` are not yet referenced in this file.
+
+- [ ] **Step 3: Add the import and the `accessGate` helper**
+
+In `src/ai_chat_tools.zig`, add near the top imports:
+
+```zig
+const ai_agent_access = @import("ai_agent_access.zig");
+```
+
+Add this helper just above `localCommandExecTool` (around line 405):
+
+```zig
+const AccessGate = struct {
+    dangerous: bool,
+    blacklisted: bool,
+    force: bool,
+    skip: bool,
+    matched: []const u8,
+};
+
+/// Combine the destructive-command check with the private file-access guard.
+/// `force` => must prompt even in full mode; `skip` => may run without a prompt
+/// even in confirm mode.
+fn accessGate(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8) AccessGate {
+    const dangerous = isDangerousCommand(command);
+    const result = if (ctx.settings.access_rules) |rules|
+        ai_agent_access.evaluate(ctx.allocator, rules, command, cwd)
+    else
+        ai_agent_access.EvalResult{};
+    const blacklisted = result.decision == .blacklisted;
+    return .{
+        .dangerous = dangerous,
+        .blacklisted = blacklisted,
+        .force = dangerous or blacklisted,
+        .skip = result.decision == .whitelisted_safe and !dangerous,
+        .matched = result.matched,
+    };
+}
+
+/// Allocate a human-readable approval reason naming the protected path. Returns
+/// null on OOM (callers fall back to a static reason).
+fn allocBlacklistReason(allocator: std.mem.Allocator, matched: []const u8) ?[]u8 {
+    return std.fmt.allocPrint(allocator, "Reads protected path \"{s}\" — confirm to allow", .{matched}) catch null;
+}
+```
+
+- [ ] **Step 4: Refactor `localCommandExecTool`**
+
+Replace the gate block (current lines 408-414):
+
+```zig
+    const dangerous = isDangerousCommand(command);
+    if (ctx.settings.permission != .full or dangerous) {
+        const reason = if (dangerous) DANGEROUS_COMMAND_APPROVAL_REASON else platform_process.localCommandApprovalLabel();
+        if (!ctx.requestApproval(platform_process.localCommandToolName(), command, reason)) {
+            return deniedResult(ctx.allocator, command, platform_process.localCommandDeniedReason());
+        }
+    }
+```
+
+with:
+
+```zig
+    const gate = accessGate(ctx, command, cwd);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous) DANGEROUS_COMMAND_APPROVAL_REASON else platform_process.localCommandApprovalLabel();
+        if (!ctx.requestApproval(platform_process.localCommandToolName(), command, reason)) {
+            return deniedResult(ctx.allocator, command, platform_process.localCommandDeniedReason());
+        }
+    }
+```
+
+- [ ] **Step 5: Refactor `unixSessionExecTool`**
+
+Replace its gate block (current lines 1063-1073):
+
+```zig
+    const dangerous = isDangerousCommand(command);
+    if (ctx.settings.permission != .full or dangerous) {
+        var reason_buf: [64]u8 = undefined;
+        const reason = if (dangerous)
+            DANGEROUS_COMMAND_APPROVAL_REASON
+        else
+            std.fmt.bufPrint(&reason_buf, "Type command into opened {s} terminal", .{kind.label()}) catch "Type command into terminal";
+        if (!ctx.requestApproval(kind.toolName(), command, reason)) {
+            return deniedResult(ctx.allocator, command, if (kind == .ssh) "operator rejected SSH PTY command" else "operator rejected WSL PTY command");
+        }
+    }
+```
+
+with:
+
+```zig
+    const gate = accessGate(ctx, command, null);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+        var reason_buf: [64]u8 = undefined;
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous)
+            DANGEROUS_COMMAND_APPROVAL_REASON
+        else
+            std.fmt.bufPrint(&reason_buf, "Type command into opened {s} terminal", .{kind.label()}) catch "Type command into terminal";
+        if (!ctx.requestApproval(kind.toolName(), command, reason)) {
+            return deniedResult(ctx.allocator, command, if (kind == .ssh) "operator rejected SSH PTY command" else "operator rejected WSL PTY command");
+        }
+    }
+```
+
+- [ ] **Step 6: Refactor `terminalReplExecTool`**
+
+Replace its gate block (current lines 769-781):
+
+```zig
+    const dangerous = isDangerousCommand(code);
+    if (ctx.settings.permission != .full or dangerous) {
+        var reason_buf: [96]u8 = undefined;
+        const reason = if (dangerous)
+            DANGEROUS_COMMAND_APPROVAL_REASON
+        else if (control != null)
+            std.fmt.bufPrint(&reason_buf, "Send control key {s} to terminal", .{std.mem.trim(u8, code, " \t\r\n")}) catch "Send control key to terminal"
+        else
+            std.fmt.bufPrint(&reason_buf, "Type input into opened {s} REPL/app terminal", .{repl.label()}) catch "Type input into terminal";
+        if (!ctx.requestApproval("terminal_repl_exec", code, reason)) {
+            return deniedResult(ctx.allocator, code, "operator rejected REPL terminal input");
+        }
+    }
+```
+
+with:
+
+```zig
+    const gate = accessGate(ctx, code, null);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+        var reason_buf: [96]u8 = undefined;
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous)
+            DANGEROUS_COMMAND_APPROVAL_REASON
+        else if (control != null)
+            std.fmt.bufPrint(&reason_buf, "Send control key {s} to terminal", .{std.mem.trim(u8, code, " \t\r\n")}) catch "Send control key to terminal"
+        else
+            std.fmt.bufPrint(&reason_buf, "Type input into opened {s} REPL/app terminal", .{repl.label()}) catch "Type input into terminal";
+        if (!ctx.requestApproval("terminal_repl_exec", code, reason)) {
+            return deniedResult(ctx.allocator, code, "operator rejected REPL terminal input");
+        }
+    }
+```
+
+- [ ] **Step 7: Run the full suite to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS (new `accessGate` tests pass; existing dangerous-command tests still pass).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "feat(agent-access): enforce file-access guard in all exec gates"
+```
+
+---
+
+### Task 11: Final verification + ship the example rules file
+
+**Files:**
+- Create: `docs/agent-access.local.example` (a copy-paste starting point for users)
+
+- [ ] **Step 1: Write the example file**
+
+```
+# WispTerm agent file-access rules (private, machine-local).
+# Copy to ~/.config/wispterm/agent-access.local and edit.
+#
+#   allow <path>   folders the agent may read freely (read-only commands skip the prompt)
+#   deny  <path>   paths/files the agent must never read without your per-command approval
+#
+# '~' and $HOME expand. An entry without '/' is a basename glob (e.g. *.pem, .env).
+# Built-in deny defaults are ALWAYS on (~/.ssh, ~/.aws, ~/.gnupg, ~/.config/gh,
+# ~/.config/wispterm, ~/.kube, ~/.netrc, ~/.docker/config.json, *.pem, *.key, .env);
+# the lines below extend them. deny always wins over allow.
+
+# allow ~/project
+# allow ~/work
+
+# deny ~/Documents/finance
+# deny *.kdbx
+```
+
+- [ ] **Step 2: Run both test suites**
+
+Run: `zig build test && zig build test-full`
+Expected: both succeed with no failures.
+
+- [ ] **Step 3: Confirm the app builds**
+
+Run: `zig build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/agent-access.local.example
+git commit -m "docs(agent-access): add example private rules file"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New leaf module `ai_agent_access.zig` (pure, fast-suite) → Tasks 1-8. ✓
+- Private file `~/.config/wispterm/agent-access.local`, `allow`/`deny`, `~`/`$HOME`, dir-prefix vs basename/glob, comments, absent-file → built-ins → Tasks 4, 8, 9 (path via `platform_dirs.pathInConfigDir`). ✓
+- Built-in secure-by-default deny list, always on → `BUILTIN_DENY` (Task 1) merged in `parseRules` (Task 4). ✓
+- Precedence deny > allow > base mode; deny forces approval even in full; allow auto-approves read-only confined reads even in confirm → `evaluate` (Tasks 6-7) + `accessGate` (Task 10). ✓
+- Generous deny matching / strict allow matching → Tasks 6, 7. ✓
+- All three exec paths gated via one shared helper → Task 10. ✓
+- Rules loaded once, owned by app layer, threaded via `AgentSettings`/`ToolContext` → Task 9. ✓
+- Tests: pure parser/matcher in fast suite (Tasks 2-7), loader (Task 8), gate wiring (Task 10). ✓
+- Error handling: missing file → built-ins; malformed line → warn+skip; load failure → guard inactive → Tasks 4, 8, 9. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `Decision`, `EvalResult{ decision, matched }`, `AccessRules{ arena, home, allow_roots, deny_roots, deny_names }`, and the signatures of `parseRules`/`loadRules`/`evaluate`/`isReadOnlyCommand` are fixed in Task 1 and used unchanged thereafter. `accessGate`/`AccessGate{ dangerous, blacklisted, force, skip, matched }` introduced and consumed only in Task 10. ✓
+
+## Known limitations (documented, accepted in the spec)
+
+- Heuristic command-string gate, not an OS sandbox: deliberate obfuscation (runtime-constructed paths, base64 decode-then-read) can evade the deny scan.
+- For SSH/WSL/REPL the matcher runs with `cwd = null`, so cwd-relative *remote* paths won't prefix-match deny roots; `~`/`$HOME`/absolute/basename-glob matches still fire. Whitelist auto-approve therefore rarely triggers on remote (safe default: more prompts, never fewer).
+```

--- a/docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md
+++ b/docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md
@@ -1,0 +1,207 @@
+# Agent File-Access Guard (private allow/deny lists)
+
+**Date:** 2026-06-03
+**Branch:** `feat/agent-file-access-guard`
+**Status:** Design — approved by user, pending spec review
+
+## Problem
+
+WispTerm's built-in AI agent can read any file on the machine. It does so not
+through a structured `read_file` tool but by running ordinary shell commands
+(`cat`, `head`, `less`, `xxd`, …) through the exec tools in
+`src/ai_chat_tools.zig`:
+
+- `localCommandExecTool` — commands on this machine
+- `unixSessionExecTool` — `ssh_session_exec` and `wsl_session_exec`
+- `terminalReplExecTool` — REPL input
+
+We want a **private, machine-local** guard so that:
+
+- **Deny list (blacklist):** defined paths must never be read without the user
+  explicitly agreeing. Even in `full` permission mode, touching a denied path
+  forces a per-command approval prompt.
+- **Allow list (whitelist):** folders the user trusts can be read freely — safe
+  reads confined to them skip the approval prompt even in `confirm` mode.
+
+## Constraints & honest scope
+
+Because reads ride on arbitrary shell command text, enforcement is a **heuristic
+command-string gate**, not an OS sandbox. It scans the command for path
+references and folds the verdict into the existing approval gate. This is a
+strong guardrail but is bypassable by deliberate obfuscation (base64 decoding,
+constructing paths from env vars at runtime, etc.). An unbypassable sandbox
+(seccomp / landlock / `sandbox-exec`) is explicitly out of scope.
+
+Rejected alternatives:
+
+- **Structured `read_file` tool** — easy to gate, but the agent can still `cat`
+  via the shell tools, so the hole stays open.
+- **OS-level confinement** — truly unbypassable, but a large platform-specific
+  effort; deferred.
+
+## Architecture
+
+### New leaf module: `src/ai_agent_access.zig`
+
+Pure and Session-free so it registers in the **fast** test suite. The matcher
+does **no filesystem access** — it resolves paths *lexically* against an injected
+home directory and cwd, which keeps it deterministic and unit-testable.
+
+Public surface:
+
+```zig
+pub const Decision = enum { neutral, blacklisted, whitelisted_safe };
+
+pub const EvalResult = struct {
+    decision: Decision,
+    matched: []const u8, // borrowed slice into `command`; the path that triggered deny
+};
+
+pub const AccessRules = struct {
+    allow_roots: [][]u8,   // absolute, lexically-normalized directory prefixes
+    deny_roots:  [][]u8,   // absolute, lexically-normalized directory prefixes
+    deny_names:  [][]u8,   // basename / glob patterns (e.g. "*.pem", ".env")
+
+    pub fn deinit(self: *AccessRules, alloc) void;
+};
+
+/// Pure parser for the private file contents. `home` is injected (no env reads).
+pub fn parseRules(alloc, file_contents: []const u8, home: []const u8) !AccessRules;
+
+/// Pure, heuristic classification of one exec command.
+pub fn evaluate(rules: *const AccessRules, command, cwd, home) EvalResult;
+
+/// Compiled-in secure-by-default deny list (always merged in; see below).
+pub const BUILTIN_DENY: []const []const u8;
+```
+
+A thin, non-pure loader lives alongside the pure core (tested under
+`test_posix.zig`):
+
+```zig
+/// Reads the private file (if present), merges with BUILTIN_DENY, returns owned rules.
+pub fn loadRules(alloc, file_path: []const u8, home: []const u8) !AccessRules;
+```
+
+### Private file
+
+Path: `~/.config/wispterm/agent-access.local` (never written to synced/exported
+config; `stripConfigKeys` / restore-defaults do not touch it). Line format:
+
+```
+# WispTerm agent file-access rules (private, machine-local)
+allow ~/project
+allow ~/work
+deny  ~/.ssh
+deny  *.pem
+```
+
+- `allow <path>` / `deny <path>`; leading/trailing whitespace trimmed.
+- `~` and `$HOME` / `${HOME}` expand using the injected home.
+- An entry containing `/` is a **directory prefix**; an entry with no `/` is a
+  **basename/glob** matched against the basename of any referenced path.
+- `#` comments and blank lines are ignored.
+- **If the file is absent**, the built-in deny list still applies
+  (secure-by-default); the allow list is empty.
+- File entries **merge on top of** the built-ins (they extend, never replace the
+  defaults).
+
+### Built-in default deny list (`BUILTIN_DENY`)
+
+Directory prefixes: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gh`,
+`~/.config/wispterm`, `~/.kube`. Files/globs: `~/.netrc`, `~/.docker/config.json`,
+`*.pem`, `*.key`, `.env`. (Reviewable.)
+
+### Decision logic & precedence
+
+Precedence is **deny > allow > base permission mode**. `deny` always wins, so an
+`allow` entry cannot carve a hole inside a denied tree.
+
+For each exec command, computed alongside the existing `isDangerousCommand`:
+
+| Condition | Result |
+|---|---|
+| Command references a **deny** path | `blacklisted` → **force approval** even in `full` mode; reason names the matched path |
+| Else read-only command **fully confined to allow** roots, no deny hit | `whitelisted_safe` → **auto-approve** (skips prompt even in `confirm` mode) |
+| Else | `neutral` → existing behavior |
+
+The combined gate in each tool becomes:
+
+```zig
+const access = ai_agent_access.evaluate(rules, command, cwd, home);
+const dangerous = isDangerousCommand(command);
+const force = dangerous or access.decision == .blacklisted;
+const skip  = access.decision == .whitelisted_safe and !dangerous;
+if (force or (ctx.settings.permission != .full and !skip)) {
+    const reason = if (access.decision == .blacklisted)
+        "Reads protected path — confirm to allow"  // includes matched path
+    else if (dangerous) DANGEROUS_COMMAND_APPROVAL_REASON
+    else <existing per-tool label>;
+    if (!ctx.requestApproval(tool, command, reason)) return denied;
+}
+```
+
+### Matching heuristics
+
+- **Deny matching is generous** (bias to over-trigger → safer). Scan the command
+  for path-like tokens; for each, lexically expand `~`/`$HOME`, resolve relative
+  tokens against cwd, collapse `.`/`..`, then test prefix against `deny_roots`
+  and basename against `deny_names`. A false positive only adds one extra prompt.
+- **Allow auto-approve is strict** (bias to ask). Fires only when:
+  1. every leading verb (the command, plus each segment after `|`, `&&`, `||`,
+     `;`) is in a known **read-only verb set**
+     (`cat bat head tail less more grep egrep fgrep rg ls ll find stat file wc nl
+     od xxd hexdump strings cut sort uniq diff tree readlink realpath dirname
+     basename pwd`), and
+  2. **every** path-like token resolves under an `allow_root`, and
+  3. no deny hit.
+  Any parsing uncertainty (unknown verb, unresolvable token) → not
+  `whitelisted_safe` → falls through to normal approval.
+
+### Wiring
+
+- `AccessRules` is loaded once at app startup and **owned by `App`**.
+- A `?*const AccessRules` pointer is threaded through `AgentSettings` (keeps the
+  struct copyable) and reaches the tool layer via `ToolContext.settings`.
+- The home dir and the command's `cwd` reach the matcher: home from the app
+  environment at load time (stored on the rules or passed alongside); cwd from
+  the existing exec-tool `cwd` argument (or the surface cwd for ssh/wsl/repl).
+- The three gates call **one shared helper** so the logic lives in a single place
+  rather than being copy-pasted across `localCommandExecTool`,
+  `unixSessionExecTool`, and `terminalReplExecTool`.
+
+### Error handling
+
+- Missing private file → use built-ins only (not an error).
+- Malformed line → log a warning, skip that line, keep parsing the rest.
+- If rules fail to load entirely → fall back to `BUILTIN_DENY` so deny protection
+  is never silently disabled.
+- `null` rules pointer (feature not wired for a surface) → behaves as built-ins
+  only is still preferable, but if genuinely null, the gate degrades to existing
+  behavior (no crash).
+
+## Testing
+
+**Fast suite (`src/ai_agent_access.zig` tests, pure):**
+
+- Parser: allow/deny lines, `~` and `$HOME` expansion, comments/blanks, glob vs
+  directory entry, malformed-line skipping.
+- `evaluate` deny: `cat ~/.ssh/id_rsa`, `cat $HOME/.ssh/config`,
+  `cat /home/u/.ssh/x` (absolute), cwd-relative `cat ../.ssh/id_rsa`, glob
+  `cat secret.pem`, `.env`, and that deny beats an overlapping allow.
+- `evaluate` allow: read-only command confined to an allow root → `whitelisted_safe`;
+  a write/unknown verb in the same dir → `neutral`; a read touching one allowed +
+  one outside path → `neutral`.
+- Read-only verb classification incl. pipelines (`cat a | grep b`).
+
+**Posix suite (`src/test_posix.zig`):**
+
+- `loadRules`: real file read, merge with built-ins, absent-file path.
+
+## YAGNI / out of scope
+
+- OS-level sandboxing.
+- Per-profile rule sets (single machine-local file for v1).
+- Allowing `allow` to override `deny` (deny always wins).
+- A UI editor for the rules (hand-edited file for v1).
+```

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -91,6 +91,84 @@ pub fn isReadOnlyCommand(command: []const u8) bool {
     return false;
 }
 
+fn expandHome(a: std.mem.Allocator, raw: []const u8, home: []const u8) ![]const u8 {
+    if (std.mem.eql(u8, raw, "~")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "~/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[1..] });
+    if (std.mem.eql(u8, raw, "$HOME")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "$HOME/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[5..] });
+    if (std.mem.eql(u8, raw, "${HOME}")) return a.dupe(u8, home);
+    if (std.mem.startsWith(u8, raw, "${HOME}/")) return std.fmt.allocPrint(a, "{s}{s}", .{ home, raw[7..] });
+    return a.dupe(u8, raw);
+}
+
+fn lexicalNormalize(a: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const absolute = path.len > 0 and path[0] == '/';
+    var stack: List = .empty;
+    defer stack.deinit(a);
+    var it = std.mem.tokenizeScalar(u8, path, '/');
+    while (it.next()) |comp| {
+        if (std.mem.eql(u8, comp, ".")) continue;
+        if (std.mem.eql(u8, comp, "..")) {
+            if (stack.items.len > 0 and !std.mem.eql(u8, stack.items[stack.items.len - 1], "..")) {
+                _ = stack.pop();
+            } else if (!absolute) {
+                try stack.append(a, "..");
+            }
+            continue;
+        }
+        try stack.append(a, comp);
+    }
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(a);
+    if (absolute) try out.append(a, '/');
+    for (stack.items, 0..) |comp, i| {
+        if (i != 0) try out.append(a, '/');
+        try out.appendSlice(a, comp);
+    }
+    if (out.items.len == 0) try out.append(a, '.');
+    return out.toOwnedSlice(a);
+}
+
+fn stripQuotes(token: []const u8) []const u8 {
+    if (token.len >= 2 and (token[0] == '"' or token[0] == '\'') and token[token.len - 1] == token[0]) {
+        return token[1 .. token.len - 1];
+    }
+    return token;
+}
+
+/// Resolve a command-line token to a normalized absolute (or cwd-relative)
+/// path, or null for non-path tokens (empty / option flags). `a` MUST be an
+/// arena: the returned string and its intermediates (`expanded`, `joined`) all
+/// come from `a` and are not freed individually. Every caller (parseRules,
+/// evaluate) passes a scratch arena.
+fn resolveToken(a: std.mem.Allocator, token: []const u8, home: []const u8, cwd: ?[]const u8) !?[]const u8 {
+    const t = stripQuotes(token);
+    if (t.len == 0 or t[0] == '-') return null;
+    const expanded = try expandHome(a, t, home);
+    if (expanded.len > 0 and expanded[0] == '/') return try lexicalNormalize(a, expanded);
+    if (cwd) |c| {
+        const joined = try std.fmt.allocPrint(a, "{s}/{s}", .{ c, expanded });
+        return try lexicalNormalize(a, joined);
+    }
+    return try lexicalNormalize(a, expanded);
+}
+
+fn matchesRoot(path: []const u8, root: []const u8) bool {
+    if (root.len == 0) return false;
+    if (std.mem.eql(u8, path, root)) return true;
+    if (path.len > root.len and std.mem.startsWith(u8, path, root) and path[root.len] == '/') return true;
+    return false;
+}
+
+fn looksLikePath(token: []const u8) bool {
+    const t = stripQuotes(token);
+    if (t.len == 0 or t[0] == '-') return false;
+    if (std.mem.indexOfScalar(u8, t, '/') != null) return true;
+    if (t[0] == '~' or t[0] == '.' or t[0] == '/') return true;
+    if (std.mem.startsWith(u8, t, "$HOME") or std.mem.startsWith(u8, t, "${HOME}")) return true;
+    return false;
+}
+
 fn globMatch(pat: []const u8, str: []const u8) bool {
     var pi: usize = 0;
     var si: usize = 0;
@@ -130,4 +208,55 @@ test "globMatch handles wildcards and exact names" {
     try std.testing.expect(!globMatch(".env", "env"));
     try std.testing.expect(!globMatch("a?c", "ac"));
     try std.testing.expect(globMatch("a?c", "abc"));
+}
+
+test "expandHome expands ~ and $HOME prefixes" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh", try expandHome(z, "~/.ssh", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u", try expandHome(z, "~", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u/.aws", try expandHome(z, "$HOME/.aws", "/home/u"));
+    try std.testing.expectEqualStrings("/home/u/x", try expandHome(z, "${HOME}/x", "/home/u"));
+    try std.testing.expectEqualStrings("/etc/passwd", try expandHome(z, "/etc/passwd", "/home/u"));
+}
+
+test "lexicalNormalize collapses . and .. and trailing slashes" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh", try lexicalNormalize(z, "/home/u/./.ssh/"));
+    try std.testing.expectEqualStrings("/home/.ssh", try lexicalNormalize(z, "/home/u/../.ssh"));
+    try std.testing.expectEqualStrings("/", try lexicalNormalize(z, "/"));
+    try std.testing.expectEqualStrings("a/b", try lexicalNormalize(z, "a/./b"));
+}
+
+test "resolveToken expands, strips quotes, and resolves against cwd" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const z = arena.allocator();
+    try std.testing.expectEqualStrings("/home/u/.ssh/id_rsa", (try resolveToken(z, "~/.ssh/id_rsa", "/home/u", null)).?);
+    try std.testing.expectEqualStrings("/home/u/.ssh/cfg", (try resolveToken(z, "\"$HOME/.ssh/cfg\"", "/home/u", "/tmp")).?);
+    try std.testing.expectEqualStrings("/work/a.txt", (try resolveToken(z, "a.txt", "/home/u", "/work")).?);
+    try std.testing.expect((try resolveToken(z, "-rf", "/home/u", "/work")) == null);
+}
+
+test "matchesRoot is a path-component prefix match" {
+    try std.testing.expect(matchesRoot("/home/u/.ssh", "/home/u/.ssh"));
+    try std.testing.expect(matchesRoot("/home/u/.ssh/id_rsa", "/home/u/.ssh"));
+    try std.testing.expect(!matchesRoot("/home/u/.sshconfig", "/home/u/.ssh"));
+    try std.testing.expect(!matchesRoot("/home/u", "/home/u/.ssh"));
+}
+
+test "looksLikePath recognizes path-shaped tokens" {
+    try std.testing.expect(looksLikePath("~/.ssh"));
+    try std.testing.expect(looksLikePath("/etc/passwd"));
+    try std.testing.expect(looksLikePath("./rel"));
+    try std.testing.expect(looksLikePath("a/b"));
+    try std.testing.expect(looksLikePath(".env"));
+    try std.testing.expect(!looksLikePath("grep"));
+    try std.testing.expect(!looksLikePath("-rf"));
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -91,9 +91,43 @@ pub fn isReadOnlyCommand(command: []const u8) bool {
     return false;
 }
 
+fn globMatch(pat: []const u8, str: []const u8) bool {
+    var pi: usize = 0;
+    var si: usize = 0;
+    var star_pi: ?usize = null;
+    var star_si: usize = 0;
+    while (si < str.len) {
+        if (pi < pat.len and (pat[pi] == '?' or pat[pi] == str[si])) {
+            pi += 1;
+            si += 1;
+        } else if (pi < pat.len and pat[pi] == '*') {
+            star_pi = pi;
+            star_si = si;
+            pi += 1;
+        } else if (star_pi) |sp| {
+            pi = sp + 1;
+            star_si += 1;
+            si = star_si;
+        } else return false;
+    }
+    while (pi < pat.len and pat[pi] == '*') pi += 1;
+    return pi == pat.len;
+}
+
 test "module scaffold compiles and parseRules yields a valid struct" {
     var rules = try parseRules(std.testing.allocator, "", "/home/u");
     defer rules.deinit();
     try std.testing.expectEqualStrings("/home/u", rules.home);
     try std.testing.expectEqual(@as(usize, 0), rules.deny_roots.len);
+}
+
+test "globMatch handles wildcards and exact names" {
+    try std.testing.expect(globMatch("*.pem", "server.pem"));
+    try std.testing.expect(globMatch(".env", ".env"));
+    try std.testing.expect(globMatch("id_*", "id_rsa"));
+    try std.testing.expect(globMatch("*", "anything"));
+    try std.testing.expect(!globMatch("*.pem", "notes.txt"));
+    try std.testing.expect(!globMatch(".env", "env"));
+    try std.testing.expect(!globMatch("a?c", "ac"));
+    try std.testing.expect(globMatch("a?c", "abc"));
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -124,8 +124,18 @@ fn normalizeEntry(a: std.mem.Allocator, raw: []const u8, home: []const u8) ![]co
 }
 
 pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules {
-    _ = file_path;
-    return parseRules(allocator, "", home);
+    // Any failure to read the private file (missing, is-a-dir, permission, I/O)
+    // falls back to the built-in deny defaults so deny protection is never
+    // silently disabled. A missing file is the normal case (no warning); other
+    // errors warn but still degrade to built-ins.
+    const contents = std.fs.cwd().readFileAlloc(allocator, file_path, MAX_RULES_BYTES) catch |err| {
+        if (err != error.FileNotFound) {
+            std.log.warn("agent-access: cannot read {s} ({s}); using built-in deny defaults only", .{ file_path, @errorName(err) });
+        }
+        return parseRules(allocator, "", home);
+    };
+    defer allocator.free(contents);
+    return parseRules(allocator, contents, home);
 }
 
 pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult {
@@ -557,4 +567,59 @@ test "evaluate handles paths embedded in option flags" {
     try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "grep -f/etc/passwd ~/project/a", null).decision);
     // A flag path inside the allow root stays safe.
     try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "grep --file=~/project/patterns ~/project/a", null).decision);
+}
+
+test "loadRules reads a private file and merges built-ins" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "agent-access.local", .data = "allow ~/project\ndeny ~/private\n" });
+    const path = try tmp.dir.realpathAlloc(a, "agent-access.local");
+    defer a.free(path);
+
+    var rules = try loadRules(a, path, "/home/u");
+    defer rules.deinit();
+
+    var found_allow = false;
+    for (rules.allow_roots) |r| if (std.mem.eql(u8, r, "/home/u/project")) {
+        found_allow = true;
+    };
+    try std.testing.expect(found_allow);
+    var found_private = false;
+    var found_builtin = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/private")) found_private = true;
+        if (std.mem.eql(u8, r, "/home/u/.ssh")) found_builtin = true;
+    }
+    try std.testing.expect(found_private);
+    try std.testing.expect(found_builtin);
+}
+
+test "loadRules with a missing file falls back to built-ins" {
+    const a = std.testing.allocator;
+    var rules = try loadRules(a, "/nonexistent/path/agent-access.local", "/home/u");
+    defer rules.deinit();
+    var found_builtin = false;
+    for (rules.deny_roots) |r| if (std.mem.eql(u8, r, "/home/u/.ssh")) {
+        found_builtin = true;
+    };
+    try std.testing.expect(found_builtin);
+}
+
+test "loadRules with an unreadable path still keeps built-in deny defaults" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // A directory where a file is expected → readFileAlloc errors; must not
+    // disable the built-in deny protection.
+    try tmp.dir.makeDir("agent-access.local");
+    const path = try tmp.dir.realpathAlloc(a, "agent-access.local");
+    defer a.free(path);
+    var rules = try loadRules(a, path, "/home/u");
+    defer rules.deinit();
+    var found_builtin = false;
+    for (rules.deny_roots) |r| if (std.mem.eql(u8, r, "/home/u/.ssh")) {
+        found_builtin = true;
+    };
+    try std.testing.expect(found_builtin);
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -129,10 +129,26 @@ pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []co
 }
 
 pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult {
-    _ = allocator;
-    _ = rules;
-    _ = command;
-    _ = cwd;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Deny pass: generous, first hit wins.
+    var tokens = std.mem.tokenizeAny(u8, command, " \t\r\n|&;<>()");
+    while (tokens.next()) |tok| {
+        const t = stripQuotes(tok);
+        if (t.len == 0) continue;
+        const base = std.fs.path.basename(t);
+        for (rules.deny_names) |pat| {
+            if (globMatch(pat, base)) return .{ .decision = .blacklisted, .matched = tok };
+        }
+        if (looksLikePath(tok)) {
+            const resolved = (resolveToken(a, tok, rules.home, cwd) catch null) orelse continue;
+            for (rules.deny_roots) |root| {
+                if (matchesRoot(resolved, root)) return .{ .decision = .blacklisted, .matched = tok };
+            }
+        }
+    }
     return .{};
 }
 
@@ -424,4 +440,32 @@ test "isReadOnlyCommand rejects find with side-effecting predicates" {
     try std.testing.expect(!isReadOnlyCommand("find . -exec cp {} /dst \\;"));
     try std.testing.expect(!isReadOnlyCommand("find . -delete"));
     try std.testing.expect(isReadOnlyCommand("find . -name '*.zig'"));
+}
+
+test "evaluate flags reads of denied paths (generous)" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ~/.ssh/id_rsa", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat \"$HOME/.ssh/config\"", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat /home/u/.ssh/id_rsa", null).decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ../.ssh/id_rsa", "/home/u/project").decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat server.pem", "/work").decision);
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat < .env", "/work").decision);
+}
+
+test "evaluate leaves unrelated reads neutral" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "cat /work/readme.txt", null).decision);
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "ls -la", null).decision);
+}
+
+test "evaluate matched names the triggering token" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    const r = evaluate(a, &rules, "cat ~/.ssh/id_rsa", null);
+    try std.testing.expectEqualStrings("~/.ssh/id_rsa", r.matched);
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -91,12 +91,18 @@ pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []co
         }
     }
 
+    // Finalize the slices before the struct literal copies the arena, so that
+    // every allocation (including any toOwnedSlice node) lands in the arena
+    // state captured by `.arena = arena` — see the buffer_list note above.
+    const allow_slice = try allow.toOwnedSlice(a);
+    const deny_slice = try deny.toOwnedSlice(a);
+    const names_slice = try names.toOwnedSlice(a);
     return .{
         .arena = arena,
         .home = home_copy,
-        .allow_roots = try allow.toOwnedSlice(a),
-        .deny_roots = try deny.toOwnedSlice(a),
-        .deny_names = try names.toOwnedSlice(a),
+        .allow_roots = allow_slice,
+        .deny_roots = deny_slice,
+        .deny_names = names_slice,
     };
 }
 

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -207,6 +207,26 @@ pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command
     return .{};
 }
 
+/// True if `path` — a single filesystem path, NOT a shell command — references
+/// a denied location. For tools that read a literal path argument (e.g. sending
+/// a file attachment) rather than running a shell command through `evaluate`.
+pub fn isPathDenied(allocator: std.mem.Allocator, rules: *const AccessRules, path: []const u8, cwd: ?[]const u8) bool {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const t = stripQuotes(path);
+    if (t.len == 0) return false;
+    const base = std.fs.path.basename(t);
+    for (rules.deny_names) |pat| {
+        if (globMatch(pat, base)) return true;
+    }
+    const resolved = (resolveToken(a, t, rules.home, cwd) catch null) orelse return false;
+    for (rules.deny_roots) |root| {
+        if (matchesRoot(resolved, root)) return true;
+    }
+    return false;
+}
+
 pub fn isReadOnlyCommand(command: []const u8) bool {
     if (std.mem.indexOfScalar(u8, command, '>') != null) return false; // output redirect
     if (std.mem.indexOf(u8, command, "$(") != null) return false; // command substitution
@@ -560,6 +580,18 @@ test "evaluate: deny beats allow even when nested" {
     var rules = try parseRules(a, "allow ~/project\ndeny ~/project/.git\n", "/home/u");
     defer rules.deinit();
     try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ~/project/.git/config", null).decision);
+}
+
+test "isPathDenied flags protected file paths" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expect(isPathDenied(a, &rules, "~/.ssh/id_rsa", null));
+    try std.testing.expect(isPathDenied(a, &rules, "/home/u/.aws/credentials", null));
+    try std.testing.expect(isPathDenied(a, &rules, "secret.pem", null));
+    try std.testing.expect(isPathDenied(a, &rules, "\"$HOME/.gnupg/secring.gpg\"", null));
+    try std.testing.expect(!isPathDenied(a, &rules, "/home/u/project/notes.txt", null));
+    try std.testing.expect(!isPathDenied(a, &rules, "report.txt", "/home/u/project"));
 }
 
 test "evaluate handles paths embedded in option flags" {

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -1,0 +1,99 @@
+//! Private file-access guard for the AI agent. Pure + Session-free so it lives
+//! in the fast test suite. Reads ride on arbitrary shell commands, so this is a
+//! heuristic command-string gate (bias: over-trigger deny, under-trigger allow),
+//! not an OS sandbox.
+//! Spec: docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md
+const std = @import("std");
+
+const MAX_RULES_BYTES = 64 * 1024;
+const List = std.ArrayListUnmanaged([]const u8);
+
+pub const Decision = enum { neutral, blacklisted, whitelisted_safe };
+
+pub const EvalResult = struct {
+    decision: Decision = .neutral,
+    /// Borrowed slice into the input command: the token that tripped the deny list.
+    matched: []const u8 = "",
+};
+
+/// Compiled-in secure-by-default deny entries. Entries containing '/' (or a
+/// leading '~') are directory/file path prefixes; bare names are basename globs.
+pub const BUILTIN_DENY = [_][]const u8{
+    "~/.ssh",
+    "~/.aws",
+    "~/.gnupg",
+    "~/.config/gh",
+    "~/.config/wispterm",
+    "~/.kube",
+    "~/.netrc",
+    "~/.docker/config.json",
+    "*.pem",
+    "*.key",
+    ".env",
+};
+
+const READ_ONLY_VERBS = [_][]const u8{
+    "cat",      "bat",  "head",   "tail",     "less",     "more", "grep",
+    "egrep",    "fgrep", "rg",    "ag",       "ls",       "ll",   "find",
+    "stat",     "file", "wc",     "nl",       "od",       "xxd",  "hexdump",
+    "strings",  "cut",  "sort",   "uniq",     "diff",     "tree", "readlink",
+    "realpath", "dirname", "basename", "pwd",
+};
+
+pub const AccessRules = struct {
+    arena: std.heap.ArenaAllocator,
+    home: []const u8,
+    allow_roots: [][]const u8,
+    deny_roots: [][]const u8,
+    deny_names: [][]const u8,
+
+    pub fn deinit(self: *AccessRules) void {
+        self.arena.deinit();
+    }
+};
+
+pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []const u8) !AccessRules {
+    _ = contents;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+    // All arena allocations must happen *before* the struct literal so the
+    // arena's buffer_list is fully populated when the struct value is copied
+    // into the caller. Struct fields evaluate in declaration order, so an
+    // inline `try a.dupe(...)` in a later field allocates only *after*
+    // `.arena = arena` has already copied the (then-empty) arena — leaving the
+    // returned struct's arena with a stale buffer_list and leaking the buffer.
+    const home_copy = try a.dupe(u8, home);
+    return .{
+        .arena = arena,
+        .home = home_copy,
+        .allow_roots = &.{},
+        .deny_roots = &.{},
+        .deny_names = &.{},
+    };
+}
+
+pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules {
+    _ = file_path;
+    return parseRules(allocator, "", home);
+}
+
+pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command: []const u8, cwd: ?[]const u8) EvalResult {
+    _ = allocator;
+    _ = rules;
+    _ = command;
+    _ = cwd;
+    return .{};
+}
+
+pub fn isReadOnlyCommand(command: []const u8) bool {
+    _ = command;
+    return false;
+}
+
+test "module scaffold compiles and parseRules yields a valid struct" {
+    var rules = try parseRules(std.testing.allocator, "", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqualStrings("/home/u", rules.home);
+    try std.testing.expectEqual(@as(usize, 0), rules.deny_roots.len);
+}

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -53,10 +53,14 @@ pub const AccessRules = struct {
 };
 
 pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []const u8) !AccessRules {
-    _ = contents;
     var arena = std.heap.ArenaAllocator.init(allocator);
     errdefer arena.deinit();
     const a = arena.allocator();
+
+    var allow: List = .empty;
+    var deny: List = .empty;
+    var names: List = .empty;
+
     // All arena allocations must happen *before* the struct literal so the
     // arena's buffer_list is fully populated when the struct value is copied
     // into the caller. Struct fields evaluate in declaration order, so an
@@ -64,13 +68,59 @@ pub fn parseRules(allocator: std.mem.Allocator, contents: []const u8, home: []co
     // `.arena = arena` has already copied the (then-empty) arena — leaving the
     // returned struct's arena with a stale buffer_list and leaking the buffer.
     const home_copy = try a.dupe(u8, home);
+
+    for (BUILTIN_DENY) |entry| {
+        try addDenyEntry(a, &deny, &names, entry, home_copy);
+    }
+
+    var lines = std.mem.tokenizeAny(u8, contents, "\r\n");
+    while (lines.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (parseKeyword(line, "allow")) |rest| {
+            // Skip a bare `allow` with no path: it would normalize to "." and
+            // silently whitelist the whole cwd once evaluate() consults it.
+            if (rest.len != 0) {
+                const norm = try normalizeEntry(a, rest, home_copy);
+                if (norm.len != 0) try allow.append(a, norm);
+            }
+        } else if (parseKeyword(line, "deny")) |rest| {
+            try addDenyEntry(a, &deny, &names, rest, home_copy);
+        } else {
+            std.log.warn("agent-access: ignoring malformed rule line: {s}", .{line});
+        }
+    }
+
     return .{
         .arena = arena,
         .home = home_copy,
-        .allow_roots = &.{},
-        .deny_roots = &.{},
-        .deny_names = &.{},
+        .allow_roots = try allow.toOwnedSlice(a),
+        .deny_roots = try deny.toOwnedSlice(a),
+        .deny_names = try names.toOwnedSlice(a),
     };
+}
+
+fn parseKeyword(line: []const u8, kw: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, line, kw)) return null;
+    if (line.len == kw.len) return "";
+    if (line[kw.len] != ' ' and line[kw.len] != '\t') return null;
+    return std.mem.trim(u8, line[kw.len..], " \t");
+}
+
+fn addDenyEntry(a: std.mem.Allocator, deny: *List, names: *List, entry: []const u8, home: []const u8) !void {
+    const e = std.mem.trim(u8, entry, " \t");
+    if (e.len == 0) return;
+    if (std.mem.indexOfScalar(u8, e, '/') == null and e[0] != '~') {
+        try names.append(a, try a.dupe(u8, e));
+    } else {
+        const norm = try normalizeEntry(a, e, home);
+        if (norm.len != 0) try deny.append(a, norm);
+    }
+}
+
+fn normalizeEntry(a: std.mem.Allocator, raw: []const u8, home: []const u8) ![]const u8 {
+    const expanded = try expandHome(a, raw, home);
+    return lexicalNormalize(a, expanded);
 }
 
 pub fn loadRules(allocator: std.mem.Allocator, file_path: []const u8, home: []const u8) !AccessRules {
@@ -196,7 +246,8 @@ test "module scaffold compiles and parseRules yields a valid struct" {
     var rules = try parseRules(std.testing.allocator, "", "/home/u");
     defer rules.deinit();
     try std.testing.expectEqualStrings("/home/u", rules.home);
-    try std.testing.expectEqual(@as(usize, 0), rules.deny_roots.len);
+    // deny_roots is populated by BUILTIN_DENY defaults (path-shaped entries)
+    try std.testing.expect(rules.deny_roots.len > 0);
 }
 
 test "globMatch handles wildcards and exact names" {
@@ -259,4 +310,53 @@ test "looksLikePath recognizes path-shaped tokens" {
     try std.testing.expect(looksLikePath(".env"));
     try std.testing.expect(!looksLikePath("grep"));
     try std.testing.expect(!looksLikePath("-rf"));
+}
+
+test "parseRules loads built-in deny defaults" {
+    var rules = try parseRules(std.testing.allocator, "", "/home/u");
+    defer rules.deinit();
+    var found_ssh = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/.ssh")) found_ssh = true;
+    }
+    try std.testing.expect(found_ssh);
+    var found_pem = false;
+    for (rules.deny_names) |n| {
+        if (std.mem.eql(u8, n, "*.pem")) found_pem = true;
+    }
+    try std.testing.expect(found_pem);
+}
+
+test "parseRules reads allow/deny lines and ignores comments" {
+    const contents =
+        \\# private rules
+        \\allow ~/project
+        \\deny  ~/secrets
+        \\deny  *.key
+        \\garbage line
+        \\
+    ;
+    var rules = try parseRules(std.testing.allocator, contents, "/home/u");
+    defer rules.deinit();
+    var found_allow = false;
+    for (rules.allow_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/project")) found_allow = true;
+    }
+    try std.testing.expect(found_allow);
+    var found_secrets = false;
+    for (rules.deny_roots) |r| {
+        if (std.mem.eql(u8, r, "/home/u/secrets")) found_secrets = true;
+    }
+    try std.testing.expect(found_secrets);
+    var found_key = false;
+    for (rules.deny_names) |n| {
+        if (std.mem.eql(u8, n, "*.key")) found_key = true;
+    }
+    try std.testing.expect(found_key);
+}
+
+test "parseRules ignores a bare allow with no path" {
+    var rules = try parseRules(std.testing.allocator, "allow\nallow   \n", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(@as(usize, 0), rules.allow_roots.len);
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -133,22 +133,61 @@ pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command
     defer arena.deinit();
     const a = arena.allocator();
 
-    // Deny pass: generous, first hit wins.
+    // Deny pass: generous, first hit wins. Inspects the path-bearing substring
+    // of each token, including paths glued into option flags (`--file=/etc/x`,
+    // `-f/etc/x`), so deny is not bypassed by flag syntax.
     var tokens = std.mem.tokenizeAny(u8, command, " \t\r\n|&;<>()");
     while (tokens.next()) |tok| {
-        const t = stripQuotes(tok);
-        if (t.len == 0) continue;
-        const base = std.fs.path.basename(t);
+        const cand = pathCandidate(tok);
+        if (cand.len == 0) continue;
+        const base = std.fs.path.basename(cand);
         for (rules.deny_names) |pat| {
             if (globMatch(pat, base)) return .{ .decision = .blacklisted, .matched = tok };
         }
-        if (looksLikePath(tok)) {
-            const resolved = (resolveToken(a, tok, rules.home, cwd) catch null) orelse continue;
+        if (looksLikePath(cand)) {
+            const resolved = (resolveToken(a, cand, rules.home, cwd) catch null) orelse continue;
             for (rules.deny_roots) |root| {
                 if (matchesRoot(resolved, root)) return .{ .decision = .blacklisted, .matched = tok };
             }
         }
     }
+
+    // Allow pass: strict. Read-only, >=1 path token, and EVERY path token
+    // confined to an allow root. A single out-of-root path — including one
+    // embedded in an option flag — makes the whole command neutral, so deny
+    // continues to beat allow here.
+    if (!isReadOnlyCommand(command)) return .{};
+    var any_path = false;
+    var verb_skipped = false;
+    var toks2 = std.mem.tokenizeAny(u8, command, " \t\r\n|&;<>()");
+    while (toks2.next()) |tok| {
+        const cand = pathCandidate(tok);
+        if (cand.len == 0) continue;
+        // Skip the command's leading verb (and any env-assignment / `sudo`
+        // prefix before it) so e.g. `/usr/bin/cat <file>` isn't rejected on the
+        // binary's own path. Only the first verb is skipped; later pipeline
+        // verbs are harmlessly re-checked as (confined) path candidates.
+        if (!verb_skipped) {
+            if (isAssignment(cand) or std.mem.eql(u8, cand, "sudo") or std.mem.eql(u8, cand, "command")) continue;
+            verb_skipped = true;
+            continue;
+        }
+        if (!looksLikePath(cand)) {
+            if (cand[0] == '-') continue; // pure option flag, no embedded path
+            if (cwd == null) continue; // bare name with no cwd to anchor it
+        }
+        const resolved = (resolveToken(a, cand, rules.home, cwd) catch null) orelse continue;
+        any_path = true;
+        var confined = false;
+        for (rules.allow_roots) |root| {
+            if (matchesRoot(resolved, root)) {
+                confined = true;
+                break;
+            }
+        }
+        if (!confined) return .{};
+    }
+    if (any_path) return .{ .decision = .whitelisted_safe };
     return .{};
 }
 
@@ -258,6 +297,22 @@ fn resolveToken(a: std.mem.Allocator, token: []const u8, home: []const u8, cwd: 
         return try lexicalNormalize(a, joined);
     }
     return try lexicalNormalize(a, expanded);
+}
+
+/// The path-bearing substring of a shell token: the token itself, the value
+/// after `=` in an option flag (`--file=/etc/x`), or the path glued onto a
+/// short flag (`-f/etc/x`). Returned slice is a sub-slice of `tok` (after
+/// stripping surrounding quotes), so callers may still report it via `matched`.
+fn pathCandidate(tok: []const u8) []const u8 {
+    var t = stripQuotes(tok);
+    if (t.len != 0 and t[0] == '-') {
+        if (std.mem.indexOfScalar(u8, t, '=')) |eq| {
+            t = t[eq + 1 ..];
+        } else if (std.mem.indexOfScalar(u8, t, '/')) |slash| {
+            t = t[slash..];
+        }
+    }
+    return t;
 }
 
 fn matchesRoot(path: []const u8, root: []const u8) bool {
@@ -468,4 +523,38 @@ test "evaluate matched names the triggering token" {
     defer rules.deinit();
     const r = evaluate(a, &rules, "cat ~/.ssh/id_rsa", null);
     try std.testing.expectEqualStrings("~/.ssh/id_rsa", r.matched);
+}
+
+test "evaluate auto-approves read-only commands confined to allow roots" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "allow ~/project\n", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "cat ~/project/readme.md", null).decision);
+    try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "cat a.txt", "/home/u/project").decision);
+    // A path outside the allow root → not safe.
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "cat ~/project/a /etc/hosts", null).decision);
+    // Not read-only → not safe.
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "rm ~/project/a", null).decision);
+    // No path argument → not safe (avoid blanket auto-approve).
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "ls", "/home/u/project").decision);
+}
+
+test "evaluate: deny beats allow even when nested" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "allow ~/project\ndeny ~/project/.git\n", "/home/u");
+    defer rules.deinit();
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "cat ~/project/.git/config", null).decision);
+}
+
+test "evaluate handles paths embedded in option flags" {
+    const a = std.testing.allocator;
+    var rules = try parseRules(a, "allow ~/project\n", "/home/u");
+    defer rules.deinit();
+    // Deny still fires for a protected path glued into a flag value.
+    try std.testing.expectEqual(Decision.blacklisted, evaluate(a, &rules, "grep --file=$HOME/.ssh/known_hosts x ~/project/a", null).decision);
+    // An out-of-root flag path must NOT be auto-approved (no silent skip).
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "grep --file=/etc/passwd x ~/project/a", null).decision);
+    try std.testing.expectEqual(Decision.neutral, evaluate(a, &rules, "grep -f/etc/passwd ~/project/a", null).decision);
+    // A flag path inside the allow root stays safe.
+    try std.testing.expectEqual(Decision.whitelisted_safe, evaluate(a, &rules, "grep --file=~/project/patterns ~/project/a", null).decision);
 }

--- a/src/ai_agent_access.zig
+++ b/src/ai_agent_access.zig
@@ -137,7 +137,48 @@ pub fn evaluate(allocator: std.mem.Allocator, rules: *const AccessRules, command
 }
 
 pub fn isReadOnlyCommand(command: []const u8) bool {
-    _ = command;
+    if (std.mem.indexOfScalar(u8, command, '>') != null) return false; // output redirect
+    if (std.mem.indexOf(u8, command, "$(") != null) return false; // command substitution
+    if (std.mem.indexOfScalar(u8, command, '`') != null) return false; // command substitution
+    // find(1) action predicates run commands or delete files, turning an
+    // otherwise read-only verb destructive. Substring scan over-triggers
+    // safely (worst case is one extra approval prompt).
+    if (std.mem.indexOf(u8, command, "-exec") != null) return false;
+    if (std.mem.indexOf(u8, command, "-delete") != null) return false;
+    var segs = std.mem.tokenizeAny(u8, command, ";|&");
+    var any = false;
+    while (segs.next()) |seg| {
+        const verb = firstVerb(seg) orelse return false;
+        any = true;
+        if (!isReadVerb(verb)) return false;
+    }
+    return any;
+}
+
+fn firstVerb(seg: []const u8) ?[]const u8 {
+    var words = std.mem.tokenizeAny(u8, seg, " \t");
+    while (words.next()) |w| {
+        if (isAssignment(w)) continue;
+        if (std.mem.eql(u8, w, "sudo") or std.mem.eql(u8, w, "command") or std.mem.eql(u8, w, "\\")) continue;
+        if (w[0] == '(' or w[0] == '{') {
+            if (w.len == 1) continue;
+            return std.fs.path.basename(w[1..]);
+        }
+        return std.fs.path.basename(w);
+    }
+    return null;
+}
+
+fn isAssignment(w: []const u8) bool {
+    const eq = std.mem.indexOfScalar(u8, w, '=') orelse return false;
+    const slash = std.mem.indexOfScalar(u8, w, '/') orelse w.len;
+    return eq > 0 and eq < slash;
+}
+
+fn isReadVerb(verb: []const u8) bool {
+    for (READ_ONLY_VERBS) |v| {
+        if (std.mem.eql(u8, v, verb)) return true;
+    }
     return false;
 }
 
@@ -359,4 +400,28 @@ test "parseRules ignores a bare allow with no path" {
     var rules = try parseRules(std.testing.allocator, "allow\nallow   \n", "/home/u");
     defer rules.deinit();
     try std.testing.expectEqual(@as(usize, 0), rules.allow_roots.len);
+}
+
+test "isReadOnlyCommand accepts read verbs and pipelines" {
+    try std.testing.expect(isReadOnlyCommand("cat foo.txt"));
+    try std.testing.expect(isReadOnlyCommand("cat a | grep b"));
+    try std.testing.expect(isReadOnlyCommand("FOO=1 ls -la"));
+    try std.testing.expect(isReadOnlyCommand("/bin/cat foo"));
+    try std.testing.expect(isReadOnlyCommand("grep x a && head b"));
+}
+
+test "isReadOnlyCommand rejects writes and unknown verbs" {
+    try std.testing.expect(!isReadOnlyCommand("rm foo"));
+    try std.testing.expect(!isReadOnlyCommand("cat foo > bar"));
+    try std.testing.expect(!isReadOnlyCommand("cat a | tee b"));
+    try std.testing.expect(!isReadOnlyCommand("echo `cat secret`"));
+    try std.testing.expect(!isReadOnlyCommand("cat $(find / -name id_rsa)"));
+    try std.testing.expect(!isReadOnlyCommand(""));
+}
+
+test "isReadOnlyCommand rejects find with side-effecting predicates" {
+    try std.testing.expect(!isReadOnlyCommand("find / -exec rm {} +"));
+    try std.testing.expect(!isReadOnlyCommand("find . -exec cp {} /dst \\;"));
+    try std.testing.expect(!isReadOnlyCommand("find . -delete"));
+    try std.testing.expect(isReadOnlyCommand("find . -name '*.zig'"));
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -20,6 +20,8 @@ const ai_chat_composer = @import("ai_chat_composer.zig");
 const ai_chat_skills = @import("ai_chat_skills.zig");
 const ai_chat_types = @import("ai_chat_types.zig");
 const ai_chat_tools = @import("ai_chat_tools.zig");
+const ai_agent_access = @import("ai_agent_access.zig");
+const platform_dirs = @import("platform/dirs.zig");
 const ai_chat_markdown = @import("ai_chat_markdown.zig");
 const weixin_types = @import("weixin/types.zig");
 
@@ -234,6 +236,8 @@ fn fireDeferredAction(action: DeferredAction) void {
 
 var g_agent_mutex: std.Thread.Mutex = .{};
 var g_agent_settings: AgentSettings = .{};
+var g_access_rules_storage: ?ai_agent_access.AccessRules = null;
+var g_access_rules: ?*const ai_agent_access.AccessRules = null;
 var g_session_id_counter = std.atomic.Value(u64).init(1);
 var g_skill_update_trigger: ?*const fn () void = null;
 var g_session_resume_trigger: ?*const fn () void = null;
@@ -265,6 +269,37 @@ pub fn configureAgent(settings: AgentSettings) void {
     g_agent_settings = settings;
 }
 
+/// Load the private agent-access rules once at startup. Safe to call repeatedly
+/// (loads only the first time). Never fails the app: on any error the guard
+/// simply stays inactive.
+pub fn loadAccessRules(allocator: std.mem.Allocator) void {
+    g_agent_mutex.lock();
+    const already = g_access_rules_storage != null;
+    g_agent_mutex.unlock();
+    if (already) return;
+
+    const home = resolveHomeDir(allocator) orelse "";
+    defer if (home.len != 0) allocator.free(home);
+    const path = platform_dirs.pathInConfigDir(allocator, "agent-access.local") catch return;
+    defer allocator.free(path);
+    const rules = ai_agent_access.loadRules(allocator, path, home) catch return;
+
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    g_access_rules_storage = rules;
+    g_access_rules = &g_access_rules_storage.?;
+}
+
+fn resolveHomeDir(allocator: std.mem.Allocator) ?[]u8 {
+    if (std.process.getEnvVarOwned(allocator, "HOME")) |v| {
+        return v;
+    } else |_| {}
+    if (std.process.getEnvVarOwned(allocator, "USERPROFILE")) |v| {
+        return v;
+    } else |_| {}
+    return null;
+}
+
 pub fn setToolHost(host: ?ToolHost) void {
     g_tool_host = host;
 }
@@ -272,7 +307,9 @@ pub fn setToolHost(host: ?ToolHost) void {
 pub fn currentAgentSettings() AgentSettings {
     g_agent_mutex.lock();
     defer g_agent_mutex.unlock();
-    return g_agent_settings;
+    var s = g_agent_settings;
+    s.access_rules = g_access_rules;
+    return s;
 }
 
 fn applyPermissionArg(arg: []const u8) void {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -23,6 +23,7 @@ const ai_chat_skills = @import("ai_chat_skills.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_agent_prompt = @import("platform/agent_prompt.zig");
+const ai_agent_access = @import("ai_agent_access.zig");
 
 /// Number of output lines included in a copilot context block.
 pub const COPILOT_CONTEXT_LINES: usize = 40;
@@ -403,11 +404,46 @@ pub fn rememberClosedTab(ctx: *ToolContext, closed: ToolClosedTab) !void {
 // Local command exec tool
 // ---------------------------------------------------------------------------
 
+const AccessGate = struct {
+    dangerous: bool,
+    blacklisted: bool,
+    force: bool,
+    skip: bool,
+    matched: []const u8,
+};
+
+/// Combine the destructive-command check with the private file-access guard.
+/// `force` => must prompt even in full mode; `skip` => may run without a prompt
+/// even in confirm mode.
+fn accessGate(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8) AccessGate {
+    const dangerous = isDangerousCommand(command);
+    const result = if (ctx.settings.access_rules) |rules|
+        ai_agent_access.evaluate(ctx.allocator, rules, command, cwd)
+    else
+        ai_agent_access.EvalResult{};
+    const blacklisted = result.decision == .blacklisted;
+    return .{
+        .dangerous = dangerous,
+        .blacklisted = blacklisted,
+        .force = dangerous or blacklisted,
+        .skip = result.decision == .whitelisted_safe and !dangerous,
+        .matched = result.matched,
+    };
+}
+
+/// Allocate a human-readable approval reason naming the protected path. Returns
+/// null on OOM (callers fall back to a static reason).
+fn allocBlacklistReason(allocator: std.mem.Allocator, matched: []const u8) ?[]u8 {
+    return std.fmt.allocPrint(allocator, "Reads protected path \"{s}\" — confirm to allow", .{matched}) catch null;
+}
+
 fn localCommandExecTool(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
-    const dangerous = isDangerousCommand(command);
-    if (ctx.settings.permission != .full or dangerous) {
-        const reason = if (dangerous) DANGEROUS_COMMAND_APPROVAL_REASON else platform_process.localCommandApprovalLabel();
+    const gate = accessGate(ctx, command, cwd);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous) DANGEROUS_COMMAND_APPROVAL_REASON else platform_process.localCommandApprovalLabel();
         if (!ctx.requestApproval(platform_process.localCommandToolName(), command, reason)) {
             return deniedResult(ctx.allocator, command, platform_process.localCommandDeniedReason());
         }
@@ -766,10 +802,12 @@ fn terminalReplExecTool(ctx: *ToolContext, surface_id: []const u8, repl_name: []
     const repl = ReplKind.parse(repl_name) orelse return std.fmt.allocPrint(ctx.allocator, "Unsupported repl \"{s}\". Use r, python, codex, claude_code, or plain.", .{repl_name});
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
     const control = controlKeyByte(code);
-    const dangerous = isDangerousCommand(code);
-    if (ctx.settings.permission != .full or dangerous) {
+    const gate = accessGate(ctx, code, null);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
         var reason_buf: [96]u8 = undefined;
-        const reason = if (dangerous)
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous)
             DANGEROUS_COMMAND_APPROVAL_REASON
         else if (control != null)
             std.fmt.bufPrint(&reason_buf, "Send control key {s} to terminal", .{std.mem.trim(u8, code, " \t\r\n")}) catch "Send control key to terminal"
@@ -1060,10 +1098,12 @@ fn hasPendingAgentCommand(snapshot: []const u8) bool {
 
 fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
-    const dangerous = isDangerousCommand(command);
-    if (ctx.settings.permission != .full or dangerous) {
+    const gate = accessGate(ctx, command, null);
+    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
         var reason_buf: [64]u8 = undefined;
-        const reason = if (dangerous)
+        const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
+        defer if (bl_reason) |r| ctx.allocator.free(r);
+        const reason = bl_reason orelse if (gate.dangerous)
             DANGEROUS_COMMAND_APPROVAL_REASON
         else
             std.fmt.bufPrint(&reason_buf, "Type command into opened {s} terminal", .{kind.label()}) catch "Type command into terminal";
@@ -2164,6 +2204,55 @@ const ReplWaitTestHost = struct {
         };
     }
 };
+
+test "accessGate forces approval for denied paths and skips safe allowed reads" {
+    const a = std.testing.allocator;
+    var rules = try ai_agent_access.parseRules(a, "allow /work/ok\n", "/home/u");
+    defer rules.deinit();
+
+    var session_dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &session_dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = &rules },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    // Denied path → force approval even in full mode.
+    const denied = accessGate(&ctx, "cat ~/.ssh/id_rsa", null);
+    try std.testing.expect(denied.force);
+    try std.testing.expect(denied.blacklisted);
+
+    // Safe read confined to an allow root → skip even in confirm mode.
+    ctx.settings.permission = .confirm;
+    const safe = accessGate(&ctx, "cat /work/ok/readme.md", null);
+    try std.testing.expect(safe.skip);
+    try std.testing.expect(!safe.force);
+
+    // Unrelated read → neutral (no force, no skip).
+    const neutral = accessGate(&ctx, "cat /work/other.txt", null);
+    try std.testing.expect(!neutral.force);
+    try std.testing.expect(!neutral.skip);
+}
+
+test "accessGate with no rules degrades to dangerous-only behavior" {
+    const a = std.testing.allocator;
+    var session_dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &session_dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    try std.testing.expect(!accessGate(&ctx, "cat foo.txt", null).force);
+    try std.testing.expect(accessGate(&ctx, "rm foo.txt", null).force); // dangerous still forces
+}
 
 test "Claude Code REPL input waits for app state before returning" {
     const allocator = std.testing.allocator;

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -230,6 +230,19 @@ fn weixinSendAttachmentTool(
     const wx_ctx = ctx.weixin_reply_context orelse {
         return ctx.allocator.dupe(u8, "No active Weixin reply context; cannot send attachment.");
     };
+    // Sending an attachment reads the file off disk and uploads it to a remote
+    // user, so a protected path here is an exfiltration risk. Force approval for
+    // a denied path even in full-permission mode (deny list always wins).
+    if (ctx.settings.access_rules) |rules| {
+        if (ai_agent_access.isPathDenied(ctx.allocator, rules, path, null)) {
+            const bl_reason = allocBlacklistReason(ctx.allocator, path);
+            defer if (bl_reason) |r| ctx.allocator.free(r);
+            const reason = bl_reason orelse "Sends a protected file — confirm to allow";
+            if (!ctx.requestApproval("weixin_send_attachment", path, reason)) {
+                return deniedResult(ctx.allocator, path, "operator rejected sending a protected file");
+            }
+        }
+    }
     wx_ctx.sender.sendAttachment(kind, path, display_name, wx_ctx.to_user_id, wx_ctx.context_token) catch |err| {
         return std.fmt.allocPrint(ctx.allocator, "Failed to send {s} to Weixin: {}", .{ kind.name(), err });
     };

--- a/src/ai_chat_types.zig
+++ b/src/ai_chat_types.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const weixin_types = @import("weixin/types.zig");
 const agent_detector = @import("agent_detector.zig");
+const ai_agent_access = @import("ai_agent_access.zig");
 
 const DEFAULT_AGENT_TIMEOUT_MS: u32 = 60_000;
 const DEFAULT_AGENT_OUTPUT_LIMIT: u32 = 16 * 1024;
@@ -13,6 +14,8 @@ pub const AgentSettings = struct {
     permission: AgentPermission = .confirm,
     command_timeout_ms: u32 = DEFAULT_AGENT_TIMEOUT_MS,
     output_limit: u32 = DEFAULT_AGENT_OUTPUT_LIMIT,
+    /// Private file-access rules (owned by the app layer; null = guard inactive).
+    access_rules: ?*const ai_agent_access.AccessRules = null,
 };
 
 // AgentPermission lives in ai_agent_config.zig (extracted on main so config.zig

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,7 @@ const platform_console = @import("platform/console.zig");
 const font_backend = @import("platform/font_backend.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
 const i18n = @import("i18n.zig");
+const ai_chat = @import("ai_chat.zig");
 
 // ============================================================================
 // Font Discovery Test Functions (use --list-fonts or --test-font-discovery)
@@ -170,6 +171,7 @@ pub fn main() !void {
     // Create the App and run (first window on main thread, spawned windows on separate threads)
     var app = try App.init(allocator, cfg);
     defer app.deinit();
+    ai_chat.loadAccessRules(allocator);
 
     // App now lives at a stable address; start the WeChat direct bridge (no-op
     // unless weixin-direct-enabled is set).

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -37,6 +37,7 @@ test {
     _ = @import("startup_tabs.zig");
     _ = @import("config.zig");
     _ = @import("ai_agent_config.zig");
+    _ = @import("ai_agent_access.zig");
     _ = @import("ssh_connection.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("scp.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -606,6 +606,7 @@ comptime {
     _ = @import("ai_chat_tools.zig");
     _ = @import("ai_chat_skills.zig");
     _ = @import("ai_chat_types.zig");
+    _ = @import("ai_agent_access.zig");
     _ = @import("ai_chat_protocol.zig");
     _ = @import("ai_chat_markdown.zig");
     _ = @import("agent_history.zig");


### PR DESCRIPTION
## Summary

Adds a private, machine-local **file-access guard** for the AI agent. The agent reads files by running shell commands (`cat`, `less`, …) through its exec tools, so this is a heuristic command-string gate (documented as **not** an OS sandbox).

- **Deny list (blacklist):** forces per-command approval — even in full-permission mode — when a command references a protected path. A compiled-in secure-by-default deny list is always on (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gh`, `~/.config/wispterm`, `~/.kube`, `~/.netrc`, `~/.docker/config.json`, `*.pem`, `*.key`, `.env`). A private file `~/.config/wispterm/agent-access.local` extends it.
- **Allow list (whitelist):** read-only commands confined to allow-listed folders skip the approval prompt even in `confirm` mode.
- **Precedence:** `deny > allow > base permission mode`.
- **Coverage:** all three exec paths (`local`, `ssh`/`wsl`, `repl`) via one shared `accessGate` helper, plus `weixin_send_attachment` (gated against the deny list to prevent exfiltrating a protected file to a remote WeChat user).

## Design / implementation

- New pure, Session-free leaf module `src/ai_agent_access.zig` (fast-suite tested; lexical path matching, no filesystem access in the matcher): `parseRules`, `loadRules`, `evaluate`, `isReadOnlyCommand`, `isPathDenied`.
- Rules loaded once at startup (`ai_chat.loadAccessRules` from `main.zig`), owned by the app, threaded to the tool layer via `AgentSettings.access_rules`.
- Enforcement folds the verdict into the existing `isDangerousCommand` → `requestApproval` gate.
- Spec: `docs/superpowers/specs/2026-06-03-agent-file-access-guard-design.md`; plan: `docs/superpowers/plans/2026-06-03-agent-file-access-guard.md`; example rules file: `docs/agent-access.local.example`.

### Notable review findings (fixed in-branch)
- `find … -exec`/`-delete` no longer classified read-only (could have auto-approved a destructive command).
- Paths glued into option flags (`grep --file=/etc/passwd`, `-f/etc/x`) are now extracted and checked, so deny still beats allow and out-of-root flag paths aren't wrongly whitelisted.
- `loadRules` falls back to built-in deny defaults on any read error (deny protection never silently disabled).
- `weixin_send_attachment` exfiltration path gated against the deny list (found in the holistic review).

### Known limitations (by design — heuristic, not a sandbox)
- Deliberate obfuscation (runtime-constructed paths, base64, shell-variable indirection like `FOO=/etc/x cat $FOO`) can evade the string-level scan.
- `~username` (other users' homes) is not expanded.
- For SSH/WSL/REPL the matcher runs with `cwd = null`, so cwd-relative *remote* paths don't prefix-match deny roots (`~`/`$HOME`/absolute/basename-glob still fire).

## Test Plan
- [x] `zig build test` (fast suite) — exit 0
- [x] `zig build test-full` (full app graph) — exit 0
- [x] `zig build` — exit 0
- [ ] GUI / runtime verification on macOS/Windows (no Linux GUI backend): confirm a denied-path read prompts in full mode and an allowed read skips the prompt in confirm mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)