### PR TITLE
feat(repl): human-like REPL execution for Copilot agent

### DIFF
--- a/docs/superpowers/plans/2026-06-09-repl-human-typing.md
+++ b/docs/superpowers/plans/2026-06-09-repl-human-typing.md
@@ -1,0 +1,529 @@
+# Human-like REPL execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `terminal_repl_exec` type code into Python/R/Node/any line REPL exactly as a human would (raw input, prompt-return detection) instead of injecting an `exec()`+sentinel wrapper, and fix the prompt guidance that forced verbose `print()`-wrapped code.
+
+**Architecture:** Replace the Python/R sentinel-wrapper eval tools and the crude `.plain` fixed-wait with one general engine: capture the REPL's current prompt, write the raw code + Enter, then poll the live per-surface snapshot until the screen quiesces *and* a ready prompt has returned (the captured prompt reappears, or a generic prompt heuristic matches). Codex/Claude Code TUIs and the shell-exec (`ssh`/`wsl`) sentinels are untouched.
+
+**Tech Stack:** Zig 0.15.2; single file `src/ai_chat_tools.zig`; inline `test "..."` blocks run under `zig build test-full`. Prompt files `src/platform/agent_prompt.zig` (runtime) + `src/prompt.md` (parity).
+
+---
+
+## File Structure
+
+- `src/ai_chat_tools.zig` — all mechanism + tests:
+  - **Add** pure helpers: `extractPromptLine`, `looksLikeReadyPrompt`, `promptReturned`.
+  - **Add** `waitForReplPromptReturn` (poll loop) and `lineReplEvalTool` (capture → write raw → wait).
+  - **Reroute** the `terminalReplExecTool` switch so `.r`/`.python`/`.plain` use `lineReplEvalTool`.
+  - **Simplify** `plainReplInputTool` to its now-only callers (`.codex`/`.claude_code`).
+  - **Remove** `pythonSessionEvalTool`, `rSessionEvalTool`, `pythonStringLiteral`, `rStringLiteral`, `doubleQuotedStringLiteral`, and their two now-obsolete tests.
+- `src/platform/agent_prompt.zig` — REPL usage guidance (runtime prompt).
+- `src/prompt.md` — parity copy of the guidance.
+
+**Untouched (do NOT remove):** `hasPendingAgentCommand`, `extractUnixCommandResult`, `findCompletedEnd`, `AGENT_START_PREFIX` (used by shell-exec); `waitForAgentAppReplResult`, `replSnapshotLooksBusy`, `allocAgentAppReplResult` (codex/claude_code); `allocPlainReplInput`, `plainReplSubmitKey` (reused by the new engine).
+
+---
+
+## Task 1: Pure helper `extractPromptLine`
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig` (add function near the other REPL helpers, e.g. just above `const AGENT_START_PREFIX`, around line 1396; add test in the test region near line 2898)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test next to `test "ai chat REPL kind parses..."` (~line 2898):
+
+```zig
+test "extractPromptLine returns the trailing non-empty prompt line" {
+    try std.testing.expectEqualStrings(">>>", extractPromptLine("hello\nworld\n>>> "));
+    try std.testing.expectEqualStrings("In [3]:", extractPromptLine("Out[2]: 5\n\nIn [3]: "));
+    try std.testing.expectEqualStrings("julia>", extractPromptLine("julia> "));
+    try std.testing.expectEqualStrings("", extractPromptLine("\n  \n"));
+    try std.testing.expectEqualStrings("", extractPromptLine(""));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: compile error — `use of undeclared identifier 'extractPromptLine'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add above `const AGENT_START_PREFIX = ...` (~line 1396):
+
+```zig
+/// The trailing prompt of a terminal snapshot: the last non-empty line, trimmed
+/// of surrounding whitespace. Returns "" when no non-empty line exists. Used to
+/// learn a REPL's prompt dynamically so completion detection is language-agnostic.
+fn extractPromptLine(snapshot: []const u8) []const u8 {
+    var it = std.mem.splitBackwardsScalar(u8, snapshot, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r\n");
+        if (trimmed.len != 0) return trimmed;
+    }
+    return "";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS (no failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "feat(repl): add extractPromptLine helper for prompt-return detection"
+```
+
+---
+
+## Task 2: Pure helper `looksLikeReadyPrompt`
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig` (add function directly below `extractPromptLine`; add test below the Task 1 test)
+
+- [ ] **Step 1: Write the failing test**
+
+```zig
+test "looksLikeReadyPrompt accepts prompts and rejects output" {
+    try std.testing.expect(looksLikeReadyPrompt(">>>"));
+    try std.testing.expect(looksLikeReadyPrompt(">"));
+    try std.testing.expect(looksLikeReadyPrompt("In [3]:"));
+    try std.testing.expect(looksLikeReadyPrompt("julia>"));
+    try std.testing.expect(looksLikeReadyPrompt("dbname=#"));
+    try std.testing.expect(looksLikeReadyPrompt("$"));
+    // Output / results are not prompts.
+    try std.testing.expect(!looksLikeReadyPrompt(""));
+    try std.testing.expect(!looksLikeReadyPrompt("2"));
+    try std.testing.expect(!looksLikeReadyPrompt("TypeError: unsupported operand"));
+    // Too long to be a prompt line.
+    try std.testing.expect(!looksLikeReadyPrompt("this is a very long line of output that should not be treated as a prompt at all"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: compile error — `use of undeclared identifier 'looksLikeReadyPrompt'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add directly below `extractPromptLine`:
+
+```zig
+/// Heuristic: does a trailing line look like an interactive REPL prompt waiting
+/// for input? True for `>>>`, `>`, `In [3]:`, `julia>`, `dbname=#`, `$`, ... .
+/// Conservative on length so long output lines are not mistaken for a prompt.
+/// This is only the *fallback* signal; an exact match against the prompt captured
+/// before typing (see `promptReturned`) is the primary, precise signal.
+fn looksLikeReadyPrompt(line: []const u8) bool {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0 or trimmed.len > 64) return false;
+    return switch (trimmed[trimmed.len - 1]) {
+        '>', ':', '$', '#' => true,
+        else => false,
+    };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "feat(repl): add looksLikeReadyPrompt heuristic"
+```
+
+---
+
+## Task 3: Pure helper `promptReturned`
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig` (add function directly below `looksLikeReadyPrompt`; add test below the Task 2 test)
+
+- [ ] **Step 1: Write the failing test**
+
+```zig
+test "promptReturned matches the captured prompt or a generic prompt" {
+    // Prompt unchanged: exact captured-prompt match.
+    try std.testing.expect(promptReturned("foo\n>>> ", ">>>"));
+    // Prompt changed (e.g. just launched python): generic heuristic catches >>>.
+    try std.testing.expect(promptReturned("$ python\nPython 3.12\n>>> ", "$"));
+    // Still running: last line is output, not a prompt.
+    try std.testing.expect(!promptReturned("computing...\n42", ">>>"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: compile error — `use of undeclared identifier 'promptReturned'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add directly below `looksLikeReadyPrompt`:
+
+```zig
+/// True when the snapshot's trailing line shows the REPL is back at a ready
+/// prompt: it equals the prompt captured before we typed, or it matches the
+/// generic ready-prompt heuristic. The exact match handles prompts that stayed
+/// the same; the heuristic handles prompts that changed (e.g. `$ ` -> `>>> `).
+fn promptReturned(snapshot: []const u8, captured_prompt: []const u8) bool {
+    const line = extractPromptLine(snapshot);
+    if (captured_prompt.len != 0 and std.mem.eql(u8, line, captured_prompt)) return true;
+    return looksLikeReadyPrompt(line);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test-full`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "feat(repl): add promptReturned settle predicate"
+```
+
+---
+
+## Task 4: General `lineReplEvalTool` + `waitForReplPromptReturn`, reroute the switch
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig`
+  - Add `lineReplEvalTool` + `waitForReplPromptReturn` (place them just above `fn rSessionEvalTool`, ~line 1318).
+  - Reroute the switch in `terminalReplExecTool` (~lines 1145-1150).
+  - Simplify `plainReplInputTool` tail (~lines 1192-1205).
+  - Add an integration test near the existing REPL-wait tests (~line 2970).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add next to the codex repl test (~line 2970):
+
+```zig
+test "line REPL eval types raw code and settles on the returned prompt" {
+    const allocator = std.testing.allocator;
+    var host_ctx = ReplWaitTestHost.Ctx{ .busy_until = 2, .settled_text = ">>> 1+1\n2\n>>> " };
+    var dummy: u8 = 0;
+    const ctx = ToolContext{
+        .allocator = allocator,
+        .ctx = &dummy,
+        .tool_host = ReplWaitTestHost.host(&host_ctx),
+        .tool_snapshot = null,
+        .settings = .{},
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const surface = ToolSurface{
+        .id = @constCast("surface-py"),
+        .title = @constCast("python"),
+        .cwd = @constCast("/home/xzg"),
+        .snapshot = @constCast(">>> "),
+        .tab_index = 0,
+        .focused = true,
+        .is_ssh = false,
+        .is_wsl = false,
+        .agent_app = .none,
+        .agent_state = .none,
+        .agent_confidence = 0,
+        .ptr = @ptrCast(&host_ctx),
+    };
+
+    const result = try lineReplEvalTool(&ctx, ReplWaitTestHost.host(&host_ctx), surface, .python, "1+1", 5000);
+    defer allocator.free(result);
+
+    // Raw code typed (code + Enter), NOT an exec()-wrapped sentinel blob.
+    try std.testing.expectEqualStrings("1+1\r", host_ctx.all_writes[0..host_ctx.all_len]);
+    try std.testing.expect(std.mem.indexOf(u8, result, "__WISPTERM_AGENT_START_") == null);
+    // The REPL's own output is handed back for the model to read.
+    try std.testing.expect(std.mem.indexOf(u8, result, "2") != null);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full`
+Expected: compile error — `use of undeclared identifier 'lineReplEvalTool'`.
+
+- [ ] **Step 3: Add `lineReplEvalTool` and `waitForReplPromptReturn`**
+
+Insert just above `fn rSessionEvalTool(...)` (~line 1318):
+
+```zig
+/// Run code in a line-oriented REPL (Python, R, Node, IPython, Julia, psql, ...)
+/// the way a human does: capture the current prompt, type the raw code + Enter,
+/// then wait until the screen settles back at a ready prompt. No sentinel wrapper
+/// is injected, so the REPL echoes the user's code verbatim and the value of a
+/// bare expression (e.g. `1+1`) is displayed normally. Errors appear as the REPL's
+/// native traceback in the returned snapshot; there is no synthetic status code.
+fn lineReplEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, repl: ReplKind, code: []const u8, timeout_ms: u32) ![]u8 {
+    // Learn the prompt currently shown so we can recognise its return. Read the
+    // live per-surface snapshot (collectSnapshot is empty on the worker thread).
+    const before = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+        try ctx.allocator.dupe(u8, surface.snapshot);
+    defer ctx.allocator.free(before);
+    const captured_prompt = try ctx.allocator.dupe(u8, extractPromptLine(before));
+    defer ctx.allocator.free(captured_prompt);
+
+    const input = try allocPlainReplInput(ctx.allocator, repl, surface, code);
+    defer ctx.allocator.free(input);
+    if (!host.writeSurface(host.ctx, surface.ptr, input)) {
+        return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
+    }
+
+    return waitForReplPromptReturn(ctx, host, surface, repl, captured_prompt, timeout_ms);
+}
+
+/// Poll the live per-surface snapshot until the screen has been unchanged for
+/// `quiet_ms` (after a `min_wait_ms` floor) AND a ready prompt has returned, then
+/// hand back the screen. On timeout, return the latest screen tagged as still in
+/// progress so the model does not treat a partial result as final.
+fn waitForReplPromptReturn(
+    ctx: *const ToolContext,
+    host: ToolHost,
+    surface: ToolSurface,
+    repl: ReplKind,
+    captured_prompt: []const u8,
+    timeout_ms: u32,
+) ![]u8 {
+    const wait_ms = @max(timeout_ms, 1000);
+    const quiet_ms: i64 = 1000;
+    const min_wait_ms: i64 = 500;
+    const started = std.time.milliTimestamp();
+    const deadline = started + @as(i64, @intCast(wait_ms));
+
+    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+        try ctx.allocator.dupe(u8, surface.snapshot);
+    defer ctx.allocator.free(last_text);
+    var last_change_ms = started;
+
+    while (std.time.milliTimestamp() < deadline) {
+        if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+        std.Thread.sleep(150 * std.time.ns_per_ms);
+        const now = std.time.milliTimestamp();
+
+        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch continue;
+        if (std.mem.eql(u8, last_text, text)) {
+            ctx.allocator.free(text);
+        } else {
+            ctx.allocator.free(last_text);
+            last_text = text;
+            last_change_ms = now;
+        }
+
+        const quiesced = now - started >= min_wait_ms and now - last_change_ms >= quiet_ms;
+        if (quiesced and promptReturned(last_text, captured_prompt)) {
+            return truncateOwned(ctx.allocator, ctx.settings, try ctx.allocator.dupe(u8, last_text));
+        }
+    }
+
+    const note = try std.fmt.allocPrint(
+        ctx.allocator,
+        "\n[{s} REPL still busy after {d} ms; treat this as in progress, not a final result]",
+        .{ repl.label(), wait_ms },
+    );
+    defer ctx.allocator.free(note);
+    const combined = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ last_text, note });
+    return truncateOwned(ctx.allocator, ctx.settings, combined);
+}
+```
+
+- [ ] **Step 4: Reroute the `terminalReplExecTool` switch**
+
+Replace the switch at ~lines 1145-1150:
+
+```zig
+    return switch (repl) {
+        .r => rSessionEvalTool(ctx, host, surface, code, timeout_ms),
+        .python => pythonSessionEvalTool(ctx, host, surface, code, timeout_ms),
+        .codex, .claude_code => plainReplInputTool(ctx, host, surface, repl, code, timeout_ms),
+        .plain => plainReplInputTool(ctx, host, surface, repl, code, timeout_ms),
+    };
+```
+
+with:
+
+```zig
+    return switch (repl) {
+        .r, .python, .plain => lineReplEvalTool(ctx, host, surface, repl, code, timeout_ms),
+        .codex, .claude_code => plainReplInputTool(ctx, host, surface, repl, code, timeout_ms),
+    };
+```
+
+- [ ] **Step 5: Simplify `plainReplInputTool` tail (now only codex/claude_code reach it)**
+
+Replace the tail of `plainReplInputTool` — everything from the `if (repl == .codex or repl == .claude_code)` line through the end of the function (~lines 1192-1205):
+
+```zig
+    if (repl == .codex or repl == .claude_code) {
+        return waitForAgentAppReplResult(ctx, host, surface, repl, timeout_ms);
+    }
+
+    const wait_ms = @min(@max(timeout_ms, 500), 5000);
+    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(wait_ms));
+    while (std.time.milliTimestamp() < deadline) {
+        if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+        std.Thread.sleep(100 * std.time.ns_per_ms);
+    }
+
+    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch return ctx.allocator.dupe(u8, "Input sent; failed to read terminal snapshot.");
+    return truncateOwned(ctx.allocator, ctx.settings, latest);
+}
+```
+
+with:
+
+```zig
+    // Only Codex / Claude Code reach this tool now (line REPLs use
+    // lineReplEvalTool); both settle on the busy-marker-aware waiter.
+    return waitForAgentAppReplResult(ctx, host, surface, repl, timeout_ms);
+}
+```
+
+- [ ] **Step 6: Run the integration test + full build**
+
+Run: `zig build test-full`
+Expected: PASS, including `line REPL eval types raw code and settles on the returned prompt`. The build must compile (the switch is now exhaustive without a separate `.plain` arm; `pythonSessionEvalTool`/`rSessionEvalTool` are still referenced — they are removed in Task 5).
+
+Note: this task still references `rSessionEvalTool`/`pythonSessionEvalTool` only via the *old* switch text you just deleted, so they are now unused but still defined — that is fine until Task 5 removes them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "feat(repl): general human-typing line-REPL engine with prompt-return detection"
+```
+
+---
+
+## Task 5: Remove the sentinel REPL wrappers and dead string-literal helpers
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig`
+  - Delete `rSessionEvalTool` (~lines 1318-1339) and `pythonSessionEvalTool` (~lines 1341-1367).
+  - Delete `rStringLiteral`, `pythonStringLiteral`, `doubleQuotedStringLiteral` (~lines 1369-1394).
+  - Delete the two obsolete tests: `"ai chat R string literal escapes code for REPL eval"` (~line 2890) and `"ai chat Python string literal escapes code for REPL eval"` (~line 2972).
+
+- [ ] **Step 1: Delete the two sentinel eval tools**
+
+Remove the entire `fn rSessionEvalTool(...) { ... }` and `fn pythonSessionEvalTool(...) { ... }` bodies. (They are no longer referenced after Task 4's reroute.)
+
+- [ ] **Step 2: Delete the now-dead string-literal helpers**
+
+Remove `pub fn rStringLiteral`, `pub fn pythonStringLiteral`, and `fn doubleQuotedStringLiteral`. Verify no remaining references first:
+
+Run: `grep -n "StringLiteral\|pythonSessionEvalTool\|rSessionEvalTool" src/ai_chat_tools.zig`
+Expected after deletion: only matches are inside the two test bodies you remove in Step 3 (or none).
+
+- [ ] **Step 3: Delete the two obsolete tests**
+
+Remove:
+- `test "ai chat R string literal escapes code for REPL eval" { ... }`
+- `test "ai chat Python string literal escapes code for REPL eval" { ... }`
+
+Keep `test "ai chat REPL kind parses Python Codex and Claude Code aliases"` and the codex tests.
+
+- [ ] **Step 4: Verify no dangling references and the suite is green**
+
+Run: `grep -rn "StringLiteral\|pythonSessionEvalTool\|rSessionEvalTool\|doubleQuotedStringLiteral" src/`
+Expected: no matches.
+
+Run: `zig build test-full`
+Expected: PASS (compiles cleanly; the removed-test count is gone, no unused-function errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ai_chat_tools.zig
+git commit -m "refactor(repl): drop exec()+sentinel Python/R wrappers and dead string-literal helpers"
+```
+
+---
+
+## Task 6: Prompt guidance — write direct, REPL-native code
+
+**Files:**
+- Modify: `src/platform/agent_prompt.zig` (runtime prompt; near the `terminal_repl_exec` lines ~49-54)
+- Modify: `src/prompt.md` (parity; near line 13)
+
+- [ ] **Step 1: Update the runtime prompt**
+
+In `src/platform/agent_prompt.zig`, just after the existing line (~50):
+
+```zig
+    \\- Start Codex/Claude Code/REPLs (Python/R/Node) via `terminal_repl_exec repl=plain`; never shell-exec them.
+```
+
+add these lines (match the file's `\\- ` bullet style and indentation exactly):
+
+```zig
+    \\- In a REPL, send code exactly as you would type it at the prompt. The REPL echoes the value of the last expression, so do NOT wrap results in `print(...)`/`cat(...)` just to see them — e.g. send `1+1`, not `print("result", 1+1)`.
+    \\- Send the direct answer, not multiple alternative solutions or explanatory scaffolding. Keep multi-line code compact: no blank lines inside an indented block (a blank line can end the block early in a line REPL).
+```
+
+- [ ] **Step 2: Update the parity doc**
+
+In `src/prompt.md`, after line 13 (`- If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use \`terminal_repl_exec\`.`), add:
+
+```markdown
+- In a REPL, send code exactly as you would type it at the prompt. The REPL echoes the value of the last expression, so do not wrap results in `print(...)`/`cat(...)` just to see them — e.g. send `1+1`, not `print("result", 1+1)`.
+- Send the direct answer, not multiple alternative solutions or scaffolding. Keep multi-line code compact: no blank lines inside an indented block.
+```
+
+- [ ] **Step 3: Verify the prompt still builds**
+
+Run: `zig build test-full`
+Expected: PASS (the prompt is a compile-time string; a malformed `\\` multiline literal would fail to compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/platform/agent_prompt.zig src/prompt.md
+git commit -m "feat(repl): prompt guidance to send direct REPL-native code, no print wrappers"
+```
+
+---
+
+## Task 7: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the fast suite**
+
+Run: `zig build test`
+Expected: PASS, 0 failed.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `zig build test-full`
+Expected: PASS, 0 failed (4 pre-existing skips are fine; see project memory baseline).
+
+- [ ] **Step 3: Confirm the sentinel wrapper is gone from the REPL path only**
+
+Run: `grep -n "__WISPTERM_AGENT_START_" src/ai_chat_tools.zig`
+Expected: matches remain ONLY in the shell-exec wrapper (`extractUnixCommandResult` path, the `setopt hist_ignore_space ...` line) and its tests — NOT in any Python/R REPL path.
+
+- [ ] **Step 4: Manual GUI smoke (deferred / user-run)**
+
+In a running build, open a Python REPL tab, ask the Copilot agent to "解决下报错" for `1+'1'`. Confirm:
+- The terminal shows `>>> '1'+'1'` (or `1+1`) and its result — no `exec("...__WISPTERM_AGENT_START_...")` blob.
+- An error shows the native traceback and the agent reads it.
+- Repeat for R (`> `) and Node (`> `).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 general engine → Tasks 4-5; §2 pure helpers → Tasks 1-3; §3 prompt guidance → Task 6; §4 multi-line (raw-send + guidance) → Task 6 guidance; non-goals (keep shell sentinels, codex/claude_code waiter, no bracketed paste) → preserved in Task 4/5 scope and Task 7 Step 3 check.
+- **Type/name consistency:** `extractPromptLine`, `looksLikeReadyPrompt`, `promptReturned`, `lineReplEvalTool`, `waitForReplPromptReturn` used consistently across tasks; reuses existing `allocPlainReplInput`, `plainReplSubmitKey`, `truncateOwned`, `ToolHost.surfaceSnapshot`, `ReplKind`, `ReplWaitTestHost`.
+- **No placeholders:** every code/edit step shows the actual code or exact old→new text.

--- a/docs/superpowers/specs/2026-06-09-repl-human-typing-design.md
+++ b/docs/superpowers/specs/2026-06-09-repl-human-typing-design.md
@@ -1,0 +1,172 @@
+# Human-like REPL execution for the Copilot agent
+
+Date: 2026-06-09
+Status: Approved (design)
+
+## Problem
+
+When the Copilot agent runs code in an interactive REPL via the
+`terminal_repl_exec` tool, two things go wrong from the user's point of view:
+
+1. **The terminal fills with garbage.** For `repl=python` / `repl=r`, the agent
+   does not type the user's code. It types a sentinel-wrapped blob, e.g. (Python):
+
+   ```python
+   exec("print(\"\\n__WISPTERM_AGENT_START_1780968464133__\")\n__wispterm_agent_status = 0\n__wispterm_agent_code = ...\ntry:\n    exec(__wispterm_agent_code, globals())\nexcept Exception:\n    __wispterm_agent_status = 1\n    import traceback\n    traceback.print_exc()\nprint(\"\\n__WISPTERM_AGENT_END_...__:%s\" % __wispterm_agent_status)\ndel ...")
+   ```
+
+   The REPL echoes whatever is typed, so the user sees this whole blob.
+
+2. **The agent writes verbose, indirect code** (e.g. two labelled `print(...)`
+   "方式1 / 方式2" alternatives) instead of just `1+1` or `'1'+'1'`.
+
+### Root cause (both symptoms, one design)
+
+Both symptoms come from the same mechanism. The Python/R paths wrap user code in
+`exec(code, globals())` (Python) / `eval(parse(...))` inside a `tryCatch`(R),
+bracketed by `__WISPTERM_AGENT_START/END__` sentinel markers. The wrapper exists to:
+
+- know **when** the command finished (a REPL has no exit code to read), and
+- capture **whether** it errored (the `:0` / `:1` status suffix).
+
+Consequences:
+
+- The wrapper is **echoed** → terminal garbage (symptom 1).
+- `exec(code, globals())` **discards expression values**, so a bare expression
+  like `1+1` prints nothing. The agent is therefore forced to wrap everything in
+  `print(...)` — which trains the verbose-code behaviour (symptom 2).
+
+## Goal
+
+Make REPL execution behave like a human typing at the prompt:
+
+- Type the code **raw**. `1+1` echoes `2`; an error prints its native traceback.
+- Detect completion the way a human does — **the prompt comes back** — rather than
+  via injected sentinels.
+- **No exact status code.** The agent reads the output (traceback / `Error:`) to
+  judge success, exactly like a person. This is an explicit, accepted trade-off.
+- **Generalize.** Not Python/R/Node-specific; any line-oriented REPL
+  (IPython, Julia, Ruby `irb`, `psql`, …) should work, because the prompt is
+  learned dynamically rather than hard-coded.
+
+## Non-goals / out of scope
+
+- **Shell-exec sentinels stay.** `ssh_session_exec` / `wsl_session_exec` (and the
+  local shell-exec path) keep their `__WISPTERM_AGENT_*__` sentinel machinery —
+  that is a different context and not part of this complaint. Only the REPL paths
+  change. The shared helpers `hasPendingAgentCommand`, `extractUnixCommandResult`,
+  `findCompletedEnd` remain in use by shell-exec and must not be removed.
+- **Codex / Claude Code stay on their existing waiter.** `repl=codex` /
+  `repl=claude_code` are full-screen TUI apps, not line REPLs; they keep
+  `waitForAgentAppReplResult` with its busy-marker gates (`replSnapshotLooksBusy`).
+- **Bracketed paste is not adopted now.** It is not universally supported
+  (classic CPython < 3.13 ignores the markers), so it is left as a possible future
+  enhancement, not part of this change.
+
+## Design
+
+### 1. One general line-REPL engine
+
+Replace three things with a single engine:
+
+- `pythonSessionEvalTool` (sentinel `exec()` wrapper)
+- `rSessionEvalTool` (sentinel `tryCatch`/`eval(parse)` wrapper)
+- the crude fixed-wait `.plain` branch in `plainReplInputTool`
+  (lines ~1196–1204: it just sleeps up to 5000 ms then snapshots)
+
+New behaviour for `repl` ∈ { `r`, `python`, `plain`, and any other non-TUI REPL }:
+
+1. **Capture the current prompt** before sending: take a surface snapshot and
+   extract the trailing prompt — the last non-empty line (trimmed). Examples:
+   `>>> `, `> `, `In [3]: `, `julia> `, `dbname=# `.
+2. **Send raw input**: write `code` + Enter (`\r`). No wrapper, no markers.
+   (Codex's paste-burst special-case in `plainReplInputTool` is preserved as-is.)
+3. **Wait for the prompt to return / screen to settle** (new
+   `waitForReplPromptReturn`, modelled on `waitForAgentAppReplResult`):
+   - Poll the per-surface snapshot (NOT `collectSnapshot` — the tab model is
+     thread-local to the UI thread and reads empty on the worker; see the existing
+     comment in `waitForAgentAppReplResult`).
+   - Settle when the screen has been **unchanged for `quiet_ms`** (~800–1200 ms)
+     after a `min_wait_ms` floor, **and** the last line looks like a ready prompt:
+     the captured prompt reappeared, or it matches a generic ready-prompt heuristic.
+   - Prompt-match only makes it return *faster*; **quiescence is the backstop** so
+     exotic/custom prompts still terminate.
+   - On `timeout_ms` exceeded → return the latest snapshot with the existing
+     "still waiting … treat this as in progress, not a final result" note.
+4. **Return the raw snapshot.** No status line, no synthesised success/failure —
+   the agent reads the traceback/output itself.
+
+### 2. Pure helpers (TDD targets)
+
+These are pure string functions, unit-testable by feeding snapshot strings — no
+terminal required:
+
+- `extractPromptLine(snapshot: []const u8) []const u8` — last non-empty line,
+  trimmed; "" if none.
+- `looksLikeReadyPrompt(line: []const u8) bool` — generic heuristic: trimmed line
+  ends with one of `>`, `:`, `$`, `#`, `)` followed by an optional single space,
+  and is short (e.g. ≤ ~64 chars) so it is a prompt, not output. Plus exact-match
+  against the captured prompt.
+- A settle predicate combining "unchanged for quiet_ms" + ready-prompt, factored so
+  it can be tested independently of the polling loop.
+
+### 3. Prompt guidance (fixes verbose code)
+
+The **live** system prompt is `src/platform/agent_prompt.zig` (note: `src/prompt.md`
+is NOT the live prompt but is kept in parity). Add guidance near the existing
+`terminal_repl_exec` lines, in substance:
+
+- Send code exactly as you would type it at the REPL prompt.
+- The REPL echoes the value of the last expression — do **not** wrap results in
+  `print(...)` / `cat(...)` just to see them.
+- Send the **direct** answer, not multiple alternative solutions or commentary.
+- Keep multi-line code compact: no blank lines inside an indented block (a blank
+  line can close the block early in a line REPL).
+
+Update `src/prompt.md` to match (parity only; it is not the runtime prompt).
+
+### 4. Multi-line handling
+
+Raw-send only. Correct multi-line formatting (no intra-block blank lines) is carried
+by the prompt guidance in §3, the same way a careful human pastes into a REPL. No
+language-specific wrapping is reintroduced. (Decision confirmed with user; bracketed
+paste deferred — see non-goals.)
+
+## Files touched
+
+- `src/ai_chat_tools.zig`
+  - Remove `pythonSessionEvalTool`, `rSessionEvalTool` (sentinel REPL wrappers).
+  - Route `.python`, `.r`, `.plain` through the new general engine.
+  - Add `waitForReplPromptReturn` + pure helpers (`extractPromptLine`,
+    `looksLikeReadyPrompt`, settle predicate).
+  - Keep `.codex` / `.claude_code` → `waitForAgentAppReplResult` unchanged.
+  - Keep shell-exec sentinel helpers (`hasPendingAgentCommand`,
+    `extractUnixCommandResult`, `findCompletedEnd`) — still used by shell exec.
+  - Remove now-dead REPL-only helpers if any (`pythonStringLiteral`/`rStringLiteral`
+    only if no remaining caller — verify before deleting).
+- `src/platform/agent_prompt.zig` — REPL usage guidance (runtime prompt).
+- `src/prompt.md` — parity copy of the guidance.
+- Tests in `src/ai_chat_tools.zig` (or the posix test file if libc-dependent) for
+  the pure helpers.
+
+## Testing
+
+- Unit: `extractPromptLine` (various trailing-prompt shapes, blank lines, empty).
+- Unit: `looksLikeReadyPrompt` (true for `>>> `, `> `, `In [3]: `, `julia> `,
+  `dbname=# `; false for output lines, long lines, tracebacks).
+- Unit: settle predicate (unchanged+ready → settled; changed → not; ready but still
+  changing → not).
+- `zig build test` and `zig build test-full` both green.
+- Manual GUI smoke (deferred to user / later): `repl=python` `code="1+1"` shows
+  `>>> 1+1` / `2` and nothing else; an error shows the native traceback; a
+  multi-statement snippet still terminates.
+
+## Risks
+
+- **False-early settle** if the REPL pauses mid-computation with a prompt-looking
+  line: mitigated by the `quiet_ms` floor + last-line ready-prompt check; same class
+  of risk the existing quiescence waiter already accepts.
+- **Classic-Python multi-line blank-line breakage**: accepted; mitigated by prompt
+  guidance (§3/§4). Worst case the agent sees the error in the snapshot and retries —
+  human-like recovery.
+- **Loss of exact error status**: accepted by design; the agent reads the traceback.

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -5088,7 +5088,7 @@ test "ai chat responses endpoint normalization" {
 }
 
 test "ai chat default system prompt comes from platform agent prompt" {
-    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 2700);
+    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 3000);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "wispterm_docs") != null);
     try std.testing.expectEqualStrings(platform_agent_prompt.defaultSystemPrompt, DEFAULT_SYSTEM_PROMPT);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "uv") != null);

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1166,6 +1166,9 @@ pub fn allocPlainReplInput(allocator: std.mem.Allocator, repl: ReplKind, surface
 }
 
 pub fn plainReplInputTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, repl: ReplKind, text: []const u8, timeout_ms: u32) ![]u8 {
+    // Line REPLs (.r/.python/.plain) go through lineReplEvalTool instead; this
+    // tool is only for the agent TUIs, whose completion is judged by busy markers.
+    std.debug.assert(repl == .codex or repl == .claude_code);
     if (repl == .codex) {
         // Codex's TUI treats a fast input burst as a paste and folds a trailing
         // Enter into the pasted text, leaving a literal newline that never
@@ -1340,6 +1343,9 @@ fn waitForReplPromptReturn(
     timeout_ms: u32,
 ) ![]u8 {
     const wait_ms = @max(timeout_ms, 1000);
+    // Line REPLs respond faster than the agent TUIs (waitForAgentAppReplResult
+    // uses 1500/750), so settle a bit sooner. The min_wait_ms floor also defends
+    // against returning before the typed input has echoed and reset the screen.
     const quiet_ms: i64 = 1000;
     const min_wait_ms: i64 = 500;
     const started = std.time.milliTimestamp();

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1405,6 +1405,20 @@ fn extractPromptLine(snapshot: []const u8) []const u8 {
     return "";
 }
 
+/// Heuristic: does a trailing line look like an interactive REPL prompt waiting
+/// for input? True for `>>>`, `>`, `In [3]:`, `julia>`, `dbname=#`, `$`, ... .
+/// Conservative on length so long output lines are not mistaken for a prompt.
+/// This is only the *fallback* signal; an exact match against the prompt captured
+/// before typing (see `promptReturned`) is the primary, precise signal.
+fn looksLikeReadyPrompt(line: []const u8) bool {
+    const trimmed = std.mem.trim(u8, line, " \t\r\n");
+    if (trimmed.len == 0 or trimmed.len > 64) return false;
+    return switch (trimmed[trimmed.len - 1]) {
+        '>', ':', '$', '#' => true,
+        else => false,
+    };
+}
+
 const AGENT_START_PREFIX = "__WISPTERM_AGENT_START_";
 
 /// Whether the surface's most recent agent command is still running: find the
@@ -2913,6 +2927,19 @@ test "extractPromptLine returns the trailing non-empty prompt line" {
     try std.testing.expectEqualStrings("julia>", extractPromptLine("julia> "));
     try std.testing.expectEqualStrings("", extractPromptLine("\n  \n"));
     try std.testing.expectEqualStrings("", extractPromptLine(""));
+}
+
+test "looksLikeReadyPrompt accepts prompts and rejects output" {
+    try std.testing.expect(looksLikeReadyPrompt(">>>"));
+    try std.testing.expect(looksLikeReadyPrompt(">"));
+    try std.testing.expect(looksLikeReadyPrompt("In [3]:"));
+    try std.testing.expect(looksLikeReadyPrompt("julia>"));
+    try std.testing.expect(looksLikeReadyPrompt("dbname=#"));
+    try std.testing.expect(looksLikeReadyPrompt("$"));
+    try std.testing.expect(!looksLikeReadyPrompt(""));
+    try std.testing.expect(!looksLikeReadyPrompt("2"));
+    try std.testing.expect(!looksLikeReadyPrompt("TypeError: unsupported operand"));
+    try std.testing.expect(!looksLikeReadyPrompt("this is a very long line of output that should not be treated as a prompt at all"));
 }
 
 test "ai chat REPL kind parses Python Codex and Claude Code aliases" {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1419,6 +1419,16 @@ fn looksLikeReadyPrompt(line: []const u8) bool {
     };
 }
 
+/// True when the snapshot's trailing line shows the REPL is back at a ready
+/// prompt: it equals the prompt captured before we typed, or it matches the
+/// generic ready-prompt heuristic. The exact match handles prompts that stayed
+/// the same; the heuristic handles prompts that changed (e.g. `$ ` -> `>>> `).
+fn promptReturned(snapshot: []const u8, captured_prompt: []const u8) bool {
+    const line = extractPromptLine(snapshot);
+    if (captured_prompt.len != 0 and std.mem.eql(u8, line, captured_prompt)) return true;
+    return looksLikeReadyPrompt(line);
+}
+
 const AGENT_START_PREFIX = "__WISPTERM_AGENT_START_";
 
 /// Whether the surface's most recent agent command is still running: find the
@@ -2940,6 +2950,12 @@ test "looksLikeReadyPrompt accepts prompts and rejects output" {
     try std.testing.expect(!looksLikeReadyPrompt("2"));
     try std.testing.expect(!looksLikeReadyPrompt("TypeError: unsupported operand"));
     try std.testing.expect(!looksLikeReadyPrompt("this is a very long line of output that should not be treated as a prompt at all"));
+}
+
+test "promptReturned matches the captured prompt or a generic prompt" {
+    try std.testing.expect(promptReturned("foo\n>>> ", ">>>"));
+    try std.testing.expect(promptReturned("$ python\nPython 3.12\n>>> ", "$"));
+    try std.testing.expect(!promptReturned("computing...\n42", ">>>"));
 }
 
 test "ai chat REPL kind parses Python Codex and Claude Code aliases" {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1386,84 +1386,6 @@ fn waitForReplPromptReturn(
     return truncateOwned(ctx.allocator, ctx.settings, combined);
 }
 
-fn rSessionEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, code: []const u8, timeout_ms: u32) ![]u8 {
-    const nonce = std.time.milliTimestamp();
-    const code_literal = try rStringLiteral(ctx.allocator, code);
-    defer ctx.allocator.free(code_literal);
-
-    const wrapped = try std.fmt.allocPrint(
-        ctx.allocator,
-        "cat(\"\\n__WISPTERM_AGENT_START_{d}__\\n\", sep=\"\")\n.wispterm_agent_status <- 0L\n.wispterm_agent_code <- {s}\ntryCatch({{\n  eval(parse(text=.wispterm_agent_code), envir=.GlobalEnv)\n}}, error=function(e) {{\n  .wispterm_agent_status <<- 1L\n  message(\"Error: \", conditionMessage(e))\n}})\ncat(\"\\n__WISPTERM_AGENT_END_{d}__:\", .wispterm_agent_status, \"\\n\", sep=\"\")\nrm(.wispterm_agent_status, .wispterm_agent_code)\r",
-        .{ nonce, code_literal, nonce },
-    );
-    defer ctx.allocator.free(wrapped);
-
-    if (!host.writeSurface(host.ctx, surface.ptr, wrapped)) {
-        return ctx.allocator.dupe(u8, "Failed to write to R terminal surface.");
-    }
-
-    const start_marker = try std.fmt.allocPrint(ctx.allocator, "__WISPTERM_AGENT_START_{d}__", .{nonce});
-    defer ctx.allocator.free(start_marker);
-    const end_marker = try std.fmt.allocPrint(ctx.allocator, "__WISPTERM_AGENT_END_{d}__", .{nonce});
-    defer ctx.allocator.free(end_marker);
-    return waitForSentinelResult(ctx, host, surface, "R", start_marker, end_marker, timeout_ms);
-}
-
-fn pythonSessionEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, code: []const u8, timeout_ms: u32) ![]u8 {
-    const nonce = std.time.milliTimestamp();
-    const code_literal = try pythonStringLiteral(ctx.allocator, code);
-    defer ctx.allocator.free(code_literal);
-
-    const wrapper = try std.fmt.allocPrint(
-        ctx.allocator,
-        "print(\"\\\\n__WISPTERM_AGENT_START_{d}__\")\n__wispterm_agent_status = 0\n__wispterm_agent_code = {s}\ntry:\n    exec(__wispterm_agent_code, globals())\nexcept Exception:\n    __wispterm_agent_status = 1\n    import traceback\n    traceback.print_exc()\nprint(\"\\\\n__WISPTERM_AGENT_END_{d}__:%s\" % __wispterm_agent_status)\ndel __wispterm_agent_status, __wispterm_agent_code",
-        .{ nonce, code_literal, nonce },
-    );
-    defer ctx.allocator.free(wrapper);
-
-    const wrapper_literal = try pythonStringLiteral(ctx.allocator, wrapper);
-    defer ctx.allocator.free(wrapper_literal);
-    const wrapped = try std.fmt.allocPrint(ctx.allocator, "exec({s})\r", .{wrapper_literal});
-    defer ctx.allocator.free(wrapped);
-
-    if (!host.writeSurface(host.ctx, surface.ptr, wrapped)) {
-        return ctx.allocator.dupe(u8, "Failed to write to Python terminal surface.");
-    }
-
-    const start_marker = try std.fmt.allocPrint(ctx.allocator, "__WISPTERM_AGENT_START_{d}__", .{nonce});
-    defer ctx.allocator.free(start_marker);
-    const end_marker = try std.fmt.allocPrint(ctx.allocator, "__WISPTERM_AGENT_END_{d}__", .{nonce});
-    defer ctx.allocator.free(end_marker);
-    return waitForSentinelResult(ctx, host, surface, "Python", start_marker, end_marker, timeout_ms);
-}
-
-pub fn rStringLiteral(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
-    return doubleQuotedStringLiteral(allocator, text);
-}
-
-pub fn pythonStringLiteral(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
-    return doubleQuotedStringLiteral(allocator, text);
-}
-
-fn doubleQuotedStringLiteral(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
-    var out: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer out.deinit(allocator);
-
-    try out.append(allocator, '"');
-    for (text) |ch| {
-        switch (ch) {
-            '\\' => try out.appendSlice(allocator, "\\\\"),
-            '"' => try out.appendSlice(allocator, "\\\""),
-            '\n' => try out.appendSlice(allocator, "\\n"),
-            '\r' => try out.appendSlice(allocator, "\\r"),
-            '\t' => try out.appendSlice(allocator, "\\t"),
-            else => try out.append(allocator, ch),
-        }
-    }
-    try out.append(allocator, '"');
-    return out.toOwnedSlice(allocator);
-}
-
 /// The trailing prompt of a terminal snapshot: the last non-empty line, trimmed
 /// of surrounding whitespace. Returns "" when no non-empty line exists. Used to
 /// learn a REPL's prompt dynamically so completion detection is language-agnostic.
@@ -2994,14 +2916,6 @@ test "shell exec refuses bare REPL launchers but allows run-and-exit invocations
     }
 }
 
-test "ai chat R string literal escapes code for REPL eval" {
-    const allocator = std.testing.allocator;
-    const literal = try rStringLiteral(allocator, "print(\"hello\")\npath <- \"C:\\\\tmp\"");
-    defer allocator.free(literal);
-
-    try std.testing.expectEqualStrings("\"print(\\\"hello\\\")\\npath <- \\\"C:\\\\\\\\tmp\\\"\"", literal);
-}
-
 test "extractPromptLine returns the trailing non-empty prompt line" {
     try std.testing.expectEqualStrings(">>>", extractPromptLine("hello\nworld\n>>> "));
     try std.testing.expectEqualStrings("In [3]:", extractPromptLine("Out[2]: 5\n\nIn [3]: "));
@@ -3139,14 +3053,6 @@ test "line REPL eval types raw code and settles on the returned prompt" {
     try std.testing.expect(std.mem.indexOf(u8, result, "__WISPTERM_AGENT_START_") == null);
     // The REPL's own output is handed back for the model to read.
     try std.testing.expect(std.mem.indexOf(u8, result, "2") != null);
-}
-
-test "ai chat Python string literal escapes code for REPL eval" {
-    const allocator = std.testing.allocator;
-    const literal = try pythonStringLiteral(allocator, "print(\"hello\")\npath = \"C:\\\\tmp\"");
-    defer allocator.free(literal);
-
-    try std.testing.expectEqualStrings("\"print(\\\"hello\\\")\\npath = \\\"C:\\\\\\\\tmp\\\"\"", literal);
 }
 
 test "agent control-key tokens parse to raw bytes, plain text is unaffected" {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1143,10 +1143,8 @@ fn terminalReplExecTool(ctx: *ToolContext, surface_id: []const u8, repl_name: []
     }
 
     return switch (repl) {
-        .r => rSessionEvalTool(ctx, host, surface, code, timeout_ms),
-        .python => pythonSessionEvalTool(ctx, host, surface, code, timeout_ms),
+        .r, .python, .plain => lineReplEvalTool(ctx, host, surface, repl, code, timeout_ms),
         .codex, .claude_code => plainReplInputTool(ctx, host, surface, repl, code, timeout_ms),
-        .plain => plainReplInputTool(ctx, host, surface, repl, code, timeout_ms),
     };
 }
 
@@ -1189,19 +1187,9 @@ pub fn plainReplInputTool(ctx: *const ToolContext, host: ToolHost, surface: Tool
         }
     }
 
-    if (repl == .codex or repl == .claude_code) {
-        return waitForAgentAppReplResult(ctx, host, surface, repl, timeout_ms);
-    }
-
-    const wait_ms = @min(@max(timeout_ms, 500), 5000);
-    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(wait_ms));
-    while (std.time.milliTimestamp() < deadline) {
-        if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
-        std.Thread.sleep(100 * std.time.ns_per_ms);
-    }
-
-    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch return ctx.allocator.dupe(u8, "Input sent; failed to read terminal snapshot.");
-    return truncateOwned(ctx.allocator, ctx.settings, latest);
+    // Only Codex / Claude Code reach this tool now (line REPLs use
+    // lineReplEvalTool); both settle on the busy-marker-aware waiter.
+    return waitForAgentAppReplResult(ctx, host, surface, repl, timeout_ms);
 }
 
 fn replSnapshotLooksBusy(repl: ReplKind, snapshot: []const u8) bool {
@@ -1313,6 +1301,83 @@ fn waitForAgentAppReplResult(ctx: *const ToolContext, host: ToolHost, surface: T
         note,
         last_text,
     );
+}
+
+/// Run code in a line-oriented REPL (Python, R, Node, IPython, Julia, psql, ...)
+/// the way a human does: capture the current prompt, type the raw code + Enter,
+/// then wait until the screen settles back at a ready prompt. No sentinel wrapper
+/// is injected, so the REPL echoes the user's code verbatim and the value of a
+/// bare expression (e.g. `1+1`) is displayed normally. Errors appear as the REPL's
+/// native traceback in the returned snapshot; there is no synthetic status code.
+fn lineReplEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, repl: ReplKind, code: []const u8, timeout_ms: u32) ![]u8 {
+    // Learn the prompt currently shown so we can recognise its return. Read the
+    // live per-surface snapshot (collectSnapshot is empty on the worker thread).
+    const before = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+        try ctx.allocator.dupe(u8, surface.snapshot);
+    defer ctx.allocator.free(before);
+    const captured_prompt = try ctx.allocator.dupe(u8, extractPromptLine(before));
+    defer ctx.allocator.free(captured_prompt);
+
+    const input = try allocPlainReplInput(ctx.allocator, repl, surface, code);
+    defer ctx.allocator.free(input);
+    if (!host.writeSurface(host.ctx, surface.ptr, input)) {
+        return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
+    }
+
+    return waitForReplPromptReturn(ctx, host, surface, repl, captured_prompt, timeout_ms);
+}
+
+/// Poll the live per-surface snapshot until the screen has been unchanged for
+/// `quiet_ms` (after a `min_wait_ms` floor) AND a ready prompt has returned, then
+/// hand back the screen. On timeout, return the latest screen tagged as still in
+/// progress so the model does not treat a partial result as final.
+fn waitForReplPromptReturn(
+    ctx: *const ToolContext,
+    host: ToolHost,
+    surface: ToolSurface,
+    repl: ReplKind,
+    captured_prompt: []const u8,
+    timeout_ms: u32,
+) ![]u8 {
+    const wait_ms = @max(timeout_ms, 1000);
+    const quiet_ms: i64 = 1000;
+    const min_wait_ms: i64 = 500;
+    const started = std.time.milliTimestamp();
+    const deadline = started + @as(i64, @intCast(wait_ms));
+
+    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+        try ctx.allocator.dupe(u8, surface.snapshot);
+    defer ctx.allocator.free(last_text);
+    var last_change_ms = started;
+
+    while (std.time.milliTimestamp() < deadline) {
+        if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+        std.Thread.sleep(150 * std.time.ns_per_ms);
+        const now = std.time.milliTimestamp();
+
+        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch continue;
+        if (std.mem.eql(u8, last_text, text)) {
+            ctx.allocator.free(text);
+        } else {
+            ctx.allocator.free(last_text);
+            last_text = text;
+            last_change_ms = now;
+        }
+
+        const quiesced = now - started >= min_wait_ms and now - last_change_ms >= quiet_ms;
+        if (quiesced and promptReturned(last_text, captured_prompt)) {
+            return truncateOwned(ctx.allocator, ctx.settings, try ctx.allocator.dupe(u8, last_text));
+        }
+    }
+
+    const note = try std.fmt.allocPrint(
+        ctx.allocator,
+        "\n[{s} REPL still busy after {d} ms; treat this as in progress, not a final result]",
+        .{ repl.label(), wait_ms },
+    );
+    defer ctx.allocator.free(note);
+    const combined = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ last_text, note });
+    return truncateOwned(ctx.allocator, ctx.settings, combined);
 }
 
 fn rSessionEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, code: []const u8, timeout_ms: u32) ![]u8 {
@@ -3030,6 +3095,44 @@ test "codex repl input submits the Enter keystroke separately from the message b
     // text, so the body and the Enter keystroke must be two separate writes.
     try std.testing.expectEqual(@as(usize, 2), host_ctx.write_calls);
     try std.testing.expectEqualStrings("hello codex\r", host_ctx.all_writes[0..host_ctx.all_len]);
+}
+
+test "line REPL eval types raw code and settles on the returned prompt" {
+    const allocator = std.testing.allocator;
+    var host_ctx = ReplWaitTestHost.Ctx{ .busy_until = 2, .settled_text = ">>> 1+1\n2\n>>> " };
+    var dummy: u8 = 0;
+    const ctx = ToolContext{
+        .allocator = allocator,
+        .ctx = &dummy,
+        .tool_host = ReplWaitTestHost.host(&host_ctx),
+        .tool_snapshot = null,
+        .settings = .{},
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const surface = ToolSurface{
+        .id = @constCast("surface-py"),
+        .title = @constCast("python"),
+        .cwd = @constCast("/home/xzg"),
+        .snapshot = @constCast(">>> "),
+        .tab_index = 0,
+        .focused = true,
+        .is_ssh = false,
+        .is_wsl = false,
+        .agent_app = .none,
+        .agent_state = .none,
+        .agent_confidence = 0,
+        .ptr = @ptrCast(&host_ctx),
+    };
+
+    const result = try lineReplEvalTool(&ctx, ReplWaitTestHost.host(&host_ctx), surface, .python, "1+1", 5000);
+    defer allocator.free(result);
+
+    // Raw code typed (code + Enter), NOT an exec()-wrapped sentinel blob.
+    try std.testing.expectEqualStrings("1+1\r", host_ctx.all_writes[0..host_ctx.all_len]);
+    try std.testing.expect(std.mem.indexOf(u8, result, "__WISPTERM_AGENT_START_") == null);
+    // The REPL's own output is handed back for the model to read.
+    try std.testing.expect(std.mem.indexOf(u8, result, "2") != null);
 }
 
 test "ai chat Python string literal escapes code for REPL eval" {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1393,6 +1393,18 @@ fn doubleQuotedStringLiteral(allocator: std.mem.Allocator, text: []const u8) ![]
     return out.toOwnedSlice(allocator);
 }
 
+/// The trailing prompt of a terminal snapshot: the last non-empty line, trimmed
+/// of surrounding whitespace. Returns "" when no non-empty line exists. Used to
+/// learn a REPL's prompt dynamically so completion detection is language-agnostic.
+fn extractPromptLine(snapshot: []const u8) []const u8 {
+    var it = std.mem.splitBackwardsScalar(u8, snapshot, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r\n");
+        if (trimmed.len != 0) return trimmed;
+    }
+    return "";
+}
+
 const AGENT_START_PREFIX = "__WISPTERM_AGENT_START_";
 
 /// Whether the surface's most recent agent command is still running: find the
@@ -2893,6 +2905,14 @@ test "ai chat R string literal escapes code for REPL eval" {
     defer allocator.free(literal);
 
     try std.testing.expectEqualStrings("\"print(\\\"hello\\\")\\npath <- \\\"C:\\\\\\\\tmp\\\"\"", literal);
+}
+
+test "extractPromptLine returns the trailing non-empty prompt line" {
+    try std.testing.expectEqualStrings(">>>", extractPromptLine("hello\nworld\n>>> "));
+    try std.testing.expectEqualStrings("In [3]:", extractPromptLine("Out[2]: 5\n\nIn [3]: "));
+    try std.testing.expectEqualStrings("julia>", extractPromptLine("julia> "));
+    try std.testing.expectEqualStrings("", extractPromptLine("\n  \n"));
+    try std.testing.expectEqualStrings("", extractPromptLine(""));
 }
 
 test "ai chat REPL kind parses Python Codex and Claude Code aliases" {

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -48,7 +48,7 @@ const wsl_tool_guidance =
 const common_tools_after_wsl =
     \\- Use `terminal_repl_exec` for Codex, Claude Code, Python, R, or other REPL/app terminals.
     \\- Start Codex/Claude Code/REPLs (Python/R/Node) via `terminal_repl_exec repl=plain`; never shell-exec them.
-    \\- In a REPL, type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
+    \\- In a line REPL (Python/R/Node), type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
     \\- surface_id accepts `focused`.
     \\- Do not paste shell commands into Codex or Claude Code; send user text.
     \\- A slow session/exec command is usually still running; wait, then re-check with `terminal_snapshot`.

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -48,6 +48,7 @@ const wsl_tool_guidance =
 const common_tools_after_wsl =
     \\- Use `terminal_repl_exec` for Codex, Claude Code, Python, R, or other REPL/app terminals.
     \\- Start Codex/Claude Code/REPLs (Python/R/Node) via `terminal_repl_exec repl=plain`; never shell-exec them.
+    \\- In a REPL, type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
     \\- surface_id accepts `focused`.
     \\- Do not paste shell commands into Codex or Claude Code; send user text.
     \\- A slow session/exec command is usually still running; wait, then re-check with `terminal_snapshot`.

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -11,7 +11,7 @@ Terminal tools:
 - Use `ssh_profile_save` to create/update a saved WispTerm SSH profile when the user gives SSH details; use `ssh_profile_connect` to open it.
 - Use `wsl_session_exec` only for commands at an already-open WSL shell prompt.
 - If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use `terminal_repl_exec`.
-- In a REPL, type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
+- In a line REPL (Python/R/Node), type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
 - Do not paste shell commands into Codex or Claude Code; send user-facing text there.
 - Open a new local terminal with `tab_new` only when no suitable terminal exists.
 - For questions about WispTerm itself (features, config, shortcuts), call `wispterm_docs` to list and read the built-in docs.

--- a/src/prompt.md
+++ b/src/prompt.md
@@ -11,6 +11,7 @@ Terminal tools:
 - Use `ssh_profile_save` to create/update a saved WispTerm SSH profile when the user gives SSH details; use `ssh_profile_connect` to open it.
 - Use `wsl_session_exec` only for commands at an already-open WSL shell prompt.
 - If the target terminal is Codex, Claude Code, Python, R, or another app/REPL, use `terminal_repl_exec`.
+- In a REPL, type code as a human would: the last expression auto-displays, so send `1+1`, not `print("result", 1+1)`. Give one direct answer (no print wrappers, no alternative versions); no blank lines inside an indented block.
 - Do not paste shell commands into Codex or Claude Code; send user-facing text there.
 - Open a new local terminal with `tab_new` only when no suitable terminal exists.
 - For questions about WispTerm itself (features, config, shortcuts), call `wispterm_docs` to list and read the built-in docs.


### PR DESCRIPTION
## Summary

Fixes two coupled problems with how the Copilot agent runs code in interactive REPLs (Python/R/Node), both traced to one design: `terminal_repl_exec` used to inject an `exec()`-wrapped blob with `__WISPTERM_AGENT_START/END__` sentinel markers.

1. **Terminal garbage** — the wrapper was echoed verbatim into the user's REPL (the giant `exec("print(\"\\n__WISPTERM_AGENT_START_…`).
2. **Verbose code** — because `exec(code, globals())` discards expression values, a bare `1+1` printed nothing, so the model was forced to wrap everything in `print(...)` and offer multiple "方式1/方式2" alternatives.

Now the agent **types code like a human and detects completion when the prompt returns** — no sentinels, no synthetic status code. `1+1` echoes `2`; errors show their native traceback; the terminal looks exactly like manual use. Generalized to any line REPL (IPython, Julia, psql, …), not just Python/R/Node, by learning the prompt dynamically.

### What changed
- New pure helpers `extractPromptLine` / `looksLikeReadyPrompt` / `promptReturned` (prompt-return detection).
- New `lineReplEvalTool` + `waitForReplPromptReturn`: capture the prompt, write raw `code + \r`, poll until the screen quiesces **and** a ready prompt has returned (timeout → "still in progress" note). Mirrors the existing `waitForAgentAppReplResult` ownership/threading pattern.
- `terminalReplExecTool` reroutes `.r`/`.python`/`.plain` to the new engine; `plainReplInputTool` now serves only Codex/Claude Code (with an assert guard).
- Removed the `exec()`/sentinel `pythonSessionEvalTool`/`rSessionEvalTool` and the now-dead `*StringLiteral` helpers + their two tests.
- Prompt guidance (runtime `agent_prompt.zig` + parity `prompt.md`) tells the agent to send direct, REPL-native code; prompt-length guard bumped 2700→3000.

### Out of scope (intentional)
- Shell-exec (`ssh`/`wsl`) keeps its sentinel machinery — different context.
- Codex/Claude Code keep their busy-marker waiter.
- No bracketed-paste; multi-line correctness is carried by prompt guidance. Exact error status is dropped by design (agent reads the traceback).

Spec: `docs/superpowers/specs/2026-06-09-repl-human-typing-design.md` · Plan: `docs/superpowers/plans/2026-06-09-repl-human-typing.md`

## Test Plan
- [x] `zig build test` (fast suite) — green
- [x] `zig build test-full` (full app graph) — green; new unit tests for the 3 helpers + an integration test asserting raw input is typed (`1+1\r`), no sentinel in the result, and output returned
- [x] Confirmed `__WISPTERM_AGENT_START_` remains only on the shell-exec path + its tests
- [x] Manual GUI smoke (deferred): open a Python REPL, ask the agent to "解决下报错" for `1+'1'` — terminal shows `>>> '1'+'1'` and its result, no `exec(...)` blob; repeat for R (`> `) and Node (`> `)

🤖 Generated with [Claude Code](https://claude.com/claude-code)