### PR TITLE
[codex] coalesce pty output reads

### DIFF
--- a/src/termio/ReadThread.zig
+++ b/src/termio/ReadThread.zig
@@ -11,6 +11,7 @@
 const std = @import("std");
 const Surface = @import("../Surface.zig");
 const window_backend = @import("../platform/window_backend.zig");
+const read_coalesce = @import("read_coalesce.zig");
 
 const READ_BUF_SIZE = 4096;
 
@@ -18,6 +19,8 @@ pub fn threadMain(surface: *Surface) void {
     var buf: [READ_BUF_SIZE]u8 = undefined;
     var resize_pending: std.ArrayListUnmanaged(u8) = .empty;
     defer resize_pending.deinit(surface.allocator);
+    var output_pending: std.ArrayListUnmanaged(u8) = .empty;
+    defer output_pending.deinit(surface.allocator);
 
     while (!surface.exited.load(.acquire)) {
         const bytes_read = surface.pty.readOutput(&buf) catch |err| {
@@ -64,13 +67,13 @@ pub fn threadMain(surface: *Surface) void {
             resize_pending.appendSlice(surface.allocator, data) catch {
                 processOutput(surface, resize_pending.items);
                 resize_pending.clearRetainingCapacity();
-                processOutput(surface, data);
+                processOutputCoalesced(surface, data, &output_pending, &buf);
                 continue;
             };
             processOutput(surface, resize_pending.items);
             resize_pending.clearRetainingCapacity();
         } else {
-            processOutput(surface, data);
+            processOutputCoalesced(surface, data, &output_pending, &buf);
         }
     }
 }
@@ -102,6 +105,53 @@ fn drainResizeOutput(
         }
         pending.appendSlice(surface.allocator, data) catch {
             pending.clearRetainingCapacity();
+            return;
+        };
+    }
+}
+
+fn processOutputCoalesced(
+    surface: *Surface,
+    first: []const u8,
+    pending: *std.ArrayListUnmanaged(u8),
+    scratch: *[READ_BUF_SIZE]u8,
+) void {
+    if (first.len == 0) return;
+
+    pending.clearRetainingCapacity();
+    pending.appendSlice(surface.allocator, first) catch {
+        processOutput(surface, first);
+        return;
+    };
+
+    drainAvailableOutput(surface, pending, scratch);
+    processOutput(surface, pending.items);
+}
+
+fn drainAvailableOutput(
+    surface: *Surface,
+    pending: *std.ArrayListUnmanaged(u8),
+    scratch: *[READ_BUF_SIZE]u8,
+) void {
+    while (!surface.exited.load(.acquire)) {
+        const available = surface.pty.outputAvailable() orelse return;
+        const to_read = read_coalesce.nextDrainLen(available, scratch.len, pending.items.len);
+        if (to_read == 0) return;
+
+        const bytes_read = surface.pty.readOutput(scratch[0..to_read]) catch |err| switch (err) {
+            error.ReadInterrupted => continue,
+            else => return,
+        };
+        if (bytes_read == 0) return;
+
+        const data = scratch[0..bytes_read];
+        if (surface.remote_client) |client| {
+            client.sendOutput(surface.remote_id[0..], data);
+        }
+        pending.appendSlice(surface.allocator, data) catch {
+            processOutput(surface, pending.items);
+            pending.clearRetainingCapacity();
+            processOutput(surface, data);
             return;
         };
     }

--- a/src/termio/read_coalesce.zig
+++ b/src/termio/read_coalesce.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub const MAX_BATCH_BYTES: usize = 64 * 1024;
+
+pub fn nextDrainLen(available: usize, scratch_len: usize, buffered_len: usize) usize {
+    if (available == 0 or scratch_len == 0) return 0;
+    if (buffered_len >= MAX_BATCH_BYTES) return 0;
+    const remaining = MAX_BATCH_BYTES - buffered_len;
+    return @min(available, @min(scratch_len, remaining));
+}
+
+test "nextDrainLen drains immediately available PTY bytes" {
+    try std.testing.expectEqual(@as(usize, 128), nextDrainLen(128, 4096, 32));
+}
+
+test "nextDrainLen clamps to scratch buffer" {
+    try std.testing.expectEqual(@as(usize, 4096), nextDrainLen(9000, 4096, 32));
+}
+
+test "nextDrainLen stops when no bytes are immediately available" {
+    try std.testing.expectEqual(@as(usize, 0), nextDrainLen(0, 4096, 32));
+}
+
+test "nextDrainLen stops at batch cap" {
+    try std.testing.expectEqual(@as(usize, 0), nextDrainLen(9000, 4096, MAX_BATCH_BYTES));
+    try std.testing.expectEqual(@as(usize, 10), nextDrainLen(9000, 4096, MAX_BATCH_BYTES - 10));
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -111,6 +111,7 @@ test {
     _ = @import("ai_sidebar.zig");
     _ = @import("appwindow/flush_scheduler.zig");
     _ = @import("appwindow/resize_throttle.zig");
+    _ = @import("termio/read_coalesce.zig");
     _ = @import("ai_chat_protocol.zig");
     _ = @import("weixin/types.zig");
     _ = @import("weixin/ilink_codec.zig");


### PR DESCRIPTION
## Summary

- Coalesce immediately available PTY output reads before feeding the VT parser and waking the renderer.
- Add a small std-only batching policy with fast-suite tests.

## Root Cause

Codex/Claude-style TUIs frequently save the cursor, repaint status areas, and restore the cursor. WispTerm woke the renderer after each PTY read chunk, so a frame could present while that sequence was only partially consumed, making the terminal cursor appear to jump between the status area and input line.

## Impact

The reader now drains already-available PTY bytes up to a bounded 64 KiB batch before processing and waking the UI. This reduces intermediate-frame cursor artifacts while keeping large output responsive.

## Verification

- `zig fmt src/termio/read_coalesce.zig src/termio/ReadThread.zig src/test_fast.zig --check`
- `zig test src/termio/read_coalesce.zig`
- `zig build test`
- `zig build test-full`
