### PR TITLE
fix(port-forward): address PR #191 review follow-ups

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1310,8 +1310,8 @@ pub fn portForwardingFormMove(delta: isize) bool {
     return true;
 }
 
-/// Adjust the focused selector field by `delta` steps. Profile (field 1) cycles
-/// through the SSH profiles in the store; Direction and Auto start flip. Other
+/// Adjust the focused selector field by `delta` steps. Profile cycles through
+/// the SSH profiles in the store; Direction and Auto start flip. Other
 /// (text/port) fields are unaffected. Used by Space (+1) and the ←/→ arrows.
 pub fn portForwardingFormAdjust(delta: isize) bool {
     const session = activePortForwarding() orelse return false;
@@ -1325,7 +1325,7 @@ pub fn portForwardingFormAdjust(delta: isize) bool {
     };
     var current_buf: [port_forward_rule.PROFILE_MAX]u8 = undefined;
     var current_len: usize = 0;
-    if (focus == 1) {
+    if (focus == port_forwarding.FIELD_PROFILE) {
         const form = session.model.form().?;
         const current = form.rule.profileName();
         current_len = @min(current_buf.len, current.len);
@@ -1333,7 +1333,7 @@ pub fn portForwardingFormAdjust(delta: isize) bool {
     }
     session.mutex.unlock();
 
-    if (focus == 1) {
+    if (focus == port_forwarding.FIELD_PROFILE) {
         const manager = activePortForwardManager() orelse return false;
         const allocator = manager.allocator;
         const content = readSshHostsContent(allocator) orelse return false;
@@ -1353,7 +1353,7 @@ pub fn portForwardingFormAdjust(delta: isize) bool {
     session.mutex.lock();
     defer session.mutex.unlock();
     const form = session.model.form() orelse return false;
-    if (form.focus != 2 and form.focus != 7) return false;
+    if (form.focus != port_forwarding.FIELD_DIRECTION and form.focus != port_forwarding.FIELD_AUTO_START) return false;
     form.toggleFocused();
     markUiDirty();
     return true;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1345,6 +1345,9 @@ pub fn portForwardingFormAdjust(delta: isize) bool {
         session.mutex.lock();
         defer session.mutex.unlock();
         const form = session.model.form() orelse return false;
+        // The lock was released across the ssh_hosts read; re-verify the
+        // Profile field still has focus before writing the cycled name.
+        if (form.focus != port_forwarding.FIELD_PROFILE) return false;
         form.rule.setProfileName(next);
         markUiDirty();
         return true;

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1206,8 +1206,17 @@ fn firstSshProfileName(buf: []u8) []const u8 {
     return ssh_profile_store.cycleProfileName(content, "", 0, buf);
 }
 
+/// Test seam: when set, readSshHostsContent serves a copy of this instead of
+/// the real store, so tests never depend on the host's ssh_hosts file.
+threadlocal var g_ssh_hosts_content_for_test: ?[]const u8 = null;
+
+pub fn setSshHostsContentForTest(content: ?[]const u8) void {
+    g_ssh_hosts_content_for_test = content;
+}
+
 /// Read the encoded ssh_hosts file. Caller frees. Returns null when unavailable.
 fn readSshHostsContent(allocator: std.mem.Allocator) ?[]u8 {
+    if (g_ssh_hosts_content_for_test) |content| return allocator.dupe(u8, content) catch null;
     const path = platform_dirs.sshHostsPath(allocator) catch return null;
     defer allocator.free(path);
     return std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024) catch null;

--- a/src/input.zig
+++ b/src/input.zig
@@ -157,6 +157,22 @@ const arrow_down_event = platform_input.KeyEvent{
     .super = false,
 };
 
+const arrow_left_event = platform_input.KeyEvent{
+    .key_code = platform_input.key_left,
+    .ctrl = false,
+    .shift = false,
+    .alt = false,
+    .super = false,
+};
+
+const arrow_right_event = platform_input.KeyEvent{
+    .key_code = platform_input.key_right,
+    .ctrl = false,
+    .shift = false,
+    .alt = false,
+    .super = false,
+};
+
 const enter_event = platform_input.KeyEvent{
     .key_code = platform_input.key_enter,
     .ctrl = false,
@@ -283,6 +299,55 @@ test "input: port forwarding arrow navigation requests a repaint" {
 
     try std.testing.expect(AppWindow.g_force_rebuild);
     try std.testing.expect(!AppWindow.g_cells_valid);
+}
+
+test "input: port forwarding form left/right arrows toggle Direction and request a repaint" {
+    const allocator = std.testing.allocator;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > previous_count) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+        active_tab_state.g_active_tab = previous_active;
+    }
+
+    try std.testing.expect(AppWindow.portForwardingOpenNew());
+    handleKey(arrow_down_event); // Name -> Profile
+    handleKey(arrow_down_event); // Profile -> Direction
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    handleKey(arrow_right_event);
+
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
+    {
+        const session = AppWindow.activePortForwarding() orelse return error.ExpectedPortForwardingTab;
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        const form = session.model.form() orelse return error.ExpectedPortForwardingForm;
+        try std.testing.expect(form.rule.direction == .local);
+    }
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    handleKey(arrow_left_event);
+
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
+    const session = AppWindow.activePortForwarding() orelse return error.ExpectedPortForwardingTab;
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const form = session.model.form() orelse return error.ExpectedPortForwardingForm;
+    try std.testing.expect(form.rule.direction == .reverse);
 }
 
 test "input: port forwarding form letter keys remain text input" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -303,6 +303,8 @@ test "input: port forwarding arrow navigation requests a repaint" {
 
 test "input: port forwarding form left/right arrows toggle Direction and request a repaint" {
     const allocator = std.testing.allocator;
+    AppWindow.setSshHostsContentForTest("");
+    defer AppWindow.setSshHostsContentForTest(null);
     const previous_count = tab.g_tab_count;
     const previous_active = active_tab_state.g_active_tab;
     if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
@@ -352,6 +354,8 @@ test "input: port forwarding form left/right arrows toggle Direction and request
 
 test "input: port forwarding form letter keys remain text input" {
     const allocator = std.testing.allocator;
+    AppWindow.setSshHostsContentForTest("");
+    defer AppWindow.setSshHostsContentForTest(null);
     const previous_count = tab.g_tab_count;
     const previous_active = active_tab_state.g_active_tab;
     if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;
@@ -382,6 +386,8 @@ test "input: port forwarding form letter keys remain text input" {
 
 test "input: port forwarding new command suppresses its follow-up char event" {
     const allocator = std.testing.allocator;
+    AppWindow.setSshHostsContentForTest("");
+    defer AppWindow.setSshHostsContentForTest(null);
     const previous_count = tab.g_tab_count;
     const previous_active = active_tab_state.g_active_tab;
     if (!tab.spawnPortForwardingTab(allocator)) return error.SkipZigTest;

--- a/src/port_forwarding.zig
+++ b/src/port_forwarding.zig
@@ -2,7 +2,23 @@ const std = @import("std");
 const rule_mod = @import("port_forward_rule.zig");
 
 pub const FormMode = enum { new, edit };
+
+/// Form field indices in focus order. Referenced by the input router
+/// (AppWindow.portForwardingFormAdjust) and the form renderer; adding or
+/// removing a field means updating all three switch sites plus the count.
+pub const FIELD_NAME: usize = 0;
+pub const FIELD_PROFILE: usize = 1;
+pub const FIELD_DIRECTION: usize = 2;
+pub const FIELD_LOCAL_HOST: usize = 3;
+pub const FIELD_LOCAL_PORT: usize = 4;
+pub const FIELD_REMOTE_HOST: usize = 5;
+pub const FIELD_REMOTE_PORT: usize = 6;
+pub const FIELD_AUTO_START: usize = 7;
 pub const FORM_FIELD_COUNT: usize = 8;
+
+comptime {
+    std.debug.assert(FIELD_AUTO_START + 1 == FORM_FIELD_COUNT);
+}
 
 pub const FormState = struct {
     mode: FormMode,
@@ -33,35 +49,35 @@ pub const FormState = struct {
     pub fn insertChar(self: *FormState, ch: u8) void {
         if (!isPrintableAscii(ch)) return;
         switch (self.focus) {
-            0 => _ = appendAscii(&self.rule.name_buf, &self.rule.name_len, ch),
-            // Profile (field 1) is a selector cycled with arrows/space, not typed.
-            3 => _ = appendAscii(&self.rule.local_host_buf, &self.rule.local_host_len, ch),
-            4 => insertPortDigit(&self.rule.local_port, ch),
-            5 => _ = appendAscii(&self.rule.remote_host_buf, &self.rule.remote_host_len, ch),
-            6 => insertPortDigit(&self.rule.remote_port, ch),
+            FIELD_NAME => _ = appendAscii(&self.rule.name_buf, &self.rule.name_len, ch),
+            // FIELD_PROFILE is a selector cycled with arrows/space, not typed.
+            FIELD_LOCAL_HOST => _ = appendAscii(&self.rule.local_host_buf, &self.rule.local_host_len, ch),
+            FIELD_LOCAL_PORT => insertPortDigit(&self.rule.local_port, ch),
+            FIELD_REMOTE_HOST => _ = appendAscii(&self.rule.remote_host_buf, &self.rule.remote_host_len, ch),
+            FIELD_REMOTE_PORT => insertPortDigit(&self.rule.remote_port, ch),
             else => {},
         }
     }
 
     pub fn backspace(self: *FormState) void {
         switch (self.focus) {
-            0 => truncateText(&self.rule.name_len),
-            // Profile (field 1) is a selector cycled with arrows/space, not typed.
-            3 => truncateText(&self.rule.local_host_len),
-            4 => backspacePort(&self.rule.local_port),
-            5 => truncateText(&self.rule.remote_host_len),
-            6 => backspacePort(&self.rule.remote_port),
+            FIELD_NAME => truncateText(&self.rule.name_len),
+            // FIELD_PROFILE is a selector cycled with arrows/space, not typed.
+            FIELD_LOCAL_HOST => truncateText(&self.rule.local_host_len),
+            FIELD_LOCAL_PORT => backspacePort(&self.rule.local_port),
+            FIELD_REMOTE_HOST => truncateText(&self.rule.remote_host_len),
+            FIELD_REMOTE_PORT => backspacePort(&self.rule.remote_port),
             else => {},
         }
     }
 
     pub fn toggleFocused(self: *FormState) void {
         switch (self.focus) {
-            2 => self.rule.direction = switch (self.rule.direction) {
+            FIELD_DIRECTION => self.rule.direction = switch (self.rule.direction) {
                 .local => .reverse,
                 .reverse => .local,
             },
-            7 => self.rule.auto_start = !self.rule.auto_start,
+            FIELD_AUTO_START => self.rule.auto_start = !self.rule.auto_start,
             else => {},
         }
     }

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const rule_mod = @import("../port_forward_rule.zig");
+const form_mod = @import("../port_forwarding.zig");
 
 const HEADER_H: f32 = 54;
 const ROW_H: f32 = 52;
@@ -85,31 +86,31 @@ pub fn autoLabel(auto_start: bool) []const u8 {
 
 pub fn formFieldLabel(index: usize) []const u8 {
     return switch (index) {
-        0 => "Name",
-        1 => "Profile",
-        2 => "Direction",
-        3 => "Local host",
-        4 => "Local port",
-        5 => "Remote host",
-        6 => "Remote port",
-        7 => "Auto start",
+        form_mod.FIELD_NAME => "Name",
+        form_mod.FIELD_PROFILE => "Profile",
+        form_mod.FIELD_DIRECTION => "Direction",
+        form_mod.FIELD_LOCAL_HOST => "Local host",
+        form_mod.FIELD_LOCAL_PORT => "Local port",
+        form_mod.FIELD_REMOTE_HOST => "Remote host",
+        form_mod.FIELD_REMOTE_PORT => "Remote port",
+        form_mod.FIELD_AUTO_START => "Auto start",
         else => "",
     };
 }
 
 pub fn formFieldValue(form: *const FormView, index: usize, buf: []u8) []const u8 {
     return switch (index) {
-        0 => form.rule.name(),
+        form_mod.FIELD_NAME => form.rule.name(),
         // The Profile selector cannot be typed into; an empty name means the
         // ssh_hosts store has no decodable profiles, so hint at that instead
         // of rendering a silently dead blank field.
-        1 => if (form.rule.profileName().len > 0) form.rule.profileName() else "No SSH profiles found",
-        2 => directionLabel(form.rule.direction),
-        3 => form.rule.localHost(),
-        4 => std.fmt.bufPrint(buf, "{d}", .{form.rule.local_port}) catch "",
-        5 => form.rule.remoteHost(),
-        6 => std.fmt.bufPrint(buf, "{d}", .{form.rule.remote_port}) catch "",
-        7 => autoLabel(form.rule.auto_start),
+        form_mod.FIELD_PROFILE => if (form.rule.profileName().len > 0) form.rule.profileName() else "No SSH profiles found",
+        form_mod.FIELD_DIRECTION => directionLabel(form.rule.direction),
+        form_mod.FIELD_LOCAL_HOST => form.rule.localHost(),
+        form_mod.FIELD_LOCAL_PORT => std.fmt.bufPrint(buf, "{d}", .{form.rule.local_port}) catch "",
+        form_mod.FIELD_REMOTE_HOST => form.rule.remoteHost(),
+        form_mod.FIELD_REMOTE_PORT => std.fmt.bufPrint(buf, "{d}", .{form.rule.remote_port}) catch "",
+        form_mod.FIELD_AUTO_START => autoLabel(form.rule.auto_start),
         else => "",
     };
 }

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -100,7 +100,10 @@ pub fn formFieldLabel(index: usize) []const u8 {
 pub fn formFieldValue(form: *const FormView, index: usize, buf: []u8) []const u8 {
     return switch (index) {
         0 => form.rule.name(),
-        1 => form.rule.profileName(),
+        // The Profile selector cannot be typed into; an empty name means the
+        // ssh_hosts store has no decodable profiles, so hint at that instead
+        // of rendering a silently dead blank field.
+        1 => if (form.rule.profileName().len > 0) form.rule.profileName() else "No SSH profiles found",
         2 => directionLabel(form.rule.direction),
         3 => form.rule.localHost(),
         4 => std.fmt.bufPrint(buf, "{d}", .{form.rule.local_port}) catch "",
@@ -507,6 +510,13 @@ test "port_forwarding_renderer: form field values" {
     try std.testing.expectEqualStrings("Reverse", formFieldValue(&form, 2, &buf));
     try std.testing.expectEqualStrings("18080", formFieldValue(&form, 4, &buf));
     try std.testing.expectEqualStrings("Manual", formFieldValue(&form, 7, &buf));
+}
+
+test "port_forwarding_renderer: empty profile renders a store hint" {
+    var buf: [32]u8 = undefined;
+    const rule = rule_mod.defaultReverseProxy("");
+    const form = FormView{ .mode = "New forwarding rule", .focus = 1, .rule = rule };
+    try std.testing.expectEqualStrings("No SSH profiles found", formFieldValue(&form, 1, &buf));
 }
 
 test "port_forwarding_renderer: clamp scroll keeps selected row visible" {


### PR DESCRIPTION
处理 PR #191 审查（LGTM with nits）中遗留的 3 项 MINOR + 2 项 NIT；该 PR 已合并，故在 main 上跟进。

## MINOR
- **空 profile 商店无提示**：ssh_hosts 缺失或无可解码 profile 时，表单 Profile 字段的 value 列渲染 `No SSH profiles found` 占位提示，不再呈现一个无法输入、无法切换的死空白（纯函数 `formFieldValue`，TDD）。
- **缺 ←/→ input 层测试**：按既有 "...arrow navigation requests a repaint" 模式补齐 — Direction 字段（不依赖 ssh_hosts）上 ←/→ 每次按键必须翻转方向并请求 repaint。
- **跨锁窗口防御**：`portForwardingFormAdjust` 在读 ssh_hosts 期间释放 `session.mutex`，重新加锁后现复核 `focus` 仍为 Profile 字段（当前不可触发，纯防御性自洽）。

## NIT
- **测试隔离**：新增 `setSshHostsContentForTest` 缝隙，3 个表单测试固定为空商店，不再读开发者真实 `~/.../ssh_hosts`。
- **字段索引常量化**：`FIELD_NAME..FIELD_AUTO_START` 定义在 `port_forwarding.zig`（comptime 校验与 `FORM_FIELD_COUNT` 一致），表单模型、AppWindow 路由、渲染器三处 switch 全部改用常量。

未处理：极窄面板 + 大字号下 value 列宽为 0 的 NIT — 审查本身将其归为极端布局取舍，且 Linux 主机无法做 GUI 目检，不盲改布局。

`zig build test` / `zig build test-full` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)