### PR TITLE
feat: /loop and /watch — scheduled & recurring AI prompts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -589,6 +589,28 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(fast_tests).step);
 
+    // Posix-native libc-linked tests: file I/O, libc (localtime), fork.
+    // Runs on any non-Windows host. Added to test-full so the store tests
+    // (ai_loop_store) execute on the Linux CI host where test_main.zig is skipped
+    // (Linux has no desktop backend, so supports_desktop_exe = false there).
+    if (b.graph.host.result.os.tag != .windows) {
+        const posix_test_mod = b.createModule(.{
+            .root_source_file = b.path("src/test_posix.zig"),
+            .target = b.resolveTargetQuery(.{}),
+            .optimize = optimize,
+            .link_libc = true,
+        });
+        const posix_test_options = b.addOptions();
+        posix_test_options.addOption([]const u8, "app_version", app_version);
+        posix_test_options.addOption([]const u8, "release_notes", "");
+        posix_test_mod.addOptions("build_options", posix_test_options);
+        const posix_tests = b.addTest(.{
+            .name = "wispterm-posix-test",
+            .root_module = posix_test_mod,
+        });
+        test_full_step.dependOn(&b.addRunArtifact(posix_tests).step);
+    }
+
     const shared_test_mod = b.createModule(.{
         .root_source_file = b.path("src/shared_compile_test.zig"),
         .target = target,

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -45,6 +45,7 @@ const hit_test = @import("input/hit_test.zig");
 pub const ai_chat = @import("ai_chat.zig");
 const ai_history_cache = @import("ai_history_cache.zig");
 const ai_history_resume = @import("ai_history_resume.zig");
+const ai_loop_store = @import("ai_loop_store.zig");
 const ai_history_types = @import("ai_history_types.zig");
 pub const ai_history_session = @import("ai_history_session.zig");
 pub const ai_history_source = @import("ai_history_source.zig");
@@ -124,6 +125,17 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     try ensureGlobalAgentHistoryStore(allocator);
     tab.g_ai_history_change_hook = saveAiHistoryChangeEvent;
     installSessionRestoreHooks();
+    // Init the scheduler store once per process (guard prevents re-init on
+    // subsequent window creations). The store must not move after setActive, so
+    // we keep it in the stable g_loop_store global.
+    if (g_loop_store == null) {
+        if (platform_dirs.pathInConfigDir(allocator, "loop_tasks.json")) |loop_path| {
+            defer allocator.free(loop_path);
+            g_loop_store = ai_loop_store.Store.init(allocator, loop_path);
+            ai_loop_store.setActive(&g_loop_store.?);
+            ai_loop_store.setInjector(loopInjector);
+        } else |_| {}
+    }
 
     // Apply config from App to globals
     g_theme = app.theme;
@@ -255,6 +267,13 @@ pub fn deinit(self: *AppWindow) void {
     tab.g_tab_count = 0;
     tab.g_remote_client = null;
     if (is_last_window) deinitGlobalAgentHistoryStore(self.allocator);
+    if (is_last_window) {
+        if (g_loop_store != null) {
+            ai_loop_store.clearActive();
+            g_loop_store.?.deinit();
+            g_loop_store = null;
+        }
+    }
     markdown_preview_renderer.deinit();
     markdown_preview_panel.deinit();
     browser_panel.deinit();
@@ -417,6 +436,28 @@ var g_agent_history_mutex: std.Thread.Mutex = .{};
 pub var g_agent_history: ?*agent_history.Store = null;
 var g_flush_scheduler: flush_scheduler.FlushScheduler = .{};
 var g_agent_history_revision: u64 = 0;
+
+// Process-wide scheduler store for /loop and /watch tasks.
+// Must be a stable global so setActive(&g_loop_store.?) never dangles.
+var g_loop_store: ?ai_loop_store.Store = null;
+
+/// Resolves a session by id across all open tabs (UI thread only: tab.g_tabs
+/// is threadlocal and only populated on the window's UI thread).
+fn loopInjector(session_id: []const u8, prompt: []const u8) ai_loop_store.InjectOutcome {
+    var i: usize = 0;
+    while (i < tab.MAX_TABS) : (i += 1) {
+        const t = tab.g_tabs[i] orelse continue;
+        if (t.ai_chat_session) |s| {
+            if (std.mem.eql(u8, s.sessionId(), session_id))
+                return if (s.submitScheduledPrompt(prompt)) .sent else .busy;
+        }
+        if (t.copilot_session) |s| {
+            if (std.mem.eql(u8, s.sessionId(), session_id))
+                return if (s.submitScheduledPrompt(prompt)) .sent else .busy;
+        }
+    }
+    return .closed;
+}
 
 // Initial CWD for this window (used when spawning the first tab)
 threadlocal var g_initial_cwd_buf: platform_pty_command.CwdBuffer = undefined;
@@ -5001,6 +5042,8 @@ fn runMainLoop(self: *AppWindow) !void {
         // Track the last windowed position so a maximized/fullscreen close still
         // persists where the window was, not (0,0).
         rememberWindowedPosition(win);
+        // Fire any due /loop or /watch tasks (UI thread: tab.g_tabs is populated).
+        ai_loop_store.tick(std.time.milliTimestamp());
 
         // Update focus state
         const focused = window_backend.isFocused(win);

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -359,6 +359,9 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
         .distill => allocator.dupe(u8, "Use /distill [topic] to preview a reusable skill candidate."),
         .unknown => allocator.dupe(u8, "Unknown command. Use /commands to list commands."),
         .skills => ai_chat_skills.listSkillsForDisplay(allocator),
+        // .loop and .watch suppress output and emit their own messages via
+        // runLoopCommandLocked; this path is never reached.
+        .loop, .watch => allocator.dupe(u8, ""),
     };
 }
 

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1837,8 +1837,9 @@ pub const Session = struct {
         const w = buf.writer(self.allocator);
         for (views) |v| {
             if (kind == .loop) {
-                w.print("#{d}  every {d}m  remaining {d}  \u{2192} {s}\n", .{
-                    v.id, @divTrunc(v.interval_ms, std.time.ms_per_min), v.remaining, previewPrompt(v.prompt),
+                const iv = ai_loop_schedule.formatInterval(v.interval_ms);
+                w.print("#{d}  every {d}{c}  remaining {d}  \u{2192} {s}\n", .{
+                    v.id, iv.value, iv.unit, v.remaining, previewPrompt(v.prompt),
                 }) catch return;
             } else if (v.daily) {
                 w.print("#{d}  daily {d:0>2}:{d:0>2}  \u{2192} {s}\n", .{
@@ -1854,9 +1855,12 @@ pub const Session = struct {
     fn emitRegisterConfirmationLocked(self: *Session, info: ai_loop_store.RegisterInfo) void {
         var buf: [160]u8 = undefined;
         const msg = switch (info.kind) {
-            .loop => std.fmt.bufPrint(&buf, "Created loop task #{d}: every {d}m, {d} times.", .{
-                info.id, @divTrunc(info.interval_ms, std.time.ms_per_min), info.remaining,
-            }) catch "Created loop task.",
+            .loop => blk: {
+                const iv = ai_loop_schedule.formatInterval(info.interval_ms);
+                break :blk std.fmt.bufPrint(&buf, "Created loop task #{d}: every {d}{c}, {d} times.", .{
+                    info.id, iv.value, iv.unit, info.remaining,
+                }) catch "Created loop task.";
+            },
             .watch => if (info.daily)
                 std.fmt.bufPrint(&buf, "Created watch task #{d} (daily).", .{info.id}) catch "Created watch task."
             else

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1067,6 +1067,27 @@ pub const Session = struct {
         if (text_start < data.len) self.appendInputText(data[text_start..]);
     }
 
+    /// Inject a scheduled prompt as if the user typed + submitted it. Returns
+    /// false (skipped, nothing sent) if a request is already inflight. Clears any
+    /// half-typed composer text first so the scheduled prompt is sent verbatim.
+    /// Caller must run this on the UI thread (mirrors applyRemoteInput).
+    pub fn submitScheduledPrompt(self: *Session, text: []const u8) bool {
+        self.mutex.lock();
+        if (self.request_inflight) {
+            self.mutex.unlock();
+            return false;
+        }
+        self.input_len = 0;
+        self.input_cursor = 0;
+        self.input_scroll_row = 0;
+        self.input_scroll_follow_cursor = true;
+        self.input_select_all = false;
+        self.mutex.unlock();
+        self.appendInputText(text);
+        self.submit();
+        return true;
+    }
+
     pub fn applyWeixinInput(self: *Session, data: []const u8, ctx: weixin_types.ReplyContext) void {
         self.mutex.lock();
         if (self.pending_weixin_reply_context) |*old| old.deinit(self.allocator);
@@ -6011,4 +6032,20 @@ test "copilot session pre-targets the bound surface in its request" {
     defer req.deinit();
 
     try std.testing.expectEqualStrings("abc123", req.write_context_surface_id[0..req.write_context_surface_id_len]);
+}
+
+test "submitScheduledPrompt sets composer and reports busy state" {
+    const a = std.testing.allocator;
+    const session = try Session.init(a, "test", "", "", "", "", "", "", "", "");
+    defer session.deinit();
+
+    // Not inflight: returns true and submit is invoked (no agent configured, no-ops).
+    const ok = session.submitScheduledPrompt("hello world");
+    try std.testing.expect(ok);
+
+    // Inflight: returns false (skip).
+    session.request_inflight = true;
+    const skipped = session.submitScheduledPrompt("again");
+    try std.testing.expect(!skipped);
+    session.request_inflight = false;
 }

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -25,6 +25,8 @@ const ai_agent_access = @import("ai_agent_access.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const ai_chat_markdown = @import("ai_chat_markdown.zig");
 const weixin_types = @import("weixin/types.zig");
+const ai_loop_store = @import("ai_loop_store.zig");
+const ai_loop_schedule = @import("ai_loop_schedule.zig");
 
 pub const AgentSettings = ai_chat_types.AgentSettings;
 pub const AgentPermission = ai_chat_types.AgentPermission;
@@ -362,6 +364,24 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
         // .loop and .watch suppress output and emit their own messages via
         // runLoopCommandLocked; this path is never reached.
         .loop, .watch => allocator.dupe(u8, ""),
+    };
+}
+
+fn previewPrompt(p: []const u8) []const u8 {
+    return if (p.len > 48) p[0..48] else p;
+}
+
+fn loopErrorText(err: ai_loop_schedule.ParseError, kind: ai_loop_schedule.TaskKind) []const u8 {
+    return switch (err) {
+        error.MissingArgs => if (kind == .loop)
+            "Usage: /loop <interval> <count> <prompt>  e.g. /loop 30m 8 check ci"
+        else
+            "Usage: /watch <HH:MM | YYYY-MM-DD HH:MM> <prompt>",
+        error.BadInterval => "Bad interval. Use a number + s/m/h/d, e.g. 30m, 5h.",
+        error.BadCount => "Count must be a positive integer.",
+        error.BadTime => "Bad time. Use HH:MM or YYYY-MM-DD HH:MM (24h).",
+        error.PastTime => "That time is already in the past.",
+        error.EmptyPrompt => "Add the prompt text after the schedule.",
     };
 }
 
@@ -1731,6 +1751,8 @@ pub const Session = struct {
             .export_markdown => result.deferred = .{
                 .export_markdown = if (std.mem.eql(u8, std.mem.trim(u8, arg, " \t\r\n"), "full")) .full else .clean,
             },
+            .loop => self.runLoopCommandLocked(.loop, arg, &result),
+            .watch => self.runLoopCommandLocked(.watch, arg, &result),
             else => {},
         }
         if (result.suppress_output) return result;
@@ -1746,6 +1768,110 @@ pub const Session = struct {
         self.clearSubmittedInputLocked();
         self.setStatusLocked("Ready");
         return result;
+    }
+
+    fn runLoopCommandLocked(self: *Session, kind: ai_loop_schedule.TaskKind, arg: []const u8, result: *BuiltinResult) void {
+        result.suppress_output = true;
+        const store = ai_loop_store.active() orelse {
+            self.emitLoopMessageLocked("Scheduler is not available.");
+            return;
+        };
+        const trimmed = std.mem.trim(u8, arg, " \t\r\n");
+        const now_ms = std.time.milliTimestamp();
+        const offset_s = @import("ai_history_time.zig").localOffsetSeconds();
+        const ctx = ai_loop_store.SessionCtx{
+            .session_id = self.sessionId(),
+            .model = self.model(),
+            .title = self.title(),
+        };
+
+        if (trimmed.len == 0) {
+            self.listLoopTasksLocked(store, kind);
+            return;
+        }
+        if (std.mem.startsWith(u8, trimmed, "stop")) {
+            const rest = std.mem.trim(u8, trimmed["stop".len..], " \t\r\n");
+            if (std.mem.eql(u8, rest, "all")) {
+                const n = store.stopAll(ctx.session_id, kind);
+                var buf: [64]u8 = undefined;
+                self.emitLoopMessageLocked(std.fmt.bufPrint(&buf, "Cancelled {d} task(s).", .{n}) catch "Cancelled tasks.");
+            } else {
+                const id = std.fmt.parseInt(u32, rest, 10) catch {
+                    self.emitLoopMessageLocked("Usage: stop <id> | stop all");
+                    return;
+                };
+                const ok = store.stop(ctx.session_id, id);
+                self.emitLoopMessageLocked(if (ok) "Task cancelled." else "No such task in this session.");
+            }
+            return;
+        }
+
+        const info = switch (kind) {
+            .loop => store.registerLoop(trimmed, ctx, now_ms, offset_s),
+            .watch => store.registerWatch(trimmed, ctx, now_ms, offset_s),
+        } catch |err| switch (err) {
+            error.OutOfMemory => {
+                self.emitLoopMessageLocked("Out of memory.");
+                return;
+            },
+            else => |parse_err| {
+                self.emitLoopMessageLocked(loopErrorText(parse_err, kind));
+                return;
+            },
+        };
+        self.emitRegisterConfirmationLocked(info);
+    }
+
+    fn listLoopTasksLocked(self: *Session, store: *ai_loop_store.Store, kind: ai_loop_schedule.TaskKind) void {
+        const views = store.snapshotForSession(self.allocator, self.sessionId(), kind) catch {
+            self.emitLoopMessageLocked("Out of memory.");
+            return;
+        };
+        defer ai_loop_store.freeSnapshot(self.allocator, views);
+        if (views.len == 0) {
+            self.emitLoopMessageLocked(if (kind == .loop) "No active loop tasks." else "No active watch tasks.");
+            return;
+        }
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        const w = buf.writer(self.allocator);
+        for (views) |v| {
+            if (kind == .loop) {
+                w.print("#{d}  every {d}m  remaining {d}  \u{2192} {s}\n", .{
+                    v.id, @divTrunc(v.interval_ms, std.time.ms_per_min), v.remaining, previewPrompt(v.prompt),
+                }) catch return;
+            } else if (v.daily) {
+                w.print("#{d}  daily {d:0>2}:{d:0>2}  \u{2192} {s}\n", .{
+                    v.id, @divTrunc(v.tod_minutes, 60), @mod(v.tod_minutes, 60), previewPrompt(v.prompt),
+                }) catch return;
+            } else {
+                w.print("#{d}  once  \u{2192} {s}\n", .{ v.id, previewPrompt(v.prompt) }) catch return;
+            }
+        }
+        self.emitLoopMessageLocked(buf.items);
+    }
+
+    fn emitRegisterConfirmationLocked(self: *Session, info: ai_loop_store.RegisterInfo) void {
+        var buf: [160]u8 = undefined;
+        const msg = switch (info.kind) {
+            .loop => std.fmt.bufPrint(&buf, "Created loop task #{d}: every {d}m, {d} times.", .{
+                info.id, @divTrunc(info.interval_ms, std.time.ms_per_min), info.remaining,
+            }) catch "Created loop task.",
+            .watch => if (info.daily)
+                std.fmt.bufPrint(&buf, "Created watch task #{d} (daily).", .{info.id}) catch "Created watch task."
+            else
+                std.fmt.bufPrint(&buf, "Created watch task #{d} (one-shot).", .{info.id}) catch "Created watch task.",
+        };
+        self.emitLoopMessageLocked(msg);
+    }
+
+    fn emitLoopMessageLocked(self: *Session, text: []const u8) void {
+        self.appendLocalToolMessageLocked(text) catch {
+            self.setStatusLocked("Out of memory");
+            return;
+        };
+        self.clearSubmittedInputLocked();
+        self.setStatusLocked("Ready");
     }
 
     fn cancelDistillCandidate(self: *Session) void {
@@ -6051,4 +6177,40 @@ test "submitScheduledPrompt sets composer and reports busy state" {
     const skipped = session.submitScheduledPrompt("again");
     try std.testing.expect(!skipped);
     session.request_inflight = false;
+}
+
+test "runLoopCommandLocked creates, lists, and stops a loop task" {
+    const a = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = ai_loop_store.Store.init(a, path);
+    defer store.deinit();
+    ai_loop_store.setActive(&store);
+    defer ai_loop_store.clearActive();
+
+    const session = try Session.init(a, "test", "", "", "", "", "", "", "", "");
+    defer session.deinit();
+    session.copySessionId("session-test");
+
+    session.mutex.lock();
+    _ = session.runBuiltinCommandLocked(.loop, "30m 3 hello");
+    session.mutex.unlock();
+
+    const snap = try store.snapshotForSession(a, "session-test", .loop);
+    defer ai_loop_store.freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expectEqualStrings("hello", snap[0].prompt);
+
+    session.mutex.lock();
+    _ = session.runBuiltinCommandLocked(.loop, "stop 1");
+    session.mutex.unlock();
+    const snap2 = try store.snapshotForSession(a, "session-test", .loop);
+    defer ai_loop_store.freeSnapshot(a, snap2);
+    try std.testing.expectEqual(@as(usize, 0), snap2.len);
 }

--- a/src/ai_chat_composer.zig
+++ b/src/ai_chat_composer.zig
@@ -15,6 +15,8 @@ pub const SlashCommand = enum {
     permission,
     export_markdown,
     distill,
+    loop,
+    watch,
     unknown,
 };
 
@@ -83,6 +85,14 @@ pub const slash_command_entries = [_]SlashCommandEntry{
     .{
         .suggestion = .{ .command = "/reload-commands", .description = "rescan the commands directory" },
         .action = .reload_commands,
+    },
+    .{
+        .suggestion = .{ .command = "/loop", .description = "repeat a prompt every interval N times" },
+        .action = .loop,
+    },
+    .{
+        .suggestion = .{ .command = "/watch", .description = "send a prompt at a daily or one-shot time" },
+        .action = .watch,
     },
 };
 
@@ -315,6 +325,13 @@ const test_skills = [_]skill_registry.SkillMeta{
     .{ .name = &test_skill_review_name, .description = &test_skill_review_desc, .dir_name = &test_skill_review_dir, .rel_dir = &test_skill_review_rel },
 };
 
+test "parseSlashCommand recognizes loop and watch" {
+    try std.testing.expectEqual(SlashCommand.loop, parseSlashCommand("/loop").?);
+    try std.testing.expectEqual(SlashCommand.watch, parseSlashCommand("/watch").?);
+    try std.testing.expectEqual(SlashCommand.loop, exactBuiltinCommand("/loop").?);
+    try std.testing.expectEqual(SlashCommand.watch, exactBuiltinCommand("/watch").?);
+}
+
 test "parseSlashCommand recognizes new lifecycle commands" {
     try std.testing.expectEqual(SlashCommand.clear, parseSlashCommand("/clear").?);
     try std.testing.expectEqual(SlashCommand.resume_session, parseSlashCommand("/resume").?);
@@ -344,7 +361,7 @@ test "slash command suggestions filter by prefix" {
     try std.testing.expectEqual(@as(usize, 1), slashCommandSuggestionCountForInput("/sk", 3, &.{}));
     const s = slashCommandSuggestionAtForInput("/sk", 3, 0, &.{}).?;
     try std.testing.expectEqualStrings("/skills", s.command);
-    try std.testing.expectEqual(@as(usize, 11), slashCommandSuggestionCountForInput("/", 1, &.{}));
+    try std.testing.expectEqual(@as(usize, 13), slashCommandSuggestionCountForInput("/", 1, &.{}));
     try std.testing.expectEqual(@as(usize, 1), slashCommandSuggestionCountForInput("/di", 3, &.{}));
     try std.testing.expectEqualStrings("/distill", slashCommandSuggestionAtForInput("/di", 3, 0, &.{}).?.command);
 }

--- a/src/ai_loop_schedule.zig
+++ b/src/ai_loop_schedule.zig
@@ -115,6 +115,19 @@ pub fn nextDailyOccurrence(tod_minutes: i32, now_ms: i64, offset_s: i32) i64 {
     return candidate - off_ms;
 }
 
+pub const IntervalDisplay = struct { value: i64, unit: u8 };
+
+/// Render an interval back to its largest evenly-dividing unit for display
+/// (e.g. 3_600_000 -> {1,'h'}, 1_000 -> {1,'s'}). Since intervals are entered as
+/// a single `<int><unit>`, this recovers a natural, human-readable form and
+/// avoids showing sub-minute intervals as "0m".
+pub fn formatInterval(ms: i64) IntervalDisplay {
+    if (ms != 0 and @rem(ms, std.time.ms_per_day) == 0) return .{ .value = @divTrunc(ms, std.time.ms_per_day), .unit = 'd' };
+    if (ms != 0 and @rem(ms, std.time.ms_per_hour) == 0) return .{ .value = @divTrunc(ms, std.time.ms_per_hour), .unit = 'h' };
+    if (ms != 0 and @rem(ms, std.time.ms_per_min) == 0) return .{ .value = @divTrunc(ms, std.time.ms_per_min), .unit = 'm' };
+    return .{ .value = @divTrunc(ms, std.time.ms_per_s), .unit = 's' };
+}
+
 pub const TaskKind = enum { loop, watch };
 
 pub const Task = struct {
@@ -337,4 +350,15 @@ test "encode/decode round-trip" {
     try std.testing.expectEqual(TaskKind.watch, parsed.value.tasks[1].kind);
     try std.testing.expectEqual(@as(i32, 540), parsed.value.tasks[1].tod_minutes);
     try std.testing.expectEqualStrings("check ci", parsed.value.tasks[0].prompt);
+}
+
+test "formatInterval picks the largest evenly-dividing unit" {
+    try std.testing.expectEqual(IntervalDisplay{ .value = 1, .unit = 's' }, formatInterval(std.time.ms_per_s));
+    try std.testing.expectEqual(IntervalDisplay{ .value = 30, .unit = 's' }, formatInterval(30 * std.time.ms_per_s));
+    try std.testing.expectEqual(IntervalDisplay{ .value = 1, .unit = 'm' }, formatInterval(std.time.ms_per_min));
+    try std.testing.expectEqual(IntervalDisplay{ .value = 5, .unit = 'h' }, formatInterval(5 * std.time.ms_per_hour));
+    try std.testing.expectEqual(IntervalDisplay{ .value = 1, .unit = 'd' }, formatInterval(std.time.ms_per_day));
+    // 120s collapses to the larger exact unit (2m); 90s stays seconds.
+    try std.testing.expectEqual(IntervalDisplay{ .value = 2, .unit = 'm' }, formatInterval(120 * std.time.ms_per_s));
+    try std.testing.expectEqual(IntervalDisplay{ .value = 90, .unit = 's' }, formatInterval(90 * std.time.ms_per_s));
 }

--- a/src/ai_loop_schedule.zig
+++ b/src/ai_loop_schedule.zig
@@ -1,0 +1,340 @@
+//! Pure (std-only) schedule engine for the /loop and /watch AI-chat commands.
+//! No I/O, no Session, no globals. The caller passes the current time (`now_ms`,
+//! ms since epoch) and the local UTC offset (`offset_s`, seconds); nothing here
+//! reads the clock or the timezone. The runtime store (ai_loop_store.zig) is the
+//! I/O layer over this.
+const std = @import("std");
+
+pub const ParseError = error{
+    MissingArgs,
+    BadInterval,
+    BadCount,
+    BadTime,
+    PastTime,
+    EmptyPrompt,
+};
+
+/// "<positive int><unit>" where unit is s|m|h|d -> milliseconds.
+pub fn parseIntervalMs(tok: []const u8) ParseError!i64 {
+    if (tok.len < 2) return error.BadInterval;
+    const unit = tok[tok.len - 1];
+    const n = std.fmt.parseInt(i64, tok[0 .. tok.len - 1], 10) catch return error.BadInterval;
+    if (n <= 0) return error.BadInterval;
+    const mult: i64 = switch (unit) {
+        's' => std.time.ms_per_s,
+        'm' => std.time.ms_per_min,
+        'h' => std.time.ms_per_hour,
+        'd' => std.time.ms_per_day,
+        else => return error.BadInterval,
+    };
+    return n * mult;
+}
+
+/// Positive decimal integer -> u32 (0 rejected).
+pub fn parseCount(tok: []const u8) ParseError!u32 {
+    const n = std.fmt.parseInt(u32, tok, 10) catch return error.BadCount;
+    if (n == 0) return error.BadCount;
+    return n;
+}
+
+pub const LoopArgs = struct { interval_ms: i64, count: u32, prompt: []const u8 };
+pub const WatchArgs = struct { daily: bool, tod_minutes: i32, next_fire_ms: i64, prompt: []const u8 };
+
+pub fn parseLoopArgs(arg: []const u8) ParseError!LoopArgs {
+    const trimmed = std.mem.trim(u8, arg, " \t\r\n");
+    if (trimmed.len == 0) return error.MissingArgs;
+    var it = std.mem.tokenizeAny(u8, trimmed, " \t");
+    const interval_tok = it.next() orelse return error.MissingArgs;
+    const count_tok = it.next() orelse return error.MissingArgs;
+    const interval_ms = try parseIntervalMs(interval_tok);
+    const count = try parseCount(count_tok);
+    const prompt = std.mem.trim(u8, trimmed[it.index..], " \t\r\n");
+    if (prompt.len == 0) return error.EmptyPrompt;
+    return .{ .interval_ms = interval_ms, .count = count, .prompt = prompt };
+}
+
+pub fn parseWatchArgs(arg: []const u8, now_ms: i64, offset_s: i32) ParseError!WatchArgs {
+    const trimmed = std.mem.trim(u8, arg, " \t\r\n");
+    if (trimmed.len == 0) return error.MissingArgs;
+    var it = std.mem.tokenizeAny(u8, trimmed, " \t");
+    const first = it.next() orelse return error.MissingArgs;
+    if (std.mem.indexOfScalar(u8, first, '-') != null) {
+        const time_tok = it.next() orelse return error.BadTime;
+        const abs = try parseAbsoluteMs(first, time_tok, offset_s);
+        if (abs <= now_ms) return error.PastTime;
+        const prompt = std.mem.trim(u8, trimmed[it.index..], " \t\r\n");
+        if (prompt.len == 0) return error.EmptyPrompt;
+        return .{ .daily = false, .tod_minutes = 0, .next_fire_ms = abs, .prompt = prompt };
+    }
+    const tod = try parseHourMinute(first);
+    const next = nextDailyOccurrence(tod, now_ms, offset_s);
+    const prompt = std.mem.trim(u8, trimmed[it.index..], " \t\r\n");
+    if (prompt.len == 0) return error.EmptyPrompt;
+    return .{ .daily = true, .tod_minutes = tod, .next_fire_ms = next, .prompt = prompt };
+}
+
+fn parseHourMinute(tok: []const u8) ParseError!i32 {
+    const colon = std.mem.indexOfScalar(u8, tok, ':') orelse return error.BadTime;
+    const hh = std.fmt.parseInt(i32, tok[0..colon], 10) catch return error.BadTime;
+    const mm = std.fmt.parseInt(i32, tok[colon + 1 ..], 10) catch return error.BadTime;
+    if (hh < 0 or hh > 23 or mm < 0 or mm > 59) return error.BadTime;
+    return hh * 60 + mm;
+}
+
+fn parseAbsoluteMs(date_tok: []const u8, time_tok: []const u8, offset_s: i32) ParseError!i64 {
+    var dit = std.mem.splitScalar(u8, date_tok, '-');
+    const y = std.fmt.parseInt(i64, dit.next() orelse return error.BadTime, 10) catch return error.BadTime;
+    const mo = std.fmt.parseInt(i64, dit.next() orelse return error.BadTime, 10) catch return error.BadTime;
+    const d = std.fmt.parseInt(i64, dit.next() orelse return error.BadTime, 10) catch return error.BadTime;
+    if (dit.next() != null) return error.BadTime;
+    if (mo < 1 or mo > 12 or d < 1 or d > 31) return error.BadTime;
+    const tod = try parseHourMinute(time_tok);
+    const days = daysFromCivil(y, mo, d);
+    const local_ms = (days * std.time.s_per_day + @as(i64, tod) * std.time.s_per_min) * std.time.ms_per_s;
+    return local_ms - @as(i64, offset_s) * std.time.ms_per_s;
+}
+
+/// Days since 1970-01-01 for a proleptic-Gregorian date (Howard Hinnant).
+fn daysFromCivil(y_in: i64, m: i64, d: i64) i64 {
+    const y = if (m <= 2) y_in - 1 else y_in;
+    const era = @divFloor(y, 400);
+    const yoe = y - era * 400; // [0, 399]
+    const mp = if (m > 2) m - 3 else m + 9; // [0, 11]
+    const doy = @divFloor(153 * mp + 2, 5) + d - 1; // [0, 365]
+    const doe = yoe * 365 + @divFloor(yoe, 4) - @divFloor(yoe, 100) + doy; // [0, 146096]
+    return era * 146097 + doe - 719468;
+}
+
+/// Next UTC ms at which local time-of-day `tod_minutes` occurs (strictly future).
+pub fn nextDailyOccurrence(tod_minutes: i32, now_ms: i64, offset_s: i32) i64 {
+    const off_ms: i64 = @as(i64, offset_s) * std.time.ms_per_s;
+    const local_now = now_ms + off_ms;
+    const day_start = @divFloor(local_now, std.time.ms_per_day) * std.time.ms_per_day;
+    var candidate = day_start + @as(i64, tod_minutes) * std.time.ms_per_min;
+    if (candidate <= local_now) candidate += std.time.ms_per_day;
+    return candidate - off_ms;
+}
+
+pub const TaskKind = enum { loop, watch };
+
+pub const Task = struct {
+    id: u32 = 0,
+    kind: TaskKind,
+    session_id: []const u8,
+    model: []const u8 = "",
+    title: []const u8 = "",
+    prompt: []const u8,
+    interval_ms: i64 = 0, // loop only
+    remaining: u32 = 0, // loop: sends left. one-shot watch: 1 pending -> 0 done. daily: unused.
+    daily: bool = false, // watch: true=recurring HH:MM, false=one-shot absolute
+    tod_minutes: i32 = 0, // daily watch: minutes since local midnight
+    next_fire_ms: i64 = 0,
+    created_ms: i64 = 0,
+};
+
+pub fn isDue(t: *const Task, now_ms: i64) bool {
+    return t.next_fire_ms <= now_ms;
+}
+
+pub fn isFinished(t: *const Task) bool {
+    return switch (t.kind) {
+        .loop => t.remaining == 0,
+        .watch => if (t.daily) false else t.remaining == 0,
+    };
+}
+
+pub fn advanceAfterFire(t: *Task, now_ms: i64, offset_s: i32) void {
+    switch (t.kind) {
+        .loop => {
+            if (t.remaining > 0) t.remaining -= 1;
+            t.next_fire_ms += t.interval_ms;
+            if (t.next_fire_ms <= now_ms) t.next_fire_ms = now_ms + t.interval_ms; // drift guard
+        },
+        .watch => {
+            if (t.daily) {
+                t.next_fire_ms = nextDailyOccurrence(t.tod_minutes, now_ms, offset_s);
+            } else {
+                t.remaining = 0; // one-shot done
+            }
+        },
+    }
+}
+
+/// Fix `next_fire_ms` on load: loop skips missed intervals (resume cadence),
+/// daily watch -> next future occurrence, missed one-shot -> fire ASAP (now).
+pub fn recomputeAfterRestart(t: *Task, now_ms: i64, offset_s: i32) void {
+    switch (t.kind) {
+        .loop => {
+            if (t.next_fire_ms <= now_ms) t.next_fire_ms = now_ms + t.interval_ms;
+        },
+        .watch => {
+            if (t.daily) {
+                t.next_fire_ms = nextDailyOccurrence(t.tod_minutes, now_ms, offset_s);
+            } else if (t.next_fire_ms <= now_ms) {
+                t.next_fire_ms = now_ms;
+            }
+        },
+    }
+}
+
+pub const FileModel = struct {
+    version: u32 = 1,
+    next_id: u32 = 1,
+    tasks: []Task = &.{},
+};
+
+pub fn encode(allocator: std.mem.Allocator, model: FileModel) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, model, .{});
+}
+
+pub fn decodeAlloc(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(FileModel) {
+    return std.json.parseFromSlice(FileModel, allocator, bytes, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+}
+
+// ---- Tests ----
+
+test "parseIntervalMs accepts units s/m/h/d" {
+    try std.testing.expectEqual(@as(i64, 30_000), try parseIntervalMs("30s"));
+    try std.testing.expectEqual(@as(i64, 5 * 60_000), try parseIntervalMs("5m"));
+    try std.testing.expectEqual(@as(i64, 2 * 3_600_000), try parseIntervalMs("2h"));
+    try std.testing.expectEqual(@as(i64, 24 * 3_600_000), try parseIntervalMs("1d"));
+}
+
+test "parseIntervalMs rejects bad forms" {
+    try std.testing.expectError(error.BadInterval, parseIntervalMs("5"));
+    try std.testing.expectError(error.BadInterval, parseIntervalMs("h"));
+    try std.testing.expectError(error.BadInterval, parseIntervalMs("0h"));
+    try std.testing.expectError(error.BadInterval, parseIntervalMs("-3h"));
+    try std.testing.expectError(error.BadInterval, parseIntervalMs("5x"));
+}
+
+test "parseCount" {
+    try std.testing.expectEqual(@as(u32, 10), try parseCount("10"));
+    try std.testing.expectError(error.BadCount, parseCount("0"));
+    try std.testing.expectError(error.BadCount, parseCount("abc"));
+    try std.testing.expectError(error.BadCount, parseCount("-1"));
+}
+
+test "parseLoopArgs splits interval, count, prompt" {
+    const r = try parseLoopArgs("30m 8 检查 CI，把失败的测试贴出来");
+    try std.testing.expectEqual(@as(i64, 30 * std.time.ms_per_min), r.interval_ms);
+    try std.testing.expectEqual(@as(u32, 8), r.count);
+    try std.testing.expectEqualStrings("检查 CI，把失败的测试贴出来", r.prompt);
+}
+
+test "parseLoopArgs errors" {
+    try std.testing.expectError(error.MissingArgs, parseLoopArgs("   "));
+    try std.testing.expectError(error.MissingArgs, parseLoopArgs("30m"));
+    try std.testing.expectError(error.EmptyPrompt, parseLoopArgs("30m 8"));
+    try std.testing.expectError(error.BadInterval, parseLoopArgs("30 8 hi"));
+}
+
+test "parseWatchArgs daily HH:MM" {
+    // 2024-01-01 00:00 UTC = 1704067200000 ms; offset 0 for determinism.
+    const now: i64 = 1_704_067_200_000;
+    const r = try parseWatchArgs("09:00 生成早报", now, 0);
+    try std.testing.expect(r.daily);
+    try std.testing.expectEqual(@as(i32, 9 * 60), r.tod_minutes);
+    try std.testing.expectEqual(now + 9 * std.time.ms_per_hour, r.next_fire_ms);
+    try std.testing.expectEqualStrings("生成早报", r.prompt);
+}
+
+test "parseWatchArgs daily rolls to tomorrow when time passed" {
+    const now: i64 = 1_704_067_200_000 + 10 * std.time.ms_per_hour; // 10:00 UTC
+    const r = try parseWatchArgs("09:00 x", now, 0);
+    try std.testing.expectEqual(1_704_067_200_000 + std.time.ms_per_day + 9 * std.time.ms_per_hour, r.next_fire_ms);
+}
+
+test "parseWatchArgs one-shot absolute" {
+    const now: i64 = 1_704_067_200_000; // 2024-01-01 00:00 UTC
+    const r = try parseWatchArgs("2024-01-02 09:30 提醒", now, 0);
+    try std.testing.expect(!r.daily);
+    try std.testing.expectEqual(1_704_067_200_000 + std.time.ms_per_day + 9 * std.time.ms_per_hour + 30 * std.time.ms_per_min, r.next_fire_ms);
+    try std.testing.expectEqualStrings("提醒", r.prompt);
+}
+
+test "parseWatchArgs one-shot in the past errors" {
+    const now: i64 = 1_704_067_200_000;
+    try std.testing.expectError(error.PastTime, parseWatchArgs("2023-12-31 09:00 x", now, 0));
+}
+
+test "parseWatchArgs bad time" {
+    try std.testing.expectError(error.BadTime, parseWatchArgs("25:00 x", 0, 0));
+    try std.testing.expectError(error.BadTime, parseWatchArgs("09:99 x", 0, 0));
+    try std.testing.expectError(error.MissingArgs, parseWatchArgs("   ", 0, 0));
+}
+
+fn fixtureLoop(remaining: u32, next_fire: i64) Task {
+    return .{ .kind = .loop, .session_id = "s", .prompt = "p", .interval_ms = 30 * std.time.ms_per_min, .remaining = remaining, .next_fire_ms = next_fire };
+}
+
+test "isDue at boundary" {
+    const t = fixtureLoop(3, 1000);
+    try std.testing.expect(isDue(&t, 1000));
+    try std.testing.expect(isDue(&t, 2000));
+    try std.testing.expect(!isDue(&t, 999));
+}
+
+test "advanceAfterFire loop decrements and pushes interval" {
+    var t = fixtureLoop(3, 1000);
+    advanceAfterFire(&t, 1000, 0);
+    try std.testing.expectEqual(@as(u32, 2), t.remaining);
+    try std.testing.expectEqual(@as(i64, 1000 + 30 * std.time.ms_per_min), t.next_fire_ms);
+    try std.testing.expect(!isFinished(&t));
+}
+
+test "advanceAfterFire loop reaching zero is finished" {
+    var t = fixtureLoop(1, 1000);
+    advanceAfterFire(&t, 1000, 0);
+    try std.testing.expectEqual(@as(u32, 0), t.remaining);
+    try std.testing.expect(isFinished(&t));
+}
+
+test "advanceAfterFire one-shot watch finishes" {
+    var t = Task{ .kind = .watch, .session_id = "s", .prompt = "p", .daily = false, .remaining = 1, .next_fire_ms = 1000 };
+    advanceAfterFire(&t, 1000, 0);
+    try std.testing.expect(isFinished(&t));
+}
+
+test "advanceAfterFire daily watch rolls forward and never finishes" {
+    var t = Task{ .kind = .watch, .session_id = "s", .prompt = "p", .daily = true, .tod_minutes = 9 * 60, .next_fire_ms = 1_704_067_200_000 + 9 * std.time.ms_per_hour };
+    advanceAfterFire(&t, t.next_fire_ms, 0);
+    try std.testing.expectEqual(1_704_067_200_000 + std.time.ms_per_day + 9 * std.time.ms_per_hour, t.next_fire_ms);
+    try std.testing.expect(!isFinished(&t));
+}
+
+test "recomputeAfterRestart loop skips missed intervals" {
+    var t = fixtureLoop(3, 1000); // far in the past
+    recomputeAfterRestart(&t, 10_000, 0);
+    try std.testing.expectEqual(@as(i64, 10_000 + 30 * std.time.ms_per_min), t.next_fire_ms);
+}
+
+test "recomputeAfterRestart one-shot caught up to now when missed" {
+    var t = Task{ .kind = .watch, .session_id = "s", .prompt = "p", .daily = false, .remaining = 1, .next_fire_ms = 1000 };
+    recomputeAfterRestart(&t, 10_000, 0);
+    try std.testing.expectEqual(@as(i64, 10_000), t.next_fire_ms);
+}
+
+test "encode/decode round-trip" {
+    const a = std.testing.allocator;
+    const tasks = [_]Task{
+        .{ .id = 1, .kind = .loop, .session_id = "session-7", .model = "glm", .title = "Build", .prompt = "check ci", .interval_ms = 1_800_000, .remaining = 8, .next_fire_ms = 123, .created_ms = 100 },
+        .{ .id = 2, .kind = .watch, .session_id = "session-7", .prompt = "report", .daily = true, .tod_minutes = 540, .remaining = 0, .next_fire_ms = 456, .created_ms = 100 },
+    };
+    const model = FileModel{ .version = 1, .next_id = 3, .tasks = @constCast(tasks[0..]) };
+
+    const bytes = try encode(a, model);
+    defer a.free(bytes);
+
+    var parsed = try decodeAlloc(a, bytes);
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(u32, 3), parsed.value.next_id);
+    try std.testing.expectEqual(@as(usize, 2), parsed.value.tasks.len);
+    try std.testing.expectEqualStrings("session-7", parsed.value.tasks[0].session_id);
+    try std.testing.expectEqual(TaskKind.watch, parsed.value.tasks[1].kind);
+    try std.testing.expectEqual(@as(i32, 540), parsed.value.tasks[1].tod_minutes);
+    try std.testing.expectEqualStrings("check ci", parsed.value.tasks[0].prompt);
+}

--- a/src/ai_loop_store.zig
+++ b/src/ai_loop_store.zig
@@ -1,0 +1,404 @@
+//! Runtime store + persistence for /loop and /watch tasks. Thin glue over the
+//! pure engine (ai_loop_schedule.zig). Owns the in-memory task list, the
+//! `loop_tasks.json` file, and the per-frame `tick` that fires due tasks through
+//! a wired injector callback. All mutation happens on the UI thread (slash-command
+//! handling + tick), guarded by a mutex for defensive safety.
+const std = @import("std");
+const engine = @import("ai_loop_schedule.zig");
+const ai_history_time = @import("ai_history_time.zig");
+
+pub const Task = engine.Task;
+pub const TaskKind = engine.TaskKind;
+pub const ParseError = engine.ParseError;
+
+/// Result the injector reports back so the store knows whether to advance.
+pub const InjectOutcome = enum { sent, busy, closed };
+
+/// Resolves a session by id and injects the prompt. Set by the app layer.
+pub const Injector = *const fn (session_id: []const u8, prompt: []const u8) InjectOutcome;
+
+/// Session context captured at registration (for binding + list display).
+pub const SessionCtx = struct {
+    session_id: []const u8,
+    model: []const u8 = "",
+    title: []const u8 = "",
+};
+
+/// Returned to the chat layer to format a confirmation message.
+pub const RegisterInfo = struct {
+    id: u32,
+    kind: TaskKind,
+    interval_ms: i64 = 0,
+    remaining: u32 = 0,
+    daily: bool = false,
+    next_fire_ms: i64,
+};
+
+/// A read-only copy of a task for listing (owned by the caller's allocator).
+pub const TaskView = struct {
+    id: u32,
+    kind: TaskKind,
+    interval_ms: i64,
+    remaining: u32,
+    daily: bool,
+    tod_minutes: i32,
+    next_fire_ms: i64,
+    prompt: []u8,
+};
+
+pub fn freeSnapshot(allocator: std.mem.Allocator, views: []TaskView) void {
+    for (views) |v| allocator.free(v.prompt);
+    allocator.free(views);
+}
+
+// ---- Module-level globals ----
+
+var g_injector: ?Injector = null;
+var g_store: ?*Store = null;
+
+/// Wire the app-layer injector (resolve session by id + inject). Call once at startup.
+pub fn setInjector(inj: Injector) void {
+    g_injector = inj;
+}
+
+/// Register the process-wide store instance the app ticks/queries.
+pub fn setActive(store: *Store) void {
+    g_store = store;
+}
+
+/// Unregister the store (call before deinit to prevent dangling pointer).
+pub fn clearActive() void {
+    g_store = null;
+}
+
+pub fn active() ?*Store {
+    return g_store;
+}
+
+/// Called once per UI frame from the app layer (UI thread, where tab.g_tabs is
+/// populated). No-op until both a store and an injector are wired.
+pub fn tick(now_ms: i64) void {
+    const store = g_store orelse return;
+    const inj = g_injector orelse return;
+    const offset_s = ai_history_time.localOffsetSeconds();
+    store.tickWith(now_ms, offset_s, inj);
+}
+
+// ---- Store ----
+
+pub const Store = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    tasks: std.ArrayListUnmanaged(Task) = .empty,
+    next_id: u32 = 1,
+    path: []const u8, // owned
+    last_scan_ms: i64 = 0,
+
+    pub fn init(allocator: std.mem.Allocator, path: []const u8) Store {
+        var store = Store{
+            .allocator = allocator,
+            .path = allocator.dupe(u8, path) catch path,
+        };
+        store.load();
+        return store;
+    }
+
+    pub fn deinit(self: *Store) void {
+        for (self.tasks.items) |*t| self.freeTask(t);
+        self.tasks.deinit(self.allocator);
+        self.allocator.free(self.path);
+    }
+
+    fn freeTask(self: *Store, t: *Task) void {
+        self.allocator.free(t.session_id);
+        self.allocator.free(t.model);
+        self.allocator.free(t.title);
+        self.allocator.free(t.prompt);
+    }
+
+    /// Append a task, duping all string fields and assigning the next id.
+    fn appendOwned(self: *Store, src: Task) !u32 {
+        var t = src;
+        t.session_id = try self.allocator.dupe(u8, src.session_id);
+        errdefer self.allocator.free(t.session_id);
+        t.model = try self.allocator.dupe(u8, src.model);
+        errdefer self.allocator.free(t.model);
+        t.title = try self.allocator.dupe(u8, src.title);
+        errdefer self.allocator.free(t.title);
+        t.prompt = try self.allocator.dupe(u8, src.prompt);
+        errdefer self.allocator.free(t.prompt);
+        t.id = self.next_id;
+        self.next_id += 1;
+        try self.tasks.append(self.allocator, t);
+        return t.id;
+    }
+
+    pub fn registerLoop(self: *Store, arg: []const u8, ctx: SessionCtx, now_ms: i64, offset_s: i32) (ParseError || error{OutOfMemory})!RegisterInfo {
+        _ = offset_s; // unused for loop (no time-of-day math needed)
+        const p = try engine.parseLoopArgs(arg);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const id = try self.appendOwned(.{
+            .kind = .loop,
+            .session_id = ctx.session_id,
+            .model = ctx.model,
+            .title = ctx.title,
+            .prompt = p.prompt,
+            .interval_ms = p.interval_ms,
+            .remaining = p.count,
+            .next_fire_ms = now_ms + p.interval_ms,
+            .created_ms = now_ms,
+        });
+        self.saveLocked();
+        return .{ .id = id, .kind = .loop, .interval_ms = p.interval_ms, .remaining = p.count, .next_fire_ms = now_ms + p.interval_ms };
+    }
+
+    pub fn registerWatch(self: *Store, arg: []const u8, ctx: SessionCtx, now_ms: i64, offset_s: i32) (ParseError || error{OutOfMemory})!RegisterInfo {
+        const p = try engine.parseWatchArgs(arg, now_ms, offset_s);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const id = try self.appendOwned(.{
+            .kind = .watch,
+            .session_id = ctx.session_id,
+            .model = ctx.model,
+            .title = ctx.title,
+            .prompt = p.prompt,
+            .daily = p.daily,
+            .tod_minutes = p.tod_minutes,
+            .remaining = if (p.daily) 0 else 1,
+            .next_fire_ms = p.next_fire_ms,
+            .created_ms = now_ms,
+        });
+        self.saveLocked();
+        return .{ .id = id, .kind = .watch, .daily = p.daily, .next_fire_ms = p.next_fire_ms };
+    }
+
+    pub fn snapshotForSession(self: *Store, allocator: std.mem.Allocator, session_id: []const u8, kind: TaskKind) ![]TaskView {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var out: std.ArrayListUnmanaged(TaskView) = .empty;
+        errdefer {
+            for (out.items) |v| allocator.free(v.prompt);
+            out.deinit(allocator);
+        }
+        for (self.tasks.items) |t| {
+            if (t.kind != kind) continue;
+            if (!std.mem.eql(u8, t.session_id, session_id)) continue;
+            try out.append(allocator, .{
+                .id = t.id,
+                .kind = t.kind,
+                .interval_ms = t.interval_ms,
+                .remaining = t.remaining,
+                .daily = t.daily,
+                .tod_minutes = t.tod_minutes,
+                .next_fire_ms = t.next_fire_ms,
+                .prompt = try allocator.dupe(u8, t.prompt),
+            });
+        }
+        return out.toOwnedSlice(allocator);
+    }
+
+    /// Remove one task by id within a session. Returns true if removed.
+    pub fn stop(self: *Store, session_id: []const u8, id: u32) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var i: usize = 0;
+        while (i < self.tasks.items.len) : (i += 1) {
+            const t = self.tasks.items[i];
+            if (t.id == id and std.mem.eql(u8, t.session_id, session_id)) {
+                var removed = self.tasks.orderedRemove(i);
+                self.freeTask(&removed);
+                self.saveLocked();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Remove all tasks of `kind` in a session. Returns the count removed.
+    pub fn stopAll(self: *Store, session_id: []const u8, kind: TaskKind) u32 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var removed: u32 = 0;
+        var i: usize = 0;
+        while (i < self.tasks.items.len) {
+            const t = self.tasks.items[i];
+            if (t.kind == kind and std.mem.eql(u8, t.session_id, session_id)) {
+                var r = self.tasks.orderedRemove(i);
+                self.freeTask(&r);
+                removed += 1;
+            } else i += 1;
+        }
+        if (removed > 0) self.saveLocked();
+        return removed;
+    }
+
+    /// Testable core of the per-frame tick. Throttled to once per second.
+    pub fn tickWith(self: *Store, now_ms: i64, offset_s: i32, inj: Injector) void {
+        if (now_ms - self.last_scan_ms < std.time.ms_per_s) return;
+        self.last_scan_ms = now_ms;
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var changed = false;
+        var i: usize = 0;
+        while (i < self.tasks.items.len) {
+            const t = &self.tasks.items[i];
+            if (!engine.isDue(t, now_ms)) {
+                i += 1;
+                continue;
+            }
+            switch (inj(t.session_id, t.prompt)) {
+                .sent => {
+                    engine.advanceAfterFire(t, now_ms, offset_s);
+                    changed = true;
+                    if (engine.isFinished(t)) {
+                        var removed = self.tasks.orderedRemove(i);
+                        self.freeTask(&removed);
+                        continue; // don't advance i; next task shifted into place
+                    }
+                },
+                .busy, .closed => {
+                    // Leave unchanged: stays due, retried on a later tick (no
+                    // decrement, no next_fire advance). A daily/one-shot bound to a
+                    // closed session fires the instant that session is reopened.
+                },
+            }
+            i += 1;
+        }
+        if (changed) self.saveLocked();
+    }
+
+    // ---- persistence ----
+
+    fn load(self: *Store) void {
+        const bytes = std.fs.cwd().readFileAlloc(self.allocator, self.path, 8 * 1024 * 1024) catch return;
+        defer self.allocator.free(bytes);
+        var parsed = engine.decodeAlloc(self.allocator, bytes) catch return;
+        defer parsed.deinit();
+        const offset_s = ai_history_time.localOffsetSeconds();
+        const now_ms = std.time.milliTimestamp();
+        self.next_id = parsed.value.next_id;
+        for (parsed.value.tasks) |src| {
+            var copy = src;
+            engine.recomputeAfterRestart(&copy, now_ms, offset_s);
+            if (engine.isFinished(&copy)) continue;
+            _ = self.appendOwnedKeepingId(copy) catch {};
+        }
+    }
+
+    fn appendOwnedKeepingId(self: *Store, src: Task) !void {
+        var t = src;
+        t.session_id = try self.allocator.dupe(u8, src.session_id);
+        errdefer self.allocator.free(t.session_id);
+        t.model = try self.allocator.dupe(u8, src.model);
+        errdefer self.allocator.free(t.model);
+        t.title = try self.allocator.dupe(u8, src.title);
+        errdefer self.allocator.free(t.title);
+        t.prompt = try self.allocator.dupe(u8, src.prompt);
+        errdefer self.allocator.free(t.prompt);
+        try self.tasks.append(self.allocator, t); // keeps src.id
+        if (t.id >= self.next_id) self.next_id = t.id + 1;
+    }
+
+    fn saveLocked(self: *Store) void {
+        const model = engine.FileModel{ .version = 1, .next_id = self.next_id, .tasks = self.tasks.items };
+        const bytes = engine.encode(self.allocator, model) catch return;
+        defer self.allocator.free(bytes);
+        const file = std.fs.cwd().createFile(self.path, .{ .truncate = true }) catch return;
+        defer file.close();
+        file.writeAll(bytes) catch return;
+    }
+};
+
+// ---- Tests ----
+
+test "register loop, snapshot, stop, persist round-trip" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = Store.init(a, path);
+    defer store.deinit();
+
+    const info = try store.registerLoop("30m 3 hello", .{ .session_id = "session-7", .model = "glm", .title = "t" }, 1000, 0);
+    try std.testing.expectEqual(@as(u32, 1), info.id);
+    try std.testing.expectEqual(@as(u32, 3), info.remaining);
+    try std.testing.expectEqual(@as(i64, 1000 + 30 * std.time.ms_per_min), info.next_fire_ms);
+
+    const snap = try store.snapshotForSession(a, "session-7", .loop);
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expectEqualStrings("hello", snap[0].prompt);
+
+    // Reload from disk into a second store sees the persisted task.
+    var store2 = Store.init(a, path);
+    defer store2.deinit();
+    const snap2 = try store2.snapshotForSession(a, "session-7", .loop);
+    defer freeSnapshot(a, snap2);
+    try std.testing.expectEqual(@as(usize, 1), snap2.len);
+
+    try std.testing.expect(store2.stop("session-7", 1));
+    const snap3 = try store2.snapshotForSession(a, "session-7", .loop);
+    defer freeSnapshot(a, snap3);
+    try std.testing.expectEqual(@as(usize, 0), snap3.len);
+}
+
+// Test injector that records calls and returns a scripted outcome.
+const TestInjector = struct {
+    var outcome: InjectOutcome = .sent;
+    var calls: u32 = 0;
+    var last_prompt_buf: [256]u8 = undefined;
+    var last_prompt_len: usize = 0;
+    fn inject(session_id: []const u8, prompt: []const u8) InjectOutcome {
+        _ = session_id;
+        calls += 1;
+        last_prompt_len = @min(prompt.len, last_prompt_buf.len);
+        @memcpy(last_prompt_buf[0..last_prompt_len], prompt[0..last_prompt_len]);
+        return outcome;
+    }
+};
+
+test "tick fires due loop task, advances, and skips when busy" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = Store.init(a, path);
+    defer store.deinit();
+
+    // next_fire = 1000 + 30m; we tick at a time well past it.
+    _ = try store.registerLoop("30m 2 do-it", .{ .session_id = "s" }, 1000, 0);
+    const fire_at = 1000 + 30 * std.time.ms_per_min + 5;
+
+    // Busy => skip, no decrement, still 1 task with remaining 2.
+    TestInjector.outcome = .busy;
+    TestInjector.calls = 0;
+    store.tickWith(fire_at, 0, TestInjector.inject);
+    try std.testing.expectEqual(@as(u32, 1), TestInjector.calls);
+    {
+        const snap = try store.snapshotForSession(a, "s", .loop);
+        defer freeSnapshot(a, snap);
+        try std.testing.expectEqual(@as(u32, 2), snap[0].remaining);
+    }
+
+    // Sent => decrement to 1, prompt forwarded.
+    TestInjector.outcome = .sent;
+    TestInjector.calls = 0;
+    store.tickWith(fire_at + std.time.ms_per_s, 0, TestInjector.inject); // +1s to bypass the 1s throttle
+    try std.testing.expectEqual(@as(u32, 1), TestInjector.calls);
+    try std.testing.expectEqualStrings("do-it", TestInjector.last_prompt_buf[0..TestInjector.last_prompt_len]);
+    {
+        const snap = try store.snapshotForSession(a, "s", .loop);
+        defer freeSnapshot(a, snap);
+        try std.testing.expectEqual(@as(u32, 1), snap[0].remaining);
+    }
+}

--- a/src/ai_loop_store.zig
+++ b/src/ai_loop_store.zig
@@ -402,3 +402,24 @@ test "tick fires due loop task, advances, and skips when busy" {
         try std.testing.expectEqual(@as(u32, 1), snap[0].remaining);
     }
 }
+
+test "setActive/clearActive/active module globals" {
+    // Verify the module-level store pointer is absent by default and round-trips.
+    clearActive();
+    try std.testing.expectEqual(@as(?*Store, null), active());
+
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+    var store = Store.init(a, path);
+    defer store.deinit();
+
+    setActive(&store);
+    try std.testing.expect(active() != null);
+    clearActive();
+    try std.testing.expectEqual(@as(?*Store, null), active());
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("ai_loop_schedule.zig");
     _ = @import("ai_skill_distill.zig");
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -614,6 +614,7 @@ comptime {
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
     _ = @import("ai_loop_schedule.zig");
+    _ = @import("ai_loop_store.zig");
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -613,6 +613,7 @@ comptime {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("ai_loop_schedule.zig");
     _ = @import("ai_history_types.zig");
     _ = @import("ai_history_provider_codex.zig");
     _ = @import("ai_history_provider_claude.zig");

--- a/src/test_posix.zig
+++ b/src/test_posix.zig
@@ -1,0 +1,20 @@
+//! Native libc-linked test runner for modules that need real file I/O, the
+//! libc timezone functions, or other POSIX capabilities unavailable in the
+//! fast (no-libc) or cross-compiled (windows-gnu) test runners.
+//!
+//! Added to `test-full` (see build.zig) for all non-Windows hosts. Put tests
+//! here when they involve:
+//!   - std.fs / tmpDir file round-trips
+//!   - ai_history_time.localOffsetSeconds() (calls localtime_r / timegm)
+//!   - socketpair / fork / other POSIX syscalls
+//!
+//! Do NOT put tests here that can live in test_fast.zig (no libc needed) or
+//! test_main.zig (full app graph, Windows/macOS CI).
+
+const std = @import("std");
+// Suppress unused build_options import expected by some imported modules.
+pub const build_options = @import("build_options");
+
+comptime {
+    _ = @import("ai_loop_store.zig");
+}


### PR DESCRIPTION
## Summary
Two AI-chat slash commands that re-submit a prompt to the **bound AI session** on a schedule:
- `/loop <interval> <count> <prompt>` — every interval (s/m/h/d), `count` times, then stop (first fire after one interval).
- `/watch <HH:MM | YYYY-MM-DD HH:MM> <prompt>` — daily or one-shot at a clock time (time-only in v1).
- `/loop` / `/watch` (no arg) list this session's tasks; `stop <id>` / `stop all` cancel.

Bound to the originating session and **persisted across restart** (`loop_tasks.json`).

## Architecture (approach A: pure engine + tick-driven store, no new thread)
- **`src/ai_loop_schedule.zig`** — pure engine: arg parsing, civil-date time math, `Task` lifecycle (advance/restart/finished/due), JSON codec. Clock + tz are parameters → fully fast-suite testable.
- **`src/ai_loop_store.zig`** — runtime store: owns the task list, persists `loop_tasks.json`, fires due tasks on each UI frame via a wired injector.
- **`Session.submitScheduledPrompt`** (`ai_chat.zig`) — injects + submits; returns false (skip) if a request is in-flight.
- Dispatch (create/list/stop) in `ai_chat.zig`; `/loop`·`/watch` registered in `ai_chat_composer.zig`.
- **`AppWindow.zig`** — injector resolves a session by id across open tabs on the UI thread; `tick()` per frame; store init/deinit guarded.

## Behavior decisions
- Agent busy at fire → skip (no count decrement, retry next interval); `count` = successful sends only.
- Restart: loop skips missed intervals; one-shot watch catches up once; daily watch → next occurrence.
- Closed bound session → skip + keep the task (re-fires when the session is reopened). Auto-resume of a closed session is deferred (no programmatic resume-by-id exists yet).
- Output text is English, matching existing slash-command siblings.

## Test plan
- [x] `zig build` links cleanly
- [x] `zig build test` (fast suite) — engine tests green
- [x] `zig build test-full` — store tests run via the native `test_posix.zig` runner; chat-dispatch test compile-checked (executes on Windows/macOS CI)
- [x] Manual GUI smoke (macOS/Windows — no Linux GUI backend): `/loop 1m 3 …`, list, `/watch`, `stop`, error paths, and `loop_tasks.json` restore after restart

## Notes
- Adds a native `src/test_posix.zig` test runner + build.zig wiring (libc + real file I/O). The unmerged tmux branch also adds a same-named runner — expect a conflict if both land.
- Spec: `docs/superpowers/specs/2026-06-04-ai-loop-watch-scheduled-prompts-design.md`; plan: `docs/superpowers/plans/2026-06-04-ai-loop-watch-scheduled-prompts.md` (already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)