### PR TITLE
fix(agent): unlatch ssh/wsl exec busy guard once the shell shows a ready prompt

### DIFF
--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -1539,11 +1539,12 @@ fn promptReturned(snapshot: []const u8, captured_prompt: []const u8) bool {
 
 const AGENT_START_PREFIX = "__WISPTERM_AGENT_START_";
 
-/// Whether the surface's most recent agent command is still running: find the
-/// last START marker, read its nonce, and report true if no completed END
-/// (`__WISPTERM_AGENT_END_<nonce>__:<digit>`) appears after it. If the start has
-/// scrolled out of the snapshot we report false (idle) — an acceptable
-/// false-negative; a stale false-positive self-heals via <ctrl-c> + retry.
+/// Whether the snapshot's most recent agent command never reported completion:
+/// find the last START marker, read its nonce, and report true if no completed
+/// END (`__WISPTERM_AGENT_END_<nonce>__:<digit>`) appears after it. If the
+/// start has scrolled out of the snapshot we report false (idle) — an
+/// acceptable false-negative. Marker scan only; see agentCommandStillRunning
+/// for the actual busy-guard predicate.
 fn hasPendingAgentCommand(snapshot: []const u8) bool {
     const last_start = std.mem.lastIndexOf(u8, snapshot, AGENT_START_PREFIX) orelse return false;
     const nonce_start = last_start + AGENT_START_PREFIX.len;
@@ -1555,6 +1556,19 @@ fn hasPendingAgentCommand(snapshot: []const u8) bool {
     var buf: [64]u8 = undefined;
     const end_marker = std.fmt.bufPrint(&buf, "__WISPTERM_AGENT_END_{s}__", .{nonce}) catch return false;
     return findCompletedEnd(snapshot[last_start..], end_marker) == null;
+}
+
+/// Busy-guard predicate for injecting a new wrapped command. A pending START
+/// without a completed END only means "still running" while the terminal has
+/// not returned to a ready prompt. An interrupted command (<ctrl-c>) never
+/// prints its END marker, so the marker scan alone would latch the guard on
+/// until the stale START scrolls out of the snapshot window — refusing every
+/// new command on this surface even though the shell sits idle. A trailing
+/// ready prompt overrides the markers: a foreground command cannot still be
+/// running while the shell is showing its prompt.
+fn agentCommandStillRunning(snapshot: []const u8) bool {
+    if (!hasPendingAgentCommand(snapshot)) return false;
+    return !looksLikeReadyPrompt(extractPromptLine(snapshot));
 }
 
 fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []const u8, command: []const u8, timeout_ms: u32) ![]u8 {
@@ -1590,7 +1604,7 @@ fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []c
     // authoritative; the cached surface snapshot may be stale.
     if (host.surfaceSnapshot(host.ctx, ctx.allocator, surface.ptr) catch null) |guard_snapshot| {
         defer ctx.allocator.free(guard_snapshot);
-        if (hasPendingAgentCommand(guard_snapshot)) {
+        if (agentCommandStillRunning(guard_snapshot)) {
             return std.fmt.allocPrint(ctx.allocator, "A previous command is still running in this {s} terminal. Do not start another command. Wait and re-check with terminal_snapshot, or interrupt it first with terminal_repl_exec repl=plain code=<ctrl-c>.", .{kind.label()});
         }
     }
@@ -3212,6 +3226,32 @@ test "agent exec detects a still-pending previous command" {
 
     // No agent markers at all -> not pending.
     try std.testing.expect(!hasPendingAgentCommand("(base) u@h:~$ "));
+}
+
+test "agent exec busy guard clears at a ready prompt after an interrupt" {
+    // A wrapped command was interrupted with <ctrl-c>: its END marker never
+    // printed, so the stale START stays in scrollback. The shell is back at a
+    // ready prompt, so nothing is running in the foreground — the guard must
+    // let the next command through instead of latching on forever.
+    const interrupted =
+        "__WISPTERM_AGENT_START_444__\n" ++
+        "Cloning into 'x'...\n" ++
+        "^C\n" ++
+        "(base) root@guozi-server02:~# ";
+    try std.testing.expect(hasPendingAgentCommand(interrupted));
+    try std.testing.expect(!agentCommandStillRunning(interrupted));
+
+    // Still streaming output, no trailing prompt -> still running, keep refusing.
+    const running = "__WISPTERM_AGENT_START_444__\nCloning into 'x'...\n";
+    try std.testing.expect(agentCommandStillRunning(running));
+
+    // Running silently: the last line is the START marker itself, not a prompt.
+    const silent = "(base) u@h:~$  printf ...\n__WISPTERM_AGENT_START_444__\n";
+    try std.testing.expect(agentCommandStillRunning(silent));
+
+    // Completed normally -> not running regardless of the prompt heuristic.
+    const done = "__WISPTERM_AGENT_START_444__\nhi\n__WISPTERM_AGENT_END_444__:0\n$ ";
+    try std.testing.expect(!agentCommandStillRunning(done));
 }
 
 test "agent exec timeout message says still running, do not re-issue" {


### PR DESCRIPTION
## Problem

Copilot's `ssh_session_exec` / `wsl_session_exec` "often never sends the command": the terminal prompt stays empty, the model keeps sending `<ctrl-c>` and retrying, and nothing ever gets typed (user report with screenshot, GLM-5.1 + SSH session).

## Root cause

The busy guard in `unixSessionExecTool` refused to type a new command whenever the snapshot (live screen + 400 history rows) contained a `__WISPTERM_AGENT_START_` marker with no completed `__WISPTERM_AGENT_END_<nonce>__:<digit>` after it. But an **interrupted command never prints its END marker** — and `<ctrl-c>` is exactly the recovery that both the refusal message and the timeout message tell the model to use. One slow command (over the 60s default timeout) + one interrupt latched the guard on permanently:

1. wrapped command times out → tool says "still running… interrupt with ctrl-c"
2. model sends ctrl-c → command dies, no END marker ever printed
3. every subsequent exec is refused **before any byte is written** (prompt stays empty)
4. refusal message again advises ctrl-c → model loops ctrl-c → retry → refused…

The stale START only clears after ~400 rows of new output scroll it away — which can't happen, because no command can run. The old comment claimed a stale false-positive "self-heals via ctrl-c + retry"; in reality ctrl-c is what creates the permanent false-positive.

## Fix

New guard predicate `agentCommandStillRunning`: a pending START only means "still running" while the terminal has **not** returned to a ready prompt (reuses the existing `looksLikeReadyPrompt` / `extractPromptLine` heuristic from the REPL path). A foreground command cannot still be running while the shell is showing its prompt. After an interrupt the prompt is back, so the advertised ctrl-c + retry recovery now actually works.

## Testing

- TDD: new test `agent exec busy guard clears at a ready prompt after an interrupt` covering interrupted-then-prompt (unlatch), still-streaming output (keep refusing), silently-running (tail is the START marker line → keep refusing), and completed-normally.
- `zig build test-full`: 1528 passed, 6 skipped (pre-existing platform gates)
- `zig build test`: 988 passed, 1 skipped

Known residual: `looksLikeReadyPrompt` does not recognize zsh `%` prompts (deliberately left out — short progress lines like `100%` would false-positive), so a default-zsh remote could still latch; bash `$`/`#` prompts are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)