### PR TITLE
fix(win32): guard the DXGI flip present path against silently broken drivers

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3588,6 +3588,11 @@ pub threadlocal var term_rows: u16 = 24;
 // Dirty tracking — skip rebuildCells when nothing changed
 pub threadlocal var g_cells_valid: bool = false;
 pub threadlocal var g_force_rebuild: bool = true;
+/// One-shot per window thread: the first present that returns settles the
+/// D3D bring-up crash fuse (the process survived presenter bring-up, so the
+/// "probing" state-file marker can be removed). No-op off-Windows and when
+/// no marker exists.
+threadlocal var g_present_bringup_settled: bool = false;
 
 pub threadlocal var window_focused: bool = true; // Track window focus state
 
@@ -7081,10 +7086,24 @@ fn runMainLoop(self: *AppWindow) !void {
         forceOpaqueBackbufferForPresent();
         gpu.state.endFrame();
         window_backend.swapBuffers(win);
+        if (!g_present_bringup_settled) {
+            g_present_bringup_settled = true;
+            platform_window_state.settleD3dBringup(allocator);
+        }
         recordFrameLatencyIfInputDriven();
         clearAllSurfaceDirty();
         g_force_rebuild = false;
         g_cells_valid = true;
+        if (window_backend.takePresentFallbackEvent(win)) {
+            // The DXGI present path was just latched off mid-session. While
+            // it was broken the GPU may have dropped glyph-atlas uploads
+            // (device reset / stalled context), leaving every glyph first
+            // seen during that window permanently blank — rebuild the atlas
+            // and re-render everything on the GDI path.
+            font.clearGlyphCache(allocator);
+            g_force_rebuild = true;
+            g_cells_valid = false;
+        }
     }
 
     // Save window position + size for next session

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -675,6 +675,9 @@ extern "opengl32" fn wglGetProcAddress(lpszProc: [*:0]const u8) callconv(.winapi
 var g_wgl_swap_interval: ?*const fn (c_int) callconv(.winapi) BOOL = null;
 var g_swap_interval_loaded: bool = false;
 
+extern "opengl32" fn glGetString(name: u32) callconv(.winapi) ?[*:0]const u8;
+const GL_VENDOR: u32 = 0x1F00;
+
 /// Desired vsync interval, consumed by the DXGI flip-model presenter's
 /// `Present` call (wglSwapIntervalEXT only affects the GDI fallback path).
 var g_present_interval: c_int = 1;
@@ -840,6 +843,11 @@ pub const Window = struct {
     /// DXGI flip-model presenter; null = legacy GDI SwapBuffers path (either
     /// disabled by config or unavailable/failed on this machine).
     dx: ?dx_present.Presenter = null,
+    /// Set when the presenter latched a mid-session failure and the window
+    /// reverted to GDI. Consumed by the app loop (takePresentFallbackEvent)
+    /// to rebuild GPU-side caches the broken period may have corrupted
+    /// (glyph-atlas uploads dropped during a device reset → missing glyphs).
+    present_fallback_event: bool = false,
     should_close: bool = false,
     close_requested: bool = false,
     width: i32 = 800,
@@ -1184,9 +1192,11 @@ pub const Window = struct {
         // BLT present composites through the DWM redirection surface, which is
         // what produced the cross-DPI / resize artifacts of #46/#47/#88 on
         // Intel Arc and AMD iGPU drivers. Requires the GL context current.
+        // The GL vendor pins the D3D device to the GPU the context runs on.
+        const gl_vendor: []const u8 = if (glGetString(GL_VENDOR)) |v| std.mem.span(v) else "";
         const dx: ?dx_present.Presenter = if (g_flip_present_enabled)
-            dx_present.Presenter.init(hwnd, rect.right - rect.left, rect.bottom - rect.top) catch |err| blk: {
-                render_diagnostics.log("dx-present unavailable ({s}) — using GDI SwapBuffers", .{@errorName(err)});
+            dx_present.Presenter.init(hwnd, rect.right - rect.left, rect.bottom - rect.top, gl_vendor) catch |err| blk: {
+                render_diagnostics.log("dx-present unavailable ({s}, GL vendor \"{s}\") — using GDI SwapBuffers", .{ @errorName(err), gl_vendor });
                 std.debug.print("Win32: DXGI flip present unavailable ({s}), using SwapBuffers\n", .{@errorName(err)});
                 break :blk null;
             }
@@ -1194,8 +1204,8 @@ pub const Window = struct {
             null;
         if (dx != null) {
             render_diagnostics.log(
-                "dx-present active: flip-model swapchain {}x{}",
-                .{ rect.right - rect.left, rect.bottom - rect.top },
+                "dx-present active: flip-model swapchain {}x{} (GL vendor \"{s}\")",
+                .{ rect.right - rect.left, rect.bottom - rect.top, gl_vendor },
             );
             std.debug.print("Win32: presenting via DXGI flip-model swapchain\n", .{});
         }
@@ -1257,8 +1267,17 @@ pub const Window = struct {
             std.debug.print("Win32: DXGI present failed, reverting to SwapBuffers\n", .{});
             dx.deinit();
             self.dx = null;
+            self.present_fallback_event = true;
         }
         _ = SwapBuffers(self.hdc);
+    }
+
+    /// One-shot: true when the DXGI presenter latched a mid-session failure
+    /// since the last call. The app loop reacts by rebuilding GPU caches.
+    pub fn takePresentFallbackEvent(self: *Window) bool {
+        const fired = self.present_fallback_event;
+        self.present_fallback_event = false;
+        return fired;
     }
 
     /// Get the client area size (for OpenGL viewport).

--- a/src/apprt/win32_dx_present.zig
+++ b/src/apprt/win32_dx_present.zig
@@ -18,6 +18,23 @@
 //! Every failure latches `PresentPolicy.fail()` and the caller reverts to
 //! GDI `SwapBuffers` for the rest of the session, so machines without
 //! `WGL_NV_DX_interop2` (or with a broken driver) keep the old behavior.
+//!
+//! Errors alone are not enough, though — the v1.18.0 field reports (black
+//! "slideshow" frames, multi-second stalls, crashes at launch) came from
+//! drivers that misbehave *without* failing any call. Three guards cover
+//! those silent modes:
+//!   • adapter matching: the D3D11 device is created on the DXGI adapter
+//!     whose PCI vendor matches `GL_VENDOR`, never the default adapter —
+//!     cross-adapter interop on hybrid-GPU laptops is what stalled/blacked
+//!     out, and matching also keeps dGPU laptops on the flip-model path;
+//!   • a first-frames content probe: GL readback vs staging readback of the
+//!     shared texture must agree on a frame with real content, otherwise the
+//!     path is silently dropping pixels → latch fallback;
+//!   • a present-duration watchdog: sustained multi-hundred-ms presents
+//!     (cross-GPU syncs, TDR recovery loops) → latch fallback.
+//! Crashes *inside* driver init are handled one level up by the bring-up
+//! fuse (state-file marker, see dxgi_core + main.zig): the next launch skips
+//! the D3D path for this app version.
 
 const std = @import("std");
 const windows = std.os.windows;
@@ -48,6 +65,8 @@ const GL_COLOR_BUFFER_BIT: u32 = 0x00004000;
 const GL_NEAREST: u32 = 0x2600;
 const GL_FRAMEBUFFER_COMPLETE: u32 = 0x8CD5;
 const GL_SCISSOR_TEST: u32 = 0x0C11;
+const GL_RGBA: u32 = 0x1908;
+const GL_UNSIGNED_BYTE: u32 = 0x1401;
 
 const WGL_ACCESS_WRITE_DISCARD_NV: u32 = 0x0002;
 
@@ -62,8 +81,11 @@ const GlFns = struct {
     delete_renderbuffers: *const fn (i32, [*]const u32) callconv(.winapi) void,
     blit_framebuffer: *const fn (i32, i32, i32, i32, i32, i32, i32, i32, u32, u32) callconv(.winapi) void,
     check_framebuffer_status: *const fn (u32) callconv(.winapi) u32,
-    // GL 1.0 entry point: comes from opengl32.dll directly, not wglGetProcAddress.
+    // GL 1.0/1.1 entry points: come from opengl32.dll directly, not
+    // wglGetProcAddress.
     disable: *const fn (u32) callconv(.winapi) void,
+    read_pixels: *const fn (i32, i32, i32, i32, u32, u32, *anyopaque) callconv(.winapi) void,
+    get_error: *const fn () callconv(.winapi) u32,
 
     fn load() error{GlFunctionsMissing}!GlFns {
         const opengl32 = GetModuleHandleW(std.unicode.utf8ToUtf16LeStringLiteral("opengl32.dll")) orelse
@@ -78,6 +100,8 @@ const GlFns = struct {
             .blit_framebuffer = @ptrCast(wglGetProcAddress("glBlitFramebuffer") orelse return error.GlFunctionsMissing),
             .check_framebuffer_status = @ptrCast(wglGetProcAddress("glCheckFramebufferStatus") orelse return error.GlFunctionsMissing),
             .disable = @ptrCast(GetProcAddress(opengl32, "glDisable") orelse return error.GlFunctionsMissing),
+            .read_pixels = @ptrCast(GetProcAddress(opengl32, "glReadPixels") orelse return error.GlFunctionsMissing),
+            .get_error = @ptrCast(GetProcAddress(opengl32, "glGetError") orelse return error.GlFunctionsMissing),
         };
     }
 };
@@ -146,6 +170,7 @@ pub const InitError = error{
     D3D11Unavailable,
     DeviceCreateFailed,
     FactoryUnavailable,
+    AdapterVendorMismatch,
     SwapchainCreateFailed,
     InteropUnavailable,
     InteropOpenFailed,
@@ -161,6 +186,8 @@ pub const InitError = error{
 const PresentError = error{
     LockFailed,
     PresentFailed,
+    ProbeReadbackFailed,
+    ProbeMismatch,
 };
 
 // ============================================================================
@@ -182,16 +209,29 @@ pub const Presenter = struct {
     interop_object: ?HANDLE = null,
     gl_fbo: u32 = 0,
     gl_rbo: u32 = 0,
+    // First-frames probe: a CPU-readable copy of shared_tex, compared against
+    // GL readbacks until the path has verifiably carried real content once.
+    probe_staging: ?*anyopaque = null, // ID3D11Texture2D (STAGING)
+    probe_done: bool = false,
+    probe_frames: u32 = 0,
 
     policy: core.PresentPolicy,
 
     /// Requires the window's GL context to be current (interop + GL function
-    /// loading both depend on it).
-    pub fn init(hwnd: HWND, width: i32, height: i32) InitError!Presenter {
+    /// loading both depend on it). `gl_vendor` is `glGetString(GL_VENDOR)`:
+    /// the D3D11 device must be created on the same adapter the GL context
+    /// runs on — interop with the default adapter on a hybrid-GPU machine
+    /// silently presents black or stalls on cross-GPU syncs.
+    pub fn init(hwnd: HWND, width: i32, height: i32, gl_vendor: []const u8) InitError!Presenter {
         if (width <= 0 or height <= 0) return error.SwapchainCreateFailed;
 
         const gl = try GlFns.load();
         const interop = try InteropFns.load();
+
+        const want_vendor = core.pciVendorForGlVendor(gl_vendor) orelse
+            return error.AdapterVendorMismatch;
+        const adapter = try pickAdapter(want_vendor);
+        defer comRelease(adapter);
 
         const d3d11 = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("d3d11.dll")) orelse
             return error.D3D11Unavailable;
@@ -200,9 +240,10 @@ pub const Presenter = struct {
 
         var device: ?*anyopaque = null;
         var context: ?*anyopaque = null;
+        // Driver type must be UNKNOWN when an explicit adapter is passed.
         if (create_device(
-            null,
-            core.D3D_DRIVER_TYPE_HARDWARE,
+            adapter,
+            core.D3D_DRIVER_TYPE_UNKNOWN,
             null,
             core.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
             null,
@@ -234,6 +275,42 @@ pub const Presenter = struct {
         };
         try self.createSizedResources(width, height);
         return self;
+    }
+
+    /// Find the first DXGI adapter belonging to the GL context's GPU vendor.
+    /// No match → the machine has no adapter we can safely interop with
+    /// (or GL runs on something exotic) → caller falls back to GDI.
+    fn pickAdapter(want_vendor: u32) InitError!*anyopaque {
+        const dxgi = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("dxgi.dll")) orelse
+            return error.FactoryUnavailable;
+        const CreateFactoryFn = *const fn (*const core.Guid, *?*anyopaque) callconv(.winapi) HRESULT;
+        const create_factory: CreateFactoryFn = @ptrCast(GetProcAddress(dxgi, "CreateDXGIFactory1") orelse
+            return error.FactoryUnavailable);
+
+        var factory: ?*anyopaque = null;
+        if (create_factory(&core.IID_IDXGIFactory1, &factory) < 0 or factory == null)
+            return error.FactoryUnavailable;
+        defer comRelease(factory.?);
+
+        const enum_adapters = comCall(factory.?, core.slot.DXGIFactory1_EnumAdapters1, *const fn (*anyopaque, u32, *?*anyopaque) callconv(.winapi) HRESULT);
+        var index: u32 = 0;
+        while (index < 16) : (index += 1) {
+            var adapter: ?*anyopaque = null;
+            if (enum_adapters(factory.?, index, &adapter) < 0 or adapter == null) break;
+            const get_desc = comCall(adapter.?, core.slot.DXGIAdapter1_GetDesc1, *const fn (*anyopaque, *core.DXGI_ADAPTER_DESC1) callconv(.winapi) HRESULT);
+            var desc: core.DXGI_ADAPTER_DESC1 = undefined;
+            if (get_desc(adapter.?, &desc) >= 0 and
+                core.adapterUsableForVendor(desc.vendor_id, desc.flags, want_vendor))
+            {
+                render_diagnostics.log(
+                    "dx-present adapter {}: vendor=0x{x} device=0x{x} (GL vendor match)",
+                    .{ index, desc.vendor_id, desc.device_id },
+                );
+                return adapter.?;
+            }
+            comRelease(adapter.?);
+        }
+        return error.AdapterVendorMismatch;
     }
 
     fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) InitError!*anyopaque {
@@ -359,6 +436,10 @@ pub const Presenter = struct {
     }
 
     fn destroySizedResources(self: *Presenter) void {
+        if (self.probe_staging) |s| {
+            comRelease(s);
+            self.probe_staging = null;
+        }
         if (self.backbuffer) |b| {
             comRelease(b);
             self.backbuffer = null;
@@ -406,11 +487,34 @@ pub const Presenter = struct {
             },
             .present => {},
         }
+        const start_ms = std.time.milliTimestamp();
         self.blitAndPresent(width, height, interval) catch |err| {
             self.policy.fail();
             render_diagnostics.log("dx-present present failed: {s}", .{@errorName(err)});
             return false;
         };
+        const elapsed_ms: u64 = @intCast(@max(std.time.milliTimestamp() - start_ms, 0));
+
+        // The dangerous failure modes here never return an error: a broken
+        // interop path happily "presents" frames GL never wrote (hybrid-GPU
+        // share bugs, driver-forced MSAA making the Y-flip blit an illegal
+        // no-op) or takes seconds per frame (cross-GPU syncs, TDR loops).
+        // Two watchers convert those into the latched GDI fallback.
+        if (!self.probe_done) {
+            self.probeStep(width, height) catch |err| {
+                self.policy.fail();
+                render_diagnostics.log("dx-present probe failed: {s} — frames are not reaching the swapchain", .{@errorName(err)});
+                return false;
+            };
+        }
+        if (self.policy.notePresentMillis(elapsed_ms)) {
+            render_diagnostics.log(
+                "dx-present watchdog: {} consecutive presents over {}ms (last {}ms)",
+                .{ core.PresentPolicy.slow_latch_frames, core.PresentPolicy.slow_frame_ms, elapsed_ms },
+            );
+            // This frame did reach the screen; the latch takes effect on the
+            // next call via frameAction → .fallback.
+        }
         return true;
     }
 
@@ -437,6 +541,98 @@ pub const Presenter = struct {
         const present = comCall(self.swapchain, core.slot.DXGISwapChain_Present, *const fn (*anyopaque, u32, u32) callconv(.winapi) HRESULT);
         const interval_u: u32 = if (interval > 0) 1 else 0;
         if (present(self.swapchain, interval_u, 0) < 0) return error.PresentFailed;
+    }
+
+    /// Verify the present path actually carries pixels: read the same sample
+    /// points back from GL FBO 0 and from the D3D shared texture and compare.
+    /// Runs after each present until a frame with real content matches
+    /// (`probe_done`), erroring out the moment any sample disagrees. Bounded
+    /// by `probe_max_frames` so the Map() sync cost doesn't run forever.
+    fn probeStep(self: *Presenter, width: i32, height: i32) PresentError!void {
+        self.probe_frames += 1;
+        if (self.probe_frames > core.probe_max_frames) {
+            self.settleProbe(true);
+            return;
+        }
+        if (width < 8 or height < 8) return;
+
+        // Informational only: renderer code may legitimately leave a stale
+        // error queued, so a GL error must not fail the probe by itself —
+        // but it's the smoking gun for the forced-MSAA illegal-blit case.
+        const gl_err = self.gl.get_error();
+        if (gl_err != 0)
+            render_diagnostics.log("dx-present probe: GL error 0x{x} pending after blit", .{gl_err});
+
+        if (self.probe_staging == null) try self.createProbeStaging(width, height);
+        const staging = self.probe_staging.?;
+
+        const copy_resource = comCall(self.context, core.slot.D3D11DeviceContext_CopyResource, *const fn (*anyopaque, *anyopaque, *anyopaque) callconv(.winapi) void);
+        copy_resource(self.context, staging, self.shared_tex.?);
+
+        const map = comCall(self.context, core.slot.D3D11DeviceContext_Map, *const fn (*anyopaque, *anyopaque, u32, u32, u32, *core.D3D11_MAPPED_SUBRESOURCE) callconv(.winapi) HRESULT);
+        const unmap = comCall(self.context, core.slot.D3D11DeviceContext_Unmap, *const fn (*anyopaque, *anyopaque, u32) callconv(.winapi) void);
+        var mapped: core.D3D11_MAPPED_SUBRESOURCE = undefined;
+        if (map(self.context, staging, 0, core.D3D11_MAP_READ, 0, &mapped) < 0 or mapped.p_data == null)
+            return error.ProbeReadbackFailed;
+        defer unmap(self.context, staging, 0);
+        const dx_bytes: [*]const u8 = @ptrCast(mapped.p_data.?);
+
+        // 3×3 grid; corners-ish + center so titlebar/background/content areas
+        // are all represented.
+        var gl_rgb: [9][3]u8 = undefined;
+        var dx_rgb: [9][3]u8 = undefined;
+        var i: usize = 0;
+        for ([3]i32{ @divTrunc(height, 4), @divTrunc(height, 2), @divTrunc(height * 3, 4) }) |y| {
+            for ([3]i32{ @divTrunc(width, 4), @divTrunc(width, 2), @divTrunc(width * 3, 4) }) |x| {
+                var px: [4]u8 = undefined; // RGBA from GL
+                // The shared texture holds the Y-flipped (top-down) image;
+                // FBO 0 is bottom-up, so sample its mirrored row.
+                self.gl.read_pixels(x, height - 1 - y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, &px);
+                gl_rgb[i] = .{ px[0], px[1], px[2] };
+                const row_offset: usize = @as(usize, @intCast(y)) * mapped.row_pitch;
+                const dx_px = dx_bytes[row_offset + @as(usize, @intCast(x)) * 4 ..][0..4]; // BGRA
+                dx_rgb[i] = .{ dx_px[2], dx_px[1], dx_px[0] };
+                i += 1;
+            }
+        }
+
+        switch (core.evaluateProbe(&gl_rgb, &dx_rgb)) {
+            .mismatched => return error.ProbeMismatch,
+            .matched_uniform => {}, // keep probing until a frame has content
+            .matched_content => self.settleProbe(false),
+        }
+    }
+
+    fn settleProbe(self: *Presenter, gave_up: bool) void {
+        self.probe_done = true;
+        if (self.probe_staging) |s| {
+            comRelease(s);
+            self.probe_staging = null;
+        }
+        if (gave_up)
+            render_diagnostics.log("dx-present probe: no content frame within {} frames — accepting path, watchdog stays armed", .{core.probe_max_frames})
+        else
+            render_diagnostics.log("dx-present probe passed: swapchain verifiably carries GL content", .{});
+    }
+
+    fn createProbeStaging(self: *Presenter, width: i32, height: i32) PresentError!void {
+        const desc = core.D3D11_TEXTURE2D_DESC{
+            .width = @intCast(width),
+            .height = @intCast(height),
+            .mip_levels = 1,
+            .array_size = 1,
+            .format = core.DXGI_FORMAT_B8G8R8A8_UNORM,
+            .sample_desc = .{ .count = 1, .quality = 0 },
+            .usage = core.D3D11_USAGE_STAGING,
+            .bind_flags = 0,
+            .cpu_access_flags = core.D3D11_CPU_ACCESS_READ,
+            .misc_flags = 0,
+        };
+        const create_tex = comCall(self.device, core.slot.D3D11Device_CreateTexture2D, *const fn (*anyopaque, *const core.D3D11_TEXTURE2D_DESC, ?*const anyopaque, *?*anyopaque) callconv(.winapi) HRESULT);
+        var tex: ?*anyopaque = null;
+        if (create_tex(self.device, &desc, null, &tex) < 0 or tex == null)
+            return error.ProbeReadbackFailed;
+        self.probe_staging = tex;
     }
 
     /// Requires the GL context to still be current (interop teardown).

--- a/src/config.zig
+++ b/src/config.zig
@@ -385,8 +385,12 @@ language: i18n.LanguageSetting = .auto,
 /// SwapBuffers (Windows only). The legacy BLT present goes through the DWM
 /// redirection surface, which on some iGPU drivers (Intel Arc, AMD) produces
 /// ghosting/black regions on cross-DPI drags and resizes (#46/#47/#88). Set to
-/// false to force the legacy path; machines where DXGI/interop is unavailable
-/// fall back automatically. Read at startup.
+/// false to force the legacy path. Machines where the D3D path can't work
+/// revert to the legacy path automatically: at init (no interop / no DXGI
+/// adapter matching the GL context's GPU), at runtime (first-frames content
+/// probe + sustained-slow-present watchdog, both latch GDI for the session),
+/// and across launches (a bring-up that crashed the process trips a
+/// state-file fuse for that app version). Read at startup.
 @"wispterm-d3d-present": bool = true,
 
 // ============================================================================

--- a/src/main.zig
+++ b/src/main.zig
@@ -173,6 +173,39 @@ pub fn main() !void {
     // created (the presenter is built right after the GL context).
     window_backend.setFlipPresentEnabled(cfg.@"wispterm-d3d-present");
 
+    // Bring-up crash fuse: presenter init runs driver code (wglDX*NV, D3D11)
+    // that broken ICDs crash in instead of failing — which previously meant
+    // the app never opened again on those machines. Leave a marker before
+    // the first attempt; AppWindow clears it after the first survived
+    // present. Finding our own marker at startup = last bring-up died →
+    // stop trying the D3D path for this app version (an upgrade retries).
+    if (comptime builtin.os.tag == .windows) {
+        if (cfg.@"wispterm-d3d-present") {
+            const window_state = @import("platform/window_state.zig");
+            const dxgi_core = @import("platform/dxgi_core.zig");
+            var stored_buf: [dxgi_core.bringup_marker_max_len]u8 = undefined;
+            const stored = window_state.d3dBringup(allocator, &stored_buf);
+            var marker_buf: [dxgi_core.bringup_marker_max_len]u8 = undefined;
+            switch (dxgi_core.bringupFuseDecision(stored, app_metadata.version)) {
+                .blocked => {
+                    window_backend.setFlipPresentEnabled(false);
+                    render_diagnostics.log("dx-present bring-up fuse tripped (\"{s}\") — GDI for this version", .{stored});
+                    std.debug.print("Win32: last DXGI present bring-up did not survive; using SwapBuffers for v{s}\n", .{app_metadata.version});
+                    if (dxgi_core.bringupMarkerIsProbing(stored)) {
+                        if (dxgi_core.bringupBlockedMarker(&marker_buf, app_metadata.version)) |m|
+                            window_state.recordD3dBringup(allocator, m)
+                        else |_| {}
+                    }
+                },
+                .attempt => {
+                    if (dxgi_core.bringupProbingMarker(&marker_buf, app_metadata.version)) |m|
+                        window_state.recordD3dBringup(allocator, m)
+                    else |_| {}
+                },
+            }
+        }
+    }
+
     // Create the App and run (first window on main thread, spawned windows on separate threads)
     var app = try App.init(allocator, cfg);
     defer ai_chat.deinitAccessRules();

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -51,6 +51,7 @@ fn hexByte(comptime pair: *const [2]u8) u8 {
 
 // Interface IDs the presenter queries.
 pub const IID_IDXGIDevice = guid("54ec77fa-1377-44e6-8c32-88fd5f44c84c");
+pub const IID_IDXGIFactory1 = guid("770aae78-f26f-4dba-a829-253c83d1b387");
 pub const IID_IDXGIFactory2 = guid("50c83a1c-e072-4c48-87b0-3630fa36a6d0");
 pub const IID_IDXGIResource = guid("035f3ab4-482e-4e50-b41f-8a7f8bd8960b");
 pub const IID_ID3D11Texture2D = guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
@@ -93,19 +94,89 @@ pub const D3D11_TEXTURE2D_DESC = extern struct {
     misc_flags: u32,
 };
 
+/// dxgi.h LUID (8 bytes, two-int layout).
+pub const LUID = extern struct {
+    low_part: u32,
+    high_part: i32,
+};
+
+/// dxgi1_2.h DXGI_ADAPTER_DESC1. `dedicated_*`/`shared_*` are SIZE_T, so the
+/// layout test below pins the 64-bit shape the presenter actually runs on.
+pub const DXGI_ADAPTER_DESC1 = extern struct {
+    description: [128]u16,
+    vendor_id: u32,
+    device_id: u32,
+    sub_sys_id: u32,
+    revision: u32,
+    dedicated_video_memory: usize,
+    dedicated_system_memory: usize,
+    shared_system_memory: usize,
+    adapter_luid: LUID,
+    flags: u32,
+};
+
+/// d3d11.h D3D11_MAPPED_SUBRESOURCE.
+pub const D3D11_MAPPED_SUBRESOURCE = extern struct {
+    p_data: ?*anyopaque,
+    row_pitch: u32,
+    depth_pitch: u32,
+};
+
 pub const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87;
 pub const DXGI_USAGE_RENDER_TARGET_OUTPUT: u32 = 0x20;
 pub const DXGI_SCALING_NONE: u32 = 1;
 pub const DXGI_SCALING_STRETCH: u32 = 0;
 pub const DXGI_SWAP_EFFECT_FLIP_DISCARD: u32 = 4;
 pub const DXGI_ALPHA_MODE_IGNORE: u32 = 3;
+pub const DXGI_ADAPTER_FLAG_SOFTWARE: u32 = 2;
 
+pub const D3D_DRIVER_TYPE_UNKNOWN: u32 = 0;
 pub const D3D_DRIVER_TYPE_HARDWARE: u32 = 1;
 pub const D3D11_SDK_VERSION: u32 = 7;
 pub const D3D11_CREATE_DEVICE_BGRA_SUPPORT: u32 = 0x20;
 pub const D3D11_USAGE_DEFAULT: u32 = 0;
+pub const D3D11_USAGE_STAGING: u32 = 3;
 pub const D3D11_BIND_RENDER_TARGET: u32 = 0x20;
+pub const D3D11_CPU_ACCESS_READ: u32 = 0x20000;
 pub const D3D11_RESOURCE_MISC_SHARED: u32 = 0x2;
+pub const D3D11_MAP_READ: u32 = 1;
+
+// PCI vendor IDs, for matching the GL context's GPU to a DXGI adapter.
+pub const PCI_VENDOR_NVIDIA: u32 = 0x10DE;
+pub const PCI_VENDOR_INTEL: u32 = 0x8086;
+pub const PCI_VENDOR_AMD: u32 = 0x1002;
+pub const PCI_VENDOR_MICROSOFT: u32 = 0x1414; // WARP / Basic Render
+
+/// Map `glGetString(GL_VENDOR)` to the PCI vendor id of the GPU the GL
+/// context runs on. WGL_NV_DX_interop2 sharing is only defined when the D3D11
+/// device lives on the *same* adapter as the GL context; on hybrid-GPU
+/// laptops `D3D11CreateDevice(adapter=null)` picks the default adapter, which
+/// is frequently the *other* GPU — drivers then either stall every frame on
+/// cross-GPU syncs or "succeed" while presenting frames GL never wrote
+/// (the v1.18.0 black-screen/slideshow reports). Returns null for vendors
+/// with no reliable interop story (e.g. ARM GL emulation) — callers must
+/// fall back to GDI rather than guess.
+pub fn pciVendorForGlVendor(gl_vendor: []const u8) ?u32 {
+    var lower_buf: [64]u8 = undefined;
+    if (gl_vendor.len == 0 or gl_vendor.len > lower_buf.len) return null;
+    const lower = std.ascii.lowerString(&lower_buf, gl_vendor);
+    if (std.mem.indexOf(u8, lower, "nvidia") != null) return PCI_VENDOR_NVIDIA;
+    if (std.mem.indexOf(u8, lower, "intel") != null) return PCI_VENDOR_INTEL;
+    if (std.mem.indexOf(u8, lower, "amd") != null) return PCI_VENDOR_AMD;
+    if (std.mem.indexOf(u8, lower, "ati ") != null or
+        std.mem.startsWith(u8, lower, "ati")) return PCI_VENDOR_AMD;
+    if (std.mem.indexOf(u8, lower, "microsoft") != null) return PCI_VENDOR_MICROSOFT;
+    return null;
+}
+
+/// Whether a DXGI adapter is an acceptable home for the presenter's D3D11
+/// device given the GL context's vendor. Software adapters (WARP) only match
+/// when GL itself is software-rendered.
+pub fn adapterUsableForVendor(desc_vendor_id: u32, desc_flags: u32, want_vendor: u32) bool {
+    if ((desc_flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0 and want_vendor != PCI_VENDOR_MICROSOFT)
+        return false;
+    return desc_vendor_id == want_vendor;
+}
 
 // ============================================================================
 // COM vtable slots
@@ -125,7 +196,10 @@ pub const slot = struct {
     // ID3D11Device (derives IUnknown directly)
     pub const D3D11Device_CreateTexture2D: usize = 5;
 
-    // ID3D11DeviceContext (IUnknown + ID3D11DeviceChild(4) → first own slot 7)
+    // ID3D11DeviceContext (IUnknown + ID3D11DeviceChild(4) → first own slot 7:
+    // VSSetConstantBuffers(7) … Draw(13) Map(14) Unmap(15) … CopyResource(47))
+    pub const D3D11DeviceContext_Map: usize = 14;
+    pub const D3D11DeviceContext_Unmap: usize = 15;
     pub const D3D11DeviceContext_CopyResource: usize = 47;
 
     // IDXGIObject: SetPrivateData(3) SetPrivateDataInterface(4)
@@ -138,9 +212,16 @@ pub const slot = struct {
     // IDXGIFactory (IDXGIObject + EnumAdapters(7) MakeWindowAssociation(8) …)
     pub const DXGIFactory_MakeWindowAssociation: usize = 8;
 
+    // IDXGIFactory1 (IDXGIObject + IDXGIFactory(5) → EnumAdapters1(12))
+    pub const DXGIFactory1_EnumAdapters1: usize = 12;
+
     // IDXGIFactory2 (IDXGIObject + IDXGIFactory(5) + IDXGIFactory1(2) →
     // IsWindowedStereoEnabled(14), CreateSwapChainForHwnd(15))
     pub const DXGIFactory2_CreateSwapChainForHwnd: usize = 15;
+
+    // IDXGIAdapter1 (IDXGIObject + EnumOutputs(7) GetDesc(8)
+    // CheckInterfaceSupport(9) → GetDesc1(10))
+    pub const DXGIAdapter1_GetDesc1: usize = 10;
 
     // IDXGIDeviceSubObject: GetDevice(7)
     // IDXGISwapChain: Present(8) GetBuffer(9) SetFullscreenState(10)
@@ -162,9 +243,17 @@ pub const slot = struct {
 pub const PresentPolicy = struct {
     pub const Action = enum { skip, present, resize_then_present, fallback };
 
+    /// Watchdog: a present this slow is a stalled interop sync / TDR loop,
+    /// not vsync (16ms) or a scheduler hiccup.
+    pub const slow_frame_ms: u64 = 400;
+    /// Consecutive slow presents before latching fallback. High enough that a
+    /// burst of post-resume / driver-recovery frames doesn't trip it.
+    pub const slow_latch_frames: u32 = 5;
+
     width: i32,
     height: i32,
     failed: bool = false,
+    slow_streak: u32 = 0,
 
     pub fn init(width: i32, height: i32) PresentPolicy {
         return .{ .width = width, .height = height };
@@ -184,12 +273,111 @@ pub const PresentPolicy = struct {
         self.height = height;
     }
 
+    /// Watchdog feed: duration of a *successful* present. A broken interop
+    /// path can stall for seconds per frame without ever returning an error
+    /// (cross-GPU syncs, TDR recovery loops) — the only externally visible
+    /// signal is time. Latches `failed` after `slow_latch_frames` consecutive
+    /// slow presents; returns true exactly when this call latched it.
+    pub fn notePresentMillis(self: *PresentPolicy, ms: u64) bool {
+        if (self.failed) return false;
+        if (ms < slow_frame_ms) {
+            self.slow_streak = 0;
+            return false;
+        }
+        self.slow_streak += 1;
+        if (self.slow_streak < slow_latch_frames) return false;
+        self.failed = true;
+        return true;
+    }
+
     /// Latch the fallback path for the rest of the session — a presenter that
     /// failed once must not flap between DXGI and GDI presents.
     pub fn fail(self: *PresentPolicy) void {
         self.failed = true;
     }
 };
+
+// ============================================================================
+// First-frames content probe
+// ============================================================================
+
+/// Stop probing after this many presented frames without a verdict: the cost
+/// of the staging-readback sync isn't worth carrying forever, and the
+/// watchdog still covers late-onset stalls.
+pub const probe_max_frames: u32 = 120;
+
+pub const ProbeVerdict = enum {
+    /// A sampled pixel differs between what GL rendered and what reached the
+    /// swapchain: the interop path is silently dropping/corrupting frames.
+    mismatched,
+    /// Samples agree but the GL frame was a single flat color — consistent
+    /// with a broken path that happens to show the same flat color (e.g.
+    /// black-on-black), so not yet proof the path works.
+    matched_uniform,
+    /// Samples agree on a frame with real content: the path verifiably
+    /// carries pixels end-to-end.
+    matched_content,
+};
+
+/// Compare per-sample RGB read back from the GL framebuffer against the same
+/// points read back from the D3D shared texture (callers handle the Y-flip
+/// and BGRA→RGB swizzle when sampling). The blit + CopyResource chain is
+/// bit-exact, so any difference means the present path is broken even though
+/// every API call "succeeded".
+pub fn evaluateProbe(gl_rgb: []const [3]u8, dx_rgb: []const [3]u8) ProbeVerdict {
+    std.debug.assert(gl_rgb.len == dx_rgb.len and gl_rgb.len > 0);
+    for (gl_rgb, dx_rgb) |g, d| {
+        if (g[0] != d[0] or g[1] != d[1] or g[2] != d[2]) return .mismatched;
+    }
+    for (gl_rgb[1..]) |g| {
+        if (g[0] != gl_rgb[0][0] or g[1] != gl_rgb[0][1] or g[2] != gl_rgb[0][2])
+            return .matched_content;
+    }
+    return .matched_uniform;
+}
+
+// ============================================================================
+// Bring-up crash fuse
+// ============================================================================
+//
+// Presenter init + the first present run driver code (wglDX*NV, D3D11) that
+// on broken ICDs can crash the process outright instead of returning an
+// error — the "v1.18 won't open" reports. The fuse is a state-file marker
+// written before the first window is created and removed after the first
+// successful present: a leftover "probing:<version>" marker on the next
+// launch means the last bring-up died mid-flight, so that app version stops
+// trying D3D on this machine ("blocked:<version>"). A new app version
+// retries once.
+
+pub const bringup_probing_prefix = "probing:";
+pub const bringup_blocked_prefix = "blocked:";
+/// Marker = prefix + version; sized for window_state_codec's version cap.
+pub const bringup_marker_max_len: usize = 32;
+
+pub const BringupFuse = enum { attempt, blocked };
+
+pub fn bringupProbingMarker(buf: []u8, version: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, bringup_probing_prefix ++ "{s}", .{version});
+}
+
+pub fn bringupBlockedMarker(buf: []u8, version: []const u8) ![]const u8 {
+    return std.fmt.bufPrint(buf, bringup_blocked_prefix ++ "{s}", .{version});
+}
+
+pub fn bringupMarkerIsProbing(stored: []const u8) bool {
+    return std.mem.startsWith(u8, stored, bringup_probing_prefix);
+}
+
+/// Decide whether this launch may try the D3D present path. Only markers for
+/// the *current* version block: an upgrade retries once (the driver bug may
+/// be fixed, ours may be), and stale markers from other versions are ignored.
+pub fn bringupFuseDecision(stored: []const u8, version: []const u8) BringupFuse {
+    inline for (.{ bringup_probing_prefix, bringup_blocked_prefix }) |prefix| {
+        if (std.mem.startsWith(u8, stored, prefix) and
+            std.mem.eql(u8, stored[prefix.len..], version)) return .blocked;
+    }
+    return .attempt;
+}
 
 // ============================================================================
 // Tests (fast suite — registered in test_fast.zig)
@@ -275,4 +463,84 @@ test "PresentPolicy latches fallback after a failure" {
     // No recovery mid-session: a flaky presenter must not flap between paths.
     p.noteResized(800, 600);
     try std.testing.expectEqual(PresentPolicy.Action.fallback, p.frameAction(800, 600));
+}
+
+test "DXGI_ADAPTER_DESC1 matches the documented 64-bit layout" {
+    try std.testing.expectEqual(@as(usize, 312), @sizeOf(DXGI_ADAPTER_DESC1));
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(DXGI_ADAPTER_DESC1, "description"));
+    try std.testing.expectEqual(@as(usize, 256), @offsetOf(DXGI_ADAPTER_DESC1, "vendor_id"));
+    try std.testing.expectEqual(@as(usize, 272), @offsetOf(DXGI_ADAPTER_DESC1, "dedicated_video_memory"));
+    try std.testing.expectEqual(@as(usize, 296), @offsetOf(DXGI_ADAPTER_DESC1, "adapter_luid"));
+    try std.testing.expectEqual(@as(usize, 304), @offsetOf(DXGI_ADAPTER_DESC1, "flags"));
+}
+
+test "D3D11_MAPPED_SUBRESOURCE matches the documented 64-bit layout" {
+    try std.testing.expectEqual(@as(usize, 16), @sizeOf(D3D11_MAPPED_SUBRESOURCE));
+    try std.testing.expectEqual(@as(usize, 8), @offsetOf(D3D11_MAPPED_SUBRESOURCE, "row_pitch"));
+    try std.testing.expectEqual(@as(usize, 12), @offsetOf(D3D11_MAPPED_SUBRESOURCE, "depth_pitch"));
+}
+
+test "pciVendorForGlVendor maps the real GL vendor strings" {
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_NVIDIA), pciVendorForGlVendor("NVIDIA Corporation"));
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_INTEL), pciVendorForGlVendor("Intel"));
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_INTEL), pciVendorForGlVendor("Intel Open Source Technology Center"));
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_AMD), pciVendorForGlVendor("ATI Technologies Inc."));
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_AMD), pciVendorForGlVendor("AMD"));
+    try std.testing.expectEqual(@as(?u32, PCI_VENDOR_MICROSOFT), pciVendorForGlVendor("Microsoft Corporation"));
+    // Unknown vendors must NOT guess an adapter — callers fall back to GDI.
+    try std.testing.expectEqual(@as(?u32, null), pciVendorForGlVendor("Mesa/X.org"));
+    try std.testing.expectEqual(@as(?u32, null), pciVendorForGlVendor(""));
+}
+
+test "adapterUsableForVendor rejects software adapters for hardware GL" {
+    try std.testing.expect(adapterUsableForVendor(PCI_VENDOR_NVIDIA, 0, PCI_VENDOR_NVIDIA));
+    // Hybrid laptop: iGPU enumerated first must not match a dGPU GL context.
+    try std.testing.expect(!adapterUsableForVendor(PCI_VENDOR_INTEL, 0, PCI_VENDOR_NVIDIA));
+    // WARP only pairs with software GL.
+    try std.testing.expect(!adapterUsableForVendor(PCI_VENDOR_MICROSOFT, DXGI_ADAPTER_FLAG_SOFTWARE, PCI_VENDOR_NVIDIA));
+    try std.testing.expect(adapterUsableForVendor(PCI_VENDOR_MICROSOFT, DXGI_ADAPTER_FLAG_SOFTWARE, PCI_VENDOR_MICROSOFT));
+}
+
+test "PresentPolicy watchdog latches only on a sustained slow streak" {
+    var p = PresentPolicy.init(800, 600);
+    // A fast frame resets the streak: 4 slow + fast + 4 slow never latches.
+    for (0..PresentPolicy.slow_latch_frames - 1) |_| try std.testing.expect(!p.notePresentMillis(900));
+    try std.testing.expect(!p.notePresentMillis(5));
+    for (0..PresentPolicy.slow_latch_frames - 1) |_| try std.testing.expect(!p.notePresentMillis(900));
+    try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(800, 600));
+    // The Nth consecutive slow frame latches, exactly once.
+    try std.testing.expect(p.notePresentMillis(900));
+    try std.testing.expect(!p.notePresentMillis(900));
+    try std.testing.expectEqual(PresentPolicy.Action.fallback, p.frameAction(800, 600));
+}
+
+test "evaluateProbe verdicts: mismatch, uniform match, content match" {
+    const black: [3]u8 = .{ 0, 0, 0 };
+    const grey: [3]u8 = .{ 30, 33, 40 };
+    const text: [3]u8 = .{ 220, 220, 225 };
+    // Broken interop: GL drew content, swapchain got nothing.
+    try std.testing.expectEqual(ProbeVerdict.mismatched, evaluateProbe(&.{ grey, text }, &.{ black, black }));
+    // Single-channel corruption counts too.
+    try std.testing.expectEqual(ProbeVerdict.mismatched, evaluateProbe(&.{ grey, grey }, &.{ grey, .{ 30, 33, 41 } }));
+    // Flat frame matching is not yet proof.
+    try std.testing.expectEqual(ProbeVerdict.matched_uniform, evaluateProbe(&.{ black, black }, &.{ black, black }));
+    // Real content matching settles the probe.
+    try std.testing.expectEqual(ProbeVerdict.matched_content, evaluateProbe(&.{ grey, text }, &.{ grey, text }));
+}
+
+test "bringup fuse blocks only markers for the current version" {
+    var buf: [bringup_marker_max_len]u8 = undefined;
+    const probing = try bringupProbingMarker(&buf, "1.19.0");
+    try std.testing.expectEqualStrings("probing:1.19.0", probing);
+    try std.testing.expect(bringupMarkerIsProbing(probing));
+
+    // Crashed during last bring-up of this version → blocked.
+    try std.testing.expectEqual(BringupFuse.blocked, bringupFuseDecision("probing:1.19.0", "1.19.0"));
+    try std.testing.expectEqual(BringupFuse.blocked, bringupFuseDecision("blocked:1.19.0", "1.19.0"));
+    // A new version retries once; stale/garbage markers don't block.
+    try std.testing.expectEqual(BringupFuse.attempt, bringupFuseDecision("blocked:1.18.0", "1.19.0"));
+    try std.testing.expectEqual(BringupFuse.attempt, bringupFuseDecision("probing:1.18.0", "1.19.0"));
+    try std.testing.expectEqual(BringupFuse.attempt, bringupFuseDecision("", "1.19.0"));
+    try std.testing.expectEqual(BringupFuse.attempt, bringupFuseDecision("garbage", "1.19.0"));
+    try std.testing.expect(!bringupMarkerIsProbing("blocked:1.19.0"));
 }

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -174,6 +174,15 @@ pub fn swapBuffers(window: *Window) void {
     window.swapBuffers();
 }
 
+/// One-shot (Windows-only): true when the DXGI presenter latched a
+/// mid-session failure and the window reverted to GDI since the last call.
+/// The app loop rebuilds GPU-side caches (glyph atlas) in response, since a
+/// stalling/TDR-ing present path drops texture uploads made while broken.
+pub fn takePresentFallbackEvent(window: *Window) bool {
+    if (comptime @hasDecl(Window, "takePresentFallbackEvent")) return window.takePresentFallbackEvent();
+    return false;
+}
+
 pub fn framebufferSize(window: *Window) Size {
     const size = window.getFramebufferSize();
     return .{ .width = size.width, .height = size.height };

--- a/src/platform/window_state.zig
+++ b/src/platform/window_state.zig
@@ -50,7 +50,7 @@ fn loadPersisted(allocator: std.mem.Allocator) codec.PersistedState {
 fn savePersisted(allocator: std.mem.Allocator, state: codec.PersistedState) void {
     const path = stateFilePath(allocator) orelse return;
     defer allocator.free(path);
-    var buf: [256]u8 = undefined;
+    var buf: [384]u8 = undefined;
     const content = codec.format(&buf, state) catch return;
     if (std.fs.cwd().createFile(path, .{})) |file| {
         defer file.close();
@@ -143,4 +143,30 @@ pub fn recordSeenVersion(allocator: std.mem.Allocator, version: []const u8) void
     const current = loadPersisted(allocator);
     if (std.mem.eql(u8, current.lastSeenVersion(), version)) return;
     savePersisted(allocator, codec.withLastSeenVersion(current, version));
+}
+
+/// The stored D3D present bring-up marker (empty when none). The returned
+/// slice is copied into `buf`; pass at least `codec.bringup_max_len` bytes.
+pub fn d3dBringup(allocator: std.mem.Allocator, buf: []u8) []const u8 {
+    const m = loadPersisted(allocator).d3dBringup();
+    const n = @min(m.len, buf.len);
+    @memcpy(buf[0..n], m[0..n]);
+    return buf[0..n];
+}
+
+/// Persist a D3D bring-up marker (read-modify-write). Written *before* the
+/// first presenter init so a driver crash during bring-up leaves it behind.
+pub fn recordD3dBringup(allocator: std.mem.Allocator, marker: []const u8) void {
+    const current = loadPersisted(allocator);
+    savePersisted(allocator, codec.withD3dBringup(current, marker));
+}
+
+/// Clear the marker after the process survived its first present — but only
+/// a "probing" marker. A "blocked" marker must persist across launches, or a
+/// machine whose driver crashes at init would alternate crash/run forever.
+pub fn settleD3dBringup(allocator: std.mem.Allocator) void {
+    const current = loadPersisted(allocator);
+    if (current.d3d_bringup_len == 0) return;
+    if (!std.mem.startsWith(u8, current.d3dBringup(), "probing:")) return;
+    savePersisted(allocator, codec.withD3dBringup(current, ""));
 }

--- a/src/platform/window_state_codec.zig
+++ b/src/platform/window_state_codec.zig
@@ -14,6 +14,10 @@ pub const MAX_DIMENSION: i32 = 32_767;
 /// values are truncated on read (never overflow).
 pub const version_max_len: usize = 24;
 
+/// Max stored length of the D3D present bring-up marker
+/// ("probing:<version>" / "blocked:<version>", see dxgi_core's crash fuse).
+pub const bringup_max_len: usize = 32;
+
 pub const PersistedState = struct {
     x: ?i32 = null,
     y: ?i32 = null,
@@ -32,9 +36,19 @@ pub const PersistedState = struct {
     // so this pure codec stays allocation-free and never aliases the parse input.
     last_seen_version_buf: [version_max_len]u8 = undefined,
     last_seen_version_len: usize = 0,
+    // Windows D3D present bring-up crash-fuse marker (empty = no marker).
+    // Written before the first presenter init, cleared after the first
+    // successful present; a leftover marker disables the D3D path for that
+    // app version (see dxgi_core.bringupFuseDecision).
+    d3d_bringup_buf: [bringup_max_len]u8 = undefined,
+    d3d_bringup_len: usize = 0,
 
     pub fn lastSeenVersion(self: *const PersistedState) []const u8 {
         return self.last_seen_version_buf[0..self.last_seen_version_len];
+    }
+
+    pub fn d3dBringup(self: *const PersistedState) []const u8 {
+        return self.d3d_bringup_buf[0..self.d3d_bringup_len];
     }
 };
 
@@ -78,6 +92,10 @@ pub fn parse(data: []const u8) PersistedState {
             const n = @min(val.len, version_max_len);
             @memcpy(state.last_seen_version_buf[0..n], val[0..n]);
             state.last_seen_version_len = n;
+        } else if (std.mem.eql(u8, key, "d3d-bringup")) {
+            const n = @min(val.len, bringup_max_len);
+            @memcpy(state.d3d_bringup_buf[0..n], val[0..n]);
+            state.d3d_bringup_len = n;
         }
     }
     return state;
@@ -99,7 +117,20 @@ pub fn format(buf: []u8, state: PersistedState) ![]const u8 {
     if (state.last_seen_version_len > 0) {
         len += (try std.fmt.bufPrint(buf[len..], "last-seen-version = {s}\n", .{state.lastSeenVersion()})).len;
     }
+    if (state.d3d_bringup_len > 0) {
+        len += (try std.fmt.bufPrint(buf[len..], "d3d-bringup = {s}\n", .{state.d3dBringup()})).len;
+    }
     return buf[0..len];
+}
+
+/// Copy of `state` with the D3D bring-up marker replaced (truncated to
+/// bringup_max_len; empty clears it). Leaves everything else untouched.
+pub fn withD3dBringup(state: PersistedState, marker: []const u8) PersistedState {
+    var next = state;
+    const n = @min(marker.len, bringup_max_len);
+    @memcpy(next.d3d_bringup_buf[0..n], marker[0..n]);
+    next.d3d_bringup_len = n;
+    return next;
 }
 
 /// Copy of `state` with position overwritten; size fields replaced only when the
@@ -269,4 +300,39 @@ test "over-length last-seen-version is truncated, never overflows" {
     const long = "1.2.3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const s = withLastSeenVersion(.{}, long);
     try std.testing.expectEqual(version_max_len, s.last_seen_version_len);
+}
+
+test "d3d-bringup marker round-trips, clears, and is omitted when empty" {
+    var buf: [384]u8 = undefined;
+    // empty → omitted
+    const empty_text = try format(&buf, .{});
+    try std.testing.expect(std.mem.indexOf(u8, empty_text, "d3d-bringup") == null);
+    // set → present and reparses alongside other keys
+    const set = withD3dBringup(.{ .x = 4, .ai_setup_prompted = true }, "probing:1.19.0");
+    const text = try format(&buf, set);
+    const reparsed = parse(text);
+    try std.testing.expectEqualStrings("probing:1.19.0", reparsed.d3dBringup());
+    try std.testing.expectEqual(@as(?i32, 4), reparsed.x);
+    // clearing with an empty marker removes the key on the next format
+    const cleared_text = try format(&buf, withD3dBringup(reparsed, ""));
+    try std.testing.expect(std.mem.indexOf(u8, cleared_text, "d3d-bringup") == null);
+}
+
+test "old state file without d3d-bringup leaves the marker empty" {
+    const s = parse("window-x = 10\nai-setup-prompted = 1\n");
+    try std.testing.expectEqual(@as(usize, 0), s.d3d_bringup_len);
+}
+
+test "a full state file fits the save buffer with the bring-up marker" {
+    // savePersisted formats into a fixed buffer; every key at worst-case
+    // width must fit or the marker write would be silently dropped.
+    var full = PersistedState{
+        .x = -32768, .y = -32768, .width = 32767, .height = 32767,
+        .quake_x = -32768, .quake_y = -32768, .quake_width = 32767, .quake_height = 32767,
+        .ai_setup_prompted = true,
+    };
+    full = withLastSeenVersion(full, "1.2.3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    full = withD3dBringup(full, "probing:1.2.3-aaaaaaaaaaaaaaaaaaaaaaaa");
+    var buf: [384]u8 = undefined;
+    _ = try format(&buf, full);
 }


### PR DESCRIPTION
## 背景

v1.18.0 默认启用了 #189 的 DXGI flip-model present 路径后，多名 Windows 用户反馈：

- 黑屏、画面像幻灯片一样几秒一跳，伴随严重卡顿
- 窗口点 X 关不掉（win32 host 消息泵与 present 同线程，present 卡死即泵死）
- 部分 Win11 机器升级后**完全打不开**
- 卡顿期间出现的中文字**永久缺字**（GPU TDR 重置丢掉字形图集上传，缓存却认为已上传）
- 同机并跑 v1.17.0 一切正常

共同根因：这些失效模式下**每个 D3D/WGL 调用都返回成功**——跨显卡 interop 静默出黑帧/每帧跨 GPU 同步、驱动强制 MSAA 使 Y-flip blit 成为非法 no-op、驱动在 init 中直接崩溃——现有"报错才回退 GDI"的 latch 一次都不会触发。

## 方案：四道防线（长期方案，保持默认开启）

1. **适配器一致性匹配**（`pickAdapter`）：按 `GL_VENDOR` 的 PCI vendor 枚举 DXGI 适配器建 D3D11 设备，不再用默认适配器。治混合显卡（iGPU+dGPU）静默黑屏/卡顿的主嫌疑路径；同时让双显卡笔记本真正用上 flip 修复而非退回。
2. **首帧内容探针**（`probeStep` + 纯函数 `evaluateProbe`）：present 后用 staging 纹理回读共享纹理 3×3 采样点，与 `glReadPixels` 从 GL FBO 0 读回的同位置（Y-flip 对应）比对；有内容帧出现任何不一致 → 像素根本没到 swapchain → latch 回退 GDI。最多探 120 帧，验证通过即停。
3. **present 看门狗**（`PresentPolicy.notePresentMillis`）：连续 5 帧 blit+present 超 400ms（跨 GPU 同步、TDR 恢复循环）→ latch 回退。
4. **启动崩溃保险丝**（state 文件 `d3d-bringup` 标记）：首个 presenter init 前写入 `probing:<version>`，首帧 present 存活后清除；下次启动发现残留标记 = 上次 bring-up 死在驱动里 → 本版本不再尝试 D3D 路径（写 `blocked:<version>`），升级新版本重试一次。治"打不开"——第二次启动必然能开。

另外：任何会话中途回退 GDI 时，主循环重建字形图集（`font.clearGlyphCache` + 全量 rebuild），治坏窗口期造成的永久缺字。

## 实现说明

- 纯逻辑全部在 `dxgi_core.zig`（vendor 映射、探针判定、看门狗、保险丝状态机、`DXGI_ADAPTER_DESC1`/`D3D11_MAPPED_SUBRESOURCE` ABI 布局）和 `window_state_codec.zig`（`d3d-bringup` 键），fast suite 直接覆盖
- AppWindow 保持 backend-neutral（无 `builtin.os.tag`，通过 `window_backend.takePresentFallbackEvent` 分发，非 Windows 恒 false；settle 在无标记时为空操作）
- 显式适配器 + `D3D_DRIVER_TYPE_UNKNOWN`（API 要求）；WARP 仅在 GL 本身软渲染时匹配
- 探针对 GL error 只记日志不判死（渲染器可能合法残留 error），判定唯一依据是像素比对

## 验证

- `zig build test` ✅
- `zig build test-full` ✅
- `zig build`（windows-gnu app，`wispterm.exe`）✅
- Windows 真机 GUI 验证：待发版前冒烟（重点：混合显卡笔记本 + Intel 核显机器；可让反馈用户先用 `wispterm-d3d-present = false` 验证根因，再换装本分支构建验证防线生效。诊断日志看 `wispterm-debug-render = true` 输出的 `dx-present adapter/probe/watchdog/fuse` 行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)