### PR TITLE
Revert "fix(resize): hold SSH PTY resize during interactive drags (#171)"

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -26,7 +26,6 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
 const ssh_connection_mod = @import("ssh_connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
-const resize_gate_mod = @import("resize_gate.zig");
 
 const Surface = @This();
 
@@ -161,11 +160,6 @@ remote_id: [16]u8,
 /// Size information for this surface (screen size, cell size, padding).
 /// Used by the renderer to position content correctly.
 size: renderer.size.Size = .{},
-
-/// Gate between the per-frame layout grid and the IO thread (PTY + terminal
-/// resize). Holds resizes during interactive drags so an SSH surface gets a
-/// single SIGWINCH per drag instead of a burst (issue #171). Main thread only.
-resize_gate: resize_gate_mod.ResizeGate,
 
 // ============================================================================
 // IO threads (Ghostty two-thread architecture: writer + reader)
@@ -420,12 +414,6 @@ pub fn init(
     surface.size.grid.cols = cols;
     surface.size.grid.rows = rows;
 
-    // The IO thread already knows the startup grid; seed the gate with it so
-    // the first layout pass queues no resize (same guarantee as the preset
-    // grid above). allocator.create does not apply struct field defaults, so
-    // this must be initialized explicitly like every other field here.
-    surface.resize_gate = resize_gate_mod.ResizeGate.init(cols, rows);
-
     // Initialize per-surface renderer (Ghostty architecture)
     surface.surface_renderer = Renderer.init(surface);
     surface.renderer_thread = RendererThread.init(&surface.surface_renderer, surface);
@@ -599,12 +587,6 @@ pub fn setSshConnection(
 pub const ResizePolicy = enum {
     coalesced,
     immediate,
-    /// An interactive drag (window border, split divider, side-panel edge) is
-    /// in progress: park the PTY + terminal resize for SSH surfaces and flush
-    /// the final grid once on the first non-held layout pass after release.
-    /// Local surfaces still resize live — their redraw round-trip is fast
-    /// enough that the burst is harmless (issue #171).
-    held,
 };
 
 /// Update the surface size and queue a resize to the IO thread if needed.
@@ -613,10 +595,9 @@ pub const ResizePolicy = enum {
 ///
 /// The main thread updates pixel/grid dimensions in surface.size (needed
 /// for layout/rendering), but the actual PTY + terminal resize happens
-/// on the IO thread via queueIo() with 25ms coalescing. With the `.held`
-/// policy the IO resize is parked until the drag ends (see ResizePolicy).
+/// on the IO thread via queueIo() with 25ms coalescing.
 ///
-/// Returns true if the grid dimensions changed.
+/// Returns true if the grid dimensions changed (resize was queued).
 pub fn setScreenSize(
     self: *Surface,
     screen_width: u32,
@@ -663,23 +644,19 @@ pub fn setScreenSizeWithPolicy(
     self.size.grid.cols = new_cols;
     self.size.grid.rows = new_rows;
 
-    // Queue the resize to the IO thread through the gate. The gate dedupes
-    // against the grid the IO thread last received, which both suppresses
-    // repeat submissions (layout runs every frame) and flushes a held resize
-    // on the first pass after a drag ends. Holding only applies to SSH
-    // surfaces; everything else keeps live resize.
-    const hold = resize_policy == .held and self.launch_kind == .ssh;
-    if (self.resize_gate.submit(hold, .{ .cols = new_cols, .rows = new_rows })) |grid| {
+    // Queue resize to IO thread if grid dimensions changed
+    if (changed) {
         // Terminal rows/cols and pixel dimensions are updated together in
         // the IO thread, under the render-state lock.
-        const msg_grid: renderer.size.GridSize = .{ .cols = grid.cols, .rows = grid.rows };
+        const grid: renderer.size.GridSize = .{ .cols = new_cols, .rows = new_rows };
         switch (resize_policy) {
-            .coalesced, .held => self.queueIo(.{ .resize = msg_grid }),
-            .immediate => self.queueIo(.{ .resize_immediate = msg_grid }),
+            .coalesced => self.queueIo(.{ .resize = grid }),
+            .immediate => self.queueIo(.{ .resize_immediate = grid }),
         }
+        return true;
     }
 
-    return changed;
+    return false;
 }
 
 /// Send a message to the IO writer thread via the mailbox.

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -888,9 +888,6 @@ pub const Window = struct {
     mouse_move_events: RingBuffer(MouseMoveEvent, 64) = .{},
     mouse_wheel_events: RingBuffer(MouseWheelEvent, 16) = .{},
     size_changed: bool = false, // set by WM_SIZE, cleared after processing
-    /// True between WM_ENTERSIZEMOVE and WM_EXITSIZEMOVE (OS-modal border
-    /// drag). SSH surfaces park their PTY resize while this is set (#171).
-    in_size_move: bool = false,
 
     /// Optional callback invoked from WM_SIZE so the application can
     /// do a GL clear+swap during the Win32 modal resize loop. Without
@@ -1786,17 +1783,11 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
         // and blocks our main loop. Drop vsync so the synchronous WM_SIZE paints
         // (Window.on_resize) don't each stall on vblank during the drag.
         WM_ENTERSIZEMOVE => {
-            w.in_size_move = true;
             setSwapInterval(0);
             return 0;
         },
         WM_EXITSIZEMOVE => {
-            w.in_size_move = false;
             setSwapInterval(1);
-            // Force a layout pass after the drag: this is what flushes a
-            // resize parked by an SSH surface during the drag (#171). The
-            // drag may end without a trailing WM_SIZE or mouse move.
-            w.size_changed = true;
             return 0;
         },
 

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -13,7 +13,6 @@ const gl_init = AppWindow.gpu.gl_init;
 const Surface = @import("../Surface.zig");
 const SplitTree = @import("../split_tree.zig");
 const renderer = @import("../renderer.zig");
-const window_backend = @import("../platform/window_backend.zig");
 
 const TabState = tab.TabState;
 pub const MAX_SPLITS_PER_TAB = tab.MAX_SPLITS_PER_TAB;
@@ -137,23 +136,6 @@ pub fn hitTestDivider(x: i32, y: i32) ?DividerHit {
     return null;
 }
 
-/// True while the user is interactively dragging something that resizes
-/// terminal panes: a split divider, a side-panel edge, or the OS window
-/// border (Windows modal size-move loop). While active, SSH surfaces park
-/// their PTY + terminal resize and commit once on release (issue #171:
-/// the per-frame resize burst corrupts remote scrollback because SIGWINCH
-/// prompt redraws arrive one network round-trip behind the grid).
-fn interactiveResizeDragActive() bool {
-    if (input.g_divider_dragging or
-        input.g_sidebar_resize_dragging or
-        input.g_explorer_resize_dragging or
-        input.g_markdown_preview_resize_dragging or
-        input.g_browser_resize_dragging or
-        input.g_ai_copilot_resize_dragging) return true;
-    const win = AppWindow.g_window orelse return false;
-    return window_backend.inSizeMove(win);
-}
-
 /// Compute split layout for a tab, returning pixel rects for each surface.
 /// Each surface is resized to fit its allocated area with proper padding.
 /// Returns the number of surfaces (0 if tree is empty).
@@ -181,8 +163,6 @@ pub fn computeSplitLayout(
 
     const resize_policy: Surface.ResizePolicy = if (AppWindow.consumeImmediateLayoutResize())
         .immediate
-    else if (interactiveResizeDragActive())
-        .held
     else
         .coalesced;
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -4131,16 +4131,6 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 platform_cursor.set(cursor_shape);
                 return;
             }
-            // A pane-resizing drag is ending: guarantee one more layout pass so
-            // SSH surfaces flush the PTY resize parked during the drag (#171),
-            // instead of waiting for the next incidental frame.
-            if (g_sidebar_resize_dragging or g_explorer_resize_dragging or
-                g_markdown_preview_resize_dragging or g_browser_resize_dragging or
-                g_ai_copilot_resize_dragging or g_divider_dragging)
-            {
-                AppWindow.g_force_rebuild = true;
-                AppWindow.g_cells_valid = false;
-            }
             if (g_sidebar_resize_dragging) {
                 g_sidebar_resize_dragging = false;
                 g_sidebar_resize_hover = hitTestSidebarResizeHandle(xpos, ypos);

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -452,15 +452,6 @@ pub fn consumeSizeChanged(window: *Window) bool {
     return changed;
 }
 
-/// True while the OS-modal interactive move/size loop is running for this
-/// window (Windows border drag: WM_ENTERSIZEMOVE..WM_EXITSIZEMOVE). Backends
-/// without that concept report false; in-app drags (split dividers, panel
-/// edges) are tracked separately by input.zig flags.
-pub fn inSizeMove(window: *const Window) bool {
-    if (comptime @hasField(Window, "in_size_move")) return window.in_size_move;
-    return false;
-}
-
 pub fn clearTransientInput(window: *Window) void {
     window.clearTransientInputQueues();
 }


### PR DESCRIPTION
撤销 PR #188（`dcfa734`，issue #171 的 resize-gate 修复）。

**撤销原因：实测该修复没有解决 #171 的问题**（SSH 拖拽 resize 后 scrollback 仍被刷坏），保留无效的复杂度没有意义，先回退，后续重新分析根因。

- #188 之上已叠 6 个已合并 PR（#189/#191/#193/#194/#195），不能 reset 重写 main，故走 revert。
- revert 干净应用（无冲突，9+/80-，为原提交的精确镜像）；后续 PR 对 `src/apprt/win32.zig`、`src/input.zig`、`src/platform/window_backend.zig` 的改动均不依赖 #188 引入的符号。
- `zig build test` / `zig build test-full` 全绿。

注意：issue #171 仍处于未解决状态（#188 合并时如果关闭了它，需要手动 reopen）；若日后要重试 resize-gate 思路，需 revert 本 revert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)