### PR TITLE
[codex] Add SSH port forwarding manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ English | [简体中文](README.zh-CN.md)
 - **Splits and tabs** - vertical/horizontal splits, tab strip, focus-follows-mouse, equalize sizes
 - **File Explorer and previews** - browse local, WSL, and SSH files; preview Markdown/text/tables/images without leaving the terminal
 - **Embedded browser panel** - open web URLs in a side WebView2 panel or the default browser, with persistent SSH loopback port forwarding for profile sessions
+- **SSH port forwarding manager** - silently manage local and reverse SSH forwarding rules from a dedicated tab
 - **AI Agent sessions** - launch OpenAI-compatible Agent tabs, configure profiles, restore history, export Markdown transcripts, and distill reusable local skills
 - **AI history browser** - browse local, WSL, and SSH Codex / Claude Code / Reasonix history and resume sessions from their original project directories
 - **Kitty Graphics protocol** - display inline images and PDFs from remote shells via `imgcat.py` / `pdfcat.py`
@@ -30,6 +31,7 @@ English | [简体中文](README.zh-CN.md)
 - [File Explorer and previews](docs/file-explorer.md)
 - [AI Agent sessions](docs/ai-agent.md)
 - [Media, background images, and inline remote images](docs/media.md)
+- [SSH port forwarding](docs/port-forwarding.md)
 - [Development, architecture, packaging, and releases](docs/development.md)
 - [FAQ](docs/faq.md)
 

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -1,0 +1,40 @@
+# Port Forwarding
+
+Open **Port Forwarding** from the command center to manage silent SSH forwarding
+rules. Rules are global and bind to saved SSH profiles. Closing the management
+tab does not stop running forwarding helpers.
+
+## Reverse Forwarding
+
+Reverse forwarding lets a server use a local port on your workstation. The
+common proxy/VPN rule is:
+
+```text
+Reverse: server 127.0.0.1:7890 -> local 127.0.0.1:7890
+```
+
+On the server:
+
+```sh
+export HTTP_PROXY=http://127.0.0.1:7890
+export HTTPS_PROXY=http://127.0.0.1:7890
+```
+
+## Local Forwarding
+
+Local forwarding lets a local browser or service use a loopback service on the
+server:
+
+```text
+Local: local 127.0.0.1:8888 -> server 127.0.0.1:8888
+```
+
+## Safety Boundary
+
+v1 only supports loopback hosts (`127.0.0.1` and `localhost`). It does not bind
+`0.0.0.0` or other non-loopback addresses.
+
+## SSH Compatibility
+
+WispTerm starts independent OpenSSH helper processes and does not use
+ControlMaster, ControlPersist, or ControlPath for forwarding helpers.

--- a/docs/superpowers/plans/2026-06-09-port-forwarding.md
+++ b/docs/superpowers/plans/2026-06-09-port-forwarding.md
@@ -1,0 +1,2933 @@
+# Port Forwarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a silent SSH local/reverse port-forwarding manager with a dedicated non-terminal Port Forwarding tab, global rules bound to saved SSH profiles, and startup auto-start support.
+
+**Architecture:** Keep forwarding out of terminal surfaces: `App` owns a process-wide `port_forward_manager.Manager`; the Port Forwarding tab owns only UI selection/form state. Forwarding uses OpenSSH helper processes (`ssh -N -T -L/-R`) and reuses WispTerm's SSH profile, askpass, ProxyJump, legacy-algorithm, and child-cleanup conventions. Ghostty has no port-forwarding manager; its `ghostty +ssh` wrapper passes SSH args through to OpenSSH and only uses ControlMaster for short-lived terminfo installation, so WispTerm should keep this feature as OpenSSH helper orchestration rather than SSH protocol code.
+
+**Tech Stack:** Zig 0.15, WispTerm App/AppWindow tab model, `std.process.Child`, OpenSSH (`ssh.exe` on Windows), existing `ssh_connection`, `platform/process`, `platform/pty_command`, `renderer/overlays/profile_codec`, Skill Center-style non-terminal tab rendering.
+
+---
+
+## File Structure
+
+- Create `src/port_forward_rule.zig`: pure rule type, validation, hex line codec, default reverse rule, `-L/-R` forward spec builder, and helper argv fragment builder. This file is platform-independent and belongs in `src/test_fast.zig`.
+- Create `src/ssh_profile_store.zig`: profile-file reader that turns saved `ssh_hosts` records into `ssh_connection.SshConnection` values without importing `overlays.zig` or mutating the SSH profile page. This keeps Port Forwarding independent from the existing SSH profile UI while reusing `profile_codec`.
+- Create `src/port_forward_manager.zig`: app-owned rule list, runtime state, child process lifecycle, load/save to the platform config directory's `port_forwards` file, startup auto-start, start/stop/restart/tick operations, and snapshot callbacks for the renderer.
+- Create `src/port_forwarding.zig`: UI-only panel/session model: selected row, scroll, in-tab form, confirmation state, and edit helpers. It does not own child processes.
+- Create `src/renderer/port_forwarding_renderer.zig`: Skill Center-style table renderer and pure label/layout helpers.
+- Modify `src/App.zig`: add app-owned manager, load rules during app init, start enabled auto-start rules, and stop children during app deinit.
+- Modify `src/AppWindow.zig`: expose active Port Forwarding tab helpers, render the tab, route manager snapshots to the renderer, tick manager state, and add command-center action wrapper.
+- Modify `src/appwindow/tab.zig`: add `port_forwarding` tab kind and session pointer.
+- Modify `src/input.zig`: route Port Forwarding keys/chars before terminal input and set render dirty flags through AppWindow wrappers.
+- Modify `src/command_center_state.zig`: add `open_port_forwarding` action and command entry.
+- Modify `src/i18n.zig`: add English/Chinese labels and command search text.
+- Modify `src/test_fast.zig` and `src/test_main.zig`: import the new pure/app modules.
+- Create `docs/port-forwarding.md` and modify `README.md`: document reverse/local rules and the loopback-only v1 safety boundary.
+
+## Dependency Order
+
+1. `port_forward_rule.zig` first; every later module depends on the rule type and validation.
+2. `ssh_profile_store.zig` second; manager needs profile resolution without touching the SSH profile UI.
+3. `port_forward_manager.zig` third; UI and App lifecycle depend on its APIs.
+4. `port_forwarding.zig` and `port_forwarding_renderer.zig` fourth; they depend on manager row snapshots.
+5. App/tab/input/command/i18n wiring last; they depend on all previous APIs.
+6. Docs and full verification after code compiles.
+
+---
+
+### Task 1: Pure Port-Forwarding Rule Model And Codec
+
+**Files:**
+- Create: `src/port_forward_rule.zig`
+- Modify: `src/test_fast.zig`
+- Test: `src/port_forward_rule.zig`
+
+- [ ] **Step 1: Create failing rule-model tests**
+
+Create `src/port_forward_rule.zig` with these tests and minimal imports only:
+
+```zig
+const std = @import("std");
+
+test "port_forward_rule: default reverse rule targets local proxy" {
+    const rule = defaultReverseProxy("devbox");
+    try std.testing.expectEqual(Direction.reverse, rule.direction);
+    try std.testing.expectEqualStrings("devbox", rule.profileName());
+    try std.testing.expectEqualStrings("127.0.0.1", rule.localHost());
+    try std.testing.expectEqual(@as(u16, 7890), rule.local_port);
+    try std.testing.expectEqualStrings("127.0.0.1", rule.remoteHost());
+    try std.testing.expectEqual(@as(u16, 7890), rule.remote_port);
+    try std.testing.expect(rule.enabled);
+    try std.testing.expect(rule.auto_start);
+}
+
+test "port_forward_rule: validates loopback hosts and port range" {
+    try std.testing.expect(validateHost("127.0.0.1"));
+    try std.testing.expect(validateHost("localhost"));
+    try std.testing.expect(!validateHost("0.0.0.0"));
+    try std.testing.expect(!validateHost("10.0.0.1"));
+    try std.testing.expect(parsePort("1").? == 1);
+    try std.testing.expect(parsePort("65535").? == 65535);
+    try std.testing.expect(parsePort("0") == null);
+    try std.testing.expect(parsePort("65536") == null);
+    try std.testing.expect(parsePort("abc") == null);
+}
+
+test "port_forward_rule: forward specs match ssh -L and -R semantics" {
+    var rule = defaultReverseProxy("devbox");
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "127.0.0.1:7890:127.0.0.1:7890",
+        rule.forwardSpec(&buf).?,
+    );
+    try std.testing.expectEqualStrings("-R", rule.direction.flag());
+
+    rule.direction = .local;
+    rule.local_port = 8888;
+    rule.remote_port = 8888;
+    try std.testing.expectEqualStrings(
+        "127.0.0.1:8888:127.0.0.1:8888",
+        rule.forwardSpec(&buf).?,
+    );
+    try std.testing.expectEqualStrings("-L", rule.direction.flag());
+}
+
+test "port_forward_rule: storage round trips two rules" {
+    var rules = [_]Rule{
+        defaultReverseProxy("devbox"),
+        defaultReverseProxy("lab"),
+    };
+    rules[1].direction = .local;
+    rules[1].local_port = 8888;
+    rules[1].remote_port = 8888;
+    rules[1].auto_start = false;
+    rules[1].setName("Jupyter");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    var decoded = try decodeRules(std.testing.allocator, out.items);
+    defer freeRules(std.testing.allocator, decoded);
+
+    try std.testing.expectEqual(@as(usize, 2), decoded.len);
+    try std.testing.expectEqual(Direction.reverse, decoded[0].direction);
+    try std.testing.expectEqualStrings("devbox", decoded[0].profileName());
+    try std.testing.expectEqual(Direction.local, decoded[1].direction);
+    try std.testing.expectEqualStrings("Jupyter", decoded[1].name());
+    try std.testing.expect(!decoded[1].auto_start);
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/port_forward_rule.zig
+```
+
+Expected: FAIL with undefined identifiers such as `defaultReverseProxy`, `Direction`, and `Rule`.
+
+- [ ] **Step 3: Implement the rule model, validation, spec builder, and codec**
+
+Replace `src/port_forward_rule.zig` with this implementation, preserving the tests from Step 1 at the bottom:
+
+```zig
+const std = @import("std");
+
+pub const NAME_MAX: usize = 96;
+pub const PROFILE_MAX: usize = 128;
+pub const HOST_MAX: usize = 64;
+
+pub const Direction = enum {
+    local,
+    reverse,
+
+    pub fn flag(self: Direction) []const u8 {
+        return switch (self) {
+            .local => "-L",
+            .reverse => "-R",
+        };
+    }
+
+    pub fn text(self: Direction) []const u8 {
+        return switch (self) {
+            .local => "local",
+            .reverse => "reverse",
+        };
+    }
+
+    pub fn parse(value: []const u8) ?Direction {
+        if (std.ascii.eqlIgnoreCase(value, "local")) return .local;
+        if (std.ascii.eqlIgnoreCase(value, "reverse")) return .reverse;
+        return null;
+    }
+};
+
+pub const Rule = struct {
+    name_buf: [NAME_MAX]u8 = undefined,
+    name_len: usize = 0,
+    profile_buf: [PROFILE_MAX]u8 = undefined,
+    profile_len: usize = 0,
+    direction: Direction = .reverse,
+    local_host_buf: [HOST_MAX]u8 = undefined,
+    local_host_len: usize = 0,
+    local_port: u16 = 7890,
+    remote_host_buf: [HOST_MAX]u8 = undefined,
+    remote_host_len: usize = 0,
+    remote_port: u16 = 7890,
+    enabled: bool = true,
+    auto_start: bool = true,
+
+    pub fn name(self: *const Rule) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+
+    pub fn profileName(self: *const Rule) []const u8 {
+        return self.profile_buf[0..self.profile_len];
+    }
+
+    pub fn localHost(self: *const Rule) []const u8 {
+        return self.local_host_buf[0..self.local_host_len];
+    }
+
+    pub fn remoteHost(self: *const Rule) []const u8 {
+        return self.remote_host_buf[0..self.remote_host_len];
+    }
+
+    pub fn setName(self: *Rule, value: []const u8) void {
+        self.name_len = copyBounded(self.name_buf[0..], value);
+    }
+
+    pub fn setProfileName(self: *Rule, value: []const u8) void {
+        self.profile_len = copyBounded(self.profile_buf[0..], value);
+    }
+
+    pub fn setLocalHost(self: *Rule, value: []const u8) void {
+        self.local_host_len = copyBounded(self.local_host_buf[0..], value);
+    }
+
+    pub fn setRemoteHost(self: *Rule, value: []const u8) void {
+        self.remote_host_len = copyBounded(self.remote_host_buf[0..], value);
+    }
+
+    pub fn validate(self: *const Rule) bool {
+        return self.profileName().len > 0 and
+            validateHost(self.localHost()) and
+            validateHost(self.remoteHost()) and
+            self.local_port != 0 and
+            self.remote_port != 0;
+    }
+
+    pub fn forwardSpec(self: *const Rule, buf: []u8) ?[]const u8 {
+        if (!self.validate()) return null;
+        return switch (self.direction) {
+            .local => std.fmt.bufPrint(
+                buf,
+                "{s}:{d}:{s}:{d}",
+                .{ self.localHost(), self.local_port, self.remoteHost(), self.remote_port },
+            ) catch null,
+            .reverse => std.fmt.bufPrint(
+                buf,
+                "{s}:{d}:{s}:{d}",
+                .{ self.remoteHost(), self.remote_port, self.localHost(), self.local_port },
+            ) catch null,
+        };
+    }
+};
+
+pub fn defaultReverseProxy(profile_name: []const u8) Rule {
+    var rule: Rule = .{};
+    rule.setName("Local proxy");
+    rule.setProfileName(profile_name);
+    rule.direction = .reverse;
+    rule.setLocalHost("127.0.0.1");
+    rule.local_port = 7890;
+    rule.setRemoteHost("127.0.0.1");
+    rule.remote_port = 7890;
+    rule.enabled = true;
+    rule.auto_start = true;
+    return rule;
+}
+
+pub fn validateHost(host: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(host, "127.0.0.1") or
+        std.ascii.eqlIgnoreCase(host, "localhost");
+}
+
+pub fn parsePort(text: []const u8) ?u16 {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const value = std.fmt.parseInt(u32, trimmed, 10) catch return null;
+    if (value == 0 or value > std.math.maxInt(u16)) return null;
+    return @intCast(value);
+}
+
+pub fn freeRules(allocator: std.mem.Allocator, rules: []Rule) void {
+    allocator.free(rules);
+}
+
+pub fn encodeRules(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), rules: []const Rule) !void {
+    try out.appendSlice(allocator, "# WispTerm port forwarding rules. Fields are hex encoded: name, profile, direction, local_host, local_port, remote_host, remote_port, enabled, auto_start.\n");
+    for (rules) |rule| {
+        try appendHexField(allocator, out, rule.name());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.profileName());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.direction.text());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.localHost());
+        try out.append(allocator, '\t');
+        var local_port_buf: [8]u8 = undefined;
+        try appendHexField(allocator, out, std.fmt.bufPrint(&local_port_buf, "{d}", .{rule.local_port}) catch unreachable);
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.remoteHost());
+        try out.append(allocator, '\t');
+        var remote_port_buf: [8]u8 = undefined;
+        try appendHexField(allocator, out, std.fmt.bufPrint(&remote_port_buf, "{d}", .{rule.remote_port}) catch unreachable);
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, if (rule.enabled) "true" else "false");
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, if (rule.auto_start) "true" else "false");
+        try out.append(allocator, '\n');
+    }
+}
+
+pub fn decodeRules(allocator: std.mem.Allocator, content: []const u8) ![]Rule {
+    var rules: std.ArrayListUnmanaged(Rule) = .empty;
+    errdefer rules.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (decodeRuleLine(line)) |rule| {
+            try rules.append(allocator, rule);
+        }
+    }
+    return rules.toOwnedSlice(allocator);
+}
+
+pub fn decodeRuleLine(line: []const u8) ?Rule {
+    var fields: [9][128]u8 = undefined;
+    var lens: [9]usize = .{0} ** 9;
+    var parts = std.mem.splitScalar(u8, line, '\t');
+    var idx: usize = 0;
+    while (idx < fields.len) : (idx += 1) {
+        const part = parts.next() orelse return null;
+        lens[idx] = decodeHexField(part, fields[idx][0..]) orelse return null;
+    }
+    var rule: Rule = .{};
+    rule.setName(fields[0][0..lens[0]]);
+    rule.setProfileName(fields[1][0..lens[1]]);
+    rule.direction = Direction.parse(fields[2][0..lens[2]]) orelse return null;
+    rule.setLocalHost(fields[3][0..lens[3]]);
+    rule.local_port = parsePort(fields[4][0..lens[4]]) orelse return null;
+    rule.setRemoteHost(fields[5][0..lens[5]]);
+    rule.remote_port = parsePort(fields[6][0..lens[6]]) orelse return null;
+    rule.enabled = parseBool(fields[7][0..lens[7]]) orelse return null;
+    rule.auto_start = parseBool(fields[8][0..lens[8]]) orelse return null;
+    return rule;
+}
+
+fn parseBool(text: []const u8) ?bool {
+    if (std.ascii.eqlIgnoreCase(text, "true")) return true;
+    if (std.ascii.eqlIgnoreCase(text, "false")) return false;
+    return null;
+}
+
+fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), field: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (field) |ch| {
+        try out.append(allocator, hex[ch >> 4]);
+        try out.append(allocator, hex[ch & 0x0f]);
+    }
+}
+
+fn decodeHexField(value: []const u8, out: []u8) ?usize {
+    if (value.len % 2 != 0) return null;
+    const len = @min(value.len / 2, out.len);
+    var i: usize = 0;
+    while (i < len) : (i += 1) {
+        const hi = hexValue(value[i * 2]) orelse return null;
+        const lo = hexValue(value[i * 2 + 1]) orelse return null;
+        out[i] = (hi << 4) | lo;
+    }
+    return len;
+}
+
+fn hexValue(ch: u8) ?u8 {
+    if (ch >= '0' and ch <= '9') return ch - '0';
+    if (ch >= 'a' and ch <= 'f') return ch - 'a' + 10;
+    if (ch >= 'A' and ch <= 'F') return ch - 'A' + 10;
+    return null;
+}
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+zig test src/port_forward_rule.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the module to the fast suite**
+
+In `src/test_fast.zig`, add this import after `ssh_connection.zig`:
+
+```zig
+    _ = @import("port_forward_rule.zig");
+```
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/port_forward_rule.zig src/test_fast.zig
+git commit -m "feat(port-forward): add rule codec"
+```
+
+---
+
+### Task 2: Saved SSH Profile Resolver For Background Forwarding
+
+**Files:**
+- Create: `src/ssh_profile_store.zig`
+- Modify: `src/test_fast.zig`
+- Test: `src/ssh_profile_store.zig`
+
+- [ ] **Step 1: Create failing tests for profile resolution**
+
+Create `src/ssh_profile_store.zig` with these tests and imports:
+
+```zig
+const std = @import("std");
+const ssh_connection = @import("ssh_connection.zig");
+
+test "ssh_profile_store: resolves connection from encoded ssh_hosts content" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{
+        "devbox", "10.0.0.9", "alice", "secret", "2222", "jump@example.com:22",
+    });
+
+    const conn = findConnectionInContent(content.items, "devbox", true) orelse return error.ExpectedConnection;
+    try std.testing.expectEqualStrings("alice", conn.user());
+    try std.testing.expectEqualStrings("10.0.0.9", conn.host());
+    try std.testing.expectEqualStrings("2222", conn.port());
+    try std.testing.expectEqualStrings("secret", conn.password());
+    try std.testing.expectEqualStrings("jump@example.com:22", conn.proxyJump());
+    try std.testing.expect(conn.password_auth);
+    try std.testing.expect(conn.legacy_algorithms);
+}
+
+test "ssh_profile_store: rejects unsafe profile fields" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{
+        "bad", "host;rm -rf /", "alice", "", "22", "",
+    });
+
+    try std.testing.expect(findConnectionInContent(content.items, "bad", false) == null);
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/ssh_profile_store.zig
+```
+
+Expected: FAIL with undefined identifiers such as `appendEncodedProfileForTest` and `findConnectionInContent`.
+
+- [ ] **Step 3: Implement resolver and tests**
+
+Add this implementation above the tests in `src/ssh_profile_store.zig`:
+
+```zig
+const profile_codec = @import("renderer/overlays/profile_codec.zig");
+const platform_dirs = @import("platform/dirs.zig");
+const command_palette_model = @import("command_palette_model.zig");
+
+pub fn connectionByName(allocator: std.mem.Allocator, profile_name: []const u8, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    const path = platform_dirs.sshHostsPath(allocator) catch return null;
+    defer allocator.free(path);
+    const content = std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch return null;
+    defer allocator.free(content);
+    return findConnectionInContent(content, profile_name, legacy_algorithms);
+}
+
+pub fn findConnectionInContent(content: []const u8, profile_name: []const u8, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const profile = profile_codec.decodeSshProfileLine(line) orelse continue;
+        if (!std.ascii.eqlIgnoreCase(profile_name, profile_codec.profileField(&profile, .name))) continue;
+        return connectionFromProfile(&profile, legacy_algorithms);
+    }
+    return null;
+}
+
+pub fn connectionFromProfile(profile: *const profile_codec.SshProfile, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    const host = profile_codec.profileField(profile, .ip);
+    const user = profile_codec.profileField(profile, .user);
+    const port = profile_codec.profileField(profile, .port);
+    const password = profile_codec.profileField(profile, .password);
+    const proxy_jump = profile_codec.profileField(profile, .proxy_jump);
+    if (host.len == 0 or user.len == 0) return null;
+    if (!isSshTokenSafe(host) or !isSshTokenSafe(user)) return null;
+    if (port.len > 0 and !isPortTokenSafe(port)) return null;
+    if (!command_palette_model.isProxyJumpSafe(proxy_jump)) return null;
+
+    var conn: ssh_connection.SshConnection = .{};
+    conn.host_len = copyBounded(conn.host_buf[0..], host);
+    conn.user_len = copyBounded(conn.user_buf[0..], user);
+    conn.port_len = copyBounded(conn.port_buf[0..], port);
+    conn.password_len = copyBounded(conn.password_buf[0..], password);
+    conn.proxy_jump_len = copyBounded(conn.proxy_jump_buf[0..], proxy_jump);
+    conn.password_auth = password.len > 0;
+    conn.legacy_algorithms = legacy_algorithms;
+    return conn;
+}
+
+fn isSshTokenSafe(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        if (std.ascii.isAlphanumeric(ch)) continue;
+        switch (ch) {
+            '.', '-', '_', ':', '@' => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+fn isPortTokenSafe(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        if (!std.ascii.isDigit(ch)) return false;
+    }
+    return true;
+}
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+
+fn appendEncodedProfileForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), fields: []const []const u8) !void {
+    for (fields, 0..) |field, idx| {
+        if (idx > 0) try out.append(allocator, '\t');
+        try appendHexFieldForTest(allocator, out, field);
+    }
+    try out.append(allocator, '\n');
+}
+
+fn appendHexFieldForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), field: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (field) |ch| {
+        try out.append(allocator, hex[ch >> 4]);
+        try out.append(allocator, hex[ch & 0x0f]);
+    }
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+zig test src/ssh_profile_store.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the module to the fast suite**
+
+In `src/test_fast.zig`, add this import after `port_forward_rule.zig`:
+
+```zig
+    _ = @import("ssh_profile_store.zig");
+```
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ssh_profile_store.zig src/test_fast.zig
+git commit -m "feat(port-forward): resolve saved ssh profiles"
+```
+
+---
+
+### Task 3: Port Forward Manager State, Persistence, And Status Transitions
+
+**Files:**
+- Create: `src/port_forward_manager.zig`
+- Modify: `src/test_fast.zig`
+- Test: `src/port_forward_manager.zig`
+
+- [ ] **Step 1: Create failing manager-state tests**
+
+Create `src/port_forward_manager.zig` with these tests and imports:
+
+```zig
+const std = @import("std");
+const rule_mod = @import("port_forward_rule.zig");
+
+test "port_forward_manager: add save load and toggle auto start" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expectEqual(@as(usize, 1), manager.count());
+    try std.testing.expect(manager.rowAt(0).?.auto_start);
+
+    try std.testing.expect(manager.toggleAutoStart(0));
+    try std.testing.expect(!manager.rowAt(0).?.auto_start);
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try manager.encode(std.testing.allocator, &out);
+
+    var loaded = Manager.init(std.testing.allocator);
+    defer loaded.deinit();
+    try loaded.loadFromContent(out.items);
+    try std.testing.expectEqual(@as(usize, 1), loaded.count());
+    try std.testing.expect(!loaded.rowAt(0).?.auto_start);
+}
+
+test "port_forward_manager: missing profile records status without spawning" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("missing"));
+
+    const started = manager.markMissingProfileForTest(0);
+    try std.testing.expect(!started);
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.missing_profile, row.status);
+    try std.testing.expectEqualStrings("profile missing", row.reason);
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: FAIL with undefined identifiers such as `Manager` and `StatusKind`.
+
+- [ ] **Step 3: Implement manager state without child spawning**
+
+Add this implementation above the tests:
+
+```zig
+pub const MAX_RULES: usize = 128;
+pub const REASON_MAX: usize = 192;
+
+pub const StatusKind = enum {
+    stopped,
+    starting,
+    running,
+    error_,
+    missing_profile,
+};
+
+pub const RowView = struct {
+    rule: rule_mod.Rule,
+    status: StatusKind,
+    reason: []const u8,
+    auto_start: bool,
+};
+
+const Entry = struct {
+    rule: rule_mod.Rule,
+    status: StatusKind = .stopped,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
+
+    fn reason(self: *const Entry) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
+
+    fn setStatus(self: *Entry, status: StatusKind, reason: []const u8) void {
+        self.status = status;
+        self.reason_len = copyBounded(self.reason_buf[0..], reason);
+    }
+};
+
+pub const Manager = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    entries: std.ArrayListUnmanaged(Entry) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator) Manager {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Manager) void {
+        self.stopAll();
+        self.entries.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn count(self: *Manager) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.entries.items.len;
+    }
+
+    pub fn rowAt(self: *Manager, index: usize) ?RowView {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return null;
+        const entry = &self.entries.items[index];
+        return .{
+            .rule = entry.rule,
+            .status = entry.status,
+            .reason = entry.reason(),
+            .auto_start = entry.rule.auto_start,
+        };
+    }
+
+    pub fn addRule(self: *Manager, rule: rule_mod.Rule) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.entries.items.len >= MAX_RULES) return error.TooManyRules;
+        try self.entries.append(self.allocator, .{ .rule = rule });
+    }
+
+    pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].rule = rule;
+        self.entries.items[index].setStatus(.stopped, "");
+        return true;
+    }
+
+    pub fn deleteRule(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        _ = self.entries.orderedRemove(index);
+        return true;
+    }
+
+    pub fn toggleAutoStart(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].rule.auto_start = !self.entries.items[index].rule.auto_start;
+        return true;
+    }
+
+    pub fn encode(self: *Manager, allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var rules = try allocator.alloc(rule_mod.Rule, self.entries.items.len);
+        defer allocator.free(rules);
+        for (self.entries.items, 0..) |entry, i| rules[i] = entry.rule;
+        try rule_mod.encodeRules(allocator, out, rules);
+    }
+
+    pub fn loadFromContent(self: *Manager, content: []const u8) !void {
+        const rules = try rule_mod.decodeRules(self.allocator, content);
+        defer rule_mod.freeRules(self.allocator, rules);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.entries.clearRetainingCapacity();
+        for (rules) |rule| {
+            try self.entries.append(self.allocator, .{ .rule = rule });
+        }
+    }
+
+    pub fn markMissingProfileForTest(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].setStatus(.missing_profile, "profile missing");
+        return false;
+    }
+
+    pub fn stopAll(self: *Manager) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.entries.items) |*entry| {
+            entry.setStatus(.stopped, "");
+        }
+    }
+};
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add manager to fast suite**
+
+In `src/test_fast.zig`, add this import after `ssh_profile_store.zig`:
+
+```zig
+    _ = @import("port_forward_manager.zig");
+```
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/port_forward_manager.zig src/test_fast.zig
+git commit -m "feat(port-forward): add manager state"
+```
+
+---
+
+### Task 4: OpenSSH Helper Argv, Spawn, Stop, And Tick
+
+**Files:**
+- Modify: `src/port_forward_manager.zig`
+- Test: `src/port_forward_manager.zig`
+
+- [ ] **Step 1: Add failing tests for argv and ControlMaster exclusion**
+
+Append these tests to `src/port_forward_manager.zig`:
+
+```zig
+const ssh_connection = @import("ssh_connection.zig");
+
+test "port_forward_manager: builds reverse ssh argv without connection sharing" {
+    var conn: ssh_connection.SshConnection = .{};
+    conn.user_len = copyBounded(conn.user_buf[0..], "alice");
+    conn.host_len = copyBounded(conn.host_buf[0..], "example.test");
+    conn.port_len = copyBounded(conn.port_buf[0..], "2222");
+    conn.proxy_jump_len = copyBounded(conn.proxy_jump_buf[0..], "jump@example.test:22");
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const rule = rule_mod.defaultReverseProxy("devbox");
+    const argv = try buildSshArgvForTest(allocator, &rule, &conn);
+
+    try std.testing.expectEqualStrings("ssh", argv[0]);
+    try std.testing.expect(argvContainsForTest(argv, "-R"));
+    try std.testing.expect(argvContainsForTest(argv, "127.0.0.1:7890:127.0.0.1:7890"));
+    try std.testing.expect(argvContainsForTest(argv, "-p"));
+    try std.testing.expect(argvContainsForTest(argv, "2222"));
+
+    for (argv) |arg| {
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlMaster") == null);
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPersist") == null);
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPath") == null);
+    }
+}
+
+test "port_forward_manager: running child exit becomes error" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+
+    try std.testing.expect(manager.markRunningForTest(0, 99));
+    try std.testing.expect(manager.markExitedForTest(0, "ssh exited"));
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.error_, row.status);
+    try std.testing.expectEqualStrings("ssh exited", row.reason);
+}
+
+fn argvContainsForTest(argv: []const []const u8, needle: []const u8) bool {
+    for (argv) |arg| {
+        if (std.mem.eql(u8, arg, needle)) return true;
+    }
+    return false;
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: FAIL with undefined identifiers such as `buildSshArgvForTest`, `markRunningForTest`, and `markExitedForTest`.
+
+- [ ] **Step 3: Add process-facing imports and child state**
+
+At the top of `src/port_forward_manager.zig`, add:
+
+```zig
+const builtin = @import("builtin");
+const platform_process = @import("platform/process.zig");
+const platform_pty_command = @import("platform/pty_command.zig");
+const ssh_profile_store = @import("ssh_profile_store.zig");
+const ssh_error = @import("ssh_error.zig");
+```
+
+Extend `Entry` with child state:
+
+```zig
+    child: ?std.process.Child = null,
+    fake_pid_for_test: ?u32 = null,
+```
+
+- [ ] **Step 4: Add argv construction helpers**
+
+Add these helpers below `Manager`:
+
+```zig
+const MAX_TUNNEL_SPEC_BYTES: usize = 160;
+const MAX_SSH_DEST_BYTES: usize = 280;
+
+pub fn buildSshArgvForTest(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) ![][]const u8 {
+    return buildSshArgv(allocator, rule, conn);
+}
+
+fn buildSshArgv(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) ![][]const u8 {
+    var spec_buf: [MAX_TUNNEL_SPEC_BYTES]u8 = undefined;
+    const spec = rule.forwardSpec(&spec_buf) orelse return error.InvalidRule;
+    var dest_buf: [MAX_SSH_DEST_BYTES]u8 = undefined;
+    const dest = sshDestination(&dest_buf, conn) orelse return error.InvalidProfile;
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer argv.deinit(allocator);
+    try argv.append(allocator, platform_pty_command.sshExecutableName());
+    try argv.append(allocator, "-N");
+    try argv.append(allocator, "-T");
+    try argv.append(allocator, rule.direction.flag());
+    try argv.append(allocator, try allocator.dupe(u8, spec));
+
+    try appendSshOption(allocator, &argv, "ExitOnForwardFailure=yes");
+    try appendSshOption(allocator, &argv, "StrictHostKeyChecking=accept-new");
+    try appendSshOption(allocator, &argv, "ConnectTimeout=8");
+    try appendSshOption(allocator, &argv, "ServerAliveInterval=60");
+    try appendSshOption(allocator, &argv, "ServerAliveCountMax=3");
+    if (conn.legacy_algorithms) {
+        try appendSshOption(allocator, &argv, "HostkeyAlgorithms=+ssh-rsa,ssh-dss");
+        try appendSshOption(allocator, &argv, "PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss");
+        try appendSshOption(allocator, &argv, "KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1");
+        try appendSshOption(allocator, &argv, "Ciphers=+aes128-cbc,3des-cbc");
+    }
+    if (conn.password_auth) {
+        try appendSshOption(allocator, &argv, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        try appendSshOption(allocator, &argv, "NumberOfPasswordPrompts=1");
+    } else {
+        try appendSshOption(allocator, &argv, "BatchMode=yes");
+    }
+    if (conn.proxyJump().len > 0) {
+        try appendSshOption(allocator, &argv, try std.fmt.allocPrint(allocator, "ProxyJump={s}", .{conn.proxyJump()}));
+    }
+    if (conn.port().len > 0) {
+        try argv.append(allocator, "-p");
+        try argv.append(allocator, try allocator.dupe(u8, conn.port()));
+    }
+    try argv.append(allocator, try allocator.dupe(u8, dest));
+    return argv.toOwnedSlice(allocator);
+}
+
+fn appendSshOption(allocator: std.mem.Allocator, argv: *std.ArrayListUnmanaged([]const u8), option: []const u8) !void {
+    try argv.append(allocator, "-o");
+    try argv.append(allocator, option);
+}
+
+fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const ssh_connection.SshConnection) ?[]const u8 {
+    const user = conn.user();
+    const host = conn.host();
+    const len = user.len + 1 + host.len;
+    if (user.len == 0 or host.len == 0 or len > buf.len) return null;
+    @memcpy(buf[0..user.len], user);
+    buf[user.len] = '@';
+    @memcpy(buf[user.len + 1 ..][0..host.len], host);
+    return buf[0..len];
+}
+```
+
+- [ ] **Step 5: Add start/stop/tick methods**
+
+Add these methods inside `Manager`:
+
+```zig
+    pub fn startIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
+        self.mutex.lock();
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        const rule = self.entries.items[index].rule;
+        self.entries.items[index].setStatus(.starting, "");
+        self.mutex.unlock();
+
+        const conn = ssh_profile_store.connectionByName(self.allocator, rule.profileName(), legacy_algorithms) orelse {
+            self.mutex.lock();
+            if (index < self.entries.items.len) self.entries.items[index].setStatus(.missing_profile, "profile missing");
+            self.mutex.unlock();
+            return false;
+        };
+
+        const child = spawnForward(self.allocator, &rule, &conn) catch |err| {
+            var buf: [REASON_MAX]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "spawn failed: {}", .{err}) catch "spawn failed";
+            self.mutex.lock();
+            if (index < self.entries.items.len) self.entries.items[index].setStatus(.error_, msg);
+            self.mutex.unlock();
+            return false;
+        };
+
+        self.mutex.lock();
+        if (index < self.entries.items.len) {
+            self.entries.items[index].child = child;
+            self.entries.items[index].setStatus(.running, "");
+        }
+        self.mutex.unlock();
+        return true;
+    }
+
+    pub fn stopIndex(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        stopEntry(&self.entries.items[index]);
+        self.entries.items[index].setStatus(.stopped, "");
+        return true;
+    }
+
+    pub fn restartIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
+        _ = self.stopIndex(index);
+        return self.startIndex(index, legacy_algorithms);
+    }
+
+    pub fn startAuto(self: *Manager, legacy_algorithms: bool) void {
+        var i: usize = 0;
+        while (true) : (i += 1) {
+            self.mutex.lock();
+            const done = i >= self.entries.items.len;
+            const should_start = !done and self.entries.items[i].rule.enabled and self.entries.items[i].rule.auto_start;
+            self.mutex.unlock();
+            if (done) break;
+            if (should_start) _ = self.startIndex(i, legacy_algorithms);
+        }
+    }
+
+    pub fn tick(self: *Manager) bool {
+        var changed = false;
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.entries.items) |*entry| {
+            if (entry.child) |*child| {
+                if (childHasExited(child)) {
+                    stopEntry(entry);
+                    entry.setStatus(.error_, "ssh exited");
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    pub fn markRunningForTest(self: *Manager, index: usize, pid: u32) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].fake_pid_for_test = pid;
+        self.entries.items[index].setStatus(.running, "");
+        return true;
+    }
+
+    pub fn markExitedForTest(self: *Manager, index: usize, reason: []const u8) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].fake_pid_for_test = null;
+        self.entries.items[index].setStatus(.error_, reason);
+        return true;
+    }
+```
+
+Add these helpers outside `Manager`:
+
+```zig
+fn spawnForward(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) !std.process.Child {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const argv = try buildSshArgv(arena.allocator(), rule, conn);
+
+    var askpass_path: ?[]const u8 = null;
+    defer if (askpass_path) |path| allocator.free(path);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return error.AskPassUnavailable;
+        env_map = try std.process.getEnvMap(allocator);
+        try platform_process.putSshAskPassEnv(&env_map.?, askpass_path.?, conn.password());
+    }
+
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Inherit;
+    if (env_map) |*map| child.env_map = map;
+    try child.spawn();
+    return child;
+}
+
+fn stopEntry(entry: *Entry) void {
+    if (entry.child) |*child| {
+        if (childHasExited(child)) {
+            if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
+            _ = child.wait() catch {};
+        } else {
+            _ = child.kill() catch {};
+        }
+        entry.child = null;
+    }
+    entry.fake_pid_for_test = null;
+}
+
+fn childHasExited(child: *const std.process.Child) bool {
+    return switch (platform_process.childExited(child.id, 0)) {
+        .running => false,
+        .exited, .gone => true,
+    };
+}
+```
+
+Change `Manager.stopAll` so it calls `stopEntry(entry)` before setting stopped.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/port_forward_manager.zig
+git commit -m "feat(port-forward): manage ssh helper processes"
+```
+
+---
+
+### Task 5: Port Forwarding Panel Model
+
+**Files:**
+- Create: `src/port_forwarding.zig`
+- Modify: `src/test_fast.zig`
+- Test: `src/port_forwarding.zig`
+
+- [ ] **Step 1: Create failing panel-model tests**
+
+Create `src/port_forwarding.zig` with:
+
+```zig
+const std = @import("std");
+const rule_mod = @import("port_forward_rule.zig");
+
+test "port_forwarding: selection clamps to row count" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    session.model.move(1, 0);
+    try std.testing.expectEqual(@as(usize, 0), session.model.sel_row);
+    session.model.move(1, 3);
+    try std.testing.expectEqual(@as(usize, 1), session.model.sel_row);
+    session.model.move(99, 3);
+    try std.testing.expectEqual(@as(usize, 2), session.model.sel_row);
+    session.model.move(-99, 3);
+    try std.testing.expectEqual(@as(usize, 0), session.model.sel_row);
+}
+
+test "port_forwarding: new form defaults to reverse proxy" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form = session.model.form() orelse return error.ExpectedForm;
+    try std.testing.expectEqual(FormMode.new, form.mode);
+    try std.testing.expectEqual(rule_mod.Direction.reverse, form.rule.direction);
+    try std.testing.expectEqualStrings("devbox", form.rule.profileName());
+}
+
+test "port_forwarding: delete confirmation records selected index" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openDeleteConfirm(2, "Local proxy");
+    const confirm = session.model.confirm() orelse return error.ExpectedConfirm;
+    try std.testing.expectEqual(@as(usize, 2), confirm.index);
+    try std.testing.expectEqualStrings("Delete Local proxy? Enter confirms, Esc cancels.", confirm.text);
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/port_forwarding.zig
+```
+
+Expected: FAIL with undefined identifiers such as `Session`, `FormMode`, and `PanelModel`.
+
+- [ ] **Step 3: Implement panel/session model**
+
+Add this implementation above the tests:
+
+```zig
+pub const FormMode = enum { new, edit };
+pub const FORM_FIELD_COUNT: usize = 8;
+
+pub const FormState = struct {
+    mode: FormMode,
+    edit_index: ?usize,
+    focus: usize = 0,
+    rule: rule_mod.Rule,
+
+    pub fn moveFocus(self: *FormState, delta: isize) void {
+        const cur: isize = @intCast(self.focus);
+        self.focus = @intCast(std.math.clamp(cur + delta, 0, @as(isize, FORM_FIELD_COUNT - 1)));
+    }
+
+    pub fn insertChar(self: *FormState, codepoint: u21) void {
+        if (codepoint > 0x7f) return;
+        const ch: u8 = @intCast(codepoint);
+        switch (self.focus) {
+            0 => appendAscii(&self.rule.name_buf, &self.rule.name_len, ch),
+            1 => appendAscii(&self.rule.profile_buf, &self.rule.profile_len, ch),
+            3 => appendAscii(&self.rule.local_host_buf, &self.rule.local_host_len, ch),
+            4 => self.rule.local_port = appendPortDigit(self.rule.local_port, ch),
+            5 => appendAscii(&self.rule.remote_host_buf, &self.rule.remote_host_len, ch),
+            6 => self.rule.remote_port = appendPortDigit(self.rule.remote_port, ch),
+            else => {},
+        }
+    }
+
+    pub fn backspace(self: *FormState) void {
+        switch (self.focus) {
+            0 => if (self.rule.name_len > 0) self.rule.name_len -= 1,
+            1 => if (self.rule.profile_len > 0) self.rule.profile_len -= 1,
+            3 => if (self.rule.local_host_len > 0) self.rule.local_host_len -= 1,
+            4 => self.rule.local_port /= 10,
+            5 => if (self.rule.remote_host_len > 0) self.rule.remote_host_len -= 1,
+            6 => self.rule.remote_port /= 10,
+            else => {},
+        }
+    }
+
+    pub fn toggleFocused(self: *FormState) void {
+        switch (self.focus) {
+            2 => self.rule.direction = if (self.rule.direction == .reverse) .local else .reverse,
+            7 => self.rule.auto_start = !self.rule.auto_start,
+            else => {},
+        }
+    }
+};
+
+pub const ConfirmState = struct {
+    index: usize,
+    text: []u8,
+
+    fn deinit(self: *ConfirmState, allocator: std.mem.Allocator) void {
+        allocator.free(self.text);
+        self.* = undefined;
+    }
+};
+
+pub const Overlay = union(enum) {
+    none,
+    form: FormState,
+    confirm_delete: ConfirmState,
+
+    fn deinit(self: *Overlay, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .none, .form => {},
+            .confirm_delete => |*c| c.deinit(allocator),
+        }
+        self.* = .none;
+    }
+};
+
+pub const PanelModel = struct {
+    allocator: std.mem.Allocator,
+    sel_row: usize = 0,
+    scroll: usize = 0,
+    overlay: Overlay = .none,
+
+    pub fn init(allocator: std.mem.Allocator) PanelModel {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *PanelModel) void {
+        self.overlay.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn move(self: *PanelModel, delta: isize, row_count: usize) void {
+        if (row_count == 0) {
+            self.sel_row = 0;
+            return;
+        }
+        const cur: isize = @intCast(self.sel_row);
+        self.sel_row = @intCast(std.math.clamp(cur + delta, 0, @as(isize, @intCast(row_count - 1))));
+    }
+
+    pub fn clearOverlay(self: *PanelModel) void {
+        self.overlay.deinit(self.allocator);
+    }
+
+    pub fn openNewForm(self: *PanelModel, profile_name: []const u8) !void {
+        self.clearOverlay();
+        self.overlay = .{ .form = .{
+            .mode = .new,
+            .edit_index = null,
+            .rule = rule_mod.defaultReverseProxy(profile_name),
+        } };
+    }
+
+    pub fn openEditForm(self: *PanelModel, index: usize, rule: rule_mod.Rule) void {
+        self.clearOverlay();
+        self.overlay = .{ .form = .{
+            .mode = .edit,
+            .edit_index = index,
+            .rule = rule,
+        } };
+    }
+
+    pub fn openDeleteConfirm(self: *PanelModel, index: usize, label: []const u8) !void {
+        self.clearOverlay();
+        const text = try std.fmt.allocPrint(self.allocator, "Delete {s}? Enter confirms, Esc cancels.", .{label});
+        self.overlay = .{ .confirm_delete = .{ .index = index, .text = text } };
+    }
+
+    pub fn form(self: *PanelModel) ?*FormState {
+        return switch (self.overlay) {
+            .form => |*f| f,
+            else => null,
+        };
+    }
+
+    pub fn confirm(self: *PanelModel) ?*ConfirmState {
+        return switch (self.overlay) {
+            .confirm_delete => |*c| c,
+            else => null,
+        };
+    }
+};
+
+pub const Session = struct {
+    mutex: std.Thread.Mutex = .{},
+    model: PanelModel,
+
+    pub fn create(allocator: std.mem.Allocator) !*Session {
+        const session = try allocator.create(Session);
+        session.* = .{ .model = PanelModel.init(allocator) };
+        return session;
+    }
+
+    pub fn destroy(self: *Session) void {
+        const allocator = self.model.allocator;
+        self.model.deinit();
+        allocator.destroy(self);
+    }
+};
+
+fn appendAscii(buf: *[64]u8, len: *usize, ch: u8) void {
+    if (len.* >= buf.len) return;
+    if (ch < 0x20 or ch > 0x7e) return;
+    buf[len.*] = ch;
+    len.* += 1;
+}
+
+fn appendPortDigit(port: u16, ch: u8) u16 {
+    if (ch < '0' or ch > '9') return port;
+    const next = @as(u32, port) * 10 + (ch - '0');
+    if (next > std.math.maxInt(u16)) return port;
+    return @intCast(next);
+}
+```
+
+Adjust `appendAscii` to accept all three fixed buffer sizes by replacing it with:
+
+```zig
+fn appendAscii(buf: anytype, len: *usize, ch: u8) void {
+    if (len.* >= buf.len) return;
+    if (ch < 0x20 or ch > 0x7e) return;
+    buf[len.*] = ch;
+    len.* += 1;
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+zig test src/port_forwarding.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add module to fast suite**
+
+In `src/test_fast.zig`, add:
+
+```zig
+    _ = @import("port_forwarding.zig");
+```
+
+after `port_forward_manager.zig`.
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/port_forwarding.zig src/test_fast.zig
+git commit -m "feat(port-forward): add panel model"
+```
+
+---
+
+### Task 6: Port Forwarding Renderer
+
+**Files:**
+- Create: `src/renderer/port_forwarding_renderer.zig`
+- Modify: `src/test_fast.zig`
+- Test: `src/renderer/port_forwarding_renderer.zig`
+
+- [ ] **Step 1: Create failing renderer-helper tests**
+
+Create `src/renderer/port_forwarding_renderer.zig` with:
+
+```zig
+const std = @import("std");
+const manager = @import("../port_forward_manager.zig");
+const rule_mod = @import("../port_forward_rule.zig");
+
+test "port_forwarding_renderer: status labels" {
+    try std.testing.expectEqualStrings("Stopped", statusLabel(.stopped));
+    try std.testing.expectEqualStrings("Starting", statusLabel(.starting));
+    try std.testing.expectEqualStrings("Running", statusLabel(.running));
+    try std.testing.expectEqualStrings("Error", statusLabel(.error_));
+    try std.testing.expectEqualStrings("Missing", statusLabel(.missing_profile));
+}
+
+test "port_forwarding_renderer: listen and target labels" {
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    var listen_buf: [96]u8 = undefined;
+    var target_buf: [96]u8 = undefined;
+    try std.testing.expectEqualStrings("remote 127.0.0.1:7890", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("local 127.0.0.1:7890", targetLabel(&rule, &target_buf));
+
+    rule.direction = .local;
+    rule.local_port = 8888;
+    rule.remote_port = 8888;
+    try std.testing.expectEqualStrings("local 127.0.0.1:8888", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("remote 127.0.0.1:8888", targetLabel(&rule, &target_buf));
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/renderer/port_forwarding_renderer.zig
+```
+
+Expected: FAIL with undefined identifiers such as `statusLabel`, `listenLabel`, and `targetLabel`.
+
+- [ ] **Step 3: Implement renderer helpers and render API**
+
+Add this implementation above the tests:
+
+```zig
+pub const Color = @Vector(3, f32);
+
+pub const DrawContext = struct {
+    bg: Color,
+    fg: Color,
+    accent: Color,
+    cell_h: f32,
+    fillQuad: *const fn (f32, f32, f32, f32, Color) void,
+    fillQuadAlpha: *const fn (f32, f32, f32, f32, Color, f32) void,
+    renderTextLimited: *const fn ([]const u8, f32, f32, Color, f32) f32,
+    glyphAdvance: *const fn () f32,
+};
+
+pub const RowAt = *const fn (*anyopaque, usize) manager.RowView;
+
+pub const View = struct {
+    title: []const u8,
+    legend: []const u8,
+    row_count: usize,
+    selected: usize,
+    scroll: usize,
+    ctx: *anyopaque,
+    rowAt: RowAt,
+    overlay_text: []const u8 = "",
+};
+
+pub fn statusLabel(status: manager.StatusKind) []const u8 {
+    return switch (status) {
+        .stopped => "Stopped",
+        .starting => "Starting",
+        .running => "Running",
+        .error_ => "Error",
+        .missing_profile => "Missing",
+    };
+}
+
+pub fn directionLabel(direction: rule_mod.Direction) []const u8 {
+    return switch (direction) {
+        .local => "Local",
+        .reverse => "Reverse",
+    };
+}
+
+pub fn autoLabel(value: bool) []const u8 {
+    return if (value) "On" else "Off";
+}
+
+pub fn listenLabel(rule: *const rule_mod.Rule, buf: []u8) []const u8 {
+    return switch (rule.direction) {
+        .local => std.fmt.bufPrint(buf, "local {s}:{d}", .{ rule.localHost(), rule.local_port }) catch "",
+        .reverse => std.fmt.bufPrint(buf, "remote {s}:{d}", .{ rule.remoteHost(), rule.remote_port }) catch "",
+    };
+}
+
+pub fn targetLabel(rule: *const rule_mod.Rule, buf: []u8) []const u8 {
+    return switch (rule.direction) {
+        .local => std.fmt.bufPrint(buf, "remote {s}:{d}", .{ rule.remoteHost(), rule.remote_port }) catch "",
+        .reverse => std.fmt.bufPrint(buf, "local {s}:{d}", .{ rule.localHost(), rule.local_port }) catch "",
+    };
+}
+
+pub fn bodyVisibleCapacity(height: f32, titlebar_offset: f32, cell_h: f32) usize {
+    const body_h = height - titlebar_offset - cell_h * 5;
+    if (body_h <= cell_h) return 1;
+    return @max(1, @as(usize, @intFromFloat(@floor(body_h / cell_h))));
+}
+
+pub fn clampScroll(scroll: usize, selected: usize, visible: usize) usize {
+    if (selected < scroll) return selected;
+    if (visible == 0) return scroll;
+    if (selected >= scroll + visible) return selected - visible + 1;
+    return scroll;
+}
+
+pub fn render(draw: DrawContext, view: View, width: f32, height: f32, titlebar_offset: f32, left: f32, content_w: f32) void {
+    const pad_x: f32 = 18;
+    const x = left + pad_x;
+    const y0 = titlebar_offset + draw.cell_h * 1.4;
+    const title_end = draw.renderTextLimited(view.title, x, y0, draw.fg, content_w - pad_x * 2);
+    _ = title_end;
+
+    const header_y = y0 + draw.cell_h * 1.6;
+    _ = draw.renderTextLimited("Status", x, header_y, draw.accent, 90);
+    _ = draw.renderTextLimited("Dir", x + 95, header_y, draw.accent, 80);
+    _ = draw.renderTextLimited("Profile", x + 180, header_y, draw.accent, 110);
+    _ = draw.renderTextLimited("Listen", x + 295, header_y, draw.accent, 210);
+    _ = draw.renderTextLimited("Target", x + 510, header_y, draw.accent, 210);
+    _ = draw.renderTextLimited("Auto", x + 725, header_y, draw.accent, 55);
+    _ = draw.renderTextLimited("Name", x + 785, header_y, draw.accent, content_w - 800);
+
+    const visible = bodyVisibleCapacity(height, titlebar_offset, draw.cell_h);
+    const scroll = clampScroll(view.scroll, view.selected, visible);
+    var row: usize = 0;
+    while (row < visible and row + scroll < view.row_count) : (row += 1) {
+        const idx = row + scroll;
+        const item = view.rowAt(view.ctx, idx);
+        const row_y = header_y + draw.cell_h * @as(f32, @floatFromInt(row + 1));
+        if (idx == view.selected) {
+            draw.fillQuadAlpha(x - 8, row_y - draw.cell_h + 3, content_w - pad_x * 2, draw.cell_h, draw.accent, 0.18);
+        }
+        var listen_buf: [96]u8 = undefined;
+        var target_buf: [96]u8 = undefined;
+        _ = draw.renderTextLimited(statusLabel(item.status), x, row_y, draw.fg, 90);
+        _ = draw.renderTextLimited(directionLabel(item.rule.direction), x + 95, row_y, draw.fg, 80);
+        _ = draw.renderTextLimited(item.rule.profileName(), x + 180, row_y, draw.fg, 110);
+        _ = draw.renderTextLimited(listenLabel(&item.rule, &listen_buf), x + 295, row_y, draw.fg, 210);
+        _ = draw.renderTextLimited(targetLabel(&item.rule, &target_buf), x + 510, row_y, draw.fg, 210);
+        _ = draw.renderTextLimited(autoLabel(item.auto_start), x + 725, row_y, draw.fg, 55);
+        const display_name = if (item.rule.name().len > 0) item.rule.name() else item.reason;
+        _ = draw.renderTextLimited(display_name, x + 785, row_y, draw.fg, content_w - 800);
+    }
+
+    const legend_y = height - draw.cell_h * 1.2;
+    _ = draw.renderTextLimited(view.legend, x, legend_y, draw.fg, content_w - pad_x * 2);
+    if (view.overlay_text.len > 0) {
+        const box_w = @min(content_w - 80, 720);
+        const box_h = draw.cell_h * 3.0;
+        const box_x = left + (content_w - box_w) / 2;
+        const box_y = titlebar_offset + (height - titlebar_offset - box_h) / 2;
+        draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.bg, 0.92);
+        draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.accent, 0.20);
+        _ = draw.renderTextLimited(view.overlay_text, box_x + 18, box_y + draw.cell_h * 1.8, draw.fg, box_w - 36);
+    }
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+zig test src/renderer/port_forwarding_renderer.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add renderer to fast suite**
+
+In `src/test_fast.zig`, add:
+
+```zig
+    _ = @import("renderer/port_forwarding_renderer.zig");
+```
+
+after the Skill Center renderer import.
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/port_forwarding_renderer.zig src/test_fast.zig
+git commit -m "feat(port-forward): add management renderer"
+```
+
+---
+
+### Task 7: App-Owned Manager Lifecycle
+
+**Files:**
+- Modify: `src/port_forward_manager.zig`
+- Modify: `src/App.zig`
+- Test: `src/port_forward_manager.zig`
+
+- [ ] **Step 1: Add failing tests for load/save path helpers**
+
+Append to `src/port_forward_manager.zig`:
+
+```zig
+test "port_forward_manager: save and load from explicit path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp.dir.realpath(".", &dir_buf);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "rules.txt" });
+    defer std.testing.allocator.free(path);
+
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    manager.setStoragePathForTest(path);
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expect(manager.save());
+
+    var loaded = Manager.init(std.testing.allocator);
+    defer loaded.deinit();
+    loaded.setStoragePathForTest(path);
+    try std.testing.expect(loaded.load());
+    try std.testing.expectEqual(@as(usize, 1), loaded.count());
+}
+```
+
+- [ ] **Step 2: Run focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: FAIL with undefined methods `setStoragePathForTest`, `save`, and `load`.
+
+- [ ] **Step 3: Add storage path support**
+
+Add to `Manager` fields:
+
+```zig
+    storage_path: ?[]u8 = null,
+```
+
+Update `deinit`:
+
+```zig
+        if (self.storage_path) |p| self.allocator.free(p);
+```
+
+Add methods:
+
+```zig
+    pub fn setStoragePath(self: *Manager, path: []const u8) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.storage_path) |old| self.allocator.free(old);
+        self.storage_path = try self.allocator.dupe(u8, path);
+    }
+
+    pub fn setStoragePathForTest(self: *Manager, path: []const u8) void {
+        self.setStoragePath(path) catch unreachable;
+    }
+
+    pub fn load(self: *Manager) !bool {
+        const path = self.storage_path orelse return false;
+        const content = std.fs.cwd().readFileAlloc(self.allocator, path, 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        defer self.allocator.free(content);
+        try self.loadFromContent(content);
+        return true;
+    }
+
+    pub fn save(self: *Manager) bool {
+        const path = self.storage_path orelse return false;
+        if (std.fs.path.dirname(path)) |dir| {
+            std.fs.cwd().makePath(dir) catch return false;
+        }
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        defer out.deinit(self.allocator);
+        self.encode(self.allocator, &out) catch return false;
+        const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
+        defer file.close();
+        file.writeAll(out.items) catch return false;
+        return true;
+    }
+```
+
+- [ ] **Step 4: Run manager tests**
+
+Run:
+
+```bash
+zig test src/port_forward_manager.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire manager into App**
+
+In `src/App.zig`, add imports:
+
+```zig
+const port_forward_manager = @import("port_forward_manager.zig");
+```
+
+Add field after `weixin_controller`:
+
+```zig
+port_forward_manager: port_forward_manager.Manager,
+```
+
+In `App.init`, before `var app = App{`, create and load the manager:
+
+```zig
+    var forward_manager = port_forward_manager.Manager.init(allocator);
+    errdefer forward_manager.deinit();
+    if (platform_dirs.pathInConfigDir(allocator, "port_forwards")) |forward_path| {
+        defer allocator.free(forward_path);
+        forward_manager.setStoragePath(forward_path) catch {};
+        _ = forward_manager.load() catch |err| blk: {
+            std.debug.print("Port forwarding rules not loaded: {}\n", .{err});
+            break :blk false;
+        };
+        forward_manager.startAuto(cfg.@"ssh-legacy-algorithms");
+    } else |err| {
+        std.debug.print("Port forwarding storage unavailable: {}\n", .{err});
+    }
+```
+
+Add the field in the `App{}` literal:
+
+```zig
+        .port_forward_manager = forward_manager,
+```
+
+In `App.deinit`, before freeing owned strings:
+
+```zig
+    self.port_forward_manager.deinit();
+```
+
+- [ ] **Step 6: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/port_forward_manager.zig src/App.zig
+git commit -m "feat(port-forward): load app-level rules"
+```
+
+---
+
+### Task 8: Tab Kind, AppWindow Rendering, And Manager Actions
+
+**Files:**
+- Modify: `src/appwindow/tab.zig`
+- Modify: `src/AppWindow.zig`
+- Modify: `src/test_main.zig`
+- Test: `zig build test-full`
+
+- [ ] **Step 1: Add imports and tab fields**
+
+In `src/appwindow/tab.zig`, add:
+
+```zig
+const port_forwarding = @import("../port_forwarding.zig");
+```
+
+Add field to `TabState`:
+
+```zig
+    port_forwarding_session: ?*port_forwarding.Session = null,
+```
+
+Add enum value:
+
+```zig
+        port_forwarding,
+```
+
+Update `getTitle`:
+
+```zig
+        if (self.kind == .port_forwarding) {
+            return i18n.s().pf_title;
+        }
+```
+
+Update `deinit` switch:
+
+```zig
+            .port_forwarding => {
+                if (self.port_forwarding_session) |session| {
+                    session.destroy();
+                    self.port_forwarding_session = null;
+                }
+            },
+```
+
+Set `port_forwarding_session = null` in existing tab constructors, and set other session pointers to null in the new constructor below.
+
+- [ ] **Step 2: Add tab spawn/accessor functions**
+
+Add after `spawnSkillCenterTab`:
+
+```zig
+pub fn spawnPortForwardingTab(allocator: std.mem.Allocator) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+    const session_ptr = port_forwarding.Session.create(allocator) catch return false;
+
+    const t = allocator.create(TabState) catch {
+        session_ptr.destroy();
+        return false;
+    };
+    t.kind = .port_forwarding;
+    t.tree = .empty;
+    t.focused = .root;
+    t.ai_chat_session = null;
+    t.ai_history_session = null;
+    t.skill_center_session = null;
+    t.port_forwarding_session = session_ptr;
+    t.copilot_session = null;
+    t.copilot_visible = false;
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+    return true;
+}
+
+pub fn activePortForwarding() ?*port_forwarding.Session {
+    const t = activeTab() orelse return null;
+    if (t.kind != .port_forwarding) return null;
+    return t.port_forwarding_session;
+}
+```
+
+Update `applyRestoredTabMetadata` switch with `.port_forwarding => {}`.
+
+- [ ] **Step 3: Wire AppWindow imports and active helper**
+
+In `src/AppWindow.zig`, add imports near Skill Center:
+
+```zig
+pub const port_forwarding = @import("port_forwarding.zig");
+pub const port_forwarding_renderer = @import("renderer/port_forwarding_renderer.zig");
+```
+
+Add:
+
+```zig
+pub fn activePortForwarding() ?*port_forwarding.Session {
+    return tab.activePortForwarding();
+}
+```
+
+- [ ] **Step 4: Add renderer callback and frame renderer**
+
+Add near Skill Center renderer helpers:
+
+```zig
+fn pfRowAt(ctx: *anyopaque, i: usize) port_forward_manager.RowView {
+    const manager: *port_forward_manager.Manager = @ptrCast(@alignCast(ctx));
+    return manager.rowAt(i) orelse .{
+        .rule = port_forward_rule.defaultReverseProxy(""),
+        .status = .stopped,
+        .reason = "",
+        .auto_start = false,
+    };
+}
+
+fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
+    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
+    gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    clearWithBackground(fb_width, fb_height);
+    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
+    file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    const session = active_tab.port_forwarding_session orelse return;
+    const app = g_app orelse return;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const row_count = app.port_forward_manager.count();
+    session.model.move(0, row_count);
+    const draw: port_forwarding_renderer.DrawContext = .{
+        .bg = g_theme.background,
+        .fg = g_theme.foreground,
+        .accent = g_theme.cursor_color,
+        .cell_h = font.g_titlebar_cell_height,
+        .fillQuad = ui_pipeline.fillQuad,
+        .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
+        .renderTextLimited = titlebar.renderTextLimited,
+        .glyphAdvance = titlebar.titlebarGlyphAdvance,
+    };
+    const overlay_text = switch (session.model.overlay) {
+        .none, .form => "",
+        .confirm_delete => |*c| c.text,
+    };
+    const view: port_forwarding_renderer.View = .{
+        .title = i18n.s().pf_title,
+        .legend = i18n.s().pf_legend,
+        .row_count = row_count,
+        .selected = session.model.sel_row,
+        .scroll = session.model.scroll,
+        .ctx = @ptrCast(&app.port_forward_manager),
+        .rowAt = pfRowAt,
+        .overlay_text = overlay_text,
+    };
+    port_forwarding_renderer.render(
+        draw,
+        view,
+        @floatFromInt(fb_width),
+        @floatFromInt(fb_height),
+        titlebar_offset,
+        left_panels_w,
+        aiHistoryContentWidth(fb_width, left_panels_w, right_panels_w),
+    );
+}
+```
+
+Add missing imports:
+
+```zig
+const port_forward_manager = @import("port_forward_manager.zig");
+const port_forward_rule = @import("port_forward_rule.zig");
+```
+
+- [ ] **Step 5: Add AppWindow spawn and action wrappers**
+
+Add near `spawnSkillCenterTab`:
+
+```zig
+pub fn spawnPortForwardingTab() bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.spawnPortForwardingTab(allocator)) return false;
+    clearUiStateOnTabChange();
+    markUiDirty();
+    return true;
+}
+
+fn activePortForwardManager() ?*port_forward_manager.Manager {
+    const app = g_app orelse return null;
+    return &app.port_forward_manager;
+}
+
+pub fn portForwardingMove(delta: isize) bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.move(delta, manager.count());
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingToggleSelected() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    const app = g_app orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+    const ok = switch (row.status) {
+        .running, .starting => manager.stopIndex(idx),
+        else => manager.startIndex(idx, app.ssh_legacy_algorithms),
+    };
+    markUiDirty();
+    return ok;
+}
+
+pub fn portForwardingRestartSelected() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    const app = g_app orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const ok = manager.restartIndex(idx, app.ssh_legacy_algorithms);
+    markUiDirty();
+    return ok;
+}
+
+pub fn portForwardingToggleAutoStart() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const ok = manager.toggleAutoStart(idx);
+    if (ok) _ = manager.save();
+    markUiDirty();
+    return ok;
+}
+```
+
+- [ ] **Step 6: Render the new tab kind and tick manager**
+
+In both render switch locations that currently handle `.skill_center`, add:
+
+```zig
+            } else if (active_tab.kind == .port_forwarding) {
+                renderPortForwardingFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+```
+
+In the main loop near `pollSkillCenterOp`, add:
+
+```zig
+        if (self.app.port_forward_manager.tick()) {
+            if (activePortForwarding() != null) {
+                g_force_rebuild = true;
+                g_cells_valid = false;
+            }
+        }
+```
+
+- [ ] **Step 7: Import new modules in test_main**
+
+In `src/test_main.zig`, add near Skill Center imports:
+
+```zig
+    _ = @import("port_forward_rule.zig");
+    _ = @import("ssh_profile_store.zig");
+    _ = @import("port_forward_manager.zig");
+    _ = @import("port_forwarding.zig");
+    _ = @import("renderer/port_forwarding_renderer.zig");
+```
+
+- [ ] **Step 8: Run full compile gate**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS. If the first run reports missing `TabState` field initializers, set `port_forwarding_session = null` in every existing `TabState` constructor, rerun `zig build test-full`, and proceed only after PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/appwindow/tab.zig src/AppWindow.zig src/test_main.zig
+git commit -m "feat(port-forward): add management tab"
+```
+
+---
+
+### Task 9: Command Center, I18n, And Input Routing
+
+**Files:**
+- Modify: `src/command_center_state.zig`
+- Modify: `src/i18n.zig`
+- Modify: `src/renderer/overlays.zig`
+- Modify: `src/input.zig`
+- Test: `src/command_center_state.zig`, `src/input.zig`, `zig build test-full`
+
+- [ ] **Step 1: Add failing command-center test**
+
+In `src/command_center_state.zig`, add enum value:
+
+```zig
+    open_port_forwarding,
+```
+
+Add command entry before Skill Center:
+
+```zig
+    .{ .title = "Port Forwarding", .detail = "Manage SSH port forwarding rules", .shortcut = "", .action = .open_port_forwarding },
+```
+
+Add test near the Skill Center test:
+
+```zig
+test "command center includes Port Forwarding action" {
+    try std.testing.expectEqual(CommandAction.open_port_forwarding, findCommandAction("Port Forwarding"));
+}
+```
+
+Run:
+
+```bash
+zig test src/command_center_state.zig
+```
+
+Expected: PASS after the enum and entry are present.
+
+- [ ] **Step 2: Add i18n fields**
+
+In `src/i18n.zig` `Strings`, add:
+
+```zig
+    pf_title: []const u8,
+    pf_detail: []const u8,
+    pf_legend: []const u8,
+```
+
+In English strings, add:
+
+```zig
+    .pf_title = "Port Forwarding",
+    .pf_detail = "Manage SSH port forwarding rules",
+    .pf_legend = "[n] new   [e] edit   [space] start/stop   [r] restart   [a] auto   [d] delete   [esc] close/cancel",
+```
+
+In Chinese strings, add:
+
+```zig
+    .pf_title = "端口转发",
+    .pf_detail = "管理 SSH 端口转发规则",
+    .pf_legend = "[n] 新建   [e] 编辑   [space] 启停   [r] 重启   [a] 自动启动   [d] 删除   [esc] 关闭/取消",
+```
+
+In `commandTitle`, add:
+
+```zig
+        .open_port_forwarding => "端口转发",
+```
+
+In `commandDetail`, add:
+
+```zig
+        .open_port_forwarding => "管理 SSH 端口转发规则",
+```
+
+- [ ] **Step 3: Wire command execution**
+
+In `src/renderer/overlays.zig` `executeCommand`, add:
+
+```zig
+        .open_port_forwarding => {
+            _ = AppWindow.spawnPortForwardingTab();
+        },
+```
+
+- [ ] **Step 4: Add input routing**
+
+In `src/input.zig` `handleChar`, before the Skill Center branch, add:
+
+```zig
+    if (AppWindow.activePortForwarding() != null) {
+        if (!ev.ctrl and !ev.alt and !ev.super) {
+            _ = AppWindow.portForwardingInsertChar(ev.codepoint);
+        }
+        return;
+    }
+```
+
+In `handleKey`, before the Skill Center branch, add:
+
+```zig
+    if (AppWindow.activePortForwarding() != null) {
+        const plain = !ev.ctrl and !ev.alt and !ev.super;
+        switch (ev.key_code) {
+            platform_input.key_up => {
+                _ = AppWindow.portForwardingMove(-1);
+                return;
+            },
+            platform_input.key_down => {
+                _ = AppWindow.portForwardingMove(1);
+                return;
+            },
+            platform_input.key_tab => {
+                _ = AppWindow.portForwardingFormMove(1);
+                return;
+            },
+            platform_input.key_enter => {
+                _ = AppWindow.portForwardingConfirmOrApply();
+                return;
+            },
+            platform_input.key_escape => {
+                _ = AppWindow.portForwardingCancelOrClose();
+                return;
+            },
+            platform_input.key_backspace => {
+                _ = AppWindow.portForwardingBackspace();
+                return;
+            },
+            platform_input.key_space => if (plain and !ev.shift) {
+                if (AppWindow.portForwardingFormToggle()) return;
+                _ = AppWindow.portForwardingToggleSelected();
+                return;
+            },
+            0x4E => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenNew();
+                return;
+            },
+            0x45 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenEdit();
+                return;
+            },
+            0x44 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenDeleteConfirm();
+                return;
+            },
+            0x52 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingRestartSelected();
+                return;
+            },
+            0x41 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingToggleAutoStart();
+                return;
+            },
+            else => {},
+        }
+        return;
+    }
+```
+
+- [ ] **Step 5: Add AppWindow form/delete wrappers**
+
+In `src/AppWindow.zig`, add:
+
+```zig
+pub fn portForwardingOpenNew() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openNewForm("") catch return false;
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingOpenEdit() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openEditForm(idx, row.rule);
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingOpenDeleteConfirm() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+    const label = if (row.rule.name().len > 0) row.rule.name() else row.rule.profileName();
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openDeleteConfirm(idx, label) catch return false;
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingConfirmOrApply() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    switch (session.model.overlay) {
+        .form => |form| {
+            if (!form.rule.validate()) return false;
+            const ok = switch (form.mode) {
+                .new => blk: {
+                    manager.addRule(form.rule) catch break :blk false;
+                    break :blk true;
+                },
+                .edit => if (form.edit_index) |idx| manager.updateRule(idx, form.rule) else false,
+            };
+            if (ok) {
+                _ = manager.save();
+                session.model.clearOverlay();
+                markUiDirty();
+            }
+            return ok;
+        },
+        .confirm_delete => |confirm| {
+            const ok = manager.deleteRule(confirm.index);
+            if (ok) {
+                _ = manager.save();
+                session.model.clearOverlay();
+                session.model.move(0, manager.count());
+                markUiDirty();
+            }
+            return ok;
+        },
+        .none => return false,
+    }
+}
+
+pub fn portForwardingCancelOrClose() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    const had_overlay = session.model.overlay != .none;
+    if (had_overlay) session.model.clearOverlay();
+    session.mutex.unlock();
+    if (had_overlay) {
+        markUiDirty();
+        return true;
+    }
+    input.closePanelOrTab();
+    return true;
+}
+
+pub fn portForwardingFormMove(delta: isize) bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.moveFocus(delta);
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingFormToggle() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.toggleFocused();
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingInsertChar(codepoint: u21) bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.insertChar(codepoint);
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingBackspace() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.backspace();
+    markUiDirty();
+    return true;
+}
+```
+
+- [ ] **Step 6: Add input dirty regression test**
+
+In `src/input.zig`, add a full-app test near the Skill Center dirty tests:
+
+```zig
+test "input: port forwarding arrow navigation requests a repaint" {
+    const allocator = std.testing.allocator;
+    if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
+    defer {
+        if (tab.g_tab_count > 0) tab.closeTab(tab.g_tab_count - 1, allocator);
+    }
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    const ev: platform_input.KeyEvent = .{ .key_code = platform_input.key_down };
+    handleKey(ev);
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
+}
+```
+
+- [ ] **Step 7: Run focused and full tests**
+
+Run:
+
+```bash
+zig test src/command_center_state.zig
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/command_center_state.zig src/i18n.zig src/renderer/overlays.zig src/input.zig src/AppWindow.zig
+git commit -m "feat(port-forward): wire command and input"
+```
+
+---
+
+### Task 10: Form Rendering Details
+
+**Files:**
+- Modify: `src/renderer/port_forwarding_renderer.zig`
+- Modify: `src/AppWindow.zig`
+- Test: `src/renderer/port_forwarding_renderer.zig`
+
+- [ ] **Step 1: Add failing form-label helper test**
+
+Append:
+
+```zig
+test "port_forwarding_renderer: form field labels" {
+    try std.testing.expectEqualStrings("Name", formFieldLabel(0));
+    try std.testing.expectEqualStrings("Profile", formFieldLabel(1));
+    try std.testing.expectEqualStrings("Direction", formFieldLabel(2));
+    try std.testing.expectEqualStrings("Local host", formFieldLabel(3));
+    try std.testing.expectEqualStrings("Local port", formFieldLabel(4));
+    try std.testing.expectEqualStrings("Remote host", formFieldLabel(5));
+    try std.testing.expectEqualStrings("Remote port", formFieldLabel(6));
+    try std.testing.expectEqualStrings("Auto start", formFieldLabel(7));
+    try std.testing.expectEqualStrings("", formFieldLabel(99));
+}
+```
+
+- [ ] **Step 2: Run focused test to verify it fails**
+
+Run:
+
+```bash
+zig test src/renderer/port_forwarding_renderer.zig
+```
+
+Expected: FAIL with undefined `formFieldLabel`.
+
+- [ ] **Step 3: Add form renderer view data**
+
+In `src/renderer/port_forwarding_renderer.zig`, add:
+
+```zig
+pub const FormView = struct {
+    mode: []const u8,
+    focus: usize,
+    rule: rule_mod.Rule,
+};
+
+pub fn formFieldLabel(index: usize) []const u8 {
+    return switch (index) {
+        0 => "Name",
+        1 => "Profile",
+        2 => "Direction",
+        3 => "Local host",
+        4 => "Local port",
+        5 => "Remote host",
+        6 => "Remote port",
+        7 => "Auto start",
+        else => "",
+    };
+}
+
+pub fn formFieldValue(form: FormView, index: usize, buf: []u8) []const u8 {
+    return switch (index) {
+        0 => form.rule.name(),
+        1 => form.rule.profileName(),
+        2 => directionLabel(form.rule.direction),
+        3 => form.rule.localHost(),
+        4 => std.fmt.bufPrint(buf, "{d}", .{form.rule.local_port}) catch "",
+        5 => form.rule.remoteHost(),
+        6 => std.fmt.bufPrint(buf, "{d}", .{form.rule.remote_port}) catch "",
+        7 => autoLabel(form.rule.auto_start),
+        else => "",
+    };
+}
+```
+
+Add optional `form: ?FormView = null` to `View`.
+
+Inside `render`, after the confirmation overlay block, draw the form when present:
+
+```zig
+    if (view.form) |form| {
+        const box_w = @min(content_w - 80, 720);
+        const box_h = draw.cell_h * 11.0;
+        const box_x = left + (content_w - box_w) / 2;
+        const box_y = titlebar_offset + (height - titlebar_offset - box_h) / 2;
+        draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.bg, 0.95);
+        draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.accent, 0.22);
+        _ = draw.renderTextLimited(form.mode, box_x + 18, box_y + draw.cell_h * 1.4, draw.fg, box_w - 36);
+        var field: usize = 0;
+        while (field < 8) : (field += 1) {
+            const row_y = box_y + draw.cell_h * @as(f32, @floatFromInt(field + 3));
+            if (field == form.focus) {
+                draw.fillQuadAlpha(box_x + 12, row_y - draw.cell_h + 3, box_w - 24, draw.cell_h, draw.accent, 0.20);
+            }
+            var value_buf: [32]u8 = undefined;
+            _ = draw.renderTextLimited(formFieldLabel(field), box_x + 22, row_y, draw.accent, 160);
+            _ = draw.renderTextLimited(formFieldValue(form, field, &value_buf), box_x + 190, row_y, draw.fg, box_w - 220);
+        }
+    }
+```
+
+- [ ] **Step 4: Pass form data from AppWindow**
+
+In `renderPortForwardingFrame`, compute:
+
+```zig
+    const form_view: ?port_forwarding_renderer.FormView = switch (session.model.overlay) {
+        .form => |form| .{
+            .mode = if (form.mode == .new) "New forwarding rule" else "Edit forwarding rule",
+            .focus = form.focus,
+            .rule = form.rule,
+        },
+        else => null,
+    };
+```
+
+Add `.form = form_view,` to the `View` literal.
+
+- [ ] **Step 5: Run focused and full tests**
+
+Run:
+
+```bash
+zig test src/renderer/port_forwarding_renderer.zig
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/port_forwarding_renderer.zig src/AppWindow.zig
+git commit -m "feat(port-forward): render rule form"
+```
+
+---
+
+### Task 11: Preserve Existing SSH Profile And URL Tunnel Behavior
+
+**Files:**
+- Modify: `src/test_main.zig`
+- Test: `zig build test-full`
+
+- [ ] **Step 1: Add source-guard tests**
+
+In `src/test_main.zig`, add tests after the existing source-guard tests:
+
+```zig
+test "port forwarding does not extend ssh_hosts profile schema" {
+    const profile_source = @embedFile("renderer/overlays/profile_codec.zig");
+    try std.testing.expect(std.mem.indexOf(u8, profile_source, "pub const SSH_FIELD_COUNT = 6") != null);
+    try std.testing.expect(std.mem.indexOf(u8, profile_source, "port_forward") == null);
+}
+
+test "existing ssh_tunnel remains URL-driven local forwarding" {
+    const tunnel_source = @embedFile("ssh_tunnel.zig");
+    try std.testing.expect(std.mem.indexOf(u8, tunnel_source, "\"-L\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, tunnel_source, "\"-R\"") == null);
+}
+```
+
+- [ ] **Step 2: Run full tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/test_main.zig
+git commit -m "test(port-forward): guard existing ssh surfaces"
+```
+
+---
+
+### Task 12: Documentation And Manual Verification Notes
+
+**Files:**
+- Create: `docs/port-forwarding.md`
+- Modify: `README.md`
+- Test: markdown review, Windows manual checks
+
+- [ ] **Step 1: Add feature documentation**
+
+Create `docs/port-forwarding.md`:
+
+```markdown
+# Port Forwarding
+
+Open **Port Forwarding** from the command center to manage silent SSH forwarding
+rules. Rules are global and bind to saved SSH profiles. Closing the management
+tab does not stop running forwarding helpers.
+
+## Reverse Forwarding
+
+Reverse forwarding lets a server use a local port on your workstation. The
+common proxy/VPN rule is:
+
+```text
+Reverse: server 127.0.0.1:7890 -> local 127.0.0.1:7890
+```
+
+On the server:
+
+```sh
+export HTTP_PROXY=http://127.0.0.1:7890
+export HTTPS_PROXY=http://127.0.0.1:7890
+```
+
+## Local Forwarding
+
+Local forwarding lets a local browser or service use a loopback service on the
+server:
+
+```text
+Local: local 127.0.0.1:8888 -> server 127.0.0.1:8888
+```
+
+## Safety Boundary
+
+v1 only supports loopback hosts (`127.0.0.1` and `localhost`). It does not bind
+`0.0.0.0` or other non-loopback addresses.
+
+## SSH Compatibility
+
+WispTerm starts independent OpenSSH helper processes and does not use
+ControlMaster, ControlPersist, or ControlPath for forwarding helpers.
+```
+
+- [ ] **Step 2: Link docs from README**
+
+In `README.md`, add a feature bullet near the embedded browser/SSH bullets:
+
+```markdown
+- **SSH port forwarding manager** - silently manage local and reverse SSH forwarding rules from a dedicated tab
+```
+
+Add a docs link near the other docs links:
+
+```markdown
+- [SSH port forwarding](docs/port-forwarding.md)
+```
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/port-forwarding.md
+git commit -m "docs(port-forward): document forwarding manager"
+```
+
+---
+
+### Task 13: Final Verification Gates
+
+**Files:**
+- No source edits expected unless a verification failure points to a bug.
+
+- [ ] **Step 1: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run focused module tests**
+
+Run:
+
+```bash
+zig test src/port_forward_rule.zig
+zig test src/ssh_profile_store.zig
+zig test src/port_forward_manager.zig
+zig test src/port_forwarding.zig
+zig test src/renderer/port_forwarding_renderer.zig
+```
+
+Expected: PASS for all five commands.
+
+- [ ] **Step 4: Run Windows checkout-safety checks in PowerShell**
+
+Run on Windows PowerShell:
+
+```powershell
+$paths = git ls-files
+$reserved = @('CON', 'PRN', 'AUX', 'NUL') + (1..9 | ForEach-Object { "COM$_"; "LPT$_" })
+$violations = [System.Collections.Generic.List[object]]::new()
+$collisions = [System.Collections.Generic.List[object]]::new()
+$seen = @{}
+
+foreach ($path in $paths) {
+    foreach ($part in ($path -split '/')) {
+        $stem = ($part -split '\.')[0].ToUpperInvariant()
+        $reasons = @()
+        if ($part.IndexOfAny([char[]]'<>:"\|?*') -ge 0) { $reasons += 'illegal_char' }
+        if ($part.EndsWith(' ') -or $part.EndsWith('.')) { $reasons += 'trailing_space_or_dot' }
+        if ($reserved -contains $stem) { $reasons += 'reserved_name' }
+        if ($reasons.Count -gt 0) {
+            $violations.Add([pscustomobject]@{ Path = $path; Part = $part; Reasons = ($reasons -join ',') })
+        }
+    }
+
+    $key = $path.ToLowerInvariant()
+    if ($seen.ContainsKey($key) -and $seen[$key] -ne $path) {
+        $collisions.Add([pscustomobject]@{ A = $seen[$key]; B = $path })
+    } else {
+        $seen[$key] = $path
+    }
+}
+
+"tracked_files=$($paths.Count)"
+"windows_name_violations=$($violations.Count)"
+$violations | ForEach-Object { "violation`t$($_.Path)`t$($_.Part)`t$($_.Reasons)" }
+"casefold_collisions=$($collisions.Count)"
+$collisions | ForEach-Object { "collision`t$($_.A)`t$($_.B)" }
+$longest = $paths | Sort-Object Length -Descending | Select-Object -First 1
+"max_path_length=$($longest.Length) $longest"
+git ls-files -s | Select-String '^120000'
+```
+
+Expected: `windows_name_violations=0`, `casefold_collisions=0`, and no symlink output.
+
+- [ ] **Step 5: Manual Windows reverse forwarding check**
+
+Use a saved SSH profile with access to a server and a local proxy on `127.0.0.1:7890`.
+
+1. Open WispTerm.
+2. Open Command Center -> `Port Forwarding`.
+3. Create a reverse rule:
+
+```text
+Profile: devbox
+Direction: Reverse
+Remote host: 127.0.0.1
+Remote port: 7890
+Local host: 127.0.0.1
+Local port: 7890
+Auto start: On
+Name: Local proxy
+```
+
+4. Start the rule with Space.
+5. On the server, run:
+
+```sh
+curl -I -x http://127.0.0.1:7890 https://github.com
+```
+
+Expected: curl reaches GitHub through the local proxy, or any proxy-specific authentication error is from the local proxy rather than SSH forwarding.
+
+- [ ] **Step 6: Manual Windows local forwarding check**
+
+1. On the server, start a loopback HTTP service:
+
+```sh
+python3 -m http.server 8888 --bind 127.0.0.1
+```
+
+2. In WispTerm Port Forwarding, create:
+
+```text
+Profile: devbox
+Direction: Local
+Local host: 127.0.0.1
+Local port: 8888
+Remote host: 127.0.0.1
+Remote port: 8888
+Auto start: Off
+Name: Remote HTTP
+```
+
+3. Start the rule.
+4. Open `http://127.0.0.1:8888` in the local browser.
+
+Expected: the browser shows the server directory listing.
+
+- [ ] **Step 7: Manual compatibility checks**
+
+Check:
+
+- Password profile starts without printing the password.
+- ProxyJump profile starts with the same jump host as the SSH profile.
+- A failed remote bind shows an `Error` row and leaves useful OpenSSH stderr in the debug console.
+- No helper command contains `ControlMaster`, `ControlPersist`, or `ControlPath`.
+
+- [ ] **Step 8: Final commit if verification required fixes**
+
+If any verification step required code changes:
+
+```bash
+git add src README.md docs
+git commit -m "fix(port-forward): address verification findings"
+```
+
+If no changes were needed, do not create an empty commit.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Dedicated tab: Tasks 5, 6, 8, 9.
+  - Global rules and auto-start: Tasks 3, 4, 7.
+  - `-L` and `-R`: Tasks 1, 4, 13.
+  - Separate storage from SSH profiles: Tasks 1, 7, 11.
+  - Existing SSH profile page untouched: Tasks 2, 11.
+  - Loopback-only v1: Tasks 1, 12.
+  - No OpenSSH connection sharing: Tasks 4, 13.
+  - Existing URL-click `ssh_tunnel.zig` unchanged: Task 11.
+- Ghostty comparison included in plan header and architecture.
+- No `remote/` work is included.
+- Keyboard shortcut README rule is not triggered because no application shortcut binding is added; only tab-local keys are introduced.
+- Full app input dirty rule is covered by Task 9's `input.zig` regression test.

--- a/docs/superpowers/specs/2026-06-09-port-forwarding-design.md
+++ b/docs/superpowers/specs/2026-06-09-port-forwarding-design.md
@@ -1,0 +1,320 @@
+# Port Forwarding Design
+
+## Summary
+
+Add a silent SSH port-forwarding manager to WispTerm. The feature opens as a
+dedicated non-terminal tab, similar to Skill Center, and manages a global list of
+rules bound to saved SSH profiles. Rules run in the background even when the
+management tab is closed.
+
+The primary use case is reverse forwarding a local proxy/VPN endpoint to a
+server:
+
+```text
+Reverse (-R): server 127.0.0.1:7890 -> local 127.0.0.1:7890
+```
+
+The secondary use case is regular local forwarding for remote development
+services:
+
+```text
+Local (-L): local 127.0.0.1:8888 -> server 127.0.0.1:8888
+```
+
+## Context
+
+Issue #177 asks for tunnel and port-forwarding support in both directions:
+
+- Remote service -> local browser or local service.
+- Local VPN/proxy -> remote server, so the server can use a local port such as
+  `127.0.0.1:7890`.
+
+WispTerm already has automatic local loopback forwarding in `src/ssh_tunnel.zig`
+for URLs clicked/opened from SSH profile sessions. That path is URL-driven and
+only creates `ssh -L` tunnels. It is intentionally separate from this design:
+existing URL click behavior should not change.
+
+Ghostty comparison: Ghostty does not provide a port-forwarding management page.
+Its SSH integration wraps OpenSSH through `ghostty +ssh` for shell integration,
+environment forwarding, and terminfo installation. WispTerm should follow the
+same general principle here: use OpenSSH helper processes for forwarding rather
+than implementing the SSH protocol in the terminal core.
+
+## Goals
+
+- Provide a dedicated `Port Forwarding` tab opened from the Command Center.
+- Keep forwarding silent and background-driven.
+- Store forwarding rules separately from SSH profiles.
+- Do not change the existing SSH profile configuration page.
+- Support both `local` (`ssh -L`) and `reverse` (`ssh -R`) rules.
+- Allow `enabled && auto_start` rules to start when WispTerm starts.
+- Reuse saved SSH profile metadata, including password auth and ProxyJump.
+- Keep Windows OpenSSH compatibility: no ControlMaster/ControlPersist/ControlPath.
+- Keep OpenSSH stderr useful for diagnosis.
+
+## Non-Goals
+
+- No `0.0.0.0` or non-loopback listener support in v1.
+- No automatic reconnect loop in v1.
+- No traffic counters or bandwidth graphs.
+- No changes to `remote/` web console.
+- No changes to existing SSH profile form fields or `ssh_hosts` schema.
+- No changes to URL-click automatic `-L` forwarding.
+
+## Rule Model
+
+Rules are stored in a new file under the platform config directory:
+
+```text
+<config>/port_forwards
+```
+
+Each rule owns:
+
+```text
+name
+profile_name
+direction = local | reverse
+local_host
+local_port
+remote_host
+remote_port
+enabled
+auto_start
+```
+
+Direction semantics:
+
+```text
+local   (-L): local_host:local_port   -> remote_host:remote_port
+reverse (-R): remote_host:remote_port -> local_host:local_port
+```
+
+Default new rule values should bias toward the issue #177 proxy use case:
+
+```text
+direction = reverse
+remote_host = 127.0.0.1
+remote_port = 7890
+local_host = 127.0.0.1
+local_port = 7890
+enabled = true
+auto_start = true
+```
+
+Validation:
+
+- `profile_name` must resolve to a saved SSH profile at start time.
+- `direction` must be `local` or `reverse`.
+- Ports must be `1..65535`.
+- Hosts must be `127.0.0.1` or `localhost` in v1.
+- Rule names may be empty; the UI can synthesize a display label from direction
+  and ports.
+
+The storage codec should be a pure, unit-tested module. The exact on-disk format
+can be either line-oriented key/value blocks or tab-separated encoded fields,
+but it must be independent from `ssh_hosts`.
+
+## User Interface
+
+Add a Command Center entry:
+
+```text
+Port Forwarding
+Manage SSH port forwarding rules
+```
+
+Opening it creates/selects a dedicated non-terminal tab, similar to Skill
+Center. It should have its own tab kind, model, renderer, and input branch.
+
+The main view is a compact table:
+
+```text
+Status   Dir       Profile   Listen                 Target                  Auto   Name
+Running  Reverse   devbox    remote 127.0.0.1:7890  local 127.0.0.1:7890   On     Local proxy
+Stopped  Local     lab       local 127.0.0.1:8888   remote 127.0.0.1:8888  Off    Jupyter
+Error    Reverse   gpu       remote 127.0.0.1:7890  local 127.0.0.1:7890   On     Proxy
+```
+
+Keyboard behavior:
+
+```text
+Up/Down   Move selection
+n         New rule
+e         Edit selected rule
+d         Delete selected rule, with confirmation
+Space     Start/stop selected rule
+r         Restart selected rule
+a         Toggle auto_start
+Esc       Close tab, or cancel the active form/confirmation
+```
+
+New/edit uses an in-tab form or overlay, not the SSH profile page. The form
+fields are:
+
+- Profile
+- Direction
+- Local host
+- Local port
+- Remote host
+- Remote port
+- Auto start
+- Name
+
+The profile picker reads existing SSH profiles as references only. It must not
+modify profile data.
+
+## Runtime
+
+Add a `port_forward_manager` that owns loaded rules and active helper children.
+It is process-global app state, not per terminal surface state. The management
+tab displays and mutates the manager state, but closing the tab does not stop
+active rules.
+
+Application startup:
+
+```text
+load port_forwards
+for each enabled && auto_start rule:
+  start silently
+  if start fails, record status; do not block startup
+```
+
+Application shutdown:
+
+```text
+stop all active forwarding helper children
+```
+
+Command shapes:
+
+```text
+Local:
+ssh -N -T -L local_host:local_port:remote_host:remote_port user@host
+
+Reverse:
+ssh -N -T -R remote_host:remote_port:local_host:local_port user@host
+```
+
+OpenSSH options should match existing tunnel practice:
+
+```text
+-o ExitOnForwardFailure=yes
+-o StrictHostKeyChecking=accept-new
+-o ConnectTimeout=8
+-o ServerAliveInterval=60
+-o ServerAliveCountMax=3
+```
+
+Authentication:
+
+- Password profiles reuse the existing askpass helper path.
+- Key-based profiles use batch mode.
+- ProxyJump is forwarded from the saved SSH profile.
+- Existing legacy algorithm settings are respected.
+
+Compatibility:
+
+- Do not add ControlMaster, ControlPersist, or ControlPath.
+- Keep helper stderr available and parse/summarize it for the management UI.
+
+## Status Model
+
+Each rule has a runtime state independent from its persisted fields:
+
+```text
+stopped
+starting
+running
+error(reason)
+missing_profile
+```
+
+The manager should prune/check active children during the app loop or via the
+same polling style used by other app-level background state. If a child exits,
+the state becomes `error(exited)` or a more specific parsed reason.
+
+v1 does not auto-reconnect. `auto_start` only means "start this rule when the app
+starts." Users can manually start or restart from the tab.
+
+## Error Handling
+
+Silent behavior is the default:
+
+- Startup failures update rule state without blocking the app.
+- The tab shows `Error` plus a short reason.
+- Manual start/restart failures may also show a non-blocking toast.
+
+Examples of useful reasons:
+
+```text
+profile missing
+local port unavailable
+remote bind failed
+ssh authentication failed
+ssh exited
+```
+
+Raw stderr should remain visible in debug output or be retained in the rule's
+detail view so users can diagnose real OpenSSH failures.
+
+## Implementation Shape
+
+Expected modules:
+
+- `src/port_forward_rule.zig`: pure rule model, validation, storage codec, argv
+  spec helpers.
+- `src/port_forward_manager.zig`: active rule state, child lifecycle, start/stop,
+  profile resolution callbacks.
+- `src/renderer/port_forwarding_renderer.zig`: table/form renderer.
+- `AppWindow.zig`: app-global manager lifecycle, startup auto-start, polling,
+  tab spawning, command center action.
+- `appwindow/tab.zig`: new tab kind/session storage for Port Forwarding.
+- `input.zig`: key routing for the Port Forwarding tab, including render dirty
+  flags after consumed UI mutations.
+- `command_center_state.zig` and `i18n.zig`: command center entry and labels.
+
+The Skill Center pattern is the preferred local reference for tab/model/renderer
+separation. The existing `ssh_tunnel.zig` helper is the preferred reference for
+OpenSSH child options, askpass handling, ProxyJump handling, and child cleanup.
+
+## Testing
+
+Fast tests:
+
+- Rule parse/serialize round trips.
+- Validation accepts only loopback hosts and valid ports.
+- Local `-L` argv spec is correct.
+- Reverse `-R` argv spec is correct.
+- ProxyJump and profile port are included.
+- Password mode includes askpass behavior; key mode uses batch behavior.
+- No ControlMaster/ControlPersist/ControlPath strings appear in helper argv.
+- Status transitions for start success, spawn failure, child exit, missing
+  profile.
+
+Full app tests:
+
+- Command Center includes `Port Forwarding`.
+- `spawnPortForwardingTab()` creates/selects the new non-terminal tab kind.
+- Port Forwarding input handlers dirty the UI after navigation, form edits,
+  start/stop, restart, auto-toggle, and confirmation changes.
+- Existing SSH profile codec/page behavior is unchanged.
+- Existing URL-click SSH tunnel behavior is unchanged.
+
+Manual Windows verification:
+
+- Reverse rule: server `127.0.0.1:7890` reaches local `127.0.0.1:7890`.
+- Local rule: local browser reaches a remote loopback HTTP/Jupyter service.
+- Password profile works without printing the password.
+- ProxyJump profile works.
+- OpenSSH stderr remains useful on failure.
+- No OpenSSH connection sharing options are used.
+
+## Approved Constraints
+
+- Forwarding is silent.
+- Management lives in a dedicated tab similar to Skill Center.
+- Existing SSH profile configuration page is not changed.
+- Rules are global and bind to saved SSH profiles.
+- Auto-start rules do not require an interactive SSH terminal tab to be open.
+- v1 supports both local and reverse directions.

--- a/src/App.zig
+++ b/src/App.zig
@@ -200,24 +200,6 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
     errdefer allocator.free(ai_agent_working_dir);
     const jina_api_key = try dupeStr(allocator, cfg.@"jina-api-key");
     errdefer allocator.free(jina_api_key);
-    var forward_manager = port_forward_manager_mod.Manager.init(allocator);
-    errdefer forward_manager.deinit();
-    if (platform_dirs.pathInConfigDir(allocator, "port_forwards")) |path| {
-        defer allocator.free(path);
-        forward_manager.setStoragePath(path) catch |err| {
-            std.debug.print("Port forwarding storage disabled: {}\n", .{err});
-        };
-        if (forward_manager.load()) |loaded| {
-            if (loaded) {
-                std.debug.print("Port forwarding rules loaded from {s}\n", .{path});
-            }
-        } else |err| {
-            std.debug.print("Port forwarding rules load failed: {}\n", .{err});
-        }
-    } else |err| {
-        std.debug.print("Port forwarding storage unavailable: {}\n", .{err});
-    }
-    forward_manager.startAuto(cfg.@"ssh-legacy-algorithms");
 
     var app = App{
         .allocator = allocator,
@@ -263,7 +245,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .remote_client = remote_client_ptr,
         // Created later by startWeixin(), once App lives at a stable address.
         .weixin_controller = null,
-        .port_forward_manager = forward_manager,
+        .port_forward_manager = port_forward_manager_mod.Manager.init(allocator),
         .ai_agent_enabled = cfg.@"ai-agent-enabled",
         .ai_agent_permission = cfg.@"ai-agent-permission",
         .ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
@@ -331,6 +313,30 @@ fn startRemoteClient(
         std.debug.print("Remote client disabled: {}\n", .{err});
         return null;
     };
+}
+
+/// Load app-owned SSH forwarding rules and start enabled auto-start entries.
+/// Call after `App.init` returns and the App value is at its final address; the
+/// manager contains a mutex and child handles, so it should not be used before
+/// the App has settled.
+pub fn startPortForwarding(self: *App, cfg: *const Config) void {
+    if (platform_dirs.pathInConfigDir(self.allocator, "port_forwards")) |path| {
+        defer self.allocator.free(path);
+        self.port_forward_manager.setStoragePath(path) catch |err| {
+            std.debug.print("Port forwarding storage disabled: {}\n", .{err});
+            return;
+        };
+        if (self.port_forward_manager.load()) |loaded| {
+            if (loaded) {
+                std.debug.print("Port forwarding rules loaded from {s}\n", .{path});
+            }
+        } else |err| {
+            std.debug.print("Port forwarding rules load failed: {}\n", .{err});
+        }
+        self.port_forward_manager.startAuto(cfg.@"ssh-legacy-algorithms");
+    } else |err| {
+        std.debug.print("Port forwarding storage unavailable: {}\n", .{err});
+    }
 }
 
 // WeChat direct (embedded ilink). App owns the controller's lifecycle; the

--- a/src/App.zig
+++ b/src/App.zig
@@ -20,6 +20,7 @@ const window_backend = @import("platform/window_backend.zig");
 const remote = @import("remote_client.zig");
 const weixin = @import("weixin/controller.zig");
 const weixin_types = @import("weixin/types.zig");
+const port_forward_manager_mod = @import("port_forward_manager.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_open_url = @import("platform/open_url.zig");
 const update_check = @import("update_check.zig");
@@ -96,6 +97,8 @@ remote_client: ?*remote.Client,
 
 // WeChat direct (embedded ilink). Independent from the remote relay client.
 weixin_controller: ?*weixin.Controller,
+
+port_forward_manager: port_forward_manager_mod.Manager,
 
 // AI agent config
 ai_agent_enabled: bool,
@@ -197,6 +200,24 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
     errdefer allocator.free(ai_agent_working_dir);
     const jina_api_key = try dupeStr(allocator, cfg.@"jina-api-key");
     errdefer allocator.free(jina_api_key);
+    var forward_manager = port_forward_manager_mod.Manager.init(allocator);
+    errdefer forward_manager.deinit();
+    if (platform_dirs.pathInConfigDir(allocator, "port_forwards")) |path| {
+        defer allocator.free(path);
+        forward_manager.setStoragePath(path) catch |err| {
+            std.debug.print("Port forwarding storage disabled: {}\n", .{err});
+        };
+        if (forward_manager.load()) |loaded| {
+            if (loaded) {
+                std.debug.print("Port forwarding rules loaded from {s}\n", .{path});
+            }
+        } else |err| {
+            std.debug.print("Port forwarding rules load failed: {}\n", .{err});
+        }
+    } else |err| {
+        std.debug.print("Port forwarding storage unavailable: {}\n", .{err});
+    }
+    forward_manager.startAuto(cfg.@"ssh-legacy-algorithms");
 
     var app = App{
         .allocator = allocator,
@@ -242,6 +263,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .remote_client = remote_client_ptr,
         // Created later by startWeixin(), once App lives at a stable address.
         .weixin_controller = null,
+        .port_forward_manager = forward_manager,
         .ai_agent_enabled = cfg.@"ai-agent-enabled",
         .ai_agent_permission = cfg.@"ai-agent-permission",
         .ai_agent_command_timeout_ms = cfg.@"ai-agent-command-timeout-ms",
@@ -1052,6 +1074,8 @@ pub fn deinit(self: *App) void {
         }
         self.weixin_controller = null;
     }
+
+    self.port_forward_manager.deinit();
 
     // Free owned string copies
     self.allocator.free(self.font_family);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1108,6 +1108,23 @@ pub fn activePortForwarding() ?*port_forwarding.Session {
     return tab.activePortForwarding();
 }
 
+pub const PortForwardingOverlayKind = enum {
+    none,
+    form,
+    confirm_delete,
+};
+
+pub fn portForwardingOverlayKind() ?PortForwardingOverlayKind {
+    const session = activePortForwarding() orelse return null;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    return switch (session.model.overlay) {
+        .none => .none,
+        .form => .form,
+        .confirm_delete => .confirm_delete,
+    };
+}
+
 fn activePortForwardManager() ?*port_forward_manager.Manager {
     const app = g_app orelse return null;
     return &app.port_forward_manager;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -50,6 +50,9 @@ const ai_history_types = @import("ai_history_types.zig");
 pub const ai_history_session = @import("ai_history_session.zig");
 pub const ai_history_source = @import("ai_history_source.zig");
 pub const skill_center = @import("skill_center.zig");
+pub const port_forwarding = @import("port_forwarding.zig");
+const port_forward_manager = @import("port_forward_manager.zig");
+const port_forward_rule = @import("port_forward_rule.zig");
 const skill_scan = @import("skill_scan.zig");
 const skill_transfer_cmd = @import("skill_transfer_cmd.zig");
 const remote_file = @import("platform/remote_file.zig");
@@ -91,6 +94,7 @@ else
 pub const ai_chat_renderer = @import("renderer/ai_chat_renderer.zig");
 pub const ai_history_renderer = @import("renderer/ai_history_renderer.zig");
 pub const skill_center_renderer = @import("renderer/skill_center_renderer.zig");
+pub const port_forwarding_renderer = @import("renderer/port_forwarding_renderer.zig");
 const ai_sidebar = @import("ai_sidebar.zig");
 pub const ui_perf = @import("ui_perf.zig");
 const log = std.log.scoped(.app_window);
@@ -881,6 +885,90 @@ fn renderSkillCenterFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_i
     }
 }
 
+fn pfStatusKind(status: port_forward_manager.StatusKind) port_forwarding_renderer.StatusKind {
+    return switch (status) {
+        .stopped => .stopped,
+        .starting => .starting,
+        .running => .running,
+        .error_ => .error_,
+        .missing_profile => .missing_profile,
+    };
+}
+
+fn pfRowAt(ctx: *anyopaque, i: usize) port_forwarding_renderer.RowView {
+    const manager: *port_forward_manager.Manager = @ptrCast(@alignCast(ctx));
+    if (manager.rowAt(i)) |row| {
+        var out: port_forwarding_renderer.RowView = .{
+            .rule = row.rule,
+            .status = pfStatusKind(row.status),
+            .auto_start = row.auto_start,
+        };
+        out.reason_len = copyPortForwardingReason(out.reason_buf[0..], row.reason());
+        return out;
+    }
+    return .{
+        .rule = port_forward_rule.defaultReverseProxy(""),
+        .status = .stopped,
+        .auto_start = false,
+    };
+}
+
+fn copyPortForwardingReason(dest: []u8, reason: []const u8) usize {
+    const n = @min(dest.len, reason.len);
+    @memcpy(dest[0..n], reason[0..n]);
+    return n;
+}
+
+fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
+    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
+    gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    clearWithBackground(fb_width, fb_height);
+    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    markdown_preview_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, 0);
+    file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    const session = active_tab.port_forwarding_session orelse return;
+    const app = g_app orelse return;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const row_count = app.port_forward_manager.count();
+    session.model.move(0, row_count);
+    const overlay_text = switch (session.model.overlay) {
+        .none, .form => "",
+        .confirm_delete => |*c| c.text,
+    };
+    const draw: port_forwarding_renderer.DrawContext = .{
+        .bg = g_theme.background,
+        .fg = g_theme.foreground,
+        .accent = g_theme.cursor_color,
+        .cell_h = font.g_titlebar_cell_height,
+        .fillQuad = ui_pipeline.fillQuad,
+        .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
+        .renderTextLimited = titlebar.renderTextLimited,
+        .glyphAdvance = titlebar.titlebarGlyphAdvance,
+    };
+    const view: port_forwarding_renderer.View = .{
+        .title = i18n.s().pf_title,
+        .legend = i18n.s().pf_legend,
+        .count = row_count,
+        .selected = session.model.sel_row,
+        .scroll = session.model.scroll,
+        .ctx = @ptrCast(&app.port_forward_manager),
+        .rowAt = pfRowAt,
+        .overlay_text = overlay_text,
+    };
+    port_forwarding_renderer.render(
+        draw,
+        view,
+        @floatFromInt(fb_width),
+        @floatFromInt(fb_height),
+        titlebar_offset,
+        left_panels_w,
+        aiHistoryContentWidth(fb_width, left_panels_w, right_panels_w),
+    );
+}
+
 /// Renderer accessor: library skill name at index i (read under the session lock).
 fn scNameAt(ctx: *anyopaque, i: usize) []const u8 {
     const m: *const skill_center.PanelModel = @ptrCast(@alignCast(ctx));
@@ -1005,6 +1093,65 @@ pub fn activeAiHistory() ?*ai_history_session.Session {
 
 pub fn activeSkillCenter() ?*skill_center.Session {
     return tab.activeSkillCenter();
+}
+
+pub fn activePortForwarding() ?*port_forwarding.Session {
+    return tab.activePortForwarding();
+}
+
+fn activePortForwardManager() ?*port_forward_manager.Manager {
+    const app = g_app orelse return null;
+    return &app.port_forward_manager;
+}
+
+pub fn portForwardingMove(delta: isize) bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.move(delta, manager.count());
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingToggleSelected() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    const app = g_app orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+    const ok = switch (row.status) {
+        .running, .starting => manager.stopIndex(idx),
+        else => manager.startIndex(idx, app.ssh_legacy_algorithms),
+    };
+    markUiDirty();
+    return ok;
+}
+
+pub fn portForwardingRestartSelected() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    const app = g_app orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const ok = manager.restartIndex(idx, app.ssh_legacy_algorithms);
+    markUiDirty();
+    return ok;
+}
+
+pub fn portForwardingToggleAutoStart() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const ok = manager.toggleAutoStart(idx);
+    if (ok) _ = manager.save();
+    markUiDirty();
+    return ok;
 }
 
 fn scMoveSel(sel: *usize, len: usize, delta: isize) void {
@@ -2811,6 +2958,14 @@ pub fn spawnSkillCenterTab() bool {
     return true;
 }
 
+pub fn spawnPortForwardingTab() bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.spawnPortForwardingTab(allocator)) return false;
+    clearUiStateOnTabChange();
+    markUiDirty();
+    return true;
+}
+
 pub fn reopenAiChatTabFromHistorySessionId(session_id: []const u8) bool {
     if (tab.switchToAiTabBySessionId(session_id)) {
         clearUiStateOnTabChange();
@@ -3343,6 +3498,8 @@ fn renderResizeFrame(width: i32, height: i32) void {
                 renderAiHistoryFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (active_tab.kind == .skill_center) {
                 renderSkillCenterFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .port_forwarding) {
+                renderPortForwardingFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (activeSurface()) |surface| {
                 // Single surface: simple render path
                 const rend = &surface.surface_renderer;
@@ -6151,6 +6308,10 @@ fn runMainLoop(self: *AppWindow) !void {
         pollUpdateCheck(self.app);
         pollSkillUpdate(self.app);
         if (activeSkillCenter()) |sc_session| pollSkillCenterOp(sc_session);
+        if (self.app.port_forward_manager.tick() and activePortForwarding() != null) {
+            g_force_rebuild = true;
+            g_cells_valid = false;
+        }
 
         // Process pending resize (coalesced, like Ghostty)
         // We wait for RESIZE_COALESCE_MS after last resize event before applying.
@@ -6329,7 +6490,7 @@ fn runMainLoop(self: *AppWindow) !void {
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
             syncRemoteLayout(allocator);
             syncImeCaretPosition(win, split_count);
-            if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and active_tab.kind != .skill_center and synchronizedOutputPendingForVisibleSplits(split_count)) {
+            if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and active_tab.kind != .skill_center and active_tab.kind != .port_forwarding and synchronizedOutputPendingForVisibleSplits(split_count)) {
                 std.Thread.sleep(std.time.ns_per_ms);
                 continue;
             }
@@ -6342,6 +6503,8 @@ fn runMainLoop(self: *AppWindow) !void {
                 renderAiHistoryFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (active_tab.kind == .skill_center) {
                 renderSkillCenterFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .port_forwarding) {
+                renderPortForwardingFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (post_process.g_post_enabled) {
                 // Post-processing path: only render focused surface for now
                 if (activeSurface()) |surface| {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1106,10 +1106,10 @@ fn activePortForwardManager() ?*port_forward_manager.Manager {
 
 pub fn portForwardingMove(delta: isize) bool {
     const session = activePortForwarding() orelse return false;
-    const manager = activePortForwardManager() orelse return false;
+    const row_count = if (activePortForwardManager()) |manager| manager.count() else 0;
     session.mutex.lock();
     defer session.mutex.unlock();
-    session.model.move(delta, manager.count());
+    session.model.move(delta, row_count);
     markUiDirty();
     return true;
 }
@@ -1152,6 +1152,143 @@ pub fn portForwardingToggleAutoStart() bool {
     if (ok) _ = manager.save();
     markUiDirty();
     return ok;
+}
+
+pub fn portForwardingOpenNew() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openNewForm("") catch return false;
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingOpenEdit() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openEditForm(idx, row.rule) catch return false;
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingOpenDeleteConfirm() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+    session.mutex.lock();
+    const idx = session.model.sel_row;
+    session.mutex.unlock();
+    const row = manager.rowAt(idx) orelse return false;
+    const label = if (row.rule.name().len > 0) row.rule.name() else row.rule.profileName();
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.openDeleteConfirm(idx, label) catch return false;
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingConfirmOrApply() bool {
+    const session = activePortForwarding() orelse return false;
+    const manager = activePortForwardManager() orelse return false;
+
+    var form_copy: ?port_forwarding.FormState = null;
+    var delete_index: ?usize = null;
+    session.mutex.lock();
+    switch (session.model.overlay) {
+        .form => |form| form_copy = form,
+        .confirm_delete => |confirm| delete_index = confirm.index,
+        .none => {
+            session.mutex.unlock();
+            return false;
+        },
+    }
+    session.mutex.unlock();
+
+    var ok = false;
+    if (form_copy) |form| {
+        if (!form.rule.validate()) return false;
+        ok = switch (form.mode) {
+            .new => blk: {
+                manager.addRule(form.rule) catch break :blk false;
+                break :blk true;
+            },
+            .edit => if (form.edit_index) |idx| manager.updateRule(idx, form.rule) else false,
+        };
+    } else if (delete_index) |idx| {
+        ok = manager.deleteRule(idx);
+    }
+
+    if (!ok) return false;
+    _ = manager.save();
+    const row_count = manager.count();
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    session.model.clearOverlay();
+    session.model.move(0, row_count);
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingCancelOrClose() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    const had_overlay = session.model.overlay != .none;
+    if (had_overlay) session.model.clearOverlay();
+    session.mutex.unlock();
+    if (had_overlay) {
+        markUiDirty();
+        return true;
+    }
+    input.closePanelOrTab();
+    return true;
+}
+
+pub fn portForwardingFormMove(delta: isize) bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.moveFocus(delta);
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingFormToggle() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.toggleFocused();
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingInsertChar(codepoint: u21) bool {
+    if (codepoint > std.math.maxInt(u8)) return false;
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.insertChar(@intCast(codepoint));
+    markUiDirty();
+    return true;
+}
+
+pub fn portForwardingBackspace() bool {
+    const session = activePortForwarding() orelse return false;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return false;
+    form.backspace();
+    markUiDirty();
+    return true;
 }
 
 fn scMoveSel(sel: *usize, len: usize, delta: isize) void {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -938,6 +938,14 @@ fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: 
         .none, .form => "",
         .confirm_delete => |*c| c.text,
     };
+    const form_view: ?port_forwarding_renderer.FormView = switch (session.model.overlay) {
+        .form => |form| .{
+            .mode = if (form.mode == .new) "New forwarding rule" else "Edit forwarding rule",
+            .focus = form.focus,
+            .rule = form.rule,
+        },
+        else => null,
+    };
     const draw: port_forwarding_renderer.DrawContext = .{
         .bg = g_theme.background,
         .fg = g_theme.foreground,
@@ -957,6 +965,7 @@ fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: 
         .ctx = @ptrCast(&app.port_forward_manager),
         .rowAt = pfRowAt,
         .overlay_text = overlay_text,
+        .form = form_view,
     };
     port_forwarding_renderer.render(
         draw,

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -15,6 +15,7 @@ const ai_chat = @import("../ai_chat.zig");
 const ai_history_session = @import("../ai_history_session.zig");
 const ai_history_source = @import("../ai_history_source.zig");
 const skill_center = @import("../skill_center.zig");
+const port_forwarding = @import("../port_forwarding.zig");
 const ai_history_time = @import("../ai_history_time.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
@@ -50,6 +51,7 @@ pub const TabState = struct {
     ai_chat_session: ?*ai_chat.Session = null,
     ai_history_session: ?*ai_history_session.Session = null,
     skill_center_session: ?*skill_center.Session = null,
+    port_forwarding_session: ?*port_forwarding.Session = null,
     /// Copilot conversation for a terminal tab (Issue #98). Distinct from
     /// `ai_chat_session`, which backs a dedicated AI-chat tab. Lazily created
     /// the first time the copilot sidebar is opened on this tab.
@@ -64,6 +66,7 @@ pub const TabState = struct {
         ai_chat,
         ai_history,
         skill_center,
+        port_forwarding,
     };
 
     /// Get the focused surface in this tab, or null if tree is empty
@@ -93,6 +96,9 @@ pub const TabState = struct {
         }
         if (self.kind == .skill_center) {
             return i18n.s().sl_skill_center;
+        }
+        if (self.kind == .port_forwarding) {
+            return i18n.s().pf_title;
         }
         const surface = self.focusedSurface() orelse return "wispterm";
         return surface.getTitle();
@@ -124,6 +130,13 @@ pub const TabState = struct {
                 if (self.skill_center_session) |session| {
                     session.destroy();
                     self.skill_center_session = null;
+                }
+            },
+            .port_forwarding => {
+                if (self.port_forwarding_session) |session| {
+                    session.destroy();
+                    allocator.destroy(session);
+                    self.port_forwarding_session = null;
                 }
             },
         }
@@ -383,6 +396,7 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
     t.ai_chat_session = null;
     t.ai_history_session = null;
     t.skill_center_session = null;
+    t.port_forwarding_session = null;
     t.copilot_session = null;
     t.copilot_visible = false;
 
@@ -441,6 +455,7 @@ pub fn spawnAiChatTab(
     t.ai_chat_session = session;
     t.ai_history_session = null;
     t.skill_center_session = null;
+    t.port_forwarding_session = null;
     t.copilot_session = null;
     t.copilot_visible = false;
 
@@ -472,6 +487,7 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
     t.ai_chat_session = session;
     t.ai_history_session = null;
     t.skill_center_session = null;
+    t.port_forwarding_session = null;
     t.copilot_session = null;
     t.copilot_visible = false;
 
@@ -505,6 +521,7 @@ pub fn spawnAiHistoryTab(allocator: std.mem.Allocator, source: ai_history_source
     t.copilot_visible = false;
     t.ai_history_session = session_ptr;
     t.skill_center_session = null;
+    t.port_forwarding_session = null;
 
     g_tabs[g_tab_count] = t;
     active_tab_state.g_active_tab = g_tab_count;
@@ -529,6 +546,37 @@ pub fn spawnSkillCenterTab(allocator: std.mem.Allocator) bool {
     t.ai_chat_session = null;
     t.ai_history_session = null;
     t.skill_center_session = session_ptr;
+    t.port_forwarding_session = null;
+    t.copilot_session = null;
+    t.copilot_visible = false;
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+    return true;
+}
+
+/// Create and activate a new Port Forwarding management tab.
+pub fn spawnPortForwardingTab(allocator: std.mem.Allocator) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+    const session_ptr = allocator.create(port_forwarding.Session) catch return false;
+    session_ptr.* = port_forwarding.Session.create(allocator) catch {
+        allocator.destroy(session_ptr);
+        return false;
+    };
+
+    const t = allocator.create(TabState) catch {
+        session_ptr.destroy();
+        allocator.destroy(session_ptr);
+        return false;
+    };
+    t.kind = .port_forwarding;
+    t.tree = .empty;
+    t.focused = .root;
+    t.ai_chat_session = null;
+    t.ai_history_session = null;
+    t.skill_center_session = null;
+    t.port_forwarding_session = session_ptr;
     t.copilot_session = null;
     t.copilot_visible = false;
 
@@ -543,6 +591,13 @@ pub fn activeSkillCenter() ?*skill_center.Session {
     const t = activeTab() orelse return null;
     if (t.kind != .skill_center) return null;
     return t.skill_center_session;
+}
+
+/// Active tab's Port Forwarding session, or null if the active tab isn't one.
+pub fn activePortForwarding() ?*port_forwarding.Session {
+    const t = activeTab() orelse return null;
+    if (t.kind != .port_forwarding) return null;
+    return t.port_forwarding_session;
 }
 
 /// Close the tab at the given index.
@@ -983,6 +1038,7 @@ pub fn commitTabRename() void {
                     },
                     .ai_history => {},
                     .skill_center => {},
+                    .port_forwarding => {},
                 }
             }
         }
@@ -1426,6 +1482,7 @@ pub fn restoreTab(
     t.ai_chat_session = null;
     t.ai_history_session = null;
     t.skill_center_session = null;
+    t.port_forwarding_session = null;
     t.copilot_session = null;
     t.copilot_visible = false;
     applyRestoredTabMetadata(t, snap);
@@ -1447,6 +1504,7 @@ fn applyRestoredTabMetadata(t: *TabState, snap: *const session_persist.TabSnap) 
         },
         .ai_history => {},
         .skill_center => {},
+        .port_forwarding => {},
     }
 }
 

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -42,6 +42,7 @@ pub const CommandAction = enum {
     show_whats_new,
     update_skills,
     open_skill_center,
+    open_port_forwarding,
 };
 
 pub const CommandEntry = struct {
@@ -90,6 +91,7 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "Open Latest Release", .detail = "Open the latest WispTerm GitHub Release", .shortcut = "", .action = .open_latest_release },
     .{ .title = "What's New", .detail = "Show what changed in this version of WispTerm", .shortcut = app_metadata.version, .action = .show_whats_new },
     .{ .title = "Update Skills", .detail = "Download the latest skills from GitHub", .shortcut = "", .action = .update_skills },
+    .{ .title = "Port Forwarding", .detail = "Manage SSH port forwarding rules", .shortcut = "", .action = .open_port_forwarding },
     .{ .title = "Skill Center", .detail = "Inventory Claude Code / Codex skills across servers", .shortcut = "", .action = .open_skill_center },
 };
 
@@ -284,6 +286,10 @@ test "findCommandAction resolves What's New" {
 
 test "command center includes Skill Center action" {
     try std.testing.expectEqual(CommandAction.open_skill_center, findCommandAction("Skill Center"));
+}
+
+test "command center includes Port Forwarding action" {
+    try std.testing.expectEqual(CommandAction.open_port_forwarding, findCommandAction("Port Forwarding"));
 }
 
 test "findCommandAction resolves Open Jupyter" {

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -54,6 +54,8 @@ pub const Strings = struct {
     sl_sessions_detail: []const u8,
     sl_skill_center: []const u8,
     sl_skill_center_detail: []const u8,
+    pf_title: []const u8,
+    pf_legend: []const u8,
 
     // —— Skill Center 面板 ——
     sc_local: []const u8,
@@ -239,6 +241,8 @@ const en = Strings{
     .sl_sessions_detail = "Browse Codex / Claude Code sessions",
     .sl_skill_center = "Skill Center",
     .sl_skill_center_detail = "Inventory Claude Code / Codex skills across servers",
+    .pf_title = "Port Forwarding",
+    .pf_legend = "[n] new   [e] edit   [space] start/stop   [r] restart   [a] auto   [d] delete   [esc] close/cancel",
 
     .sc_local = "Local",
     .sc_scanning = "No skills found. Scanning…",
@@ -418,6 +422,8 @@ const zh_CN = Strings{
     .sl_sessions_detail = "浏览 Codex / Claude Code 会话",
     .sl_skill_center = "技能中心",
     .sl_skill_center_detail = "盘点各服务器上的 Claude Code / Codex 技能",
+    .pf_title = "端口转发",
+    .pf_legend = "[n] 新建   [e] 编辑   [space] 启停   [r] 重启   [a] 自动启动   [d] 删除   [esc] 关闭/取消",
 
     .sc_local = "本地",
     .sc_scanning = "未发现技能，扫描中…",

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -55,6 +55,7 @@ pub const Strings = struct {
     sl_skill_center: []const u8,
     sl_skill_center_detail: []const u8,
     pf_title: []const u8,
+    pf_detail: []const u8,
     pf_legend: []const u8,
 
     // —— Skill Center 面板 ——
@@ -242,6 +243,7 @@ const en = Strings{
     .sl_skill_center = "Skill Center",
     .sl_skill_center_detail = "Inventory Claude Code / Codex skills across servers",
     .pf_title = "Port Forwarding",
+    .pf_detail = "Manage SSH port forwarding rules",
     .pf_legend = "[n] new   [e] edit   [space] start/stop   [r] restart   [a] auto   [d] delete   [esc] close/cancel",
 
     .sc_local = "Local",
@@ -423,6 +425,7 @@ const zh_CN = Strings{
     .sl_skill_center = "技能中心",
     .sl_skill_center_detail = "盘点各服务器上的 Claude Code / Codex 技能",
     .pf_title = "端口转发",
+    .pf_detail = "管理 SSH 端口转发规则",
     .pf_legend = "[n] 新建   [e] 编辑   [space] 启停   [r] 重启   [a] 自动启动   [d] 删除   [esc] 关闭/取消",
 
     .sc_local = "本地",
@@ -706,6 +709,7 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
         .show_whats_new => "更新内容",
         .update_skills => "更新技能",
         .open_skill_center => "技能中心",
+        .open_port_forwarding => "端口转发",
     };
 }
 
@@ -754,6 +758,7 @@ pub fn commandDetail(action: CommandAction) ?[]const u8 {
         .show_whats_new => "查看本版本的更新内容",
         .update_skills => "从 GitHub 下载最新技能",
         .open_skill_center => "盘点各服务器上的 Claude Code / Codex 技能",
+        .open_port_forwarding => "管理 SSH 端口转发规则",
     };
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -247,6 +247,64 @@ test "input: port forwarding arrow navigation requests a repaint" {
     try std.testing.expect(!AppWindow.g_cells_valid);
 }
 
+test "input: port forwarding form letter keys remain text input" {
+    const allocator = std.testing.allocator;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > previous_count) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+        active_tab_state.g_active_tab = previous_active;
+    }
+
+    try std.testing.expect(AppWindow.portForwardingOpenNew());
+    handleChar(.{ .codepoint = 'P' });
+    handleKey(.{ .key_code = 0x4E, .ctrl = false, .shift = false, .alt = false });
+    handleChar(.{ .codepoint = 'n' });
+
+    const session = AppWindow.activePortForwarding() orelse return error.ExpectedPortForwardingTab;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return error.ExpectedPortForwardingForm;
+    try std.testing.expectEqualStrings("Local proxyPn", form.rule.name());
+}
+
+test "input: port forwarding new command suppresses its follow-up char event" {
+    const allocator = std.testing.allocator;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > previous_count) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+        active_tab_state.g_active_tab = previous_active;
+    }
+
+    handleKey(.{ .key_code = 0x4E, .ctrl = false, .shift = false, .alt = false });
+    handleChar(.{ .codepoint = 'n' });
+
+    const session = AppWindow.activePortForwarding() orelse return error.ExpectedPortForwardingTab;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return error.ExpectedPortForwardingForm;
+    try std.testing.expectEqualStrings("Local proxy", form.rule.name());
+}
+
 // Ties the fix end-to-end: a consumed overlay key must make the next render-gate
 // evaluation decide to render (the exact signal the main loop builds), instead of
 // blocking until an incidental wake — that decision IS the anti-lag invariant.
@@ -376,6 +434,7 @@ threadlocal var g_ai_transcript_selecting: bool = false;
 threadlocal var g_ai_transcript_select_chat: ?*AppWindow.ai_chat.Session = null;
 threadlocal var g_ai_transcript_select_auto_copy: bool = false;
 threadlocal var g_ai_history_suppress_refresh_char: bool = false;
+threadlocal var g_port_forwarding_suppress_command_char: ?u21 = null;
 pub threadlocal var g_sidebar_resize_hover: bool = false; // Mouse is over the sidebar resize edge
 pub threadlocal var g_sidebar_resize_dragging: bool = false; // Currently dragging the sidebar edge
 pub threadlocal var g_explorer_resize_hover: bool = false; // Mouse is over the file explorer resize edge
@@ -1163,6 +1222,11 @@ fn handleChar(ev: platform_input.CharEvent) void {
         return;
     }
     if (AppWindow.activePortForwarding() != null) {
+        if (g_port_forwarding_suppress_command_char) |codepoint| {
+            const suppress = !ev.ctrl and !ev.alt and !ev.super and ev.codepoint == codepoint;
+            g_port_forwarding_suppress_command_char = null;
+            if (suppress) return;
+        }
         if (!ev.ctrl and !ev.alt and !ev.super) {
             _ = AppWindow.portForwardingInsertChar(ev.codepoint);
         }
@@ -1640,21 +1704,32 @@ fn handleKey(ev: platform_input.KeyEvent) void {
 
     if (AppWindow.activePortForwarding() != null) {
         const plain = !ev.ctrl and !ev.alt and !ev.super;
+        const overlay_kind = AppWindow.portForwardingOverlayKind() orelse .none;
+        const form_active = overlay_kind == .form;
+        const overlay_active = overlay_kind != .none;
         switch (ev.key_code) {
             platform_input.key_up => {
-                _ = AppWindow.portForwardingMove(-1);
+                if (form_active) {
+                    _ = AppWindow.portForwardingFormMove(-1);
+                } else if (!overlay_active) {
+                    _ = AppWindow.portForwardingMove(-1);
+                }
                 return;
             },
             platform_input.key_down => {
-                _ = AppWindow.portForwardingMove(1);
+                if (form_active) {
+                    _ = AppWindow.portForwardingFormMove(1);
+                } else if (!overlay_active) {
+                    _ = AppWindow.portForwardingMove(1);
+                }
                 return;
             },
             platform_input.key_tab => {
-                _ = AppWindow.portForwardingFormMove(1);
+                if (form_active) _ = AppWindow.portForwardingFormMove(1);
                 return;
             },
             platform_input.key_enter => {
-                _ = AppWindow.portForwardingConfirmOrApply();
+                if (overlay_active) _ = AppWindow.portForwardingConfirmOrApply();
                 return;
             },
             platform_input.key_escape => {
@@ -1662,32 +1737,39 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 return;
             },
             platform_input.key_backspace => {
-                _ = AppWindow.portForwardingBackspace();
+                if (form_active) _ = AppWindow.portForwardingBackspace();
                 return;
             },
             platform_input.key_space => if (plain and !ev.shift) {
-                if (AppWindow.portForwardingFormToggle()) return;
-                _ = AppWindow.portForwardingToggleSelected();
+                if (form_active) {
+                    _ = AppWindow.portForwardingFormToggle();
+                } else if (!overlay_active) {
+                    _ = AppWindow.portForwardingToggleSelected();
+                }
                 return;
             },
             0x4E => if (plain and !ev.shift) {
-                _ = AppWindow.portForwardingOpenNew();
+                if (!overlay_active and AppWindow.portForwardingOpenNew()) {
+                    g_port_forwarding_suppress_command_char = 'n';
+                }
                 return;
             },
             0x45 => if (plain and !ev.shift) {
-                _ = AppWindow.portForwardingOpenEdit();
+                if (!overlay_active and AppWindow.portForwardingOpenEdit()) {
+                    g_port_forwarding_suppress_command_char = 'e';
+                }
                 return;
             },
             0x44 => if (plain and !ev.shift) {
-                _ = AppWindow.portForwardingOpenDeleteConfirm();
+                if (!overlay_active) _ = AppWindow.portForwardingOpenDeleteConfirm();
                 return;
             },
             0x52 => if (plain and !ev.shift) {
-                _ = AppWindow.portForwardingRestartSelected();
+                if (!overlay_active) _ = AppWindow.portForwardingRestartSelected();
                 return;
             },
             0x41 => if (plain and !ev.shift) {
-                _ = AppWindow.portForwardingToggleAutoStart();
+                if (!overlay_active) _ = AppWindow.portForwardingToggleAutoStart();
                 return;
             },
             else => {},

--- a/src/input.zig
+++ b/src/input.zig
@@ -221,6 +221,32 @@ test "input: settings page arrow navigation requests a repaint" {
     try std.testing.expect(!AppWindow.g_cells_valid);
 }
 
+test "input: port forwarding arrow navigation requests a repaint" {
+    const allocator = std.testing.allocator;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > previous_count) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+        active_tab_state.g_active_tab = previous_active;
+    }
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    handleKey(arrow_down_event);
+
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
+}
+
 // Ties the fix end-to-end: a consumed overlay key must make the next render-gate
 // evaluation decide to render (the exact signal the main loop builds), instead of
 // blocking until an incidental wake — that decision IS the anti-lag invariant.
@@ -1136,6 +1162,12 @@ fn handleChar(ev: platform_input.CharEvent) void {
         }
         return;
     }
+    if (AppWindow.activePortForwarding() != null) {
+        if (!ev.ctrl and !ev.alt and !ev.super) {
+            _ = AppWindow.portForwardingInsertChar(ev.codepoint);
+        }
+        return;
+    }
     // Skill Center has no text input; swallow character input so the rescan
     // hotkey ('r') and other keys never leak to the terminal/copilot.
     if (AppWindow.activeSkillCenter() != null) {
@@ -1599,6 +1631,63 @@ fn handleKey(ev: platform_input.KeyEvent) void {
             },
             0x52 => if (plain and !ev.shift) {
                 g_ai_history_suppress_refresh_char = AppWindow.aiHistoryScanLocalNow();
+                return;
+            },
+            else => {},
+        }
+        return;
+    }
+
+    if (AppWindow.activePortForwarding() != null) {
+        const plain = !ev.ctrl and !ev.alt and !ev.super;
+        switch (ev.key_code) {
+            platform_input.key_up => {
+                _ = AppWindow.portForwardingMove(-1);
+                return;
+            },
+            platform_input.key_down => {
+                _ = AppWindow.portForwardingMove(1);
+                return;
+            },
+            platform_input.key_tab => {
+                _ = AppWindow.portForwardingFormMove(1);
+                return;
+            },
+            platform_input.key_enter => {
+                _ = AppWindow.portForwardingConfirmOrApply();
+                return;
+            },
+            platform_input.key_escape => {
+                _ = AppWindow.portForwardingCancelOrClose();
+                return;
+            },
+            platform_input.key_backspace => {
+                _ = AppWindow.portForwardingBackspace();
+                return;
+            },
+            platform_input.key_space => if (plain and !ev.shift) {
+                if (AppWindow.portForwardingFormToggle()) return;
+                _ = AppWindow.portForwardingToggleSelected();
+                return;
+            },
+            0x4E => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenNew();
+                return;
+            },
+            0x45 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenEdit();
+                return;
+            },
+            0x44 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingOpenDeleteConfirm();
+                return;
+            },
+            0x52 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingRestartSelected();
+                return;
+            },
+            0x41 => if (plain and !ev.shift) {
+                _ = AppWindow.portForwardingToggleAutoStart();
                 return;
             },
             else => {},

--- a/src/main.zig
+++ b/src/main.zig
@@ -174,8 +174,11 @@ pub fn main() !void {
     defer app.deinit();
     ai_chat.loadAccessRules(allocator);
 
-    // App now lives at a stable address; start the WeChat direct bridge (no-op
-    // unless weixin-direct-enabled is set).
+    // App now lives at a stable address; start app-owned background services
+    // before opening the first window.
+    app.startPortForwarding(&cfg);
+
+    // Start the WeChat direct bridge (no-op unless weixin-direct-enabled is set).
     app.startWeixin(&cfg);
 
     try app.run();

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -32,6 +32,7 @@ pub const RowView = struct {
 };
 
 const Entry = struct {
+    id: u64 = 0,
     rule: rule_mod.Rule,
     generation: u64 = 0,
     status: StatusKind = .stopped,
@@ -55,7 +56,7 @@ const ChildState = union(enum) {
 };
 
 const PendingStart = struct {
-    index: usize,
+    entry_id: u64,
     generation: u64,
     rule: rule_mod.Rule,
 };
@@ -82,15 +83,15 @@ const FakeChild = struct {
 };
 
 const ExitedChild = struct {
-    index: usize,
+    entry_id: u64,
     generation: u64,
     child: ChildState,
     reason_buf: [REASON_MAX]u8 = undefined,
     reason_len: usize = 0,
 
-    fn init(index: usize, generation: u64, child: ChildState) ExitedChild {
+    fn init(entry_id: u64, generation: u64, child: ChildState) ExitedChild {
         var item: ExitedChild = .{
-            .index = index,
+            .entry_id = entry_id,
             .generation = generation,
             .child = child,
         };
@@ -119,7 +120,7 @@ const ExitedChildList = struct {
 };
 
 const StoppedEntry = struct {
-    index: usize,
+    entry_id: u64,
     generation: u64,
     child: ?ChildState,
 };
@@ -143,6 +144,7 @@ pub const Manager = struct {
     allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},
     entries: std.ArrayListUnmanaged(Entry) = .empty,
+    next_entry_id: u64 = 1,
     next_generation: u64 = 1,
 
     pub fn init(allocator: std.mem.Allocator) Manager {
@@ -180,6 +182,7 @@ pub const Manager = struct {
         defer self.mutex.unlock();
         if (self.entries.items.len >= MAX_RULES) return error.TooManyRules;
         try self.entries.append(self.allocator, .{
+            .id = self.nextEntryIdLocked(),
             .rule = rule,
             .generation = self.nextGenerationLocked(),
         });
@@ -187,6 +190,7 @@ pub const Manager = struct {
 
     pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
         var child_to_stop: ?ChildState = null;
+        var entry_id: u64 = 0;
         var generation: u64 = 0;
 
         self.mutex.lock();
@@ -194,6 +198,7 @@ pub const Manager = struct {
             self.mutex.unlock();
             return false;
         }
+        entry_id = self.entries.items[index].id;
         child_to_stop = self.entries.items[index].child;
         self.entries.items[index].child = null;
         generation = self.nextGenerationLocked();
@@ -204,9 +209,9 @@ pub const Manager = struct {
 
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (!self.entryGenerationMatchesLocked(index, generation)) return false;
-        self.entries.items[index].rule = rule;
-        self.entries.items[index].setStatus(.stopped, "");
+        const current_index = self.findEntryIndexByIdAndGenerationLocked(entry_id, generation) orelse return false;
+        self.entries.items[current_index].rule = rule;
+        self.entries.items[current_index].setStatus(.stopped, "");
         return true;
     }
 
@@ -266,6 +271,7 @@ pub const Manager = struct {
         std.debug.assert(self.entries.items.len == 0);
         self.entries.deinit(self.allocator);
         for (entries.items) |*entry| {
+            entry.id = self.nextEntryIdLocked();
             entry.generation = self.nextGenerationLocked();
         }
         self.entries = entries.*;
@@ -297,6 +303,7 @@ pub const Manager = struct {
 
     pub fn stopIndex(self: *Manager, index: usize) bool {
         var child_to_stop: ?ChildState = null;
+        var entry_id: u64 = 0;
         var generation: u64 = 0;
 
         self.mutex.lock();
@@ -304,6 +311,7 @@ pub const Manager = struct {
             self.mutex.unlock();
             return false;
         }
+        entry_id = self.entries.items[index].id;
         child_to_stop = self.entries.items[index].child;
         self.entries.items[index].child = null;
         generation = self.nextGenerationLocked();
@@ -314,13 +322,12 @@ pub const Manager = struct {
 
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (!self.entryGenerationMatchesLocked(index, generation)) return false;
-        self.entries.items[index].setStatus(.stopped, "");
+        const current_index = self.findEntryIndexByIdAndGenerationLocked(entry_id, generation) orelse return false;
+        self.entries.items[current_index].setStatus(.stopped, "");
         return true;
     }
 
     pub fn restartIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
-        _ = self.stopIndex(index);
         return self.startIndex(index, legacy_algorithms);
     }
 
@@ -342,8 +349,8 @@ pub const Manager = struct {
         var exited: ExitedChildList = .{};
 
         self.mutex.lock();
-        for (self.entries.items, 0..) |*entry, index| {
-            if (takeExitedChildFromEntry(entry, index)) |child| {
+        for (self.entries.items) |*entry| {
+            if (takeExitedChildFromEntry(entry)) |child| {
                 exited.append(child);
             }
         }
@@ -415,23 +422,31 @@ pub const Manager = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return null;
-        return takeExitedChildFromEntry(&self.entries.items[index], index);
+        return takeExitedChildFromEntry(&self.entries.items[index]);
     }
 
     fn finishExitedChildForTest(self: *Manager, exited: *ExitedChild) bool {
         return self.finishExitedChild(exited);
     }
 
+    fn beginRestartForTest(self: *Manager, index: usize) ?PendingStart {
+        return self.beginPendingStartForTest(index);
+    }
+
+    fn completeRestartFakeForTest(self: *Manager, pending: *const PendingStart, pid: u32) bool {
+        return self.completePendingStartFakeForTest(pending.*, pid);
+    }
+
     pub fn stopAll(self: *Manager) void {
         var stopped: StopList = .{};
 
         self.mutex.lock();
-        for (self.entries.items, 0..) |*entry, index| {
+        for (self.entries.items) |*entry| {
             const child = entry.child;
             entry.child = null;
             entry.generation = self.nextGenerationLocked();
             stopped.append(.{
-                .index = index,
+                .entry_id = entry.id,
                 .generation = entry.generation,
                 .child = child,
             });
@@ -445,8 +460,8 @@ pub const Manager = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         for (stopped.slice()) |item| {
-            if (self.entryGenerationMatchesLocked(item.index, item.generation)) {
-                self.entries.items[item.index].setStatus(.stopped, "");
+            if (self.findEntryIndexByIdAndGenerationLocked(item.entry_id, item.generation)) |index| {
+                self.entries.items[index].setStatus(.stopped, "");
             }
         }
     }
@@ -463,7 +478,7 @@ pub const Manager = struct {
         entry.setStatus(.starting, "");
         return .{
             .pending = .{
-                .index = index,
+                .entry_id = entry.id,
                 .generation = generation,
                 .rule = entry.rule,
             },
@@ -474,37 +489,52 @@ pub const Manager = struct {
     fn completePendingStartFailure(self: *Manager, pending: PendingStart, status: StatusKind, reason: []const u8) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (!self.pendingStartMatchesLocked(pending)) return false;
-        self.entries.items[pending.index].setStatus(status, reason);
+        const index = self.pendingStartIndexLocked(pending) orelse return false;
+        self.entries.items[index].setStatus(status, reason);
         return true;
     }
 
     fn completePendingStartInstall(self: *Manager, pending: PendingStart, child: ChildState) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (!self.pendingStartMatchesLocked(pending)) return false;
-        self.entries.items[pending.index].child = child;
-        self.entries.items[pending.index].setStatus(.running, "");
+        const index = self.pendingStartIndexLocked(pending) orelse return false;
+        self.entries.items[index].child = child;
+        self.entries.items[index].setStatus(.running, "");
         return true;
     }
 
     fn finishExitedChild(self: *Manager, exited: *const ExitedChild) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (!self.entryGenerationMatchesLocked(exited.index, exited.generation)) return false;
-        if (self.entries.items[exited.index].child != null) return false;
-        self.entries.items[exited.index].setStatus(.error_, exited.reason());
+        const index = self.findEntryIndexByIdAndGenerationLocked(exited.entry_id, exited.generation) orelse return false;
+        if (self.entries.items[index].child != null) return false;
+        self.entries.items[index].setStatus(.error_, exited.reason());
         return true;
     }
 
-    fn pendingStartMatchesLocked(self: *Manager, pending: PendingStart) bool {
-        if (!self.entryGenerationMatchesLocked(pending.index, pending.generation)) return false;
-        const entry = &self.entries.items[pending.index];
-        return entry.child == null and rulesEqual(&entry.rule, &pending.rule);
+    fn pendingStartIndexLocked(self: *Manager, pending: PendingStart) ?usize {
+        const index = self.findEntryIndexByIdAndGenerationLocked(pending.entry_id, pending.generation) orelse return null;
+        const entry = &self.entries.items[index];
+        if (entry.child != null or !rulesEqual(&entry.rule, &pending.rule)) return null;
+        return index;
     }
 
-    fn entryGenerationMatchesLocked(self: *Manager, index: usize, generation: u64) bool {
-        return index < self.entries.items.len and self.entries.items[index].generation == generation;
+    fn findEntryIndexByIdAndGenerationLocked(self: *Manager, entry_id: u64, generation: u64) ?usize {
+        const index = self.findEntryIndexByIdLocked(entry_id) orelse return null;
+        return if (self.entries.items[index].generation == generation) index else null;
+    }
+
+    fn findEntryIndexByIdLocked(self: *Manager, entry_id: u64) ?usize {
+        for (self.entries.items, 0..) |entry, index| {
+            if (entry.id == entry_id) return index;
+        }
+        return null;
+    }
+
+    fn nextEntryIdLocked(self: *Manager) u64 {
+        const id = self.next_entry_id;
+        self.next_entry_id = if (self.next_entry_id == std.math.maxInt(u64)) 1 else self.next_entry_id + 1;
+        return id;
     }
 
     fn nextGenerationLocked(self: *Manager) u64 {
@@ -599,9 +629,13 @@ fn spawnForward(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: 
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Inherit;
+    child.create_no_window = true;
     if (env_map) |*map| child.env_map = map;
     try child.spawn();
-    try child.waitForSpawn();
+    child.waitForSpawn() catch |err| {
+        stopRealChild(&child);
+        return err;
+    };
     return child;
 }
 
@@ -625,11 +659,22 @@ fn stopChildState(child: *ChildState) void {
 
 fn stopRealChild(child: *std.process.Child) void {
     if (childHasExitedReal(child)) {
-        if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
-        _ = child.wait() catch {};
+        cleanupExitedChild(child);
     } else {
-        _ = child.kill() catch {};
+        _ = child.kill() catch |err| {
+            switch (err) {
+                error.AlreadyTerminated => cleanupExitedChild(child),
+                else => {
+                    if (childHasExitedReal(child)) cleanupExitedChild(child);
+                },
+            }
+        };
     }
+}
+
+fn cleanupExitedChild(child: *std.process.Child) void {
+    if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
+    _ = child.wait() catch {};
 }
 
 fn childHasExited(child: *const ChildState) bool {
@@ -639,11 +684,11 @@ fn childHasExited(child: *const ChildState) bool {
     };
 }
 
-fn takeExitedChildFromEntry(entry: *Entry, index: usize) ?ExitedChild {
+fn takeExitedChildFromEntry(entry: *Entry) ?ExitedChild {
     const child = entry.child orelse return null;
     if (!childHasExited(&child)) return null;
     entry.child = null;
-    return ExitedChild.init(index, entry.generation, child);
+    return ExitedChild.init(entry.id, entry.generation, child);
 }
 
 fn childHasExitedReal(child: *const std.process.Child) bool {
@@ -982,6 +1027,41 @@ test "port_forward_manager: stale pending start failure leaves replacement row a
     try std.testing.expectEqualStrings("replacement", row.rule.profileName());
 }
 
+test "port_forward_manager: shifted pending start failure follows logical row" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("earlier"));
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+
+    const pending = manager.beginPendingStartForTest(1) orelse return error.ExpectedPendingStart;
+    try std.testing.expect(manager.deleteRule(0));
+
+    try std.testing.expect(manager.completePendingStartFailureForTest(pending, .missing_profile, "profile missing"));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.missing_profile, row.status);
+    try std.testing.expectEqualStrings("profile missing", row.reason());
+}
+
+test "port_forward_manager: shifted pending start install follows logical row" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("earlier"));
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+
+    const pending = manager.beginPendingStartForTest(1) orelse return error.ExpectedPendingStart;
+    try std.testing.expect(manager.deleteRule(0));
+
+    try std.testing.expect(manager.completePendingStartFakeForTest(pending, 444));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.running, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expect(manager.markExitedForTest(0, "installed child exited"));
+}
+
 test "port_forward_manager: stale pending start install leaves replacement row alone" {
     var manager = Manager.init(std.testing.allocator);
     defer manager.deinit();
@@ -1033,6 +1113,46 @@ test "port_forward_manager: stale exited child does not mark replacement row err
     try std.testing.expectEqual(StatusKind.stopped, row.status);
     try std.testing.expectEqualStrings("", row.reason());
     try std.testing.expectEqualStrings("replacement", row.rule.profileName());
+}
+
+test "port_forward_manager: shifted exited child completion follows logical row" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("earlier"));
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+    try std.testing.expect(manager.markRunningForTest(1, 111));
+    try std.testing.expect(manager.markExitedForTest(1, "target exited"));
+
+    var exited = manager.takeExitedChildForTest(1) orelse return error.ExpectedExitedChild;
+    try std.testing.expect(manager.deleteRule(0));
+
+    try std.testing.expect(manager.finishExitedChildForTest(&exited));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.error_, row.status);
+    try std.testing.expectEqualStrings("target exited", row.reason());
+}
+
+test "port_forward_manager: shifted restart lease does not start wrong row" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("earlier"));
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+    try manager.addRule(rule_mod.defaultReverseProxy("wrong"));
+
+    var restart = manager.beginRestartForTest(1) orelse return error.ExpectedRestart;
+    try std.testing.expect(manager.deleteRule(0));
+
+    try std.testing.expect(manager.completeRestartFakeForTest(&restart, 222));
+
+    const target = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", target.rule.profileName());
+    try std.testing.expectEqual(StatusKind.running, target.status);
+
+    const wrong = manager.rowAt(1).?;
+    try std.testing.expectEqualStrings("wrong", wrong.rule.profileName());
+    try std.testing.expectEqual(StatusKind.stopped, wrong.status);
 }
 
 fn sshConnectionForTest(

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -1,8 +1,15 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const rule_mod = @import("port_forward_rule.zig");
+const platform_process = @import("platform/process.zig");
+const platform_pty_command = @import("platform/pty_command.zig");
+const ssh_connection = @import("ssh_connection.zig");
+const ssh_profile_store = @import("ssh_profile_store.zig");
 
 pub const MAX_RULES: usize = 128;
 pub const REASON_MAX: usize = 192;
+const MAX_TUNNEL_SPEC_BYTES: usize = 160;
+const MAX_SSH_DEST_BYTES: usize = 280;
 
 pub const StatusKind = enum {
     stopped,
@@ -29,6 +36,7 @@ const Entry = struct {
     status: StatusKind = .stopped,
     reason_buf: [REASON_MAX]u8 = undefined,
     reason_len: usize = 0,
+    child: ?ChildState = null,
 
     fn reason(self: *const Entry) []const u8 {
         return self.reason_buf[0..self.reason_len];
@@ -37,6 +45,77 @@ const Entry = struct {
     fn setStatus(self: *Entry, status: StatusKind, reason_text: []const u8) void {
         self.status = status;
         self.reason_len = copyBounded(self.reason_buf[0..], reason_text);
+    }
+};
+
+const ChildState = union(enum) {
+    real: std.process.Child,
+    fake: FakeChild,
+};
+
+const FakeChild = struct {
+    pid: u32,
+    exited: bool = false,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
+
+    fn reason(self: *const FakeChild) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
+
+    fn setExited(self: *FakeChild, reason_text: []const u8) void {
+        self.exited = true;
+        self.reason_len = copyBounded(self.reason_buf[0..], reason_text);
+    }
+};
+
+const ChildList = struct {
+    items: [MAX_RULES]ChildState = undefined,
+    len: usize = 0,
+
+    fn append(self: *ChildList, child: ChildState) void {
+        std.debug.assert(self.len < self.items.len);
+        self.items[self.len] = child;
+        self.len += 1;
+    }
+
+    fn slice(self: *ChildList) []ChildState {
+        return self.items[0..self.len];
+    }
+};
+
+const ExitedChild = struct {
+    index: usize,
+    child: ChildState,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
+
+    fn init(index: usize, child: ChildState) ExitedChild {
+        var item: ExitedChild = .{
+            .index = index,
+            .child = child,
+        };
+        item.reason_len = copyBounded(item.reason_buf[0..], childExitReason(&item.child));
+        return item;
+    }
+
+    fn reason(self: *const ExitedChild) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
+};
+
+const ExitedChildList = struct {
+    items: [MAX_RULES]ExitedChild = undefined,
+    len: usize = 0,
+
+    fn append(self: *ExitedChildList, child: ExitedChild) void {
+        std.debug.assert(self.len < self.items.len);
+        self.items[self.len] = child;
+        self.len += 1;
+    }
+
+    fn slice(self: *ExitedChildList) []ExitedChild {
+        return self.items[0..self.len];
     }
 };
 
@@ -83,6 +162,19 @@ pub const Manager = struct {
     }
 
     pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
+        var child_to_stop: ?ChildState = null;
+
+        self.mutex.lock();
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        child_to_stop = self.entries.items[index].child;
+        self.entries.items[index].child = null;
+        self.mutex.unlock();
+
+        if (child_to_stop) |*child| stopChildState(child);
+
         self.mutex.lock();
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return false;
@@ -92,10 +184,17 @@ pub const Manager = struct {
     }
 
     pub fn deleteRule(self: *Manager, index: usize) bool {
+        var removed: Entry = undefined;
+
         self.mutex.lock();
-        defer self.mutex.unlock();
-        if (index >= self.entries.items.len) return false;
-        _ = self.entries.orderedRemove(index);
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        removed = self.entries.orderedRemove(index);
+        self.mutex.unlock();
+
+        stopEntry(&removed);
         return true;
     }
 
@@ -120,15 +219,140 @@ pub const Manager = struct {
         var entries = try decodeEntriesBounded(self.allocator, content);
         defer entries.deinit(self.allocator);
 
+        var old_entries: std.ArrayListUnmanaged(Entry) = .empty;
+        self.mutex.lock();
+        old_entries = self.entries;
+        self.entries = .empty;
+        self.mutex.unlock();
+
+        stopEntries(old_entries.items);
+        old_entries.deinit(self.allocator);
+
         self.mutex.lock();
         defer self.mutex.unlock();
         self.replaceEntriesLocked(&entries);
     }
 
     fn replaceEntriesLocked(self: *Manager, entries: *std.ArrayListUnmanaged(Entry)) void {
+        std.debug.assert(self.entries.items.len == 0);
         self.entries.deinit(self.allocator);
         self.entries = entries.*;
         entries.* = .empty;
+    }
+
+    pub fn startIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
+        var child_to_stop: ?ChildState = null;
+
+        self.mutex.lock();
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        const rule = self.entries.items[index].rule;
+        child_to_stop = self.entries.items[index].child;
+        self.entries.items[index].child = null;
+        self.entries.items[index].setStatus(.starting, "");
+        self.mutex.unlock();
+
+        if (child_to_stop) |*child| stopChildState(child);
+
+        const conn = ssh_profile_store.connectionByName(self.allocator, rule.profileName(), legacy_algorithms) orelse {
+            self.mutex.lock();
+            if (index < self.entries.items.len) self.entries.items[index].setStatus(.missing_profile, "profile missing");
+            self.mutex.unlock();
+            return false;
+        };
+
+        const child = spawnForward(self.allocator, &rule, &conn) catch |err| {
+            var buf: [REASON_MAX]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "spawn failed: {}", .{err}) catch "spawn failed";
+            self.mutex.lock();
+            if (index < self.entries.items.len) self.entries.items[index].setStatus(.error_, msg);
+            self.mutex.unlock();
+            return false;
+        };
+
+        var spawned_state: ChildState = .{ .real = child };
+        var replaced_child: ?ChildState = null;
+        var accepted = false;
+        self.mutex.lock();
+        if (index < self.entries.items.len) {
+            replaced_child = self.entries.items[index].child;
+            self.entries.items[index].child = spawned_state;
+            self.entries.items[index].setStatus(.running, "");
+            accepted = true;
+        }
+        self.mutex.unlock();
+
+        if (replaced_child) |*old_child| stopChildState(old_child);
+        if (!accepted) stopChildState(&spawned_state);
+        return accepted;
+    }
+
+    pub fn stopIndex(self: *Manager, index: usize) bool {
+        var child_to_stop: ?ChildState = null;
+
+        self.mutex.lock();
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        child_to_stop = self.entries.items[index].child;
+        self.entries.items[index].child = null;
+        self.mutex.unlock();
+
+        if (child_to_stop) |*child| stopChildState(child);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].setStatus(.stopped, "");
+        return true;
+    }
+
+    pub fn restartIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
+        _ = self.stopIndex(index);
+        return self.startIndex(index, legacy_algorithms);
+    }
+
+    pub fn startAuto(self: *Manager, legacy_algorithms: bool) void {
+        var i: usize = 0;
+        while (true) : (i += 1) {
+            self.mutex.lock();
+            const done = i >= self.entries.items.len;
+            const should_start = !done and
+                self.entries.items[i].rule.enabled and
+                self.entries.items[i].rule.auto_start;
+            self.mutex.unlock();
+            if (done) break;
+            if (should_start) _ = self.startIndex(i, legacy_algorithms);
+        }
+    }
+
+    pub fn tick(self: *Manager) bool {
+        var exited: ExitedChildList = .{};
+
+        self.mutex.lock();
+        for (self.entries.items, 0..) |*entry, index| {
+            const child = entry.child orelse continue;
+            if (!childHasExited(&child)) continue;
+            entry.child = null;
+            exited.append(ExitedChild.init(index, child));
+        }
+        self.mutex.unlock();
+
+        for (exited.slice()) |*item| {
+            stopChildState(&item.child);
+        }
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (exited.slice()) |*item| {
+            if (item.index < self.entries.items.len) {
+                self.entries.items[item.index].setStatus(.error_, item.reason());
+            }
+        }
+        return exited.len > 0;
     }
 
     pub fn markMissingProfileForTest(self: *Manager, index: usize) bool {
@@ -139,7 +363,51 @@ pub const Manager = struct {
         return false;
     }
 
+    pub fn markRunningForTest(self: *Manager, index: usize, pid: u32) bool {
+        var child_to_stop: ?ChildState = null;
+
+        self.mutex.lock();
+        if (index >= self.entries.items.len) {
+            self.mutex.unlock();
+            return false;
+        }
+        child_to_stop = self.entries.items[index].child;
+        self.entries.items[index].child = .{ .fake = .{ .pid = pid } };
+        self.entries.items[index].setStatus(.running, "");
+        self.mutex.unlock();
+
+        if (child_to_stop) |*child| stopChildState(child);
+        return true;
+    }
+
+    pub fn markExitedForTest(self: *Manager, index: usize, reason: []const u8) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        const child = if (self.entries.items[index].child) |*child| child else return false;
+        switch (child.*) {
+            .fake => |*fake| fake.setExited(reason),
+            .real => return false,
+        }
+        return true;
+    }
+
     pub fn stopAll(self: *Manager) void {
+        var children: ChildList = .{};
+
+        self.mutex.lock();
+        for (self.entries.items) |*entry| {
+            if (entry.child) |child| {
+                children.append(child);
+                entry.child = null;
+            }
+        }
+        self.mutex.unlock();
+
+        for (children.slice()) |*child| {
+            stopChildState(child);
+        }
+
         self.mutex.lock();
         defer self.mutex.unlock();
         for (self.entries.items) |*entry| {
@@ -147,6 +415,144 @@ pub const Manager = struct {
         }
     }
 };
+
+pub fn buildSshArgvForTest(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) ![][]const u8 {
+    return buildSshArgv(allocator, rule, conn);
+}
+
+fn buildSshArgv(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) ![][]const u8 {
+    var spec_buf: [MAX_TUNNEL_SPEC_BYTES]u8 = undefined;
+    const spec = rule.forwardSpec(&spec_buf) orelse return error.InvalidRule;
+    var dest_buf: [MAX_SSH_DEST_BYTES]u8 = undefined;
+    const dest = sshDestination(&dest_buf, conn) orelse return error.InvalidProfile;
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer argv.deinit(allocator);
+
+    try argv.append(allocator, platform_pty_command.sshExecutableName());
+    try argv.append(allocator, "-N");
+    try argv.append(allocator, "-T");
+    try argv.append(allocator, rule.direction.flag());
+    try argv.append(allocator, try allocator.dupe(u8, spec));
+
+    try appendSshOption(allocator, &argv, "ExitOnForwardFailure=yes");
+    try appendSshOption(allocator, &argv, "StrictHostKeyChecking=accept-new");
+    try appendSshOption(allocator, &argv, "ConnectTimeout=8");
+    try appendSshOption(allocator, &argv, "ServerAliveInterval=60");
+    try appendSshOption(allocator, &argv, "ServerAliveCountMax=3");
+    if (conn.legacy_algorithms) {
+        try appendSshOption(allocator, &argv, "HostkeyAlgorithms=+ssh-rsa,ssh-dss");
+        try appendSshOption(allocator, &argv, "PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss");
+        try appendSshOption(allocator, &argv, "KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1");
+        try appendSshOption(allocator, &argv, "Ciphers=+aes128-cbc,3des-cbc");
+    }
+    if (conn.password_auth) {
+        try appendSshOption(allocator, &argv, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        try appendSshOption(allocator, &argv, "NumberOfPasswordPrompts=1");
+    } else {
+        try appendSshOption(allocator, &argv, "BatchMode=yes");
+    }
+    if (conn.proxyJump().len > 0) {
+        try appendSshOption(allocator, &argv, try std.fmt.allocPrint(allocator, "ProxyJump={s}", .{conn.proxyJump()}));
+    }
+    if (conn.port().len > 0) {
+        try argv.append(allocator, "-p");
+        try argv.append(allocator, try allocator.dupe(u8, conn.port()));
+    }
+    try argv.append(allocator, try allocator.dupe(u8, dest));
+    return argv.toOwnedSlice(allocator);
+}
+
+fn appendSshOption(allocator: std.mem.Allocator, argv: *std.ArrayListUnmanaged([]const u8), option: []const u8) !void {
+    try argv.append(allocator, "-o");
+    try argv.append(allocator, option);
+}
+
+fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const ssh_connection.SshConnection) ?[]const u8 {
+    const user = conn.user();
+    const host = conn.host();
+    const len = user.len + 1 + host.len;
+    if (user.len == 0 or host.len == 0 or len > buf.len) return null;
+    @memcpy(buf[0..user.len], user);
+    buf[user.len] = '@';
+    @memcpy(buf[user.len + 1 ..][0..host.len], host);
+    return buf[0..len];
+}
+
+fn spawnForward(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: *const ssh_connection.SshConnection) !std.process.Child {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const argv = try buildSshArgv(arena.allocator(), rule, conn);
+
+    var askpass_path: ?[]const u8 = null;
+    defer if (askpass_path) |path| allocator.free(path);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return error.AskPassUnavailable;
+        env_map = try std.process.getEnvMap(allocator);
+        if (env_map) |*map| {
+            try platform_process.putSshAskPassEnv(map, askpass_path.?, conn.password());
+        }
+    }
+
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Inherit;
+    if (env_map) |*map| child.env_map = map;
+    try child.spawn();
+    return child;
+}
+
+fn stopEntries(entries: []Entry) void {
+    for (entries) |*entry| stopEntry(entry);
+}
+
+fn stopEntry(entry: *Entry) void {
+    if (entry.child) |*child| {
+        stopChildState(child);
+        entry.child = null;
+    }
+}
+
+fn stopChildState(child: *ChildState) void {
+    switch (child.*) {
+        .real => |*real_child| stopRealChild(real_child),
+        .fake => {},
+    }
+}
+
+fn stopRealChild(child: *std.process.Child) void {
+    if (childHasExitedReal(child)) {
+        if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
+        _ = child.wait() catch {};
+    } else {
+        _ = child.kill() catch {};
+    }
+}
+
+fn childHasExited(child: *const ChildState) bool {
+    return switch (child.*) {
+        .real => |*real_child| childHasExitedReal(real_child),
+        .fake => |*fake| fake.exited,
+    };
+}
+
+fn childHasExitedReal(child: *const std.process.Child) bool {
+    return switch (platform_process.childExited(child.id, 0)) {
+        .running => false,
+        .exited, .gone => true,
+    };
+}
+
+fn childExitReason(child: *const ChildState) []const u8 {
+    return switch (child.*) {
+        .real => "ssh exited",
+        .fake => |*fake| if (fake.reason().len > 0) fake.reason() else "ssh exited",
+    };
+}
 
 fn copyBounded(dest: []u8, text: []const u8) usize {
     const n = @min(dest.len, text.len);
@@ -297,4 +703,182 @@ test "port_forward_manager: update resets status and invalid indexes are ignored
     try std.testing.expectEqual(StatusKind.stopped, row.status);
     try std.testing.expectEqualStrings("", row.reason());
     try std.testing.expectEqualStrings("updated", row.rule.profileName());
+}
+
+test "port_forward_manager: builds reverse ssh argv without connection sharing" {
+    var conn = sshConnectionForTest("alice", "example.test", "2222", "jump@example.test:22", "", false, false);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const rule = rule_mod.defaultReverseProxy("devbox");
+    const argv = try buildSshArgvForTest(allocator, &rule, &conn);
+
+    try std.testing.expectEqualStrings("ssh", argv[0]);
+    try std.testing.expect(argvContainsForTest(argv, "-N"));
+    try std.testing.expect(argvContainsForTest(argv, "-T"));
+    try std.testing.expect(argvContainsForTest(argv, "-R"));
+    try std.testing.expect(argvContainsForTest(argv, "127.0.0.1:7890:127.0.0.1:7890"));
+    try std.testing.expect(argvContainsForTest(argv, "ProxyJump=jump@example.test:22"));
+    try std.testing.expect(argvContainsForTest(argv, "-p"));
+    try std.testing.expect(argvContainsForTest(argv, "2222"));
+    try std.testing.expect(argvContainsForTest(argv, "alice@example.test"));
+    try expectNoControlSharingOptionsForTest(argv);
+}
+
+test "port_forward_manager: builds local ssh argv with distinct endpoints" {
+    var conn = sshConnectionForTest("alice", "example.test", "", "", "", false, false);
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    rule.direction = .local;
+    rule.setLocalHost("127.0.0.1");
+    rule.local_port = 18080;
+    rule.setRemoteHost("localhost");
+    rule.remote_port = 8080;
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const argv = try buildSshArgvForTest(arena.allocator(), &rule, &conn);
+    try std.testing.expect(argvContainsForTest(argv, "-L"));
+    try std.testing.expect(argvContainsForTest(argv, "127.0.0.1:18080:localhost:8080"));
+    try expectNoControlSharingOptionsForTest(argv);
+}
+
+test "port_forward_manager: legacy profile includes legacy algorithm ssh options" {
+    var conn = sshConnectionForTest("alice", "legacy.test", "", "", "", false, true);
+    const rule = rule_mod.defaultReverseProxy("legacy");
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const argv = try buildSshArgvForTest(arena.allocator(), &rule, &conn);
+    try std.testing.expect(argvContainsForTest(argv, "HostkeyAlgorithms=+ssh-rsa,ssh-dss"));
+    try std.testing.expect(argvContainsForTest(argv, "PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss"));
+    try std.testing.expect(argvContainsForTest(argv, "KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1"));
+    try std.testing.expect(argvContainsForTest(argv, "Ciphers=+aes128-cbc,3des-cbc"));
+    try expectNoControlSharingOptionsForTest(argv);
+}
+
+test "port_forward_manager: password auth argv uses askpass compatible options and key auth uses BatchMode" {
+    var password_conn = sshConnectionForTest("alice", "password.test", "", "", "secret", true, false);
+    const rule = rule_mod.defaultReverseProxy("password");
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const password_argv = try buildSshArgvForTest(arena.allocator(), &rule, &password_conn);
+    try std.testing.expect(argvContainsForTest(password_argv, "PreferredAuthentications=publickey,password,keyboard-interactive"));
+    try std.testing.expect(argvContainsForTest(password_argv, "NumberOfPasswordPrompts=1"));
+    try std.testing.expect(!argvContainsForTest(password_argv, "BatchMode=yes"));
+
+    var key_conn = sshConnectionForTest("alice", "key.test", "", "", "", false, false);
+    const key_argv = try buildSshArgvForTest(arena.allocator(), &rule, &key_conn);
+    try std.testing.expect(argvContainsForTest(key_argv, "BatchMode=yes"));
+    try std.testing.expect(!argvContainsForTest(key_argv, "PreferredAuthentications=publickey,password,keyboard-interactive"));
+}
+
+test "port_forward_manager: running child exit becomes error on tick" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+
+    try std.testing.expect(manager.markRunningForTest(0, 99));
+    try std.testing.expect(manager.markExitedForTest(0, "ssh exited"));
+    try std.testing.expect(manager.tick());
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.error_, row.status);
+    try std.testing.expectEqualStrings("ssh exited", row.reason());
+    try std.testing.expect(!manager.tick());
+}
+
+test "port_forward_manager: update clears fake child before replacing rule" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expect(manager.markRunningForTest(0, 123));
+
+    try std.testing.expect(manager.updateRule(0, rule_mod.defaultReverseProxy("updated")));
+    try std.testing.expect(!manager.markExitedForTest(0, "old child exited"));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("updated", row.rule.profileName());
+}
+
+test "port_forward_manager: delete clears fake child for removed rule" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expect(manager.markRunningForTest(0, 123));
+
+    try std.testing.expect(manager.deleteRule(0));
+    try std.testing.expectEqual(@as(usize, 0), manager.count());
+    try std.testing.expect(!manager.markExitedForTest(0, "old child exited"));
+}
+
+test "port_forward_manager: load replacement clears old fake child" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old"));
+    try std.testing.expect(manager.markRunningForTest(0, 123));
+
+    var rules = [_]rule_mod.Rule{rule_mod.defaultReverseProxy("new")};
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    try manager.loadFromContent(out.items);
+    try std.testing.expect(!manager.markExitedForTest(0, "old child exited"));
+    try std.testing.expectEqualStrings("new", manager.rowAt(0).?.rule.profileName());
+}
+
+test "port_forward_manager: stop all clears fake children after stopping" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expect(manager.markRunningForTest(0, 123));
+
+    manager.stopAll();
+    try std.testing.expect(!manager.markExitedForTest(0, "old child exited"));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+}
+
+fn sshConnectionForTest(
+    user: []const u8,
+    host: []const u8,
+    port: []const u8,
+    proxy_jump: []const u8,
+    password: []const u8,
+    password_auth: bool,
+    legacy_algorithms: bool,
+) ssh_connection.SshConnection {
+    var conn: ssh_connection.SshConnection = .{};
+    conn.user_len = copyBounded(conn.user_buf[0..], user);
+    conn.host_len = copyBounded(conn.host_buf[0..], host);
+    conn.port_len = copyBounded(conn.port_buf[0..], port);
+    conn.proxy_jump_len = copyBounded(conn.proxy_jump_buf[0..], proxy_jump);
+    conn.password_len = copyBounded(conn.password_buf[0..], password);
+    conn.password_auth = password_auth;
+    conn.legacy_algorithms = legacy_algorithms;
+    return conn;
+}
+
+fn argvContainsForTest(argv: []const []const u8, needle: []const u8) bool {
+    for (argv) |arg| {
+        if (std.mem.eql(u8, arg, needle)) return true;
+    }
+    return false;
+}
+
+fn expectNoControlSharingOptionsForTest(argv: []const []const u8) !void {
+    for (argv) |arg| {
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlMaster") == null);
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPersist") == null);
+        try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPath") == null);
+    }
 }

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const rule_mod = @import("port_forward_rule.zig");
+
+pub const MAX_RULES: usize = 128;
+pub const REASON_MAX: usize = 192;
+
+pub const StatusKind = enum {
+    stopped,
+    starting,
+    running,
+    error_,
+    missing_profile,
+};
+
+pub const RowView = struct {
+    rule: rule_mod.Rule,
+    status: StatusKind,
+    reason: []const u8,
+    auto_start: bool,
+};
+
+const Entry = struct {
+    rule: rule_mod.Rule,
+    status: StatusKind = .stopped,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
+
+    fn reason(self: *const Entry) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
+
+    fn setStatus(self: *Entry, status: StatusKind, reason_text: []const u8) void {
+        self.status = status;
+        self.reason_len = copyBounded(self.reason_buf[0..], reason_text);
+    }
+};
+
+pub const Manager = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    entries: std.ArrayListUnmanaged(Entry) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator) Manager {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Manager) void {
+        self.stopAll();
+        self.entries.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn count(self: *Manager) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.entries.items.len;
+    }
+
+    pub fn rowAt(self: *Manager, index: usize) ?RowView {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return null;
+        const entry = &self.entries.items[index];
+        return .{
+            .rule = entry.rule,
+            .status = entry.status,
+            .reason = entry.reason(),
+            .auto_start = entry.rule.auto_start,
+        };
+    }
+
+    pub fn addRule(self: *Manager, rule: rule_mod.Rule) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.entries.items.len >= MAX_RULES) return error.TooManyRules;
+        try self.entries.append(self.allocator, .{ .rule = rule });
+    }
+
+    pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].rule = rule;
+        self.entries.items[index].setStatus(.stopped, "");
+        return true;
+    }
+
+    pub fn deleteRule(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        _ = self.entries.orderedRemove(index);
+        return true;
+    }
+
+    pub fn toggleAutoStart(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].rule.auto_start = !self.entries.items[index].rule.auto_start;
+        return true;
+    }
+
+    pub fn encode(self: *Manager, allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var rules = try allocator.alloc(rule_mod.Rule, self.entries.items.len);
+        defer allocator.free(rules);
+        for (self.entries.items, 0..) |entry, i| rules[i] = entry.rule;
+        try rule_mod.encodeRules(allocator, out, rules);
+    }
+
+    pub fn loadFromContent(self: *Manager, content: []const u8) !void {
+        const rules = try rule_mod.decodeRules(self.allocator, content);
+        defer rule_mod.freeRules(self.allocator, rules);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.entries.clearRetainingCapacity();
+        for (rules) |rule| {
+            try self.entries.append(self.allocator, .{ .rule = rule });
+        }
+    }
+
+    pub fn markMissingProfileForTest(self: *Manager, index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return false;
+        self.entries.items[index].setStatus(.missing_profile, "profile missing");
+        return false;
+    }
+
+    pub fn stopAll(self: *Manager) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.entries.items) |*entry| {
+            entry.setStatus(.stopped, "");
+        }
+    }
+};
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+
+test "port_forward_manager: add save load and toggle auto start" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expectEqual(@as(usize, 1), manager.count());
+    try std.testing.expect(manager.rowAt(0).?.auto_start);
+
+    try std.testing.expect(manager.toggleAutoStart(0));
+    try std.testing.expect(!manager.rowAt(0).?.auto_start);
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try manager.encode(std.testing.allocator, &out);
+
+    var loaded = Manager.init(std.testing.allocator);
+    defer loaded.deinit();
+    try loaded.loadFromContent(out.items);
+    try std.testing.expectEqual(@as(usize, 1), loaded.count());
+    try std.testing.expect(!loaded.rowAt(0).?.auto_start);
+}
+
+test "port_forward_manager: missing profile records status without spawning" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("missing"));
+
+    const started = manager.markMissingProfileForTest(0);
+    try std.testing.expect(!started);
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.missing_profile, row.status);
+    try std.testing.expectEqualStrings("profile missing", row.reason);
+}

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -15,8 +15,13 @@ pub const StatusKind = enum {
 pub const RowView = struct {
     rule: rule_mod.Rule,
     status: StatusKind,
-    reason: []const u8,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
     auto_start: bool,
+
+    pub fn reason(self: *const RowView) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
 };
 
 const Entry = struct {
@@ -61,12 +66,13 @@ pub const Manager = struct {
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return null;
         const entry = &self.entries.items[index];
-        return .{
+        var row: RowView = .{
             .rule = entry.rule,
             .status = entry.status,
-            .reason = entry.reason(),
             .auto_start = entry.rule.auto_start,
         };
+        row.reason_len = copyBounded(row.reason_buf[0..], entry.reason());
+        return row;
     }
 
     pub fn addRule(self: *Manager, rule: rule_mod.Rule) !void {
@@ -113,11 +119,18 @@ pub const Manager = struct {
     pub fn loadFromContent(self: *Manager, content: []const u8) !void {
         const rules = try rule_mod.decodeRules(self.allocator, content);
         defer rule_mod.freeRules(self.allocator, rules);
+        if (rules.len > MAX_RULES) return error.TooManyRules;
         self.mutex.lock();
         defer self.mutex.unlock();
+        try self.replaceRulesLocked(rules);
+    }
+
+    fn replaceRulesLocked(self: *Manager, rules: []const rule_mod.Rule) !void {
+        if (rules.len > MAX_RULES) return error.TooManyRules;
+        try self.entries.ensureTotalCapacity(self.allocator, rules.len);
         self.entries.clearRetainingCapacity();
         for (rules) |rule| {
-            try self.entries.append(self.allocator, .{ .rule = rule });
+            self.entries.appendAssumeCapacity(.{ .rule = rule });
         }
     }
 
@@ -175,5 +188,116 @@ test "port_forward_manager: missing profile records status without spawning" {
     try std.testing.expect(!started);
     const row = manager.rowAt(0).?;
     try std.testing.expectEqual(StatusKind.missing_profile, row.status);
-    try std.testing.expectEqualStrings("profile missing", row.reason);
+    try std.testing.expectEqualStrings("profile missing", row.reason());
+}
+
+test "port_forward_manager: row view reason snapshot survives status changes" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    _ = manager.markMissingProfileForTest(0);
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.missing_profile, row.status);
+    try std.testing.expectEqualStrings("profile missing", row.reason());
+    try std.testing.expect(row.reason().ptr != manager.entries.items[0].reason_buf[0..].ptr);
+
+    manager.entries.items[0].setStatus(.error_, "rewritten");
+    try std.testing.expectEqual(StatusKind.missing_profile, row.status);
+    try std.testing.expectEqualStrings("profile missing", row.reason());
+}
+
+test "port_forward_manager: load rejects too many rules without replacing existing" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("existing"));
+
+    var rules: [MAX_RULES + 1]rule_mod.Rule = undefined;
+    for (&rules) |*rule| {
+        rule.* = rule_mod.defaultReverseProxy("loaded");
+    }
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    try std.testing.expectError(error.TooManyRules, manager.loadFromContent(out.items));
+    try std.testing.expectEqual(@as(usize, 1), manager.count());
+    try std.testing.expectEqualStrings("existing", manager.rowAt(0).?.rule.profileName());
+}
+
+test "port_forward_manager: load replacement fully replaces old entries" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old-a"));
+    try manager.addRule(rule_mod.defaultReverseProxy("old-b"));
+
+    var rules = [_]rule_mod.Rule{rule_mod.defaultReverseProxy("new")};
+    rules[0].auto_start = false;
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    try manager.loadFromContent(out.items);
+    try std.testing.expectEqual(@as(usize, 1), manager.count());
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("new", row.rule.profileName());
+    try std.testing.expect(!row.auto_start);
+}
+
+test "port_forward_manager: load allocation failure keeps existing rules" {
+    var rules: [MAX_RULES]rule_mod.Rule = undefined;
+    for (&rules) |*rule| {
+        rule.* = rule_mod.defaultReverseProxy("loaded");
+    }
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    var saw_failure = false;
+    var fail_index: usize = 0;
+    while (fail_index < 256) : (fail_index += 1) {
+        var manager = Manager.init(std.testing.allocator);
+        defer manager.deinit();
+        try manager.addRule(rule_mod.defaultReverseProxy("existing"));
+
+        var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+            .fail_index = fail_index,
+        });
+        manager.allocator = failing_allocator.allocator();
+        const result = manager.loadFromContent(out.items);
+        manager.allocator = std.testing.allocator;
+
+        if (result) |_| {
+            if (!failing_allocator.has_induced_failure) break;
+            try std.testing.expectEqual(@as(usize, MAX_RULES), manager.count());
+        } else |err| {
+            try std.testing.expectEqual(error.OutOfMemory, err);
+            try std.testing.expect(failing_allocator.has_induced_failure);
+            saw_failure = true;
+            try std.testing.expectEqual(@as(usize, 1), manager.count());
+            try std.testing.expectEqualStrings("existing", manager.rowAt(0).?.rule.profileName());
+        }
+    }
+    try std.testing.expect(saw_failure);
+}
+
+test "port_forward_manager: update resets status and invalid indexes are ignored" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    _ = manager.markMissingProfileForTest(0);
+
+    try std.testing.expect(!manager.updateRule(8, rule_mod.defaultReverseProxy("ignored")));
+    try std.testing.expect(!manager.toggleAutoStart(8));
+    try std.testing.expect(!manager.deleteRule(8));
+    try std.testing.expect(manager.rowAt(8) == null);
+
+    try std.testing.expect(manager.updateRule(0, rule_mod.defaultReverseProxy("updated")));
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expectEqualStrings("updated", row.rule.profileName());
 }

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -66,6 +66,15 @@ const StartLease = struct {
     child_to_stop: ?ChildState,
 };
 
+const UpdateRuleLease = struct {
+    child_to_stop: ?ChildState,
+};
+
+const AutoStartCandidate = struct {
+    entry_id: u64,
+    generation: u64,
+};
+
 const FakeChild = struct {
     pid: u32,
     exited: bool = false,
@@ -189,29 +198,8 @@ pub const Manager = struct {
     }
 
     pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
-        var child_to_stop: ?ChildState = null;
-        var entry_id: u64 = 0;
-        var generation: u64 = 0;
-
-        self.mutex.lock();
-        if (index >= self.entries.items.len) {
-            self.mutex.unlock();
-            return false;
-        }
-        entry_id = self.entries.items[index].id;
-        child_to_stop = self.entries.items[index].child;
-        self.entries.items[index].child = null;
-        generation = self.nextGenerationLocked();
-        self.entries.items[index].generation = generation;
-        self.mutex.unlock();
-
-        if (child_to_stop) |*child| stopChildState(child);
-
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const current_index = self.findEntryIndexByIdAndGenerationLocked(entry_id, generation) orelse return false;
-        self.entries.items[current_index].rule = rule;
-        self.entries.items[current_index].setStatus(.stopped, "");
+        var lease = self.beginUpdateRule(index, rule) orelse return false;
+        stopUpdateRuleLease(&lease);
         return true;
     }
 
@@ -273,25 +261,7 @@ pub const Manager = struct {
 
     pub fn startIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
         var lease = self.beginStart(index) orelse return false;
-        if (lease.child_to_stop) |*child| stopChildState(child);
-        const pending = lease.pending;
-
-        const conn = ssh_profile_store.connectionByName(self.allocator, pending.rule.profileName(), legacy_algorithms) orelse {
-            _ = self.completePendingStartFailure(pending, .missing_profile, "profile missing");
-            return false;
-        };
-
-        const child = spawnForward(self.allocator, &pending.rule, &conn) catch |err| {
-            var buf: [REASON_MAX]u8 = undefined;
-            const msg = std.fmt.bufPrint(&buf, "spawn failed: {}", .{err}) catch "spawn failed";
-            _ = self.completePendingStartFailure(pending, .error_, msg);
-            return false;
-        };
-
-        var spawned_state: ChildState = .{ .real = child };
-        const accepted = self.completePendingStartInstall(pending, spawned_state);
-        if (!accepted) stopChildState(&spawned_state);
-        return accepted;
+        return self.runStartLease(&lease, legacy_algorithms);
     }
 
     pub fn stopIndex(self: *Manager, index: usize) bool {
@@ -327,14 +297,18 @@ pub const Manager = struct {
     pub fn startAuto(self: *Manager, legacy_algorithms: bool) void {
         var i: usize = 0;
         while (true) : (i += 1) {
+            var candidate: ?AutoStartCandidate = null;
+
             self.mutex.lock();
             const done = i >= self.entries.items.len;
-            const should_start = !done and
-                self.entries.items[i].rule.enabled and
-                self.entries.items[i].rule.auto_start;
+            if (!done) candidate = self.autoStartCandidateAtIndexLocked(i);
             self.mutex.unlock();
+
             if (done) break;
-            if (should_start) _ = self.startIndex(i, legacy_algorithms);
+            if (candidate) |item| {
+                var lease = self.beginAutoStart(item) orelse continue;
+                _ = self.runStartLease(&lease, legacy_algorithms);
+            }
         }
     }
 
@@ -411,6 +385,27 @@ pub const Manager = struct {
         return self.completePendingStartInstall(pending, .{ .fake = .{ .pid = pid } });
     }
 
+    fn beginUpdateRuleForTest(self: *Manager, index: usize, rule: rule_mod.Rule) ?UpdateRuleLease {
+        return self.beginUpdateRule(index, rule);
+    }
+
+    fn finishUpdateRuleForTest(self: *Manager, lease: *UpdateRuleLease) void {
+        _ = self;
+        stopUpdateRuleLease(lease);
+    }
+
+    fn sampleAutoStartForTest(self: *Manager, index: usize) ?AutoStartCandidate {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.autoStartCandidateAtIndexLocked(index);
+    }
+
+    fn beginAutoStartForTest(self: *Manager, candidate: AutoStartCandidate) ?PendingStart {
+        var lease = self.beginAutoStart(candidate) orelse return null;
+        if (lease.child_to_stop) |*child| stopChildState(child);
+        return lease.pending;
+    }
+
     fn takeExitedChildForTest(self: *Manager, index: usize) ?ExitedChild {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -459,10 +454,35 @@ pub const Manager = struct {
         }
     }
 
+    fn beginUpdateRule(self: *Manager, index: usize, rule: rule_mod.Rule) ?UpdateRuleLease {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return null;
+        const entry = &self.entries.items[index];
+        const child_to_stop = entry.child;
+        entry.child = null;
+        entry.rule = rule;
+        entry.generation = self.nextGenerationLocked();
+        entry.setStatus(.stopped, "");
+        return .{ .child_to_stop = child_to_stop };
+    }
+
     fn beginStart(self: *Manager, index: usize) ?StartLease {
         self.mutex.lock();
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return null;
+        return self.beginStartAtIndexLocked(index);
+    }
+
+    fn beginAutoStart(self: *Manager, candidate: AutoStartCandidate) ?StartLease {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const index = self.findEntryIndexByIdAndGenerationLocked(candidate.entry_id, candidate.generation) orelse return null;
+        if (self.autoStartCandidateAtIndexLocked(index) == null) return null;
+        return self.beginStartAtIndexLocked(index);
+    }
+
+    fn beginStartAtIndexLocked(self: *Manager, index: usize) StartLease {
         const entry = &self.entries.items[index];
         const child_to_stop = entry.child;
         const generation = self.nextGenerationLocked();
@@ -477,6 +497,29 @@ pub const Manager = struct {
             },
             .child_to_stop = child_to_stop,
         };
+    }
+
+    fn runStartLease(self: *Manager, lease: *StartLease, legacy_algorithms: bool) bool {
+        if (lease.child_to_stop) |*child| stopChildState(child);
+        lease.child_to_stop = null;
+        const pending = lease.pending;
+
+        const conn = ssh_profile_store.connectionByName(self.allocator, pending.rule.profileName(), legacy_algorithms) orelse {
+            _ = self.completePendingStartFailure(pending, .missing_profile, "profile missing");
+            return false;
+        };
+
+        const child = spawnForward(self.allocator, &pending.rule, &conn) catch |err| {
+            var buf: [REASON_MAX]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "spawn failed: {}", .{err}) catch "spawn failed";
+            _ = self.completePendingStartFailure(pending, .error_, msg);
+            return false;
+        };
+
+        var spawned_state: ChildState = .{ .real = child };
+        const accepted = self.completePendingStartInstall(pending, spawned_state);
+        if (!accepted) stopChildState(&spawned_state);
+        return accepted;
     }
 
     fn completePendingStartFailure(self: *Manager, pending: PendingStart, status: StatusKind, reason: []const u8) bool {
@@ -510,6 +553,16 @@ pub const Manager = struct {
         const entry = &self.entries.items[index];
         if (entry.child != null or !rulesEqual(&entry.rule, &pending.rule)) return null;
         return index;
+    }
+
+    fn autoStartCandidateAtIndexLocked(self: *Manager, index: usize) ?AutoStartCandidate {
+        if (index >= self.entries.items.len) return null;
+        const entry = &self.entries.items[index];
+        if (!entry.rule.enabled or !entry.rule.auto_start) return null;
+        return .{
+            .entry_id = entry.id,
+            .generation = entry.generation,
+        };
     }
 
     fn findEntryIndexByIdAndGenerationLocked(self: *Manager, entry_id: u64, generation: u64) ?usize {
@@ -647,6 +700,13 @@ fn stopChildState(child: *ChildState) void {
     switch (child.*) {
         .real => |*real_child| stopRealChild(real_child),
         .fake => {},
+    }
+}
+
+fn stopUpdateRuleLease(lease: *UpdateRuleLease) void {
+    if (lease.child_to_stop) |*child| {
+        stopChildState(child);
+        lease.child_to_stop = null;
     }
 }
 
@@ -963,6 +1023,29 @@ test "port_forward_manager: update clears fake child before replacing rule" {
     try std.testing.expectEqualStrings("updated", row.rule.profileName());
 }
 
+test "port_forward_manager: update applies logical replacement before detached child cleanup" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old"));
+    try std.testing.expect(manager.markRunningForTest(0, 123));
+
+    var update = manager.beginUpdateRuleForTest(0, rule_mod.defaultReverseProxy("updated")) orelse return error.ExpectedUpdate;
+    defer manager.finishUpdateRuleForTest(&update);
+
+    const updated = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, updated.status);
+    try std.testing.expectEqualStrings("", updated.reason());
+    try std.testing.expectEqualStrings("updated", updated.rule.profileName());
+
+    const pending = manager.beginPendingStartForTest(0) orelse return error.ExpectedPendingStart;
+    try std.testing.expectEqualStrings("updated", pending.rule.profileName());
+    try std.testing.expect(manager.completePendingStartFakeForTest(pending, 456));
+
+    const running = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.running, running.status);
+    try std.testing.expectEqualStrings("updated", running.rule.profileName());
+}
+
 test "port_forward_manager: delete clears fake child for removed rule" {
     var manager = Manager.init(std.testing.allocator);
     defer manager.deinit();
@@ -1182,6 +1265,48 @@ test "port_forward_manager: shifted restart lease does not start wrong row" {
     const wrong = manager.rowAt(1).?;
     try std.testing.expectEqualStrings("wrong", wrong.rule.profileName());
     try std.testing.expectEqual(StatusKind.stopped, wrong.status);
+}
+
+test "port_forward_manager: sampled auto-start follows shifted logical row" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("earlier"));
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+    try manager.addRule(rule_mod.defaultReverseProxy("wrong"));
+
+    const candidate = manager.sampleAutoStartForTest(1) orelse return error.ExpectedAutoStart;
+    try std.testing.expect(manager.deleteRule(0));
+
+    const pending = manager.beginAutoStartForTest(candidate) orelse return error.ExpectedPendingStart;
+    try std.testing.expectEqualStrings("target", pending.rule.profileName());
+    try std.testing.expect(manager.completePendingStartFakeForTest(pending, 333));
+
+    const target = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", target.rule.profileName());
+    try std.testing.expectEqual(StatusKind.running, target.status);
+
+    const wrong = manager.rowAt(1).?;
+    try std.testing.expectEqualStrings("wrong", wrong.rule.profileName());
+    try std.testing.expectEqual(StatusKind.stopped, wrong.status);
+}
+
+test "port_forward_manager: sampled auto-start skips loaded replacement" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+
+    const candidate = manager.sampleAutoStartForTest(0) orelse return error.ExpectedAutoStart;
+
+    var rules = [_]rule_mod.Rule{rule_mod.defaultReverseProxy("replacement")};
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
+    try manager.loadFromContent(out.items);
+
+    try std.testing.expect(manager.beginAutoStartForTest(candidate) == null);
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("replacement", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
 }
 
 fn sshConnectionForTest(

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -236,7 +236,6 @@ pub const Manager = struct {
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return false;
         self.entries.items[index].rule.auto_start = !self.entries.items[index].rule.auto_start;
-        self.entries.items[index].generation = self.nextGenerationLocked();
         return true;
     }
 
@@ -255,27 +254,21 @@ pub const Manager = struct {
 
         var old_entries: std.ArrayListUnmanaged(Entry) = .empty;
         self.mutex.lock();
+        self.prepareEntriesLocked(entries.items);
         old_entries = self.entries;
-        self.entries = .empty;
+        self.entries = entries;
+        entries = .empty;
         self.mutex.unlock();
 
         stopEntries(old_entries.items);
         old_entries.deinit(self.allocator);
-
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        self.replaceEntriesLocked(&entries);
     }
 
-    fn replaceEntriesLocked(self: *Manager, entries: *std.ArrayListUnmanaged(Entry)) void {
-        std.debug.assert(self.entries.items.len == 0);
-        self.entries.deinit(self.allocator);
-        for (entries.items) |*entry| {
+    fn prepareEntriesLocked(self: *Manager, entries: []Entry) void {
+        for (entries) |*entry| {
             entry.id = self.nextEntryIdLocked();
             entry.generation = self.nextGenerationLocked();
         }
-        self.entries = entries.*;
-        entries.* = .empty;
     }
 
     pub fn startIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
@@ -713,8 +706,7 @@ fn rulesEqual(a: *const rule_mod.Rule, b: *const rule_mod.Rule) bool {
         a.local_port == b.local_port and
         std.mem.eql(u8, a.remoteHost(), b.remoteHost()) and
         a.remote_port == b.remote_port and
-        a.enabled == b.enabled and
-        a.auto_start == b.auto_start;
+        a.enabled == b.enabled;
 }
 
 fn copyBounded(dest: []u8, text: []const u8) usize {
@@ -934,6 +926,7 @@ test "port_forward_manager: password auth argv uses askpass compatible options a
     try std.testing.expect(argvContainsForTest(password_argv, "PreferredAuthentications=publickey,password,keyboard-interactive"));
     try std.testing.expect(argvContainsForTest(password_argv, "NumberOfPasswordPrompts=1"));
     try std.testing.expect(!argvContainsForTest(password_argv, "BatchMode=yes"));
+    try expectArgvLacksForTest(password_argv, "secret");
 
     var key_conn = sshConnectionForTest("alice", "key.test", "", "", "", false, false);
     const key_argv = try buildSshArgvForTest(arena.allocator(), &rule, &key_conn);
@@ -1062,6 +1055,23 @@ test "port_forward_manager: shifted pending start install follows logical row" {
     try std.testing.expect(manager.markExitedForTest(0, "installed child exited"));
 }
 
+test "port_forward_manager: pending start survives auto-start toggle" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+
+    const pending = manager.beginPendingStartForTest(0) orelse return error.ExpectedPendingStart;
+    try std.testing.expect(manager.toggleAutoStart(0));
+
+    try std.testing.expect(manager.completePendingStartFakeForTest(pending, 555));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.running, row.status);
+    try std.testing.expect(!row.auto_start);
+    try std.testing.expect(manager.markExitedForTest(0, "installed child exited"));
+}
+
 test "port_forward_manager: stale pending start install leaves replacement row alone" {
     var manager = Manager.init(std.testing.allocator);
     defer manager.deinit();
@@ -1134,6 +1144,25 @@ test "port_forward_manager: shifted exited child completion follows logical row"
     try std.testing.expectEqualStrings("target exited", row.reason());
 }
 
+test "port_forward_manager: exited child completion survives auto-start toggle" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("target"));
+    try std.testing.expect(manager.markRunningForTest(0, 111));
+    try std.testing.expect(manager.markExitedForTest(0, "target exited"));
+
+    var exited = manager.takeExitedChildForTest(0) orelse return error.ExpectedExitedChild;
+    try std.testing.expect(manager.toggleAutoStart(0));
+
+    try std.testing.expect(manager.finishExitedChildForTest(&exited));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqualStrings("target", row.rule.profileName());
+    try std.testing.expectEqual(StatusKind.error_, row.status);
+    try std.testing.expectEqualStrings("target exited", row.reason());
+    try std.testing.expect(!row.auto_start);
+}
+
 test "port_forward_manager: shifted restart lease does not start wrong row" {
     var manager = Manager.init(std.testing.allocator);
     defer manager.deinit();
@@ -1187,5 +1216,11 @@ fn expectNoControlSharingOptionsForTest(argv: []const []const u8) !void {
         try std.testing.expect(std.mem.indexOf(u8, arg, "ControlMaster") == null);
         try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPersist") == null);
         try std.testing.expect(std.mem.indexOf(u8, arg, "ControlPath") == null);
+    }
+}
+
+fn expectArgvLacksForTest(argv: []const []const u8, needle: []const u8) !void {
+    for (argv) |arg| {
+        try std.testing.expect(std.mem.indexOf(u8, arg, needle) == null);
     }
 }

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -117,21 +117,18 @@ pub const Manager = struct {
     }
 
     pub fn loadFromContent(self: *Manager, content: []const u8) !void {
-        const rules = try rule_mod.decodeRules(self.allocator, content);
-        defer rule_mod.freeRules(self.allocator, rules);
-        if (rules.len > MAX_RULES) return error.TooManyRules;
+        var entries = try decodeEntriesBounded(self.allocator, content);
+        defer entries.deinit(self.allocator);
+
         self.mutex.lock();
         defer self.mutex.unlock();
-        try self.replaceRulesLocked(rules);
+        self.replaceEntriesLocked(&entries);
     }
 
-    fn replaceRulesLocked(self: *Manager, rules: []const rule_mod.Rule) !void {
-        if (rules.len > MAX_RULES) return error.TooManyRules;
-        try self.entries.ensureTotalCapacity(self.allocator, rules.len);
-        self.entries.clearRetainingCapacity();
-        for (rules) |rule| {
-            self.entries.appendAssumeCapacity(.{ .rule = rule });
-        }
+    fn replaceEntriesLocked(self: *Manager, entries: *std.ArrayListUnmanaged(Entry)) void {
+        self.entries.deinit(self.allocator);
+        self.entries = entries.*;
+        entries.* = .empty;
     }
 
     pub fn markMissingProfileForTest(self: *Manager, index: usize) bool {
@@ -155,6 +152,23 @@ fn copyBounded(dest: []u8, text: []const u8) usize {
     const n = @min(dest.len, text.len);
     @memcpy(dest[0..n], text[0..n]);
     return n;
+}
+
+fn decodeEntriesBounded(allocator: std.mem.Allocator, content: []const u8) !std.ArrayListUnmanaged(Entry) {
+    var entries: std.ArrayListUnmanaged(Entry) = .empty;
+    errdefer entries.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (rule_mod.decodeRuleLine(line)) |rule| {
+            if (entries.items.len >= MAX_RULES) return error.TooManyRules;
+            if (entries.capacity == 0) try entries.ensureTotalCapacity(allocator, MAX_RULES);
+            entries.appendAssumeCapacity(.{ .rule = rule });
+        }
+    }
+    return entries;
 }
 
 test "port_forward_manager: add save load and toggle auto start" {
@@ -246,8 +260,8 @@ test "port_forward_manager: load replacement fully replaces old entries" {
     try std.testing.expect(!row.auto_start);
 }
 
-test "port_forward_manager: load allocation failure keeps existing rules" {
-    var rules: [MAX_RULES]rule_mod.Rule = undefined;
+test "port_forward_manager: oversized load stops at the max rule boundary" {
+    var rules: [MAX_RULES + 1]rule_mod.Rule = undefined;
     for (&rules) |*rule| {
         rule.* = rule_mod.defaultReverseProxy("loaded");
     }
@@ -256,32 +270,15 @@ test "port_forward_manager: load allocation failure keeps existing rules" {
     defer out.deinit(std.testing.allocator);
     try rule_mod.encodeRules(std.testing.allocator, &out, rules[0..]);
 
-    var saw_failure = false;
-    var fail_index: usize = 0;
-    while (fail_index < 256) : (fail_index += 1) {
-        var manager = Manager.init(std.testing.allocator);
-        defer manager.deinit();
-        try manager.addRule(rule_mod.defaultReverseProxy("existing"));
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 1,
+    });
+    var manager = Manager.init(failing_allocator.allocator());
+    defer manager.deinit();
 
-        var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
-            .fail_index = fail_index,
-        });
-        manager.allocator = failing_allocator.allocator();
-        const result = manager.loadFromContent(out.items);
-        manager.allocator = std.testing.allocator;
-
-        if (result) |_| {
-            if (!failing_allocator.has_induced_failure) break;
-            try std.testing.expectEqual(@as(usize, MAX_RULES), manager.count());
-        } else |err| {
-            try std.testing.expectEqual(error.OutOfMemory, err);
-            try std.testing.expect(failing_allocator.has_induced_failure);
-            saw_failure = true;
-            try std.testing.expectEqual(@as(usize, 1), manager.count());
-            try std.testing.expectEqualStrings("existing", manager.rowAt(0).?.rule.profileName());
-        }
-    }
-    try std.testing.expect(saw_failure);
+    try std.testing.expectError(error.TooManyRules, manager.loadFromContent(out.items));
+    try std.testing.expect(!failing_allocator.has_induced_failure);
+    try std.testing.expectEqual(@as(usize, 0), manager.count());
 }
 
 test "port_forward_manager: update resets status and invalid indexes are ignored" {

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -182,7 +182,7 @@ pub const Manager = struct {
     }
 
     pub fn load(self: *Manager) !bool {
-        const path = self.storagePathSnapshot() orelse return false;
+        const path = try self.storagePathSnapshot() orelse return false;
         defer self.allocator.free(path);
 
         const content = std.fs.cwd().readFileAlloc(self.allocator, path, 1024 * 1024) catch |err| switch (err) {
@@ -196,7 +196,7 @@ pub const Manager = struct {
     }
 
     pub fn save(self: *Manager) bool {
-        const path = self.storagePathSnapshot() orelse return false;
+        const path = (self.storagePathSnapshot() catch return false) orelse return false;
         defer self.allocator.free(path);
 
         var out: std.ArrayListUnmanaged(u8) = .empty;
@@ -513,11 +513,11 @@ pub const Manager = struct {
         return .{ .child_to_stop = child_to_stop };
     }
 
-    fn storagePathSnapshot(self: *Manager) ?[]u8 {
+    fn storagePathSnapshot(self: *Manager) !?[]u8 {
         self.mutex.lock();
         defer self.mutex.unlock();
         const path = self.storage_path orelse return null;
-        return self.allocator.dupe(u8, path) catch null;
+        return try self.allocator.dupe(u8, path);
     }
 
     fn beginStart(self: *Manager, index: usize) ?StartLease {
@@ -898,6 +898,17 @@ test "port_forward_manager: save and load from explicit path" {
     try std.testing.expectEqualStrings("devbox", row.rule.profileName());
     try std.testing.expect(!row.auto_start);
     try std.testing.expectEqual(StatusKind.stopped, row.status);
+}
+
+test "port_forward_manager: load reports storage path snapshot allocation failure" {
+    var failing_allocator = std.testing.FailingAllocator.init(std.testing.allocator, .{
+        .fail_index = 1,
+    });
+    var manager = Manager.init(failing_allocator.allocator());
+    defer manager.deinit();
+    try manager.setStoragePath("port_forwards");
+
+    try std.testing.expectError(error.OutOfMemory, manager.load());
 }
 
 test "port_forward_manager: missing profile records status without spawning" {

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -155,6 +155,7 @@ pub const Manager = struct {
     entries: std.ArrayListUnmanaged(Entry) = .empty,
     next_entry_id: u64 = 1,
     next_generation: u64 = 1,
+    storage_path: ?[]u8 = null,
 
     pub fn init(allocator: std.mem.Allocator) Manager {
         return .{ .allocator = allocator };
@@ -163,7 +164,52 @@ pub const Manager = struct {
     pub fn deinit(self: *Manager) void {
         self.stopAll();
         self.entries.deinit(self.allocator);
+        if (self.storage_path) |path| self.allocator.free(path);
         self.* = undefined;
+    }
+
+    pub fn setStoragePath(self: *Manager, path: []const u8) !void {
+        const owned = try self.allocator.dupe(u8, path);
+        self.mutex.lock();
+        const old = self.storage_path;
+        self.storage_path = owned;
+        self.mutex.unlock();
+        if (old) |old_path| self.allocator.free(old_path);
+    }
+
+    pub fn setStoragePathForTest(self: *Manager, path: []const u8) void {
+        self.setStoragePath(path) catch @panic("setStoragePathForTest failed");
+    }
+
+    pub fn load(self: *Manager) !bool {
+        const path = self.storagePathSnapshot() orelse return false;
+        defer self.allocator.free(path);
+
+        const content = std.fs.cwd().readFileAlloc(self.allocator, path, 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        defer self.allocator.free(content);
+
+        try self.loadFromContent(content);
+        return true;
+    }
+
+    pub fn save(self: *Manager) bool {
+        const path = self.storagePathSnapshot() orelse return false;
+        defer self.allocator.free(path);
+
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        defer out.deinit(self.allocator);
+        self.encode(self.allocator, &out) catch return false;
+
+        if (std.fs.path.dirname(path)) |dir| {
+            std.fs.cwd().makePath(dir) catch return false;
+        }
+        const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
+        defer file.close();
+        file.writeAll(out.items) catch return false;
+        return true;
     }
 
     pub fn count(self: *Manager) usize {
@@ -465,6 +511,13 @@ pub const Manager = struct {
         entry.generation = self.nextGenerationLocked();
         entry.setStatus(.stopped, "");
         return .{ .child_to_stop = child_to_stop };
+    }
+
+    fn storagePathSnapshot(self: *Manager) ?[]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const path = self.storage_path orelse return null;
+        return self.allocator.dupe(u8, path) catch null;
     }
 
     fn beginStart(self: *Manager, index: usize) ?StartLease {
@@ -812,6 +865,39 @@ test "port_forward_manager: add save load and toggle auto start" {
     try loaded.loadFromContent(out.items);
     try std.testing.expectEqual(@as(usize, 1), loaded.count());
     try std.testing.expect(!loaded.rowAt(0).?.auto_start);
+}
+
+test "port_forward_manager: save and load from explicit path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(tmp_root);
+    const storage_path = try std.fs.path.join(std.testing.allocator, &.{ tmp_root, "nested", "port_forwards" });
+    defer std.testing.allocator.free(storage_path);
+
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    manager.setStoragePathForTest(storage_path);
+
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    rule.setName("Proxy");
+    rule.auto_start = false;
+    try manager.addRule(rule);
+
+    try std.testing.expect(manager.save());
+
+    var loaded = Manager.init(std.testing.allocator);
+    defer loaded.deinit();
+    loaded.setStoragePathForTest(storage_path);
+
+    try std.testing.expect(try loaded.load());
+    try std.testing.expectEqual(@as(usize, 1), loaded.count());
+    const row = loaded.rowAt(0).?;
+    try std.testing.expectEqualStrings("Proxy", row.rule.name());
+    try std.testing.expectEqualStrings("devbox", row.rule.profileName());
+    try std.testing.expect(!row.auto_start);
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
 }
 
 test "port_forward_manager: missing profile records status without spawning" {

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const rule_mod = @import("port_forward_rule.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
 const ssh_profile_store = @import("ssh_profile_store.zig");
 
@@ -206,9 +207,7 @@ pub const Manager = struct {
         if (std.fs.path.dirname(path)) |dir| {
             std.fs.cwd().makePath(dir) catch return false;
         }
-        const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
-        defer file.close();
-        file.writeAll(out.items) catch return false;
+        platform_atomic_file.writeFileReplaceSafe(path, out.items) catch return false;
         return true;
     }
 

--- a/src/port_forward_manager.zig
+++ b/src/port_forward_manager.zig
@@ -33,6 +33,7 @@ pub const RowView = struct {
 
 const Entry = struct {
     rule: rule_mod.Rule,
+    generation: u64 = 0,
     status: StatusKind = .stopped,
     reason_buf: [REASON_MAX]u8 = undefined,
     reason_len: usize = 0,
@@ -53,6 +54,17 @@ const ChildState = union(enum) {
     fake: FakeChild,
 };
 
+const PendingStart = struct {
+    index: usize,
+    generation: u64,
+    rule: rule_mod.Rule,
+};
+
+const StartLease = struct {
+    pending: PendingStart,
+    child_to_stop: ?ChildState,
+};
+
 const FakeChild = struct {
     pid: u32,
     exited: bool = false,
@@ -69,30 +81,17 @@ const FakeChild = struct {
     }
 };
 
-const ChildList = struct {
-    items: [MAX_RULES]ChildState = undefined,
-    len: usize = 0,
-
-    fn append(self: *ChildList, child: ChildState) void {
-        std.debug.assert(self.len < self.items.len);
-        self.items[self.len] = child;
-        self.len += 1;
-    }
-
-    fn slice(self: *ChildList) []ChildState {
-        return self.items[0..self.len];
-    }
-};
-
 const ExitedChild = struct {
     index: usize,
+    generation: u64,
     child: ChildState,
     reason_buf: [REASON_MAX]u8 = undefined,
     reason_len: usize = 0,
 
-    fn init(index: usize, child: ChildState) ExitedChild {
+    fn init(index: usize, generation: u64, child: ChildState) ExitedChild {
         var item: ExitedChild = .{
             .index = index,
+            .generation = generation,
             .child = child,
         };
         item.reason_len = copyBounded(item.reason_buf[0..], childExitReason(&item.child));
@@ -119,10 +118,32 @@ const ExitedChildList = struct {
     }
 };
 
+const StoppedEntry = struct {
+    index: usize,
+    generation: u64,
+    child: ?ChildState,
+};
+
+const StopList = struct {
+    items: [MAX_RULES]StoppedEntry = undefined,
+    len: usize = 0,
+
+    fn append(self: *StopList, stopped: StoppedEntry) void {
+        std.debug.assert(self.len < self.items.len);
+        self.items[self.len] = stopped;
+        self.len += 1;
+    }
+
+    fn slice(self: *StopList) []StoppedEntry {
+        return self.items[0..self.len];
+    }
+};
+
 pub const Manager = struct {
     allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},
     entries: std.ArrayListUnmanaged(Entry) = .empty,
+    next_generation: u64 = 1,
 
     pub fn init(allocator: std.mem.Allocator) Manager {
         return .{ .allocator = allocator };
@@ -158,11 +179,15 @@ pub const Manager = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         if (self.entries.items.len >= MAX_RULES) return error.TooManyRules;
-        try self.entries.append(self.allocator, .{ .rule = rule });
+        try self.entries.append(self.allocator, .{
+            .rule = rule,
+            .generation = self.nextGenerationLocked(),
+        });
     }
 
     pub fn updateRule(self: *Manager, index: usize, rule: rule_mod.Rule) bool {
         var child_to_stop: ?ChildState = null;
+        var generation: u64 = 0;
 
         self.mutex.lock();
         if (index >= self.entries.items.len) {
@@ -171,13 +196,15 @@ pub const Manager = struct {
         }
         child_to_stop = self.entries.items[index].child;
         self.entries.items[index].child = null;
+        generation = self.nextGenerationLocked();
+        self.entries.items[index].generation = generation;
         self.mutex.unlock();
 
         if (child_to_stop) |*child| stopChildState(child);
 
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (index >= self.entries.items.len) return false;
+        if (!self.entryGenerationMatchesLocked(index, generation)) return false;
         self.entries.items[index].rule = rule;
         self.entries.items[index].setStatus(.stopped, "");
         return true;
@@ -191,6 +218,7 @@ pub const Manager = struct {
             self.mutex.unlock();
             return false;
         }
+        _ = self.nextGenerationLocked();
         removed = self.entries.orderedRemove(index);
         self.mutex.unlock();
 
@@ -203,6 +231,7 @@ pub const Manager = struct {
         defer self.mutex.unlock();
         if (index >= self.entries.items.len) return false;
         self.entries.items[index].rule.auto_start = !self.entries.items[index].rule.auto_start;
+        self.entries.items[index].generation = self.nextGenerationLocked();
         return true;
     }
 
@@ -236,61 +265,39 @@ pub const Manager = struct {
     fn replaceEntriesLocked(self: *Manager, entries: *std.ArrayListUnmanaged(Entry)) void {
         std.debug.assert(self.entries.items.len == 0);
         self.entries.deinit(self.allocator);
+        for (entries.items) |*entry| {
+            entry.generation = self.nextGenerationLocked();
+        }
         self.entries = entries.*;
         entries.* = .empty;
     }
 
     pub fn startIndex(self: *Manager, index: usize, legacy_algorithms: bool) bool {
-        var child_to_stop: ?ChildState = null;
+        var lease = self.beginStart(index) orelse return false;
+        if (lease.child_to_stop) |*child| stopChildState(child);
+        const pending = lease.pending;
 
-        self.mutex.lock();
-        if (index >= self.entries.items.len) {
-            self.mutex.unlock();
-            return false;
-        }
-        const rule = self.entries.items[index].rule;
-        child_to_stop = self.entries.items[index].child;
-        self.entries.items[index].child = null;
-        self.entries.items[index].setStatus(.starting, "");
-        self.mutex.unlock();
-
-        if (child_to_stop) |*child| stopChildState(child);
-
-        const conn = ssh_profile_store.connectionByName(self.allocator, rule.profileName(), legacy_algorithms) orelse {
-            self.mutex.lock();
-            if (index < self.entries.items.len) self.entries.items[index].setStatus(.missing_profile, "profile missing");
-            self.mutex.unlock();
+        const conn = ssh_profile_store.connectionByName(self.allocator, pending.rule.profileName(), legacy_algorithms) orelse {
+            _ = self.completePendingStartFailure(pending, .missing_profile, "profile missing");
             return false;
         };
 
-        const child = spawnForward(self.allocator, &rule, &conn) catch |err| {
+        const child = spawnForward(self.allocator, &pending.rule, &conn) catch |err| {
             var buf: [REASON_MAX]u8 = undefined;
             const msg = std.fmt.bufPrint(&buf, "spawn failed: {}", .{err}) catch "spawn failed";
-            self.mutex.lock();
-            if (index < self.entries.items.len) self.entries.items[index].setStatus(.error_, msg);
-            self.mutex.unlock();
+            _ = self.completePendingStartFailure(pending, .error_, msg);
             return false;
         };
 
         var spawned_state: ChildState = .{ .real = child };
-        var replaced_child: ?ChildState = null;
-        var accepted = false;
-        self.mutex.lock();
-        if (index < self.entries.items.len) {
-            replaced_child = self.entries.items[index].child;
-            self.entries.items[index].child = spawned_state;
-            self.entries.items[index].setStatus(.running, "");
-            accepted = true;
-        }
-        self.mutex.unlock();
-
-        if (replaced_child) |*old_child| stopChildState(old_child);
+        const accepted = self.completePendingStartInstall(pending, spawned_state);
         if (!accepted) stopChildState(&spawned_state);
         return accepted;
     }
 
     pub fn stopIndex(self: *Manager, index: usize) bool {
         var child_to_stop: ?ChildState = null;
+        var generation: u64 = 0;
 
         self.mutex.lock();
         if (index >= self.entries.items.len) {
@@ -299,13 +306,15 @@ pub const Manager = struct {
         }
         child_to_stop = self.entries.items[index].child;
         self.entries.items[index].child = null;
+        generation = self.nextGenerationLocked();
+        self.entries.items[index].generation = generation;
         self.mutex.unlock();
 
         if (child_to_stop) |*child| stopChildState(child);
 
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (index >= self.entries.items.len) return false;
+        if (!self.entryGenerationMatchesLocked(index, generation)) return false;
         self.entries.items[index].setStatus(.stopped, "");
         return true;
     }
@@ -334,10 +343,9 @@ pub const Manager = struct {
 
         self.mutex.lock();
         for (self.entries.items, 0..) |*entry, index| {
-            const child = entry.child orelse continue;
-            if (!childHasExited(&child)) continue;
-            entry.child = null;
-            exited.append(ExitedChild.init(index, child));
+            if (takeExitedChildFromEntry(entry, index)) |child| {
+                exited.append(child);
+            }
         }
         self.mutex.unlock();
 
@@ -345,12 +353,8 @@ pub const Manager = struct {
             stopChildState(&item.child);
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
         for (exited.slice()) |*item| {
-            if (item.index < self.entries.items.len) {
-                self.entries.items[item.index].setStatus(.error_, item.reason());
-            }
+            _ = self.finishExitedChild(item);
         }
         return exited.len > 0;
     }
@@ -373,6 +377,7 @@ pub const Manager = struct {
         }
         child_to_stop = self.entries.items[index].child;
         self.entries.items[index].child = .{ .fake = .{ .pid = pid } };
+        self.entries.items[index].generation = self.nextGenerationLocked();
         self.entries.items[index].setStatus(.running, "");
         self.mutex.unlock();
 
@@ -392,27 +397,120 @@ pub const Manager = struct {
         return true;
     }
 
+    fn beginPendingStartForTest(self: *Manager, index: usize) ?PendingStart {
+        var lease = self.beginStart(index) orelse return null;
+        if (lease.child_to_stop) |*child| stopChildState(child);
+        return lease.pending;
+    }
+
+    fn completePendingStartFailureForTest(self: *Manager, pending: PendingStart, status: StatusKind, reason: []const u8) bool {
+        return self.completePendingStartFailure(pending, status, reason);
+    }
+
+    fn completePendingStartFakeForTest(self: *Manager, pending: PendingStart, pid: u32) bool {
+        return self.completePendingStartInstall(pending, .{ .fake = .{ .pid = pid } });
+    }
+
+    fn takeExitedChildForTest(self: *Manager, index: usize) ?ExitedChild {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return null;
+        return takeExitedChildFromEntry(&self.entries.items[index], index);
+    }
+
+    fn finishExitedChildForTest(self: *Manager, exited: *ExitedChild) bool {
+        return self.finishExitedChild(exited);
+    }
+
     pub fn stopAll(self: *Manager) void {
-        var children: ChildList = .{};
+        var stopped: StopList = .{};
 
         self.mutex.lock();
-        for (self.entries.items) |*entry| {
-            if (entry.child) |child| {
-                children.append(child);
-                entry.child = null;
-            }
+        for (self.entries.items, 0..) |*entry, index| {
+            const child = entry.child;
+            entry.child = null;
+            entry.generation = self.nextGenerationLocked();
+            stopped.append(.{
+                .index = index,
+                .generation = entry.generation,
+                .child = child,
+            });
         }
         self.mutex.unlock();
 
-        for (children.slice()) |*child| {
-            stopChildState(child);
+        for (stopped.slice()) |*item| {
+            if (item.child) |*child| stopChildState(child);
         }
 
         self.mutex.lock();
         defer self.mutex.unlock();
-        for (self.entries.items) |*entry| {
-            entry.setStatus(.stopped, "");
+        for (stopped.slice()) |item| {
+            if (self.entryGenerationMatchesLocked(item.index, item.generation)) {
+                self.entries.items[item.index].setStatus(.stopped, "");
+            }
         }
+    }
+
+    fn beginStart(self: *Manager, index: usize) ?StartLease {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (index >= self.entries.items.len) return null;
+        const entry = &self.entries.items[index];
+        const child_to_stop = entry.child;
+        const generation = self.nextGenerationLocked();
+        entry.child = null;
+        entry.generation = generation;
+        entry.setStatus(.starting, "");
+        return .{
+            .pending = .{
+                .index = index,
+                .generation = generation,
+                .rule = entry.rule,
+            },
+            .child_to_stop = child_to_stop,
+        };
+    }
+
+    fn completePendingStartFailure(self: *Manager, pending: PendingStart, status: StatusKind, reason: []const u8) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.pendingStartMatchesLocked(pending)) return false;
+        self.entries.items[pending.index].setStatus(status, reason);
+        return true;
+    }
+
+    fn completePendingStartInstall(self: *Manager, pending: PendingStart, child: ChildState) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.pendingStartMatchesLocked(pending)) return false;
+        self.entries.items[pending.index].child = child;
+        self.entries.items[pending.index].setStatus(.running, "");
+        return true;
+    }
+
+    fn finishExitedChild(self: *Manager, exited: *const ExitedChild) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (!self.entryGenerationMatchesLocked(exited.index, exited.generation)) return false;
+        if (self.entries.items[exited.index].child != null) return false;
+        self.entries.items[exited.index].setStatus(.error_, exited.reason());
+        return true;
+    }
+
+    fn pendingStartMatchesLocked(self: *Manager, pending: PendingStart) bool {
+        if (!self.entryGenerationMatchesLocked(pending.index, pending.generation)) return false;
+        const entry = &self.entries.items[pending.index];
+        return entry.child == null and rulesEqual(&entry.rule, &pending.rule);
+    }
+
+    fn entryGenerationMatchesLocked(self: *Manager, index: usize, generation: u64) bool {
+        return index < self.entries.items.len and self.entries.items[index].generation == generation;
+    }
+
+    fn nextGenerationLocked(self: *Manager) u64 {
+        const generation = self.next_generation;
+        self.next_generation = if (self.next_generation == std.math.maxInt(u64)) 1 else self.next_generation + 1;
+        return generation;
     }
 };
 
@@ -503,6 +601,7 @@ fn spawnForward(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: 
     child.stderr_behavior = .Inherit;
     if (env_map) |*map| child.env_map = map;
     try child.spawn();
+    try child.waitForSpawn();
     return child;
 }
 
@@ -540,6 +639,13 @@ fn childHasExited(child: *const ChildState) bool {
     };
 }
 
+fn takeExitedChildFromEntry(entry: *Entry, index: usize) ?ExitedChild {
+    const child = entry.child orelse return null;
+    if (!childHasExited(&child)) return null;
+    entry.child = null;
+    return ExitedChild.init(index, entry.generation, child);
+}
+
 fn childHasExitedReal(child: *const std.process.Child) bool {
     return switch (platform_process.childExited(child.id, 0)) {
         .running => false,
@@ -552,6 +658,18 @@ fn childExitReason(child: *const ChildState) []const u8 {
         .real => "ssh exited",
         .fake => |*fake| if (fake.reason().len > 0) fake.reason() else "ssh exited",
     };
+}
+
+fn rulesEqual(a: *const rule_mod.Rule, b: *const rule_mod.Rule) bool {
+    return std.mem.eql(u8, a.name(), b.name()) and
+        std.mem.eql(u8, a.profileName(), b.profileName()) and
+        a.direction == b.direction and
+        std.mem.eql(u8, a.localHost(), b.localHost()) and
+        a.local_port == b.local_port and
+        std.mem.eql(u8, a.remoteHost(), b.remoteHost()) and
+        a.remote_port == b.remote_port and
+        a.enabled == b.enabled and
+        a.auto_start == b.auto_start;
 }
 
 fn copyBounded(dest: []u8, text: []const u8) usize {
@@ -715,7 +833,7 @@ test "port_forward_manager: builds reverse ssh argv without connection sharing" 
     const rule = rule_mod.defaultReverseProxy("devbox");
     const argv = try buildSshArgvForTest(allocator, &rule, &conn);
 
-    try std.testing.expectEqualStrings("ssh", argv[0]);
+    try std.testing.expectEqualStrings(platform_pty_command.sshExecutableName(), argv[0]);
     try std.testing.expect(argvContainsForTest(argv, "-N"));
     try std.testing.expect(argvContainsForTest(argv, "-T"));
     try std.testing.expect(argvContainsForTest(argv, "-R"));
@@ -846,6 +964,75 @@ test "port_forward_manager: stop all clears fake children after stopping" {
     const row = manager.rowAt(0).?;
     try std.testing.expectEqual(StatusKind.stopped, row.status);
     try std.testing.expectEqualStrings("", row.reason());
+}
+
+test "port_forward_manager: stale pending start failure leaves replacement row alone" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old"));
+
+    const pending = manager.beginPendingStartForTest(0) orelse return error.ExpectedPendingStart;
+    try std.testing.expect(manager.updateRule(0, rule_mod.defaultReverseProxy("replacement")));
+
+    try std.testing.expect(!manager.completePendingStartFailureForTest(pending, .missing_profile, "profile missing"));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expectEqualStrings("replacement", row.rule.profileName());
+}
+
+test "port_forward_manager: stale pending start install leaves replacement row alone" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old"));
+
+    const pending = manager.beginPendingStartForTest(0) orelse return error.ExpectedPendingStart;
+    try std.testing.expect(manager.updateRule(0, rule_mod.defaultReverseProxy("replacement")));
+
+    try std.testing.expect(!manager.completePendingStartFakeForTest(pending, 444));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expectEqualStrings("replacement", row.rule.profileName());
+    try std.testing.expect(!manager.markExitedForTest(0, "stale child should not exist"));
+}
+
+test "port_forward_manager: stale exited child does not mark restarted row error" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("devbox"));
+    try std.testing.expect(manager.markRunningForTest(0, 111));
+    try std.testing.expect(manager.markExitedForTest(0, "old ssh exited"));
+
+    var exited = manager.takeExitedChildForTest(0) orelse return error.ExpectedExitedChild;
+    try std.testing.expect(manager.markRunningForTest(0, 222));
+
+    try std.testing.expect(!manager.finishExitedChildForTest(&exited));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.running, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expect(manager.markExitedForTest(0, "new ssh exited"));
+}
+
+test "port_forward_manager: stale exited child does not mark replacement row error" {
+    var manager = Manager.init(std.testing.allocator);
+    defer manager.deinit();
+    try manager.addRule(rule_mod.defaultReverseProxy("old"));
+    try std.testing.expect(manager.markRunningForTest(0, 111));
+    try std.testing.expect(manager.markExitedForTest(0, "old ssh exited"));
+
+    var exited = manager.takeExitedChildForTest(0) orelse return error.ExpectedExitedChild;
+    try std.testing.expect(manager.updateRule(0, rule_mod.defaultReverseProxy("replacement")));
+
+    try std.testing.expect(!manager.finishExitedChildForTest(&exited));
+
+    const row = manager.rowAt(0).?;
+    try std.testing.expectEqual(StatusKind.stopped, row.status);
+    try std.testing.expectEqualStrings("", row.reason());
+    try std.testing.expectEqualStrings("replacement", row.rule.profileName());
 }
 
 fn sshConnectionForTest(

--- a/src/port_forward_rule.zig
+++ b/src/port_forward_rule.zig
@@ -4,6 +4,10 @@ pub const NAME_MAX: usize = 96;
 pub const PROFILE_MAX: usize = 128;
 pub const HOST_MAX: usize = 64;
 
+const DIRECTION_TEXT_MAX: usize = 7;
+const PORT_TEXT_MAX: usize = 5;
+const BOOL_TEXT_MAX: usize = 5;
+
 pub const Direction = enum {
     local,
     reverse,
@@ -174,24 +178,39 @@ pub fn decodeRules(allocator: std.mem.Allocator, content: []const u8) ![]Rule {
 }
 
 pub fn decodeRuleLine(line: []const u8) ?Rule {
-    var fields: [9][128]u8 = undefined;
-    var lens: [9]usize = .{0} ** 9;
     var parts = std.mem.splitScalar(u8, line, '\t');
-    var idx: usize = 0;
-    while (idx < fields.len) : (idx += 1) {
-        const part = parts.next() orelse return null;
-        lens[idx] = decodeHexField(part, fields[idx][0..]) orelse return null;
-    }
+
+    var name_buf: [NAME_MAX]u8 = undefined;
+    const name_len = decodeHexField(parts.next() orelse return null, name_buf[0..]) orelse return null;
+    var profile_buf: [PROFILE_MAX]u8 = undefined;
+    const profile_len = decodeHexField(parts.next() orelse return null, profile_buf[0..]) orelse return null;
+    var direction_buf: [DIRECTION_TEXT_MAX]u8 = undefined;
+    const direction_len = decodeHexField(parts.next() orelse return null, direction_buf[0..]) orelse return null;
+    var local_host_buf: [HOST_MAX]u8 = undefined;
+    const local_host_len = decodeHexField(parts.next() orelse return null, local_host_buf[0..]) orelse return null;
+    var local_port_buf: [PORT_TEXT_MAX]u8 = undefined;
+    const local_port_len = decodeHexField(parts.next() orelse return null, local_port_buf[0..]) orelse return null;
+    var remote_host_buf: [HOST_MAX]u8 = undefined;
+    const remote_host_len = decodeHexField(parts.next() orelse return null, remote_host_buf[0..]) orelse return null;
+    var remote_port_buf: [PORT_TEXT_MAX]u8 = undefined;
+    const remote_port_len = decodeHexField(parts.next() orelse return null, remote_port_buf[0..]) orelse return null;
+    var enabled_buf: [BOOL_TEXT_MAX]u8 = undefined;
+    const enabled_len = decodeHexField(parts.next() orelse return null, enabled_buf[0..]) orelse return null;
+    var auto_start_buf: [BOOL_TEXT_MAX]u8 = undefined;
+    const auto_start_len = decodeHexField(parts.next() orelse return null, auto_start_buf[0..]) orelse return null;
+    if (parts.next() != null) return null;
+
     var rule: Rule = .{};
-    rule.setName(fields[0][0..lens[0]]);
-    rule.setProfileName(fields[1][0..lens[1]]);
-    rule.direction = Direction.parse(fields[2][0..lens[2]]) orelse return null;
-    rule.setLocalHost(fields[3][0..lens[3]]);
-    rule.local_port = parsePort(fields[4][0..lens[4]]) orelse return null;
-    rule.setRemoteHost(fields[5][0..lens[5]]);
-    rule.remote_port = parsePort(fields[6][0..lens[6]]) orelse return null;
-    rule.enabled = parseBool(fields[7][0..lens[7]]) orelse return null;
-    rule.auto_start = parseBool(fields[8][0..lens[8]]) orelse return null;
+    rule.setName(name_buf[0..name_len]);
+    rule.setProfileName(profile_buf[0..profile_len]);
+    rule.direction = Direction.parse(direction_buf[0..direction_len]) orelse return null;
+    rule.setLocalHost(local_host_buf[0..local_host_len]);
+    rule.local_port = parsePort(local_port_buf[0..local_port_len]) orelse return null;
+    rule.setRemoteHost(remote_host_buf[0..remote_host_len]);
+    rule.remote_port = parsePort(remote_port_buf[0..remote_port_len]) orelse return null;
+    rule.enabled = parseBool(enabled_buf[0..enabled_len]) orelse return null;
+    rule.auto_start = parseBool(auto_start_buf[0..auto_start_len]) orelse return null;
+    if (!rule.validate()) return null;
     return rule;
 }
 
@@ -211,7 +230,8 @@ fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)
 
 fn decodeHexField(value: []const u8, out: []u8) ?usize {
     if (value.len % 2 != 0) return null;
-    const len = @min(value.len / 2, out.len);
+    const len = value.len / 2;
+    if (len > out.len) return null;
     var i: usize = 0;
     while (i < len) : (i += 1) {
         const hi = hexValue(value[i * 2]) orelse return null;
@@ -260,18 +280,25 @@ test "port_forward_rule: validates loopback hosts and port range" {
 
 test "port_forward_rule: forward specs match ssh -L and -R semantics" {
     var rule = defaultReverseProxy("devbox");
+    rule.setRemoteHost("localhost");
+    rule.remote_port = 1111;
+    rule.setLocalHost("127.0.0.1");
+    rule.local_port = 2222;
+
     var buf: [128]u8 = undefined;
     try std.testing.expectEqualStrings(
-        "127.0.0.1:7890:127.0.0.1:7890",
+        "localhost:1111:127.0.0.1:2222",
         rule.forwardSpec(&buf).?,
     );
     try std.testing.expectEqualStrings("-R", rule.direction.flag());
 
     rule.direction = .local;
-    rule.local_port = 8888;
-    rule.remote_port = 8888;
+    rule.setLocalHost("localhost");
+    rule.local_port = 1111;
+    rule.setRemoteHost("127.0.0.1");
+    rule.remote_port = 2222;
     try std.testing.expectEqualStrings(
-        "127.0.0.1:8888:127.0.0.1:8888",
+        "localhost:1111:127.0.0.1:2222",
         rule.forwardSpec(&buf).?,
     );
     try std.testing.expectEqualStrings("-L", rule.direction.flag());
@@ -301,4 +328,104 @@ test "port_forward_rule: storage round trips two rules" {
     try std.testing.expectEqual(Direction.local, decoded[1].direction);
     try std.testing.expectEqualStrings("Jupyter", decoded[1].name());
     try std.testing.expect(!decoded[1].auto_start);
+}
+
+test "port_forward_rule: decoder rejects extra fields" {
+    var line: std.ArrayListUnmanaged(u8) = .empty;
+    defer line.deinit(std.testing.allocator);
+
+    try appendValidEncodedRuleForTest(std.testing.allocator, &line);
+    try line.append(std.testing.allocator, '\t');
+    try appendHexField(std.testing.allocator, &line, "extra");
+    try std.testing.expect(decodeRuleLine(line.items) == null);
+}
+
+test "port_forward_rule: decoder rejects malformed hex" {
+    try std.testing.expect(decodeRuleLine("GG") == null);
+}
+
+test "port_forward_rule: decoder rejects overlong fields" {
+    var line: std.ArrayListUnmanaged(u8) = .empty;
+    defer line.deinit(std.testing.allocator);
+
+    var too_long_name: [NAME_MAX + 1]u8 = undefined;
+    @memset(too_long_name[0..], 'n');
+    try appendEncodedFieldsForTest(std.testing.allocator, &line, &.{
+        too_long_name[0..],
+        "devbox",
+        "reverse",
+        "127.0.0.1",
+        "7890",
+        "127.0.0.1",
+        "7890",
+        "true",
+        "true",
+    });
+    try std.testing.expect(decodeRuleLine(line.items) == null);
+
+    line.clearRetainingCapacity();
+    var too_long_profile: [PROFILE_MAX + 1]u8 = undefined;
+    @memset(too_long_profile[0..], 'p');
+    try appendEncodedFieldsForTest(std.testing.allocator, &line, &.{
+        "Local proxy",
+        too_long_profile[0..],
+        "reverse",
+        "127.0.0.1",
+        "7890",
+        "127.0.0.1",
+        "7890",
+        "true",
+        "true",
+    });
+    try std.testing.expect(decodeRuleLine(line.items) == null);
+}
+
+test "port_forward_rule: decoder rejects invalid decoded rules" {
+    var line: std.ArrayListUnmanaged(u8) = .empty;
+    defer line.deinit(std.testing.allocator);
+
+    try appendEncodedFieldsForTest(std.testing.allocator, &line, &.{
+        "Local proxy",
+        "devbox",
+        "reverse",
+        "0.0.0.0",
+        "7890",
+        "127.0.0.1",
+        "7890",
+        "true",
+        "true",
+    });
+    try std.testing.expect(decodeRuleLine(line.items) == null);
+}
+
+test "port_forward_rule: forward specs reject invalid rules and small buffers" {
+    var rule = defaultReverseProxy("devbox");
+    rule.setLocalHost("0.0.0.0");
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(rule.forwardSpec(&buf) == null);
+
+    rule = defaultReverseProxy("devbox");
+    var tiny_buf: [4]u8 = undefined;
+    try std.testing.expect(rule.forwardSpec(&tiny_buf) == null);
+}
+
+fn appendValidEncodedRuleForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+    try appendEncodedFieldsForTest(allocator, out, &.{
+        "Local proxy",
+        "devbox",
+        "reverse",
+        "127.0.0.1",
+        "7890",
+        "127.0.0.1",
+        "7890",
+        "true",
+        "true",
+    });
+}
+
+fn appendEncodedFieldsForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), fields: []const []const u8) !void {
+    for (fields, 0..) |field, idx| {
+        if (idx > 0) try out.append(allocator, '\t');
+        try appendHexField(allocator, out, field);
+    }
 }

--- a/src/port_forward_rule.zig
+++ b/src/port_forward_rule.zig
@@ -1,0 +1,304 @@
+const std = @import("std");
+
+pub const NAME_MAX: usize = 96;
+pub const PROFILE_MAX: usize = 128;
+pub const HOST_MAX: usize = 64;
+
+pub const Direction = enum {
+    local,
+    reverse,
+
+    pub fn flag(self: Direction) []const u8 {
+        return switch (self) {
+            .local => "-L",
+            .reverse => "-R",
+        };
+    }
+
+    pub fn text(self: Direction) []const u8 {
+        return switch (self) {
+            .local => "local",
+            .reverse => "reverse",
+        };
+    }
+
+    pub fn parse(value: []const u8) ?Direction {
+        if (std.ascii.eqlIgnoreCase(value, "local")) return .local;
+        if (std.ascii.eqlIgnoreCase(value, "reverse")) return .reverse;
+        return null;
+    }
+};
+
+pub const Rule = struct {
+    name_buf: [NAME_MAX]u8 = undefined,
+    name_len: usize = 0,
+    profile_buf: [PROFILE_MAX]u8 = undefined,
+    profile_len: usize = 0,
+    direction: Direction = .reverse,
+    local_host_buf: [HOST_MAX]u8 = undefined,
+    local_host_len: usize = 0,
+    local_port: u16 = 7890,
+    remote_host_buf: [HOST_MAX]u8 = undefined,
+    remote_host_len: usize = 0,
+    remote_port: u16 = 7890,
+    enabled: bool = true,
+    auto_start: bool = true,
+
+    pub fn name(self: *const Rule) []const u8 {
+        return self.name_buf[0..self.name_len];
+    }
+
+    pub fn profileName(self: *const Rule) []const u8 {
+        return self.profile_buf[0..self.profile_len];
+    }
+
+    pub fn localHost(self: *const Rule) []const u8 {
+        return self.local_host_buf[0..self.local_host_len];
+    }
+
+    pub fn remoteHost(self: *const Rule) []const u8 {
+        return self.remote_host_buf[0..self.remote_host_len];
+    }
+
+    pub fn setName(self: *Rule, value: []const u8) void {
+        self.name_len = copyBounded(self.name_buf[0..], value);
+    }
+
+    pub fn setProfileName(self: *Rule, value: []const u8) void {
+        self.profile_len = copyBounded(self.profile_buf[0..], value);
+    }
+
+    pub fn setLocalHost(self: *Rule, value: []const u8) void {
+        self.local_host_len = copyBounded(self.local_host_buf[0..], value);
+    }
+
+    pub fn setRemoteHost(self: *Rule, value: []const u8) void {
+        self.remote_host_len = copyBounded(self.remote_host_buf[0..], value);
+    }
+
+    pub fn validate(self: *const Rule) bool {
+        return self.profileName().len > 0 and
+            validateHost(self.localHost()) and
+            validateHost(self.remoteHost()) and
+            self.local_port != 0 and
+            self.remote_port != 0;
+    }
+
+    pub fn forwardSpec(self: *const Rule, buf: []u8) ?[]const u8 {
+        if (!self.validate()) return null;
+        return switch (self.direction) {
+            .local => std.fmt.bufPrint(
+                buf,
+                "{s}:{d}:{s}:{d}",
+                .{ self.localHost(), self.local_port, self.remoteHost(), self.remote_port },
+            ) catch null,
+            .reverse => std.fmt.bufPrint(
+                buf,
+                "{s}:{d}:{s}:{d}",
+                .{ self.remoteHost(), self.remote_port, self.localHost(), self.local_port },
+            ) catch null,
+        };
+    }
+};
+
+pub fn defaultReverseProxy(profile_name: []const u8) Rule {
+    var rule: Rule = .{};
+    rule.setName("Local proxy");
+    rule.setProfileName(profile_name);
+    rule.direction = .reverse;
+    rule.setLocalHost("127.0.0.1");
+    rule.local_port = 7890;
+    rule.setRemoteHost("127.0.0.1");
+    rule.remote_port = 7890;
+    rule.enabled = true;
+    rule.auto_start = true;
+    return rule;
+}
+
+pub fn validateHost(host: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(host, "127.0.0.1") or
+        std.ascii.eqlIgnoreCase(host, "localhost");
+}
+
+pub fn parsePort(text: []const u8) ?u16 {
+    const trimmed = std.mem.trim(u8, text, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    const value = std.fmt.parseInt(u32, trimmed, 10) catch return null;
+    if (value == 0 or value > std.math.maxInt(u16)) return null;
+    return @intCast(value);
+}
+
+pub fn freeRules(allocator: std.mem.Allocator, rules: []Rule) void {
+    allocator.free(rules);
+}
+
+pub fn encodeRules(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), rules: []const Rule) !void {
+    try out.appendSlice(allocator, "# WispTerm port forwarding rules. Fields are hex encoded: name, profile, direction, local_host, local_port, remote_host, remote_port, enabled, auto_start.\n");
+    for (rules) |rule| {
+        try appendHexField(allocator, out, rule.name());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.profileName());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.direction.text());
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.localHost());
+        try out.append(allocator, '\t');
+        var local_port_buf: [8]u8 = undefined;
+        try appendHexField(allocator, out, std.fmt.bufPrint(&local_port_buf, "{d}", .{rule.local_port}) catch unreachable);
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, rule.remoteHost());
+        try out.append(allocator, '\t');
+        var remote_port_buf: [8]u8 = undefined;
+        try appendHexField(allocator, out, std.fmt.bufPrint(&remote_port_buf, "{d}", .{rule.remote_port}) catch unreachable);
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, if (rule.enabled) "true" else "false");
+        try out.append(allocator, '\t');
+        try appendHexField(allocator, out, if (rule.auto_start) "true" else "false");
+        try out.append(allocator, '\n');
+    }
+}
+
+pub fn decodeRules(allocator: std.mem.Allocator, content: []const u8) ![]Rule {
+    var rules: std.ArrayListUnmanaged(Rule) = .empty;
+    errdefer rules.deinit(allocator);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (decodeRuleLine(line)) |rule| {
+            try rules.append(allocator, rule);
+        }
+    }
+    return rules.toOwnedSlice(allocator);
+}
+
+pub fn decodeRuleLine(line: []const u8) ?Rule {
+    var fields: [9][128]u8 = undefined;
+    var lens: [9]usize = .{0} ** 9;
+    var parts = std.mem.splitScalar(u8, line, '\t');
+    var idx: usize = 0;
+    while (idx < fields.len) : (idx += 1) {
+        const part = parts.next() orelse return null;
+        lens[idx] = decodeHexField(part, fields[idx][0..]) orelse return null;
+    }
+    var rule: Rule = .{};
+    rule.setName(fields[0][0..lens[0]]);
+    rule.setProfileName(fields[1][0..lens[1]]);
+    rule.direction = Direction.parse(fields[2][0..lens[2]]) orelse return null;
+    rule.setLocalHost(fields[3][0..lens[3]]);
+    rule.local_port = parsePort(fields[4][0..lens[4]]) orelse return null;
+    rule.setRemoteHost(fields[5][0..lens[5]]);
+    rule.remote_port = parsePort(fields[6][0..lens[6]]) orelse return null;
+    rule.enabled = parseBool(fields[7][0..lens[7]]) orelse return null;
+    rule.auto_start = parseBool(fields[8][0..lens[8]]) orelse return null;
+    return rule;
+}
+
+fn parseBool(text: []const u8) ?bool {
+    if (std.ascii.eqlIgnoreCase(text, "true")) return true;
+    if (std.ascii.eqlIgnoreCase(text, "false")) return false;
+    return null;
+}
+
+fn appendHexField(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), field: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (field) |ch| {
+        try out.append(allocator, hex[ch >> 4]);
+        try out.append(allocator, hex[ch & 0x0f]);
+    }
+}
+
+fn decodeHexField(value: []const u8, out: []u8) ?usize {
+    if (value.len % 2 != 0) return null;
+    const len = @min(value.len / 2, out.len);
+    var i: usize = 0;
+    while (i < len) : (i += 1) {
+        const hi = hexValue(value[i * 2]) orelse return null;
+        const lo = hexValue(value[i * 2 + 1]) orelse return null;
+        out[i] = (hi << 4) | lo;
+    }
+    return len;
+}
+
+fn hexValue(ch: u8) ?u8 {
+    if (ch >= '0' and ch <= '9') return ch - '0';
+    if (ch >= 'a' and ch <= 'f') return ch - 'a' + 10;
+    if (ch >= 'A' and ch <= 'F') return ch - 'A' + 10;
+    return null;
+}
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+
+test "port_forward_rule: default reverse rule targets local proxy" {
+    const rule = defaultReverseProxy("devbox");
+    try std.testing.expectEqual(Direction.reverse, rule.direction);
+    try std.testing.expectEqualStrings("devbox", rule.profileName());
+    try std.testing.expectEqualStrings("127.0.0.1", rule.localHost());
+    try std.testing.expectEqual(@as(u16, 7890), rule.local_port);
+    try std.testing.expectEqualStrings("127.0.0.1", rule.remoteHost());
+    try std.testing.expectEqual(@as(u16, 7890), rule.remote_port);
+    try std.testing.expect(rule.enabled);
+    try std.testing.expect(rule.auto_start);
+}
+
+test "port_forward_rule: validates loopback hosts and port range" {
+    try std.testing.expect(validateHost("127.0.0.1"));
+    try std.testing.expect(validateHost("localhost"));
+    try std.testing.expect(!validateHost("0.0.0.0"));
+    try std.testing.expect(!validateHost("10.0.0.1"));
+    try std.testing.expect(parsePort("1").? == 1);
+    try std.testing.expect(parsePort("65535").? == 65535);
+    try std.testing.expect(parsePort("0") == null);
+    try std.testing.expect(parsePort("65536") == null);
+    try std.testing.expect(parsePort("abc") == null);
+}
+
+test "port_forward_rule: forward specs match ssh -L and -R semantics" {
+    var rule = defaultReverseProxy("devbox");
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "127.0.0.1:7890:127.0.0.1:7890",
+        rule.forwardSpec(&buf).?,
+    );
+    try std.testing.expectEqualStrings("-R", rule.direction.flag());
+
+    rule.direction = .local;
+    rule.local_port = 8888;
+    rule.remote_port = 8888;
+    try std.testing.expectEqualStrings(
+        "127.0.0.1:8888:127.0.0.1:8888",
+        rule.forwardSpec(&buf).?,
+    );
+    try std.testing.expectEqualStrings("-L", rule.direction.flag());
+}
+
+test "port_forward_rule: storage round trips two rules" {
+    var rules = [_]Rule{
+        defaultReverseProxy("devbox"),
+        defaultReverseProxy("lab"),
+    };
+    rules[1].direction = .local;
+    rules[1].local_port = 8888;
+    rules[1].remote_port = 8888;
+    rules[1].auto_start = false;
+    rules[1].setName("Jupyter");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try encodeRules(std.testing.allocator, &out, rules[0..]);
+
+    var decoded = try decodeRules(std.testing.allocator, out.items);
+    defer freeRules(std.testing.allocator, decoded);
+
+    try std.testing.expectEqual(@as(usize, 2), decoded.len);
+    try std.testing.expectEqual(Direction.reverse, decoded[0].direction);
+    try std.testing.expectEqualStrings("devbox", decoded[0].profileName());
+    try std.testing.expectEqual(Direction.local, decoded[1].direction);
+    try std.testing.expectEqualStrings("Jupyter", decoded[1].name());
+    try std.testing.expect(!decoded[1].auto_start);
+}

--- a/src/port_forwarding.zig
+++ b/src/port_forwarding.zig
@@ -1,0 +1,336 @@
+const std = @import("std");
+const rule_mod = @import("port_forward_rule.zig");
+
+pub const FormMode = enum { new, edit };
+pub const FORM_FIELD_COUNT: usize = 8;
+
+pub const FormState = struct {
+    mode: FormMode,
+    edit_index: ?usize,
+    focus: usize = 0,
+    rule: rule_mod.Rule,
+
+    pub fn new(profile_name: []const u8) FormState {
+        return .{
+            .mode = .new,
+            .edit_index = null,
+            .rule = rule_mod.defaultReverseProxy(profile_name),
+        };
+    }
+
+    pub fn edit(index: usize, rule: rule_mod.Rule) FormState {
+        return .{
+            .mode = .edit,
+            .edit_index = index,
+            .rule = rule,
+        };
+    }
+
+    pub fn moveFocus(self: *FormState, delta: isize) void {
+        self.focus = moveIndexClamped(self.focus, delta, FORM_FIELD_COUNT);
+    }
+
+    pub fn insertChar(self: *FormState, ch: u8) void {
+        if (!isPrintableAscii(ch)) return;
+        switch (self.focus) {
+            0 => _ = appendAscii(&self.rule.name_buf, &self.rule.name_len, ch),
+            1 => _ = appendAscii(&self.rule.profile_buf, &self.rule.profile_len, ch),
+            3 => _ = appendAscii(&self.rule.local_host_buf, &self.rule.local_host_len, ch),
+            4 => insertPortDigit(&self.rule.local_port, ch),
+            5 => _ = appendAscii(&self.rule.remote_host_buf, &self.rule.remote_host_len, ch),
+            6 => insertPortDigit(&self.rule.remote_port, ch),
+            else => {},
+        }
+    }
+
+    pub fn backspace(self: *FormState) void {
+        switch (self.focus) {
+            0 => truncateText(&self.rule.name_len),
+            1 => truncateText(&self.rule.profile_len),
+            3 => truncateText(&self.rule.local_host_len),
+            4 => backspacePort(&self.rule.local_port),
+            5 => truncateText(&self.rule.remote_host_len),
+            6 => backspacePort(&self.rule.remote_port),
+            else => {},
+        }
+    }
+
+    pub fn toggleFocused(self: *FormState) void {
+        switch (self.focus) {
+            2 => self.rule.direction = switch (self.rule.direction) {
+                .local => .reverse,
+                .reverse => .local,
+            },
+            7 => self.rule.auto_start = !self.rule.auto_start,
+            else => {},
+        }
+    }
+};
+
+pub const ConfirmState = struct {
+    index: usize,
+    text: []u8,
+
+    pub fn init(allocator: std.mem.Allocator, index: usize, name: []const u8) !ConfirmState {
+        return .{
+            .index = index,
+            .text = try std.fmt.allocPrint(allocator, "Delete {s}? Enter confirms, Esc cancels.", .{name}),
+        };
+    }
+
+    pub fn deinit(self: *ConfirmState, allocator: std.mem.Allocator) void {
+        allocator.free(self.text);
+        self.* = undefined;
+    }
+};
+
+pub const Overlay = union(enum) {
+    none,
+    form: FormState,
+    confirm_delete: ConfirmState,
+
+    pub fn deinit(self: *Overlay, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            .none => {},
+            .form => {},
+            .confirm_delete => |*confirm_state| confirm_state.deinit(allocator),
+        }
+        self.* = .none;
+    }
+};
+
+pub const PanelModel = struct {
+    allocator: std.mem.Allocator,
+    sel_row: usize = 0,
+    scroll: usize = 0,
+    overlay: Overlay = .none,
+
+    pub fn init(allocator: std.mem.Allocator) PanelModel {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *PanelModel) void {
+        self.overlay.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    pub fn move(self: *PanelModel, delta: isize, row_count: usize) void {
+        self.sel_row = moveIndexClamped(self.sel_row, delta, row_count);
+        self.clamp(row_count);
+    }
+
+    pub fn clamp(self: *PanelModel, row_count: usize) void {
+        if (row_count == 0) {
+            self.sel_row = 0;
+            self.scroll = 0;
+            return;
+        }
+        if (self.sel_row >= row_count) self.sel_row = row_count - 1;
+        if (self.scroll >= row_count) self.scroll = row_count - 1;
+        if (self.scroll > self.sel_row) self.scroll = self.sel_row;
+    }
+
+    pub fn setOverlay(self: *PanelModel, overlay: Overlay) void {
+        self.overlay.deinit(self.allocator);
+        self.overlay = overlay;
+    }
+
+    pub fn clearOverlay(self: *PanelModel) void {
+        self.overlay.deinit(self.allocator);
+    }
+
+    pub fn openNewForm(self: *PanelModel, profile_name: []const u8) !void {
+        self.setOverlay(.{ .form = FormState.new(profile_name) });
+    }
+
+    pub fn openEditForm(self: *PanelModel, index: usize, rule: rule_mod.Rule) !void {
+        self.setOverlay(.{ .form = FormState.edit(index, rule) });
+    }
+
+    pub fn openDeleteConfirm(self: *PanelModel, index: usize, name: []const u8) !void {
+        const confirm_state = try ConfirmState.init(self.allocator, index, name);
+        self.setOverlay(.{ .confirm_delete = confirm_state });
+    }
+
+    pub fn form(self: *PanelModel) ?*FormState {
+        return switch (self.overlay) {
+            .form => |*form_state| form_state,
+            else => null,
+        };
+    }
+
+    pub fn confirm(self: *PanelModel) ?*ConfirmState {
+        return switch (self.overlay) {
+            .confirm_delete => |*confirm_state| confirm_state,
+            else => null,
+        };
+    }
+};
+
+pub const Session = struct {
+    allocator: std.mem.Allocator,
+    mutex: std.Thread.Mutex = .{},
+    model: PanelModel,
+
+    pub fn create(allocator: std.mem.Allocator) !Session {
+        return .{
+            .allocator = allocator,
+            .model = PanelModel.init(allocator),
+        };
+    }
+
+    pub fn destroy(self: *Session) void {
+        self.mutex.lock();
+        self.model.deinit();
+        self.mutex.unlock();
+        self.* = undefined;
+    }
+};
+
+fn moveIndexClamped(current: usize, delta: isize, count: usize) usize {
+    if (count == 0) return 0;
+    const max_index = count - 1;
+    const base = @min(current, max_index);
+    if (delta >= 0) {
+        const amount: usize = @intCast(delta);
+        return if (amount > max_index - base) max_index else base + amount;
+    }
+
+    const amount: usize = @as(usize, @intCast(-(delta + 1))) + 1;
+    return if (amount > base) 0 else base - amount;
+}
+
+fn truncateText(len: *usize) void {
+    if (len.* > 0) len.* -= 1;
+}
+
+fn insertPortDigit(port: *u16, ch: u8) void {
+    if (ch < '0' or ch > '9') return;
+    const next = @as(u32, port.*) * 10 + (ch - '0');
+    if (next > std.math.maxInt(u16)) return;
+    port.* = @intCast(next);
+}
+
+fn backspacePort(port: *u16) void {
+    port.* /= 10;
+}
+
+fn appendAscii(buf: anytype, len: *usize, ch: u8) bool {
+    if (!isPrintableAscii(ch)) return false;
+    const slice = buf[0..];
+    if (len.* >= slice.len) return false;
+    slice[len.*] = ch;
+    len.* += 1;
+    return true;
+}
+
+fn isPrintableAscii(ch: u8) bool {
+    return ch >= 0x20 and ch <= 0x7e;
+}
+
+test "port_forwarding: selection clamps to row count" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    session.model.move(1, 0);
+    try std.testing.expectEqual(@as(usize, 0), session.model.sel_row);
+    session.model.move(1, 3);
+    try std.testing.expectEqual(@as(usize, 1), session.model.sel_row);
+    session.model.move(99, 3);
+    try std.testing.expectEqual(@as(usize, 2), session.model.sel_row);
+    session.model.move(-99, 3);
+    try std.testing.expectEqual(@as(usize, 0), session.model.sel_row);
+}
+
+test "port_forwarding: new form defaults to reverse proxy" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form = session.model.form() orelse return error.ExpectedForm;
+    try std.testing.expectEqual(FormMode.new, form.mode);
+    try std.testing.expectEqual(rule_mod.Direction.reverse, form.rule.direction);
+    try std.testing.expectEqualStrings("devbox", form.rule.profileName());
+}
+
+test "port_forwarding: delete confirmation records selected index" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openDeleteConfirm(2, "Local proxy");
+    const confirm = session.model.confirm() orelse return error.ExpectedConfirm;
+    try std.testing.expectEqual(@as(usize, 2), confirm.index);
+    try std.testing.expectEqualStrings("Delete Local proxy? Enter confirms, Esc cancels.", confirm.text);
+}
+
+test "port_forwarding: form focus clamps" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form_state = session.model.form() orelse return error.ExpectedForm;
+
+    form_state.moveFocus(99);
+    try std.testing.expectEqual(FORM_FIELD_COUNT - 1, form_state.focus);
+    form_state.moveFocus(-99);
+    try std.testing.expectEqual(@as(usize, 0), form_state.focus);
+}
+
+test "port_forwarding: form edits text and port fields" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form_state = session.model.form() orelse return error.ExpectedForm;
+
+    form_state.rule.setName("");
+    form_state.insertChar('A');
+    form_state.insertChar('\n');
+    form_state.insertChar(0x7f);
+    try std.testing.expectEqualStrings("A", form_state.rule.name());
+    form_state.backspace();
+    try std.testing.expectEqualStrings("", form_state.rule.name());
+
+    form_state.moveFocus(4);
+    form_state.backspace();
+    try std.testing.expectEqual(@as(u16, 789), form_state.rule.local_port);
+    form_state.insertChar('1');
+    form_state.insertChar('x');
+    try std.testing.expectEqual(@as(u16, 7891), form_state.rule.local_port);
+}
+
+test "port_forwarding: form toggles direction and auto start" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form_state = session.model.form() orelse return error.ExpectedForm;
+
+    form_state.moveFocus(2);
+    form_state.toggleFocused();
+    try std.testing.expectEqual(rule_mod.Direction.local, form_state.rule.direction);
+
+    form_state.moveFocus(5);
+    form_state.toggleFocused();
+    try std.testing.expect(!form_state.rule.auto_start);
+}
+
+test "port_forwarding: opening form replaces delete confirmation" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openDeleteConfirm(1, "Local proxy");
+    try std.testing.expect(session.model.confirm() != null);
+
+    try session.model.openNewForm("devbox");
+    try std.testing.expect(session.model.confirm() == null);
+    try std.testing.expect(session.model.form() != null);
+}
+
+test "port_forwarding: appendAscii accepts fixed buffers and printable ASCII only" {
+    var one: [1]u8 = undefined;
+    var one_len: usize = 0;
+    try std.testing.expect(appendAscii(&one, &one_len, 'A'));
+    try std.testing.expectEqualStrings("A", one[0..one_len]);
+    try std.testing.expect(!appendAscii(&one, &one_len, 'B'));
+
+    var host: [rule_mod.HOST_MAX]u8 = undefined;
+    var host_len: usize = 0;
+    try std.testing.expect(appendAscii(&host, &host_len, 'x'));
+    try std.testing.expect(!appendAscii(&host, &host_len, '\n'));
+    try std.testing.expect(!appendAscii(&host, &host_len, 0x7f));
+    try std.testing.expectEqualStrings("x", host[0..host_len]);
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -580,6 +580,9 @@ fn executeCommand(action: CommandAction) void {
         .open_skill_center => {
             _ = AppWindow.spawnSkillCenterTab();
         },
+        .open_port_forwarding => {
+            _ = AppWindow.spawnPortForwardingTab();
+        },
     }
 }
 

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -384,17 +384,19 @@ fn renderOverlayText(draw: DrawContext, text: []const u8, content_x: f32, conten
 }
 
 fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32, window_height: f32, top: f32, fg: [3]f32, accent: [3]f32) void {
-    const box_w = @max(1.0, @min(content_w - 32, 720));
-    const box_h = @max(draw.cell_h * 11.0, 220);
-    const box_x = content_x + @max(0.0, (content_w - box_w) / 2);
+    const box_w = @max(1.0, @min(@max(1.0, content_w - 32), 720));
     const available_h = @max(1.0, window_height - top - legendHeight(draw.cell_h));
+    const desired_h = @max(draw.cell_h * 11.0, 220);
+    const box_h = @min(desired_h, available_h);
+    const box_x = content_x + @max(0.0, (content_w - box_w) / 2);
     const box_top = top + @max(8.0, (available_h - box_h) / 2);
     const box_y = yFromTop(window_height, box_top, box_h);
-    const content_right = box_x + box_w - 18;
+    const content_right = @max(box_x, box_x + box_w - 18);
 
     draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.bg, 0.96);
     draw.fillQuadAlpha(box_x, box_y, box_w, box_h, accent, 0.22);
-    _ = draw.renderTextLimited(form.mode, box_x + 18, yTextFromTop(draw, window_height, box_top + 16), fg, box_w - 36);
+    const title_x = box_x + @min(18.0, box_w);
+    _ = draw.renderTextLimited(form.mode, title_x, yTextFromTop(draw, window_height, box_top + 16), fg, clampedTextWidth(title_x, content_right, content_right - title_x));
 
     var field: usize = 0;
     while (field < 8) : (field += 1) {
@@ -402,11 +404,13 @@ fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32,
         const row_y = yFromTop(window_height, row_top, draw.cell_h);
         const text_y = yTextFromTop(draw, window_height, row_top);
         if (field == form.focus) {
-            draw.fillQuadAlpha(box_x + 12, row_y - 2, box_w - 24, draw.cell_h + 6, accent, 0.20);
+            const focus_x = box_x + @min(12.0, box_w);
+            draw.fillQuadAlpha(focus_x, row_y - 2, clampedTextWidth(focus_x, box_x + box_w, box_w), draw.cell_h + 6, accent, 0.20);
         }
         var value_buf: [32]u8 = undefined;
-        const label_x = box_x + 22;
-        const value_x = box_x + @min(190.0, @max(130.0, box_w * 0.34));
+        const label_x = box_x + @min(22.0, box_w);
+        const preferred_value_offset = @min(190.0, @max(72.0, box_w * 0.34));
+        const value_x = @min(content_right, box_x + preferred_value_offset);
         _ = draw.renderTextLimited(formFieldLabel(field), label_x, text_y, accent, clampedTextWidth(label_x, content_right, value_x - label_x - COL_GAP));
         _ = draw.renderTextLimited(formFieldValue(&form, field, &value_buf), value_x, text_y, fg, clampedTextWidth(value_x, content_right, content_right - value_x));
     }
@@ -630,6 +634,8 @@ test "port_forwarding_renderer: narrow row text widths stay within content" {
     };
 
     const Rows = struct {
+        marker: u8 = 0,
+
         fn rowAt(_: *anyopaque, index: usize) RowView {
             _ = index;
             return .{
@@ -654,6 +660,62 @@ test "port_forwarding_renderer: narrow row text widths stay within content" {
         .renderTextLimited = InstrumentedDraw.renderTextLimited,
         .glyphAdvance = InstrumentedDraw.glyphAdvance,
     };
+    var rows = Rows{};
+
+    render(draw, .{
+        .title = "Port Forwarding",
+        .legend = "Enter start/stop  n new",
+        .count = 1,
+        .selected = 0,
+        .scroll = 0,
+        .ctx = &rows,
+        .rowAt = Rows.rowAt,
+    }, width, 160, 0, 0, width);
+
+    try std.testing.expect(!InstrumentedDraw.bad_width);
+}
+
+test "port_forwarding_renderer: narrow form stays within non-negative draw bounds" {
+    const InstrumentedDraw = struct {
+        var bad_width: bool = false;
+
+        fn fillQuad(_: f32, _: f32, w: f32, h: f32, _: [3]f32) void {
+            if (std.math.isNan(w) or std.math.isNan(h) or w < 0.0 or h < 0.0) bad_width = true;
+        }
+        fn fillQuadAlpha(_: f32, _: f32, w: f32, h: f32, _: [3]f32, _: f32) void {
+            if (std.math.isNan(w) or std.math.isNan(h) or w < 0.0 or h < 0.0) bad_width = true;
+        }
+        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, max_w: f32) f32 {
+            if (std.math.isNan(max_w) or max_w < 0.0) bad_width = true;
+            return x + @min(max_w, @as(f32, @floatFromInt(text.len)) * 8.0);
+        }
+        fn glyphAdvance(_: u32) f32 {
+            return 8;
+        }
+    };
+
+    const Rows = struct {
+        fn rowAt(_: *anyopaque, index: usize) RowView {
+            _ = index;
+            return .{
+                .rule = rule_mod.defaultReverseProxy("devbox"),
+                .status = .running,
+                .auto_start = true,
+            };
+        }
+    };
+
+    InstrumentedDraw.bad_width = false;
+    const draw = DrawContext{
+        .bg = .{ 0.02, 0.02, 0.02 },
+        .fg = .{ 0.95, 0.95, 0.95 },
+        .accent = .{ 0.2, 0.6, 1.0 },
+        .cell_h = 16,
+        .fillQuad = InstrumentedDraw.fillQuad,
+        .fillQuadAlpha = InstrumentedDraw.fillQuadAlpha,
+        .renderTextLimited = InstrumentedDraw.renderTextLimited,
+        .glyphAdvance = InstrumentedDraw.glyphAdvance,
+    };
 
     render(draw, .{
         .title = "Port Forwarding",
@@ -663,7 +725,12 @@ test "port_forwarding_renderer: narrow row text widths stay within content" {
         .scroll = 0,
         .ctx = undefined,
         .rowAt = Rows.rowAt,
-    }, width, 160, 0, 0, width);
+        .form = .{
+            .mode = "New forwarding rule",
+            .focus = 4,
+            .rule = rule_mod.defaultReverseProxy("devbox"),
+        },
+    }, 48, 80, 0, 0, 48);
 
     try std.testing.expect(!InstrumentedDraw.bad_width);
 }

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const manager = @import("../port_forward_manager.zig");
 const rule_mod = @import("../port_forward_rule.zig");
 
 const HEADER_H: f32 = 54;
@@ -10,6 +9,27 @@ const COL_GAP: f32 = 10;
 const DIRECTION_W: f32 = 78;
 const AUTO_W: f32 = 70;
 const STATUS_W: f32 = 92;
+pub const REASON_MAX: usize = 192;
+
+pub const StatusKind = enum {
+    stopped,
+    starting,
+    running,
+    error_,
+    missing_profile,
+};
+
+pub const RowView = struct {
+    rule: rule_mod.Rule,
+    status: StatusKind,
+    reason_buf: [REASON_MAX]u8 = undefined,
+    reason_len: usize = 0,
+    auto_start: bool,
+
+    pub fn reason(self: *const RowView) []const u8 {
+        return self.reason_buf[0..self.reason_len];
+    }
+};
 
 pub const DrawContext = struct {
     bg: [3]f32,
@@ -22,7 +42,7 @@ pub const DrawContext = struct {
     glyphAdvance: *const fn (u32) f32,
 };
 
-pub const RowAt = *const fn (*anyopaque, usize) manager.RowView;
+pub const RowAt = *const fn (*anyopaque, usize) RowView;
 
 pub const View = struct {
     title: []const u8,
@@ -35,7 +55,7 @@ pub const View = struct {
     overlay_text: []const u8 = "",
 };
 
-pub fn statusLabel(status: manager.StatusKind) []const u8 {
+pub fn statusLabel(status: StatusKind) []const u8 {
     return switch (status) {
         .stopped => "Stopped",
         .starting => "Starting",
@@ -54,6 +74,12 @@ pub fn directionLabel(direction: rule_mod.Direction) []const u8 {
 
 pub fn autoLabel(auto_start: bool) []const u8 {
     return if (auto_start) "Auto" else "Manual";
+}
+
+pub fn clampedTextWidth(x: f32, content_right: f32, requested: f32) f32 {
+    const positive_requested = @max(0.0, requested);
+    const available = @max(0.0, content_right - x);
+    return @min(positive_requested, available);
 }
 
 pub fn listenLabel(rule: *const rule_mod.Rule, buf: []u8) []const u8 {
@@ -182,14 +208,16 @@ fn renderHeader(
     line: [3]f32,
 ) void {
     const header_h = headerHeight(draw.cell_h);
+    const content_right = content_x + content_w - PAD_X;
+    const title_x = content_x + PAD_X;
     draw.fillQuadAlpha(content_x, yFromTop(window_height, top, header_h), content_w, header_h, panel_strong, 0.9);
     draw.fillQuad(content_x, yFromTop(window_height, top + header_h, 1), content_w, 1, line);
 
     const title_y = yTextFromTop(draw, window_height, top + 11);
-    const title_end = draw.renderTextLimited(view.title, content_x + PAD_X, title_y, fg, content_w - PAD_X * 2);
+    const title_end = draw.renderTextLimited(view.title, title_x, title_y, fg, clampedTextWidth(title_x, content_right, content_w - PAD_X * 2));
     var count_buf: [48]u8 = undefined;
     const count_text = std.fmt.bufPrint(&count_buf, " - {d}", .{view.count}) catch "";
-    _ = draw.renderTextLimited(count_text, title_end, title_y, muted, @max(0.0, content_x + content_w - PAD_X - title_end));
+    _ = draw.renderTextLimited(count_text, title_end, title_y, muted, clampedTextWidth(title_end, content_right, content_right - title_end));
 }
 
 fn renderRows(
@@ -208,7 +236,9 @@ fn renderRows(
 ) void {
     if (view.count == 0) {
         const empty = if (view.overlay_text.len > 0) view.overlay_text else "No port forwarding rules";
-        _ = draw.renderTextLimited(empty, content_x + PAD_X, yTextFromTop(draw, window_height, body_top + 24), muted, content_w - PAD_X * 2);
+        const text_x = content_x + PAD_X;
+        const content_right = content_x + content_w - PAD_X;
+        _ = draw.renderTextLimited(empty, text_x, yTextFromTop(draw, window_height, body_top + 24), muted, clampedTextWidth(text_x, content_right, content_w - PAD_X * 2));
         return;
     }
 
@@ -228,7 +258,7 @@ fn renderRows(
 
 fn renderRow(
     draw: DrawContext,
-    row: manager.RowView,
+    row: RowView,
     selected: bool,
     content_x: f32,
     content_w: f32,
@@ -252,11 +282,12 @@ fn renderRow(
     const show_columns = content_w >= PAD_X * 2 + right_w + 120;
     const right_x = content_x + content_w - PAD_X - right_w;
     const text_x = content_x + PAD_X;
+    const content_right = content_x + content_w - PAD_X;
     const primary_y = yTextFromTop(draw, window_height, row_top_px + 8);
     const secondary_y = yTextFromTop(draw, window_height, row_top_px + row_h - draw.cell_h - 8);
 
     const title_limit = if (show_columns) @max(0.0, right_x - text_x - COL_GAP) else @max(0.0, content_w - PAD_X * 2);
-    _ = draw.renderTextLimited(rowTitle(&row), text_x, primary_y, fg, title_limit);
+    _ = draw.renderTextLimited(rowTitle(&row), text_x, primary_y, fg, clampedTextWidth(text_x, content_right, title_limit));
 
     if (show_columns) {
         var x = right_x;
@@ -279,20 +310,22 @@ fn renderRow(
 
     const profile = if (row.rule.profileName().len > 0) row.rule.profileName() else "No profile";
     const profile_w: f32 = 128;
-    const profile_end = draw.renderTextLimited(profile, text_x, secondary_y, accent, profile_w);
+    const profile_limit = clampedTextWidth(text_x, content_right, profile_w);
+    const profile_end = @min(content_right, draw.renderTextLimited(profile, text_x, secondary_y, accent, profile_limit));
     const reason = row.reason();
-    const detail_limit = @max(0.0, content_x + content_w - PAD_X - profile_end - COL_GAP);
+    const detail_x = @min(content_right, profile_end + COL_GAP);
+    const detail_limit = clampedTextWidth(detail_x, content_right, content_right - detail_x);
     const detail = if (reason.len > 0) reason else endpoint;
-    _ = draw.renderTextLimited(detail, profile_end + COL_GAP, secondary_y, if (reason.len > 0) statusColor(row.status, fg, muted, accent) else muted, detail_limit);
+    _ = draw.renderTextLimited(detail, detail_x, secondary_y, if (reason.len > 0) statusColor(row.status, fg, muted, accent) else muted, detail_limit);
 }
 
-fn rowTitle(row: *const manager.RowView) []const u8 {
+fn rowTitle(row: *const RowView) []const u8 {
     if (row.rule.name().len > 0) return row.rule.name();
     if (row.reason().len > 0) return row.reason();
     return "Port forward";
 }
 
-fn statusColor(status: manager.StatusKind, fg: [3]f32, muted: [3]f32, accent: [3]f32) [3]f32 {
+fn statusColor(status: StatusKind, fg: [3]f32, muted: [3]f32, accent: [3]f32) [3]f32 {
     return switch (status) {
         .running => accent,
         .starting => mixColor(fg, accent, 0.25),
@@ -305,24 +338,28 @@ fn statusColor(status: manager.StatusKind, fg: [3]f32, muted: [3]f32, accent: [3
 fn renderOverlayText(draw: DrawContext, text: []const u8, content_x: f32, content_w: f32, fg: [3]f32, accent: [3]f32) void {
     const bar_h = rowHeight(draw.cell_h);
     const bar_y = legendHeight(draw.cell_h);
+    const text_x = content_x + PAD_X;
+    const content_right = content_x + content_w - PAD_X;
     draw.fillQuadAlpha(content_x, bar_y, content_w, bar_h, mixColor(draw.bg, accent, 0.22), 0.97);
     const text_y = bar_y + (bar_h - draw.cell_h) / 2;
-    _ = draw.renderTextLimited(text, content_x + PAD_X, text_y, fg, content_w - PAD_X * 2);
+    _ = draw.renderTextLimited(text, text_x, text_y, fg, clampedTextWidth(text_x, content_right, content_w - PAD_X * 2));
 }
 
 fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w: f32, muted: [3]f32, line: [3]f32) void {
     const legend_h = legendHeight(draw.cell_h);
+    const text_x = content_x + PAD_X;
+    const content_right = content_x + content_w - PAD_X;
     draw.fillQuad(content_x, legend_h, content_w, 1, line);
     const text_y = (legend_h - draw.cell_h) / 2;
-    _ = draw.renderTextLimited(legend, content_x + PAD_X, text_y, muted, content_w - PAD_X * 2);
+    _ = draw.renderTextLimited(legend, text_x, text_y, muted, clampedTextWidth(text_x, content_right, content_w - PAD_X * 2));
 }
 
 test "port_forwarding_renderer: status labels" {
-    try std.testing.expectEqualStrings("Stopped", statusLabel(.stopped));
-    try std.testing.expectEqualStrings("Starting", statusLabel(.starting));
-    try std.testing.expectEqualStrings("Running", statusLabel(.running));
-    try std.testing.expectEqualStrings("Error", statusLabel(.error_));
-    try std.testing.expectEqualStrings("Missing", statusLabel(.missing_profile));
+    try std.testing.expectEqualStrings("Stopped", statusLabel(StatusKind.stopped));
+    try std.testing.expectEqualStrings("Starting", statusLabel(StatusKind.starting));
+    try std.testing.expectEqualStrings("Running", statusLabel(StatusKind.running));
+    try std.testing.expectEqualStrings("Error", statusLabel(StatusKind.error_));
+    try std.testing.expectEqualStrings("Missing", statusLabel(StatusKind.missing_profile));
 }
 
 test "port_forwarding_renderer: listen and target labels" {
@@ -384,9 +421,9 @@ test "port_forwarding_renderer: render accepts row accessor view" {
     };
 
     const Rows = struct {
-        row: manager.RowView,
+        row: RowView,
 
-        fn rowAt(ctx: *anyopaque, index: usize) manager.RowView {
+        fn rowAt(ctx: *anyopaque, index: usize) RowView {
             _ = index;
             const self: *@This() = @ptrCast(@alignCast(ctx));
             return self.row;
@@ -424,4 +461,114 @@ test "port_forwarding_renderer: render accepts row accessor view" {
         .rowAt = row_at,
         .overlay_text = "Profile missing",
     }, 900, 600, 40, 0, 900);
+}
+
+test "port_forwarding_renderer: render does not request rows with zero visible capacity" {
+    const NoopDraw = struct {
+        fn fillQuad(_: f32, _: f32, _: f32, _: f32, _: [3]f32) void {}
+        fn fillQuadAlpha(_: f32, _: f32, _: f32, _: f32, _: [3]f32, _: f32) void {}
+        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, _: f32) f32 {
+            return x + @as(f32, @floatFromInt(text.len));
+        }
+        fn glyphAdvance(_: u32) f32 {
+            return 8;
+        }
+    };
+
+    const Rows = struct {
+        calls: usize = 0,
+
+        fn rowAt(ctx: *anyopaque, index: usize) RowView {
+            _ = index;
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.calls += 1;
+            return .{
+                .rule = rule_mod.defaultReverseProxy("devbox"),
+                .status = .running,
+                .auto_start = true,
+            };
+        }
+    };
+
+    var rows = Rows{};
+    const draw = DrawContext{
+        .bg = .{ 0.02, 0.02, 0.02 },
+        .fg = .{ 0.95, 0.95, 0.95 },
+        .accent = .{ 0.2, 0.6, 1.0 },
+        .cell_h = 16,
+        .fillQuad = NoopDraw.fillQuad,
+        .fillQuadAlpha = NoopDraw.fillQuadAlpha,
+        .renderTextLimited = NoopDraw.renderTextLimited,
+        .glyphAdvance = NoopDraw.glyphAdvance,
+    };
+
+    render(draw, .{
+        .title = "Port Forwarding",
+        .legend = "Enter start/stop  n new",
+        .count = 1,
+        .selected = 0,
+        .scroll = 0,
+        .ctx = &rows,
+        .rowAt = Rows.rowAt,
+    }, 200, 80, 0, 0, 200);
+
+    try std.testing.expectEqual(@as(usize, 0), rows.calls);
+}
+
+test "port_forwarding_renderer: narrow row text widths stay within content" {
+    const InstrumentedDraw = struct {
+        var content_right: f32 = 0;
+        var bad_width: bool = false;
+
+        fn fillQuad(_: f32, _: f32, _: f32, _: f32, _: [3]f32) void {}
+        fn fillQuadAlpha(_: f32, _: f32, _: f32, _: f32, _: [3]f32, _: f32) void {}
+        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, max_w: f32) f32 {
+            const available = @max(0.0, content_right - x);
+            if (std.math.isNan(max_w) or max_w < 0.0 or max_w > available + 0.01) {
+                bad_width = true;
+            }
+            return x + @min(max_w, @as(f32, @floatFromInt(text.len)) * 8.0);
+        }
+        fn glyphAdvance(_: u32) f32 {
+            return 8;
+        }
+    };
+
+    const Rows = struct {
+        fn rowAt(_: *anyopaque, index: usize) RowView {
+            _ = index;
+            return .{
+                .rule = rule_mod.defaultReverseProxy("devbox"),
+                .status = .running,
+                .auto_start = true,
+            };
+        }
+    };
+
+    const width: f32 = 80;
+    InstrumentedDraw.content_right = width - PAD_X;
+    InstrumentedDraw.bad_width = false;
+
+    const draw = DrawContext{
+        .bg = .{ 0.02, 0.02, 0.02 },
+        .fg = .{ 0.95, 0.95, 0.95 },
+        .accent = .{ 0.2, 0.6, 1.0 },
+        .cell_h = 16,
+        .fillQuad = InstrumentedDraw.fillQuad,
+        .fillQuadAlpha = InstrumentedDraw.fillQuadAlpha,
+        .renderTextLimited = InstrumentedDraw.renderTextLimited,
+        .glyphAdvance = InstrumentedDraw.glyphAdvance,
+    };
+
+    render(draw, .{
+        .title = "Port Forwarding",
+        .legend = "Enter start/stop  n new",
+        .count = 1,
+        .selected = 0,
+        .scroll = 0,
+        .ctx = undefined,
+        .rowAt = Rows.rowAt,
+    }, width, 160, 0, 0, width);
+
+    try std.testing.expect(!InstrumentedDraw.bad_width);
 }

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -389,23 +389,32 @@ fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32,
     const desired_h = @max(draw.cell_h * 11.0, 220);
     const box_h = @min(desired_h, available_h);
     const box_x = content_x + @max(0.0, (content_w - box_w) / 2);
-    const box_top = top + @max(8.0, (available_h - box_h) / 2);
+    const box_top = top + @min(@max(0.0, available_h - box_h), @max(0.0, (available_h - box_h) / 2));
     const box_y = yFromTop(window_height, box_top, box_h);
+    const box_bottom_y = box_y;
+    const box_top_y = box_y + box_h;
+    const box_bottom_top_px = box_top + box_h;
     const content_right = @max(box_x, box_x + box_w - 18);
 
     draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.bg, 0.96);
     draw.fillQuadAlpha(box_x, box_y, box_w, box_h, accent, 0.22);
     const title_x = box_x + @min(18.0, box_w);
-    _ = draw.renderTextLimited(form.mode, title_x, yTextFromTop(draw, window_height, box_top + 16), fg, clampedTextWidth(title_x, content_right, content_right - title_x));
+    const title_top = box_top + @min(16.0, @max(0.0, box_h - draw.cell_h));
+    if (title_top + draw.cell_h <= box_bottom_top_px) {
+        _ = draw.renderTextLimited(form.mode, title_x, yTextFromTop(draw, window_height, title_top), fg, clampedTextWidth(title_x, content_right, content_right - title_x));
+    }
 
     var field: usize = 0;
     while (field < 8) : (field += 1) {
         const row_top = box_top + draw.cell_h * @as(f32, @floatFromInt(field + 3));
+        if (row_top + draw.cell_h > box_bottom_top_px) break;
         const row_y = yFromTop(window_height, row_top, draw.cell_h);
         const text_y = yTextFromTop(draw, window_height, row_top);
         if (field == form.focus) {
             const focus_x = box_x + @min(12.0, box_w);
-            draw.fillQuadAlpha(focus_x, row_y - 2, clampedTextWidth(focus_x, box_x + box_w, box_w), draw.cell_h + 6, accent, 0.20);
+            const focus_y = @max(box_bottom_y, row_y - 2);
+            const focus_h = @max(0.0, @min(draw.cell_h + 6, box_top_y - focus_y));
+            draw.fillQuadAlpha(focus_x, focus_y, clampedTextWidth(focus_x, box_x + box_w, box_w), focus_h, accent, 0.20);
         }
         var value_buf: [32]u8 = undefined;
         const label_x = box_x + @min(22.0, box_w);
@@ -678,15 +687,16 @@ test "port_forwarding_renderer: narrow row text widths stay within content" {
 test "port_forwarding_renderer: narrow form stays within non-negative draw bounds" {
     const InstrumentedDraw = struct {
         var bad_width: bool = false;
+        var window_h: f32 = 0;
 
-        fn fillQuad(_: f32, _: f32, w: f32, h: f32, _: [3]f32) void {
-            if (std.math.isNan(w) or std.math.isNan(h) or w < 0.0 or h < 0.0) bad_width = true;
+        fn fillQuad(_: f32, y: f32, w: f32, h: f32, _: [3]f32) void {
+            if (std.math.isNan(w) or std.math.isNan(h) or std.math.isNan(y) or w < 0.0 or h < 0.0 or y < 0.0 or y + h > window_h + 0.01) bad_width = true;
         }
-        fn fillQuadAlpha(_: f32, _: f32, w: f32, h: f32, _: [3]f32, _: f32) void {
-            if (std.math.isNan(w) or std.math.isNan(h) or w < 0.0 or h < 0.0) bad_width = true;
+        fn fillQuadAlpha(_: f32, y: f32, w: f32, h: f32, _: [3]f32, _: f32) void {
+            if (std.math.isNan(w) or std.math.isNan(h) or std.math.isNan(y) or w < 0.0 or h < 0.0 or y < 0.0 or y + h > window_h + 0.01) bad_width = true;
         }
-        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, max_w: f32) f32 {
-            if (std.math.isNan(max_w) or max_w < 0.0) bad_width = true;
+        fn renderTextLimited(text: []const u8, x: f32, y: f32, _: [3]f32, max_w: f32) f32 {
+            if (std.math.isNan(max_w) or std.math.isNan(y) or max_w < 0.0 or y < 0.0 or y > window_h + 0.01) bad_width = true;
             return x + @min(max_w, @as(f32, @floatFromInt(text.len)) * 8.0);
         }
         fn glyphAdvance(_: u32) f32 {
@@ -706,6 +716,7 @@ test "port_forwarding_renderer: narrow form stays within non-negative draw bound
     };
 
     InstrumentedDraw.bad_width = false;
+    InstrumentedDraw.window_h = 80;
     const draw = DrawContext{
         .bg = .{ 0.02, 0.02, 0.02 },
         .fg = .{ 0.95, 0.95, 0.95 },
@@ -716,6 +727,7 @@ test "port_forwarding_renderer: narrow form stays within non-negative draw bound
         .renderTextLimited = InstrumentedDraw.renderTextLimited,
         .glyphAdvance = InstrumentedDraw.glyphAdvance,
     };
+    var rows = Rows{};
 
     render(draw, .{
         .title = "Port Forwarding",
@@ -723,7 +735,7 @@ test "port_forwarding_renderer: narrow form stays within non-negative draw bound
         .count = 1,
         .selected = 0,
         .scroll = 0,
-        .ctx = undefined,
+        .ctx = &rows,
         .rowAt = Rows.rowAt,
         .form = .{
             .mode = "New forwarding rule",

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -1,0 +1,427 @@
+const std = @import("std");
+const manager = @import("../port_forward_manager.zig");
+const rule_mod = @import("../port_forward_rule.zig");
+
+const HEADER_H: f32 = 54;
+const ROW_H: f32 = 52;
+const LEGEND_H: f32 = 36;
+const PAD_X: f32 = 16;
+const COL_GAP: f32 = 10;
+const DIRECTION_W: f32 = 78;
+const AUTO_W: f32 = 70;
+const STATUS_W: f32 = 92;
+
+pub const DrawContext = struct {
+    bg: [3]f32,
+    fg: [3]f32,
+    accent: [3]f32,
+    cell_h: f32,
+    fillQuad: *const fn (f32, f32, f32, f32, [3]f32) void,
+    fillQuadAlpha: *const fn (f32, f32, f32, f32, [3]f32, f32) void,
+    renderTextLimited: *const fn ([]const u8, f32, f32, [3]f32, f32) f32,
+    glyphAdvance: *const fn (u32) f32,
+};
+
+pub const RowAt = *const fn (*anyopaque, usize) manager.RowView;
+
+pub const View = struct {
+    title: []const u8,
+    legend: []const u8,
+    count: usize,
+    selected: usize,
+    scroll: usize,
+    ctx: *anyopaque,
+    rowAt: RowAt,
+    overlay_text: []const u8 = "",
+};
+
+pub fn statusLabel(status: manager.StatusKind) []const u8 {
+    return switch (status) {
+        .stopped => "Stopped",
+        .starting => "Starting",
+        .running => "Running",
+        .error_ => "Error",
+        .missing_profile => "Missing",
+    };
+}
+
+pub fn directionLabel(direction: rule_mod.Direction) []const u8 {
+    return switch (direction) {
+        .local => "Local",
+        .reverse => "Reverse",
+    };
+}
+
+pub fn autoLabel(auto_start: bool) []const u8 {
+    return if (auto_start) "Auto" else "Manual";
+}
+
+pub fn listenLabel(rule: *const rule_mod.Rule, buf: []u8) []const u8 {
+    return switch (rule.direction) {
+        .local => endpointLabel("local", rule.localHost(), rule.local_port, buf),
+        .reverse => endpointLabel("remote", rule.remoteHost(), rule.remote_port, buf),
+    };
+}
+
+pub fn targetLabel(rule: *const rule_mod.Rule, buf: []u8) []const u8 {
+    return switch (rule.direction) {
+        .local => endpointLabel("remote", rule.remoteHost(), rule.remote_port, buf),
+        .reverse => endpointLabel("local", rule.localHost(), rule.local_port, buf),
+    };
+}
+
+pub fn bodyVisibleCapacity(window_height: f32, titlebar_offset: f32, cell_h: f32) usize {
+    const top = @round(titlebar_offset);
+    const content_h = @round(@max(1.0, window_height - top));
+    const usable = content_h - headerHeight(cell_h) - legendHeight(cell_h);
+    if (usable <= 0) return 0;
+    return @intFromFloat(@max(0.0, @floor(usable / rowHeight(cell_h))));
+}
+
+pub fn visibleCapacity(window_height: f32, titlebar_offset: f32, cell_h: f32) usize {
+    return bodyVisibleCapacity(window_height, titlebar_offset, cell_h);
+}
+
+pub fn clampScroll(requested: usize, total: usize, visible: usize) usize {
+    if (visible == 0 or total <= visible) return 0;
+    return @min(requested, total - visible);
+}
+
+pub fn scrollToSelection(selected: usize, requested: usize, total: usize, visible: usize) usize {
+    if (visible == 0 or total == 0) return 0;
+    const bounded_selected = @min(selected, total - 1);
+    var scroll = clampScroll(requested, total, visible);
+    if (bounded_selected < scroll) return bounded_selected;
+    if (bounded_selected >= scroll + visible) {
+        scroll = bounded_selected - visible + 1;
+    }
+    return clampScroll(scroll, total, visible);
+}
+
+pub fn render(
+    draw: DrawContext,
+    view: View,
+    window_width: f32,
+    window_height: f32,
+    titlebar_offset: f32,
+    x: f32,
+    width: f32,
+) void {
+    _ = window_width;
+    _ = draw.glyphAdvance;
+
+    const content_x = @round(x);
+    const content_w = @round(@max(1.0, width));
+    const top = @round(titlebar_offset);
+    const content_h = @round(@max(1.0, window_height - top));
+    if (content_w <= 1 or content_h <= 1) return;
+
+    const bg = draw.bg;
+    const fg = draw.fg;
+    const accent = draw.accent;
+    const panel_strong = mixColor(bg, fg, 0.075);
+    const line = mixColor(bg, fg, 0.18);
+    const muted = mixColor(bg, fg, 0.58);
+    const selected_bg = mixColor(bg, accent, 0.18);
+
+    draw.fillQuad(content_x, 0, content_w, content_h, bg);
+    renderHeader(draw, view, content_x, content_w, window_height, top, fg, muted, panel_strong, line);
+
+    const body_top = top + headerHeight(draw.cell_h);
+    renderRows(draw, view, content_x, content_w, window_height, top, body_top, fg, muted, accent, line, selected_bg);
+
+    if (view.overlay_text.len > 0) {
+        renderOverlayText(draw, view.overlay_text, content_x, content_w, fg, accent);
+    }
+    renderLegend(draw, view.legend, content_x, content_w, muted, line);
+}
+
+fn endpointLabel(scope: []const u8, host: []const u8, port: u16, buf: []u8) []const u8 {
+    return std.fmt.bufPrint(buf, "{s} {s}:{d}", .{ scope, host, port }) catch scope;
+}
+
+fn headerHeight(cell_h: f32) f32 {
+    return @max(HEADER_H, cell_h + 18);
+}
+
+fn rowHeight(cell_h: f32) f32 {
+    return @max(ROW_H, cell_h * 2 + 20);
+}
+
+fn legendHeight(cell_h: f32) f32 {
+    return @max(LEGEND_H, cell_h + 18);
+}
+
+fn yFromTop(window_height: f32, top_px: f32, h: f32) f32 {
+    return window_height - top_px - h;
+}
+
+fn yTextFromTop(draw: DrawContext, window_height: f32, top_px: f32) f32 {
+    return window_height - top_px - draw.cell_h;
+}
+
+fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    const clamped = @max(0.0, @min(1.0, t));
+    return .{
+        a[0] + (b[0] - a[0]) * clamped,
+        a[1] + (b[1] - a[1]) * clamped,
+        a[2] + (b[2] - a[2]) * clamped,
+    };
+}
+
+fn renderHeader(
+    draw: DrawContext,
+    view: View,
+    content_x: f32,
+    content_w: f32,
+    window_height: f32,
+    top: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    panel_strong: [3]f32,
+    line: [3]f32,
+) void {
+    const header_h = headerHeight(draw.cell_h);
+    draw.fillQuadAlpha(content_x, yFromTop(window_height, top, header_h), content_w, header_h, panel_strong, 0.9);
+    draw.fillQuad(content_x, yFromTop(window_height, top + header_h, 1), content_w, 1, line);
+
+    const title_y = yTextFromTop(draw, window_height, top + 11);
+    const title_end = draw.renderTextLimited(view.title, content_x + PAD_X, title_y, fg, content_w - PAD_X * 2);
+    var count_buf: [48]u8 = undefined;
+    const count_text = std.fmt.bufPrint(&count_buf, " - {d}", .{view.count}) catch "";
+    _ = draw.renderTextLimited(count_text, title_end, title_y, muted, @max(0.0, content_x + content_w - PAD_X - title_end));
+}
+
+fn renderRows(
+    draw: DrawContext,
+    view: View,
+    content_x: f32,
+    content_w: f32,
+    window_height: f32,
+    top: f32,
+    body_top: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+    line: [3]f32,
+    selected_bg: [3]f32,
+) void {
+    if (view.count == 0) {
+        const empty = if (view.overlay_text.len > 0) view.overlay_text else "No port forwarding rules";
+        _ = draw.renderTextLimited(empty, content_x + PAD_X, yTextFromTop(draw, window_height, body_top + 24), muted, content_w - PAD_X * 2);
+        return;
+    }
+
+    const row_h = rowHeight(draw.cell_h);
+    const cap = bodyVisibleCapacity(window_height, top, draw.cell_h);
+    const scroll = scrollToSelection(view.selected, view.scroll, view.count, cap);
+    const selected = @min(view.selected, view.count - 1);
+    var rendered: usize = 0;
+    var ri: usize = scroll;
+    while (ri < view.count and rendered < cap) : (ri += 1) {
+        const row = view.rowAt(view.ctx, ri);
+        const row_top_px = body_top + @as(f32, @floatFromInt(rendered)) * row_h;
+        renderRow(draw, row, ri == selected, content_x, content_w, window_height, row_top_px, row_h, fg, muted, accent, line, selected_bg);
+        rendered += 1;
+    }
+}
+
+fn renderRow(
+    draw: DrawContext,
+    row: manager.RowView,
+    selected: bool,
+    content_x: f32,
+    content_w: f32,
+    window_height: f32,
+    row_top_px: f32,
+    row_h: f32,
+    fg: [3]f32,
+    muted: [3]f32,
+    accent: [3]f32,
+    line: [3]f32,
+    selected_bg: [3]f32,
+) void {
+    const row_y = yFromTop(window_height, row_top_px, row_h);
+    if (selected) {
+        draw.fillQuadAlpha(content_x, row_y, content_w, row_h, selected_bg, 0.88);
+        draw.fillQuad(content_x, row_y, 3, row_h, accent);
+    }
+    draw.fillQuadAlpha(content_x, row_y, content_w, 1, line, 0.45);
+
+    const right_w = DIRECTION_W + AUTO_W + STATUS_W + COL_GAP * 2;
+    const show_columns = content_w >= PAD_X * 2 + right_w + 120;
+    const right_x = content_x + content_w - PAD_X - right_w;
+    const text_x = content_x + PAD_X;
+    const primary_y = yTextFromTop(draw, window_height, row_top_px + 8);
+    const secondary_y = yTextFromTop(draw, window_height, row_top_px + row_h - draw.cell_h - 8);
+
+    const title_limit = if (show_columns) @max(0.0, right_x - text_x - COL_GAP) else @max(0.0, content_w - PAD_X * 2);
+    _ = draw.renderTextLimited(rowTitle(&row), text_x, primary_y, fg, title_limit);
+
+    if (show_columns) {
+        var x = right_x;
+        _ = draw.renderTextLimited(directionLabel(row.rule.direction), x, primary_y, muted, DIRECTION_W);
+        x += DIRECTION_W + COL_GAP;
+        _ = draw.renderTextLimited(autoLabel(row.auto_start), x, primary_y, muted, AUTO_W);
+        x += AUTO_W + COL_GAP;
+        _ = draw.renderTextLimited(statusLabel(row.status), x, primary_y, statusColor(row.status, fg, muted, accent), STATUS_W);
+    }
+
+    var listen_buf: [96]u8 = undefined;
+    var target_buf: [96]u8 = undefined;
+    var endpoint_buf: [224]u8 = undefined;
+    const listen = listenLabel(&row.rule, &listen_buf);
+    const target = targetLabel(&row.rule, &target_buf);
+    const endpoint = if (show_columns)
+        std.fmt.bufPrint(&endpoint_buf, "{s} -> {s}", .{ listen, target }) catch ""
+    else
+        std.fmt.bufPrint(&endpoint_buf, "{s} - {s} -> {s}", .{ statusLabel(row.status), listen, target }) catch "";
+
+    const profile = if (row.rule.profileName().len > 0) row.rule.profileName() else "No profile";
+    const profile_w: f32 = 128;
+    const profile_end = draw.renderTextLimited(profile, text_x, secondary_y, accent, profile_w);
+    const reason = row.reason();
+    const detail_limit = @max(0.0, content_x + content_w - PAD_X - profile_end - COL_GAP);
+    const detail = if (reason.len > 0) reason else endpoint;
+    _ = draw.renderTextLimited(detail, profile_end + COL_GAP, secondary_y, if (reason.len > 0) statusColor(row.status, fg, muted, accent) else muted, detail_limit);
+}
+
+fn rowTitle(row: *const manager.RowView) []const u8 {
+    if (row.rule.name().len > 0) return row.rule.name();
+    if (row.reason().len > 0) return row.reason();
+    return "Port forward";
+}
+
+fn statusColor(status: manager.StatusKind, fg: [3]f32, muted: [3]f32, accent: [3]f32) [3]f32 {
+    return switch (status) {
+        .running => accent,
+        .starting => mixColor(fg, accent, 0.25),
+        .stopped => muted,
+        .error_ => .{ 0.95, 0.28, 0.28 },
+        .missing_profile => .{ 0.95, 0.72, 0.28 },
+    };
+}
+
+fn renderOverlayText(draw: DrawContext, text: []const u8, content_x: f32, content_w: f32, fg: [3]f32, accent: [3]f32) void {
+    const bar_h = rowHeight(draw.cell_h);
+    const bar_y = legendHeight(draw.cell_h);
+    draw.fillQuadAlpha(content_x, bar_y, content_w, bar_h, mixColor(draw.bg, accent, 0.22), 0.97);
+    const text_y = bar_y + (bar_h - draw.cell_h) / 2;
+    _ = draw.renderTextLimited(text, content_x + PAD_X, text_y, fg, content_w - PAD_X * 2);
+}
+
+fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w: f32, muted: [3]f32, line: [3]f32) void {
+    const legend_h = legendHeight(draw.cell_h);
+    draw.fillQuad(content_x, legend_h, content_w, 1, line);
+    const text_y = (legend_h - draw.cell_h) / 2;
+    _ = draw.renderTextLimited(legend, content_x + PAD_X, text_y, muted, content_w - PAD_X * 2);
+}
+
+test "port_forwarding_renderer: status labels" {
+    try std.testing.expectEqualStrings("Stopped", statusLabel(.stopped));
+    try std.testing.expectEqualStrings("Starting", statusLabel(.starting));
+    try std.testing.expectEqualStrings("Running", statusLabel(.running));
+    try std.testing.expectEqualStrings("Error", statusLabel(.error_));
+    try std.testing.expectEqualStrings("Missing", statusLabel(.missing_profile));
+}
+
+test "port_forwarding_renderer: listen and target labels" {
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    var listen_buf: [96]u8 = undefined;
+    var target_buf: [96]u8 = undefined;
+    try std.testing.expectEqualStrings("remote 127.0.0.1:7890", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("local 127.0.0.1:7890", targetLabel(&rule, &target_buf));
+
+    rule.direction = .local;
+    rule.local_port = 8888;
+    rule.remote_port = 8888;
+    try std.testing.expectEqualStrings("local 127.0.0.1:8888", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("remote 127.0.0.1:8888", targetLabel(&rule, &target_buf));
+}
+
+test "port_forwarding_renderer: direction and auto labels" {
+    try std.testing.expectEqualStrings("Reverse", directionLabel(.reverse));
+    try std.testing.expectEqualStrings("Local", directionLabel(.local));
+    try std.testing.expectEqualStrings("Auto", autoLabel(true));
+    try std.testing.expectEqualStrings("Manual", autoLabel(false));
+}
+
+test "port_forwarding_renderer: clamp scroll keeps selected row visible" {
+    try std.testing.expectEqual(@as(usize, 0), clampScroll(5, 3, 10));
+    try std.testing.expectEqual(@as(usize, 2), clampScroll(5, 12, 10));
+    try std.testing.expectEqual(@as(usize, 1), clampScroll(1, 12, 10));
+    try std.testing.expectEqual(@as(usize, 7), scrollToSelection(12, 5, 10, 3));
+    try std.testing.expectEqual(@as(usize, 3), scrollToSelection(3, 6, 10, 4));
+}
+
+test "port_forwarding_renderer: endpoint labels preserve distinct hosts and ports" {
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    rule.setLocalHost("localhost");
+    rule.local_port = 18080;
+    rule.setRemoteHost("127.0.0.1");
+    rule.remote_port = 8080;
+
+    var listen_buf: [96]u8 = undefined;
+    var target_buf: [96]u8 = undefined;
+    try std.testing.expectEqualStrings("remote 127.0.0.1:8080", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("local localhost:18080", targetLabel(&rule, &target_buf));
+
+    rule.direction = .local;
+    try std.testing.expectEqualStrings("local localhost:18080", listenLabel(&rule, &listen_buf));
+    try std.testing.expectEqualStrings("remote 127.0.0.1:8080", targetLabel(&rule, &target_buf));
+}
+
+test "port_forwarding_renderer: render accepts row accessor view" {
+    const NoopDraw = struct {
+        fn fillQuad(_: f32, _: f32, _: f32, _: f32, _: [3]f32) void {}
+        fn fillQuadAlpha(_: f32, _: f32, _: f32, _: f32, _: [3]f32, _: f32) void {}
+        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, _: f32) f32 {
+            return x + @as(f32, @floatFromInt(text.len));
+        }
+        fn glyphAdvance(_: u32) f32 {
+            return 8;
+        }
+    };
+
+    const Rows = struct {
+        row: manager.RowView,
+
+        fn rowAt(ctx: *anyopaque, index: usize) manager.RowView {
+            _ = index;
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            return self.row;
+        }
+    };
+
+    var rows = Rows{
+        .row = .{
+            .rule = rule_mod.defaultReverseProxy("devbox"),
+            .status = .error_,
+            .auto_start = false,
+        },
+    };
+    rows.row.reason_len = @min(rows.row.reason_buf.len, "ssh exited".len);
+    @memcpy(rows.row.reason_buf[0..rows.row.reason_len], "ssh exited"[0..rows.row.reason_len]);
+
+    const draw = DrawContext{
+        .bg = .{ 0.02, 0.02, 0.02 },
+        .fg = .{ 0.95, 0.95, 0.95 },
+        .accent = .{ 0.2, 0.6, 1.0 },
+        .cell_h = 16,
+        .fillQuad = NoopDraw.fillQuad,
+        .fillQuadAlpha = NoopDraw.fillQuadAlpha,
+        .renderTextLimited = NoopDraw.renderTextLimited,
+        .glyphAdvance = NoopDraw.glyphAdvance,
+    };
+    const row_at: RowAt = Rows.rowAt;
+    render(draw, .{
+        .title = "Port Forwarding",
+        .legend = "Enter start/stop  n new",
+        .count = 1,
+        .selected = 0,
+        .scroll = 0,
+        .ctx = &rows,
+        .rowAt = row_at,
+        .overlay_text = "Profile missing",
+    }, 900, 600, 40, 0, 900);
+}

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -44,6 +44,12 @@ pub const DrawContext = struct {
 
 pub const RowAt = *const fn (*anyopaque, usize) RowView;
 
+pub const FormView = struct {
+    mode: []const u8,
+    focus: usize,
+    rule: rule_mod.Rule,
+};
+
 pub const View = struct {
     title: []const u8,
     legend: []const u8,
@@ -53,6 +59,7 @@ pub const View = struct {
     ctx: *anyopaque,
     rowAt: RowAt,
     overlay_text: []const u8 = "",
+    form: ?FormView = null,
 };
 
 pub fn statusLabel(status: StatusKind) []const u8 {
@@ -74,6 +81,34 @@ pub fn directionLabel(direction: rule_mod.Direction) []const u8 {
 
 pub fn autoLabel(auto_start: bool) []const u8 {
     return if (auto_start) "Auto" else "Manual";
+}
+
+pub fn formFieldLabel(index: usize) []const u8 {
+    return switch (index) {
+        0 => "Name",
+        1 => "Profile",
+        2 => "Direction",
+        3 => "Local host",
+        4 => "Local port",
+        5 => "Remote host",
+        6 => "Remote port",
+        7 => "Auto start",
+        else => "",
+    };
+}
+
+pub fn formFieldValue(form: *const FormView, index: usize, buf: []u8) []const u8 {
+    return switch (index) {
+        0 => form.rule.name(),
+        1 => form.rule.profileName(),
+        2 => directionLabel(form.rule.direction),
+        3 => form.rule.localHost(),
+        4 => std.fmt.bufPrint(buf, "{d}", .{form.rule.local_port}) catch "",
+        5 => form.rule.remoteHost(),
+        6 => std.fmt.bufPrint(buf, "{d}", .{form.rule.remote_port}) catch "",
+        7 => autoLabel(form.rule.auto_start),
+        else => "",
+    };
 }
 
 pub fn clampedTextWidth(x: f32, content_right: f32, requested: f32) f32 {
@@ -158,6 +193,9 @@ pub fn render(
 
     if (view.overlay_text.len > 0) {
         renderOverlayText(draw, view.overlay_text, content_x, content_w, fg, accent);
+    }
+    if (view.form) |form| {
+        renderForm(draw, form, content_x, content_w, window_height, top, fg, accent);
     }
     renderLegend(draw, view.legend, content_x, content_w, muted, line);
 }
@@ -345,6 +383,35 @@ fn renderOverlayText(draw: DrawContext, text: []const u8, content_x: f32, conten
     _ = draw.renderTextLimited(text, text_x, text_y, fg, clampedTextWidth(text_x, content_right, content_w - PAD_X * 2));
 }
 
+fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32, window_height: f32, top: f32, fg: [3]f32, accent: [3]f32) void {
+    const box_w = @max(1.0, @min(content_w - 32, 720));
+    const box_h = @max(draw.cell_h * 11.0, 220);
+    const box_x = content_x + @max(0.0, (content_w - box_w) / 2);
+    const available_h = @max(1.0, window_height - top - legendHeight(draw.cell_h));
+    const box_top = top + @max(8.0, (available_h - box_h) / 2);
+    const box_y = yFromTop(window_height, box_top, box_h);
+    const content_right = box_x + box_w - 18;
+
+    draw.fillQuadAlpha(box_x, box_y, box_w, box_h, draw.bg, 0.96);
+    draw.fillQuadAlpha(box_x, box_y, box_w, box_h, accent, 0.22);
+    _ = draw.renderTextLimited(form.mode, box_x + 18, yTextFromTop(draw, window_height, box_top + 16), fg, box_w - 36);
+
+    var field: usize = 0;
+    while (field < 8) : (field += 1) {
+        const row_top = box_top + draw.cell_h * @as(f32, @floatFromInt(field + 3));
+        const row_y = yFromTop(window_height, row_top, draw.cell_h);
+        const text_y = yTextFromTop(draw, window_height, row_top);
+        if (field == form.focus) {
+            draw.fillQuadAlpha(box_x + 12, row_y - 2, box_w - 24, draw.cell_h + 6, accent, 0.20);
+        }
+        var value_buf: [32]u8 = undefined;
+        const label_x = box_x + 22;
+        const value_x = box_x + @min(190.0, @max(130.0, box_w * 0.34));
+        _ = draw.renderTextLimited(formFieldLabel(field), label_x, text_y, accent, clampedTextWidth(label_x, content_right, value_x - label_x - COL_GAP));
+        _ = draw.renderTextLimited(formFieldValue(&form, field, &value_buf), value_x, text_y, fg, clampedTextWidth(value_x, content_right, content_right - value_x));
+    }
+}
+
 fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w: f32, muted: [3]f32, line: [3]f32) void {
     const legend_h = legendHeight(draw.cell_h);
     const text_x = content_x + PAD_X;
@@ -381,6 +448,34 @@ test "port_forwarding_renderer: direction and auto labels" {
     try std.testing.expectEqualStrings("Local", directionLabel(.local));
     try std.testing.expectEqualStrings("Auto", autoLabel(true));
     try std.testing.expectEqualStrings("Manual", autoLabel(false));
+}
+
+test "port_forwarding_renderer: form field labels" {
+    try std.testing.expectEqualStrings("Name", formFieldLabel(0));
+    try std.testing.expectEqualStrings("Profile", formFieldLabel(1));
+    try std.testing.expectEqualStrings("Direction", formFieldLabel(2));
+    try std.testing.expectEqualStrings("Local host", formFieldLabel(3));
+    try std.testing.expectEqualStrings("Local port", formFieldLabel(4));
+    try std.testing.expectEqualStrings("Remote host", formFieldLabel(5));
+    try std.testing.expectEqualStrings("Remote port", formFieldLabel(6));
+    try std.testing.expectEqualStrings("Auto start", formFieldLabel(7));
+    try std.testing.expectEqualStrings("", formFieldLabel(99));
+}
+
+test "port_forwarding_renderer: form field values" {
+    var rule = rule_mod.defaultReverseProxy("devbox");
+    rule.setName("Proxy");
+    rule.local_port = 18080;
+    rule.remote_port = 7890;
+    rule.auto_start = false;
+    var buf: [32]u8 = undefined;
+    const form = FormView{ .mode = "Edit forwarding rule", .focus = 4, .rule = rule };
+
+    try std.testing.expectEqualStrings("Proxy", formFieldValue(&form, 0, &buf));
+    try std.testing.expectEqualStrings("devbox", formFieldValue(&form, 1, &buf));
+    try std.testing.expectEqualStrings("Reverse", formFieldValue(&form, 2, &buf));
+    try std.testing.expectEqualStrings("18080", formFieldValue(&form, 4, &buf));
+    try std.testing.expectEqualStrings("Manual", formFieldValue(&form, 7, &buf));
 }
 
 test "port_forwarding_renderer: clamp scroll keeps selected row visible" {

--- a/src/ssh_profile_store.zig
+++ b/src/ssh_profile_store.zig
@@ -1,0 +1,116 @@
+const std = @import("std");
+const ssh_connection = @import("ssh_connection.zig");
+const profile_codec = @import("renderer/overlays/profile_codec.zig");
+const platform_dirs = @import("platform/dirs.zig");
+const command_palette_model = @import("command_palette_model.zig");
+
+pub fn connectionByName(allocator: std.mem.Allocator, profile_name: []const u8, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    const path = platform_dirs.sshHostsPath(allocator) catch return null;
+    defer allocator.free(path);
+    const content = std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch return null;
+    defer allocator.free(content);
+    return findConnectionInContent(content, profile_name, legacy_algorithms);
+}
+
+pub fn findConnectionInContent(content: []const u8, profile_name: []const u8, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const profile = profile_codec.decodeSshProfileLine(line) orelse continue;
+        if (!std.ascii.eqlIgnoreCase(profile_name, profile_codec.profileField(&profile, .name))) continue;
+        return connectionFromProfile(&profile, legacy_algorithms);
+    }
+    return null;
+}
+
+pub fn connectionFromProfile(profile: *const profile_codec.SshProfile, legacy_algorithms: bool) ?ssh_connection.SshConnection {
+    const host = profile_codec.profileField(profile, .ip);
+    const user = profile_codec.profileField(profile, .user);
+    const port = profile_codec.profileField(profile, .port);
+    const password = profile_codec.profileField(profile, .password);
+    const proxy_jump = profile_codec.profileField(profile, .proxy_jump);
+    if (host.len == 0 or user.len == 0) return null;
+    if (!isSshTokenSafe(host) or !isSshTokenSafe(user)) return null;
+    if (port.len > 0 and !isPortTokenSafe(port)) return null;
+    if (!command_palette_model.isProxyJumpSafe(proxy_jump)) return null;
+
+    var conn: ssh_connection.SshConnection = .{};
+    conn.host_len = copyBounded(conn.host_buf[0..], host);
+    conn.user_len = copyBounded(conn.user_buf[0..], user);
+    conn.port_len = copyBounded(conn.port_buf[0..], port);
+    conn.password_len = copyBounded(conn.password_buf[0..], password);
+    conn.proxy_jump_len = copyBounded(conn.proxy_jump_buf[0..], proxy_jump);
+    conn.password_auth = password.len > 0;
+    conn.legacy_algorithms = legacy_algorithms;
+    return conn;
+}
+
+fn isSshTokenSafe(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        if (std.ascii.isAlphanumeric(ch)) continue;
+        switch (ch) {
+            '.', '-', '_', ':', '@' => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+fn isPortTokenSafe(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        if (!std.ascii.isDigit(ch)) return false;
+    }
+    return true;
+}
+
+fn copyBounded(dest: []u8, text: []const u8) usize {
+    const n = @min(dest.len, text.len);
+    @memcpy(dest[0..n], text[0..n]);
+    return n;
+}
+
+fn appendEncodedProfileForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), fields: []const []const u8) !void {
+    for (fields, 0..) |field, idx| {
+        if (idx > 0) try out.append(allocator, '\t');
+        try appendHexFieldForTest(allocator, out, field);
+    }
+    try out.append(allocator, '\n');
+}
+
+fn appendHexFieldForTest(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), field: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (field) |ch| {
+        try out.append(allocator, hex[ch >> 4]);
+        try out.append(allocator, hex[ch & 0x0f]);
+    }
+}
+
+test "ssh_profile_store: resolves connection from encoded ssh_hosts content" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{
+        "devbox", "10.0.0.9", "alice", "secret", "2222", "jump@example.com:22",
+    });
+
+    const conn = findConnectionInContent(content.items, "devbox", true) orelse return error.ExpectedConnection;
+    try std.testing.expectEqualStrings("alice", conn.user());
+    try std.testing.expectEqualStrings("10.0.0.9", conn.host());
+    try std.testing.expectEqualStrings("2222", conn.port());
+    try std.testing.expectEqualStrings("secret", conn.password());
+    try std.testing.expectEqualStrings("jump@example.com:22", conn.proxyJump());
+    try std.testing.expect(conn.password_auth);
+    try std.testing.expect(conn.legacy_algorithms);
+}
+
+test "ssh_profile_store: rejects unsafe profile fields" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{
+        "bad", "host;rm -rf /", "alice", "", "22", "",
+    });
+
+    try std.testing.expect(findConnectionInContent(content.items, "bad", false) == null);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -46,6 +46,7 @@ test {
     _ = @import("ssh_connection.zig");
     _ = @import("port_forward_rule.zig");
     _ = @import("ssh_profile_store.zig");
+    _ = @import("port_forward_manager.zig");
     _ = @import("openssh_config_import.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -45,6 +45,7 @@ test {
     _ = @import("agent_file_copy.zig");
     _ = @import("ssh_connection.zig");
     _ = @import("port_forward_rule.zig");
+    _ = @import("ssh_profile_store.zig");
     _ = @import("openssh_config_import.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -47,6 +47,7 @@ test {
     _ = @import("port_forward_rule.zig");
     _ = @import("ssh_profile_store.zig");
     _ = @import("port_forward_manager.zig");
+    _ = @import("port_forwarding.zig");
     _ = @import("openssh_config_import.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -44,6 +44,7 @@ test {
     _ = @import("agent_file_edit.zig");
     _ = @import("agent_file_copy.zig");
     _ = @import("ssh_connection.zig");
+    _ = @import("port_forward_rule.zig");
     _ = @import("openssh_config_import.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -76,6 +76,7 @@ test {
     _ = @import("skill_inventory_cache.zig");
     _ = @import("skill_center.zig");
     _ = @import("renderer/skill_center_renderer.zig");
+    _ = @import("renderer/port_forwarding_renderer.zig");
     _ = @import("skill_pairing.zig");
     _ = @import("skill_transfer_cmd.zig");
     _ = @import("skill_transfer.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -724,6 +724,11 @@ comptime {
     _ = @import("skill_inventory_cache.zig");
     _ = @import("skill_center.zig");
     _ = @import("renderer/skill_center_renderer.zig");
+    _ = @import("port_forward_rule.zig");
+    _ = @import("ssh_profile_store.zig");
+    _ = @import("port_forward_manager.zig");
+    _ = @import("port_forwarding.zig");
+    _ = @import("renderer/port_forwarding_renderer.zig");
     _ = @import("command_registry.zig");
     _ = @import("scrollbar_model.zig");
     _ = @import("ai_chat_scrollbar_model.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -117,6 +117,20 @@ comptime {
         @compileError("App/AppWindow launch APIs must use native command line names, not UTF-16-specific names");
     }
 
+    const profile_codec_source = @embedFile("renderer/overlays/profile_codec.zig");
+    if (std.mem.indexOf(u8, profile_codec_source, "pub const SSH_FIELD_COUNT = 6") == null or
+        std.mem.indexOf(u8, profile_codec_source, "port_forward") != null)
+    {
+        @compileError("Port forwarding must not extend the existing ssh_hosts profile schema");
+    }
+
+    const ssh_tunnel_source = @embedFile("ssh_tunnel.zig");
+    if (std.mem.indexOf(u8, ssh_tunnel_source, "\"-L\"") == null or
+        std.mem.indexOf(u8, ssh_tunnel_source, "\"-R\"") != null)
+    {
+        @compileError("Existing URL SSH tunnel code must remain local-forwarding only");
+    }
+
     const shared_pty_sources = .{
         @embedFile("Surface.zig"),
         @embedFile("termio/Thread.zig"),


### PR DESCRIPTION
## Summary

- Add a dedicated silent Port Forwarding management tab for global SSH local and reverse forwarding rules.
- Add rule validation/storage, saved SSH profile resolution, OpenSSH helper lifecycle management, auto-start support, command center/input wiring, and renderer/UI tests.
- Document the loopback-only v1 safety boundary and usage examples in `docs/port-forwarding.md`, with the detailed implementation plan under `docs/superpowers/plans/`.

## Impact

Servers can use local workstation loopback services such as `127.0.0.1:7890` through reverse forwarding, and local tools can use remote loopback services through local forwarding. The feature is managed in its own tab and does not modify the existing SSH profile configuration page.

## Notes

The helper process path intentionally avoids OpenSSH `ControlMaster`, `ControlPersist`, and `ControlPath` for Windows SSH/SCP compatibility. The final fix also makes the Port Forwarding form modal for input routing so command letters like `n/e/d/r/a` remain valid text while editing a rule.

## Verification

- `zig build test`
- `zig build test-full`
- `zig test src/port_forward_rule.zig`
- `zig test src/ssh_profile_store.zig`
- `zig test src/port_forward_manager.zig`
- `zig test src/port_forwarding.zig`
- `zig test src/test_fast.zig --test-filter port_forwarding_renderer`
- Windows checkout-safety equivalent check: 0 name violations, 0 casefold collisions, 0 symlink entries

Not run: live Windows manual reverse-forwarding check with a real saved SSH profile and local proxy.
