### PR TITLE
Directory download/upload + cancelable downloads

### DIFF
--- a/docs/superpowers/plans/2026-06-10-directory-download-upload.md
+++ b/docs/superpowers/plans/2026-06-10-directory-download-upload.md
@@ -1,0 +1,785 @@
+# Directory Download/Upload + Cancelable Downloads Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the remote file explorer download and upload whole directories (recursively), and make download tasks — including folder downloads — cancelable with the partial result cleaned up.
+
+**Architecture:** Reuse the existing single-job transfer system. Add an `scp -r` variant in `src/scp.zig` (`transferDirWithControl`) that matches the existing `TransferFn` signature, so directories flow through the unchanged job queue/worker/toast/cancel machinery. The file explorer picks the recursive transfer function for directory entries (download) and for the new `Shift+U` folder upload. On cancel, the download's partial destination is deleted. A new cross-platform `pickFolder` dialog backs folder selection.
+
+**Tech Stack:** Zig 0.15.2; `scp`/`ssh` child processes; Windows `comdlg32`/`shell32`/`ole32`, macOS `NSOpenPanel` (ObjC bridge), Linux `zenity`. Fast tests: `zig build test`. Full suite (default target windows-gnu): `zig build test-full`.
+
+---
+
+## File Structure
+
+- `src/scp.zig` — add `transferDirWithControl` + an internal `transferImpl(..., recursive)`; thread a `recursive` flag through `runScpTransfer`; extract a pure `buildScpFlagArgs` so the `-r` flag is unit-testable. (Modify)
+- `src/file_explorer.zig` — `downloadSelected` handles directories via a new pure `pickDownloadTransferFn`; add `uploadFolder`; add `removePartialDownload` and call it when a download cancels. (Modify)
+- `src/platform/file_dialog.zig` — re-export `pickFolder`; add a signature test. (Modify)
+- `src/platform/file_dialog_windows.zig` — `pickFolder` via `SHBrowseForFolderW`. (Modify)
+- `src/platform/file_dialog_macos.zig` — `pickFolder` extern + wrapper. (Modify)
+- `src/platform/services_macos_bridge.m` — `wispterm_macos_pick_folder_dialog`. (Modify)
+- `src/platform/file_dialog_linux.zig` — `pickFolder` via `zenity --directory`. (Modify)
+- `src/platform/file_dialog_unsupported.zig` — `pickFolder` returns null. (Modify)
+- `src/input.zig` — `Shift+U` → `openFolderDialogAndUpload`. (Modify)
+
+---
+
+## Task 1: `scp -r` recursive transfer
+
+**Files:**
+- Modify: `src/scp.zig` (`runScpTransfer` ~120-181, `transferWithControl` ~64-94)
+- Test: `src/scp.zig` (tests section, after `test "buildUploadCommand handles target directories"`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the tests section of `src/scp.zig` (e.g. after the `appendShellQuote` test):
+
+```zig
+fn containsArg(args: []const []const u8, needle: []const u8) bool {
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, needle)) return true;
+    }
+    return false;
+}
+
+test "buildScpFlagArgs includes -r only for recursive transfers" {
+    var conn: SshConnection = .{};
+    conn.password_auth = false;
+    conn.port_len = 0;
+
+    var argv_buf: [32][]const u8 = undefined;
+
+    const argc_file = buildScpFlagArgs(&argv_buf, &conn, null, false, false);
+    try std.testing.expect(!containsArg(argv_buf[0..argc_file], "-r"));
+
+    const argc_dir = buildScpFlagArgs(&argv_buf, &conn, null, false, true);
+    try std.testing.expect(containsArg(argv_buf[0..argc_dir], "-r"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: compile error — `buildScpFlagArgs` is not defined.
+
+- [ ] **Step 3: Add the pure `buildScpFlagArgs` helper (only)**
+
+In `src/scp.zig`, add this helper just above `fn runScpTransfer(`. Add **only** the helper in this step — leave `runScpTransfer` untouched so the file keeps compiling (the temporary duplication of the flag-building logic is removed in Step 5):
+
+```zig
+/// Build the scp argv up to (but excluding) the src/dst path arguments.
+/// Returns the count of arguments written into `argv_buf`. Pure/testable.
+fn buildScpFlagArgs(
+    argv_buf: *[32][]const u8,
+    conn: *const SshConnection,
+    control_path: ?[]const u8,
+    legacy_protocol: bool,
+    recursive: bool,
+) usize {
+    var argc: usize = 0;
+    argv_buf[argc] = platform_pty_command.scpExecutableName();
+    argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
+    if (recursive) {
+        argv_buf[argc] = "-r";
+        argc += 1;
+    }
+    if (legacy_protocol) {
+        argv_buf[argc] = "-O";
+        argc += 1;
+    }
+    return appendSshOptions(argv_buf, argc, conn, .scp, control_path);
+}
+```
+
+(Unused file-scope functions are allowed in Zig, so this compiles even though nothing calls it yet.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: the `buildScpFlagArgs` test passes; the rest of the file is unchanged and still compiles.
+
+- [ ] **Step 5: Route `runScpTransfer` through the helper, add the `recursive` parameter, and add `transferImpl` + `transferDirWithControl`**
+
+First, change `runScpTransfer`'s signature to add a `recursive: bool` parameter (place it right before `control`) and replace its inline argv-prefix building. The current head:
+
+```zig
+fn runScpTransfer(
+    allocator: std.mem.Allocator,
+    conn: *const SshConnection,
+    src: []const u8,
+    dst: []const u8,
+    control_path: ?[]const u8,
+    env_map: ?*std.process.EnvMap,
+    legacy_protocol: bool,
+    control: *TransferControl,
+) TransferResult {
+    if (control.cancelRequested()) return .cancelled;
+
+    var argv_buf: [32][]const u8 = undefined;
+    var argc: usize = 0;
+    argv_buf[argc] = platform_pty_command.scpExecutableName();
+    argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
+    if (legacy_protocol) {
+        argv_buf[argc] = "-O";
+        argc += 1;
+    }
+
+    argc = appendSshOptions(&argv_buf, argc, conn, .scp, control_path);
+
+    argv_buf[argc] = src;
+    argc += 1;
+    argv_buf[argc] = dst;
+    argc += 1;
+```
+
+becomes:
+
+```zig
+fn runScpTransfer(
+    allocator: std.mem.Allocator,
+    conn: *const SshConnection,
+    src: []const u8,
+    dst: []const u8,
+    control_path: ?[]const u8,
+    env_map: ?*std.process.EnvMap,
+    legacy_protocol: bool,
+    recursive: bool,
+    control: *TransferControl,
+) TransferResult {
+    if (control.cancelRequested()) return .cancelled;
+
+    var argv_buf: [32][]const u8 = undefined;
+    var argc = buildScpFlagArgs(&argv_buf, conn, control_path, legacy_protocol, recursive);
+
+    argv_buf[argc] = src;
+    argc += 1;
+    argv_buf[argc] = dst;
+    argc += 1;
+```
+
+(The rest of `runScpTransfer` — spawn, wait, result — is unchanged.)
+
+Next, in the **same step**, replace the body of `transferWithControl` (lines ~64-94) so it delegates to a shared `transferImpl`, and add the public recursive variant. Doing the `runScpTransfer` change and this together keeps the file compiling (`transferWithControl` is the only caller of `runScpTransfer`). Replace:
+
+```zig
+pub fn transferWithControl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl) TransferResult {
+    var askpass_path: ?[]const u8 = null;
+    defer if (askpass_path) |p| allocator.free(p);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return .spawn_error;
+        env_map = std.process.getEnvMap(allocator) catch return .spawn_error;
+        if (env_map) |*map| {
+            platform_process.putSshAskPassEnv(map, askpass_path.?, conn.password()) catch return .spawn_error;
+        }
+    }
+
+    // Windows OpenSSH's ControlMaster support relies on Unix-domain socket
+    // semantics that fail here with "getsockname failed: Not a socket".
+    // Keep helper SSH/SCP calls independent; the real interactive SSH session
+    // remains untouched.
+    const control_path: ?[]const u8 = null;
+
+    const env_ptr: ?*std.process.EnvMap = if (env_map) |*map| map else null;
+    const default_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, false, control);
+    if (default_result == .ok or default_result == .spawn_error or default_result == .cancelled) return default_result;
+
+    std.debug.print("SCP default mode failed; retrying legacy scp protocol (-O)\n", .{});
+    const legacy_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, true, control);
+    if (legacy_result == .ok or legacy_result == .spawn_error or legacy_result == .cancelled) return legacy_result;
+
+    std.debug.print("SCP legacy mode failed; retrying over ssh stream\n", .{});
+    return runSshStreamTransfer(allocator, conn, src, dst, control_path, env_ptr, control);
+}
+```
+
+with:
+
+```zig
+pub fn transferWithControl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl) TransferResult {
+    return transferImpl(allocator, conn, src, dst, control, false);
+}
+
+/// Recursively transfer a directory with `scp -r`. Falls back through the
+/// legacy scp protocol (`-O`) but NOT the ssh `cat` stream (which cannot
+/// transfer directories).
+pub fn transferDirWithControl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl) TransferResult {
+    return transferImpl(allocator, conn, src, dst, control, true);
+}
+
+fn transferImpl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl, recursive: bool) TransferResult {
+    var askpass_path: ?[]const u8 = null;
+    defer if (askpass_path) |p| allocator.free(p);
+    var env_map: ?std.process.EnvMap = null;
+    defer if (env_map) |*map| map.deinit();
+
+    if (conn.password_auth) {
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return .spawn_error;
+        env_map = std.process.getEnvMap(allocator) catch return .spawn_error;
+        if (env_map) |*map| {
+            platform_process.putSshAskPassEnv(map, askpass_path.?, conn.password()) catch return .spawn_error;
+        }
+    }
+
+    // Windows OpenSSH's ControlMaster support relies on Unix-domain socket
+    // semantics that fail here with "getsockname failed: Not a socket".
+    // Keep helper SSH/SCP calls independent; the real interactive SSH session
+    // remains untouched.
+    const control_path: ?[]const u8 = null;
+
+    const env_ptr: ?*std.process.EnvMap = if (env_map) |*map| map else null;
+    const default_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, false, recursive, control);
+    if (default_result == .ok or default_result == .spawn_error or default_result == .cancelled) return default_result;
+
+    std.debug.print("SCP default mode failed; retrying legacy scp protocol (-O)\n", .{});
+    const legacy_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, true, recursive, control);
+    if (legacy_result == .ok or legacy_result == .spawn_error or legacy_result == .cancelled) return legacy_result;
+
+    // The ssh `cat` stream fallback only handles single files; directories have
+    // no further fallback after both scp modes fail.
+    if (recursive) return legacy_result;
+
+    std.debug.print("SCP legacy mode failed; retrying over ssh stream\n", .{});
+    return runSshStreamTransfer(allocator, conn, src, dst, control_path, env_ptr, control);
+}
+```
+
+- [ ] **Step 6: Run the full fast suite to verify it compiles and passes**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: all tests pass (the new test + existing scp tests). No remaining `runScpTransfer` call-site errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/scp.zig
+git commit -m "feat(scp): add recursive transferDirWithControl (scp -r)"
+```
+
+---
+
+## Task 2: File explorer — directory download + folder upload
+
+**Files:**
+- Modify: `src/file_explorer.zig` (`downloadSelected` ~1561-1584, `uploadFile` ~1586-1599)
+- Test: `src/file_explorer.zig` (tests section)
+
+- [ ] **Step 1: Write the failing test**
+
+Add near the other file_explorer transfer tests (e.g. after `test "file_explorer: download helper starts transfer with explicit remote path"`):
+
+```zig
+test "file_explorer: download picks recursive transfer for directories" {
+    try std.testing.expectEqual(
+        @as(TransferFn, scp.transferDirWithControl),
+        pickDownloadTransferFn(true),
+    );
+    try std.testing.expectEqual(
+        @as(TransferFn, scp.transferWithControl),
+        pickDownloadTransferFn(false),
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: compile error — `pickDownloadTransferFn` is not defined.
+
+- [ ] **Step 3: Add `pickDownloadTransferFn` and use it in `downloadSelected`; add `uploadFolder`**
+
+In `src/file_explorer.zig`, add the helper just above `pub fn downloadSelected`:
+
+```zig
+/// Choose the transfer function for a download based on whether the selected
+/// entry is a directory (recursive `scp -r`) or a regular file.
+fn pickDownloadTransferFn(is_dir: bool) TransferFn {
+    return if (is_dir) scp.transferDirWithControl else scp.transferWithControl;
+}
+```
+
+Then change `downloadSelected` — remove the directory skip and select the transfer function. Replace:
+
+```zig
+    const entry = &g_entries[sel];
+    if (entry.is_dir) return; // Only download files
+
+    const remote_path = entry.path_buf[0..entry.path_len];
+
+    // Build remote spec: user@host:path
+    var spec_buf: [512]u8 = undefined;
+    const src = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_path);
+
+    var dst_buf: [512]u8 = undefined;
+    const name = entry.name_buf[0..entry.name_len];
+    const dst = platform_local_path.joinInto(dst_buf[0..], local_dir, name) orelse {
+        setTransferStatusForKind(.download, .failed, "Path too long");
+        return;
+    };
+
+    _ = startTransferJob(.download, &g_ssh_conn, src, dst, name, scp.transferWithControl);
+```
+
+with:
+
+```zig
+    const entry = &g_entries[sel];
+
+    const remote_path = entry.path_buf[0..entry.path_len];
+
+    // Build remote spec: user@host:path
+    var spec_buf: [512]u8 = undefined;
+    const src = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_path);
+
+    var dst_buf: [512]u8 = undefined;
+    const name = entry.name_buf[0..entry.name_len];
+    const dst = platform_local_path.joinInto(dst_buf[0..], local_dir, name) orelse {
+        setTransferStatusForKind(.download, .failed, "Path too long");
+        return;
+    };
+
+    _ = startTransferJob(.download, &g_ssh_conn, src, dst, name, pickDownloadTransferFn(entry.is_dir));
+```
+
+Also update the doc comment on `downloadSelected` from `/// Download the selected remote file to a local directory.` to `/// Download the selected remote file or directory to a local directory.`
+
+Then add `uploadFolder` immediately after `uploadFile` (after line ~1599):
+
+```zig
+/// Upload a local folder (recursively) to the current remote directory.
+pub fn uploadFolder(local_path: []const u8) void {
+    if (g_mode != .remote or !g_has_ssh_conn) return;
+
+    // Destination: current remote dir
+    const remote_dir = g_root_path[0..g_root_path_len];
+
+    var spec_buf: [512]u8 = undefined;
+    const dst = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_dir);
+
+    const name = platform_local_path.basename(local_path);
+
+    _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, name, scp.transferDirWithControl);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: the new test passes; existing file_explorer tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/file_explorer.zig
+git commit -m "feat(file-explorer): download directories and add uploadFolder"
+```
+
+---
+
+## Task 3: Cancel deletes the partial download
+
+**Files:**
+- Modify: `src/file_explorer.zig` (`tickTransferJob` `.cancelled` branch ~1104)
+- Test: `src/file_explorer.zig` (extend cancel coverage)
+
+- [ ] **Step 1: Write the failing test**
+
+Add after `test "file_explorer: active download transfer can be cancelled"`:
+
+```zig
+test "file_explorer: cancelling a download deletes the partial destination" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "partial.bin", .data = "incomplete" });
+    const dst = try tmp.dir.realpathAlloc(std.testing.allocator, "partial.bin");
+    defer std.testing.allocator.free(dst);
+
+    var conn: ssh_connection.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "partial.bin", transferWaitForCancelForTest));
+    try std.testing.expect(cancelActiveDownloadForTest());
+
+    tickTransfersUntilIdleForTest();
+
+    try std.testing.expectEqual(TransferStatus.cancelled, g_transfer_status);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("partial.bin", .{}));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: FAIL — the partial file still exists (`access` succeeds, so `expectError` fails), or `removePartialDownload` is undefined if referenced early. It should fail on the `expectError` assertion.
+
+- [ ] **Step 3: Add `removePartialDownload` and call it when a download cancels**
+
+In `src/file_explorer.zig`, add the helper near the other transfer helpers (e.g. just above `pub fn cancelActiveTransfer`):
+
+```zig
+/// Remove a partially-transferred download destination — a half-written file or
+/// an incomplete folder tree. Best-effort: any error (e.g. already gone) is
+/// ignored.
+fn removePartialDownload(path: []const u8) void {
+    if (path.len == 0) return;
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.deleteTreeAbsolute(path) catch {};
+    } else {
+        std.fs.cwd().deleteTree(path) catch {};
+    }
+}
+```
+
+Then update the `.cancelled` arm of the `switch (job.result)` in `tickTransferJob`. Replace:
+
+```zig
+        .cancelled => setTransferStatusForKind(job.request.kind, .cancelled, display),
+```
+
+with:
+
+```zig
+        .cancelled => {
+            if (job.request.kind == .download) {
+                removePartialDownload(job.request.dst_buf[0..job.request.dst_len]);
+            }
+            setTransferStatusForKind(job.request.kind, .cancelled, display);
+        },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: the new test passes; the existing "active download transfer can be cancelled" test (dst = `"local"`, a non-existent relative path) still passes — `removePartialDownload` no-ops on the missing path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/file_explorer.zig
+git commit -m "feat(file-explorer): delete partial destination when a download is cancelled"
+```
+
+---
+
+## Task 4: Cross-platform `pickFolder` dialog
+
+**Files:**
+- Modify: `src/platform/file_dialog.zig` (re-export + test)
+- Modify: `src/platform/file_dialog_windows.zig`
+- Modify: `src/platform/file_dialog_macos.zig`
+- Modify: `src/platform/services_macos_bridge.m`
+- Modify: `src/platform/file_dialog_linux.zig`
+- Modify: `src/platform/file_dialog_unsupported.zig`
+- Test: `src/platform/file_dialog.zig`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/platform/file_dialog.zig` after the existing `"platform file dialog exposes typed open and save APIs"` test:
+
+```zig
+test "platform file dialog exposes a folder picker" {
+    try std.testing.expectEqual(@as(usize, 2), @typeInfo(@TypeOf(pickFolder)).@"fn".params.len);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".params[0].type.? == std.mem.Allocator);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".params[1].type.? == OpenRequest);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".return_type.? == ?[]u8);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full 2>&1 | tail -30`
+Expected: compile error — `pickFolder` is not defined in `file_dialog.zig` (and the backends).
+
+- [ ] **Step 3: Re-export `pickFolder` from the dispatcher**
+
+In `src/platform/file_dialog.zig`, add after `pub const saveFile = impl.saveFile;`:
+
+```zig
+pub const pickFolder = impl.pickFolder;
+```
+
+- [ ] **Step 4: Implement the unsupported backend**
+
+In `src/platform/file_dialog_unsupported.zig`, add after `saveFile`:
+
+```zig
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    _ = allocator;
+    _ = request;
+    return null;
+}
+```
+
+- [ ] **Step 5: Implement the Linux backend (zenity --directory)**
+
+In `src/platform/file_dialog_linux.zig`, add after `openFile`:
+
+```zig
+/// Open a folder-chooser dialog via zenity and return the selected directory,
+/// or null if the user cancelled or zenity is unavailable.
+/// The returned slice is allocated with `allocator`; caller must free it.
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    argv.append(a, "zenity") catch return null;
+    argv.append(a, "--file-selection") catch return null;
+    argv.append(a, "--directory") catch return null;
+    argv.append(a, "--title") catch return null;
+    argv.append(a, request.title) catch return null;
+
+    return runZenityDialog(allocator, a, argv.items);
+}
+```
+
+- [ ] **Step 6: Implement the macOS backend**
+
+In `src/platform/services_macos_bridge.m`, add right after `wispterm_macos_open_file_dialog` (after its closing `}`):
+
+```objc
+char *wispterm_macos_pick_folder_dialog(const char *title) {
+    @autoreleasepool {
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
+        panel.canChooseFiles = NO;
+        panel.canChooseDirectories = YES;
+        panel.allowsMultipleSelection = NO;
+        if (title != NULL) panel.title = [NSString stringWithUTF8String:title];
+        if ([panel runModal] != NSModalResponseOK) return NULL;
+        return wispterm_macos_copy_nsstring(panel.URL.path);
+    }
+}
+```
+
+In `src/platform/file_dialog_macos.zig`, add the extern next to the others (after the `wispterm_macos_save_file_dialog` extern):
+
+```zig
+extern fn wispterm_macos_pick_folder_dialog(title: [*:0]const u8) ?[*:0]u8;
+```
+
+and the wrapper after `openFile`:
+
+```zig
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    _ = request.owner;
+    _ = request.filters;
+    const title = allocator.dupeZ(u8, request.title) catch return null;
+    defer allocator.free(title);
+    const raw = wispterm_macos_pick_folder_dialog(title.ptr) orelse return null;
+    defer wispterm_macos_services_free(raw);
+    return allocator.dupe(u8, std.mem.span(raw)) catch null;
+}
+```
+
+- [ ] **Step 7: Implement the Windows backend (SHBrowseForFolderW)**
+
+In `src/platform/file_dialog_windows.zig`, add these extern declarations and constants after the existing `extern "comdlg32"` lines (after line ~37):
+
+```zig
+const BIF_RETURNONLYFSDIRS: windows.UINT = 0x00000001;
+const BIF_EDITBOX: windows.UINT = 0x00000010;
+const BIF_NEWDIALOGSTYLE: windows.UINT = 0x00000040;
+const COINIT_APARTMENTTHREADED: windows.DWORD = 0x2;
+
+const BROWSEINFOW = extern struct {
+    hwndOwner: ?windows.HWND = null,
+    pidlRoot: ?*anyopaque = null,
+    pszDisplayName: ?[*]windows.WCHAR = null,
+    lpszTitle: ?[*:0]const windows.WCHAR = null,
+    ulFlags: windows.UINT = 0,
+    lpfn: ?*const anyopaque = null,
+    lParam: windows.LPARAM = 0,
+    iImage: c_int = 0,
+};
+
+extern "shell32" fn SHBrowseForFolderW(lpbi: *BROWSEINFOW) callconv(.winapi) ?*anyopaque;
+extern "shell32" fn SHGetPathFromIDListW(pidl: ?*anyopaque, pszPath: [*]windows.WCHAR) callconv(.winapi) windows.BOOL;
+extern "ole32" fn CoTaskMemFree(pv: ?*anyopaque) callconv(.winapi) void;
+extern "ole32" fn CoInitializeEx(pvReserved: ?*anyopaque, dwCoInit: windows.DWORD) callconv(.winapi) windows.HRESULT;
+extern "ole32" fn CoUninitialize() callconv(.winapi) void;
+```
+
+Add the public `pickFolder` after `saveFile` (after line ~79):
+
+```zig
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    return switch (builtin.os.tag) {
+        .windows => pickWindowsFolder(allocator, request),
+        else => null,
+    };
+}
+```
+
+Add the implementation near `openWindowsFile`:
+
+```zig
+fn pickWindowsFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    const title_w = std.unicode.utf8ToUtf16LeAllocZ(allocator, request.title) catch return null;
+    defer allocator.free(title_w);
+
+    // BIF_NEWDIALOGSTYLE needs an apartment-threaded COM context. Initialize it
+    // here; tolerate "already initialized" (S_FALSE) and a pre-existing
+    // different mode (RPC_E_CHANGED_MODE) by only uninitializing when we
+    // actually acquired a reference.
+    const hr = CoInitializeEx(null, COINIT_APARTMENTTHREADED);
+    const we_initialized = (hr == 0) or (hr == 1); // S_OK or S_FALSE
+    defer if (we_initialized) CoUninitialize();
+
+    var display_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
+    var bi: BROWSEINFOW = .{
+        .hwndOwner = ownerHwnd(request.owner),
+        .pszDisplayName = &display_buf,
+        .lpszTitle = title_w.ptr,
+        .ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE | BIF_EDITBOX,
+    };
+
+    const pidl = SHBrowseForFolderW(&bi) orelse return null;
+    defer CoTaskMemFree(pidl);
+
+    var path_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
+    if (SHGetPathFromIDListW(pidl, &path_buf) == 0) return null;
+    return pathFromWindowsBuffer(allocator, path_buf[0..]);
+}
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `zig build test-full 2>&1 | tail -30`
+Expected: the signature test passes and the whole suite compiles (default target windows-gnu builds `file_dialog_windows.zig`).
+
+- [ ] **Step 9: Verify the macOS backend compiles for an Apple target**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | tail -30`
+Expected: compiles past the dialog backends. If the cross-SDK is unavailable on this host and it fails for an unrelated SDK/linker reason (not in `file_dialog_macos.zig`/`services_macos_bridge.m`), note it and rely on the macOS CI build. Do not let an SDK-availability failure block the task.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/platform/file_dialog.zig src/platform/file_dialog_windows.zig src/platform/file_dialog_macos.zig src/platform/services_macos_bridge.m src/platform/file_dialog_linux.zig src/platform/file_dialog_unsupported.zig
+git commit -m "feat(file-dialog): add cross-platform pickFolder"
+```
+
+---
+
+## Task 5: Wire `Shift+U` to folder upload
+
+**Files:**
+- Modify: `src/input.zig` (`0x55` handler ~2492-2500, helpers near `openFileDialogAndUpload` ~2550-2565)
+
+- [ ] **Step 1: Replace the `0x55` ('U') key handler**
+
+In `src/input.zig`, replace:
+
+```zig
+        0x55 => { // 'U' key = upload local file to remote
+            if (!ev.ctrl and !ev.alt and !ev.shift and !ev.super) {
+                if (file_explorer.g_mode == .remote) {
+                    openFileDialogAndUpload();
+                    return true;
+                }
+            }
+            return false;
+        },
+```
+
+with:
+
+```zig
+        0x55 => { // 'U' = upload file; Shift+U = upload folder
+            if (file_explorer.g_mode == .remote and !ev.ctrl and !ev.alt and !ev.super) {
+                if (ev.shift) {
+                    openFolderDialogAndUpload();
+                } else {
+                    openFileDialogAndUpload();
+                }
+                return true;
+            }
+            return false;
+        },
+```
+
+- [ ] **Step 2: Add `openFolderDialogAndUpload` next to `openFileDialogAndUpload`**
+
+In `src/input.zig`, add immediately after the `openFileDialogAndUpload` function (after line ~2565):
+
+```zig
+fn openFolderDialogAndUpload() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    const filters = [_]platform_file_dialog.Filter{.{ .name = "All Files", .pattern = "*.*" }};
+    const owner: platform_file_dialog.Owner = if (AppWindow.currentNativeHandleBits()) |handle_bits|
+        platform_file_dialog.windowOwner(handle_bits)
+    else
+        .{};
+    const path = platform_file_dialog.pickFolder(allocator, .{
+        .owner = owner,
+        .title = "Upload folder to remote",
+        .filters = &filters,
+    }) orelse return;
+    defer allocator.free(path);
+
+    file_explorer.uploadFolder(path);
+}
+```
+
+- [ ] **Step 3: Verify it compiles (debug build)**
+
+Run: `zig build 2>&1 | tail -20`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/input.zig
+git commit -m "feat(input): Shift+U uploads a folder to the remote"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the fast suite**
+
+Run: `zig build test 2>&1 | tail -20`
+Expected: PASS (all fast tests, including the new scp `-r`, download-fn-selection, and cancel-cleanup tests).
+
+- [ ] **Step 2: Run the full suite (default windows-gnu target)**
+
+Run: `zig build test-full 2>&1 | tail -30`
+Expected: PASS (includes the `pickFolder` signature test; cross-compiles the Windows `SHBrowseForFolderW` backend).
+
+- [ ] **Step 3: Debug build**
+
+Run: `zig build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Manual GUI verification (record results; do not block on environments you cannot run)**
+
+In a real GUI build, with an SSH remote open in the file explorer:
+- Select a remote **directory**, press **Ctrl/Cmd+S** → it downloads recursively into Downloads; toast shows progress; the folder appears with its contents.
+- Press **Shift+U** → folder picker opens; choose a local folder → it uploads recursively into the current remote dir; the remote listing refreshes to show it.
+- Start a large folder **download**, click the transfer toast → confirm → it cancels and the partial `Downloads/<name>` folder is removed.
+- Existing single-**file** download (Ctrl/Cmd+S on a file) and upload (**U**) still work unchanged.
+
+- [ ] **Step 5: Final commit (if any verification fixes were needed)**
+
+```bash
+git add -A
+git commit -m "test: verify directory download/upload + cancel"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage:** scp `-r` (Task 1) · directory download (Task 2) · folder upload + `Shift+U` (Tasks 2, 5) · folder picker on all 4 backends (Task 4) · cancel + partial cleanup (Task 3) · folder progress = graceful "calculating…" with no code change (covered by inaction; noted in spec). Toast wording reuses existing generic verbs (no change needed).
+- **Type consistency:** `transferDirWithControl`/`transferWithControl` share the `TransferFn` signature `(Allocator, *const SshConnection, []const u8, []const u8, *TransferControl) TransferResult`. `pickDownloadTransferFn(bool) TransferFn`. `pickFolder(Allocator, OpenRequest) ?[]u8` matches `openFile` across all backends.
+- **Uploads remain non-cancelable** (out of scope; `cancelActiveTransfer` keeps its `kind != .download` guard). Folder downloads are cancelable through the unchanged job system.

--- a/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
+++ b/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
@@ -1,0 +1,179 @@
+# Directory download/upload + cancelable downloads — Design
+
+Date: 2026-06-10
+Status: Approved (design)
+
+## Goal
+
+Extend the existing remote SSH file-transfer feature so it can also transfer
+**directories** (recursive download and upload), and ensure **download tasks
+remain cancelable** — including the new folder downloads.
+
+This builds directly on the shipped single-file transfer system
+(`2026-05-19-ssh-file-transfer-design.md`). It reuses the existing transfer-job
+queue, worker thread, progress toast, and cancel-confirm overlay; directories
+flow through the same machinery.
+
+## Background — what exists today
+
+- `src/scp.zig`
+  - `transferWithControl(allocator, conn, src, dst, control)` runs
+    `scp -q` → `scp -q -O` (legacy protocol) → `ssh cat` stream fallback.
+  - `scp` already supports `-r` for recursion; it is simply never passed today.
+  - The `ssh cat` stream fallback only handles single files.
+  - `TransferControl` cancels by killing the registered child process.
+- `src/file_explorer.zig`
+  - Single active `TransferJob` + a queue; `transfer_fn: TransferFn` is stored
+    per request, so the job system is agnostic to which transfer function runs.
+  - `downloadSelected(local_dir)` downloads the selected remote file and
+    **explicitly skips directories** (`if (entry.is_dir) return; // Only download files`).
+  - `uploadFile(local_path)` uploads one local file to the current remote dir.
+  - `cancelActiveTransfer()` cancels the active job **only when it is a download**;
+    it returns `false` for uploads. It already kills the scp child via
+    `TransferControl.cancel()`.
+  - Progress for downloads is derived from the destination *file* size
+    (`observedTransferBytes` → `localFileSize`).
+- `src/input.zig`
+  - `Ctrl/Cmd+S` → `downloadSelected(Downloads)`.
+  - `U` → `openFileDialogAndUpload()` (single-**file** picker only).
+  - Cancel UX: click the transfer toast → `transferCancelConfirmOpen()` →
+    confirm → `cancelActiveTransfer()`.
+- `src/platform/file_dialog*.zig`
+  - `openFile` / `saveFile` per backend (Windows `GetOpenFileNameW`, macOS
+    `NSOpenPanel` via ObjC bridge, Linux `zenity`). **No folder picker exists.**
+- `TransferKind = enum { upload, download }` and the toast verbs already map
+  both kinds across in_progress/success/failed/cancelled states.
+
+## Decisions (confirmed with user)
+
+1. **Folder transfer backend: `scp -r` only.** Add `-r` to the existing scp and
+   scp `-O` attempts; skip the `cat`-stream fallback for directories (it cannot
+   transfer dirs). No tar-over-ssh fallback.
+2. **Folder upload trigger: `Shift+U`.** Keep `U` = upload file. `Shift+U` opens
+   a folder picker and uploads the chosen directory recursively. Mirrors the
+   existing `N` / `Shift+N` (new file / new dir) convention.
+3. **Cancel cleanup: delete the partial.** When a download is cancelled, remove
+   the partially-transferred destination (half file, or incomplete folder tree
+   under `Downloads/<name>`). The dst is always a fresh path, so deletion is safe.
+
+## Design
+
+### 1. SCP backend — `src/scp.zig`
+
+Refactor the body of `transferWithControl` into a shared internal
+`transferImpl(allocator, conn, src, dst, control, recursive: bool)`:
+
+- `runScpTransfer(..., recursive: bool)` inserts `-r` into argv immediately
+  after `-q` when `recursive` is true.
+- `recursive == false` → **unchanged** behavior: scp → scp `-O` → `ssh cat`
+  stream fallback.
+- `recursive == true` → scp → scp `-O`; if both fail, return the failure. **No**
+  `cat` fallback (cat cannot transfer directories).
+
+Public API:
+
+- `transferWithControl(...)` stays as the file path (`recursive = false`), with
+  its exact current signature and behavior — every existing caller (clipboard
+  paste, agent file copy, single-file up/download) is untouched.
+- New `transferDirWithControl(...)` = `transferImpl(..., recursive = true)`.
+
+Both match the existing `TransferFn` signature, so they drop straight into the
+file_explorer job system without any queue/struct changes.
+
+To keep the `-r` placement unit-testable, extract a small pure helper that
+builds the scp argv (or, minimally, a helper that reports whether `-r` is
+included for a given `recursive` flag) so the fast suite can assert it.
+
+### 2. Transfer jobs — `src/file_explorer.zig`
+
+- **`downloadSelected`**: remove the `if (entry.is_dir) return;` guard. Select
+  the transfer function by entry type:
+  - `entry.is_dir` → `scp.transferDirWithControl`
+  - file → `scp.transferWithControl`
+
+  `dst = Downloads/<name>` for both. For a fresh download, `Downloads/<name>`
+  does not exist, so `scp -r remote:dir Downloads/dir` creates the folder with
+  the remote dir's contents.
+
+- **New `uploadFolder(local_path)`**: mirrors `uploadFile` but passes
+  `scp.transferDirWithControl`. dst = `scp.remoteSpec(current remote dir)`.
+  `scp -r localdir user@host:/remotedir` nests the folder into the remote dir,
+  matching file-upload behavior.
+
+- **Cancel cleanup (downloads only)**: in `tickTransferJob`, the safe cleanup
+  point is the post-join `.cancelled` branch of the `switch (job.result)` (the
+  worker thread has been joined there, so no race with scp still writing). When
+  the cancelled job is a download, delete the partial destination:
+  - `removePartialDownload(dst)` calls `std.fs.deleteTreeAbsolute(dst)` (or the
+    cwd-relative variant) — `deleteTree` removes a file or a directory tree, so
+    it covers both. Best-effort: ignore errors.
+  - The early `cancelRequested()` branch in `tickTransferJob` continues to set
+    the `.cancelled` toast immediately for UX feedback but does **not** delete
+    (worker may still be running); cleanup waits for the real completion.
+  - Uploads remain non-cancelable (out of scope; dst is remote-side).
+
+- **Folder download progress**: extend `observedTransferBytes` so that when the
+  download dst is a directory, it returns the recursive byte size of that tree
+  (best-effort walk; on error return null → toast shows "calculating…"). This
+  keeps the speed readout meaningful for folder downloads. File downloads keep
+  using `localFileSize` unchanged.
+
+### 3. Folder picker — `src/platform/file_dialog*.zig`
+
+Add `pickFolder(allocator, request: OpenRequest) ?[]u8` to the dispatcher and
+all four backends (reuse the existing `OpenRequest`/`Owner` types):
+
+- **Windows** (`file_dialog_windows.zig`): `SHBrowseForFolderW` (shell32) +
+  `SHGetPathFromIDListW` → UTF-8 path. `GetOpenFileNameW` cannot pick folders;
+  `SHBrowseForFolder` is a single shell call and fits the existing extern style.
+- **macOS** (`file_dialog_macos.zig` + `services_macos_bridge.m`): new extern
+  `wispterm_macos_pick_folder_dialog(title)` driving `NSOpenPanel` with
+  `canChooseDirectories = YES`, `canChooseFiles = NO`.
+- **Linux** (`file_dialog_linux.zig`): `zenity --file-selection --directory`.
+- **unsupported** (`file_dialog_unsupported.zig`): returns null.
+
+### 4. Input wiring — `src/input.zig`
+
+- In the `0x55` ('U') handler:
+  - bare `U` (no modifiers) → `openFileDialogAndUpload()` (unchanged).
+  - `Shift+U` (remote mode) → new `openFolderDialogAndUpload()`:
+    `pickFolder` → `file_explorer.uploadFolder(path)`.
+- `Ctrl/Cmd+S` trigger unchanged; it now downloads a selected folder because
+  `downloadSelected` handles directories.
+
+### 5. Toast wording — `src/i18n.zig`
+
+No new states. The existing download/upload toast verbs
+(`tt_downloading`/`tt_uploaded`/`tt_*_interrupted`/…) cover folder transfers
+generically; the folder's name flows through as the toast display string.
+
+## Error handling
+
+- `scp -r` failure → `.failed` → "Download/Upload failed: \<name\>" toast.
+- Cancel → kills the scp child → `.cancelled` toast + partial destination
+  deleted (downloads).
+- Folder picker cancelled / unavailable → no-op (matches `openFile` behavior).
+- Re-downloading an existing folder nests per `scp -r` semantics (same class of
+  behavior as files being overwritten) — documented, not specially handled.
+
+## Testing (TDD; fast suite where possible)
+
+- **scp** (`src/scp.zig`): unit-test that the recursive argv includes `-r` and
+  the non-recursive argv does not, via the extracted pure arg helper.
+- **file_explorer** (`src/file_explorer.zig`):
+  - a directory entry no longer early-returns from `downloadSelected` and starts
+    a `.download` job using the dir transfer function;
+  - `uploadFolder` starts an `.upload` job using the dir transfer function;
+  - **cancel deletes the partial dst**: extend the existing
+    `transferWaitForCancelForTest` flow — set a real temp file as dst, cancel,
+    and assert the file is removed after the job completes.
+- **file_dialog** (`src/platform/file_dialog.zig`): `pickFolder` signature test
+  and backend-selection test, matching the existing dialog tests.
+
+## Out of scope / YAGNI
+
+- tar-over-ssh fallback for directories.
+- Cancel support for uploads (remote-side cleanup).
+- A unified file/folder picker prompt for `U`.
+- Right-click context menu entries (transfers stay keybinding-driven).
+- Special handling of folder-name collisions on re-download.

--- a/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
+++ b/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
@@ -112,11 +112,12 @@ included for a given `recursive` flag) so the fast suite can assert it.
     (worker may still be running); cleanup waits for the real completion.
   - Uploads remain non-cancelable (out of scope; dst is remote-side).
 
-- **Folder download progress**: extend `observedTransferBytes` so that when the
-  download dst is a directory, it returns the recursive byte size of that tree
-  (best-effort walk; on error return null → toast shows "calculating…"). This
-  keeps the speed readout meaningful for folder downloads. File downloads keep
-  using `localFileSize` unchanged.
+- **Folder download progress**: no code change needed. `observedTransferBytes`
+  → `localFileSize` opens the dst as a file; for a directory that open fails and
+  returns null, so the toast already falls back to "\<name\> - calculating…".
+  This is intentional — recursively walking the growing tree on every 500 ms
+  tick would be O(n) per tick for large folders, so we accept the indeterminate
+  readout for folders. File downloads keep their byte-rate readout unchanged.
 
 ### 3. Folder picker — `src/platform/file_dialog*.zig`
 
@@ -167,6 +168,12 @@ generically; the folder's name flows through as the toast display string.
   - **cancel deletes the partial dst**: extend the existing
     `transferWaitForCancelForTest` flow — set a real temp file as dst, cancel,
     and assert the file is removed after the job completes.
+
+  Note: `uploadFolder` is a thin convenience wrapper over the already-tested
+  `startTransferJob` plumbing plus the `-r` behavior tested in scp, so it needs
+  no dedicated test (it would otherwise spawn a real `scp`). Input-layer wiring
+  (`Shift+U`) follows the codebase convention of not unit-testing key handlers;
+  it is verified by compile + manual GUI.
 - **file_dialog** (`src/platform/file_dialog.zig`): `pickFolder` signature test
   and backend-selection test, matching the existing dialog tests.
 

--- a/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
+++ b/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
@@ -52,9 +52,15 @@ flow through the same machinery.
 2. **Folder upload trigger: `Shift+U`.** Keep `U` = upload file. `Shift+U` opens
    a folder picker and uploads the chosen directory recursively. Mirrors the
    existing `N` / `Shift+N` (new file / new dir) convention.
-3. **Cancel cleanup: delete the partial.** When a download is cancelled, remove
-   the partially-transferred destination (half file, or incomplete folder tree
-   under `Downloads/<name>`). The dst is always a fresh path, so deletion is safe.
+3. **Cancel cleanup: delete the partial — only if this transfer created it.**
+   When a download is cancelled, remove the partially-transferred destination
+   (half file, or incomplete folder tree under `Downloads/<name>`). The dst is
+   NOT always fresh — `scp -r` nests into an existing same-name directory, and
+   a file dst may be an earlier completed download — so dst existence is
+   snapshotted before scp starts and a pre-existing dst is never deleted.
+   Cleanup runs on the transfer worker thread (before `done` is stored) so a
+   large partial tree never stalls the UI and the next queued transfer cannot
+   race it.
 
 ## Design
 

--- a/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
+++ b/docs/superpowers/specs/2026-06-10-directory-download-upload-design.md
@@ -112,12 +112,15 @@ included for a given `recursive` flag) so the fast suite can assert it.
     (worker may still be running); cleanup waits for the real completion.
   - Uploads remain non-cancelable (out of scope; dst is remote-side).
 
-- **Folder download progress**: no code change needed. `observedTransferBytes`
-  → `localFileSize` opens the dst as a file; for a directory that open fails and
-  returns null, so the toast already falls back to "\<name\> - calculating…".
-  This is intentional — recursively walking the growing tree on every 500 ms
-  tick would be O(n) per tick for large folders, so we accept the indeterminate
-  readout for folders. File downloads keep their byte-rate readout unchanged.
+- **Folder download progress**: `observedTransferBytes` → `localFileSize` returns
+  null when the dst is a directory, so the toast shows "\<name\> - calculating…".
+  `localFileSize` `stat`s the opened dst and returns null for `.directory` (on
+  Windows opening a dir as a file already fails → null; on POSIX the open
+  succeeds and returns the inode size, so the explicit `stat` kind check is
+  required for consistent behavior across platforms). This is intentional —
+  recursively walking the growing tree on every 500 ms tick would be O(n) per
+  tick for large folders, so we accept the indeterminate readout for folders.
+  File downloads keep their byte-rate readout unchanged.
 
 ### 3. Folder picker — `src/platform/file_dialog*.zig`
 

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1937,8 +1937,17 @@ test "file_explorer: active download transfer can be cancelled" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
+    // dst must not be a relative path: cancel cleanup deletes the dst tree,
+    // and a cwd-relative name could collide with a real directory.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+    const dst = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "file.txt" });
+    defer std.testing.allocator.free(dst);
+
     var conn: ssh_connection.SshConnection = .{};
-    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", "local", "file.txt", transferWaitForCancelForTest));
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "file.txt", transferWaitForCancelForTest));
     try std.testing.expect(cancelActiveDownloadForTest());
 
     tickTransfersUntilIdleForTest();

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1558,14 +1558,19 @@ pub fn latestTransferNotification() ?TransferNotification {
     };
 }
 
-/// Download the selected remote file to a local directory.
+/// Choose the transfer function for a download based on whether the selected
+/// entry is a directory (recursive `scp -r`) or a regular file.
+fn pickDownloadTransferFn(is_dir: bool) TransferFn {
+    return if (is_dir) scp.transferDirWithControl else scp.transferWithControl;
+}
+
+/// Download the selected remote file or directory to a local directory.
 pub fn downloadSelected(local_dir: []const u8) void {
     if (g_mode != .remote or !g_has_ssh_conn) return;
     const sel = g_selected orelse return;
     if (sel >= g_entry_count) return;
 
     const entry = &g_entries[sel];
-    if (entry.is_dir) return; // Only download files
 
     const remote_path = entry.path_buf[0..entry.path_len];
 
@@ -1580,7 +1585,7 @@ pub fn downloadSelected(local_dir: []const u8) void {
         return;
     };
 
-    _ = startTransferJob(.download, &g_ssh_conn, src, dst, name, scp.transferWithControl);
+    _ = startTransferJob(.download, &g_ssh_conn, src, dst, name, pickDownloadTransferFn(entry.is_dir));
 }
 
 /// Upload a local file to the current remote directory.
@@ -1596,6 +1601,21 @@ pub fn uploadFile(local_path: []const u8) void {
     const filename = platform_local_path.basename(local_path);
 
     _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, filename, scp.transferWithControl);
+}
+
+/// Upload a local folder (recursively) to the current remote directory.
+pub fn uploadFolder(local_path: []const u8) void {
+    if (g_mode != .remote or !g_has_ssh_conn) return;
+
+    // Destination: current remote dir
+    const remote_dir = g_root_path[0..g_root_path_len];
+
+    var spec_buf: [512]u8 = undefined;
+    const dst = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_dir);
+
+    const name = platform_local_path.basename(local_path);
+
+    _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, name, scp.transferDirWithControl);
 }
 
 pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
@@ -1763,6 +1783,17 @@ test "file_explorer: download helper starts transfer with explicit remote path" 
     try std.testing.expectEqual(TransferStatus.in_progress, g_transfer_status);
     try std.testing.expectEqualStrings("file.txt - calculating...", g_transfer_msg[0..g_transfer_msg_len]);
     try std.testing.expect(g_transfer_job != null);
+}
+
+test "file_explorer: download picks recursive transfer for directories" {
+    try std.testing.expectEqual(
+        @as(TransferFn, scp.transferDirWithControl),
+        pickDownloadTransferFn(true),
+    );
+    try std.testing.expectEqual(
+        @as(TransferFn, scp.transferWithControl),
+        pickDownloadTransferFn(false),
+    );
 }
 
 test "file_explorer: download transfer emits notification" {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1065,13 +1065,23 @@ fn startTransferRequestNow(request: TransferRequest) bool {
 
 fn transferThread(job: *TransferJob) void {
     const allocator = std.heap.page_allocator;
+    const dst = job.request.dst_buf[0..job.request.dst_len];
+    // Snapshot dst existence before scp runs: on cancel only a path this
+    // transfer created may be deleted. A pre-existing dst holds user data
+    // (scp -r nests into an existing same-name directory; a file dst may be
+    // an earlier completed download) and must survive.
+    const cleanup_on_cancel = job.request.kind == .download and !localPathExists(dst);
     job.result = job.request.transfer_fn(
         allocator,
         &job.request.conn,
         job.request.src_buf[0..job.request.src_len],
-        job.request.dst_buf[0..job.request.dst_len],
+        dst,
         &job.control,
     );
+    // Cleanup runs here, on the worker thread, so deleting a large partial
+    // tree never stalls the UI tick; done is stored after, so the next queued
+    // transfer cannot race the deletion.
+    if (job.result == .cancelled and cleanup_on_cancel) removePartialDownload(dst);
     job.done.store(true, .release);
 }
 
@@ -1101,12 +1111,7 @@ fn tickTransferJob() void {
                 rescanRemote();
             }
         },
-        .cancelled => {
-            if (job.request.kind == .download) {
-                removePartialDownload(job.request.dst_buf[0..job.request.dst_len]);
-            }
-            setTransferStatusForKind(job.request.kind, .cancelled, display);
-        },
+        .cancelled => setTransferStatusForKind(job.request.kind, .cancelled, display),
         else => setTransferStatusForKind(job.request.kind, .failed, display),
     }
 }
@@ -1190,6 +1195,16 @@ fn formatTransferRate(buf: []u8, bytes_per_sec: u64) ![]u8 {
     if (speed < mb) return std.fmt.bufPrint(buf, "{d:.1} KB/s", .{speed / kb});
     if (speed < gb) return std.fmt.bufPrint(buf, "{d:.1} MB/s", .{speed / mb});
     return std.fmt.bufPrint(buf, "{d:.1} GB/s", .{speed / gb});
+}
+
+fn localPathExists(path: []const u8) bool {
+    if (path.len == 0) return false;
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.accessAbsolute(path, .{}) catch return false;
+    } else {
+        std.fs.cwd().access(path, .{}) catch return false;
+    }
+    return true;
 }
 
 /// Remove a partially-transferred download destination — a half-written file or
@@ -1873,25 +1888,56 @@ test "file_explorer: active download transfer can be cancelled" {
     try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
 }
 
-test "file_explorer: cancelling a download deletes the partial destination" {
+fn transferCreateDstThenWaitForCancelForTest(allocator: std.mem.Allocator, conn: *const ssh_connection.SshConnection, src: []const u8, dst: []const u8, control: *scp.TransferControl) scp.TransferResult {
+    if (std.fs.createFileAbsolute(dst, .{})) |file| {
+        file.close();
+    } else |_| {}
+    return transferWaitForCancelForTest(allocator, conn, src, dst, control);
+}
+
+test "file_explorer: cancelling a download deletes the partial destination it created" {
     resetTransferStateForTest();
     defer resetTransferStateForTest();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.writeFile(.{ .sub_path = "partial.bin", .data = "incomplete" });
-    const dst = try tmp.dir.realpathAlloc(std.testing.allocator, "partial.bin");
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+    const dst = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "partial.bin" });
     defer std.testing.allocator.free(dst);
 
     var conn: ssh_connection.SshConnection = .{};
-    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "partial.bin", transferWaitForCancelForTest));
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "partial.bin", transferCreateDstThenWaitForCancelForTest));
     try std.testing.expect(cancelActiveDownloadForTest());
 
     tickTransfersUntilIdleForTest();
 
     try std.testing.expectEqual(TransferStatus.cancelled, g_transfer_status);
     try std.testing.expectError(error.FileNotFound, tmp.dir.access("partial.bin", .{}));
+}
+
+test "file_explorer: cancelling a download preserves a pre-existing destination" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "existing.bin", .data = "precious" });
+    const dst = try tmp.dir.realpathAlloc(std.testing.allocator, "existing.bin");
+    defer std.testing.allocator.free(dst);
+
+    var conn: ssh_connection.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "existing.bin", transferWaitForCancelForTest));
+    try std.testing.expect(cancelActiveDownloadForTest());
+
+    tickTransfersUntilIdleForTest();
+
+    try std.testing.expectEqual(TransferStatus.cancelled, g_transfer_status);
+    const contents = try tmp.dir.readFileAlloc(std.testing.allocator, "existing.bin", 64);
+    defer std.testing.allocator.free(contents);
+    try std.testing.expectEqualStrings("precious", contents);
 }
 
 test "buildChildPathInto avoids duplicate separators" {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1101,7 +1101,12 @@ fn tickTransferJob() void {
                 rescanRemote();
             }
         },
-        .cancelled => setTransferStatusForKind(job.request.kind, .cancelled, display),
+        .cancelled => {
+            if (job.request.kind == .download) {
+                removePartialDownload(job.request.dst_buf[0..job.request.dst_len]);
+            }
+            setTransferStatusForKind(job.request.kind, .cancelled, display);
+        },
         else => setTransferStatusForKind(job.request.kind, .failed, display),
     }
 }
@@ -1181,6 +1186,18 @@ fn formatTransferRate(buf: []u8, bytes_per_sec: u64) ![]u8 {
     if (speed < mb) return std.fmt.bufPrint(buf, "{d:.1} KB/s", .{speed / kb});
     if (speed < gb) return std.fmt.bufPrint(buf, "{d:.1} MB/s", .{speed / mb});
     return std.fmt.bufPrint(buf, "{d:.1} GB/s", .{speed / gb});
+}
+
+/// Remove a partially-transferred download destination — a half-written file or
+/// an incomplete folder tree. Best-effort: any error (e.g. already gone) is
+/// ignored.
+fn removePartialDownload(path: []const u8) void {
+    if (path.len == 0) return;
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.deleteTreeAbsolute(path) catch {};
+    } else {
+        std.fs.cwd().deleteTree(path) catch {};
+    }
 }
 
 pub fn cancelActiveTransfer() bool {
@@ -1850,6 +1867,27 @@ test "file_explorer: active download transfer can be cancelled" {
     try std.testing.expectEqual(@as(?*TransferJob, null), g_transfer_job);
     try std.testing.expectEqual(TransferStatus.cancelled, g_transfer_status);
     try std.testing.expectEqualStrings("file.txt", g_transfer_msg[0..g_transfer_msg_len]);
+}
+
+test "file_explorer: cancelling a download deletes the partial destination" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "partial.bin", .data = "incomplete" });
+    const dst = try tmp.dir.realpathAlloc(std.testing.allocator, "partial.bin");
+    defer std.testing.allocator.free(dst);
+
+    var conn: ssh_connection.SshConnection = .{};
+    try std.testing.expect(startTransferJobForTest(.download, &conn, "remote", dst, "partial.bin", transferWaitForCancelForTest));
+    try std.testing.expect(cancelActiveDownloadForTest());
+
+    tickTransfersUntilIdleForTest();
+
+    try std.testing.expectEqual(TransferStatus.cancelled, g_transfer_status);
+    try std.testing.expectError(error.FileNotFound, tmp.dir.access("partial.bin", .{}));
 }
 
 test "buildChildPathInto avoids duplicate separators" {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1165,7 +1165,11 @@ fn localFileSize(path: []const u8) ?u64 {
     else
         std.fs.cwd().openFile(path, .{}) catch return null;
     defer file.close();
-    return file.getEndPos() catch null;
+    const info = file.stat() catch return null;
+    // A directory destination (folder download) has no meaningful byte count;
+    // returning null lets the progress toast show "calculating…".
+    if (info.kind == .directory) return null;
+    return info.size;
 }
 
 fn formatTransferProgressMessage(buf: []u8, display: []const u8, bytes_per_sec: ?u64) ![]u8 {
@@ -2370,4 +2374,18 @@ test "file_explorer: history row text keeps valid utf8 when truncated" {
     try std.testing.expectEqual(@as(usize, 1), g_history_row_count);
     try std.testing.expect(std.unicode.utf8ValidateSlice(g_history_rows[0].title_buf[0..g_history_rows[0].title_len]));
     try std.testing.expect(std.unicode.utf8ValidateSlice(g_history_rows[0].model_buf[0..g_history_rows[0].model_len]));
+}
+
+test "file_explorer: localFileSize returns null for a directory but size for a file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+    try std.testing.expectEqual(@as(?u64, null), localFileSize(dir_path));
+
+    try tmp.dir.writeFile(.{ .sub_path = "f.txt", .data = "hello" });
+    const file_path = try tmp.dir.realpathAlloc(std.testing.allocator, "f.txt");
+    defer std.testing.allocator.free(file_path);
+    try std.testing.expectEqual(@as(?u64, 5), localFileSize(file_path));
 }

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -1600,6 +1600,18 @@ fn pickDownloadTransferFn(is_dir: bool) TransferFn {
     return if (is_dir) scp.transferDirWithControl else scp.transferWithControl;
 }
 
+/// Remote entry names come from `ls -1p` output, where `\` is a legal file
+/// name byte but a path separator on Windows: a hostile remote can smuggle
+/// `..\..\name` to steer the download destination — and the cancel cleanup's
+/// recursive delete — outside the chosen directory. Reject separators and
+/// `..` outright before a local path is built from the name.
+fn isSafeDownloadEntryName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (std.mem.indexOfAny(u8, name, "/\\") != null) return false;
+    if (std.mem.indexOf(u8, name, "..") != null) return false;
+    return true;
+}
+
 /// Download the selected remote file or directory to a local directory.
 pub fn downloadSelected(local_dir: []const u8) void {
     if (g_mode != .remote or !g_has_ssh_conn) return;
@@ -1608,6 +1620,12 @@ pub fn downloadSelected(local_dir: []const u8) void {
 
     const entry = &g_entries[sel];
 
+    const name = entry.name_buf[0..entry.name_len];
+    if (!isSafeDownloadEntryName(name)) {
+        setTransferStatusForKind(.download, .failed, "Unsafe file name");
+        return;
+    }
+
     const remote_path = entry.path_buf[0..entry.path_len];
 
     // Build remote spec: user@host:path
@@ -1615,7 +1633,6 @@ pub fn downloadSelected(local_dir: []const u8) void {
     const src = scp.remoteSpec(&spec_buf, &g_ssh_conn, remote_path);
 
     var dst_buf: [512]u8 = undefined;
-    const name = entry.name_buf[0..entry.name_len];
     const dst = platform_local_path.joinInto(dst_buf[0..], local_dir, name) orelse {
         setTransferStatusForKind(.download, .failed, "Path too long");
         return;
@@ -1830,6 +1847,49 @@ test "file_explorer: download picks recursive transfer for directories" {
         @as(TransferFn, scp.transferWithControl),
         pickDownloadTransferFn(false),
     );
+}
+
+test "file_explorer: isSafeDownloadEntryName rejects separators and dot-dot" {
+    try std.testing.expect(isSafeDownloadEntryName("report.txt"));
+    try std.testing.expect(isSafeDownloadEntryName("data dir"));
+    try std.testing.expect(isSafeDownloadEntryName(".hidden"));
+
+    try std.testing.expect(!isSafeDownloadEntryName(""));
+    try std.testing.expect(!isSafeDownloadEntryName(".."));
+    try std.testing.expect(!isSafeDownloadEntryName("..\\..\\evil"));
+    try std.testing.expect(!isSafeDownloadEntryName("a\\b"));
+    try std.testing.expect(!isSafeDownloadEntryName("a/b"));
+    try std.testing.expect(!isSafeDownloadEntryName("archive..tar"));
+}
+
+test "file_explorer: download refuses remote entry names that can escape the destination dir" {
+    resetTransferStateForTest();
+    defer resetTransferStateForTest();
+    defer {
+        g_mode = .local;
+        g_has_ssh_conn = false;
+        g_ssh_conn = .{};
+        g_entry_count = 0;
+        g_selected = null;
+    }
+
+    g_mode = .remote;
+    g_has_ssh_conn = true;
+    g_ssh_conn = .{};
+    g_selected = 0;
+    g_entry_count = 1;
+    g_entries[0] = .{};
+    const evil_name = "..\\..\\evil";
+    @memcpy(g_entries[0].name_buf[0..evil_name.len], evil_name);
+    g_entries[0].name_len = evil_name.len;
+    const evil_path = "/srv/..\\..\\evil";
+    @memcpy(g_entries[0].path_buf[0..evil_path.len], evil_path);
+    g_entries[0].path_len = evil_path.len;
+
+    downloadSelected("/tmp/wispterm-test-downloads");
+
+    try std.testing.expectEqual(@as(?*TransferJob, null), g_transfer_job);
+    try std.testing.expectEqual(TransferStatus.failed, g_transfer_status);
 }
 
 test "file_explorer: download transfer emits notification" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -2489,12 +2489,14 @@ fn handleFileExplorerKey(ev: platform_input.KeyEvent) bool {
             }
             return false;
         },
-        0x55 => { // 'U' key = upload local file to remote
-            if (!ev.ctrl and !ev.alt and !ev.shift and !ev.super) {
-                if (file_explorer.g_mode == .remote) {
+        0x55 => { // 'U' = upload file; Shift+U = upload folder
+            if (file_explorer.g_mode == .remote and !ev.ctrl and !ev.alt and !ev.super) {
+                if (ev.shift) {
+                    openFolderDialogAndUpload();
+                } else {
                     openFileDialogAndUpload();
-                    return true;
                 }
+                return true;
             }
             return false;
         },
@@ -2562,6 +2564,23 @@ fn openFileDialogAndUpload() void {
     defer allocator.free(path);
 
     file_explorer.uploadFile(path);
+}
+
+fn openFolderDialogAndUpload() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    const filters = [_]platform_file_dialog.Filter{.{ .name = "All Files", .pattern = "*.*" }};
+    const owner: platform_file_dialog.Owner = if (AppWindow.currentNativeHandleBits()) |handle_bits|
+        platform_file_dialog.windowOwner(handle_bits)
+    else
+        .{};
+    const path = platform_file_dialog.pickFolder(allocator, .{
+        .owner = owner,
+        .title = "Upload folder to remote",
+        .filters = &filters,
+    }) orelse return;
+    defer allocator.free(path);
+
+    file_explorer.uploadFolder(path);
 }
 
 fn handleFileExplorerPress(xpos: f64, ypos: f64, ctrl: bool, shift: bool, alt: bool, super: bool) void {

--- a/src/platform/file_dialog.zig
+++ b/src/platform/file_dialog.zig
@@ -32,6 +32,7 @@ pub const SaveRequest = impl.SaveRequest;
 pub const windowOwner = impl.windowOwner;
 pub const openFile = impl.openFile;
 pub const saveFile = impl.saveFile;
+pub const pickFolder = impl.pickFolder;
 
 test "platform file dialog exposes typed open and save APIs" {
     const owner = windowOwner(1234);
@@ -61,6 +62,13 @@ test "platform file dialog exposes typed open and save APIs" {
     try std.testing.expect(@typeInfo(@TypeOf(saveFile)).@"fn".params[0].type.? == std.mem.Allocator);
     try std.testing.expect(@typeInfo(@TypeOf(saveFile)).@"fn".params[1].type.? == SaveRequest);
     try std.testing.expect(@typeInfo(@TypeOf(saveFile)).@"fn".return_type.? == ?[]u8);
+}
+
+test "platform file dialog exposes a folder picker" {
+    try std.testing.expectEqual(@as(usize, 2), @typeInfo(@TypeOf(pickFolder)).@"fn".params.len);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".params[0].type.? == std.mem.Allocator);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".params[1].type.? == OpenRequest);
+    try std.testing.expect(@typeInfo(@TypeOf(pickFolder)).@"fn".return_type.? == ?[]u8);
 }
 
 test "platform file dialog selects backend by target OS" {

--- a/src/platform/file_dialog_linux.zig
+++ b/src/platform/file_dialog_linux.zig
@@ -60,6 +60,24 @@ pub fn openFile(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
     return runZenityDialog(allocator, a, argv.items);
 }
 
+/// Open a folder-chooser dialog via zenity and return the selected directory,
+/// or null if the user cancelled or zenity is unavailable.
+/// The returned slice is allocated with `allocator`; caller must free it.
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    argv.append(a, "zenity") catch return null;
+    argv.append(a, "--file-selection") catch return null;
+    argv.append(a, "--directory") catch return null;
+    argv.append(a, "--title") catch return null;
+    argv.append(a, request.title) catch return null;
+
+    return runZenityDialog(allocator, a, argv.items);
+}
+
 /// Open a save-file dialog via zenity and return the chosen path,
 /// or null if the user cancelled or zenity is unavailable.
 /// The returned slice is allocated with `allocator`; caller must free it.

--- a/src/platform/file_dialog_macos.zig
+++ b/src/platform/file_dialog_macos.zig
@@ -26,6 +26,7 @@ pub const SaveRequest = struct {
 
 extern fn wispterm_macos_open_file_dialog(title: [*:0]const u8) ?[*:0]u8;
 extern fn wispterm_macos_save_file_dialog(title: [*:0]const u8, initial_dir: ?[*:0]const u8, default_filename: ?[*:0]const u8) ?[*:0]u8;
+extern fn wispterm_macos_pick_folder_dialog(title: [*:0]const u8) ?[*:0]u8;
 extern fn wispterm_macos_services_free(ptr: ?*anyopaque) void;
 
 pub fn windowOwner(native_window: usize) Owner {
@@ -38,6 +39,16 @@ pub fn openFile(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
     const title = allocator.dupeZ(u8, request.title) catch return null;
     defer allocator.free(title);
     const raw = wispterm_macos_open_file_dialog(title.ptr) orelse return null;
+    defer wispterm_macos_services_free(raw);
+    return allocator.dupe(u8, std.mem.span(raw)) catch null;
+}
+
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    _ = request.owner;
+    _ = request.filters;
+    const title = allocator.dupeZ(u8, request.title) catch return null;
+    defer allocator.free(title);
+    const raw = wispterm_macos_pick_folder_dialog(title.ptr) orelse return null;
     defer wispterm_macos_services_free(raw);
     return allocator.dupe(u8, std.mem.span(raw)) catch null;
 }

--- a/src/platform/file_dialog_unsupported.zig
+++ b/src/platform/file_dialog_unsupported.zig
@@ -39,3 +39,9 @@ pub fn saveFile(allocator: std.mem.Allocator, request: SaveRequest) ?[]u8 {
     _ = request;
     return null;
 }
+
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    _ = allocator;
+    _ = request;
+    return null;
+}

--- a/src/platform/file_dialog_windows.zig
+++ b/src/platform/file_dialog_windows.zig
@@ -221,7 +221,7 @@ fn pickWindowsFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
     // different mode (RPC_E_CHANGED_MODE) by only uninitializing when we
     // actually acquired a reference.
     const hr = CoInitializeEx(null, COINIT_APARTMENTTHREADED);
-    const we_initialized = (hr == 0) or (hr == 1); // S_OK or S_FALSE
+    const we_initialized = (hr == windows.S_OK) or (hr == windows.S_FALSE);
     defer if (we_initialized) CoUninitialize();
 
     var display_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
@@ -235,7 +235,7 @@ fn pickWindowsFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
     const pidl = SHBrowseForFolderW(&bi) orelse return null;
     defer CoTaskMemFree(pidl);
 
-    var path_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
+    var path_buf: [windows.MAX_PATH]windows.WCHAR = std.mem.zeroes([windows.MAX_PATH]windows.WCHAR);
     if (SHGetPathFromIDListW(pidl, &path_buf) == 0) return null;
     return pathFromWindowsBuffer(allocator, path_buf[0..]);
 }

--- a/src/platform/file_dialog_windows.zig
+++ b/src/platform/file_dialog_windows.zig
@@ -36,6 +36,28 @@ const OPENFILENAMEW = extern struct {
 extern "comdlg32" fn GetOpenFileNameW(lpofn: *OPENFILENAMEW) callconv(.winapi) windows.BOOL;
 extern "comdlg32" fn GetSaveFileNameW(lpofn: *OPENFILENAMEW) callconv(.winapi) windows.BOOL;
 
+const BIF_RETURNONLYFSDIRS: windows.UINT = 0x00000001;
+const BIF_EDITBOX: windows.UINT = 0x00000010;
+const BIF_NEWDIALOGSTYLE: windows.UINT = 0x00000040;
+const COINIT_APARTMENTTHREADED: windows.DWORD = 0x2;
+
+const BROWSEINFOW = extern struct {
+    hwndOwner: ?windows.HWND = null,
+    pidlRoot: ?*anyopaque = null,
+    pszDisplayName: ?[*]windows.WCHAR = null,
+    lpszTitle: ?[*:0]const windows.WCHAR = null,
+    ulFlags: windows.UINT = 0,
+    lpfn: ?*const anyopaque = null,
+    lParam: windows.LPARAM = 0,
+    iImage: c_int = 0,
+};
+
+extern "shell32" fn SHBrowseForFolderW(lpbi: *BROWSEINFOW) callconv(.winapi) ?*anyopaque;
+extern "shell32" fn SHGetPathFromIDListW(pidl: ?*anyopaque, pszPath: [*]windows.WCHAR) callconv(.winapi) windows.BOOL;
+extern "ole32" fn CoTaskMemFree(pv: ?*anyopaque) callconv(.winapi) void;
+extern "ole32" fn CoInitializeEx(pvReserved: ?*anyopaque, dwCoInit: windows.DWORD) callconv(.winapi) windows.LONG;
+extern "ole32" fn CoUninitialize() callconv(.winapi) void;
+
 pub const Owner = struct {
     native_window: ?usize = null,
 };
@@ -74,6 +96,13 @@ pub fn openFile(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
 pub fn saveFile(allocator: std.mem.Allocator, request: SaveRequest) ?[]u8 {
     return switch (builtin.os.tag) {
         .windows => saveWindowsFile(allocator, request),
+        else => null,
+    };
+}
+
+pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    return switch (builtin.os.tag) {
+        .windows => pickWindowsFolder(allocator, request),
         else => null,
     };
 }
@@ -181,6 +210,34 @@ fn appendUtf16ZPart(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(w
     defer allocator.free(value_w);
     try out.appendSlice(allocator, value_w);
     try out.append(allocator, 0);
+}
+
+fn pickWindowsFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
+    const title_w = std.unicode.utf8ToUtf16LeAllocZ(allocator, request.title) catch return null;
+    defer allocator.free(title_w);
+
+    // BIF_NEWDIALOGSTYLE needs an apartment-threaded COM context. Initialize it
+    // here; tolerate "already initialized" (S_FALSE) and a pre-existing
+    // different mode (RPC_E_CHANGED_MODE) by only uninitializing when we
+    // actually acquired a reference.
+    const hr = CoInitializeEx(null, COINIT_APARTMENTTHREADED);
+    const we_initialized = (hr == 0) or (hr == 1); // S_OK or S_FALSE
+    defer if (we_initialized) CoUninitialize();
+
+    var display_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
+    var bi: BROWSEINFOW = .{
+        .hwndOwner = ownerHwnd(request.owner),
+        .pszDisplayName = &display_buf,
+        .lpszTitle = title_w.ptr,
+        .ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE | BIF_EDITBOX,
+    };
+
+    const pidl = SHBrowseForFolderW(&bi) orelse return null;
+    defer CoTaskMemFree(pidl);
+
+    var path_buf: [windows.MAX_PATH]windows.WCHAR = undefined;
+    if (SHGetPathFromIDListW(pidl, &path_buf) == 0) return null;
+    return pathFromWindowsBuffer(allocator, path_buf[0..]);
 }
 
 fn pathFromWindowsBuffer(allocator: std.mem.Allocator, file_buf: []const windows.WCHAR) ?[]u8 {

--- a/src/platform/services_macos_bridge.m
+++ b/src/platform/services_macos_bridge.m
@@ -302,6 +302,18 @@ char *wispterm_macos_open_file_dialog(const char *title) {
     }
 }
 
+char *wispterm_macos_pick_folder_dialog(const char *title) {
+    @autoreleasepool {
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
+        panel.canChooseFiles = NO;
+        panel.canChooseDirectories = YES;
+        panel.allowsMultipleSelection = NO;
+        if (title != NULL) panel.title = [NSString stringWithUTF8String:title];
+        if ([panel runModal] != NSModalResponseOK) return NULL;
+        return wispterm_macos_copy_nsstring(panel.URL.path);
+    }
+}
+
 char *wispterm_macos_save_file_dialog(const char *title, const char *initial_dir, const char *default_filename) {
     @autoreleasepool {
         NSSavePanel *panel = [NSSavePanel savePanel];

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -834,14 +834,15 @@ test "buildScpFlagArgs includes -r only for recursive transfers" {
 
     var argv_buf: [32][]const u8 = undefined;
 
+    // argv_buf is reused, so each build's slice must be asserted before the
+    // next call overwrites it.
     const argc_file = buildScpFlagArgs(&argv_buf, &conn, null, false, false);
     try std.testing.expect(!containsArg(argv_buf[0..argc_file], "-r"));
+    try std.testing.expect(containsArg(argv_buf[0..argc_file], "-q"));
 
     const argc_dir = buildScpFlagArgs(&argv_buf, &conn, null, false, true);
     try std.testing.expect(containsArg(argv_buf[0..argc_dir], "-r"));
-
-    // -q is always present
-    try std.testing.expect(containsArg(argv_buf[0..argc_file], "-q"));
+    try std.testing.expect(containsArg(argv_buf[0..argc_dir], "-q"));
 
     // -O appears for legacy, and combines with -r for recursive+legacy
     const argc_legacy = buildScpFlagArgs(&argv_buf, &conn, null, true, false);

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -839,6 +839,18 @@ test "buildScpFlagArgs includes -r only for recursive transfers" {
 
     const argc_dir = buildScpFlagArgs(&argv_buf, &conn, null, false, true);
     try std.testing.expect(containsArg(argv_buf[0..argc_dir], "-r"));
+
+    // -q is always present
+    try std.testing.expect(containsArg(argv_buf[0..argc_file], "-q"));
+
+    // -O appears for legacy, and combines with -r for recursive+legacy
+    const argc_legacy = buildScpFlagArgs(&argv_buf, &conn, null, true, false);
+    try std.testing.expect(containsArg(argv_buf[0..argc_legacy], "-O"));
+    try std.testing.expect(!containsArg(argv_buf[0..argc_legacy], "-r"));
+
+    const argc_both = buildScpFlagArgs(&argv_buf, &conn, null, true, true);
+    try std.testing.expect(containsArg(argv_buf[0..argc_both], "-r"));
+    try std.testing.expect(containsArg(argv_buf[0..argc_both], "-O"));
 }
 
 test "buildUploadCommand handles target directories" {

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -54,6 +54,31 @@ pub const TransferControl = struct {
     }
 };
 
+/// Build the scp argv up to (but excluding) the src/dst path arguments.
+/// Returns the count of arguments written into `argv_buf`. Pure/testable.
+fn buildScpFlagArgs(
+    argv_buf: *[32][]const u8,
+    conn: *const SshConnection,
+    control_path: ?[]const u8,
+    legacy_protocol: bool,
+    recursive: bool,
+) usize {
+    var argc: usize = 0;
+    argv_buf[argc] = platform_pty_command.scpExecutableName();
+    argc += 1;
+    argv_buf[argc] = "-q";
+    argc += 1;
+    if (recursive) {
+        argv_buf[argc] = "-r";
+        argc += 1;
+    }
+    if (legacy_protocol) {
+        argv_buf[argc] = "-O";
+        argc += 1;
+    }
+    return appendSshOptions(argv_buf, argc, conn, .scp, control_path);
+}
+
 /// Run `scp src dst` with proper SSH auth options from the connection.
 /// `src` and `dst` are scp-style paths (local or user@host:remote).
 pub fn transfer(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8) TransferResult {
@@ -62,6 +87,17 @@ pub fn transfer(allocator: std.mem.Allocator, conn: *const SshConnection, src: [
 }
 
 pub fn transferWithControl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl) TransferResult {
+    return transferImpl(allocator, conn, src, dst, control, false);
+}
+
+/// Recursively transfer a directory with `scp -r`. Falls back through the
+/// legacy scp protocol (`-O`) but NOT the ssh `cat` stream (which cannot
+/// transfer directories).
+pub fn transferDirWithControl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl) TransferResult {
+    return transferImpl(allocator, conn, src, dst, control, true);
+}
+
+fn transferImpl(allocator: std.mem.Allocator, conn: *const SshConnection, src: []const u8, dst: []const u8, control: *TransferControl, recursive: bool) TransferResult {
     var askpass_path: ?[]const u8 = null;
     defer if (askpass_path) |p| allocator.free(p);
     var env_map: ?std.process.EnvMap = null;
@@ -82,12 +118,16 @@ pub fn transferWithControl(allocator: std.mem.Allocator, conn: *const SshConnect
     const control_path: ?[]const u8 = null;
 
     const env_ptr: ?*std.process.EnvMap = if (env_map) |*map| map else null;
-    const default_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, false, control);
+    const default_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, false, recursive, control);
     if (default_result == .ok or default_result == .spawn_error or default_result == .cancelled) return default_result;
 
     std.debug.print("SCP default mode failed; retrying legacy scp protocol (-O)\n", .{});
-    const legacy_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, true, control);
+    const legacy_result = runScpTransfer(allocator, conn, src, dst, control_path, env_ptr, true, recursive, control);
     if (legacy_result == .ok or legacy_result == .spawn_error or legacy_result == .cancelled) return legacy_result;
+
+    // The ssh `cat` stream fallback only handles single files; directories have
+    // no further fallback after both scp modes fail.
+    if (recursive) return legacy_result;
 
     std.debug.print("SCP legacy mode failed; retrying over ssh stream\n", .{});
     return runSshStreamTransfer(allocator, conn, src, dst, control_path, env_ptr, control);
@@ -125,22 +165,13 @@ fn runScpTransfer(
     control_path: ?[]const u8,
     env_map: ?*std.process.EnvMap,
     legacy_protocol: bool,
+    recursive: bool,
     control: *TransferControl,
 ) TransferResult {
     if (control.cancelRequested()) return .cancelled;
 
     var argv_buf: [32][]const u8 = undefined;
-    var argc: usize = 0;
-    argv_buf[argc] = platform_pty_command.scpExecutableName();
-    argc += 1;
-    argv_buf[argc] = "-q";
-    argc += 1;
-    if (legacy_protocol) {
-        argv_buf[argc] = "-O";
-        argc += 1;
-    }
-
-    argc = appendSshOptions(&argv_buf, argc, conn, .scp, control_path);
+    var argc = buildScpFlagArgs(&argv_buf, conn, control_path, legacy_protocol, recursive);
 
     argv_buf[argc] = src;
     argc += 1;
@@ -787,6 +818,27 @@ test "appendShellQuote escapes single quotes" {
     var pos: usize = 0;
     try std.testing.expect(appendShellQuote(&buf, &pos, "/tmp/it's here.png"));
     try std.testing.expectEqualStrings("'/tmp/it'\\''s here.png'", buf[0..pos]);
+}
+
+fn containsArg(args: []const []const u8, needle: []const u8) bool {
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, needle)) return true;
+    }
+    return false;
+}
+
+test "buildScpFlagArgs includes -r only for recursive transfers" {
+    var conn: SshConnection = .{};
+    conn.password_auth = false;
+    conn.port_len = 0;
+
+    var argv_buf: [32][]const u8 = undefined;
+
+    const argc_file = buildScpFlagArgs(&argv_buf, &conn, null, false, false);
+    try std.testing.expect(!containsArg(argv_buf[0..argc_file], "-r"));
+
+    const argc_dir = buildScpFlagArgs(&argv_buf, &conn, null, false, true);
+    try std.testing.expect(containsArg(argv_buf[0..argc_dir], "-r"));
 }
 
 test "buildUploadCommand handles target directories" {


### PR DESCRIPTION
## Summary

Adds **directory (recursive) download and upload** to the remote SSH file explorer, on top of the existing single-file transfer system, and makes **download tasks (including folder downloads) cancelable** with the partial result cleaned up.

- **scp** (`src/scp.zig`): new `transferDirWithControl` (`scp -r`) sharing the existing `TransferFn` signature via a shared `transferImpl(..., recursive)`; the recursive path skips the file-only `ssh cat` stream fallback. The non-recursive `transferWithControl` is behavior-identical, so clipboard paste / agent file copy / single-file transfers are unaffected.
- **file_explorer** (`src/file_explorer.zig`): `Ctrl/Cmd+S` now downloads a selected directory (via `pickDownloadTransferFn`); new `uploadFolder`; cancelling a download deletes the partial destination (`removePartialDownload`, post-join + downloads-only, so it can never touch an upload's remote spec); folder-download progress shows "calculating…" consistently across platforms.
- **file_dialog** (`src/platform/file_dialog*.zig`, `services_macos_bridge.m`): cross-platform `pickFolder` — Windows `SHBrowseForFolderW`, macOS `NSOpenPanel` (dirs only), Linux `zenity --directory`, unsupported = null.
- **input** (`src/input.zig`): `Shift+U` uploads a folder; bare `U` still uploads a file.

Design + plan: `docs/superpowers/specs/2026-06-10-directory-download-upload-design.md`, `docs/superpowers/plans/2026-06-10-directory-download-upload.md`.

## Test Plan

- [x] `zig build test` (fast suite) — green
- [x] `zig build test-full` (full suite, windows-gnu cross-compile incl. the `SHBrowseForFolderW` backend) — green
- [x] `zig build` (debug) — clean
- [x] New unit tests: scp `-r` flag gating, download transfer-fn selection, cancel-deletes-partial-dst, `pickFolder` signature, `localFileSize` returns null for a directory
- [x] **Manual GUI (pending — needs real Windows/macOS):**
  - Select a remote directory → `Ctrl/Cmd+S` downloads it recursively into Downloads
  - `Shift+U` → folder picker → uploads the chosen directory recursively
  - Cancel a large folder download via the transfer toast → confirms, cancels, and removes the partial `Downloads/<name>` tree
  - Existing single-file download (`Ctrl/Cmd+S` on a file) and upload (`U`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)