### PR TITLE
feat(win32): present via DXGI flip-model swapchain, GDI SwapBuffers fallback

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -26,6 +26,7 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
 const ssh_connection_mod = @import("ssh_connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
+const resize_gate_mod = @import("resize_gate.zig");
 
 const Surface = @This();
 
@@ -160,6 +161,11 @@ remote_id: [16]u8,
 /// Size information for this surface (screen size, cell size, padding).
 /// Used by the renderer to position content correctly.
 size: renderer.size.Size = .{},
+
+/// Gate between the per-frame layout grid and the IO thread (PTY + terminal
+/// resize). Holds resizes during interactive drags so an SSH surface gets a
+/// single SIGWINCH per drag instead of a burst (issue #171). Main thread only.
+resize_gate: resize_gate_mod.ResizeGate,
 
 // ============================================================================
 // IO threads (Ghostty two-thread architecture: writer + reader)
@@ -414,6 +420,12 @@ pub fn init(
     surface.size.grid.cols = cols;
     surface.size.grid.rows = rows;
 
+    // The IO thread already knows the startup grid; seed the gate with it so
+    // the first layout pass queues no resize (same guarantee as the preset
+    // grid above). allocator.create does not apply struct field defaults, so
+    // this must be initialized explicitly like every other field here.
+    surface.resize_gate = resize_gate_mod.ResizeGate.init(cols, rows);
+
     // Initialize per-surface renderer (Ghostty architecture)
     surface.surface_renderer = Renderer.init(surface);
     surface.renderer_thread = RendererThread.init(&surface.surface_renderer, surface);
@@ -587,6 +599,12 @@ pub fn setSshConnection(
 pub const ResizePolicy = enum {
     coalesced,
     immediate,
+    /// An interactive drag (window border, split divider, side-panel edge) is
+    /// in progress: park the PTY + terminal resize for SSH surfaces and flush
+    /// the final grid once on the first non-held layout pass after release.
+    /// Local surfaces still resize live — their redraw round-trip is fast
+    /// enough that the burst is harmless (issue #171).
+    held,
 };
 
 /// Update the surface size and queue a resize to the IO thread if needed.
@@ -595,9 +613,10 @@ pub const ResizePolicy = enum {
 ///
 /// The main thread updates pixel/grid dimensions in surface.size (needed
 /// for layout/rendering), but the actual PTY + terminal resize happens
-/// on the IO thread via queueIo() with 25ms coalescing.
+/// on the IO thread via queueIo() with 25ms coalescing. With the `.held`
+/// policy the IO resize is parked until the drag ends (see ResizePolicy).
 ///
-/// Returns true if the grid dimensions changed (resize was queued).
+/// Returns true if the grid dimensions changed.
 pub fn setScreenSize(
     self: *Surface,
     screen_width: u32,
@@ -644,19 +663,23 @@ pub fn setScreenSizeWithPolicy(
     self.size.grid.cols = new_cols;
     self.size.grid.rows = new_rows;
 
-    // Queue resize to IO thread if grid dimensions changed
-    if (changed) {
+    // Queue the resize to the IO thread through the gate. The gate dedupes
+    // against the grid the IO thread last received, which both suppresses
+    // repeat submissions (layout runs every frame) and flushes a held resize
+    // on the first pass after a drag ends. Holding only applies to SSH
+    // surfaces; everything else keeps live resize.
+    const hold = resize_policy == .held and self.launch_kind == .ssh;
+    if (self.resize_gate.submit(hold, .{ .cols = new_cols, .rows = new_rows })) |grid| {
         // Terminal rows/cols and pixel dimensions are updated together in
         // the IO thread, under the render-state lock.
-        const grid: renderer.size.GridSize = .{ .cols = new_cols, .rows = new_rows };
+        const msg_grid: renderer.size.GridSize = .{ .cols = grid.cols, .rows = grid.rows };
         switch (resize_policy) {
-            .coalesced => self.queueIo(.{ .resize = grid }),
-            .immediate => self.queueIo(.{ .resize_immediate = grid }),
+            .coalesced, .held => self.queueIo(.{ .resize = msg_grid }),
+            .immediate => self.queueIo(.{ .resize_immediate = msg_grid }),
         }
-        return true;
     }
 
-    return false;
+    return changed;
 }
 
 /// Send a message to the IO writer thread via the mailbox.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -13,6 +13,7 @@ const windows = std.os.windows;
 const platform_input = @import("../platform/input_events.zig");
 const platform_window = @import("../platform/window.zig");
 const render_diagnostics = @import("../render_diagnostics.zig");
+const dx_present = @import("win32_dx_present.zig");
 
 // ============================================================================
 // Win32 API types
@@ -674,7 +675,21 @@ extern "opengl32" fn wglGetProcAddress(lpszProc: [*:0]const u8) callconv(.winapi
 var g_wgl_swap_interval: ?*const fn (c_int) callconv(.winapi) BOOL = null;
 var g_swap_interval_loaded: bool = false;
 
+/// Desired vsync interval, consumed by the DXGI flip-model presenter's
+/// `Present` call (wglSwapIntervalEXT only affects the GDI fallback path).
+var g_present_interval: c_int = 1;
+
+/// Config gate for the DXGI flip-model present path (`wispterm-d3d-present`,
+/// default on). Read once at window creation; the GDI SwapBuffers path is the
+/// automatic fallback whenever the presenter can't initialize or fails.
+var g_flip_present_enabled: bool = true;
+
+pub fn setFlipPresentEnabled(enabled: bool) void {
+    g_flip_present_enabled = enabled;
+}
+
 fn setSwapInterval(interval: c_int) void {
+    g_present_interval = interval;
     if (!g_swap_interval_loaded) {
         g_swap_interval_loaded = true;
         if (wglGetProcAddress("wglSwapIntervalEXT")) |p| {
@@ -822,6 +837,9 @@ pub const Window = struct {
     hwnd: HWND,
     hdc: HDC,
     hglrc: HGLRC,
+    /// DXGI flip-model presenter; null = legacy GDI SwapBuffers path (either
+    /// disabled by config or unavailable/failed on this machine).
+    dx: ?dx_present.Presenter = null,
     should_close: bool = false,
     close_requested: bool = false,
     width: i32 = 800,
@@ -1165,10 +1183,31 @@ pub const Window = struct {
             physical_width, physical_height, dpi, rect.right - rect.left, rect.bottom - rect.top,
         });
 
+        // Prefer a DXGI flip-model swapchain over GDI SwapBuffers: the legacy
+        // BLT present composites through the DWM redirection surface, which is
+        // what produced the cross-DPI / resize artifacts of #46/#47/#88 on
+        // Intel Arc and AMD iGPU drivers. Requires the GL context current.
+        const dx: ?dx_present.Presenter = if (g_flip_present_enabled)
+            dx_present.Presenter.init(hwnd, rect.right - rect.left, rect.bottom - rect.top) catch |err| blk: {
+                render_diagnostics.log("dx-present unavailable ({s}) — using GDI SwapBuffers", .{@errorName(err)});
+                std.debug.print("Win32: DXGI flip present unavailable ({s}), using SwapBuffers\n", .{@errorName(err)});
+                break :blk null;
+            }
+        else
+            null;
+        if (dx != null) {
+            render_diagnostics.log(
+                "dx-present active: flip-model swapchain {}x{}",
+                .{ rect.right - rect.left, rect.bottom - rect.top },
+            );
+            std.debug.print("Win32: presenting via DXGI flip-model swapchain\n", .{});
+        }
+
         var window = Window{
             .hwnd = hwnd,
             .hdc = hdc,
             .hglrc = hglrc,
+            .dx = dx,
             .width = rect.right - rect.left,
             .height = rect.bottom - rect.top,
             .dpi = dpi,
@@ -1197,6 +1236,11 @@ pub const Window = struct {
 
     pub fn deinit(self: *Window) void {
         platform_window.unregisterEventWindow(self.hwnd);
+        // Interop teardown needs the GL context still current.
+        if (self.dx) |*dx| {
+            dx.deinit();
+            self.dx = null;
+        }
         _ = wglMakeCurrent(self.hdc, null);
         _ = wglDeleteContext(self.hglrc);
         _ = DestroyWindow(self.hwnd);
@@ -1207,6 +1251,16 @@ pub const Window = struct {
     }
 
     pub fn swapBuffers(self: *Window) void {
+        if (self.dx) |*dx| {
+            const size = self.getFramebufferSize();
+            if (dx.presentFrame(size.width, size.height, g_present_interval)) return;
+            // The presenter latched a failure; tear it down and finish the
+            // session on the GDI path (this frame included).
+            render_diagnostics.log("dx-present failed mid-session — reverting to GDI SwapBuffers", .{});
+            std.debug.print("Win32: DXGI present failed, reverting to SwapBuffers\n", .{});
+            dx.deinit();
+            self.dx = null;
+        }
         _ = SwapBuffers(self.hdc);
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -870,6 +870,9 @@ pub const Window = struct {
     mouse_move_events: RingBuffer(MouseMoveEvent, 64) = .{},
     mouse_wheel_events: RingBuffer(MouseWheelEvent, 16) = .{},
     size_changed: bool = false, // set by WM_SIZE, cleared after processing
+    /// True between WM_ENTERSIZEMOVE and WM_EXITSIZEMOVE (OS-modal border
+    /// drag). SSH surfaces park their PTY resize while this is set (#171).
+    in_size_move: bool = false,
 
     /// Optional callback invoked from WM_SIZE so the application can
     /// do a GL clear+swap during the Win32 modal resize loop. Without
@@ -1729,11 +1732,17 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         // and blocks our main loop. Drop vsync so the synchronous WM_SIZE paints
         // (Window.on_resize) don't each stall on vblank during the drag.
         WM_ENTERSIZEMOVE => {
+            w.in_size_move = true;
             setSwapInterval(0);
             return 0;
         },
         WM_EXITSIZEMOVE => {
+            w.in_size_move = false;
             setSwapInterval(1);
+            // Force a layout pass after the drag: this is what flushes a
+            // resize parked by an SSH surface during the drag (#171). The
+            // drag may end without a trailing WM_SIZE or mouse move.
+            w.size_changed = true;
             return 0;
         },
 

--- a/src/apprt/win32_dx_present.zig
+++ b/src/apprt/win32_dx_present.zig
@@ -1,0 +1,450 @@
+//! DXGI flip-model presenter for the Win32 OpenGL host.
+//!
+//! Replaces the legacy GDI `SwapBuffers` present (BLT into the DWM
+//! redirection surface) with a D3D11 flip-model swapchain shared with GL via
+//! `WGL_NV_DX_interop2`. The legacy path is the source of the cross-DPI /
+//! resize artifacts in issues #46/#47/#88: with the frame extended into the
+//! whole client area, DWM composites the redirection surface using the GL
+//! backbuffer's alpha and stale-surface contents on some drivers (Intel Arc,
+//! AMD iGPU). A flip-model swapchain with `DXGI_ALPHA_MODE_IGNORE` is
+//! composited opaquely and never goes through the redirection surface.
+//!
+//! Frame flow (per present):
+//!   renderer draws to GL FBO 0 exactly as before →
+//!   `presentFrame` blits FBO 0 into an interop renderbuffer (Y-flipped:
+//!   GL rows are bottom-up, D3D rows top-down) backed by a shared D3D11
+//!   texture → `CopyResource` into swapchain buffer 0 → `Present`.
+//!
+//! Every failure latches `PresentPolicy.fail()` and the caller reverts to
+//! GDI `SwapBuffers` for the rest of the session, so machines without
+//! `WGL_NV_DX_interop2` (or with a broken driver) keep the old behavior.
+
+const std = @import("std");
+const windows = std.os.windows;
+const core = @import("../platform/dxgi_core.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
+
+const HWND = windows.HWND;
+const HANDLE = windows.HANDLE;
+const HMODULE = windows.HMODULE;
+const BOOL = windows.BOOL;
+const HRESULT = windows.HRESULT;
+
+extern "opengl32" fn wglGetProcAddress(name: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
+extern "kernel32" fn LoadLibraryW(name: [*:0]const u16) callconv(.winapi) ?HMODULE;
+extern "kernel32" fn GetModuleHandleW(name: ?[*:0]const u16) callconv(.winapi) ?HMODULE;
+extern "kernel32" fn GetProcAddress(module: HMODULE, name: [*:0]const u8) callconv(.winapi) ?*const anyopaque;
+
+// ============================================================================
+// GL constants + function pointers (loaded per presenter, context current)
+// ============================================================================
+
+const GL_FRAMEBUFFER: u32 = 0x8D40;
+const GL_READ_FRAMEBUFFER: u32 = 0x8CA8;
+const GL_DRAW_FRAMEBUFFER: u32 = 0x8CA9;
+const GL_RENDERBUFFER: u32 = 0x8D41;
+const GL_COLOR_ATTACHMENT0: u32 = 0x8CE0;
+const GL_COLOR_BUFFER_BIT: u32 = 0x00004000;
+const GL_NEAREST: u32 = 0x2600;
+const GL_FRAMEBUFFER_COMPLETE: u32 = 0x8CD5;
+const GL_SCISSOR_TEST: u32 = 0x0C11;
+
+const WGL_ACCESS_WRITE_DISCARD_NV: u32 = 0x0002;
+
+const DXGI_MWA_NO_ALT_ENTER: u32 = 0x2;
+
+const GlFns = struct {
+    gen_framebuffers: *const fn (i32, [*]u32) callconv(.winapi) void,
+    delete_framebuffers: *const fn (i32, [*]const u32) callconv(.winapi) void,
+    bind_framebuffer: *const fn (u32, u32) callconv(.winapi) void,
+    framebuffer_renderbuffer: *const fn (u32, u32, u32, u32) callconv(.winapi) void,
+    gen_renderbuffers: *const fn (i32, [*]u32) callconv(.winapi) void,
+    delete_renderbuffers: *const fn (i32, [*]const u32) callconv(.winapi) void,
+    blit_framebuffer: *const fn (i32, i32, i32, i32, i32, i32, i32, i32, u32, u32) callconv(.winapi) void,
+    check_framebuffer_status: *const fn (u32) callconv(.winapi) u32,
+    // GL 1.0 entry point: comes from opengl32.dll directly, not wglGetProcAddress.
+    disable: *const fn (u32) callconv(.winapi) void,
+
+    fn load() error{GlFunctionsMissing}!GlFns {
+        const opengl32 = GetModuleHandleW(std.unicode.utf8ToUtf16LeStringLiteral("opengl32.dll")) orelse
+            return error.GlFunctionsMissing;
+        return .{
+            .gen_framebuffers = @ptrCast(wglGetProcAddress("glGenFramebuffers") orelse return error.GlFunctionsMissing),
+            .delete_framebuffers = @ptrCast(wglGetProcAddress("glDeleteFramebuffers") orelse return error.GlFunctionsMissing),
+            .bind_framebuffer = @ptrCast(wglGetProcAddress("glBindFramebuffer") orelse return error.GlFunctionsMissing),
+            .framebuffer_renderbuffer = @ptrCast(wglGetProcAddress("glFramebufferRenderbuffer") orelse return error.GlFunctionsMissing),
+            .gen_renderbuffers = @ptrCast(wglGetProcAddress("glGenRenderbuffers") orelse return error.GlFunctionsMissing),
+            .delete_renderbuffers = @ptrCast(wglGetProcAddress("glDeleteRenderbuffers") orelse return error.GlFunctionsMissing),
+            .blit_framebuffer = @ptrCast(wglGetProcAddress("glBlitFramebuffer") orelse return error.GlFunctionsMissing),
+            .check_framebuffer_status = @ptrCast(wglGetProcAddress("glCheckFramebufferStatus") orelse return error.GlFunctionsMissing),
+            .disable = @ptrCast(GetProcAddress(opengl32, "glDisable") orelse return error.GlFunctionsMissing),
+        };
+    }
+};
+
+const InteropFns = struct {
+    open_device: *const fn (*anyopaque) callconv(.winapi) ?HANDLE,
+    close_device: *const fn (HANDLE) callconv(.winapi) BOOL,
+    set_resource_share_handle: *const fn (*anyopaque, HANDLE) callconv(.winapi) BOOL,
+    register_object: *const fn (HANDLE, *anyopaque, u32, u32, u32) callconv(.winapi) ?HANDLE,
+    unregister_object: *const fn (HANDLE, HANDLE) callconv(.winapi) BOOL,
+    lock_objects: *const fn (HANDLE, i32, [*]HANDLE) callconv(.winapi) BOOL,
+    unlock_objects: *const fn (HANDLE, i32, [*]HANDLE) callconv(.winapi) BOOL,
+
+    fn load() error{InteropUnavailable}!InteropFns {
+        return .{
+            .open_device = @ptrCast(wglGetProcAddress("wglDXOpenDeviceNV") orelse return error.InteropUnavailable),
+            .close_device = @ptrCast(wglGetProcAddress("wglDXCloseDeviceNV") orelse return error.InteropUnavailable),
+            .set_resource_share_handle = @ptrCast(wglGetProcAddress("wglDXSetResourceShareHandleNV") orelse return error.InteropUnavailable),
+            .register_object = @ptrCast(wglGetProcAddress("wglDXRegisterObjectNV") orelse return error.InteropUnavailable),
+            .unregister_object = @ptrCast(wglGetProcAddress("wglDXUnregisterObjectNV") orelse return error.InteropUnavailable),
+            .lock_objects = @ptrCast(wglGetProcAddress("wglDXLockObjectsNV") orelse return error.InteropUnavailable),
+            .unlock_objects = @ptrCast(wglGetProcAddress("wglDXUnlockObjectsNV") orelse return error.InteropUnavailable),
+        };
+    }
+};
+
+// ============================================================================
+// COM dispatch helpers (slot indices from dxgi_core)
+// ============================================================================
+
+fn vtable(obj: *anyopaque) [*]const *const anyopaque {
+    const pp: *const [*]const *const anyopaque = @ptrCast(@alignCast(obj));
+    return pp.*;
+}
+
+fn comCall(obj: *anyopaque, comptime slot_index: usize, comptime Fn: type) Fn {
+    return @ptrCast(vtable(obj)[slot_index]);
+}
+
+fn comRelease(obj: *anyopaque) void {
+    const f = comCall(obj, core.slot.Release, *const fn (*anyopaque) callconv(.winapi) u32);
+    _ = f(obj);
+}
+
+fn comQueryInterface(obj: *anyopaque, iid: *const core.Guid) ?*anyopaque {
+    const f = comCall(obj, core.slot.QueryInterface, *const fn (*anyopaque, *const core.Guid, *?*anyopaque) callconv(.winapi) HRESULT);
+    var out: ?*anyopaque = null;
+    if (f(obj, iid, &out) < 0) return null;
+    return out;
+}
+
+const D3D11CreateDeviceFn = *const fn (
+    adapter: ?*anyopaque,
+    driver_type: u32,
+    software: ?HMODULE,
+    flags: u32,
+    feature_levels: ?[*]const u32,
+    num_feature_levels: u32,
+    sdk_version: u32,
+    device: *?*anyopaque,
+    feature_level: ?*u32,
+    immediate_context: *?*anyopaque,
+) callconv(.winapi) HRESULT;
+
+pub const InitError = error{
+    D3D11Unavailable,
+    DeviceCreateFailed,
+    FactoryUnavailable,
+    SwapchainCreateFailed,
+    InteropUnavailable,
+    InteropOpenFailed,
+    GlFunctionsMissing,
+    TextureCreateFailed,
+    ShareHandleFailed,
+    RegisterFailed,
+    BackbufferUnavailable,
+    FramebufferIncomplete,
+    LockFailed,
+};
+
+const PresentError = error{
+    LockFailed,
+    PresentFailed,
+};
+
+// ============================================================================
+// Presenter
+// ============================================================================
+
+pub const Presenter = struct {
+    gl: GlFns,
+    interop: InteropFns,
+
+    device: *anyopaque, // ID3D11Device
+    context: *anyopaque, // ID3D11DeviceContext (immediate)
+    swapchain: *anyopaque, // IDXGISwapChain1
+    interop_device: HANDLE,
+
+    // Sized resources, rebuilt on every swapchain resize.
+    backbuffer: ?*anyopaque = null, // ID3D11Texture2D (buffer 0)
+    shared_tex: ?*anyopaque = null, // ID3D11Texture2D (interop target)
+    interop_object: ?HANDLE = null,
+    gl_fbo: u32 = 0,
+    gl_rbo: u32 = 0,
+
+    policy: core.PresentPolicy,
+
+    /// Requires the window's GL context to be current (interop + GL function
+    /// loading both depend on it).
+    pub fn init(hwnd: HWND, width: i32, height: i32) InitError!Presenter {
+        if (width <= 0 or height <= 0) return error.SwapchainCreateFailed;
+
+        const gl = try GlFns.load();
+        const interop = try InteropFns.load();
+
+        const d3d11 = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("d3d11.dll")) orelse
+            return error.D3D11Unavailable;
+        const create_device: D3D11CreateDeviceFn = @ptrCast(GetProcAddress(d3d11, "D3D11CreateDevice") orelse
+            return error.D3D11Unavailable);
+
+        var device: ?*anyopaque = null;
+        var context: ?*anyopaque = null;
+        if (create_device(
+            null,
+            core.D3D_DRIVER_TYPE_HARDWARE,
+            null,
+            core.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+            null,
+            0,
+            core.D3D11_SDK_VERSION,
+            &device,
+            null,
+            &context,
+        ) < 0 or device == null or context == null) return error.DeviceCreateFailed;
+        errdefer {
+            comRelease(context.?);
+            comRelease(device.?);
+        }
+
+        const swapchain = try createSwapchain(device.?, hwnd, width, height);
+        errdefer comRelease(swapchain);
+
+        const interop_device = interop.open_device(device.?) orelse return error.InteropOpenFailed;
+        errdefer _ = interop.close_device(interop_device);
+
+        var self = Presenter{
+            .gl = gl,
+            .interop = interop,
+            .device = device.?,
+            .context = context.?,
+            .swapchain = swapchain,
+            .interop_device = interop_device,
+            .policy = core.PresentPolicy.init(width, height),
+        };
+        try self.createSizedResources(width, height);
+        return self;
+    }
+
+    fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) InitError!*anyopaque {
+        const dxgi_device = comQueryInterface(device, &core.IID_IDXGIDevice) orelse
+            return error.FactoryUnavailable;
+        defer comRelease(dxgi_device);
+
+        const get_adapter = comCall(dxgi_device, core.slot.DXGIDevice_GetAdapter, *const fn (*anyopaque, *?*anyopaque) callconv(.winapi) HRESULT);
+        var adapter: ?*anyopaque = null;
+        if (get_adapter(dxgi_device, &adapter) < 0 or adapter == null) return error.FactoryUnavailable;
+        defer comRelease(adapter.?);
+
+        const get_parent = comCall(adapter.?, core.slot.DXGIObject_GetParent, *const fn (*anyopaque, *const core.Guid, *?*anyopaque) callconv(.winapi) HRESULT);
+        var factory: ?*anyopaque = null;
+        if (get_parent(adapter.?, &core.IID_IDXGIFactory2, &factory) < 0 or factory == null)
+            return error.FactoryUnavailable;
+        defer comRelease(factory.?);
+
+        const desc = core.DXGI_SWAP_CHAIN_DESC1{
+            .width = @intCast(width),
+            .height = @intCast(height),
+            .format = core.DXGI_FORMAT_B8G8R8A8_UNORM,
+            .stereo = 0,
+            .sample_desc = .{ .count = 1, .quality = 0 },
+            .buffer_usage = core.DXGI_USAGE_RENDER_TARGET_OUTPUT,
+            .buffer_count = 2,
+            .scaling = core.DXGI_SCALING_NONE,
+            .swap_effect = core.DXGI_SWAP_EFFECT_FLIP_DISCARD,
+            .alpha_mode = core.DXGI_ALPHA_MODE_IGNORE,
+            .flags = 0,
+        };
+        const create_for_hwnd = comCall(factory.?, core.slot.DXGIFactory2_CreateSwapChainForHwnd, *const fn (
+            *anyopaque,
+            *anyopaque,
+            HWND,
+            *const core.DXGI_SWAP_CHAIN_DESC1,
+            ?*const anyopaque,
+            ?*anyopaque,
+            *?*anyopaque,
+        ) callconv(.winapi) HRESULT);
+        var swapchain: ?*anyopaque = null;
+        if (create_for_hwnd(factory.?, device, hwnd, &desc, null, null, &swapchain) < 0 or swapchain == null)
+            return error.SwapchainCreateFailed;
+
+        // DXGI grabs Alt+Enter for exclusive fullscreen by default; the app
+        // has its own borderless-fullscreen handling.
+        const make_assoc = comCall(factory.?, core.slot.DXGIFactory_MakeWindowAssociation, *const fn (*anyopaque, HWND, u32) callconv(.winapi) HRESULT);
+        _ = make_assoc(factory.?, hwnd, DXGI_MWA_NO_ALT_ENTER);
+
+        return swapchain.?;
+    }
+
+    /// Create the shared texture + interop registration + GL FBO for the
+    /// current swapchain size, and cache swapchain buffer 0.
+    fn createSizedResources(self: *Presenter, width: i32, height: i32) InitError!void {
+        const desc = core.D3D11_TEXTURE2D_DESC{
+            .width = @intCast(width),
+            .height = @intCast(height),
+            .mip_levels = 1,
+            .array_size = 1,
+            .format = core.DXGI_FORMAT_B8G8R8A8_UNORM,
+            .sample_desc = .{ .count = 1, .quality = 0 },
+            .usage = core.D3D11_USAGE_DEFAULT,
+            .bind_flags = core.D3D11_BIND_RENDER_TARGET,
+            .cpu_access_flags = 0,
+            .misc_flags = core.D3D11_RESOURCE_MISC_SHARED,
+        };
+        const create_tex = comCall(self.device, core.slot.D3D11Device_CreateTexture2D, *const fn (*anyopaque, *const core.D3D11_TEXTURE2D_DESC, ?*const anyopaque, *?*anyopaque) callconv(.winapi) HRESULT);
+        var tex: ?*anyopaque = null;
+        if (create_tex(self.device, &desc, null, &tex) < 0 or tex == null) return error.TextureCreateFailed;
+        errdefer comRelease(tex.?);
+
+        // WGL_NV_DX_interop2 requires the share handle to be communicated
+        // before registering a DX10/11 resource.
+        const dxgi_resource = comQueryInterface(tex.?, &core.IID_IDXGIResource) orelse
+            return error.ShareHandleFailed;
+        defer comRelease(dxgi_resource);
+        const get_shared = comCall(dxgi_resource, core.slot.DXGIResource_GetSharedHandle, *const fn (*anyopaque, *?HANDLE) callconv(.winapi) HRESULT);
+        var share_handle: ?HANDLE = null;
+        if (get_shared(dxgi_resource, &share_handle) < 0 or share_handle == null)
+            return error.ShareHandleFailed;
+        if (self.interop.set_resource_share_handle(tex.?, share_handle.?) == 0)
+            return error.ShareHandleFailed;
+
+        var rbo: u32 = 0;
+        self.gl.gen_renderbuffers(1, @ptrCast(&rbo));
+        errdefer self.gl.delete_renderbuffers(1, @ptrCast(&rbo));
+
+        const interop_object = self.interop.register_object(
+            self.interop_device,
+            tex.?,
+            rbo,
+            GL_RENDERBUFFER,
+            WGL_ACCESS_WRITE_DISCARD_NV,
+        ) orelse return error.RegisterFailed;
+        errdefer _ = self.interop.unregister_object(self.interop_device, interop_object);
+
+        var fbo: u32 = 0;
+        self.gl.gen_framebuffers(1, @ptrCast(&fbo));
+        errdefer self.gl.delete_framebuffers(1, @ptrCast(&fbo));
+
+        // Attachment + completeness check require the interop object locked.
+        var lock_handle = [1]HANDLE{interop_object};
+        if (self.interop.lock_objects(self.interop_device, 1, &lock_handle) == 0)
+            return error.LockFailed;
+        self.gl.bind_framebuffer(GL_FRAMEBUFFER, fbo);
+        self.gl.framebuffer_renderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rbo);
+        const status = self.gl.check_framebuffer_status(GL_FRAMEBUFFER);
+        self.gl.bind_framebuffer(GL_FRAMEBUFFER, 0);
+        _ = self.interop.unlock_objects(self.interop_device, 1, &lock_handle);
+        if (status != GL_FRAMEBUFFER_COMPLETE) return error.FramebufferIncomplete;
+
+        const get_buffer = comCall(self.swapchain, core.slot.DXGISwapChain_GetBuffer, *const fn (*anyopaque, u32, *const core.Guid, *?*anyopaque) callconv(.winapi) HRESULT);
+        var backbuffer: ?*anyopaque = null;
+        if (get_buffer(self.swapchain, 0, &core.IID_ID3D11Texture2D, &backbuffer) < 0 or backbuffer == null)
+            return error.BackbufferUnavailable;
+
+        self.shared_tex = tex;
+        self.interop_object = interop_object;
+        self.gl_fbo = fbo;
+        self.gl_rbo = rbo;
+        self.backbuffer = backbuffer;
+    }
+
+    fn destroySizedResources(self: *Presenter) void {
+        if (self.backbuffer) |b| {
+            comRelease(b);
+            self.backbuffer = null;
+        }
+        if (self.interop_object) |obj| {
+            _ = self.interop.unregister_object(self.interop_device, obj);
+            self.interop_object = null;
+        }
+        if (self.gl_fbo != 0) {
+            self.gl.delete_framebuffers(1, @ptrCast(&self.gl_fbo));
+            self.gl_fbo = 0;
+        }
+        if (self.gl_rbo != 0) {
+            self.gl.delete_renderbuffers(1, @ptrCast(&self.gl_rbo));
+            self.gl_rbo = 0;
+        }
+        if (self.shared_tex) |t| {
+            comRelease(t);
+            self.shared_tex = null;
+        }
+    }
+
+    fn resize(self: *Presenter, width: i32, height: i32) InitError!void {
+        // ResizeBuffers fails while buffer references are outstanding.
+        self.destroySizedResources();
+        const resize_buffers = comCall(self.swapchain, core.slot.DXGISwapChain_ResizeBuffers, *const fn (*anyopaque, u32, u32, u32, u32, u32) callconv(.winapi) HRESULT);
+        if (resize_buffers(self.swapchain, 0, @intCast(width), @intCast(height), 0, 0) < 0)
+            return error.SwapchainCreateFailed;
+        try self.createSizedResources(width, height);
+        self.policy.noteResized(width, height);
+        render_diagnostics.log("dx-present resized swapchain to {}x{}", .{ width, height });
+    }
+
+    /// Blit the rendered frame (GL FBO 0) into the swapchain and present.
+    /// Returns false once the presenter has failed; the caller must revert to
+    /// GDI SwapBuffers for the rest of the session.
+    pub fn presentFrame(self: *Presenter, width: i32, height: i32, interval: i32) bool {
+        switch (self.policy.frameAction(width, height)) {
+            .fallback => return false,
+            .skip => return true,
+            .resize_then_present => self.resize(width, height) catch |err| {
+                self.policy.fail();
+                render_diagnostics.log("dx-present resize failed: {s}", .{@errorName(err)});
+                return false;
+            },
+            .present => {},
+        }
+        self.blitAndPresent(width, height, interval) catch |err| {
+            self.policy.fail();
+            render_diagnostics.log("dx-present present failed: {s}", .{@errorName(err)});
+            return false;
+        };
+        return true;
+    }
+
+    fn blitAndPresent(self: *Presenter, width: i32, height: i32, interval: i32) PresentError!void {
+        var lock_handle = [1]HANDLE{self.interop_object.?};
+        if (self.interop.lock_objects(self.interop_device, 1, &lock_handle) == 0)
+            return error.LockFailed;
+
+        // Scissor clips glBlitFramebuffer; the frame's present prep disables
+        // it, but the presenter must not depend on renderer state.
+        self.gl.disable(GL_SCISSOR_TEST);
+        self.gl.bind_framebuffer(GL_READ_FRAMEBUFFER, 0);
+        self.gl.bind_framebuffer(GL_DRAW_FRAMEBUFFER, self.gl_fbo);
+        // Y-flip: GL FBO 0 rows are bottom-up, the D3D texture is top-down.
+        self.gl.blit_framebuffer(0, 0, width, height, 0, height, width, 0, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        // Leave FBO 0 bound so the renderer's next frame is unaffected.
+        self.gl.bind_framebuffer(GL_FRAMEBUFFER, 0);
+
+        _ = self.interop.unlock_objects(self.interop_device, 1, &lock_handle);
+
+        const copy_resource = comCall(self.context, core.slot.D3D11DeviceContext_CopyResource, *const fn (*anyopaque, *anyopaque, *anyopaque) callconv(.winapi) void);
+        copy_resource(self.context, self.backbuffer.?, self.shared_tex.?);
+
+        const present = comCall(self.swapchain, core.slot.DXGISwapChain_Present, *const fn (*anyopaque, u32, u32) callconv(.winapi) HRESULT);
+        const interval_u: u32 = if (interval > 0) 1 else 0;
+        if (present(self.swapchain, interval_u, 0) < 0) return error.PresentFailed;
+    }
+
+    /// Requires the GL context to still be current (interop teardown).
+    pub fn deinit(self: *Presenter) void {
+        self.destroySizedResources();
+        _ = self.interop.close_device(self.interop_device);
+        comRelease(self.swapchain);
+        comRelease(self.context);
+        comRelease(self.device);
+    }
+};

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -13,6 +13,7 @@ const gl_init = AppWindow.gpu.gl_init;
 const Surface = @import("../Surface.zig");
 const SplitTree = @import("../split_tree.zig");
 const renderer = @import("../renderer.zig");
+const window_backend = @import("../platform/window_backend.zig");
 
 const TabState = tab.TabState;
 pub const MAX_SPLITS_PER_TAB = tab.MAX_SPLITS_PER_TAB;
@@ -136,6 +137,23 @@ pub fn hitTestDivider(x: i32, y: i32) ?DividerHit {
     return null;
 }
 
+/// True while the user is interactively dragging something that resizes
+/// terminal panes: a split divider, a side-panel edge, or the OS window
+/// border (Windows modal size-move loop). While active, SSH surfaces park
+/// their PTY + terminal resize and commit once on release (issue #171:
+/// the per-frame resize burst corrupts remote scrollback because SIGWINCH
+/// prompt redraws arrive one network round-trip behind the grid).
+fn interactiveResizeDragActive() bool {
+    if (input.g_divider_dragging or
+        input.g_sidebar_resize_dragging or
+        input.g_explorer_resize_dragging or
+        input.g_markdown_preview_resize_dragging or
+        input.g_browser_resize_dragging or
+        input.g_ai_copilot_resize_dragging) return true;
+    const win = AppWindow.g_window orelse return false;
+    return window_backend.inSizeMove(win);
+}
+
 /// Compute split layout for a tab, returning pixel rects for each surface.
 /// Each surface is resized to fit its allocated area with proper padding.
 /// Returns the number of surfaces (0 if tree is empty).
@@ -163,6 +181,8 @@ pub fn computeSplitLayout(
 
     const resize_policy: Surface.ResizePolicy = if (AppWindow.consumeImmediateLayoutResize())
         .immediate
+    else if (interactiveResizeDragActive())
+        .held
     else
         .coalesced;
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -927,6 +927,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
         } else {
             log.warn("invalid wispterm-debug-memory: {s}", .{value});
         }
+    } else if (std.mem.eql(u8, key, "wispterm-debug-render")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"wispterm-debug-render" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"wispterm-debug-render" = false;
+        } else {
+            log.warn("invalid wispterm-debug-render: {s}", .{value});
+        }
     } else if (std.mem.eql(u8, key, "wispterm-d3d-present")) {
         if (std.mem.eql(u8, value, "true")) {
             self.@"wispterm-d3d-present" = true;
@@ -2165,4 +2173,18 @@ test "config: wispterm-d3d-present defaults on and parses false" {
     try std.testing.expect(cfg.@"wispterm-d3d-present");
     cfg.applyKeyValue(allocator, "wispterm-d3d-present", "maybe", ".");
     try std.testing.expect(cfg.@"wispterm-d3d-present");
+}
+
+test "config: wispterm-debug-render parses from a config line" {
+    // Regression: the field existed (read by main.zig to gate the render
+    // diagnostics log) but applyKeyValue had no branch for it, so the key
+    // users were asked to set in #88 was silently ignored.
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    try std.testing.expect(!cfg.@"wispterm-debug-render");
+    cfg.applyKeyValue(allocator, "wispterm-debug-render", "true", ".");
+    try std.testing.expect(cfg.@"wispterm-debug-render");
+    cfg.applyKeyValue(allocator, "wispterm-debug-render", "false", ".");
+    try std.testing.expect(!cfg.@"wispterm-debug-render");
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -381,6 +381,13 @@ language: i18n.LanguageSetting = .auto,
 /// the `WISPTERM_RENDER_DIAGNOSTICS=1` env var, but survives restarts and needs
 /// no shell setup — intended for users helping debug resize/DPI render glitches.
 @"wispterm-debug-render": bool = false,
+/// Present frames through a DXGI flip-model swapchain instead of GDI
+/// SwapBuffers (Windows only). The legacy BLT present goes through the DWM
+/// redirection surface, which on some iGPU drivers (Intel Arc, AMD) produces
+/// ghosting/black regions on cross-DPI drags and resizes (#46/#47/#88). Set to
+/// false to force the legacy path; machines where DXGI/interop is unavailable
+/// fall back automatically. Read at startup.
+@"wispterm-d3d-present": bool = true,
 
 // ============================================================================
 // Split pane configuration
@@ -919,6 +926,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             self.@"wispterm-debug-memory" = false;
         } else {
             log.warn("invalid wispterm-debug-memory: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "wispterm-d3d-present")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"wispterm-d3d-present" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"wispterm-d3d-present" = false;
+        } else {
+            log.warn("invalid wispterm-d3d-present: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "unfocused-split-opacity")) {
         if (std.fmt.parseFloat(f32, value)) |opacity| {
@@ -2136,4 +2151,18 @@ test "ai-distill-suggest parses true/false and defaults off" {
     // unknown value leaves it unchanged (still false)
     cfg.applyKeyValue(allocator, "ai-distill-suggest", "maybe", ".");
     try std.testing.expect(!cfg.@"ai-distill-suggest");
+}
+
+test "config: wispterm-d3d-present defaults on and parses false" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    // default on: flip-model present is the primary path, GDI is the fallback
+    try std.testing.expect(cfg.@"wispterm-d3d-present");
+    cfg.applyKeyValue(allocator, "wispterm-d3d-present", "false", ".");
+    try std.testing.expect(!cfg.@"wispterm-d3d-present");
+    cfg.applyKeyValue(allocator, "wispterm-d3d-present", "true", ".");
+    try std.testing.expect(cfg.@"wispterm-d3d-present");
+    cfg.applyKeyValue(allocator, "wispterm-d3d-present", "maybe", ".");
+    try std.testing.expect(cfg.@"wispterm-d3d-present");
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -4033,6 +4033,16 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 platform_cursor.set(cursor_shape);
                 return;
             }
+            // A pane-resizing drag is ending: guarantee one more layout pass so
+            // SSH surfaces flush the PTY resize parked during the drag (#171),
+            // instead of waiting for the next incidental frame.
+            if (g_sidebar_resize_dragging or g_explorer_resize_dragging or
+                g_markdown_preview_resize_dragging or g_browser_resize_dragging or
+                g_ai_copilot_resize_dragging or g_divider_dragging)
+            {
+                AppWindow.g_force_rebuild = true;
+                AppWindow.g_cells_valid = false;
+            }
             if (g_sidebar_resize_dragging) {
                 g_sidebar_resize_dragging = false;
                 g_sidebar_resize_hover = hitTestSidebarResizeHandle(xpos, ypos);

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,7 @@ const app_metadata = @import("app_metadata.zig");
 const platform_console = @import("platform/console.zig");
 const font_backend = @import("platform/font_backend.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
+const window_backend = @import("platform/window_backend.zig");
 const i18n = @import("i18n.zig");
 const ai_chat = @import("ai_chat.zig");
 
@@ -167,6 +168,10 @@ pub fn main() !void {
     // Honor the config opt-in for render diagnostics before any window/GL
     // exists, so the very first WM_SIZE/WM_DPICHANGED events are captured.
     render_diagnostics.enableFromConfig(cfg.@"wispterm-debug-render");
+
+    // Present-path selection must be decided before the first window is
+    // created (the presenter is built right after the GL context).
+    window_backend.setFlipPresentEnabled(cfg.@"wispterm-d3d-present");
 
     // Create the App and run (first window on main thread, spawned windows on separate threads)
     var app = try App.init(allocator, cfg);

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -1,0 +1,278 @@
+//! Pure, host-independent core for the Windows DXGI flip-model presenter
+//! (`apprt/win32_dx_present.zig`): COM GUID parsing, the few D3D11/DXGI ABI
+//! structs the presenter passes across the COM boundary, and the
+//! `PresentPolicy` state machine that decides per frame whether to present,
+//! resize the swapchain first, skip (degenerate size), or fall back to the
+//! legacy GDI `SwapBuffers` path after a latched failure.
+//!
+//! Everything here is plain data + logic so the fast suite can verify the
+//! ABI layouts and the policy on any host; the COM/WGL runtime lives in the
+//! win32-only presenter.
+
+const std = @import("std");
+
+// ============================================================================
+// COM GUIDs
+// ============================================================================
+
+/// Windows GUID with the COM in-memory layout: the first three fields are
+/// little-endian integers, `data4` is verbatim bytes.
+pub const Guid = extern struct {
+    data1: u32,
+    data2: u16,
+    data3: u16,
+    data4: [8]u8,
+};
+
+/// Parse a canonical GUID string ("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+/// at comptime, so interface IDs are declared in the same form the registry
+/// and headers document them.
+pub fn guid(comptime s: *const [36]u8) Guid {
+    return comptime blk: {
+        @setEvalBranchQuota(10_000);
+        if (s[8] != '-' or s[13] != '-' or s[18] != '-' or s[23] != '-')
+            @compileError("GUID string must use 8-4-4-4-12 grouping: " ++ s);
+        var data4: [8]u8 = undefined;
+        data4[0] = hexByte(s[19..21]);
+        data4[1] = hexByte(s[21..23]);
+        for (0..6) |i| data4[2 + i] = hexByte(s[24 + i * 2 ..][0..2]);
+        break :blk .{
+            .data1 = std.fmt.parseInt(u32, s[0..8], 16) catch @compileError("bad GUID hex: " ++ s),
+            .data2 = std.fmt.parseInt(u16, s[9..13], 16) catch @compileError("bad GUID hex: " ++ s),
+            .data3 = std.fmt.parseInt(u16, s[14..18], 16) catch @compileError("bad GUID hex: " ++ s),
+            .data4 = data4,
+        };
+    };
+}
+
+fn hexByte(comptime pair: *const [2]u8) u8 {
+    return std.fmt.parseInt(u8, pair, 16) catch @compileError("bad GUID hex byte");
+}
+
+// Interface IDs the presenter queries.
+pub const IID_IDXGIDevice = guid("54ec77fa-1377-44e6-8c32-88fd5f44c84c");
+pub const IID_IDXGIFactory2 = guid("50c83a1c-e072-4c48-87b0-3630fa36a6d0");
+pub const IID_IDXGIResource = guid("035f3ab4-482e-4e50-b41f-8a7f8bd8960b");
+pub const IID_ID3D11Texture2D = guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+// ============================================================================
+// D3D11 / DXGI ABI structs and constants
+// ============================================================================
+
+pub const DXGI_SAMPLE_DESC = extern struct {
+    count: u32,
+    quality: u32,
+};
+
+/// dxgi1_2.h DXGI_SWAP_CHAIN_DESC1 (BOOL stereo declared as u32).
+pub const DXGI_SWAP_CHAIN_DESC1 = extern struct {
+    width: u32,
+    height: u32,
+    format: u32,
+    stereo: u32,
+    sample_desc: DXGI_SAMPLE_DESC,
+    buffer_usage: u32,
+    buffer_count: u32,
+    scaling: u32,
+    swap_effect: u32,
+    alpha_mode: u32,
+    flags: u32,
+};
+
+/// d3d11.h D3D11_TEXTURE2D_DESC.
+pub const D3D11_TEXTURE2D_DESC = extern struct {
+    width: u32,
+    height: u32,
+    mip_levels: u32,
+    array_size: u32,
+    format: u32,
+    sample_desc: DXGI_SAMPLE_DESC,
+    usage: u32,
+    bind_flags: u32,
+    cpu_access_flags: u32,
+    misc_flags: u32,
+};
+
+pub const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87;
+pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: u32 = 0x20;
+pub const DXGI_SCALING_NONE: u32 = 1;
+pub const DXGI_SCALING_STRETCH: u32 = 0;
+pub const DXGI_SWAP_EFFECT_FLIP_DISCARD: u32 = 4;
+pub const DXGI_ALPHA_MODE_IGNORE: u32 = 3;
+
+pub const D3D_DRIVER_TYPE_HARDWARE: u32 = 1;
+pub const D3D11_SDK_VERSION: u32 = 7;
+pub const D3D11_CREATE_DEVICE_BGRA_SUPPORT: u32 = 0x20;
+pub const D3D11_USAGE_DEFAULT: u32 = 0;
+pub const D3D11_BIND_RENDER_TARGET: u32 = 0x20;
+pub const D3D11_RESOURCE_MISC_SHARED: u32 = 0x2;
+
+// ============================================================================
+// COM vtable slots
+// ============================================================================
+//
+// The presenter dispatches COM calls by vtable slot index instead of declaring
+// full interface vtables; only the slots below are used. Indices follow the
+// header declaration order, offset by the inherited interfaces
+// (IUnknown = slots 0..2; IDXGIObject adds 4; IDXGIDeviceSubObject adds 1;
+// ID3D11DeviceChild adds 4).
+
+pub const slot = struct {
+    // IUnknown
+    pub const QueryInterface: usize = 0;
+    pub const Release: usize = 2;
+
+    // ID3D11Device (derives IUnknown directly)
+    pub const D3D11Device_CreateTexture2D: usize = 5;
+
+    // ID3D11DeviceContext (IUnknown + ID3D11DeviceChild(4) → first own slot 7)
+    pub const D3D11DeviceContext_CopyResource: usize = 47;
+
+    // IDXGIObject: SetPrivateData(3) SetPrivateDataInterface(4)
+    // GetPrivateData(5) GetParent(6)
+    pub const DXGIObject_GetParent: usize = 6;
+
+    // IDXGIDevice (IDXGIObject + GetAdapter first)
+    pub const DXGIDevice_GetAdapter: usize = 7;
+
+    // IDXGIFactory (IDXGIObject + EnumAdapters(7) MakeWindowAssociation(8) …)
+    pub const DXGIFactory_MakeWindowAssociation: usize = 8;
+
+    // IDXGIFactory2 (IDXGIObject + IDXGIFactory(5) + IDXGIFactory1(2) →
+    // IsWindowedStereoEnabled(14), CreateSwapChainForHwnd(15))
+    pub const DXGIFactory2_CreateSwapChainForHwnd: usize = 15;
+
+    // IDXGIDeviceSubObject: GetDevice(7)
+    // IDXGISwapChain: Present(8) GetBuffer(9) SetFullscreenState(10)
+    // GetFullscreenState(11) GetDesc(12) ResizeBuffers(13)
+    pub const DXGISwapChain_Present: usize = 8;
+    pub const DXGISwapChain_GetBuffer: usize = 9;
+    pub const DXGISwapChain_ResizeBuffers: usize = 13;
+
+    // IDXGIResource (IDXGIDeviceSubObject + GetSharedHandle first)
+    pub const DXGIResource_GetSharedHandle: usize = 8;
+};
+
+// ============================================================================
+// PresentPolicy
+// ============================================================================
+
+/// Per-frame decision for the flip-model presenter. Pure so the
+/// resize/skip/fallback transitions are unit-testable off-Windows.
+pub const PresentPolicy = struct {
+    pub const Action = enum { skip, present, resize_then_present, fallback };
+
+    width: i32,
+    height: i32,
+    failed: bool = false,
+
+    pub fn init(width: i32, height: i32) PresentPolicy {
+        return .{ .width = width, .height = height };
+    }
+
+    pub fn frameAction(self: *const PresentPolicy, width: i32, height: i32) Action {
+        if (self.failed) return .fallback;
+        if (width <= 0 or height <= 0) return .skip;
+        if (width != self.width or height != self.height) return .resize_then_present;
+        return .present;
+    }
+
+    /// Commit a successful swapchain resize. frameAction never records sizes
+    /// itself because ResizeBuffers can fail mid-flight.
+    pub fn noteResized(self: *PresentPolicy, width: i32, height: i32) void {
+        self.width = width;
+        self.height = height;
+    }
+
+    /// Latch the fallback path for the rest of the session — a presenter that
+    /// failed once must not flap between DXGI and GDI presents.
+    pub fn fail(self: *PresentPolicy) void {
+        self.failed = true;
+    }
+};
+
+// ============================================================================
+// Tests (fast suite — registered in test_fast.zig)
+// ============================================================================
+
+test "guid parses canonical string into COM byte layout" {
+    // IID_ID3D11Texture2D {6f15aaf2-d208-4e89-9ab4-489535d34f9c}
+    const g = guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+    try std.testing.expectEqual(@as(u32, 0x6f15aaf2), g.data1);
+    try std.testing.expectEqual(@as(u16, 0xd208), g.data2);
+    try std.testing.expectEqual(@as(u16, 0x4e89), g.data3);
+    // In-memory layout: data1/data2/data3 little-endian, data4 verbatim.
+    const expected = [16]u8{
+        0xf2, 0xaa, 0x15, 0x6f,
+        0x08, 0xd2,
+        0x89, 0x4e,
+        0x9a, 0xb4, 0x48, 0x95, 0x35, 0xd3, 0x4f, 0x9c,
+    };
+    try std.testing.expectEqual(@as(usize, 16), @sizeOf(Guid));
+    try std.testing.expectEqualSlices(u8, &expected, std.mem.asBytes(&g));
+}
+
+test "well-known interface IIDs round-trip their documented strings" {
+    // Spot-check first/last bytes of each IID the presenter queries, so a
+    // transposed hex pair in the declarations can't reach the COM boundary.
+    try std.testing.expectEqual(@as(u32, 0x54ec77fa), IID_IDXGIDevice.data1);
+    try std.testing.expectEqual(@as(u8, 0x4c), IID_IDXGIDevice.data4[7]);
+    try std.testing.expectEqual(@as(u32, 0x50c83a1c), IID_IDXGIFactory2.data1);
+    try std.testing.expectEqual(@as(u8, 0xd0), IID_IDXGIFactory2.data4[7]);
+    try std.testing.expectEqual(@as(u32, 0x035f3ab4), IID_IDXGIResource.data1);
+    try std.testing.expectEqual(@as(u8, 0x0b), IID_IDXGIResource.data4[7]);
+    try std.testing.expectEqual(@as(u32, 0x6f15aaf2), IID_ID3D11Texture2D.data1);
+    try std.testing.expectEqual(@as(u8, 0x9c), IID_ID3D11Texture2D.data4[7]);
+}
+
+test "DXGI_SWAP_CHAIN_DESC1 matches the documented 48-byte layout" {
+    try std.testing.expectEqual(@as(usize, 48), @sizeOf(DXGI_SWAP_CHAIN_DESC1));
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "width"));
+    try std.testing.expectEqual(@as(usize, 8), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "format"));
+    try std.testing.expectEqual(@as(usize, 16), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "sample_desc"));
+    try std.testing.expectEqual(@as(usize, 24), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "buffer_usage"));
+    try std.testing.expectEqual(@as(usize, 28), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "buffer_count"));
+    try std.testing.expectEqual(@as(usize, 36), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "swap_effect"));
+    try std.testing.expectEqual(@as(usize, 40), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "alpha_mode"));
+    try std.testing.expectEqual(@as(usize, 44), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "flags"));
+}
+
+test "D3D11_TEXTURE2D_DESC matches the documented 44-byte layout" {
+    try std.testing.expectEqual(@as(usize, 44), @sizeOf(D3D11_TEXTURE2D_DESC));
+    try std.testing.expectEqual(@as(usize, 16), @offsetOf(D3D11_TEXTURE2D_DESC, "format"));
+    try std.testing.expectEqual(@as(usize, 28), @offsetOf(D3D11_TEXTURE2D_DESC, "usage"));
+    try std.testing.expectEqual(@as(usize, 32), @offsetOf(D3D11_TEXTURE2D_DESC, "bind_flags"));
+    try std.testing.expectEqual(@as(usize, 40), @offsetOf(D3D11_TEXTURE2D_DESC, "misc_flags"));
+}
+
+test "PresentPolicy presents at the established size" {
+    var p = PresentPolicy.init(800, 600);
+    try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(800, 600));
+}
+
+test "PresentPolicy requests a resize when the frame size changes" {
+    var p = PresentPolicy.init(800, 600);
+    try std.testing.expectEqual(PresentPolicy.Action.resize_then_present, p.frameAction(1024, 768));
+    // frameAction must not record the new size itself — the swapchain resize
+    // can fail; only a successful resize commits it.
+    try std.testing.expectEqual(PresentPolicy.Action.resize_then_present, p.frameAction(1024, 768));
+    p.noteResized(1024, 768);
+    try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(1024, 768));
+}
+
+test "PresentPolicy skips degenerate sizes without failing" {
+    var p = PresentPolicy.init(800, 600);
+    try std.testing.expectEqual(PresentPolicy.Action.skip, p.frameAction(0, 600));
+    try std.testing.expectEqual(PresentPolicy.Action.skip, p.frameAction(800, -1));
+    // Still healthy afterwards.
+    try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(800, 600));
+}
+
+test "PresentPolicy latches fallback after a failure" {
+    var p = PresentPolicy.init(800, 600);
+    p.fail();
+    try std.testing.expectEqual(PresentPolicy.Action.fallback, p.frameAction(800, 600));
+    // No recovery mid-session: a flaky presenter must not flap between paths.
+    p.noteResized(800, 600);
+    try std.testing.expectEqual(PresentPolicy.Action.fallback, p.frameAction(800, 600));
+}

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -446,6 +446,15 @@ pub fn consumeSizeChanged(window: *Window) bool {
     return changed;
 }
 
+/// True while the OS-modal interactive move/size loop is running for this
+/// window (Windows border drag: WM_ENTERSIZEMOVE..WM_EXITSIZEMOVE). Backends
+/// without that concept report false; in-app drags (split dividers, panel
+/// edges) are tracked separately by input.zig flags.
+pub fn inSizeMove(window: *const Window) bool {
+    if (comptime @hasField(Window, "in_size_move")) return window.in_size_move;
+    return false;
+}
+
 pub fn clearTransientInput(window: *Window) void {
     window.clearTransientInputQueues();
 }

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -83,6 +83,12 @@ pub const EventHandlers = struct {
 };
 
 pub const setGlobalWindow = impl.setGlobalWindow;
+
+/// Windows-only config gate for the DXGI flip-model present path
+/// (`wispterm-d3d-present`). No-op on backends without the seam.
+pub fn setFlipPresentEnabled(enabled: bool) void {
+    if (comptime @hasDecl(impl, "setFlipPresentEnabled")) impl.setFlipPresentEnabled(enabled);
+}
 /// Renderer surface seam (host → GPU backend). This is OpenGL-shaped: the host
 /// supplies a GL proc-address loader, which `gpu.Context.init` consumes. The
 /// seam is per-backend by design — a macOS/AppKit host pairs with the Metal

--- a/src/platform/window_backend_windows.zig
+++ b/src/platform/window_backend_windows.zig
@@ -4,3 +4,4 @@ pub const Window = win32.Window;
 pub const FileDropHandler = win32.FileDropHandler;
 pub const setGlobalWindow = win32.setGlobalWindow;
 pub const glGetProcAddress = win32.glGetProcAddress;
+pub const setFlipPresentEnabled = win32.setFlipPresentEnabled;

--- a/src/resize_gate.zig
+++ b/src/resize_gate.zig
@@ -1,0 +1,92 @@
+//! Decides when a surface's computed grid size is forwarded to the IO
+//! thread (PTY setSize + terminal resize). Pure, main-thread-only state.
+//!
+//! Issue #171: during an interactive drag (window border, split divider,
+//! side-panel edge) the per-frame layout produces a burst of grid changes
+//! (~every 30ms, 20+ per drag). For an SSH surface each PTY resize reaches
+//! the remote shell one network round-trip later, so its SIGWINCH prompt
+//! redraw comes back tuned for a grid the terminal has already left. A
+//! long (wrapping) prompt then re-wraps at the wrong width, every overflow
+//! line forces a scroll, and the scrollback floods with interleaved prompt
+//! fragments while reflow re-wraps the damage on each step. Local ConPTY
+//! shells survive the same burst because their redraw round-trip is
+//! sub-millisecond; short prompts survive because no redraw line crosses an
+//! intermediate width.
+//!
+//! The gate collapses the burst: while `hold` is true (an interactive drag
+//! is in progress) nothing is queued, and the first non-held submit flushes
+//! the latest grid once. Layout re-submits every frame, so the flush needs
+//! no explicit drag-end hook. Deduplication against the last queued grid
+//! also means a drag that returns to its starting size queues nothing.
+
+pub const Grid = struct {
+    cols: u16,
+    rows: u16,
+
+    pub fn eql(a: Grid, b: Grid) bool {
+        return a.cols == b.cols and a.rows == b.rows;
+    }
+};
+
+pub const ResizeGate = struct {
+    /// The grid the IO thread was last told about (terminal + PTY size).
+    last_queued: Grid,
+
+    pub fn init(cols: u16, rows: u16) ResizeGate {
+        return .{ .last_queued = .{ .cols = cols, .rows = rows } };
+    }
+
+    /// Decide whether `grid` should be queued to the IO thread now.
+    /// Returns the grid to queue, or null to skip this frame.
+    pub fn submit(self: *ResizeGate, hold: bool, grid: Grid) ?Grid {
+        if (hold) return null;
+        if (grid.eql(self.last_queued)) return null;
+        self.last_queued = grid;
+        return grid;
+    }
+};
+
+const std = @import("std");
+
+test "queues a changed grid and dedupes repeats" {
+    var gate = ResizeGate.init(80, 24);
+    const queued = gate.submit(false, .{ .cols = 100, .rows = 30 });
+    try std.testing.expect(queued != null);
+    try std.testing.expectEqual(@as(u16, 100), queued.?.cols);
+    try std.testing.expectEqual(@as(u16, 30), queued.?.rows);
+    // Same grid again: nothing to queue (layout re-submits every frame).
+    try std.testing.expect(gate.submit(false, .{ .cols = 100, .rows = 30 }) == null);
+}
+
+test "initial grid is the baseline: no spurious resize on first submit" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(false, .{ .cols = 142, .rows = 49 }) == null);
+}
+
+test "held submits queue nothing" {
+    var gate = ResizeGate.init(142, 49);
+    // Drag in progress: a burst of intermediate sizes is parked.
+    try std.testing.expect(gate.submit(true, .{ .cols = 94, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 74, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 60, .rows = 49 }) == null);
+}
+
+test "first non-held submit flushes the final grid once" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(true, .{ .cols = 94, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 60, .rows = 49 }) == null);
+    // Drag ended; layout re-submits the final grid without hold.
+    const queued = gate.submit(false, .{ .cols = 60, .rows = 49 });
+    try std.testing.expect(queued != null);
+    try std.testing.expectEqual(@as(u16, 60), queued.?.cols);
+    // Steady state afterwards: deduped.
+    try std.testing.expect(gate.submit(false, .{ .cols = 60, .rows = 49 }) == null);
+}
+
+test "drag that returns to the starting size queues nothing" {
+    var gate = ResizeGate.init(142, 49);
+    try std.testing.expect(gate.submit(true, .{ .cols = 90, .rows = 49 }) == null);
+    try std.testing.expect(gate.submit(true, .{ .cols = 120, .rows = 49 }) == null);
+    // Released exactly where it started: terminal is already that size.
+    try std.testing.expect(gate.submit(false, .{ .cols = 142, .rows = 49 }) == null);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -37,6 +37,7 @@ test {
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
     _ = @import("platform/window_state_codec.zig");
+    _ = @import("platform/dxgi_core.zig");
     _ = @import("whats_new_gate.zig");
     _ = @import("startup_tabs.zig");
     _ = @import("config.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -93,6 +93,7 @@ test {
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");
     _ = @import("scrollbar_model.zig");
+    _ = @import("resize_gate.zig");
     _ = @import("preview_token.zig");
     _ = @import("ime_caret.zig");
     _ = @import("sync_output.zig");


### PR DESCRIPTION
## Summary

Long-term fix for the rendering corruption class behind #46 / #47 / #88 (cross-DPI drag ghosting, resize black bands, stale/gray surfaces on Intel Arc & AMD iGPU drivers).

**Root cause recap:** the legacy present path (GDI `SwapBuffers`) is a BLT into the DWM redirection surface. With our custom titlebar extending the frame into the whole client area (`DwmExtendFrameIntoClientArea(cyTopHeight=-1)`), DWM composites that surface using the GL backbuffer's **alpha channel** plus driver-dependent stale contents — `.alpha`-blended chrome drives dst-alpha below 1, and on some iGPU drivers (both #47 reporters: Intel Arc; #46: AMD 680M; all on build 26200) the translucent pixels expose stale snapshots, the window behind, or black. `2dc5257` (v1.10.0) was the tactical fix (force alpha opaque pre-present); this PR is the architectural one.

**New path:** a D3D11 **flip-model swapchain** (`B8G8R8A8`, `FLIP_DISCARD`, `ALPHA_MODE_IGNORE`) shared with GL via `WGL_NV_DX_interop2`. Flip-model presents bypass the redirection surface entirely and are composited opaquely — the whole alpha/staleness class disappears. The renderer is untouched (still draws to GL FBO 0); per present we Y-flip-blit FBO 0 into an interop renderbuffer backed by a shared D3D11 texture, `CopyResource` into swapchain buffer 0, and `Present`. Window resizes go through `ResizeBuffers` + resource rebuild.

## Commits

- `d2d44aa` pure core `src/platform/dxgi_core.zig`: comptime GUID parser, size/offset-tested ABI structs, COM vtable slot table, `PresentPolicy` state machine (TDD, fast suite)
- `979183e` presenter `src/apprt/win32_dx_present.zig` (header-free COM via slot dispatch, d3d11.dll loaded dynamically) + win32 wiring
- `e804385` drive-by fix: the `wispterm-debug-render` config key was **never parsed** (field read by main.zig, no `applyKeyValue` branch) — the #88 diagnostics opt-in users were asked to set did nothing; only the env var worked

## Robustness

- Any init or runtime failure (no d3d11.dll, missing `WGL_NV_DX_interop2`, device removed, resize failure) **latches back to GDI SwapBuffers** for the session and logs the reason to render-diagnostics
- Config escape hatch: `wispterm-d3d-present = false` (default **on**, read at startup)
- Startup log line shows the active path: "presenting via DXGI flip-model swapchain" vs "using SwapBuffers"

## Verification

- `zig build` (x86_64-windows-gnu), `zig build test` (incl. 9 new unit tests), `zig build test-full` — all green
- ⚠️ **Windows GUI verification pending** (developed on Linux). Two specific things to check on real hardware:
  1. Image orientation — if the window renders upside-down, swap the Y coordinates in `blitAndPresent`'s `blit_framebuffer` call
  2. The original repro machines (Intel Arc / AMD iGPU, mixed-DPI monitors) — cross-DPI drag + resize + maximize; `render-diagnostic.log` now carries `dx-present` lines for init/resize/failure

Refs #46 #47 #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)