### PR TITLE
fix(tmux): html preview, per-pane dot position, and re-attach-on-drop (verification fixes for #216)

### DIFF
--- a/src/appwindow/tmux_controller_posix.zig
+++ b/src/appwindow/tmux_controller_posix.zig
@@ -29,6 +29,21 @@ threadlocal var g_controllers: std.ArrayListUnmanaged(*TmuxController) = .empty;
 const INITIAL_BACKOFF_MS: i64 = 500;
 const MAX_BACKOFF_MS: i64 = 5000;
 
+/// Rewrite the stored `… tmux -CC new -A -s <name>` connect command into its
+/// reconnect form `… tmux -CC attach -t <name>`. Reconnecting with `attach`
+/// (not `new -A`) is what lets us tell a transport drop from a genuine exit: a
+/// session that merely lost its transport (network loss / ssh killed / detach)
+/// is re-attached intact, while a session the user actually ended is NOT
+/// recreated — the attach fails (see `Session.session_gone`) and we tear down.
+/// `"new -A -s"` and `"attach -t"` are the same length, so the output is a
+/// same-size copy; if the needle is absent (e.g. a profile-less launch) the
+/// command is copied unchanged.
+fn buildAttachCommand(alloc: Allocator, connect_cmd: []const u8) Allocator.Error![]u8 {
+    const out = try alloc.alloc(u8, connect_cmd.len);
+    _ = std.mem.replace(u8, connect_cmd, "new -A -s", "attach -t", out);
+    return out;
+}
+
 pub const TmuxController = struct {
     alloc: Allocator,
     pty: Pty,
@@ -56,12 +71,18 @@ pub const TmuxController = struct {
     /// login / password prompt and tmux is not yet listening, so an early
     /// bootstrap write would be lost.
     handshake_seen: bool = false,
+    /// Sticky: set once any handshake has succeeded. After that, reconnects use
+    /// `attach` (not `new -A`) and scan for a session-gone error, so a genuine
+    /// exit tears down while a dropped transport re-attaches. Before the first
+    /// handshake, a drop is a login/connect failure and retries `new -A`.
+    had_handshake: bool = false,
     /// Last client size forwarded to tmux, to avoid redundant refresh-client.
     last_cols: u16 = 0,
     last_rows: u16 = 0,
-    /// Pre-handshake transport setup failed; retry login/connect with backoff.
-    /// Once tmux control mode has started, transport exit closes the controller
-    /// instead of re-running `new -A` and recreating a user-killed session.
+    /// A dropped transport reconnects with backoff: pre-handshake retries the
+    /// original `new -A` connect; post-handshake re-`attach`es the live session.
+    /// The controller only tears down when the reconnect attempt reports the
+    /// session is gone (`Session.session_gone`) — i.e. the user actually ended it.
     reconnecting: bool = false,
     closed: bool = false,
     next_retry_ms: i64 = 0,
@@ -97,12 +118,25 @@ pub const TmuxController = struct {
                 self.maybeInjectPassword(chunk);
                 if (!self.handshake_seen and std.mem.indexOf(u8, chunk, "\x1bP1000p") != null) {
                     self.handshake_seen = true;
+                    self.had_handshake = true;
                     self.backoff_ms = INITIAL_BACKOFF_MS; // real connection — reset backoff
                     std.debug.print("tmux: control-mode handshake seen\n", .{});
                 }
                 self.bridge.session.feed(chunk) catch {};
-                if (self.bridge.session.exited) {
+                // A reconnect `attach` to a session the user ended replies with a
+                // `%error` ("can't find session" / "no sessions"). tmux still sends
+                // the control handshake first, so this is detected from the parsed
+                // reply (Session.session_gone), not the raw prefix — tear down
+                // instead of looping reconnects forever.
+                if (self.bridge.session.session_gone) {
+                    std.debug.print("tmux: remote session gone — closing controller\n", .{});
                     self.closeFromRemoteExit();
+                    return;
+                }
+                if (self.bridge.session.exited) {
+                    // %exit on an established session: reconnect via `attach`; the
+                    // attempt re-attaches a live session or trips session_gone.
+                    self.markDisconnected();
                     return;
                 }
             } else if (fds[0].revents & (std.posix.POLL.HUP | std.posix.POLL.ERR) != 0) {
@@ -111,8 +145,13 @@ pub const TmuxController = struct {
             } else break;
         }
 
-        if (self.bridge.session.exited) {
+        if (self.bridge.session.session_gone) {
+            std.debug.print("tmux: remote session gone — closing controller\n", .{});
             self.closeFromRemoteExit();
+            return;
+        }
+        if (self.bridge.session.exited) {
+            self.markDisconnected();
             return;
         }
 
@@ -147,14 +186,12 @@ pub const TmuxController = struct {
         self.closed = true;
     }
 
-    /// Pre-handshake transport failed: tear it down and schedule a retry.
-    /// Post-handshake transport close means the tmux control session ended.
+    /// The transport went away (EOF/HUP/read error or a tmux `%exit`). Always
+    /// schedule a reconnect with backoff — never tear down here. The reconnect
+    /// attempt (`tryReconnect`) decides the outcome: a live session re-attaches,
+    /// a gone one is detected via `Session.session_gone` and closes the controller.
     fn markDisconnected(self: *TmuxController) void {
         if (self.reconnecting) return;
-        if (self.handshake_seen) {
-            self.closeFromRemoteExit();
-            return;
-        }
         std.debug.print("tmux: transport lost — reconnecting…\n", .{});
         self.command.deinit();
         self.pty.deinit();
@@ -168,12 +205,25 @@ pub const TmuxController = struct {
         self.next_retry_ms = std.time.milliTimestamp() + self.backoff_ms;
     }
 
-    /// Re-spawn the transport when the backoff elapses. On success the read loop
-    /// resumes; the list-windows reply reconciles onto the existing surfaces.
+    /// Re-spawn the transport when the backoff elapses. After a prior handshake
+    /// this reconnects with `attach` (so a user-ended session is not recreated);
+    /// before one it retries the original `new -A` connect. On success the read
+    /// loop resumes and the list-windows reply reconciles onto existing surfaces.
     fn tryReconnect(self: *TmuxController) void {
         if (std.time.milliTimestamp() < self.next_retry_ms) return;
 
-        const owned = pty_command.allocCommandLineFromUtf8(self.alloc, self.ssh_cmd) catch {
+        var attach_cmd: ?[]u8 = null;
+        const reconnect_cmd: []const u8 = if (self.had_handshake) blk: {
+            const a = buildAttachCommand(self.alloc, self.ssh_cmd) catch {
+                self.scheduleRetry();
+                return;
+            };
+            attach_cmd = a;
+            break :blk a;
+        } else self.ssh_cmd;
+        defer if (attach_cmd) |a| self.alloc.free(a);
+
+        const owned = pty_command.allocCommandLineFromUtf8(self.alloc, reconnect_cmd) catch {
             self.scheduleRetry();
             return;
         };
@@ -428,4 +478,19 @@ pub fn requestClosePane(surface: *anyopaque) bool {
         }
     }
     return false;
+}
+
+test "buildAttachCommand rewrites the connect command to its attach form" {
+    const alloc = std.testing.allocator;
+    const connect = "ssh -tt -p 28001 xzg@host 'tmux -CC new -A -s wispterm-ngs00'";
+    const reconnect = try buildAttachCommand(alloc, connect);
+    defer alloc.free(reconnect);
+    try std.testing.expectEqualStrings(
+        "ssh -tt -p 28001 xzg@host 'tmux -CC attach -t wispterm-ngs00'",
+        reconnect,
+    );
+    // No needle (e.g. a profile-less launch): copied unchanged.
+    const other = try buildAttachCommand(alloc, "ssh host 'tmux -CC'");
+    defer alloc.free(other);
+    try std.testing.expectEqualStrings("ssh host 'tmux -CC'", other);
 }

--- a/src/markdown_preview.zig
+++ b/src/markdown_preview.zig
@@ -71,6 +71,10 @@ const text_file_suffixes = &.{
     ".yaml",
     ".toml",
     ".sh",
+    ".html",
+    ".htm",
+    ".xml",
+    ".css",
 };
 
 const image_file_suffixes = &.{
@@ -466,6 +470,10 @@ test "detect preview kind" {
     try std.testing.expectEqual(Kind.text, detectKind("config.yaml").?);
     try std.testing.expectEqual(Kind.text, detectKind("Cargo.toml").?);
     try std.testing.expectEqual(Kind.text, detectKind("deploy.sh").?);
+    try std.testing.expectEqual(Kind.text, detectKind("index.html").?);
+    try std.testing.expectEqual(Kind.text, detectKind("page.HTM").?);
+    try std.testing.expectEqual(Kind.text, detectKind("data.xml").?);
+    try std.testing.expectEqual(Kind.text, detectKind("style.css").?);
     try std.testing.expectEqual(Kind.image, detectKind("image.png").?);
     try std.testing.expectEqual(Kind.image, detectKind("photo.JPEG").?);
     try std.testing.expectEqual(MAX_SOURCE_BYTES, sourceLimit(.markdown));

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -4564,14 +4564,15 @@ pub fn renderPaneAgentDots(active_tab: *const TabState, content_x: i32, content_
         const px: f32 = @as(f32, @floatCast(slot.x)) * @as(f32, @floatFromInt(content_w)) + @as(f32, @floatFromInt(content_x));
         const py: f32 = @as(f32, @floatCast(slot.y)) * @as(f32, @floatFromInt(content_h)) + @as(f32, @floatFromInt(content_y));
         const pw: f32 = @as(f32, @floatCast(slot.width)) * @as(f32, @floatFromInt(content_w));
-        const ph: f32 = @as(f32, @floatCast(slot.height)) * @as(f32, @floatFromInt(content_h));
 
-        // Top-right corner in GL coords (Y=0 at bottom):
-        //   pane GL top = window_height - py - ph  (py is top-down from content_y)
-        //   pane GL right = px + pw
-        const gl_top = window_height - py - ph;
+        // Top-right corner in GL coords (Y=0 at bottom). py is top-down from the
+        // framebuffer top, so the pane spans GL-Y [window_height - py - ph,
+        // window_height - py]; its visual top edge is the higher value
+        // (window_height - py). fillQuad's y is the quad's bottom edge (it extends
+        // upward by dot_size), so inset the dot below the top edge by the margin.
+        const gl_pane_top = window_height - py;
         const dot_x = px + pw - dot_size - dot_margin;
-        const dot_y = gl_top + dot_margin;
+        const dot_y = gl_pane_top - dot_size - dot_margin;
 
         const color = titlebar.agentBadgeColor(det.state);
         ui_pipeline.fillQuad(dot_x, dot_y, dot_size, dot_size, color);

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -683,6 +683,14 @@ comptime {
         },
         else => {},
     }
+    // The posix tmux controller (drop/reconnect decision) is posix-only; it uses
+    // std.posix poll/read paths that don't compile for the windows app target.
+    switch (@import("builtin").os.tag) {
+        .linux, .macos => {
+            _ = @import("appwindow/tmux_controller_posix.zig");
+        },
+        else => {},
+    }
     _ = @import("platform/pty_command.zig");
     _ = @import("platform/remote_file.zig");
     _ = @import("platform/remote_transport.zig");

--- a/src/tmux/control.zig
+++ b/src/tmux/control.zig
@@ -75,7 +75,15 @@ pub const Parser = struct {
         return self.processLine(line);
     }
 
-    fn processLine(self: *Parser, line: []const u8) Allocator.Error!?Notification {
+    fn processLine(self: *Parser, raw_line: []const u8) Allocator.Error!?Notification {
+        // tmux glues the control-mode enter DCS (ESC P 1000 p) onto the first
+        // reply line — e.g. `\x1bP1000p%begin …`. Strip it so the following
+        // %begin/%error is still recognized; otherwise a failed reconnect
+        // `attach` (whose %error names a gone session) would be silently dropped.
+        const line = if (std.mem.startsWith(u8, raw_line, "\x1bP1000p"))
+            raw_line["\x1bP1000p".len..]
+        else
+            raw_line;
         if (self.in_block) {
             if (std.mem.startsWith(u8, line, "%end")) {
                 self.in_block = false;
@@ -340,4 +348,15 @@ test "%error closes a block as block_err" {
     _ = try feed(&p, "%begin 2 2 0\n");
     const n = (try feed(&p, "boom\n%error 2 2 0\n")).?;
     try std.testing.expectEqualStrings("boom", n.block_err);
+}
+
+test "strips the control-mode enter DCS glued onto the first %begin (failed attach)" {
+    // A reconnect `attach` to a gone session: tmux glues its enter DCS onto the
+    // first reply, so `%begin` is not at column 0. The body must still surface as
+    // block_err (else the controller never learns the session is gone).
+    var p = Parser.init(std.testing.allocator);
+    defer p.deinit();
+    try std.testing.expectEqual(@as(?Notification, null), try feed(&p, "\x1bP1000p%begin 1 1 0\n"));
+    const n = (try feed(&p, "can't find session: wispterm-ngs00\n%error 1 1 0\n")).?;
+    try std.testing.expectEqualStrings("can't find session: wispterm-ngs00", n.block_err);
 }

--- a/src/tmux/session.zig
+++ b/src/tmux/session.zig
@@ -37,6 +37,12 @@ pub const Session = struct {
     active_window: ?usize = null,
     active_pane: ?usize = null,
     exited: bool = false,
+    /// Set when a command reply is a `%error` whose body says the attach target
+    /// is gone ("can't find session" / "no sessions"). On a reconnect `attach`
+    /// this means the user genuinely ended the session, so the controller closes
+    /// rather than looping reconnects. Distinct from `exited` (which also fires on
+    /// a survivable transport drop). Reset by `resetForReconnect`.
+    session_gone: bool = false,
     events: EventSink = .{},
 
     pub const Window = struct {
@@ -117,6 +123,7 @@ pub const Session = struct {
         self.cmds.clearRetainingCapacity();
         self.capture_queue.clearRetainingCapacity();
         self.exited = false;
+        self.session_gone = false;
     }
 
     pub fn feed(self: *Session, bytes: []const u8) Allocator.Error!void {
@@ -167,7 +174,11 @@ pub const Session = struct {
                     }
                 }
             },
-            .block_err => {
+            .block_err => |body| {
+                // A reconnect `attach` to a session the user ended replies with a
+                // `%error` whose body names the failure; flag it so the controller
+                // tears down instead of recreating the session.
+                if (isSessionGoneError(body)) self.session_gone = true;
                 // Keep the capture FIFO aligned if a capture errored.
                 if (self.capture_queue.items.len > 0) _ = self.capture_queue.orderedRemove(0);
             },
@@ -444,6 +455,17 @@ fn isPaneListReply(body: []const u8) bool {
     return found_any;
 }
 
+/// True if a `%error` reply body says the attach target no longer exists: the
+/// session was killed, or the last one exited and the server quit. These are
+/// tmux's own English (non-localized) messages. Used to tell a reconnect that
+/// found a dead session (close) from one that re-attached a live one (continue).
+pub fn isSessionGoneError(body: []const u8) bool {
+    return std.mem.indexOf(u8, body, "can't find session") != null or
+        std.mem.indexOf(u8, body, "no sessions") != null or
+        std.mem.indexOf(u8, body, "no server running") != null or
+        std.mem.indexOf(u8, body, "no current session") != null;
+}
+
 fn containsId(ids: []const usize, id: usize) bool {
     for (ids) |candidate| {
         if (candidate == id) return true;
@@ -629,6 +651,30 @@ test "a realistic notification stream builds the full model" {
     try std.testing.expectEqual(@as(usize, 2), col.last_pane);
     try std.testing.expectEqualSlices(u8, "done", col.buf.items);
     try std.testing.expect(s.exited);
+}
+
+test "a failed reconnect attach flags session_gone, not just exited" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+
+    // What `tmux -CC attach -t <gone>` actually replies (control-mode enter DCS
+    // glued onto %begin, a %error block naming the failure, then %exit).
+    try s.feed("\x1bP1000p%begin 1 1 0\r\ncan't find session: wispterm-ngs00\r\n%error 1 1 0\r\n%exit\r\n");
+    try std.testing.expect(s.session_gone);
+    try std.testing.expect(s.exited);
+
+    // A bare %exit (survivable transport drop) is NOT a gone session.
+    var s2 = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s2.deinit();
+    try s2.feed("%exit\n");
+    try std.testing.expect(s2.exited);
+    try std.testing.expect(!s2.session_gone);
+
+    // The "no sessions" variant (server quit) also counts as gone.
+    try std.testing.expect(isSessionGoneError("no sessions"));
+    try std.testing.expect(!isSessionGoneError("boom: a normal command error"));
 }
 
 const EventLog = struct {


### PR DESCRIPTION
Fixes three issues found while GUI-verifying #216 against a real tmux remote (ngs00). Stacks onto the #216 branch.

## 1. HTML preview was a no-op
`markdown_preview.detectKind` had no `.html`/`.htm` mapping, so ctrl+click on an `.html` file in a tmux/ssh pane did nothing — contradicting the PR's "preview (image/text/html)" claim. Added `.html`/`.htm` (plus `.xml`/`.css`) to the text kinds so they preview as source (like `less`).

## 2. Per-pane agent dot rendered at the bottom-right
`renderPaneAgentDots` used `gl_top = window_height - py - ph`, which is the pane's **bottom** edge in GL coords (Y=0 at bottom), so the dot drew at the bottom-right instead of the intended top-right. Now uses the pane top edge and insets downward by the dot size + margin.

## 3. Transport drop tore the tab down instead of re-attaching
A post-handshake transport drop closed the controller (the tmux tab vanished) rather than reconnecting, so a network loss / killed ssh did not survive — even though the server-side session was still alive.

The fix reconnects with backoff on every drop, but a post-handshake reconnect now uses `tmux -CC attach -t <name>` (not `new -A`):
- a live session **re-attaches intact**;
- a session the user genuinely ended is **not recreated** — the failed attach replies with a `%error` (`can't find session` / `no sessions`), which sets `Session.session_gone`, and the controller tears down then. No respawn, no reconnect loop.

tmux glues its control-mode enter DCS onto the first reply line, so the parser now strips a leading `ESC P 1000 p` before matching — otherwise the failed-attach `%error` block would be dropped (and the controller would loop reconnects forever).

## Testing
- `zig build test` (fast) + `zig build test-full -Dtarget=aarch64-macos`: **green**.
- New unit tests: `detectKind` html/htm/xml/css; control parser strips the DCS-glued `%begin`/`%error`; `Session.session_gone` set on a failed attach vs. a bare `%exit`; `buildAttachCommand` rewrite. The posix tmux controller is now wired into `test_main` on linux/macos.
- GUI-verified against a real tmux remote (ngs00):
  - ctrl+click `.html` → previews source;
  - split-pane agent dot now at the pane top-right;
  - kill the ssh transport → re-attaches with the 2-pane layout preserved;
  - exit all panes → tab closes cleanly (no respawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)