### PR TITLE
[codex] Add preview gallery keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Toggle file explorer sidebar | **Ctrl+Shift+Alt+E** | **Cmd+Shift+Opt+E** |
 | Toggle AI Copilot sidebar (current terminal) | **Ctrl+Shift+A** | **Cmd+Shift+A** |
 | Preview files (Ctrl/Cmd-click in terminal, or double-click in File Explorer) | Ctrl-click | Cmd-click |
+| Previous / next image/PDF in gallery (preview focused) | Left / Right | Left / Right |
 | Previous / next PDF page (PDF preview focused) | PageUp / PageDown | PageUp / PageDown |
 | Download SSH remote file | Ctrl+Shift-click path in SSH output | Cmd+Shift-click path in SSH output |
 | Close focused panel, tab, or window | **Ctrl+Shift+W** | **Cmd+Shift+W** |

--- a/docs/file-explorer.md
+++ b/docs/file-explorer.md
@@ -29,7 +29,7 @@ PDF engine: `Windows.Data.Pdf` on Windows 10+, CoreGraphics on macOS, and the
 your package manager (for example `sudo apt install poppler-utils`) if the
 preview reports they are missing. With the PDF preview focused, `PageUp` /
 `PageDown` switch pages inside the current PDF; the footer shows the current
-page as `N / M` next to the
+page as `N/M` next to the
 `PDF` badge. Zoom and pan work like image previews. Encrypted PDFs are not
 supported.
 

--- a/docs/file-explorer.md
+++ b/docs/file-explorer.md
@@ -19,14 +19,17 @@ Markdown previews render headings, lists, blockquotes, code blocks, inline code,
 links, and horizontal rules. Text, source-code, and script files (such as `.r`,
 `.R`, `.py`, `.zig`, `.sh`, `.json`) are shown as plain text. CSV and TSV
 files are shown as a grid table. Image previews decode PNG, JPEG, GIF, BMP, and
-WebP bytes directly into the panel.
+WebP bytes directly into the panel. With an image or PDF preview focused,
+`Left` / `Right` open the previous or next supported image/PDF in the same
+directory.
 
 PDF previews rasterize one page at a time with the operating system's own
 PDF engine: `Windows.Data.Pdf` on Windows 10+, CoreGraphics on macOS, and the
 `poppler-utils` tools (`pdfinfo` / `pdftoppm`) on Linux — install them with
 your package manager (for example `sudo apt install poppler-utils`) if the
 preview reports they are missing. With the PDF preview focused, `PageUp` /
-`PageDown` turn pages; the footer shows the current page as `N/M` next to the
+`PageDown` switch pages inside the current PDF; the footer shows the current
+page as `N / M` next to the
 `PDF` badge. Zoom and pan work like image previews. Encrypted PDFs are not
 supported.
 

--- a/docs/superpowers/plans/2026-06-13-preview-gallery-navigation.md
+++ b/docs/superpowers/plans/2026-06-13-preview-gallery-navigation.md
@@ -1,0 +1,652 @@
+# Preview Gallery Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Focused image/PDF preview panes support `Left`/`Right` gallery navigation across sibling image/PDF files while `PageUp`/`PageDown` remain PDF page navigation.
+
+**Architecture:** Add a pure `preview_gallery` helper that finds previous/next raster preview files from a directory listing. Store the current preview source kind on `PreviewPane`, then route focused preview `Left`/`Right` keys through the helper and reuse the current pane for the target file. Ghostty has terminal image rendering and input key encoding, but no file preview gallery; this follows Ghostty's relevant input pattern by consuming application UI keys only when that UI has focus and otherwise leaving arrows for terminal encoding.
+
+**Tech Stack:** Zig, existing `file_backend`, `markdown_preview`, `PreviewPane`, `input.zig`, `zig build test`, `zig build test-full`.
+
+---
+
+## File Structure
+
+- Create `src/preview_gallery.zig`: pure path/listing helper. It owns sibling ordering, media filtering, path joining, and tests.
+- Modify `src/test_fast.zig`: include `preview_gallery.zig` in the fast native test suite.
+- Modify `src/preview_pane.zig`: store the current `PreviewSourceKind` and expose it for input routing.
+- Modify `src/input.zig`: route focused raster preview `Left`/`Right` to gallery navigation; keep `Up`/`Down` pan and PDF `PageUp`/`PageDown`.
+- Modify `README.md`: document the new shortcut in the keyboard shortcut table.
+- Modify `docs/file-explorer.md`: document image/PDF gallery navigation and clarify PDF page keys.
+
+## Task 1: Pure Gallery Helper
+
+**Files:**
+- Create: `src/preview_gallery.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Write the failing gallery tests**
+
+Create `src/preview_gallery.zig` with tests first:
+
+```zig
+//! Gallery navigation helper for image/PDF preview panes.
+
+const std = @import("std");
+const file_backend = @import("file_backend.zig");
+const markdown_preview = @import("markdown_preview.zig");
+
+fn testEntry(name: []const u8, is_dir: bool) file_backend.Entry {
+    var entry: file_backend.Entry = .{ .is_dir = is_dir };
+    const len: u8 = @intCast(@min(name.len, entry.name_buf.len));
+    @memcpy(entry.name_buf[0..len], name[0..len]);
+    entry.name_len = len;
+    return entry;
+}
+
+test "preview_gallery: finds previous and next raster siblings" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("a.png", false),
+        testEntry("b.txt", false),
+        testEntry("c.pdf", false),
+        testEntry("d.jpg", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/c.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqual(markdown_preview.Kind.image, next.kind);
+    try std.testing.expectEqualStrings("d.jpg", next.title());
+    try std.testing.expectEqualStrings("/tmp/d.jpg", next.path);
+
+    var prev = (try neighborFromEntriesForTest(allocator, "/tmp/c.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqual(markdown_preview.Kind.image, prev.kind);
+    try std.testing.expectEqualStrings("a.png", prev.title());
+    try std.testing.expectEqualStrings("/tmp/a.png", prev.path);
+}
+
+test "preview_gallery: filters directories and non-raster previews" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("alpha.png", true),
+        testEntry("notes.md", false),
+        testEntry("paper.pdf", false),
+        testEntry("photo.webp", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/paper.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqualStrings("photo.webp", next.title());
+    try std.testing.expectEqual(markdown_preview.Kind.image, next.kind);
+
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "/tmp/photo.webp", entries[0..], true)) == null);
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "/tmp/paper.pdf", entries[0..], false)) == null);
+}
+
+test "preview_gallery: treats a multi-page pdf as one gallery entry" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("01.png", false),
+        testEntry("book.pdf", false),
+        testEntry("02.png", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/book.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqualStrings("02.png", next.title());
+
+    var prev = (try neighborFromEntriesForTest(allocator, "/tmp/book.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqualStrings("01.png", prev.title());
+}
+
+test "preview_gallery: supports windows-style backslash paths" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("a.bmp", false),
+        testEntry("b.pdf", false),
+    };
+
+    var prev = (try neighborFromEntriesForTest(allocator, "C:\\Users\\me\\Pictures\\b.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqualStrings("a.bmp", prev.title());
+    try std.testing.expectEqualStrings("C:\\Users\\me\\Pictures\\a.bmp", prev.path);
+}
+```
+
+- [ ] **Step 2: Run the helper test to verify RED**
+
+Run:
+
+```bash
+zig test src/preview_gallery.zig
+```
+
+Expected: FAIL because `neighborFromEntriesForTest` is not defined.
+
+- [ ] **Step 3: Implement minimal gallery helper**
+
+Replace `src/preview_gallery.zig` with the tests plus this implementation above the test helpers:
+
+```zig
+//! Gallery navigation helper for image/PDF preview panes.
+
+const std = @import("std");
+const file_backend = @import("file_backend.zig");
+const markdown_preview = @import("markdown_preview.zig");
+
+pub const MAX_GALLERY_ENTRIES: usize = 2048;
+pub const MAX_TARGET_PATH_BYTES: usize = 512;
+
+pub const Target = struct {
+    kind: markdown_preview.Kind,
+    title_buf: [256]u8 = undefined,
+    title_len: usize = 0,
+    path: []u8,
+
+    pub fn title(self: *const Target) []const u8 {
+        return self.title_buf[0..self.title_len];
+    }
+
+    pub fn deinit(self: *Target, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+    }
+};
+
+pub fn findNeighbor(
+    allocator: std.mem.Allocator,
+    backend: file_backend.Backend,
+    current_path: []const u8,
+    forward: bool,
+) !?Target {
+    const parent = parentPath(current_path) orelse return null;
+    const entries = try allocator.alloc(file_backend.Entry, MAX_GALLERY_ENTRIES);
+    defer allocator.free(entries);
+
+    const result = file_backend.list(allocator, backend, parent, entries);
+    if (result.status != .ok) return null;
+    return neighborFromEntries(allocator, current_path, entries[0..result.count], forward);
+}
+
+pub fn neighborFromEntriesForTest(
+    allocator: std.mem.Allocator,
+    current_path: []const u8,
+    entries: []const file_backend.Entry,
+    forward: bool,
+) !?Target {
+    return neighborFromEntries(allocator, current_path, entries, forward);
+}
+
+fn neighborFromEntries(
+    allocator: std.mem.Allocator,
+    current_path: []const u8,
+    entries: []const file_backend.Entry,
+    forward: bool,
+) !?Target {
+    const parent = parentPath(current_path) orelse return null;
+    const current_name = basename(current_path);
+    var previous: ?Candidate = null;
+    var found_current = false;
+
+    for (entries) |*entry| {
+        if (entry.is_dir) continue;
+        const name = entry.name();
+        const kind = markdown_preview.detectKind(name) orelse continue;
+        if (!kind.isRaster()) continue;
+
+        if (found_current and forward) {
+            return try makeTarget(allocator, parent, separatorForPath(current_path), name, kind);
+        }
+
+        if (std.mem.eql(u8, name, current_name)) {
+            if (!forward) {
+                if (previous) |candidate| {
+                    return try makeTarget(allocator, parent, separatorForPath(current_path), candidate.name, candidate.kind);
+                }
+                return null;
+            }
+            found_current = true;
+        }
+
+        previous = .{ .name = name, .kind = kind };
+    }
+
+    return null;
+}
+
+const Candidate = struct {
+    name: []const u8,
+    kind: markdown_preview.Kind,
+};
+
+fn makeTarget(
+    allocator: std.mem.Allocator,
+    parent: []const u8,
+    sep: u8,
+    name: []const u8,
+    kind: markdown_preview.Kind,
+) !?Target {
+    const add_sep = parent.len > 0 and !endsWithSeparator(parent, sep);
+    const path_len = parent.len + @as(usize, if (add_sep) 1 else 0) + name.len;
+    if (path_len > MAX_TARGET_PATH_BYTES) return null;
+
+    var target: Target = .{
+        .kind = kind,
+        .path = try allocator.alloc(u8, path_len),
+    };
+    errdefer allocator.free(target.path);
+
+    var pos: usize = 0;
+    @memcpy(target.path[pos..][0..parent.len], parent);
+    pos += parent.len;
+    if (add_sep) {
+        target.path[pos] = sep;
+        pos += 1;
+    }
+    @memcpy(target.path[pos..][0..name.len], name);
+
+    target.title_len = @min(name.len, target.title_buf.len);
+    @memcpy(target.title_buf[0..target.title_len], name[0..target.title_len]);
+    return target;
+}
+
+fn parentPath(path: []const u8) ?[]const u8 {
+    var i = path.len;
+    while (i > 0) {
+        i -= 1;
+        if (isSeparator(path[i])) {
+            if (i == 0) return path[0..1];
+            return path[0..i];
+        }
+    }
+    return null;
+}
+
+fn basename(path: []const u8) []const u8 {
+    var start: usize = 0;
+    for (path, 0..) |ch, i| {
+        if (isSeparator(ch)) start = i + 1;
+    }
+    return path[start..];
+}
+
+fn separatorForPath(path: []const u8) u8 {
+    for (path) |ch| {
+        if (ch == '\\') return '\\';
+    }
+    return '/';
+}
+
+fn isSeparator(ch: u8) bool {
+    return ch == '/' or ch == '\\';
+}
+
+fn endsWithSeparator(path: []const u8, sep: u8) bool {
+    if (path.len == 0) return false;
+    const last = path[path.len - 1];
+    if (sep == '\\') return last == '\\' or last == '/';
+    return last == sep;
+}
+```
+
+Keep the tests from Step 1 below this implementation.
+
+- [ ] **Step 4: Run helper tests to verify GREEN**
+
+Run:
+
+```bash
+zig test src/preview_gallery.zig
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add helper to the fast test suite**
+
+Modify `src/test_fast.zig` in the existing `test { ... }` import list near `pdf_preview.zig` and `file_backend.zig`:
+
+```zig
+    _ = @import("pdf_preview.zig");
+    _ = @import("preview_gallery.zig");
+    _ = @import("file_backend.zig");
+```
+
+- [ ] **Step 6: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add src/preview_gallery.zig src/test_fast.zig
+git commit -m "feat(preview): add gallery sibling selection"
+```
+
+## Task 2: Preserve Preview Source Kind
+
+**Files:**
+- Modify: `src/preview_pane.zig`
+
+- [ ] **Step 1: Write failing source-kind test**
+
+Add this test near the other `PreviewPane` tests:
+
+```zig
+test "PreviewPane: async load stores current source kind" {
+    const gpa = std.testing.allocator;
+    var p = try create(gpa);
+    defer p.unref(gpa);
+
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .local => true,
+        else => false,
+    });
+    try std.testing.expect(p.beginAsyncLoadWith(.image, "a.png", "/tmp/a.png", .wsl, previewReadOkForTest));
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .wsl => true,
+        else => false,
+    });
+    drainJobs(p);
+}
+```
+
+- [ ] **Step 2: Run preview pane test to verify RED**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: FAIL because `currentSourceKind` is not defined.
+
+- [ ] **Step 3: Add source kind state and accessor**
+
+In `src/preview_pane.zig`, add the field near `kind`:
+
+```zig
+kind: markdown_preview.Kind = .markdown,
+source_kind: PreviewSourceKind = .local,
+load_status: LoadStatus = .idle,
+```
+
+Add an accessor near the existing accessors:
+
+```zig
+pub fn currentSourceKind(self: *const PreviewPane) PreviewSourceKind { return self.source_kind; }
+```
+
+Update `open` so synchronous opens have a deterministic local source:
+
+```zig
+pub fn open(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p: []const u8, source_text: []const u8) void {
+    self.request_id +%= 1;
+    self.source_kind = .local;
+    self.applyOwned(kind, t, p, std.heap.page_allocator.dupe(u8, source_text) catch null, .ready);
+}
+```
+
+Update `beginAsyncLoadWith` immediately after `self.request_id +%= 1;`:
+
+```zig
+    self.source_kind = source_kind;
+```
+
+- [ ] **Step 4: Run the preview pane test to verify GREEN**
+
+Run the same command from Step 2.
+
+Expected: PASS for the new source-kind test.
+
+- [ ] **Step 5: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/preview_pane.zig
+git commit -m "feat(preview): remember preview source kind"
+```
+
+## Task 3: Wire Focused Preview Arrow Navigation
+
+**Files:**
+- Modify: `src/input.zig`
+
+- [ ] **Step 1: Add imports and helper, expecting compile failure before the helper exists**
+
+Add imports near the other preview imports:
+
+```zig
+const file_backend = @import("file_backend.zig");
+const preview_gallery = @import("preview_gallery.zig");
+```
+
+Add this helper near `openPreviewAsync`:
+
+```zig
+fn openPreviewGalleryNeighbor(p: *PreviewPane, forward: bool) bool {
+    const gpa = AppWindow.g_allocator orelse return false;
+    var target = findPreviewGalleryNeighbor(gpa, p, forward) orelse return false;
+    defer target.deinit(gpa);
+
+    if (!p.beginAsyncLoad(target.kind, target.title(), target.path, p.currentSourceKind())) {
+        file_explorer.setTransferStatus(.failed, "Preview failed");
+        return false;
+    }
+
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+    return true;
+}
+
+fn findPreviewGalleryNeighbor(allocator: std.mem.Allocator, p: *const PreviewPane, forward: bool) ?preview_gallery.Target {
+    return switch (p.currentSourceKind()) {
+        .local => preview_gallery.findNeighbor(allocator, .local, p.path(), forward) catch null,
+        .wsl => preview_gallery.findNeighbor(allocator, .wsl, p.path(), forward) catch null,
+        .remote => |conn| preview_gallery.findNeighbor(allocator, .{ .ssh = &conn }, p.path(), forward) catch null,
+    };
+}
+```
+
+- [ ] **Step 2: Run full compile/test to verify RED if Task 1 or Task 2 was skipped**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected if earlier tasks are complete: PASS. If earlier tasks were skipped: compile FAIL on missing `preview_gallery` or `currentSourceKind`; do not continue until Task 1 and Task 2 are complete.
+
+- [ ] **Step 3: Route left/right keys to gallery navigation**
+
+In the focused preview key branch, replace the `key_left` / `key_right` cases with gallery navigation. The full raster navigation part should read:
+
+```zig
+                platform_input.key_up => if (p.kind.isRaster()) {
+                    _ = p.panImageBy(0, 40);
+                } else p.scrollBy(-60),
+                platform_input.key_down => if (p.kind.isRaster()) {
+                    _ = p.panImageBy(0, -40);
+                } else p.scrollBy(60),
+                platform_input.key_left => if (p.kind.isRaster()) {
+                    _ = openPreviewGalleryNeighbor(p, false);
+                } else {
+                    consumed = false;
+                },
+                platform_input.key_right => if (p.kind.isRaster()) {
+                    _ = openPreviewGalleryNeighbor(p, true);
+                } else {
+                    consumed = false;
+                },
+```
+
+Leave the existing `PageUp` / `PageDown` PDF cases unchanged:
+
+```zig
+                platform_input.key_page_up => if (p.kind == .pdf) {
+                    _ = p.flipPdfPage(false);
+                } else p.scrollBy(-360),
+                platform_input.key_page_down => if (p.kind == .pdf) {
+                    _ = p.flipPdfPage(true);
+                } else p.scrollBy(360),
+```
+
+This preserves multi-page PDF behavior: `PageUp`/`PageDown` call `flipPdfPage`, while `Left`/`Right` never call it.
+
+- [ ] **Step 4: Run full tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS. If it fails, stop and debug the failure before continuing.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/input.zig
+git commit -m "feat(preview): navigate gallery with arrows"
+```
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/file-explorer.md`
+
+- [ ] **Step 1: Update README keyboard shortcuts**
+
+In `README.md`, replace the current PDF row:
+
+```markdown
+| Previous / next PDF page (PDF preview focused) | PageUp / PageDown | PageUp / PageDown |
+```
+
+with:
+
+```markdown
+| Previous / next image/PDF in gallery (preview focused) | Left / Right | Left / Right |
+| Previous / next PDF page (PDF preview focused) | PageUp / PageDown | PageUp / PageDown |
+```
+
+- [ ] **Step 2: Update file explorer preview docs**
+
+In `docs/file-explorer.md`, replace:
+
+```markdown
+PDF previews rasterize one page at a time with the operating system's own
+PDF engine: `Windows.Data.Pdf` on Windows 10+, CoreGraphics on macOS, and the
+`poppler-utils` tools (`pdfinfo` / `pdftoppm`) on Linux — install them with
+your package manager (for example `sudo apt install poppler-utils`) if the
+preview reports they are missing. With the PDF preview focused, `PageUp` /
+`PageDown` turn pages; the footer shows the current page as `N/M` next to the
+`PDF` badge. Zoom and pan work like image previews. Encrypted PDFs are not
+supported.
+```
+
+with:
+
+```markdown
+PDF previews rasterize one page at a time with the operating system's own
+PDF engine: `Windows.Data.Pdf` on Windows 10+, CoreGraphics on macOS, and the
+`poppler-utils` tools (`pdfinfo` / `pdftoppm`) on Linux — install them with
+your package manager (for example `sudo apt install poppler-utils`) if the
+preview reports they are missing. With an image or PDF preview focused,
+`Left` / `Right` open the previous or next supported image/PDF in the same
+directory. With a PDF preview focused, `PageUp` / `PageDown` turn pages inside
+the current PDF; the footer shows the current page as `N/M` next to the `PDF`
+badge. Zoom and pan work like image previews. Encrypted PDFs are not supported.
+```
+
+- [ ] **Step 3: Run docs-sensitive tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 4**
+
+```bash
+git add README.md docs/file-explorer.md
+git commit -m "docs: document preview gallery keys"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- No edits expected.
+
+- [ ] **Step 1: Run fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full pre-merge suite**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check worktree**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no uncommitted changes.
+
+- [ ] **Step 4: Manual smoke test on Windows PowerShell**
+
+Build and launch the app on Windows, then verify:
+
+```powershell
+zig build
+```
+
+Manual checks:
+
+- Open a directory containing `a.png`, `b.pdf`, and `c.jpg`.
+- Open `b.pdf` in a preview pane.
+- Focus the preview pane.
+- Press `PageDown`: the PDF advances to the next page and the footer changes.
+- Press `Right`: the preview opens `c.jpg`.
+- Press `Left`: the preview opens `b.pdf` again.
+- Press `Left`: the preview opens `a.png`.
+- Press `Left` at the first item: nothing changes and no characters appear in the terminal.
+
+- [ ] **Step 5: Windows checkout safety if files were added**
+
+Because this plan adds `src/preview_gallery.zig`, run the Windows path-safety checks documented in `docs/development.md#windows-checkout-safety` before merging.

--- a/docs/superpowers/specs/2026-06-13-preview-gallery-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-13-preview-gallery-navigation-design.md
@@ -1,0 +1,79 @@
+# Preview Gallery Navigation Design
+
+## Goal
+
+Image and PDF preview panes should behave like a lightweight gallery. When a raster preview pane is focused, the user can press the left or right arrow key to switch to the previous or next supported media file in the same directory as the current preview path.
+
+Supported gallery members are the existing preview raster kinds:
+
+- Images supported by `markdown_preview.detectKind`
+- PDFs supported by `markdown_preview.detectKind`
+
+This applies to previews opened from the File Explorer and from terminal path clicks, across local, WSL, and SSH sources when the source can be listed.
+
+## Ghostty Comparison
+
+Ghostty has image rendering paths for terminal image protocols and related renderer support, but it does not have WispTerm's split-tree file preview pane or file-gallery browsing feature. The relevant Ghostty-aligned constraint is input isolation: arrow keys must keep reaching the PTY unless a non-terminal preview leaf has focus and explicitly consumes them.
+
+## Interaction
+
+When a focused preview pane is showing an image or PDF:
+
+- `Left` opens the previous supported image/PDF in the same directory.
+- `Right` opens the next supported image/PDF in the same directory.
+- `Up` and `Down` keep the existing pan behavior for raster previews.
+- `PageUp` and `PageDown` keep the existing PDF page flip behavior.
+- Modified arrow keys (`Ctrl`, `Alt`, `Super`) remain available to app keybinds or terminal input.
+
+At the first or last media file, the corresponding direction is a no-op. The pane remains focused and no terminal input is sent.
+
+## Architecture
+
+Add a small pure gallery helper at `src/preview_gallery.zig`, responsible for path and ordering logic:
+
+- Determine the parent directory and basename of the current path.
+- List sibling entries through the existing `file_backend` abstraction.
+- Filter out directories and unsupported preview kinds.
+- Treat images and PDFs as one gallery sequence.
+- Sort using the existing `file_backend` order.
+- Return the target title/path/kind for previous or next.
+
+`PreviewPane` should store the `PreviewSourceKind` used for the current load, so navigation does not depend on the File Explorer's global state after the pane is open. `beginAsyncLoad` should update this stored source kind. Terminal-click previews already resolve the path before opening, so the gallery should operate on the resolved path.
+
+The input layer should call a narrow navigation helper only from the existing focused preview branch in `src/input.zig`. Successful navigation reuses the current preview pane and starts `beginAsyncLoad` for the target file. It must mark the UI dirty with `AppWindow.g_force_rebuild = true` and `AppWindow.g_cells_valid = false`.
+
+## Data Flow
+
+1. User opens an image or PDF preview.
+2. The pane stores `kind`, `path`, `title`, and `source_kind`.
+3. User focuses that pane and presses `Left` or `Right`.
+4. Input asks the gallery helper for a sibling target.
+5. If a target exists, the same pane begins an async load for that target.
+6. The existing preview async tick path applies the loaded content and triggers repaint.
+
+## Error Handling
+
+If directory listing fails, no target is found, or the target path cannot fit the existing preview path buffers, navigation is a no-op and the current preview remains visible.
+
+If target loading starts but fails, the existing preview failure state is shown in the same pane. This matches current preview-open behavior.
+
+## Testing
+
+Add unit tests for the pure gallery helper:
+
+- Finds previous and next media files in sorted sibling entries.
+- Filters unsupported files and directories.
+- Handles first/last file boundaries.
+- Handles mixed image/PDF sequences.
+- Handles Unix-style `/` paths and Windows-style `\` paths in pure path-splitting tests.
+
+Add a focused `PreviewPane` test proving `beginAsyncLoad` preserves the current `source_kind`. Because `input.zig` only compiles in the full app test binary, route-level input coverage belongs in `zig build test-full`; pure helper coverage should run in `zig build test`.
+
+## Documentation
+
+Update:
+
+- `README.md` keyboard shortcut table
+- `docs/file-explorer.md` preview controls
+
+The docs should mention that gallery navigation applies when an image or PDF preview pane is focused.

--- a/docs/superpowers/specs/2026-06-13-preview-gallery-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-13-preview-gallery-navigation-design.md
@@ -22,8 +22,10 @@ When a focused preview pane is showing an image or PDF:
 - `Left` opens the previous supported image/PDF in the same directory.
 - `Right` opens the next supported image/PDF in the same directory.
 - `Up` and `Down` keep the existing pan behavior for raster previews.
-- `PageUp` and `PageDown` keep the existing PDF page flip behavior.
+- `PageUp` and `PageDown` keep the existing PDF page flip behavior within the current PDF document.
 - Modified arrow keys (`Ctrl`, `Alt`, `Super`) remain available to app keybinds or terminal input.
+
+For a multi-page PDF, the PDF document itself is one gallery item. `Left` and `Right` never turn pages inside that document; they leave the current PDF and open the neighboring image/PDF file. Page-level movement remains exclusively on `PageUp` and `PageDown`.
 
 At the first or last media file, the corresponding direction is a no-op. The pane remains focused and no terminal input is sent.
 
@@ -47,9 +49,11 @@ The input layer should call a narrow navigation helper only from the existing fo
 1. User opens an image or PDF preview.
 2. The pane stores `kind`, `path`, `title`, and `source_kind`.
 3. User focuses that pane and presses `Left` or `Right`.
-4. Input asks the gallery helper for a sibling target.
-5. If a target exists, the same pane begins an async load for that target.
+4. Input asks the gallery helper for a sibling file target, not a PDF page target.
+5. If a target file exists, the same pane begins an async load for that target.
 6. The existing preview async tick path applies the loaded content and triggers repaint.
+
+PDF page flips remain on the existing `flipPdfPage` path and are only triggered by `PageUp` and `PageDown`.
 
 ## Error Handling
 
@@ -65,6 +69,7 @@ Add unit tests for the pure gallery helper:
 - Filters unsupported files and directories.
 - Handles first/last file boundaries.
 - Handles mixed image/PDF sequences.
+- Treats a multi-page PDF as one gallery entry; page count does not affect sibling selection.
 - Handles Unix-style `/` paths and Windows-style `\` paths in pure path-splitting tests.
 
 Add a focused `PreviewPane` test proving `beginAsyncLoad` preserves the current `source_kind`. Because `input.zig` only compiles in the full app test binary, route-level input coverage belongs in `zig build test-full`; pure helper coverage should run in `zig build test`.

--- a/src/input.zig
+++ b/src/input.zig
@@ -14,8 +14,10 @@ const font = AppWindow.font;
 const overlays = AppWindow.overlays;
 const split_layout = AppWindow.split_layout;
 const file_explorer = AppWindow.file_explorer;
+const file_backend = @import("file_backend.zig");
 const markdown_preview = @import("markdown_preview.zig");
 const markdown_preview_panel = AppWindow.markdown_preview_panel;
+const preview_gallery = @import("preview_gallery.zig");
 const preview_token = @import("preview_token.zig");
 const browser_panel = AppWindow.browser_panel;
 const html_server = @import("html_server.zig");
@@ -148,6 +150,38 @@ test "input: command palette shortcut toggles command center" {
 test "input: browser toolbar has a refresh action entrypoint" {
     const info = @typeInfo(@TypeOf(refreshBrowserPanel)).@"fn";
     try std.testing.expectEqual(@as(usize, 0), info.params.len);
+}
+
+test "input: preview gallery neighbor opens next raster sibling" {
+    const gpa = std.testing.allocator;
+    const prev_allocator = AppWindow.g_allocator;
+    defer AppWindow.g_allocator = prev_allocator;
+    AppWindow.g_allocator = gpa;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "a.png", .data = "a" });
+    try tmp.dir.writeFile(.{ .sub_path = "b.pdf", .data = "b" });
+    try tmp.dir.writeFile(.{ .sub_path = "c.jpg", .data = "c" });
+
+    const root = try tmp.dir.realpathAlloc(gpa, ".");
+    defer gpa.free(root);
+    const current_path = try std.fs.path.join(gpa, &.{ root, "b.pdf" });
+    defer gpa.free(current_path);
+    const next_path = try std.fs.path.join(gpa, &.{ root, "c.jpg" });
+    defer gpa.free(next_path);
+
+    var pane = try PreviewPane.create(gpa);
+    defer pane.unref(gpa);
+    pane.open(.pdf, "b.pdf", current_path, "current");
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    try std.testing.expect(openPreviewGalleryNeighbor(pane, true));
+    try std.testing.expectEqualStrings("c.jpg", pane.title());
+    try std.testing.expectEqualStrings(next_path, pane.path());
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
 }
 
 // Regression: the event-driven render loop (PR #168) only paints a frame when
@@ -2089,12 +2123,12 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                     _ = p.panImageBy(0, -40);
                 } else p.scrollBy(60),
                 platform_input.key_left => if (p.kind.isRaster()) {
-                    _ = p.panImageBy(40, 0);
+                    _ = openPreviewGalleryNeighbor(p, false);
                 } else {
                     consumed = false;
                 },
                 platform_input.key_right => if (p.kind.isRaster()) {
-                    _ = p.panImageBy(-40, 0);
+                    _ = openPreviewGalleryNeighbor(p, true);
                 } else {
                     consumed = false;
                 },
@@ -3341,6 +3375,29 @@ fn openPreviewAsync(kind: markdown_preview.Kind, title: []const u8, path: []cons
     AppWindow.g_force_rebuild = true;
     AppWindow.g_cells_valid = false;
     return true;
+}
+
+fn openPreviewGalleryNeighbor(p: *PreviewPane, forward: bool) bool {
+    const gpa = AppWindow.g_allocator orelse return false;
+    var target = findPreviewGalleryNeighbor(gpa, p, forward) orelse return false;
+    defer target.deinit(gpa);
+
+    if (!p.beginAsyncLoad(target.kind, target.title(), target.path, p.currentSourceKind())) {
+        file_explorer.setTransferStatus(.failed, "Preview failed");
+        return false;
+    }
+
+    AppWindow.g_force_rebuild = true;
+    AppWindow.g_cells_valid = false;
+    return true;
+}
+
+fn findPreviewGalleryNeighbor(allocator: std.mem.Allocator, p: *const PreviewPane, forward: bool) ?preview_gallery.Target {
+    return switch (p.currentSourceKind()) {
+        .local => preview_gallery.findNeighbor(allocator, @as(file_backend.Backend, .local), p.path(), forward) catch null,
+        .wsl => preview_gallery.findNeighbor(allocator, @as(file_backend.Backend, .wsl), p.path(), forward) catch null,
+        .remote => |conn| preview_gallery.findNeighbor(allocator, .{ .ssh = &conn }, p.path(), forward) catch null,
+    };
 }
 
 fn openPreviewNew(kind: markdown_preview.Kind, title: []const u8, path: []const u8, source_kind: markdown_preview_panel.PreviewSourceKind) bool {

--- a/src/input.zig
+++ b/src/input.zig
@@ -184,6 +184,52 @@ test "input: preview gallery neighbor opens next raster sibling" {
     try std.testing.expect(!AppWindow.g_cells_valid);
 }
 
+test "input: focused preview ignores shift-modified navigation keys" {
+    const gpa = std.testing.allocator;
+    const prev_allocator = AppWindow.g_allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    const previous_force_rebuild = AppWindow.g_force_rebuild;
+    const previous_cells_valid = AppWindow.g_cells_valid;
+
+    var pane = try PreviewPane.create(gpa);
+    defer pane.unref(gpa);
+    pane.open(.image, "a.png", "a.png", "current");
+
+    var tab_state = tab.TabState{
+        .tree = try SplitTree.initPane(gpa, .{ .preview = pane }),
+    };
+    defer tab_state.tree.deinit();
+
+    AppWindow.g_allocator = gpa;
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tabs[0] = &tab_state;
+    tab.g_tab_count = 1;
+    active_tab_state.g_active_tab = 0;
+    defer {
+        AppWindow.g_allocator = prev_allocator;
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        AppWindow.g_force_rebuild = previous_force_rebuild;
+        AppWindow.g_cells_valid = previous_cells_valid;
+    }
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    handleKey(.{
+        .key_code = platform_input.key_right,
+        .ctrl = false,
+        .shift = true,
+        .alt = false,
+        .super = false,
+    });
+
+    try std.testing.expect(!AppWindow.g_force_rebuild);
+    try std.testing.expect(AppWindow.g_cells_valid);
+}
+
 // Regression: the event-driven render loop (PR #168) only paints a frame when
 // something marks the UI dirty. Command-center family overlays consume their own
 // key/char events and never reach the terminal, so each navigation/typing keystroke
@@ -2105,9 +2151,9 @@ fn handleKey(ev: platform_input.KeyEvent) void {
     // A focused preview leaf consumes plain navigation keys for scroll/pan.
     // Only engaged when a preview actually holds focus; otherwise this block is
     // skipped entirely and terminal/copilot key handling is unchanged. Modified
-    // keys (ctrl/alt/super) are left for keybinds and the terminal.
+    // keys (ctrl/shift/alt/super) are left for keybinds and the terminal.
     if (AppWindow.focusedPreviewPane()) |p| {
-        if (!ev.ctrl and !ev.alt and !ev.super) {
+        if (!ev.ctrl and !ev.shift and !ev.alt and !ev.super) {
             var consumed = true;
             switch (ev.key_code) {
                 platform_input.key_page_up => if (p.kind == .pdf) {

--- a/src/preview_gallery.zig
+++ b/src/preview_gallery.zig
@@ -1,0 +1,234 @@
+//! Gallery navigation helper for image/PDF preview panes.
+
+const std = @import("std");
+const file_backend = @import("file_backend.zig");
+const markdown_preview = @import("markdown_preview.zig");
+
+pub const MAX_GALLERY_ENTRIES: usize = 2048;
+pub const MAX_TARGET_PATH_BYTES: usize = 512;
+
+pub const Target = struct {
+    kind: markdown_preview.Kind,
+    title_buf: [file_backend.MAX_NAME_LEN]u8 = undefined,
+    title_len: u8 = 0,
+    path: []u8,
+
+    pub fn title(self: *const Target) []const u8 {
+        return self.title_buf[0..self.title_len];
+    }
+
+    pub fn deinit(self: *Target, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+    }
+};
+
+pub fn findNeighbor(
+    allocator: std.mem.Allocator,
+    backend: file_backend.Backend,
+    current_path: []const u8,
+    forward: bool,
+) !?Target {
+    const parent = parentPath(current_path) orelse return null;
+
+    const entries = try allocator.alloc(file_backend.Entry, MAX_GALLERY_ENTRIES);
+    defer allocator.free(entries);
+
+    const result = file_backend.list(allocator, backend, parent, entries);
+    if (result.status != .ok) return null;
+
+    return neighborFromEntriesForTest(allocator, current_path, entries[0..result.count], forward);
+}
+
+pub fn neighborFromEntriesForTest(
+    allocator: std.mem.Allocator,
+    current_path: []const u8,
+    entries: []const file_backend.Entry,
+    forward: bool,
+) !?Target {
+    const parent = parentPath(current_path) orelse return null;
+    const current_name = basename(current_path);
+    const separator = separatorForPath(current_path);
+
+    var found_current = false;
+    var previous_entry: ?*const file_backend.Entry = null;
+    var previous_kind: markdown_preview.Kind = undefined;
+
+    for (entries) |*entry| {
+        const kind = rasterKind(entry) orelse continue;
+        const name = entry.name();
+
+        if (std.mem.eql(u8, name, current_name)) {
+            if (forward) {
+                found_current = true;
+            } else if (previous_entry) |prev| {
+                return makeTarget(allocator, parent, separator, prev.name(), previous_kind);
+            } else {
+                return null;
+            }
+            continue;
+        }
+
+        if (forward and found_current) {
+            return makeTarget(allocator, parent, separator, name, kind);
+        }
+
+        previous_entry = entry;
+        previous_kind = kind;
+    }
+
+    return null;
+}
+
+fn rasterKind(entry: *const file_backend.Entry) ?markdown_preview.Kind {
+    if (entry.is_dir) return null;
+    const kind = markdown_preview.detectKind(entry.name()) orelse return null;
+    if (!kind.isRaster()) return null;
+    return kind;
+}
+
+fn parentPath(path: []const u8) ?[]const u8 {
+    const index = lastSeparatorIndex(path) orelse return null;
+    if (index == 0) return path[0..1];
+    return path[0..index];
+}
+
+fn basename(path: []const u8) []const u8 {
+    const index = lastSeparatorIndex(path) orelse return path;
+    return path[index + 1 ..];
+}
+
+fn lastSeparatorIndex(path: []const u8) ?usize {
+    var index = path.len;
+    while (index > 0) {
+        index -= 1;
+        if (isSeparator(path[index])) return index;
+    }
+    return null;
+}
+
+fn separatorForPath(path: []const u8) u8 {
+    return if (std.mem.indexOfScalar(u8, path, '\\') != null) '\\' else '/';
+}
+
+fn makeTarget(
+    allocator: std.mem.Allocator,
+    parent: []const u8,
+    separator: u8,
+    name: []const u8,
+    kind: markdown_preview.Kind,
+) !?Target {
+    const path = try makeTargetPath(allocator, parent, separator, name) orelse return null;
+
+    var target: Target = .{
+        .kind = kind,
+        .path = path,
+    };
+    @memcpy(target.title_buf[0..name.len], name);
+    target.title_len = @intCast(name.len);
+    return target;
+}
+
+fn makeTargetPath(
+    allocator: std.mem.Allocator,
+    parent: []const u8,
+    separator: u8,
+    name: []const u8,
+) !?[]u8 {
+    const needs_separator = parent.len > 0 and !isSeparator(parent[parent.len - 1]);
+    const separator_len: usize = if (needs_separator) 1 else 0;
+    const path_len = parent.len + separator_len + name.len;
+    if (path_len > MAX_TARGET_PATH_BYTES) return null;
+
+    const path = try allocator.alloc(u8, path_len);
+    var offset: usize = 0;
+    @memcpy(path[offset .. offset + parent.len], parent);
+    offset += parent.len;
+    if (needs_separator) {
+        path[offset] = separator;
+        offset += 1;
+    }
+    @memcpy(path[offset .. offset + name.len], name);
+    return path;
+}
+
+fn isSeparator(byte: u8) bool {
+    return byte == '/' or byte == '\\';
+}
+
+fn testEntry(name: []const u8, is_dir: bool) file_backend.Entry {
+    var entry: file_backend.Entry = .{ .is_dir = is_dir };
+    const len: u8 = @intCast(@min(name.len, entry.name_buf.len));
+    @memcpy(entry.name_buf[0..len], name[0..len]);
+    entry.name_len = len;
+    return entry;
+}
+
+test "preview_gallery: finds previous and next raster siblings" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("a.png", false),
+        testEntry("b.txt", false),
+        testEntry("c.pdf", false),
+        testEntry("d.jpg", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/c.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqual(markdown_preview.Kind.image, next.kind);
+    try std.testing.expectEqualStrings("d.jpg", next.title());
+    try std.testing.expectEqualStrings("/tmp/d.jpg", next.path);
+
+    var prev = (try neighborFromEntriesForTest(allocator, "/tmp/c.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqual(markdown_preview.Kind.image, prev.kind);
+    try std.testing.expectEqualStrings("a.png", prev.title());
+    try std.testing.expectEqualStrings("/tmp/a.png", prev.path);
+}
+
+test "preview_gallery: filters directories and non-raster previews" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("alpha.png", true),
+        testEntry("notes.md", false),
+        testEntry("paper.pdf", false),
+        testEntry("photo.webp", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/paper.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqualStrings("photo.webp", next.title());
+    try std.testing.expectEqual(markdown_preview.Kind.image, next.kind);
+
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "/tmp/photo.webp", entries[0..], true)) == null);
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "/tmp/paper.pdf", entries[0..], false)) == null);
+}
+
+test "preview_gallery: treats a multi-page pdf as one gallery entry" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("01.png", false),
+        testEntry("book.pdf", false),
+        testEntry("02.png", false),
+    };
+
+    var next = (try neighborFromEntriesForTest(allocator, "/tmp/book.pdf", entries[0..], true)).?;
+    defer next.deinit(allocator);
+    try std.testing.expectEqualStrings("02.png", next.title());
+
+    var prev = (try neighborFromEntriesForTest(allocator, "/tmp/book.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqualStrings("01.png", prev.title());
+}
+
+test "preview_gallery: supports windows-style backslash paths" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("a.bmp", false),
+        testEntry("b.pdf", false),
+    };
+
+    var prev = (try neighborFromEntriesForTest(allocator, "C:\\Users\\me\\Pictures\\b.pdf", entries[0..], false)).?;
+    defer prev.deinit(allocator);
+    try std.testing.expectEqualStrings("a.bmp", prev.title());
+    try std.testing.expectEqualStrings("C:\\Users\\me\\Pictures\\a.bmp", prev.path);
+}

--- a/src/preview_gallery.zig
+++ b/src/preview_gallery.zig
@@ -36,10 +36,19 @@ pub fn findNeighbor(
     const result = file_backend.list(allocator, backend, parent, entries);
     if (result.status != .ok) return null;
 
-    return neighborFromEntriesForTest(allocator, current_path, entries[0..result.count], forward);
+    return neighborFromEntries(allocator, current_path, entries[0..result.count], forward);
 }
 
 pub fn neighborFromEntriesForTest(
+    allocator: std.mem.Allocator,
+    current_path: []const u8,
+    entries: []const file_backend.Entry,
+    forward: bool,
+) !?Target {
+    return neighborFromEntries(allocator, current_path, entries, forward);
+}
+
+fn neighborFromEntries(
     allocator: std.mem.Allocator,
     current_path: []const u8,
     entries: []const file_backend.Entry,
@@ -89,6 +98,7 @@ fn rasterKind(entry: *const file_backend.Entry) ?markdown_preview.Kind {
 fn parentPath(path: []const u8) ?[]const u8 {
     const index = lastSeparatorIndex(path) orelse return null;
     if (index == 0) return path[0..1];
+    if (isWindowsDriveRootSeparator(path, index)) return path[0 .. index + 1];
     return path[0..index];
 }
 
@@ -153,6 +163,10 @@ fn makeTargetPath(
 
 fn isSeparator(byte: u8) bool {
     return byte == '/' or byte == '\\';
+}
+
+fn isWindowsDriveRootSeparator(path: []const u8, index: usize) bool {
+    return index == 2 and path.len >= 3 and path[1] == ':' and std.ascii.isAlphabetic(path[0]);
 }
 
 fn testEntry(name: []const u8, is_dir: bool) file_backend.Entry {
@@ -231,4 +245,46 @@ test "preview_gallery: supports windows-style backslash paths" {
     defer prev.deinit(allocator);
     try std.testing.expectEqualStrings("a.bmp", prev.title());
     try std.testing.expectEqualStrings("C:\\Users\\me\\Pictures\\a.bmp", prev.path);
+}
+
+test "preview_gallery: preserves windows drive-root parent separator" {
+    try std.testing.expectEqualStrings("C:\\", parentPath("C:\\file.pdf").?);
+    try std.testing.expectEqualStrings("C:/", parentPath("C:/file.pdf").?);
+}
+
+test "preview_gallery: returns null when current path has no parent" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("current.pdf", false),
+        testEntry("next.png", false),
+    };
+
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "current.pdf", entries[0..], true)) == null);
+}
+
+test "preview_gallery: returns null when current file is absent" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("a.png", false),
+        testEntry("b.pdf", false),
+    };
+
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, "/tmp/missing.pdf", entries[0..], true)) == null);
+}
+
+test "preview_gallery: returns null when target path exceeds byte cap" {
+    const allocator = std.testing.allocator;
+    var entries = [_]file_backend.Entry{
+        testEntry("current.pdf", false),
+        testEntry("next.png", false),
+    };
+
+    const parent_len = MAX_TARGET_PATH_BYTES - "next.png".len + 1;
+    var current_buf: [MAX_TARGET_PATH_BYTES + 32]u8 = undefined;
+    @memset(current_buf[0..parent_len], 'a');
+    current_buf[parent_len] = '/';
+    @memcpy(current_buf[parent_len + 1 ..][0.."current.pdf".len], "current.pdf");
+    const current_path = current_buf[0 .. parent_len + 1 + "current.pdf".len];
+
+    try std.testing.expect((try neighborFromEntriesForTest(allocator, current_path, entries[0..], true)) == null);
 }

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -444,6 +444,16 @@ test "PreviewPane: async load stores current source kind" {
         else => false,
     });
     drainJobs(p);
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .wsl => true,
+        else => false,
+    });
+
+    p.open(.markdown, "b.md", "b.md", "# Reset\n");
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .local => true,
+        else => false,
+    });
 }
 
 test "PreviewPane: image zoom/pan are image-only and clamped" {

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -444,6 +444,8 @@ test "PreviewPane: async load stores current source kind" {
         else => false,
     });
     drainJobs(p);
+    try std.testing.expectEqual(@as(usize, 0), p.jobs.items.len);
+    try std.testing.expectEqual(LoadStatus.ready, p.load_status);
     try std.testing.expect(switch (p.currentSourceKind()) {
         .wsl => true,
         else => false,

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -59,6 +59,7 @@ const PreviewJob = struct {
 
 refcount: usize = 1,
 kind: markdown_preview.Kind = .markdown,
+source_kind: PreviewSourceKind = .local,
 load_status: LoadStatus = .idle,
 title_buf: [256]u8 = undefined,
 title_len: usize = 0,
@@ -112,6 +113,7 @@ pub fn title(self: *const PreviewPane) []const u8 { return self.title_buf[0..sel
 pub fn path(self: *const PreviewPane) []const u8 { return self.path_buf[0..self.path_len]; }
 pub fn sourceText(self: *const PreviewPane) []const u8 { return self.source orelse ""; }
 pub fn contentGeneration(self: *const PreviewPane) u64 { return self.content_generation; }
+pub fn currentSourceKind(self: *const PreviewPane) PreviewSourceKind { return self.source_kind; }
 pub fn imageZoom(self: *const PreviewPane) f32 { return self.image_zoom; }
 pub fn imagePanX(self: *const PreviewPane) f32 { return self.image_pan_x; }
 pub fn imagePanY(self: *const PreviewPane) f32 { return self.image_pan_y; }
@@ -125,6 +127,7 @@ fn setTitlePath(self: *PreviewPane, t: []const u8, p: []const u8) void {
 
 pub fn open(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p: []const u8, source_text: []const u8) void {
     self.request_id +%= 1;
+    self.source_kind = .local;
     self.applyOwned(kind, t, p, std.heap.page_allocator.dupe(u8, source_text) catch null, .ready);
 }
 
@@ -203,6 +206,7 @@ pub fn beginAsyncLoad(self: *PreviewPane, kind: markdown_preview.Kind, t: []cons
 
 fn beginAsyncLoadWith(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p: []const u8, source_kind: PreviewSourceKind, read_fn: PreviewReadFn) bool {
     self.request_id +%= 1;
+    self.source_kind = source_kind;
     if (p.len > 512) { self.applyOwned(kind, t, p, std.heap.page_allocator.dupe(u8, FAILED_SOURCE) catch null, .failed); return false; }
     self.applyOwned(kind, t, p, std.heap.page_allocator.dupe(u8, LOADING_SOURCE) catch null, .loading);
     const alloc = std.heap.page_allocator;
@@ -423,6 +427,23 @@ test "PreviewPane: open sets content and bumps generation" {
     try std.testing.expectEqual(LoadStatus.ready, p.load_status);
     try std.testing.expectEqualStrings("# Title\n", p.sourceText());
     try std.testing.expect(p.contentGeneration() != g0);
+}
+
+test "PreviewPane: async load stores current source kind" {
+    const gpa = std.testing.allocator;
+    var p = try create(gpa);
+    defer p.unref(gpa);
+
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .local => true,
+        else => false,
+    });
+    try std.testing.expect(p.beginAsyncLoadWith(.image, "a.png", "/tmp/a.png", .wsl, previewReadOkForTest));
+    try std.testing.expect(switch (p.currentSourceKind()) {
+        .wsl => true,
+        else => false,
+    });
+    drainJobs(p);
 }
 
 test "PreviewPane: image zoom/pan are image-only and clamped" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -65,6 +65,7 @@ test {
     _ = @import("surface_registry.zig");
     _ = @import("png_dimensions.zig");
     _ = @import("pdf_preview.zig");
+    _ = @import("preview_gallery.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");


### PR DESCRIPTION
## Summary
- Add focused preview gallery navigation so plain `Left` / `Right` opens the previous or next supported image/PDF sibling.
- Keep multi-page PDF page navigation on plain `PageUp` / `PageDown`.
- Preserve preview source kind for local, WSL, and SSH previews, with README and file explorer docs updated.

## Validation
- `zig build test` passed.
- `zig build test-full` still fails only on the known unrelated baseline: `src/ai_chat.zig:5241` `ai chat default system prompt comes from platform agent prompt`.
- Windows checkout safety checks passed: no path violations, no case-fold collisions, no symlink output.

## Notes
- Final code review found no Critical, Important, or Minor issues. The remaining risk is possible UI blocking on slow SSH/WSL directory listings because gallery sibling listing follows the existing synchronous file backend path.
