### PR TITLE
fix(macos): worker-thread window crash on Dock reopen + frozen first-glyph garble

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -6783,6 +6783,7 @@ fn runMainLoop(self: *AppWindow) !void {
             .cursor_blink_due = blink_due,
             .ai_streaming = aiStreamingActive(),
             .overlay_active = overlays.anyOverlayActive(gate_now),
+            .atlas_sync_pending = font.atlasSyncPending(),
         };
 
         const needs_render = render_gate.frameNeedsRender(signals);

--- a/src/appwindow/render_gate.zig
+++ b/src/appwindow/render_gate.zig
@@ -16,6 +16,10 @@ pub const RenderSignals = struct {
     cursor_blink_due: bool, // 到达光标翻转点（仅聚焦且开启闪烁）
     ai_streaming: bool, // 任一相关 AI session.request_inflight
     overlay_active: bool, // 任一 overlay/面板/时间动画活动
+    // 上一渲染帧把新字形（如首个 emoji）光栅化进了 atlas，但 GPU 纹理是在
+    // 帧首同步的——那一帧采样的是旧纹理。必须再渲染一帧让帧首同步把新
+    // 字形上传，否则坏帧会被本门控冻结在屏幕上（重开窗口首个 emoji 乱码）。
+    atlas_sync_pending: bool,
 };
 
 /// 空闲阻塞超时计算的输入。
@@ -37,7 +41,8 @@ pub fn frameNeedsRender(s: RenderSignals) bool {
         s.any_surface_dirty or
         s.cursor_blink_due or
         s.ai_streaming or
-        s.overlay_active;
+        s.overlay_active or
+        s.atlas_sync_pending;
 }
 
 pub fn computeBlockTimeoutMs(in: TimeoutInputs) i64 {
@@ -59,6 +64,7 @@ test "frameNeedsRender: 任一信号为真即需渲染" {
         .cursor_blink_due = false,
         .ai_streaming = false,
         .overlay_active = false,
+        .atlas_sync_pending = false,
     };
     try std.testing.expect(!frameNeedsRender(base));
 
@@ -80,6 +86,10 @@ test "frameNeedsRender: 任一信号为真即需渲染" {
 
     s = base;
     s.overlay_active = true;
+    try std.testing.expect(frameNeedsRender(s));
+
+    s = base;
+    s.atlas_sync_pending = true;
     try std.testing.expect(frameNeedsRender(s));
 }
 

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -662,6 +662,29 @@ pub fn packColorBitmapIntoAtlas(
     return region;
 }
 
+/// True when any of this thread's atlases has CPU pixel writes the GPU
+/// texture has not seen yet (mirrors syncAtlasTexture's modified check).
+/// Glyphs are rasterized lazily DURING a frame's cell rebuild and overlay
+/// draws — after that frame's top-of-frame syncAtlasTexture already ran — so
+/// the presented frame sampled stale textures. The render gate uses this to
+/// schedule one follow-up frame; without it the event-driven idle loop can
+/// freeze the garbled frame on screen (e.g. the first emoji a window shows).
+pub fn atlasSyncPending() bool {
+    if (g_atlas) |a| {
+        if (a.modified.load(.monotonic) > g_atlas_modified) return true;
+    }
+    if (g_color_atlas) |a| {
+        if (a.modified.load(.monotonic) > g_color_atlas_modified) return true;
+    }
+    if (g_icon_atlas) |a| {
+        if (a.modified.load(.monotonic) > g_icon_atlas_modified) return true;
+    }
+    if (g_titlebar_atlas) |a| {
+        if (a.modified.load(.monotonic) > g_titlebar_atlas_modified) return true;
+    }
+    return false;
+}
+
 /// Sync the font atlas CPU data to the GPU texture.
 /// Called once per frame before rendering. Only uploads if the atlas was modified.
 /// Supports both grayscale (GL_RED) and BGRA (GL_RGBA) atlas formats.

--- a/src/input.zig
+++ b/src/input.zig
@@ -435,6 +435,7 @@ test "input: overlay navigation drives the render gate to repaint" {
         .cursor_blink_due = false,
         .ai_streaming = false,
         .overlay_active = false,
+        .atlas_sync_pending = false,
     };
     try std.testing.expect(render_gate.frameNeedsRender(signals));
 }

--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -756,3 +756,61 @@ test "macOS backend drains file drop events" {
     try std.testing.expectEqual(@as(i32, 11), test_drop_x);
     try std.testing.expectEqual(@as(i32, 22), test_drop_y);
 }
+
+// Worker-thread idle wait: every window past the first runs its loop on a
+// worker thread (Dock reopen / new-window), and the event-driven render gate
+// blocks in pumpAppEvents between frames. -[NSApp nextEventMatchingMask:] is
+// main-thread-only (AppKit throws NSInternalInconsistencyException off-main),
+// so off-main the pump must block on the wakeup condition instead.
+const WorkerPumpProbe = struct {
+    ready: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    elapsed_ms: std.atomic.Value(i64) = std.atomic.Value(i64).init(-1),
+
+    fn run(self: *@This()) void {
+        // Consume any wakeup signalled before this test (earlier tests push
+        // events) so the timed pump below measures only the test's wakeup.
+        platform_window.pumpAppEvents(0.001);
+        self.ready.store(true, .release);
+        var timer = std.time.Timer.start() catch unreachable;
+        platform_window.pumpAppEvents(5.0);
+        self.elapsed_ms.store(@intCast(timer.read() / std.time.ns_per_ms), .release);
+    }
+
+    fn awaitReady(self: *@This()) void {
+        while (!self.ready.load(.acquire)) std.Thread.yield() catch {};
+    }
+};
+
+test "macOS pumpAppEvents on a worker thread blocks and wakes on postWakeup" {
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Worker Pump");
+    var window = try Window.init(320, 180, title, null, null, false);
+    defer window.deinit();
+
+    var probe = WorkerPumpProbe{};
+    const worker = try std.Thread.spawn(.{}, WorkerPumpProbe.run, .{&probe});
+    probe.awaitReady();
+    // Even if this lands before the worker re-enters the pump, the wakeup must
+    // not be lost: the next pump call has to return immediately.
+    platform_window.postWakeup();
+    worker.join();
+
+    const elapsed = probe.elapsed_ms.load(.acquire);
+    try std.testing.expect(elapsed >= 0);
+    try std.testing.expect(elapsed < 3000);
+}
+
+test "macOS pumpAppEvents on a worker thread wakes when input is pushed" {
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Worker Pump Input");
+    var window = try Window.init(320, 180, title, null, null, false);
+    defer window.deinit();
+
+    var probe = WorkerPumpProbe{};
+    const worker = try std.Thread.spawn(.{}, WorkerPumpProbe.run, .{&probe});
+    probe.awaitReady();
+    wispterm_macos_window_test_push_key(window.hwnd, 0x41, false, false, false);
+    worker.join();
+
+    const elapsed = probe.elapsed_ms.load(.acquire);
+    try std.testing.expect(elapsed >= 0);
+    try std.testing.expect(elapsed < 3000);
+}

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -254,12 +254,15 @@ pub fn requestQuit() void {
 
 /// Pump pending NSApp events; blocks up to `timeout_seconds` waiting for the
 /// first event so the main thread's run loop also drains the GCD main queue
-/// (needed for worker-thread dispatch_sync to the main thread).
+/// (needed for worker-thread dispatch_sync to the main thread). On worker
+/// threads (every window past the first) this must not touch NSApp — AppKit
+/// throws off-main — so the bridge instead blocks on a wakeup condition that
+/// input pushes, close requests, and postWakeup() signal.
 pub fn pumpAppEvents(timeout_seconds: f64) void {
     wispterm_macos_app_pump_events(timeout_seconds);
 }
 
-/// 从任意线程唤醒阻塞中的主线程事件泵。
+/// 从任意线程唤醒阻塞中的事件泵：主线程的 NSApp 泵和 worker 窗口的条件等待都会被唤醒。
 pub fn postWakeup() void {
     wispterm_macos_post_wakeup();
 }

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -2,6 +2,7 @@
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
 #include <os/lock.h>
+#include <pthread.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -133,16 +134,23 @@ struct WispTermMacWindowState {
     size_t file_drop_count;
 };
 
+// Defined with the other worker-wakeup primitives below; the close callbacks
+// need it early so a worker window blocked in its idle wait notices
+// close_requested promptly instead of sleeping out its full timeout.
+static void wispterm_macos_worker_wakeup_signal(void);
+
 @implementation WispTermMacWindowDelegate
 - (BOOL)windowShouldClose:(id)sender {
     (void)sender;
     if (self.state != NULL) self.state->close_requested = true;
+    wispterm_macos_worker_wakeup_signal();
     return YES;
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
     (void)notification;
     if (self.state != NULL) self.state->close_requested = true;
+    wispterm_macos_worker_wakeup_signal();
 }
 @end
 
@@ -281,6 +289,50 @@ static double wispterm_macos_scale(WispTermMacWindowState *state) {
     return scale > 0.0 ? scale : 1.0;
 }
 
+// ---------------------------------------------------------------------------
+// Worker-thread idle wait. -[NSApp nextEventMatchingMask:] is main-thread-only
+// (AppKit throws NSInternalInconsistencyException off-main), but every window
+// past the first runs its loop on a worker thread and blocks in
+// wispterm_macos_app_pump_events between frames. Off-main the pump waits on
+// this condition instead; producers signal it: the main thread after pushing
+// into any per-window event ring, the window-close delegate callbacks, and
+// wispterm_macos_post_wakeup (already the cross-thread render wakeup).
+//
+// Each waiter remembers the last sequence it consumed, so a signal landing
+// between a caller's "nothing to render" check and the wait itself is never
+// lost — the next wait returns immediately. Same semantics the Windows
+// backend gets from MsgWaitForMultipleObjectsEx(MWMO_INPUTAVAILABLE).
+// ---------------------------------------------------------------------------
+
+static pthread_mutex_t g_worker_wakeup_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_worker_wakeup_cond = PTHREAD_COND_INITIALIZER;
+static uint64_t g_worker_wakeup_seq = 0;
+static _Thread_local uint64_t t_worker_wakeup_seen = 0;
+
+static void wispterm_macos_worker_wakeup_signal(void) {
+    pthread_mutex_lock(&g_worker_wakeup_mutex);
+    g_worker_wakeup_seq += 1;
+    pthread_cond_broadcast(&g_worker_wakeup_cond);
+    pthread_mutex_unlock(&g_worker_wakeup_mutex);
+}
+
+static void wispterm_macos_worker_wakeup_wait(double timeout_seconds) {
+    pthread_mutex_lock(&g_worker_wakeup_mutex);
+    if (t_worker_wakeup_seen == g_worker_wakeup_seq && timeout_seconds > 0) {
+        struct timespec rel;
+        rel.tv_sec = (time_t)timeout_seconds;
+        rel.tv_nsec = (long)((timeout_seconds - (double)rel.tv_sec) * 1e9);
+        if (rel.tv_nsec > 999999999L) rel.tv_nsec = 999999999L;
+        if (rel.tv_nsec < 0) rel.tv_nsec = 0;
+        // A single timed wait suffices: a spurious wakeup just returns to the
+        // caller's loop, which re-checks its rings and render gate anyway.
+        (void)pthread_cond_timedwait_relative_np(
+            &g_worker_wakeup_cond, &g_worker_wakeup_mutex, &rel);
+    }
+    t_worker_wakeup_seen = g_worker_wakeup_seq;
+    pthread_mutex_unlock(&g_worker_wakeup_mutex);
+}
+
 static void wispterm_macos_push_key_event(WispTermMacWindowState *state, WispTermMacKeyEvent event) {
     if (state == NULL) return;
     const size_t capacity = sizeof(state->key_events) / sizeof(state->key_events[0]);
@@ -293,6 +345,7 @@ static void wispterm_macos_push_key_event(WispTermMacWindowState *state, WispTer
         state->key_head = (state->key_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_key_event(WispTermMacWindowState *state, WispTermMacKeyEvent *out) {
@@ -321,6 +374,7 @@ static void wispterm_macos_push_char_event(WispTermMacWindowState *state, WispTe
         state->char_head = (state->char_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_char_event(WispTermMacWindowState *state, WispTermMacCharEvent *out) {
@@ -349,6 +403,7 @@ static void wispterm_macos_push_mouse_button_event(WispTermMacWindowState *state
         state->mouse_button_head = (state->mouse_button_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_mouse_button_event(WispTermMacWindowState *state, WispTermMacMouseButtonEvent *out) {
@@ -377,6 +432,7 @@ static void wispterm_macos_push_mouse_move_event(WispTermMacWindowState *state, 
         state->mouse_move_head = (state->mouse_move_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_mouse_move_event(WispTermMacWindowState *state, WispTermMacMouseMoveEvent *out) {
@@ -405,6 +461,7 @@ static void wispterm_macos_push_mouse_wheel_event(WispTermMacWindowState *state,
         state->mouse_wheel_head = (state->mouse_wheel_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_mouse_wheel_event(WispTermMacWindowState *state, WispTermMacMouseWheelEvent *out) {
@@ -437,6 +494,7 @@ static void wispterm_macos_push_message_event(WispTermMacWindowState *state, Wis
         state->message_head = (state->message_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->message_lock);
+    wispterm_macos_worker_wakeup_signal();
 }
 
 static bool wispterm_macos_pop_message_event(WispTermMacWindowState *state, WispTermMacMessageEvent *out) {
@@ -472,6 +530,7 @@ static bool wispterm_macos_push_file_drop_event(WispTermMacWindowState *state, c
         state->file_drop_head = (state->file_drop_head + 1) % capacity;
     }
     os_unfair_lock_unlock(&state->input_lock);
+    wispterm_macos_worker_wakeup_signal();
     return true;
 }
 
@@ -1114,7 +1173,8 @@ void wispterm_macos_window_poll(void *handle) {
 // Pump pending NSApp events without requiring a window handle. Used by the
 // zig idle loop in App.run() between window sessions so the AppDelegate's
 // reopen / terminate callbacks (Dock icon, cmd+Q) still fire while no
-// AppWindow loop is running.
+// AppWindow loop is running, and by every AppWindow render loop as its idle
+// block between frames.
 //
 // `timeout_seconds` is how long the main thread is willing to block waiting
 // for the next event. Blocking (rather than spinning + sleeping in zig) is
@@ -1124,6 +1184,13 @@ void wispterm_macos_window_poll(void *handle) {
 // worker dispatch_sync to main deadlocks until something else wakes the run
 // loop.
 void wispterm_macos_app_pump_events(double timeout_seconds) {
+    // Worker-thread window loops (every window past the first) must not touch
+    // NSApp — AppKit throws off-main. They block on the wakeup condition; the
+    // main thread's pump dispatches their input into the rings and signals it.
+    if (![NSThread isMainThread]) {
+        wispterm_macos_worker_wakeup_wait(timeout_seconds);
+        return;
+    }
     @autoreleasepool {
         NSDate *first_until = (timeout_seconds > 0)
             ? [NSDate dateWithTimeIntervalSinceNow:timeout_seconds]
@@ -1145,8 +1212,9 @@ void wispterm_macos_app_pump_events(double timeout_seconds) {
     }
 }
 
-// Wake the main thread's -nextEventMatchingMask: (used by the idle render loop)
-// from any thread, by posting an application-defined NSEvent. Safe off-main.
+// Wake any blocked idle pump from any thread: posts an application-defined
+// NSEvent for the main thread's -nextEventMatchingMask: and signals the
+// worker-window wakeup condition. Safe off-main.
 void wispterm_macos_post_wakeup(void) {
     @autoreleasepool {
         NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
@@ -1160,6 +1228,7 @@ void wispterm_macos_post_wakeup(void) {
                                                data2:0];
         if (event != nil) [NSApp postEvent:event atStart:NO];
     }
+    wispterm_macos_worker_wakeup_signal();
 }
 
 bool wispterm_macos_window_close_requested(void *handle) {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -55,6 +55,7 @@ test {
     _ = @import("apprt/window_registry.zig");
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");
+    _ = @import("appwindow/render_gate.zig");
     _ = @import("scp.zig");
     _ = @import("surface_registry.zig");
     _ = @import("png_dimensions.zig");


### PR DESCRIPTION
## Summary

Two fixes for windows that run their loop on a worker thread on macOS (every window past the first: Dock-icon reopen, new-window keybind), both fallout from the event-driven render loop (#168) meeting AppKit's threading rules.

### 1. SIGABRT on Dock reopen (`fix(macos): stop worker-thread windows from pumping NSApp events`)

Repro: close the last window with the X button, click the WispTerm Dock icon → crash within ~1s.

The reopened window's idle block called `wispterm_macos_app_pump_events`, which pumps NSApp via `-nextEventMatchingMask:` — main-thread-only; AppKit throws `NSInternalInconsistencyException` off-main (uncaught → `abort()`). The Windows backend never had this problem because `MsgWaitForMultipleObjectsEx` waits on the calling thread's own message queue.

Off the main thread the pump now blocks on a pthread condvar signalled by every input-ring push, the window-close delegate callbacks, and `wispterm_macos_post_wakeup`. A thread-local last-seen sequence prevents lost wakeups between the render-gate check and the wait (`MWMO_INPUTAVAILABLE` semantics).

### 2. First emoji frozen as red garbage (`fix(render-gate): repaint when atlases hold glyphs the GPU has not seen`)

Glyphs rasterize lazily during cell rebuild / overlay draws — after that frame's top-of-frame `syncAtlasTexture` already ran — so the frame introducing a glyph samples a stale texture (the first emoji showed mono-atlas slots `!"#$%` at the color atlas's UVs). The continuous loop used to self-heal in 16ms; the event-driven gate froze the garbled frame until an incidental event.

New `atlas_sync_pending` render-gate signal (`font.atlasSyncPending()` compares each threadlocal atlas's modified counter vs the last-synced counter) forces one repair frame.

## Tests

- New: 2 worker-thread pump tests in `window_backend_macos.zig` — pre-fix they abort with the exact crash from the report (`nextEventMatchingMask should only be called from the Main Thread!`)
- New: `atlas_sync_pending` case in the render-gate test; `render_gate.zig` added to the fast suite
- Suites: `test` 1043/1044 (1 pre-existing skip), `test-macos-window` 39/39, `test-macos-ui` 1537/1538, `test-full` 26/26, `macos-app` builds
- Manual on macOS 26.5: launch → close via X → reopen via Dock event → window appears with clean emoji prompt, accepts typing; second close/reopen cycle; menu Quit exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)