### PR TITLE
fix(win32): stop the DXGI guard from blanking flip-presented windows mid-session

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -7154,6 +7154,17 @@ fn runMainLoop(self: *AppWindow) !void {
             font.clearGlyphCache(allocator);
             g_force_rebuild = true;
             g_cells_valid = false;
+            // The in-session GDI switch is best-effort only: this HWND has
+            // already flip-presented, and blt presents on such a window are
+            // undefined (often blank). Persist the marker so the next launch
+            // of this version runs GDI from frame 0, which always works.
+            platform_window_state.blockD3dBringup(allocator, build_options.app_version);
+        }
+        if (window_backend.takePresentDegradedEvent(win)) {
+            // Watchdog: presents are sustained-slow but frames do reach the
+            // screen, so the session keeps the flip path (switching would
+            // blank the window). Next launch goes straight to GDI instead.
+            platform_window_state.blockD3dBringup(allocator, build_options.app_version);
         }
     }
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -846,8 +846,14 @@ pub const Window = struct {
     /// Set when the presenter latched a mid-session failure and the window
     /// reverted to GDI. Consumed by the app loop (takePresentFallbackEvent)
     /// to rebuild GPU-side caches the broken period may have corrupted
-    /// (glyph-atlas uploads dropped during a device reset → missing glyphs).
+    /// (glyph-atlas uploads dropped during a device reset → missing glyphs)
+    /// and to persist the marker that keeps the next launch on GDI.
     present_fallback_event: bool = false,
+    /// Set when the presenter's watchdog flagged sustained slow presents.
+    /// The session stays on the flip path (flip→GDI on a presented HWND is
+    /// unsupported and blanks the window); the app loop persists the marker
+    /// that sends the next launch down the GDI path from frame 0.
+    present_degraded_event: bool = false,
     should_close: bool = false,
     close_requested: bool = false,
     width: i32 = 800,
@@ -1260,9 +1266,16 @@ pub const Window = struct {
     pub fn swapBuffers(self: *Window) void {
         if (self.dx) |*dx| {
             const size = self.getFramebufferSize();
-            if (dx.presentFrame(size.width, size.height, g_present_interval)) return;
-            // The presenter latched a failure; tear it down and finish the
-            // session on the GDI path (this frame included).
+            if (dx.presentFrame(size.width, size.height, g_present_interval)) {
+                if (dx.takeDegradedEvent()) self.present_degraded_event = true;
+                return;
+            }
+            // The presenter latched a hard failure (API error / probe
+            // mismatch): pixels were not reaching the screen anyway, so a
+            // GDI finish for the session is a best effort — flip→blt on an
+            // already-presented HWND is unsupported and may stay blank. The
+            // fallback event also persists the marker that guarantees the
+            // next launch runs GDI from frame 0.
             render_diagnostics.log("dx-present failed mid-session — reverting to GDI SwapBuffers", .{});
             std.debug.print("Win32: DXGI present failed, reverting to SwapBuffers\n", .{});
             dx.deinit();
@@ -1273,10 +1286,20 @@ pub const Window = struct {
     }
 
     /// One-shot: true when the DXGI presenter latched a mid-session failure
-    /// since the last call. The app loop reacts by rebuilding GPU caches.
+    /// since the last call. The app loop reacts by rebuilding GPU caches and
+    /// persisting the next-launch GDI marker.
     pub fn takePresentFallbackEvent(self: *Window) bool {
         const fired = self.present_fallback_event;
         self.present_fallback_event = false;
+        return fired;
+    }
+
+    /// One-shot: true when the presenter's watchdog flagged sustained slow
+    /// presents since the last call. Presentation continues on the flip path;
+    /// the app loop persists the next-launch GDI marker.
+    pub fn takePresentDegradedEvent(self: *Window) bool {
+        const fired = self.present_degraded_event;
+        self.present_degraded_event = false;
         return fired;
     }
 

--- a/src/apprt/win32_dx_present.zig
+++ b/src/apprt/win32_dx_present.zig
@@ -31,7 +31,18 @@
 //!     shared texture must agree on a frame with real content, otherwise the
 //!     path is silently dropping pixels → latch fallback;
 //!   • a present-duration watchdog: sustained multi-hundred-ms presents
-//!     (cross-GPU syncs, TDR recovery loops) → latch fallback.
+//!     (cross-GPU syncs, TDR recovery loops) → flag the session degraded.
+//!
+//! The two react differently because the mid-session fallback is itself
+//! dangerous: an HWND that has presented through a flip-model swapchain
+//! cannot revert to GDI/blt presents (DWM behavior is undefined; in the
+//! v1.19.0 field reports it rendered the window black on machines that were
+//! merely *slow* in v1.18.0). Only failure modes where pixels verifiably do
+//! NOT reach the screen (API errors, probe mismatch) still switch to GDI
+//! in-session — the screen is already broken there, GDI is a best effort.
+//! The watchdog instead keeps the session on the flip path and emits a
+//! degraded event; the caller persists a state-file marker so the NEXT
+//! launch uses GDI from frame 0, which is the supported configuration.
 //! Crashes *inside* driver init are handled one level up by the bring-up
 //! fuse (state-file marker, see dxgi_core + main.zig): the next launch skips
 //! the D3D path for this app version.
@@ -214,6 +225,10 @@ pub const Presenter = struct {
     probe_staging: ?*anyopaque = null, // ID3D11Texture2D (STAGING)
     probe_done: bool = false,
     probe_frames: u32 = 0,
+    // One-shot: the watchdog saw sustained slow presents. The session stays
+    // on the flip path (see module docs); the consumer persists the marker
+    // that sends the next launch down the GDI path from frame 0.
+    degraded_event: bool = false,
 
     policy: core.PresentPolicy,
 
@@ -509,13 +524,22 @@ pub const Presenter = struct {
         }
         if (self.policy.notePresentMillis(elapsed_ms)) {
             render_diagnostics.log(
-                "dx-present watchdog: {} consecutive presents over {}ms (last {}ms)",
+                "dx-present watchdog: {} consecutive presents over {}ms (last {}ms) — staying on the flip path this session, GDI from next launch",
                 .{ core.PresentPolicy.slow_latch_frames, core.PresentPolicy.slow_frame_ms, elapsed_ms },
             );
-            // This frame did reach the screen; the latch takes effect on the
-            // next call via frameAction → .fallback.
+            // Frames ARE reaching the screen, just slowly — switching this
+            // HWND to GDI now would blank it (flip→blt is unsupported).
+            self.degraded_event = true;
         }
         return true;
+    }
+
+    /// One-shot: true when the watchdog flagged sustained slow presents
+    /// since the last call. Presentation continues on the flip path.
+    pub fn takeDegradedEvent(self: *Presenter) bool {
+        const fired = self.degraded_event;
+        self.degraded_event = false;
+        return fired;
     }
 
     fn blitAndPresent(self: *Presenter, width: i32, height: i32, interval: i32) PresentError!void {

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -560,6 +560,13 @@ test "bringup fuse blocks only markers for the current version" {
     try std.testing.expectEqualStrings("probing:1.19.0", probing);
     try std.testing.expect(bringupMarkerIsProbing(probing));
 
+    // Mid-session degraded/failed sessions persist this marker; the next
+    // launch of the same version must come out blocked (GDI from frame 0).
+    var blocked_buf: [bringup_marker_max_len]u8 = undefined;
+    const blocked = try bringupBlockedMarker(&blocked_buf, "1.19.0");
+    try std.testing.expectEqualStrings("blocked:1.19.0", blocked);
+    try std.testing.expectEqual(BringupFuse.blocked, bringupFuseDecision(blocked, "1.19.0"));
+
     // Crashed during last bring-up of this version → blocked.
     try std.testing.expectEqual(BringupFuse.blocked, bringupFuseDecision("probing:1.19.0", "1.19.0"));
     try std.testing.expectEqual(BringupFuse.blocked, bringupFuseDecision("blocked:1.19.0", "1.19.0"));

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -254,6 +254,7 @@ pub const PresentPolicy = struct {
     height: i32,
     failed: bool = false,
     slow_streak: u32 = 0,
+    slow_reported: bool = false,
 
     pub fn init(width: i32, height: i32) PresentPolicy {
         return .{ .width = width, .height = height };
@@ -276,17 +277,24 @@ pub const PresentPolicy = struct {
     /// Watchdog feed: duration of a *successful* present. A broken interop
     /// path can stall for seconds per frame without ever returning an error
     /// (cross-GPU syncs, TDR recovery loops) — the only externally visible
-    /// signal is time. Latches `failed` after `slow_latch_frames` consecutive
-    /// slow presents; returns true exactly when this call latched it.
+    /// signal is time. Returns true exactly once, on the `slow_latch_frames`th
+    /// consecutive slow present.
+    ///
+    /// Sustained slowness must NOT switch the present path mid-session: the
+    /// frames *are* reaching the screen (unlike a probe mismatch), and an
+    /// HWND that has presented through a flip-model swapchain cannot revert
+    /// to GDI/blt presents — DWM behavior is undefined and in the field that
+    /// "fallback" rendered the window black. The caller persists a marker so
+    /// the *next* launch uses GDI from frame 0 instead.
     pub fn notePresentMillis(self: *PresentPolicy, ms: u64) bool {
-        if (self.failed) return false;
+        if (self.failed or self.slow_reported) return false;
         if (ms < slow_frame_ms) {
             self.slow_streak = 0;
             return false;
         }
         self.slow_streak += 1;
         if (self.slow_streak < slow_latch_frames) return false;
-        self.failed = true;
+        self.slow_reported = true;
         return true;
     }
 
@@ -319,15 +327,26 @@ pub const ProbeVerdict = enum {
     matched_content,
 };
 
+/// Per-channel slack for the GL↔DX comparison. The blit + CopyResource chain
+/// is bit-exact for an RGBA8 backbuffer, but drivers can hand the window a
+/// deeper default framebuffer (10bpc pipelines) or dither it, and then the
+/// readback→u8 and blit→8bit conversions round independently — off-by-a-LSB
+/// differences on a perfectly working path. A real failure (content rendered,
+/// black presented) differs by whole channel ranges, far beyond this.
+pub const probe_channel_tolerance: u8 = 2;
+
 /// Compare per-sample RGB read back from the GL framebuffer against the same
 /// points read back from the D3D shared texture (callers handle the Y-flip
-/// and BGRA→RGB swizzle when sampling). The blit + CopyResource chain is
-/// bit-exact, so any difference means the present path is broken even though
-/// every API call "succeeded".
+/// and BGRA→RGB swizzle when sampling). Any sample differing beyond
+/// `probe_channel_tolerance` means pixels are not reaching the swapchain even
+/// though every API call "succeeded".
 pub fn evaluateProbe(gl_rgb: []const [3]u8, dx_rgb: []const [3]u8) ProbeVerdict {
     std.debug.assert(gl_rgb.len == dx_rgb.len and gl_rgb.len > 0);
     for (gl_rgb, dx_rgb) |g, d| {
-        if (g[0] != d[0] or g[1] != d[1] or g[2] != d[2]) return .mismatched;
+        for (g, d) |gc, dc| {
+            if (@abs(@as(i16, gc) - @as(i16, dc)) > probe_channel_tolerance)
+                return .mismatched;
+        }
     }
     for (gl_rgb[1..]) |g| {
         if (g[0] != gl_rgb[0][0] or g[1] != gl_rgb[0][1] or g[2] != gl_rgb[0][2])
@@ -501,17 +520,20 @@ test "adapterUsableForVendor rejects software adapters for hardware GL" {
     try std.testing.expect(adapterUsableForVendor(PCI_VENDOR_MICROSOFT, DXGI_ADAPTER_FLAG_SOFTWARE, PCI_VENDOR_MICROSOFT));
 }
 
-test "PresentPolicy watchdog latches only on a sustained slow streak" {
+test "PresentPolicy watchdog reports a sustained slow streak once, without switching paths" {
     var p = PresentPolicy.init(800, 600);
-    // A fast frame resets the streak: 4 slow + fast + 4 slow never latches.
+    // A fast frame resets the streak: 4 slow + fast + 4 slow never reports.
     for (0..PresentPolicy.slow_latch_frames - 1) |_| try std.testing.expect(!p.notePresentMillis(900));
     try std.testing.expect(!p.notePresentMillis(5));
     for (0..PresentPolicy.slow_latch_frames - 1) |_| try std.testing.expect(!p.notePresentMillis(900));
     try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(800, 600));
-    // The Nth consecutive slow frame latches, exactly once.
+    // The Nth consecutive slow frame reports, exactly once.
     try std.testing.expect(p.notePresentMillis(900));
     try std.testing.expect(!p.notePresentMillis(900));
-    try std.testing.expectEqual(PresentPolicy.Action.fallback, p.frameAction(800, 600));
+    // Slowness must NOT flip the session to GDI: frames are reaching the
+    // screen, and blt presents on a flip-presented HWND are undefined (black
+    // in the field). The session stays on the flip path.
+    try std.testing.expectEqual(PresentPolicy.Action.present, p.frameAction(800, 600));
 }
 
 test "evaluateProbe verdicts: mismatch, uniform match, content match" {
@@ -520,8 +542,12 @@ test "evaluateProbe verdicts: mismatch, uniform match, content match" {
     const text: [3]u8 = .{ 220, 220, 225 };
     // Broken interop: GL drew content, swapchain got nothing.
     try std.testing.expectEqual(ProbeVerdict.mismatched, evaluateProbe(&.{ grey, text }, &.{ black, black }));
-    // Single-channel corruption counts too.
-    try std.testing.expectEqual(ProbeVerdict.mismatched, evaluateProbe(&.{ grey, grey }, &.{ grey, .{ 30, 33, 41 } }));
+    // Single-channel corruption beyond the rounding tolerance counts too.
+    try std.testing.expectEqual(ProbeVerdict.mismatched, evaluateProbe(&.{ grey, grey }, &.{ grey, .{ 30, 33, 43 } }));
+    // 10bpc/dither rounding skew within the tolerance is a working path, not
+    // a broken one — a bit-exact probe latched the black GDI fallback on
+    // machines whose flip path was fine.
+    try std.testing.expectEqual(ProbeVerdict.matched_content, evaluateProbe(&.{ grey, text }, &.{ .{ 30, 33, 42 }, .{ 222, 218, 225 } }));
     // Flat frame matching is not yet proof.
     try std.testing.expectEqual(ProbeVerdict.matched_uniform, evaluateProbe(&.{ black, black }, &.{ black, black }));
     // Real content matching settles the probe.

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -183,6 +183,16 @@ pub fn takePresentFallbackEvent(window: *Window) bool {
     return false;
 }
 
+/// One-shot (Windows-only): true when the DXGI presenter's watchdog flagged
+/// sustained slow presents. The session stays on the flip path (an HWND that
+/// has flip-presented cannot revert to GDI without going blank); the app
+/// loop persists the state-file marker that makes the next launch use GDI
+/// from frame 0.
+pub fn takePresentDegradedEvent(window: *Window) bool {
+    if (comptime @hasDecl(Window, "takePresentDegradedEvent")) return window.takePresentDegradedEvent();
+    return false;
+}
+
 pub fn framebufferSize(window: *Window) Size {
     const size = window.getFramebufferSize();
     return .{ .width = size.width, .height = size.height };

--- a/src/platform/window_state.zig
+++ b/src/platform/window_state.zig
@@ -170,3 +170,15 @@ pub fn settleD3dBringup(allocator: std.mem.Allocator) void {
     if (!std.mem.startsWith(u8, current.d3dBringup(), "probing:")) return;
     savePersisted(allocator, codec.withD3dBringup(current, ""));
 }
+
+/// Persist "blocked:<version>" so every later launch of this app version
+/// skips the D3D present path from frame 0. Written when the flip path
+/// proved broken or degraded *mid-session* — the only supported way to be on
+/// GDI is to never flip-present the HWND, so recovery happens at the next
+/// launch rather than in-session. An upgrade retries the flip path once.
+pub fn blockD3dBringup(allocator: std.mem.Allocator, version: []const u8) void {
+    const dxgi_core = @import("dxgi_core.zig");
+    var buf: [dxgi_core.bringup_marker_max_len]u8 = undefined;
+    const marker = dxgi_core.bringupBlockedMarker(&buf, version) catch return;
+    recordD3dBringup(allocator, marker);
+}


### PR DESCRIPTION
## Field pattern (v1.19.0 regression)

User reports flipped between releases:

- **v1.18 black screen → v1.19 opens**: these users are saved by #203's *init-time* fallbacks (adapter match / crash fuse). Those run before any flip present, so finishing the session on GDI from frame 0 is legal.
- **v1.18 slow-but-working → v1.19 black screen**: these users are *blacked out by the guard itself*. An HWND that has presented through a flip-model swapchain cannot revert to GDI/blt presents — DWM behavior is undefined and in practice the window goes blank. Two of #203's latches fire exactly that unsupported **mid-session** switch, and both prefer slow machines:
  - the present watchdog (5 consecutive presents over 400ms) trips on machines whose frames **are** reaching the screen, trading a slow-but-working session for a black one;
  - the content probe required bit-exact GL↔DX sample equality, so 10bpc / dithering pipelines whose two 8-bit conversions round independently (off-by-a-LSB) were misdiagnosed as silently-broken paths.

## Fix

- **Watchdog no longer switches paths in-session.** `PresentPolicy.notePresentMillis` reports sustained slowness exactly once (`slow_reported`) without latching `failed`; the presenter emits a one-shot degraded event and keeps presenting on the flip path. The app loop persists `blocked:<version>` through the existing bring-up fuse storage (new `window_state.blockD3dBringup`), so the **next launch runs GDI from frame 0** — the only supported way to be on GDI. An upgrade retries the flip path once, as before.
- **Probe tolerance**: `evaluateProbe` gains `probe_channel_tolerance = 2` per channel. Real failures (content rendered, black presented) differ by whole channel ranges, so detection power is unchanged.
- **Hard failures keep the in-session GDI switch** (API errors, probe mismatch, resize failure — pixels were not reaching the screen anyway, so GDI is a best effort) **but now also persist the blocked marker**: even when blt-after-flip stays blank, the very next launch is guaranteed clean.

## Verification

- `zig build test` ✅ (includes updated `dxgi_core` watchdog-semantics tests + probe tolerance boundary cases)
- `zig build test-full` ✅
- `zig build -Dtarget=x86_64-windows-gnu` ✅

GUI verification on affected hardware (hybrid-GPU / slow machines) still pending, as with #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)