### PR TITLE
fix(config): stop aliasing config-owned strings into long-lived font globals (UAF)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -202,9 +202,12 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     tab.g_shell_cmd_len = app.shell_cmd_len;
 
     // Store config values we need for init
-    g_requested_font = app.font_family;
-    font.g_cjk_font_family = app.font_family_cjk;
-    font.g_fallback_font_families = app.font_family_fallback;
+    setRequestedFont(app.font_family);
+    // Copy into the font module's own buffers rather than aliasing App's
+    // strings: App frees and reallocates these on every config reload (see
+    // App.replaceOptStr), which would leave the globals dangling.
+    font.setCjkFontFamily(app.font_family_cjk);
+    font.setFallbackFontFamilies(app.font_family_fallback);
     g_requested_weight = app.font_weight;
     font.g_font_size = app.font_size;
     g_shader_path = app.shader_path;
@@ -496,6 +499,11 @@ var g_session_restore_attempted: std.atomic.Value(bool) = .init(false);
 
 // Stored config values for deferred initialization
 threadlocal var g_requested_font: []const u8 = "";
+// Backing buffer for g_requested_font. The configured family must be copied
+// here rather than aliasing App.font_family: App frees and reallocates that
+// string on every config reload (App.replaceStr), and g_requested_font is read
+// later in the event loop (handleWindowDpiChanged), which would dangle.
+threadlocal var g_requested_font_buf: [256]u8 = undefined;
 threadlocal var g_requested_weight: font_backend.FontWeight = .NORMAL;
 threadlocal var g_shader_path: ?[]const u8 = null;
 threadlocal var g_start_maximize: bool = false;
@@ -3132,6 +3140,14 @@ pub fn syncDefaultShellCommandFromConfig(shell: []const u8) void {
     tab.g_shell_cmd_len = App.resolveShellCommandLine(&tab.g_shell_cmd_buf, shell);
 }
 
+/// Store the configured primary font family in our own buffer. Must be used
+/// instead of aliasing App.font_family, which is freed/reallocated on reload.
+fn setRequestedFont(family: []const u8) void {
+    const n = @min(family.len, g_requested_font_buf.len);
+    @memcpy(g_requested_font_buf[0..n], family[0..n]);
+    g_requested_font = g_requested_font_buf[0..n];
+}
+
 threadlocal var g_configured_shell_title_buf: [1024]u8 = undefined;
 threadlocal var g_configured_shell_detail_buf: [1024]u8 = undefined;
 
@@ -4140,8 +4156,11 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     const new_font_size = cfg.@"font-size";
     const new_weight = font_backend.fontWeightFromValue(cfg.@"font-style".value());
     const new_family = cfg.@"font-family";
-    font.g_cjk_font_family = cfg.@"font-family-cjk";
-    font.g_fallback_font_families = cfg.@"font-family-fallback";
+    // Copy into the font module's own buffers: `cfg` is deinit'd right after
+    // this returns, and these globals are read lazily on the next fallback
+    // lookup. Aliasing the config-owned slices here was a use-after-free.
+    font.setCjkFontFamily(cfg.@"font-family-cjk");
+    font.setFallbackFontFamilies(cfg.@"font-family-fallback");
 
     const font_changed = new_font_size != font.g_font_size;
 
@@ -4998,20 +5017,24 @@ fn makeAgentToolSurface(
     tab_index: usize,
     focused: bool,
 ) anyerror!ai_chat.ToolSurface {
-    return .{
-        .id = try allocator.dupe(u8, surface.remote_id[0..]),
-        .title = try allocator.dupe(u8, surface.getTitle()),
-        .cwd = try allocator.dupe(u8, surface.getCwd() orelse surface.getInitialCwd() orelse ""),
-        .snapshot = buildRemoteSurfaceSnapshot(allocator, surface, remote_snapshot.agent_max_history_rows) catch try allocator.dupe(u8, ""),
-        .tab_index = tab_index,
-        .focused = focused,
-        .is_ssh = surface.launch_kind == .ssh and surface.ssh_connection != null,
-        .is_wsl = surface.launch_kind == .wsl,
-        .agent_app = surface.agent_detection.app,
-        .agent_state = surface.agent_detection.state,
-        .agent_confidence = surface.agent_detection.confidence,
-        .ptr = @ptrCast(surface),
-    };
+    const snapshot = buildRemoteSurfaceSnapshot(allocator, surface, remote_snapshot.agent_max_history_rows) catch try allocator.dupe(u8, "");
+    return ai_chat.ToolSurface.initOwned(
+        allocator,
+        surface.remote_id[0..],
+        surface.getTitle(),
+        surface.getCwd() orelse surface.getInitialCwd() orelse "",
+        snapshot,
+        .{
+            .tab_index = tab_index,
+            .focused = focused,
+            .is_ssh = surface.launch_kind == .ssh and surface.ssh_connection != null,
+            .is_wsl = surface.launch_kind == .wsl,
+            .agent_app = surface.agent_detection.app,
+            .agent_state = surface.agent_detection.state,
+            .agent_confidence = surface.agent_detection.confidence,
+            .ptr = @ptrCast(surface),
+        },
+    );
 }
 
 fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!ai_chat.ToolSnapshot {
@@ -5031,12 +5054,14 @@ fn collectAgentToolSnapshot(ctx: *anyopaque, allocator: std.mem.Allocator) anyer
         while (it.next()) |entry| {
             const is_context = context_surface_id.len > 0 and std.mem.eql(u8, entry.surface.remote_id[0..], context_surface_id);
             if (is_context) active_tab = tab_index;
-            try surfaces.append(allocator, try makeAgentToolSurface(
+            const tool_surface = try makeAgentToolSurface(
                 allocator,
                 entry.surface,
                 tab_index,
                 is_context,
-            ));
+            );
+            errdefer tool_surface.deinit(allocator);
+            try surfaces.append(allocator, tool_surface);
         }
     }
 
@@ -7197,6 +7222,26 @@ fn runMainLoop(self: *AppWindow) !void {
     browser_panel.deinit();
 
     // Tab cleanup is handled by AppWindow.deinit()
+}
+
+test "appwindow: setRequestedFont keeps a private copy of the family string" {
+    // Regression: g_requested_font aliased App.font_family, which App frees and
+    // reallocates on every config reload (App.replaceStr). The captured family
+    // is read later in the event loop (handleWindowDpiChanged), so it must not
+    // point into freed memory. The setter copies into its own buffer.
+    defer {
+        @memset(&g_requested_font_buf, 0);
+        g_requested_font = "";
+    }
+    var src: [16]u8 = undefined;
+    @memcpy(src[0..11], "JetBrains M");
+    setRequestedFont(src[0..11]);
+    @memset(&src, 'x'); // clobber the source the way replaceStr would
+    try std.testing.expectEqualStrings("JetBrains M", g_requested_font);
+
+    const long = "z" ** 1000;
+    setRequestedFont(long);
+    try std.testing.expect(g_requested_font.len < long.len);
 }
 
 test "appwindow: syncDefaultShellCommandFromConfig refreshes tab default shell" {

--- a/src/ai_chat_types.zig
+++ b/src/ai_chat_types.zig
@@ -55,6 +55,50 @@ pub const ToolSurface = struct {
         allocator.free(self.snapshot);
     }
 
+    pub const InitMeta = struct {
+        tab_index: usize,
+        focused: bool,
+        is_ssh: bool,
+        is_wsl: bool,
+        agent_app: agent_detector.App = .none,
+        agent_state: agent_detector.State = .none,
+        agent_confidence: u8 = 0,
+        ptr: *anyopaque,
+    };
+
+    /// Build an owned ToolSurface from borrowed strings plus an already-owned
+    /// snapshot. Takes ownership of `snapshot` even on failure, so a caller
+    /// can pass a freshly built snapshot without its own cleanup path.
+    pub fn initOwned(
+        allocator: std.mem.Allocator,
+        id: []const u8,
+        title: []const u8,
+        cwd: []const u8,
+        snapshot: []u8,
+        meta: InitMeta,
+    ) !ToolSurface {
+        errdefer allocator.free(snapshot);
+        const id_owned = try allocator.dupe(u8, id);
+        errdefer allocator.free(id_owned);
+        const title_owned = try allocator.dupe(u8, title);
+        errdefer allocator.free(title_owned);
+        const cwd_owned = try allocator.dupe(u8, cwd);
+        return .{
+            .id = id_owned,
+            .title = title_owned,
+            .cwd = cwd_owned,
+            .snapshot = snapshot,
+            .tab_index = meta.tab_index,
+            .focused = meta.focused,
+            .is_ssh = meta.is_ssh,
+            .is_wsl = meta.is_wsl,
+            .agent_app = meta.agent_app,
+            .agent_state = meta.agent_state,
+            .agent_confidence = meta.agent_confidence,
+            .ptr = meta.ptr,
+        };
+    }
+
     pub fn clone(self: ToolSurface, allocator: std.mem.Allocator) !ToolSurface {
         const id = try allocator.dupe(u8, self.id);
         errdefer allocator.free(id);
@@ -243,3 +287,55 @@ pub const ToolContext = struct {
         return resolver(host.ctx, surface_id);
     }
 };
+
+test "ToolSurface.initOwned dupes borrowed strings and adopts the owned snapshot" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    const snapshot = try a.dupe(u8, "snap");
+    const id_src = "surface-1";
+    const ts = try ToolSurface.initOwned(a, id_src, "title-1", "/work", snapshot, .{
+        .tab_index = 3,
+        .focused = true,
+        .is_ssh = false,
+        .is_wsl = true,
+        .ptr = @ptrCast(&dummy),
+    });
+    defer ts.deinit(a);
+
+    try std.testing.expectEqualStrings("surface-1", ts.id);
+    try std.testing.expect(ts.id.ptr != id_src.ptr); // copied, not aliased
+    try std.testing.expectEqualStrings("title-1", ts.title);
+    try std.testing.expectEqualStrings("/work", ts.cwd);
+    try std.testing.expect(ts.snapshot.ptr == snapshot.ptr); // ownership moved, no copy
+    try std.testing.expectEqual(@as(usize, 3), ts.tab_index);
+    try std.testing.expect(ts.focused);
+    try std.testing.expect(ts.is_wsl);
+}
+
+test "ToolSurface.initOwned frees the snapshot and earlier dupes when an allocation fails" {
+    // Fail each of the three dupes in turn. The adopted snapshot comes from
+    // the leak-checking testing allocator, so any path that drops it (or an
+    // earlier dupe) fails the test at the end-of-test leak check.
+    var dummy: u8 = 0;
+    var fail_index: usize = 0;
+    while (fail_index < 3) : (fail_index += 1) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{
+            .fail_index = fail_index,
+        });
+        const snapshot = try std.testing.allocator.dupe(u8, "snap");
+        try std.testing.expectError(error.OutOfMemory, ToolSurface.initOwned(
+            failing.allocator(),
+            "surface-1",
+            "title-1",
+            "/work",
+            snapshot,
+            .{
+                .tab_index = 0,
+                .focused = false,
+                .is_ssh = false,
+                .is_wsl = false,
+                .ptr = @ptrCast(&dummy),
+            },
+        ));
+    }
+}

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -126,6 +126,64 @@ pub threadlocal var g_dpi: u32 = platform_display.default_dpi;
 pub threadlocal var g_cjk_font_family: ?[]const u8 = null;
 pub threadlocal var g_fallback_font_families: ?[]const u8 = null;
 
+// The globals above must never alias config-owned memory: the config that
+// carries these strings is deinit'd right after a reload is applied, and the
+// globals are read lazily on the next fallback-face lookup. Set them only
+// through these setters, which copy into the thread's own buffers.
+threadlocal var g_cjk_font_family_buf: [256]u8 = undefined;
+threadlocal var g_fallback_font_families_buf: [1024]u8 = undefined;
+
+pub fn setCjkFontFamily(family: ?[]const u8) void {
+    const value = family orelse {
+        g_cjk_font_family = null;
+        return;
+    };
+    const n = @min(value.len, g_cjk_font_family_buf.len);
+    @memcpy(g_cjk_font_family_buf[0..n], value[0..n]);
+    g_cjk_font_family = g_cjk_font_family_buf[0..n];
+}
+
+pub fn setFallbackFontFamilies(csv: ?[]const u8) void {
+    const value = csv orelse {
+        g_fallback_font_families = null;
+        return;
+    };
+    const n = @min(value.len, g_fallback_font_families_buf.len);
+    @memcpy(g_fallback_font_families_buf[0..n], value[0..n]);
+    g_fallback_font_families = g_fallback_font_families_buf[0..n];
+}
+
+test "fallback family setters keep a private copy of config-owned strings" {
+    // Regression: config reload assigned cfg-owned slices directly to the
+    // globals, which dangled once the reloaded Config was deinit'd. The
+    // setters must copy, so clobbering the source must not change the values.
+    var src: [16]u8 = undefined;
+    @memcpy(src[0..6], "Sarasa");
+    setCjkFontFamily(src[0..6]);
+    @memset(&src, 'x');
+    try std.testing.expectEqualStrings("Sarasa", g_cjk_font_family.?);
+
+    @memcpy(src[0..8], "AA, B, C");
+    setFallbackFontFamilies(src[0..8]);
+    @memset(&src, 'y');
+    try std.testing.expectEqualStrings("AA, B, C", g_fallback_font_families.?);
+
+    setCjkFontFamily(null);
+    try std.testing.expect(g_cjk_font_family == null);
+    setFallbackFontFamilies(null);
+    try std.testing.expect(g_fallback_font_families == null);
+}
+
+test "fallback family setters truncate values longer than their buffers" {
+    const long = "x" ** 2000;
+    setCjkFontFamily(long);
+    try std.testing.expect(g_cjk_font_family.?.len < long.len);
+    setFallbackFontFamilies(long);
+    try std.testing.expect(g_fallback_font_families.?.len < long.len);
+    setCjkFontFamily(null);
+    setFallbackFontFamilies(null);
+}
+
 // HarfBuzz shaping state
 pub threadlocal var g_hb_buf: ?harfbuzz.Buffer = null;
 pub threadlocal var g_hb_font: ?harfbuzz.Font = null; // HB font for primary face

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -114,6 +114,7 @@ test {
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");
     _ = @import("ai_chat_layout.zig");
+    _ = @import("ai_chat_types.zig");
     _ = @import("ai_sidebar.zig");
     _ = @import("appwindow/flush_scheduler.zig");
     _ = @import("appwindow/resize_throttle.zig");


### PR DESCRIPTION
## Summary

Fixes two use-after-free hazards (plus one OOM-only leak) found while auditing the config-reload path. All share one root cause: **config/App-owned strings were aliased into long-lived globals that outlive the owner**.

### Finding 1 — config-reload font UAF (primary)
`applyReloadedConfig` stored `cfg`-owned slices directly into `font.g_cjk_font_family` / `font.g_fallback_font_families`. Both reload callers `defer cfg.deinit(...)` immediately after applying, while those globals are read **lazily** on the next fallback-face lookup (`font/manager.zig` `findConfiguredFallbackFont`). CJK/emoji users hit this the first time a not-yet-cached glyph needs a fallback face after editing config.

**Fix:** added copy-setters `setCjkFontFamily` / `setFallbackFontFamilies` (thread-local backing buffers) and used them at both the startup (`AppWindow.zig:205`) and reload (`AppWindow.zig:4156`) sites. The startup path previously aliased `App.font_family_cjk`, which `App.replaceOptStr` frees and reallocates on every reload.

### Finding 2 — `g_requested_font` UAF in the event loop
`g_requested_font` aliased `App.font_family` (freed by `App.replaceStr` on reload) and is read later in the event loop via `handleWindowDpiChanged`. Repro: change any config setting while running, then move the window to a different-DPI monitor.

**Fix:** added `setRequestedFont` + backing buffer; startup copies instead of aliasing.

### Finding 3 — OOM-only leak in `makeAgentToolSurface`
A bare struct literal with sequential `try allocator.dupe(...)` calls leaked earlier allocations if a later one failed; `collectAgentToolSnapshot` also dropped the built surface if the `ArrayList` append failed.

**Fix:** added `ToolSurface.initOwned` with a proper `errdefer` chain (adopts the snapshot even on failure); `collectAgentToolSnapshot` now `errdefer`-frees the surface before append.

### Deliberately left alone
`g_shader_path` has the same aliasing shape but its only consumer (`post_process.init`) reads the path to open the file before the event loop and doesn't retain the pointer — no reachable bug.

## Tests (TDD)
- `ai_chat_types.zig`: `initOwned` copy/adopt; per-allocation-failure cleanup via `FailingAllocator` under the leak-checking allocator. Module added to the fast suite.
- `font/manager.zig`: setters copy (clobber-source test) + truncate over-long values.
- `AppWindow.zig`: `setRequestedFont` copies + truncates.

`zig build test`, `zig build test-full`, and `zig build` all green.

## Pending
GUI smoke test (edit config → type a new CJK char → confirm no crash) still needs a manual pass on a real display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)