### PR TITLE
[codex] Fix command center child escape behavior

### DIFF
--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -116,6 +116,7 @@ pub const State = struct {
     startup_shortcuts_visible: bool = false,
     session_launcher_visible: bool = false,
     session_launcher_selected: usize = 0,
+    session_launcher_return_to_command_palette: bool = false,
     ssh_list_visible: bool = false,
     ssh_form_visible: bool = false,
     ai_list_visible: bool = false,
@@ -142,6 +143,7 @@ pub const State = struct {
         self.command_palette_filter_len = 0;
         self.commandPaletteSetMode(mode);
         self.command_palette_history_selected = 0;
+        self.session_launcher_return_to_command_palette = false;
         self.startup_shortcuts_visible = false;
     }
 
@@ -155,6 +157,7 @@ pub const State = struct {
         self.command_palette_selected = 0;
         self.commandPaletteSetMode(.commands);
         self.command_palette_history_selected = 0;
+        self.session_launcher_return_to_command_palette = false;
     }
 
     pub fn commandPaletteOpenAgentHistory(self: *State) void {
@@ -223,8 +226,14 @@ pub const State = struct {
         self.ai_form_visible = false;
         self.ai_history_source_visible = false;
         self.command_palette_visible = false;
+        self.session_launcher_return_to_command_palette = false;
         self.settings_visible = false;
         self.startup_shortcuts_visible = false;
+    }
+
+    pub fn sessionLauncherOpenFromCommandPalette(self: *State) void {
+        self.sessionLauncherOpen();
+        self.session_launcher_return_to_command_palette = true;
     }
 
     pub fn sessionLauncherClose(self: *State) void {
@@ -234,6 +243,14 @@ pub const State = struct {
         self.ai_list_visible = false;
         self.ai_form_visible = false;
         self.ai_history_source_visible = false;
+        self.session_launcher_return_to_command_palette = false;
+    }
+
+    pub fn sessionLauncherBackToCommandPalette(self: *State) bool {
+        if (!self.session_launcher_return_to_command_palette) return false;
+        self.sessionLauncherClose();
+        self.commandPaletteOpen();
+        return true;
     }
 
     pub fn settingsPageOpen(self: *State) void {
@@ -399,6 +416,32 @@ test "agent history picker escape returns to command list mode" {
 
     try std.testing.expect(state.command_palette_visible);
     try std.testing.expect(!state.commandPaletteIsHistoryMode());
+}
+
+test "session launcher opened from command center escapes back to command list" {
+    var state = State{};
+    state.commandPaletteOpen();
+
+    state.sessionLauncherOpenFromCommandPalette();
+    try std.testing.expect(!state.command_palette_visible);
+    try std.testing.expect(state.sessionLauncherVisible());
+    try std.testing.expect(state.session_launcher_return_to_command_palette);
+
+    try std.testing.expect(state.sessionLauncherBackToCommandPalette());
+    try std.testing.expect(state.command_palette_visible);
+    try std.testing.expect(!state.sessionLauncherVisible());
+    try std.testing.expect(!state.session_launcher_return_to_command_palette);
+}
+
+test "standalone session launcher escape still closes" {
+    var state = State{};
+    state.sessionLauncherOpen();
+
+    try std.testing.expect(!state.sessionLauncherBackToCommandPalette());
+    state.sessionLauncherClose();
+
+    try std.testing.expect(!state.command_palette_visible);
+    try std.testing.expect(!state.sessionLauncherVisible());
 }
 
 test "agent history picker has no selection when the history list is empty" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -157,6 +157,22 @@ const arrow_down_event = platform_input.KeyEvent{
     .super = false,
 };
 
+const enter_event = platform_input.KeyEvent{
+    .key_code = platform_input.key_enter,
+    .ctrl = false,
+    .shift = false,
+    .alt = false,
+    .super = false,
+};
+
+const escape_event = platform_input.KeyEvent{
+    .key_code = platform_input.key_escape,
+    .ctrl = false,
+    .shift = false,
+    .alt = false,
+    .super = false,
+};
+
 test "input: command palette arrow navigation requests a repaint" {
     const previous_keybinds = AppWindow.g_keybinds;
     defer AppWindow.g_keybinds = previous_keybinds;
@@ -202,6 +218,28 @@ test "input: session launcher arrow navigation requests a repaint" {
 
     try std.testing.expect(AppWindow.g_force_rebuild);
     try std.testing.expect(!AppWindow.g_cells_valid);
+}
+
+test "input: command center child escape returns to command center" {
+    const previous_keybinds = AppWindow.g_keybinds;
+    defer AppWindow.g_keybinds = previous_keybinds;
+    defer overlays.commandPaletteClose();
+    defer overlays.sessionLauncherClose();
+
+    AppWindow.g_keybinds = keybind.Set.defaults();
+    overlays.commandPaletteClose();
+    overlays.sessionLauncherClose();
+
+    overlays.commandPaletteOpen();
+    try std.testing.expect(overlays.commandPaletteVisible());
+
+    handleKey(enter_event);
+    try std.testing.expect(!overlays.commandPaletteVisible());
+    try std.testing.expect(overlays.sessionLauncherVisible());
+
+    handleKey(escape_event);
+    try std.testing.expect(overlays.commandPaletteVisible());
+    try std.testing.expect(!overlays.sessionLauncherVisible());
 }
 
 test "input: settings page arrow navigation requests a repaint" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -516,10 +516,10 @@ fn transferCancelConfirmExecuteAtForTest(xpos: f32, ypos: f32, window_width: f32
 
 fn executeCommand(action: CommandAction) void {
     switch (action) {
-        .new_tab => sessionLauncherOpen(),
+        .new_tab => sessionLauncherOpenFromCommandPalette(),
         .load_openssh_config => loadOpenSshConfigDefault(),
         .new_agent => openDefaultAgentSessionFromCommandCenter(),
-        .manage_ai_profiles => openAiList(),
+        .manage_ai_profiles => openAiListFromCommandPalette(),
         .select_agent_history => commandPaletteOpenAgentHistory(),
         .split_right => AppWindow.splitFocused(.right),
         .split_down => AppWindow.splitFocused(.down),
@@ -1706,6 +1706,7 @@ const SessionLayout = struct {
 
 pub threadlocal var g_session_launcher_visible: bool = false;
 threadlocal var g_session_launcher_selected: usize = 0;
+threadlocal var g_session_launcher_return_to_command_palette: bool = false;
 threadlocal var g_ssh_list_visible: bool = false;
 threadlocal var g_ssh_form_visible: bool = false;
 threadlocal var g_ai_list_visible: bool = false;
@@ -1763,6 +1764,7 @@ fn commandCenterStateSnapshot() command_center_state.State {
         .startup_shortcuts_visible = startup_shortcuts.g_startup_shortcuts_visible,
         .session_launcher_visible = g_session_launcher_visible,
         .session_launcher_selected = g_session_launcher_selected,
+        .session_launcher_return_to_command_palette = g_session_launcher_return_to_command_palette,
         .ssh_list_visible = g_ssh_list_visible,
         .ssh_form_visible = g_ssh_form_visible,
         .ai_list_visible = g_ai_list_visible,
@@ -1789,6 +1791,7 @@ fn commandCenterStateApply(state: command_center_state.State) void {
     startup_shortcuts.g_startup_shortcuts_visible = state.startup_shortcuts_visible;
     g_session_launcher_visible = state.session_launcher_visible;
     g_session_launcher_selected = state.session_launcher_selected;
+    g_session_launcher_return_to_command_palette = state.session_launcher_return_to_command_palette;
     g_ssh_list_visible = state.ssh_list_visible;
     g_ssh_form_visible = state.ssh_form_visible;
     g_ai_list_visible = state.ai_list_visible;
@@ -1801,6 +1804,17 @@ pub fn sessionLauncherOpen() void {
     var state = commandCenterStateSnapshot();
     state.sessionLauncherOpen();
     commandCenterStateCommit(state);
+    resetSessionLauncherTransientModes();
+}
+
+pub fn sessionLauncherOpenFromCommandPalette() void {
+    var state = commandCenterStateSnapshot();
+    state.sessionLauncherOpenFromCommandPalette();
+    commandCenterStateCommit(state);
+    resetSessionLauncherTransientModes();
+}
+
+fn resetSessionLauncherTransientModes() void {
     g_ssh_list_mode = .manage;
     g_ai_list_mode = .manage;
     g_ai_history_source_selected = 0;
@@ -1810,9 +1824,34 @@ pub fn sessionLauncherClose() void {
     var state = commandCenterStateSnapshot();
     state.sessionLauncherClose();
     commandCenterStateCommit(state);
-    g_ssh_list_mode = .manage;
-    g_ai_list_mode = .manage;
-    g_ai_history_source_selected = 0;
+    resetSessionLauncherTransientModes();
+}
+
+fn sessionLauncherBackOrClose() void {
+    var state = commandCenterStateSnapshot();
+    if (!state.sessionLauncherBackToCommandPalette()) {
+        state.sessionLauncherClose();
+    }
+    commandCenterStateCommit(state);
+    resetSessionLauncherTransientModes();
+}
+
+fn sessionLauncherCancelLabel() []const u8 {
+    return if (g_session_launcher_return_to_command_palette) i18n.s().sl_back else i18n.s().sl_cancel;
+}
+
+fn markSessionLauncherReturnToCommandPalette() void {
+    g_session_launcher_return_to_command_palette = true;
+}
+
+fn openAiListFromCommandPalette() void {
+    openAiList();
+    markSessionLauncherReturnToCommandPalette();
+}
+
+fn openAiFormNewFromCommandPalette() void {
+    openAiFormNew();
+    markSessionLauncherReturnToCommandPalette();
 }
 
 pub fn sessionLauncherInsertChar(codepoint: u21) void {
@@ -1900,7 +1939,7 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
             openAiHistorySourcePicker();
             return;
         }
-        cancelAiFormOrLauncher();
+        sessionLauncherBackOrClose();
         return;
     }
 
@@ -2012,7 +2051,7 @@ pub fn sessionLauncherExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_
         .save => saveSshFormOnly(),
         .connect_ai => connectAiFromForm(),
         .save_ai => saveAiFormOnly(),
-        .cancel => sessionLauncherClose(),
+        .cancel => sessionLauncherBackOrClose(),
     }
     return true;
 }
@@ -2837,7 +2876,7 @@ fn openDefaultAiSession() void {
 fn openDefaultAgentSessionFromCommandCenter() void {
     loadAiProfiles();
     switch (command_center_state.resolveNewAgentLaunch(g_ai_profile_count != 0)) {
-        .open_form => openAiFormNew(),
+        .open_form => openAiFormNewFromCommandPalette(),
         .connect_default_profile_as_agent => connectAiProfileWithAgentOverride(defaultAiProfileIndex(), "true"),
     }
 }
@@ -3162,7 +3201,7 @@ fn saveAiFormOnly() void {
 }
 
 fn cancelAiFormOrLauncher() void {
-    sessionLauncherClose();
+    sessionLauncherBackOrClose();
 }
 
 fn runAiFormFocusAction() void {
@@ -3595,7 +3634,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ai_vision, aiVisionDisplay()));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save_open, i18n.s().sl_v_agent));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save, i18n.s().sl_v_profile));
-        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
+        desired = @max(desired, sessionTwoColumnWidth(sessionLauncherCancelLabel(), "Esc"));
         return desired;
     }
 
@@ -3608,7 +3647,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_jump_host, sshField(.proxy_jump)));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save_connect, platform_pty_command.sshLauncherDetail()));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save, i18n.s().sl_v_profile));
-        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
+        desired = @max(desired, sessionTwoColumnWidth(sessionLauncherCancelLabel(), "Esc"));
         return desired;
     }
 
@@ -3630,7 +3669,7 @@ fn sessionDesiredBoxWidth() f32 {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_new_llm_provider, i18n.s().sl_v_add));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_edit_llm_provider, if (g_ai_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_profile));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_delete_llm_provider, if (g_ai_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_profile));
-                desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
+                desired = @max(desired, sessionTwoColumnWidth(sessionLauncherCancelLabel(), "Esc"));
             },
             .edit_select, .delete_select => {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, i18n.s().sl_v_manage));
@@ -3660,7 +3699,7 @@ fn sessionDesiredBoxWidth() f32 {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_new_ssh_server, i18n.s().sl_v_add));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_edit_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server));
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_delete_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server));
-                desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
+                desired = @max(desired, sessionTwoColumnWidth(sessionLauncherCancelLabel(), "Esc"));
             },
             .edit_select, .delete_select => {
                 desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_back, i18n.s().sl_v_manage));
@@ -3678,7 +3717,7 @@ fn sessionDesiredBoxWidth() f32 {
             desired = @max(desired, sessionTwoColumnWidth("WSL", "Default distro"));
         }
         desired = @max(desired, sessionTwoColumnWidth("SSH Profile...", "Choose server"));
-        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_cancel, "Esc"));
+        desired = @max(desired, sessionTwoColumnWidth(sessionLauncherCancelLabel(), "Esc"));
         return desired;
     }
 
@@ -3936,7 +3975,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             }
             renderSessionRow(layout, window_height, row, "SSH Profile...", "Choose server", g_ai_history_source_selected == row);
             row += 1;
-            renderSessionRow(layout, window_height, row, i18n.s().sl_cancel, "Esc", g_ai_history_source_selected == row);
+            renderSessionRow(layout, window_height, row, sessionLauncherCancelLabel(), "Esc", g_ai_history_source_selected == row);
             return;
         }
         if (g_ai_list_visible) {
@@ -3952,7 +3991,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
                     row += 1;
                     renderSessionRow(layout, window_height, row, i18n.s().sl_delete_llm_provider, if (g_ai_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_profile, g_ai_list_selected == row);
                     row += 1;
-                    renderSessionRow(layout, window_height, row, i18n.s().sl_cancel, "Esc", g_ai_list_selected == row);
+                    renderSessionRow(layout, window_height, row, sessionLauncherCancelLabel(), "Esc", g_ai_list_selected == row);
                 },
                 .edit_select, .delete_select => {
                     renderSessionRow(layout, window_height, row, i18n.s().sl_back, i18n.s().sl_v_manage, g_ai_list_selected == row);
@@ -3979,7 +4018,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
                     row += 1;
                     renderSessionRow(layout, window_height, row, i18n.s().sl_delete_ssh_server, if (g_ssh_profile_count > 0) i18n.s().sl_v_choose else i18n.s().sl_v_no_server, g_ssh_list_selected == row);
                     row += 1;
-                    renderSessionRow(layout, window_height, row, i18n.s().sl_cancel, "Esc", g_ssh_list_selected == row);
+                    renderSessionRow(layout, window_height, row, sessionLauncherCancelLabel(), "Esc", g_ssh_list_selected == row);
                 },
                 .edit_select, .delete_select => {
                     renderSessionRow(layout, window_height, row, i18n.s().sl_back, i18n.s().sl_v_manage, g_ssh_list_selected == row);
@@ -4020,7 +4059,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         renderAiSessionField(layout, window_height, @intFromEnum(AiField.vision), i18n.s().sl_ai_vision, aiVisionDisplay(), false);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT, i18n.s().sl_save_open, i18n.s().sl_v_agent, g_ai_focus == AI_FIELD_COUNT);
         renderSessionRow(layout, window_height, AI_FIELD_COUNT + 1, i18n.s().sl_save, i18n.s().sl_v_profile, g_ai_focus == AI_FIELD_COUNT + 1);
-        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, i18n.s().sl_cancel, "Esc", g_ai_focus == AI_FIELD_COUNT + 2);
+        renderSessionRow(layout, window_height, AI_FIELD_COUNT + 2, sessionLauncherCancelLabel(), "Esc", g_ai_focus == AI_FIELD_COUNT + 2);
         return;
     }
 
@@ -4032,7 +4071,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     renderSessionField(layout, window_height, @intFromEnum(SshField.proxy_jump), i18n.s().sl_ssh_jump_host, sshField(.proxy_jump), false);
     renderSessionRow(layout, window_height, SSH_FIELD_COUNT, i18n.s().sl_save_connect, platform_pty_command.sshLauncherDetail(), g_ssh_focus == SSH_FIELD_COUNT);
     renderSessionRow(layout, window_height, SSH_FIELD_COUNT + 1, i18n.s().sl_save, i18n.s().sl_v_profile, g_ssh_focus == SSH_FIELD_COUNT + 1);
-    renderSessionRow(layout, window_height, SSH_FIELD_COUNT + 2, i18n.s().sl_cancel, "Esc", g_ssh_focus == SSH_FIELD_COUNT + 2);
+    renderSessionRow(layout, window_height, SSH_FIELD_COUNT + 2, sessionLauncherCancelLabel(), "Esc", g_ssh_focus == SSH_FIELD_COUNT + 2);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Track when command-center child views were opened from the command center.
- Make Esc in those second-level views return to the command center instead of closing the flow.
- Keep standalone New Session behavior unchanged, where Esc still closes the launcher.
- Update the visible Esc row label from Cancel to Back when it returns to the command center.

## Root Cause

Command-center actions such as New Session reused the standalone session launcher open path. That path hid the command center and did not retain any parent relationship, so Esc could only close the launcher instead of navigating back.

## Validation

- `zig build test`
- `zig build test-full`
