### PR TITLE
feat(render-loop): 事件驱动主循环，降低空闲/后台 CPU（阶段1）

### DIFF
--- a/docs/superpowers/plans/2026-06-07-event-driven-render-loop.md
+++ b/docs/superpowers/plans/2026-06-07-event-driven-render-loop.md
@@ -1,0 +1,738 @@
+# 事件驱动主循环（阶段 1）实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 WispTerm 主渲染循环从"每个 vsync 无条件全量渲染"改为"事件驱动 + 脏门控"，使空闲/失焦/后台时主线程 CPU 降到接近 0。
+
+**Architecture:** 在主线程内（不引入渲染线程）新增：(1) 纯逻辑脏门控模块 `render_gate.zig` 判定"本帧是否需要渲染"并计算阻塞超时；(2) `NSApp postEvent` 跨线程唤醒，使 PTY/IO 线程产出数据时能唤醒阻塞的主循环；(3) 直接查询 `occlusionState`/`isKeyWindow` 做可见性/焦点分级。主循环不需渲染时阻塞在带超时的事件泵上，被事件或唤醒打断后重新评估。
+
+**Tech Stack:** Zig + Objective-C（AppKit / Metal），comptime 选择的平台 backend。
+
+参考 spec：[docs/superpowers/specs/2026-06-07-event-driven-render-loop-design.md](../specs/2026-06-07-event-driven-render-loop-design.md)
+
+---
+
+## 关键前提（已核实）
+
+- 主循环：`src/AppWindow.zig` 的 `pub fn run`，`while (running)` 在 5672；循环末尾 5996-6001 `endFrame` + `swapBuffers`，**当前无任何 sleep / 帧节流 / 脏门控**。
+- `g_force_rebuild`（`AppWindow.zig:2826-2827`，threadlocal bool，默认 true）+ `g_cells_valid`：几乎所有交互/UI 变更（input.zig 上百处、overlay 打开、focus 变化）已设 `g_force_rebuild=true`。脏门控把它当一票通过来源即可，**无需改这些站点**。
+- `surface.dirty`（`Surface.zig:193`，`std.atomic.Value(bool)`，默认 true）：IO 线程标脏（`ReadThread.zig:119`、`termio/Thread.zig:172`），当前主循环不读，只有 `RendererThread.zig:116` 在 `swap(false)` 消费（但 RendererThread 不真渲染）。
+- 光标闪烁：`g_cursor_blink`（threadlocal bool）、`CURSOR_BLINK_INTERVAL_MS=600`；`updateCursorBlinkForRenderer(rend)`（`AppWindow.zig:2896`）只翻转 renderer 字段、**不设任何 dirty**。失焦不停。→ blink 必须作为独立"到点该翻转"唤醒源。
+- AI 流式：`ai_chat.Session.request_inflight`（`ai_chat.zig:538`）；流式时后台线程追加 token **不设脏**。→ 门控必须在 AI session `request_inflight` 时强制渲染。
+- 事件泵：comptime 选 backend（`window_backend.zig:18-26`）；`Window` 是 struct；`g_window: ?*window_backend.Window`（`AppWindow.zig:503`，threadlocal）。`pumpAppEvents(timeout)` → `wispterm_macos_app_pump_events`（`bridge:1104`，`untilDate:` 已支持阻塞，windowless）。
+- 跨线程唤醒：**完全不存在**（`postEvent`/`CFRunLoop`/`performSelectorOnMainThread` 全零命中）。`NSApp` 直接用全局宏，`finishLaunching` 已在 `wispterm_macos_app_ensure`（`bridge:200`）调用，`postEvent:atStart:` 可用。
+- IO 线程只持有 `*Surface`，Surface 无任何 window/backend/app 引用 → 唤醒只能走**全局**通道（postEvent 是 app 级，主线程醒来后重评所有 surface）。
+- occlusion/focus delegate 全缺失，但 `[state->window occlusionState]` / `isKeyWindow` / `isMiniaturized` 可随时直接查询；NSWindow 经 `handle → WispTermMacWindowState* → state->window`（模板 `wispterm_macos_window_ns_window`，`bridge:1060`）。
+
+## 测试与构建命令（macOS）
+
+- 纯逻辑单测（零项目依赖）：`zig test src/appwindow/render_gate.zig`
+- 构建 macOS app：`zig build macos-app -Dtarget=aarch64-macos`
+- 注意：默认 `zig build` 目标是 Windows；`zig build test` 在 macOS 有 pre-existing link gap。native 行为靠"构建 + 运行 + 活动监视器观察 CPU"手动验证。
+
+## File Structure
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `src/appwindow/render_gate.zig` | 纯逻辑：`RenderSignals`/`frameNeedsRender` + `TimeoutInputs`/`computeBlockTimeoutMs`，零项目依赖、可独立单测 | 新建 |
+| `src/renderer/overlays.zig` | 新增 `anyOverlayActive(now)` 聚合查询（overlays.zig 内的所有可见态 + 时间动画 toast） | 修改 |
+| `src/platform/window_macos_bridge.m` | 新增 `wispterm_macos_post_wakeup`、`wispterm_macos_window_visible`、`wispterm_macos_window_is_key` | 修改 |
+| `src/platform/window_macos.zig` | extern 声明 + 模块级 `postWakeup()` | 修改 |
+| `src/platform/window_backend_macos.zig` | `Window.isVisible()`；`pollEvents` 刷新真实 `focused` | 修改 |
+| `src/platform/window_backend.zig` | 抽象层 `isVisible(window)`、模块级 `postWakeup()` | 修改 |
+| `src/platform/window_windows.zig`、`window_unsupported.zig` | `postWakeup()` no-op stub | 修改 |
+| `src/platform/window_backend_windows.zig`、`window_backend_unsupported.zig` | `Window.isVisible()` 返回 true stub | 修改 |
+| `src/termio/ReadThread.zig`、`src/termio/Thread.zig` | 标 dirty 后调 `window_backend.postWakeup()` | 修改 |
+| `src/RendererThread.zig` | 停用 `surface.dirty` 消费（避免与主循环互吃） | 修改 |
+| `src/AppWindow.zig` | 主循环集成脏门控 + 阻塞泵 + 渲染后清 dirty + 失焦停 blink | 修改 |
+
+---
+
+## Task 1: 纯逻辑脏门控模块 render_gate.zig
+
+**Files:**
+- Create: `src/appwindow/render_gate.zig`
+
+- [ ] **Step 1: 写失败测试 + 模块骨架**
+
+创建 `src/appwindow/render_gate.zig`（先只写类型 + 空实现 + 测试，让测试先失败）：
+
+```zig
+//! 纯逻辑脏门控：判定"本帧是否需要渲染"以及空闲时阻塞多久。
+//! 刻意零项目依赖（只用 std），便于 `zig test src/appwindow/render_gate.zig` 独立单测。
+const std = @import("std");
+
+/// 窗口可见性/焦点分级。
+pub const Visibility = enum {
+    focused, // 可见且为 key window
+    unfocused_visible, // 可见但非 key
+    hidden, // 被遮挡 / 最小化 / 后台不可见
+};
+
+/// 一帧是否需要渲染的所有信号（采集自主循环）。
+pub const RenderSignals = struct {
+    force_rebuild: bool, // g_force_rebuild（交互/UI 变更，一票通过）
+    any_surface_dirty: bool, // 任一可见 surface.dirty（PTY 输出）
+    cursor_blink_due: bool, // 到达光标翻转点（仅聚焦且开启闪烁）
+    ai_streaming: bool, // 任一相关 AI session.request_inflight
+    overlay_active: bool, // 任一 overlay/面板/时间动画活动
+};
+
+/// 空闲阻塞超时计算的输入。
+pub const TimeoutInputs = struct {
+    visibility: Visibility,
+    cursor_blink_enabled: bool, // g_cursor_blink 且聚焦
+    ms_until_next_blink: i64, // 距下次光标翻转的毫秒数
+};
+
+/// 分级超时上限（毫秒）。保证 void tick（loop/watch、异步加载）定期被驱动。
+pub const CAP_FOCUSED_MS: i64 = 100;
+pub const CAP_UNFOCUSED_MS: i64 = 250;
+pub const CAP_HIDDEN_MS: i64 = 500;
+/// 阻塞超时下限，避免过度唤醒。
+pub const MIN_TIMEOUT_MS: i64 = 16;
+
+pub fn frameNeedsRender(s: RenderSignals) bool {
+    return false; // 占位：让测试先失败
+}
+
+pub fn computeBlockTimeoutMs(in: TimeoutInputs) i64 {
+    return 0; // 占位：让测试先失败
+}
+
+test "frameNeedsRender: 任一信号为真即需渲染" {
+    const base = RenderSignals{
+        .force_rebuild = false,
+        .any_surface_dirty = false,
+        .cursor_blink_due = false,
+        .ai_streaming = false,
+        .overlay_active = false,
+    };
+    try std.testing.expect(!frameNeedsRender(base));
+
+    var s = base;
+    s.force_rebuild = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.any_surface_dirty = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.cursor_blink_due = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.ai_streaming = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.overlay_active = true;
+    try std.testing.expect(frameNeedsRender(s));
+}
+
+test "computeBlockTimeoutMs: 分级上限" {
+    try std.testing.expectEqual(@as(i64, CAP_FOCUSED_MS), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+    try std.testing.expectEqual(@as(i64, CAP_UNFOCUSED_MS), computeBlockTimeoutMs(.{
+        .visibility = .unfocused_visible,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+    try std.testing.expectEqual(@as(i64, CAP_HIDDEN_MS), computeBlockTimeoutMs(.{
+        .visibility = .hidden,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+}
+
+test "computeBlockTimeoutMs: 光标临近翻转时收紧，但不低于下限" {
+    // 聚焦 + blink 还有 40ms 翻转 → 取 40
+    try std.testing.expectEqual(@as(i64, 40), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = true,
+        .ms_until_next_blink = 40,
+    }));
+    // blink 仅剩 3ms → 收到下限 16
+    try std.testing.expectEqual(@as(i64, MIN_TIMEOUT_MS), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = true,
+        .ms_until_next_blink = 3,
+    }));
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `zig test src/appwindow/render_gate.zig`
+Expected: FAIL（`frameNeedsRender`/`computeBlockTimeoutMs` 返回占位值，断言不通过）
+
+- [ ] **Step 3: 实现 frameNeedsRender 与 computeBlockTimeoutMs**
+
+替换两个占位实现：
+
+```zig
+pub fn frameNeedsRender(s: RenderSignals) bool {
+    return s.force_rebuild or
+        s.any_surface_dirty or
+        s.cursor_blink_due or
+        s.ai_streaming or
+        s.overlay_active;
+}
+
+pub fn computeBlockTimeoutMs(in: TimeoutInputs) i64 {
+    var t: i64 = switch (in.visibility) {
+        .focused => CAP_FOCUSED_MS,
+        .unfocused_visible => CAP_UNFOCUSED_MS,
+        .hidden => CAP_HIDDEN_MS,
+    };
+    if (in.cursor_blink_enabled and in.ms_until_next_blink > 0) {
+        t = @min(t, in.ms_until_next_blink);
+    }
+    return @max(MIN_TIMEOUT_MS, t);
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `zig test src/appwindow/render_gate.zig`
+Expected: PASS（3 个 test 全通过）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/appwindow/render_gate.zig
+git commit -m "feat(render-loop): pure render-gate logic (frameNeedsRender + timeout)"
+```
+
+---
+
+## Task 2: overlays.anyOverlayActive() 聚合查询
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`（在文件末尾的 pub 函数区新增；紧邻已有 `anyBlockingOverlayVisible`，约 5418）
+
+- [ ] **Step 1: 新增 anyOverlayActive**
+
+在 `overlays.zig` 内 `anyBlockingOverlayVisible`（约 5418）之后新增。`now` 由调用方传入 `std.time.milliTimestamp()`：
+
+```zig
+/// 脏门控用：是否有任何 overlay / 面板 / 时间动画处于活动状态。
+/// 与 `anyBlockingOverlayVisible`（仅模态遮挡 webview）不同 —— 这里要尽量全，
+/// 漏判会导致 overlay 动画卡住，所以宁可多列。`now` = std.time.milliTimestamp()。
+pub fn anyOverlayActive(now: i64) bool {
+    // 打开态 overlay
+    if (commandPaletteVisible()) return true;
+    if (commandPaletteAgentHistoryVisible()) return true;
+    if (settingsPageVisible()) return true;
+    if (sessionLauncherVisible()) return true;
+    if (whatsNewVisible()) return true;
+    if (windowCloseConfirmVisible()) return true;
+    if (restoreDefaultsConfirmVisible()) return true;
+    if (transferCancelConfirmVisible()) return true;
+    if (jupyter_picker.isVisible()) return true;
+    if (startup_shortcuts.g_startup_shortcuts_visible) return true;
+    if (browser_panel.urlBarFocused()) return true;
+
+    // 时间动画：到期前每帧需持续渲染
+    if (now < g_copy_toast_until_ms) return true;
+    if (g_transfer_toast_sticky or now < g_transfer_toast_until_ms) return true;
+    if (now < g_update_prompt_until_ms) return true;
+    if (now < g_close_shortcut_confirm_until_ms) return true;
+    if (now < g_remote_key_copied_until_ms) return true;
+    if (now < resize.g_split_resize_overlay_until) return true;
+
+    // FPS 叠层开启时每秒刷新
+    if (g_debug_fps) return true;
+
+    return false;
+}
+```
+
+> 注：以上符号均为 `overlays.zig` 内既有定义（getter 见 spec 块5；`g_*_until_ms` 计时字段、`g_transfer_toast_sticky`、`g_debug_fps`、`resize.g_split_resize_overlay_until`、子模块 `jupyter_picker`/`startup_shortcuts`/`browser_panel`）。若某符号在当前作用域需经子模块前缀访问，按文件内既有引用方式补前缀；不要新增字段。`file_explorer` / `markdown_preview` 的可见性在别的模块，留到主循环 Task 7 单独 OR，不放这里。
+
+- [ ] **Step 2: 编译验证（无独立单测，靠整体构建）**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过（若报某符号未定义/需前缀，按报错补正确的模块前缀，仅限符号路径，不改语义）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "feat(render-loop): add overlays.anyOverlayActive() for render gate"
+```
+
+---
+
+## Task 3: 跨线程唤醒 postWakeup（native + 抽象层 + stubs）
+
+**Files:**
+- Modify: `src/platform/window_macos_bridge.m`（在 `wispterm_macos_app_pump_events` 之后，约 1124 之后新增）
+- Modify: `src/platform/window_macos.zig`（extern 声明 + 模块级 `postWakeup`）
+- Modify: `src/platform/window_backend.zig`（模块级 `postWakeup`）
+- Modify: `src/platform/window_windows.zig`、`src/platform/window_unsupported.zig`（no-op stub）
+
+- [ ] **Step 1: native postEvent 唤醒函数**
+
+在 `window_macos_bridge.m` 的 `wispterm_macos_app_pump_events`（约 1104-1124）之后新增。这是 GLFW `glfwPostEmptyEvent` 同款模式，`postEvent:atStart:` 可从任意线程安全调用：
+
+```objc
+// Wake the main thread's -nextEventMatchingMask: (used by the idle render loop)
+// from any thread, by posting an application-defined NSEvent. Safe off-main.
+void wispterm_macos_post_wakeup(void) {
+    @autoreleasepool {
+        NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+                                            location:NSMakePoint(0, 0)
+                                       modifierFlags:0
+                                           timestamp:0
+                                        windowNumber:0
+                                             context:nil
+                                             subtype:0
+                                               data1:0
+                                               data2:0];
+        if (event != nil) [NSApp postEvent:event atStart:NO];
+    }
+}
+```
+
+- [ ] **Step 2: Zig extern + 模块级包装**
+
+在 `window_macos.zig` 的 extern 区（约 49-52）补声明：
+
+```zig
+extern fn wispterm_macos_post_wakeup() void;
+```
+
+在 `window_macos.zig` 适当的 pub 区新增（紧邻 `pumpAppEvents`，约 257）：
+
+```zig
+/// 从任意线程唤醒阻塞中的主线程事件泵。
+pub fn postWakeup() void {
+    wispterm_macos_post_wakeup();
+}
+```
+
+- [ ] **Step 3: 抽象层模块级函数**
+
+在 `window_backend.zig` 的 `pumpAppEvents`（约 255）之后新增：
+
+```zig
+/// 从任意线程唤醒阻塞中的主线程事件泵（app 级，无需 window 句柄）。
+pub fn postWakeup() void {
+    platform_window.postWakeup();
+}
+```
+
+- [ ] **Step 4: 非 macOS stub**
+
+在 `window_windows.zig` 与 `window_unsupported.zig` 各新增（紧邻它们的 `pumpAppEvents`，分别约 214 / 170）：
+
+```zig
+pub fn postWakeup() void {}
+```
+
+- [ ] **Step 5: 编译验证**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/platform/window_macos_bridge.m src/platform/window_macos.zig src/platform/window_backend.zig src/platform/window_windows.zig src/platform/window_unsupported.zig
+git commit -m "feat(render-loop): cross-thread main-loop wakeup via NSApp postEvent"
+```
+
+---
+
+## Task 4: 可见性/焦点直接查询（occlusion / key window）
+
+**Files:**
+- Modify: `src/platform/window_macos_bridge.m`（新增两个查询函数，照 `wispterm_macos_window_ns_window`（1060）模板）
+- Modify: `src/platform/window_backend_macos.zig`（extern + `isVisible()` + `pollEvents` 刷新 `focused`）
+- Modify: `src/platform/window_backend.zig`（`isVisible(window)`）
+- Modify: `src/platform/window_backend_windows.zig`、`src/platform/window_backend_unsupported.zig`（`isVisible` stub）
+
+- [ ] **Step 1: native 查询函数**
+
+在 `window_macos_bridge.m` 的 `wispterm_macos_window_ns_window`（1060-1064）之后新增。保守策略：取不到当作可见/聚焦（宁可多渲染）：
+
+```objc
+// True iff the window is on-screen (not occluded) and not miniaturized.
+bool wispterm_macos_window_visible(void *handle) {
+    WispTermMacWindowState *state = wispterm_macos_state(handle);
+    if (state == NULL || state->window == NULL) return true;
+    NSWindowOcclusionState occ = [state->window occlusionState];
+    bool visible = (occ & NSWindowOcclusionStateVisible) != 0;
+    bool miniaturized = [state->window isMiniaturized];
+    return visible && !miniaturized;
+}
+
+// True iff the window is the key window (has keyboard focus).
+bool wispterm_macos_window_is_key(void *handle) {
+    WispTermMacWindowState *state = wispterm_macos_state(handle);
+    if (state == NULL || state->window == NULL) return true;
+    return [state->window isKeyWindow] ? true : false;
+}
+```
+
+- [ ] **Step 2: backend_macos extern + isVisible + 刷新 focused**
+
+在 `window_backend_macos.zig` 的 extern 区（紧邻 `wispterm_macos_window_close_requested` 等，约 119）补：
+
+```zig
+extern fn wispterm_macos_window_visible(handle: NativeHandle) bool;
+extern fn wispterm_macos_window_is_key(handle: NativeHandle) bool;
+```
+
+在 `Window` 结构体的方法区新增（紧邻 `swapBuffers`，约 225）：
+
+```zig
+    pub fn isVisible(self: *Window) bool {
+        return wispterm_macos_window_visible(self.hwnd);
+    }
+```
+
+修改 `pollEvents`（215-223），让 `focused` 反映真实 key 状态（当前永远是默认 true）。在 `self.refreshGeometry();` 之后加一行：
+
+```zig
+    pub fn pollEvents(self: *Window) bool {
+        wispterm_macos_window_poll(self.hwnd);
+        self.drainMessageEvents();
+        self.drainFileDropEvents();
+        self.drainInputEvents();
+        self.refreshGeometry();
+        self.focused = wispterm_macos_window_is_key(self.hwnd);
+        self.close_requested = self.close_requested or wispterm_macos_window_close_requested(self.hwnd);
+        return !self.close_requested;
+    }
+```
+
+- [ ] **Step 3: 抽象层 isVisible**
+
+在 `window_backend.zig` 的 `isFocused`（约 321）之后新增：
+
+```zig
+pub fn isVisible(window: *Window) bool {
+    return window.isVisible();
+}
+```
+
+- [ ] **Step 4: 非 macOS stub**
+
+在 `window_backend_windows.zig` 与 `window_backend_unsupported.zig` 的 `Window` 结构体内各新增（紧邻它们的 `swapBuffers`）：
+
+```zig
+    pub fn isVisible(self: *Window) bool {
+        _ = self;
+        return true;
+    }
+```
+
+- [ ] **Step 5: 编译 + 手动验证焦点查询**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过。
+手动：运行 app，点击其它应用使其失焦 —— 现有逻辑 `AppWindow.zig:5755`（`if (window_focused != focused) g_force_rebuild=true`）现在会真正在失焦/聚焦切换时各触发一次重建（此前 `focused` 恒 true，从不触发）。确认切换焦点时界面无异常（不闪、不卡）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/platform/window_macos_bridge.m src/platform/window_backend_macos.zig src/platform/window_backend.zig src/platform/window_backend_windows.zig src/platform/window_backend_unsupported.zig
+git commit -m "feat(render-loop): query window visibility/key state (occlusion, isKeyWindow)"
+```
+
+---
+
+## Task 5: IO/PTY 线程标 dirty 后唤醒主循环
+
+**Files:**
+- Modify: `src/termio/ReadThread.zig`（119 之后）
+- Modify: `src/termio/Thread.zig`（172 之后）
+
+- [ ] **Step 1: ReadThread 标脏后唤醒**
+
+在 `ReadThread.zig` 顶部 import 区加（若尚无）：
+
+```zig
+const window_backend = @import("../platform/window_backend.zig");
+```
+
+在 `processOutput`（109-120）末尾 `surface.dirty.store(true, .release);` 之后加一行：
+
+```zig
+    surface.dirty.store(true, .release);
+    window_backend.postWakeup();
+```
+
+- [ ] **Step 2: termio/Thread 标脏后唤醒**
+
+在 `Thread.zig` 顶部 import 区加（若尚无）：
+
+```zig
+const window_backend = @import("../platform/window_backend.zig");
+```
+
+在 `applyResize`（151-173）末尾 `surface.dirty.store(true, .release);` 之后加一行：
+
+```zig
+    surface.dirty.store(true, .release);
+    window_backend.postWakeup();
+```
+
+- [ ] **Step 3: 编译 + 手动验证**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过。
+手动：运行 app，在终端里 `ls`、`cat` 大文件、`top`，确认输出实时刷新无延迟（此步骤本身不省 CPU，省 CPU 在 Task 7；此处只验证唤醒链通畅，输出不卡）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/termio/ReadThread.zig src/termio/Thread.zig
+git commit -m "feat(render-loop): wake main loop on PTY output / resize"
+```
+
+---
+
+## Task 6: RendererThread 停用 surface.dirty 消费
+
+**Files:**
+- Modify: `src/RendererThread.zig`（114-118）
+
+**原因：** Task 7 让主循环以 `surface.dirty.swap(false)` 消费脏位；若 RendererThread 仍 `swap(false)`，两者互吃脏位会导致丢帧。RendererThread 当前不真渲染，停掉它对 dirty 的消费即可（保留它的光标计时存在，避免牵动其它逻辑）。
+
+- [ ] **Step 1: 移除 dirty 消费**
+
+把 `RendererThread.zig:114-118`：
+
+```zig
+        // Check if the surface is dirty (PTY output received)
+        // If so, signal that we need a redraw
+        if (self.surface.dirty.swap(false, .acq_rel)) {
+            self.renderer.markDirty();
+        }
+```
+
+改为（不再消费 surface.dirty，留给主循环）：
+
+```zig
+        // surface.dirty is now consumed by the main render loop (event-driven
+        // render gate). RendererThread must NOT swap it here or it would steal
+        // the dirty bit from the main loop. Cursor-blink timing stays above.
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过（若 `self.renderer` 因此变为未使用导致告警/报错，保留 `_ = self;` 或按编译器提示处理，不删字段）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/RendererThread.zig
+git commit -m "refactor(render-loop): stop RendererThread consuming surface.dirty"
+```
+
+---
+
+## Task 7: 主循环集成脏门控 + 阻塞泵 + 渲染后清 dirty
+
+**Files:**
+- Modify: `src/AppWindow.zig`（主循环 `run`：新增 import、采集信号、门控分支；渲染后清 dirty）
+
+- [ ] **Step 1: 顶部 import render_gate**
+
+在 `AppWindow.zig` 顶部 import 区新增：
+
+```zig
+const render_gate = @import("appwindow/render_gate.zig");
+```
+
+- [ ] **Step 2: 新增门控辅助函数**
+
+在 `AppWindow.zig` 内（如 `markAllRenderersDirty` 附近，约 4670 之后）新增三个 helper。门控专用的 blink 计时全局变量也在此声明：
+
+```zig
+/// 门控专用：上次因光标闪烁而渲染的时间戳（驱动聚焦空闲时每 600ms 一帧）。
+threadlocal var g_gate_last_blink_render: i64 = 0;
+
+/// 任一可见 surface 是否有未消费的脏位（PTY 输出）。只 load 不清除。
+fn anySurfaceDirtyLoad() bool {
+    for (0..tab.g_tab_count) |ti| {
+        if (tab.g_tabs[ti]) |tb| {
+            var it = tb.tree.iterator();
+            while (it.next()) |entry| {
+                if (entry.surface.dirty.load(.acquire)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+/// 渲染后清除所有 surface 的脏位。
+fn clearAllSurfaceDirty() void {
+    for (0..tab.g_tab_count) |ti| {
+        if (tab.g_tabs[ti]) |tb| {
+            var it = tb.tree.iterator();
+            while (it.next()) |entry| {
+                _ = entry.surface.dirty.swap(false, .acq_rel);
+            }
+        }
+    }
+}
+
+/// 活动 tab 是否有 AI 会话正在流式输出（chat 或 copilot）。
+fn aiStreamingActive() bool {
+    if (activeAiChat()) |sess| {
+        if (sess.request_inflight) return true;
+    }
+    if (tab.g_tabs[active_tab_state.g_active_tab]) |tb| {
+        if (tb.copilot_session) |sess| {
+            if (sess.request_inflight) return true;
+        }
+    }
+    return false;
+}
+```
+
+> 注：`activeAiChat()`、`active_tab_state.g_active_tab`、`TabState.copilot_session`、`Session.request_inflight` 均为既有 API（spec 块5/块6）。若 `copilot_session` 字段类型非 optional，按其真实类型调整解包；不要改其定义。
+
+- [ ] **Step 3: 在主循环渲染前插入门控分支**
+
+定位主循环里"最小化跳过"那段（`AppWindow.zig:5761-5764`）：
+
+```zig
+        if (window_backend.isMinimized(win) or fb_width <= 0 or fb_height <= 0) {
+            std.Thread.sleep(16 * std.time.ns_per_ms);
+            continue;
+        }
+```
+
+在它**之后、`gpu.gl_init.g_draw_call_count = 0;`（5766）之前**插入门控逻辑：
+
+```zig
+        // ---- 事件驱动脏门控 ----
+        const gate_now = std.time.milliTimestamp();
+        const visible = window_backend.isVisible(win);
+        const vis: render_gate.Visibility = if (!visible)
+            .hidden
+        else if (window_focused)
+            .focused
+        else
+            .unfocused_visible;
+
+        // 光标闪烁仅在聚焦时驱动；失焦/不可见停闪以省唤醒。
+        const blink_enabled = g_cursor_blink and vis == .focused;
+        const blink_due = blink_enabled and
+            (gate_now - g_gate_last_blink_render >= CURSOR_BLINK_INTERVAL_MS);
+
+        const signals = render_gate.RenderSignals{
+            .force_rebuild = g_force_rebuild,
+            .any_surface_dirty = anySurfaceDirtyLoad(),
+            .cursor_blink_due = blink_due,
+            .ai_streaming = aiStreamingActive(),
+            .overlay_active = overlays.anyOverlayActive(gate_now) or
+                file_explorer.isVisibleForActiveTab() or
+                markdown_preview_panel.isVisibleForActiveTab(),
+        };
+
+        if (!render_gate.frameNeedsRender(signals)) {
+            const ms_until_blink = if (blink_enabled)
+                CURSOR_BLINK_INTERVAL_MS - (gate_now - g_gate_last_blink_render)
+            else
+                CURSOR_BLINK_INTERVAL_MS;
+            const timeout_ms = render_gate.computeBlockTimeoutMs(.{
+                .visibility = vis,
+                .cursor_blink_enabled = blink_enabled,
+                .ms_until_next_blink = ms_until_blink,
+            });
+            window_backend.pumpAppEvents(@as(f64, @floatFromInt(timeout_ms)) / 1000.0);
+            continue;
+        }
+        if (blink_due) g_gate_last_blink_render = gate_now;
+        // ---- 门控通过，正常渲染 ----
+```
+
+- [ ] **Step 4: 渲染后清 dirty**
+
+在主循环末尾 `window_backend.swapBuffers(win);`（6000）之后、`}`（6001 循环结束）之前加：
+
+```zig
+        window_backend.swapBuffers(win);
+        clearAllSurfaceDirty();
+```
+
+- [ ] **Step 5: 编译验证**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 编译通过。若 `overlays`/`file_explorer`/`markdown_preview_panel`/`activeAiChat`/`active_tab_state` 等在 `run` 作用域的引用名与既有用法不一致，按文件内既有调用方式对齐（这些模块在 AppWindow.zig 已被大量使用，参照现有调用）。
+
+- [ ] **Step 6: 手动验证（核心 — CPU 与功能）**
+
+运行 `zig build macos-app -Dtarget=aarch64-macos`，启动 app，用活动监视器 / `top -pid <pid>` 观察主进程 CPU：
+
+1. **聚焦空闲**（终端无输出、无 overlay）：CPU 应从 ~73% 降到个位数（光标每 600ms 一帧）。
+2. **失焦**（点其它 app）：CPU 应进一步降到接近 0（光标停闪、无唤醒源）。
+3. **遮挡 / 最小化**：CPU ≈ 0。
+4. **终端持续输出**（`yes`、`top`、`htop`）：渲染正常实时，CPU 与输出量相称。
+5. **功能回归**：光标闪烁正常；打开命令面板/设置页/文件浏览器/Markdown 预览，动画与交互正常不卡；复制触发 toast，toast 正常出现并到期消失；AI 流式回复时文字持续刷新不卡住；resize 窗口正常。
+
+逐项确认，任一卡顿/不刷新即记录现象（很可能是某变化来源未纳入信号）并回到 Task 2 / Step 2-3 补该来源。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "feat(render-loop): event-driven main loop with render gate + blocking pump"
+```
+
+---
+
+## Task 8: 失焦停光标闪烁的视觉确认与收尾
+
+**Files:**
+- 无新增改动（失焦停闪已在 Task 7 Step 3 的 `blink_enabled = ... and vis == .focused` 实现）；本任务是验收与可选回退点。
+
+- [ ] **Step 1: 验证失焦时光标行为**
+
+运行 app，聚焦时光标闪烁；切到其它 app 后，终端光标应停止闪烁（保持显示，不再翻转）。这与 macOS 终端习惯一致，且消除了失焦时的周期性唤醒。
+
+- [ ] **Step 2: 最终 CPU 验收对照 spec §10**
+
+对照 spec 验收标准逐条记录改造前/后 CPU：
+- 聚焦空闲：个位数%（含 600ms blink 帧）
+- 失焦/遮挡/最小化：≈ 0
+- 持续输出：与输出量相称
+- 输入/输出无可感延迟；所有 overlay 动画正常
+
+- [ ] **Step 3: 提交（若有任何收尾微调）**
+
+```bash
+git add -A
+git commit -m "chore(render-loop): finalize phase-1 event-driven loop"
+```
+
+---
+
+## Self-Review（计划作者已执行）
+
+**Spec 覆盖：**
+- M1 阻塞事件泵 → Task 7 Step 3（`pumpAppEvents(timeout)`）。
+- M2 跨线程唤醒 → Task 3 + Task 5。
+- M3 保守脏门控 → Task 1（逻辑）+ Task 2（overlay 来源）+ Task 7（采集与集成）。
+- M4 超时驱动定时 → Task 1（`computeBlockTimeoutMs`）+ Task 7 Step 3。
+- M5 occlusion/focus 桥接 → Task 4（直接查询，独立函数，阶段 2 可复用）。
+- M6 tick 周期保证 → Task 1 分级上限（focused 100 / unfocused 250 / hidden 500ms，均 < loop/watch 分钟级间隔）+ Task 7 覆盖分析（file explorer→overlay_active、ai_loop→ai_streaming、SSH→surface.dirty）。
+- 变化来源清单 → Task 2 + Task 7 Step 3 信号采集。
+- RendererThread 互吃协调 → Task 6。
+
+**占位扫描：** 无 TBD/TODO；所有代码步骤含完整代码；手动验证步骤给出具体操作与预期。
+
+**类型一致性：** `RenderSignals`/`TimeoutInputs`/`Visibility`/`frameNeedsRender`/`computeBlockTimeoutMs`/`anyOverlayActive`/`postWakeup`/`isVisible`/`anySurfaceDirtyLoad`/`clearAllSurfaceDirty`/`aiStreamingActive` 在定义与调用处命名一致；`CURSOR_BLINK_INTERVAL_MS` 复用 AppWindow 既有常量。
+
+**已知实现期需对照（非阻塞）：** 各模块符号在主循环作用域的精确引用前缀、`copilot_session` 的 optional 性、`overlays.zig` 内子模块前缀 —— 均在对应步骤注明"按文件内既有用法对齐"，因这些模块在目标文件已被大量使用。

--- a/docs/superpowers/specs/2026-06-07-event-driven-render-loop-design.md
+++ b/docs/superpowers/specs/2026-06-07-event-driven-render-loop-design.md
@@ -1,0 +1,172 @@
+# WispTerm 渲染循环 CPU 优化设计
+
+**阶段 1:事件驱动主循环（脏门控 + 阻塞事件泵 + 后台/遮挡暂停）**
+
+日期：2026-06-07
+状态：设计已与用户对齐，待 spec 评审 → 转实现计划
+
+---
+
+## 1. 背景与问题
+
+现象：WispTerm 启动后主进程 CPU 占用约 73%，**即使切到后台、被其它窗口遮挡也居高不下**。
+
+### 已核实的根因（带证据）
+
+主渲染循环 [AppWindow.zig:5672](../../../src/AppWindow.zig) 的 `while (running)` **每个 vsync 周期都无条件做整屏全量渲染并 present，从不判断画面是否有变化**：
+
+- 循环里唯一的提前退出是窗口最小化时 `sleep(16ms)`（[AppWindow.zig:5761](../../../src/AppWindow.zig)），其余情况一律执行：清屏 → 画所有 cell → 画 titlebar/sidebar/scrollbar → 画一长串 overlay（[AppWindow.zig:5978-5995](../../../src/AppWindow.zig)）→ present。
+- 全库搜索确认主循环内对 `dirty` 的引用只有一行注释（[AppWindow.zig:5702](../../../src/AppWindow.zig)），脏标记从未被读来跳过帧。
+- 事件泵是零超时轮询：`pollEvents` → `nextEventMatchingMask:untilDate:[NSDate distantPast]`（[window_macos_bridge.m:1080](../../../src/platform/window_macos_bridge.m)），不阻塞等待。
+- **为什么是 73% 而非爆 100%+**：`CAMetalLayer` 未设置 `displaySyncEnabled`，macOS 默认 `YES`（开 vsync），`nextDrawable`（[bridge.m:859](../../../src/renderer/gpu/metal/bridge.m)）在 drawable 用尽时阻塞，把帧率限制在显示器刷新率。于是它在 120Hz 屏上"老老实实每秒画 120 整帧"，占满约 0.7 个核 → 73%。**vsync 限了帧率，但没人限"该不该画"。**
+- **后台/遮挡不暂停**：只检测了 `isFocused`（失焦仅触发一次重建）与 `isMinimized`，**没有 `NSWindowOcclusionState` 检测**（[AppWindow.zig:5754-5764](../../../src/AppWindow.zig)）。被其它窗口盖住但未最小化时，照样满速渲染。
+- IO 线程本身已是 libxev 事件驱动（[termio/Thread.zig](../../../src/termio/Thread.zig)），不烧 CPU。**问题纯粹在主线程渲染循环。**
+
+---
+
+## 2. 目标与非目标
+
+### 目标
+- 聚焦且活跃时：行为与体验不变（终端输出、光标闪烁、所有 overlay 动画照常流畅）。
+- 空闲（聚焦但无内容变化）：主线程 CPU 降到接近 0。
+- 失焦 / 被遮挡 / 最小化 / app 后台：主线程 CPU 接近 0。
+- 输入（键盘/鼠标）与终端输出：无可感知的额外延迟。
+
+### 非目标（阶段 1 明确不做）
+- 不把渲染搬到独立线程。
+- 不引入 CVDisplayLink。
+- 不做 per-surface 并行渲染。
+- 不改"单 layer + viewport"渲染架构。
+
+以上属于**阶段 2**（见 §8）。
+
+---
+
+## 3. 架构现状（决定方案的硬约束）
+
+核实结论（带证据），这些约束直接决定了为什么阶段 1 选事件驱动而非一步到位重构：
+
+1. **单 Context / 单 CAMetalLayer / 单 drawable**：整个窗口一个 `gpu.Context`，主线程初始化（[AppWindow.zig:5340](../../../src/AppWindow.zig)），`Handles` 仅一个 `layer` + 一个 `drawable`（[Context.zig:23-30](../../../src/renderer/gpu/metal/Context.zig)）。多 split 靠 viewport 切分，**不是** per-surface layer。
+2. **GPU 渲染状态全 `threadlocal`**，且 [Context.zig:20](../../../src/renderer/gpu/metal/Context.zig) 注释明示 "rendering runs on the renderer thread" —— 作者已为"渲染上渲染线程"预埋设计（threadlocal 存储类 + [RendererThread.zig](../../../src/RendererThread.zig) 的 Phase 2 注释）。
+3. **全 UI 自绘在一个主循环**：phantty 用 GPU 自绘了**全部** UI（终端 + 标题栏 + 侧栏 + 滚动条 + 文件浏览器 + Markdown 预览 + AI 面板 + 命令面板 + 设置页 + 各种 toast/确认框 + IME），这些 overlay 状态全由主线程的输入与 tick 更新。
+4. `swapBuffers` 在 macOS 是 no-op（[window_backend_macos.zig:225](../../../src/platform/window_backend_macos.zig)），present 实际在 `frame_end` 的 `presentDrawable` 完成。
+
+**关键推论**：因为第 1 + 第 3 条，把渲染搬到线程（阶段 2）意味着几乎所有 UI 状态都要变成线程安全，跨线程同步面远大于 Ghostty —— 这是真正的大手术。而降 CPU 这个原始目标，阶段 1 在主线程内即可达成。
+
+---
+
+## 4. 方案决策
+
+### 候选方案对比
+
+| 方案 | 形态 | 空闲/后台效果 | 改动 / 风险 |
+|---|---|---|---|
+| 1 脏门控补丁 | 单线程 + sleep 轮询节流 | 空闲个位数%、后台近 0 | 集中主循环，低 |
+| **2 事件驱动（选定）** | 单线程 + 阻塞等事件 + 跨线程唤醒 | 空闲/后台**真 0** | 中等 |
+| 3 完整 Ghostty 化 | 渲染上线程 + CVDisplayLink | 最优（含 vsync 对齐） | 大重构 + 全 UI 状态跨线程同步，高 |
+
+### 决策：分两阶段
+- **阶段 1 = 方案 2**（本文档）。
+- **阶段 2 = 方案 3**，作为独立的架构演进项目后续立项（见 §8）。
+
+### 理由
+- 降 CPU 目标方案 2 即可完全达成（空闲/后台真 0），且无需触碰跨线程 UI 状态同步。
+- 方案 3 相对方案 2 的额外收益（渲染脱离主线程、vsync 对齐更顺滑）是**架构演进价值，不是当前痛点**；在 phantty 的"单 layer + 全 UI 自绘"约束下，其代价/回归风险与降 CPU 目标不成比例。
+- 方案 2 是方案 3 的**前置地基**（事件驱动 + 变化来源收口 + occlusion 桥接都可复用），先做方案 2 不浪费。
+
+---
+
+## 5. 阶段 1 详细设计
+
+### 可行性验证结论（go）
+- **阻塞事件泵已存在**：`pumpAppEvents(timeout)` 底层即 `nextEventMatchingMask:untilDate:until`（[window_macos_bridge.m:1101-1120](../../../src/platform/window_macos_bridge.m)），真正阻塞等事件到超时。
+- **唯一缺口 = 跨线程唤醒**：当前 PTY/IO 线程只 `surface.dirty.store(true)`（[ReadThread.zig:119](../../../src/termio/ReadThread.zig)、[termio/Thread.zig:172](../../../src/termio/Thread.zig)），靠主线程轮询。无 `postEvent`/application-defined event 机制。需新增。
+
+### 6 个核心机制
+
+#### M1. 阻塞事件泵替代零超时轮询
+主循环判定"本帧无需渲染"（见 M3）时，改用带超时的事件等待（复用 `pumpAppEvents` 的 `nextEventMatchingMask:untilDate:` 模式）阻塞，直到来事件或超时。聚焦且活跃时仍走快速渲染路径，体验不变。
+- 改动：`AppWindow.zig` 主循环；可能复用/抽出 `window_macos.zig` 的带超时泵。
+
+#### M2. 跨线程唤醒（新增 `post_wakeup`）
+新增 C 函数（`window_macos_bridge.m`）：从任意线程 `[NSApp postEvent:atStart:]` 一个 application-defined `NSEvent`，让阻塞在 `nextEventMatchingMask` 的主线程立即返回。
+- 调用点：PTY/IO 线程标 `surface.dirty` 后；AI 流式回包；其它后台→UI 通知。
+- 暴露为 `window_backend` 接口，供 Zig 侧跨线程调用。
+
+#### M3. 保守脏门控 `frameNeedsRender()`（关键设计决策）
+新增判定函数，采用 **"白名单进入省电"** 策略：**只有当全部活跃信号静默时才阻塞跳帧；任何不确定都倾向渲染**。这样"漏判一个来源导致画面卡住"的风险被结构性消除（漏判最坏只是多画，不会少画）。
+- 判定为"需要渲染"的信号见 §6 变化来源清单。
+- 改动：`AppWindow.zig` 新增 `frameNeedsRender()`；逐步把散落的 `g_force_rebuild`/`g_cells_valid` 等收口到统一的 `markNeedsRender()` 语义（为阶段 2 的 wakeup 入口铺路）。
+
+#### M4. 超时驱动定时性工作
+阻塞超时 = `min(距下次光标翻转, 距下次必须执行的 tick, 分级上限)`。
+- 分级上限（初始默认，可在评审中调整）：聚焦 ~100ms / 失焦可见 ~250ms / 遮挡·最小化·后台 ~500ms。
+- 光标闪烁由超时自然驱动，**不需要单独 NSTimer**。
+- 改动：`AppWindow.zig` 主循环超时计算。
+
+#### M5. occlusion / focus 检测（独立桥接，阶段 2 复用）
+新增 `window_is_visible()` 读 `NSWindow.occlusionState.contains(.visible)`（一个信号同时覆盖遮挡/最小化/后台，与 Ghostty 一致）。
+- 失焦/遮挡时：拉长 M4 的超时上限；失焦时停止光标闪烁（符合 macOS 习惯，并省一个唤醒源）。
+- **刻意做成干净独立模块**：`window_macos_bridge.m` 桥接 + `window_backend` 接口，阶段 2 上 CVDisplayLink 时直接用它来 `start/stop`。
+
+#### M6. 定时 tick 周期保证
+主循环开头那批 tick（[AppWindow.zig:5674-5683](../../../src/AppWindow.zig)：config watcher、session launcher、file explorer async、markdown async、ai_loop_store、update/skill check 等）靠 M4 的超时上限保证至少每 ≤500ms 执行一次；报告"有变化"的 tick（如 `markdown_preview_panel.tickAsync()` 返回 true）设脏触发渲染。
+
+---
+
+## 6. 变化来源清单（脏门控输入）
+
+`frameNeedsRender()` 须在以下任一信号活跃时返回"需要渲染"。**实现前需用代码搜索逐条核全**（本清单为已知主项，宁多勿漏）：
+
+| 类别 | 信号 | 当前是否已有可门控标记 |
+|---|---|---|
+| 终端内容 | 任一 `surface.dirty`（PTY 输出） | 有（atomic bool） |
+| 光标闪烁 | 到达 600ms 翻转点 | 有（时间戳计算） |
+| 强制重建 | `g_force_rebuild` / `!g_cells_valid` | 有 |
+| 字体图集 | `font.g_atlas_modified` 等 | 有 |
+| 窗口状态 | resize 待处理 / focus 变化 / dpi 变化 | 部分有（多置 g_force_rebuild） |
+| Overlay/面板 | 命令面板、设置页、文件浏览器、Markdown 预览、AI 面板、session launcher、各 toast、确认框、whats-new、IME preedit、debug/fps overlay 处于**打开或动画态** | **门控盲区，多数无统一"活动态"查询，需新增** |
+| AI 流式 | AI 回复流式打字、loop/watch 任务进行中 | 待核实 |
+| 异步 tick | 各 `tickAsync`/`tick` 报告有变化 | 部分有返回值（如 markdown），部分无 |
+
+**门控盲区**（overlay 活动态、AI 流式、部分 tick）是实现重点：要么为每个活动态提供查询函数，要么让其在活动期间持续 `markNeedsRender()`（粗粒度但安全）。
+
+---
+
+## 7. 风险与缓解
+
+- **漏判变化来源 → 画面卡住**：① 保守白名单（不确定就画）；② M4 分级超时上限兜底——即便全静默，也每 ≤500ms 醒来重新评估；③ 可选"最大不渲染间隔"做最终保险（默认开，如 1s，权衡极小 CPU 换绝对不卡）。
+- **输入延迟**：postEvent + NSEvent 唤醒即时，无额外延迟。
+- **后台命令仍要刷新**：PTY 输出经 M2 唤醒主循环，后台运行的程序输出照常更新，只是不再空转。
+
+---
+
+## 8. 范围边界
+
+### 阶段 1 做
+M1–M6，全部在主线程内；不碰渲染线程、不碰跨线程 UI 状态同步。
+
+### 阶段 1 不做（留给阶段 2）
+渲染上单一窗口级渲染线程 + CVDisplayLink 驱动 + 失焦/遮挡 `stop` link。
+
+### 阶段 2 可复用阶段 1 的资产
+- M5 的 occlusion/focus 桥接（直接驱动 display link start/stop）。
+- M3 的脏门控逻辑（迁入渲染线程的 `drawFrame`，对应 Ghostty 的 `needs_redraw`）。
+- 变化来源收口的 `markNeedsRender()`（对应 Ghostty 的 `queueRender → wakeup.notify`）。
+
+---
+
+## 9. 实现前待核实项
+
+- **多窗口主循环交互**：[App.zig:852/961](../../../src/App.zig) 支持多 window，每个 `run()` 是阻塞循环；postEvent 是 app 级唤醒。需在 plan 阶段确认多窗口下阻塞/唤醒的正确性，可能影响主循环改造细节。
+
+---
+
+## 10. 验收标准
+
+- 空闲（聚焦、终端无输出、无 overlay）：CPU 降到极低（个位数%）。注：光标闪烁仍会每 600ms 唤醒画一帧，故非绝对 0；这是预期，失焦停闪或关闭光标闪烁可进一步到 0。
+- 失焦 / 遮挡 / 最小化 / 后台：光标停闪、无唤醒源，主进程 CPU ≈ 0。
+- 终端持续输出（如 `yes`、`htop`）：渲染正常，CPU 与输出量相称。
+- 光标闪烁、所有 overlay 动画/打字机/toast 淡出：正常不卡顿、不掉帧。
+- 键盘/鼠标输入：无可感知延迟。
+- 测量手段：活动监视器 / `top` 对比改造前后；必要时加帧计数日志验证空闲时不再 present。

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -70,6 +70,7 @@ pub const overlays = @import("renderer/overlays.zig");
 pub const post_process = @import("renderer/post_process.zig");
 pub const gpu = @import("renderer/gpu/gpu.zig");
 pub const split_layout = @import("appwindow/split_layout.zig");
+const render_gate = @import("appwindow/render_gate.zig");
 const flush_scheduler = @import("appwindow/flush_scheduler.zig");
 const resize_throttle = @import("appwindow/resize_throttle.zig");
 pub const fbo = @import("renderer/fbo.zig");
@@ -4673,6 +4674,44 @@ fn markAllRenderersDirty() void {
     }
 }
 
+/// Last render timestamp driven by the render gate's focused cursor blink.
+threadlocal var g_gate_last_blink_render: i64 = 0;
+
+fn anySurfaceDirtyLoad() bool {
+    for (0..tab.g_tab_count) |ti| {
+        if (tab.g_tabs[ti]) |tb| {
+            var it = tb.tree.iterator();
+            while (it.next()) |entry| {
+                if (entry.surface.dirty.load(.acquire)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+fn clearAllSurfaceDirty() void {
+    for (0..tab.g_tab_count) |ti| {
+        if (tab.g_tabs[ti]) |tb| {
+            var it = tb.tree.iterator();
+            while (it.next()) |entry| {
+                _ = entry.surface.dirty.swap(false, .acq_rel);
+            }
+        }
+    }
+}
+
+fn aiStreamingActive() bool {
+    if (activeAiChat()) |session| {
+        if (session.request_inflight) return true;
+    }
+    if (activeTab()) |tb| {
+        if (tb.copilot_session) |session| {
+            if (session.request_inflight) return true;
+        }
+    }
+    return false;
+}
+
 fn clearIconFont(allocator: std.mem.Allocator) void {
     if (font.icon_face) |old_icon| old_icon.deinit();
     font.icon_face = null;
@@ -5677,14 +5716,26 @@ fn runMainLoop(self: *AppWindow) !void {
         // Check for config file changes
         if (config_watcher) |*w| checkConfigReload(allocator, w);
         overlays.tickSessionLauncher();
-        file_explorer.tickAsync();
+        if (file_explorer.tickAsync()) {
+            g_force_rebuild = true;
+            g_cells_valid = false;
+        }
         syncTransferToastFromFileExplorer();
         if (markdown_preview_panel.tickAsync()) {
             g_force_rebuild = true;
             g_cells_valid = false;
         }
+        if (weixin_qr_panel.visible()) {
+            const qr_allocator = g_allocator orelse allocator;
+            if (weixin_qr_panel.refresh(qr_allocator)) {
+                g_force_rebuild = true;
+                g_cells_valid = false;
+            }
+        }
         maybePrintMemoryDebug(std.time.milliTimestamp());
         flushAgentHistoryStoreIfDirty(false);
+        pollUpdateCheck(self.app);
+        pollSkillUpdate(self.app);
 
         // Process pending resize (coalesced, like Ghostty)
         // We wait for RESIZE_COALESCE_MS after last resize event before applying.
@@ -5763,14 +5814,54 @@ fn runMainLoop(self: *AppWindow) !void {
         const fb_width: c_int = fb.width;
         const fb_height: c_int = fb.height;
         if (window_backend.isMinimized(win) or fb_width <= 0 or fb_height <= 0) {
-            std.Thread.sleep(16 * std.time.ns_per_ms);
+            const timeout_ms = render_gate.computeBlockTimeoutMs(.{
+                .visibility = .hidden,
+                .cursor_blink_enabled = false,
+                .ms_until_next_blink = CURSOR_BLINK_INTERVAL_MS,
+            });
+            window_backend.pumpAppEvents(@as(f64, @floatFromInt(timeout_ms)) / 1000.0);
             continue;
         }
 
+        const gate_now = std.time.milliTimestamp();
+        const visible = window_backend.isVisible(win);
+        const vis: render_gate.Visibility = if (!visible)
+            .hidden
+        else if (window_focused)
+            .focused
+        else
+            .unfocused_visible;
+
+        const blink_enabled = g_cursor_blink and vis == .focused;
+        const blink_due = blink_enabled and
+            (gate_now - g_gate_last_blink_render >= CURSOR_BLINK_INTERVAL_MS);
+
+        const signals = render_gate.RenderSignals{
+            .force_rebuild = g_force_rebuild or !g_cells_valid or g_pending_resize or g_layout_resize_immediate,
+            .any_surface_dirty = anySurfaceDirtyLoad(),
+            .cursor_blink_due = blink_due,
+            .ai_streaming = aiStreamingActive(),
+            .overlay_active = overlays.anyOverlayActive(gate_now),
+        };
+
+        const needs_render = render_gate.frameNeedsRender(signals);
+        if (!needs_render) {
+            const ms_until_blink = if (blink_enabled)
+                CURSOR_BLINK_INTERVAL_MS - (gate_now - g_gate_last_blink_render)
+            else
+                CURSOR_BLINK_INTERVAL_MS;
+            const timeout_ms = render_gate.computeBlockTimeoutMs(.{
+                .visibility = vis,
+                .cursor_blink_enabled = blink_enabled,
+                .ms_until_next_blink = ms_until_blink,
+            });
+            window_backend.pumpAppEvents(@as(f64, @floatFromInt(timeout_ms)) / 1000.0);
+            continue;
+        }
+        if (blink_due) g_gate_last_blink_render = gate_now;
+
         gpu.gl_init.g_draw_call_count = 0;
         overlays.updateFps();
-        pollUpdateCheck(self.app);
-        pollSkillUpdate(self.app);
 
         // Sync atlas textures to GPU if modified
         if (font.g_atlas != null) font.syncAtlasTexture(&font.g_atlas, &font.g_atlas_texture, &font.g_atlas_modified);
@@ -6002,6 +6093,9 @@ fn runMainLoop(self: *AppWindow) !void {
         forceOpaqueBackbufferForPresent();
         gpu.state.endFrame();
         window_backend.swapBuffers(win);
+        clearAllSurfaceDirty();
+        g_force_rebuild = false;
+        g_cells_valid = true;
     }
 
     // Save window position + size for next session

--- a/src/RendererThread.zig
+++ b/src/RendererThread.zig
@@ -7,7 +7,6 @@
 ///
 /// Phase 1: Basic structure - signals main thread to redraw
 /// Phase 2: Full cell snapshotting will be moved here from AppWindow.zig
-
 const std = @import("std");
 const Surface = @import("Surface.zig");
 const Renderer = @import("renderer/Renderer.zig");
@@ -111,11 +110,9 @@ fn threadMain(self: *RendererThread) void {
         if (now - last_render_time < RENDER_INTERVAL_MS) continue;
         last_render_time = now;
 
-        // Check if the surface is dirty (PTY output received)
-        // If so, signal that we need a redraw
-        if (self.surface.dirty.swap(false, .acq_rel)) {
-            self.renderer.markDirty();
-        }
+        // surface.dirty is consumed by the main render loop's event-driven
+        // render gate. This thread must not swap it or it can steal a PTY
+        // update before the UI thread sees it.
 
         // The actual cell snapshotting and rebuilding is still done in
         // AppWindow.zig on the main thread for now. This thread just:

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -708,6 +708,7 @@ const SM_CXPADDEDBORDER: INT = 92;
 
 // IsZoomed (maximized check)
 extern "user32" fn IsZoomed(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn IsWindowVisible(hWnd: HWND) callconv(.winapi) BOOL;
 
 // Screen-to-client coordinate conversion
 extern "user32" fn ScreenToClient(hWnd: HWND, lpPoint: *POINT) callconv(.winapi) BOOL;
@@ -1186,19 +1187,20 @@ pub const Window = struct {
         // drag-between-monitors / high-DPI render glitches.
         logDisplayTopology();
         logWindowMonitor(hwnd, "startup");
+        platform_window.registerEventWindow(hwnd);
 
         return window;
     }
 
     pub fn deinit(self: *Window) void {
+        platform_window.unregisterEventWindow(self.hwnd);
         _ = wglMakeCurrent(self.hdc, null);
         _ = wglDeleteContext(self.hglrc);
         _ = DestroyWindow(self.hwnd);
     }
 
     pub fn isVisible(self: *Window) bool {
-        _ = self;
-        return true;
+        return IsWindowVisible(self.hwnd) != 0 and !self.is_minimized;
     }
 
     pub fn swapBuffers(self: *Window) void {

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1196,6 +1196,11 @@ pub const Window = struct {
         _ = DestroyWindow(self.hwnd);
     }
 
+    pub fn isVisible(self: *Window) bool {
+        _ = self;
+        return true;
+    }
+
     pub fn swapBuffers(self: *Window) void {
         _ = SwapBuffers(self.hdc);
     }

--- a/src/appwindow/render_gate.zig
+++ b/src/appwindow/render_gate.zig
@@ -1,0 +1,117 @@
+//! 纯逻辑脏门控：判定"本帧是否需要渲染"以及空闲时阻塞多久。
+//! 刻意零项目依赖（只用 std），便于 `zig test src/appwindow/render_gate.zig` 独立单测。
+const std = @import("std");
+
+/// 窗口可见性/焦点分级。
+pub const Visibility = enum {
+    focused, // 可见且为 key window
+    unfocused_visible, // 可见但非 key
+    hidden, // 被遮挡 / 最小化 / 后台不可见
+};
+
+/// 一帧是否需要渲染的所有信号（采集自主循环）。
+pub const RenderSignals = struct {
+    force_rebuild: bool, // g_force_rebuild（交互/UI 变更，一票通过）
+    any_surface_dirty: bool, // 任一可见 surface.dirty（PTY 输出）
+    cursor_blink_due: bool, // 到达光标翻转点（仅聚焦且开启闪烁）
+    ai_streaming: bool, // 任一相关 AI session.request_inflight
+    overlay_active: bool, // 任一 overlay/面板/时间动画活动
+};
+
+/// 空闲阻塞超时计算的输入。
+pub const TimeoutInputs = struct {
+    visibility: Visibility,
+    cursor_blink_enabled: bool, // g_cursor_blink 且聚焦
+    ms_until_next_blink: i64, // 距下次光标翻转的毫秒数
+};
+
+/// 分级超时上限（毫秒）。保证 void tick（loop/watch、异步加载）定期被驱动。
+pub const CAP_FOCUSED_MS: i64 = 100;
+pub const CAP_UNFOCUSED_MS: i64 = 250;
+pub const CAP_HIDDEN_MS: i64 = 500;
+/// 阻塞超时下限，避免过度唤醒。
+pub const MIN_TIMEOUT_MS: i64 = 16;
+
+pub fn frameNeedsRender(s: RenderSignals) bool {
+    return s.force_rebuild or
+        s.any_surface_dirty or
+        s.cursor_blink_due or
+        s.ai_streaming or
+        s.overlay_active;
+}
+
+pub fn computeBlockTimeoutMs(in: TimeoutInputs) i64 {
+    var t: i64 = switch (in.visibility) {
+        .focused => CAP_FOCUSED_MS,
+        .unfocused_visible => CAP_UNFOCUSED_MS,
+        .hidden => CAP_HIDDEN_MS,
+    };
+    if (in.cursor_blink_enabled and in.ms_until_next_blink > 0) {
+        t = @min(t, in.ms_until_next_blink);
+    }
+    return @max(MIN_TIMEOUT_MS, t);
+}
+
+test "frameNeedsRender: 任一信号为真即需渲染" {
+    const base = RenderSignals{
+        .force_rebuild = false,
+        .any_surface_dirty = false,
+        .cursor_blink_due = false,
+        .ai_streaming = false,
+        .overlay_active = false,
+    };
+    try std.testing.expect(!frameNeedsRender(base));
+
+    var s = base;
+    s.force_rebuild = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.any_surface_dirty = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.cursor_blink_due = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.ai_streaming = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.overlay_active = true;
+    try std.testing.expect(frameNeedsRender(s));
+}
+
+test "computeBlockTimeoutMs: 分级上限" {
+    try std.testing.expectEqual(@as(i64, CAP_FOCUSED_MS), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+    try std.testing.expectEqual(@as(i64, CAP_UNFOCUSED_MS), computeBlockTimeoutMs(.{
+        .visibility = .unfocused_visible,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+    try std.testing.expectEqual(@as(i64, CAP_HIDDEN_MS), computeBlockTimeoutMs(.{
+        .visibility = .hidden,
+        .cursor_blink_enabled = false,
+        .ms_until_next_blink = 999,
+    }));
+}
+
+test "computeBlockTimeoutMs: 光标临近翻转时收紧，但不低于下限" {
+    // 聚焦 + blink 还有 40ms 翻转 → 取 40
+    try std.testing.expectEqual(@as(i64, 40), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = true,
+        .ms_until_next_blink = 40,
+    }));
+    // blink 仅剩 3ms → 收到下限 16
+    try std.testing.expectEqual(@as(i64, MIN_TIMEOUT_MS), computeBlockTimeoutMs(.{
+        .visibility = .focused,
+        .cursor_blink_enabled = true,
+        .ms_until_next_blink = 3,
+    }));
+}

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -554,20 +554,23 @@ pub fn setRoot(path: []const u8) void {
     }
 }
 
-pub fn tickAsync() void {
+pub fn tickAsync() bool {
+    const before_transfer_seq = g_transfer_notification_seq;
     tickTransferJob();
+    var changed = g_transfer_notification_seq != before_transfer_seq;
 
-    const job = g_async_job orelse return;
-    if (!job.done.load(.acquire)) return;
+    const job = g_async_job orelse return changed;
+    if (!job.done.load(.acquire)) return changed;
 
     if (job.thread) |thread| thread.join();
     g_async_job = null;
     g_loading = false;
+    changed = true;
     defer maybeStartPendingAsyncList();
     defer destroyAsyncJob(job);
 
     if (job.context_id != g_async_context_id or g_mode != .remote or !g_has_ssh_conn) {
-        return;
+        return changed;
     }
 
     if (job.status != .ok) {
@@ -577,7 +580,7 @@ pub fn tickAsync() void {
                 g_entries[idx].expanded = false;
             }
         }
-        return;
+        return true;
     }
 
     switch (job.kind) {
@@ -595,11 +598,12 @@ pub fn tickAsync() void {
         },
         .expand => {
             const path = job.path_buf[0..job.path_len];
-            const idx = findEntryByPath(path) orelse return;
-            if (!g_entries[idx].expanded) return;
+            const idx = findEntryByPath(path) orelse return true;
+            if (!g_entries[idx].expanded) return true;
             _ = insertBackendChildren(idx + 1, job.entries[0..job.count], job.depth, path, '/');
         },
     }
+    return true;
 }
 
 pub fn rescan() void {

--- a/src/platform/window.zig
+++ b/src/platform/window.zig
@@ -76,6 +76,8 @@ pub const consumeQuitRequest = impl.consumeQuitRequest;
 pub const requestQuit = impl.requestQuit;
 pub const pumpAppEvents = impl.pumpAppEvents;
 pub const postWakeup = impl.postWakeup;
+pub const registerEventWindow = impl.registerEventWindow;
+pub const unregisterEventWindow = impl.unregisterEventWindow;
 
 test "platform window exposes native handle helpers" {
     const rect_info = @typeInfo(@TypeOf(getWindowRect)).@"fn";

--- a/src/platform/window.zig
+++ b/src/platform/window.zig
@@ -75,6 +75,7 @@ pub const consumeReopenRequest = impl.consumeReopenRequest;
 pub const consumeQuitRequest = impl.consumeQuitRequest;
 pub const requestQuit = impl.requestQuit;
 pub const pumpAppEvents = impl.pumpAppEvents;
+pub const postWakeup = impl.postWakeup;
 
 test "platform window exposes native handle helpers" {
     const rect_info = @typeInfo(@TypeOf(getWindowRect)).@"fn";

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -327,6 +327,10 @@ pub fn isFocused(window: *const Window) bool {
     return window.focused;
 }
 
+pub fn isVisible(window: *Window) bool {
+    return window.isVisible();
+}
+
 pub fn isMinimized(window: *const Window) bool {
     return window.is_minimized;
 }

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -256,6 +256,11 @@ pub fn pumpAppEvents(timeout_seconds: f64) void {
     platform_window.pumpAppEvents(timeout_seconds);
 }
 
+/// 从任意线程唤醒阻塞中的主线程事件泵（app 级，无需 window 句柄）。
+pub fn postWakeup() void {
+    platform_window.postWakeup();
+}
+
 pub fn refreshClientSizeFromNative(window: *Window) bool {
     const rect = clientRect(window) orelse return false;
     setClientSize(window, rect.right - rect.left, rect.bottom - rect.top);

--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -118,6 +118,8 @@ extern fn wispterm_macos_window_create(
 extern fn wispterm_macos_window_destroy(handle: NativeHandle) void;
 extern fn wispterm_macos_window_poll(handle: NativeHandle) void;
 extern fn wispterm_macos_window_close_requested(handle: NativeHandle) bool;
+extern fn wispterm_macos_window_visible(handle: NativeHandle) bool;
+extern fn wispterm_macos_window_is_key(handle: NativeHandle) bool;
 extern fn wispterm_macos_window_get_framebuffer_size(handle: NativeHandle, width: *i32, height: *i32, dpi: *u32) void;
 extern fn wispterm_macos_window_set_content_size(handle: NativeHandle, width: i32, height: i32) void;
 extern fn wispterm_macos_window_metal_layer(handle: NativeHandle) ?*anyopaque;
@@ -218,8 +220,13 @@ pub const Window = struct {
         self.drainFileDropEvents();
         self.drainInputEvents();
         self.refreshGeometry();
+        self.focused = wispterm_macos_window_is_key(self.hwnd);
         self.close_requested = self.close_requested or wispterm_macos_window_close_requested(self.hwnd);
         return !self.close_requested;
+    }
+
+    pub fn isVisible(self: *Window) bool {
+        return wispterm_macos_window_visible(self.hwnd);
     }
 
     pub fn swapBuffers(self: *Window) void {

--- a/src/platform/window_backend_unsupported.zig
+++ b/src/platform/window_backend_unsupported.zig
@@ -72,6 +72,11 @@ pub const Window = struct {
         return !self.close_requested;
     }
 
+    pub fn isVisible(self: *Window) bool {
+        _ = self;
+        return true;
+    }
+
     pub fn swapBuffers(self: *Window) void {
         _ = self;
     }

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -264,6 +264,14 @@ pub fn postWakeup() void {
     wispterm_macos_post_wakeup();
 }
 
+pub fn registerEventWindow(hwnd: NativeHandle) void {
+    _ = hwnd;
+}
+
+pub fn unregisterEventWindow(hwnd: NativeHandle) void {
+    _ = hwnd;
+}
+
 test "macOS window constants defer caption controls to AppKit" {
     try std.testing.expectEqual(@as(i32, 0), titlebar_height);
     try std.testing.expectEqual(@as(f32, 0), caption_button_width);

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -50,6 +50,7 @@ extern fn wispterm_macos_app_consume_reopen() bool;
 extern fn wispterm_macos_app_consume_quit() bool;
 extern fn wispterm_macos_app_request_quit() void;
 extern fn wispterm_macos_app_pump_events(timeout_seconds: f64) void;
+extern fn wispterm_macos_post_wakeup() void;
 
 pub fn appMessage(offset: u32) MessageId {
     return wm_app + offset;
@@ -256,6 +257,11 @@ pub fn requestQuit() void {
 /// (needed for worker-thread dispatch_sync to the main thread).
 pub fn pumpAppEvents(timeout_seconds: f64) void {
     wispterm_macos_app_pump_events(timeout_seconds);
+}
+
+/// 从任意线程唤醒阻塞中的主线程事件泵。
+pub fn postWakeup() void {
+    wispterm_macos_post_wakeup();
 }
 
 test "macOS window constants defer caption controls to AppKit" {

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -1063,6 +1063,23 @@ void *wispterm_macos_window_ns_window(void *handle) {
     return (void *)state->window;
 }
 
+// True iff the window is on-screen (not occluded) and not miniaturized.
+bool wispterm_macos_window_visible(void *handle) {
+    WispTermMacWindowState *state = wispterm_macos_state(handle);
+    if (state == NULL || state->window == NULL) return true;
+    NSWindowOcclusionState occ = [state->window occlusionState];
+    bool visible = (occ & NSWindowOcclusionStateVisible) != 0;
+    bool miniaturized = [state->window isMiniaturized];
+    return visible && !miniaturized;
+}
+
+// True iff the window is the key window (has keyboard focus).
+bool wispterm_macos_window_is_key(void *handle) {
+    WispTermMacWindowState *state = wispterm_macos_state(handle);
+    if (state == NULL || state->window == NULL) return true;
+    return [state->window isKeyWindow] ? true : false;
+}
+
 void wispterm_macos_window_poll(void *handle) {
     @autoreleasepool {
         WispTermMacWindowState *state = wispterm_macos_state(handle);

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -1123,6 +1123,23 @@ void wispterm_macos_app_pump_events(double timeout_seconds) {
     }
 }
 
+// Wake the main thread's -nextEventMatchingMask: (used by the idle render loop)
+// from any thread, by posting an application-defined NSEvent. Safe off-main.
+void wispterm_macos_post_wakeup(void) {
+    @autoreleasepool {
+        NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+                                            location:NSMakePoint(0, 0)
+                                       modifierFlags:0
+                                           timestamp:0
+                                        windowNumber:0
+                                             context:nil
+                                             subtype:0
+                                               data1:0
+                                               data2:0];
+        if (event != nil) [NSApp postEvent:event atStart:NO];
+    }
+}
+
 bool wispterm_macos_window_close_requested(void *handle) {
     WispTermMacWindowState *state = wispterm_macos_state(handle);
     return state != NULL && state->close_requested;

--- a/src/platform/window_unsupported.zig
+++ b/src/platform/window_unsupported.zig
@@ -172,3 +172,11 @@ pub fn pumpAppEvents(timeout_seconds: f64) void {
 }
 
 pub fn postWakeup() void {}
+
+pub fn registerEventWindow(hwnd: NativeHandle) void {
+    _ = hwnd;
+}
+
+pub fn unregisterEventWindow(hwnd: NativeHandle) void {
+    _ = hwnd;
+}

--- a/src/platform/window_unsupported.zig
+++ b/src/platform/window_unsupported.zig
@@ -170,3 +170,5 @@ pub fn requestQuit() void {}
 pub fn pumpAppEvents(timeout_seconds: f64) void {
     _ = timeout_seconds;
 }
+
+pub fn postWakeup() void {}

--- a/src/platform/window_windows.zig
+++ b/src/platform/window_windows.zig
@@ -212,11 +212,66 @@ pub fn consumeQuitRequest() bool {
 pub fn requestQuit() void {}
 
 pub fn pumpAppEvents(timeout_seconds: f64) void {
-    _ = timeout_seconds;
+    const timeout_ms = timeoutMilliseconds(timeout_seconds);
+    _ = MsgWaitForMultipleObjectsEx(0, null, timeout_ms, qs_allinput, mwmo_inputavailable);
 }
 
-pub fn postWakeup() void {}
+pub fn postWakeup() void {
+    var handles: [max_event_windows]NativeHandle = undefined;
+    var count: usize = 0;
+    event_windows_mutex.lock();
+    for (event_windows) |slot| {
+        if (slot) |hwnd| {
+            handles[count] = hwnd;
+            count += 1;
+        }
+    }
+    event_windows_mutex.unlock();
 
+    for (handles[0..count]) |hwnd| {
+        _ = postMessage(hwnd, wm_null, 0, 0);
+    }
+}
+
+pub fn registerEventWindow(hwnd: NativeHandle) void {
+    event_windows_mutex.lock();
+    defer event_windows_mutex.unlock();
+
+    for (event_windows) |slot| {
+        if (slot) |existing| {
+            if (existing == hwnd) return;
+        }
+    }
+    for (&event_windows) |*slot| {
+        if (slot.* == null) {
+            slot.* = hwnd;
+            return;
+        }
+    }
+}
+
+pub fn unregisterEventWindow(hwnd: NativeHandle) void {
+    event_windows_mutex.lock();
+    defer event_windows_mutex.unlock();
+
+    for (&event_windows) |*slot| {
+        if (slot.*) |existing| {
+            if (existing == hwnd) {
+                slot.* = null;
+                return;
+            }
+        }
+    }
+}
+
+fn timeoutMilliseconds(timeout_seconds: f64) u32 {
+    if (timeout_seconds <= 0) return 0;
+    const max_ms: f64 = @floatFromInt(infinite - 1);
+    const clamped = @min(timeout_seconds * 1000.0, max_ms);
+    return @max(@as(u32, 1), @as(u32, @intFromFloat(@ceil(clamped))));
+}
+
+const wm_null: u32 = 0x0000;
 const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 const sw_hide: i32 = 0;
@@ -229,6 +284,13 @@ const HMONITOR = *opaque {};
 const swp_show_window: u32 = 0x0040;
 const hwnd_topmost: std.os.windows.HWND = @ptrFromInt(@as(usize, @bitCast(@as(isize, -1))));
 const hwnd_notopmost: std.os.windows.HWND = @ptrFromInt(@as(usize, @bitCast(@as(isize, -2))));
+const infinite: u32 = 0xFFFFFFFF;
+const qs_allinput: u32 = 0x04FF;
+const mwmo_inputavailable: u32 = 0x0004;
+const max_event_windows = 32;
+
+var event_windows_mutex: std.Thread.Mutex = .{};
+var event_windows: [max_event_windows]?NativeHandle = .{null} ** max_event_windows;
 
 const MONITORINFO = extern struct {
     cbSize: u32,
@@ -279,6 +341,13 @@ extern "user32" fn SetWindowPos(
 ) callconv(.winapi) std.os.windows.BOOL;
 extern "user32" fn MonitorFromWindow(hWnd: std.os.windows.HWND, dwFlags: u32) callconv(.winapi) ?HMONITOR;
 extern "user32" fn GetMonitorInfoW(hMonitor: HMONITOR, lpmi: *MONITORINFO) callconv(.winapi) std.os.windows.BOOL;
+extern "user32" fn MsgWaitForMultipleObjectsEx(
+    nCount: u32,
+    pHandles: ?[*]const std.os.windows.HANDLE,
+    dwMilliseconds: u32,
+    dwWakeMask: u32,
+    dwFlags: u32,
+) callconv(.winapi) u32;
 
 test "platform window exposes native handle helpers" {
     const rect_info = @typeInfo(@TypeOf(getWindowRect)).@"fn";

--- a/src/platform/window_windows.zig
+++ b/src/platform/window_windows.zig
@@ -215,6 +215,8 @@ pub fn pumpAppEvents(timeout_seconds: f64) void {
     _ = timeout_seconds;
 }
 
+pub fn postWakeup() void {}
+
 const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 const sw_hide: i32 = 0;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -5425,26 +5425,14 @@ pub fn anyBlockingOverlayVisible() bool {
         transferCancelConfirmVisible();
 }
 
-/// 脏门控用：是否有任何 overlay / 面板 / 时间动画处于活动状态。
+/// 脏门控用：是否有任何 overlay 时间动画处于活动状态。
 /// 与 `anyBlockingOverlayVisible`（仅模态遮挡 webview）不同 —— 这里要尽量全，
-/// 漏判会导致 overlay 动画卡住，所以宁可多列。`now` = std.time.milliTimestamp()。
+/// 漏判会导致 overlay 动画卡住，所以宁可多列。静态打开态 overlay 不放这里；
+/// 打开/输入/关闭时已有 g_force_rebuild 触发一帧。`now` = std.time.milliTimestamp()。
 pub fn anyOverlayActive(now: i64) bool {
-    // 打开态 overlay
-    if (commandPaletteVisible()) return true;
-    if (commandPaletteAgentHistoryVisible()) return true;
-    if (settingsPageVisible()) return true;
-    if (sessionLauncherVisible()) return true;
-    if (whatsNewVisible()) return true;
-    if (windowCloseConfirmVisible()) return true;
-    if (restoreDefaultsConfirmVisible()) return true;
-    if (transferCancelConfirmVisible()) return true;
-    if (jupyter_picker.isVisible()) return true;
-    if (startup_shortcuts.g_startup_shortcuts_visible) return true;
-    if (browser_panel.urlBarFocused()) return true;
-
     // 时间动画：到期前每帧需持续渲染
     if (now < g_copy_toast_until_ms) return true;
-    if (g_transfer_toast_sticky or now < g_transfer_toast_until_ms) return true;
+    if (now < g_transfer_toast_until_ms) return true;
     if (now < g_update_prompt_until_ms) return true;
     if (now < g_close_shortcut_confirm_until_ms) return true;
     if (now < g_remote_key_copied_until_ms) return true;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -5425,6 +5425,37 @@ pub fn anyBlockingOverlayVisible() bool {
         transferCancelConfirmVisible();
 }
 
+/// 脏门控用：是否有任何 overlay / 面板 / 时间动画处于活动状态。
+/// 与 `anyBlockingOverlayVisible`（仅模态遮挡 webview）不同 —— 这里要尽量全，
+/// 漏判会导致 overlay 动画卡住，所以宁可多列。`now` = std.time.milliTimestamp()。
+pub fn anyOverlayActive(now: i64) bool {
+    // 打开态 overlay
+    if (commandPaletteVisible()) return true;
+    if (commandPaletteAgentHistoryVisible()) return true;
+    if (settingsPageVisible()) return true;
+    if (sessionLauncherVisible()) return true;
+    if (whatsNewVisible()) return true;
+    if (windowCloseConfirmVisible()) return true;
+    if (restoreDefaultsConfirmVisible()) return true;
+    if (transferCancelConfirmVisible()) return true;
+    if (jupyter_picker.isVisible()) return true;
+    if (startup_shortcuts.g_startup_shortcuts_visible) return true;
+    if (browser_panel.urlBarFocused()) return true;
+
+    // 时间动画：到期前每帧需持续渲染
+    if (now < g_copy_toast_until_ms) return true;
+    if (g_transfer_toast_sticky or now < g_transfer_toast_until_ms) return true;
+    if (now < g_update_prompt_until_ms) return true;
+    if (now < g_close_shortcut_confirm_until_ms) return true;
+    if (now < g_remote_key_copied_until_ms) return true;
+    if (now < resize.g_split_resize_overlay_until) return true;
+
+    // FPS 叠层开启时每秒刷新
+    if (g_debug_fps) return true;
+
+    return false;
+}
+
 pub fn whatsNewHandleKey(ev: input_key.KeyEvent) void {
     if (!g_whats_new_visible) return;
     switch (ev.key) {

--- a/src/termio/ReadThread.zig
+++ b/src/termio/ReadThread.zig
@@ -10,6 +10,7 @@
 /// Shutdown is delegated to the platform PTY backend.
 const std = @import("std");
 const Surface = @import("../Surface.zig");
+const window_backend = @import("../platform/window_backend.zig");
 
 const READ_BUF_SIZE = 4096;
 
@@ -117,4 +118,5 @@ fn processOutput(surface: *Surface, data: []const u8) void {
     surface.scanForOscTitle(data);
     surface.noteAgentOutput(data);
     surface.dirty.store(true, .release);
+    window_backend.postWakeup();
 }

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -18,6 +18,7 @@ const std = @import("std");
 const xev = @import("xev");
 const Surface = @import("../Surface.zig");
 const renderer = @import("../renderer.zig");
+const window_backend = @import("../platform/window_backend.zig");
 
 const Thread = @This();
 
@@ -170,4 +171,5 @@ fn applyResize(surface: *Surface, grid: renderer.size.GridSize) void {
 
     surface.terminal.scrollViewport(.{ .bottom = {} });
     surface.dirty.store(true, .release);
+    window_backend.postWakeup();
 }

--- a/src/web_read_cache.zig
+++ b/src/web_read_cache.zig
@@ -76,13 +76,19 @@ test "cacheRoot uses cache_dir when set, else the file's directory" {
     const a = std.testing.allocator;
     const with = try cacheRoot(a, "/work/proj", "/dl/x.pdf");
     defer a.free(with);
-    try std.testing.expectEqualStrings("/work/proj/.webread_cache", with);
+    const expected_with = try std.fs.path.join(a, &.{ "/work/proj", cache_dir_name });
+    defer a.free(expected_with);
+    try std.testing.expectEqualStrings(expected_with, with);
+
     const without = try cacheRoot(a, null, "/dl/x.pdf");
     defer a.free(without);
-    try std.testing.expectEqualStrings("/dl/.webread_cache", without);
+    const expected_without = try std.fs.path.join(a, &.{ "/dl", cache_dir_name });
+    defer a.free(expected_without);
+    try std.testing.expectEqualStrings(expected_without, without);
+
     const empty = try cacheRoot(a, "", "/dl/x.pdf");
     defer a.free(empty);
-    try std.testing.expectEqualStrings("/dl/.webread_cache", empty);
+    try std.testing.expectEqualStrings(expected_without, empty);
 }
 
 test "cacheFileName is basename.sha16.md" {


### PR DESCRIPTION
## 背景 / 根因

WispTerm 启动后主进程 CPU ~73%，即使切后台/失焦也高。根因：主渲染循环（`AppWindow.zig` 的 `run`）每个 vsync 无条件全量渲染 + present，无脏门控、无后台暂停（仅最小化时 sleep）。`CAMetalLayer` 默认 vsync 把帧率限在刷新率，所以是 ~73% 而非爆 100%——vsync 限了帧率，但没人限“该不该画”。

## 方案（阶段 1：事件驱动主循环，全部在主线程内，不引入渲染线程）

- **M1 阻塞事件泵**：空闲时 `pumpAppEvents(timeout)` 阻塞，不再零超时轮询
- **M2 跨线程唤醒**：IO 线程标 `surface.dirty` 后用 `NSApp postEvent` 唤醒阻塞中的主循环
- **M3 保守脏门控 `frameNeedsRender`**：仅当所有视觉来源静默才跳帧（`g_force_rebuild` / 任一 `surface.dirty` / 光标闪烁到点 / AI 流式 `request_inflight` / overlay 活动）
- **M4 分级超时**：聚焦 100ms / 失焦 250ms / 遮挡·后台 500ms，光标临近翻转时收紧
- **M5 occlusion/focus 查询**：`occlusionState` + `isKeyWindow`（顺带修复 `focused` 恒为 true 的旧 bug）
- **关键修复**：渲染一帧后清 `g_force_rebuild`——它原本只升不降会令门控永久失效（final review 抓到）

## 验收（真机 CPU + 单测）

| 场景 | 主进程 CPU |
|---|---|
| 旧版基线 | 73.8% |
| 聚焦空闲 | 0.2% |
| 失焦可见 | 0.2% |
| 持续输出中 | 24–30%（渲染正常响应）|
| 输出停止后 | ~0–1.7%（门控重新生效）|

- `render_gate` 单元测试 3/3 通过
- `zig build macos-app -Dtarget=aarch64-macos` 编译干净
- 反向验证（往活 shell tty 注入持续输出）确认门控未误伤正常渲染：有内容全速渲染、停止后回落

## 已知限制 / 后续

- **阶段 2（独立后续立项）**：渲染上单线程 + CVDisplayLink。受 phantty“单 CAMetalLayer + 全 UI 自绘”架构约束，跨线程同步面大，作为架构演进单独做。
- bell / overlay 动画、AI 流式的主观流畅度建议日常使用确认。
- 整套 `zig build test-full` 因编译大量测试二进制被系统 OOM-kill（资源限制，非本次代码问题）。

设计与计划文档：`docs/superpowers/specs/2026-06-07-event-driven-render-loop-design.md`、`docs/superpowers/plans/2026-06-07-event-driven-render-loop.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)