### PR TITLE
feat(port-forward): switchable Profile selector + full-width form labels

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -53,6 +53,7 @@ pub const skill_center = @import("skill_center.zig");
 pub const port_forwarding = @import("port_forwarding.zig");
 const port_forward_manager = @import("port_forward_manager.zig");
 const port_forward_rule = @import("port_forward_rule.zig");
+const ssh_profile_store = @import("ssh_profile_store.zig");
 const skill_scan = @import("skill_scan.zig");
 const skill_transfer_cmd = @import("skill_transfer_cmd.zig");
 const remote_file = @import("platform/remote_file.zig");
@@ -957,9 +958,10 @@ fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: 
         .renderTextLimited = titlebar.renderTextLimited,
         .glyphAdvance = titlebar.titlebarGlyphAdvance,
     };
+    const legend = if (form_view != null) i18n.s().pf_form_legend else i18n.s().pf_legend;
     const view: port_forwarding_renderer.View = .{
         .title = i18n.s().pf_title,
-        .legend = i18n.s().pf_legend,
+        .legend = legend,
         .count = row_count,
         .selected = session.model.sel_row,
         .scroll = session.model.scroll,
@@ -1183,11 +1185,32 @@ pub fn portForwardingToggleAutoStart() bool {
 
 pub fn portForwardingOpenNew() bool {
     const session = activePortForwarding() orelse return false;
+    var name_buf: [port_forward_rule.PROFILE_MAX]u8 = undefined;
+    const default_profile = firstSshProfileName(&name_buf);
     session.mutex.lock();
     defer session.mutex.unlock();
-    session.model.openNewForm("") catch return false;
+    session.model.openNewForm(default_profile) catch return false;
     markUiDirty();
     return true;
+}
+
+/// Name of the first SSH profile in the store, written into `buf` (the returned
+/// slice points into `buf`, not the freed file content). Returns "" when no
+/// profiles exist or the store can't be read. Used to preselect the Profile
+/// selector when opening a new forwarding rule.
+fn firstSshProfileName(buf: []u8) []const u8 {
+    const manager = activePortForwardManager() orelse return "";
+    const allocator = manager.allocator;
+    const content = readSshHostsContent(allocator) orelse return "";
+    defer allocator.free(content);
+    return ssh_profile_store.cycleProfileName(content, "", 0, buf);
+}
+
+/// Read the encoded ssh_hosts file. Caller frees. Returns null when unavailable.
+fn readSshHostsContent(allocator: std.mem.Allocator) ?[]u8 {
+    const path = platform_dirs.sshHostsPath(allocator) catch return null;
+    defer allocator.free(path);
+    return std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch null;
 }
 
 pub fn portForwardingOpenEdit() bool {
@@ -1287,11 +1310,50 @@ pub fn portForwardingFormMove(delta: isize) bool {
     return true;
 }
 
-pub fn portForwardingFormToggle() bool {
+/// Adjust the focused selector field by `delta` steps. Profile (field 1) cycles
+/// through the SSH profiles in the store; Direction and Auto start flip. Other
+/// (text/port) fields are unaffected. Used by Space (+1) and the ←/→ arrows.
+pub fn portForwardingFormAdjust(delta: isize) bool {
     const session = activePortForwarding() orelse return false;
+
+    // Determine the focused field and the current profile name without holding
+    // the lock across the ssh_hosts file read below.
+    session.mutex.lock();
+    const focus = if (session.model.form()) |form| form.focus else {
+        session.mutex.unlock();
+        return false;
+    };
+    var current_buf: [port_forward_rule.PROFILE_MAX]u8 = undefined;
+    var current_len: usize = 0;
+    if (focus == 1) {
+        const form = session.model.form().?;
+        const current = form.rule.profileName();
+        current_len = @min(current_buf.len, current.len);
+        @memcpy(current_buf[0..current_len], current[0..current_len]);
+    }
+    session.mutex.unlock();
+
+    if (focus == 1) {
+        const manager = activePortForwardManager() orelse return false;
+        const allocator = manager.allocator;
+        const content = readSshHostsContent(allocator) orelse return false;
+        defer allocator.free(content);
+        var next_buf: [port_forward_rule.PROFILE_MAX]u8 = undefined;
+        const next = ssh_profile_store.cycleProfileName(content, current_buf[0..current_len], delta, &next_buf);
+        if (next.len == 0) return false;
+
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        const form = session.model.form() orelse return false;
+        form.rule.setProfileName(next);
+        markUiDirty();
+        return true;
+    }
+
     session.mutex.lock();
     defer session.mutex.unlock();
     const form = session.model.form() orelse return false;
+    if (form.focus != 2 and form.focus != 7) return false;
     form.toggleFocused();
     markUiDirty();
     return true;

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -58,6 +58,7 @@ pub const Strings = struct {
     pf_title: []const u8,
     pf_detail: []const u8,
     pf_legend: []const u8,
+    pf_form_legend: []const u8,
 
     // —— Skill Center 面板 ——
     sc_local: []const u8,
@@ -247,6 +248,7 @@ const en = Strings{
     .pf_title = "Port Forwarding",
     .pf_detail = "Manage SSH port forwarding rules",
     .pf_legend = "[n] new   [e] edit   [space] start/stop   [r] restart   [a] auto   [d] delete   [esc] close/cancel",
+    .pf_form_legend = "[up/down] move   [left/right/space] change   [enter] save   [esc] cancel",
 
     .sc_local = "Local",
     .sc_scanning = "No skills found. Scanning…",
@@ -430,6 +432,7 @@ const zh_CN = Strings{
     .pf_title = "端口转发",
     .pf_detail = "管理 SSH 端口转发规则",
     .pf_legend = "[n] 新建   [e] 编辑   [space] 启停   [r] 重启   [a] 自动启动   [d] 删除   [esc] 关闭/取消",
+    .pf_form_legend = "[上/下] 切换字段   [左/右 或 空格] 切换选项   [enter] 保存   [esc] 取消",
 
     .sc_local = "本地",
     .sc_scanning = "未发现技能，扫描中…",

--- a/src/input.zig
+++ b/src/input.zig
@@ -1762,6 +1762,14 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 }
                 return;
             },
+            platform_input.key_left => {
+                if (form_active) _ = AppWindow.portForwardingFormAdjust(-1);
+                return;
+            },
+            platform_input.key_right => {
+                if (form_active) _ = AppWindow.portForwardingFormAdjust(1);
+                return;
+            },
             platform_input.key_tab => {
                 if (form_active) _ = AppWindow.portForwardingFormMove(1);
                 return;
@@ -1780,7 +1788,7 @@ fn handleKey(ev: platform_input.KeyEvent) void {
             },
             platform_input.key_space => if (plain and !ev.shift) {
                 if (form_active) {
-                    _ = AppWindow.portForwardingFormToggle();
+                    _ = AppWindow.portForwardingFormAdjust(1);
                 } else if (!overlay_active) {
                     _ = AppWindow.portForwardingToggleSelected();
                 }

--- a/src/port_forwarding.zig
+++ b/src/port_forwarding.zig
@@ -34,7 +34,7 @@ pub const FormState = struct {
         if (!isPrintableAscii(ch)) return;
         switch (self.focus) {
             0 => _ = appendAscii(&self.rule.name_buf, &self.rule.name_len, ch),
-            1 => _ = appendAscii(&self.rule.profile_buf, &self.rule.profile_len, ch),
+            // Profile (field 1) is a selector cycled with arrows/space, not typed.
             3 => _ = appendAscii(&self.rule.local_host_buf, &self.rule.local_host_len, ch),
             4 => insertPortDigit(&self.rule.local_port, ch),
             5 => _ = appendAscii(&self.rule.remote_host_buf, &self.rule.remote_host_len, ch),
@@ -46,7 +46,7 @@ pub const FormState = struct {
     pub fn backspace(self: *FormState) void {
         switch (self.focus) {
             0 => truncateText(&self.rule.name_len),
-            1 => truncateText(&self.rule.profile_len),
+            // Profile (field 1) is a selector cycled with arrows/space, not typed.
             3 => truncateText(&self.rule.local_host_len),
             4 => backspacePort(&self.rule.local_port),
             5 => truncateText(&self.rule.remote_host_len),
@@ -292,6 +292,20 @@ test "port_forwarding: form edits text and port fields" {
     form_state.insertChar('1');
     form_state.insertChar('x');
     try std.testing.expectEqual(@as(u16, 7891), form_state.rule.local_port);
+}
+
+test "port_forwarding: profile field ignores typed input (it is a selector)" {
+    var session = try Session.create(std.testing.allocator);
+    defer session.destroy();
+    try session.model.openNewForm("devbox");
+    const form_state = session.model.form() orelse return error.ExpectedForm;
+
+    form_state.moveFocus(1);
+    try std.testing.expectEqual(@as(usize, 1), form_state.focus);
+    form_state.insertChar('x');
+    try std.testing.expectEqualStrings("devbox", form_state.rule.profileName());
+    form_state.backspace();
+    try std.testing.expectEqualStrings("devbox", form_state.rule.profileName());
 }
 
 test "port_forwarding: form toggles direction and auto start" {

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -169,7 +169,6 @@ pub fn render(
     width: f32,
 ) void {
     _ = window_width;
-    _ = draw.glyphAdvance;
 
     const content_x = @round(x);
     const content_w = @round(@max(1.0, width));
@@ -404,6 +403,14 @@ fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32,
         _ = draw.renderTextLimited(form.mode, title_x, yTextFromTop(draw, window_height, title_top), fg, clampedTextWidth(title_x, content_right, content_right - title_x));
     }
 
+    // Start the value column just past the widest label so no label is clipped,
+    // even at large font sizes. Keep the previous offset as a lower bound so the
+    // value column never collapses for short labels.
+    const label_x = box_x + @min(22.0, box_w);
+    const widest_label = widestFormLabelWidth(draw);
+    const min_value_x = box_x + @min(190.0, @max(72.0, box_w * 0.34));
+    const value_x = @min(content_right, @max(min_value_x, label_x + widest_label + COL_GAP));
+
     var field: usize = 0;
     while (field < 8) : (field += 1) {
         const row_top = box_top + draw.cell_h * @as(f32, @floatFromInt(field + 3));
@@ -417,12 +424,23 @@ fn renderForm(draw: DrawContext, form: FormView, content_x: f32, content_w: f32,
             draw.fillQuadAlpha(focus_x, focus_y, clampedTextWidth(focus_x, box_x + box_w, box_w), focus_h, accent, 0.20);
         }
         var value_buf: [32]u8 = undefined;
-        const label_x = box_x + @min(22.0, box_w);
-        const preferred_value_offset = @min(190.0, @max(72.0, box_w * 0.34));
-        const value_x = @min(content_right, box_x + preferred_value_offset);
         _ = draw.renderTextLimited(formFieldLabel(field), label_x, text_y, accent, clampedTextWidth(label_x, content_right, value_x - label_x - COL_GAP));
         _ = draw.renderTextLimited(formFieldValue(&form, field, &value_buf), value_x, text_y, fg, clampedTextWidth(value_x, content_right, content_right - value_x));
     }
+}
+
+/// Pixel width of the widest form field label at the current font, used to size
+/// the value column so labels render in full.
+fn widestFormLabelWidth(draw: DrawContext) f32 {
+    var widest: f32 = 0;
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        const label = formFieldLabel(i);
+        var w: f32 = 0;
+        for (label) |ch| w += draw.glyphAdvance(ch);
+        widest = @max(widest, w);
+    }
+    return widest;
 }
 
 fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w: f32, muted: [3]f32, line: [3]f32) void {
@@ -621,6 +639,62 @@ test "port_forwarding_renderer: render does not request rows with zero visible c
     }, 200, 80, 0, 0, 200);
 
     try std.testing.expectEqual(@as(usize, 0), rows.calls);
+}
+
+test "port_forwarding_renderer: form labels get full width at large font sizes" {
+    const Probe = struct {
+        const advance: f32 = 20;
+        const widest = "Remote port";
+        var widest_label_max_w: f32 = -1;
+
+        fn fillQuad(_: f32, _: f32, _: f32, _: f32, _: [3]f32) void {}
+        fn fillQuadAlpha(_: f32, _: f32, _: f32, _: f32, _: [3]f32, _: f32) void {}
+        fn renderTextLimited(text: []const u8, x: f32, _: f32, _: [3]f32, max_w: f32) f32 {
+            if (std.mem.eql(u8, text, widest)) widest_label_max_w = max_w;
+            return x + max_w;
+        }
+        fn glyphAdvance(_: u32) f32 {
+            return advance;
+        }
+    };
+
+    const Rows = struct {
+        fn rowAt(_: *anyopaque, index: usize) RowView {
+            _ = index;
+            return .{ .rule = rule_mod.defaultReverseProxy("devbox"), .status = .running, .auto_start = true };
+        }
+    };
+
+    Probe.widest_label_max_w = -1;
+    const draw = DrawContext{
+        .bg = .{ 0.02, 0.02, 0.02 },
+        .fg = .{ 0.95, 0.95, 0.95 },
+        .accent = .{ 0.2, 0.6, 1.0 },
+        .cell_h = 28,
+        .fillQuad = Probe.fillQuad,
+        .fillQuadAlpha = Probe.fillQuadAlpha,
+        .renderTextLimited = Probe.renderTextLimited,
+        .glyphAdvance = Probe.glyphAdvance,
+    };
+    var rows = Rows{};
+
+    render(draw, .{
+        .title = "Port Forwarding",
+        .legend = "x",
+        .count = 1,
+        .selected = 0,
+        .scroll = 0,
+        .ctx = &rows,
+        .rowAt = Rows.rowAt,
+        .form = .{
+            .mode = "New forwarding rule",
+            .focus = 1,
+            .rule = rule_mod.defaultReverseProxy("devbox"),
+        },
+    }, 900, 600, 40, 0, 760);
+
+    const natural = @as(f32, @floatFromInt(Probe.widest.len)) * Probe.advance;
+    try std.testing.expect(Probe.widest_label_max_w >= natural);
 }
 
 test "port_forwarding_renderer: narrow row text widths stay within content" {

--- a/src/ssh_profile_store.zig
+++ b/src/ssh_profile_store.zig
@@ -46,6 +46,49 @@ pub fn connectionFromProfile(profile: *const profile_codec.SshProfile, legacy_al
     return conn;
 }
 
+/// Cycle to the name of the SSH profile `delta` steps from `current` (matched
+/// case-insensitively by name) in the order they appear in `content`, wrapping
+/// around. The result is copied into `out` and the written slice is returned.
+///
+/// Returns "" when `content` holds no decodable profiles. When `current` is not
+/// found, a positive/zero delta starts at the first profile and a negative delta
+/// at the last, so the very first keypress always lands on a real profile.
+pub fn cycleProfileName(content: []const u8, current: []const u8, delta: isize, out: []u8) []const u8 {
+    var total: usize = 0;
+    var found: ?usize = null;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const profile = profile_codec.decodeSshProfileLine(line) orelse continue;
+        if (found == null and std.ascii.eqlIgnoreCase(current, profile_codec.profileField(&profile, .name))) {
+            found = total;
+        }
+        total += 1;
+    }
+    if (total == 0) return out[0..0];
+
+    const target: usize = if (found) |base| blk: {
+        const span: isize = @intCast(total);
+        break :blk @intCast(@mod(@as(isize, @intCast(base)) + delta, span));
+    } else if (delta < 0) total - 1 else 0;
+
+    var index: usize = 0;
+    var walk = std.mem.splitScalar(u8, content, '\n');
+    while (walk.next()) |line_raw| {
+        const line = std.mem.trimRight(u8, line_raw, "\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const profile = profile_codec.decodeSshProfileLine(line) orelse continue;
+        if (index == target) {
+            const name = profile_codec.profileField(&profile, .name);
+            const n = copyBounded(out, name);
+            return out[0..n];
+        }
+        index += 1;
+    }
+    return out[0..0];
+}
+
 fn isSshTokenSafe(value: []const u8) bool {
     if (value.len == 0) return false;
     for (value) |ch| {
@@ -113,4 +156,38 @@ test "ssh_profile_store: rejects unsafe profile fields" {
     });
 
     try std.testing.expect(findConnectionInContent(content.items, "bad", false) == null);
+}
+
+test "ssh_profile_store: cycleProfileName steps through profiles and wraps" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{ "devbox", "10.0.0.1", "a", "", "22", "" });
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{ "lab", "10.0.0.2", "a", "", "22", "" });
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{ "prod", "10.0.0.3", "a", "", "22", "" });
+
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("lab", cycleProfileName(content.items, "devbox", 1, &buf));
+    try std.testing.expectEqualStrings("prod", cycleProfileName(content.items, "devbox", -1, &buf));
+    try std.testing.expectEqualStrings("devbox", cycleProfileName(content.items, "prod", 1, &buf));
+    // Case-insensitive match on the current name.
+    try std.testing.expectEqualStrings("prod", cycleProfileName(content.items, "LAB", 1, &buf));
+}
+
+test "ssh_profile_store: cycleProfileName falls back when current is unknown" {
+    var content: std.ArrayListUnmanaged(u8) = .empty;
+    defer content.deinit(std.testing.allocator);
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{ "devbox", "10.0.0.1", "a", "", "22", "" });
+    try appendEncodedProfileForTest(std.testing.allocator, &content, &.{ "prod", "10.0.0.3", "a", "", "22", "" });
+
+    var buf: [128]u8 = undefined;
+    // Empty/unknown current: forward picks the first, backward picks the last.
+    try std.testing.expectEqualStrings("devbox", cycleProfileName(content.items, "", 1, &buf));
+    try std.testing.expectEqualStrings("devbox", cycleProfileName(content.items, "", 0, &buf));
+    try std.testing.expectEqualStrings("prod", cycleProfileName(content.items, "missing", -1, &buf));
+}
+
+test "ssh_profile_store: cycleProfileName returns empty without profiles" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("", cycleProfileName("# only comments\n", "devbox", 1, &buf));
+    try std.testing.expectEqualStrings("", cycleProfileName("", "", -1, &buf));
 }


### PR DESCRIPTION
Optimizes the **New forwarding rule** form from #181 based on two pieces of feedback: Profile should switch among existing SSH profiles (not be typed manually), and the field labels should not be truncated.

## Changes

### Profile is now a selector
- Cycles through your existing SSH profiles with `←` / `→` (or `Space` for next); typing is disabled.
- New rules **preselect the first available SSH profile** instead of opening blank.
- Wrapping + case-insensitive; if the current name isn't in the store (e.g. editing a rule whose profile was deleted), the first keypress still lands on a real profile.
- New pure helper `cycleProfileName()` in `ssh_profile_store.zig`; driven by `AppWindow.portForwardingFormAdjust()`. `Direction` and `Auto start` now also respond to `←`/`→` (they already toggled on `Space`).

### Labels no longer clipped
- `renderForm` used a fixed ~158px label column that clipped `Direction`, `Local host`, `Remote port`, etc. at larger fonts.
- It now measures the widest label via `glyphAdvance` and starts the value column just past it, so every label renders in full (old offset kept as a lower bound for small fonts).

### Form-specific legend
- While the form is open the bottom bar shows `[up/down] move  [left/right/space] change  [enter] save  [esc] cancel` instead of the misleading list shortcuts (EN + zh-CN).

## Tests
TDD throughout — new tests in `ssh_profile_store`, `port_forwarding`, and the renderer. `zig build test` and `zig build test-full` (windows-gnu app binary) both green.

⚠️ GUI not visually verified (WSLg can't screenshot the GL surface) — worth a manual look on a real display before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)