### PR TITLE
feat: add $websearch (Jina web search) command and agent tool

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,7 @@ const macos_objective_c_sources = [_][]const u8{
     "src/platform/font_macos_bridge.m",
     "src/platform/services_macos_bridge.m",
     "src/platform/menu_macos_bridge.m",
+    "src/platform/http_client_macos_bridge.m",
 };
 
 const MacosBundleMetadata = struct {
@@ -607,6 +608,19 @@ pub fn build(b: *std.Build) void {
         .name = "wispterm-fast-test",
         .root_module = fast_test_mod,
     });
+    switch (b.graph.host.result.os.tag) {
+        .windows => fast_test_mod.linkSystemLibrary("winhttp", .{}),
+        .macos => {
+            fast_test_mod.addCSourceFile(.{
+                .file = b.path("src/platform/http_client_macos_bridge.m"),
+                .flags = &.{},
+                .language = .objective_c,
+            });
+            fast_test_mod.linkFramework("Foundation", .{});
+            fast_test_mod.linkSystemLibrary("objc", .{});
+        },
+        else => {},
+    }
     test_step.dependOn(&b.addRunArtifact(fast_tests).step);
 
     // Posix-native libc-linked tests: file I/O, libc (localtime), fork.

--- a/docs/superpowers/plans/2026-06-05-websearch-jina.md
+++ b/docs/superpowers/plans/2026-06-05-websearch-jina.md
@@ -1,0 +1,948 @@
+# `$websearch` (Jina) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add web search to the AI chat — a `$websearch <query>` user command (shows raw Jina snippets in the transcript) and a `websearch` agent tool (returns full page content to the model) — behind an engine-agnostic core whose only engine today is Jina.
+
+**Architecture:** A new leaf module `src/web_search.zig` owns all search logic (engine enum, result types, pure request-build / response-parse / format helpers, the single HTTP call, and a process-global Jina API key). The `$websearch` command runs on a background thread that reuses the existing `request_thread`/`request_inflight` lifecycle (so `Session.deinit` joins it — no UAF). The agent tool calls the same core synchronously inside the existing tool worker.
+
+**Tech Stack:** Zig, `std.http.Client.fetch`, `std.json` (dynamic `Value` parsing), existing WispTerm AI-chat modules.
+
+> **Discovery that refines the spec:** `$` is *already* the skill-invocation prefix (`composerSuggestionPrefix` maps `'$' => .skill`, and `parseSkillInvocation` parses `$name rest`). So `$websearch` is a **reserved** command intercepted in `Session.submit` *before* skill handling, and surfaced in the existing `$` suggestion dropdown via a small reserved list. There is **no** new `firstCharKind`/prefix branch (the spec's wording there is superseded).
+
+> **Refinement of spec error handling:** Zig errors can't carry a payload, so the "HTTP status + trimmed body" detail is logged via `std.log.warn`; the user/model see a friendly message from `errorText`. This satisfies the spec's "specific, user-readable message" goal.
+
+---
+
+## File Structure
+
+- **Create** `src/web_search.zig` — engine-agnostic core: `Engine`, `SearchResult`, `Options`, `Results`, the Jina key globals, pure helpers (`buildJinaRequestBody`, `parseJinaResponse`, `formatForUser`, `formatForAgent`, `errorText`), and the impure `executeSearch`/`searchJina`. Only depends on `std`.
+- **Modify** `src/test_fast.zig` — register `web_search.zig` so its pure tests run in the fast suite.
+- **Modify** `src/config.zig` — `jina-api-key` field, parse branch, `--help` line, sample comment.
+- **Modify** `src/AppWindow.zig` — push `cfg.@"jina-api-key"` into `web_search.setJinaApiKey` on config apply.
+- **Modify** `src/ai_chat_composer.zig` — `WebCommand`/`parseWebCommand` + reserved `$websearch` suggestion in the `$` dropdown.
+- **Modify** `src/ai_chat.zig` — `WebSearchRequest`, `startWebSearchRequest`, `appendWebSearchResult`, and the `$websearch` interception in `submit`.
+- **Modify** `src/ai_chat_request.zig` — `webSearchThreadMain` worker.
+- **Modify** `src/ai_chat_protocol.zig` — one `emit(...)` line registering the `websearch` tool schema.
+- **Modify** `src/ai_chat_tools.zig` — `websearch` dispatch + `webSearchTool`.
+
+---
+
+## Task 1: `web_search.zig` core types + `buildJinaRequestBody`
+
+**Files:**
+- Create: `src/web_search.zig`
+- Modify: `src/test_fast.zig` (add the import)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/web_search.zig` with the types and the function stub plus this test at the bottom:
+
+```zig
+//! Engine-agnostic web search core. Pure request-build / response-parse / format
+//! helpers plus one HTTP call (`executeSearch`). Only the `jina` engine exists
+//! today; a new engine is a new branch in `executeSearch`. Leaf module: std only.
+const std = @import("std");
+
+pub const Engine = enum { jina };
+
+pub const SearchResult = struct {
+    title: []const u8,
+    url: []const u8,
+    description: []const u8,
+    content: ?[]const u8 = null,
+};
+
+pub const Options = struct {
+    engine: Engine = .jina,
+    api_key: []const u8,
+    with_content: bool,
+    max_results: usize = 10,
+};
+
+fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {
+    try out.append(allocator, '"');
+    for (s) |c| switch (c) {
+        '"' => try out.appendSlice(allocator, "\\\""),
+        '\\' => try out.appendSlice(allocator, "\\\\"),
+        '\n' => try out.appendSlice(allocator, "\\n"),
+        '\r' => try out.appendSlice(allocator, "\\r"),
+        '\t' => try out.appendSlice(allocator, "\\t"),
+        else => |ch| if (ch < 0x20)
+            try out.writer(allocator).print("\\u{x:0>4}", .{ch})
+        else
+            try out.append(allocator, ch),
+    };
+    try out.append(allocator, '"');
+}
+
+/// Build the Jina search request body: `{"q":<json-escaped query>}`.
+pub fn buildJinaRequestBody(allocator: std.mem.Allocator, query: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "{\"q\":");
+    try appendJsonString(allocator, &out, query);
+    try out.append(allocator, '}');
+    return out.toOwnedSlice(allocator);
+}
+
+test "buildJinaRequestBody json-escapes the query" {
+    const a = std.testing.allocator;
+    const body = try buildJinaRequestBody(a, "say \"hi\"\nbye");
+    defer a.free(body);
+    try std.testing.expectEqualStrings("{\"q\":\"say \\\"hi\\\"\\nbye\"}", body);
+}
+```
+
+Then add this line to `src/test_fast.zig` next to the other `ai_chat_*` imports (after line `_ = @import("ai_chat_composer.zig");`):
+
+```zig
+    _ = @import("web_search.zig");
+```
+
+- [ ] **Step 2: Run test to verify it fails (then passes once the file compiles)**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: compiles and the `buildJinaRequestBody` test passes. (If you stubbed the body to return `""` first, it FAILS on the string compare; the implementation above already makes it pass.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web_search.zig src/test_fast.zig
+git commit -m "feat(websearch): web_search core types + request body builder"
+```
+
+---
+
+## Task 2: `parseJinaResponse` + `Results`
+
+**Files:**
+- Modify: `src/web_search.zig`
+
+- [ ] **Step 1: Write the failing test**
+
+Add the `Results` type and `parseJinaResponse` + helper to `src/web_search.zig` (place `Results` after `Options`):
+
+```zig
+pub const Results = struct {
+    arena: std.heap.ArenaAllocator,
+    items: []SearchResult,
+    pub fn deinit(self: *Results) void {
+        self.arena.deinit();
+    }
+};
+
+fn jsonStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Parse a Jina search JSON response (`{"data":[{title,url,description,content?},...]}`)
+/// into result structs whose strings are duped into `arena`. Caps at `max_results`.
+/// Duping into `arena` means the parsed value may safely alias `json_bytes`, which
+/// the caller frees after this returns.
+pub fn parseJinaResponse(arena: std.mem.Allocator, json_bytes: []const u8, max_results: usize) ![]SearchResult {
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, json_bytes, .{}) catch return error.ParseFailed;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.ParseFailed;
+    const data_val = parsed.value.object.get("data") orelse return error.ParseFailed;
+    if (data_val != .array) return &.{};
+    const arr = data_val.array.items;
+    const n = @min(arr.len, max_results);
+    const list = try arena.alloc(SearchResult, n);
+    var count: usize = 0;
+    for (arr[0..n]) |item| {
+        if (item != .object) continue;
+        const obj = item.object;
+        list[count] = .{
+            .title = try arena.dupe(u8, jsonStr(obj, "title") orelse ""),
+            .url = try arena.dupe(u8, jsonStr(obj, "url") orelse ""),
+            .description = try arena.dupe(u8, jsonStr(obj, "description") orelse ""),
+            .content = if (jsonStr(obj, "content")) |c| try arena.dupe(u8, c) else null,
+        };
+        count += 1;
+    }
+    return list[0..count];
+}
+
+test "parseJinaResponse extracts fields, honors max, tolerates missing content" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const json =
+        \\{"code":200,"data":[
+        \\{"title":"First","url":"https://a.example","description":"desc a","content":"body a"},
+        \\{"title":"Second","url":"https://b.example","description":"desc b"}
+        \\]}
+    ;
+    const items = try parseJinaResponse(arena.allocator(), json, 10);
+    try std.testing.expectEqual(@as(usize, 2), items.len);
+    try std.testing.expectEqualStrings("First", items[0].title);
+    try std.testing.expectEqualStrings("https://b.example", items[1].url);
+    try std.testing.expectEqualStrings("body a", items[0].content.?);
+    try std.testing.expect(items[1].content == null);
+}
+
+test "parseJinaResponse caps at max_results and handles empty data" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const json = "{\"data\":[{\"title\":\"a\",\"url\":\"u\",\"description\":\"d\"},{\"title\":\"b\",\"url\":\"u\",\"description\":\"d\"}]}";
+    const capped = try parseJinaResponse(arena.allocator(), json, 1);
+    try std.testing.expectEqual(@as(usize, 1), capped.len);
+    const empty = try parseJinaResponse(arena.allocator(), "{\"data\":[]}", 10);
+    try std.testing.expectEqual(@as(usize, 0), empty.len);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS (3 web_search tests now).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web_search.zig
+git commit -m "feat(websearch): parse Jina JSON response into result structs"
+```
+
+---
+
+## Task 3: `formatForUser` + `formatForAgent`
+
+**Files:**
+- Modify: `src/web_search.zig`
+
+- [ ] **Step 1: Write the failing test**
+
+Add both formatters to `src/web_search.zig`:
+
+```zig
+/// Render results for the transcript (user `$websearch`): snippets only.
+pub fn formatForUser(allocator: std.mem.Allocator, query: []const u8, results: []const SearchResult) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+    if (results.len == 0) {
+        try w.print("No web results for: {s}", .{query});
+        return out.toOwnedSlice(allocator);
+    }
+    try w.print("Web results for \"{s}\":\n", .{query});
+    for (results, 0..) |r, i| {
+        try w.print("\n{d}. {s}\n{s}\n", .{ i + 1, r.title, r.url });
+        if (r.description.len > 0) try w.print("{s}\n", .{r.description});
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Render results for the model (agent `websearch` tool): includes page content.
+pub fn formatForAgent(allocator: std.mem.Allocator, query: []const u8, results: []const SearchResult) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+    if (results.len == 0) {
+        try w.print("No results found for query: {s}", .{query});
+        return out.toOwnedSlice(allocator);
+    }
+    try w.print("Search results for \"{s}\" ({d} results):\n", .{ query, results.len });
+    for (results, 0..) |r, i| {
+        try w.print("\n[{d}] {s}\nURL: {s}\n", .{ i + 1, r.title, r.url });
+        if (r.description.len > 0) try w.print("{s}\n", .{r.description});
+        if (r.content) |c| try w.print("\n{s}\n", .{c});
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+test "formatForUser lists snippets and omits content" {
+    const a = std.testing.allocator;
+    const results = [_]SearchResult{
+        .{ .title = "T", .url = "https://x", .description = "d", .content = "SECRET-CONTENT" },
+    };
+    const text = try formatForUser(a, "q", &results);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "1. T") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "https://x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "SECRET-CONTENT") == null);
+}
+
+test "formatForAgent includes content; empty results message" {
+    const a = std.testing.allocator;
+    const results = [_]SearchResult{
+        .{ .title = "T", .url = "https://x", .description = "d", .content = "BODY-TEXT" },
+    };
+    const text = try formatForAgent(a, "q", &results);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "BODY-TEXT") != null);
+    const none = try formatForAgent(a, "q", &.{});
+    defer a.free(none);
+    try std.testing.expect(std.mem.indexOf(u8, none, "No results") != null);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web_search.zig
+git commit -m "feat(websearch): user (snippets) and agent (content) result formatters"
+```
+
+---
+
+## Task 4: Jina key globals + `errorText` + `executeSearch`/`searchJina`
+
+**Files:**
+- Modify: `src/web_search.zig`
+
+- [ ] **Step 1: Write the code + tests**
+
+Add to `src/web_search.zig`:
+
+```zig
+// --- Process-global Jina API key (set from config, read by both entry points) ---
+var g_jina_mutex: std.Thread.Mutex = .{};
+var g_jina_key_buf: [512]u8 = undefined;
+var g_jina_key_len: usize = 0;
+
+/// Set the Jina API key from config. Empty clears it. Oversized keys truncate.
+pub fn setJinaApiKey(key: []const u8) void {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    const n = @min(key.len, g_jina_key_buf.len);
+    @memcpy(g_jina_key_buf[0..n], key[0..n]);
+    g_jina_key_len = n;
+}
+
+pub fn jinaApiKeySet() bool {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    return g_jina_key_len > 0;
+}
+
+/// Return an owned copy of the Jina key, or null when unset. Caller frees.
+/// Copying under the lock avoids racing a concurrent `setJinaApiKey`.
+pub fn jinaApiKeyAlloc(allocator: std.mem.Allocator) !?[]u8 {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    if (g_jina_key_len == 0) return null;
+    return try allocator.dupe(u8, g_jina_key_buf[0..g_jina_key_len]);
+}
+
+/// Friendly, user/model-facing message for a search error.
+pub fn errorText(err: anyerror) []const u8 {
+    return switch (err) {
+        error.MissingApiKey => "Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.",
+        error.Network => "Web search failed: could not reach the Jina search service.",
+        error.HttpStatus => "Web search failed: the Jina search service returned an error.",
+        error.ParseFailed => "Web search failed: could not parse the Jina response.",
+        else => "Web search failed.",
+    };
+}
+
+/// Run a web search. `gpa` is used for transient HTTP buffers; the returned
+/// `Results` owns its strings via its own arena (free with `results.deinit()`).
+pub fn executeSearch(gpa: std.mem.Allocator, query: []const u8, opts: Options) !Results {
+    if (opts.api_key.len == 0) return error.MissingApiKey;
+    var results = Results{ .arena = std.heap.ArenaAllocator.init(gpa), .items = &.{} };
+    errdefer results.arena.deinit();
+    results.items = switch (opts.engine) {
+        .jina => try searchJina(results.arena.allocator(), gpa, query, opts),
+    };
+    return results;
+}
+
+fn searchJina(arena: std.mem.Allocator, gpa: std.mem.Allocator, query: []const u8, opts: Options) ![]SearchResult {
+    const body = try buildJinaRequestBody(gpa, query);
+    defer gpa.free(body);
+    const bearer = try std.fmt.allocPrint(gpa, "Bearer {s}", .{opts.api_key});
+    defer gpa.free(bearer);
+
+    var client: std.http.Client = .{ .allocator = gpa };
+    defer client.deinit();
+
+    var resp_buf: std.Io.Writer.Allocating = .init(gpa);
+    defer resp_buf.deinit();
+
+    var extra: [2]std.http.Header = undefined;
+    var extra_len: usize = 0;
+    extra[extra_len] = .{ .name = "Accept", .value = "application/json" };
+    extra_len += 1;
+    if (!opts.with_content) {
+        extra[extra_len] = .{ .name = "X-Respond-With", .value = "no-content" };
+        extra_len += 1;
+    }
+
+    const result = client.fetch(.{
+        .location = .{ .url = "https://s.jina.ai/" },
+        .method = .POST,
+        .payload = body,
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .authorization = .{ .override = bearer },
+        },
+        .extra_headers = extra[0..extra_len],
+        .response_writer = &resp_buf.writer,
+    }) catch return error.Network;
+
+    var resp_list = resp_buf.toArrayList();
+    defer resp_list.deinit(gpa);
+
+    if (result.status != .ok) {
+        std.log.warn("jina search HTTP {d}: {s}", .{ @intFromEnum(result.status), std.mem.trim(u8, resp_list.items, " \t\r\n") });
+        return error.HttpStatus;
+    }
+    return parseJinaResponse(arena, resp_list.items, opts.max_results);
+}
+
+test "executeSearch rejects an empty api key without touching the network" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try std.testing.expectError(error.MissingApiKey, executeSearch(arena.allocator(), "q", .{ .api_key = "", .with_content = false }));
+}
+
+test "errorText maps known errors to friendly text" {
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.MissingApiKey), "jina-api-key") != null);
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.Network), "reach") != null);
+}
+
+test "jina api key globals round-trip and clear" {
+    setJinaApiKey("abc123");
+    try std.testing.expect(jinaApiKeySet());
+    const k = (try jinaApiKeyAlloc(std.testing.allocator)).?;
+    defer std.testing.allocator.free(k);
+    try std.testing.expectEqualStrings("abc123", k);
+    setJinaApiKey("");
+    try std.testing.expect(!jinaApiKeySet());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS (no network is hit — only the empty-key, errorText, and globals tests run).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/web_search.zig
+git commit -m "feat(websearch): Jina key globals, errorText, and executeSearch HTTP"
+```
+
+---
+
+## Task 5: Config `jina-api-key` + push into `web_search`
+
+**Files:**
+- Modify: `src/config.zig` (field ~line 306, parse ~line 820, help ~line 1280, sample ~line 1644)
+- Modify: `src/AppWindow.zig` (config apply, after line 2605)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test near the other config tests at the end of `src/config.zig` (mirroring the existing `ai-agent-working-dir` test at line 2059):
+
+```zig
+test "config: jina-api-key parses from a config line" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    cfg.applyKeyValue(allocator, "jina-api-key", "jina_abc", ".");
+    try std.testing.expectEqualStrings("jina_abc", cfg.@"jina-api-key");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: FAIL — `cfg.@"jina-api-key"` does not exist (compile error: no field named 'jina-api-key').
+
+- [ ] **Step 3: Add the field**
+
+In `src/config.zig`, after the `@"ai-agent-working-dir"` field (line 306) add:
+
+```zig
+/// API key for the Jina web search engine (https://s.jina.ai). Empty = unset.
+@"jina-api-key": []const u8 = "",
+```
+
+- [ ] **Step 4: Add the parse branch**
+
+In `applyKeyValue`, after the `ai-agent-working-dir` branch (line 820-821) add:
+
+```zig
+    } else if (std.mem.eql(u8, key, "jina-api-key")) {
+        self.@"jina-api-key" = self.dupeString(allocator, value) orelse return;
+```
+
+- [ ] **Step 5: Add help + sample lines**
+
+After the `--ai-agent-working-dir` help line (line 1280) add:
+
+```zig
+        \\  --jina-api-key <key>         API key for the Jina web search ($websearch)
+```
+
+After the `# ai-agent-working-dir =` sample line (line 1644) add:
+
+```zig
+    \\
+    \\# Web search (Jina) — used by $websearch and the websearch agent tool
+    \\# jina-api-key =
+```
+
+- [ ] **Step 6: Push the key into web_search on config apply**
+
+In `src/AppWindow.zig`, immediately after line 2605 (`ai_chat.setDefaultWorkingDir(cfg.@"ai-agent-working-dir");`) add:
+
+```zig
+    @import("web_search.zig").setJinaApiKey(cfg.@"jina-api-key");
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/config.zig src/AppWindow.zig
+git commit -m "feat(websearch): add jina-api-key config and wire it to web_search"
+```
+
+---
+
+## Task 6: Composer `parseWebCommand` + reserved `$websearch` suggestion
+
+**Files:**
+- Modify: `src/ai_chat_composer.zig`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test at the end of `src/ai_chat_composer.zig` (after the existing suggestion tests):
+
+```zig
+test "parseWebCommand matches only the $websearch token" {
+    try std.testing.expectEqual(WebCommand.websearch, parseWebCommand("$websearch").?);
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("$websearchx"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("$web"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("/websearch"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("websearch"));
+}
+
+test "reserved $websearch appears in the $ suggestion dropdown" {
+    // Typing "$web" with no skills should surface the reserved websearch entry.
+    try std.testing.expectEqual(@as(usize, 1), skillSuggestionCountForPrefix("$web", &.{}));
+    const s = skillSuggestionAtForPrefix("$web", &.{}, 0).?;
+    try std.testing.expectEqual(ComposerSuggestionKind.skill, s.kind);
+    try std.testing.expectEqualStrings("websearch", s.text);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: FAIL — `WebCommand` / `parseWebCommand` undefined.
+
+- [ ] **Step 3: Add `WebCommand` + `parseWebCommand`**
+
+In `src/ai_chat_composer.zig`, after the `SlashCommand` enum (line 22) add:
+
+```zig
+pub const WebCommand = enum { websearch };
+
+/// Reserved `$`-prefixed commands shown in the same dropdown as skills.
+pub const ReservedWebCommand = struct { name: []const u8, description: []const u8 };
+pub const reserved_web_commands = [_]ReservedWebCommand{
+    .{ .name = "websearch", .description = "search the web (Jina)" },
+};
+
+/// Match the first whitespace-delimited token against a reserved `$` command.
+/// `token` is e.g. "$websearch" (the value of `first_tok` in Session.submit).
+pub fn parseWebCommand(token: []const u8) ?WebCommand {
+    if (std.mem.eql(u8, token, "$websearch")) return .websearch;
+    return null;
+}
+```
+
+- [ ] **Step 4: Surface reserved commands in the `$` dropdown**
+
+In `skillSuggestionCountForPrefix` (line 257), add reserved-command counting at the top of the function body (after the `if (prefix.len == 0 or prefix[0] != '$') return 0;` guard and `const skill_prefix = prefix[1..];`):
+
+```zig
+    var count: usize = 0;
+    for (reserved_web_commands) |rc| {
+        if (std.mem.startsWith(u8, rc.name, skill_prefix)) count += 1;
+    }
+```
+
+(Remove the existing `var count: usize = 0;` line so it is not declared twice; keep the existing skills loop that follows.)
+
+In `skillSuggestionAtForPrefix` (line 267), enumerate reserved commands before skills. After the guard and `const skill_prefix = prefix[1..];`, replace `var match_index: usize = 0;` with:
+
+```zig
+    var match_index: usize = 0;
+    for (reserved_web_commands) |rc| {
+        if (!std.mem.startsWith(u8, rc.name, skill_prefix)) continue;
+        if (match_index == suggestion_index) return .{
+            .kind = .skill,
+            .text = rc.name,
+            .description = rc.description,
+        };
+        match_index += 1;
+    }
+```
+
+(The existing skills loop continues incrementing `match_index` after this.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS, including the two new tests. The existing composer suggestion tests still pass (they pass `&.{}` skills and prefixes like `$br` that do not match `websearch`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai_chat_composer.zig
+git commit -m "feat(websearch): parse \$websearch and surface it in the \$ dropdown"
+```
+
+---
+
+## Task 7: `ai_chat` dispatch + background worker
+
+**Files:**
+- Modify: `src/ai_chat.zig` (struct + methods + `submit` interception)
+- Modify: `src/ai_chat_request.zig` (`webSearchThreadMain`)
+
+- [ ] **Step 1: Add the `web_search` import and `WebSearchRequest`**
+
+In `src/ai_chat.zig`, near the other top-level imports (e.g. after `const ai_chat_request = @import("ai_chat_request.zig");` at line 141) add:
+
+```zig
+const web_search = @import("web_search.zig");
+```
+
+After the `ChatRequest` struct (after line 189) add:
+
+```zig
+/// Lightweight background job for a `$websearch` user command. Owns its query.
+/// The spawning code stores the thread in `session.request_thread`, so
+/// `Session.deinit` joins it before freeing the session (no use-after-free).
+pub const WebSearchRequest = struct {
+    allocator: std.mem.Allocator,
+    session: *Session,
+    query: []u8,
+
+    pub fn create(allocator: std.mem.Allocator, session: *Session, query: []const u8) !*WebSearchRequest {
+        const self = try allocator.create(WebSearchRequest);
+        errdefer allocator.destroy(self);
+        self.* = .{ .allocator = allocator, .session = session, .query = try allocator.dupe(u8, query) };
+        return self;
+    }
+
+    pub fn deinit(self: *WebSearchRequest) void {
+        self.allocator.free(self.query);
+        self.allocator.destroy(self);
+    }
+};
+```
+
+- [ ] **Step 2: Add `appendWebSearchResult` (worker → transcript)**
+
+In `src/ai_chat.zig`, after `appendAssistantResult` (after line 3404) add:
+
+```zig
+/// Append a `$websearch` result (or error text) as a local tool message and
+/// finish the in-flight request. Called from the web-search worker thread with
+/// no lock held. Mirrors the closing-guarded shape of `appendAssistantResult`.
+pub fn appendWebSearchResult(session: *Session, text: []const u8) void {
+    if (session.closing.load(.acquire)) return;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return;
+    session.appendLocalToolMessageLocked(text) catch {
+        session.request_inflight = false;
+        session.setStatusLocked("Out of memory");
+        return;
+    };
+    session.request_inflight = false;
+    session.setStatusLocked("Ready");
+}
+```
+
+- [ ] **Step 3: Add `startWebSearchRequest`**
+
+In `src/ai_chat.zig`, add this method to the `Session` struct, right after `startDistillRequest`'s closing brace (after line 2130):
+
+```zig
+    /// Run a `$websearch <query>` command on a background thread. Mirrors
+    /// `startDistillRequest`: reuses `request_thread`/`request_inflight` so the
+    /// existing submit-guard and `deinit` join cover lifetime. Called AFTER the
+    /// caller has unlocked `self.mutex`.
+    fn startWebSearchRequest(self: *Session, query_in: []const u8) void {
+        self.mutex.lock();
+        if (self.request_thread) |thread| {
+            if (self.request_inflight) {
+                self.clearSubmittedInputLocked();
+                self.appendLocalToolMessageLocked("Wait for the current request to finish.") catch {};
+                self.setStatusLocked("Ready");
+                self.mutex.unlock();
+                return;
+            }
+            self.request_thread = null;
+            self.mutex.unlock();
+            thread.join();
+            self.mutex.lock();
+        }
+
+        const query = std.mem.trim(u8, query_in, " \t\r\n");
+        if (query.len == 0) {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Usage: $websearch <query>") catch self.setStatusLocked("Out of memory");
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        }
+        if (!web_search.jinaApiKeySet()) {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.") catch self.setStatusLocked("Out of memory");
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        }
+
+        const req = WebSearchRequest.create(self.allocator, self, query) catch {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Out of memory.") catch {};
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        };
+        self.clearSubmittedInputLocked();
+        self.stop_requested.store(false, .release);
+        self.request_stopping = false;
+        self.request_inflight = true;
+        self.setStatusLocked("Searching the web…");
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, ai_chat_request.webSearchThreadMain, .{req}) catch {
+            req.deinit();
+            self.mutex.lock();
+            self.request_inflight = false;
+            self.appendLocalToolMessageLocked("Failed to start web search thread.") catch {};
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        };
+        self.mutex.lock();
+        self.request_thread = thread;
+        self.mutex.unlock();
+    }
+```
+
+- [ ] **Step 4: Intercept `$websearch` in `submit`**
+
+In `src/ai_chat.zig` `submit`, after the custom-command block and before the `if (self.api_key_len == 0)` gate — i.e. immediately after the `// otherwise (...): fall through.` comment (line 1628) — insert:
+
+```zig
+        if (ai_chat_composer.parseWebCommand(first_tok)) |_| {
+            self.clearPendingWeixinReplyContextLocked();
+            self.mutex.unlock();
+            self.startWebSearchRequest(arg);
+            return;
+        }
+```
+
+- [ ] **Step 5: Add the worker in `ai_chat_request.zig`**
+
+In `src/ai_chat_request.zig`, add the import near the other imports (after line 11 `const ai_chat_tools = @import("ai_chat_tools.zig");`):
+
+```zig
+const web_search = @import("web_search.zig");
+```
+
+Then add this function after `distillThreadMain` (after the function that ends around line 110):
+
+```zig
+/// Background worker for one `$websearch` command. Owns `req`; frees it on exit.
+/// Re-fetches the Jina key on this thread, runs the search (snippets only), and
+/// appends the formatted results to the transcript.
+pub fn webSearchThreadMain(req: *ai_chat.WebSearchRequest) void {
+    defer req.deinit();
+    const allocator = req.allocator;
+    const session = req.session;
+    if (session.closing.load(.acquire)) return;
+
+    const key = (web_search.jinaApiKeyAlloc(allocator) catch null) orelse {
+        ai_chat.appendWebSearchResult(session, web_search.errorText(error.MissingApiKey));
+        return;
+    };
+    defer allocator.free(key);
+
+    var results = web_search.executeSearch(allocator, req.query, .{
+        .engine = .jina,
+        .api_key = key,
+        .with_content = false,
+        .max_results = 10,
+    }) catch |err| {
+        ai_chat.appendWebSearchResult(session, web_search.errorText(err));
+        return;
+    };
+    defer results.deinit();
+
+    const text = web_search.formatForUser(allocator, req.query, results.items) catch {
+        ai_chat.appendWebSearchResult(session, "Out of memory formatting results.");
+        return;
+    };
+    defer allocator.free(text);
+    ai_chat.appendWebSearchResult(session, text);
+}
+```
+
+- [ ] **Step 6: Build to verify it compiles**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: PASS — full graph compiles and all existing tests still pass. (No new unit test here; behavior is verified by the build plus the GUI smoke test in Task 9.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai_chat.zig src/ai_chat_request.zig
+git commit -m "feat(websearch): \$websearch command dispatch and background worker"
+```
+
+---
+
+## Task 8: Agent `websearch` tool
+
+**Files:**
+- Modify: `src/ai_chat_protocol.zig` (`forEachToolSpec` + a schema test)
+- Modify: `src/ai_chat_tools.zig` (import + dispatch + `webSearchTool`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `src/ai_chat_protocol.zig` after the test at line 1478:
+
+```zig
+test "agent tool set includes websearch" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("hi") }};
+    const params = RequestParams{ .model = "m", .system_prompt = "", .protocol = .anthropic, .thinking_enabled = false, .reasoning_effort = "", .stream = false, .max_tokens = 8192 };
+    const json = try buildRequestJson(a, params, &msgs, true);
+    defer a.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"websearch\"") != null);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: FAIL — `"websearch"` not present in the tool JSON.
+
+- [ ] **Step 3: Register the tool schema**
+
+In `src/ai_chat_protocol.zig` `forEachToolSpec`, after the `wispterm_docs` emit line (line 670) add:
+
+```zig
+    try emit(ctx, "websearch", "Search the web for current information via Jina. Returns the top results with titles, URLs, and page content. Use when you need facts newer than your training or to look something up online.", "{\"query\":{\"type\":\"string\",\"description\":\"The search query.\"},\"max_results\":{\"type\":\"integer\",\"description\":\"Optional max number of results (default 10, max 20).\"}}");
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: PASS.
+
+- [ ] **Step 5: Add the tool implementation + dispatch**
+
+In `src/ai_chat_tools.zig`, add the import after line 27 (`const ai_agent_access = @import("ai_agent_access.zig");`):
+
+```zig
+const web_search = @import("web_search.zig");
+```
+
+Add the `websearch` dispatch in `executeToolCall`, after the `wispterm_docs` branch (the dispatch lives around line 139-145 in this file; place it just before the final `return std.fmt.allocPrint(... "Unknown tool: {s}" ...)`):
+
+```zig
+    if (std.mem.eql(u8, call.name, "websearch")) {
+        const args = parseArgs(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const query = jsonStringArg(args.value, "query") orelse return ctx.allocator.dupe(u8, "Missing query");
+        const max_results = jsonIntArg(args.value, "max_results");
+        return webSearchTool(ctx.allocator, query, max_results);
+    }
+```
+
+Add the implementation in the "Skill / docs tools" area (e.g. after `wisptermDocsTool`, near line 220):
+
+```zig
+/// Agent `websearch` tool: full-content Jina search, formatted for the model.
+fn webSearchTool(allocator: std.mem.Allocator, query: []const u8, max_results: ?u32) ![]u8 {
+    const key = (web_search.jinaApiKeyAlloc(allocator) catch null) orelse
+        return allocator.dupe(u8, web_search.errorText(error.MissingApiKey));
+    defer allocator.free(key);
+    const max: usize = if (max_results) |m| @min(@max(m, 1), 20) else 10;
+    var results = web_search.executeSearch(allocator, query, .{
+        .engine = .jina,
+        .api_key = key,
+        .with_content = true,
+        .max_results = max,
+    }) catch |err| return allocator.dupe(u8, web_search.errorText(err));
+    defer results.deinit();
+    return web_search.formatForAgent(allocator, query, results.items);
+}
+```
+
+- [ ] **Step 6: Run tests to verify everything passes**
+
+Run: `zig build test-full 2>&1 | tail -25`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai_chat_protocol.zig src/ai_chat_tools.zig
+git commit -m "feat(websearch): register and implement the websearch agent tool"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none (verification + optional GUI smoke).
+
+- [ ] **Step 1: Run the full fast + full suites**
+
+Run: `zig build test 2>&1 | tail -5 && zig build test-full 2>&1 | tail -5`
+Expected: both exit 0, 0 failed. (Baseline per project memory is ~0 failed; the new web_search/composer/protocol/config tests are additive.)
+
+- [ ] **Step 2: Build the app**
+
+Run: `zig build 2>&1 | tail -5`
+Expected: builds clean.
+
+- [ ] **Step 3: GUI smoke (manual, requires a Jina key)**
+
+Set `jina-api-key = <key>` in the WispTerm config, open the AI chat, and verify:
+- Typing `$` shows `websearch` in the dropdown; typing `$websearch zig language\n` appends a numbered snippet list to the transcript (no AI turn) and the status returns to "Ready".
+- `$websearch` with no query shows the usage hint; with no key set, shows the "not set" message.
+- With the agent enabled, ask the model something requiring fresh info and confirm it calls the `websearch` tool (results include page content) with no approval prompt.
+
+Note any failures and fix before merging. This step is best-effort: there is no Linux GUI backend in this repo, so it may be deferred to macOS/Windows per project practice.
+
+- [ ] **Step 4: (Optional) docs sync**
+
+If documenting this feature for users, add a short note to the config reference in `docs/` AND `wiki/` (they must stay in sync — `docs/*.md` are `@embedFile`'d for the in-app `wispterm_docs` tool). Out of scope for the core feature; do only if requested.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** core module (Tasks 1-4), Jina HTTP specifics (Task 4), `jina-api-key` config-only key + setter (Task 5), `$websearch` snippets command with no AI turn (Tasks 6-7), `websearch` agent tool with content and no approval gate (Task 8), tests + verification (Tasks 1-3, 5, 6, 8, 9). All spec sections map to a task.
+- **Type consistency:** `Engine`/`SearchResult`/`Options`/`Results`, `executeSearch`/`searchJina`/`parseJinaResponse`/`formatForUser`/`formatForAgent`/`errorText`, `setJinaApiKey`/`jinaApiKeySet`/`jinaApiKeyAlloc`, `WebSearchRequest.create`/`deinit`, `appendWebSearchResult`, `startWebSearchRequest`, `webSearchThreadMain`, `WebCommand`/`parseWebCommand`/`reserved_web_commands` are referenced with identical names across all tasks.
+- **Spec deviations (documented above):** `$` is the existing skill prefix → `$websearch` is reserved + intercepted (no new prefix branch); HTTP error body is logged not surfaced (errors can't carry payloads).

--- a/docs/superpowers/specs/2026-06-05-websearch-jina-design.md
+++ b/docs/superpowers/specs/2026-06-05-websearch-jina-design.md
@@ -1,0 +1,198 @@
+# `$websearch` (Jina Search, pluggable engines) Design
+
+## Goal
+
+Add web search to the AI chat, exposed two ways:
+
+1. **`$websearch <query>` user command** — typed in the chat composer. WispTerm runs
+   the search itself and renders the raw results into the transcript. No AI turn.
+2. **`websearch` agent tool** — the AI model calls it on its own when it needs current
+   information. Returns results (including page content) to the model.
+
+The search backend is provider-agnostic so other engines can be added later, but the
+only engine implemented now is **Jina** (`s.jina.ai`). A future engine is a new branch
+in one `switch`, nothing more.
+
+## Architecture
+
+A new module `src/web_search.zig` owns everything search-specific: the engine enum, the
+result types, the pure request-building / response-parsing / formatting logic, and the
+single impure HTTP function. Both entry points (the `$websearch` command and the agent
+tool) call into this module; neither knows anything about Jina directly.
+
+The `$websearch` command runs on a background thread that reuses the existing AI-request
+lifecycle so it inherits the proven cancellation/teardown guarantees (the worker re-checks
+`session.closing` under the session lock before touching the transcript). The agent tool
+runs synchronously inside the existing tool worker thread, like every other tool.
+
+```
+ai_chat_composer.parseWebCommand ──► ai_chat (spawn bg job) ─┐
+                                                             ├─► web_search.executeSearch ─► Jina HTTP
+ai_chat_protocol.forEachToolSpec ──► ai_chat_tools.executeToolCall ─┘
+```
+
+## `src/web_search.zig`
+
+### Types
+
+```zig
+pub const Engine = enum { jina };   // future engines added here
+
+pub const SearchResult = struct {
+    title: []const u8,
+    url: []const u8,
+    description: []const u8,
+    content: ?[]const u8 = null,    // only when with_content == true
+};
+
+pub const Options = struct {
+    engine: Engine = .jina,
+    api_key: []const u8,
+    with_content: bool,             // false = snippets, true = full page content
+    max_results: usize = 10,
+};
+
+pub const Results = struct {        // owns its backing memory via an arena
+    arena: std.heap.ArenaAllocator,
+    items: []SearchResult,
+    pub fn deinit(self: *Results) void;
+};
+```
+
+### Pure functions (no network — unit tested)
+
+- `buildJinaRequestBody(allocator, query) ![]u8` → `{"q":"<query>"}` (query JSON-escaped).
+- `parseJinaResponse(arena, json_bytes) ![]SearchResult` → reads the `data[]` array of
+  `{title, url, description, content?}`. Tolerates missing optional fields; caps at
+  `max_results`. Uses `parseFromSlice` with `.allocate = .alloc_always` because the source
+  buffer is freed before the parsed value is used (see the parseFromSlice alias UAF note).
+- `formatForUser(allocator, query, results) ![]u8` → numbered markdown list for the
+  transcript: `N. **title**` / `url` / `description`. Header line echoes the query and the
+  result count. Snippets only (no `content`).
+- `formatForAgent(allocator, query, results) ![]u8` → compact text block per result
+  including `content` when present, sized for the model's context.
+
+### Impure function
+
+- `executeSearch(allocator, query, opts) !Results`
+  - `switch (opts.engine)` → currently `.jina => searchJina(...)`.
+  - `searchJina`: `POST https://s.jina.ai/` via `std.http.Client.fetch` with headers
+    `Authorization: Bearer <api_key>`, `Content-Type: application/json`,
+    `Accept: application/json`, and `X-Respond-With: no-content` when
+    `opts.with_content == false`. Body is `buildJinaRequestBody`. On a non-`ok` status it
+    returns `error.SearchHttp` carrying the trimmed body for the caller to surface; on a
+    transport failure it returns the underlying error.
+
+### Config key plumbing
+
+`web_search.zig` holds a module-level Jina key (fixed buffer + length, mirroring
+`ai_chat.g_default_working_dir_*`), set by:
+
+```zig
+pub fn setJinaApiKey(key: []const u8) void;   // called from the config-apply path
+pub fn jinaApiKey() []const u8;               // "" when unset
+```
+
+Both entry points read `jinaApiKey()`; an empty key short-circuits with a clear message
+("Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.") and never
+hits the network.
+
+## Config: `jina-api-key`
+
+In `src/config.zig`:
+
+- New field `@"jina-api-key": []const u8 = ""`.
+- Parse in `applyKeyValue` (dupe like `ai-agent-working-dir`).
+- Allow in `setConfigValue`.
+- `--help` line and a commented sample in the generated default config.
+
+In the existing config-apply path (alongside `ai_chat.setDefaultWorkingDir(cfg.…)` in
+`AppWindow`/`App`), add `web_search.setJinaApiKey(cfg.@"jina-api-key")` so live config
+reloads update the key.
+
+Decisions (locked): config-file only — **no** `JINA_API_KEY` env fallback, **no**
+per-profile key.
+
+## `$websearch` user command
+
+### Composer (`src/ai_chat_composer.zig`)
+
+- Add a `WebCommand = enum { websearch }` and `parseWebCommand(input) ?WebCommand` that
+  matches a leading `$websearch` token (trimmed; rejects bare `$`, `$foo`, etc.).
+- Add a single `$websearch` suggestion so typing `$` surfaces it, mirroring the existing
+  slash-suggestion data (one entry — not a general `$`-command framework).
+- Add a `firstCharKind` / prefix branch for `$` so the suggestion popup triggers.
+
+### Dispatch (`src/ai_chat.zig`)
+
+- In the submit path (where `parseSlashCommand` is checked, ~line 1619), detect
+  `parseWebCommand`. Extract the query = text after the command token, trimmed.
+  - Empty query → append a usage tool message (`Usage: $websearch <query>`); no network.
+  - Otherwise: set status "Searching the web…", clear the submitted input, and spawn a
+    background search job carrying an owned copy of the query.
+- The job reuses the existing background-request lifecycle. Concretely: a
+  `webSearchThreadMain(req)` worker (sibling to `titleThreadMain`/`distillThreadMain`)
+  that owns its request, calls `web_search.executeSearch(..., with_content=false)`, then
+  on success calls a new `pub fn appendWebSearchResult(session, text)` and on failure a
+  `pub fn appendWebSearchError(session, msg)`. Both mirror `appendAssistantResult`:
+  bail if `session.closing`, take the lock, append a local tool message, set status
+  "Ready", notify the history change. This is what makes the result show up in the
+  transcript as raw text with no assistant turn.
+
+## Agent `websearch` tool
+
+### Schema (`src/ai_chat_protocol.zig`)
+
+One new `emit(...)` line in `forEachToolSpec` (single source of truth → all three
+protocols):
+
+- name: `websearch`
+- description: "Search the web for current information via Jina. Returns the top results
+  with titles, URLs, and page content. Use when you need facts newer than your training or
+  to look something up online."
+- properties: `{"query":{"type":"string"},"max_results":{"type":"integer"}}`
+
+### Dispatch (`src/ai_chat_tools.zig`)
+
+- New branch in `executeToolCall` for `"websearch"`: parse `query` (required) and optional
+  `max_results`; call `web_search.executeSearch(..., with_content=true)`; return
+  `formatForAgent`. Missing key / empty query / HTTP error → return a clear message string
+  (tools return error text, they do not throw).
+- **No approval gate** (read-only network fetch) — runs unprompted at every permission
+  level.
+
+## Errors
+
+Each surface produces a specific, user-readable message; none logs the API key:
+
+- Jina API key not set.
+- Empty query (command usage hint; tool "query is required").
+- HTTP non-200 from Jina (status + trimmed body).
+- Network/transport failure.
+- Zero results ("No results for: <query>").
+
+## Testing
+
+Pure tests in `web_search.zig`, registered in the fast suite (import in
+`test_fast.zig`/`test_main.zig` so they actually run):
+
+- `parseJinaResponse` on captured sample JSON (with and without `content`); missing
+  optional fields; `max_results` cap; empty `data[]`.
+- `buildJinaRequestBody` escapes a query containing quotes.
+- `formatForUser` (snippets, no content) and `formatForAgent` (includes content) shape.
+- Empty-key short-circuit path.
+
+Composer test in test-full: `parseWebCommand` accepts `$websearch foo bar`, extracts the
+query, and rejects `$`, `$websearchx`, `/websearch`, and plain text.
+
+No live network in tests — the Jina HTTP path is exercised only against captured JSON.
+
+Implement with TDD. Run `zig build test`; run `zig build test-full` before finishing.
+
+## Scope guards (YAGNI)
+
+- Only the `jina` engine.
+- Config-file key only; no env var, no per-profile key.
+- User command shows snippets only — no AI summarization turn.
+- Autocomplete is a single `$websearch` entry, not a general `$`-command system.
+- No result caching, no pagination, no rerank/reader (`r.jina.ai`) integration.

--- a/src/App.zig
+++ b/src/App.zig
@@ -103,6 +103,7 @@ ai_agent_permission: ai_chat.AgentPermission,
 ai_agent_command_timeout_ms: u32,
 ai_agent_output_limit: u32,
 ai_agent_working_dir: []const u8,
+jina_api_key: []const u8,
 
 // Session persistence
 restore_tabs_on_startup: bool,
@@ -193,6 +194,8 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
     errdefer freeOptStr(allocator, background_image);
     const ai_agent_working_dir = try dupeStr(allocator, cfg.@"ai-agent-working-dir");
     errdefer allocator.free(ai_agent_working_dir);
+    const jina_api_key = try dupeStr(allocator, cfg.@"jina-api-key");
+    errdefer allocator.free(jina_api_key);
 
     var app = App{
         .allocator = allocator,
@@ -243,6 +246,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
         .ai_agent_output_limit = cfg.@"ai-agent-output-limit",
         .ai_agent_working_dir = ai_agent_working_dir,
+        .jina_api_key = jina_api_key,
         .restore_tabs_on_startup = cfg.@"restore-tabs-on-startup",
         .auto_update_check = cfg.@"auto-update-check",
         .whats_new_on_update = cfg.@"whats-new-on-update",
@@ -412,6 +416,7 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms";
     self.ai_agent_output_limit = cfg.@"ai-agent-output-limit";
     self.replaceStr(&self.ai_agent_working_dir, cfg.@"ai-agent-working-dir");
+    self.replaceStr(&self.jina_api_key, cfg.@"jina-api-key");
     self.restore_tabs_on_startup = cfg.@"restore-tabs-on-startup";
     self.auto_update_check = cfg.@"auto-update-check";
     self.whats_new_on_update = cfg.@"whats-new-on-update";
@@ -1050,6 +1055,7 @@ pub fn deinit(self: *App) void {
     freeOptStr(self.allocator, self.font_family_cjk);
     freeOptStr(self.allocator, self.font_family_fallback);
     self.allocator.free(self.ai_agent_working_dir);
+    self.allocator.free(self.jina_api_key);
     freeOptStr(self.allocator, self.shader_path);
     freeOptStr(self.allocator, self.title);
     freeOptStr(self.allocator, self.remote_server_url);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -170,6 +170,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
         .output_limit = app.ai_agent_output_limit,
     });
     ai_chat.setDefaultWorkingDir(app.ai_agent_working_dir);
+    @import("web_search.zig").setJinaApiKey(app.jina_api_key);
     // Copy shell command from App
     @memcpy(tab.g_shell_cmd_buf[0..app.shell_cmd_len], app.shell_cmd_buf[0..app.shell_cmd_len]);
     tab.g_shell_cmd_buf[app.shell_cmd_len] = 0;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2603,6 +2603,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
         .output_limit = cfg.@"ai-agent-output-limit",
     });
     ai_chat.setDefaultWorkingDir(cfg.@"ai-agent-working-dir");
+    @import("web_search.zig").setJinaApiKey(cfg.@"jina-api-key");
 
     if (g_window == null) return;
     g_quake_mode = cfg.@"quake-mode";

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -139,6 +139,7 @@ const ImageBlock = ai_chat_protocol.ImageBlock;
 const ai_chat_title = @import("ai_chat_title.zig");
 const ToolCall = ai_chat_protocol.ToolCall;
 const ai_chat_request = @import("ai_chat_request.zig");
+const web_search = @import("web_search.zig");
 
 pub const ChatRequest = struct {
     allocator: std.mem.Allocator,
@@ -185,6 +186,27 @@ pub const ChatRequest = struct {
             .stream = self.stream,
             .max_tokens = self.max_tokens,
         };
+    }
+};
+
+/// Lightweight background job for a `$websearch` user command. Owns its query.
+/// The spawning code stores the thread in `session.request_thread`, so
+/// `Session.deinit` joins it before freeing the session (no use-after-free).
+pub const WebSearchRequest = struct {
+    allocator: std.mem.Allocator,
+    session: *Session,
+    query: []u8,
+
+    pub fn create(allocator: std.mem.Allocator, session: *Session, query: []const u8) !*WebSearchRequest {
+        const self = try allocator.create(WebSearchRequest);
+        errdefer allocator.destroy(self);
+        self.* = .{ .allocator = allocator, .session = session, .query = try allocator.dupe(u8, query) };
+        return self;
+    }
+
+    pub fn deinit(self: *WebSearchRequest) void {
+        self.allocator.free(self.query);
+        self.allocator.destroy(self);
     }
 };
 
@@ -1627,6 +1649,13 @@ pub const Session = struct {
         }
         // otherwise (e.g. "/help me", "/usr/bin path", or a rebound template body): fall through.
 
+        if (ai_chat_composer.parseWebCommand(first_tok)) |_| {
+            self.clearPendingWeixinReplyContextLocked();
+            self.mutex.unlock();
+            self.startWebSearchRequest(arg);
+            return;
+        }
+
         if (self.api_key_len == 0) {
             self.setStatusLocked("Missing API key. Edit the Copilot profile or set DEEPSEEK_API_KEY.");
             self.clearPendingWeixinReplyContextLocked();
@@ -2124,6 +2153,70 @@ pub const Session = struct {
             return;
         };
 
+        self.mutex.lock();
+        self.request_thread = thread;
+        self.mutex.unlock();
+    }
+
+    /// Run a `$websearch <query>` command on a background thread. Mirrors
+    /// `startDistillRequest`: reuses `request_thread`/`request_inflight` so the
+    /// existing submit-guard and `deinit` join cover lifetime. Called AFTER the
+    /// caller has unlocked `self.mutex`.
+    fn startWebSearchRequest(self: *Session, query_in: []const u8) void {
+        self.mutex.lock();
+        if (self.request_thread) |thread| {
+            if (self.request_inflight) {
+                self.clearSubmittedInputLocked();
+                self.appendLocalToolMessageLocked("Wait for the current request to finish.") catch {};
+                self.setStatusLocked("Ready");
+                self.mutex.unlock();
+                return;
+            }
+            self.request_thread = null;
+            self.mutex.unlock();
+            thread.join();
+            self.mutex.lock();
+        }
+
+        const query = std.mem.trim(u8, query_in, " \t\r\n");
+        if (query.len == 0) {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Usage: $websearch <query>") catch self.setStatusLocked("Out of memory");
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        }
+        if (!web_search.jinaApiKeySet()) {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.") catch self.setStatusLocked("Out of memory");
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        }
+
+        const req = WebSearchRequest.create(self.allocator, self, query) catch {
+            self.clearSubmittedInputLocked();
+            self.appendLocalToolMessageLocked("Out of memory.") catch {};
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        };
+        self.clearSubmittedInputLocked();
+        self.stop_requested.store(false, .release);
+        self.request_stopping = false;
+        self.request_inflight = true;
+        self.setStatusLocked("Searching the web…");
+        self.mutex.unlock();
+
+        const thread = std.Thread.spawn(.{}, ai_chat_request.webSearchThreadMain, .{req}) catch {
+            req.deinit();
+            self.mutex.lock();
+            self.request_inflight = false;
+            self.appendLocalToolMessageLocked("Failed to start web search thread.") catch {};
+            self.setStatusLocked("Ready");
+            self.mutex.unlock();
+            return;
+        };
         self.mutex.lock();
         self.request_thread = thread;
         self.mutex.unlock();
@@ -3401,6 +3494,23 @@ pub fn appendAssistantResult(session: *Session, result: ApiResult, started_ms: i
     session.setCompletionStatusLocked(started_ms, result.usage);
     session.maybeAppendDistillSuggestionLocked();
     history_change = session.captureHistoryChangeLocked();
+}
+
+/// Append a `$websearch` result (or error text) as a local tool message and
+/// finish the in-flight request. Called from the web-search worker thread with
+/// no lock held. Mirrors the closing-guarded shape of `appendAssistantResult`.
+pub fn appendWebSearchResult(session: *Session, text: []const u8) void {
+    if (session.closing.load(.acquire)) return;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    if (session.closing.load(.acquire)) return;
+    session.appendLocalToolMessageLocked(text) catch {
+        session.request_inflight = false;
+        session.setStatusLocked("Out of memory");
+        return;
+    };
+    session.request_inflight = false;
+    session.setStatusLocked("Ready");
 }
 
 pub fn applyDistillCandidate(session: *Session, candidate: *ai_skill_distill.Candidate) void {

--- a/src/ai_chat_composer.zig
+++ b/src/ai_chat_composer.zig
@@ -21,6 +21,21 @@ pub const SlashCommand = enum {
     unknown,
 };
 
+pub const WebCommand = enum { websearch };
+
+/// Reserved `$`-prefixed commands shown in the same dropdown as skills.
+pub const ReservedWebCommand = struct { name: []const u8, description: []const u8 };
+pub const reserved_web_commands = [_]ReservedWebCommand{
+    .{ .name = "websearch", .description = "search the web (Jina)" },
+};
+
+/// Match the first whitespace-delimited token against a reserved `$` command.
+/// `token` is e.g. "$websearch" (the value of `first_tok` in Session.submit).
+pub fn parseWebCommand(token: []const u8) ?WebCommand {
+    if (std.mem.eql(u8, token, "$websearch")) return .websearch;
+    return null;
+}
+
 pub const ComposerSuggestionKind = enum {
     slash_command,
     skill,
@@ -258,6 +273,9 @@ pub fn skillSuggestionCountForPrefix(prefix: []const u8, skills: []const skill_r
     if (prefix.len == 0 or prefix[0] != '$') return 0;
     const skill_prefix = prefix[1..];
     var count: usize = 0;
+    for (reserved_web_commands) |rc| {
+        if (std.mem.startsWith(u8, rc.name, skill_prefix)) count += 1;
+    }
     for (skills) |meta| {
         if (std.mem.startsWith(u8, meta.name, skill_prefix)) count += 1;
     }
@@ -272,6 +290,15 @@ pub fn skillSuggestionAtForPrefix(
     if (prefix.len == 0 or prefix[0] != '$') return null;
     const skill_prefix = prefix[1..];
     var match_index: usize = 0;
+    for (reserved_web_commands) |rc| {
+        if (!std.mem.startsWith(u8, rc.name, skill_prefix)) continue;
+        if (match_index == suggestion_index) return .{
+            .kind = .skill,
+            .text = rc.name,
+            .description = rc.description,
+        };
+        match_index += 1;
+    }
     for (skills) |meta| {
         if (!std.mem.startsWith(u8, meta.name, skill_prefix)) continue;
         if (match_index == suggestion_index) return .{
@@ -413,6 +440,21 @@ test "suggestionReplacementText adds a space after a skill when needed" {
     try std.testing.expectEqualStrings("$build", suggestionReplacementText(&buf, sk, " x").?);
     const cmd = ComposerSuggestion{ .kind = .slash_command, .text = "/skills", .description = "" };
     try std.testing.expectEqualStrings("/skills", suggestionReplacementText(&buf, cmd, "").?);
+}
+
+test "parseWebCommand matches only the $websearch token" {
+    try std.testing.expectEqual(WebCommand.websearch, parseWebCommand("$websearch").?);
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("$websearchx"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("$web"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("/websearch"));
+    try std.testing.expectEqual(@as(?WebCommand, null), parseWebCommand("websearch"));
+}
+
+test "reserved $websearch appears in the $ suggestion dropdown" {
+    try std.testing.expectEqual(@as(usize, 1), skillSuggestionCountForPrefix("$web", &.{}));
+    const s = skillSuggestionAtForPrefix("$web", &.{}, 0).?;
+    try std.testing.expectEqual(ComposerSuggestionKind.skill, s.kind);
+    try std.testing.expectEqualStrings("websearch", s.text);
 }
 
 test "parseCwdArg classifies show, reset, and set" {

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -668,6 +668,7 @@ fn forEachToolSpec(
     try emit(ctx, "tab_close", "Close a terminal tab by tab_number (the one-based `tab` shown by terminal_list, matching the tab number the user sees), surface_id, title, or the active terminal tab when no selector is provided. Cannot close the AI chat tab running the agent.", "{\"tab_number\":{\"type\":\"integer\",\"description\":\"One-based UI tab number — the `tab` value shown by terminal_list and what the user sees.\"},\"tab_index\":{\"type\":\"integer\",\"description\":\"Zero-based tab index (tab_number minus one). Prefer tab_number.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list.\"},\"title\":{\"type\":\"string\",\"description\":\"Terminal tab title to close, such as CPU2.\"}}");
     try emit(ctx, "skill_info", "Load a WispTerm skill by stable name. Use when the user explicitly names a skill or asks for specialized skill instructions.", "{\"skill_name\":{\"type\":\"string\",\"description\":\"Skill name or skill directory name.\"}}");
     try emit(ctx, "wispterm_docs", "Read WispTerm's own documentation (features, configuration, shortcuts, AI agent, file explorer, media). Call with no topic to list available topics, then call again with a topic to read its full text.", "{\"topic\":{\"type\":\"string\",\"description\":\"Topic name from the list. Omit to list available topics.\"}}");
+    try emit(ctx, "websearch", "Search the web for current information via Jina. Returns the top results with titles, URLs, and page content. Use when you need facts newer than your training or to look something up online.", "{\"query\":{\"type\":\"string\",\"description\":\"The search query.\"},\"max_results\":{\"type\":\"integer\",\"description\":\"Optional max number of results (default 10, max 20).\"}}");
     try emit(ctx, "weixin_send_attachment", "Send a local file back to the active Weixin conversation that triggered this agent request. Use only when the current request came from Weixin; normal local chat requests have no Weixin reply context. Audio and voice files are sent as ordinary file attachments.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice. Voice is accepted as an alias for file.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in Weixin for file attachments; defaults to the path basename.\"}}");
 }
 
@@ -1475,6 +1476,15 @@ test "anthropic maps tool_calls to tool_use and tool results to grouped tool_res
     try std.testing.expect(std.mem.indexOf(u8, json, "\"type\":\"tool_result\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"tool_use_id\":\"call_1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"input_schema\"") != null);
+}
+
+test "agent tool set includes websearch" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("hi") }};
+    const params = RequestParams{ .model = "m", .system_prompt = "", .protocol = .anthropic, .thinking_enabled = false, .reasoning_effort = "", .stream = false, .max_tokens = 8192 };
+    const json = try buildRequestJson(a, params, &msgs, true);
+    defer a.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"websearch\"") != null);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -9,6 +9,7 @@ const ChatRequest = ai_chat.ChatRequest;
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
 const ai_skill_distill = @import("ai_skill_distill.zig");
 const ai_chat_tools = @import("ai_chat_tools.zig");
+const web_search = @import("web_search.zig");
 const ai_chat_types = @import("ai_chat_types.zig");
 
 // Type aliases from ai_chat_protocol
@@ -123,6 +124,40 @@ pub fn distillThreadMain(request: *ChatRequest) void {
         return;
     };
     ai_chat.applyDistillCandidate(request.session, &candidate);
+}
+
+/// Background worker for one `$websearch` command. Owns `req`; frees it on exit.
+/// Re-fetches the Jina key on this thread, runs the search (snippets only), and
+/// appends the formatted results to the transcript.
+pub fn webSearchThreadMain(req: *ai_chat.WebSearchRequest) void {
+    defer req.deinit();
+    const allocator = req.allocator;
+    const session = req.session;
+    if (session.closing.load(.acquire)) return;
+
+    const key = (web_search.jinaApiKeyAlloc(allocator) catch null) orelse {
+        ai_chat.appendWebSearchResult(session, web_search.errorText(error.MissingApiKey));
+        return;
+    };
+    defer allocator.free(key);
+
+    var results = web_search.executeSearch(allocator, req.query, .{
+        .engine = .jina,
+        .api_key = key,
+        .with_content = false,
+        .max_results = 10,
+    }) catch |err| {
+        ai_chat.appendWebSearchResult(session, web_search.errorText(err));
+        return;
+    };
+    defer results.deinit();
+
+    const text = web_search.formatForUser(allocator, req.query, results.items) catch {
+        ai_chat.appendWebSearchResult(session, "Out of memory formatting results.");
+        return;
+    };
+    defer allocator.free(text);
+    ai_chat.appendWebSearchResult(session, text);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -147,7 +147,12 @@ pub fn webSearchThreadMain(req: *ai_chat.WebSearchRequest) void {
         .with_content = false,
         .max_results = 10,
     }) catch |err| {
-        ai_chat.appendWebSearchResult(session, web_search.errorText(err));
+        const text = web_search.formatErrorText(allocator, err) catch {
+            ai_chat.appendWebSearchResult(session, web_search.errorText(err));
+            return;
+        };
+        defer allocator.free(text);
+        ai_chat.appendWebSearchResult(session, text);
         return;
     };
     defer results.deinit();

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -25,6 +25,7 @@ const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_agent_prompt = @import("platform/agent_prompt.zig");
 const ai_agent_access = @import("ai_agent_access.zig");
+const web_search = @import("web_search.zig");
 
 /// Number of output lines included in a copilot context block.
 pub const COPILOT_CONTEXT_LINES: usize = 40;
@@ -144,6 +145,13 @@ pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
         const display_name = jsonStringArg(args.value, "display_name") orelse "";
         return weixinSendAttachmentTool(ctx, kind, path, display_name);
     }
+    if (std.mem.eql(u8, call.name, "websearch")) {
+        const args = parseArgs(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const query = jsonStringArg(args.value, "query") orelse return ctx.allocator.dupe(u8, "Missing query");
+        const max_results = jsonIntArg(args.value, "max_results");
+        return webSearchTool(ctx.allocator, query, max_results);
+    }
     return std.fmt.allocPrint(ctx.allocator, "Unknown tool: {s}", .{call.name});
 }
 
@@ -216,6 +224,22 @@ pub fn wisptermDocsTool(allocator: std.mem.Allocator, topic: ?[]const u8) ![]u8 
         return out.toOwnedSlice(allocator);
     }
     return wispterm_docs.listTopics(allocator);
+}
+
+/// Agent `websearch` tool: full-content Jina search, formatted for the model.
+fn webSearchTool(allocator: std.mem.Allocator, query: []const u8, max_results: ?u32) ![]u8 {
+    const key = (web_search.jinaApiKeyAlloc(allocator) catch null) orelse
+        return allocator.dupe(u8, web_search.errorText(error.MissingApiKey));
+    defer allocator.free(key);
+    const max: usize = if (max_results) |m| @min(@max(m, 1), 20) else 10;
+    var results = web_search.executeSearch(allocator, query, .{
+        .engine = .jina,
+        .api_key = key,
+        .with_content = true,
+        .max_results = max,
+    }) catch |err| return allocator.dupe(u8, web_search.errorText(err));
+    defer results.deinit();
+    return web_search.formatForAgent(allocator, query, results.items);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -229,7 +229,7 @@ pub fn wisptermDocsTool(allocator: std.mem.Allocator, topic: ?[]const u8) ![]u8 
 /// Agent `websearch` tool: full-content Jina search, formatted for the model.
 fn webSearchTool(allocator: std.mem.Allocator, query: []const u8, max_results: ?u32) ![]u8 {
     const key = (web_search.jinaApiKeyAlloc(allocator) catch null) orelse
-        return allocator.dupe(u8, web_search.errorText(error.MissingApiKey));
+        return web_search.formatErrorText(allocator, error.MissingApiKey);
     defer allocator.free(key);
     const max: usize = if (max_results) |m| @min(@max(m, 1), 20) else 10;
     var results = web_search.executeSearch(allocator, query, .{
@@ -237,7 +237,7 @@ fn webSearchTool(allocator: std.mem.Allocator, query: []const u8, max_results: ?
         .api_key = key,
         .with_content = true,
         .max_results = max,
-    }) catch |err| return allocator.dupe(u8, web_search.errorText(err));
+    }) catch |err| return web_search.formatErrorText(allocator, err);
     defer results.deinit();
     return web_search.formatForAgent(allocator, query, results.items);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -305,6 +305,9 @@ theme: ?[]const u8 = null,
 /// Default working directory for the AI agent's local commands (empty = unset).
 @"ai-agent-working-dir": []const u8 = "",
 
+/// API key for the Jina web search engine (https://s.jina.ai). Empty = unset.
+@"jina-api-key": []const u8 = "",
+
 /// The shell to run in the terminal. Platform aliases are resolved by
 /// platform/pty_command.zig; any other value is treated as a raw command path.
 shell: []const u8 = platform_pty_command.default_shell_name,
@@ -819,6 +822,8 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         };
     } else if (std.mem.eql(u8, key, "ai-agent-working-dir")) {
         self.@"ai-agent-working-dir" = self.dupeString(allocator, value) orelse return;
+    } else if (std.mem.eql(u8, key, "jina-api-key")) {
+        self.@"jina-api-key" = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "shell")) {
         self.shell = self.dupeString(allocator, value) orelse return;
     } else if (std.mem.eql(u8, key, "ai-default-profile")) {
@@ -1278,6 +1283,7 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --ai-agent-command-timeout-ms <ms> Agent command timeout budget
         \\  --ai-agent-output-limit <bytes> Max bytes returned by each tool
         \\  --ai-agent-working-dir <path> Default working directory for agent local commands
+        \\  --jina-api-key <key>         API key for the Jina web search ($websearch)
         \\  --auto-update-check <bool>  Check GitHub Releases after startup
         \\  --config-file <path>         Include another config file (prefix ? for optional)
         \\  --keybind <binding>          Configure a shortcut, e.g. global:ctrl+backquote=toggle_quake
@@ -1642,6 +1648,9 @@ const default_config_template =
     \\# ai-agent-command-timeout-ms = 60000
     \\# ai-agent-output-limit = 16384
     \\# ai-agent-working-dir =          # default dir for downloads/clones (empty = unset)
+    \\
+    \\# Web search (Jina) — used by $websearch and the websearch agent tool
+    \\# jina-api-key =
     \\
     \\# Updates
     \\# auto-update-check = true
@@ -2062,4 +2071,12 @@ test "config: ai-agent-working-dir parses from a config line" {
     defer cfg.deinit(allocator); // dupeString tracks the value in _owned_strings
     cfg.applyKeyValue(allocator, "ai-agent-working-dir", "/home/u/proj", ".");
     try std.testing.expectEqualStrings("/home/u/proj", cfg.@"ai-agent-working-dir");
+}
+
+test "config: jina-api-key parses from a config line" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    cfg.applyKeyValue(allocator, "jina-api-key", "jina_abc", ".");
+    try std.testing.expectEqualStrings("jina_abc", cfg.@"jina-api-key");
 }

--- a/src/platform/http_client.zig
+++ b/src/platform/http_client.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Backend = enum {
+    windows,
+    macos,
+    unsupported,
+};
+
+pub fn backendForOs(comptime os_tag: std.Target.Os.Tag) Backend {
+    return switch (os_tag) {
+        .windows => .windows,
+        .macos => .macos,
+        else => .unsupported,
+    };
+}
+
+const impl = switch (backendForOs(builtin.os.tag)) {
+    .windows => @import("http_client_windows.zig"),
+    .macos => @import("http_client_macos.zig"),
+    .unsupported => @import("http_client_unsupported.zig"),
+};
+
+pub const Method = enum {
+    GET,
+    POST,
+};
+
+pub const Header = std.http.Header;
+
+pub const Request = struct {
+    method: Method,
+    url: []const u8,
+    headers: []const Header = &.{},
+    body: []const u8 = "",
+    timeout_ms: u32 = 30_000,
+};
+
+pub const Response = struct {
+    status: u16,
+    body: []u8,
+
+    pub fn deinit(self: *Response, allocator: std.mem.Allocator) void {
+        allocator.free(self.body);
+        self.* = undefined;
+    }
+};
+
+pub fn fetch(allocator: std.mem.Allocator, request: Request) !Response {
+    return impl.fetch(allocator, request);
+}
+
+pub fn methodName(method: Method) []const u8 {
+    return switch (method) {
+        .GET => "GET",
+        .POST => "POST",
+    };
+}
+
+pub fn buildHeaderBlock(allocator: std.mem.Allocator, headers: []const Header) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var w = out.writer(allocator);
+    for (headers) |header| {
+        try w.print("{s}: {s}\r\n", .{ header.name, header.value });
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn objectNameFromUri(allocator: std.mem.Allocator, uri: std.Uri) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    const uri_path: std.Uri.Component = if (uri.path.isEmpty()) .{ .percent_encoded = "/" } else uri.path;
+    try uri_path.formatPath(&out.writer);
+    if (uri.query) |query| {
+        try out.writer.writeByte('?');
+        try query.formatQuery(&out.writer);
+    }
+    var list = out.toArrayList();
+    errdefer list.deinit(allocator);
+    return list.toOwnedSlice(allocator);
+}
+
+pub fn fetchWithStdHttp(allocator: std.mem.Allocator, request: Request) !Response {
+    const method: std.http.Method = switch (request.method) {
+        .GET => .GET,
+        .POST => .POST,
+    };
+
+    var client: std.http.Client = .{
+        .allocator = allocator,
+        .write_buffer_size = 16 * 1024,
+    };
+    defer client.deinit();
+
+    // Non-native fallback: still honor conventional proxy env vars when a
+    // platform backend does not exist.
+    var proxy_arena = std.heap.ArenaAllocator.init(allocator);
+    defer proxy_arena.deinit();
+    try client.initDefaultProxies(proxy_arena.allocator());
+
+    var response_body: std.Io.Writer.Allocating = .init(allocator);
+    defer response_body.deinit();
+
+    const response = try client.fetch(.{
+        .location = .{ .url = request.url },
+        .method = method,
+        .payload = request.body,
+        .headers = .{},
+        .extra_headers = request.headers,
+        .keep_alive = false,
+        .response_writer = &response_body.writer,
+    });
+
+    var list = response_body.toArrayList();
+    errdefer list.deinit(allocator);
+    return .{
+        .status = @intFromEnum(response.status),
+        .body = try list.toOwnedSlice(allocator),
+    };
+}
+
+test "platform http client selects backend by target OS" {
+    try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
+    try std.testing.expectEqual(Backend.macos, backendForOs(.macos));
+    try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
+}
+
+test "platform http client builds CRLF header blocks" {
+    const headers = [_]Header{
+        .{ .name = "Accept", .value = "application/json" },
+        .{ .name = "X-Test", .value = "yes" },
+    };
+    const text = try buildHeaderBlock(std.testing.allocator, &headers);
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqualStrings("Accept: application/json\r\nX-Test: yes\r\n", text);
+}
+
+test "platform http client builds URI object name with query" {
+    const uri = try std.Uri.parse("https://example.test/search?q=a%20b");
+    const object_name = try objectNameFromUri(std.testing.allocator, uri);
+    defer std.testing.allocator.free(object_name);
+    try std.testing.expectEqualStrings("/search?q=a%20b", object_name);
+}

--- a/src/platform/http_client_macos.zig
+++ b/src/platform/http_client_macos.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const http_client = @import("http_client.zig");
+
+const CHeader = extern struct {
+    name: [*:0]const u8,
+    value: [*:0]const u8,
+};
+
+const CResponse = extern struct {
+    status: i32,
+    body: ?*anyopaque,
+    body_len: i32,
+    error_code: i32,
+};
+
+extern fn wispterm_macos_http_fetch(
+    method: [*:0]const u8,
+    url: [*:0]const u8,
+    headers: ?[*]const CHeader,
+    header_count: c_int,
+    body: ?*const anyopaque,
+    body_len: c_int,
+    timeout_ms: c_int,
+    out: *CResponse,
+) c_int;
+
+extern fn wispterm_macos_http_free(ptr: ?*anyopaque) void;
+
+pub fn fetch(allocator: std.mem.Allocator, request: http_client.Request) !http_client.Response {
+    const method_z = try allocator.dupeZ(u8, http_client.methodName(request.method));
+    defer allocator.free(method_z);
+    const url_z = try allocator.dupeZ(u8, request.url);
+    defer allocator.free(url_z);
+
+    var names = try allocator.alloc(?[:0]u8, request.headers.len);
+    defer allocator.free(names);
+    @memset(names, null);
+    var values = try allocator.alloc(?[:0]u8, request.headers.len);
+    defer allocator.free(values);
+    @memset(values, null);
+    var c_headers = try allocator.alloc(CHeader, request.headers.len);
+    defer allocator.free(c_headers);
+    for (request.headers, 0..) |header, i| {
+        names[i] = try allocator.dupeZ(u8, header.name);
+        values[i] = try allocator.dupeZ(u8, header.value);
+        c_headers[i] = .{ .name = names[i].?.ptr, .value = values[i].?.ptr };
+    }
+    defer {
+        for (names) |name| if (name) |n| allocator.free(n);
+        for (values) |value| if (value) |v| allocator.free(v);
+    }
+
+    var response: CResponse = .{
+        .status = 0,
+        .body = null,
+        .body_len = 0,
+        .error_code = 0,
+    };
+    const body_ptr: ?*const anyopaque = if (request.body.len > 0) @ptrCast(request.body.ptr) else null;
+    const ok = wispterm_macos_http_fetch(
+        method_z.ptr,
+        url_z.ptr,
+        if (c_headers.len > 0) c_headers.ptr else null,
+        @intCast(c_headers.len),
+        body_ptr,
+        @intCast(request.body.len),
+        @intCast(request.timeout_ms),
+        &response,
+    );
+    defer wispterm_macos_http_free(response.body);
+    if (ok == 0) return macosNetworkError(response.error_code);
+    if (response.body_len < 0) return error.MacosHttpRequestFailed;
+
+    const len: usize = @intCast(response.body_len);
+    const out = try allocator.alloc(u8, len);
+    if (len > 0) {
+        const src: [*]const u8 = @ptrCast(response.body.?);
+        @memcpy(out, src[0..len]);
+    }
+    return .{
+        .status = @intCast(response.status),
+        .body = out,
+    };
+}
+
+fn macosNetworkError(code: i32) anyerror {
+    return switch (code) {
+        -1001 => error.ConnectionTimedOut,
+        -1003, -1006 => error.UnknownHostName,
+        -1004 => error.ConnectionRefused,
+        -1005 => error.ConnectionResetByPeer,
+        -1009 => error.NetworkUnreachable,
+        -1200, -1201, -1202, -1203, -1204, -1205, -1206 => error.TlsInitializationFailed,
+        -1002 => error.UnsupportedUriScheme,
+        -3 => error.OutOfMemory,
+        -2 => error.ConnectionTimedOut,
+        else => error.MacosHttpRequestFailed,
+    };
+}

--- a/src/platform/http_client_macos_bridge.m
+++ b/src/platform/http_client_macos_bridge.m
@@ -1,0 +1,125 @@
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct WispTermMacHttpHeader {
+    const char *name;
+    const char *value;
+} WispTermMacHttpHeader;
+
+typedef struct WispTermMacHttpResponse {
+    int32_t status;
+    void *body;
+    int32_t body_len;
+    int32_t error_code;
+} WispTermMacHttpResponse;
+
+void wispterm_macos_http_free(void *ptr) {
+    free(ptr);
+}
+
+static NSString *wispterm_macos_http_string(const char *text) {
+    if (text == NULL) return nil;
+    return [NSString stringWithUTF8String:text];
+}
+
+static void wispterm_macos_http_release_semaphore(dispatch_semaphore_t sema) {
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(sema);
+#else
+    (void)sema;
+#endif
+}
+
+int32_t wispterm_macos_http_fetch(
+    const char *method,
+    const char *url,
+    const WispTermMacHttpHeader *headers,
+    int32_t header_count,
+    const void *body,
+    int32_t body_len,
+    int32_t timeout_ms,
+    WispTermMacHttpResponse *out
+) {
+    @autoreleasepool {
+        if (out == NULL) return 0;
+        out->status = 0;
+        out->body = NULL;
+        out->body_len = 0;
+        out->error_code = 0;
+
+        NSString *method_string = wispterm_macos_http_string(method);
+        NSString *url_string = wispterm_macos_http_string(url);
+        if (method_string == nil || url_string == nil) {
+            out->error_code = -1;
+            return 0;
+        }
+        NSURL *ns_url = [NSURL URLWithString:url_string];
+        if (ns_url == nil) {
+            out->error_code = -1002; // NSURLErrorUnsupportedURL
+            return 0;
+        }
+
+        NSTimeInterval timeout = timeout_ms > 0 ? ((NSTimeInterval)timeout_ms / 1000.0) : 30.0;
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        config.timeoutIntervalForRequest = timeout;
+        config.timeoutIntervalForResource = timeout;
+
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:ns_url];
+        request.HTTPMethod = method_string;
+        request.timeoutInterval = timeout;
+        if (body != NULL && body_len > 0) {
+            request.HTTPBody = [NSData dataWithBytes:body length:(NSUInteger)body_len];
+        }
+        for (int32_t i = 0; i < header_count; i++) {
+            NSString *name = wispterm_macos_http_string(headers[i].name);
+            NSString *value = wispterm_macos_http_string(headers[i].value);
+            if (name != nil && value != nil) {
+                [request setValue:value forHTTPHeaderField:name];
+            }
+        }
+
+        NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:
+            ^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error != nil) {
+                    out->error_code = (int32_t)[error code];
+                } else {
+                    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                        out->status = (int32_t)[(NSHTTPURLResponse *)response statusCode];
+                    }
+                    NSUInteger len = data != nil ? [data length] : 0;
+                    if (len > 0) {
+                        void *copy = malloc(len);
+                        if (copy == NULL) {
+                            out->error_code = -3;
+                        } else {
+                            memcpy(copy, [data bytes], len);
+                            out->body = copy;
+                            out->body_len = (int32_t)len;
+                        }
+                    }
+                }
+                dispatch_semaphore_signal(sema);
+            }
+        ];
+        [task resume];
+
+        int64_t wait_ms = timeout_ms > 0 ? (int64_t)timeout_ms + 5000 : 35000;
+        long wait_result = dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, wait_ms * NSEC_PER_MSEC));
+        if (wait_result != 0) {
+            [task cancel];
+            [session invalidateAndCancel];
+            wispterm_macos_http_release_semaphore(sema);
+            out->error_code = -1001; // NSURLErrorTimedOut
+            return 0;
+        }
+
+        [session finishTasksAndInvalidate];
+        wispterm_macos_http_release_semaphore(sema);
+        return out->error_code == 0 ? 1 : 0;
+    }
+}

--- a/src/platform/http_client_unsupported.zig
+++ b/src/platform/http_client_unsupported.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+const http_client = @import("http_client.zig");
+
+pub fn fetch(allocator: std.mem.Allocator, request: http_client.Request) !http_client.Response {
+    return http_client.fetchWithStdHttp(allocator, request);
+}

--- a/src/platform/http_client_windows.zig
+++ b/src/platform/http_client_windows.zig
@@ -1,0 +1,231 @@
+const std = @import("std");
+const windows = std.os.windows;
+const http_client = @import("http_client.zig");
+
+const HINTERNET = *opaque {};
+
+extern "winhttp" fn WinHttpOpen(
+    pszAgentW: ?windows.LPCWSTR,
+    dwAccessType: windows.DWORD,
+    pszProxyW: ?windows.LPCWSTR,
+    pszProxyBypassW: ?windows.LPCWSTR,
+    dwFlags: windows.DWORD,
+) callconv(.winapi) ?HINTERNET;
+
+extern "winhttp" fn WinHttpConnect(
+    hSession: HINTERNET,
+    pswzServerName: windows.LPCWSTR,
+    nServerPort: u16,
+    dwReserved: windows.DWORD,
+) callconv(.winapi) ?HINTERNET;
+
+extern "winhttp" fn WinHttpOpenRequest(
+    hConnect: HINTERNET,
+    pwszVerb: windows.LPCWSTR,
+    pwszObjectName: windows.LPCWSTR,
+    pwszVersion: ?windows.LPCWSTR,
+    pwszReferrer: ?windows.LPCWSTR,
+    ppwszAcceptTypes: ?*const ?windows.LPCWSTR,
+    dwFlags: windows.DWORD,
+) callconv(.winapi) ?HINTERNET;
+
+extern "winhttp" fn WinHttpSetTimeouts(
+    hInternet: HINTERNET,
+    dwResolveTimeout: c_int,
+    dwConnectTimeout: c_int,
+    dwSendTimeout: c_int,
+    dwReceiveTimeout: c_int,
+) callconv(.winapi) windows.BOOL;
+
+extern "winhttp" fn WinHttpSendRequest(
+    hRequest: HINTERNET,
+    lpszHeaders: ?windows.LPCWSTR,
+    dwHeadersLength: windows.DWORD,
+    lpOptional: ?*anyopaque,
+    dwOptionalLength: windows.DWORD,
+    dwTotalLength: windows.DWORD,
+    dwContext: usize,
+) callconv(.winapi) windows.BOOL;
+
+extern "winhttp" fn WinHttpReceiveResponse(
+    hRequest: HINTERNET,
+    lpReserved: ?*anyopaque,
+) callconv(.winapi) windows.BOOL;
+
+extern "winhttp" fn WinHttpQueryHeaders(
+    hRequest: HINTERNET,
+    dwInfoLevel: windows.DWORD,
+    pwszName: ?windows.LPCWSTR,
+    lpBuffer: ?*anyopaque,
+    lpdwBufferLength: *windows.DWORD,
+    lpdwIndex: ?*windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+
+extern "winhttp" fn WinHttpReadData(
+    hRequest: HINTERNET,
+    lpBuffer: ?*anyopaque,
+    dwNumberOfBytesToRead: windows.DWORD,
+    lpdwNumberOfBytesRead: *windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+
+extern "winhttp" fn WinHttpCloseHandle(hInternet: HINTERNET) callconv(.winapi) windows.BOOL;
+
+const winhttp_access_type_automatic_proxy: windows.DWORD = 4;
+const winhttp_flag_secure: windows.DWORD = 0x00800000;
+const winhttp_query_status_code: windows.DWORD = 19;
+const winhttp_query_flag_number: windows.DWORD = 0x20000000;
+
+const error_winhttp_timeout: u32 = 12002;
+const error_winhttp_incorrect_handle_state: u32 = 12019;
+const error_winhttp_name_not_resolved: u32 = 12007;
+const error_winhttp_cannot_connect: u32 = 12029;
+const error_winhttp_connection_error: u32 = 12030;
+const error_winhttp_resend_request: u32 = 12032;
+const error_winhttp_secure_failure: u32 = 12175;
+const error_winhttp_client_auth_cert_needed: u32 = 12044;
+const error_winhttp_secure_cert_date_invalid: u32 = 12037;
+const error_winhttp_secure_cert_cn_invalid: u32 = 12038;
+const error_winhttp_secure_invalid_ca: u32 = 12045;
+const error_winhttp_secure_cert_rev_failed: u32 = 12057;
+const error_winhttp_bad_auto_proxy_script: u32 = 12166;
+const error_winhttp_unable_to_download_script: u32 = 12167;
+const error_winhttp_auto_proxy_service_error: u32 = 12178;
+const error_winhttp_autodetection_failed: u32 = 12180;
+
+const Handles = struct {
+    session: ?HINTERNET = null,
+    connect: ?HINTERNET = null,
+    request: ?HINTERNET = null,
+
+    fn close(self: *Handles) void {
+        if (self.request) |h| {
+            _ = WinHttpCloseHandle(h);
+            self.request = null;
+        }
+        if (self.connect) |h| {
+            _ = WinHttpCloseHandle(h);
+            self.connect = null;
+        }
+        if (self.session) |h| {
+            _ = WinHttpCloseHandle(h);
+            self.session = null;
+        }
+    }
+};
+
+pub fn fetch(allocator: std.mem.Allocator, request: http_client.Request) !http_client.Response {
+    const uri = try std.Uri.parse(request.url);
+    if (!std.mem.eql(u8, uri.scheme, "https") and !std.mem.eql(u8, uri.scheme, "http")) return error.UnsupportedUriScheme;
+    const secure = std.mem.eql(u8, uri.scheme, "https");
+    const port: u16 = uri.port orelse if (secure) 443 else 80;
+    var uri_arena = std.heap.ArenaAllocator.init(allocator);
+    defer uri_arena.deinit();
+    const host = try uri.getHostAlloc(uri_arena.allocator());
+    const object_name = try http_client.objectNameFromUri(allocator, uri);
+    defer allocator.free(object_name);
+    const header_block = try http_client.buildHeaderBlock(allocator, request.headers);
+    defer allocator.free(header_block);
+
+    const host_w = try std.unicode.utf8ToUtf16LeAllocZ(allocator, host);
+    defer allocator.free(host_w);
+    const object_w = try std.unicode.utf8ToUtf16LeAllocZ(allocator, object_name);
+    defer allocator.free(object_w);
+    const method_w = try std.unicode.utf8ToUtf16LeAllocZ(allocator, http_client.methodName(request.method));
+    defer allocator.free(method_w);
+    const header_w = try std.unicode.utf8ToUtf16LeAllocZ(allocator, header_block);
+    defer allocator.free(header_w);
+
+    var handles: Handles = .{};
+    defer handles.close();
+
+    const agent = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm");
+    handles.session = WinHttpOpen(agent, winhttp_access_type_automatic_proxy, null, null, 0) orelse return winHttpError();
+    _ = WinHttpSetTimeouts(
+        handles.session.?,
+        @intCast(request.timeout_ms),
+        @intCast(request.timeout_ms),
+        @intCast(request.timeout_ms),
+        @intCast(request.timeout_ms),
+    );
+    handles.connect = WinHttpConnect(handles.session.?, host_w.ptr, port, 0) orelse return winHttpError();
+    handles.request = WinHttpOpenRequest(
+        handles.connect.?,
+        method_w.ptr,
+        object_w.ptr,
+        null,
+        null,
+        null,
+        if (secure) winhttp_flag_secure else 0,
+    ) orelse return winHttpError();
+
+    const optional: ?*anyopaque = if (request.body.len > 0) @constCast(request.body.ptr) else null;
+    if (WinHttpSendRequest(
+        handles.request.?,
+        if (header_w.len > 0) header_w.ptr else null,
+        if (header_w.len > 0) @intCast(header_w.len) else 0,
+        optional,
+        @intCast(request.body.len),
+        @intCast(request.body.len),
+        0,
+    ) == 0) return winHttpError();
+
+    if (WinHttpReceiveResponse(handles.request.?, null) == 0) return winHttpError();
+
+    var status_u32: windows.DWORD = 0;
+    var status_len: windows.DWORD = @sizeOf(windows.DWORD);
+    if (WinHttpQueryHeaders(
+        handles.request.?,
+        winhttp_query_status_code | winhttp_query_flag_number,
+        null,
+        &status_u32,
+        &status_len,
+        null,
+    ) == 0) return winHttpError();
+
+    var body: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer body.deinit(allocator);
+    var buffer: [16 * 1024]u8 = undefined;
+    while (true) {
+        var bytes_read: windows.DWORD = 0;
+        if (WinHttpReadData(
+            handles.request.?,
+            &buffer,
+            @intCast(buffer.len),
+            &bytes_read,
+        ) == 0) return winHttpError();
+        if (bytes_read == 0) break;
+        try body.appendSlice(allocator, buffer[0..bytes_read]);
+    }
+
+    return .{
+        .status = @intCast(status_u32),
+        .body = try body.toOwnedSlice(allocator),
+    };
+}
+
+fn winHttpError() anyerror {
+    const code = @intFromEnum(windows.GetLastError());
+    std.log.warn("WinHTTP request failed: {d}", .{code});
+    return switch (code) {
+        error_winhttp_timeout => error.ConnectionTimedOut,
+        error_winhttp_name_not_resolved => error.UnknownHostName,
+        error_winhttp_cannot_connect => error.ConnectionRefused,
+        error_winhttp_connection_error,
+        error_winhttp_resend_request,
+        error_winhttp_incorrect_handle_state,
+        => error.ConnectionResetByPeer,
+        error_winhttp_secure_failure,
+        error_winhttp_client_auth_cert_needed,
+        error_winhttp_secure_cert_date_invalid,
+        error_winhttp_secure_cert_cn_invalid,
+        error_winhttp_secure_invalid_ca,
+        error_winhttp_secure_cert_rev_failed,
+        => error.TlsInitializationFailed,
+        error_winhttp_bad_auto_proxy_script,
+        error_winhttp_unable_to_download_script,
+        error_winhttp_auto_proxy_service_error,
+        error_winhttp_autodetection_failed,
+        => error.ProxyConfigurationFailed,
+        else => error.WinHttpRequestFailed,
+    };
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("web_search.zig");
     _ = @import("ai_loop_schedule.zig");
     _ = @import("ai_skill_distill.zig");
     _ = @import("ai_history_types.zig");

--- a/src/web_search.zig
+++ b/src/web_search.zig
@@ -19,6 +19,14 @@ pub const Options = struct {
     max_results: usize = 10,
 };
 
+pub const Results = struct {
+    arena: std.heap.ArenaAllocator,
+    items: []SearchResult,
+    pub fn deinit(self: *Results) void {
+        self.arena.deinit();
+    }
+};
+
 fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {
     try out.append(allocator, '"');
     for (s) |c| switch (c) {
@@ -45,9 +53,72 @@ pub fn buildJinaRequestBody(allocator: std.mem.Allocator, query: []const u8) ![]
     return out.toOwnedSlice(allocator);
 }
 
+fn jsonStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Parse a Jina search JSON response (`{"data":[{title,url,description,content?},...]}`)
+/// into result structs whose strings are duped into `arena`. Caps at `max_results`.
+/// Duping into `arena` means the parsed value may safely alias `json_bytes`, which
+/// the caller frees after this returns.
+pub fn parseJinaResponse(arena: std.mem.Allocator, json_bytes: []const u8, max_results: usize) ![]SearchResult {
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, json_bytes, .{}) catch return error.ParseFailed;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.ParseFailed;
+    const data_val = parsed.value.object.get("data") orelse return error.ParseFailed;
+    if (data_val != .array) return &.{};
+    const arr = data_val.array.items;
+    const n = @min(arr.len, max_results);
+    const list = try arena.alloc(SearchResult, n);
+    var count: usize = 0;
+    for (arr[0..n]) |item| {
+        if (item != .object) continue;
+        const obj = item.object;
+        list[count] = .{
+            .title = try arena.dupe(u8, jsonStr(obj, "title") orelse ""),
+            .url = try arena.dupe(u8, jsonStr(obj, "url") orelse ""),
+            .description = try arena.dupe(u8, jsonStr(obj, "description") orelse ""),
+            .content = if (jsonStr(obj, "content")) |c| try arena.dupe(u8, c) else null,
+        };
+        count += 1;
+    }
+    return list[0..count];
+}
+
 test "buildJinaRequestBody json-escapes the query" {
     const a = std.testing.allocator;
     const body = try buildJinaRequestBody(a, "say \"hi\"\nbye");
     defer a.free(body);
     try std.testing.expectEqualStrings("{\"q\":\"say \\\"hi\\\"\\nbye\"}", body);
+}
+
+test "parseJinaResponse extracts fields, honors max, tolerates missing content" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const json =
+        \\{"code":200,"data":[
+        \\{"title":"First","url":"https://a.example","description":"desc a","content":"body a"},
+        \\{"title":"Second","url":"https://b.example","description":"desc b"}
+        \\]}
+    ;
+    const items = try parseJinaResponse(arena.allocator(), json, 10);
+    try std.testing.expectEqual(@as(usize, 2), items.len);
+    try std.testing.expectEqualStrings("First", items[0].title);
+    try std.testing.expectEqualStrings("https://b.example", items[1].url);
+    try std.testing.expectEqualStrings("body a", items[0].content.?);
+    try std.testing.expect(items[1].content == null);
+}
+
+test "parseJinaResponse caps at max_results and handles empty data" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const json = "{\"data\":[{\"title\":\"a\",\"url\":\"u\",\"description\":\"d\"},{\"title\":\"b\",\"url\":\"u\",\"description\":\"d\"}]}";
+    const capped = try parseJinaResponse(arena.allocator(), json, 1);
+    try std.testing.expectEqual(@as(usize, 1), capped.len);
+    const empty = try parseJinaResponse(arena.allocator(), "{\"data\":[]}", 10);
+    try std.testing.expectEqual(@as(usize, 0), empty.len);
 }

--- a/src/web_search.zig
+++ b/src/web_search.zig
@@ -182,3 +182,119 @@ test "formatForAgent includes content; empty results message" {
     defer a.free(none);
     try std.testing.expect(std.mem.indexOf(u8, none, "No results") != null);
 }
+
+// --- Process-global Jina API key (set from config, read by both entry points) ---
+var g_jina_mutex: std.Thread.Mutex = .{};
+var g_jina_key_buf: [512]u8 = undefined;
+var g_jina_key_len: usize = 0;
+
+/// Set the Jina API key from config. Empty clears it. Oversized keys truncate.
+pub fn setJinaApiKey(key: []const u8) void {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    const n = @min(key.len, g_jina_key_buf.len);
+    @memcpy(g_jina_key_buf[0..n], key[0..n]);
+    g_jina_key_len = n;
+}
+
+pub fn jinaApiKeySet() bool {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    return g_jina_key_len > 0;
+}
+
+/// Return an owned copy of the Jina key, or null when unset. Caller frees.
+/// Copying under the lock avoids racing a concurrent `setJinaApiKey`.
+pub fn jinaApiKeyAlloc(allocator: std.mem.Allocator) !?[]u8 {
+    g_jina_mutex.lock();
+    defer g_jina_mutex.unlock();
+    if (g_jina_key_len == 0) return null;
+    return try allocator.dupe(u8, g_jina_key_buf[0..g_jina_key_len]);
+}
+
+/// Friendly, user/model-facing message for a search error.
+pub fn errorText(err: anyerror) []const u8 {
+    return switch (err) {
+        error.MissingApiKey => "Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.",
+        error.Network => "Web search failed: could not reach the Jina search service.",
+        error.HttpStatus => "Web search failed: the Jina search service returned an error.",
+        error.ParseFailed => "Web search failed: could not parse the Jina response.",
+        else => "Web search failed.",
+    };
+}
+
+/// Run a web search. `gpa` is used for transient HTTP buffers; the returned
+/// `Results` owns its strings via its own arena (free with `results.deinit()`).
+pub fn executeSearch(gpa: std.mem.Allocator, query: []const u8, opts: Options) !Results {
+    if (opts.api_key.len == 0) return error.MissingApiKey;
+    var results = Results{ .arena = std.heap.ArenaAllocator.init(gpa), .items = &.{} };
+    errdefer results.arena.deinit();
+    results.items = switch (opts.engine) {
+        .jina => try searchJina(results.arena.allocator(), gpa, query, opts),
+    };
+    return results;
+}
+
+fn searchJina(arena: std.mem.Allocator, gpa: std.mem.Allocator, query: []const u8, opts: Options) ![]SearchResult {
+    const body = try buildJinaRequestBody(gpa, query);
+    defer gpa.free(body);
+    const bearer = try std.fmt.allocPrint(gpa, "Bearer {s}", .{opts.api_key});
+    defer gpa.free(bearer);
+
+    var client: std.http.Client = .{ .allocator = gpa };
+    defer client.deinit();
+
+    var resp_buf: std.Io.Writer.Allocating = .init(gpa);
+    defer resp_buf.deinit();
+
+    var extra: [2]std.http.Header = undefined;
+    var extra_len: usize = 0;
+    extra[extra_len] = .{ .name = "Accept", .value = "application/json" };
+    extra_len += 1;
+    if (!opts.with_content) {
+        extra[extra_len] = .{ .name = "X-Respond-With", .value = "no-content" };
+        extra_len += 1;
+    }
+
+    const result = client.fetch(.{
+        .location = .{ .url = "https://s.jina.ai/" },
+        .method = .POST,
+        .payload = body,
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .authorization = .{ .override = bearer },
+        },
+        .extra_headers = extra[0..extra_len],
+        .response_writer = &resp_buf.writer,
+    }) catch return error.Network;
+
+    var resp_list = resp_buf.toArrayList();
+    defer resp_list.deinit(gpa);
+
+    if (result.status != .ok) {
+        std.log.warn("jina search HTTP {d}: {s}", .{ @intFromEnum(result.status), std.mem.trim(u8, resp_list.items, " \t\r\n") });
+        return error.HttpStatus;
+    }
+    return parseJinaResponse(arena, resp_list.items, opts.max_results);
+}
+
+test "executeSearch rejects an empty api key without touching the network" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try std.testing.expectError(error.MissingApiKey, executeSearch(arena.allocator(), "q", .{ .api_key = "", .with_content = false }));
+}
+
+test "errorText maps known errors to friendly text" {
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.MissingApiKey), "jina-api-key") != null);
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.Network), "reach") != null);
+}
+
+test "jina api key globals round-trip and clear" {
+    setJinaApiKey("abc123");
+    try std.testing.expect(jinaApiKeySet());
+    const k = (try jinaApiKeyAlloc(std.testing.allocator)).?;
+    defer std.testing.allocator.free(k);
+    try std.testing.expectEqualStrings("abc123", k);
+    setJinaApiKey("");
+    try std.testing.expect(!jinaApiKeySet());
+}

--- a/src/web_search.zig
+++ b/src/web_search.zig
@@ -122,3 +122,63 @@ test "parseJinaResponse caps at max_results and handles empty data" {
     const empty = try parseJinaResponse(arena.allocator(), "{\"data\":[]}", 10);
     try std.testing.expectEqual(@as(usize, 0), empty.len);
 }
+
+/// Render results for the transcript (user `$websearch`): snippets only.
+pub fn formatForUser(allocator: std.mem.Allocator, query: []const u8, results: []const SearchResult) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+    if (results.len == 0) {
+        try w.print("No web results for: {s}", .{query});
+        return out.toOwnedSlice(allocator);
+    }
+    try w.print("Web results for \"{s}\":\n", .{query});
+    for (results, 0..) |r, i| {
+        try w.print("\n{d}. {s}\n{s}\n", .{ i + 1, r.title, r.url });
+        if (r.description.len > 0) try w.print("{s}\n", .{r.description});
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Render results for the model (agent `websearch` tool): includes page content.
+pub fn formatForAgent(allocator: std.mem.Allocator, query: []const u8, results: []const SearchResult) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+    if (results.len == 0) {
+        try w.print("No results found for query: {s}", .{query});
+        return out.toOwnedSlice(allocator);
+    }
+    try w.print("Search results for \"{s}\" ({d} results):\n", .{ query, results.len });
+    for (results, 0..) |r, i| {
+        try w.print("\n[{d}] {s}\nURL: {s}\n", .{ i + 1, r.title, r.url });
+        if (r.description.len > 0) try w.print("{s}\n", .{r.description});
+        if (r.content) |c| try w.print("\n{s}\n", .{c});
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+test "formatForUser lists snippets and omits content" {
+    const a = std.testing.allocator;
+    const results = [_]SearchResult{
+        .{ .title = "T", .url = "https://x", .description = "d", .content = "SECRET-CONTENT" },
+    };
+    const text = try formatForUser(a, "q", &results);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "1. T") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "https://x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "SECRET-CONTENT") == null);
+}
+
+test "formatForAgent includes content; empty results message" {
+    const a = std.testing.allocator;
+    const results = [_]SearchResult{
+        .{ .title = "T", .url = "https://x", .description = "d", .content = "BODY-TEXT" },
+    };
+    const text = try formatForAgent(a, "q", &results);
+    defer a.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "BODY-TEXT") != null);
+    const none = try formatForAgent(a, "q", &.{});
+    defer a.free(none);
+    try std.testing.expect(std.mem.indexOf(u8, none, "No results") != null);
+}

--- a/src/web_search.zig
+++ b/src/web_search.zig
@@ -1,7 +1,11 @@
 //! Engine-agnostic web search core. Pure request-build / response-parse / format
 //! helpers plus one HTTP call (`executeSearch`). Only the `jina` engine exists
-//! today; a new engine is a new branch in `executeSearch`. Leaf module: std only.
+//! today; a new engine is a new branch in `executeSearch`. HTTP transport goes
+//! through `platform/http_client.zig` so desktop builds can use system proxies.
 const std = @import("std");
+const platform_http = @import("platform/http_client.zig");
+
+const jina_search_url = "https://s.jina.ai/";
 
 pub const Engine = enum { jina };
 
@@ -212,20 +216,109 @@ pub fn jinaApiKeyAlloc(allocator: std.mem.Allocator) !?[]u8 {
     return try allocator.dupe(u8, g_jina_key_buf[0..g_jina_key_len]);
 }
 
+const ErrorDetailKind = enum { none, network, http_status, parse_failed };
+
+threadlocal var g_error_detail_kind: ErrorDetailKind = .none;
+threadlocal var g_error_detail_buf: [512]u8 = undefined;
+threadlocal var g_error_detail_len: usize = 0;
+
+fn clearErrorDetail() void {
+    g_error_detail_kind = .none;
+    g_error_detail_len = 0;
+}
+
+fn setErrorDetail(kind: ErrorDetailKind, comptime fmt: []const u8, args: anytype) void {
+    const text = std.fmt.bufPrint(&g_error_detail_buf, fmt, args) catch {
+        const fallback = "Web search failed: diagnostic message was too long.";
+        @memcpy(g_error_detail_buf[0..fallback.len], fallback);
+        g_error_detail_len = fallback.len;
+        g_error_detail_kind = kind;
+        return;
+    };
+    g_error_detail_len = text.len;
+    g_error_detail_kind = kind;
+}
+
+fn errorDetail(kind: ErrorDetailKind) ?[]const u8 {
+    if (g_error_detail_kind != kind or g_error_detail_len == 0) return null;
+    return g_error_detail_buf[0..g_error_detail_len];
+}
+
+fn setNetworkErrorDetail(err: anyerror) void {
+    switch (err) {
+        error.ConnectionTimedOut => setErrorDetail(
+            .network,
+            "Web search request timed out before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        error.UnknownHostName,
+        error.TemporaryNameServerFailure,
+        error.NameServerFailure,
+        error.HostLacksNetworkAddresses,
+        => setErrorDetail(
+            .network,
+            "Web search DNS lookup failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        error.TlsInitializationFailed,
+        error.CertificateBundleLoadFailure,
+        => setErrorDetail(
+            .network,
+            "Web search TLS setup failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        error.ConnectionRefused,
+        error.NetworkUnreachable,
+        error.ConnectionResetByPeer,
+        => setErrorDetail(
+            .network,
+            "Web search connection failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        error.ProxyConfigurationFailed => setErrorDetail(
+            .network,
+            "Web search system proxy configuration failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        error.WinHttpRequestFailed,
+        error.MacosHttpRequestFailed,
+        => setErrorDetail(
+            .network,
+            "Web search platform HTTP request failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+        else => setErrorDetail(
+            .network,
+            "Web search request failed before response: {s} ({s})",
+            .{ @errorName(err), jina_search_url },
+        ),
+    }
+}
+
 /// Friendly, user/model-facing message for a search error.
 pub fn errorText(err: anyerror) []const u8 {
     return switch (err) {
         error.MissingApiKey => "Jina API key not set — add `jina-api-key = <key>` to your WispTerm config.",
-        error.Network => "Web search failed: could not reach the Jina search service.",
-        error.HttpStatus => "Web search failed: the Jina search service returned an error.",
-        error.ParseFailed => "Web search failed: could not parse the Jina response.",
+        error.Network => errorDetail(.network) orelse "Web search failed: could not reach the Jina search service.",
+        error.HttpStatus => errorDetail(.http_status) orelse "Web search failed: the Jina search service returned an error.",
+        error.ParseFailed => errorDetail(.parse_failed) orelse "Web search failed: could not parse the Jina response.",
         else => "Web search failed.",
+    };
+}
+
+/// Owned error text for transcript/model output. Unlike `errorText`, this keeps
+/// unexpected lower-level error names visible instead of collapsing them.
+pub fn formatErrorText(allocator: std.mem.Allocator, err: anyerror) ![]u8 {
+    return switch (err) {
+        error.MissingApiKey, error.Network, error.HttpStatus, error.ParseFailed => allocator.dupe(u8, errorText(err)),
+        else => std.fmt.allocPrint(allocator, "Web search failed: {s}.", .{@errorName(err)}),
     };
 }
 
 /// Run a web search. `gpa` is used for transient HTTP buffers; the returned
 /// `Results` owns its strings via its own arena (free with `results.deinit()`).
 pub fn executeSearch(gpa: std.mem.Allocator, query: []const u8, opts: Options) !Results {
+    clearErrorDetail();
     if (opts.api_key.len == 0) return error.MissingApiKey;
     var results = Results{ .arena = std.heap.ArenaAllocator.init(gpa), .items = &.{} };
     errdefer results.arena.deinit();
@@ -241,41 +334,57 @@ fn searchJina(arena: std.mem.Allocator, gpa: std.mem.Allocator, query: []const u
     const bearer = try std.fmt.allocPrint(gpa, "Bearer {s}", .{opts.api_key});
     defer gpa.free(bearer);
 
-    var client: std.http.Client = .{ .allocator = gpa };
-    defer client.deinit();
-
-    var resp_buf: std.Io.Writer.Allocating = .init(gpa);
-    defer resp_buf.deinit();
-
-    var extra: [2]std.http.Header = undefined;
-    var extra_len: usize = 0;
-    extra[extra_len] = .{ .name = "Accept", .value = "application/json" };
-    extra_len += 1;
+    var headers: [4]platform_http.Header = undefined;
+    var header_len: usize = 0;
+    headers[header_len] = .{ .name = "Content-Type", .value = "application/json" };
+    header_len += 1;
+    headers[header_len] = .{ .name = "Authorization", .value = bearer };
+    header_len += 1;
+    headers[header_len] = .{ .name = "Accept", .value = "application/json" };
+    header_len += 1;
     if (!opts.with_content) {
-        extra[extra_len] = .{ .name = "X-Respond-With", .value = "no-content" };
-        extra_len += 1;
+        headers[header_len] = .{ .name = "X-Respond-With", .value = "no-content" };
+        header_len += 1;
     }
 
-    const result = client.fetch(.{
-        .location = .{ .url = "https://s.jina.ai/" },
+    var response = platform_http.fetch(gpa, .{
         .method = .POST,
-        .payload = body,
-        .headers = .{
-            .content_type = .{ .override = "application/json" },
-            .authorization = .{ .override = bearer },
-        },
-        .extra_headers = extra[0..extra_len],
-        .response_writer = &resp_buf.writer,
-    }) catch return error.Network;
+        .url = jina_search_url,
+        .headers = headers[0..header_len],
+        .body = body,
+        .timeout_ms = 30_000,
+    }) catch |err| {
+        setNetworkErrorDetail(err);
+        std.log.warn("{s}", .{errorText(error.Network)});
+        return error.Network;
+    };
+    defer response.deinit(gpa);
 
-    var resp_list = resp_buf.toArrayList();
-    defer resp_list.deinit(gpa);
-
-    if (result.status != .ok) {
-        std.log.warn("jina search HTTP {d}: {s}", .{ @intFromEnum(result.status), std.mem.trim(u8, resp_list.items, " \t\r\n") });
+    if (response.status != 200) {
+        const trimmed = std.mem.trim(u8, response.body, " \t\r\n");
+        const excerpt = trimmed[0..@min(trimmed.len, 300)];
+        if (excerpt.len > 0) {
+            setErrorDetail(
+                .http_status,
+                "Web search failed: Jina returned HTTP {d}: {s}",
+                .{ response.status, excerpt },
+            );
+        } else {
+            setErrorDetail(
+                .http_status,
+                "Web search failed: Jina returned HTTP {d}.",
+                .{response.status},
+            );
+        }
+        std.log.warn("jina search HTTP {d}: {s}", .{ response.status, trimmed });
         return error.HttpStatus;
     }
-    return parseJinaResponse(arena, resp_list.items, opts.max_results);
+    return parseJinaResponse(arena, response.body, opts.max_results) catch |err| {
+        if (err == error.ParseFailed) {
+            setErrorDetail(.parse_failed, "Web search failed: could not parse the Jina response ({s}).", .{@errorName(err)});
+        }
+        return err;
+    };
 }
 
 test "executeSearch rejects an empty api key without touching the network" {
@@ -285,8 +394,26 @@ test "executeSearch rejects an empty api key without touching the network" {
 }
 
 test "errorText maps known errors to friendly text" {
+    clearErrorDetail();
     try std.testing.expect(std.mem.indexOf(u8, errorText(error.MissingApiKey), "jina-api-key") != null);
     try std.testing.expect(std.mem.indexOf(u8, errorText(error.Network), "reach") != null);
+}
+
+test "errorText exposes captured transport and HTTP details" {
+    clearErrorDetail();
+    setNetworkErrorDetail(error.ConnectionTimedOut);
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.Network), "ConnectionTimedOut") != null);
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.Network), "timed out") != null);
+    clearErrorDetail();
+    setErrorDetail(.http_status, "Web search failed: Jina returned HTTP {d}: {s}", .{ 401, "AuthenticationRequiredError" });
+    try std.testing.expect(std.mem.indexOf(u8, errorText(error.HttpStatus), "401") != null);
+    clearErrorDetail();
+}
+
+test "formatErrorText includes unexpected lower-level error names" {
+    const text = try formatErrorText(std.testing.allocator, error.ConnectionTimedOut);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "ConnectionTimedOut") != null);
 }
 
 test "jina api key globals round-trip and clear" {

--- a/src/web_search.zig
+++ b/src/web_search.zig
@@ -1,0 +1,53 @@
+//! Engine-agnostic web search core. Pure request-build / response-parse / format
+//! helpers plus one HTTP call (`executeSearch`). Only the `jina` engine exists
+//! today; a new engine is a new branch in `executeSearch`. Leaf module: std only.
+const std = @import("std");
+
+pub const Engine = enum { jina };
+
+pub const SearchResult = struct {
+    title: []const u8,
+    url: []const u8,
+    description: []const u8,
+    content: ?[]const u8 = null,
+};
+
+pub const Options = struct {
+    engine: Engine = .jina,
+    api_key: []const u8,
+    with_content: bool,
+    max_results: usize = 10,
+};
+
+fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {
+    try out.append(allocator, '"');
+    for (s) |c| switch (c) {
+        '"' => try out.appendSlice(allocator, "\\\""),
+        '\\' => try out.appendSlice(allocator, "\\\\"),
+        '\n' => try out.appendSlice(allocator, "\\n"),
+        '\r' => try out.appendSlice(allocator, "\\r"),
+        '\t' => try out.appendSlice(allocator, "\\t"),
+        else => |ch| if (ch < 0x20)
+            try out.writer(allocator).print("\\u{x:0>4}", .{ch})
+        else
+            try out.append(allocator, ch),
+    };
+    try out.append(allocator, '"');
+}
+
+/// Build the Jina search request body: `{"q":<json-escaped query>}`.
+pub fn buildJinaRequestBody(allocator: std.mem.Allocator, query: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, "{\"q\":");
+    try appendJsonString(allocator, &out, query);
+    try out.append(allocator, '}');
+    return out.toOwnedSlice(allocator);
+}
+
+test "buildJinaRequestBody json-escapes the query" {
+    const a = std.testing.allocator;
+    const body = try buildJinaRequestBody(a, "say \"hi\"\nbye");
+    defer a.free(body);
+    try std.testing.expectEqualStrings("{\"q\":\"say \\\"hi\\\"\\nbye\"}", body);
+}


### PR DESCRIPTION
## Summary

Adds web search to the AI chat behind an engine-agnostic core (`src/web_search.zig`) whose only engine today is **Jina** (`s.jina.ai`). Two entry points:

- **`$websearch <query>`** - user command in the chat composer. Runs the Jina search itself and renders the raw results (titles, URLs, snippets) into the transcript. No AI turn. Runs on a background thread that reuses the existing `request_thread`/`request_inflight` lifecycle, so `Session.deinit` joins it (no UAF). Surfaced in the existing `$` dropdown as a reserved entry.
- **`websearch` agent tool** - LLM-callable, returns full page content so the model can read pages. No approval gate (read-only fetch).

Config: new **`jina-api-key`** key (config-file only - no env var), threaded through an `App` field so it loads at startup *and* on config reload. Empty key -> friendly "not set" message, no network call.

This update also fixes system-proxy handling for web search:

- Windows now uses a platform HTTP backend over WinHTTP with `WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY`, so it follows Windows per-user/system proxy settings instead of direct `std.http.Client` connects.
- macOS now has an `NSURLSession` backend, which follows the macOS system proxy/PAC configuration.
- Other platforms keep a `std.http.Client` fallback that honors conventional proxy env vars.
- Web search network failures now expose the underlying transport error (`ConnectionTimedOut`, DNS, TLS, proxy config failure, HTTP status/body excerpt) instead of collapsing everything into a generic reachability message.

Future engines are a single new branch in `executeSearch` - `SearchResult`/`Options`/`Results` and the format/parse helpers are provider-agnostic.

Spec: `docs/superpowers/specs/2026-06-05-websearch-jina-design.md`
Plan: `docs/superpowers/plans/2026-06-05-websearch-jina.md`

## Test Plan

- [x] `zig build test`
- [x] `zig build test-full`
- [x] `zig build`
- [x] Windows system-proxy smoke: platform HTTP POST to `https://s.jina.ai/` reached Jina and returned expected `401 AuthenticationRequiredError` without a Jina key, instead of `ConnectionTimedOut`
- [x] Windows GUI smoke completed
- [x] Windows checkout safety checks: reserved names, illegal characters, case-fold collisions, symlinks, and path length
- [x] macOS HTTP backend Zig compile check: `zig test .\src\platform\http_client.zig -target x86_64-macos -fno-emit-bin`
- [x] macOS GUI smoke still needed on a real macOS host with a Jina key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
