### PR TITLE
feat(preview): focus on open + × close button for preview panes

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3889,6 +3889,7 @@ fn renderResizeFrame(width: i32, height: i32) void {
                         // terminal arm leaves a per-rect viewport set).
                         gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                         gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+                        const close_hovered = if (input.g_preview_close_hover) |h| h == rect.handle else false;
                         markdown_preview_renderer.renderInto(
                             p,
                             @floatFromInt(rect.x),
@@ -3896,6 +3897,7 @@ fn renderResizeFrame(width: i32, height: i32) void {
                             @floatFromInt(rect.width),
                             @floatFromInt(rect.height),
                             @floatFromInt(fb_height),
+                            close_hovered,
                         );
                         if (is_focused) drawPaneFocusRing(rect, @floatFromInt(fb_height));
                     },
@@ -3995,6 +3997,8 @@ fn openSkillMdInPreviewLeaf(allocator: std.mem.Allocator, title: []const u8, con
         }
     else
         (tab.splitIntoPreviewStacked(allocator) orelse return);
+    // Select the preview so Ctrl+Shift+W closes it (not the terminal).
+    _ = tab.focusPreviewPane(pane);
     pane.open(.markdown, title, "SKILL.md", content);
 }
 
@@ -7067,6 +7071,7 @@ fn runMainLoop(self: *AppWindow) !void {
                                 // so restore the full-window viewport/projection first.
                                 gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
                                 gpu.gl_init.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+                                const close_hovered = if (input.g_preview_close_hover) |h| h == rect.handle else false;
                                 markdown_preview_renderer.renderInto(
                                     p,
                                     @floatFromInt(rect.x),
@@ -7074,6 +7079,7 @@ fn runMainLoop(self: *AppWindow) !void {
                                     @floatFromInt(rect.width),
                                     @floatFromInt(rect.height),
                                     @floatFromInt(fb_height),
+                                    close_hovered,
                                 );
                                 if (is_focused) drawPaneFocusRing(rect, @floatFromInt(fb_height));
 

--- a/src/appwindow/split_layout.zig
+++ b/src/appwindow/split_layout.zig
@@ -13,6 +13,7 @@ const gl_init = AppWindow.gpu.gl_init;
 const Surface = @import("../Surface.zig");
 const SplitTree = @import("../split_tree.zig");
 const renderer = @import("../renderer.zig");
+const preview_close_button = @import("../input/preview_close_button.zig");
 
 const TabState = tab.TabState;
 pub const MAX_SPLITS_PER_TAB = tab.MAX_SPLITS_PER_TAB;
@@ -106,6 +107,32 @@ pub fn paneAtPoint(x: i32, y: i32) ?PaneHit {
         if (!cachedRectIsLive(r)) continue;
         if (x >= r.x and x < r.x + r.width and y >= r.y and y < r.y + r.height)
             return .{ .pane = r.pane, .handle = r.handle };
+    }
+    return null;
+}
+
+/// If (x, y) lands on a preview pane's top-right close (×) button, return that
+/// preview's handle; null otherwise. Mirrors the button geometry the preview
+/// renderer draws (shared via preview_close_button), so the clickable box and
+/// the drawn box stay in sync. Only live preview leaves are considered.
+pub fn previewCloseButtonAtPoint(x: i32, y: i32) ?SplitTree.Node.Handle {
+    const xf: f32 = @floatFromInt(x);
+    const yf: f32 = @floatFromInt(y);
+    for (0..g_split_rect_count) |i| {
+        const r = g_split_rects[i];
+        if (!cachedRectIsLive(r)) continue;
+        switch (r.pane) {
+            .preview => {
+                if (preview_close_button.contains(
+                    @floatFromInt(r.x),
+                    @floatFromInt(r.y),
+                    @floatFromInt(r.width),
+                    xf,
+                    yf,
+                )) return r.handle;
+            },
+            .terminal => {},
+        }
     }
     return null;
 }

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -876,6 +876,35 @@ pub fn previewForReuse(gpa: std.mem.Allocator, t: *const TabState, kind: markdow
     return null;
 }
 
+/// Move split-tree focus to the leaf holding `pane` in the active tab, so a
+/// just-opened (or reused) preview becomes the focused pane. With the preview
+/// focused, Ctrl+Shift+W closes IT — not the terminal the user came from — and
+/// PgUp/PgDn/arrows/Home/End/+/- scroll & zoom it (see input.zig). Closing the
+/// preview refocuses the surviving terminal, so typing resumes naturally.
+///
+/// Matching is by pointer identity (the leaf handle equals the node index), so
+/// it is allocation-free and unambiguous even with multiple same-kind previews.
+/// Returns false without changing focus when there is no active terminal tab or
+/// `pane` is not a leaf of its tree — defensive against a tree reshaped between
+/// pane creation and this call.
+pub fn focusPreviewPane(pane: *PreviewPane) bool {
+    const t = activeTab() orelse return false;
+    if (t.kind != .terminal) return false;
+    for (t.tree.nodes, 0..) |node, i| {
+        switch (node) {
+            .leaf => |pn| switch (pn) {
+                .preview => |p| if (p == pane) {
+                    t.focused = @enumFromInt(i);
+                    return true;
+                },
+                else => {},
+            },
+            .split => {},
+        }
+    }
+    return false;
+}
+
 /// Split the focused surface in the given direction.
 /// Returns true on success. The caller handles g_resize_active and rebuild flags.
 pub fn splitFocused(
@@ -2533,6 +2562,76 @@ test "tab: splitIntoPreview adds a preview leaf and grows the tree by 2 nodes" {
     // t.deinit (deferred) will call tree.deinit(), which unrefs the preview pane
     // (freeing it) and decrements the surface refcount. The testing allocator
     // must report no leak after the defer runs.
+}
+
+test "tab: focusPreviewPane selects the just-opened preview leaf" {
+    resetTestTabGlobals();
+    const gpa = std.testing.allocator;
+
+    var surface: Surface = undefined;
+    surface.ref_count = 1;
+    surface.ssh_connection = null;
+    surface.cwd_path_len = 0;
+    surface.initial_cwd_path_len = 0;
+    surface.title_override_len = 0;
+    surface.agent_recent_output_len = 0;
+
+    const t = try gpa.create(TabState);
+    t.* = .{
+        .kind = .terminal,
+        .tree = try SplitTree.init(gpa, &surface),
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = null,
+        .skill_center_session = null,
+        .copilot_session = null,
+        .copilot_visible = false,
+    };
+    defer {
+        t.deinit(gpa);
+        gpa.destroy(t);
+        resetTestTabGlobals();
+    }
+
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_count = g_tab_count;
+    const saved_tab0 = g_tabs[0];
+    defer {
+        active_tab_state.g_active_tab = saved_active;
+        g_tab_count = saved_count;
+        g_tabs[0] = saved_tab0;
+    }
+    g_tabs[0] = t;
+    active_tab_state.g_active_tab = 0;
+    g_tab_count = 1;
+
+    // splitIntoPreview keeps the TERMINAL focused (its documented contract).
+    const p = splitIntoPreview(gpa) orelse return error.SplitIntoPreviewFailed;
+    switch (t.tree.nodes[t.focused.idx()]) {
+        .leaf => |pane| switch (pane) {
+            .terminal => {}, // precondition: terminal focused, preview not.
+            .preview => return error.PreconditionPreviewAlreadyFocused,
+        },
+        .split => return error.PreconditionFocusedIsSplit,
+    }
+
+    // focusPreviewPane moves focus onto the preview leaf holding `p`.
+    try std.testing.expect(focusPreviewPane(p));
+    try std.testing.expect(t.focused.idx() < t.tree.nodes.len);
+    switch (t.tree.nodes[t.focused.idx()]) {
+        .leaf => |pane| switch (pane) {
+            .preview => |fp| try std.testing.expectEqual(p, fp),
+            .terminal => return error.FocusedIsTerminalNotPreview,
+        },
+        .split => return error.FocusedIsSplitNotPreview,
+    }
+
+    // A pane that is not in the tree leaves focus untouched (returns false).
+    const focused_before = t.focused;
+    const foreign = try PreviewPane.create(gpa);
+    defer foreign.unref(gpa);
+    try std.testing.expect(!focusPreviewPane(foreign));
+    try std.testing.expectEqual(focused_before, t.focused);
 }
 
 test "tab: closeFocusedSplit closes a focused preview and refocuses the terminal" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -598,6 +598,10 @@ const TokenAtCell = struct {
 pub const SPLIT_DIVIDER_HIT_WIDTH: f32 = 8; // Larger hit area for easier grabbing
 
 pub threadlocal var g_divider_hover: bool = false; // Mouse is over a divider
+// Handle of the preview pane whose close (×) button the mouse is currently
+// hovering, or null. The renderer brightens that pane's button; updated on
+// mouse-move. Just a hover hint — clicks are hit-tested independently.
+pub threadlocal var g_preview_close_hover: ?SplitTree.Node.Handle = null;
 pub threadlocal var g_divider_dragging: bool = false; // Currently dragging a divider
 pub threadlocal var g_divider_drag_handle: ?SplitTree.Node.Handle = null; // Handle of the split node being resized
 pub threadlocal var g_divider_drag_layout: ?SplitTree.Split.Layout = null; // horizontal or vertical
@@ -946,6 +950,30 @@ pub fn closePanelOrTab() void {
     }
     g_close_shortcut_confirm_until_ms = 0;
     AppWindow.closeFocusedSplit();
+}
+
+/// Close a specific preview pane by handle (the preview's × button). Focuses
+/// the pane, then reuses the standard close-split path, which removes it and
+/// refocuses the surviving terminal. Defensive: a no-op unless `handle` is still
+/// a live preview leaf (the tree may reshape between the cached rect and the
+/// click). Closing a preview never closes the window or hits a running program,
+/// so the close-shortcut/running-program confirmations are intentionally skipped.
+fn closePreviewPaneByHandle(handle: SplitTree.Node.Handle) void {
+    const tb = AppWindow.activeTab() orelse return;
+    if (tb.kind != .terminal) return;
+    if (handle.idx() >= tb.tree.nodes.len) return;
+    switch (tb.tree.nodes[handle.idx()]) {
+        .leaf => |pane| switch (pane) {
+            .preview => {},
+            else => return,
+        },
+        .split => return,
+    }
+    g_preview_close_hover = null;
+    tb.focused = handle;
+    AppWindow.closeFocusedSplit();
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
 }
 
 /// Close a tab via a pointer gesture (middle-click or the × button), honoring
@@ -3334,6 +3362,9 @@ fn openPreviewAsync(kind: markdown_preview.Kind, title: []const u8, path: []cons
         }
     else
         (tab.splitIntoPreviewStacked(gpa) orelse return false);
+    // Select the just-opened/reused preview so Ctrl+Shift+W closes it (not the
+    // terminal) and PgUp/PgDn/arrows scroll it.
+    _ = tab.focusPreviewPane(pane);
     if (!pane.beginAsyncLoad(kind, title, path, source_kind)) {
         file_explorer.setTransferStatus(.failed, "Preview failed");
         return true;
@@ -3349,6 +3380,8 @@ fn openPreviewNew(kind: markdown_preview.Kind, title: []const u8, path: []const 
 
     const gpa = AppWindow.g_allocator orelse return false;
     const pane = tab.splitIntoPreviewStacked(gpa) orelse return false;
+    // Select the new preview so Ctrl+Shift+W closes it (not the terminal).
+    _ = tab.focusPreviewPane(pane);
     if (!pane.beginAsyncLoad(kind, title, path, source_kind)) {
         file_explorer.setTransferStatus(.failed, "Preview failed");
         return true;
@@ -4161,6 +4194,15 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 return;
             }
 
+            // A click on a preview's top-right × button closes that preview, so
+            // users who don't know the close-split keybind can dismiss it with
+            // the mouse. Checked before the focus/drag path below (the button
+            // sits inside the pane rect).
+            if (split_layout.previewCloseButtonAtPoint(ev.x, ev.y)) |close_handle| {
+                closePreviewPaneByHandle(close_handle);
+                return;
+            }
+
             // A click on a preview leaf focuses it (so keyboard/wheel scroll-zoom
             // route there) and consumes the event — previews have no terminal
             // grid to select into. Terminal leaves fall through to the surface
@@ -4730,6 +4772,15 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
             platform_cursor.set(.arrow);
             g_divider_hover = false;
         }
+    }
+
+    // Track which preview's × button (if any) the mouse is over, so the renderer
+    // can brighten it. Re-render only when the hovered button changes.
+    const new_close_hover = if (!g_selecting) split_layout.previewCloseButtonAtPoint(ev.x, ev.y) else null;
+    if (new_close_hover != g_preview_close_hover) {
+        g_preview_close_hover = new_close_hover;
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
     }
 
     // Normal selection handling

--- a/src/input/preview_close_button.zig
+++ b/src/input/preview_close_button.zig
@@ -1,0 +1,87 @@
+//! Pure geometry for the preview pane's top-right close (×) button.
+//!
+//! Shared by the renderer (markdown_preview_renderer.zig draws the button) and
+//! the click hit-test (split_layout/input.zig), so the box that is drawn and the
+//! box that is clickable can never drift apart. All coordinates here are
+//! TOP-DOWN window pixels (y grows downward, matching mouse events and
+//! SplitRect); the renderer flips y into GL space when drawing.
+//!
+//! This module owns HEADER_HEIGHT (the preview header-bar height) so there is a
+//! single source of truth; the renderer re-exports it for its own use.
+
+const std = @import("std");
+
+/// Height of the preview header bar. The header is an otherwise-empty separator
+/// strip (the badge/title/path live in the footer), so the whole top-right
+/// corner is free for the close button.
+pub const HEADER_HEIGHT: f32 = 42;
+
+/// Side length of the square draw/hit box for the × button.
+pub const BUTTON_SIZE: f32 = 24;
+
+pub const Rect = struct { x: f32, y: f32, w: f32, h: f32 };
+
+/// Close-button box for a preview pane whose content rect starts at
+/// (`panel_x`, `panel_top`) with width `panel_w`. Right-aligned in the header
+/// and vertically centered within it.
+pub fn rect(panel_x: f32, panel_top: f32, panel_w: f32) Rect {
+    const margin = (HEADER_HEIGHT - BUTTON_SIZE) / 2;
+    return .{
+        .x = panel_x + panel_w - BUTTON_SIZE - margin,
+        .y = panel_top + margin,
+        .w = BUTTON_SIZE,
+        .h = BUTTON_SIZE,
+    };
+}
+
+/// True when (`px`, `py`) — top-down window pixels — lies within the close
+/// button of a pane at (`panel_x`, `panel_top`, `panel_w`).
+pub fn contains(panel_x: f32, panel_top: f32, panel_w: f32, px: f32, py: f32) bool {
+    const b = rect(panel_x, panel_top, panel_w);
+    return px >= b.x and px < b.x + b.w and py >= b.y and py < b.y + b.h;
+}
+
+test "rect sits in the header's top-right corner" {
+    const b = rect(100, 50, 400);
+    // Right-aligned: the button's right edge hugs the panel's right edge with a
+    // small margin, and never spills past it.
+    try std.testing.expect(b.x + b.w <= 100 + 400);
+    try std.testing.expect(b.x + b.w > 100 + 400 - HEADER_HEIGHT);
+    // Vertically centered inside the header band.
+    try std.testing.expect(b.y >= 50);
+    try std.testing.expect(b.y + b.h <= 50 + HEADER_HEIGHT);
+    try std.testing.expectEqual(BUTTON_SIZE, b.w);
+    try std.testing.expectEqual(BUTTON_SIZE, b.h);
+}
+
+test "contains matches the rect bounds" {
+    const panel_x: f32 = 100;
+    const panel_top: f32 = 50;
+    const panel_w: f32 = 400;
+    const b = rect(panel_x, panel_top, panel_w);
+
+    // Center of the button is inside.
+    try std.testing.expect(contains(panel_x, panel_top, panel_w, b.x + b.w / 2, b.y + b.h / 2));
+
+    // The far-left of the header (over the empty title area) is NOT the button.
+    try std.testing.expect(!contains(panel_x, panel_top, panel_w, panel_x + 8, panel_top + 8));
+
+    // Just below the header band is NOT the button (that's the document body).
+    try std.testing.expect(!contains(panel_x, panel_top, panel_w, b.x + 1, panel_top + HEADER_HEIGHT + 4));
+
+    // Just past the panel's right edge is NOT the button.
+    try std.testing.expect(!contains(panel_x, panel_top, panel_w, panel_x + panel_w + 1, b.y + 1));
+}
+
+test "rect tracks panel position and width" {
+    const a = rect(0, 0, 300);
+    const b = rect(0, 0, 600);
+    // Wider panel pushes the button further right by exactly the width delta.
+    try std.testing.expectEqual(a.x + 300, b.x);
+
+    const shifted = rect(120, 0, 300);
+    try std.testing.expectEqual(a.x + 120, shifted.x);
+
+    const lowered = rect(0, 80, 300);
+    try std.testing.expectEqual(a.y + 80, lowered.y);
+}

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -7,6 +7,7 @@ const pdf_preview = @import("../pdf_preview.zig");
 const text_wrap = @import("../text_wrap.zig");
 const ui_perf = @import("../ui_perf.zig");
 const PreviewPane = @import("../preview_pane.zig");
+const preview_close_button = @import("../input/preview_close_button.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
 const gpu = AppWindow.gpu;
@@ -16,7 +17,9 @@ const c = @cImport({
 });
 
 const FOOTER_HEIGHT: f32 = 44;
-pub const HEADER_HEIGHT: f32 = 42;
+/// Re-exported from the pure geometry module so the drawn header height and the
+/// close-button hit-test share a single source of truth.
+pub const HEADER_HEIGHT: f32 = preview_close_button.HEADER_HEIGHT;
 const PAD_X: f32 = 16;
 const PAD_Y: f32 = 18;
 const LINE_GAP: f32 = 6;
@@ -46,6 +49,7 @@ pub fn renderInto(
     panel_w: f32,
     panel_h: f32,
     window_height: f32,
+    close_hovered: bool,
 ) void {
     if (panel_h <= 0) return;
 
@@ -67,7 +71,7 @@ pub fn renderInto(
     // Side background: fillQuad(x, gl_y, w, h) — gl_y = pane_gl_bottom
     ui_pipeline.fillQuad(panel_x, pane_gl_bottom, panel_w, panel_h, panel_bg);
 
-    renderHeader(panel_x, panel_w, window_height, panel_top, card_bg, border);
+    renderHeader(panel_x, panel_w, window_height, panel_top, card_bg, border, muted, normal, close_hovered);
     renderFooter(pane, panel_x, panel_w, pane_gl_bottom, card_bg, border, muted, normal, accent);
 
     renderDocument(pane, panel_x, panel_w, window_height, panel_top, panel_h, pane_gl_bottom, normal, muted, strong, accent, code_bg, border);
@@ -84,13 +88,29 @@ fn renderHeader(
     panel_top: f32,
     card_bg: [3]f32,
     border: [3]f32,
+    muted: [3]f32,
+    normal: [3]f32,
+    close_hovered: bool,
 ) void {
-    // A preview pane closes via the standard close-split keybind (like a terminal
-    // pane), so the header is just a top separator bar — no close button.
+    // The header is a top separator bar (badge/title/path live in the footer),
+    // so its top-right corner is free for a close (×) button. The button lets
+    // users dismiss the preview with the mouse without knowing the close-split
+    // keybind; Ctrl+Shift+W still works too.
     // header_y (GL): window_height - panel_top - HEADER_HEIGHT.
     const header_y = window_height - panel_top - HEADER_HEIGHT;
     ui_pipeline.fillQuad(panel_x, header_y, panel_w, HEADER_HEIGHT, card_bg);
     ui_pipeline.fillQuad(panel_x, header_y, panel_w, 1, border);
+
+    // Close (×) button, top-right. Geometry comes from the shared pure module
+    // (top-down px); flip to GL for drawing. Symmetric box, so the X centers the
+    // same in either y-convention.
+    const b = preview_close_button.rect(panel_x, panel_top, panel_w);
+    const btn_gl_y = window_height - b.y - b.h;
+    if (close_hovered) {
+        ui_pipeline.fillQuad(b.x, btn_gl_y, b.w, b.h, blend(card_bg, normal, 0.18));
+    }
+    const icon_color = if (close_hovered) normal else muted;
+    titlebar.renderCloseIcon(b.x, btn_gl_y, b.w, b.h, icon_color);
 }
 
 fn renderFooter(

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -585,7 +585,10 @@ fn executeCommand(action: CommandAction) void {
         },
         .split_preview => {
             if (AppWindow.g_allocator) |gpa| {
-                _ = AppWindow.tab.splitIntoPreview(gpa);
+                // Focus the new (empty) preview so Ctrl+Shift+W closes it.
+                if (AppWindow.tab.splitIntoPreview(gpa)) |pane| {
+                    _ = AppWindow.tab.focusPreviewPane(pane);
+                }
                 AppWindow.g_force_rebuild = true;
                 AppWindow.g_cells_valid = false;
             }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -26,6 +26,7 @@ test {
     _ = @import("input/mouse_wheel_scroll.zig");
     _ = @import("input/mouse_report.zig");
     _ = @import("input/preview_path.zig");
+    _ = @import("input/preview_close_button.zig");
     _ = @import("input/ls_path_context.zig");
     _ = @import("input/terminal_link_action.zig");
     _ = @import("input/underline_span.zig");


### PR DESCRIPTION
## Summary

Two related UX fixes that make preview panes (markdown / image / PDF) easier to dismiss.

### 1. Focus the preview when it opens
Opening or reusing a preview now moves split-tree focus onto that preview. So `Ctrl+Shift+W` (and the `PgUp`/`PgDn`/arrow scroll & zoom keys) target the preview the user just opened, instead of the terminal they came from. Closing the preview refocuses the surviving terminal, so typing resumes naturally.

Before this, focus stayed on the terminal, so `Ctrl+Shift+W` closed the *terminal* — you had to click the preview first to select it.

- New `tab.focusPreviewPane(pane)` — focuses the leaf holding a pane by pointer identity (allocation-free, defensive).
- Wired into every **user-initiated** open path: terminal `Ctrl+click`, file explorer, `SKILL.md`, and the command-center *split preview*. The **session-restore** path is intentionally left untouched (it should reconstruct saved focus, not steal it).

### 2. Clickable × close button
Not everyone knows the close-split keybind, so each preview now has a × button in its header's top-right corner.

- Geometry lives in a new **pure module** `src/input/preview_close_button.zig`, shared by the renderer (draw) and the click hit-test, so the drawn box and the clickable box can't drift apart.
- `renderHeader` draws the × via the existing `titlebar.renderCloseIcon`; it brightens with a subtle background on hover.
- `split_layout.previewCloseButtonAtPoint()` + `input.zig` close/hover handlers. Clicking the × is checked before the focus/image-pan path, so it never starts a drag. Closing a preview never closes the window or hits a running program, so the running-program/close-shortcut confirms are intentionally skipped.

Together: two easy ways to close a preview — click its ×, or `Ctrl+Shift+W` (which now works because opening focuses it).

## Tests
- `tab: focusPreviewPane selects the just-opened preview leaf` (focuses the preview leaf; no-op for a foreign pane).
- `preview_close_button`: rect placement (top-right, in-header) + hit containment + tracks panel position/width.
- `zig build test` (fast): green. `zig build test-full`: **1692/1699 passed**; the one failure is a **pre-existing, unrelated** `ai_chat default system prompt` budget assert (`DEFAULT_SYSTEM_PROMPT.len < 3200`) that fails on `main` too — this PR touches neither `ai_chat.zig` nor `agent_prompt.zig`.

## Notes
- Side effects of a preview holding focus were audited: render (focus ring + dimmed terminal), selection (no-op dummy), and **session persistence** (preview leaves are persisted and `computeFocusedLeafIndex` walks all leaves, so a preview-focused state round-trips correctly).
- **GUI verification pending** — this dev host is WSLg, which can't screenshot GL, so the button's exact placement/contrast hasn't been eyeballed. The × sits ~9px inset in the header's top-right, 24px square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)