### PR TITLE
feat: focus panel by number (Cmd/Ctrl+1-9)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-panel-focus-by-number.md
+++ b/docs/superpowers/plans/2026-06-03-panel-focus-by-number.md
@@ -1,0 +1,562 @@
+# Focus Panel by Number (Cmd/Ctrl + 1–9) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user focus the Nth panel of the active tab by number (Cmd+1..9 on macOS, Ctrl+1..9 elsewhere), numbered by on-screen position top-left → bottom-right.
+
+**Architecture:** Reuse `SplitTree.spatial()` (normalized 0–1 leaf rects) to sort leaf panels into row-major reading order (pure `sortReadingOrder`), expose `SplitTree.readingOrder`/`panelHandleAt`, focus via `tab.focusPanelByIndex` → `AppWindow.focusPanel` (mirroring `gotoSplit`, with fall-through when there's no panel at that index). New `focus_panel_1..9` keybind actions default to `Ctrl+1..9` (the existing macOS remap renders them as Cmd+1..9).
+
+**Tech Stack:** Zig 0.15. Tests: `zig build test` (fast suite — `command_dispatch.zig`), `zig build test-full` (full graph — `split_tree.zig`, `keybind.zig`, `tab.zig`, `AppWindow.zig`, `input.zig`). Test output contains unrelated `[config]`/`[session_persist]` warnings — those are EXPECTED noise; success = exit 0, no test-failure lines.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-panel-focus-by-number-design.md`
+
+---
+
+## File structure / responsibilities
+
+- `src/split_tree.zig` — `PanelPos`, pure `sortReadingOrder`, `readingOrder`, `panelHandleAt` (ordering lives next to the existing `Spatial`/`spatial`).
+- `src/appwindow/tab.zig` — `focusPanelByIndex` (active-tab glue).
+- `src/AppWindow.zig` — `focusPanel` (mirrors `gotoSplit`, runs focus side-effects).
+- `src/keybind.zig` — `focus_panel_1..9` actions + `Ctrl+1..9` default triggers.
+- `src/input/command_dispatch.zig` — `Command.focus_panel` + `focusPanelNumber` + resolve arm.
+- `src/input.zig` — dispatch arm with fall-through.
+- `src/renderer/overlays/startup_shortcuts.zig` — shortcut hint row (cosmetic).
+
+Task order keeps every commit compiling: ordering core (1–2) → focus glue (3) → keybind actions (4) → command wiring (5) → hint + final verify (6).
+
+---
+
+### Task 1: Pure reading-order sort (`PanelPos` + `sortReadingOrder`)
+
+**Files:**
+- Modify: `src/split_tree.zig` (add types/functions just after the `Spatial` struct, near line ~885; add tests in the test section near the bottom)
+
+- [ ] **Step 1: Write the failing tests** (append to the test section at the bottom of `src/split_tree.zig`)
+
+```zig
+test "sortReadingOrder orders panels top-left to bottom-right" {
+    const at = struct {
+        fn h(i: u16) Node.Handle {
+            return @enumFromInt(i);
+        }
+    }.h;
+    // Shuffled input: BR, TL, BL, TR (2x2 grid positions).
+    var items = [_]PanelPos{
+        .{ .handle = at(6), .x = 0.5, .y = 0.5 }, // bottom-right
+        .{ .handle = at(2), .x = 0.0, .y = 0.0 }, // top-left
+        .{ .handle = at(5), .x = 0.0, .y = 0.5 }, // bottom-left
+        .{ .handle = at(3), .x = 0.5, .y = 0.0 }, // top-right
+    };
+    sortReadingOrder(&items);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(items[0].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(items[1].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 5), @intFromEnum(items[2].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 6), @intFromEnum(items[3].handle));
+}
+
+test "sortReadingOrder: a tall left panel precedes a stacked right column" {
+    const at = struct {
+        fn h(i: u16) Node.Handle {
+            return @enumFromInt(i);
+        }
+    }.h;
+    // Left spans full height (top-left at y=0); right column split top (y=0) / bottom (y=0.5).
+    var items = [_]PanelPos{
+        .{ .handle = at(4), .x = 0.5, .y = 0.5 }, // right-bottom
+        .{ .handle = at(2), .x = 0.0, .y = 0.0 }, // left (tall)
+        .{ .handle = at(3), .x = 0.5, .y = 0.0 }, // right-top
+    };
+    sortReadingOrder(&items);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(items[0].handle)); // left (row 0, x 0)
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(items[1].handle)); // right-top (row 0, x 0.5)
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 4), @intFromEnum(items[2].handle)); // right-bottom (row 1)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `zig build test-full`
+Expected: FAIL — `PanelPos` / `sortReadingOrder` are not defined.
+
+- [ ] **Step 3: Implement `PanelPos` + `sortReadingOrder`** (add immediately after the closing `};` of the `Spatial` struct, around line ~885)
+
+```zig
+/// A leaf panel's handle plus its normalized top-left position (from `spatial`),
+/// used to order panels by on-screen reading order.
+pub const PanelPos = struct {
+    handle: Node.Handle,
+    x: f16,
+    y: f16,
+};
+
+/// Number of vertical buckets across the 1.0-tall grid. Panels whose `y` round
+/// to the same bucket are treated as the same visual row (then ordered by `x`).
+/// 64 ≈ 1.5% tolerance — fine because rows are separated by a meaningful
+/// fraction of the height. A quantized integer key keeps the comparison
+/// transitive (avoids the floating-epsilon-comparator hazard).
+const ROW_QUANTA: f32 = 64.0;
+
+fn rowKey(y: f16) i32 {
+    return @intFromFloat(@round(@as(f32, @floatCast(y)) * ROW_QUANTA));
+}
+
+fn readingOrderLessThan(_: void, a: PanelPos, b: PanelPos) bool {
+    const ay = rowKey(a.y);
+    const by = rowKey(b.y);
+    if (ay != by) return ay < by;
+    return a.x < b.x;
+}
+
+/// Sort panels into screen reading order: top-left → bottom-right (row-major).
+/// Stable (so exact ties keep tree order); N is the tiny panel count.
+pub fn sortReadingOrder(items: []PanelPos) void {
+    std.sort.insertion(PanelPos, items, {}, readingOrderLessThan);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `zig build test-full`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/split_tree.zig
+git commit -m "feat(split): add row-major panel reading-order sort"
+```
+
+---
+
+### Task 2: `SplitTree.readingOrder` + `panelHandleAt`
+
+**Files:**
+- Modify: `src/split_tree.zig` (add the two public methods after `sortReadingOrder`; add a test in the test section)
+
+- [ ] **Step 1: Write the failing test** (append to the test section)
+
+```zig
+test "SplitTree: readingOrder is row-major top-left to bottom-right" {
+    const session_persist = @import("session_persist.zig");
+    // 2x2 grid: root stacks two rows (vertical); each row is left|right (horizontal).
+    var tl = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var tr = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var bl = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var br = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var top = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &tl, .right = &tr } };
+    var bot = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &bl, .right = &br } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .vertical, .ratio = 0.5, .left = &top, .right = &bot } };
+
+    const Stub = struct {
+        var counter: usize = 0;
+        var sentinels: [16]usize = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: Allocator) ?*Surface {
+            const ptr = &sentinels[counter];
+            counter += 1;
+            return @ptrCast(@alignCast(ptr));
+        }
+    };
+    Stub.counter = 0;
+
+    var tree = try fromSnapshot(std.testing.allocator, &root, Stub.make);
+    defer {
+        if (tree.nodes.len > 0) tree.arena.deinit();
+        tree = undefined;
+    }
+
+    const order = try tree.readingOrder(std.testing.allocator);
+    defer std.testing.allocator.free(order);
+
+    // Pre-order node handles: root=0, top=1, tl=2, tr=3, bot=4, bl=5, br=6.
+    try std.testing.expectEqual(@as(usize, 4), order.len);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(order[0])); // top-left
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(order[1])); // top-right
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 5), @intFromEnum(order[2])); // bottom-left
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 6), @intFromEnum(order[3])); // bottom-right
+
+    // panelHandleAt is 1-based and range-checked.
+    try std.testing.expectEqual(@as(?Node.Handle, @enumFromInt(2)), try tree.panelHandleAt(std.testing.allocator, 1));
+    try std.testing.expectEqual(@as(?Node.Handle, @enumFromInt(6)), try tree.panelHandleAt(std.testing.allocator, 4));
+    try std.testing.expectEqual(@as(?Node.Handle, null), try tree.panelHandleAt(std.testing.allocator, 5));
+    try std.testing.expectEqual(@as(?Node.Handle, null), try tree.panelHandleAt(std.testing.allocator, 0));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: FAIL — `readingOrder` / `panelHandleAt` are not defined.
+
+- [ ] **Step 3: Implement the two methods** (add after `sortReadingOrder`)
+
+```zig
+/// Leaf-panel handles in screen reading order (top-left → bottom-right).
+/// Caller owns the returned slice. Empty tree → zero-length slice.
+pub fn readingOrder(self: *const SplitTree, alloc: Allocator) Allocator.Error![]Node.Handle {
+    if (self.nodes.len == 0) return alloc.alloc(Node.Handle, 0);
+
+    var sp = try self.spatial(alloc);
+    defer sp.deinit(alloc);
+
+    var positions: std.ArrayListUnmanaged(PanelPos) = .empty;
+    defer positions.deinit(alloc);
+    var it = self.iterator();
+    while (it.next()) |entry| {
+        const slot = sp.slots[entry.handle.idx()];
+        try positions.append(alloc, .{ .handle = entry.handle, .x = slot.x, .y = slot.y });
+    }
+    sortReadingOrder(positions.items);
+
+    const handles = try alloc.alloc(Node.Handle, positions.items.len);
+    for (positions.items, 0..) |p, i| handles[i] = p.handle;
+    return handles;
+}
+
+/// Handle of the n-th panel (1-based) in reading order, or null if out of range.
+pub fn panelHandleAt(self: *const SplitTree, alloc: Allocator, n_one_based: usize) Allocator.Error!?Node.Handle {
+    const order = try self.readingOrder(alloc);
+    defer alloc.free(order);
+    if (n_one_based >= 1 and n_one_based <= order.len) return order[n_one_based - 1];
+    return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/split_tree.zig
+git commit -m "feat(split): enumerate panels in reading order + index lookup"
+```
+
+---
+
+### Task 3: `tab.focusPanelByIndex` + `AppWindow.focusPanel`
+
+**Files:**
+- Modify: `src/appwindow/tab.zig` (add `focusPanelByIndex` after `gotoSplit`, ~line 820; add a test in the test section)
+- Modify: `src/AppWindow.zig` (add `focusPanel` after `gotoSplit`, ~line 2116)
+
+- [ ] **Step 1: Write the failing test** (append to `src/appwindow/tab.zig` test section)
+
+```zig
+test "focusPanelByIndex focuses panels in screen reading order" {
+    const session_persist = @import("../session_persist.zig");
+    // Two side-by-side panels: root horizontal, left | right.
+    var l = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var r = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &l, .right = &r } };
+    const Stub = struct {
+        var counter: usize = 0;
+        var sentinels: [8]usize = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: std.mem.Allocator) ?*Surface {
+            const ptr = &sentinels[counter];
+            counter += 1;
+            return @ptrCast(@alignCast(ptr));
+        }
+    };
+    Stub.counter = 0;
+
+    var ts = TabState{
+        .kind = .terminal,
+        .tree = try SplitTree.fromSnapshot(std.testing.allocator, &root, Stub.make),
+        .focused = .root,
+    };
+    // Sentinel surfaces can't be unref'd, so free the arena directly (no TabState.deinit).
+    defer ts.tree.arena.deinit();
+
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_count = g_tab_count;
+    const saved_tab0 = g_tabs[0];
+    defer {
+        active_tab_state.g_active_tab = saved_active;
+        g_tab_count = saved_count;
+        g_tabs[0] = saved_tab0;
+    }
+    g_tabs[0] = &ts;
+    active_tab_state.g_active_tab = 0;
+    g_tab_count = 1;
+
+    // Handles: root=0, left=1, right=2. Reading order: [left(1), right(2)].
+    try std.testing.expect(focusPanelByIndex(std.testing.allocator, 1));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 1), @intFromEnum(ts.focused));
+    try std.testing.expect(focusPanelByIndex(std.testing.allocator, 2));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 2), @intFromEnum(ts.focused));
+    // Out of range → false, focus unchanged.
+    try std.testing.expect(!focusPanelByIndex(std.testing.allocator, 3));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 2), @intFromEnum(ts.focused));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: FAIL — `focusPanelByIndex` is not defined.
+
+- [ ] **Step 3a: Implement `focusPanelByIndex`** in `src/appwindow/tab.zig` (add right after the `gotoSplit` function, ~line 820)
+
+```zig
+/// Focus the n-th panel (1-based) of the active tab in screen reading order
+/// (top-left → bottom-right). Returns false if there is no such panel (n out of
+/// range, empty/non-terminal tab), leaving focus unchanged so the caller can let
+/// the key fall through to the terminal.
+pub fn focusPanelByIndex(allocator: std.mem.Allocator, n: usize) bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    const handle = (t.tree.panelHandleAt(allocator, n) catch return false) orelse return false;
+    t.focused = handle;
+    return true;
+}
+```
+
+- [ ] **Step 3b: Implement `focusPanel`** in `src/AppWindow.zig` (add right after the `gotoSplit` function, ~line 2116)
+
+```zig
+/// Focus the n-th panel (1-based) of the active tab by screen reading order.
+/// Returns whether focus moved (false = no such panel, so the caller can let the
+/// key fall through to the terminal).
+pub fn focusPanel(n: usize) bool {
+    const allocator = g_allocator orelse return false;
+    if (tab.focusPanelByIndex(allocator, n)) {
+        handleActiveSurfaceChangeWithinTab();
+        return true;
+    }
+    return false;
+}
+```
+
+- [ ] **Step 4: Run test + build to verify**
+
+Run: `zig build test-full && zig build`
+Expected: PASS, build exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/appwindow/tab.zig src/AppWindow.zig
+git commit -m "feat(tab): focus a panel by reading-order index"
+```
+
+---
+
+### Task 4: Keybind actions `focus_panel_1..9` + default `Ctrl+1..9`
+
+**Files:**
+- Modify: `src/keybind.zig` (add enum variants after `switch_tab_9` ~line 91; add default triggers after the `switch_tab_9` binding ~line 435; add a test)
+
+- [ ] **Step 1: Write the failing test** (append to the test section of `src/keybind.zig`)
+
+```zig
+test "focus_panel actions parse and have default Ctrl+number bindings" {
+    try std.testing.expectEqual(Action.focus_panel_1, Action.parse("focus_panel_1").?);
+    try std.testing.expectEqual(Action.focus_panel_9, Action.parse("focus_panel_9").?);
+    // Each focus_panel_N has a default Ctrl+digit binding (→ Cmd+digit on macOS
+    // via the Ctrl→Cmd remap in the Set builder).
+    var found: usize = 0;
+    for (default_bindings) |b| {
+        switch (b.action) {
+            .focus_panel_1, .focus_panel_2, .focus_panel_3, .focus_panel_4, .focus_panel_5, .focus_panel_6, .focus_panel_7, .focus_panel_8, .focus_panel_9 => {
+                try std.testing.expect(b.trigger.mods.ctrl);
+                found += 1;
+            },
+            else => {},
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 9), found);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: FAIL — `focus_panel_1` is not a member of `Action`.
+
+- [ ] **Step 3a: Add the actions** to the `Action` enum in `src/keybind.zig` — insert these nine lines immediately after `switch_tab_9,` (line 91, before `open_config,`):
+
+```zig
+    focus_panel_1,
+    focus_panel_2,
+    focus_panel_3,
+    focus_panel_4,
+    focus_panel_5,
+    focus_panel_6,
+    focus_panel_7,
+    focus_panel_8,
+    focus_panel_9,
+```
+
+- [ ] **Step 3b: Add the default bindings** to the `default_bindings` array — insert these nine lines immediately after the `switch_tab_9` binding (line 435):
+
+```zig
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '1' }, .action = .focus_panel_1 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '2' }, .action = .focus_panel_2 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '3' }, .action = .focus_panel_3 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '4' }, .action = .focus_panel_4 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '5' }, .action = .focus_panel_5 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '6' }, .action = .focus_panel_6 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '7' }, .action = .focus_panel_7 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '8' }, .action = .focus_panel_8 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '9' }, .action = .focus_panel_9 },
+```
+
+(The Set builder at `keybind.zig:122-142` remaps every non-global, non-Tab Ctrl default to the `win`/Cmd modifier on macOS, so these become Cmd+1..9 there. The digit keys are unaffected by the Tab/global exceptions.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS. (At this point `focus_panel_N` actions resolve to `null` in `command_dispatch` — inert — until Task 5; nothing else switches exhaustively on `Action`, so this compiles.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/keybind.zig
+git commit -m "feat(keybind): add focus_panel_1..9 actions + Ctrl/Cmd+1..9 defaults"
+```
+
+---
+
+### Task 5: Command wiring (`command_dispatch` + `input.zig`)
+
+**Files:**
+- Modify: `src/input/command_dispatch.zig` (add `Command.focus_panel`, `focusPanelNumber`, resolve arm; add a test)
+- Modify: `src/input.zig` (add the `.focus_panel` handler arm)
+
+- [ ] **Step 1: Write the failing test** (append to the test section of `src/input/command_dispatch.zig`)
+
+```zig
+test "focus_panel actions resolve to a 1-based focus_panel command (late phase only)" {
+    try std.testing.expectEqual(Command{ .focus_panel = 1 }, resolve(.focus_panel_1, .late).?);
+    try std.testing.expectEqual(Command{ .focus_panel = 9 }, resolve(.focus_panel_9, .late).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.focus_panel_1, .early));
+    // Regression: the shared `else` arm still resolves switch_tab.
+    try std.testing.expectEqual(Command{ .switch_tab = 0 }, resolve(.switch_tab_1, .late).?);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test`
+Expected: FAIL — `Command.focus_panel` does not exist.
+
+- [ ] **Step 3a: Add the `Command` variant** in `src/input/command_dispatch.zig` — add to the `Command` union (after `switch_tab: usize,`):
+
+```zig
+    focus_panel: usize,
+```
+
+- [ ] **Step 3b: Resolve the new actions** — in `resolve`'s `.late` switch, replace the existing terminal arm:
+
+```zig
+            else => if (switchTabIndex(action)) |idx| .{ .switch_tab = idx } else null,
+```
+
+with:
+
+```zig
+            else => if (focusPanelNumber(action)) |n|
+                .{ .focus_panel = n }
+            else if (switchTabIndex(action)) |idx|
+                .{ .switch_tab = idx }
+            else
+                null,
+```
+
+- [ ] **Step 3c: Add the `focusPanelNumber` helper** — add right after `switchTabIndex` (~line 92):
+
+```zig
+/// focus_panel_1..9 → 1-based panel number, else null.
+fn focusPanelNumber(action: keybind.Action) ?usize {
+    return switch (action) {
+        .focus_panel_1 => 1,
+        .focus_panel_2 => 2,
+        .focus_panel_3 => 3,
+        .focus_panel_4 => 4,
+        .focus_panel_5 => 5,
+        .focus_panel_6 => 6,
+        .focus_panel_7 => 7,
+        .focus_panel_8 => 8,
+        .focus_panel_9 => 9,
+        else => null,
+    };
+}
+```
+
+- [ ] **Step 3d: Handle the command** in `src/input.zig` — in the command `switch` (executeCommand), add this arm right after the `.focus_split => |target| return switch (target) { ... },` arm (~line 1158):
+
+```zig
+        // Numeric panel focus: like focus_split, "performable" — if there is no
+        // panel at that index (single-panel tab, or index past the panel count),
+        // don't consume the key so it falls through to the terminal.
+        .focus_panel => |n| return AppWindow.focusPanel(n),
+```
+
+- [ ] **Step 4: Run tests + build to verify**
+
+Run: `zig build test && zig build test-full && zig build`
+Expected: PASS (fast suite includes the new `command_dispatch` test), full suite PASS, build exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/input/command_dispatch.zig src/input.zig
+git commit -m "feat(input): wire focus_panel_N to AppWindow.focusPanel with fall-through"
+```
+
+---
+
+### Task 6: Shortcut hint + final verification
+
+**Files:**
+- Modify: `src/renderer/overlays/startup_shortcuts.zig` (add a hint row near the existing "Previous / next panel" entry, line 62)
+
+- [ ] **Step 1: Add the hint row** — in `src/renderer/overlays/startup_shortcuts.zig`, add a new entry immediately after the line containing `.action = "Previous / next panel", .action_zh = "上一个 / 下一个面板"` (line 62). Match the existing struct shape of the surrounding entries exactly; use the single-action form (not the `.pair` form), referencing `.focus_panel_1`:
+
+```zig
+    .{ .keys = "Ctrl+1..9", .kind = .single, .first = .focus_panel_1, .action = "Focus panel by number", .action_zh = "按编号聚焦面板" },
+```
+
+Note: open `startup_shortcuts.zig` and copy the EXACT field set of an existing `.kind = .single` entry (field names/order, and whether a `.second` field is required) — mirror it precisely. If every existing entry is `.pair`, use the `.pair` form with `.first = .focus_panel_1, .second = .focus_panel_9` and label "Focus panel 1–9 by number". Do not invent fields.
+
+- [ ] **Step 2: Build to verify the hint compiles**
+
+Run: `zig build`
+Expected: exit 0.
+
+- [ ] **Step 3: Full verification**
+
+Run: `zig build test && zig build test-full && zig build`
+Expected: all exit 0, no test-failure lines.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/overlays/startup_shortcuts.zig
+git commit -m "docs(shortcuts): add focus-panel-by-number hint row"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Cmd/Ctrl+1..9 → focus panel N → Task 4 (actions+defaults) + Task 5 (dispatch). ✓
+- Numbering by screen position, row-major top-left→bottom-right → Task 1 (`sortReadingOrder`) + Task 2 (`readingOrder`). ✓
+- macOS renders as Cmd via existing remap → Task 4 default uses `Ctrl`; note + test assert. ✓
+- Panels 1–9 only → `focusPanelNumber` maps 1..9; `panelHandleAt` range-checks. ✓
+- Fall-through when no panel at index → `focusPanelByIndex`/`focusPanel` return bool; `input.zig` arm `return AppWindow.focusPanel(n)` (Task 5). ✓
+- Reuse focus side-effects → `AppWindow.focusPanel` calls `handleActiveSurfaceChangeWithinTab()` (Task 3). ✓
+- Independent of `focus_previous/next` and `Alt+Arrow` → no existing arms modified; only added. ✓
+- Testing: pure sort (Task 1), readingOrder on real tree (Task 2), tab glue (Task 3), keybind mapping (Task 4), command resolve (Task 5). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. Task 6 Step 1 defers exact struct shape to the file's existing entries (cosmetic, non-load-bearing) with explicit fallback — acceptable.
+
+**Type consistency:** `PanelPos{ handle: Node.Handle, x: f16, y: f16 }`, `sortReadingOrder([]PanelPos)`, `readingOrder(alloc) ![]Node.Handle`, `panelHandleAt(alloc, usize) !?Node.Handle`, `focusPanelByIndex(allocator, usize) bool`, `focusPanel(usize) bool`, `Command.focus_panel: usize`, `focusPanelNumber(action) ?usize`, `focus_panel_1..9` — names match across all tasks. Indices: `focusPanelNumber` and `panelHandleAt`/`focusPanelByIndex` are all **1-based**; `switchTabIndex` stays 0-based (unchanged). Consistent.
+
+## Notes / out of scope
+
+- GUI/runtime verification (macOS/Windows) is pending after implementation — no Linux GUI backend here.
+- No panel-number overlay badges; no >9 panels; no reordering UI (per spec).

--- a/docs/superpowers/specs/2026-06-03-panel-focus-by-number-design.md
+++ b/docs/superpowers/specs/2026-06-03-panel-focus-by-number-design.md
@@ -1,0 +1,175 @@
+# Focus Panel by Number (Cmd/Ctrl + 1–9)
+
+**Date:** 2026-06-03
+**Status:** Design — approved by user, pending spec review
+
+## Problem
+
+Within a single tab, WispTerm can hold multiple terminal panels (leaves of the
+tab's `SplitTree`). Today you can only move panel focus **directionally**
+(`Alt/Option+Arrow` → `focus_left/right/up/down`) or **cyclically**
+(`Ctrl/Cmd+Shift+[` / `]` → `focus_previous/next`). There is no way to jump
+directly to a specific panel by number.
+
+We want **Cmd+1 … Cmd+9** (macOS) to focus the 1st…9th panel in the active tab,
+numbered by **screen position, top-left → bottom-right (row-major)**.
+
+The number keys are otherwise unused with this modifier: tab switching is bound
+to `Alt/Option+number` (`switch_tab_1..9`, `keybind.zig:427`), and `Cmd+number`
+is currently unbound.
+
+## Constraints & decisions
+
+- **Numbering:** by on-screen position, row-major — top rows first, left→right
+  within a row. Independent of tree/insertion order.
+- **Modifier:** default `Ctrl+1..9`. The keybind table is authored in `Ctrl`
+  and remapped to `Cmd` on macOS (`keybind.zig:122-142`), so this renders as
+  **Cmd+1..9** on macOS and `Ctrl+1..9` on Linux/Windows. Tabs keep
+  `Alt/Option+number`; no conflict.
+- **Range:** panels 1–9 only. A 10th+ panel is not reachable by number.
+- **Fall-through:** if there is no panel at the requested index (e.g. a
+  single-panel tab, or the index exceeds the panel count), the action does
+  nothing and **does not consume** the key — it falls through to the terminal,
+  mirroring `gotoSplit`'s `bool` return (`AppWindow.zig:2108`). This avoids
+  shadowing terminal `Ctrl+number` input on Linux/Windows when there's nothing
+  to focus.
+- **No conflict** with the existing `focus_previous/next` cycle (tree order) or
+  `Alt+Arrow` directional focus — those are unchanged.
+
+## Architecture
+
+The split tree already exposes everything needed:
+
+- `SplitTree.spatial(alloc) → Spatial{ slots: []Slot }` — each node gets a
+  normalized `Slot{ x, y, width, height }` in a 1×1 space, top-left = (0,0)
+  (`split_tree.zig:892-940`). Slots are indexed by node handle.
+- `SplitTree.iterator()` yields `SurfaceEntry{ handle, surface }` for every leaf
+  (`split_tree.zig:154-183`).
+- Focus is just `TabState.focused: SplitTree.Node.Handle` (`tab.zig:47`); the
+  existing `gotoSplit` sets it and the app reacts via
+  `handleActiveSurfaceChangeWithinTab()` (`AppWindow.zig:2108-2116`).
+
+### Reading-order ordering (pure, testable)
+
+A small pure layer, independent of `Surface`:
+
+```zig
+pub const PanelPos = struct { handle: SplitTree.Node.Handle, x: f16, y: f16 };
+
+/// Stable row-major sort: primary key y quantized to a tolerance so panels
+/// sharing a visual row group together, secondary key x (left→right).
+pub fn sortReadingOrder(items: []PanelPos) void;
+```
+
+Quantization: bucket `y` by `@round(y * ROW_QUANTA)` (with `ROW_QUANTA = 64`,
+giving ~1.5% tolerance) as the primary sort key, then `x` ascending. Splits
+produce clean fractions and rows are separated by a meaningful fraction of
+height, so quantization groups true same-row panels (whose `y` are equal or
+near-equal) without merging distinct rows. Using a quantized integer key keeps
+the comparator transitive (avoids the floating-epsilon-comparator hazard). The
+sort is stable so ties (same bucket, same x — not expected) keep tree order.
+
+### Enumerate + focus
+
+In `appwindow/tab.zig`:
+
+```zig
+/// Leaf-panel handles in screen reading order (top-left → bottom-right).
+/// Caller owns the returned slice (allocated with `alloc`).
+pub fn panelsInReadingOrder(alloc: std.mem.Allocator) ![]SplitTree.Node.Handle;
+
+/// Focus the n-th panel (1-based) in reading order. Returns false if there is
+/// no such panel (n < 1 or n > panel count), leaving focus unchanged.
+pub fn focusPanelByIndex(alloc: std.mem.Allocator, n: usize) bool;
+```
+
+`panelsInReadingOrder` builds `[]PanelPos` from `tree.spatial(alloc)` (reading
+`slots[handle.idx()]`) for each leaf from `tree.iterator()`, calls
+`sortReadingOrder`, and returns the handles. `focusPanelByIndex` calls it; if
+`n >= 1 and n <= handles.len`, sets `t.focused = handles[n-1]` and returns true,
+else returns false.
+
+In `AppWindow.zig` (mirrors `gotoSplit`):
+
+```zig
+/// Focus the n-th panel by reading order. Returns whether focus moved (false =
+/// no such panel, so the caller can let the key fall through).
+pub fn focusPanel(n: usize) bool {
+    const allocator = g_allocator orelse return false;
+    if (tab.focusPanelByIndex(allocator, n)) {
+        handleActiveSurfaceChangeWithinTab();
+        return true;
+    }
+    return false;
+}
+```
+
+### Keybind actions + dispatch
+
+- Add `focus_panel_1 … focus_panel_9` to `keybind.Action`
+  (`keybind.zig:83-91`, beside `switch_tab_1..9`).
+- Add default triggers `Ctrl + '1'..'9' → focus_panel_N`
+  (`keybind.zig` default table, beside the `Alt+number` tab binds at 427-435).
+- A `focusPanelIndex(action) ?usize` helper (mirroring `switchTabIndex` in
+  `input/command_dispatch.zig:80-92`) maps `focus_panel_N → N`.
+- In `input.zig`, where actions are handled (beside the `focus_left/right/...`
+  → `gotoSplit` arm at `input.zig:1152-1157` and the `switch_tab` arm at
+  `1163-1169`): `focus_panel_N → if (!AppWindow.focusPanel(N)) <fall through>`.
+  Consume the key only when `focusPanel` returns true; otherwise let it pass to
+  the terminal (same convention as the directional `gotoSplit` arm).
+
+## Files
+
+- `src/split_tree.zig` — add `PanelPos` + `sortReadingOrder` (pure). (Or a tiny
+  new leaf module if it keeps `split_tree.zig` focused; default: keep in
+  `split_tree.zig` next to `Spatial`, since it operates on spatial slots.)
+- `src/appwindow/tab.zig` — `panelsInReadingOrder`, `focusPanelByIndex`.
+- `src/AppWindow.zig` — `focusPanel`.
+- `src/keybind.zig` — `focus_panel_1..9` actions + default `Ctrl+1..9` triggers.
+- `src/input/command_dispatch.zig` — `focusPanelIndex` mapping helper.
+- `src/input.zig` — dispatch arm + fall-through.
+- (Optional) `src/renderer/overlays/startup_shortcuts.zig` — add a hint row for
+  the new shortcut, matching the existing "Previous / next panel" entry
+  (`startup_shortcuts.zig:62`).
+
+## Error handling / edge cases
+
+- Empty tree / no `g_allocator` → `focusPanel` returns false (no-op,
+  fall-through).
+- Single-panel tab → only index 1 exists; `Cmd+1` re-focuses it (no visible
+  change), `Cmd+2..9` fall through.
+- Index beyond panel count → false / fall-through.
+- `spatial()` allocates; `panelsInReadingOrder` frees the spatial slots and
+  returns its own owned handle slice (caller frees). On allocation failure,
+  `focusPanelByIndex` returns false (treated as no-op).
+- Zoomed/maximized panel state is unaffected — we only change which leaf is
+  focused; existing focus-change handling applies.
+
+## Testing
+
+**Pure (`sortReadingOrder`, runs wherever `split_tree.zig` tests run):**
+- Two-wide row `[(h0,x0,y0),(h1,x0.5,y0)]` → `[h0,h1]`.
+- Two-stacked column `[(h0,x0,y0),(h1,x0,y0.5)]` → `[h0,h1]`.
+- 2×2 grid (handles shuffled on input) → row-major `[top-left, top-right,
+  bottom-left, bottom-right]`.
+- Uneven nesting: one tall left panel + two stacked right panels → `[left,
+  top-right, bottom-right]` (left `y=0` groups with top-right's row by quanta;
+  tie broken by x so left precedes top-right).
+- Already-ordered input stays ordered (stability).
+
+**Tab-level (`focusPanelByIndex`, where `tab.zig` tests run — full suite):**
+- Build a 2-panel split; `focusPanelByIndex(1)`/`(2)` set the expected handle
+  and return true; `(3)` and `(0)` return false and leave `focused` unchanged.
+
+**Keybind:**
+- Default-binding test: `Ctrl+1` resolves to `.focus_panel_1` (and on macOS the
+  remap yields the `Cmd` form), mirroring the existing `switch_tab` binding
+  test.
+
+## YAGNI / out of scope
+
+- No numbers beyond 9; no "panel 10+".
+- No on-screen panel-number overlay/badges (focus is already indicated by the
+  active-surface border).
+- No reordering/renumbering UI; order is derived from layout each time.
+- No change to tab switching, directional focus, or the prev/next cycle.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2114,6 +2114,18 @@ pub fn gotoSplit(direction: SplitTree.Goto) bool {
     return false;
 }
 
+/// Focus the n-th panel (1-based) of the active tab by screen reading order.
+/// Returns whether focus moved (false = no such panel, so the caller can let the
+/// key fall through to the terminal).
+pub fn focusPanel(n: usize) bool {
+    const allocator = g_allocator orelse return false;
+    if (tab.focusPanelByIndex(allocator, n)) {
+        handleActiveSurfaceChangeWithinTab();
+        return true;
+    }
+    return false;
+}
+
 pub fn equalizeSplits() void {
     const allocator = g_allocator orelse return;
     if (tab.equalizeSplits(allocator)) {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -818,6 +818,18 @@ pub fn gotoSplit(allocator: std.mem.Allocator, direction: SplitTree.Goto) bool {
     return false;
 }
 
+/// Focus the n-th panel (1-based) of the active tab in screen reading order
+/// (top-left → bottom-right). Returns false if there is no such panel (n out of
+/// range, empty/non-terminal tab), leaving focus unchanged so the caller can let
+/// the key fall through to the terminal.
+pub fn focusPanelByIndex(allocator: std.mem.Allocator, n: usize) bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    const handle = (t.tree.panelHandleAt(allocator, n) catch return false) orelse return false;
+    t.focused = handle;
+    return true;
+}
+
 /// Equalize all split ratios. Returns true if equalization was performed.
 pub fn equalizeSplits(allocator: std.mem.Allocator) bool {
     const t = activeTab() orelse return false;
@@ -2036,4 +2048,50 @@ test "tab: reorder rejects invalid and no-op moves" {
     try std.testing.expect(!reorderTab(1, 0));
     try std.testing.expect(g_tabs[0].? == &a);
     try std.testing.expectEqual(@as(usize, 0), active_tab_state.g_active_tab);
+}
+
+test "focusPanelByIndex focuses panels in screen reading order" {
+    // Two side-by-side panels: root horizontal, left | right.
+    var l = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var r = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &l, .right = &r } };
+    const Stub = struct {
+        var counter: usize = 0;
+        var sentinels: [8]usize = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: std.mem.Allocator) ?*Surface {
+            const ptr = &sentinels[counter];
+            counter += 1;
+            return @ptrCast(@alignCast(ptr));
+        }
+    };
+    Stub.counter = 0;
+
+    var ts = TabState{
+        .kind = .terminal,
+        .tree = try SplitTree.fromSnapshot(std.testing.allocator, &root, Stub.make),
+        .focused = .root,
+    };
+    // Sentinel surfaces can't be unref'd, so free the arena directly (no TabState.deinit).
+    defer ts.tree.arena.deinit();
+
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_count = g_tab_count;
+    const saved_tab0 = g_tabs[0];
+    defer {
+        active_tab_state.g_active_tab = saved_active;
+        g_tab_count = saved_count;
+        g_tabs[0] = saved_tab0;
+    }
+    g_tabs[0] = &ts;
+    active_tab_state.g_active_tab = 0;
+    g_tab_count = 1;
+
+    // Handles: root=0, left=1, right=2. Reading order: [left(1), right(2)].
+    try std.testing.expect(focusPanelByIndex(std.testing.allocator, 1));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 1), @intFromEnum(ts.focused));
+    try std.testing.expect(focusPanelByIndex(std.testing.allocator, 2));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 2), @intFromEnum(ts.focused));
+    // Out of range → false, focus unchanged.
+    try std.testing.expect(!focusPanelByIndex(std.testing.allocator, 3));
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 2), @intFromEnum(ts.focused));
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -1156,6 +1156,10 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
             .previous => AppWindow.gotoSplit(.previous_wrapped),
             .next => AppWindow.gotoSplit(.next_wrapped),
         },
+        // Numeric panel focus: like focus_split, "performable" — if there is no
+        // panel at that index (single-panel tab, or index past the panel count),
+        // don't consume the key so it falls through to the terminal.
+        .focus_panel => |n| return AppWindow.focusPanel(n),
         .equalize_splits => AppWindow.equalizeSplits(),
         .next_tab => AppWindow.switchTab((active_tab_state.g_active_tab + 1) % tab.g_tab_count),
         .previous_tab => {

--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -37,6 +37,7 @@ pub const Command = union(enum) {
     previous_tab,
     open_config,
     switch_tab: usize,
+    focus_panel: usize,
 };
 
 /// Map a configured action + phase to the command it triggers, or null if the
@@ -72,7 +73,12 @@ pub fn resolve(action: keybind.Action, phase: Phase) ?Command {
             .next_tab => .next_tab,
             .previous_tab => .previous_tab,
             .open_config => .open_config,
-            else => if (switchTabIndex(action)) |idx| .{ .switch_tab = idx } else null,
+            else => if (focusPanelNumber(action)) |n|
+                .{ .focus_panel = n }
+            else if (switchTabIndex(action)) |idx|
+                .{ .switch_tab = idx }
+            else
+                null,
         },
     };
 }
@@ -89,6 +95,22 @@ fn switchTabIndex(action: keybind.Action) ?usize {
         .switch_tab_7 => 6,
         .switch_tab_8 => 7,
         .switch_tab_9 => 8,
+        else => null,
+    };
+}
+
+/// focus_panel_1..9 → 1-based panel number, else null.
+fn focusPanelNumber(action: keybind.Action) ?usize {
+    return switch (action) {
+        .focus_panel_1 => 1,
+        .focus_panel_2 => 2,
+        .focus_panel_3 => 3,
+        .focus_panel_4 => 4,
+        .focus_panel_5 => 5,
+        .focus_panel_6 => 6,
+        .focus_panel_7 => 7,
+        .focus_panel_8 => 8,
+        .focus_panel_9 => 9,
         else => null,
     };
 }
@@ -126,4 +148,12 @@ test "switch_tab_N maps to a zero-based index" {
 test "toggle_ai_copilot resolves in the early phase" {
     try std.testing.expectEqual(Command.toggle_ai_copilot, resolve(.toggle_ai_copilot, .early).?);
     try std.testing.expectEqual(@as(?Command, null), resolve(.toggle_ai_copilot, .late));
+}
+
+test "focus_panel actions resolve to a 1-based focus_panel command (late phase only)" {
+    try std.testing.expectEqual(Command{ .focus_panel = 1 }, resolve(.focus_panel_1, .late).?);
+    try std.testing.expectEqual(Command{ .focus_panel = 9 }, resolve(.focus_panel_9, .late).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.focus_panel_1, .early));
+    // Regression: the shared `else` arm still resolves switch_tab.
+    try std.testing.expectEqual(Command{ .switch_tab = 0 }, resolve(.switch_tab_1, .late).?);
 }

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -89,6 +89,15 @@ pub const Action = enum {
     switch_tab_7,
     switch_tab_8,
     switch_tab_9,
+    focus_panel_1,
+    focus_panel_2,
+    focus_panel_3,
+    focus_panel_4,
+    focus_panel_5,
+    focus_panel_6,
+    focus_panel_7,
+    focus_panel_8,
+    focus_panel_9,
     open_config,
 
     pub fn parse(value: []const u8) ?Action {
@@ -433,6 +442,15 @@ pub const default_bindings = [_]Binding{
     .{ .trigger = .{ .mods = .{ .alt = true }, .key_code = '7' }, .action = .switch_tab_7 },
     .{ .trigger = .{ .mods = .{ .alt = true }, .key_code = '8' }, .action = .switch_tab_8 },
     .{ .trigger = .{ .mods = .{ .alt = true }, .key_code = '9' }, .action = .switch_tab_9 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '1' }, .action = .focus_panel_1 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '2' }, .action = .focus_panel_2 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '3' }, .action = .focus_panel_3 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '4' }, .action = .focus_panel_4 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '5' }, .action = .focus_panel_5 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '6' }, .action = .focus_panel_6 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '7' }, .action = .focus_panel_7 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '8' }, .action = .focus_panel_8 },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '9' }, .action = .focus_panel_9 },
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = Key.comma }, .action = .open_config },
 };
 
@@ -542,4 +560,22 @@ test "keybind parses displayed plus shortcut spelling" {
         .mods = .{ .ctrl = true },
         .key_code = Key.plus,
     }));
+}
+
+test "focus_panel actions parse and have default Ctrl+number bindings" {
+    try std.testing.expectEqual(Action.focus_panel_1, Action.parse("focus_panel_1").?);
+    try std.testing.expectEqual(Action.focus_panel_9, Action.parse("focus_panel_9").?);
+    // Each focus_panel_N has a default Ctrl+digit binding (→ Cmd+digit on macOS
+    // via the Ctrl→Cmd remap in the Set builder).
+    var found: usize = 0;
+    for (default_bindings) |b| {
+        switch (b.action) {
+            .focus_panel_1, .focus_panel_2, .focus_panel_3, .focus_panel_4, .focus_panel_5, .focus_panel_6, .focus_panel_7, .focus_panel_8, .focus_panel_9 => {
+                try std.testing.expect(b.trigger.mods.ctrl);
+                found += 1;
+            },
+            else => {},
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 9), found);
 }

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -60,6 +60,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl/double-click file", .keys_macos = "Cmd/double-click file", .action = "Preview file", .action_zh = "预览文件" },
     .{ .keys = "Ctrl+Shift-click SSH file", .keys_macos = "Cmd+Shift-click SSH file", .action = "Download file", .action_zh = "下载文件" },
     .{ .keys = "Ctrl+Shift+[ / Ctrl+Shift+]", .kind = .pair, .first = .focus_previous, .second = .focus_next, .action = "Previous / next panel", .action_zh = "上一个 / 下一个面板" },
+    .{ .keys = "Ctrl+1..9", .kind = .pair, .first = .focus_panel_1, .second = .focus_panel_9, .action = "Focus panel 1–9 by number", .action_zh = "按编号聚焦面板 (1–9)" },
     .{ .keys = "Alt+Left / Alt+Right / Alt+Up / Alt+Down", .kind = .quad, .first = .focus_left, .second = .focus_right, .third = .focus_up, .fourth = .focus_down, .action = "Focus panel", .action_zh = "聚焦面板" },
     .{ .keys = "Ctrl+Shift+Z", .kind = .action, .first = .equalize_splits, .action = "Equalize panels", .action_zh = "均分面板" },
     .{ .keys = "Ctrl+Shift+W", .kind = .action, .first = .close_panel_or_tab, .action = "Close panel / tab; confirm last", .action_zh = "关闭面板 / 标签页；最后一个需确认" },

--- a/src/split_tree.zig
+++ b/src/split_tree.zig
@@ -921,6 +921,36 @@ pub fn sortReadingOrder(items: []PanelPos) void {
     std.sort.insertion(PanelPos, items, {}, readingOrderLessThan);
 }
 
+/// Leaf-panel handles in screen reading order (top-left → bottom-right).
+/// Caller owns the returned slice. Empty tree → zero-length slice.
+pub fn readingOrder(self: *const SplitTree, alloc: Allocator) Allocator.Error![]Node.Handle {
+    if (self.nodes.len == 0) return alloc.alloc(Node.Handle, 0);
+
+    var sp = try self.spatial(alloc);
+    defer sp.deinit(alloc);
+
+    var positions: std.ArrayListUnmanaged(PanelPos) = .empty;
+    defer positions.deinit(alloc);
+    var it = self.iterator();
+    while (it.next()) |entry| {
+        const slot = sp.slots[entry.handle.idx()];
+        try positions.append(alloc, .{ .handle = entry.handle, .x = slot.x, .y = slot.y });
+    }
+    sortReadingOrder(positions.items);
+
+    const handles = try alloc.alloc(Node.Handle, positions.items.len);
+    for (positions.items, 0..) |p, i| handles[i] = p.handle;
+    return handles;
+}
+
+/// Handle of the n-th panel (1-based) in reading order, or null if out of range.
+pub fn panelHandleAt(self: *const SplitTree, alloc: Allocator, n_one_based: usize) Allocator.Error!?Node.Handle {
+    const order = try self.readingOrder(alloc);
+    defer alloc.free(order);
+    if (n_one_based >= 1 and n_one_based <= order.len) return order[n_one_based - 1];
+    return null;
+}
+
 /// Spatial representation of the split tree. This can be used to
 /// better understand the layout of the tree in a 2D space.
 ///
@@ -1350,4 +1380,49 @@ test "sortReadingOrder: a tall left panel precedes a stacked right column" {
     try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(items[0].handle)); // left (row 0, x 0)
     try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(items[1].handle)); // right-top (row 0, x 0.5)
     try std.testing.expectEqual(@as(Node.Handle.Backing, 4), @intFromEnum(items[2].handle)); // right-bottom (row 1)
+}
+
+test "SplitTree: readingOrder is row-major top-left to bottom-right" {
+    const session_persist = @import("session_persist.zig");
+    // 2x2 grid: root stacks two rows (vertical); each row is left|right (horizontal).
+    var tl = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var tr = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var bl = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var br = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var top = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &tl, .right = &tr } };
+    var bot = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &bl, .right = &br } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .vertical, .ratio = 0.5, .left = &top, .right = &bot } };
+
+    const Stub = struct {
+        var counter: usize = 0;
+        var sentinels: [16]usize = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: Allocator) ?*Surface {
+            const ptr = &sentinels[counter];
+            counter += 1;
+            return @ptrCast(@alignCast(ptr));
+        }
+    };
+    Stub.counter = 0;
+
+    var tree = try fromSnapshot(std.testing.allocator, &root, Stub.make);
+    defer {
+        if (tree.nodes.len > 0) tree.arena.deinit();
+        tree = undefined;
+    }
+
+    const order = try tree.readingOrder(std.testing.allocator);
+    defer std.testing.allocator.free(order);
+
+    // Pre-order node handles: root=0, top=1, tl=2, tr=3, bot=4, bl=5, br=6.
+    try std.testing.expectEqual(@as(usize, 4), order.len);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(order[0])); // top-left
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(order[1])); // top-right
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 5), @intFromEnum(order[2])); // bottom-left
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 6), @intFromEnum(order[3])); // bottom-right
+
+    // panelHandleAt is 1-based and range-checked.
+    try std.testing.expectEqual(@as(?Node.Handle, @enumFromInt(2)), try tree.panelHandleAt(std.testing.allocator, 1));
+    try std.testing.expectEqual(@as(?Node.Handle, @enumFromInt(6)), try tree.panelHandleAt(std.testing.allocator, 4));
+    try std.testing.expectEqual(@as(?Node.Handle, null), try tree.panelHandleAt(std.testing.allocator, 5));
+    try std.testing.expectEqual(@as(?Node.Handle, null), try tree.panelHandleAt(std.testing.allocator, 0));
 }

--- a/src/split_tree.zig
+++ b/src/split_tree.zig
@@ -889,6 +889,38 @@ pub const Spatial = struct {
     }
 };
 
+/// A leaf panel's handle plus its normalized top-left position (from `spatial`),
+/// used to order panels by on-screen reading order.
+pub const PanelPos = struct {
+    handle: Node.Handle,
+    x: f16,
+    y: f16,
+};
+
+/// Number of vertical buckets across the 1.0-tall grid. Panels whose `y` round
+/// to the same bucket are treated as the same visual row (then ordered by `x`).
+/// 64 ≈ 1.5% tolerance — fine because rows are separated by a meaningful
+/// fraction of the height. A quantized integer key keeps the comparison
+/// transitive (avoids the floating-epsilon-comparator hazard).
+const ROW_QUANTA: f32 = 64.0;
+
+fn rowKey(y: f16) i32 {
+    return @intFromFloat(@round(@as(f32, @floatCast(y)) * ROW_QUANTA));
+}
+
+fn readingOrderLessThan(_: void, a: PanelPos, b: PanelPos) bool {
+    const ay = rowKey(a.y);
+    const by = rowKey(b.y);
+    if (ay != by) return ay < by;
+    return a.x < b.x;
+}
+
+/// Sort panels into screen reading order: top-left → bottom-right (row-major).
+/// Stable (so exact ties keep tree order); N is the tiny panel count.
+pub fn sortReadingOrder(items: []PanelPos) void {
+    std.sort.insertion(PanelPos, items, {}, readingOrderLessThan);
+}
+
 /// Spatial representation of the split tree. This can be used to
 /// better understand the layout of the tree in a 2D space.
 ///
@@ -1280,4 +1312,42 @@ test "SplitTree: swapLeaves exchanges leaf surfaces and preserves topology" {
     tree.swapLeaves(a, b);
     try std.testing.expectEqual(surf_a, tree.nodes[1].leaf);
     try std.testing.expectEqual(surf_b, tree.nodes[2].leaf);
+}
+
+test "sortReadingOrder orders panels top-left to bottom-right" {
+    const at = struct {
+        fn h(i: u16) Node.Handle {
+            return @enumFromInt(i);
+        }
+    }.h;
+    // Shuffled input: BR, TL, BL, TR (2x2 grid positions).
+    var items = [_]PanelPos{
+        .{ .handle = at(6), .x = 0.5, .y = 0.5 }, // bottom-right
+        .{ .handle = at(2), .x = 0.0, .y = 0.0 }, // top-left
+        .{ .handle = at(5), .x = 0.0, .y = 0.5 }, // bottom-left
+        .{ .handle = at(3), .x = 0.5, .y = 0.0 }, // top-right
+    };
+    sortReadingOrder(&items);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(items[0].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(items[1].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 5), @intFromEnum(items[2].handle));
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 6), @intFromEnum(items[3].handle));
+}
+
+test "sortReadingOrder: a tall left panel precedes a stacked right column" {
+    const at = struct {
+        fn h(i: u16) Node.Handle {
+            return @enumFromInt(i);
+        }
+    }.h;
+    // Left spans full height (top-left at y=0); right column split top (y=0) / bottom (y=0.5).
+    var items = [_]PanelPos{
+        .{ .handle = at(4), .x = 0.5, .y = 0.5 }, // right-bottom
+        .{ .handle = at(2), .x = 0.0, .y = 0.0 }, // left (tall)
+        .{ .handle = at(3), .x = 0.5, .y = 0.0 }, // right-top
+    };
+    sortReadingOrder(&items);
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 2), @intFromEnum(items[0].handle)); // left (row 0, x 0)
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 3), @intFromEnum(items[1].handle)); // right-top (row 0, x 0.5)
+    try std.testing.expectEqual(@as(Node.Handle.Backing, 4), @intFromEnum(items[2].handle)); // right-bottom (row 1)
 }


### PR DESCRIPTION
## Summary

Adds **focus-the-Nth-panel-by-number** to the active tab: **Cmd+1..9** (macOS) / **Ctrl+1..9** (Linux/Windows) focuses the 1st–9th panel, numbered by on-screen position **top-left → bottom-right** (row-major).

Previously panel focus was only directional (`Alt/Option+Arrow`) or cyclic (`Cmd/Ctrl+Shift+[` / `]`); there was no jump-to-panel-N. Tab switching keeps `Alt/Option+number`, so the number keys with the primary modifier were free.

## How it works

- `src/split_tree.zig` — reuses the existing normalized `spatial()` slots to sort leaf panels into reading order: new pure `sortReadingOrder` (row-major, y quantized into row buckets then x) + `readingOrder` / `panelHandleAt` (1-based).
- `src/appwindow/tab.zig` `focusPanelByIndex` + `src/AppWindow.zig` `focusPanel` — mirror the existing `gotoSplit` path (set `t.focused`, run `handleActiveSurfaceChangeWithinTab()`).
- `src/keybind.zig` — `focus_panel_1..9` actions + default `Ctrl+1..9`; the existing macOS Ctrl→Cmd remap renders them as Cmd+1..9 there.
- `src/input/command_dispatch.zig` + `src/input.zig` — `Command.focus_panel` resolves in the late phase; the dispatch arm `return AppWindow.focusPanel(n)` so a miss (no panel at that index — single-panel tab, or N beyond the count) **falls through to the terminal** instead of being consumed.
- `src/renderer/overlays/startup_shortcuts.zig` — hint row (renders the live binding, so it shows Cmd on macOS).

Independent of the directional/cycle focus and of tab switching; deny-list-style numbering is derived from layout each time (no stored index).

## Test Plan
- [x] `zig build test` (fast suite — `command_dispatch`) — exit 0
- [x] `zig build test-full` (full graph — split_tree/keybind/tab/AppWindow/input) — exit 0
- [x] `zig build` — exit 0
- New tests: pure `sortReadingOrder` (2×2 + tall-left cases), `readingOrder` on a real `fromSnapshot` 2×2 tree, tab-level `focusPanelByIndex`, keybind default mapping, `command_dispatch` resolve.
- [ ] GUI/runtime verification on macOS/Windows (no Linux GUI backend): Cmd+2 in a 2×2 grid focuses the top-right panel; Cmd+3 in a single-panel tab falls through to the terminal.

Spec/plan: `docs/superpowers/specs/2026-06-03-panel-focus-by-number-design.md`, `docs/superpowers/plans/2026-06-03-panel-focus-by-number.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)