### PR TITLE
[codex] Add OpenSSH import and session UX fixes

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -54,6 +54,9 @@ target. WispTerm connects to the selected target, scans `$HOME/.codex`,
 `$HOME/.claude`, and `$HOME/.reasonix` for metadata, and loads a transcript
 only when you open that row.
 
+The `Subagent` category separates sessions whose title starts with `You are`;
+those sessions still appear under `All`.
+
 Use `Resume` to open a real terminal tab on the same target. WispTerm first
 checks the original project directory recorded in the history file; if that
 directory is missing, resume stops instead of falling back to `$HOME`.

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -64,8 +64,8 @@ Press `Ctrl+Shift+A` (`Cmd+Shift+A` on macOS) on a terminal tab to toggle a
 right-side AI copilot bound to the currently focused terminal. The copilot is
 terminal-only — it does not open on a Copilot tab or other non-terminal tabs.
 
-- Each terminal tab keeps its own copilot conversation. The conversation is
-  per-tab, and closing the tab discards it.
+- Each terminal tab keeps its own copilot conversation and open/closed sidebar
+  state. Closing the tab discards that conversation.
 - Terminal actions default to the current terminal, so there is no tab to pick
   before asking. The copilot can still operate other terminals when you
   explicitly ask it to.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,13 @@ to their defaults after a confirmation dialog. It only clears the keys exposed o
 the settings page; it leaves Quake mode, your saved AI profiles, and custom
 `keybind` lines untouched.
 
+## OpenSSH config import
+
+Open the command center and run **Load OpenSSH Config** to import compatible
+entries from `~/.ssh/config` into WispTerm's SSH profiles. WispTerm imports
+`Host`, `HostName`, `User`, `Port`, and `ProxyJump`, skips wildcard host
+patterns, and does not import passwords.
+
 ## Keyboard Shortcuts
 
 WispTerm follows Ghostty's `keybind = trigger=action` style for app-level

--- a/docs/superpowers/plans/2026-06-05-openssh-config-import.md
+++ b/docs/superpowers/plans/2026-06-05-openssh-config-import.md
@@ -1,0 +1,935 @@
+# OpenSSH Config Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-run and Command Center path that imports compatible `~/.ssh/config` entries into WispTerm SSH profiles.
+
+**Architecture:** Keep OpenSSH parsing in a pure module that can run in the fast test suite. Keep UI state, profile merging, profile persistence, and tab launching in `src/renderer/overlays.zig`, where WispTerm already owns SSH profile storage and New Session behavior. Add a small platform-dir helper for the default OpenSSH config path so Windows uses `%USERPROFILE%\.ssh\config` while POSIX uses `$HOME/.ssh/config`.
+
+**Tech Stack:** Zig 0.15.2, WispTerm custom overlay renderer, existing `renderer/overlays/profile_codec.zig` SSH profile storage, existing `platform/dirs.zig`, `zig build test`, `zig build test-full`.
+
+---
+
+## File Structure
+
+- Create `src/openssh_config_import.zig`: pure OpenSSH config parser. It returns fixed-buffer import candidates and has no renderer/AppWindow imports.
+- Modify `src/test_fast.zig`: add the parser to the fast test aggregate.
+- Modify `src/test_main.zig`: add the parser to full-suite compile coverage.
+- Modify `src/platform/dirs.zig`: add `openSshConfigPath()` and `openSshConfigPathFromEnvForOs()` with unit tests.
+- Modify `src/command_center_state.zig`: add the static `Load OpenSSH Config` command action and tests.
+- Modify `src/i18n.zig`: add Chinese command title/detail cases so the new command switch remains exhaustive and searchable under Chinese UI.
+- Modify `src/renderer/overlays.zig`: add the command execution route, SSH manage-list import row, OpenSSH import/merge/persist logic, row mapping tests, and merge tests.
+- Modify `docs/configuration.md`: document the Command Center import entry.
+
+## Task 1: Add The Pure OpenSSH Config Parser
+
+**Files:**
+- Create: `src/openssh_config_import.zig`
+- Modify: `src/test_fast.zig`
+- Modify: `src/test_main.zig`
+
+- [ ] **Step 1: Register the missing module in the fast test aggregate**
+
+In `src/test_fast.zig`, add this import inside the existing `test { ... }` block near the SSH modules:
+
+```zig
+    _ = @import("openssh_config_import.zig");
+```
+
+In `src/test_main.zig`, add this import inside the existing `comptime { ... }` block near `command_center_state.zig` and `command_palette_model.zig`:
+
+```zig
+    _ = @import("openssh_config_import.zig");
+```
+
+- [ ] **Step 2: Create parser tests and stubs**
+
+Create `src/openssh_config_import.zig` with this test-first skeleton:
+
+```zig
+const std = @import("std");
+
+pub const FIELD_MAX: usize = 128;
+pub const MAX_ALIASES_PER_HOST: usize = 16;
+
+pub const Candidate = struct {
+    name_buf: [FIELD_MAX]u8 = undefined,
+    name_len: usize = 0,
+    host_buf: [FIELD_MAX]u8 = undefined,
+    host_len: usize = 0,
+    user_buf: [FIELD_MAX]u8 = undefined,
+    user_len: usize = 0,
+    port_buf: [FIELD_MAX]u8 = undefined,
+    port_len: usize = 0,
+    proxy_jump_buf: [FIELD_MAX]u8 = undefined,
+    proxy_jump_len: usize = 0,
+
+    pub fn name(self: *const Candidate) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+
+    pub fn host(self: *const Candidate) []const u8 {
+        return self.host_buf[0..self.host_len];
+    }
+
+    pub fn user(self: *const Candidate) []const u8 {
+        return self.user_buf[0..self.user_len];
+    }
+
+    pub fn port(self: *const Candidate) []const u8 {
+        return self.port_buf[0..self.port_len];
+    }
+
+    pub fn proxyJump(self: *const Candidate) []const u8 {
+        return self.proxy_jump_buf[0..self.proxy_jump_len];
+    }
+};
+
+pub fn parseCandidates(_: []const u8, _: []Candidate) []Candidate {
+    return &.{};
+}
+
+test "openssh config import: parses a basic host block" {
+    const config =
+        \\Host lab
+        \\  HostName 192.0.2.10
+        \\  User alice
+        \\  Port 2222
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("lab", rows[0].name());
+    try std.testing.expectEqualStrings("192.0.2.10", rows[0].host());
+    try std.testing.expectEqualStrings("alice", rows[0].user());
+    try std.testing.expectEqualStrings("2222", rows[0].port());
+}
+
+test "openssh config import: defaults host from alias and port to 22" {
+    const config =
+        \\Host staging
+        \\  User deploy
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("staging", rows[0].host());
+    try std.testing.expectEqualStrings("22", rows[0].port());
+}
+
+test "openssh config import: parses proxy jump" {
+    const config =
+        \\Host prod
+        \\  HostName prod.internal
+        \\  User root
+        \\  ProxyJump jumpuser@bastion:22
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("jumpuser@bastion:22", rows[0].proxyJump());
+}
+
+test "openssh config import: splits aliases and skips wildcard aliases" {
+    const config =
+        \\Host gpu gpu-* ?bad [group] *
+        \\  HostName gpu.example
+        \\  User xzg
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("gpu", rows[0].name());
+}
+
+test "openssh config import: ignores comments blank lines and unsupported blocks" {
+    const config =
+        \\# comment
+        \\
+        \\Host nouser
+        \\  HostName 192.0.2.11
+        \\
+        \\Host ok # inline comment
+        \\  HostName ok.example
+        \\  User bob
+        \\  IdentityFile ~/.ssh/id_ed25519
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("ok", rows[0].name());
+    try std.testing.expectEqualStrings("ok.example", rows[0].host());
+}
+```
+
+- [ ] **Step 3: Run the fast test and verify it fails for the missing behavior**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL. At least the parser tests fail because `parseCandidates()` returns an empty slice.
+
+- [ ] **Step 4: Implement the parser**
+
+Replace the stub with these helpers and implementation in `src/openssh_config_import.zig`:
+
+```zig
+const PendingBlock = struct {
+    alias_bufs: [MAX_ALIASES_PER_HOST][FIELD_MAX]u8 = undefined,
+    alias_lens: [MAX_ALIASES_PER_HOST]usize = .{0} ** MAX_ALIASES_PER_HOST,
+    alias_count: usize = 0,
+    host_buf: [FIELD_MAX]u8 = undefined,
+    host_len: usize = 0,
+    user_buf: [FIELD_MAX]u8 = undefined,
+    user_len: usize = 0,
+    port_buf: [FIELD_MAX]u8 = undefined,
+    port_len: usize = 0,
+    proxy_jump_buf: [FIELD_MAX]u8 = undefined,
+    proxy_jump_len: usize = 0,
+
+    fn reset(self: *PendingBlock) void {
+        self.* = .{};
+    }
+
+    fn addAlias(self: *PendingBlock, alias_raw: []const u8) void {
+        const alias = std.mem.trim(u8, alias_raw, " \t\r\n");
+        if (!isImportableAlias(alias)) return;
+        if (self.alias_count >= MAX_ALIASES_PER_HOST) return;
+        copyInto(&self.alias_bufs[self.alias_count], &self.alias_lens[self.alias_count], alias);
+        self.alias_count += 1;
+    }
+};
+
+fn copyInto(buf: *[FIELD_MAX]u8, len: *usize, value_raw: []const u8) void {
+    const value = std.mem.trim(u8, value_raw, " \t\r\n");
+    const n = @min(value.len, FIELD_MAX);
+    @memcpy(buf[0..n], value[0..n]);
+    len.* = n;
+}
+
+fn isImportableAlias(alias: []const u8) bool {
+    if (alias.len == 0) return false;
+    if (std.mem.eql(u8, alias, "*")) return false;
+    for (alias) |ch| {
+        if (ch == '*' or ch == '?' or ch == '[' or ch == ']') return false;
+    }
+    return true;
+}
+
+fn stripComment(line: []const u8) []const u8 {
+    const hash = std.mem.indexOfScalar(u8, line, '#') orelse return line;
+    return line[0..hash];
+}
+
+fn splitKeywordValue(line_raw: []const u8) ?struct { key: []const u8, value: []const u8 } {
+    const line = std.mem.trim(u8, stripComment(line_raw), " \t\r\n");
+    if (line.len == 0) return null;
+    var i: usize = 0;
+    while (i < line.len and line[i] != ' ' and line[i] != '\t') : (i += 1) {}
+    const key = line[0..i];
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+    return .{ .key = key, .value = line[i..] };
+}
+
+fn flushBlock(block: *const PendingBlock, out: []Candidate, count: *usize) void {
+    if (block.alias_count == 0 or block.user_len == 0) return;
+    for (0..block.alias_count) |idx| {
+        if (count.* >= out.len) return;
+        var row = Candidate{};
+        const alias = block.alias_bufs[idx][0..block.alias_lens[idx]];
+        copyInto(&row.name_buf, &row.name_len, alias);
+        if (block.host_len > 0) {
+            copyInto(&row.host_buf, &row.host_len, block.host_buf[0..block.host_len]);
+        } else {
+            copyInto(&row.host_buf, &row.host_len, alias);
+        }
+        copyInto(&row.user_buf, &row.user_len, block.user_buf[0..block.user_len]);
+        if (block.port_len > 0) {
+            copyInto(&row.port_buf, &row.port_len, block.port_buf[0..block.port_len]);
+        } else {
+            copyInto(&row.port_buf, &row.port_len, "22");
+        }
+        copyInto(&row.proxy_jump_buf, &row.proxy_jump_len, block.proxy_jump_buf[0..block.proxy_jump_len]);
+        out[count.*] = row;
+        count.* += 1;
+    }
+}
+
+pub fn parseCandidates(text: []const u8, out: []Candidate) []Candidate {
+    var block = PendingBlock{};
+    var count: usize = 0;
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        const parsed = splitKeywordValue(line) orelse continue;
+        if (std.ascii.eqlIgnoreCase(parsed.key, "Host")) {
+            flushBlock(&block, out, &count);
+            block.reset();
+            var aliases = std.mem.tokenizeAny(u8, parsed.value, " \t");
+            while (aliases.next()) |alias| block.addAlias(alias);
+            continue;
+        }
+        if (block.alias_count == 0) continue;
+        if (std.ascii.eqlIgnoreCase(parsed.key, "HostName")) {
+            copyInto(&block.host_buf, &block.host_len, parsed.value);
+        } else if (std.ascii.eqlIgnoreCase(parsed.key, "User")) {
+            copyInto(&block.user_buf, &block.user_len, parsed.value);
+        } else if (std.ascii.eqlIgnoreCase(parsed.key, "Port")) {
+            copyInto(&block.port_buf, &block.port_len, parsed.value);
+        } else if (std.ascii.eqlIgnoreCase(parsed.key, "ProxyJump")) {
+            copyInto(&block.proxy_jump_buf, &block.proxy_jump_len, parsed.value);
+        }
+    }
+    flushBlock(&block, out, &count);
+    return out[0..count];
+}
+```
+
+- [ ] **Step 5: Run the fast test and verify the parser passes**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit parser work**
+
+Run:
+
+```bash
+git add src/openssh_config_import.zig src/test_fast.zig src/test_main.zig
+git commit -m "feat: parse openssh config imports"
+```
+
+## Task 2: Add Default OpenSSH Config Path Resolution
+
+**Files:**
+- Modify: `src/platform/dirs.zig`
+
+- [ ] **Step 1: Write path-resolution tests**
+
+Add this test near the existing platform dirs path tests:
+
+```zig
+test "platform dirs resolve openssh config path per OS" {
+    const allocator = std.testing.allocator;
+
+    const windows = try openSshConfigPathFromEnvForOs(allocator, .windows, .{
+        .userprofile = "C:/Users/alice",
+        .home = "/ignored",
+    });
+    defer allocator.free(windows);
+    const expected_windows = try std.fs.path.join(allocator, &.{ "C:/Users/alice", ".ssh", "config" });
+    defer allocator.free(expected_windows);
+    try std.testing.expectEqualStrings(expected_windows, windows);
+
+    const linux = try openSshConfigPathFromEnvForOs(allocator, .linux, .{
+        .home = "/home/alice",
+    });
+    defer allocator.free(linux);
+    const expected_linux = try std.fs.path.join(allocator, &.{ "/home/alice", ".ssh", "config" });
+    defer allocator.free(expected_linux);
+    try std.testing.expectEqualStrings(expected_linux, linux);
+
+    try std.testing.expectError(error.NoOpenSshConfigPath, openSshConfigPathFromEnvForOs(allocator, .linux, .{}));
+}
+```
+
+- [ ] **Step 2: Run the fast test and verify it fails**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL with an undeclared `openSshConfigPathFromEnvForOs` symbol.
+
+- [ ] **Step 3: Implement path helpers**
+
+In `src/platform/dirs.zig`, add these functions near `sshHostsPath()`:
+
+```zig
+pub fn openSshConfigPath(allocator: std.mem.Allocator) ![]const u8 {
+    const userprofile = envVarOwned(allocator, "USERPROFILE");
+    defer if (userprofile) |value| allocator.free(value);
+    const home = envVarOwned(allocator, "HOME");
+    defer if (home) |value| allocator.free(value);
+    return openSshConfigPathFromEnvForOs(allocator, builtin.os.tag, .{
+        .userprofile = userprofile,
+        .home = home,
+    });
+}
+
+pub fn openSshConfigPathFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    const base = switch (os_tag) {
+        .windows => nonEmpty(env.userprofile) orelse nonEmpty(env.home) orelse return error.NoOpenSshConfigPath,
+        else => nonEmpty(env.home) orelse return error.NoOpenSshConfigPath,
+    };
+    return std.fs.path.join(allocator, &.{ base, ".ssh", "config" });
+}
+```
+
+- [ ] **Step 4: Run the fast test and verify path helpers pass**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit path helper work**
+
+Run:
+
+```bash
+git add src/platform/dirs.zig
+git commit -m "feat: resolve openssh config path"
+```
+
+## Task 3: Add SSH Profile Import And New Session Row
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+
+- [ ] **Step 1: Add failing overlay tests for row mapping and password-preserving merge**
+
+Append these tests near the existing SSH list tests in `src/renderer/overlays.zig`:
+
+```zig
+test "overlays: SSH manage list includes Load OpenSSH config action" {
+    const saved_count = g_ssh_profile_count;
+    const saved_mode = g_ssh_list_mode;
+    defer {
+        g_ssh_profile_count = saved_count;
+        g_ssh_list_mode = saved_mode;
+    }
+
+    g_ssh_profile_count = 0;
+    g_ssh_list_mode = .manage;
+    try std.testing.expectEqual(@as(usize, 5), sshListRowCount());
+    try std.testing.expectEqual(SshManageAction.load_openssh_config, sshManageActionForRow(0, sshVisibleProfileCount()));
+    try std.testing.expectEqual(SshManageAction.new_ssh, sshManageActionForRow(1, sshVisibleProfileCount()));
+
+    g_ssh_profile_count = 1;
+    g_ssh_profiles[0] = makeSshProfile("GPU", "10.0.0.1", "user", "22");
+    try std.testing.expectEqual(@as(usize, 6), sshListRowCount());
+    try std.testing.expectEqual(SshManageAction.profile, sshManageActionForRow(0, sshVisibleProfileCount()));
+    try std.testing.expectEqual(SshManageAction.load_openssh_config, sshManageActionForRow(1, sshVisibleProfileCount()));
+}
+
+test "overlays: OpenSSH import merge preserves existing password" {
+    const saved_count = g_ssh_profile_count;
+    defer {
+        g_ssh_profile_count = saved_count;
+    }
+
+    g_ssh_profile_count = 1;
+    g_ssh_profiles[0] = makeSshProfile("lab", "old.example", "olduser", "22");
+    copySshProfileField(&g_ssh_profiles[0], .password, "secret");
+
+    var candidate = openssh_config_import.Candidate{};
+    opensshCandidateSetForTest(&candidate, .name, "lab");
+    opensshCandidateSetForTest(&candidate, .host, "new.example");
+    opensshCandidateSetForTest(&candidate, .user, "alice");
+    opensshCandidateSetForTest(&candidate, .port, "2222");
+    opensshCandidateSetForTest(&candidate, .proxy_jump, "jump.example");
+
+    var stats = OpenSshImportStats{};
+    mergeOpenSshCandidate(candidate, &stats);
+
+    try std.testing.expectEqual(@as(usize, 1), stats.updated);
+    try std.testing.expectEqualStrings("new.example", profileField(&g_ssh_profiles[0], .ip));
+    try std.testing.expectEqualStrings("alice", profileField(&g_ssh_profiles[0], .user));
+    try std.testing.expectEqualStrings("2222", profileField(&g_ssh_profiles[0], .port));
+    try std.testing.expectEqualStrings("jump.example", profileField(&g_ssh_profiles[0], .proxy_jump));
+    try std.testing.expectEqualStrings("secret", profileField(&g_ssh_profiles[0], .password));
+}
+```
+
+- [ ] **Step 2: Run the full test compile and verify it fails**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: FAIL with missing `SshManageAction`, `sshManageActionForRow`, `OpenSshImportStats`, `mergeOpenSshCandidate`, or `opensshCandidateSetForTest`.
+
+- [ ] **Step 3: Add imports, action enum values, and row mapping helper**
+
+In `src/renderer/overlays.zig`, add the parser import near `profile_codec`:
+
+```zig
+const openssh_config_import = @import("../openssh_config_import.zig");
+```
+
+Add `load_openssh_config` to `SessionAction`:
+
+```zig
+    load_openssh_config,
+```
+
+Add this helper near `sshListRowCount()`:
+
+```zig
+const SshManageAction = enum {
+    profile,
+    load_openssh_config,
+    new_ssh,
+    edit_ssh,
+    delete_ssh,
+    cancel,
+};
+
+fn sshManageActionForRow(row: usize, visible_profile_count: usize) SshManageAction {
+    if (row < visible_profile_count) return .profile;
+    return switch (row - visible_profile_count) {
+        0 => .load_openssh_config,
+        1 => .new_ssh,
+        2 => .edit_ssh,
+        3 => .delete_ssh,
+        else => .cancel,
+    };
+}
+```
+
+Change `sshListRowCount()` manage mode from `sshVisibleProfileCount() + 4` to:
+
+```zig
+        .manage => sshVisibleProfileCount() + 5,
+```
+
+- [ ] **Step 4: Route the new row from mouse and keyboard**
+
+Update `sessionLauncherExecuteAt()`:
+
+```zig
+        .load_openssh_config => loadOpenSshConfigDefault(),
+```
+
+Update the `g_ssh_list_visible` branch of `sessionHitTest()` to use `sshManageActionForRow()`:
+
+```zig
+        if (row < sshVisibleProfileCount()) return .connect_selected;
+        if (g_ssh_list_mode != .manage) return .connect_selected;
+        return switch (sshManageActionForRow(row, sshVisibleProfileCount())) {
+            .profile => .connect_selected,
+            .load_openssh_config => .load_openssh_config,
+            .new_ssh => .new_ssh,
+            .edit_ssh => .edit_selected,
+            .delete_ssh => .delete_selected,
+            .cancel => .cancel,
+        };
+```
+
+Update the `.manage` branch of `runSshListRow()`:
+
+```zig
+            switch (sshManageActionForRow(row, visible_profile_count)) {
+                .profile => {
+                    const profile_idx = sshVisibleProfileIndexAt(row) orelse return;
+                    connectSshProfile(profile_idx);
+                },
+                .load_openssh_config => loadOpenSshConfigDefault(),
+                .new_ssh => openSshFormNew(),
+                .edit_ssh => openSshEditPicker(),
+                .delete_ssh => openSshDeletePicker(),
+                .cancel => sessionLauncherClose(),
+            }
+```
+
+- [ ] **Step 5: Implement merge statistics and candidate merge**
+
+Add this code near `agentSaveSshProfile()`:
+
+```zig
+const OpenSshImportStats = struct {
+    created: usize = 0,
+    updated: usize = 0,
+    skipped: usize = 0,
+    capped: bool = false,
+};
+
+fn findLoadedSshProfileIndex(identifier_raw: []const u8) ?usize {
+    const identifier = std.mem.trim(u8, identifier_raw, " \t\r\n");
+    if (identifier.len == 0) return null;
+    for (0..g_ssh_profile_count) |idx| {
+        if (std.ascii.eqlIgnoreCase(identifier, profileField(&g_ssh_profiles[idx], .name))) return idx;
+    }
+    for (0..g_ssh_profile_count) |idx| {
+        if (std.ascii.eqlIgnoreCase(identifier, profileField(&g_ssh_profiles[idx], .ip))) return idx;
+    }
+    return null;
+}
+
+fn mergeOpenSshCandidate(candidate: openssh_config_import.Candidate, stats: *OpenSshImportStats) void {
+    const name = candidate.name();
+    const host = candidate.host();
+    const user = candidate.user();
+    const port = candidate.port();
+    const proxy_jump = candidate.proxyJump();
+    if (name.len == 0 or host.len == 0 or user.len == 0) {
+        stats.skipped += 1;
+        return;
+    }
+    if (!isSshTokenSafe(name) or !isSshTokenSafe(host) or !isSshTokenSafe(user)) {
+        stats.skipped += 1;
+        return;
+    }
+    if (!isPortTokenSafe(port) or !command_palette_model.isProxyJumpSafe(proxy_jump)) {
+        stats.skipped += 1;
+        return;
+    }
+
+    const found_idx = findLoadedSshProfileIndex(name) orelse findLoadedSshProfileIndex(host);
+    var created_new = false;
+    const idx = found_idx orelse blk: {
+        if (g_ssh_profile_count >= SSH_PROFILE_MAX) {
+            stats.capped = true;
+            return;
+        }
+        const next = g_ssh_profile_count;
+        g_ssh_profile_count += 1;
+        g_ssh_profiles[next] = .{};
+        created_new = true;
+        break :blk next;
+    };
+
+    if (idx >= g_ssh_profile_count) {
+        stats.skipped += 1;
+        return;
+    }
+
+    if (created_new) {
+        stats.created += 1;
+    } else {
+        stats.updated += 1;
+    }
+    const profile = &g_ssh_profiles[idx];
+    copySshProfileField(profile, .name, name);
+    copySshProfileField(profile, .ip, host);
+    copySshProfileField(profile, .user, user);
+    copySshProfileField(profile, .port, if (port.len > 0) port else "22");
+    copySshProfileField(profile, .proxy_jump, proxy_jump);
+}
+
+fn opensshCandidateSetForTest(candidate: *openssh_config_import.Candidate, comptime field: enum { name, host, user, port, proxy_jump }, value: []const u8) void {
+    const len = @min(value.len, openssh_config_import.FIELD_MAX);
+    switch (field) {
+        .name => {
+            @memcpy(candidate.name_buf[0..len], value[0..len]);
+            candidate.name_len = len;
+        },
+        .host => {
+            @memcpy(candidate.host_buf[0..len], value[0..len]);
+            candidate.host_len = len;
+        },
+        .user => {
+            @memcpy(candidate.user_buf[0..len], value[0..len]);
+            candidate.user_len = len;
+        },
+        .port => {
+            @memcpy(candidate.port_buf[0..len], value[0..len]);
+            candidate.port_len = len;
+        },
+        .proxy_jump => {
+            @memcpy(candidate.proxy_jump_buf[0..len], value[0..len]);
+            candidate.proxy_jump_len = len;
+        },
+    }
+}
+```
+
+- [ ] **Step 6: Implement default file import**
+
+Refactor the existing `saveSshProfiles()` body into a checked helper so the import command can avoid claiming persistence after a failed write:
+
+```zig
+fn saveSshProfiles(allocator: std.mem.Allocator) void {
+    _ = saveSshProfilesChecked(allocator);
+}
+
+fn saveSshProfilesChecked(allocator: std.mem.Allocator) bool {
+    const path = sshProfilesPath(allocator) catch return false;
+    defer allocator.free(path);
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.cwd().makePath(dir) catch return false;
+    }
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    out.appendSlice(allocator, "# WispTerm SSH profiles. Fields are hex encoded: name, host, user, password, port, proxy_jump.\n") catch return false;
+    for (g_ssh_profiles[0..g_ssh_profile_count]) |profile| {
+        for (0..SSH_FIELD_COUNT) |i| {
+            if (i > 0) out.append(allocator, '\t') catch return false;
+            appendHexField(allocator, &out, profile.fields[i][0..profile.lens[i]]) catch return false;
+        }
+        out.append(allocator, '\n') catch return false;
+    }
+
+    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
+    defer file.close();
+    file.writeAll(out.items) catch return false;
+    return true;
+}
+```
+
+Add this function near the SSH profile persistence functions:
+
+```zig
+fn loadOpenSshConfigDefault() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    loadSshProfiles();
+
+    const path = platform_dirs.openSshConfigPath(allocator) catch {
+        openSshList();
+        showStatusToast("OpenSSH config not found");
+        return;
+    };
+    defer allocator.free(path);
+
+    const content = std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch {
+        openSshList();
+        showStatusToast("OpenSSH config not found");
+        return;
+    };
+    defer allocator.free(content);
+
+    var candidates_buf: [64]openssh_config_import.Candidate = undefined;
+    const candidates = openssh_config_import.parseCandidates(content, &candidates_buf);
+    var stats = OpenSshImportStats{};
+    for (candidates) |candidate| mergeOpenSshCandidate(candidate, &stats);
+
+    var saved = true;
+    if (stats.created + stats.updated > 0) {
+        saved = saveSshProfilesChecked(allocator);
+    }
+    openSshList();
+
+    var msg_buf: [96]u8 = undefined;
+    const msg = if (stats.created + stats.updated == 0)
+        "No OpenSSH hosts imported"
+    else if (!saved)
+        std.fmt.bufPrint(&msg_buf, "Imported {d}, updated {d} SSH profiles (not saved)", .{ stats.created, stats.updated }) catch "Imported OpenSSH profiles (not saved)"
+    else
+        std.fmt.bufPrint(&msg_buf, "Imported {d}, updated {d} SSH profiles", .{ stats.created, stats.updated }) catch "Imported OpenSSH profiles";
+    showStatusToast(msg);
+}
+```
+
+- [ ] **Step 7: Render the import row in the SSH list**
+
+In `renderSessionLauncher()` under `g_ssh_list_visible` and `.manage`, render the new action before New/Edit/Delete:
+
+```zig
+                    renderSessionRow(layout, window_height, row, "Load OpenSSH config", "~/.ssh/config", g_ssh_list_selected == row);
+                    row += 1;
+                    renderSessionRow(layout, window_height, row, i18n.s().sl_new_ssh_server, i18n.s().sl_v_add, g_ssh_list_selected == row);
+```
+
+Update `sessionDesiredBoxWidth()` for `g_ssh_list_visible` manage mode so the new row participates in sizing:
+
+```zig
+                    desired = @max(desired, sessionTwoColumnWidth("Load OpenSSH config", "~/.ssh/config"));
+```
+
+- [ ] **Step 8: Update existing SSH list tests for the extra action row**
+
+In existing tests that expect `sshListRowCount()` in manage mode, update counts by one. For example:
+
+```zig
+try std.testing.expectEqual(@as(usize, 7), sshListRowCount());
+```
+
+for the test with two visible filtered profiles.
+
+- [ ] **Step 9: Run full tests and verify overlay behavior passes**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit overlay import work**
+
+Run:
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "feat: import openssh config into ssh profiles"
+```
+
+## Task 4: Add Command Center Entry, Localization, And Docs
+
+**Files:**
+- Modify: `src/command_center_state.zig`
+- Modify: `src/i18n.zig`
+- Modify: `docs/configuration.md`
+
+- [ ] **Step 1: Add failing command lookup test**
+
+In `src/command_center_state.zig`, add:
+
+```zig
+test "findCommandAction resolves Load OpenSSH Config" {
+    try std.testing.expectEqual(CommandAction.load_openssh_config, findCommandAction("Load OpenSSH Config"));
+}
+```
+
+- [ ] **Step 2: Run the fast test and verify it fails**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL with missing `CommandAction.load_openssh_config`.
+
+- [ ] **Step 3: Add the command action and static entry**
+
+In `src/command_center_state.zig`, add this enum member:
+
+```zig
+    load_openssh_config,
+```
+
+Add this `command_entries` item near `New Session`:
+
+```zig
+    .{ .title = "Load OpenSSH Config", .detail = "Import ~/.ssh/config into SSH profiles", .shortcut = "", .action = .load_openssh_config },
+```
+
+- [ ] **Step 4: Route command execution**
+
+In `src/renderer/overlays.zig`, update `executeCommand()`:
+
+```zig
+        .load_openssh_config => loadOpenSshConfigDefault(),
+```
+
+The function should leave the command palette by opening the SSH list through `openSshList()` after import.
+
+- [ ] **Step 5: Add i18n switch cases**
+
+In `src/i18n.zig`, update `commandTitle()`:
+
+```zig
+        .load_openssh_config => "导入 OpenSSH 配置",
+```
+
+Update `commandDetail()`:
+
+```zig
+        .load_openssh_config => "把 ~/.ssh/config 导入为 SSH profile",
+```
+
+- [ ] **Step 6: Document the new command**
+
+In `docs/configuration.md`, after the Settings page section, add:
+
+```markdown
+## OpenSSH config import
+
+Open the command center and run **Load OpenSSH Config** to import compatible
+entries from `~/.ssh/config` into WispTerm's SSH profiles. WispTerm imports
+`Host`, `HostName`, `User`, `Port`, and `ProxyJump`, skips wildcard host
+patterns, and does not import passwords.
+```
+
+- [ ] **Step 7: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit command and docs work**
+
+Run:
+
+```bash
+git add src/command_center_state.zig src/i18n.zig src/renderer/overlays.zig docs/configuration.md
+git commit -m "feat: expose openssh config import command"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Check final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: only intended files are committed or staged for final cleanup. Existing untracked `.claude/` remains untracked and is not committed.
+
+- [ ] **Step 2: Check whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Summarize implementation**
+
+Report:
+
+- Parser module added in `src/openssh_config_import.zig`.
+- Default path helper added in `src/platform/dirs.zig`.
+- Command Center command and first-run SSH list row added.
+- Import preserves existing saved passwords and never reads password data from OpenSSH config.
+- Verification command outputs.

--- a/docs/superpowers/specs/2026-06-05-openssh-config-import-design.md
+++ b/docs/superpowers/specs/2026-06-05-openssh-config-import-design.md
@@ -1,0 +1,131 @@
+# Design: Load OpenSSH Config Into SSH Profiles
+
+## Goal
+
+Make the first SSH setup faster by letting users import existing OpenSSH config
+entries into WispTerm's saved SSH profiles. The feature is available from the
+Command Center and from the New Session -> SSH flow when no WispTerm SSH
+profiles exist yet.
+
+## User Flow
+
+1. Open Command Center and run `Load OpenSSH Config`, or open New Session -> SSH
+   with an empty WispTerm SSH profile list and choose `Load OpenSSH config`.
+2. WispTerm reads the default OpenSSH config file for the current user:
+   `~/.ssh/config`.
+3. WispTerm imports compatible host blocks and returns to the SSH profile list.
+4. The user can select an imported profile to open a new SSH session, or edit it
+   before connecting.
+
+If no compatible entries are found, the SSH list stays open so the user can add
+a server manually.
+
+## Import Semantics
+
+WispTerm imports one profile per compatible `Host` alias.
+
+Imported fields:
+
+- `name`: the OpenSSH `Host` alias.
+- `host`: `HostName` when present, otherwise the alias.
+- `user`: `User`.
+- `port`: `Port`, defaulting to `22` when omitted.
+- `proxy_jump`: `ProxyJump` when present.
+
+Skipped entries:
+
+- `Host *`.
+- Any alias containing OpenSSH pattern characters (`*`, `?`, `[`, `]`).
+- Entries missing both a usable alias and host.
+- Entries missing `User`, because WispTerm's SSH profile form requires a user.
+- Entries whose host/user/port/proxy jump do not pass the existing WispTerm SSH
+  safety validators.
+
+Existing profile merge:
+
+- Match existing WispTerm profiles by profile name first, then by host.
+- Update name, host, user, port, and proxy jump.
+- Preserve the existing password unless the profile is newly created.
+- Do not import passwords; OpenSSH config does not store password auth.
+
+The profile cap remains the current `SSH_PROFILE_MAX` of 16. Import stops when
+the cap is reached.
+
+## UI Integration
+
+Command Center adds a searchable command:
+
+- Title: `Load OpenSSH Config`
+- Detail: `Import ~/.ssh/config into SSH profiles`
+
+New Session -> SSH changes:
+
+- In normal SSH manage mode, show `Load OpenSSH config` as an action row.
+- When the SSH profile list is empty, this row is still visible along with
+  `New SSH Server` and `Cancel`, giving first-time users a direct import path.
+- Activating the row imports and then reopens the SSH profile list.
+
+No new global keyboard shortcut is added.
+
+## Architecture
+
+OpenSSH parsing belongs in a small pure module, not in the renderer:
+
+- New module: `src/openssh_config_import.zig`
+- Responsibilities:
+  - Parse OpenSSH config text into import candidates.
+  - Apply only the supported keys: `Host`, `HostName`, `User`, `Port`,
+    `ProxyJump`.
+  - Ignore comments and blank lines.
+  - Handle multiple aliases on one `Host` line by producing one candidate per
+    compatible alias with the same block settings.
+
+The overlay remains responsible for persistence because it already owns
+`g_ssh_profiles`, `saveSshProfiles`, and the existing profile merge behavior.
+It will call the pure parser, merge candidates into `g_ssh_profiles`, save
+`ssh_hosts`, and return to the list UI.
+
+## Ghostty Reference
+
+Ghostty has `ghostty +ssh` and `ssh-cache`, but those are CLI conveniences for
+wrapping `ssh`, forwarding environment, installing terminfo, and caching
+terminfo installation state. Ghostty does not save GUI SSH profiles or import
+OpenSSH config into a launcher. WispTerm should therefore keep this feature in
+its Command Center / New Session profile layer, while preserving the existing
+Windows SSH/SCP rule: do not introduce OpenSSH connection sharing options.
+
+## Error Handling
+
+The import should be non-destructive:
+
+- Missing `~/.ssh/config`: keep the SSH list open.
+- Malformed or unsupported blocks: skip those entries.
+- Profile cap reached: import up to the cap and stop.
+- Save failure: keep in-memory imported rows for the current UI session if they
+  were added, but do not claim persistence.
+
+The UI should avoid printing or exposing secrets. This path does not read
+passwords.
+
+## Tests
+
+Add fast unit tests for the pure parser:
+
+- Parses a basic host with `HostName`, `User`, and `Port`.
+- Defaults `host` from alias and `port` to `22`.
+- Parses `ProxyJump`.
+- Splits multiple aliases and skips wildcard aliases.
+- Ignores comments and blank lines.
+- Skips candidates without `User`.
+
+Add overlay-level tests where practical:
+
+- Empty SSH list row count includes `Load OpenSSH config`.
+- SSH manage row mapping activates the import action row.
+- Merge preserves an existing password when updating an existing profile.
+
+Full verification before finishing:
+
+- `git diff --check`
+- `zig build test`
+- `zig build test-full`

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1393,14 +1393,13 @@ pub fn leftPanelsWidth() f32 {
 }
 
 pub fn aiCopilotVisible() bool {
-    return ai_sidebar.g_visible and isActiveTabTerminal();
+    return tab.activeCopilotVisible();
 }
 
-/// Hide the copilot panel if visible (used by the right-slot arbiter when
-/// another right panel opens). No-op if already hidden.
+/// Hide the active tab's copilot panel if visible (used by the right-slot
+/// arbiter when another right panel opens). No-op if already hidden.
 pub fn hideAiCopilot() void {
-    if (!ai_sidebar.g_visible) return;
-    ai_sidebar.hide();
+    if (!tab.setActiveCopilotVisible(false)) return;
     input.blurAiCopilot();
     g_force_rebuild = true;
     g_cells_valid = false;
@@ -1470,8 +1469,8 @@ pub fn appendDroppedPathToChatAtPoint(text: []const u8, x: i32, y: i32) bool {
 
 pub fn toggleAiCopilot() void {
     if (!isActiveTabTerminal()) return; // copilot is terminal-only
-    if (ai_sidebar.g_visible) {
-        ai_sidebar.hide();
+    if (tab.activeCopilotVisible()) {
+        _ = tab.setActiveCopilotVisible(false);
         input.blurAiCopilot();
         g_force_rebuild = true;
         g_cells_valid = false;
@@ -1480,7 +1479,7 @@ pub fn toggleAiCopilot() void {
     // Exclusive right slot: close the other right panels first.
     browser_panel.close();
     markdown_preview_panel.close();
-    ai_sidebar.show();
+    _ = tab.setActiveCopilotVisible(true);
     _ = ensureActiveCopilotSession();
     input.focusAiCopilot();
     g_force_rebuild = true;
@@ -1621,6 +1620,7 @@ fn clearUiStateOnTabChange() void {
     input.g_markdown_preview_resize_dragging = false;
     input.g_browser_resize_hover = false;
     input.g_browser_resize_dragging = false;
+    input.blurAiCopilot();
     browser_panel.blurUrlBar();
     input.g_divider_dragging = false;
     input.g_divider_drag_handle = null;

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -173,9 +173,16 @@ pub const Focus = enum(u8) {
 const FILTER_BUCKET_CAP: usize = 256;
 /// Combined-filter cursor layout: category rows first, then "All dates", then
 /// individual days.
-pub const FILTER_CATEGORY_ROWS: usize = @typeInfo(types.CategoryFilter).@"enum".fields.len;
+pub const FILTER_CATEGORY_ROWS: usize = types.CATEGORY_ORDER.len;
 pub const FILTER_ALL_DATES_ROW: usize = FILTER_CATEGORY_ROWS;
 pub const FILTER_DAY_BASE: usize = FILTER_ALL_DATES_ROW + 1;
+
+fn categoryOrderIndex(category: types.CategoryFilter) usize {
+    for (types.CATEGORY_ORDER, 0..) |candidate, i| {
+        if (candidate == category) return i;
+    }
+    return 0;
+}
 
 pub const Session = struct {
     /// Allocator used for row storage. Do not change while rows are live.
@@ -619,7 +626,7 @@ pub const Session = struct {
 
     pub fn rowVisible(self: *const Session, row: types.SessionMeta, query: []const u8) bool {
         const key = types.dateKeyFromMs(row.last_active_at_ms, self.tz_offset_seconds);
-        return types.categoryMatches(self.category, row.provider) and
+        return types.categoryMatchesMeta(self.category, row) and
             types.dateMatches(self.date_filter, key) and
             types.metadataMatches(row, query);
     }
@@ -684,9 +691,9 @@ pub const Session = struct {
 
     pub fn cycleCategory(self: *Session, delta: isize) void {
         const count: isize = @intCast(FILTER_CATEGORY_ROWS);
-        const cur: isize = @intFromEnum(self.category);
+        const cur: isize = @intCast(categoryOrderIndex(self.category));
         const next: usize = @intCast(@mod(cur + delta, count));
-        self.setCategory(@enumFromInt(next));
+        self.setCategory(types.CATEGORY_ORDER[next]);
     }
 
     pub fn setDateFilter(self: *Session, filter: ?types.DateKey) void {
@@ -705,23 +712,22 @@ pub const Session = struct {
         }
     }
 
-    pub fn categoryCounts(self: *const Session, query: []const u8) struct { all: usize, codex: usize, claude: usize, reasonix: usize } {
-        var all: usize = 0;
-        var codex: usize = 0;
-        var claude: usize = 0;
-        var reasonix: usize = 0;
+    pub fn categoryCounts(self: *const Session, query: []const u8) types.CategoryCounts {
+        var counts: types.CategoryCounts = .{};
         for (self.rows.items) |row| {
             if (!types.metadataMatches(row, query)) continue;
             const key = types.dateKeyFromMs(row.last_active_at_ms, self.tz_offset_seconds);
             if (!types.dateMatches(self.date_filter, key)) continue;
-            all += 1;
-            switch (row.provider) {
-                .codex => codex += 1,
-                .claude => claude += 1,
-                .reasonix => reasonix += 1,
+            counts.all += 1;
+            if (types.isSubagentSession(row)) {
+                counts.subagent += 1;
+            } else switch (row.provider) {
+                .codex => counts.codex += 1,
+                .claude => counts.claude += 1,
+                .reasonix => counts.reasonix += 1,
             }
         }
-        return .{ .all = all, .codex = codex, .claude = claude, .reasonix = reasonix };
+        return counts;
     }
 
     /// Fill `buf` with the distinct local days present under the current
@@ -734,7 +740,7 @@ pub const Session = struct {
         var n: usize = 0;
         var have_last = false;
         for (self.rows.items) |row| {
-            if (!types.categoryMatches(self.category, row.provider)) continue;
+            if (!types.categoryMatchesMeta(self.category, row)) continue;
             if (!types.metadataMatches(row, query)) continue;
             const key = types.dateKeyFromMs(row.last_active_at_ms, self.tz_offset_seconds);
             if (key == 0) continue; // no timestamp -> only under "All dates"
@@ -757,7 +763,7 @@ pub const Session = struct {
         const query = self.filter[0..self.filter_len];
         var count: usize = 0;
         for (self.rows.items) |row| {
-            if (!types.categoryMatches(self.category, row.provider)) continue;
+            if (!types.categoryMatchesMeta(self.category, row)) continue;
             if (!types.metadataMatches(row, query)) continue;
             count += 1;
         }
@@ -817,7 +823,7 @@ pub const Session = struct {
     fn applyFilterCursorLocked(self: *Session, buckets: []const types.DateBucket) void {
         const c = self.filter_cursor;
         if (c < FILTER_CATEGORY_ROWS) {
-            self.setCategory(@enumFromInt(c));
+            self.setCategory(types.CATEGORY_ORDER[c]);
         } else if (c == FILTER_ALL_DATES_ROW) {
             self.setDateFilter(null);
         } else {
@@ -2704,18 +2710,21 @@ test "ai_history_session: categoryCounts splits by provider and respects query" 
         .{ .provider = .codex, .session_id = "a", .title = "Renderer fix", .source_path = "a.jsonl", .resume_kind = .codex_resume },
         .{ .provider = .codex, .session_id = "b", .title = "Docs", .source_path = "b.jsonl", .resume_kind = .codex_resume },
         .{ .provider = .claude, .session_id = "c", .title = "Renderer test", .source_path = "c.jsonl", .resume_kind = .claude_resume },
+        .{ .provider = .claude, .session_id = "d", .title = "You are implementing Task 3", .source_path = "d.jsonl", .resume_kind = .claude_resume },
     };
     try session.replaceRows(&rows);
 
     const counts = session.categoryCounts("");
-    try std.testing.expectEqual(@as(usize, 3), counts.all);
+    try std.testing.expectEqual(@as(usize, 4), counts.all);
     try std.testing.expectEqual(@as(usize, 2), counts.codex);
     try std.testing.expectEqual(@as(usize, 1), counts.claude);
+    try std.testing.expectEqual(@as(usize, 1), counts.subagent);
 
     const filtered = session.categoryCounts("renderer");
     try std.testing.expectEqual(@as(usize, 2), filtered.all);
     try std.testing.expectEqual(@as(usize, 1), filtered.codex);
     try std.testing.expectEqual(@as(usize, 1), filtered.claude);
+    try std.testing.expectEqual(@as(usize, 0), filtered.subagent);
 }
 
 test "ai_history_session: setCategory resets selection" {
@@ -2748,9 +2757,30 @@ test "ai_history_session: cycleCategory wraps forward and backward" {
     session.cycleCategory(1);
     try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
     session.cycleCategory(1);
+    try std.testing.expectEqual(types.CategoryFilter.subagent, session.category);
+    session.cycleCategory(1);
     try std.testing.expectEqual(types.CategoryFilter.all, session.category);
     session.cycleCategory(-1);
-    try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
+    try std.testing.expectEqual(types.CategoryFilter.subagent, session.category);
+}
+
+test "ai_history_session: subagent category separates You are sessions from provider category" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{
+        .{ .provider = .claude, .session_id = "regular", .title = "Review panel behavior", .source_path = "a.jsonl", .resume_kind = .claude_resume },
+        .{ .provider = .claude, .session_id = "subagent", .title = "You are implementing Task 3", .source_path = "b.jsonl", .resume_kind = .claude_resume },
+    };
+    try session.replaceRows(&rows);
+
+    session.setCategory(.claude);
+    try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
+    try std.testing.expectEqualStrings("regular", (session.selectedVisible() orelse return error.ExpectedSelection).session_id);
+
+    session.setCategory(.subagent);
+    try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
+    try std.testing.expectEqualStrings("subagent", (session.selectedVisible() orelse return error.ExpectedSelection).session_id);
 }
 
 test "ai_history_session: finishScan applies rows when generation current" {
@@ -3049,8 +3079,8 @@ test "ai_history_session: moveFilterCursor walks categories then dates, applying
     };
     try session.replaceRows(&rows);
 
-    // Combined list: All, Codex, Claude, Reasonix, All dates, 20260602, 20260601 => 7 rows.
-    try std.testing.expectEqual(@as(usize, 7), session.filterRowCount());
+    // Combined list: All, Codex, Claude, Reasonix, Subagent, All dates, 20260602, 20260601 => 8 rows.
+    try std.testing.expectEqual(@as(usize, 8), session.filterRowCount());
     try std.testing.expectEqual(types.CategoryFilter.all, session.category);
 
     session.moveFilterCursor(1); // -> Codex
@@ -3059,8 +3089,10 @@ test "ai_history_session: moveFilterCursor walks categories then dates, applying
     try std.testing.expectEqual(types.CategoryFilter.claude, session.category);
     session.moveFilterCursor(1); // -> Reasonix
     try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
+    session.moveFilterCursor(1); // -> Subagent
+    try std.testing.expectEqual(types.CategoryFilter.subagent, session.category);
     session.moveFilterCursor(1); // -> All dates (date filter cleared, category kept)
-    try std.testing.expectEqual(types.CategoryFilter.reasonix, session.category);
+    try std.testing.expectEqual(types.CategoryFilter.subagent, session.category);
     try std.testing.expectEqual(@as(?types.DateKey, null), session.date_filter);
 
     // Reset category so both days are present, then step onto a specific day.

--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -19,6 +19,17 @@ pub const CategoryFilter = enum {
     codex,
     claude,
     reasonix,
+    subagent,
+};
+
+pub const CATEGORY_ORDER = [_]CategoryFilter{ .all, .codex, .claude, .reasonix, .subagent };
+
+pub const CategoryCounts = struct {
+    all: usize = 0,
+    codex: usize = 0,
+    claude: usize = 0,
+    reasonix: usize = 0,
+    subagent: usize = 0,
 };
 
 pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
@@ -27,6 +38,23 @@ pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
         .codex => provider == .codex,
         .claude => provider == .claude,
         .reasonix => provider == .reasonix,
+        .subagent => false,
+    };
+}
+
+pub fn isSubagentSession(meta: SessionMeta) bool {
+    const title = std.mem.trimLeft(u8, meta.title, " \t\r\n");
+    return std.mem.startsWith(u8, title, "You are");
+}
+
+pub fn categoryMatchesMeta(category: CategoryFilter, meta: SessionMeta) bool {
+    const subagent = isSubagentSession(meta);
+    return switch (category) {
+        .all => true,
+        .codex => meta.provider == .codex and !subagent,
+        .claude => meta.provider == .claude and !subagent,
+        .reasonix => meta.provider == .reasonix and !subagent,
+        .subagent => subagent,
     };
 }
 
@@ -36,6 +64,17 @@ pub fn categoryLabel(category: CategoryFilter) []const u8 {
         .codex => "Codex",
         .claude => "Claude Code",
         .reasonix => "Reasonix",
+        .subagent => "Subagent",
+    };
+}
+
+pub fn categoryCount(counts: CategoryCounts, category: CategoryFilter) usize {
+    return switch (category) {
+        .all => counts.all,
+        .codex => counts.codex,
+        .claude => counts.claude,
+        .reasonix => counts.reasonix,
+        .subagent => counts.subagent,
     };
 }
 
@@ -206,11 +245,36 @@ test "ai_history_types: categoryMatches respects provider" {
     try std.testing.expect(!categoryMatches(.reasonix, .codex));
 }
 
+test "ai_history_types: You are titles are classified as subagent metadata" {
+    const subagent: SessionMeta = .{
+        .provider = .claude,
+        .session_id = "subagent",
+        .title = "  You are implementing Task 3 of the plan",
+        .source_path = "subagent.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    const normal: SessionMeta = .{
+        .provider = .claude,
+        .session_id = "normal",
+        .title = "Fix renderer panel",
+        .source_path = "normal.jsonl",
+        .resume_kind = .claude_resume,
+    };
+
+    try std.testing.expect(isSubagentSession(subagent));
+    try std.testing.expect(categoryMatchesMeta(.subagent, subagent));
+    try std.testing.expect(!categoryMatchesMeta(.claude, subagent));
+    try std.testing.expect(!isSubagentSession(normal));
+    try std.testing.expect(categoryMatchesMeta(.claude, normal));
+    try std.testing.expect(!categoryMatchesMeta(.subagent, normal));
+}
+
 test "ai_history_types: categoryLabel is stable" {
     try std.testing.expectEqualStrings("All", categoryLabel(.all));
     try std.testing.expectEqualStrings("Codex", categoryLabel(.codex));
     try std.testing.expectEqualStrings("Claude Code", categoryLabel(.claude));
     try std.testing.expectEqualStrings("Reasonix", categoryLabel(.reasonix));
+    try std.testing.expectEqualStrings("Subagent", categoryLabel(.subagent));
 }
 
 test "ai_history_types: dateKeyFromMs packs local civil date and handles sentinels" {

--- a/src/ai_sidebar.zig
+++ b/src/ai_sidebar.zig
@@ -1,9 +1,11 @@
 //! State and layout math for the right-side AI copilot sidebar.
 //!
-//! Mirrors browser_panel's right-dock width model, but the conversation lives
-//! per-tab in TabState.copilot_session — this module owns only visibility and
-//! width. Kept free of tab/AppWindow imports so the math runs in the fast test
-//! suite; the "only on terminal tabs" gate is applied by the caller (AppWindow).
+//! Mirrors browser_panel's right-dock width model, but per-tab UI state lives
+//! in TabState: `copilot_session` stores the conversation and `copilot_visible`
+//! stores whether that tab's panel is open. This module owns only shared width
+//! and layout math. Kept free of tab/AppWindow imports so the math runs in the
+//! fast test suite; visibility and the "only on terminal tabs" gate are applied
+//! by the caller (AppWindow).
 
 const std = @import("std");
 
@@ -20,8 +22,6 @@ pub const Bounds = struct {
     bottom: i32,
 };
 
-/// Global visibility flag (the active terminal tab's session is what renders).
-pub threadlocal var g_visible: bool = false;
 /// Shared width across tabs; not persisted across restarts (design decision).
 pub threadlocal var g_width: f32 = DEFAULT_WIDTH;
 
@@ -41,10 +41,9 @@ pub fn setWidth(w: f32, window_width: f32) bool {
 /// Width the panel should occupy for a given window, leaving MIN_CONTENT_WIDTH
 /// for the terminal. PURE MATH — does NOT check visibility. Callers MUST gate
 /// on visibility themselves; the only supported caller is AppWindow, which
-/// checks `aiCopilotVisible()` (g_visible AND active tab is a terminal) before
-/// using this result. The terminal-tab half of that gate cannot live here
-/// because this module deliberately avoids importing `tab`/`AppWindow` so it
-/// stays in the fast test suite.
+/// checks `aiCopilotVisible()` before using this result. The visibility gate
+/// cannot live here because this module deliberately avoids importing
+/// `tab`/`AppWindow` so it stays in the fast test suite.
 pub fn panelWidthForWindow(window_width: i32, left_offset: f32, right_offset: f32) f32 {
     const win_w: f32 = @floatFromInt(window_width);
     const max_width = @max(MIN_WIDTH, @min(MAX_WIDTH, win_w - left_offset - right_offset - MIN_CONTENT_WIDTH));
@@ -67,18 +66,6 @@ pub fn boundsForWindow(window_width: i32, window_height: i32, titlebar_height: f
         .right = @intFromFloat(@round(right)),
         .bottom = @intFromFloat(@round(bottom)),
     };
-}
-
-pub fn show() void {
-    g_visible = true;
-}
-
-pub fn hide() void {
-    g_visible = false;
-}
-
-pub fn toggle() void {
-    g_visible = !g_visible;
 }
 
 test "panelWidthForWindow clamps to g_width when it fits" {
@@ -130,12 +117,4 @@ test "boundsForWindow respects left_offset and right_offset" {
     const b = boundsForWindow(1600, 900, 30, 200, 100);
     try std.testing.expectEqual(@as(i32, 1500), b.right); // 1600 - 100
     try std.testing.expectEqual(@as(i32, 1020), b.left); // 1500 - 480
-}
-
-test "toggle flips visibility" {
-    g_visible = false;
-    toggle();
-    try std.testing.expect(g_visible);
-    toggle();
-    try std.testing.expect(!g_visible);
 }

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -52,6 +52,10 @@ pub const TabState = struct {
     /// `ai_chat_session`, which backs a dedicated AI-chat tab. Lazily created
     /// the first time the copilot sidebar is opened on this tab.
     copilot_session: ?*ai_chat.Session = null,
+    /// Whether this terminal tab's right-side Copilot sidebar is currently
+    /// open. The session is also per-tab; this flag prevents a Copilot opened
+    /// on one tab from appearing on another tab.
+    copilot_visible: bool = false,
 
     pub const Kind = enum {
         terminal,
@@ -217,6 +221,26 @@ pub fn activeCopilotSession(
     return t.copilot_session;
 }
 
+pub fn activeCopilotVisible() bool {
+    const t = activeTab() orelse return false;
+    return t.kind == .terminal and t.copilot_visible;
+}
+
+pub fn setActiveCopilotVisible(visible: bool) bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    if (t.copilot_visible == visible) return false;
+    t.copilot_visible = visible;
+    return true;
+}
+
+pub fn toggleActiveCopilotVisible() bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    t.copilot_visible = !t.copilot_visible;
+    return t.copilot_visible;
+}
+
 pub fn findAiTabBySessionId(session_id: []const u8) ?usize {
     for (0..g_tab_count) |idx| {
         const t = g_tabs[idx] orelse continue;
@@ -347,6 +371,7 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
     t.ai_chat_session = null;
     t.ai_history_session = null;
     t.copilot_session = null;
+    t.copilot_visible = false;
 
     g_tabs[g_tab_count] = t;
     active_tab_state.g_active_tab = g_tab_count;
@@ -403,6 +428,7 @@ pub fn spawnAiChatTab(
     t.ai_chat_session = session;
     t.ai_history_session = null;
     t.copilot_session = null;
+    t.copilot_visible = false;
 
     g_tabs[g_tab_count] = t;
     active_tab_state.g_active_tab = g_tab_count;
@@ -432,6 +458,7 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
     t.ai_chat_session = session;
     t.ai_history_session = null;
     t.copilot_session = null;
+    t.copilot_visible = false;
 
     g_tabs[g_tab_count] = t;
     active_tab_state.g_active_tab = g_tab_count;
@@ -460,6 +487,7 @@ pub fn spawnAiHistoryTab(allocator: std.mem.Allocator, source: ai_history_source
     t.focused = .root;
     t.ai_chat_session = null;
     t.copilot_session = null;
+    t.copilot_visible = false;
     t.ai_history_session = session_ptr;
 
     g_tabs[g_tab_count] = t;
@@ -1348,6 +1376,7 @@ pub fn restoreTab(
     t.ai_chat_session = null;
     t.ai_history_session = null;
     t.copilot_session = null;
+    t.copilot_visible = false;
     applyRestoredTabMetadata(t, snap);
 
     g_tabs[g_tab_count] = t;
@@ -1595,6 +1624,47 @@ test "tab: restoreTab skips an ai_history tab when no restore hook is installed"
     };
     try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
     try std.testing.expectEqual(@as(usize, 0), g_tab_count);
+}
+
+test "tab: copilot visibility is scoped to the active terminal tab" {
+    resetTestTabGlobals();
+
+    var first = TabState{
+        .kind = .terminal,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = null,
+        .copilot_session = null,
+    };
+    var second = TabState{
+        .kind = .terminal,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = null,
+        .copilot_session = null,
+    };
+
+    g_tabs[0] = &first;
+    g_tabs[1] = &second;
+    g_tab_count = 2;
+
+    active_tab_state.g_active_tab = 0;
+    try std.testing.expect(!activeCopilotVisible());
+    try std.testing.expect(toggleActiveCopilotVisible());
+    try std.testing.expect(activeCopilotVisible());
+
+    active_tab_state.g_active_tab = 1;
+    try std.testing.expect(!activeCopilotVisible());
+    try std.testing.expect(!second.copilot_visible);
+    try std.testing.expect(!setActiveCopilotVisible(false));
+    try std.testing.expect(setActiveCopilotVisible(true));
+    try std.testing.expect(activeCopilotVisible());
+
+    active_tab_state.g_active_tab = 0;
+    try std.testing.expect(activeCopilotVisible());
+    try std.testing.expect(first.copilot_visible);
 }
 
 test "tab: snapshotTab persists focused surface title override" {

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 
 pub const CommandAction = enum {
     new_tab,
+    load_openssh_config,
     new_agent,
     manage_ai_profiles,
     select_agent_history,
@@ -51,6 +52,7 @@ pub const CommandEntry = struct {
 
 pub const command_entries = [_]CommandEntry{
     .{ .title = "New Session", .detail = platform_pty_command.session_launcher_detail, .shortcut = "", .action = .new_tab },
+    .{ .title = "Load OpenSSH Config", .detail = "Import ~/.ssh/config into SSH profiles", .shortcut = "", .action = .load_openssh_config },
     .{ .title = "New Copilot", .detail = "Open a new Copilot tab with the default AI config", .shortcut = "", .action = .new_agent },
     .{ .title = "Manage AI Profiles", .detail = "Create, edit, or delete saved AI profiles", .shortcut = "", .action = .manage_ai_profiles },
     .{ .title = "Select Copilot History", .detail = "Open the command-center Copilot history picker", .shortcut = "", .action = .select_agent_history },
@@ -280,6 +282,10 @@ test "findCommandAction resolves What's New" {
 
 test "findCommandAction resolves Open Jupyter" {
     try std.testing.expectEqual(CommandAction.open_jupyter_panel, findCommandAction("Open Jupyter"));
+}
+
+test "findCommandAction resolves Load OpenSSH Config" {
+    try std.testing.expectEqual(CommandAction.load_openssh_config, findCommandAction("Load OpenSSH Config"));
 }
 
 test "command center includes Copilot Markdown export actions" {

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -534,6 +534,7 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
     if (active_lang != .zh_CN) return null;
     return switch (action) {
         .new_tab => "新建会话",
+        .load_openssh_config => "导入 OpenSSH 配置",
         .new_agent => "新建副驾",
         .manage_ai_profiles => "管理 AI 配置",
         .select_agent_history => "选择副驾历史",
@@ -580,6 +581,7 @@ pub fn commandDetail(action: CommandAction) ?[]const u8 {
     if (active_lang != .zh_CN) return null;
     return switch (action) {
         .new_tab => "选择 Shell、SSH、WSL、副驾 或 会话",
+        .load_openssh_config => "把 ~/.ssh/config 导入为 SSH profile",
         .new_agent => "用默认 AI 配置打开一个新的副驾标签页",
         .manage_ai_profiles => "创建、编辑或删除已保存的 AI 配置",
         .select_agent_history => "打开命令中心的副驾历史选择器",

--- a/src/openssh_config_import.zig
+++ b/src/openssh_config_import.zig
@@ -40,9 +40,13 @@ const PendingBlock = struct {
     aliases: [MAX_ALIASES_PER_HOST][]const u8 = undefined,
     alias_count: usize = 0,
     host: []const u8 = "",
+    has_host: bool = false,
     user: []const u8 = "",
+    has_user: bool = false,
     port: []const u8 = "",
+    has_port: bool = false,
     proxy_jump: []const u8 = "",
+    has_proxy_jump: bool = false,
 
     fn addAlias(self: *PendingBlock, alias: []const u8) void {
         if (self.alias_count >= MAX_ALIASES_PER_HOST) return;
@@ -81,14 +85,18 @@ pub fn parseCandidates(config: []const u8, out: []Candidate) []Candidate {
 
         if (!have_block) continue;
 
-        if (std.ascii.eqlIgnoreCase(key_value.key, "HostName")) {
+        if (std.ascii.eqlIgnoreCase(key_value.key, "HostName") and !pending.has_host) {
             pending.host = key_value.value;
-        } else if (std.ascii.eqlIgnoreCase(key_value.key, "User")) {
+            pending.has_host = true;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "User") and !pending.has_user) {
             pending.user = key_value.value;
-        } else if (std.ascii.eqlIgnoreCase(key_value.key, "Port")) {
+            pending.has_user = true;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "Port") and !pending.has_port) {
             pending.port = key_value.value;
-        } else if (std.ascii.eqlIgnoreCase(key_value.key, "ProxyJump")) {
+            pending.has_port = true;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "ProxyJump") and !pending.has_proxy_jump) {
             pending.proxy_jump = key_value.value;
+            pending.has_proxy_jump = true;
         }
     }
 
@@ -102,8 +110,11 @@ const KeyValue = struct {
 };
 
 fn stripComment(line: []const u8) []const u8 {
-    const comment_idx = std.mem.indexOfScalar(u8, line, '#') orelse return line;
-    return line[0..comment_idx];
+    for (line, 0..) |ch, idx| {
+        if (ch != '#') continue;
+        if (idx == 0 or isConfigWhitespace(line[idx - 1])) return line[0..idx];
+    }
+    return line;
 }
 
 fn trimLine(line: []const u8) []const u8 {
@@ -113,7 +124,7 @@ fn trimLine(line: []const u8) []const u8 {
 fn splitKeyValue(line: []const u8) KeyValue {
     const sep_idx = firstSeparator(line) orelse return .{ .key = line, .value = "" };
     const key = trimLine(line[0..sep_idx]);
-    const value_start = if (line[sep_idx] == '=') sep_idx + 1 else skipWhitespace(line, sep_idx);
+    const value_start = valueStart(line, sep_idx);
     return .{
         .key = key,
         .value = trimLine(line[value_start..]),
@@ -122,19 +133,35 @@ fn splitKeyValue(line: []const u8) KeyValue {
 
 fn firstSeparator(line: []const u8) ?usize {
     for (line, 0..) |ch, idx| {
-        if (ch == ' ' or ch == '\t' or ch == '=') return idx;
+        if (isConfigWhitespace(ch) or ch == '=') return idx;
     }
     return null;
 }
 
+fn valueStart(line: []const u8, sep_idx: usize) usize {
+    var idx = sep_idx;
+    if (idx < line.len and line[idx] == '=') {
+        idx += 1;
+    } else {
+        idx = skipWhitespace(line, idx);
+        if (idx < line.len and line[idx] == '=') idx += 1;
+    }
+    return skipWhitespace(line, idx);
+}
+
 fn skipWhitespace(line: []const u8, start: usize) usize {
     var idx = start;
-    while (idx < line.len and (line[idx] == ' ' or line[idx] == '\t')) : (idx += 1) {}
+    while (idx < line.len and isConfigWhitespace(line[idx])) : (idx += 1) {}
     return idx;
+}
+
+fn isConfigWhitespace(ch: u8) bool {
+    return ch == ' ' or ch == '\t' or ch == '\r';
 }
 
 fn compatibleAlias(alias: []const u8) bool {
     if (alias.len == 0 or alias.len > FIELD_MAX) return false;
+    if (alias[0] == '!') return false;
     for (alias) |ch| {
         if (ch == '*' or ch == '?' or ch == '[' or ch == ']') return false;
     }
@@ -194,6 +221,25 @@ test "openssh config import: parses a basic host block" {
     try std.testing.expectEqualStrings("2222", rows[0].port());
 }
 
+test "openssh config import: parses optional equals separators" {
+    const config =
+        \\Host = lab
+        \\  HostName = 192.0.2.10
+        \\  User = alice
+        \\  Port = 2222
+        \\  ProxyJump = jumpuser@bastion:22
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("lab", rows[0].name());
+    try std.testing.expectEqualStrings("192.0.2.10", rows[0].host());
+    try std.testing.expectEqualStrings("alice", rows[0].user());
+    try std.testing.expectEqualStrings("2222", rows[0].port());
+    try std.testing.expectEqualStrings("jumpuser@bastion:22", rows[0].proxyJump());
+}
+
 test "openssh config import: defaults host from alias and port to 22" {
     const config =
         \\Host staging
@@ -237,6 +283,55 @@ test "openssh config import: splits aliases and skips wildcard aliases" {
     try std.testing.expectEqualStrings("gpu-lab", rows[1].name());
     try std.testing.expectEqualStrings("gpu.example", rows[1].host());
     try std.testing.expectEqualStrings("xzg", rows[1].user());
+}
+
+test "openssh config import: skips negated host patterns" {
+    const config =
+        \\Host !prod prod prod-* !backup
+        \\  HostName prod.example
+        \\  User deploy
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("prod", rows[0].name());
+    try std.testing.expectEqualStrings("prod.example", rows[0].host());
+}
+
+test "openssh config import: keeps hash inside tokens" {
+    const config =
+        \\Host hashy
+        \\  HostName hashy.example
+        \\  User alice#x # trailing comment
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("alice#x", rows[0].user());
+}
+
+test "openssh config import: repeated directives keep first value" {
+    const config =
+        \\Host repeat
+        \\  HostName first.example
+        \\  HostName second.example
+        \\  User alice
+        \\  User root
+        \\  Port 2222
+        \\  Port 22
+        \\  ProxyJump jump1
+        \\  ProxyJump jump2
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("first.example", rows[0].host());
+    try std.testing.expectEqualStrings("alice", rows[0].user());
+    try std.testing.expectEqualStrings("2222", rows[0].port());
+    try std.testing.expectEqualStrings("jump1", rows[0].proxyJump());
 }
 
 test "openssh config import: ignores comments blank lines and unsupported blocks" {

--- a/src/openssh_config_import.zig
+++ b/src/openssh_config_import.zig
@@ -223,15 +223,20 @@ test "openssh config import: parses proxy jump" {
 
 test "openssh config import: splits aliases and skips wildcard aliases" {
     const config =
-        \\Host gpu gpu-* ?bad [group] *
+        \\Host gpu gpu-lab gpu-* ?bad [group] *
         \\  HostName gpu.example
         \\  User xzg
         \\
     ;
     var out: [8]Candidate = undefined;
     const rows = parseCandidates(config, &out);
-    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
     try std.testing.expectEqualStrings("gpu", rows[0].name());
+    try std.testing.expectEqualStrings("gpu.example", rows[0].host());
+    try std.testing.expectEqualStrings("xzg", rows[0].user());
+    try std.testing.expectEqualStrings("gpu-lab", rows[1].name());
+    try std.testing.expectEqualStrings("gpu.example", rows[1].host());
+    try std.testing.expectEqualStrings("xzg", rows[1].user());
 }
 
 test "openssh config import: ignores comments blank lines and unsupported blocks" {

--- a/src/openssh_config_import.zig
+++ b/src/openssh_config_import.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+
+pub const FIELD_MAX: usize = 128;
+pub const MAX_ALIASES_PER_HOST: usize = 16;
+
+pub const Candidate = struct {
+    name_buf: [FIELD_MAX]u8 = undefined,
+    name_len: usize = 0,
+    host_buf: [FIELD_MAX]u8 = undefined,
+    host_len: usize = 0,
+    user_buf: [FIELD_MAX]u8 = undefined,
+    user_len: usize = 0,
+    port_buf: [FIELD_MAX]u8 = undefined,
+    port_len: usize = 0,
+    proxy_jump_buf: [FIELD_MAX]u8 = undefined,
+    proxy_jump_len: usize = 0,
+
+    pub fn name(self: *const Candidate) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+
+    pub fn host(self: *const Candidate) []const u8 {
+        return self.host_buf[0..self.host_len];
+    }
+
+    pub fn user(self: *const Candidate) []const u8 {
+        return self.user_buf[0..self.user_len];
+    }
+
+    pub fn port(self: *const Candidate) []const u8 {
+        return self.port_buf[0..self.port_len];
+    }
+
+    pub fn proxyJump(self: *const Candidate) []const u8 {
+        return self.proxy_jump_buf[0..self.proxy_jump_len];
+    }
+};
+
+const PendingBlock = struct {
+    aliases: [MAX_ALIASES_PER_HOST][]const u8 = undefined,
+    alias_count: usize = 0,
+    host: []const u8 = "",
+    user: []const u8 = "",
+    port: []const u8 = "",
+    proxy_jump: []const u8 = "",
+
+    fn addAlias(self: *PendingBlock, alias: []const u8) void {
+        if (self.alias_count >= MAX_ALIASES_PER_HOST) return;
+        if (!compatibleAlias(alias)) return;
+        self.aliases[self.alias_count] = alias;
+        self.alias_count += 1;
+    }
+};
+
+pub fn parseCandidates(config: []const u8, out: []Candidate) []Candidate {
+    var pending: PendingBlock = .{};
+    var have_block = false;
+    var count: usize = 0;
+
+    var lines = std.mem.splitScalar(u8, config, '\n');
+    while (lines.next()) |raw_line| {
+        const line = trimLine(stripComment(raw_line));
+        if (line.len == 0) continue;
+
+        const key_value = splitKeyValue(line);
+        if (std.ascii.eqlIgnoreCase(key_value.key, "Host")) {
+            if (have_block) flushPending(&pending, out, &count);
+            pending = .{};
+            have_block = true;
+
+            var aliases = std.mem.tokenizeAny(u8, key_value.value, " \t");
+            while (aliases.next()) |alias| pending.addAlias(alias);
+            continue;
+        }
+        if (std.ascii.eqlIgnoreCase(key_value.key, "Match")) {
+            if (have_block) flushPending(&pending, out, &count);
+            pending = .{};
+            have_block = false;
+            continue;
+        }
+
+        if (!have_block) continue;
+
+        if (std.ascii.eqlIgnoreCase(key_value.key, "HostName")) {
+            pending.host = key_value.value;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "User")) {
+            pending.user = key_value.value;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "Port")) {
+            pending.port = key_value.value;
+        } else if (std.ascii.eqlIgnoreCase(key_value.key, "ProxyJump")) {
+            pending.proxy_jump = key_value.value;
+        }
+    }
+
+    if (have_block) flushPending(&pending, out, &count);
+    return out[0..count];
+}
+
+const KeyValue = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+fn stripComment(line: []const u8) []const u8 {
+    const comment_idx = std.mem.indexOfScalar(u8, line, '#') orelse return line;
+    return line[0..comment_idx];
+}
+
+fn trimLine(line: []const u8) []const u8 {
+    return std.mem.trim(u8, line, " \t\r\n");
+}
+
+fn splitKeyValue(line: []const u8) KeyValue {
+    const sep_idx = firstSeparator(line) orelse return .{ .key = line, .value = "" };
+    const key = trimLine(line[0..sep_idx]);
+    const value_start = if (line[sep_idx] == '=') sep_idx + 1 else skipWhitespace(line, sep_idx);
+    return .{
+        .key = key,
+        .value = trimLine(line[value_start..]),
+    };
+}
+
+fn firstSeparator(line: []const u8) ?usize {
+    for (line, 0..) |ch, idx| {
+        if (ch == ' ' or ch == '\t' or ch == '=') return idx;
+    }
+    return null;
+}
+
+fn skipWhitespace(line: []const u8, start: usize) usize {
+    var idx = start;
+    while (idx < line.len and (line[idx] == ' ' or line[idx] == '\t')) : (idx += 1) {}
+    return idx;
+}
+
+fn compatibleAlias(alias: []const u8) bool {
+    if (alias.len == 0 or alias.len > FIELD_MAX) return false;
+    for (alias) |ch| {
+        if (ch == '*' or ch == '?' or ch == '[' or ch == ']') return false;
+    }
+    return true;
+}
+
+fn flushPending(block: *const PendingBlock, out: []Candidate, count: *usize) void {
+    if (block.alias_count == 0 or block.user.len == 0) return;
+
+    for (block.aliases[0..block.alias_count]) |alias| {
+        if (count.* >= out.len) return;
+
+        const host = if (block.host.len > 0) block.host else alias;
+        const port = if (block.port.len > 0) block.port else "22";
+        if (!candidateFieldsFit(alias, host, block.user, port, block.proxy_jump)) continue;
+
+        var candidate: Candidate = .{};
+        candidate.name_len = copyExact(candidate.name_buf[0..], alias).?;
+        candidate.host_len = copyExact(candidate.host_buf[0..], host).?;
+        candidate.user_len = copyExact(candidate.user_buf[0..], block.user).?;
+        candidate.port_len = copyExact(candidate.port_buf[0..], port).?;
+        candidate.proxy_jump_len = copyExact(candidate.proxy_jump_buf[0..], block.proxy_jump).?;
+
+        out[count.*] = candidate;
+        count.* += 1;
+    }
+}
+
+fn candidateFieldsFit(name: []const u8, host: []const u8, user: []const u8, port: []const u8, proxy_jump: []const u8) bool {
+    return name.len <= FIELD_MAX and
+        host.len <= FIELD_MAX and
+        user.len <= FIELD_MAX and
+        port.len <= FIELD_MAX and
+        proxy_jump.len <= FIELD_MAX;
+}
+
+fn copyExact(buf: []u8, value: []const u8) ?usize {
+    if (value.len > buf.len) return null;
+    @memcpy(buf[0..value.len], value);
+    return value.len;
+}
+
+test "openssh config import: parses a basic host block" {
+    const config =
+        \\Host lab
+        \\  HostName 192.0.2.10
+        \\  User alice
+        \\  Port 2222
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("lab", rows[0].name());
+    try std.testing.expectEqualStrings("192.0.2.10", rows[0].host());
+    try std.testing.expectEqualStrings("alice", rows[0].user());
+    try std.testing.expectEqualStrings("2222", rows[0].port());
+}
+
+test "openssh config import: defaults host from alias and port to 22" {
+    const config =
+        \\Host staging
+        \\  User deploy
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("staging", rows[0].host());
+    try std.testing.expectEqualStrings("22", rows[0].port());
+}
+
+test "openssh config import: parses proxy jump" {
+    const config =
+        \\Host prod
+        \\  HostName prod.internal
+        \\  User root
+        \\  ProxyJump jumpuser@bastion:22
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("jumpuser@bastion:22", rows[0].proxyJump());
+}
+
+test "openssh config import: splits aliases and skips wildcard aliases" {
+    const config =
+        \\Host gpu gpu-* ?bad [group] *
+        \\  HostName gpu.example
+        \\  User xzg
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("gpu", rows[0].name());
+}
+
+test "openssh config import: ignores comments blank lines and unsupported blocks" {
+    const config =
+        \\# comment
+        \\
+        \\Host nouser
+        \\  HostName 192.0.2.11
+        \\
+        \\Host ok # inline comment
+        \\  HostName ok.example
+        \\  User bob
+        \\  IdentityFile ~/.ssh/id_ed25519
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("ok", rows[0].name());
+    try std.testing.expectEqualStrings("ok.example", rows[0].host());
+}
+
+test "openssh config import: ignores match blocks" {
+    const config =
+        \\Host ok
+        \\  HostName ok.example
+        \\  User bob
+        \\Match host *
+        \\  HostName ignored.example
+        \\  User root
+        \\Host next
+        \\  HostName next.example
+        \\  User alice
+        \\
+    ;
+    var out: [8]Candidate = undefined;
+    const rows = parseCandidates(config, &out);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    try std.testing.expectEqualStrings("ok", rows[0].name());
+    try std.testing.expectEqualStrings("ok.example", rows[0].host());
+    try std.testing.expectEqualStrings("bob", rows[0].user());
+    try std.testing.expectEqualStrings("next", rows[1].name());
+    try std.testing.expectEqualStrings("next.example", rows[1].host());
+    try std.testing.expectEqualStrings("alice", rows[1].user());
+}

--- a/src/openssh_config_import.zig
+++ b/src/openssh_config_import.zig
@@ -76,13 +76,6 @@ pub fn parseCandidates(config: []const u8, out: []Candidate) []Candidate {
             while (aliases.next()) |alias| pending.addAlias(alias);
             continue;
         }
-        if (std.ascii.eqlIgnoreCase(key_value.key, "Match")) {
-            if (have_block) flushPending(&pending, out, &count);
-            pending = .{};
-            have_block = false;
-            continue;
-        }
-
         if (!have_block) continue;
 
         if (std.ascii.eqlIgnoreCase(key_value.key, "HostName") and !pending.has_host) {
@@ -352,28 +345,4 @@ test "openssh config import: ignores comments blank lines and unsupported blocks
     try std.testing.expectEqual(@as(usize, 1), rows.len);
     try std.testing.expectEqualStrings("ok", rows[0].name());
     try std.testing.expectEqualStrings("ok.example", rows[0].host());
-}
-
-test "openssh config import: ignores match blocks" {
-    const config =
-        \\Host ok
-        \\  HostName ok.example
-        \\  User bob
-        \\Match host *
-        \\  HostName ignored.example
-        \\  User root
-        \\Host next
-        \\  HostName next.example
-        \\  User alice
-        \\
-    ;
-    var out: [8]Candidate = undefined;
-    const rows = parseCandidates(config, &out);
-    try std.testing.expectEqual(@as(usize, 2), rows.len);
-    try std.testing.expectEqualStrings("ok", rows[0].name());
-    try std.testing.expectEqualStrings("ok.example", rows[0].host());
-    try std.testing.expectEqualStrings("bob", rows[0].user());
-    try std.testing.expectEqualStrings("next", rows[1].name());
-    try std.testing.expectEqualStrings("next.example", rows[1].host());
-    try std.testing.expectEqualStrings("alice", rows[1].user());
 }

--- a/src/platform/dirs.zig
+++ b/src/platform/dirs.zig
@@ -151,6 +151,29 @@ pub fn sshHostsPathFromEnvForOs(
     return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "ssh_hosts");
 }
 
+pub fn openSshConfigPath(allocator: std.mem.Allocator) ![]const u8 {
+    const userprofile = envVarOwned(allocator, "USERPROFILE");
+    defer if (userprofile) |value| allocator.free(value);
+    const home = envVarOwned(allocator, "HOME");
+    defer if (home) |value| allocator.free(value);
+    return openSshConfigPathFromEnvForOs(allocator, builtin.os.tag, .{
+        .userprofile = userprofile,
+        .home = home,
+    });
+}
+
+pub fn openSshConfigPathFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    const base = switch (os_tag) {
+        .windows => nonEmpty(env.userprofile) orelse nonEmpty(env.home) orelse return error.NoOpenSshConfigPath,
+        else => nonEmpty(env.home) orelse return error.NoOpenSshConfigPath,
+    };
+    return std.fs.path.join(allocator, &.{ base, ".ssh", "config" });
+}
+
 pub fn agentHistoryPath(allocator: std.mem.Allocator) ![]const u8 {
     return pathInConfigDir(allocator, "agent-history.json");
 }
@@ -531,4 +554,27 @@ test "platform dirs resolve downloads directory per OS" {
     const expected = try std.fs.path.join(allocator, &.{ "C:/Users/alice", "Downloads" });
     defer allocator.free(expected);
     try std.testing.expectEqualStrings(expected, downloads);
+}
+
+test "platform dirs resolve openssh config path per OS" {
+    const allocator = std.testing.allocator;
+
+    const windows = try openSshConfigPathFromEnvForOs(allocator, .windows, .{
+        .userprofile = "C:/Users/alice",
+        .home = "/ignored",
+    });
+    defer allocator.free(windows);
+    const expected_windows = try std.fs.path.join(allocator, &.{ "C:/Users/alice", ".ssh", "config" });
+    defer allocator.free(expected_windows);
+    try std.testing.expectEqualStrings(expected_windows, windows);
+
+    const linux = try openSshConfigPathFromEnvForOs(allocator, .linux, .{
+        .home = "/home/alice",
+    });
+    defer allocator.free(linux);
+    const expected_linux = try std.fs.path.join(allocator, &.{ "/home/alice", ".ssh", "config" });
+    defer allocator.free(expected_linux);
+    try std.testing.expectEqualStrings(expected_linux, linux);
+
+    try std.testing.expectError(error.NoOpenSshConfigPath, openSshConfigPathFromEnvForOs(allocator, .linux, .{}));
 }

--- a/src/preview_token.zig
+++ b/src/preview_token.zig
@@ -65,6 +65,7 @@ fn previousCodepointStart(text: []const u8, start: usize, end: usize) ?usize {
 
 fn isLeadingTrimCodepoint(cp: u21) bool {
     return switch (cp) {
+        '@',
         '\'',
         '"',
         '`',
@@ -121,6 +122,13 @@ fn isTrailingTrimCodepoint(cp: u21) bool {
 
 test "trim keeps preview path and drops ASCII sentence punctuation" {
     try std.testing.expectEqualStrings("docs/readme.md", trim("`docs/readme.md`."));
+}
+
+test "trim drops leading mention marker before markdown path" {
+    try std.testing.expectEqualStrings(
+        "docs/superpowers/plans/2026-06-04-copilot-tiling-panel.md",
+        trim("@docs/superpowers/plans/2026-06-04-copilot-tiling-panel.md"),
+    );
 }
 
 test "trim drops Chinese sentence punctuation after markdown path" {

--- a/src/renderer/ai_history_renderer.zig
+++ b/src/renderer/ai_history_renderer.zig
@@ -75,7 +75,7 @@ pub fn leftColumnLayout(top: f32, cell_h: f32) LeftColumnLayout {
     y += cell_h + 8;
     const category_rows_top = y;
     const category_row_h = cell_h + 10;
-    y += category_row_h * 4;
+    y += category_row_h * @as(f32, @floatFromInt(types.CATEGORY_ORDER.len));
     y += 14;
     const date_heading_top = y;
     y += cell_h + 8;
@@ -200,8 +200,7 @@ pub fn interactionHitTest(
     const my: f32 = @floatCast(mouse_y);
 
     const lc = leftColumnLayout(top, cell_h);
-    const categories = [_]types.CategoryFilter{ .all, .codex, .claude, .reasonix };
-    for (categories, 0..) |cat, i| {
+    for (types.CATEGORY_ORDER, 0..) |cat, i| {
         const cat_top = lc.category_rows_top + @as(f32, @floatFromInt(i)) * lc.category_row_h;
         if (rectContains(mx, my, layout.left_x, cat_top, layout.left_w, lc.category_row_h)) {
             return .{ .category = cat };
@@ -364,8 +363,7 @@ fn renderLeftColumn(
     const query = session.filter[0..session.filter_len];
     const counts = session.categoryCounts(query);
     const selected_bg = mixColor(draw.bg, accent, 0.18);
-    const categories = [_]types.CategoryFilter{ .all, .codex, .claude, .reasonix };
-    for (categories, 0..) |cat, i| {
+    for (types.CATEGORY_ORDER, 0..) |cat, i| {
         const row_top = lc.category_rows_top + @as(f32, @floatFromInt(i)) * lc.category_row_h;
         const active = session.category == cat;
         const cursor = filters_focused and session.filter_cursor == i;
@@ -377,12 +375,7 @@ fn renderLeftColumn(
         }
         const text_top = row_top + (lc.category_row_h - draw.cell_h) / 2;
         const label_color = if (highlight) fg else muted;
-        const count = switch (cat) {
-            .all => counts.all,
-            .codex => counts.codex,
-            .claude => counts.claude,
-            .reasonix => counts.reasonix,
-        };
+        const count = types.categoryCount(counts, cat);
         var num_buf: [16]u8 = undefined;
         const num_text = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch "";
         const count_w: f32 = 44;
@@ -492,6 +485,7 @@ fn renderList(
             .codex => "No Codex sessions",
             .claude => "No Claude Code sessions",
             .reasonix => "No Reasonix sessions",
+            .subagent => "No Subagent sessions",
         };
         _ = draw.renderTextLimited(empty, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top + 24), muted, layout.list_w - PAD_X * 2);
     }
@@ -1038,6 +1032,12 @@ test "ai_history_renderer: interaction hit test maps category rows" {
     try std.testing.expectEqual(
         Hit{ .category = .reasonix },
         interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + 10, reasonix_y),
+    );
+
+    const subagent_y = lc.category_rows_top + lc.category_row_h * 4.5;
+    try std.testing.expectEqual(
+        Hit{ .category = .subagent },
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.left_x + 10, subagent_y),
     );
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -517,6 +517,7 @@ fn transferCancelConfirmExecuteAtForTest(xpos: f32, ypos: f32, window_width: f32
 fn executeCommand(action: CommandAction) void {
     switch (action) {
         .new_tab => sessionLauncherOpen(),
+        .load_openssh_config => loadOpenSshConfigDefault(),
         .new_agent => openDefaultAgentSessionFromCommandCenter(),
         .manage_ai_profiles => openAiList(),
         .select_agent_history => commandPaletteOpenAgentHistory(),

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1623,6 +1623,7 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
 // ============================================================================
 
 const profile_codec = @import("overlays/profile_codec.zig");
+const openssh_config_import = @import("../openssh_config_import.zig");
 const SSH_FIELD_COUNT = profile_codec.SSH_FIELD_COUNT;
 const SSH_FIELD_MAX = profile_codec.SSH_FIELD_MAX;
 const SSH_PROFILE_MAX = 16;
@@ -1644,6 +1645,7 @@ const SessionAction = enum {
     ai_history_wsl,
     ai_history_ssh,
     connect_selected,
+    load_openssh_config,
     new_ssh,
     edit_selected,
     delete_selected,
@@ -1994,6 +1996,7 @@ pub fn sessionLauncherExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_
         .ai_history_wsl => openWslAiHistorySession(),
         .ai_history_ssh => openAiHistorySshPicker(),
         .connect_selected => runSshListRow(g_ssh_list_selected),
+        .load_openssh_config => loadOpenSshConfigDefault(),
         .new_ssh => openSshFormNew(),
         .edit_selected => openSshEditPicker(),
         .delete_selected => openSshDeletePicker(),
@@ -2177,8 +2180,28 @@ fn handleSshListKey(ev: input_key.KeyEvent) void {
 
 fn sshListRowCount() usize {
     return switch (g_ssh_list_mode) {
-        .manage => sshVisibleProfileCount() + 4,
+        .manage => sshVisibleProfileCount() + 5,
         .edit_select, .delete_select, .ai_history_select => sshVisibleProfileCount() + 1,
+    };
+}
+
+const SshManageAction = enum {
+    profile,
+    load_openssh_config,
+    new_ssh,
+    edit_ssh,
+    delete_ssh,
+    cancel,
+};
+
+fn sshManageActionForRow(row: usize, visible_profile_count: usize) SshManageAction {
+    if (row < visible_profile_count) return .profile;
+    return switch (row - visible_profile_count) {
+        0 => .load_openssh_config,
+        1 => .new_ssh,
+        2 => .edit_ssh,
+        3 => .delete_ssh,
+        else => .cancel,
     };
 }
 
@@ -2262,6 +2285,10 @@ const profileField = profile_codec.profileField;
 
 fn findSshProfileIndex(identifier_raw: []const u8) ?usize {
     loadSshProfiles();
+    return findLoadedSshProfileIndex(identifier_raw);
+}
+
+fn findLoadedSshProfileIndex(identifier_raw: []const u8) ?usize {
     const identifier = std.mem.trim(u8, identifier_raw, " \t\r\n");
     if (identifier.len == 0) return null;
 
@@ -2324,6 +2351,90 @@ pub fn aiHistorySshConnection(identifier: []const u8) ?ssh_connection.SshConnect
 const copySshProfileField = profile_codec.copySshProfileField;
 
 const makeSshProfile = profile_codec.makeSshProfile;
+
+const OpenSshImportStats = struct {
+    created: usize = 0,
+    updated: usize = 0,
+    skipped: usize = 0,
+    capped: bool = false,
+};
+
+fn mergeOpenSshCandidate(candidate: openssh_config_import.Candidate, stats: *OpenSshImportStats) void {
+    const name = candidate.name();
+    const host = candidate.host();
+    const user = candidate.user();
+    const port = candidate.port();
+    const proxy_jump = candidate.proxyJump();
+    if (name.len == 0 or host.len == 0 or user.len == 0) {
+        stats.skipped += 1;
+        return;
+    }
+    if (!isSshTokenSafe(name) or !isSshTokenSafe(host) or !isSshTokenSafe(user)) {
+        stats.skipped += 1;
+        return;
+    }
+    if (!isPortTokenSafe(port) or !command_palette_model.isProxyJumpSafe(proxy_jump)) {
+        stats.skipped += 1;
+        return;
+    }
+
+    const found_idx = findLoadedSshProfileIndex(name) orelse findLoadedSshProfileIndex(host);
+    var created_new = false;
+    const idx = found_idx orelse blk: {
+        if (g_ssh_profile_count >= SSH_PROFILE_MAX) {
+            stats.capped = true;
+            return;
+        }
+        const next = g_ssh_profile_count;
+        g_ssh_profile_count += 1;
+        g_ssh_profiles[next] = .{};
+        created_new = true;
+        break :blk next;
+    };
+
+    if (idx >= g_ssh_profile_count) {
+        stats.skipped += 1;
+        return;
+    }
+
+    if (created_new) {
+        stats.created += 1;
+    } else {
+        stats.updated += 1;
+    }
+    const profile = &g_ssh_profiles[idx];
+    copySshProfileField(profile, .name, name);
+    copySshProfileField(profile, .ip, host);
+    copySshProfileField(profile, .user, user);
+    copySshProfileField(profile, .port, if (port.len > 0) port else "22");
+    copySshProfileField(profile, .proxy_jump, proxy_jump);
+}
+
+fn opensshCandidateSetForTest(candidate: *openssh_config_import.Candidate, comptime field: enum { name, host, user, port, proxy_jump }, value: []const u8) void {
+    const len = @min(value.len, openssh_config_import.FIELD_MAX);
+    switch (field) {
+        .name => {
+            @memcpy(candidate.name_buf[0..len], value[0..len]);
+            candidate.name_len = len;
+        },
+        .host => {
+            @memcpy(candidate.host_buf[0..len], value[0..len]);
+            candidate.host_len = len;
+        },
+        .user => {
+            @memcpy(candidate.user_buf[0..len], value[0..len]);
+            candidate.user_len = len;
+        },
+        .port => {
+            @memcpy(candidate.port_buf[0..len], value[0..len]);
+            candidate.port_len = len;
+        },
+        .proxy_jump => {
+            @memcpy(candidate.proxy_jump_buf[0..len], value[0..len]);
+            candidate.proxy_jump_len = len;
+        },
+    }
+}
 
 pub fn agentSaveSshProfile(allocator: std.mem.Allocator, args: AppWindow.ai_chat.SshProfileSaveArgs) !AppWindow.ai_chat.SavedSshProfile {
     loadSshProfiles();
@@ -2396,17 +2507,16 @@ fn runSshListRow(row: usize) void {
     const visible_profile_count = sshVisibleProfileCount();
     switch (g_ssh_list_mode) {
         .manage => {
-            if (row < visible_profile_count) {
-                const profile_idx = sshVisibleProfileIndexAt(row) orelse return;
-                connectSshProfile(profile_idx);
-                return;
-            }
-            const action_row = row - visible_profile_count;
-            switch (action_row) {
-                0 => openSshFormNew(),
-                1 => openSshEditPicker(),
-                2 => openSshDeletePicker(),
-                else => sessionLauncherClose(),
+            switch (sshManageActionForRow(row, visible_profile_count)) {
+                .profile => {
+                    const profile_idx = sshVisibleProfileIndexAt(row) orelse return;
+                    connectSshProfile(profile_idx);
+                },
+                .load_openssh_config => loadOpenSshConfigDefault(),
+                .new_ssh => openSshFormNew(),
+                .edit_ssh => openSshEditPicker(),
+                .delete_ssh => openSshDeletePicker(),
+                .cancel => sessionLauncherClose(),
             }
         },
         .edit_select => {
@@ -3311,26 +3421,70 @@ fn loadSshProfiles() void {
 const decodeSshProfileLine = profile_codec.decodeSshProfileLine;
 
 fn saveSshProfiles(allocator: std.mem.Allocator) void {
-    const path = sshProfilesPath(allocator) catch return;
+    _ = saveSshProfilesChecked(allocator);
+}
+
+fn saveSshProfilesChecked(allocator: std.mem.Allocator) bool {
+    const path = sshProfilesPath(allocator) catch return false;
     defer allocator.free(path);
     if (std.fs.path.dirname(path)) |dir| {
-        std.fs.cwd().makePath(dir) catch return;
+        std.fs.cwd().makePath(dir) catch return false;
     }
 
     var out: std.ArrayListUnmanaged(u8) = .empty;
     defer out.deinit(allocator);
-    out.appendSlice(allocator, "# WispTerm SSH profiles. Fields are hex encoded: name, host, user, password, port, proxy_jump.\n") catch return;
+    out.appendSlice(allocator, "# WispTerm SSH profiles. Fields are hex encoded: name, host, user, password, port, proxy_jump.\n") catch return false;
     for (g_ssh_profiles[0..g_ssh_profile_count]) |profile| {
         for (0..SSH_FIELD_COUNT) |i| {
-            if (i > 0) out.append(allocator, '\t') catch return;
-            appendHexField(allocator, &out, profile.fields[i][0..profile.lens[i]]) catch return;
+            if (i > 0) out.append(allocator, '\t') catch return false;
+            appendHexField(allocator, &out, profile.fields[i][0..profile.lens[i]]) catch return false;
         }
-        out.append(allocator, '\n') catch return;
+        out.append(allocator, '\n') catch return false;
     }
 
-    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return;
+    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
     defer file.close();
-    file.writeAll(out.items) catch {};
+    file.writeAll(out.items) catch return false;
+    return true;
+}
+
+fn loadOpenSshConfigDefault() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    loadSshProfiles();
+
+    const path = platform_dirs.openSshConfigPath(allocator) catch {
+        openSshList();
+        showStatusToast("OpenSSH config not found");
+        return;
+    };
+    defer allocator.free(path);
+
+    const content = std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch {
+        openSshList();
+        showStatusToast("OpenSSH config not found");
+        return;
+    };
+    defer allocator.free(content);
+
+    var candidates_buf: [64]openssh_config_import.Candidate = undefined;
+    const candidates = openssh_config_import.parseCandidates(content, &candidates_buf);
+    var stats = OpenSshImportStats{};
+    for (candidates) |candidate| mergeOpenSshCandidate(candidate, &stats);
+
+    var saved = true;
+    if (stats.created + stats.updated > 0) {
+        saved = saveSshProfilesChecked(allocator);
+    }
+    openSshList();
+
+    var msg_buf: [96]u8 = undefined;
+    const msg = if (stats.created + stats.updated == 0)
+        "No OpenSSH hosts imported"
+    else if (!saved)
+        std.fmt.bufPrint(&msg_buf, "Imported {d}, updated {d} SSH profiles (not saved)", .{ stats.created, stats.updated }) catch "Imported OpenSSH profiles (not saved)"
+    else
+        std.fmt.bufPrint(&msg_buf, "Imported {d}, updated {d} SSH profiles", .{ stats.created, stats.updated }) catch "Imported OpenSSH profiles";
+    showStatusToast(msg);
 }
 
 fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: []const u8) !void {
@@ -3479,6 +3633,7 @@ fn sessionDesiredBoxWidth() f32 {
         }
         switch (g_ssh_list_mode) {
             .manage => {
+                desired = @max(desired, sessionTwoColumnWidth("Load OpenSSH config", "~/.ssh/config"));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_new_ssh_server, i18n.s().sl_v_add));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_edit_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_delete_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server));
@@ -3571,10 +3726,12 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
         g_ssh_list_selected = row;
         if (row < sshVisibleProfileCount()) return .connect_selected;
         if (g_ssh_list_mode != .manage) return .connect_selected;
-        return switch (row - sshVisibleProfileCount()) {
-            0 => .new_ssh,
-            1 => .edit_selected,
-            2 => .delete_selected,
+        return switch (sshManageActionForRow(row, sshVisibleProfileCount())) {
+            .profile => .connect_selected,
+            .load_openssh_config => .load_openssh_config,
+            .new_ssh => .new_ssh,
+            .edit_ssh => .edit_selected,
+            .delete_ssh => .delete_selected,
             else => .cancel,
         };
     }
@@ -3791,6 +3948,8 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             }
             switch (g_ssh_list_mode) {
                 .manage => {
+                    renderSessionRow(layout, window_height, row, "Load OpenSSH config", "~/.ssh/config", g_ssh_list_selected == row);
+                    row += 1;
                     renderSessionRow(layout, window_height, row, i18n.s().sl_new_ssh_server, i18n.s().sl_v_add, g_ssh_list_selected == row);
                     row += 1;
                     renderSessionRow(layout, window_height, row, i18n.s().sl_edit_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server, g_ssh_list_selected == row);
@@ -4717,11 +4876,66 @@ test "overlays: SSH list filter matches server name prefixes case-insensitively"
     try std.testing.expectEqual(@as(usize, 2), sshVisibleProfileCount());
     try std.testing.expectEqual(@as(?usize, 1), sshVisibleProfileIndexAt(0));
     try std.testing.expectEqual(@as(?usize, 2), sshVisibleProfileIndexAt(1));
-    try std.testing.expectEqual(@as(usize, 6), sshListRowCount());
+    try std.testing.expectEqual(@as(usize, 7), sshListRowCount());
 
     appendSshListFilterText("x1");
     try std.testing.expectEqual(@as(usize, 1), sshVisibleProfileCount());
     try std.testing.expectEqual(@as(?usize, 1), sshVisibleProfileIndexAt(0));
+}
+
+test "overlays: SSH manage list includes Load OpenSSH config action" {
+    const saved_count = g_ssh_profile_count;
+    const saved_mode = g_ssh_list_mode;
+    const saved_filter_len = g_ssh_list_filter_len;
+    const saved_selected = g_ssh_list_selected;
+    defer {
+        g_ssh_profile_count = saved_count;
+        g_ssh_list_mode = saved_mode;
+        g_ssh_list_filter_len = saved_filter_len;
+        g_ssh_list_selected = saved_selected;
+    }
+
+    g_ssh_profile_count = 0;
+    g_ssh_list_mode = .manage;
+    g_ssh_list_filter_len = 0;
+    g_ssh_list_selected = 0;
+    try std.testing.expectEqual(@as(usize, 5), sshListRowCount());
+    try std.testing.expectEqual(SshManageAction.load_openssh_config, sshManageActionForRow(0, sshVisibleProfileCount()));
+    try std.testing.expectEqual(SshManageAction.new_ssh, sshManageActionForRow(1, sshVisibleProfileCount()));
+
+    g_ssh_profile_count = 1;
+    g_ssh_profiles[0] = makeSshProfile("GPU", "10.0.0.1", "user", "22");
+    try std.testing.expectEqual(@as(usize, 6), sshListRowCount());
+    try std.testing.expectEqual(SshManageAction.profile, sshManageActionForRow(0, sshVisibleProfileCount()));
+    try std.testing.expectEqual(SshManageAction.load_openssh_config, sshManageActionForRow(1, sshVisibleProfileCount()));
+}
+
+test "overlays: OpenSSH import merge preserves existing password" {
+    const saved_count = g_ssh_profile_count;
+    defer {
+        g_ssh_profile_count = saved_count;
+    }
+
+    g_ssh_profile_count = 1;
+    g_ssh_profiles[0] = makeSshProfile("lab", "old.example", "olduser", "22");
+    copySshProfileField(&g_ssh_profiles[0], .password, "secret");
+
+    var candidate = openssh_config_import.Candidate{};
+    opensshCandidateSetForTest(&candidate, .name, "lab");
+    opensshCandidateSetForTest(&candidate, .host, "new.example");
+    opensshCandidateSetForTest(&candidate, .user, "alice");
+    opensshCandidateSetForTest(&candidate, .port, "2222");
+    opensshCandidateSetForTest(&candidate, .proxy_jump, "jump.example");
+
+    var stats = OpenSshImportStats{};
+    mergeOpenSshCandidate(candidate, &stats);
+
+    try std.testing.expectEqual(@as(usize, 1), stats.updated);
+    try std.testing.expectEqualStrings("new.example", profileField(&g_ssh_profiles[0], .ip));
+    try std.testing.expectEqualStrings("alice", profileField(&g_ssh_profiles[0], .user));
+    try std.testing.expectEqualStrings("2222", profileField(&g_ssh_profiles[0], .port));
+    try std.testing.expectEqualStrings("jump.example", profileField(&g_ssh_profiles[0], .proxy_jump));
+    try std.testing.expectEqualStrings("secret", profileField(&g_ssh_profiles[0], .password));
 }
 
 test "overlays: SSH list filter backspace restores matching rows" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -41,6 +41,7 @@ test {
     _ = @import("ai_agent_config.zig");
     _ = @import("ai_agent_access.zig");
     _ = @import("ssh_connection.zig");
+    _ = @import("openssh_config_import.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("scp.zig");
     _ = @import("file_backend.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -636,6 +636,7 @@ comptime {
     _ = @import("build_guards.zig");
     _ = @import("command_center_state.zig");
     _ = @import("command_palette_model.zig");
+    _ = @import("openssh_config_import.zig");
     _ = @import("config.zig");
     _ = @import("i18n.zig");
     _ = @import("config_watcher.zig");


### PR DESCRIPTION
## Summary

- Add OpenSSH config import support for SSH profiles, including a pure parser, default `~/.ssh/config` path resolution, a New Session SSH-list row, and a Command Center command.
- Preserve existing saved SSH passwords during import and document that OpenSSH passwords are not imported.
- Include the earlier session UX fixes on this branch: markdown mention path matching, tab-scoped Copilot sidebar state, and session history subagent categorization.

## Impact

Users can import compatible `Host`, `HostName`, `User`, `Port`, and `ProxyJump` entries from OpenSSH config into WispTerm SSH profiles from either New Session or Command Center. The import updates existing profiles by name or host and keeps stored passwords untouched.

## Validation

- `git diff --check`
- `zig build test`
- `zig build test-full`
- Windows checkout path-safety equivalent check: no illegal names, case-fold collisions, or symlinks
