### PR TITLE
fix: five memory-safety hardening fixes (UAF guard, capped reads, decode bomb)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -4877,21 +4877,22 @@ fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyer
     };
 }
 
-fn agentSurfaceSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator, surface_ptr: *anyopaque) anyerror![]u8 {
+fn agentSurfaceSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator, surface_id: []const u8, surface_ptr: *anyopaque) anyerror![]u8 {
     _ = ctx;
     // Runs on the agent request worker with a pointer captured at request
     // start; the UI thread may have freed the surface since. The registry
-    // guard blocks Surface.deinit for the duration of the snapshot.
-    if (!surface_registry.acquire(surface_ptr)) return error.SurfaceClosed;
+    // guard blocks Surface.deinit for the duration of the snapshot. Matching
+    // the captured id prevents a reused pointer from targeting a new surface.
+    if (!surface_registry.acquire(surface_ptr, surface_id)) return error.SurfaceClosed;
     defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
     return buildRemoteSurfaceSnapshot(allocator, surface, remote_snapshot.agent_max_history_rows);
 }
 
-fn agentWriteSurface(ctx: *anyopaque, surface_ptr: *anyopaque, data: []const u8) bool {
+fn agentWriteSurface(ctx: *anyopaque, surface_id: []const u8, surface_ptr: *anyopaque, data: []const u8) bool {
     _ = ctx;
     // Same worker-thread hazard as agentSurfaceSnapshot.
-    if (!surface_registry.acquire(surface_ptr)) return false;
+    if (!surface_registry.acquire(surface_ptr, surface_id)) return false;
     defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
     surface.queuePtyWrite(data);
@@ -4907,8 +4908,8 @@ test "agent surface callbacks reject a surface that is not registered as live" {
     var dummy_buf: [@sizeOf(Surface)]u8 align(@alignOf(Surface)) = @splat(0);
     const ptr: *anyopaque = @ptrCast(&dummy_buf);
 
-    try std.testing.expectError(error.SurfaceClosed, agentSurfaceSnapshot(ptr, std.testing.allocator, ptr));
-    try std.testing.expect(!agentWriteSurface(ptr, ptr, "x"));
+    try std.testing.expectError(error.SurfaceClosed, agentSurfaceSnapshot(ptr, std.testing.allocator, "missing", ptr));
+    try std.testing.expect(!agentWriteSurface(ptr, "missing", ptr, "x"));
 }
 
 fn agentSshConnectionForSurface(ctx: *anyopaque, surface_id: []const u8) ?Surface.SshConnection {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -20,6 +20,7 @@ const remote_snapshot = @import("remote_snapshot.zig");
 const weixin_control = @import("weixin/control.zig");
 const weixin_types = @import("weixin/types.zig");
 const memory_debug = @import("memory_debug.zig");
+const surface_registry = @import("surface_registry.zig");
 const agent_detector = @import("agent_detector.zig");
 const agent_history = @import("agent_history.zig");
 const close_confirm = @import("close_confirm.zig");
@@ -4878,15 +4879,36 @@ fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyer
 
 fn agentSurfaceSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator, surface_ptr: *anyopaque) anyerror![]u8 {
     _ = ctx;
+    // Runs on the agent request worker with a pointer captured at request
+    // start; the UI thread may have freed the surface since. The registry
+    // guard blocks Surface.deinit for the duration of the snapshot.
+    if (!surface_registry.acquire(surface_ptr)) return error.SurfaceClosed;
+    defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
     return buildRemoteSurfaceSnapshot(allocator, surface, remote_snapshot.agent_max_history_rows);
 }
 
 fn agentWriteSurface(ctx: *anyopaque, surface_ptr: *anyopaque, data: []const u8) bool {
     _ = ctx;
+    // Same worker-thread hazard as agentSurfaceSnapshot.
+    if (!surface_registry.acquire(surface_ptr)) return false;
+    defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
     surface.queuePtyWrite(data);
     return true;
+}
+
+test "agent surface callbacks reject a surface that is not registered as live" {
+    // The agent request worker holds ToolSurface.ptr across an entire request
+    // while the UI thread may free the surface at any time (close tab/split).
+    // Both callbacks must refuse an unregistered pointer before touching any
+    // Surface field. The stand-in below is zeroed, never-registered memory; if
+    // a callback dereferences it the test crashes instead of erroring.
+    var dummy_buf: [@sizeOf(Surface)]u8 align(@alignOf(Surface)) = @splat(0);
+    const ptr: *anyopaque = @ptrCast(&dummy_buf);
+
+    try std.testing.expectError(error.SurfaceClosed, agentSurfaceSnapshot(ptr, std.testing.allocator, ptr));
+    try std.testing.expect(!agentWriteSurface(ptr, ptr, "x"));
 }
 
 fn agentSshConnectionForSurface(ctx: *anyopaque, surface_id: []const u8) ?Surface.SshConnection {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -481,7 +481,7 @@ pub fn init(
 
     // Last step (after every fallible init step): the agent request worker may
     // only touch this surface while it stays registered.
-    surface_registry.register(surface);
+    surface_registry.register(surface, surface.remote_id[0..]);
 
     return surface;
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -23,6 +23,7 @@ const agent_detector = @import("agent_detector.zig");
 const sync_output = @import("sync_output.zig");
 const notification = @import("notification.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
+const surface_registry = @import("surface_registry.zig");
 const platform_process = @import("platform/process.zig");
 const ssh_connection_mod = @import("ssh_connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
@@ -478,12 +479,21 @@ pub fn init(
     // only adds an idle per-surface thread and stack without moving work off the
     // main render loop.
 
+    // Last step (after every fallible init step): the agent request worker may
+    // only touch this surface while it stays registered.
+    surface_registry.register(surface);
+
     return surface;
 }
 
 /// Deinitialize and free a Surface.
 /// Stops the IO thread first, then cleans up PTY and terminal.
 pub fn deinit(self: *Surface, allocator: std.mem.Allocator) void {
+    // 0. Withdraw the surface from the agent-tool liveness registry. This
+    // blocks until any in-flight guarded access on the agent request worker
+    // finishes, so nothing below can tear state out from under it.
+    surface_registry.unregister(self);
+
     // 1. Stop the renderer thread first (it accesses terminal state)
     self.renderer_thread.stop();
     self.surface_renderer.deinit();

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -5359,10 +5359,10 @@ const CopilotTestHost = struct {
         };
         return .{ .surfaces = surfaces, .active_tab = 0 };
     }
-    fn unsupportedSurfaceSnapshot(_: *anyopaque, _: std.mem.Allocator, _: *anyopaque) anyerror![]u8 {
+    fn unsupportedSurfaceSnapshot(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: *anyopaque) anyerror![]u8 {
         return error.Unsupported;
     }
-    fn unsupportedWrite(_: *anyopaque, _: *anyopaque, _: []const u8) bool {
+    fn unsupportedWrite(_: *anyopaque, _: []const u8, _: *anyopaque, _: []const u8) bool {
         return false;
     }
     fn unsupportedSpawn(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: ?[]const u8) anyerror!ToolSurface {
@@ -6665,10 +6665,10 @@ const CopilotBoundSnapshotTestHost = struct {
         };
         return .{ .surfaces = surfaces, .active_tab = 0 };
     }
-    fn unsupportedSurfaceSnapshot(_: *anyopaque, _: std.mem.Allocator, _: *anyopaque) anyerror![]u8 {
+    fn unsupportedSurfaceSnapshot(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: *anyopaque) anyerror![]u8 {
         return error.Unsupported;
     }
-    fn unsupportedWrite(_: *anyopaque, _: *anyopaque, _: []const u8) bool {
+    fn unsupportedWrite(_: *anyopaque, _: []const u8, _: *anyopaque, _: []const u8) bool {
         return false;
     }
     fn unsupportedSpawn(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: ?[]const u8) anyerror!ai_chat_types.ToolSurface {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -2301,7 +2301,7 @@ fn readFileTool(ctx: *ToolContext, path: []const u8, surface_id: ?[]const u8, of
                 return deniedResult(ctx.allocator, path, "operator rejected remote read");
             }
         }
-        const bytes = scp.sshReadFile(ctx.allocator, &conn, path) orelse
+        const bytes = scp.sshReadFile(ctx.allocator, &conn, path, agent_file_edit.MAX_FILE_BYTES) orelse
             return std.fmt.allocPrint(ctx.allocator, "Failed to read remote file {s}", .{path});
         defer ctx.allocator.free(bytes);
         return renderReadResult(ctx, path, bytes, offset, limit);
@@ -2345,7 +2345,7 @@ fn writeFileTool(ctx: *ToolContext, path: []const u8, content: []const u8, surfa
     defer if (owns_old) ctx.allocator.free(old_content);
     if (!gate.blacklisted) {
         if (remote_conn) |conn| {
-            if (scp.sshReadFile(ctx.allocator, &conn, path)) |bytes| {
+            if (scp.sshReadFile(ctx.allocator, &conn, path, agent_file_edit.MAX_FILE_BYTES)) |bytes| {
                 old_content = bytes;
                 owns_old = true;
             }
@@ -2400,7 +2400,7 @@ fn editFileTool(ctx: *ToolContext, path: []const u8, old_string: []const u8, new
 
     var old_content: []u8 = undefined;
     if (remote_conn) |conn| {
-        old_content = scp.sshReadFile(ctx.allocator, &conn, path) orelse
+        old_content = scp.sshReadFile(ctx.allocator, &conn, path, agent_file_edit.MAX_FILE_BYTES) orelse
             return std.fmt.allocPrint(ctx.allocator, "Failed to read remote file {s} for editing", .{path});
     } else {
         const resolved = try resolveLocalPath(ctx.allocator, path, ctx.settings.working_dir);

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -551,7 +551,7 @@ fn terminalSnapshotTool(ctx: *const ToolContext, surface_id: ?[]const u8) ![]u8 
         defer if (live) |t| ctx.allocator.free(t);
         if (target_id != null) {
             if (ctx.tool_host) |host| {
-                live = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch null;
+                live = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch null;
             }
         }
         try out.appendSlice(ctx.allocator, live orelse surface.snapshot);
@@ -1120,7 +1120,7 @@ fn controlKeyByte(code: []const u8) ?u8 {
 /// recovered state.
 fn sendControlKey(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, label: []const u8, byte: u8) ![]u8 {
     const bytes = [_]u8{byte};
-    if (!host.writeSurface(host.ctx, surface.ptr, &bytes)) {
+    if (!host.writeSurface(host.ctx, surface.id, surface.ptr, &bytes)) {
         return ctx.allocator.dupe(u8, "Failed to write control key to terminal surface.");
     }
 
@@ -1130,7 +1130,7 @@ fn sendControlKey(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface,
         std.Thread.sleep(100 * std.time.ns_per_ms);
     }
 
-    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         return std.fmt.allocPrint(ctx.allocator, "Sent {s}; failed to read terminal snapshot.", .{label});
     defer ctx.allocator.free(latest);
     const out = try std.fmt.allocPrint(ctx.allocator, "Sent {s} to terminal.\nLatest snapshot:\n{s}", .{ label, latest });
@@ -1203,7 +1203,7 @@ fn terminalAnswerPromptTool(ctx: *ToolContext, surface_id: ?[]const u8, answer: 
     const surface = resolveSurfaceId(snapshot, sid, selectedWriteContext(ctx)) orelse return allocNoSurfaceError(ctx.allocator, snapshot, sid);
 
     // Read the LIVE screen (per-surface, mutex-protected, worker-safe).
-    const screen = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    const screen = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         return ctx.allocator.dupe(u8, "Failed to read terminal snapshot.");
     defer ctx.allocator.free(screen);
 
@@ -1242,12 +1242,12 @@ fn terminalAnswerPromptTool(ctx: *ToolContext, surface_id: ?[]const u8, answer: 
     // pre-selected (e.g. a non-copilot caller).
     setWriteContext(ctx, surface.id);
 
-    if (!host.writeSurface(host.ctx, surface.ptr, keystroke.bytes)) {
+    if (!host.writeSurface(host.ctx, surface.id, surface.ptr, keystroke.bytes)) {
         return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
     }
     if (keystroke.confirm_enter) {
         std.Thread.sleep(CODEX_SUBMIT_DELAY_MS * std.time.ns_per_ms);
-        _ = host.writeSurface(host.ctx, surface.ptr, "\r");
+        _ = host.writeSurface(host.ctx, surface.id, surface.ptr, "\r");
     }
 
     const deadline = std.time.milliTimestamp() + 400;
@@ -1256,7 +1256,7 @@ fn terminalAnswerPromptTool(ctx: *ToolContext, surface_id: ?[]const u8, answer: 
         std.Thread.sleep(100 * std.time.ns_per_ms);
     }
 
-    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    const latest = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         return std.fmt.allocPrint(ctx.allocator, "Answer sent ({s}); failed to read terminal snapshot.", .{answer});
     defer ctx.allocator.free(latest);
     const out = try std.fmt.allocPrint(ctx.allocator, "Answered prompt ({s}).\nLatest snapshot:\n{s}", .{ answer, latest });
@@ -1290,17 +1290,17 @@ pub fn plainReplInputTool(ctx: *const ToolContext, host: ToolHost, surface: Tool
         // submits (the "多余的换行" / unsent-at-prompt symptom). Send the body,
         // pause so the burst ends, then send the submit key as its own
         // keystroke — emulating type-then-Enter.
-        if (!host.writeSurface(host.ctx, surface.ptr, text)) {
+        if (!host.writeSurface(host.ctx, surface.id, surface.ptr, text)) {
             return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
         }
         std.Thread.sleep(CODEX_SUBMIT_DELAY_MS * std.time.ns_per_ms);
-        if (!host.writeSurface(host.ctx, surface.ptr, plainReplSubmitKey(repl, surface))) {
+        if (!host.writeSurface(host.ctx, surface.id, surface.ptr, plainReplSubmitKey(repl, surface))) {
             return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
         }
     } else {
         const input = try allocPlainReplInput(ctx.allocator, repl, surface, text);
         defer ctx.allocator.free(input);
-        if (!host.writeSurface(host.ctx, surface.ptr, input)) {
+        if (!host.writeSurface(host.ctx, surface.id, surface.ptr, input)) {
             return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
         }
     }
@@ -1366,7 +1366,7 @@ fn waitForAgentAppReplResult(ctx: *const ToolContext, host: ToolHost, surface: T
     // model is thread-local to the UI thread and reads empty on the worker (see
     // the pre-capture comment in ai_chat.zig), which previously left this wait
     // blind and spinning to the full timeout while the model saw a stale screen.
-    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         try ctx.allocator.dupe(u8, surface.snapshot);
     defer ctx.allocator.free(last_text);
     var last_change_ms = started;
@@ -1376,7 +1376,7 @@ fn waitForAgentAppReplResult(ctx: *const ToolContext, host: ToolHost, surface: T
         std.Thread.sleep(150 * std.time.ns_per_ms);
         const now = std.time.milliTimestamp();
 
-        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch continue;
+        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch continue;
         if (std.mem.eql(u8, last_text, text)) {
             ctx.allocator.free(text);
         } else {
@@ -1430,7 +1430,7 @@ fn waitForAgentAppReplResult(ctx: *const ToolContext, host: ToolHost, surface: T
 fn lineReplEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurface, repl: ReplKind, code: []const u8, timeout_ms: u32) ![]u8 {
     // Learn the prompt currently shown so we can recognise its return. Read the
     // live per-surface snapshot (collectSnapshot is empty on the worker thread).
-    const before = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    const before = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         try ctx.allocator.dupe(u8, surface.snapshot);
     defer ctx.allocator.free(before);
     const captured_prompt = try ctx.allocator.dupe(u8, extractPromptLine(before));
@@ -1438,7 +1438,7 @@ fn lineReplEvalTool(ctx: *const ToolContext, host: ToolHost, surface: ToolSurfac
 
     const input = try allocPlainReplInput(ctx.allocator, repl, surface, code);
     defer ctx.allocator.free(input);
-    if (!host.writeSurface(host.ctx, surface.ptr, input)) {
+    if (!host.writeSurface(host.ctx, surface.id, surface.ptr, input)) {
         return ctx.allocator.dupe(u8, "Failed to write to terminal surface.");
     }
 
@@ -1466,7 +1466,7 @@ fn waitForReplPromptReturn(
     const started = std.time.milliTimestamp();
     const deadline = started + @as(i64, @intCast(wait_ms));
 
-    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch
+    var last_text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch
         try ctx.allocator.dupe(u8, surface.snapshot);
     defer ctx.allocator.free(last_text);
     var last_change_ms = started;
@@ -1476,7 +1476,7 @@ fn waitForReplPromptReturn(
         std.Thread.sleep(150 * std.time.ns_per_ms);
         const now = std.time.milliTimestamp();
 
-        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch continue;
+        const text = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch continue;
         if (std.mem.eql(u8, last_text, text)) {
             ctx.allocator.free(text);
         } else {
@@ -1588,7 +1588,7 @@ fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []c
     // interleaved sentinels confuse parsing and the model tends to re-issue,
     // duplicating side effects (e.g. a second git clone). A fresh snapshot is
     // authoritative; the cached surface snapshot may be stale.
-    if (host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch null) |guard_snapshot| {
+    if (host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch null) |guard_snapshot| {
         defer ctx.allocator.free(guard_snapshot);
         if (hasPendingAgentCommand(guard_snapshot)) {
             return std.fmt.allocPrint(ctx.allocator, "A previous command is still running in this {s} terminal. Do not start another command. Wait and re-check with terminal_snapshot, or interrupt it first with terminal_repl_exec repl=plain code=<ctrl-c>.", .{kind.label()});
@@ -1612,7 +1612,7 @@ fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []c
     );
     defer ctx.allocator.free(wrapped);
 
-    if (!host.writeSurface(host.ctx, surface.ptr, wrapped)) {
+    if (!host.writeSurface(host.ctx, surface.id, surface.ptr, wrapped)) {
         return std.fmt.allocPrint(ctx.allocator, "Failed to write to {s} terminal surface.", .{kind.label()});
     }
 
@@ -1651,7 +1651,7 @@ fn waitForSentinelResult(
     while (std.time.milliTimestamp() < deadline) {
         if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
         if (last) |old| ctx.allocator.free(old);
-        last = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch null;
+        last = host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch null;
         if (last) |text| {
             if (findCompletedEnd(text, end_marker) != null) {
                 return extractUnixCommandResult(ctx.allocator, text, start_marker, end_marker);
@@ -3492,14 +3492,14 @@ const ReplWaitTestHost = struct {
 
     // The per-surface snapshot holds the surface's render mutex and therefore
     // works from the worker thread. It reports a busy screen, then a settled one.
-    fn surfaceSnapshot(ctx_ptr: *anyopaque, allocator: std.mem.Allocator, _: *anyopaque) anyerror![]u8 {
+    fn surfaceSnapshot(ctx_ptr: *anyopaque, allocator: std.mem.Allocator, _: []const u8, _: *anyopaque) anyerror![]u8 {
         const ctx: *Ctx = @ptrCast(@alignCast(ctx_ptr));
         ctx.snap_calls += 1;
         const busy = ctx.snap_calls <= ctx.busy_until;
         return allocator.dupe(u8, if (busy) "Claude Code\nthinking… (esc to interrupt)" else ctx.settled_text);
     }
 
-    fn writeSurface(ctx_ptr: *anyopaque, _: *anyopaque, data: []const u8) bool {
+    fn writeSurface(ctx_ptr: *anyopaque, _: []const u8, _: *anyopaque, data: []const u8) bool {
         const ctx: *Ctx = @ptrCast(@alignCast(ctx_ptr));
         const len = @min(data.len, ctx.last_write.len);
         @memcpy(ctx.last_write[0..len], data[0..len]);

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -2461,6 +2461,7 @@ fn deniedResult(allocator: std.mem.Allocator, command: []const u8, reason: []con
 fn truncateOwned(allocator: std.mem.Allocator, settings: AgentSettings, text: []u8) ![]u8 {
     const limit = settings.output_limit;
     if (text.len <= limit) return text;
+    errdefer allocator.free(text); // owned: must not leak when allocPrint fails
     const truncated = try std.fmt.allocPrint(allocator, "{s}\n...[truncated to {d} bytes]", .{ text[0..limit], limit });
     allocator.free(text);
     return truncated;
@@ -2473,6 +2474,7 @@ fn truncateOwned(allocator: std.mem.Allocator, settings: AgentSettings, text: []
 fn truncateTailOwned(allocator: std.mem.Allocator, settings: AgentSettings, text: []u8) ![]u8 {
     const limit: usize = settings.output_limit;
     if (text.len <= limit) return text;
+    errdefer allocator.free(text); // owned: must not leak when allocPrint fails
     const tail = text[text.len - limit ..];
     const truncated = try std.fmt.allocPrint(allocator, "...[older output truncated to {d} bytes]\n{s}", .{ limit, tail });
     allocator.free(text);
@@ -3981,6 +3983,24 @@ test "truncateTailOwned returns short text unchanged" {
     const out = try truncateTailOwned(a, settings, text);
     defer a.free(out);
     try std.testing.expectEqualStrings("small", out);
+}
+
+test "truncate helpers free the owned input when the truncation alloc fails" {
+    // Both helpers take ownership of `text`; if the replacement allocPrint
+    // hits OOM they must free it. std.testing.allocator's leak check is the
+    // assertion here (allocation #0 = the input dupe, #1 = the failing
+    // allocPrint).
+    const settings = AgentSettings{ .output_limit = 4 };
+
+    var failing_tail = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+    const tail_alloc = failing_tail.allocator();
+    const tail_text = try tail_alloc.dupe(u8, "0123456789");
+    try std.testing.expectError(error.OutOfMemory, truncateTailOwned(tail_alloc, settings, tail_text));
+
+    var failing_head = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+    const head_alloc = failing_head.allocator();
+    const head_text = try head_alloc.dupe(u8, "0123456789");
+    try std.testing.expectError(error.OutOfMemory, truncateOwned(head_alloc, settings, head_text));
 }
 
 test "terminal_snapshot keeps the live screen tail when output exceeds the limit" {

--- a/src/ai_chat_types.zig
+++ b/src/ai_chat_types.zig
@@ -146,8 +146,8 @@ pub const SavedSshProfile = struct {
 pub const ToolHost = struct {
     ctx: *anyopaque,
     collectSnapshot: *const fn (*anyopaque, std.mem.Allocator) anyerror!ToolSnapshot,
-    surfaceSnapshot: *const fn (*anyopaque, std.mem.Allocator, *anyopaque) anyerror![]u8,
-    writeSurface: *const fn (*anyopaque, *anyopaque, []const u8) bool,
+    surfaceSnapshot: *const fn (*anyopaque, std.mem.Allocator, []const u8, *anyopaque) anyerror![]u8,
+    writeSurface: *const fn (*anyopaque, []const u8, *anyopaque, []const u8) bool,
     spawnTab: *const fn (*anyopaque, std.mem.Allocator, []const u8, ?[]const u8) anyerror!ToolSurface,
     closeTab: *const fn (*anyopaque, std.mem.Allocator, ?usize, ?[]const u8, ?[]const u8) anyerror!ToolClosedTab,
     saveSshProfile: *const fn (*anyopaque, std.mem.Allocator, SshProfileSaveArgs) anyerror!SavedSshProfile,

--- a/src/image_decoder.zig
+++ b/src/image_decoder.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const ghostty_vt = @import("ghostty-vt");
+const png_dimensions = @import("png_dimensions.zig");
 
 const c = @cImport({
     @cInclude("stb_image.h");
@@ -14,6 +15,13 @@ fn decodePng(
     data: []const u8,
 ) ghostty_vt.sys.DecodeError!ghostty_vt.sys.Image {
     const len = std.math.cast(c_int, data.len) orelse return error.InvalidData;
+
+    // Reject oversized declarations before stb allocates the decode buffer:
+    // a tiny crafted PNG can otherwise force a multi-GB transient allocation
+    // (kitty graphics bytes are attacker-controllable via any program that
+    // writes to the terminal).
+    const declared = png_dimensions.parse(data) orelse return error.InvalidData;
+    if (png_dimensions.exceedsLimit(declared)) return error.InvalidData;
 
     var width: c_int = 0;
     var height: c_int = 0;

--- a/src/png_dimensions.zig
+++ b/src/png_dimensions.zig
@@ -1,0 +1,80 @@
+//! Pure PNG header (IHDR) dimension probe.
+//!
+//! The kitty-graphics PNG decoder hands attacker-controllable bytes (any
+//! program that can write to the terminal can emit a graphics APC) to stb,
+//! which happily decodes images up to INT_MAX output bytes — a tiny crafted
+//! file declaring huge dimensions forces a multi-GB transient allocation
+//! (decompression bomb). Decoders consult this probe BEFORE decoding and
+//! reject oversized declarations outright.
+
+const std = @import("std");
+
+/// Per-axis ceiling, following kitty's own 10000×10000 image limit; worst
+/// case decoded RGBA stays at 400MB instead of stb's INT_MAX.
+pub const MAX_DIMENSION: u32 = 10000;
+
+pub const Dimensions = struct { width: u32, height: u32 };
+
+const png_signature = [_]u8{ 0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a };
+
+/// Extract the declared dimensions from a PNG byte stream, or null when the
+/// data is not a PNG whose first chunk is a well-formed IHDR (PNGs require
+/// IHDR first, so anything else is malformed anyway).
+pub fn parse(data: []const u8) ?Dimensions {
+    // signature(8) + chunk length(4) + "IHDR"(4) + width(4) + height(4)
+    if (data.len < 24) return null;
+    if (!std.mem.eql(u8, data[0..8], &png_signature)) return null;
+    if (std.mem.readInt(u32, data[8..12], .big) != 13) return null;
+    if (!std.mem.eql(u8, data[12..16], "IHDR")) return null;
+    return .{
+        .width = std.mem.readInt(u32, data[16..20], .big),
+        .height = std.mem.readInt(u32, data[20..24], .big),
+    };
+}
+
+pub fn exceedsLimit(dims: Dimensions) bool {
+    return dims.width > MAX_DIMENSION or dims.height > MAX_DIMENSION;
+}
+
+// ---- Tests ----
+
+fn testHeader(width: u32, height: u32) [24]u8 {
+    var bytes: [24]u8 = undefined;
+    @memcpy(bytes[0..8], &png_signature);
+    std.mem.writeInt(u32, bytes[8..12], 13, .big); // IHDR data length
+    @memcpy(bytes[12..16], "IHDR");
+    std.mem.writeInt(u32, bytes[16..20], width, .big);
+    std.mem.writeInt(u32, bytes[20..24], height, .big);
+    return bytes;
+}
+
+test "parse reads the declared IHDR dimensions" {
+    const header = testHeader(640, 480);
+    const dims = parse(&header) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(u32, 640), dims.width);
+    try std.testing.expectEqual(@as(u32, 480), dims.height);
+}
+
+test "parse rejects truncated data" {
+    const header = testHeader(640, 480);
+    try std.testing.expectEqual(@as(?Dimensions, null), parse(header[0..16]));
+    try std.testing.expectEqual(@as(?Dimensions, null), parse(""));
+}
+
+test "parse rejects a bad signature" {
+    var header = testHeader(640, 480);
+    header[0] = 'X';
+    try std.testing.expectEqual(@as(?Dimensions, null), parse(&header));
+}
+
+test "parse rejects a first chunk that is not IHDR" {
+    var header = testHeader(640, 480);
+    @memcpy(header[12..16], "IDAT");
+    try std.testing.expectEqual(@as(?Dimensions, null), parse(&header));
+}
+
+test "exceedsLimit allows up to MAX_DIMENSION per axis" {
+    try std.testing.expect(!exceedsLimit(.{ .width = MAX_DIMENSION, .height = MAX_DIMENSION }));
+    try std.testing.expect(exceedsLimit(.{ .width = MAX_DIMENSION + 1, .height = 1 }));
+    try std.testing.expect(exceedsLimit(.{ .width = 1, .height = MAX_DIMENSION + 1 }));
+}

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -204,9 +204,55 @@ fn appendSshExecPrefix(
     return argc;
 }
 
+const DrainResult = enum { complete, exceeded };
+
+/// Read `reader` (anything with `read([]u8) !usize`) appending to `list`,
+/// storing at most `max` bytes. The first byte beyond `max` yields
+/// `.exceeded`: with `stop_on_exceed` the read loop aborts immediately (the
+/// caller is expected to kill the producing child), otherwise the reader is
+/// still drained to EOF so a child blocked on a full pipe can finish —
+/// only storage stops.
+fn drainCapped(
+    reader: anytype,
+    allocator: std.mem.Allocator,
+    list: *std.ArrayListUnmanaged(u8),
+    max: usize,
+    stop_on_exceed: bool,
+) !DrainResult {
+    var exceeded = false;
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = try reader.read(&buf);
+        if (n == 0) break;
+        const take = @min(n, max - list.items.len);
+        if (take > 0) try list.appendSlice(allocator, buf[0..take]);
+        if (n > take) {
+            exceeded = true;
+            if (stop_on_exceed) return .exceeded;
+        }
+    }
+    return if (exceeded) .exceeded else .complete;
+}
+
+/// Generous ceiling for captured remote stdout: enough for any directory
+/// listing / pwd / preview read, while bounding memory if a remote command
+/// unexpectedly streams gigabytes.
+const SSH_EXEC_MAX_STDOUT_BYTES: usize = 16 * 1024 * 1024;
+/// stderr is diagnostics only; keep the first chunk for the error log.
+const SSH_EXEC_MAX_STDERR_BYTES: usize = 16 * 1024;
+
 /// Run `ssh user@host "<command>"` and capture stdout.
-/// Returns allocated output slice on success, null on failure.
+/// Returns allocated output slice on success, null on failure
+/// (including stdout exceeding the default capture cap).
 pub fn sshExec(allocator: std.mem.Allocator, conn: *const SshConnection, command: []const u8) ?[]u8 {
+    return sshExecCapped(allocator, conn, command, SSH_EXEC_MAX_STDOUT_BYTES);
+}
+
+/// sshExec with an explicit stdout cap. If the remote command produces more
+/// than `max_stdout_bytes`, the ssh child is killed and null is returned —
+/// callers get a clean failure instead of an unbounded allocation (or, worse,
+/// silently truncated file content that could be written back).
+pub fn sshExecCapped(allocator: std.mem.Allocator, conn: *const SshConnection, command: []const u8, max_stdout_bytes: usize) ?[]u8 {
     var askpass_path: ?[]const u8 = null;
     defer if (askpass_path) |p| allocator.free(p);
     var env_map: ?std.process.EnvMap = null;
@@ -254,7 +300,8 @@ pub fn sshExec(allocator: std.mem.Allocator, conn: *const SshConnection, command
         return null;
     };
 
-    // Read stdout
+    // Read stdout, bounded: a runaway/oversized remote command must not grow
+    // memory without limit. On exceed, kill ssh rather than read on.
     var output: std.ArrayListUnmanaged(u8) = .empty;
     defer output.deinit(allocator);
 
@@ -262,22 +309,19 @@ pub fn sshExec(allocator: std.mem.Allocator, conn: *const SshConnection, command
         _ = child.wait() catch {};
         return null;
     };
-    var buf: [4096]u8 = undefined;
-    while (true) {
-        const n = stdout.read(&buf) catch break;
-        if (n == 0) break;
-        output.appendSlice(allocator, buf[0..n]) catch break;
+    const stdout_drain = drainCapped(stdout, allocator, &output, max_stdout_bytes, true) catch .exceeded;
+    if (stdout_drain == .exceeded) {
+        std.debug.print("sshExec: stdout exceeded {d} bytes; killing ssh\n", .{max_stdout_bytes});
+        _ = child.kill() catch {};
+        return null;
     }
 
+    // stderr is capped but still drained to EOF: a child blocked on a full
+    // stderr pipe could otherwise never exit.
     var stderr_text: std.ArrayListUnmanaged(u8) = .empty;
     defer stderr_text.deinit(allocator);
     if (child.stderr) |stderr| {
-        var errbuf: [1024]u8 = undefined;
-        while (true) {
-            const n = stderr.read(&errbuf) catch break;
-            if (n == 0) break;
-            stderr_text.appendSlice(allocator, errbuf[0..n]) catch break;
-        }
+        _ = drainCapped(stderr, allocator, &stderr_text, SSH_EXEC_MAX_STDERR_BYTES, false) catch {};
     }
 
     const term = child.wait() catch return null;
@@ -402,11 +446,14 @@ pub fn buildRemoteWriteCommand(buf: *[2048]u8, path: []const u8, tmp: []const u8
     return buf[0..pos];
 }
 
-/// Read a remote file via `ssh ... cat`. Returns owned bytes, null on failure.
-pub fn sshReadFile(allocator: std.mem.Allocator, conn: *const SshConnection, path: []const u8) ?[]u8 {
+/// Read a remote file via `ssh ... cat`. Returns owned bytes, null on
+/// failure — including files larger than `max_bytes`, mirroring the local
+/// read_file cap. Failing outright (instead of truncating) matters: a
+/// truncated read that is later written back would corrupt the remote file.
+pub fn sshReadFile(allocator: std.mem.Allocator, conn: *const SshConnection, path: []const u8, max_bytes: usize) ?[]u8 {
     var buf: [2048]u8 = undefined;
     const cmd = buildRemoteReadCommand(&buf, path) orelse return null;
-    return sshExec(allocator, conn, cmd);
+    return sshExecCapped(allocator, conn, cmd, max_bytes);
 }
 
 /// Write `content` to a remote file atomically (temp + mv) via `ssh ... cat >`.
@@ -883,4 +930,68 @@ test "buildRemoteWriteCommand builds an atomic temp+mv" {
     var buf: [2048]u8 = undefined;
     const cmd = buildRemoteWriteCommand(&buf, "/tmp/a.txt", "/tmp/a.txt.tmp").?;
     try std.testing.expectEqualStrings("cat > '/tmp/a.txt.tmp' && mv -- '/tmp/a.txt.tmp' '/tmp/a.txt'", cmd);
+}
+
+/// Test stand-in for a pipe: serves `data` in chunks of at most `chunk` bytes.
+const FakePipeReader = struct {
+    data: []const u8,
+    chunk: usize,
+    pos: usize = 0,
+
+    fn read(self: *FakePipeReader, buf: []u8) !usize {
+        const remaining = self.data[self.pos..];
+        if (remaining.len == 0) return 0;
+        const n = @min(@min(buf.len, remaining.len), self.chunk);
+        @memcpy(buf[0..n], remaining[0..n]);
+        self.pos += n;
+        return n;
+    }
+};
+
+test "drainCapped reads everything when under the cap" {
+    var reader = FakePipeReader{ .data = "hello world", .chunk = 4 };
+    var list: std.ArrayListUnmanaged(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    const result = try drainCapped(&reader, std.testing.allocator, &list, 64, true);
+
+    try std.testing.expectEqual(DrainResult.complete, result);
+    try std.testing.expectEqualStrings("hello world", list.items);
+}
+
+test "drainCapped stops at the cap when asked to abort on exceed" {
+    var reader = FakePipeReader{ .data = "x" ** 100, .chunk = 7 };
+    var list: std.ArrayListUnmanaged(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    const result = try drainCapped(&reader, std.testing.allocator, &list, 10, true);
+
+    try std.testing.expectEqual(DrainResult.exceeded, result);
+    try std.testing.expect(list.items.len <= 10);
+    // Aborted: the reader must NOT have been drained to EOF.
+    try std.testing.expect(reader.pos < reader.data.len);
+}
+
+test "drainCapped keeps draining to EOF when storage is capped" {
+    var reader = FakePipeReader{ .data = "y" ** 100, .chunk = 7 };
+    var list: std.ArrayListUnmanaged(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    const result = try drainCapped(&reader, std.testing.allocator, &list, 10, false);
+
+    try std.testing.expectEqual(DrainResult.exceeded, result);
+    try std.testing.expectEqualStrings("y" ** 10, list.items);
+    // Fully drained so a child blocked on the pipe can exit.
+    try std.testing.expectEqual(reader.data.len, reader.pos);
+}
+
+test "drainCapped output exactly at the cap is complete" {
+    var reader = FakePipeReader{ .data = "z" ** 10, .chunk = 3 };
+    var list: std.ArrayListUnmanaged(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    const result = try drainCapped(&reader, std.testing.allocator, &list, 10, true);
+
+    try std.testing.expectEqual(DrainResult.complete, result);
+    try std.testing.expectEqualStrings("z" ** 10, list.items);
 }

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -206,6 +206,11 @@ fn appendSshExecPrefix(
 
 const DrainResult = enum { complete, exceeded };
 
+const DrainPipesResult = struct {
+    stdout: DrainResult,
+    stderr: DrainResult,
+};
+
 /// Read `reader` (anything with `read([]u8) !usize`) appending to `list`,
 /// storing at most `max` bytes. The first byte beyond `max` yields
 /// `.exceeded`: with `stop_on_exceed` the read loop aborts immediately (the
@@ -232,6 +237,65 @@ fn drainCapped(
         }
     }
     return if (exceeded) .exceeded else .complete;
+}
+
+fn DrainThreadCtx(comptime Reader: type) type {
+    return struct {
+        reader: Reader,
+        allocator: std.mem.Allocator,
+        list: *std.ArrayListUnmanaged(u8),
+        max: usize,
+        stop_on_exceed: bool,
+        result: DrainResult = .complete,
+        err: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.result = drainCapped(
+                self.reader,
+                self.allocator,
+                self.list,
+                self.max,
+                self.stop_on_exceed,
+            ) catch |err| {
+                self.err = err;
+                return;
+            };
+        }
+    };
+}
+
+fn drainOutputPipesCapped(
+    stdout_reader: anytype,
+    stderr_reader: anytype,
+    allocator: std.mem.Allocator,
+    stdout_list: *std.ArrayListUnmanaged(u8),
+    max_stdout: usize,
+    stderr_list: *std.ArrayListUnmanaged(u8),
+    max_stderr: usize,
+) !DrainPipesResult {
+    const StderrDrain = DrainThreadCtx(@TypeOf(stderr_reader));
+    var stderr_ctx = StderrDrain{
+        .reader = stderr_reader,
+        .allocator = allocator,
+        .list = stderr_list,
+        .max = max_stderr,
+        .stop_on_exceed = false,
+    };
+    const stderr_thread = try std.Thread.spawn(.{}, StderrDrain.run, .{&stderr_ctx});
+
+    var stdout_err: ?anyerror = null;
+    const stdout_result = drainCapped(stdout_reader, allocator, stdout_list, max_stdout, true) catch |err| blk: {
+        stdout_err = err;
+        break :blk DrainResult.exceeded;
+    };
+
+    stderr_thread.join();
+    if (stderr_ctx.err) |err| return err;
+    if (stdout_err) |err| return err;
+    return .{
+        .stdout = stdout_result,
+        .stderr = stderr_ctx.result,
+    };
 }
 
 /// Generous ceiling for captured remote stdout: enough for any directory
@@ -309,19 +373,43 @@ pub fn sshExecCapped(allocator: std.mem.Allocator, conn: *const SshConnection, c
         _ = child.wait() catch {};
         return null;
     };
+    child.stdout = null;
+    defer stdout.close();
+
+    var stderr_text: std.ArrayListUnmanaged(u8) = .empty;
+    defer stderr_text.deinit(allocator);
+    const stderr = child.stderr orelse {
+        _ = child.wait() catch {};
+        return null;
+    };
+    child.stderr = null;
+    defer stderr.close();
+
+    const StderrDrain = DrainThreadCtx(@TypeOf(stderr));
+    var stderr_ctx = StderrDrain{
+        .reader = stderr,
+        .allocator = allocator,
+        .list = &stderr_text,
+        .max = SSH_EXEC_MAX_STDERR_BYTES,
+        .stop_on_exceed = false,
+    };
+    const stderr_thread = std.Thread.spawn(.{}, StderrDrain.run, .{&stderr_ctx}) catch |err| {
+        std.debug.print("sshExec: stderr drain thread spawn failed: {}\n", .{err});
+        _ = child.kill() catch {};
+        return null;
+    };
+
     const stdout_drain = drainCapped(stdout, allocator, &output, max_stdout_bytes, true) catch .exceeded;
     if (stdout_drain == .exceeded) {
         std.debug.print("sshExec: stdout exceeded {d} bytes; killing ssh\n", .{max_stdout_bytes});
         _ = child.kill() catch {};
+        stderr_thread.join();
         return null;
     }
 
-    // stderr is capped but still drained to EOF: a child blocked on a full
-    // stderr pipe could otherwise never exit.
-    var stderr_text: std.ArrayListUnmanaged(u8) = .empty;
-    defer stderr_text.deinit(allocator);
-    if (child.stderr) |stderr| {
-        _ = drainCapped(stderr, allocator, &stderr_text, SSH_EXEC_MAX_STDERR_BYTES, false) catch {};
+    stderr_thread.join();
+    if (stderr_ctx.err) |err| {
+        std.debug.print("sshExec: stderr drain failed: {}\n", .{err});
     }
 
     const term = child.wait() catch return null;
@@ -994,4 +1082,64 @@ test "drainCapped output exactly at the cap is complete" {
 
     try std.testing.expectEqual(DrainResult.complete, result);
     try std.testing.expectEqualStrings("z" ** 10, list.items);
+}
+
+const StderrSignalReader = struct {
+    data: []const u8,
+    started: *std.atomic.Value(bool),
+    pos: usize = 0,
+
+    fn read(self: *StderrSignalReader, buf: []u8) !usize {
+        self.started.store(true, .release);
+        const remaining = self.data[self.pos..];
+        if (remaining.len == 0) return 0;
+        const n = @min(buf.len, remaining.len);
+        @memcpy(buf[0..n], remaining[0..n]);
+        self.pos += n;
+        return n;
+    }
+};
+
+const StdoutRequiresStderrReader = struct {
+    data: []const u8,
+    stderr_started: *std.atomic.Value(bool),
+    pos: usize = 0,
+
+    fn read(self: *StdoutRequiresStderrReader, buf: []u8) !usize {
+        var spins: usize = 0;
+        while (!self.stderr_started.load(.acquire) and spins < 200) : (spins += 1) {
+            std.Thread.sleep(std.time.ns_per_ms);
+        }
+        if (!self.stderr_started.load(.acquire)) return error.StderrNotDrained;
+        const remaining = self.data[self.pos..];
+        if (remaining.len == 0) return 0;
+        const n = @min(buf.len, remaining.len);
+        @memcpy(buf[0..n], remaining[0..n]);
+        self.pos += n;
+        return n;
+    }
+};
+
+test "drainOutputPipesCapped starts stderr draining before waiting for stdout EOF" {
+    var stderr_started = std.atomic.Value(bool).init(false);
+    var stdout = StdoutRequiresStderrReader{ .data = "out", .stderr_started = &stderr_started };
+    var stderr = StderrSignalReader{ .data = "err", .started = &stderr_started };
+    var stdout_list: std.ArrayListUnmanaged(u8) = .empty;
+    defer stdout_list.deinit(std.testing.allocator);
+    var stderr_list: std.ArrayListUnmanaged(u8) = .empty;
+    defer stderr_list.deinit(std.testing.allocator);
+
+    const result = try drainOutputPipesCapped(
+        &stdout,
+        &stderr,
+        std.testing.allocator,
+        &stdout_list,
+        64,
+        &stderr_list,
+        64,
+    );
+
+    try std.testing.expectEqual(DrainPipesResult{ .stdout = .complete, .stderr = .complete }, result);
+    try std.testing.expectEqualStrings("out", stdout_list.items);
+    try std.testing.expectEqualStrings("err", stderr_list.items);
 }

--- a/src/surface_registry.zig
+++ b/src/surface_registry.zig
@@ -7,10 +7,12 @@
 //!
 //!  - the UI thread `register`s a surface when it is created and
 //!    `unregister`s it right before it is freed;
-//!  - a worker wraps every dereference in `acquire`/`release`. `acquire`
-//!    returns true with the registry lock HELD, and `unregister` takes the
-//!    same lock, so a surface can never be freed while a guarded access is
-//!    in flight — and a freed surface can never be acquired again.
+//!  - a worker wraps every dereference in `acquire`/`release`, passing both
+//!    the raw pointer and the captured surface id. `acquire` returns true with
+//!    the registry lock HELD, and `unregister` takes the same lock, so a
+//!    surface can never be freed while a guarded access is in flight — and a
+//!    freed surface can never be acquired again. The id check prevents ABA
+//!    pointer reuse from validating a stale ToolSurface.ptr.
 //!
 //! Accesses inside the guarded section must be short (snapshot serialization,
 //! queueing PTY input); the lock is global, not per-surface.
@@ -21,20 +23,50 @@ const std = @import("std");
 /// beyond this is dropped, which fails safe: acquire() then reports the
 /// surface as gone and agent tools degrade to an error instead of a deref.
 const MAX_SURFACES = 1024;
+const MAX_SURFACE_ID_BYTES = 64;
+
+const Entry = struct {
+    ptr: *anyopaque,
+    id: [MAX_SURFACE_ID_BYTES]u8,
+    id_len: usize,
+
+    fn init(ptr: *anyopaque, id: []const u8) Entry {
+        var out = Entry{
+            .ptr = ptr,
+            .id = @splat(0),
+            .id_len = @min(id.len, MAX_SURFACE_ID_BYTES),
+        };
+        @memcpy(out.id[0..out.id_len], id[0..out.id_len]);
+        return out;
+    }
+
+    fn idSlice(self: *const Entry) []const u8 {
+        return self.id[0..self.id_len];
+    }
+
+    fn matches(self: *const Entry, ptr: *anyopaque, id: []const u8) bool {
+        return self.ptr == ptr and std.mem.eql(u8, self.idSlice(), id);
+    }
+};
 
 var g_mutex: std.Thread.Mutex = .{};
-var g_entries: [MAX_SURFACES]?*anyopaque = @splat(null);
+var g_entries: [MAX_SURFACES]?Entry = @splat(null);
 
 /// Record a live surface pointer (UI thread, surface creation).
-pub fn register(ptr: *anyopaque) void {
+pub fn register(ptr: *anyopaque, id: []const u8) void {
     g_mutex.lock();
     defer g_mutex.unlock();
-    var free_slot: ?*?*anyopaque = null;
+    var free_slot: ?*?Entry = null;
     for (&g_entries) |*entry| {
-        if (entry.* == ptr) return;
+        if (entry.*) |live| {
+            if (live.ptr == ptr) {
+                entry.* = Entry.init(ptr, id);
+                return;
+            }
+        }
         if (entry.* == null and free_slot == null) free_slot = entry;
     }
-    if (free_slot) |slot| slot.* = ptr;
+    if (free_slot) |slot| slot.* = Entry.init(ptr, id);
 }
 
 /// Drop a surface pointer (UI thread, right before the surface is freed).
@@ -44,7 +76,7 @@ pub fn unregister(ptr: *anyopaque) void {
     g_mutex.lock();
     defer g_mutex.unlock();
     for (&g_entries) |*entry| {
-        if (entry.* == ptr) {
+        if (entry.* != null and entry.*.?.ptr == ptr) {
             entry.* = null;
             return;
         }
@@ -54,10 +86,12 @@ pub fn unregister(ptr: *anyopaque) void {
 /// If `ptr` is a live registered surface, returns true with the registry
 /// lock held — the caller MUST call release() when done with the surface.
 /// Returns false (lock not held) when the surface is gone.
-pub fn acquire(ptr: *anyopaque) bool {
+pub fn acquire(ptr: *anyopaque, id: []const u8) bool {
     g_mutex.lock();
     for (g_entries) |entry| {
-        if (entry == ptr) return true;
+        if (entry) |live| {
+            if (live.matches(ptr, id)) return true;
+        }
     }
     g_mutex.unlock();
     return false;
@@ -76,36 +110,48 @@ var test_target_a: u8 = 0;
 var test_target_b: u8 = 0;
 
 test "registered pointer can be acquired (and re-acquired after release)" {
-    register(&test_target_a);
+    register(&test_target_a, "surface-a");
     defer unregister(&test_target_a);
 
-    try std.testing.expect(acquire(&test_target_a));
+    try std.testing.expect(acquire(&test_target_a, "surface-a"));
     release();
-    try std.testing.expect(acquire(&test_target_a));
+    try std.testing.expect(acquire(&test_target_a, "surface-a"));
     release();
 }
 
 test "unregistered pointer cannot be acquired" {
-    try std.testing.expect(!acquire(&test_target_b));
+    try std.testing.expect(!acquire(&test_target_b, "surface-b"));
 }
 
 test "unregister makes a pointer unacquirable" {
-    register(&test_target_a);
+    register(&test_target_a, "surface-a");
     unregister(&test_target_a);
-    try std.testing.expect(!acquire(&test_target_a));
+    try std.testing.expect(!acquire(&test_target_a, "surface-a"));
 }
 
 test "registering the same pointer twice does not duplicate the entry" {
-    register(&test_target_a);
-    register(&test_target_a);
+    register(&test_target_a, "surface-a");
+    register(&test_target_a, "surface-a");
     unregister(&test_target_a);
-    try std.testing.expect(!acquire(&test_target_a));
+    try std.testing.expect(!acquire(&test_target_a, "surface-a"));
+}
+
+test "reused pointer address does not validate a stale surface id" {
+    register(&test_target_a, "old-surface");
+    unregister(&test_target_a);
+
+    register(&test_target_a, "new-surface");
+    defer unregister(&test_target_a);
+
+    try std.testing.expect(!acquire(&test_target_a, "old-surface"));
+    try std.testing.expect(acquire(&test_target_a, "new-surface"));
+    release();
 }
 
 test "unregister blocks until an in-flight guarded access releases" {
-    register(&test_target_a);
+    register(&test_target_a, "surface-a");
 
-    try std.testing.expect(acquire(&test_target_a));
+    try std.testing.expect(acquire(&test_target_a, "surface-a"));
 
     var unregistered = std.atomic.Value(bool).init(false);
     const Closure = struct {
@@ -123,5 +169,5 @@ test "unregister blocks until an in-flight guarded access releases" {
     release();
     thread.join();
     try std.testing.expect(unregistered.load(.acquire));
-    try std.testing.expect(!acquire(&test_target_a));
+    try std.testing.expect(!acquire(&test_target_a, "surface-a"));
 }

--- a/src/surface_registry.zig
+++ b/src/surface_registry.zig
@@ -1,0 +1,127 @@
+//! Process-wide registry of live Surface pointers.
+//!
+//! The agent request worker holds raw `*Surface` pointers captured at request
+//! start (ToolSurface.ptr) and dereferences them for up to the tool timeout,
+//! while the UI thread may free the surface at any moment (close tab / close
+//! split). This registry is the liveness guard between the two threads:
+//!
+//!  - the UI thread `register`s a surface when it is created and
+//!    `unregister`s it right before it is freed;
+//!  - a worker wraps every dereference in `acquire`/`release`. `acquire`
+//!    returns true with the registry lock HELD, and `unregister` takes the
+//!    same lock, so a surface can never be freed while a guarded access is
+//!    in flight — and a freed surface can never be acquired again.
+//!
+//! Accesses inside the guarded section must be short (snapshot serialization,
+//! queueing PTY input); the lock is global, not per-surface.
+
+const std = @import("std");
+
+/// Upper bound on simultaneously live surfaces (tabs × splits). Registration
+/// beyond this is dropped, which fails safe: acquire() then reports the
+/// surface as gone and agent tools degrade to an error instead of a deref.
+const MAX_SURFACES = 1024;
+
+var g_mutex: std.Thread.Mutex = .{};
+var g_entries: [MAX_SURFACES]?*anyopaque = @splat(null);
+
+/// Record a live surface pointer (UI thread, surface creation).
+pub fn register(ptr: *anyopaque) void {
+    g_mutex.lock();
+    defer g_mutex.unlock();
+    var free_slot: ?*?*anyopaque = null;
+    for (&g_entries) |*entry| {
+        if (entry.* == ptr) return;
+        if (entry.* == null and free_slot == null) free_slot = entry;
+    }
+    if (free_slot) |slot| slot.* = ptr;
+}
+
+/// Drop a surface pointer (UI thread, right before the surface is freed).
+/// Blocks while any acquire() holder is inside the guarded section, so the
+/// caller may free the surface immediately after this returns.
+pub fn unregister(ptr: *anyopaque) void {
+    g_mutex.lock();
+    defer g_mutex.unlock();
+    for (&g_entries) |*entry| {
+        if (entry.* == ptr) {
+            entry.* = null;
+            return;
+        }
+    }
+}
+
+/// If `ptr` is a live registered surface, returns true with the registry
+/// lock held — the caller MUST call release() when done with the surface.
+/// Returns false (lock not held) when the surface is gone.
+pub fn acquire(ptr: *anyopaque) bool {
+    g_mutex.lock();
+    for (g_entries) |entry| {
+        if (entry == ptr) return true;
+    }
+    g_mutex.unlock();
+    return false;
+}
+
+/// Release the lock taken by a successful acquire().
+pub fn release() void {
+    g_mutex.unlock();
+}
+
+// ---- Tests ----
+
+// Dummy registration targets with process-unique, stable addresses; stack
+// addresses could collide across tests if a test ever leaked an entry.
+var test_target_a: u8 = 0;
+var test_target_b: u8 = 0;
+
+test "registered pointer can be acquired (and re-acquired after release)" {
+    register(&test_target_a);
+    defer unregister(&test_target_a);
+
+    try std.testing.expect(acquire(&test_target_a));
+    release();
+    try std.testing.expect(acquire(&test_target_a));
+    release();
+}
+
+test "unregistered pointer cannot be acquired" {
+    try std.testing.expect(!acquire(&test_target_b));
+}
+
+test "unregister makes a pointer unacquirable" {
+    register(&test_target_a);
+    unregister(&test_target_a);
+    try std.testing.expect(!acquire(&test_target_a));
+}
+
+test "registering the same pointer twice does not duplicate the entry" {
+    register(&test_target_a);
+    register(&test_target_a);
+    unregister(&test_target_a);
+    try std.testing.expect(!acquire(&test_target_a));
+}
+
+test "unregister blocks until an in-flight guarded access releases" {
+    register(&test_target_a);
+
+    try std.testing.expect(acquire(&test_target_a));
+
+    var unregistered = std.atomic.Value(bool).init(false);
+    const Closure = struct {
+        fn run(flag: *std.atomic.Value(bool)) void {
+            unregister(&test_target_a);
+            flag.store(true, .release);
+        }
+    };
+    const thread = try std.Thread.spawn(.{}, Closure.run, .{&unregistered});
+
+    // While we hold the guard the unregistering thread must stay blocked.
+    std.Thread.sleep(50 * std.time.ns_per_ms);
+    try std.testing.expect(!unregistered.load(.acquire));
+
+    release();
+    thread.join();
+    try std.testing.expect(unregistered.load(.acquire));
+    try std.testing.expect(!acquire(&test_target_a));
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -56,6 +56,7 @@ test {
     _ = @import("appwindow/frame_latency.zig");
     _ = @import("scp.zig");
     _ = @import("surface_registry.zig");
+    _ = @import("png_dimensions.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -55,6 +55,7 @@ test {
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");
     _ = @import("scp.zig");
+    _ = @import("surface_registry.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -642,6 +642,7 @@ comptime {
     _ = @import("agent_prompt_answer.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");
+    _ = @import("surface_registry.zig");
     _ = @import("appwindow/flush_scheduler.zig");
     _ = @import("appwindow/tab.zig");
     _ = @import("appwindow/thread_message.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -643,6 +643,7 @@ comptime {
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");
     _ = @import("surface_registry.zig");
+    _ = @import("png_dimensions.zig");
     _ = @import("appwindow/flush_scheduler.zig");
     _ = @import("appwindow/tab.zig");
     _ = @import("appwindow/thread_message.zig");

--- a/src/weixin/ilink_client.zig
+++ b/src/weixin/ilink_client.zig
@@ -590,6 +590,16 @@ fn appendQueryEscaped(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Alloc
     }
 }
 
+/// Whole-attachment ceiling for WeChat sends. The upload path holds the
+/// plain bytes AND an AES-encrypted copy in memory at once, so peak usage is
+/// roughly twice this value; the cap keeps a stray huge file (video, archive)
+/// from ballooning the process while still covering realistic WeChat sends.
+pub const MAX_ATTACHMENT_BYTES: u64 = 256 * 1024 * 1024;
+
+fn checkAttachmentSize(size: u64) error{WeixinAttachmentTooLarge}!void {
+    if (size > MAX_ATTACHMENT_BYTES) return error.WeixinAttachmentTooLarge;
+}
+
 fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     const path_kind = try localPathKind(path);
     switch (path_kind) {
@@ -608,7 +618,12 @@ fn readLocalFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     // not read if it no longer resolves to a regular file.
     const stat = try file.stat();
     switch (stat.kind) {
-        .file => return file.readToEndAlloc(allocator, std.math.maxInt(usize)),
+        .file => {
+            try checkAttachmentSize(stat.size);
+            // The readToEndAlloc cap re-bounds the read in case the file
+            // grows between the stat above and the read.
+            return file.readToEndAlloc(allocator, MAX_ATTACHMENT_BYTES);
+        },
         .directory => return error.IsDir,
         else => return error.WeixinAttachmentNotRegularFile,
     }
@@ -946,6 +961,12 @@ test "readLocalFileAlloc rejects non-regular files" {
     } else |err| {
         try std.testing.expectEqual(error.WeixinAttachmentNotRegularFile, err);
     }
+}
+
+test "checkAttachmentSize allows sizes up to the cap and rejects beyond" {
+    try checkAttachmentSize(0);
+    try checkAttachmentSize(MAX_ATTACHMENT_BYTES);
+    try std.testing.expectError(error.WeixinAttachmentTooLarge, checkAttachmentSize(MAX_ATTACHMENT_BYTES + 1));
 }
 
 test "readLocalFileAlloc rejects directories" {


### PR DESCRIPTION
## Summary

Memory-safety audit follow-up; one commit per finding, ordered by severity.

1. **Agent worker Surface UAF** — the request worker dereferences `ToolSurface.ptr` (snapshot polls every 150ms, PTY writes) for up to the tool timeout while the UI thread frees surfaces on close-tab/split with no coordination; the worker can even trigger it itself via the `close_tab` tool. New process-wide `surface_registry`: `Surface.init` registers, `Surface.deinit` unregisters first (blocking while a guarded access is in flight), `agentSurfaceSnapshot`/`agentWriteSurface` refuse unregistered pointers before any deref.
2. **`sshExec` unbounded stdout capture** — remote `read_file` (`ssh cat`) could pull a multi-GB file into memory, bypassing the 256KB local cap. New `drainCapped` bounds both pipes (stdout 16MB default, kills ssh on exceed; stderr 16KB but drained to EOF). `sshReadFile` now takes an explicit `max_bytes`; agent callers pass `MAX_FILE_BYTES`, which also prevents truncated read→write-back corruption.
3. **WeChat attachment reads** — `readToEndAlloc(maxInt)` replaced with a 256MB stat-based gate (`error.WeixinAttachmentTooLarge`) + capped read.
4. **kitty PNG decompression bomb** — new pure `png_dimensions` IHDR probe rejects >10000×10000 declarations before stb allocates (kitty graphics bytes are attacker-controllable by anything that writes to the terminal).
5. **`truncateOwned`/`truncateTailOwned` OOM leak** — owned input now freed via `errdefer` when the replacement allocPrint fails.

## Test Plan
- [x] TDD throughout: every fix landed with a failing test first (registry semantics incl. cross-thread blocking; zeroed-Surface guard test that segfaulted pre-fix; capped-drain fake-pipe tests; attachment size gate; crafted IHDR headers; FailingAllocator leak checks)
- [x] `zig build test` (fast suite) green
- [x] `zig build test-full` green
- [x] `zig build` green
- [ ] GUI smoke: close a tab/split while the copilot is mid-`terminal_repl_exec` (UAF repro path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)