### PR TITLE
feat(ui): rename "AI Agent" → Copilot and "AI History" → Sessions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,12 @@ This folder is the source for the WispTerm GitHub Pages site.
 ## Files
 
 - `index.html` — landing page (hero, features, install, config, shortcuts).
-- `ai.html` / `ai.zh.html` — DeepSeek-first AI Agent workflow pages.
-- `use-cases.html` / `use-cases.zh.html` — practical AI Agent use cases such as SSH profile setup.
+- `ai.html` / `ai.zh.html` — DeepSeek-first Copilot workflow pages.
+- `use-cases.html` / `use-cases.zh.html` — practical Copilot use cases such as SSH profile setup.
 - `themes.html` — built-in theme gallery.
 - `configuration.md` — desktop app config reference.
 - `file-explorer.md` — File Explorer, preview panel, browser panel, and SSH cwd notes.
-- `ai-agent.md` — desktop AI Chat, Agent skills, and Markdown export workflow notes.
+- `ai-agent.md` — desktop Copilot, Agent skills, and Markdown export workflow notes.
 - `media.md` — background images, shaders, and Kitty Graphics helper scripts.
 - `development.md` — build, architecture, packaging, and GitHub release notes.
 - `faq.md` — desktop and remote FAQ entries that are too detailed for the root README.

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -1,6 +1,6 @@
-# AI Chat Sessions
+# Copilot
 
-Open the session launcher with `Ctrl+Shift+T` and choose `AI Agent`. WispTerm
+Open the session launcher with `Ctrl+Shift+T` and choose `Copilot`. WispTerm
 opens the default AI profile directly in Agent mode. If no AI profile exists
 yet, it opens the AI settings form first so you can configure the provider,
 model, API key, and agent mode before the first launch.
@@ -10,7 +10,7 @@ platform config directory (`ai_profiles/`) — `%APPDATA%\wispterm\ai_profiles` 
 Windows, `~/Library/Application Support/wispterm/ai_profiles` on macOS — with
 fields hex encoded on disk.
 
-AI Chat can speak OpenAI-compatible Chat Completions, the OpenAI Responses API,
+Copilot can speak OpenAI-compatible Chat Completions, the OpenAI Responses API,
 or the Anthropic Messages API. Set the profile Protocol field to
 `chat_completions` (default), `responses`, or `anthropic`:
 
@@ -43,12 +43,12 @@ DeepSeek, WispTerm also checks `DEEPSEEK_API_KEY` in the process environment.
 Responses with `reasoning_content` are shown as a muted reasoning block above
 the assistant reply. This follows DeepSeek's
 [thinking mode guide](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode).
-Completed requests show elapsed time in the AI Chat status area, and token usage
+Completed requests show elapsed time in the Copilot status area, and token usage
 when the provider returns OpenAI-compatible `usage` fields.
 
-## AI History Sessions
+## Sessions
 
-Open the session launcher with `Ctrl+Shift+T` and choose `AI History` to browse
+Open the session launcher with `Ctrl+Shift+T` and choose `Sessions` to browse
 Codex, Claude Code, and Reasonix transcripts stored on a Local, WSL, or SSH
 target. WispTerm connects to the selected target, scans `$HOME/.codex`,
 `$HOME/.claude`, and `$HOME/.reasonix` for metadata, and loads a transcript
@@ -62,7 +62,7 @@ directory is missing, resume stops instead of falling back to `$HOME`.
 
 Press `Ctrl+Shift+A` (`Cmd+Shift+A` on macOS) on a terminal tab to toggle a
 right-side AI copilot bound to the currently focused terminal. The copilot is
-terminal-only — it does not open on AI Agent or other non-terminal tabs.
+terminal-only — it does not open on a Copilot tab or other non-terminal tabs.
 
 - Each terminal tab keeps its own copilot conversation. The conversation is
   per-tab, and closing the tab discards it.
@@ -73,7 +73,7 @@ terminal-only — it does not open on AI Agent or other non-terminal tabs.
   terminal's working directory plus its recent output — so the copilot has
   context without you pasting it.
 - The copilot shares the default AI profile (same provider, model, and key) as
-  the AI Agent.
+  Copilot.
 - It occupies the right panel slot exclusively: opening the copilot hides the
   browser panel and the Markdown preview, and opening either of those hides the
   copilot.
@@ -84,10 +84,10 @@ terminal-only — it does not open on AI Agent or other non-terminal tabs.
 
 ## Markdown Export
 
-Use the command center to run `Export AI Chat Markdown` for the full transcript,
+Use the command center to run `Export Copilot Markdown` for the full transcript,
 including reasoning, tool details, and usage metadata.
 
-Use `Export AI Chat Markdown Clean` when you want a publishing-friendly record:
+Use `Export Copilot Markdown Clean` when you want a publishing-friendly record:
 it writes only user prompts and the final AI answer, without thinking blocks,
 tool output, or usage metadata. This is useful for notes, blog drafts, and
 WeChat public account posts.

--- a/docs/superpowers/specs/2026-06-04-copilot-sessions-rename-design.md
+++ b/docs/superpowers/specs/2026-06-04-copilot-sessions-rename-design.md
@@ -1,0 +1,78 @@
+# Rename "AI Agent" → Copilot and "AI History" → Sessions — design
+
+## Problem
+
+Two distinct user-facing features both lead with a vague "AI" label, which is
+too broad and makes them read like a pair when they are unrelated:
+
+- **The built-in AI** WispTerm launches and you converse with (chat tab +
+  `Ctrl+Shift+A` sidebar). Labeled "AI Agent" / "AI 智能体" in the session
+  launcher; its own saved conversations are listed under "Agent History" /
+  "智能体历史" in the command palette.
+- **A read-only browser** of sessions logged by *external* CLI agents (Codex,
+  Claude Code, Reasonix). Labeled "AI History" — and inconsistently "Agent
+  History" in one place — even though it has nothing to do with the built-in AI.
+
+## Decision
+
+**Direction: Copilot + Sessions.** The built-in AI becomes **Copilot / 副驾**
+(an interactive, present-tense assistant — and the right-side sidebar is already
+called Copilot, so this unifies). The external log browser becomes **Sessions /
+会话** (a past-tense archive of other tools' runs). Neither keeps a bare "AI"
+prefix, and they no longer share the "Agent" word, so "Sessions" can never be
+mistaken for "Copilot's history".
+
+### Mapping
+
+**① Built-in AI → Copilot / 副驾**
+
+| Surface | Before (en / zh) | After (en / zh) |
+| --- | --- | --- |
+| Session-launcher entry (`sl_ai_agent`) | AI Agent / AI 智能体 | Copilot / 副驾 |
+| Its conversation history (`cmd_palette_history_title`) | Agent History / 智能体历史 | Copilot History / 副驾历史 |
+| `cmd_palette_recent_sessions` | Recent agent sessions / 最近的智能体会话 | Recent Copilot sessions / 最近的副驾会话 |
+| `cmd_palette_no_sessions(_yet)` | …agent sessions / …智能体会话 | …Copilot sessions / …副驾会话 |
+| Command-palette action titles (`command_center_state`) | New Agent; Select Agent History | New Copilot; Select Copilot History |
+| Chat tab fallback title | AI Chat | Copilot (`sl_ai_agent`) |
+| Chat input placeholder (plain mode) | Ask AI Chat | Ask Copilot |
+| Export command titles | Export AI Chat Markdown[ Clean] | Export Copilot Markdown[ Clean] |
+| Export Markdown header / save-dialog / empty toast | …AI Chat… | …Copilot… |
+| WeChat bridge messages | AI Agent / AI Chat | 副驾 |
+
+**② External CLI browser → Sessions / 会话**
+
+A new i18n key `sl_sessions` = "Sessions" / "会话" plus `sl_sessions_detail`
+= "Browse Codex / Claude Code sessions" / "浏览 Codex / Claude Code 会话".
+All live "AI History" chrome routes through it: workbench tab title + header,
+session-launcher row + detail subtitle, SSH-profile picker header, width calcs,
+remote-layout snapshot placeholder, and the resume-failure toasts/error
+("AI History resume failed" → "Sessions resume failed").
+
+### Out of scope (kept as-is)
+
+- **Internal identifiers**: enum values (`new_agent`, `select_agent_history`,
+  `.ai_history` tab kind), globals (`g_ai_history_*`), config keys
+  (`--ai-agent-enabled`), profile storage (`ai_profiles/`). Renaming these would
+  touch persistence/config with no user-visible benefit.
+- The **Agent/Chat capability mode** label inside the chat (it denotes tool-use,
+  not the feature name).
+- Code comments, `log.warn` developer messages, debug prints, and the
+  agent-facing tool result strings.
+- Historical design docs under `docs/superpowers/plans|specs` (the `ai-agent`
+  `wispterm_docs` topic key also stays).
+
+### Notes
+
+- `pty_command.sessionLauncherDetailForOs` is a comptime constant, so it cannot
+  use runtime i18n; its words change to Copilot/Sessions but stay English-only
+  (matching today's behavior).
+- `ai_history_session.zig`, `ai_history_renderer.zig`, and `appwindow/tab.zig`
+  gain an `i18n` import so their previously-hardcoded "AI History" strings
+  localize.
+
+## Verification
+
+`zig build test` (fast) + `zig build test-full` both green; existing
+string-assertion tests (`command_center_state`, `pty_command`,
+`ai_history_resume` PowerShell) updated to the new copy. GUI verification on
+macOS/Windows deferred (no Linux GUI backend), consistent with prior UI work.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1004,7 +1004,7 @@ pub fn spawnResumeTerminal(target: ai_history_source.Target, meta: ai_history_ty
             };
             const command = platform_pty_command.localShellInitialCommand(command_buf[0..], tab.getShellCmd(), local_checked_cmd) orelse return failAiHistoryResumePathUnavailable();
             if (spawnTabWithCommandUtf8(command)) return true;
-            overlays.showStatusToast("AI History resume failed");
+            overlays.showStatusToast("Sessions resume failed");
             return false;
         },
         .wsl => {
@@ -1015,7 +1015,7 @@ pub fn spawnResumeTerminal(target: ai_history_source.Target, meta: ai_history_ty
             };
             const command = platform_pty_command.wslShellCommand(command_buf[0..], user_shell_cmd) orelse return failAiHistoryResumePathUnavailable();
             if (spawnTabWithCommandUtf8(command)) return true;
-            overlays.showStatusToast("AI History resume failed");
+            overlays.showStatusToast("Sessions resume failed");
             return false;
         },
         .ssh => |ssh| {
@@ -1027,11 +1027,11 @@ pub fn spawnResumeTerminal(target: ai_history_source.Target, meta: ai_history_ty
             return switch (overlays.aiHistoryConnectSshProfile(ssh.profile_name, user_shell_cmd)) {
                 .connected => true,
                 .not_found => {
-                    overlays.showStatusToast("AI History resume failed: SSH profile unavailable");
+                    overlays.showStatusToast("Sessions resume failed: SSH profile unavailable");
                     return false;
                 },
                 .failed => {
-                    overlays.showStatusToast("AI History resume failed");
+                    overlays.showStatusToast("Sessions resume failed");
                     return false;
                 },
             };
@@ -1040,7 +1040,7 @@ pub fn spawnResumeTerminal(target: ai_history_source.Target, meta: ai_history_ty
 }
 
 fn failAiHistoryResumePathUnavailable() bool {
-    overlays.showStatusToast("AI History resume failed: project path unavailable");
+    overlays.showStatusToast("Sessions resume failed: project path unavailable");
     markUiDirty();
     return false;
 }
@@ -1309,7 +1309,7 @@ fn localHomeForAiHistory(allocator: std.mem.Allocator) ![]u8 {
 pub fn exportActiveAiChatMarkdown(mode: ai_chat.MarkdownExportMode) void {
     const allocator = g_allocator orelse return;
     const session = activeAiChat() orelse {
-        overlays.showStatusToast("Open an AI Chat tab first");
+        overlays.showStatusToast("Open a Copilot tab first");
         return;
     };
 
@@ -1503,7 +1503,7 @@ fn saveMarkdownDialogPath(
         .{};
     const path = platform_file_dialog.saveFile(allocator, .{
         .owner = owner,
-        .title = "Save AI Chat Markdown",
+        .title = "Save Copilot Markdown",
         .initial_dir = initial_dir,
         .default_filename = default_filename,
         .default_extension = "md",
@@ -3123,7 +3123,7 @@ fn appendRemoteAiHistoryTabJson(
     try appendAgentDetectionJson(allocator, out, null);
     // AI History is read-only in remote layouts. Keep it terminal-style so the
     // remote client does not show AI Chat composer/input affordances.
-    try out.appendSlice(allocator, ",\"kind\":\"terminal\",\"readOnly\":true,\"cols\":120,\"rows\":30,\"cursorX\":0,\"cursorY\":0,\"snapshot\":\"AI History\\n");
+    try out.appendSlice(allocator, ",\"kind\":\"terminal\",\"readOnly\":true,\"cols\":120,\"rows\":30,\"cursorX\":0,\"cursorY\":0,\"snapshot\":\"Sessions\\n");
     try remote.appendJsonString(out, allocator, title_text);
     try out.appendSlice(allocator, "\",\"x\":0,\"y\":0,\"w\":1,\"h\":1}]}");
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1465,7 +1465,7 @@ pub const Session = struct {
         // otherwise (e.g. "/help me", "/usr/bin path", or a rebound template body): fall through.
 
         if (self.api_key_len == 0) {
-            self.setStatusLocked("Missing API key. Edit the AI Chat profile or set DEEPSEEK_API_KEY.");
+            self.setStatusLocked("Missing API key. Edit the Copilot profile or set DEEPSEEK_API_KEY.");
             self.clearPendingWeixinReplyContextLocked();
             self.mutex.unlock();
             return;
@@ -2102,7 +2102,7 @@ pub const Session = struct {
             .clean => try self.appendCleanMarkdownExportLocked(allocator, &out),
         }
 
-        if (out.items.len == 0) try out.appendSlice(allocator, "# WispTerm AI Chat\n\nNo messages yet.\n");
+        if (out.items.len == 0) try out.appendSlice(allocator, "# WispTerm Copilot\n\nNo messages yet.\n");
         return out.toOwnedSlice(allocator);
     }
 

--- a/src/ai_chat_markdown.zig
+++ b/src/ai_chat_markdown.zig
@@ -24,7 +24,7 @@ pub fn appendMarkdownDocumentHeader(
     include_metadata: bool,
 ) !void {
     try out.appendSlice(allocator, "# ");
-    try appendMarkdownInline(allocator, out, if (title.len > 0) title else "WispTerm AI Chat");
+    try appendMarkdownInline(allocator, out, if (title.len > 0) title else "WispTerm Copilot");
     try out.appendSlice(allocator, "\n\n");
     if (!include_metadata) return;
     if (model.len > 0) {

--- a/src/ai_history_resume.zig
+++ b/src/ai_history_resume.zig
@@ -90,7 +90,7 @@ pub fn checkedPowerShellResume(meta: types.SessionMeta, out: []u8) ResumeError![
     try appendPowerShellSingleQuote(out, &pos, meta.session_id);
     if (meta.resume_kind == .reasonix_resume) try append(out, &pos, " --resume");
     try append(out, &pos, " } else { Write-Error ");
-    try appendPowerShellSingleQuote(out, &pos, "AI History resume failed: project path unavailable");
+    try appendPowerShellSingleQuote(out, &pos, "Sessions resume failed: project path unavailable");
     try append(out, &pos, " }");
     return out[0..pos];
 }
@@ -363,7 +363,7 @@ test "ai_history_resume: checked PowerShell resume checks directory before resum
         .resume_kind = .codex_resume,
     };
     try std.testing.expectEqualStrings(
-        "if (Test-Path -LiteralPath 'C:\\Users\\me\\it''s project' -PathType Container) { Set-Location -LiteralPath 'C:\\Users\\me\\it''s project'; codex resume 'abc def' } else { Write-Error 'AI History resume failed: project path unavailable' }",
+        "if (Test-Path -LiteralPath 'C:\\Users\\me\\it''s project' -PathType Container) { Set-Location -LiteralPath 'C:\\Users\\me\\it''s project'; codex resume 'abc def' } else { Write-Error 'Sessions resume failed: project path unavailable' }",
         try checkedPowerShellResume(meta, &out),
     );
 
@@ -376,7 +376,7 @@ test "ai_history_resume: checked PowerShell resume checks directory before resum
         .resume_kind = .reasonix_resume,
     };
     try std.testing.expectEqualStrings(
-        "if (Test-Path -LiteralPath 'C:\\Project' -PathType Container) { Set-Location -LiteralPath 'C:\\Project'; reasonix chat --session 'code-project' --resume } else { Write-Error 'AI History resume failed: project path unavailable' }",
+        "if (Test-Path -LiteralPath 'C:\\Project' -PathType Container) { Set-Location -LiteralPath 'C:\\Project'; reasonix chat --session 'code-project' --resume } else { Write-Error 'Sessions resume failed: project path unavailable' }",
         try checkedPowerShellResume(reasonix, &out),
     );
 }

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -8,6 +8,7 @@ const reasonix_provider = @import("ai_history_provider_reasonix.zig");
 const remote_file = @import("platform/remote_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
 const ai_history_cache = @import("ai_history_cache.zig");
+const i18n = @import("i18n.zig");
 
 pub const LoadState = enum { idle, scanning, ready, failed };
 pub const TranscriptState = enum { idle, loading, ready, failed };
@@ -763,15 +764,16 @@ pub const Session = struct {
         return count;
     }
 
-    /// Tab/window title for the workbench: "History · <source>", or "AI History"
-    /// when the source is unnamed. Conveys that this is the history workbench
+    /// Tab/window title for the workbench: "Sessions · <source>", or "Sessions"
+    /// when the source is unnamed. Conveys that this is the sessions workbench
     /// rather than echoing the originating terminal's name. Cached after first use.
     pub fn tabTitle(self: *Session) []const u8 {
         if (self.tab_title_len == 0) {
+            const label = i18n.s().sl_sessions;
             const composed = if (self.source.name.len == 0)
-                std.fmt.bufPrint(&self.tab_title_buf, "AI History", .{}) catch "AI History"
+                std.fmt.bufPrint(&self.tab_title_buf, "{s}", .{label}) catch label
             else
-                std.fmt.bufPrint(&self.tab_title_buf, "History · {s}", .{self.source.name}) catch self.source.name;
+                std.fmt.bufPrint(&self.tab_title_buf, "{s} · {s}", .{ label, self.source.name }) catch self.source.name;
             self.tab_title_len = composed.len;
         }
         return self.tab_title_buf[0..self.tab_title_len];

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -18,6 +18,7 @@ const ai_history_time = @import("../ai_history_time.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
 const active_tab_state = @import("active_tab.zig");
+const i18n = @import("../i18n.zig");
 
 const CursorStyle = Config.CursorStyle;
 const Selection = Surface.Selection;
@@ -75,12 +76,12 @@ pub const TabState = struct {
             return forced;
         }
         if (self.kind == .ai_chat) {
-            const chat = self.ai_chat_session orelse return "AI Chat";
+            const chat = self.ai_chat_session orelse return i18n.s().sl_ai_agent;
             const chat_title = chat.title();
-            return if (chat_title.len > 0) chat_title else "AI Chat";
+            return if (chat_title.len > 0) chat_title else i18n.s().sl_ai_agent;
         }
         if (self.kind == .ai_history) {
-            const session = self.ai_history_session orelse return "AI History";
+            const session = self.ai_history_session orelse return i18n.s().sl_sessions;
             return session.tabTitle();
         }
         const surface = self.focusedSurface() orelse return "wispterm";
@@ -1824,8 +1825,8 @@ test "tab: spawnAiHistoryTab owns mutable ssh source buffers" {
     try std.testing.expectEqualStrings("ssh-history", session.source.id);
     try std.testing.expectEqualStrings("Build Box", session.source.name);
     try std.testing.expectEqualStrings("buildbox", session.source.target.ssh.profile_name);
-    // The tab conveys the history workbench, not the bare source name.
-    try std.testing.expectEqualStrings("History · Build Box", active.getTitle());
+    // The tab conveys the sessions workbench, not the bare source name.
+    try std.testing.expectEqualStrings("Sessions · Build Box", active.getTitle());
 }
 
 test "tab: spawnAiHistoryTab rolls back when tab allocation fails" {

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -49,9 +49,9 @@ pub const CommandEntry = struct {
 
 pub const command_entries = [_]CommandEntry{
     .{ .title = "New Session", .detail = platform_pty_command.session_launcher_detail, .shortcut = "", .action = .new_tab },
-    .{ .title = "New Agent", .detail = "Open a new Agent tab with the default AI config", .shortcut = "", .action = .new_agent },
+    .{ .title = "New Copilot", .detail = "Open a new Copilot tab with the default AI config", .shortcut = "", .action = .new_agent },
     .{ .title = "Manage AI Profiles", .detail = "Create, edit, or delete saved AI profiles", .shortcut = "", .action = .manage_ai_profiles },
-    .{ .title = "Select Agent History", .detail = "Open the command-center agent history picker", .shortcut = "", .action = .select_agent_history },
+    .{ .title = "Select Copilot History", .detail = "Open the command-center Copilot history picker", .shortcut = "", .action = .select_agent_history },
     .{ .title = "Split Right", .detail = "Create a panel to the right", .shortcut = "", .action = .split_right },
     .{ .title = "Split Down", .detail = "Create a panel below", .shortcut = "", .action = .split_down },
     .{ .title = "Split Left", .detail = "Create a panel to the left", .shortcut = "", .action = .split_left },
@@ -76,8 +76,8 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "WeChat: Stop", .detail = "Stop polling and keep the saved WeChat binding", .shortcut = "", .action = .stop_wechat },
     .{ .title = "WeChat: Status", .detail = "Show the WeChat direct connection state", .shortcut = "", .action = .wechat_status },
     .{ .title = "WeChat: Unbind", .detail = "Clear the stored WeChat direct binding", .shortcut = "", .action = .unbind_wechat },
-    .{ .title = "Export AI Chat Markdown", .detail = "Save the active AI Chat transcript as Markdown", .shortcut = "", .action = .export_ai_chat_markdown },
-    .{ .title = "Export AI Chat Markdown Clean", .detail = "Save user prompts and the final AI result without thinking", .shortcut = "", .action = .export_ai_chat_markdown_clean },
+    .{ .title = "Export Copilot Markdown", .detail = "Save the active Copilot transcript as Markdown", .shortcut = "", .action = .export_ai_chat_markdown },
+    .{ .title = "Export Copilot Markdown Clean", .detail = "Save user prompts and the final AI result without thinking", .shortcut = "", .action = .export_ai_chat_markdown_clean },
     .{ .title = "Version", .detail = "Show WispTerm version", .shortcut = app_metadata.version, .action = .show_version },
     .{ .title = "Check for Updates", .detail = "Check GitHub Releases for a newer WispTerm version", .shortcut = "", .action = .check_for_updates },
     .{ .title = "Download Update", .detail = "Download the latest update to your Downloads folder", .shortcut = "", .action = .download_update },
@@ -252,16 +252,16 @@ pub fn resolveNewAgentLaunch(has_profiles: bool) NewAgentLaunchAction {
     return if (has_profiles) .connect_default_profile_as_agent else .open_form;
 }
 
-test "command center includes New Agent action" {
-    try std.testing.expectEqual(CommandAction.new_agent, findCommandAction("New Agent"));
+test "command center includes New Copilot action" {
+    try std.testing.expectEqual(CommandAction.new_agent, findCommandAction("New Copilot"));
 }
 
 test "command center includes Manage AI Profiles action" {
     try std.testing.expectEqual(CommandAction.manage_ai_profiles, findCommandAction("Manage AI Profiles"));
 }
 
-test "command center includes Select Agent History action" {
-    try std.testing.expectEqual(CommandAction.select_agent_history, findCommandAction("Select Agent History"));
+test "command center includes Select Copilot History action" {
+    try std.testing.expectEqual(CommandAction.select_agent_history, findCommandAction("Select Copilot History"));
 }
 
 test "command center includes update check actions" {
@@ -270,9 +270,9 @@ test "command center includes update check actions" {
     try std.testing.expectEqual(CommandAction.open_latest_release, findCommandAction("Open Latest Release"));
 }
 
-test "command center includes AI Markdown export actions" {
-    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown, findCommandAction("Export AI Chat Markdown"));
-    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown_clean, findCommandAction("Export AI Chat Markdown Clean"));
+test "command center includes Copilot Markdown export actions" {
+    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown, findCommandAction("Export Copilot Markdown"));
+    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown_clean, findCommandAction("Export Copilot Markdown Clean"));
 }
 
 test "command center includes WeChat direct actions" {

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -52,6 +52,8 @@ pub const Strings = struct {
     // —— 会话启动器 & AI 智能体对话框 ——
     sl_new_session: []const u8,
     sl_ai_agent: []const u8,
+    sl_sessions: []const u8,
+    sl_sessions_detail: []const u8,
     sl_llm_providers: []const u8,
     sl_new_llm_provider: []const u8,
     sl_edit_llm_provider: []const u8,
@@ -192,7 +194,9 @@ const en = Strings{
     .settings_lang_auto = "Auto",
 
     .sl_new_session = "New Session",
-    .sl_ai_agent = "AI Agent",
+    .sl_ai_agent = "Copilot",
+    .sl_sessions = "Sessions",
+    .sl_sessions_detail = "Browse Codex / Claude Code sessions",
     .sl_llm_providers = "LLM Providers",
     .sl_new_llm_provider = "New LLM Provider",
     .sl_edit_llm_provider = "Edit LLM Provider",
@@ -249,13 +253,13 @@ const en = Strings{
     .sl_default_suffix = " (default)",
 
     .cmd_palette_title = "Command Center",
-    .cmd_palette_history_title = "Agent History",
+    .cmd_palette_history_title = "Copilot History",
     .cmd_palette_esc_closes = "Esc closes",
     .cmd_palette_esc_returns = "Esc returns",
     .cmd_palette_filter_placeholder = "Filter commands or themes",
-    .cmd_palette_no_sessions_yet = "No saved agent sessions yet",
-    .cmd_palette_recent_sessions = "Recent agent sessions",
-    .cmd_palette_no_sessions = "No saved agent sessions",
+    .cmd_palette_no_sessions_yet = "No saved Copilot sessions yet",
+    .cmd_palette_recent_sessions = "Recent Copilot sessions",
+    .cmd_palette_no_sessions = "No saved Copilot sessions",
     .cmd_palette_footer = "Up/Down + Enter applies",
     .cmd_palette_footer_history = "Up/Down selects, Enter reopens, Delete removes, Esc returns",
 
@@ -329,7 +333,9 @@ const zh_CN = Strings{
     .settings_lang_auto = "自动",
 
     .sl_new_session = "新建会话",
-    .sl_ai_agent = "AI 智能体",
+    .sl_ai_agent = "副驾",
+    .sl_sessions = "会话",
+    .sl_sessions_detail = "浏览 Codex / Claude Code 会话",
     .sl_llm_providers = "LLM 提供方",
     .sl_new_llm_provider = "新建 LLM 提供方",
     .sl_edit_llm_provider = "编辑 LLM 提供方",
@@ -386,13 +392,13 @@ const zh_CN = Strings{
     .sl_default_suffix = "（默认）",
 
     .cmd_palette_title = "命令中心",
-    .cmd_palette_history_title = "智能体历史",
+    .cmd_palette_history_title = "副驾历史",
     .cmd_palette_esc_closes = "Esc 关闭",
     .cmd_palette_esc_returns = "Esc 返回",
     .cmd_palette_filter_placeholder = "筛选命令或主题",
-    .cmd_palette_no_sessions_yet = "暂无已保存的智能体会话",
-    .cmd_palette_recent_sessions = "最近的智能体会话",
-    .cmd_palette_no_sessions = "没有已保存的智能体会话",
+    .cmd_palette_no_sessions_yet = "暂无已保存的副驾会话",
+    .cmd_palette_recent_sessions = "最近的副驾会话",
+    .cmd_palette_no_sessions = "没有已保存的副驾会话",
     .cmd_palette_footer = "上下选择，回车执行",
     .cmd_palette_footer_history = "上下选择，回车重开，Delete 删除，Esc 返回",
 
@@ -534,9 +540,9 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
     if (active_lang != .zh_CN) return null;
     return switch (action) {
         .new_tab => "新建会话",
-        .new_agent => "新建智能体",
+        .new_agent => "新建副驾",
         .manage_ai_profiles => "管理 AI 配置",
-        .select_agent_history => "选择智能体历史",
+        .select_agent_history => "选择副驾历史",
         .split_right => "向右分屏",
         .split_down => "向下分屏",
         .split_left => "向左分屏",
@@ -561,8 +567,8 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
         .stop_wechat => "微信：停止",
         .wechat_status => "微信：状态",
         .unbind_wechat => "微信：解绑",
-        .export_ai_chat_markdown => "导出 AI 对话 Markdown",
-        .export_ai_chat_markdown_clean => "导出 AI 对话 Markdown 精简版",
+        .export_ai_chat_markdown => "导出副驾 Markdown",
+        .export_ai_chat_markdown_clean => "导出副驾 Markdown 精简版",
         .show_version => "版本",
         .check_for_updates => "检查更新",
         .download_update => "下载更新",
@@ -577,10 +583,10 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
 pub fn commandDetail(action: CommandAction) ?[]const u8 {
     if (active_lang != .zh_CN) return null;
     return switch (action) {
-        .new_tab => "选择 Shell、SSH、WSL 或 AI 智能体",
-        .new_agent => "用默认 AI 配置打开一个新的智能体标签页",
+        .new_tab => "选择 Shell、SSH、WSL、副驾 或 会话",
+        .new_agent => "用默认 AI 配置打开一个新的副驾标签页",
         .manage_ai_profiles => "创建、编辑或删除已保存的 AI 配置",
-        .select_agent_history => "打开命令中心的智能体历史选择器",
+        .select_agent_history => "打开命令中心的副驾历史选择器",
         .split_right => "在右侧创建一个面板",
         .split_down => "在下方创建一个面板",
         .split_left => "在左侧创建一个面板",

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -102,8 +102,8 @@ pub const session_launcher_detail = sessionLauncherDetailForOs(builtin.os.tag);
 
 pub fn sessionLauncherDetailForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
-        .windows => "Choose PowerShell, SSH, WSL, AI Agent, or AI History",
-        .unsupported => "Choose Shell, SSH, AI Agent, or AI History",
+        .windows => "Choose PowerShell, SSH, WSL, Copilot, or Sessions",
+        .unsupported => "Choose Shell, SSH, Copilot, or Sessions",
     };
 }
 
@@ -630,7 +630,7 @@ test "platform pty command exposes session launcher layout by target OS" {
     try std.testing.expectEqual(@as(?usize, null), sessionLauncherWslRowForOs(.linux));
 
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.windows), "WSL") != null);
-    try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.windows), "AI History") != null);
+    try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.windows), "Sessions") != null);
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.linux), "WSL") == null);
     try std.testing.expect(std.mem.indexOf(u8, sessionLauncherDetailForOs(.macos), "Shell") != null);
 

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -213,7 +213,7 @@ pub fn render(
 
     if (input_text.len == 0) {
         session.input_scroll_row = 0;
-        const placeholder = if (session.agent_enabled) "Ask Agent" else "Ask AI Chat";
+        const placeholder = if (session.agent_enabled) "Ask Agent" else "Ask Copilot";
         _ = titlebar.renderTextLimited(
             placeholder,
             layout.text_x,

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ai_history_session = @import("../ai_history_session.zig");
 const types = @import("../ai_history_types.zig");
+const i18n = @import("../i18n.zig");
 
 const HEADER_H: f32 = 54;
 const FILTER_H: f32 = 42;
@@ -340,7 +341,7 @@ fn renderLeftColumn(
     const header_h = headerHeight(draw.cell_h);
     draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, top, header_h), layout.left_w, header_h, panel_strong, 0.9);
     draw.fillQuad(layout.left_x, yFromTop(window_height, top + header_h, 1), layout.left_w, 1, line);
-    _ = draw.renderTextLimited("AI History", layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited(i18n.s().sl_sessions, layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
     drawFocusUnderline(draw, layout.left_x, layout.left_w, window_height, top, header_h, accent, filters_focused);
 
     const lc = leftColumnLayout(top, draw.cell_h);

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3246,7 +3246,7 @@ fn sessionTwoColumnWidth(left: []const u8, right: []const u8) f32 {
 }
 
 fn sessionLauncherTitle() []const u8 {
-    if (g_ai_history_source_visible) return "AI History";
+    if (g_ai_history_source_visible) return i18n.s().sl_sessions;
     if (g_ai_form_visible) {
         return i18n.s().sl_ai_agent;
     }
@@ -3263,7 +3263,7 @@ fn sessionLauncherTitle() []const u8 {
             .manage => i18n.s().sl_ssh_servers,
             .edit_select => i18n.s().sl_edit_ssh_server,
             .delete_select => i18n.s().sl_delete_ssh_server,
-            .ai_history_select => "AI History SSH Profile",
+            .ai_history_select => "Sessions SSH Profile",
         };
     }
     return i18n.s().sl_new_session;
@@ -3383,7 +3383,7 @@ fn sessionDesiredBoxWidth() f32 {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, i18n.s().sl_v_manage));
             },
             .ai_history_select => {
-                desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, "AI History"));
+                desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, i18n.s().sl_sessions));
             },
         }
         return desired;
@@ -3405,7 +3405,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth("WSL", platform_pty_command.wslLauncherDetail()));
     }
     desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ai_agent, defaultAiModeLabel()));
-    desired = @max(desired, sessionTwoColumnWidth("AI History", "Browse AI agent history"));
+    desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_sessions, i18n.s().sl_sessions_detail));
     return desired;
 }
 
@@ -3698,7 +3698,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
                     renderSessionRow(layout, window_height, row, i18n.s().sl_back, i18n.s().sl_v_manage, g_ssh_list_selected == row);
                 },
                 .ai_history_select => {
-                    renderSessionRow(layout, window_height, row, i18n.s().sl_back, "AI History", g_ssh_list_selected == row);
+                    renderSessionRow(layout, window_height, row, i18n.s().sl_back, i18n.s().sl_sessions, g_ssh_list_selected == row);
                 },
             }
             return;
@@ -3714,7 +3714,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             row += 1;
         }
         renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT, i18n.s().sl_ai_agent, defaultAiModeLabel(), g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT);
-        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, "AI History", "Browse AI agent history", g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
+        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, i18n.s().sl_sessions, i18n.s().sl_sessions_detail, g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
         return;
     }
 

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -89,20 +89,20 @@ pub fn route(
 fn sendAi(ctrl: control.Control, text: []const u8, reply_context: ?types.ReplyContext, out: *Reply) !void {
     const ai = ctrl.findAiSurface() orelse blk: {
         switch (ctrl.openAiAgent(AI_OPEN_TIMEOUT_MS)) {
-            .no_profile => return out.set("WispTerm 尚未配置 AI Chat profile。"),
-            .failed => return out.set("WispTerm 无法打开 AI Agent。"),
-            .offline => return out.set("WispTerm 当前离线，无法打开 AI Agent。"),
-            .timeout => return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。"),
+            .no_profile => return out.set("WispTerm 尚未配置副驾。"),
+            .failed => return out.set("WispTerm 无法打开副驾。"),
+            .offline => return out.set("WispTerm 当前离线，无法打开副驾。"),
+            .timeout => return out.set("已请求打开副驾，但未等到副驾标签页。"),
             .opened => {},
         }
-        break :blk ctrl.findAiSurface() orelse return out.set("已请求打开 AI Agent，但未等到 AI Chat tab。");
+        break :blk ctrl.findAiSurface() orelse return out.set("已请求打开副驾，但未等到副驾标签页。");
     };
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     defer buf.deinit(out.allocator);
     try buf.appendSlice(out.allocator, text);
     try buf.append(out.allocator, '\r');
-    if (!ctrl.sendInput(ai.id, buf.items, reply_context)) return out.set("WispTerm 当前离线，无法发送给 AI Agent。");
+    if (!ctrl.sendInput(ai.id, buf.items, reply_context)) return out.set("WispTerm 当前离线，无法发送给副驾。");
     try out.set(AI_ACK);
     out.expect_ai_progress = true;
 }
@@ -112,8 +112,8 @@ fn stopAi(ctrl: control.Control, out: *Reply) !void {
     // in-flight weixin reply streaming so no further progress/final reply is
     // sent after the stop (otherwise a trailing reply looks like /stop failed).
     out.stop_followup = true;
-    const ai = ctrl.findAiSurface() orelse return out.set("当前没有 AI Agent 可停止。");
-    if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止 AI Agent。");
+    const ai = ctrl.findAiSurface() orelse return out.set("当前没有副驾可停止。");
+    if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止副驾。");
     return out.set("已发送停止指令。");
 }
 
@@ -129,9 +129,9 @@ fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Repl
 
 const helpTextConst =
     "WispTerm 微信直连命令：\n" ++
-    "/ping 验证连接\n/status 查看状态\n/ai <内容> 发送给 AI Agent\n" ++
+    "/ping 验证连接\n/status 查看状态\n/ai <内容> 发送给副驾\n" ++
     "/stop 停止当前 AI 处理\n/term <命令> 发送到终端并回车\n/keys <文本> 发送原始文本\n" ++
-    "普通文本默认发送给 AI Agent。";
+    "普通文本默认发送给副驾。";
 
 fn statusText(ctrl: control.Control) []const u8 {
     return if (ctrl.isConnected()) "微信直连：在线" else "微信直连：离线";
@@ -164,7 +164,7 @@ const FakeControl = struct {
         return cast(ctx).connected;
     }
     fn find_ai_surface(ctx: *anyopaque) ?control.Surface {
-        return if (cast(ctx).has_ai) .{ .id = aiId(), .title = "AI Chat" } else null;
+        return if (cast(ctx).has_ai) .{ .id = aiId(), .title = "Copilot" } else null;
     }
     fn find_terminal_surface(_: *anyopaque) ?control.Surface {
         return .{ .id = termId(), .title = "zsh" };


### PR DESCRIPTION
## Why

The session-launcher entry for WispTerm's **built-in AI** ("AI Agent" / "AI 智能体") and the **external CLI-history browser** ("AI History") both led with a vague "AI" label. They read like a pair — *the agent and its history* — even though they're unrelated: one is the assistant you converse with, the other browses sessions logged by Codex / Claude Code / Reasonix. The command palette even called the browser "Agent History" in one place, reinforcing the confusion.

## What

**Direction: Copilot + Sessions.** Neither name keeps a bare "AI" prefix, and they no longer share the "Agent" word, so "Sessions" can't be mistaken for Copilot's own history.

### ① Built-in AI → **Copilot / 副驾**
- Launcher entry (`sl_ai_agent`)
- Its conversation history in the command palette: title `Copilot History / 副驾历史` + recent/no-sessions strings
- Command-palette actions: `New Copilot`, `Select Copilot History`, `Export Copilot Markdown[ Clean]`
- Chat tab fallback title + input placeholder (`Ask Copilot`)
- Export Markdown header, save dialog, "open a Copilot tab first" toast, API-key status
- WeChat bridge messages (副驾)

### ② External Codex / Claude Code / Reasonix browser → **Sessions / 会话**
- New i18n keys `sl_sessions` (Sessions / 会话) + `sl_sessions_detail` (Browse Codex / Claude Code sessions)
- Workbench title + header, launcher row + detail subtitle, SSH-profile picker header, width calcs, remote-layout snapshot, resume-failure toasts/error
- `ai_history_session.zig`, `ai_history_renderer.zig`, `appwindow/tab.zig` gain an `i18n` import so previously-hardcoded strings localize

### Out of scope (unchanged)
Internal identifiers (enum values, globals, config keys, `ai_profiles/` storage), the Agent/Chat capability-mode label, code comments, and dev logs. `pty_command`'s launcher detail is a comptime constant, so it stays English-only (Copilot/Sessions wording).

Design spec: `docs/superpowers/specs/2026-06-04-copilot-sessions-rename-design.md`. Docs (`docs/ai-agent.md`, `docs/README.md`) updated to match.

## Testing
- `zig build test` (fast) — green
- `zig build test-full` (full app graph) — green
- Updated the string-assertion tests the rename touched: `command_center_state` (3), `pty_command`, `ai_history_resume` PowerShell (2), tab-title.
- GUI verification on macOS/Windows deferred (no Linux GUI backend), consistent with prior UI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)