### PR TITLE
test(ai): raise default system prompt length budget 3200 → 4000

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -5238,7 +5238,10 @@ test "ai chat responses endpoint normalization" {
 }
 
 test "ai chat default system prompt comes from platform agent prompt" {
-    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 3200);
+    // Length budget: the system prompt ships on every AI API call, so this guards
+    // against silent bloat. The Windows variant is the longest (it adds the WSL
+    // tool guidance); keep headroom above it for future additions.
+    try std.testing.expect(DEFAULT_SYSTEM_PROMPT.len < 4000);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "wispterm_docs") != null);
     try std.testing.expectEqualStrings(platform_agent_prompt.defaultSystemPrompt, DEFAULT_SYSTEM_PROMPT);
     try std.testing.expect(std.mem.indexOf(u8, DEFAULT_SYSTEM_PROMPT, "uv") != null);


### PR DESCRIPTION
## Summary

`zig build test-full` was failing on one test: `ai chat default system prompt comes from platform agent prompt` (`src/ai_chat.zig`), whose assert required `DEFAULT_SYSTEM_PROMPT.len < 3200`.

The system prompt has grown past that budget. Measured lengths per OS variant:

| Variant | Length | `< 3200`? |
|---------|--------|-----------|
| **Windows** | **3298** | ❌ |
| Linux | 3164 | ✅ |
| macOS | 3164 | ✅ |

The Windows variant is the longest because it includes the WSL tool guidance, and `test-full`'s default target is windows-gnu — so that's the variant under test, and it's ~98 bytes over.

## Change

Raise the budget to **4000**, leaving headroom for future prompt additions, and add a comment explaining why the guardrail exists (the prompt ships on every AI API call, so length = token cost on every request — the assert catches silent bloat).

This is a deliberate one-line budget bump, not a removal of the guardrail; the same assert has been bumped before as the prompt grew.

## Verification
- `zig build test-full`: green (exit 0, no failures).

Unrelated to PR #213 (preview close UX); split out as its own change so each PR stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)