### PR TITLE
fix(weixin): send WeChat messages as one prompt; end follow-up on manual copilot stop

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -4729,6 +4729,7 @@ const WeixinRequest = struct {
     out_surface_id: [16]u8 = [_]u8{0} ** 16,
     open_result: weixin_control.OpenResult = .failed,
     sent: bool = false,
+    busy: bool = false, // send_input: AI chat rejected the prompt (request inflight)
     transcript: []u8 = &.{},
     dir: []u8 = &.{}, // inbound_file_dir (heap, page_allocator)
 };
@@ -4814,7 +4815,7 @@ fn handleWeixinControlRequest(req: *WeixinRequest) void {
                 if (tab_state.kind != .ai_chat) return;
                 const session = tab_state.ai_chat_session orelse return;
                 if (req.reply_context) |ctx| {
-                    session.applyWeixinInput(req.bytes, ctx);
+                    req.busy = !session.applyWeixinInput(req.bytes, ctx);
                 } else {
                     session.applyRemoteInput(req.bytes);
                 }
@@ -4904,10 +4905,10 @@ fn wxOpenAiAgent(_: *anyopaque, _: u32) weixin_control.OpenResult {
     return req.open_result;
 }
 
-fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?weixin_types.ReplyContext) bool {
+fn wxSendInput(_: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?weixin_types.ReplyContext) weixin_control.SendResult {
     var req = WeixinRequest{ .op = .send_input, .surface_id = surface_id, .bytes = bytes, .reply_context = reply_context };
-    if (!weixinDispatch(&req)) return false;
-    return req.sent;
+    if (!weixinDispatch(&req) or !req.sent) return .offline;
+    return if (req.busy) .busy else .ok;
 }
 
 fn wxTranscript(_: *anyopaque) []const u8 {

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1299,12 +1299,28 @@ pub const Session = struct {
         return true;
     }
 
-    pub fn applyWeixinInput(self: *Session, data: []const u8, ctx: weixin_types.ReplyContext) void {
+    /// WeChat delivers complete messages, not keystrokes: the whole payload is
+    /// one prompt (embedded newlines are content, unlike applyRemoteInput where
+    /// each one submits); only the trailing CR/LF byte-stream submit convention
+    /// is stripped. Returns false (busy) without touching the composer when a
+    /// request is already inflight, so the poller reports it to the sender
+    /// instead of silently swallowing the message.
+    pub fn applyWeixinInput(self: *Session, data: []const u8, ctx: weixin_types.ReplyContext) bool {
         self.mutex.lock();
+        if (self.request_inflight) {
+            self.mutex.unlock();
+            return false;
+        }
         if (self.pending_weixin_reply_context) |*old| old.deinit(self.allocator);
         self.pending_weixin_reply_context = WeixinReplyContext.init(self.allocator, ctx) catch null;
         self.mutex.unlock();
-        self.applyRemoteInput(data);
+        if (self.submitScheduledPrompt(std.mem.trimRight(u8, data, "\r\n"))) return true;
+        // Lost the race with a concurrently started request: drop the stale
+        // context so a later local prompt cannot inherit this WeChat target.
+        self.mutex.lock();
+        self.clearPendingWeixinReplyContextLocked();
+        self.mutex.unlock();
+        return false;
     }
 
     fn clearPendingWeixinReplyContextLocked(self: *Session) void {
@@ -6966,6 +6982,46 @@ test "submitScheduledPrompt sets composer and reports busy state" {
     const skipped = session.submitScheduledPrompt("again");
     try std.testing.expect(!skipped);
     session.request_inflight = false;
+}
+
+test "applyWeixinInput submits the whole multi-line message as one prompt" {
+    const a = std.testing.allocator;
+    const session = try Session.init(a, "test", "", "", "", "", "", "", "", "");
+    defer session.deinit();
+
+    var capture = WeixinAttachmentCapture{};
+    const ctx = weixin_types.ReplyContext{
+        .sender = testWeixinSender(&capture),
+        .to_user_id = "wx-user",
+        .context_token = "ctx-1",
+    };
+
+    // A WeChat message is a complete message, not a keystroke stream: embedded
+    // newlines are content, only the trailing CR is the submit convention. With
+    // no API key submit() stops at the missing-key gate WITHOUT consuming the
+    // composer, so the composer shows exactly what the single submit sent.
+    try std.testing.expect(session.applyWeixinInput("第一段\n\n第二段\r", ctx));
+    try std.testing.expectEqualStrings("第一段\n\n第二段", session.input());
+}
+
+test "applyWeixinInput reports busy and leaves composer and reply context untouched" {
+    const a = std.testing.allocator;
+    const session = try Session.init(a, "test", "", "", "", "", "", "", "", "");
+    defer session.deinit();
+
+    var capture = WeixinAttachmentCapture{};
+    const ctx = weixin_types.ReplyContext{
+        .sender = testWeixinSender(&capture),
+        .to_user_id = "wx-user",
+        .context_token = "ctx-1",
+    };
+
+    session.appendInputText("draft");
+    session.request_inflight = true;
+    try std.testing.expect(!session.applyWeixinInput("新任务\r", ctx));
+    session.request_inflight = false;
+    try std.testing.expectEqualStrings("draft", session.input());
+    try std.testing.expect(session.pending_weixin_reply_context == null);
 }
 
 test "runLoopCommandLocked creates, lists, and stops a loop task" {

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -6,6 +6,7 @@ const types = @import("types.zig");
 const approval_reply = @import("approval_reply.zig");
 
 const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。";
+const AI_BUSY = "副驾正在处理上一条消息，请稍候再发，或发送 /stop 停止当前处理。";
 const ESC = "\x1b";
 const AI_OPEN_TIMEOUT_MS: u32 = 2000;
 
@@ -125,7 +126,13 @@ fn sendAi(ctrl: control.Control, text: []const u8, reply_context: ?types.ReplyCo
     defer buf.deinit(out.allocator);
     try buf.appendSlice(out.allocator, text);
     try buf.append(out.allocator, '\r');
-    if (!ctrl.sendInput(ai.id, buf.items, reply_context)) return out.set("WispTerm 当前离线，无法发送给副驾。");
+    switch (ctrl.sendInput(ai.id, buf.items, reply_context)) {
+        .offline => return out.set("WispTerm 当前离线，无法发送给副驾。"),
+        // The copilot still has a request inflight: the message was rejected,
+        // not queued, so tell the user instead of acking "开始处理" for nothing.
+        .busy => return out.set(AI_BUSY),
+        .ok => {},
+    }
     try out.set(AI_ACK);
     out.expect_ai_progress = true;
 }
@@ -136,7 +143,7 @@ fn stopAi(ctrl: control.Control, out: *Reply) !void {
     // sent after the stop (otherwise a trailing reply looks like /stop failed).
     out.stop_followup = true;
     const ai = ctrl.findAiSurface() orelse return out.set("当前没有副驾可停止。");
-    if (!ctrl.sendInput(ai.id, ESC, null)) return out.set("WispTerm 当前离线，无法停止副驾。");
+    if (ctrl.sendInput(ai.id, ESC, null) != .ok) return out.set("WispTerm 当前离线，无法停止副驾。");
     return out.set("已发送停止指令。");
 }
 
@@ -146,7 +153,7 @@ fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Repl
     defer buf.deinit(out.allocator);
     try buf.appendSlice(out.allocator, text);
     if (enter) try buf.append(out.allocator, '\r');
-    if (!ctrl.sendInput(term.id, buf.items, null)) return out.set("WispTerm 当前离线，无法发送到终端。");
+    if (ctrl.sendInput(term.id, buf.items, null) != .ok) return out.set("WispTerm 当前离线，无法发送到终端。");
     return out.set("已发送到终端。");
 }
 
@@ -172,6 +179,7 @@ const t = std.testing;
 const FakeControl = struct {
     connected: bool = true,
     has_ai: bool = true,
+    busy: bool = false,
     buf: [256]u8 = undefined,
     len: usize = 0,
     last_surface: [16]u8 = [_]u8{0} ** 16,
@@ -198,15 +206,16 @@ const FakeControl = struct {
     fn open_ai_agent(_: *anyopaque, _: u32) control.OpenResult {
         return .opened;
     }
-    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
+    fn send_input(ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) control.SendResult {
         const self = cast(ctx);
-        if (!self.connected) return false;
+        if (!self.connected) return .offline;
+        if (self.busy) return .busy;
         self.last_surface = surface_id;
         self.last_reply_context = reply_context;
         const n = @min(bytes.len, self.buf.len);
         @memcpy(self.buf[0..n], bytes[0..n]);
         self.len = n;
-        return true;
+        return .ok;
     }
     fn latest_transcript(_: *anyopaque) []const u8 {
         return "";
@@ -266,6 +275,15 @@ test "default text goes to the AI surface with a carriage return" {
     try t.expectEqualStrings("hello world\r", fake.lastInput());
     try t.expectEqualSlices(u8, &FakeControl.aiId(), &fake.last_surface);
     try t.expect(out.expect_ai_progress);
+}
+
+test "busy copilot replies with a busy notice and does not start a follow-up" {
+    var fake = FakeControl{ .busy = true };
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "hello", null, &out);
+    try t.expect(std.mem.indexOf(u8, out.text.items, "正在处理") != null);
+    try t.expect(!out.expect_ai_progress);
 }
 
 test "default AI route forwards Weixin reply context only to AI surface" {

--- a/src/weixin/control.zig
+++ b/src/weixin/control.zig
@@ -7,6 +7,10 @@ pub const Surface = struct { id: [16]u8, title: []const u8 };
 
 pub const OpenResult = enum { opened, no_profile, failed, offline, timeout };
 
+/// Outcome of sendInput. `busy` is AI-surface only: a chat request is already
+/// inflight, so the message was rejected rather than silently swallowed.
+pub const SendResult = enum { ok, offline, busy };
+
 pub const Control = struct {
     ctx: *anyopaque,
     vtable: *const VTable,
@@ -16,7 +20,7 @@ pub const Control = struct {
         find_ai_surface: *const fn (ctx: *anyopaque) ?Surface,
         find_terminal_surface: *const fn (ctx: *anyopaque) ?Surface,
         open_ai_agent: *const fn (ctx: *anyopaque, timeout_ms: u32) OpenResult,
-        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool,
+        send_input: *const fn (ctx: *anyopaque, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) SendResult,
         latest_transcript: *const fn (ctx: *anyopaque) []const u8,
         ai_approval_pending: *const fn (ctx: *anyopaque) bool,
         resolve_ai_approval: *const fn (ctx: *anyopaque, approve: bool) bool,
@@ -37,7 +41,7 @@ pub const Control = struct {
     pub fn openAiAgent(self: Control, timeout_ms: u32) OpenResult {
         return self.vtable.open_ai_agent(self.ctx, timeout_ms);
     }
-    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) bool {
+    pub fn sendInput(self: Control, surface_id: [16]u8, bytes: []const u8, reply_context: ?types.ReplyContext) SendResult {
         return self.vtable.send_input(self.ctx, surface_id, bytes, reply_context);
     }
     pub fn latestTranscript(self: Control) []const u8 {
@@ -70,8 +74,8 @@ test "inboundFileDir forwards to the vtable and copies into the caller buffer" {
         fn open_ai_agent(_: *anyopaque, _: u32) OpenResult {
             return .offline;
         }
-        fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
-            return false;
+        fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) SendResult {
+            return .offline;
         }
         fn latest_transcript(_: *anyopaque) []const u8 {
             return "";

--- a/src/weixin/controller.zig
+++ b/src/weixin/controller.zig
@@ -495,8 +495,8 @@ const NoopControl = struct {
     fn open_ai_agent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
-        return false;
+    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) control_mod.SendResult {
+        return .offline;
     }
     fn latest_transcript(_: *anyopaque) []const u8 {
         return "";

--- a/src/weixin/poller.zig
+++ b/src/weixin/poller.zig
@@ -954,8 +954,8 @@ const NoopControl = struct {
     fn openAiAgent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
-        return false;
+    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) control_mod.SendResult {
+        return .offline;
     }
     fn latestTranscript(_: *anyopaque) []const u8 {
         return "";
@@ -1305,8 +1305,8 @@ const ApprovalTranscriptControl = struct {
     fn openAiAgent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
-        return false;
+    fn sendInput(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) control_mod.SendResult {
+        return .offline;
     }
     fn latestTranscript(_: *anyopaque) []const u8 {
         return "Model:\nGLM\n\nStatus:\nApproval needed\n\n" ++
@@ -1393,8 +1393,8 @@ const TmpDirControl = struct {
     fn open_ai_agent(_: *anyopaque, _: u32) control_mod.OpenResult {
         return .offline;
     }
-    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) bool {
-        return false;
+    fn send_input(_: *anyopaque, _: [16]u8, _: []const u8, _: ?types.ReplyContext) control_mod.SendResult {
+        return .offline;
     }
     fn latest_transcript(_: *anyopaque) []const u8 {
         return "";

--- a/src/weixin/reply_progress.zig
+++ b/src/weixin/reply_progress.zig
@@ -61,6 +61,14 @@ pub fn progress(baseline: []const u8, current: []const u8) Progress {
     if (last_assistant) |content| {
         if (!isActiveStatus(status)) return .{ .done = true, .text = content };
     }
+    // "Stopped" is a terminal state (manual stop in the copilot UI): the run
+    // ended without an answer, so finish the follow-up with an explicit notice.
+    // Checked before the tool branch — a stopped run may have tool messages.
+    // Note "Stopped"/"Stopping..." don't contain each other, so this never
+    // fires while the stop is still winding down (isActiveStatus covers that).
+    if (containsIgnoreCase(status, "stopped")) {
+        return .{ .done = true, .text = "本次处理已停止，未生成新的回复。" };
+    }
     if (containsIgnoreCase(status, "running tools") or hasRole(new_msgs, .tool)) {
         return .{ .done = false, .text = "还在处理中，工具调用仍在执行。" };
     }
@@ -255,6 +263,44 @@ test "no approval section leaves needs_approval false" {
     const p = progress("You:\nhi\n", "You:\nhi\nAI:\nthere\nStatus:\nidle\n");
     try t.expect(!p.needs_approval);
     try t.expect(p.done);
+}
+
+test "manual stop with no new assistant message reports done with a stop notice" {
+    // The user stopped the run in the copilot UI: status becomes "Stopped" and
+    // no assistant answer was produced. The follow-up must end (done) with an
+    // explicit notice instead of "还在处理中" until the 30-minute window expires.
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n";
+    const current = "Model:\nGLM\n\nStatus:\nStopped\n\nYou:\n重新做个任务\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expect(std.mem.indexOf(u8, p.text, "已停止") != null);
+}
+
+test "manual stop after a tool ran still reports done (stop beats the tool branch)" {
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n";
+    const current =
+        "Model:\nGLM\n\nStatus:\nStopped\n\n" ++
+        "You:\nq\n\nTool:\nterminal completed.\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expect(std.mem.indexOf(u8, p.text, "已停止") != null);
+}
+
+test "manual stop with a partial assistant answer reports done with that answer" {
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n";
+    const current =
+        "Model:\nGLM\n\nStatus:\nStopped\n\nYou:\nq\n\nAI:\npartial answer\n";
+    const p = progress(baseline, current);
+    try t.expect(p.done);
+    try t.expectEqualStrings("partial answer", p.text);
+}
+
+test "Stopping... still counts as in progress" {
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n";
+    const current = "Model:\nGLM\n\nStatus:\nStopping...\n\nYou:\nq\n";
+    const p = progress(baseline, current);
+    try t.expect(!p.done);
+    try t.expect(p.text.len != 0);
 }
 
 test "a resolved approval (gone from current) does not re-fire even if baseline had one" {


### PR DESCRIPTION
## 问题

微信直连的两个现场问题（见 issue 截图）：

1. **多段消息只发出第一段**：微信发来的多段文字在 copilot 中被拆开 —— 第一行成为 "You" 提示词，其余内容滞留在输入框里且换行全部丢失。
2. **手动停止后仍提示"还在处理中"**：在 copilot 里手动停止任务后，微信端按 30s/2m/5m/10m/20m 节奏持续收到「还在处理中，等待 AI 回复。」，直到 30 分钟窗口到期。

## 根因

1. `applyWeixinInput` 走的是按键模拟路径 `applyRemoteInput`，每个 `\n` 都触发一次 `submit()`：第一行提交后请求 inflight，后续每行的 submit 被静默丢弃（`submit()` 提前返回），剩余文本留在输入框、段落换行被当作提交键吃掉。
2. 手动停止后会话 Status 变为 `"Stopped"`，但 `reply_progress.progress` 没有该终态分支：没有新 AI 消息时落入「还在处理中」分支，永不结束。

## 修复

- **整条消息一次提交**（`ai_chat.zig`）：微信消息是完整消息而非按键流。剥掉尾部 CR 提交约定后，整段文本（保留内部换行）经 `submitScheduledPrompt` 路径一次性提交。
- **busy 拒绝代替静默吞掉**：请求 inflight 时拒绝新消息，`send_input` 经 control vtable 返回 `ok/offline/busy`，微信端收到「副驾正在处理上一条消息…」而不是虚假的「开始处理」。审批 Y/N 回复仍优先于 busy 检查，不受影响；`/stop`、`/term` 维持原始字节路径。
- **Stopped 终态检测**（`reply_progress.zig`）：Status 含 `Stopped` 且无新 AI 回复时，follow-up 以一次「本次处理已停止，未生成新的回复。」收尾；该分支先于 tool 分支（被停止的任务可能带有 tool 消息）。`Stopping...` 仍视为进行中；有部分回复时照旧把回复发回。

## 测试

- 新增：`reply_progress` 4 个停止态用例；`ai_chat` 多行整条提交 + busy 不动输入框/上下文用例；`agent` busy 回复用例。
- TDD：先在 native 跑出行为级失败（输入框出现「第一段第二段」、换行被吃，与截图一致）再实现。
- `zig build test` ✅ 1084 通过；`zig build test-full -Dtarget=x86_64-linux-gnu` ✅ 1647/1652（5 skipped, 0 failed）；默认 windows-gnu `test-full` 交叉编译 ✅。
- GUI（Windows + 真实微信）验证待做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)