### PR TITLE
fix(resize): hold SSH PTY resize during interactive drags (#171)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -26,6 +26,7 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
 const ssh_connection_mod = @import("ssh_connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
+const resize_gate_mod = @import("resize_gate.zig");
 
 const Surface = @This();
 
@@ -160,6 +161,11 @@ remote_id: [16]u8,
 /// Size information for this surface (screen size, cell size, padding).
 /// Used by the renderer to position content correctly.
 size: renderer.size.Size = .{},
+
+/// Gate between the per-frame layout grid and the IO thread (PTY + terminal
+/// resize). Holds resizes during interactive drags so an SSH surface gets a
+/// single SIGWINCH per drag instead of a burst (issue #171). Main thread only.
+resize_gate: resize_gate_mod.ResizeGate,
 
 // ============================================================================
 // IO threads (Ghostty two-thread architecture: writer + reader)
@@ -414,6 +420,12 @@ pub fn init(
     surface.size.grid.cols = cols;
     surface.size.grid.rows = rows;
 
+    // The IO thread already knows the startup grid; seed the gate with it so
+    // the first layout pass queues no resize (same guarantee as the preset
+    // grid above). allocator.create does not apply struct field defaults, so
+    // this must be initialized explicitly like every other field here.
+    surface.resize_gate = resize_gate_mod.ResizeGate.init(cols, rows);
+
     // Initialize per-surface renderer (Ghostty architecture)
     surface.surface_renderer = Renderer.init(surface);
     surface.renderer_thread = RendererThread.init(&surface.surface_renderer, surface);
@@ -587,6 +599,12 @@ pub fn setSshConnection(
 pub const ResizePolicy = enum {
     coalesced,
     immediate,
+    /// An interactive drag (window border, split divider, side-panel edge) is
+    /// in progress: park the PTY + terminal resize for SSH surfaces and flush
+    /// the final grid once on the first non-held layout pass after release.
+    /// Local surfaces still resize live — their redraw round-trip is fast
+    /// enough that the burst is harmless (issue #171).
+    held,
 };
 
 /// Update the surface size and queue a resize to the IO thread if needed.
@@ -595,9 +613,10 @@ pub const ResizePolicy = enum {
 ///
 /// The main thread updates pixel/grid dimensions in surface.size (needed
 /// for layout/rendering), but the actual PTY + terminal resize happens
-/// on the IO thread via queueIo() with 25ms coalescing.
+/// on the IO thread via queueIo() with 25ms coalescing. With the `.held`
+/// policy the IO resize is parked until the drag ends (see ResizePolicy).
 ///
-/// Returns true if the grid dimensions changed (resize was queued).
+/// Returns true if the grid dimensions changed.
 pub fn setScreenSize(
     self: *Surface,
     screen_width: u32,
@@ -644,19 +663,23 @@ pub fn setScreenSizeWithPolicy(
     self.size.grid.cols = new_cols;
     self.size.grid.rows = new_rows;
 
-    // Queue resize to IO thread if grid dimensions changed
-    if (changed) {
+    // Queue the resize to the IO thread through the gate. The gate dedupes
+    // against the grid the IO thread last received, which both suppresses
+    // repeat submissions (layout runs every frame) and flushes a held resize
+    // on the first pass after a drag ends. Holding only applies to SSH
+    // surfaces; everything else keeps live resize.
+    const hold = resize_policy == .held and self.launch_kind == .ssh;
+    if (self.resize_gate.submit(hold, .{ .cols = new_cols, .rows = new_rows })) |grid| {
         // Terminal rows/cols and pixel dimensions are updated together in
         // the IO thread, under the render-state lock.
-        const grid: renderer.size.GridSize = .{ .cols = new_cols, .rows = new_rows };
+        const msg_grid: renderer.size.GridSize = .{ .cols = grid.cols, .rows = grid.rows };
         switch (resize_policy) {
-            .coalesced => self.queueIo(.{ .resize = grid }),
-            .immediate => self.queueIo(.{ .resize_immediate = grid }),
+            .coalesced, .held => self.queueIo(.{ .resize = msg_grid }),
+            .immediate => self.queueIo(.{ .resize_immediate = msg_grid }),
         }
-        return true;
     }
 
-    return false;
+    return changed;
 }
 
 /// Send a message to the IO writer thread via the mailbox.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -870,6 +870,9 @@ pub const Window = struct {
     mouse_move_events: RingBuffer(MouseMoveEvent, 64) = .{},
     mouse_wheel_events: RingBuffer(MouseWheelEvent, 16) = .{},
     size_changed: bool = false, // set by WM_SIZE, cleared after processing
+    /// True between WM_ENTERSIZEMOVE and WM_EXITSIZEMOVE (OS-modal border
+    /// drag). SSH surfaces park their PTY resize while this is set (#171).
+    in_size_move: bool = false,
 
     /// Optional callback invoked from WM_SIZE so the application can
     /// do a GL clear+swap during the Win32 modal resize loop. Without
@@ -1729,11 +1732,17 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         // and blocks our main loop. Drop vsync so the synchronous WM_SIZE paints
         // (Window.on_resize) don't each stall on vblank during the drag.
         WM_ENTERSIZEMOVE => {
+            w.in_size_move = true;
             setSwapInterval(0);
             return 0;
         },
         WM_EXITSIZEMOVE => {
+            w.in_size_move = false;
             setSwapInterval(1);
+            // Force a layout pass after the drag: this is what flushes a
+            // resize parked by an SSH surface during the drag (#171). The
+            // drag may end without a trailing WM_SIZE or mouse move.
+            w.size_changed = true;
             return 0;
         },
 

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -13,6 +13,7 @@ const gl_init = AppWindow.gpu.gl_init;
 const Surface = @import("../Surface.zig");
 const SplitTree = @import("../split_tree.zig");
 const renderer = @import("../renderer.zig");
+const window_backend = @import("../platform/window_backend.zig");
 
 const TabState = tab.TabState;
 pub const MAX_SPLITS_PER_TAB = tab.MAX_SPLITS_PER_TAB;
@@ -136,6 +137,23 @@ pub fn hitTestDivider(x: i32, y: i32) ?DividerHit {
     return null;
 }
 
+/// True while the user is interactively dragging something that resizes
+/// terminal panes: a split divider, a side-panel edge, or the OS window
+/// border (Windows modal size-move loop). While active, SSH surfaces park
+/// their PTY + terminal resize and commit once on release (issue #171:
+/// the per-frame resize burst corrupts remote scrollback because SIGWINCH
+/// prompt redraws arrive one network round-trip behind the grid).
+fn interactiveResizeDragActive() bool {
+    if (input.g_divider_dragging or
+        input.g_sidebar_resize_dragging or
+        input.g_explorer_resize_dragging or
+        input.g_markdown_preview_resize_dragging or
+        input.g_browser_resize_dragging or
+        input.g_ai_copilot_resize_dragging) return true;
+    const win = AppWindow.g_window orelse return false;
+    return window_backend.inSizeMove(win);
+}
+
 /// Compute split layout for a tab, returning pixel rects for each surface.
 /// Each surface is resized to fit its allocated area with proper padding.
 /// Returns the number of surfaces (0 if tree is empty).
@@ -163,6 +181,8 @@ pub fn computeSplitLayout(
 
     const resize_policy: Surface.ResizePolicy = if (AppWindow.consumeImmediateLayoutResize())
         .immediate
+    else if (interactiveResizeDragActive())
+        .held
     else
         .coalesced;
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -4033,6 +4033,16 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 platform_cursor.set(cursor_shape);
                 return;
             }
+            // A pane-resizing drag is ending: guarantee one more layout pass so
+            // SSH surfaces flush the PTY resize parked during the drag (#171),
+            // instead of waiting for the next incidental frame.
+            if (g_sidebar_resize_dragging or g_explorer_resize_dragging or
+                g_markdown_preview_resize_dragging or g_browser_resize_dragging or
+                g_ai_copilot_resize_dragging or g_divider_dragging)
+            {
+                AppWindow.g_force_rebuild = true;
+                AppWindow.g_cells_valid = false;
+            }
             if (g_sidebar_resize_dragging) {
                 g_sidebar_resize_dragging = false;
                 g_sidebar_resize_hover = hitTestSidebarResizeHandle(xpos, ypos);

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -446,6 +446,15 @@ pub fn consumeSizeChanged(window: *Window) bool {
     return changed;
 }
 
+/// True while the OS-modal interactive move/size loop is running for this
+/// window (Windows border drag: WM_ENTERSIZEMOVE..WM_EXITSIZEMOVE). Backends
+/// without that concept report false; in-app drags (split dividers, panel
+/// edges) are tracked separately by input.zig flags.
+pub fn inSizeMove(window: *const Window) bool {
+    if (comptime @hasField(Window, "in_size_move")) return window.in_size_move;
+    return false;
+}
+
 pub fn clearTransientInput(window: *Window) void {
     window.clearTransientInputQueues();
 }

--- a/src/resize_gate.zig
+++ b/src/resize_gate.zig
@@ -1,0 +1,92 @@
+//! Decides when a surface's computed grid size is forwarded to the IO
+//! thread (PTY setSize + terminal resize). Pure, main-thread-only state.
+//!
+//! Issue #171: during an interactive drag (window border, split divider,
+//! side-panel edge) the per-frame layout produces a burst of grid changes
+//! (~every 30ms, 20+ per drag). For an SSH surface each PTY resize reaches
+//! the remote shell one network round-trip later, so its SIGWINCH prompt
+//! redraw comes back tuned for a grid the terminal has already left. A
+//! long (wrapping) prompt then re-wraps at the wrong width, every overflow
+//! line forces a scroll, and the scrollback floods with interleaved prompt
+//! fragments while reflow re-wraps the damage on each step. Local ConPTY
+//! shells survive the same burst because their redraw round-trip is
+//! sub-millisecond; short prompts survive because no redraw line crosses an
+//! intermediate width.
+//!
+//! The gate collapses the burst: while `hold` is true (an interactive drag
+//! is in progress) nothing is queued, and the first non-held submit flushes
+//! the latest grid once. Layout re-submits every frame, so the flush needs
+//! no explicit drag-end hook. Deduplication against the last queued grid
+//! also means a drag that returns to its starting size queues nothing.
+
+pub const Grid = struct {
+    cols: u16,
+    rows: u16,
+
+    pub fn eql(a: Grid, b: Grid) bool {
+        return a.cols == b.cols and a.rows == b.rows;
+    }
+};
+
+pub const ResizeGate = struct {
+    /// The grid the IO thread was last told about (terminal + PTY size).
+    last_queued: Grid,
+
+    pub fn init(cols: u16, rows: u16) ResizeGate {
+        return .{ .last_queued = .{ .cols = cols, .rows = rows } };
+    }
+
+    /// Decide whether `grid` should be queued to the IO thread now.
+    /// Returns the grid to queue, or null to skip this frame.
+    pub fn submit(self: *ResizeGate, hold: bool, grid: Grid) ?Grid {
+        if (hold) return null;
+        if (grid.eql(self.last_queued)) return null;
+        self.last_queued = grid;
+        return grid;
+    }
+};
+
+const std = @import("std");
+
+test "queues a changed grid and dedupes repeats" {
+    var gate = ResizeGate.init(80, 24);
+    const queued = gate.submit(false, .{ .cols = 100, .rows = 30 });
+    try std.testing.expect(queued != null);
+    try std.testing.expectEqual(@as(u16, 100), queued.?.cols);
+    try std.testing.expectEqual(@as(u16, 30), queued.?.rows);
+    // Same grid again: nothing to queue (layout re-submits every frame).
+    try std.testing.expect(gate.submit(false, .{ .cols = 100, .rows = 30 }) == null);
+}
+
+test "initial grid is the baseline: no spurious resize on first submit" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(false, .{ .cols = 142, .rows = 49 }) == null);
+}
+
+test "held submits queue nothing" {
+    var gate = ResizeGate.init(142, 49);
+    // Drag in progress: a burst of intermediate sizes is parked.
+    try std.testing.expect(gate.submit(true, .{ .cols = 94, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 74, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 60, .rows = 49 }) == null);
+}
+
+test "first non-held submit flushes the final grid once" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(true, .{ .cols = 94, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 60, .rows = 49 }) == null);
+    // Drag ended; layout re-submits the final grid without hold.
+    const queued = gate.submit(false, .{ .cols = 60, .rows = 49 });
+    try std.testing.expect(queued != null);
+    try std.testing.expectEqual(@as(u16, 60), queued.?.cols);
+    // Steady state afterwards: deduped.
+    try std.testing.expect(gate.submit(false, .{ .cols = 60, .rows = 49 }) == null);
+}
+
+test "drag that returns to the starting size queues nothing" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(true, .{ .cols = 90, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 120, .rows = 49 }) == null);
+    // Released exactly where it started: terminal is already that size.
+    try std.testing.expect(gate.submit(false, .{ .cols = 142, .rows = 49 }) == null);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -93,6 +93,7 @@ test {
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");
     _ = @import("scrollbar_model.zig");
+    _ = @import("resize_gate.zig");
     _ = @import("preview_token.zig");
     _ = @import("ime_caret.zig");
     _ = @import("sync_output.zig");


### PR DESCRIPTION
Fixes #171.

## Root cause

Dragging a panel edge or the window border runs layout every frame, which queues a **PTY + terminal resize every ~30ms** — the latest diagnostic log shows a single drag stepping through `cols 40→52→64→69→70→71→73→74…` with one `ResizePseudoConsole` per step.

- **Local shells (cmd/PowerShell/WSL)**: ConPTY's resize repaint round-trip is sub-millisecond, so each repaint is generated **and** interpreted under the same grid. Harmless — matches the reporter's "WSL/PowerShell 不复现".
- **SSH**: the remote shell's SIGWINCH prompt redraw arrives **one network round-trip late**, so redraw bytes produced for grid *N* are interpreted under grid *N+k*. Every redraw line that no longer fits wraps, forces a scroll at the bottom row, and pushes prompt fragments into scrollback; ghostty's reflow then re-wraps the damage on each of the 20+ steps. After one drag the viewport and scrollback are full of interleaved `faz_laptop@…` fragments and history is effectively destroyed.
- **Short prompts are immune** because no redraw line crosses an intermediate width — also matching the reporter's table.
- **OSC 133 can't help** and **filtering can't work**: ConPTY output is a stateful delta stream against its own buffer, so dropping any fragment (the v1/v2 `drop-host-redraw`/`drop-ssh-resize-window` approach) permanently desyncs the local screen from ConPTY's model. That's why all three filter builds still reproduced.

## Fix

While an interactive drag is in progress — split divider, any side-panel edge (preview / copilot / explorer / browser / sessions), or the Win32 modal size-move loop (`WM_ENTERSIZEMOVE`…`WM_EXITSIZEMOVE`) — **SSH surfaces park their IO resize and commit a single resize on release**: one SIGWINCH per drag, generated and interpreted under the same final grid. This reduces every drag to the "温和 resize" case the reporter already confirmed safe. Local/WSL surfaces keep live resize (unchanged behavior). It is also how Windows Terminal-style deferred buffer resize avoids the same ConPTY dual-buffer problem.

- `src/resize_gate.zig` — new pure gate (unit-tested, fast suite): parks submits while held, flushes the latest grid once on the first non-held layout pass, dedupes against the grid the IO thread last received (a drag returning to its starting size queues nothing).
- `src/Surface.zig` — `ResizePolicy.held`; the gate sits between layout and `queueIo(.resize)`; seeded with the startup grid so first render still queues nothing.
- `src/appwindow/split_layout.zig` — picks `.held` while `interactiveResizeDragActive()` (drag flags + `window_backend.inSizeMove`).
- `src/apprt/win32.zig` — tracks `in_size_move`; `WM_EXITSIZEMOVE` forces a layout pass so the parked resize flushes even without a trailing WM_SIZE.
- `src/input.zig` — pane-resize drag release forces one layout pass (deterministic flush instead of waiting for the next incidental frame).

During the drag the SSH pane renders its old grid clipped to the pane (same mismatch that already exists for the 25ms coalesce window today); the resize overlay still shows the live target size.

## Testing

- `zig build test` ✅ (includes new `resize_gate` unit tests)
- `zig build test-full` ✅
- `zig build -Dtarget=x86_64-windows-gnu` (Debug + ReleaseFast) ✅
- GUI verify on Windows pending — test build for the reporter: long prompt + `seq 200`, then (1) drag preview/copilot edge back and forth, (2) drag the window border across the prompt-wrap threshold; scrollback should stay intact and the prompt should redraw cleanly once per release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)