### PR TITLE
fix(preview): stream large files — SSH >16MiB cap + scrollable text head

### DIFF
--- a/src/input/preview_source.zig
+++ b/src/input/preview_source.zig
@@ -39,7 +39,86 @@ fn appendShellQuoted(list: *std.ArrayListUnmanaged(u8), allocator: std.mem.Alloc
     try list.append(allocator, '\'');
 }
 
-pub fn readLocalPreviewSource(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+/// Result of a preview read. `bytes` is ALWAYS a standalone heap allocation owned
+/// by the caller — it must be freed with the same allocator exactly once (never a
+/// sub-slice of a larger live buffer). `truncated` is true when the file exceeded
+/// the limit and only its head window was kept (text-like kinds; see
+/// `markdown_preview.allowsTruncatedHead`) so a huge log is previewable as a
+/// scrollable head instead of being refused.
+pub const PreviewRead = struct { bytes: []u8, truncated: bool = false };
+
+/// Length of the head to keep when truncating an over-limit text preview: bytes
+/// up to and including the last newline within `limit`, so the final rendered
+/// line isn't a partial line. Falls back to `limit` when no newline is in range.
+fn truncatedHeadLen(data: []const u8, limit: usize) usize {
+    const window = data[0..@min(limit, data.len)];
+    if (std.mem.lastIndexOfScalar(u8, window, '\n')) |nl| return nl + 1;
+    return window.len;
+}
+
+/// Apply the over-limit policy to a freshly read buffer (holding up to limit+1
+/// bytes), taking ownership of `source`. Within the limit it is returned as-is.
+/// Over the limit: when `allow_truncate`, the head window is kept and reported
+/// as truncated; otherwise the buffer is freed and `error.PreviewTooLarge` is
+/// surfaced (raster kinds, which can't be partially decoded).
+fn finishPreviewRead(allocator: std.mem.Allocator, source: []u8, limit: usize, allow_truncate: bool) !PreviewRead {
+    if (source.len <= limit) return .{ .bytes = source };
+    if (!allow_truncate) {
+        allocator.free(source);
+        return error.PreviewTooLarge;
+    }
+    const keep = truncatedHeadLen(source, limit); // 1..=limit, so never resizes to 0
+    // resize never moves the allocation, so source[0..keep] stays a freeable
+    // standalone allocation (PreviewRead.bytes contract); fall back to a copy if
+    // an in-place shrink is refused.
+    if (allocator.resize(source, keep)) return .{ .bytes = source[0..keep], .truncated = true };
+    const head = allocator.alloc(u8, keep) catch {
+        allocator.free(source);
+        return error.PreviewFailed;
+    };
+    @memcpy(head, source[0..keep]);
+    allocator.free(source);
+    return .{ .bytes = head, .truncated = true };
+}
+
+/// Read at most `max_bytes` from `file` into a fresh allocation, stopping at the
+/// cap instead of failing on a larger file (unlike `readToEndAlloc`, which errors
+/// with StreamTooLong). The returned buffer is sized to the bytes actually read,
+/// so a huge log yields exactly its first `max_bytes` for the head-window policy.
+fn readFileHeadAlloc(allocator: std.mem.Allocator, file: std.fs.File, max_bytes: usize) ![]u8 {
+    const buf = allocator.alloc(u8, max_bytes) catch return error.PreviewFailed;
+    var total: usize = 0;
+    while (total < max_bytes) {
+        const n = file.read(buf[total..]) catch {
+            allocator.free(buf);
+            return error.PreviewFailed;
+        };
+        if (n == 0) break;
+        total += n;
+    }
+    if (total == max_bytes) return buf; // exact fit, no shrink needed
+    if (total == 0) {
+        // Empty file: free the over-sized buffer and hand back a real 0-length
+        // allocation (returning buf[0..0] would leak the original mapping, since
+        // free() uses the slice length).
+        allocator.free(buf);
+        return allocator.alloc(u8, 0) catch error.PreviewFailed;
+    }
+    // Shrink to the bytes actually read. Allocator.resize never moves the
+    // allocation (it returns false only when it can't shrink in place), so a
+    // successful resize leaves buf[0..total] freeable as-is; otherwise copy into
+    // an exact-size buffer and release the original.
+    if (allocator.resize(buf, total)) return buf[0..total];
+    const out = allocator.alloc(u8, total) catch {
+        allocator.free(buf);
+        return error.PreviewFailed;
+    };
+    @memcpy(out, buf[0..total]);
+    allocator.free(buf);
+    return out;
+}
+
+pub fn readLocalPreviewSource(allocator: std.mem.Allocator, path: []const u8, limit: usize, allow_truncate: bool) !PreviewRead {
     const perf = ui_perf.begin("preview_source.read_local");
     defer perf.end();
 
@@ -51,10 +130,10 @@ pub fn readLocalPreviewSource(allocator: std.mem.Allocator, path: []const u8, li
     };
     defer file.close();
 
-    const source = file.readToEndAlloc(allocator, limit + 1) catch return error.PreviewFailed;
-    errdefer allocator.free(source);
-    if (source.len > limit) return error.PreviewTooLarge;
-    return source;
+    // Read up to limit+1 bytes: the +1 makes an over-limit file observable
+    // (source.len > limit) so finishPreviewRead can truncate (text) or reject it.
+    const source = try readFileHeadAlloc(allocator, file, limit + 1);
+    return finishPreviewRead(allocator, source, limit, allow_truncate);
 }
 
 fn buildRemotePreviewReadCommand(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
@@ -63,30 +142,57 @@ fn buildRemotePreviewReadCommand(allocator: std.mem.Allocator, path: []const u8,
     return std.fmt.allocPrint(allocator, "head -c {} -- {s}", .{ limit + 1, path_expr });
 }
 
-fn readSshPreviewSource(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, path: []const u8, limit: usize) ![]u8 {
-    const perf = ui_perf.begin("preview_source.read_ssh");
-    defer perf.end();
+/// Signature of `scp.sshExecCapped`, isolated so tests can inject a fake exec.
+const SshExecCappedFn = *const fn (std.mem.Allocator, *const Surface.SshConnection, []const u8, usize) ?[]u8;
 
+/// Stdout byte cap for an SSH preview read of at most `limit` bytes. The read
+/// command is `head -c {limit+1}` (the +1 lets `source.len > limit` detect an
+/// over-limit file), so the cap must admit exactly that much output. Sizing the
+/// cap to the command's own truncation point means scp's "exceeded" guard can
+/// never wrongly fire, while a genuinely too-large file is still flagged.
+///
+/// This MUST exceed scp's default 16 MiB cap (`scp.SSH_EXEC_MAX_STDOUT_BYTES`):
+/// PDF (64 MiB) and image (32 MiB) preview limits are both larger, and using the
+/// default `scp.sshExec` killed ssh mid-transfer for any >16 MiB document
+/// ("sshExec: stdout exceeded 16777216 bytes; killing ssh").
+pub fn sshPreviewStdoutCap(limit: usize) usize {
+    return limit + 1;
+}
+
+fn readSshPreviewSourceWith(
+    allocator: std.mem.Allocator,
+    conn: *const Surface.SshConnection,
+    path: []const u8,
+    limit: usize,
+    allow_truncate: bool,
+    exec_fn: SshExecCappedFn,
+) !PreviewRead {
     const command = buildRemotePreviewReadCommand(allocator, path, limit) catch return error.PreviewFailed;
     defer allocator.free(command);
 
-    const source = scp.sshExec(allocator, conn, command) orelse return error.PreviewFailed;
-    errdefer allocator.free(source);
-    if (source.len > limit) return error.PreviewTooLarge;
-    return source;
+    const source = exec_fn(allocator, conn, command, sshPreviewStdoutCap(limit)) orelse return error.PreviewFailed;
+    return finishPreviewRead(allocator, source, limit, allow_truncate);
+}
+
+fn readSshPreviewSource(allocator: std.mem.Allocator, conn: *const Surface.SshConnection, path: []const u8, limit: usize, allow_truncate: bool) !PreviewRead {
+    const perf = ui_perf.begin("preview_source.read_ssh");
+    defer perf.end();
+
+    return readSshPreviewSourceWith(allocator, conn, path, limit, allow_truncate, scp.sshExecCapped);
 }
 
 pub fn readRemotePreviewSource(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     if (!file_explorer.g_has_ssh_conn) return error.PreviewFailed;
-    return readSshPreviewSource(allocator, &file_explorer.g_ssh_conn, path, markdown_preview.MAX_SOURCE_BYTES);
+    return (try readSshPreviewSource(allocator, &file_explorer.g_ssh_conn, path, markdown_preview.MAX_SOURCE_BYTES, false)).bytes;
 }
 
-pub fn readPreviewSourceForKind(allocator: std.mem.Allocator, source_kind: SourceKind, path: []const u8, kind: markdown_preview.Kind) ![]u8 {
+pub fn readPreviewSourceForKind(allocator: std.mem.Allocator, source_kind: SourceKind, path: []const u8, kind: markdown_preview.Kind) !PreviewRead {
     const limit = markdown_preview.sourceLimit(kind);
+    const allow_truncate = markdown_preview.allowsTruncatedHead(kind);
     return switch (source_kind) {
-        .local => readLocalPreviewSource(allocator, path, limit),
-        .wsl => readWslPreviewSource(allocator, path, limit),
-        .remote => |conn| readSshPreviewSource(allocator, &conn, path, limit),
+        .local => readLocalPreviewSource(allocator, path, limit, allow_truncate),
+        .wsl => readWslPreviewSource(allocator, path, limit, allow_truncate),
+        .remote => |conn| readSshPreviewSource(allocator, &conn, path, limit, allow_truncate),
     };
 }
 
@@ -96,7 +202,7 @@ fn buildWslPreviewReadCommand(allocator: std.mem.Allocator, path: []const u8, li
     return std.fmt.allocPrint(allocator, "head -c {} -- {s}", .{ limit + 1, path_expr });
 }
 
-pub fn readWslPreviewSource(allocator: std.mem.Allocator, path: []const u8, limit: usize) ![]u8 {
+pub fn readWslPreviewSource(allocator: std.mem.Allocator, path: []const u8, limit: usize, allow_truncate: bool) !PreviewRead {
     const perf = ui_perf.begin("preview_source.read_wsl");
     defer perf.end();
 
@@ -104,9 +210,7 @@ pub fn readWslPreviewSource(allocator: std.mem.Allocator, path: []const u8, limi
     defer allocator.free(command);
 
     const source = platform_remote_file.wslExec(allocator, command) orelse return error.PreviewFailed;
-    errdefer allocator.free(source);
-    if (source.len > limit) return error.PreviewTooLarge;
-    return source;
+    return finishPreviewRead(allocator, source, limit, allow_truncate);
 }
 
 pub fn basenameForPreview(path: []const u8) []const u8 {
@@ -162,6 +266,98 @@ test "preview_source: ssh relative paths require a reported cwd" {
     try std.testing.expectEqualStrings("/srv/project/data/sample.fa", relative);
 }
 
+test "preview_source: ssh read cap admits head output and beats the default 16 MiB cap" {
+    // The remote read command is `head -c {limit+1}`; the stdout cap must admit
+    // that exact maximum.
+    try std.testing.expectEqual(@as(usize, 1025), sshPreviewStdoutCap(1024));
+
+    // Regression for "sshExec: stdout exceeded 16777216 bytes; killing ssh": the
+    // PDF (64 MiB) and image (32 MiB) preview limits both exceed scp's default
+    // 16 MiB stdout cap, so the default sshExec killed ssh for any >16 MiB file.
+    // The preview cap must beat the default for both kinds.
+    try std.testing.expect(sshPreviewStdoutCap(markdown_preview.MAX_PDF_SOURCE_BYTES) > scp.SSH_EXEC_MAX_STDOUT_BYTES);
+    try std.testing.expect(sshPreviewStdoutCap(markdown_preview.MAX_IMAGE_SOURCE_BYTES) > scp.SSH_EXEC_MAX_STDOUT_BYTES);
+}
+
+test "preview_source: local read truncates an over-limit text file to a head window" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const content = "line1\nline2\nline3\nline4\n"; // 24 bytes, four 6-byte lines
+    try tmp.dir.writeFile(.{ .sub_path = "big.log", .data = content });
+    const path = try tmp.dir.realpathAlloc(allocator, "big.log");
+    defer allocator.free(path);
+
+    // Over the limit (12): reads 13 bytes, trims to the last newline within 12 ->
+    // "line1\nline2\n" and reports truncated rather than refusing the file.
+    const head = try readLocalPreviewSource(allocator, path, 12, true);
+    defer allocator.free(head.bytes);
+    try std.testing.expect(head.truncated);
+    try std.testing.expectEqualStrings("line1\nline2\n", head.bytes);
+
+    // Within the limit: full content, not truncated.
+    const full = try readLocalPreviewSource(allocator, path, 1000, true);
+    defer allocator.free(full.bytes);
+    try std.testing.expect(!full.truncated);
+    try std.testing.expectEqualStrings(content, full.bytes);
+
+    // Raster policy (allow_truncate=false) still rejects an over-limit file.
+    try std.testing.expectError(error.PreviewTooLarge, readLocalPreviewSource(allocator, path, 12, false));
+}
+
+test "preview_source: truncatedHeadLen keeps whole lines and falls back to limit" {
+    // window = data[0..10] = "aa\nbb\ncc\nd"; last '\n' is at index 8, so the head
+    // keeps "aa\nbb\ncc\n" (9 bytes) and drops the partial final line "dd".
+    try std.testing.expectEqual(@as(usize, 9), truncatedHeadLen("aa\nbb\ncc\ndd", 10));
+    // No newline within the window -> keep exactly `limit` bytes.
+    try std.testing.expectEqual(@as(usize, 4), truncatedHeadLen("abcdefgh", 4));
+    // Data shorter than the limit -> window is the whole input (here ending in a
+    // newline at index 3, so the kept length is the full 4 bytes).
+    try std.testing.expectEqual(@as(usize, 4), truncatedHeadLen("abc\n", 5));
+}
+
+test "preview_source: ssh preview sizes the exec cap to limit+1 and applies the over-limit policy" {
+    const allocator = std.testing.allocator;
+    const Fake = struct {
+        var last_cap: usize = 0;
+        var payload_len: usize = 0;
+        var payload_byte: u8 = 'x';
+        fn exec(a: std.mem.Allocator, _: *const Surface.SshConnection, _: []const u8, cap: usize) ?[]u8 {
+            last_cap = cap;
+            const buf = a.alloc(u8, payload_len) catch return null;
+            @memset(buf, payload_byte);
+            return buf;
+        }
+    };
+    var conn: Surface.SshConnection = .{};
+
+    // A document within the limit is returned, and the cap passed to ssh is the
+    // command's own ceiling (limit+1) — NOT scp's default 16 MiB.
+    Fake.payload_byte = 'x';
+    Fake.payload_len = 10;
+    const ok = try readSshPreviewSourceWith(allocator, &conn, "/srv/a.pdf", 64, false, Fake.exec);
+    defer allocator.free(ok.bytes);
+    try std.testing.expectEqual(@as(usize, 65), Fake.last_cap);
+    try std.testing.expectEqual(@as(usize, 10), ok.bytes.len);
+    try std.testing.expect(!ok.truncated);
+
+    // Raster-style read (allow_truncate=false): an over-limit file is reported as
+    // too_large rather than failing or silently truncating.
+    Fake.payload_len = 65;
+    try std.testing.expectError(
+        error.PreviewTooLarge,
+        readSshPreviewSourceWith(allocator, &conn, "/srv/a.pdf", 64, false, Fake.exec),
+    );
+
+    // Text-style read (allow_truncate=true): the same over-limit file becomes a
+    // truncated head window instead of being refused. No newline -> keep `limit`.
+    Fake.payload_len = 65;
+    const head = try readSshPreviewSourceWith(allocator, &conn, "/srv/a.log", 64, true, Fake.exec);
+    defer allocator.free(head.bytes);
+    try std.testing.expectEqual(@as(usize, 64), head.bytes.len);
+    try std.testing.expect(head.truncated);
+}
+
 pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surface, path: []const u8, ls_prefix: ?[]const u8) ![]u8 {
     const joined = try ls_path_context.applyLsPrefix(allocator, path, ls_prefix);
     defer if (joined) |j| allocator.free(j);
@@ -188,15 +384,15 @@ pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surfac
 
 pub fn readTerminalPreviewSource(allocator: std.mem.Allocator, surface: *Surface, path: []const u8) ![]u8 {
     return switch (surface.launch_kind) {
-        .wsl => readWslPreviewSource(allocator, path, markdown_preview.MAX_SOURCE_BYTES),
+        .wsl => (try readWslPreviewSource(allocator, path, markdown_preview.MAX_SOURCE_BYTES, false)).bytes,
         .ssh => blk: {
             const conn = surface.ssh_connection orelse {
                 std.debug.print("Markdown preview over SSH needs WispTerm SSH connection metadata; manual ssh sessions are not supported yet\n", .{});
                 return error.PreviewFailed;
             };
-            break :blk try readSshPreviewSource(allocator, &conn, path, markdown_preview.MAX_SOURCE_BYTES);
+            break :blk (try readSshPreviewSource(allocator, &conn, path, markdown_preview.MAX_SOURCE_BYTES, false)).bytes;
         },
-        .local => readLocalPreviewSource(allocator, path, markdown_preview.MAX_SOURCE_BYTES),
+        .local => (try readLocalPreviewSource(allocator, path, markdown_preview.MAX_SOURCE_BYTES, false)).bytes,
     };
 }
 

--- a/src/markdown_preview.zig
+++ b/src/markdown_preview.zig
@@ -61,6 +61,14 @@ pub fn sourceLimit(kind: Kind) usize {
     };
 }
 
+/// Whether an over-limit file of this kind should be shown as a truncated head
+/// window (the first `sourceLimit` bytes) rather than refused outright. Text-like
+/// kinds stream fine, so a huge log is previewable as a scrollable head; raster
+/// kinds (image/pdf) can't be partially decoded, so they still fail as too-large.
+pub fn allowsTruncatedHead(kind: Kind) bool {
+    return !kind.isRaster();
+}
+
 pub fn isImagePath(path: []const u8) bool {
     return detectKind(path) == .image;
 }
@@ -497,6 +505,17 @@ test "raster kinds are image and pdf" {
     try std.testing.expect(!Kind.text.isRaster());
     try std.testing.expect(!Kind.csv.isRaster());
     try std.testing.expect(!Kind.tsv.isRaster());
+}
+
+test "text-like kinds allow a truncated head; raster kinds do not" {
+    // A huge log/markdown/csv shows its head and scrolls; image/pdf can't be
+    // partially decoded, so they still fail as too-large.
+    try std.testing.expect(allowsTruncatedHead(.text));
+    try std.testing.expect(allowsTruncatedHead(.markdown));
+    try std.testing.expect(allowsTruncatedHead(.csv));
+    try std.testing.expect(allowsTruncatedHead(.tsv));
+    try std.testing.expect(!allowsTruncatedHead(.image));
+    try std.testing.expect(!allowsTruncatedHead(.pdf));
 }
 
 test "delimited row parser handles csv quotes and tsv" {

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -15,7 +15,7 @@ const PreviewPane = @This();
 pub const DEFAULT_WIDTH: f32 = 440; // used to derive the initial right-edge split ratio
 pub const LoadStatus = enum { idle, loading, ready, failed, too_large };
 pub const PreviewSourceKind = preview_source.SourceKind;
-pub const PreviewReadResult = union(enum) { ok: []u8, failed, too_large };
+pub const PreviewReadResult = union(enum) { ok: []u8, ok_truncated: []u8, failed, too_large };
 const PreviewReadFn = *const fn (Allocator, PreviewSourceKind, markdown_preview.Kind, []const u8) PreviewReadResult;
 pub const PdfRenderFn = *const fn (Allocator, []const u8, u32, u32) pdf_render.RenderError!pdf_render.RenderResult;
 
@@ -54,6 +54,7 @@ const PreviewJob = struct {
     pdf_out_data: ?[]u8 = null, // on success: document bytes for the pane
     pdf_page_count: u32 = 0,
     fail_msg: ?[]const u8 = null, // static strings only
+    truncated: bool = false, // text-like head was clipped to the size limit
     render_fn: PdfRenderFn = pdf_render.renderPage,
 };
 
@@ -66,6 +67,13 @@ path_buf: [512]u8 = undefined,
 path_len: usize = 0,
 source: ?[]u8 = null,
 scroll_offset: f32 = 0,
+// Max vertical scroll for text/markdown/csv content, set by the renderer each
+// pass from the actual height it laid out (so scrolling stops exactly at the
+// last rendered line instead of falling into blank space past it).
+max_scroll: f32 = 0,
+// True when the source is only the head of a file that exceeded the size limit
+// (text-like kinds); drives the "truncated" banner. See preview_source.PreviewRead.
+content_truncated: bool = false,
 image_zoom: f32 = 1.0,
 image_pan_x: f32 = 0,
 image_pan_y: f32 = 0,
@@ -133,6 +141,8 @@ fn applyOwned(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p:
     self.kind = kind;
     self.load_status = if (owned == null and status == .ready) .failed else status;
     self.scroll_offset = 0;
+    self.max_scroll = 0;
+    self.content_truncated = false;
     self.image_zoom = 1.0;
     self.image_pan_x = 0;
     self.image_pan_y = 0;
@@ -143,15 +153,15 @@ fn applyOwned(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p:
 }
 
 pub fn scrollBy(self: *PreviewPane, delta: f32) void {
-    const max_scroll = self.estimatedMaxScroll();
-    self.scroll_offset = @max(0, @min(max_scroll, self.scroll_offset + delta));
+    // Raster panes (image/pdf) use zoom/pan, not scroll. Text/markdown/csv clamp
+    // to the renderer-reported content height so scrolling can't run past the
+    // last rendered line into blank space (the old line-count estimate let a big
+    // file scroll into a void well below its rendered content).
+    if (self.kind.isRaster()) return;
+    self.scroll_offset = @max(0, @min(self.max_scroll, self.scroll_offset + delta));
 }
 
-fn estimatedMaxScroll(self: *const PreviewPane) f32 {
-    if (self.kind.isRaster()) return 0;
-    const line_count = @max(@as(usize, 1), std.mem.count(u8, self.sourceText(), "\n") + 1);
-    return @max(0, @as(f32, @floatFromInt(line_count)) * 28 - 360);
-}
+pub fn isContentTruncated(self: *const PreviewPane) bool { return self.content_truncated; }
 
 pub fn zoomImageBySteps(self: *PreviewPane, steps: usize, zoom_in: bool) bool {
     if (!self.kind.isRaster()) return false;
@@ -230,6 +240,7 @@ pub fn tickAsync(self: *PreviewPane) bool {
             const s = job.source.?; job.source = null;
             const keep_zoom: ?f32 = if (job.is_pdf_flip) self.image_zoom else null;
             self.applyOwned(job.kind, job.title_buf[0..job.title_len], job.path_buf[0..job.path_len], s, .ready);
+            self.content_truncated = job.truncated;
             if (job.kind == .pdf) {
                 if (job.pdf_out_data) |doc| {
                     job.pdf_out_data = null;
@@ -259,6 +270,7 @@ fn jobThread(job: *PreviewJob) void {
     }
     switch (job.read_fn(std.heap.page_allocator, job.source_kind, job.kind, job.path_buf[0..job.path_len])) {
         .ok => |s| { job.source = s; job.status = .ready; },
+        .ok_truncated => |s| { job.source = s; job.status = .ready; job.truncated = true; },
         .too_large => job.status = .too_large,
         .failed => job.status = .failed,
     }
@@ -273,7 +285,9 @@ fn pdfJobThread(job: *PreviewJob) void {
             break :blk d;
         }
         switch (job.read_fn(alloc, job.source_kind, job.kind, job.path_buf[0..job.path_len])) {
-            .ok => |s| break :blk s,
+            // PDFs are raster (allowsTruncatedHead == false), so a real read never
+            // truncates; handle the variant defensively as a full read regardless.
+            .ok, .ok_truncated => |s| break :blk s,
             .too_large => {
                 job.status = .too_large;
                 return;
@@ -370,9 +384,9 @@ fn setPdfDocument(self: *PreviewPane, data: []u8, page: u32, count: u32) void {
 }
 
 fn defaultPreviewRead(alloc: Allocator, source_kind: PreviewSourceKind, kind: markdown_preview.Kind, p: []const u8) PreviewReadResult {
-    const s = preview_source.readPreviewSourceForKind(alloc, source_kind, p, kind) catch |err|
+    const r = preview_source.readPreviewSourceForKind(alloc, source_kind, p, kind) catch |err|
         return if (err == error.PreviewTooLarge) .too_large else .failed;
-    return .{ .ok = s };
+    return if (r.truncated) .{ .ok_truncated = r.bytes } else .{ .ok = r.bytes };
 }
 
 fn freeSource(self: *PreviewPane) void {
@@ -624,4 +638,49 @@ test "PreviewPane: non-pdf open clears pdf document state" {
     p.open(.markdown, "b.md", "b.md", "# hi");
     try std.testing.expect(p.pdf_data == null);
     try std.testing.expectEqual(@as(u32, 0), p.pdf_page_count);
+}
+
+fn fakeTruncatedReadOk(alloc: Allocator, _: PreviewSourceKind, _: markdown_preview.Kind, _: []const u8) PreviewReadResult {
+    return .{ .ok_truncated = alloc.dupe(u8, "line1\nline2\n") catch return .failed };
+}
+
+test "PreviewPane: truncated text read is ready and flags content as truncated" {
+    const gpa = std.testing.allocator;
+    var p = try create(gpa);
+    defer p.unref(gpa);
+    try std.testing.expect(p.beginAsyncLoadWith(.text, "big.log", "big.log", .local, fakeTruncatedReadOk));
+    drainJobs(p);
+    try std.testing.expectEqual(LoadStatus.ready, p.load_status);
+    try std.testing.expect(p.isContentTruncated());
+    try std.testing.expectEqualStrings("line1\nline2\n", p.sourceText());
+
+    // Loading new content clears the truncated flag.
+    p.open(.markdown, "b.md", "b.md", "# hi");
+    try std.testing.expect(!p.isContentTruncated());
+}
+
+test "PreviewPane: scrollBy clamps to the renderer-reported max_scroll" {
+    const gpa = std.testing.allocator;
+    var p = try create(gpa);
+    defer p.unref(gpa);
+    p.kind = .text;
+    p.load_status = .ready;
+
+    // No content height reported yet -> cannot scroll into a void.
+    p.scrollBy(500);
+    try std.testing.expectEqual(@as(f32, 0), p.scroll_offset);
+
+    // The renderer reports the laid-out height; scroll clamps to it.
+    p.max_scroll = 200;
+    p.scrollBy(500);
+    try std.testing.expectEqual(@as(f32, 200), p.scroll_offset);
+    p.scrollBy(-1000);
+    try std.testing.expectEqual(@as(f32, 0), p.scroll_offset);
+
+    // Raster panes ignore scroll entirely (they zoom/pan instead).
+    p.kind = .image;
+    p.max_scroll = 200;
+    p.scroll_offset = 0;
+    p.scrollBy(500);
+    try std.testing.expectEqual(@as(f32, 0), p.scroll_offset);
 }

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -20,7 +20,11 @@ pub const HEADER_HEIGHT: f32 = 42;
 const PAD_X: f32 = 16;
 const PAD_Y: f32 = 18;
 const LINE_GAP: f32 = 6;
-const MAX_RENDER_LINES: usize = 512;
+// Upper bound on lines/rows laid out per pass. Off-screen lines are measured
+// (to size the scrollbar) but not drawn, so this also bounds how far a large
+// text/log head can be scrolled. Generous enough to page through a sizable head
+// while keeping the per-pass walk cheap.
+const MAX_RENDER_LINES: usize = 2000;
 const MAX_TABLE_SCAN_ROWS: usize = 128;
 const TABLE_CELL_PAD_X: f32 = 8;
 const TABLE_MIN_COL_W: f32 = 64;
@@ -67,7 +71,7 @@ pub fn renderInto(
     // Side background: fillQuad(x, gl_y, w, h) — gl_y = pane_gl_bottom
     ui_pipeline.fillQuad(panel_x, pane_gl_bottom, panel_w, panel_h, panel_bg);
 
-    renderHeader(panel_x, panel_w, window_height, panel_top, card_bg, border);
+    renderHeader(pane, panel_x, panel_w, window_height, panel_top, card_bg, border, accent);
     renderFooter(pane, panel_x, panel_w, pane_gl_bottom, card_bg, border, muted, normal, accent);
 
     renderDocument(pane, panel_x, panel_w, window_height, panel_top, panel_h, pane_gl_bottom, normal, muted, strong, accent, code_bg, border);
@@ -78,12 +82,14 @@ pub fn deinit() void {
 }
 
 fn renderHeader(
+    pane: *const PreviewPane,
     panel_x: f32,
     panel_w: f32,
     window_height: f32,
     panel_top: f32,
     card_bg: [3]f32,
     border: [3]f32,
+    accent: [3]f32,
 ) void {
     // A preview pane closes via the standard close-split keybind (like a terminal
     // pane), so the header is just a top separator bar — no close button.
@@ -91,6 +97,29 @@ fn renderHeader(
     const header_y = window_height - panel_top - HEADER_HEIGHT;
     ui_pipeline.fillQuad(panel_x, header_y, panel_w, HEADER_HEIGHT, card_bg);
     ui_pipeline.fillQuad(panel_x, header_y, panel_w, 1, border);
+
+    // Large text/log files are shown as a scrollable head; tell the user the rest
+    // is clipped so they don't mistake the end of the window for the end of file.
+    if (pane.content_truncated and panel_w > PAD_X * 2) {
+        var buf: [96]u8 = undefined;
+        const label = truncatedBannerText(&buf, pane.sourceText().len);
+        const text_y = header_y + (HEADER_HEIGHT - font.g_titlebar_cell_height) / 2;
+        _ = titlebar.renderTextLimited(label, panel_x + PAD_X, text_y, accent, panel_w - PAD_X * 2);
+    }
+}
+
+/// Header banner for a truncated (head-only) preview, e.g.
+/// "Large file: showing first 1.0 MB (scroll to read more)".
+fn truncatedBannerText(buf: []u8, head_bytes: usize) []const u8 {
+    const kib: usize = 1024;
+    const mib: usize = 1024 * 1024;
+    if (head_bytes >= mib) {
+        return std.fmt.bufPrint(buf, "Large file: showing first {d}.{d} MB (scroll to read more)", .{ head_bytes / mib, (head_bytes % mib) * 10 / mib }) catch buf[0..0];
+    }
+    if (head_bytes >= kib) {
+        return std.fmt.bufPrint(buf, "Large file: showing first {d} KB (scroll to read more)", .{head_bytes / kib}) catch buf[0..0];
+    }
+    return std.fmt.bufPrint(buf, "Large file: showing first {d} bytes (scroll to read more)", .{head_bytes}) catch buf[0..0];
 }
 
 fn renderFooter(
@@ -172,7 +201,8 @@ fn renderDocument(
     }
 
     const row_h = @max(22, font.g_titlebar_cell_height + LINE_GAP);
-    var y_from_top: f32 = body_top - pane.scroll_offset;
+    const body_origin = body_top - pane.scroll_offset;
+    var y_from_top: f32 = body_origin;
     const max_w = panel_w - PAD_X * 2;
 
     var in_code = false;
@@ -181,6 +211,9 @@ fn renderDocument(
     while (lines.next()) |raw_line| {
         if (rendered >= MAX_RENDER_LINES) break;
         const line = std.mem.trimRight(u8, raw_line, "\r");
+        // renderMarkdownLine measures every line but only draws the on-screen
+        // slice, so we keep walking past the viewport bottom to accumulate the
+        // full content height (needed to clamp scroll) without extra draw cost.
         const consumed = renderMarkdownLine(
             pane,
             panel_x + PAD_X,
@@ -201,9 +234,22 @@ fn renderDocument(
         );
         y_from_top += consumed;
         rendered += 1;
-        if (y_from_top > body_top + body_h + row_h * 4) break;
     }
+    // Clamp scroll to the laid-out height so the pane can't scroll past its last
+    // rendered line into blank space (large heads now stop cleanly at the end).
+    pane.max_scroll = @max(0, (y_from_top - body_origin) - body_h);
     _ = panel_h;
+}
+
+/// Number of non-blank lines — the count of rows the delimited renderer actually
+/// draws (it skips blank/whitespace-only lines), used to size the scroll height.
+fn countNonBlankLines(source: []const u8) usize {
+    var n: usize = 0;
+    var it = std.mem.splitScalar(u8, source, '\n');
+    while (it.next()) |line| {
+        if (std.mem.trim(u8, line, " \t\r").len > 0) n += 1;
+    }
+    return n;
 }
 
 const TableLayout = struct {
@@ -270,6 +316,12 @@ fn renderDelimitedDocument(
 
     const row_h = @max(26, font.g_titlebar_cell_height + 10);
     if (body_h <= row_h) return;
+
+    // Rows are fixed-height, so clamp scroll to (visible rows × row_h) - body_h,
+    // stopping exactly at the last row. Count NON-BLANK lines (the render loop
+    // skips blank/empty lines), capped at the render budget (header + data rows).
+    const shown_rows = @min(countNonBlankLines(source), MAX_RENDER_LINES + 1);
+    pane.max_scroll = @max(0, @as(f32, @floatFromInt(shown_rows)) * row_h - body_h);
 
     var saw_header = false;
     var data_row_idx: usize = 0;
@@ -1014,4 +1066,18 @@ fn appendSlice(buf: *[1024]u8, pos: usize, text: []const u8) usize {
     const len = @min(text.len, buf.len - pos);
     @memcpy(buf[pos..][0..len], text[0..len]);
     return pos + len;
+}
+
+test "countNonBlankLines ignores blank and whitespace-only lines" {
+    try std.testing.expectEqual(@as(usize, 3), countNonBlankLines("a,b\n\nc,d\n   \ne,f\n"));
+    try std.testing.expectEqual(@as(usize, 1), countNonBlankLines("only"));
+    try std.testing.expectEqual(@as(usize, 0), countNonBlankLines("\n  \n\t\n"));
+}
+
+test "truncatedBannerText scales the head size" {
+    var buf: [96]u8 = undefined;
+    try std.testing.expectEqualStrings("Large file: showing first 1.0 MB (scroll to read more)", truncatedBannerText(&buf, 1024 * 1024));
+    try std.testing.expectEqualStrings("Large file: showing first 1.5 MB (scroll to read more)", truncatedBannerText(&buf, 1024 * 1024 * 3 / 2));
+    try std.testing.expectEqualStrings("Large file: showing first 4 KB (scroll to read more)", truncatedBannerText(&buf, 4096));
+    try std.testing.expectEqualStrings("Large file: showing first 200 bytes (scroll to read more)", truncatedBannerText(&buf, 200));
 }

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -329,10 +329,12 @@ fn drainOutputPipesCapped(
     };
 }
 
-/// Generous ceiling for captured remote stdout: enough for any directory
-/// listing / pwd / preview read, while bounding memory if a remote command
-/// unexpectedly streams gigabytes.
-const SSH_EXEC_MAX_STDOUT_BYTES: usize = 16 * 1024 * 1024;
+/// Default ceiling for captured remote stdout: enough for any directory
+/// listing / pwd, while bounding memory if a remote command unexpectedly
+/// streams gigabytes. Callers that read whole files (e.g. PDF/image previews,
+/// whose documents can exceed this) must use `sshExecCapped` with a cap sized
+/// to their own read limit — otherwise ssh is killed mid-transfer.
+pub const SSH_EXEC_MAX_STDOUT_BYTES: usize = 16 * 1024 * 1024;
 /// stderr is diagnostics only; keep the first chunk for the error log.
 const SSH_EXEC_MAX_STDERR_BYTES: usize = 16 * 1024;
 

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -777,6 +777,7 @@ comptime {
     _ = @import("system_browser.zig");
     _ = @import("split_tree.zig");
     _ = @import("preview_pane.zig");
+    _ = @import("renderer/markdown_preview_renderer.zig");
     _ = @import("ui_perf.zig");
     _ = @import("update_check.zig");
     _ = @import("update_install.zig");


### PR DESCRIPTION
## Summary

Two preview fixes.

### 1. SSH PDF/image preview of files >16 MiB crashed
`readSshPreviewSource` built `head -c {limit+1}` (PDF limit = 64 MiB, image = 32 MiB) but ran it through `scp.sshExec`, whose stdout cap is hardcoded at **16 MiB** (`SSH_EXEC_MAX_STDOUT_BYTES`). Any larger document killed ssh mid-transfer:

```
sshExec: stdout exceeded 16777216 bytes; killing ssh
```

**Fix:** size the SSH read cap to the per-kind limit via `scp.sshExecCapped(..., sshPreviewStdoutCap(limit) = limit+1)`. The cap exactly matches the `head -c {limit+1}` ceiling, so an over-limit file is still detected (`source.len > limit`) instead of killing ssh. The default 16 MiB cap is left intact for directory listings and other callers.

### 2. Large text/log files refused to preview & couldn't scroll
A big `log.txt` (e.g. 48 MB) showed "Preview too large", and the text renderer could only ever draw the first ~512 lines (scrolling beyond ran into blank space). Text-like kinds now:

- show a **scrollable truncated head** instead of refusing, with a header banner (`Large file: showing first 1.0 MB (scroll to read more)`);
- **scroll correctly through the whole loaded head** — the renderer reports an accurate content height (`pane.max_scroll`) so scrolling stops at the last rendered line; render budget raised 512 → 2000 lines;
- raster kinds (image/pdf) still fail as too-large since they can't be partially decoded.

Also fixes a latent bug: a large **local** text file would have errored (`readToEndAlloc` → `StreamTooLong`) instead of truncating to a head.

## Implementation
- `markdown_preview.allowsTruncatedHead(kind)` = `!isRaster()`.
- `preview_source`: `PreviewRead{bytes,truncated}`, `truncatedHeadLen` (trim to last newline), `finishPreviewRead` (head-or-reject policy), `readFileHeadAlloc` (head read that doesn't error on oversized files), `sshPreviewStdoutCap`.
- `preview_pane`: `PreviewReadResult.ok_truncated`, `content_truncated` + renderer-driven `max_scroll` (replaces the line-count `estimatedMaxScroll`).
- `markdown_preview_renderer`: accurate scroll height, truncation banner, `MAX_RENDER_LINES` 512→2000, CSV/TSV scroll height via non-blank row count.

## Testing
- `zig build test` (fast native) and `zig build test-full` both green.
- Added regression tests: SSH cap = limit+1 + too-large/truncate policy (injected fake exec), `truncatedHeadLen`, local-file head truncation, `allowsTruncatedHead`, scroll clamp to `max_scroll`, `countNonBlankLines`, banner formatting.
- Reviewed via a multi-lens adversarial pass; CSV scroll math and an empty-file allocation edge were fixed as a result; the allocator ownership idiom was confirmed leak/double-free clean with a runtime `testing.allocator` test.

⚠️ Not yet GUI-verified end-to-end — needs a manual smoke test (open a >16 MiB remote PDF and a large remote log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)