### PR TITLE
feat: smart ls path context for ctrl+click

### DIFF
--- a/docs/superpowers/plans/2026-06-05-smart-ls-path-context.md
+++ b/docs/superpowers/plans/2026-06-05-smart-ls-path-context.md
@@ -1,0 +1,494 @@
+# Smart `ls` Path Context for Ctrl+Click — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a clicked terminal token is a bare filename, infer the directory prefix from the nearest preceding `ls <dir>/` command line and prepend it before path resolution, so ctrl+click previews/downloads of `ls <dir>/` output resolve to the right file.
+
+**Architecture:** A new pure module `src/input/ls_path_context.zig` holds all logic (command-line parsing, upward viewport scan over a generic grid, and the bare-filename prefix-join gate) so it is unit-testable without a `Surface`. The resolver `resolveTerminalPreviewPath` (in `src/input/preview_source.zig`) gains an optional `ls_prefix` parameter and applies the join through the pure module. `src/input.zig` computes the prefix from the live grid at click time and threads it through; the unrelated `html_server.zig` caller passes `null`.
+
+**Tech Stack:** Zig 0.15.2. Fast tests: `zig build test`. Full suite: `zig build test-full`.
+
+Spec: `docs/superpowers/specs/2026-06-05-smart-ls-path-context-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `src/input/ls_path_context.zig` — pure logic: `parseLsDirArg`, `inferPrefixForClick` (+ private `encodeRow`), `isBareRelativeFilename`, `applyLsPrefix`. No `Surface`/terminal dependency; generic over a grid reader. All unit tests live here.
+- **Modify** `src/test_fast.zig` — register the new module so its tests run in the fast suite.
+- **Modify** `src/input/preview_source.zig` — `resolveTerminalPreviewPath` gains `ls_prefix: ?[]const u8` and calls `ls_path_context.applyLsPrefix`.
+- **Modify** `src/input.zig` — import `ls_path_context`, add `lsPrefixForCell` helper, update the two ctrl+click call sites to compute and pass the prefix.
+- **Modify** `src/html_server.zig` — pass `null` for the new parameter (no click context).
+
+---
+
+## Task 1: `parseLsDirArg` — parse a command line into a directory prefix
+
+**Files:**
+- Create: `src/input/ls_path_context.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Create the module with `parseLsDirArg` and its tests**
+
+Create `src/input/ls_path_context.zig` with this content:
+
+```zig
+//! Smart path context for ctrl+click: infer a directory prefix from a nearby
+//! `ls <dir>/` command line so bare-filename clicks resolve to the right file.
+//! Pure logic only — no terminal/Surface dependency — so it is unit-testable.
+
+const std = @import("std");
+
+/// Command names whose single trailing-`/` argument we treat as a path prefix.
+const ls_commands = [_][]const u8{ "ls", "ll", "la", "l", "dir" };
+
+fn isLsCommand(tok: []const u8) bool {
+    for (ls_commands) |cmd| {
+        if (std.mem.eql(u8, tok, cmd)) return true;
+    }
+    return false;
+}
+
+/// If `line` is an `ls`-family command with exactly one directory argument
+/// (a non-flag token ending in `/`), return that directory (a slice into
+/// `line`). Returns null for zero args, multiple non-flag args, a sole
+/// argument not ending in `/`, or a non-ls command. The command token may be
+/// preceded by an arbitrary prompt prefix.
+pub fn parseLsDirArg(line: []const u8) ?[]const u8 {
+    var it = std.mem.tokenizeAny(u8, line, " \t");
+
+    var found_cmd = false;
+    while (it.next()) |tok| {
+        if (isLsCommand(tok)) {
+            found_cmd = true;
+            break;
+        }
+    }
+    if (!found_cmd) return null;
+
+    var dir: ?[]const u8 = null;
+    while (it.next()) |tok| {
+        if (tok.len > 0 and tok[0] == '-') continue; // flag
+        if (dir != null) return null; // >1 non-flag arg → ambiguous
+        dir = tok;
+    }
+
+    const d = dir orelse return null; // ls of CWD, no dir arg
+    if (d.len == 0 or d[d.len - 1] != '/') return null; // must be a directory
+    return d;
+}
+
+test "parseLsDirArg: ls with a trailing-slash dir" {
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", parseLsDirArg("ls Ath/Ph_SE/").?);
+}
+
+test "parseLsDirArg: tolerates a prompt prefix" {
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", parseLsDirArg("$ ls Ath/Ph_SE/").?);
+    try std.testing.expectEqualStrings("data/", parseLsDirArg("me@box:~/proj$ ls data/").?);
+}
+
+test "parseLsDirArg: skips flags" {
+    try std.testing.expectEqualStrings("Ath/", parseLsDirArg("ls -la Ath/").?);
+    try std.testing.expectEqualStrings("Ath/", parseLsDirArg("ls --color=auto Ath/").?);
+}
+
+test "parseLsDirArg: accepts ls-family aliases" {
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("ll d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("la d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("l d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("dir d/").?);
+}
+
+test "parseLsDirArg: rejects non-ls and lookalike commands" {
+    try std.testing.expect(parseLsDirArg("lsblk d/") == null);
+    try std.testing.expect(parseLsDirArg("cat foo.txt") == null);
+    try std.testing.expect(parseLsDirArg("~/tools/ls d/") == null);
+}
+
+test "parseLsDirArg: rejects zero, multiple, and non-dir args" {
+    try std.testing.expect(parseLsDirArg("ls") == null);
+    try std.testing.expect(parseLsDirArg("ls -la") == null);
+    try std.testing.expect(parseLsDirArg("ls A/ B/") == null);
+    try std.testing.expect(parseLsDirArg("ls foo.txt") == null);
+    try std.testing.expect(parseLsDirArg("ls Ath") == null);
+}
+```
+
+- [ ] **Step 2: Register the module in the fast test suite**
+
+In `src/test_fast.zig`, add the import next to the other `input/` modules (after the `preview_path.zig` line):
+
+```zig
+    _ = @import("input/preview_path.zig");
+    _ = @import("input/ls_path_context.zig");
+```
+
+- [ ] **Step 3: Run the fast suite to verify the new tests pass**
+
+Run: `zig build test`
+Expected: PASS (exit 0), including the `parseLsDirArg` tests. If a test fails or the build errors, fix before continuing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/input/ls_path_context.zig src/test_fast.zig
+git commit -m "feat: parse ls command line into a directory prefix
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `inferPrefixForClick` — scan upward over the grid for the nearest match
+
+**Files:**
+- Modify: `src/input/ls_path_context.zig`
+
+- [ ] **Step 1: Add `encodeRow`, `inferPrefixForClick`, and fake-grid tests**
+
+Append to `src/input/ls_path_context.zig` (after `parseLsDirArg`, before the existing tests is fine — or at end; placement does not matter as long as it compiles):
+
+```zig
+/// Encode one grid row into UTF-8 bytes in `buf`. Empty cells (codepoint 0)
+/// become spaces so tokenization sees word boundaries. Truncates at `buf` len.
+fn encodeRow(grid: anytype, row: usize, buf: []u8) []const u8 {
+    const cols = grid.colCount(row);
+    var n: usize = 0;
+    var col: usize = 0;
+    while (col < cols) : (col += 1) {
+        var cp = grid.codepoint(row, col);
+        if (cp == 0) cp = ' ';
+        var tmp: [4]u8 = undefined;
+        const len = std.unicode.utf8Encode(cp, &tmp) catch continue;
+        if (n + len > buf.len) break;
+        @memcpy(buf[n .. n + len], tmp[0..len]);
+        n += len;
+    }
+    return buf[0..n];
+}
+
+/// Scan upward from `click_row` (bounded to the grid) for the nearest line that
+/// parses as an `ls <dir>/` command. On a hit, copy the directory into
+/// `out_buf` and return it; otherwise null. `grid` must expose
+/// `rowCount() usize`, `colCount(row) usize`, and `codepoint(row, col) u21`.
+pub fn inferPrefixForClick(grid: anytype, click_row: usize, out_buf: []u8) ?[]const u8 {
+    const count = grid.rowCount();
+    if (count == 0) return null;
+    var row = if (click_row >= count) count - 1 else click_row;
+    var line_buf: [1024]u8 = undefined;
+    while (true) {
+        const line = encodeRow(grid, row, &line_buf);
+        if (parseLsDirArg(line)) |dir| {
+            if (dir.len == 0 or dir.len > out_buf.len) return null;
+            @memcpy(out_buf[0..dir.len], dir);
+            return out_buf[0..dir.len];
+        }
+        if (row == 0) break;
+        row -= 1;
+    }
+    return null;
+}
+
+/// Test-only grid backed by ASCII rows (index 0 = top row).
+const FakeGrid = struct {
+    rows: []const []const u8,
+
+    fn rowCount(self: FakeGrid) usize {
+        return self.rows.len;
+    }
+    fn colCount(self: FakeGrid, row: usize) usize {
+        return self.rows[row].len;
+    }
+    fn codepoint(self: FakeGrid, row: usize, col: usize) u21 {
+        return self.rows[row][col];
+    }
+};
+
+test "inferPrefixForClick: finds the ls command above the clicked row" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ ls Ath/Ph_SE/",
+        "cluster_resolution_summary.tsv",
+        "summary.txt",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", inferPrefixForClick(grid, 2, &buf).?);
+}
+
+test "inferPrefixForClick: picks the nearest ls when several exist" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ ls first/",
+        "a.txt",
+        "$ ls second/",
+        "b.txt",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("second/", inferPrefixForClick(grid, 3, &buf).?);
+}
+
+test "inferPrefixForClick: no ls above returns null" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ cat notes.txt",
+        "some output",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(inferPrefixForClick(grid, 1, &buf) == null);
+}
+
+test "inferPrefixForClick: empty grid returns null" {
+    const grid = FakeGrid{ .rows = &.{} };
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(inferPrefixForClick(grid, 0, &buf) == null);
+}
+```
+
+- [ ] **Step 2: Run the fast suite to verify the new tests pass**
+
+Run: `zig build test`
+Expected: PASS (exit 0), including the four `inferPrefixForClick` tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/input/ls_path_context.zig
+git commit -m "feat: scan terminal grid upward for nearest ls dir prefix
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `isBareRelativeFilename` + `applyLsPrefix` — the join gate
+
+**Files:**
+- Modify: `src/input/ls_path_context.zig`
+
+- [ ] **Step 1: Add the gate functions and tests**
+
+Append to `src/input/ls_path_context.zig`:
+
+```zig
+/// True when `path` is a plain filename with no directory component: not
+/// absolute, not `~`-rooted, no `/` or `\`, and not a `X:` Windows drive path.
+pub fn isBareRelativeFilename(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (path[0] == '/' or path[0] == '~') return false;
+    if (path.len >= 2 and path[1] == ':') return false; // windows drive letter
+    for (path) |c| {
+        if (c == '/' or c == '\\') return false;
+    }
+    return true;
+}
+
+/// When `ls_prefix` is present and `path` is a bare filename, return an
+/// allocator-owned `prefix ++ path`. Returns null to mean "use `path` as-is"
+/// (no prefix, or the token is already a path). Caller frees a non-null result.
+pub fn applyLsPrefix(allocator: std.mem.Allocator, path: []const u8, ls_prefix: ?[]const u8) !?[]u8 {
+    const pfx = ls_prefix orelse return null;
+    if (!isBareRelativeFilename(path)) return null;
+    return try std.fmt.allocPrint(allocator, "{s}{s}", .{ pfx, path });
+}
+
+test "isBareRelativeFilename: accepts plain names, rejects pathed tokens" {
+    try std.testing.expect(isBareRelativeFilename("cluster_resolution_summary.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("Ath/Ph_SE/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("/abs/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("~/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("C:/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("dir\\x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename(""));
+}
+
+test "applyLsPrefix: joins prefix onto a bare filename" {
+    const allocator = std.testing.allocator;
+    const joined = (try applyLsPrefix(allocator, "x.tsv", "Ath/Ph_SE/")).?;
+    defer allocator.free(joined);
+    try std.testing.expectEqualStrings("Ath/Ph_SE/x.tsv", joined);
+}
+
+test "applyLsPrefix: null prefix or already-pathed token yields null" {
+    const allocator = std.testing.allocator;
+    try std.testing.expect((try applyLsPrefix(allocator, "x.tsv", null)) == null);
+    try std.testing.expect((try applyLsPrefix(allocator, "sub/x.tsv", "Ath/")) == null);
+    try std.testing.expect((try applyLsPrefix(allocator, "/abs/x.tsv", "Ath/")) == null);
+}
+```
+
+- [ ] **Step 2: Run the fast suite to verify the new tests pass**
+
+Run: `zig build test`
+Expected: PASS (exit 0), including the `isBareRelativeFilename` and `applyLsPrefix` tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/input/ls_path_context.zig
+git commit -m "feat: gate ls prefix join to bare relative filenames
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the prefix into resolution and the ctrl+click call sites
+
+**Files:**
+- Modify: `src/input/preview_source.zig` (`resolveTerminalPreviewPath`)
+- Modify: `src/input.zig` (import, `lsPrefixForCell`, two call sites)
+- Modify: `src/html_server.zig` (one call site)
+
+- [ ] **Step 1: Add the `ls_path_context` import to `preview_source.zig`**
+
+In `src/input/preview_source.zig`, add to the import block near the top (after the `preview_path` import on line 10):
+
+```zig
+const preview_path = @import("preview_path.zig");
+const ls_path_context = @import("ls_path_context.zig");
+```
+
+- [ ] **Step 2: Change `resolveTerminalPreviewPath` to take and apply `ls_prefix`**
+
+In `src/input/preview_source.zig`, replace the whole `resolveTerminalPreviewPath` function (currently starting at line 164) with:
+
+```zig
+pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surface, path: []const u8, ls_prefix: ?[]const u8) ![]u8 {
+    const joined = try ls_path_context.applyLsPrefix(allocator, path, ls_prefix);
+    defer if (joined) |j| allocator.free(j);
+    const eff = joined orelse path;
+
+    return switch (surface.launch_kind) {
+        .wsl => try resolveUnixTerminalPath(allocator, surface.getCwd() orelse "~", eff, false),
+        .ssh => try resolveUnixTerminalPath(allocator, surface.getCwd(), eff, true),
+        .local => blk: {
+            if (std.fs.path.isAbsolute(eff) or (eff.len >= 2 and eff[1] == ':')) {
+                break :blk try allocator.dupe(u8, eff);
+            }
+            // Resolve relative to the shell's CURRENT cwd, not its launch cwd:
+            // the user may have `cd`'d, and shells like zsh don't emit OSC 7,
+            // so we fall back to a live process-cwd query (see dupeCurrentCwd).
+            const cwd = surface.dupeCurrentCwd(allocator) orelse {
+                break :blk try allocator.dupe(u8, eff);
+            };
+            defer allocator.free(cwd);
+            break :blk try std.fs.path.join(allocator, &.{ cwd, eff });
+        },
+    };
+}
+```
+
+- [ ] **Step 3: Add the `ls_path_context` import and `lsPrefixForCell` helper to `input.zig`**
+
+In `src/input.zig`, add the import near the other input-submodule imports (the `preview_source` import is on line 50):
+
+```zig
+const preview_source = @import("input/preview_source.zig");
+const ls_path_context = @import("input/ls_path_context.zig");
+```
+
+Then add this helper immediately above `fn openPreviewPanelForCell` (line 2786). It reuses the existing `TerminalTokenGrid` (defined at line 2341) under the render-state mutex:
+
+```zig
+fn lsPrefixForCell(surface: *Surface, cell_pos: CellPos, out_buf: []u8) ?[]const u8 {
+    const cols = @as(usize, @intCast(surface.size.grid.cols));
+    const rows = @as(usize, @intCast(surface.size.grid.rows));
+    if (cols == 0 or rows == 0 or cell_pos.row >= rows) return null;
+
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+
+    const grid = TerminalTokenGrid{ .surface = surface, .rows = rows, .cols = cols };
+    return ls_path_context.inferPrefixForClick(grid, cell_pos.row, out_buf);
+}
+```
+
+- [ ] **Step 4: Update the preview call site in `openPreviewPanelForCell`**
+
+In `src/input.zig`, in `openPreviewPanelForCell`, after the line `defer allocator.free(path);` (line 2789) insert:
+
+```zig
+    defer allocator.free(path);
+
+    var ls_prefix_buf: [256]u8 = undefined;
+    const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+```
+
+Then change the resolve call (line 2792) from:
+
+```zig
+        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path) catch {
+```
+
+to:
+
+```zig
+        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch {
+```
+
+- [ ] **Step 5: Update the download call site in `downloadTerminalFileAtCell`**
+
+In `src/input.zig`, in `downloadTerminalFileAtCell`, after its `defer allocator.free(path);` (line 2820) insert:
+
+```zig
+    defer allocator.free(path);
+
+    var ls_prefix_buf: [256]u8 = undefined;
+    const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+```
+
+Then change the resolve call (line 2822) from:
+
+```zig
+    const resolved_path = resolveTerminalPreviewPath(allocator, surface, path) catch |err| {
+```
+
+to:
+
+```zig
+    const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
+```
+
+- [ ] **Step 6: Update the `html_server.zig` call site to pass `null`**
+
+In `src/html_server.zig`, in `openForSurface`, change the resolve call (line 124) from:
+
+```zig
+    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path) catch |err| {
+```
+
+to:
+
+```zig
+    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path, null) catch |err| {
+```
+
+- [ ] **Step 7: Build and run the full suite**
+
+Run: `zig build test-full`
+Expected: PASS (exit 0), 0 failed. This compiles the full app graph (covering `input.zig`, `preview_source.zig`, `html_server.zig`) and confirms the signature change is consistent across all three call sites.
+
+Also run the fast suite to confirm nothing regressed:
+
+Run: `zig build test`
+Expected: PASS (exit 0).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/input/preview_source.zig src/input.zig src/html_server.zig
+git commit -m "feat: resolve ls-listed bare filenames via inferred dir prefix
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** parsing rules → Task 1; upward viewport scan → Task 2; bare-filename gate + join → Task 3; wiring into `resolveTerminalPreviewPath` with both preview and SSH-download benefiting, local/WSL/SSH uniform → Task 4. The "no existence check / viewport-only / heuristic" trade-offs fall out of the design (no extra code). All three callers (incl. `html_server.zig`, found during planning) are updated.
+- **Type consistency:** `parseLsDirArg(line) ?[]const u8`, `inferPrefixForClick(grid, click_row, out_buf) ?[]const u8`, `isBareRelativeFilename(path) bool`, `applyLsPrefix(allocator, path, ls_prefix) !?[]u8`, `resolveTerminalPreviewPath(allocator, surface, path, ls_prefix)` are used identically everywhere they appear.
+- **GUI note:** As with prior preview work, GUI verification (Windows/WSL) is manual and out of scope for these automated steps; flag it as pending after merge.
+
+## Known limitations (accepted for v1, from the spec)
+
+- Quoted directory args containing spaces (`ls "My Dir/"`) are not handled — tokenization splits on whitespace.
+- The `ls` command must still be within the visible viewport; if it scrolled off, resolution falls back to the current CWD-relative behavior.
+- Without OSC 133 shell integration, an unrecognized intervening command could let the scan reach an earlier `ls`. Low-probability misfire; fails gracefully.

--- a/docs/superpowers/specs/2026-06-05-smart-ls-path-context-design.md
+++ b/docs/superpowers/specs/2026-06-05-smart-ls-path-context-design.md
@@ -1,0 +1,114 @@
+# Smart `ls` Path Context for Ctrl+Click — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (design), pending implementation plan
+**Branch:** `feat-smarter-path`
+
+## Problem
+
+When the user runs `ls <dir>/` (e.g. `ls Ath/Ph_SE/`), the output is a flat list of
+**bare filenames** — the directory prefix lives only on the command line above, not in
+the listing. Ctrl+clicking `cluster_resolution_summary.tsv` to preview it currently
+resolves the token relative to the shell's CWD (`$CWD/cluster_resolution_summary.tsv`),
+which does not exist. The real file is `$CWD/Ath/Ph_SE/cluster_resolution_summary.tsv`.
+
+Today's resolver (`resolveTerminalPreviewPath`, `src/input/preview_source.zig:164`) only
+looks at the clicked token text plus CWD. It ignores all surrounding terminal context, so
+bare-filename clicks from `ls <dir>/` output fail to open.
+
+## Goal
+
+Make ctrl+click "context-aware" for the **`ls` family only**: when the clicked token is a
+bare filename, infer the directory prefix from the nearest preceding `ls <dir>/` command
+line and prepend it before the existing CWD-relative resolution runs.
+
+### Explicitly out of scope
+
+- **`tree`** — its output is hierarchical/indented; a bare filename is not a complete
+  path, and correct resolution would require parsing box-drawing indentation. Deliberately
+  excluded (would be a separate, more fragile feature).
+- **`find <dir>`** — its output is already a complete relative path
+  (`Ath/Ph_SE/file.tsv`), which the existing CWD-join already resolves correctly. Nothing
+  to build.
+
+## Approach
+
+A small pure parsing layer + an upward viewport scan + a single wiring point. No OSC 133
+shell integration exists in this codebase, so command-line detection is heuristic; the
+grid is readable row-by-row (`readViewportRowLocked` / `TerminalTokenGrid`), which is
+sufficient.
+
+### Component 1 — Pure parsing (unit-testable)
+
+New pure module under `src/input/` (e.g. `ls_path_context.zig`), no terminal dependency.
+
+**`parseLsDirArg(line: []const u8) ?[]const u8`**
+Given one line of text, decide whether it is an `ls`-family command with exactly one
+directory argument; if so, return that directory prefix (a slice into `line`).
+
+Rules:
+- The command name must be one of `ls` / `ll` / `la` / `l` / `dir`, matched as a standalone
+  token (so `lsblk`, `false`, a path containing `ls` do not match). The command token may
+  be preceded by an arbitrary prompt prefix (we scan for the token boundary rather than
+  assuming column 0).
+- Skip `-`-prefixed flags (e.g. `-l`, `-la`, `--color=auto`).
+- Of the remaining non-flag arguments, require **exactly one**, and it must **end with `/`**
+  (e.g. `Ath/Ph_SE/`). Return it.
+- Return `null` for: zero args (`ls` of CWD), multiple non-flag args (`ls A/ B/` —
+  ambiguous), or a sole argument not ending in `/`. We do not guess in ambiguous cases.
+
+**`inferPrefixForClick(grid, click_row) ?[]const u8`**
+Scan **upward** from `click_row` (bounded to the visible viewport), reading each row's text
+and calling `parseLsDirArg`. Return the **nearest** matching directory; return `null` if the
+top of the viewport is reached without a match. Accepts a row-reader interface (the same
+shape as `TerminalTokenGrid`) so it can be unit-tested with a fake grid.
+
+### Component 2 — Wiring
+
+In `resolveTerminalPreviewPath` (`src/input/preview_source.zig:164`), before the existing
+per-launch-kind resolution, insert a prefix **only when both** hold:
+1. The clicked token is a **bare filename** — contains no `/`, is not absolute, is not
+   `~`-rooted. (Already-pathed tokens are left untouched.)
+2. `inferPrefixForClick` returns a prefix.
+
+On a hit: `bare_name` → `prefix ++ bare_name`, then the existing logic joins with CWD per
+`launch_kind`. This works uniformly for `local`, `wsl`, and `ssh` because it is plain
+string prefixing applied before the unchanged per-kind join.
+
+`resolveTerminalPreviewPath` will need access to the click row and a row-reader for the
+scan; these come from the same `surface` + `render_state` grid the token extraction already
+uses (under the existing `render_state.mutex`).
+
+## Behavior & boundaries (accepted trade-offs)
+
+- **No existence check.** Best-effort. A wrong guess fails gracefully exactly as today
+  (`Preview failed`). Avoids `stat` / remote round-trips for WSL/SSH.
+- **Viewport-only scan.** If the `ls` command has scrolled off the top, we fall back to the
+  current CWD-relative behavior. The common "ran `ls dir/`, then clicked a result" case has
+  the command on screen.
+- **Heuristic command detection (no OSC 133).** If an intervening command's prompt line is
+  not recognized, the upward scan could skip past it to an earlier `ls`. This is a known
+  low-probability misfire accepted for v1; a future "stop at the first prompt-looking line"
+  convergence can tighten it if needed.
+
+## Affected call sites
+
+Both ctrl+click preview (`openPreviewPanelForCell`) and SSH download
+(`downloadTerminalFileAtCell`) route through `resolveTerminalPreviewPath`, so both benefit
+automatically from the same change.
+
+## Testing
+
+- Unit tests for `parseLsDirArg`: ls/ll/la/l/dir hits with trailing-`/` arg; flag skipping;
+  rejection of zero args, multiple args, non-`/` arg, and non-ls command names
+  (`lsblk`, paths containing `ls`).
+- Unit tests for `inferPrefixForClick` against a fake grid: nearest-match selection,
+  no-match returns null, bounded scan to viewport top.
+- A resolver-level test confirming bare-name + inferred prefix joins correctly, and that
+  absolute/`~`/slash-containing tokens are left untouched.
+
+## Files
+
+- New: `src/input/ls_path_context.zig` (pure: `parseLsDirArg`, `inferPrefixForClick`).
+- Edit: `src/input/preview_source.zig` (wire into `resolveTerminalPreviewPath`).
+- Test registration in the appropriate test aggregator so the new tests actually run.

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -121,7 +121,7 @@ pub fn deinit() void {
 
 pub fn openForSurface(allocator: std.mem.Allocator, surface: *Surface, path: []const u8) OpenResult {
     if (!model.isHtmlPath(path)) return .{ .err = error.NotHtml };
-    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path) catch |err| {
+    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path, null) catch |err| {
         return .{ .err = if (err == error.CwdUnavailable) error.CwdUnavailable else error.PathTooLong };
     };
     defer allocator.free(resolved);

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -119,9 +119,9 @@ pub fn deinit() void {
     for (&g_servers) |*slot| stopServer(slot);
 }
 
-pub fn openForSurface(allocator: std.mem.Allocator, surface: *Surface, path: []const u8) OpenResult {
+pub fn openForSurface(allocator: std.mem.Allocator, surface: *Surface, path: []const u8, ls_prefix: ?[]const u8) OpenResult {
     if (!model.isHtmlPath(path)) return .{ .err = error.NotHtml };
-    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path, null) catch |err| {
+    const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
         return .{ .err = if (err == error.CwdUnavailable) error.CwdUnavailable else error.PathTooLong };
     };
     defer allocator.free(resolved);
@@ -709,7 +709,7 @@ fn termOk(term: std.process.Child.Term) bool {
 
 test "html_server: public open API shape stays stable" {
     const info = @typeInfo(@TypeOf(openForSurface)).@"fn";
-    try std.testing.expectEqual(@as(usize, 3), info.params.len);
+    try std.testing.expectEqual(@as(usize, 4), info.params.len);
     try std.testing.expect(info.return_type.? == OpenResult);
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -48,6 +48,7 @@ const clipboard = @import("input/clipboard.zig");
 const click_tracker = @import("input/click_tracker.zig");
 const hit_test = @import("input/hit_test.zig");
 const preview_source = @import("input/preview_source.zig");
+const ls_path_context = @import("input/ls_path_context.zig");
 const terminal_link_action = @import("input/terminal_link_action.zig");
 const mouse_report = @import("input/mouse_report.zig");
 const close_confirm = @import("close_confirm.zig");
@@ -2783,13 +2784,28 @@ fn openFileExplorerPreview(row_idx: usize) bool {
     return openPreviewAsync(kind, title, path, source_kind);
 }
 
+fn lsPrefixForCell(surface: *Surface, cell_pos: CellPos, out_buf: []u8) ?[]const u8 {
+    const cols = @as(usize, @intCast(surface.size.grid.cols));
+    const rows = @as(usize, @intCast(surface.size.grid.rows));
+    if (cols == 0 or rows == 0 or cell_pos.row >= rows) return null;
+
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+
+    const grid = TerminalTokenGrid{ .surface = surface, .rows = rows, .cols = cols };
+    return ls_path_context.inferPrefixForClick(grid, cell_pos.row, out_buf);
+}
+
 fn openPreviewPanelForCell(surface: *Surface, cell_pos: CellPos) bool {
     const allocator = AppWindow.g_allocator orelse return false;
     const path = extractPreviewPathAtCell(allocator, surface, cell_pos) orelse return false;
     defer allocator.free(path);
 
+    var ls_prefix_buf: [256]u8 = undefined;
+    const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+
     if (markdown_preview.detectKind(path)) |kind| {
-        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path) catch {
+        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch {
             file_explorer.setTransferStatus(.failed, "Preview failed");
             return true;
         };
@@ -2819,7 +2835,10 @@ fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
     const path = extractDownloadPathAtCell(allocator, surface, cell_pos) orelse return false;
     defer allocator.free(path);
 
-    const resolved_path = resolveTerminalPreviewPath(allocator, surface, path) catch |err| {
+    var ls_prefix_buf: [256]u8 = undefined;
+    const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+
+    const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
         if (err == error.CwdUnavailable) {
             file_explorer.setTransferStatusForKind(.download, .failed, "SSH cwd unknown");
             overlays.showSshCwdFallbackPrompt();

--- a/src/input.zig
+++ b/src/input.zig
@@ -2679,7 +2679,10 @@ fn openHtmlPanelForCell(surface: *Surface, cell_pos: CellPos) bool {
     defer allocator.free(path);
     if (!html_server_model.isHtmlPath(path)) return false;
 
-    switch (html_server.openForSurface(allocator, surface, path)) {
+    var ls_prefix_buf: [256]u8 = undefined;
+    const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+
+    switch (html_server.openForSurface(allocator, surface, path, ls_prefix)) {
         .url => |url| {
             defer allocator.free(url);
             const parent = AppWindow.currentNativeHandle();
@@ -2784,6 +2787,10 @@ fn openFileExplorerPreview(row_idx: usize) bool {
     return openPreviewAsync(kind, title, path, source_kind);
 }
 
+/// Infer the `ls <dir>/` directory prefix for the clicked cell, copied into
+/// `out_buf`. The returned slice points into `out_buf`, so the caller's buffer
+/// must outlive every use of the result. Returns null when no nearby `ls`
+/// command applies. Holds `render_state.mutex` only for the grid scan.
 fn lsPrefixForCell(surface: *Surface, cell_pos: CellPos, out_buf: []u8) ?[]const u8 {
     const cols = @as(usize, @intCast(surface.size.grid.cols));
     const rows = @as(usize, @intCast(surface.size.grid.rows));

--- a/src/input/ls_path_context.zig
+++ b/src/input/ls_path_context.zig
@@ -1,0 +1,79 @@
+//! Smart path context for ctrl+click: infer a directory prefix from a nearby
+//! `ls <dir>/` command line so bare-filename clicks resolve to the right file.
+//! Pure logic only — no terminal/Surface dependency — so it is unit-testable.
+
+const std = @import("std");
+
+/// Command names whose single trailing-`/` argument we treat as a path prefix.
+const ls_commands = [_][]const u8{ "ls", "ll", "la", "l", "dir" };
+
+fn isLsCommand(tok: []const u8) bool {
+    for (ls_commands) |cmd| {
+        if (std.mem.eql(u8, tok, cmd)) return true;
+    }
+    return false;
+}
+
+/// If `line` is an `ls`-family command with exactly one directory argument
+/// (a non-flag token ending in `/`), return that directory (a slice into
+/// `line`). Returns null for zero args, multiple non-flag args, a sole
+/// argument not ending in `/`, or a non-ls command. The command token may be
+/// preceded by an arbitrary prompt prefix.
+pub fn parseLsDirArg(line: []const u8) ?[]const u8 {
+    var it = std.mem.tokenizeAny(u8, line, " \t");
+
+    var found_cmd = false;
+    while (it.next()) |tok| {
+        if (isLsCommand(tok)) {
+            found_cmd = true;
+            break;
+        }
+    }
+    if (!found_cmd) return null;
+
+    var dir: ?[]const u8 = null;
+    while (it.next()) |tok| {
+        if (tok.len > 0 and tok[0] == '-') continue; // flag
+        if (dir != null) return null; // >1 non-flag arg → ambiguous
+        dir = tok;
+    }
+
+    const d = dir orelse return null; // ls of CWD, no dir arg
+    if (d.len == 0 or d[d.len - 1] != '/') return null; // must be a directory
+    return d;
+}
+
+test "parseLsDirArg: ls with a trailing-slash dir" {
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", parseLsDirArg("ls Ath/Ph_SE/").?);
+}
+
+test "parseLsDirArg: tolerates a prompt prefix" {
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", parseLsDirArg("$ ls Ath/Ph_SE/").?);
+    try std.testing.expectEqualStrings("data/", parseLsDirArg("me@box:~/proj$ ls data/").?);
+}
+
+test "parseLsDirArg: skips flags" {
+    try std.testing.expectEqualStrings("Ath/", parseLsDirArg("ls -la Ath/").?);
+    try std.testing.expectEqualStrings("Ath/", parseLsDirArg("ls --color=auto Ath/").?);
+}
+
+test "parseLsDirArg: accepts ls-family aliases" {
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("ll d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("la d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("l d/").?);
+    try std.testing.expectEqualStrings("d/", parseLsDirArg("dir d/").?);
+}
+
+test "parseLsDirArg: rejects non-ls and lookalike commands" {
+    try std.testing.expect(parseLsDirArg("lsblk d/") == null);
+    try std.testing.expect(parseLsDirArg("cat foo.txt") == null);
+    try std.testing.expect(parseLsDirArg("~/tools/ls d/") == null);
+}
+
+test "parseLsDirArg: rejects zero, multiple, and non-dir args" {
+    try std.testing.expect(parseLsDirArg("ls") == null);
+    try std.testing.expect(parseLsDirArg("ls -la") == null);
+    try std.testing.expect(parseLsDirArg("ls A/ B/") == null);
+    try std.testing.expect(parseLsDirArg("ls foo.txt") == null);
+    try std.testing.expect(parseLsDirArg("ls Ath") == null);
+}

--- a/src/input/ls_path_context.zig
+++ b/src/input/ls_path_context.zig
@@ -77,3 +77,99 @@ test "parseLsDirArg: rejects zero, multiple, and non-dir args" {
     try std.testing.expect(parseLsDirArg("ls foo.txt") == null);
     try std.testing.expect(parseLsDirArg("ls Ath") == null);
 }
+
+/// Encode one grid row into UTF-8 bytes in `buf`. Empty cells (codepoint 0)
+/// become spaces so tokenization sees word boundaries. Truncates at `buf` len.
+fn encodeRow(grid: anytype, row: usize, buf: []u8) []const u8 {
+    const cols = grid.colCount(row);
+    var n: usize = 0;
+    var col: usize = 0;
+    while (col < cols) : (col += 1) {
+        var cp = grid.codepoint(row, col);
+        if (cp == 0) cp = ' ';
+        var tmp: [4]u8 = undefined;
+        const len = std.unicode.utf8Encode(cp, &tmp) catch blk: {
+            // Un-encodable codepoint (shouldn't occur from a real grid):
+            // substitute a space so column structure / token boundaries hold.
+            tmp[0] = ' ';
+            break :blk @as(usize, 1);
+        };
+        if (n + len > buf.len) break;
+        @memcpy(buf[n .. n + len], tmp[0..len]);
+        n += len;
+    }
+    return buf[0..n];
+}
+
+/// Scan upward from `click_row` (bounded to the grid) for the nearest line that
+/// parses as an `ls <dir>/` command. On a hit, copy the directory into
+/// `out_buf` and return it; otherwise null. `grid` must expose
+/// `rowCount() usize`, `colCount(row) usize`, and `codepoint(row, col) u21`.
+pub fn inferPrefixForClick(grid: anytype, click_row: usize, out_buf: []u8) ?[]const u8 {
+    const count = grid.rowCount();
+    if (count == 0) return null;
+    var row = if (click_row >= count) count - 1 else click_row;
+    var line_buf: [1024]u8 = undefined;
+    while (true) {
+        const line = encodeRow(grid, row, &line_buf);
+        if (parseLsDirArg(line)) |dir| {
+            if (dir.len == 0 or dir.len > out_buf.len) return null;
+            @memcpy(out_buf[0..dir.len], dir);
+            return out_buf[0..dir.len];
+        }
+        if (row == 0) break;
+        row -= 1;
+    }
+    return null;
+}
+
+/// Test-only grid backed by ASCII rows (index 0 = top row).
+const FakeGrid = struct {
+    rows: []const []const u8,
+
+    fn rowCount(self: FakeGrid) usize {
+        return self.rows.len;
+    }
+    fn colCount(self: FakeGrid, row: usize) usize {
+        return self.rows[row].len;
+    }
+    fn codepoint(self: FakeGrid, row: usize, col: usize) u21 {
+        return self.rows[row][col];
+    }
+};
+
+test "inferPrefixForClick: finds the ls command above the clicked row" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ ls Ath/Ph_SE/",
+        "cluster_resolution_summary.tsv",
+        "summary.txt",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("Ath/Ph_SE/", inferPrefixForClick(grid, 2, &buf).?);
+}
+
+test "inferPrefixForClick: picks the nearest ls when several exist" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ ls first/",
+        "a.txt",
+        "$ ls second/",
+        "b.txt",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expectEqualStrings("second/", inferPrefixForClick(grid, 3, &buf).?);
+}
+
+test "inferPrefixForClick: no ls above returns null" {
+    const grid = FakeGrid{ .rows = &.{
+        "$ cat notes.txt",
+        "some output",
+    } };
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(inferPrefixForClick(grid, 1, &buf) == null);
+}
+
+test "inferPrefixForClick: empty grid returns null" {
+    const grid = FakeGrid{ .rows = &.{} };
+    var buf: [256]u8 = undefined;
+    try std.testing.expect(inferPrefixForClick(grid, 0, &buf) == null);
+}

--- a/src/input/ls_path_context.zig
+++ b/src/input/ls_path_context.zig
@@ -173,3 +173,59 @@ test "inferPrefixForClick: empty grid returns null" {
     var buf: [256]u8 = undefined;
     try std.testing.expect(inferPrefixForClick(grid, 0, &buf) == null);
 }
+
+/// True when `path` is a plain filename with no directory component: not
+/// absolute, not `~`-rooted, no `/` or `\`, and not a `X:` Windows drive path.
+pub fn isBareRelativeFilename(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (path[0] == '/' or path[0] == '~') return false;
+    if (path.len >= 3 and std.ascii.isAlphabetic(path[0]) and path[1] == ':' and (path[2] == '/' or path[2] == '\\')) return false; // windows drive letter
+    for (path) |c| {
+        if (c == '/' or c == '\\') return false;
+    }
+    return true;
+}
+
+/// When `ls_prefix` is present and `path` is a bare filename, return an
+/// allocator-owned `prefix ++ path`. Returns null to mean "use `path` as-is"
+/// (no prefix, or the token is already a path). Caller frees a non-null result.
+pub fn applyLsPrefix(allocator: std.mem.Allocator, path: []const u8, ls_prefix: ?[]const u8) !?[]u8 {
+    const pfx = ls_prefix orelse return null;
+    if (!isBareRelativeFilename(path)) return null;
+    return try std.fmt.allocPrint(allocator, "{s}{s}", .{ pfx, path });
+}
+
+test "isBareRelativeFilename: accepts plain names, rejects pathed tokens" {
+    try std.testing.expect(isBareRelativeFilename("cluster_resolution_summary.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("Ath/Ph_SE/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("/abs/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("~/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("C:/x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename("dir\\x.tsv"));
+    try std.testing.expect(!isBareRelativeFilename(""));
+    try std.testing.expect(isBareRelativeFilename("a:b")); // POSIX colon name, not a drive
+    try std.testing.expect(!isBareRelativeFilename("Z:\\x.tsv")); // real drive letter still rejected
+}
+
+test "applyLsPrefix: joins prefix onto a bare filename" {
+    const allocator = std.testing.allocator;
+    const joined = (try applyLsPrefix(allocator, "x.tsv", "Ath/Ph_SE/")).?;
+    defer allocator.free(joined);
+    try std.testing.expectEqualStrings("Ath/Ph_SE/x.tsv", joined);
+}
+
+test "applyLsPrefix: concatenates verbatim (caller owns the separator)" {
+    const allocator = std.testing.allocator;
+    // applyLsPrefix does not insert a separator; parseLsDirArg guarantees the
+    // trailing slash. A prefix without one concatenates directly.
+    const joined = (try applyLsPrefix(allocator, "x.tsv", "Ath")).?;
+    defer allocator.free(joined);
+    try std.testing.expectEqualStrings("Athx.tsv", joined);
+}
+
+test "applyLsPrefix: null prefix or already-pathed token yields null" {
+    const allocator = std.testing.allocator;
+    try std.testing.expect((try applyLsPrefix(allocator, "x.tsv", null)) == null);
+    try std.testing.expect((try applyLsPrefix(allocator, "sub/x.tsv", "Ath/")) == null);
+    try std.testing.expect((try applyLsPrefix(allocator, "/abs/x.tsv", "Ath/")) == null);
+}

--- a/src/input/preview_source.zig
+++ b/src/input/preview_source.zig
@@ -8,6 +8,7 @@ const platform_remote_file = @import("../platform/remote_file.zig");
 const scp = @import("../scp.zig");
 const ui_perf = @import("../ui_perf.zig");
 const preview_path = @import("preview_path.zig");
+const ls_path_context = @import("ls_path_context.zig");
 
 fn endsWithIgnoreCase(text: []const u8, suffix: []const u8) bool {
     if (text.len < suffix.len) return false;
@@ -161,22 +162,26 @@ test "preview_source: ssh relative paths require a reported cwd" {
     try std.testing.expectEqualStrings("/srv/project/data/sample.fa", relative);
 }
 
-pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surface, path: []const u8) ![]u8 {
+pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surface, path: []const u8, ls_prefix: ?[]const u8) ![]u8 {
+    const joined = try ls_path_context.applyLsPrefix(allocator, path, ls_prefix);
+    defer if (joined) |j| allocator.free(j);
+    const eff = joined orelse path;
+
     return switch (surface.launch_kind) {
-        .wsl => try resolveUnixTerminalPath(allocator, surface.getCwd() orelse "~", path, false),
-        .ssh => try resolveUnixTerminalPath(allocator, surface.getCwd(), path, true),
+        .wsl => try resolveUnixTerminalPath(allocator, surface.getCwd() orelse "~", eff, false),
+        .ssh => try resolveUnixTerminalPath(allocator, surface.getCwd(), eff, true),
         .local => blk: {
-            if (std.fs.path.isAbsolute(path) or (path.len >= 2 and path[1] == ':')) {
-                break :blk try allocator.dupe(u8, path);
+            if (std.fs.path.isAbsolute(eff) or (eff.len >= 2 and eff[1] == ':')) {
+                break :blk try allocator.dupe(u8, eff);
             }
             // Resolve relative to the shell's CURRENT cwd, not its launch cwd:
             // the user may have `cd`'d, and shells like zsh don't emit OSC 7,
             // so we fall back to a live process-cwd query (see dupeCurrentCwd).
             const cwd = surface.dupeCurrentCwd(allocator) orelse {
-                break :blk try allocator.dupe(u8, path);
+                break :blk try allocator.dupe(u8, eff);
             };
             defer allocator.free(cwd);
-            break :blk try std.fs.path.join(allocator, &.{ cwd, path });
+            break :blk try std.fs.path.join(allocator, &.{ cwd, eff });
         },
     };
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -25,6 +25,7 @@ test {
     _ = @import("input/hit_test.zig");
     _ = @import("input/mouse_report.zig");
     _ = @import("input/preview_path.zig");
+    _ = @import("input/ls_path_context.zig");
     _ = @import("input/terminal_link_action.zig");
     _ = @import("input/file_drop_path.zig");
     _ = @import("renderer/overlays/profile_codec.zig");


### PR DESCRIPTION
## Summary

Makes ctrl+click on a **bare filename** in terminal output resolve correctly when that filename came from an `ls <dir>/` listing. Previously the clicked token (e.g. `cluster_resolution_summary.tsv`) was resolved relative to the shell CWD only, so clicking a file listed by `ls Ath/Ph_SE/` opened the wrong (non-existent) path. Now we scan the visible grid upward for the nearest preceding `ls <dir>/` command line and prepend its directory before resolution.

- New pure module `src/input/ls_path_context.zig` (fully unit-tested, no `Surface` dependency):
  - `parseLsDirArg` — parse a command line into its single trailing-`/` directory argument (handles prompt prefixes, flag skipping, `ls`/`ll`/`la`/`l`/`dir`; bails on zero/multiple/non-dir args).
  - `inferPrefixForClick` — scan a generic grid reader upward from the clicked row for the nearest matching `ls` line.
  - `isBareRelativeFilename` + `applyLsPrefix` — gate the join to plain filenames (absolute/`~`/slash/drive tokens are left untouched).
- `resolveTerminalPreviewPath` (preview_source) gains an `ls_prefix: ?[]const u8`; applies the join, then runs the unchanged per-launch-kind (local/WSL/SSH) resolution.
- Threaded into all three terminal cell-click sinks via `lsPrefixForCell`: file preview, HTML preview, and SSH download.

**Scope (deliberate):** `ls` family only. `find` already emits complete relative paths (works today); `tree`'s hierarchical/indented output is out of scope.

**Known v1 limitations (documented in the spec):** best-effort with no existence check (a wrong guess fails gracefully like today), visible-viewport-only scan, soft-wrapped `ls` lines not parsed, and — without OSC 133 — the scan can in rare cases attach a prefix to a true-CWD file. Spec/plan: `docs/superpowers/specs/2026-06-05-smart-ls-path-context-design.md` and `docs/superpowers/plans/2026-06-05-smart-ls-path-context.md`.

## Test Plan

- [x] `zig build test` (fast suite) — exit 0
- [x] `zig build test-full` (full app graph) — exit 0
- [x] Pure-module unit tests: `parseLsDirArg`, `inferPrefixForClick` (fake grid), `isBareRelativeFilename`, `applyLsPrefix`
- [x] GUI verify (manual, pending): in a terminal run `ls somedir/`, ctrl+click a listed `.tsv`/`.md`/image/`.html` → opens the file under `somedir/`; confirm absolute/`~`/already-pathed tokens still resolve as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)