### PR TITLE
[codex] add guarded agent permission level

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -117,8 +117,12 @@ Local slash commands (handled in the panel, without calling the model):
 - `/reload-commands` rescans the custom `commands/` directory.
 - `/clear` clears the current conversation context (keeps the tab and profile).
 - `/resume` opens the saved-conversation history picker.
-- `/permission` shows the agent tool permission; `/permission confirm` or
-  `/permission full` changes it at runtime.
+- `/permission` shows the agent tool permission; `/permission ask`,
+  `/permission auto`, or `/permission full` changes it at runtime.
+  `ask` prompts for normal tool use, `auto` runs ordinary tools automatically
+  while still confirming protected-path and dangerous commands, and `full`
+  skips approval guard prompts. `confirm` remains accepted as an alias for
+  `ask`.
 - `/export` writes the conversation to Markdown (clean by default; `/export full`
   includes reasoning, tool details, and usage).
 

--- a/docs/ai.html
+++ b/docs/ai.html
@@ -94,7 +94,7 @@
           </div>
           <div class="feature">
             <h3>Approval-based execution</h3>
-            <p>Tool requests appear in WispTerm before execution when permission is set to <code>confirm</code>. Switch to <code>full</code> only for trusted workflows.</p>
+            <p>Tool requests appear in WispTerm before execution when permission is set to <code>ask</code>. Use <code>auto</code> for trusted unattended work that should still stop on protected paths and dangerous commands; use <code>full</code> only when you want the agent to run without those guard prompts.</p>
           </div>
           <div class="feature">
             <h3>Saved conversations</h3>
@@ -165,12 +165,12 @@ export DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
           </div>
           <div class="feature">
             <h3>Permission mode</h3>
-            <p>Keep <code>ai-agent-permission = confirm</code> for normal use. Use <code>full</code> only when you trust both the task and the opened workspace.</p>
+            <p>Keep <code>ai-agent-permission = ask</code> for normal use. Use <code>auto</code> when ordinary tools may run unattended but private-file and destructive-command guards should remain active. Use <code>full</code> only when you trust both the task and the opened workspace completely.</p>
           </div>
         </div>
 <pre class="code-block"><code># AI Chat agent tools
 ai-agent-enabled            = true
-ai-agent-permission         = confirm   # confirm | full
+ai-agent-permission         = ask       # ask | auto | full
 ai-agent-command-timeout-ms = 60000
 ai-agent-output-limit       = 16384</code></pre>
       </div>
@@ -215,7 +215,7 @@ ai-agent-output-limit       = 16384</code></pre>
           </div>
           <div class="feature">
             <h3>No tool execution</h3>
-            <p>Set the profile's <code>Agent</code> field to <code>true</code>, and approve tool cards when permission mode is <code>confirm</code>.</p>
+            <p>Set the profile's <code>Agent</code> field to <code>true</code>, and approve tool cards when permission mode is <code>ask</code>.</p>
           </div>
           <div class="feature">
             <h3>Model aliases</h3>

--- a/docs/ai.zh.html
+++ b/docs/ai.zh.html
@@ -94,7 +94,7 @@
           </div>
           <div class="feature">
             <h3>带确认的执行</h3>
-            <p>当权限为 <code>confirm</code> 时，工具请求会先显示在 WispTerm 中再执行。只有在可信任务和可信工作区中，才建议切到 <code>full</code>。</p>
+            <p>当权限为 <code>ask</code> 时，工具请求会先显示在 WispTerm 中再执行。可信的无人值守任务可使用 <code>auto</code>，普通工具会自动执行，但访问受保护路径和危险命令仍会确认；只有想完全交给 Agent 时，才使用 <code>full</code>。</p>
           </div>
           <div class="feature">
             <h3>可恢复的对话</h3>
@@ -165,12 +165,12 @@ export DEEPSEEK_API_KEY="sk-your-deepseek-api-key"
           </div>
           <div class="feature">
             <h3>权限模式</h3>
-            <p>日常使用建议保持 <code>ai-agent-permission = confirm</code>。只有在你信任任务和当前工作区时，再使用 <code>full</code>。</p>
+            <p>日常使用建议保持 <code>ai-agent-permission = ask</code>。需要无人值守但仍保留私有文件和危险命令保护时使用 <code>auto</code>。只有完全信任任务和当前工作区时，再使用 <code>full</code>。</p>
           </div>
         </div>
 <pre class="code-block"><code># AI Chat Agent 工具
 ai-agent-enabled            = true
-ai-agent-permission         = confirm   # confirm | full
+ai-agent-permission         = ask       # ask | auto | full
 ai-agent-command-timeout-ms = 60000
 ai-agent-output-limit       = 16384</code></pre>
       </div>
@@ -215,7 +215,7 @@ ai-agent-output-limit       = 16384</code></pre>
           </div>
           <div class="feature">
             <h3>工具没有执行</h3>
-            <p>确认 Profile 的 <code>Agent</code> 字段是 <code>true</code>，并在权限为 <code>confirm</code> 时确认工具卡片。</p>
+            <p>确认 Profile 的 <code>Agent</code> 字段是 <code>true</code>，并在权限为 <code>ask</code> 时确认工具卡片。</p>
           </div>
           <div class="feature">
             <h3>模型别名</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -210,7 +210,7 @@ remote-session-key     = Workstation
 
 # AI Chat agent tools
 ai-agent-enabled       = true
-ai-agent-permission    = confirm   # confirm | full
+ai-agent-permission    = ask       # ask | auto | full
 ai-agent-output-limit  = 16384</code></pre>
         <p class="section-foot">Run <code>wispterm --help</code> for the full flag list, or <code>wispterm --show-config-path</code> to print the resolved config path.</p>
       </div>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -210,7 +210,7 @@ remote-session-key     = Workstation
 
 # AI Chat Agent 工具
 ai-agent-enabled       = true
-ai-agent-permission    = confirm   # confirm | full
+ai-agent-permission    = ask       # ask | auto | full
 ai-agent-output-limit  = 16384</code></pre>
         <p class="section-foot">运行 <code>wispterm --help</code> 查看完整参数列表，或 <code>wispterm --show-config-path</code> 打印解析后的配置路径。</p>
       </div>

--- a/src/ai_agent_config.zig
+++ b/src/ai_agent_config.zig
@@ -5,30 +5,37 @@ const std = @import("std");
 
 pub const AgentPermission = enum {
     confirm,
+    auto,
     full,
 
     pub fn parse(value: []const u8) ?AgentPermission {
-        if (std.mem.eql(u8, value, "confirm")) return .confirm;
+        if (std.mem.eql(u8, value, "ask") or std.mem.eql(u8, value, "confirm")) return .confirm;
+        if (std.mem.eql(u8, value, "auto") or std.mem.eql(u8, value, "guarded")) return .auto;
         if (std.mem.eql(u8, value, "full") or std.mem.eql(u8, value, "full-permission")) return .full;
         return null;
     }
 
     pub fn name(self: AgentPermission) []const u8 {
         return switch (self) {
-            .confirm => "confirm",
+            .confirm => "ask",
+            .auto => "auto",
             .full => "full",
         };
     }
 };
 
-test "AgentPermission.parse accepts confirm/full/full-permission" {
+test "AgentPermission.parse accepts ask auto full and legacy aliases" {
     try std.testing.expectEqual(AgentPermission.confirm, AgentPermission.parse("confirm").?);
+    try std.testing.expectEqual(AgentPermission.confirm, AgentPermission.parse("ask").?);
+    try std.testing.expectEqual(AgentPermission.auto, AgentPermission.parse("auto").?);
+    try std.testing.expectEqual(AgentPermission.auto, AgentPermission.parse("guarded").?);
     try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full").?);
     try std.testing.expectEqual(AgentPermission.full, AgentPermission.parse("full-permission").?);
     try std.testing.expectEqual(@as(?AgentPermission, null), AgentPermission.parse("nope"));
 }
 
 test "AgentPermission.name round-trips" {
-    try std.testing.expectEqualStrings("confirm", AgentPermission.confirm.name());
+    try std.testing.expectEqualStrings("ask", AgentPermission.confirm.name());
+    try std.testing.expectEqualStrings("auto", AgentPermission.auto.name());
     try std.testing.expectEqualStrings("full", AgentPermission.full.name());
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -362,7 +362,7 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
 
 fn permissionStatusOutput(allocator: std.mem.Allocator) ![]u8 {
     const current = currentAgentSettings().permission;
-    return std.fmt.allocPrint(allocator, "Agent permission is '{s}'. Use /permission confirm or /permission full to change it.", .{current.name()});
+    return std.fmt.allocPrint(allocator, "Agent permission is '{s}'. Use /permission ask, /permission auto, or /permission full to change it.", .{current.name()});
 }
 
 pub fn agentPermission() AgentPermission {
@@ -5115,13 +5115,15 @@ test "clearMessages empties transcript but keeps settings" {
     try std.testing.expectEqualStrings("m1", session.model());
 }
 
-test "/permission full flips the global agent permission" {
+test "/permission accepts ask auto and full modes" {
     const saved = currentAgentSettings();
     defer configureAgent(saved); // restore global state for other tests
     configureAgent(.{ .permission = .confirm });
+    applyPermissionArg("auto");
+    try std.testing.expectEqual(AgentPermission.auto, currentAgentSettings().permission);
     applyPermissionArg("full");
     try std.testing.expectEqual(AgentPermission.full, currentAgentSettings().permission);
-    applyPermissionArg("confirm");
+    applyPermissionArg("ask");
     try std.testing.expectEqual(AgentPermission.confirm, currentAgentSettings().permission);
     applyPermissionArg("bogus"); // invalid → no change
     try std.testing.expectEqual(AgentPermission.confirm, currentAgentSettings().permission);

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -15,6 +15,7 @@ const ToolClosedTab = types.ToolClosedTab;
 const SshProfileSaveArgs = types.SshProfileSaveArgs;
 const SavedSshProfile = types.SavedSshProfile;
 const AgentSettings = types.AgentSettings;
+const AgentPermission = types.AgentPermission;
 const agent_detector = @import("agent_detector.zig");
 const skill_registry = @import("skill_registry.zig");
 const wispterm_docs = @import("wispterm_docs.zig");
@@ -231,15 +232,19 @@ fn weixinSendAttachmentTool(
         return ctx.allocator.dupe(u8, "No active Weixin reply context; cannot send attachment.");
     };
     // Sending an attachment reads the file off disk and uploads it to a remote
-    // user, so a protected path here is an exfiltration risk. Force approval for
-    // a denied path even in full-permission mode (deny list always wins).
+    // user, so a protected path here is an exfiltration risk. In auto mode,
+    // protected paths still require approval; full mode intentionally bypasses
+    // this guard.
     if (ctx.settings.access_rules) |rules| {
         if (ai_agent_access.isPathDenied(ctx.allocator, rules, path, null)) {
-            const bl_reason = allocBlacklistReason(ctx.allocator, path);
-            defer if (bl_reason) |r| ctx.allocator.free(r);
-            const reason = bl_reason orelse "Sends a protected file — confirm to allow";
-            if (!ctx.requestApproval("weixin_send_attachment", path, reason)) {
-                return deniedResult(ctx.allocator, path, "operator rejected sending a protected file");
+            const gate = AccessGate{ .dangerous = false, .blacklisted = true, .force = true, .skip = false, .matched = path };
+            if (approvalRequiredForGate(ctx.settings.permission, gate)) {
+                const bl_reason = allocBlacklistReason(ctx.allocator, path);
+                defer if (bl_reason) |r| ctx.allocator.free(r);
+                const reason = bl_reason orelse "Sends a protected file — confirm to allow";
+                if (!ctx.requestApproval("weixin_send_attachment", path, reason)) {
+                    return deniedResult(ctx.allocator, path, "operator rejected sending a protected file");
+                }
             }
         }
     }
@@ -447,8 +452,8 @@ const AccessGate = struct {
 };
 
 /// Combine the destructive-command check with the private file-access guard.
-/// `force` => must prompt even in full mode; `skip` => may run without a prompt
-/// even in confirm mode.
+/// `force` => guarded auto mode must prompt; `skip` => ask mode may run without
+/// a prompt.
 fn accessGate(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8) AccessGate {
     const dangerous = isDangerousCommand(command);
     const result = if (ctx.settings.access_rules) |rules|
@@ -465,6 +470,14 @@ fn accessGate(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8) Ac
     };
 }
 
+fn approvalRequiredForGate(permission: AgentPermission, gate: AccessGate) bool {
+    return switch (permission) {
+        .confirm => !gate.skip,
+        .auto => gate.force,
+        .full => false,
+    };
+}
+
 /// Allocate a human-readable approval reason naming the protected path. Returns
 /// null on OOM (callers fall back to a static reason).
 fn allocBlacklistReason(allocator: std.mem.Allocator, matched: []const u8) ?[]u8 {
@@ -474,7 +487,7 @@ fn allocBlacklistReason(allocator: std.mem.Allocator, matched: []const u8) ?[]u8
 fn localCommandExecTool(ctx: *const ToolContext, command: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
     const gate = accessGate(ctx, command, cwd);
-    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+    if (approvalRequiredForGate(ctx.settings.permission, gate)) {
         const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
         defer if (bl_reason) |r| ctx.allocator.free(r);
         const reason = bl_reason orelse if (gate.dangerous) DANGEROUS_COMMAND_APPROVAL_REASON else platform_process.localCommandApprovalLabel();
@@ -878,7 +891,7 @@ fn terminalReplExecTool(ctx: *ToolContext, surface_id: []const u8, repl_name: []
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
     const control = controlKeyByte(code);
     const gate = accessGate(ctx, code, null);
-    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+    if (approvalRequiredForGate(ctx.settings.permission, gate)) {
         var reason_buf: [96]u8 = undefined;
         const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
         defer if (bl_reason) |r| ctx.allocator.free(r);
@@ -1177,7 +1190,7 @@ fn hasPendingAgentCommand(snapshot: []const u8) bool {
 fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
     const gate = accessGate(ctx, command, null);
-    if (gate.force or (ctx.settings.permission != .full and !gate.skip)) {
+    if (approvalRequiredForGate(ctx.settings.permission, gate)) {
         var reason_buf: [64]u8 = undefined;
         const bl_reason = if (gate.blacklisted) allocBlacklistReason(ctx.allocator, gate.matched) else null;
         defer if (bl_reason) |r| ctx.allocator.free(r);
@@ -1305,7 +1318,7 @@ fn sshProfileSaveTool(ctx: *ToolContext, args: SshProfileSaveArgs) ![]u8 {
 
     const approval_text = try sshProfileSaveApprovalText(ctx.allocator, args);
     defer ctx.allocator.free(approval_text);
-    if (ctx.settings.permission != .full) {
+    if (ctx.settings.permission == .confirm) {
         if (!ctx.requestApproval("ssh_profile_save", approval_text, "Save SSH server profile")) {
             return deniedResult(ctx.allocator, approval_text, "operator rejected saved SSH profile update");
         }
@@ -1337,7 +1350,7 @@ fn sshProfileSaveTool(ctx: *ToolContext, args: SshProfileSaveArgs) ![]u8 {
 
 fn sshProfileConnectTool(ctx: *ToolContext, profile_name: []const u8) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
-    if (ctx.settings.permission != .full) {
+    if (ctx.settings.permission == .confirm) {
         if (!ctx.requestApproval("ssh_profile_connect", profile_name, "Open saved SSH server in a new tab")) {
             return deniedResult(ctx.allocator, profile_name, "operator rejected saved SSH profile connection");
         }
@@ -1380,7 +1393,7 @@ fn tabNewTool(ctx: *ToolContext, kind: []const u8, command: ?[]const u8) ![]u8 {
 
     const trimmed_kind = std.mem.trim(u8, kind, " \t\r\n");
     const command_for_approval = command orelse trimmed_kind;
-    if (ctx.settings.permission != .full) {
+    if (ctx.settings.permission == .confirm) {
         if (!ctx.requestApproval("tab_new", command_for_approval, "Open a new local terminal tab")) {
             return deniedResult(ctx.allocator, command_for_approval, "operator rejected new tab creation");
         }
@@ -1428,7 +1441,7 @@ fn tabCloseTool(ctx: *ToolContext, tab_index: ?usize, surface_id: ?[]const u8, t
     else
         "active terminal tab";
 
-    if (ctx.settings.permission != .full) {
+    if (ctx.settings.permission == .confirm) {
         if (!ctx.requestApproval("tab_close", selector, "Close a terminal tab")) {
             return deniedResult(ctx.allocator, selector, "operator rejected tab close");
         }
@@ -1631,9 +1644,9 @@ fn truncateOwned(allocator: std.mem.Allocator, settings: AgentSettings, text: []
 
 pub const DANGEROUS_COMMAND_APPROVAL_REASON = "Destructive command (delete/rename/format) - confirm to run";
 
-/// Whether a command is destructive enough to always require operator approval,
-/// even under full-permission mode: deletes, renames/moves, disk formatting,
-/// and a few other irreversible operations.
+/// Whether a command is destructive enough to require operator approval in
+/// auto mode: deletes, renames/moves, disk formatting, and a few other
+/// irreversible operations.
 pub fn isDangerousCommand(command: []const u8) bool {
     // Distinctive multi-token / punctuated patterns: a plain substring scan is
     // safe here (these cannot collide with ordinary words).
@@ -2527,7 +2540,7 @@ test "accessGate forces approval for denied paths and skips safe allowed reads" 
         .cancelled = fakeCancelled,
     };
 
-    // Denied path → force approval even in full mode.
+    // Denied path → force approval in auto mode.
     const denied = accessGate(&ctx, "cat ~/.ssh/id_rsa", null);
     try std.testing.expect(denied.force);
     try std.testing.expect(denied.blacklisted);
@@ -2542,6 +2555,38 @@ test "accessGate forces approval for denied paths and skips safe allowed reads" 
     const neutral = accessGate(&ctx, "cat /work/other.txt", null);
     try std.testing.expect(!neutral.force);
     try std.testing.expect(!neutral.skip);
+}
+
+test "permission modes map ask auto and full approval policy" {
+    const a = std.testing.allocator;
+    var rules = try ai_agent_access.parseRules(a, "allow /work/ok\n", "/home/u");
+    defer rules.deinit();
+
+    var session_dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &session_dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .auto, .access_rules = &rules },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    const denied = accessGate(&ctx, "cat ~/.ssh/id_rsa", null);
+    try std.testing.expect(approvalRequiredForGate(.auto, denied));
+    try std.testing.expect(!approvalRequiredForGate(.full, denied));
+
+    const dangerous = accessGate(&ctx, "rm /work/ok/readme.md", null);
+    try std.testing.expect(approvalRequiredForGate(.auto, dangerous));
+    try std.testing.expect(!approvalRequiredForGate(.full, dangerous));
+
+    const neutral = accessGate(&ctx, "cat /work/other.txt", null);
+    try std.testing.expect(approvalRequiredForGate(.confirm, neutral));
+    try std.testing.expect(!approvalRequiredForGate(.auto, neutral));
+
+    const allowed_read = accessGate(&ctx, "cat /work/ok/readme.md", null);
+    try std.testing.expect(!approvalRequiredForGate(.confirm, allowed_read));
 }
 
 test "accessGate with no rules degrades to dangerous-only behavior" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -293,7 +293,7 @@ theme: ?[]const u8 = null,
 /// that is running a full-screen (non-shell) program.
 @"confirm-close-running-program": bool = true,
 
-/// Agent command permission mode: confirm (deny until approved UI exists) or full.
+/// Agent command permission mode: ask, auto, or full.
 @"ai-agent-permission": ai_agent_config.AgentPermission = .confirm,
 
 /// Timeout budget for agent shell/SSH commands.
@@ -1257,7 +1257,7 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --language <lang>            UI language: auto | en | zh-CN (default: auto)
         \\  --ssh-legacy-algorithms <bool> Enable legacy ssh-rsa/ssh-dss OpenSSH options
         \\  --ai-agent-enabled <bool>    Enable AI Chat agent tools by default
-        \\  --ai-agent-permission <mode> Agent tool permission: confirm | full
+        \\  --ai-agent-permission <mode> Agent tool permission: ask | auto | full
         \\  --ai-agent-command-timeout-ms <ms> Agent command timeout budget
         \\  --ai-agent-output-limit <bytes> Max bytes returned by each tool
         \\  --auto-update-check <bool>  Check GitHub Releases after startup
@@ -1620,7 +1620,7 @@ const default_config_template =
     \\
     \\# AI Chat agent tools (disabled by default)
     \\# ai-agent-enabled = false
-    \\# ai-agent-permission = confirm   # confirm | full
+    \\# ai-agent-permission = ask       # ask | auto | full
     \\# ai-agent-command-timeout-ms = 60000
     \\# ai-agent-output-limit = 16384
     \\
@@ -1936,6 +1936,10 @@ test "config: ai agent options parse" {
     try std.testing.expectEqual(ai_agent_config.AgentPermission.confirm, cfg.@"ai-agent-permission");
 
     cfg.applyKeyValue(allocator, "ai-agent-enabled", "true", ".");
+    cfg.applyKeyValue(allocator, "ai-agent-permission", "ask", ".");
+    try std.testing.expectEqual(ai_agent_config.AgentPermission.confirm, cfg.@"ai-agent-permission");
+    cfg.applyKeyValue(allocator, "ai-agent-permission", "auto", ".");
+    try std.testing.expectEqual(ai_agent_config.AgentPermission.auto, cfg.@"ai-agent-permission");
     cfg.applyKeyValue(allocator, "ai-agent-permission", "full", ".");
     cfg.applyKeyValue(allocator, "ai-agent-command-timeout-ms", "120000", ".");
     cfg.applyKeyValue(allocator, "ai-agent-output-limit", "4096", ".");

--- a/src/input.zig
+++ b/src/input.zig
@@ -4319,8 +4319,9 @@ fn toggleAiAgentPermission() void {
     defer cfg.deinit(allocator);
 
     const next = switch (cfg.@"ai-agent-permission") {
-        .confirm => "full",
-        .full => "confirm",
+        .confirm => "auto",
+        .auto => "full",
+        .full => "ask",
     };
     Config.setConfigValue(allocator, "ai-agent-permission", next) catch return;
     AppWindow.reloadConfigImmediate(allocator);

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -181,9 +181,18 @@ pub fn render(
     _ = titlebar.renderTextLimited(mode_text, mode_x, header_y + 10, mixColor(fg, accent, 0.18), MODE_SLOT_W);
 
     const perm_text = permissionDisplayName(permission);
-    const perm_color = if (permission == .full) mixColor(fg, accent, 0.25) else mixColor(bg, fg, 0.66);
+    const perm_color = switch (permission) {
+        .confirm => mixColor(bg, fg, 0.66),
+        .auto => mixColor(fg, accent, 0.12),
+        .full => mixColor(fg, accent, 0.25),
+    };
     _ = titlebar.renderTextLimited(perm_text, chip_x, header_y + 10, perm_color, PERMISSION_CHIP_W);
-    ui_pipeline.fillQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, if (permission == .full) 0.38 else 0.16);
+    const perm_alpha: f32 = switch (permission) {
+        .confirm => 0.16,
+        .auto => 0.26,
+        .full => 0.38,
+    };
+    ui_pipeline.fillQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, perm_alpha);
 
     if (session.request_inflight) {
         renderStopButton(stopButtonRect(x, w, top), window_height, session.request_stopping);
@@ -1157,6 +1166,7 @@ fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) 
 fn permissionDisplayName(permission: ai_chat.AgentPermission) []const u8 {
     return switch (permission) {
         .confirm => "Ask",
+        .auto => "Auto",
         .full => "Full",
     };
 }


### PR DESCRIPTION
## Summary

- add ask/auto/full agent permission levels while keeping confirm as an ask alias
- move the current guarded full behavior to auto and make full skip approval guard prompts
- update permission chip display, config help, and AI docs for the three-level model

## Validation

- zig build test
- zig build test-full
- git diff --check