### PR TITLE
[codex] Respect configured Windows shell

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2691,26 +2691,36 @@ pub fn syncDefaultShellCommandFromConfig(shell: []const u8) void {
     tab.g_shell_cmd_len = App.resolveShellCommandLine(&tab.g_shell_cmd_buf, shell);
 }
 
+threadlocal var g_configured_shell_title_buf: [1024]u8 = undefined;
+threadlocal var g_configured_shell_detail_buf: [1024]u8 = undefined;
+
+pub fn configuredLocalShellSessionTitle() []const u8 {
+    const display = platform_pty_command.commandLineDisplay(tab.getShellCmd(), &g_configured_shell_title_buf);
+    if (display.len == 0) return platform_pty_command.localShellLauncherTitle();
+
+    const title = platform_pty_command.friendlyShellTitle(display);
+    if (title.len == 0) return platform_pty_command.localShellLauncherTitle();
+    return title;
+}
+
 pub fn configuredLocalShellSessionDetail() []const u8 {
-    return platform_pty_command.configuredLocalShellCommandForShell(tab.getShellCmd());
+    const display = platform_pty_command.commandLineDisplay(tab.getShellCmd(), &g_configured_shell_detail_buf);
+    if (display.len == 0) return platform_pty_command.guaranteedLocalShellCommand();
+    return display;
 }
 
 pub fn spawnConfiguredLocalShellTab() bool {
     const shell_cmd = tab.getShellCmd();
 
-    // When the configured shell already is PowerShell/pwsh, launch it directly.
-    if (platform_pty_command.shellCommandLooksLikeConfiguredLocalShell(shell_cmd)) {
-        if (spawnLocalShellCommandLine(shell_cmd)) return true;
-        // Configured PowerShell/pwsh is unavailable (e.g. removed from PATH):
-        // fall back to cmd.exe so the local-shell tab still opens (issue #65).
-        return spawnTabWithCommandUtf8(platform_pty_command.guaranteedLocalShellCommand());
-    }
+    if (spawnLocalShellCommandLine(shell_cmd)) return true;
 
-    // Otherwise the startup "local shell" tab prefers PowerShell. If that is not
-    // installed/on PATH, fall back to the user's actual configured shell (e.g.
-    // cmd.exe) instead of failing to open any local-shell tab (issue #65).
-    if (spawnTabWithCommandUtf8(platform_pty_command.configuredLocalShellCommandForShell(shell_cmd))) return true;
-    return spawnLocalShellCommandLine(shell_cmd);
+    // Keep the issue #65 safety net: if the configured shell cannot launch, open
+    // a guaranteed local shell so the user is not left without a terminal.
+    const fallback = platform_pty_command.guaranteedLocalShellCommand();
+    var configured_buf: [1024]u8 = undefined;
+    const configured = platform_pty_command.commandLineDisplay(shell_cmd, &configured_buf);
+    if (std.mem.eql(u8, configured, fallback)) return false;
+    return spawnTabWithCommandUtf8(fallback);
 }
 
 fn spawnLocalShellCommandLine(shell_cmd: platform_pty_command.CommandLine) bool {
@@ -6560,6 +6570,26 @@ test "appwindow: syncDefaultShellCommandFromConfig refreshes tab default shell" 
     const expected_len = platform_pty_command.resolveShellCommandLine(&expected_buf, test_shell);
     const CommandUnit = @TypeOf(expected_buf[0]);
     try testing.expectEqualSlices(CommandUnit, expected_buf[0..expected_len], tab.getShellCmd());
+}
+
+test "appwindow: configured local shell session labels reflect shell config" {
+    defer {
+        @memset(&tab.g_shell_cmd_buf, 0);
+        tab.g_shell_cmd_len = 0;
+    }
+
+    syncDefaultShellCommandFromConfig("cmd");
+
+    switch (platform_pty_command.backend()) {
+        .windows => {
+            try std.testing.expectEqualStrings("Command Prompt", configuredLocalShellSessionTitle());
+            try std.testing.expectEqualStrings("cmd.exe", configuredLocalShellSessionDetail());
+        },
+        .unsupported => {
+            try std.testing.expectEqualStrings("cmd", configuredLocalShellSessionTitle());
+            try std.testing.expectEqualStrings("cmd", configuredLocalShellSessionDetail());
+        },
+    }
 }
 
 test "appwindow: ai history content width accounts for right panels" {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -342,8 +342,24 @@ pub fn loadAccessRules(allocator: std.mem.Allocator) void {
 
     g_agent_mutex.lock();
     defer g_agent_mutex.unlock();
+    if (g_access_rules_storage != null) {
+        var unused = rules;
+        unused.deinit();
+        return;
+    }
     g_access_rules_storage = rules;
     g_access_rules = &g_access_rules_storage.?;
+}
+
+pub fn deinitAccessRules() void {
+    g_agent_mutex.lock();
+    defer g_agent_mutex.unlock();
+    g_access_rules = null;
+    g_agent_settings.access_rules = null;
+    if (g_access_rules_storage) |*rules| {
+        rules.deinit();
+        g_access_rules_storage = null;
+    }
 }
 
 /// Set the persistent default working directory (from config). Empty clears it.

--- a/src/main.zig
+++ b/src/main.zig
@@ -170,6 +170,7 @@ pub fn main() !void {
 
     // Create the App and run (first window on main thread, spawned windows on separate threads)
     var app = try App.init(allocator, cfg);
+    defer ai_chat.deinitAccessRules();
     defer app.deinit();
     ai_chat.loadAccessRules(allocator);
 

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -75,6 +75,10 @@ pub fn resolveShellCommandLine(out_buf: *CommandLineBuffer, cmd: []const u8) usi
     return impl.resolveShellCommandLine(out_buf, cmd);
 }
 
+pub fn commandLineDisplay(command: CommandLine, out: []u8) []const u8 {
+    return impl.commandLineDisplay(command, out);
+}
+
 pub fn localShellLauncherTitle() []const u8 {
     return local_shell_launcher_title;
 }
@@ -83,7 +87,7 @@ pub const local_shell_launcher_title = localShellLauncherTitleForOs(builtin.os.t
 
 pub fn localShellLauncherTitleForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
-        .windows => "PowerShell",
+        .windows => "Shell",
         .unsupported => "Shell",
     };
 }
@@ -108,7 +112,7 @@ pub const session_launcher_detail = sessionLauncherDetailForOs(builtin.os.tag);
 
 pub fn sessionLauncherDetailForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
-        .windows => "Choose PowerShell, SSH, WSL, Copilot, or Sessions",
+        .windows => "Choose Shell, SSH, WSL, Copilot, or Sessions",
         .unsupported => "Choose Shell, SSH, Copilot, or Sessions",
     };
 }
@@ -453,6 +457,7 @@ test "platform pty command resolves shell aliases to native command lines" {
         .unsupported => "cmd",
     };
     try std.testing.expectEqualStrings(expected_cmd, cmd_utf8);
+    try std.testing.expectEqualStrings(expected_cmd, commandLineDisplay(out[0..cmd_len :0], &utf8));
 
     const powershell_len = resolveShellCommandLine(&out, "powershell");
     const powershell_utf8 = try nativeCommandSliceToUtf8(&utf8, out[0..powershell_len]);
@@ -562,7 +567,7 @@ test "platform pty command exposes tab_new tool text by target OS" {
 }
 
 test "platform pty command exposes configured local shell launcher by target OS" {
-    try std.testing.expectEqualStrings("PowerShell", localShellLauncherTitleForOs(.windows));
+    try std.testing.expectEqualStrings("Shell", localShellLauncherTitleForOs(.windows));
     try std.testing.expectEqualStrings("Shell", localShellLauncherTitleForOs(.linux));
     try std.testing.expectEqualStrings("Shell", localShellLauncherTitleForOs(.macos));
 

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -47,6 +47,12 @@ pub fn commandLineFromOwned(command: OwnedCommandLine) CommandLine {
     return command;
 }
 
+pub fn commandLineDisplay(command: CommandLine, out: []u8) []const u8 {
+    const len = @min(command.len, out.len);
+    @memcpy(out[0..len], command[0..len]);
+    return out[0..len];
+}
+
 pub fn allocCwdFromUtf8(allocator: std.mem.Allocator, cwd: []const u8) !OwnedCwd {
     return allocator.dupeZ(u8, cwd);
 }

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -98,6 +98,11 @@ pub fn commandLineFromOwned(command: OwnedCommandLine) CommandLine {
     return command;
 }
 
+pub fn commandLineDisplay(command: CommandLine, out: []u8) []const u8 {
+    const len = std.unicode.utf16LeToUtf8(out, command) catch return "";
+    return out[0..len];
+}
+
 pub fn allocCwdFromUtf8(allocator: std.mem.Allocator, cwd: []const u8) !OwnedCwd {
     return std.unicode.utf8ToUtf16LeAllocZ(allocator, cwd);
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3682,7 +3682,7 @@ fn sessionDesiredBoxWidth() f32 {
         return desired;
     }
 
-    desired = @max(desired, sessionTwoColumnWidth(platform_pty_command.localShellLauncherTitle(), AppWindow.configuredLocalShellSessionDetail()));
+    desired = @max(desired, sessionTwoColumnWidth(AppWindow.configuredLocalShellSessionTitle(), AppWindow.configuredLocalShellSessionDetail()));
     desired = @max(desired, sessionTwoColumnWidth("SSH", i18n.s().sl_v_connect_server));
     if (platform_pty_command.sessionLauncherWslRow() != null) {
         desired = @max(desired, sessionTwoColumnWidth("WSL", platform_pty_command.wslLauncherDetail()));
@@ -3991,7 +3991,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             return;
         }
         var row: usize = 0;
-        renderSessionRow(layout, window_height, row, platform_pty_command.localShellLauncherTitle(), AppWindow.configuredLocalShellSessionDetail(), g_session_launcher_selected == row);
+        renderSessionRow(layout, window_height, row, AppWindow.configuredLocalShellSessionTitle(), AppWindow.configuredLocalShellSessionDetail(), g_session_launcher_selected == row);
         row += 1;
         renderSessionRow(layout, window_height, row, "SSH", i18n.s().sl_v_connect_server, g_session_launcher_selected == row);
         row += 1;


### PR DESCRIPTION
## Summary
- Respect the configured Windows shell when opening the default local shell tab, so `shell = cmd` starts `cmd.exe` instead of PowerShell.
- Update the New Session launcher to display the configured shell title/detail instead of hard-coded PowerShell text.
- Release loaded agent access rules during shutdown to avoid GPA leak reports.

## Root Cause
The Windows local-shell launcher special-cased PowerShell and used it as the preferred startup shell for non-PowerShell configs. Separately, the AI agent access rules were stored globally but their arena was never deinitialized before the app allocator leak check.

Fixes #164

## Validation
- `zig build test`
- `$env:PATH='C:\Program Files\Git\usr\bin;' + $env:PATH; zig build test-full`
- `zig build`
