### PR TITLE
fix(skill-center): native Windows scan + transfer (no POSIX shell/WSL)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -61,6 +61,7 @@ const port_forward_manager = @import("port_forward_manager.zig");
 const port_forward_rule = @import("port_forward_rule.zig");
 const ssh_profile_store = @import("ssh_profile_store.zig");
 const skill_scan = @import("skill_scan.zig");
+const skill_local_fs = @import("skill_local_fs.zig");
 const skill_transfer_cmd = @import("skill_transfer_cmd.zig");
 const remote_file = @import("platform/remote_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
@@ -1824,6 +1825,43 @@ fn skillCenterTargetConn(target: skill_center.Target) ?ssh_connection.SshConnect
     return null;
 }
 
+/// Absolute path of a local target software's skills root (`~/.claude/skills`).
+/// Used by the native (non-POSIX) scan/transfer path where `$HOME` can't be
+/// expanded by a shell. Null if the home dir can't be resolved. Caller frees.
+fn skillCenterLocalRootPath(allocator: std.mem.Allocator, software: skill_center.Software) ?[]u8 {
+    const home = platform_dirs.homeDir(allocator) catch return null;
+    defer allocator.free(home);
+    return std.fs.path.join(allocator, &.{ home, software.rootRel() }) catch null;
+}
+
+/// Scan a skills endpoint, picking the right backend:
+///   - remote (conn set): the POSIX `find`/`sha256sum` command over SSH.
+///   - local on a POSIX host: the same command via `sh -c` (preserves the
+///     existing Linux/macOS hashes).
+///   - local on a non-POSIX host (Windows, no WSL): a native `std.fs` scan whose
+///     aggregate hash matches the POSIX recipe byte-for-byte.
+/// `root_expr` is the shell root expression (for the SSH/POSIX paths);
+/// `local_path` is the raw absolute root (for the native path; null when remote).
+fn skillCenterScanOutcome(
+    allocator: std.mem.Allocator,
+    root_expr: []const u8,
+    local_path: ?[]const u8,
+    conn: ?ssh_connection.SshConnection,
+) skill_scan.ScanOutcome {
+    if (conn) |c| {
+        var le = SkillLocExec{ .conn = c };
+        return skill_scan.scanLocation(allocator, root_expr, le.host()) catch
+            return .{ .reachable = false, .rows = &.{} };
+    }
+    if (remote_file.localPosixExecSupported()) {
+        var le = SkillLocExec{ .conn = null };
+        return skill_scan.scanLocation(allocator, root_expr, le.host()) catch
+            return .{ .reachable = false, .rows = &.{} };
+    }
+    const lp = local_path orelse return .{ .reachable = false, .rows = &.{} };
+    return skill_local_fs.scanOutcome(allocator, lp);
+}
+
 /// Adapts skill_transfer.Ops onto local/ssh/scp. conn null → a local-only target.
 /// `err_buf`/`err_len` capture the last ssh error summary for the UI toast.
 const SkillTransferCtx = struct {
@@ -2002,18 +2040,22 @@ fn skillCenterOpenImportList(allocator: std.mem.Allocator, target: skill_center.
         return;
     }
     const root_expr = skill_transfer_cmd.homeRootExpr(allocator, target.software.rootRel()) catch return;
-    // ownership of root_expr moves into the job on success
+    // Raw root for the native (non-POSIX) path; null when remote or unresolvable.
+    const local_path: ?[]u8 = if (target.is_local) skillCenterLocalRootPath(allocator, target.software) else null;
+    // ownership of root_expr + local_path moves into the job on success
     const tgt = target.clone(allocator) catch {
         allocator.free(root_expr);
+        if (local_path) |p| allocator.free(p);
         return;
     };
     const job = allocator.create(SkillImportScanJob) catch {
         allocator.free(root_expr);
+        if (local_path) |p| allocator.free(p);
         var t = tgt;
         t.deinit(allocator);
         return;
     };
-    job.* = .{ .target = tgt, .conn = conn, .root_expr = root_expr };
+    job.* = .{ .target = tgt, .conn = conn, .root_expr = root_expr, .local_path = local_path };
     if (!session.startOp(.{ .ctx = job, .run = SkillImportScanJob.run, .destroy = SkillImportScanJob.destroy }, window_backend.postWakeup, i18n.s().sc_busy_syncing)) {
         SkillImportScanJob.destroy(@ptrCast(job), allocator);
         overlays.showStatusToast(i18n.s().sc_toast_op_busy);
@@ -2036,14 +2078,25 @@ fn skillCenterRunTransfer(allocator: std.mem.Allocator, is_import: bool, target:
         allocator.free(lib_root);
         return;
     };
+    const lib_path = allocator.dupe(u8, lib_dir) catch {
+        allocator.free(lib_root);
+        allocator.free(tgt_root);
+        return;
+    };
+    // Raw target root for the native (non-POSIX) path; null when remote.
+    const tgt_path: ?[]u8 = if (target.is_local) skillCenterLocalRootPath(allocator, target.software) else null;
     const name_dup = allocator.dupe(u8, name) catch {
         allocator.free(lib_root);
         allocator.free(tgt_root);
+        allocator.free(lib_path);
+        if (tgt_path) |p| allocator.free(p);
         return;
     };
     const job = allocator.create(SkillTransferJob) catch {
         allocator.free(lib_root);
         allocator.free(tgt_root);
+        allocator.free(lib_path);
+        if (tgt_path) |p| allocator.free(p);
         allocator.free(name_dup);
         return;
     };
@@ -2054,6 +2107,9 @@ fn skillCenterRunTransfer(allocator: std.mem.Allocator, is_import: bool, target:
         .tgt_root = tgt_root,
         .tgt_is_local = target.is_local,
         .name = name_dup,
+        .lib_path = lib_path,
+        .tgt_path = tgt_path,
+        .tgt_software = target.software,
     };
     if (!session.startOp(.{ .ctx = job, .run = SkillTransferJob.run, .destroy = SkillTransferJob.destroy }, window_backend.postWakeup, i18n.s().sc_busy_syncing)) {
         SkillTransferJob.destroy(@ptrCast(job), allocator);
@@ -2151,12 +2207,16 @@ fn skillCenterDeployDecide(allocator: std.mem.Allocator, target: skill_center.Ta
         return;
     }
     const root_expr = skill_transfer_cmd.homeRootExpr(allocator, target.software.rootRel()) catch return;
+    // Raw root for the native (non-POSIX) path; null when remote or unresolvable.
+    const local_path: ?[]u8 = if (target.is_local) skillCenterLocalRootPath(allocator, target.software) else null;
     const tgt = target.clone(allocator) catch {
         allocator.free(root_expr);
+        if (local_path) |p| allocator.free(p);
         return;
     };
     const name_dup = allocator.dupe(u8, name) catch {
         allocator.free(root_expr);
+        if (local_path) |p| allocator.free(p);
         var t = tgt;
         t.deinit(allocator);
         return;
@@ -2165,6 +2225,7 @@ fn skillCenterDeployDecide(allocator: std.mem.Allocator, target: skill_center.Ta
     if (src_hash) |h| {
         hash_dup = allocator.dupe(u8, h) catch {
             allocator.free(root_expr);
+            if (local_path) |p| allocator.free(p);
             var t = tgt;
             t.deinit(allocator);
             allocator.free(name_dup);
@@ -2173,13 +2234,14 @@ fn skillCenterDeployDecide(allocator: std.mem.Allocator, target: skill_center.Ta
     }
     const job = allocator.create(SkillDeployScanJob) catch {
         allocator.free(root_expr);
+        if (local_path) |p| allocator.free(p);
         var t = tgt;
         t.deinit(allocator);
         allocator.free(name_dup);
         if (hash_dup) |h| allocator.free(h);
         return;
     };
-    job.* = .{ .target = tgt, .conn = conn, .root_expr = root_expr, .name = name_dup, .src_hash = hash_dup };
+    job.* = .{ .target = tgt, .conn = conn, .root_expr = root_expr, .local_path = local_path, .name = name_dup, .src_hash = hash_dup };
     if (!session.startOp(.{ .ctx = job, .run = SkillDeployScanJob.run, .destroy = SkillDeployScanJob.destroy }, window_backend.postWakeup, i18n.s().sc_busy_syncing)) {
         SkillDeployScanJob.destroy(@ptrCast(job), allocator);
         overlays.showStatusToast(i18n.s().sc_toast_op_busy);
@@ -2686,12 +2748,12 @@ fn startAiHistoryScan(allocator: std.mem.Allocator, session: *ai_history_session
 /// that could not be resolved, or local on a non-POSIX host).
 /// Background job: scan the local library (`<config>/skills`) off the UI thread.
 const SkillLibraryScanJob = struct {
-    root_expr: []u8, // owned shell expression for the library root
+    root_expr: []u8, // owned shell expression for the library root (POSIX path)
+    local_path: []u8, // owned raw absolute library root (native path)
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror![]skill_center.LibrarySkill {
         const job: *SkillLibraryScanJob = @ptrCast(@alignCast(ctx));
-        var le = SkillLocExec{ .conn = null };
-        const outcome = try skill_scan.scanLocation(allocator, job.root_expr, le.host());
+        const outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, null);
         // Move the scanned rows into the library list (frees the rows slice).
         return skill_center.libraryFromRows(allocator, outcome.rows);
     }
@@ -2699,6 +2761,7 @@ const SkillLibraryScanJob = struct {
     fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
         const job: *SkillLibraryScanJob = @ptrCast(@alignCast(ctx));
         allocator.free(job.root_expr);
+        allocator.free(job.local_path);
         allocator.destroy(job);
     }
 };
@@ -2708,26 +2771,24 @@ const SkillImportScanJob = struct {
     target: skill_center.Target, // owned
     conn: ?ssh_connection.SshConnection,
     root_expr: []u8, // owned
+    local_path: ?[]u8, // owned raw root when local; null when remote (native path)
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillImportScanJob = @ptrCast(@alignCast(ctx));
-        var le = SkillLocExec{ .conn = job.conn };
-        var outcome = skill_scan.scanLocation(allocator, job.root_expr, le.host()) catch {
-            return .failed;
-        };
+        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn);
         const tgt = job.target.clone(allocator) catch {
             outcome.deinit(allocator);
             return .failed;
         };
-        // An unreachable source yields `{ reachable = false, rows = &.{} }` (not an
-        // exec error), so it survives the catch above; importScanResult turns it
-        // into `.failed` rather than an empty import list.
+        // An unreachable source yields `{ reachable = false, rows = &.{} }`;
+        // importScanResult turns it into `.failed` rather than an empty list.
         return skill_center.importScanResult(allocator, &outcome, tgt);
     }
     fn destroy(ctx: *anyopaque, allocator: std.mem.Allocator) void {
         const job: *SkillImportScanJob = @ptrCast(@alignCast(ctx));
         job.target.deinit(allocator);
         allocator.free(job.root_expr);
+        if (job.local_path) |p| allocator.free(p);
         allocator.destroy(job);
     }
 };
@@ -2738,15 +2799,19 @@ const SkillDeployScanJob = struct {
     target: skill_center.Target, // owned
     conn: ?ssh_connection.SshConnection,
     root_expr: []u8, // owned
+    local_path: ?[]u8, // owned raw root when local; null when remote (native path)
     name: []u8, // owned
     src_hash: ?[]u8, // owned
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillDeployScanJob = @ptrCast(@alignCast(ctx));
-        var le = SkillLocExec{ .conn = job.conn };
-        var outcome = skill_scan.scanLocation(allocator, job.root_expr, le.host()) catch {
+        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn);
+        // A genuinely unreachable target (SSH failure) → fail fast, as the old
+        // scan-error path did; a reachable-but-empty target deploys via `.direct`.
+        if (!outcome.reachable) {
+            outcome.deinit(allocator);
             return .failed;
-        };
+        }
         const tgt = job.target.clone(allocator) catch {
             outcome.deinit(allocator);
             return .failed;
@@ -2775,6 +2840,7 @@ const SkillDeployScanJob = struct {
         const job: *SkillDeployScanJob = @ptrCast(@alignCast(ctx));
         job.target.deinit(allocator);
         allocator.free(job.root_expr);
+        if (job.local_path) |p| allocator.free(p);
         allocator.free(job.name);
         if (job.src_hash) |h| allocator.free(h);
         allocator.destroy(job);
@@ -2785,20 +2851,25 @@ const SkillDeployScanJob = struct {
 const SkillTransferJob = struct {
     is_import: bool,
     conn: ?ssh_connection.SshConnection,
-    lib_root: []u8, // owned
-    tgt_root: []u8, // owned
+    lib_root: []u8, // owned shell expr (POSIX path)
+    tgt_root: []u8, // owned shell expr (POSIX path)
     tgt_is_local: bool,
     name: []u8, // owned
+    lib_path: []u8, // owned raw absolute library root (native path)
+    tgt_path: ?[]u8, // owned raw absolute target root when local; null when remote
+    tgt_software: skill_center.Software, // for resolving the remote root natively
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillTransferJob = @ptrCast(@alignCast(ctx));
         var tctx = SkillTransferCtx{ .conn = job.conn };
-        const lib_ep = skill_transfer.Endpoint{ .root_expr = job.lib_root, .is_local = true };
-        const tgt_ep = skill_transfer.Endpoint{ .root_expr = job.tgt_root, .is_local = job.tgt_is_local };
-        const from = if (job.is_import) tgt_ep else lib_ep;
-        const to = if (job.is_import) lib_ep else tgt_ep;
-        const r = skill_transfer.transfer(allocator, tctx.ops(), from, to, job.name);
-        const ok = (r == .ok);
+        const ok = if (remote_file.localPosixExecSupported()) blk: {
+            // POSIX local host: the proven tar-over-scp dance (Linux/macOS).
+            const lib_ep = skill_transfer.Endpoint{ .root_expr = job.lib_root, .is_local = true };
+            const tgt_ep = skill_transfer.Endpoint{ .root_expr = job.tgt_root, .is_local = job.tgt_is_local };
+            const from = if (job.is_import) tgt_ep else lib_ep;
+            const to = if (job.is_import) lib_ep else tgt_ep;
+            break :blk skill_transfer.transfer(allocator, tctx.ops(), from, to, job.name) == .ok;
+        } else nativeSkillTransfer(allocator, job, &tctx);
         var summary: ?[]u8 = null;
         if (!ok) {
             if (tctx.lastErr()) |s| summary = allocator.dupe(u8, s) catch null;
@@ -2810,9 +2881,143 @@ const SkillTransferJob = struct {
         allocator.free(job.lib_root);
         allocator.free(job.tgt_root);
         allocator.free(job.name);
+        allocator.free(job.lib_path);
+        if (job.tgt_path) |p| allocator.free(p);
         allocator.destroy(job);
     }
 };
+
+/// Transfer a skill without a POSIX shell (native Windows, no WSL):
+///   - local↔local: a native `std.fs` directory copy with atomic swap.
+///   - local↔remote: `scp -r` to/from a staging dir + an SSH stage/swap, so the
+///     local side never needs `tar` or a `/tmp` path. The remote side stays
+///     POSIX (its `mkdir`/`mv` run over SSH). Returns true on full success.
+fn nativeSkillTransfer(allocator: std.mem.Allocator, job: *SkillTransferJob, tctx: *SkillTransferCtx) bool {
+    if (job.conn == null) {
+        const tgt_path = job.tgt_path orelse {
+            tctx.noteErr("could not resolve target path");
+            return false;
+        };
+        const src = if (job.is_import) tgt_path else job.lib_path;
+        const dst = if (job.is_import) job.lib_path else tgt_path;
+        skill_local_fs.transferLocalToLocal(allocator, src, dst, job.name) catch {
+            tctx.noteErr("local copy failed");
+            return false;
+        };
+        return true;
+    }
+    var conn = job.conn.?;
+    if (job.is_import) return nativeImportFromRemote(allocator, job, &conn, tctx);
+    return nativeDeployToRemote(allocator, job, &conn, tctx);
+}
+
+/// Resolve the target's ABSOLUTE skills root on the remote (e.g.
+/// `/home/user/.claude/skills`) by asking the remote shell to expand `$HOME`.
+/// scp must be handed a literal path: its default (SFTP) protocol does NOT
+/// shell-expand a `"$HOME"`/quoted remote spec — passing the shell expression
+/// would only work via the legacy `-O` fallback on a POSIX login shell, which
+/// breaks on modern Windows OpenSSH (SFTP default) and non-POSIX login shells.
+/// Caller frees. Null if the home can't be resolved.
+fn resolveRemoteSkillRoot(
+    allocator: std.mem.Allocator,
+    conn: *const ssh_connection.SshConnection,
+    software: skill_center.Software,
+) ?[]u8 {
+    const home = remote_file.sshExecCapture(allocator, conn.*, "printf %s \"$HOME\"") catch return null;
+    defer allocator.free(home);
+    const trimmed = std.mem.trim(u8, home, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    // POSIX remote path → always '/' separators, never std.fs.path.join.
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ trimmed, software.rootRel() }) catch null;
+}
+
+/// Deploy the library skill to a remote target via `scp -r` (no local tar).
+fn nativeDeployToRemote(
+    allocator: std.mem.Allocator,
+    job: *SkillTransferJob,
+    conn: *const ssh_connection.SshConnection,
+    tctx: *SkillTransferCtx,
+) bool {
+    const abs_root = resolveRemoteSkillRoot(allocator, conn, job.tgt_software) orelse {
+        tctx.noteErr("could not resolve remote home");
+        return false;
+    };
+    defer allocator.free(abs_root);
+    const root_expr = skill_transfer_cmd.absRootExpr(allocator, abs_root) catch return false;
+    defer allocator.free(root_expr);
+
+    const prep = skill_transfer_cmd.remoteStagePrepCmd(allocator, root_expr) catch return false;
+    defer allocator.free(prep);
+    if (!SkillTransferCtx.remoteExec(tctx, allocator, prep)) return false;
+
+    const local_src = std.fs.path.join(allocator, &.{ job.lib_path, job.name }) catch return false;
+    defer allocator.free(local_src);
+    // Clean absolute remote path for scp (works under both the SFTP-default and
+    // legacy protocols); the ssh prep above created exactly this dir.
+    const remote_stage = std.fmt.allocPrint(allocator, "{s}/{s}", .{ abs_root, skill_transfer_cmd.XFER_STAGING }) catch return false;
+    defer allocator.free(remote_stage);
+    var spec_buf: [512]u8 = undefined;
+    const dst_spec = scp.remoteSpec(&spec_buf, conn, remote_stage);
+    var control: scp.TransferControl = .{};
+    if (scp.transferDirWithControl(allocator, conn, local_src, dst_spec, &control) != .ok) {
+        tctx.noteErr("scp upload failed");
+        return false;
+    }
+
+    const swap = skill_transfer_cmd.remoteStageSwapCmd(allocator, root_expr, job.name) catch return false;
+    defer allocator.free(swap);
+    return SkillTransferCtx.remoteExec(tctx, allocator, swap);
+}
+
+/// Import a remote skill into the library via `scp -r` into a local staging dir,
+/// then a native atomic swap.
+fn nativeImportFromRemote(
+    allocator: std.mem.Allocator,
+    job: *SkillTransferJob,
+    conn: *const ssh_connection.SshConnection,
+    tctx: *SkillTransferCtx,
+) bool {
+    const abs_root = resolveRemoteSkillRoot(allocator, conn, job.tgt_software) orelse {
+        tctx.noteErr("could not resolve remote home");
+        return false;
+    };
+    defer allocator.free(abs_root);
+
+    skill_local_fs.ensureDirAbsolute(job.lib_path) catch {
+        tctx.noteErr("library dir unavailable");
+        return false;
+    };
+    const staging = std.fs.path.join(allocator, &.{ job.lib_path, skill_transfer_cmd.XFER_STAGING }) catch return false;
+    defer allocator.free(staging);
+    std.fs.deleteTreeAbsolute(staging) catch {};
+    skill_local_fs.ensureDirAbsolute(staging) catch {
+        tctx.noteErr("local staging failed");
+        return false;
+    };
+    defer std.fs.deleteTreeAbsolute(staging) catch {};
+
+    // Clean absolute remote source path for scp (SFTP-default safe).
+    const remote_src = std.fmt.allocPrint(allocator, "{s}/{s}", .{ abs_root, job.name }) catch return false;
+    defer allocator.free(remote_src);
+    var spec_buf: [512]u8 = undefined;
+    const src_spec = scp.remoteSpec(&spec_buf, conn, remote_src);
+    var control: scp.TransferControl = .{};
+    if (scp.transferDirWithControl(allocator, conn, src_spec, staging, &control) != .ok) {
+        tctx.noteErr("scp download failed");
+        return false;
+    }
+
+    const staged_skill = std.fs.path.join(allocator, &.{ staging, job.name }) catch return false;
+    defer allocator.free(staged_skill);
+    const final = std.fs.path.join(allocator, &.{ job.lib_path, job.name }) catch return false;
+    defer allocator.free(final);
+    std.fs.deleteTreeAbsolute(final) catch {};
+    std.fs.renameAbsolute(staged_skill, final) catch {
+        tctx.noteErr("local install failed");
+        return false;
+    };
+    return true;
+}
 
 /// Background op: read one skill's SKILL.md (local or via ssh) for preview.
 const SkillPreviewJob = struct {
@@ -2916,12 +3121,18 @@ fn startSkillCenterScan(allocator: std.mem.Allocator, session: *skill_center.Ses
         session.publishScanFailure(session.scan_generation);
         return;
     };
-    const job = allocator.create(SkillLibraryScanJob) catch {
+    const local_path = allocator.dupe(u8, lib_dir) catch {
         allocator.free(root_expr);
         session.publishScanFailure(session.scan_generation);
         return;
     };
-    job.* = .{ .root_expr = root_expr };
+    const job = allocator.create(SkillLibraryScanJob) catch {
+        allocator.free(root_expr);
+        allocator.free(local_path);
+        session.publishScanFailure(session.scan_generation);
+        return;
+    };
+    job.* = .{ .root_expr = root_expr, .local_path = local_path };
     session.scanAsync(.{ .ctx = job, .run = SkillLibraryScanJob.run, .destroy = SkillLibraryScanJob.destroy });
 }
 

--- a/src/platform/dirs.zig
+++ b/src/platform/dirs.zig
@@ -174,6 +174,32 @@ pub fn openSshConfigPathFromEnvForOs(
     return std.fs.path.join(allocator, &.{ base, ".ssh", "config" });
 }
 
+/// The user's home directory (`$HOME`, or `%USERPROFILE%` on Windows). Used to
+/// resolve a target software's skills root (e.g. `~/.claude/skills`) natively
+/// when no POSIX shell is available to expand `$HOME`.
+pub fn homeDir(allocator: std.mem.Allocator) ![]const u8 {
+    const userprofile = envVarOwned(allocator, "USERPROFILE");
+    defer if (userprofile) |value| allocator.free(value);
+    const home = envVarOwned(allocator, "HOME");
+    defer if (home) |value| allocator.free(value);
+    return homeDirFromEnvForOs(allocator, builtin.os.tag, .{
+        .userprofile = userprofile,
+        .home = home,
+    });
+}
+
+pub fn homeDirFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    const base = switch (os_tag) {
+        .windows => nonEmpty(env.userprofile) orelse nonEmpty(env.home) orelse return error.NoHomeDir,
+        else => nonEmpty(env.home) orelse return error.NoHomeDir,
+    };
+    return allocator.dupe(u8, base);
+}
+
 pub fn agentHistoryPath(allocator: std.mem.Allocator) ![]const u8 {
     return pathInConfigDir(allocator, "agent-history.json");
 }
@@ -577,4 +603,21 @@ test "platform dirs resolve openssh config path per OS" {
     try std.testing.expectEqualStrings(expected_linux, linux);
 
     try std.testing.expectError(error.NoOpenSshConfigPath, openSshConfigPathFromEnvForOs(allocator, .linux, .{}));
+}
+
+test "platform dirs resolve home directory per OS" {
+    const allocator = std.testing.allocator;
+
+    const windows = try homeDirFromEnvForOs(allocator, .windows, .{
+        .userprofile = "C:/Users/alice",
+        .home = "/ignored",
+    });
+    defer allocator.free(windows);
+    try std.testing.expectEqualStrings("C:/Users/alice", windows);
+
+    const linux = try homeDirFromEnvForOs(allocator, .linux, .{ .home = "/home/alice" });
+    defer allocator.free(linux);
+    try std.testing.expectEqualStrings("/home/alice", linux);
+
+    try std.testing.expectError(error.NoHomeDir, homeDirFromEnvForOs(allocator, .linux, .{}));
 }

--- a/src/skill_local_fs.zig
+++ b/src/skill_local_fs.zig
@@ -1,0 +1,360 @@
+//! Native (no-shell) implementations of the Skill Center's LOCAL-side
+//! operations: scanning a skills root and copying a skill directory. The
+//! existing flow shells out to a POSIX shell (`find`/`sha256sum`/`tar`) via
+//! `remote_file.localPosixExec`, which is unavailable on native Windows (no
+//! WSL). These `std.fs`-based equivalents let the local library show up and the
+//! local↔local transfer work on every platform. Linux/macOS keep the POSIX path
+//! (which preserves their existing hashes); this module is used only where the
+//! local host is non-POSIX.
+//!
+//! The aggregate hash here reproduces the POSIX recipe byte-for-byte so a
+//! natively-scanned library skill and a server skill scanned with the shell
+//! command compare equal:
+//!     cd <dir> && find . -type f | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1
+//! i.e. sha256( for each regular file, in bytewise-sorted "./path" order:
+//!              <lowercase-hex sha256 of file content> + "  " + "./path" + "\n" ).
+const std = @import("std");
+const skill_scan = @import("skill_scan.zig");
+
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+/// Aggregate hash of a skill directory, matching the POSIX scan recipe for the
+/// plain-ASCII filenames real skills use. `dir` must be opened iterable. Callers
+/// only invoke this on dirs that contain a SKILL.md (≥1 file), so the degenerate
+/// empty-dir case (where the shell pipeline would hash a `sha256sum </dev/null`
+/// line) never arises. Files whose paths contain whitespace, quotes, or
+/// backslashes are dropped to mirror default `xargs` word-splitting; the rarer
+/// single-quote case (which makes the shell drop all later-sorted files too) is
+/// not byte-replicated — acceptable since skills never use such names.
+pub fn aggHashHex(allocator: std.mem.Allocator, dir: std.fs.Dir) ![64]u8 {
+    const Item = struct { path: []u8, hex: [64]u8 };
+    var items: std.ArrayListUnmanaged(Item) = .empty;
+    defer {
+        for (items.items) |it| allocator.free(it.path);
+        items.deinit(allocator);
+    }
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue; // `find -type f`: regular files only
+        // The shell recipe pipes `find` through default `xargs`, which word-splits
+        // on whitespace and mangles quotes/backslashes — so a file whose path
+        // contains any of these is silently dropped from the shell's aggregate.
+        // Drop the same files here to preserve byte parity. (Real skill files are
+        // plain ASCII paths, so this never fires in practice; the rarer
+        // single-quote case, where the shell also drops every later-sorted file,
+        // is not replicated — see the doc comment.)
+        if (std.mem.indexOfAny(u8, entry.path, " \t\n'\"\\") != null) continue;
+        const hex = try sha256FileHex(entry.dir, entry.basename);
+        const path = try findStylePath(allocator, entry.path);
+        items.append(allocator, .{ .path = path, .hex = hex }) catch |e| {
+            allocator.free(path);
+            return e;
+        };
+    }
+
+    // LC_ALL=C sort == bytewise ascending on the full "./path" string.
+    std.mem.sort(Item, items.items, {}, struct {
+        fn lt(_: void, a: Item, b: Item) bool {
+            return std.mem.lessThan(u8, a.path, b.path);
+        }
+    }.lt);
+
+    var agg = Sha256.init(.{});
+    for (items.items) |it| {
+        agg.update(&it.hex);
+        agg.update("  "); // sha256sum prints TWO spaces before the filename
+        agg.update(it.path);
+        agg.update("\n");
+    }
+    var digest: [32]u8 = undefined;
+    agg.final(&digest);
+    return std.fmt.bytesToHex(digest, .lower);
+}
+
+/// `./` + the path with `/` separators (what `find .` prints). `entry.path` is
+/// relative to the walked dir and uses the platform separator (`\` on Windows).
+fn findStylePath(allocator: std.mem.Allocator, rel: []const u8) ![]u8 {
+    const out = try allocator.alloc(u8, rel.len + 2);
+    out[0] = '.';
+    out[1] = '/';
+    for (rel, 0..) |c, i| out[i + 2] = if (c == '\\') '/' else c;
+    return out;
+}
+
+fn sha256FileHex(dir: std.fs.Dir, sub_path: []const u8) ![64]u8 {
+    var file = try dir.openFile(sub_path, .{});
+    defer file.close();
+    var h = Sha256.init(.{});
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+        h.update(buf[0..n]);
+    }
+    var digest: [32]u8 = undefined;
+    h.final(&digest);
+    return std.fmt.bytesToHex(digest, .lower);
+}
+
+/// Enumerate `<root_abs>/<name>/SKILL.md` skills natively. Mirrors the POSIX
+/// location scan output: rows `{ name, rel_path = "<name>/SKILL.md", agg_hash }`,
+/// provider forced to `.claude` (v2 keys by name). Hidden dirs (`.`-prefixed)
+/// are skipped, matching the shell's `"$R"/*/` glob — this also skips the
+/// `.install-tmp` / `.wispterm-xfer` staging dirs. A missing root yields an
+/// empty slice (not an error), matching the shell's "missing root prints
+/// nothing".
+pub fn scanRows(allocator: std.mem.Allocator, root_abs: []const u8) ![]skill_scan.SkillRow {
+    var root = std.fs.openDirAbsolute(root_abs, .{ .iterate = true }) catch |e| switch (e) {
+        error.FileNotFound, error.NotDir => return allocator.alloc(skill_scan.SkillRow, 0),
+        else => return e,
+    };
+    defer root.close();
+
+    var rows: std.ArrayListUnmanaged(skill_scan.SkillRow) = .empty;
+    errdefer {
+        for (rows.items) |*r| r.deinit(allocator);
+        rows.deinit(allocator);
+    }
+
+    var it = root.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        if (entry.name.len == 0 or entry.name[0] == '.') continue;
+
+        var sd = root.openDir(entry.name, .{ .iterate = true }) catch continue;
+        defer sd.close();
+        sd.access("SKILL.md", .{}) catch continue; // no SKILL.md → not a skill
+        const hex = aggHashHex(allocator, sd) catch continue;
+
+        const name = try allocator.dupe(u8, entry.name);
+        const rel = std.fmt.allocPrint(allocator, "{s}/SKILL.md", .{entry.name}) catch |e| {
+            allocator.free(name);
+            return e;
+        };
+        const h = allocator.dupe(u8, &hex) catch |e| {
+            allocator.free(name);
+            allocator.free(rel);
+            return e;
+        };
+        rows.append(allocator, .{
+            .provider = .claude,
+            .name = name,
+            .rel_path = rel,
+            .agg_hash = h,
+        }) catch |e| {
+            allocator.free(name);
+            allocator.free(rel);
+            allocator.free(h);
+            return e;
+        };
+    }
+
+    return rows.toOwnedSlice(allocator);
+}
+
+/// Native equivalent of `skill_scan.scanLocation` for a local root. A missing
+/// root is reachable-but-empty; an unexpected error (OOM / permission) yields an
+/// unreachable outcome so the column renders `?` rather than a phantom-empty.
+pub fn scanOutcome(allocator: std.mem.Allocator, root_abs: []const u8) skill_scan.ScanOutcome {
+    const rows = scanRows(allocator, root_abs) catch {
+        return .{ .reachable = false, .rows = &.{} };
+    };
+    return .{ .reachable = true, .rows = rows };
+}
+
+/// `mkdir -p` for an absolute path (std.fs.makeDirAbsolute is single-level).
+pub fn ensureDirAbsolute(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |e| switch (e) {
+        error.PathAlreadyExists => {},
+        error.FileNotFound => {
+            const parent = std.fs.path.dirname(path) orelse return e;
+            try ensureDirAbsolute(parent);
+            std.fs.makeDirAbsolute(path) catch |e2| switch (e2) {
+                error.PathAlreadyExists => {},
+                else => return e2,
+            };
+        },
+        else => return e,
+    };
+}
+
+/// Copy every entry of `src` into `dst` (recursive). Symlinks are skipped (the
+/// scan/transfer only deals with regular skill files).
+fn copyTree(allocator: std.mem.Allocator, src: std.fs.Dir, dst: std.fs.Dir) !void {
+    var walker = try src.walk(allocator);
+    defer walker.deinit();
+    while (try walker.next()) |entry| switch (entry.kind) {
+        .directory => try dst.makePath(entry.path),
+        .file => {
+            if (std.fs.path.dirname(entry.path)) |d| try dst.makePath(d);
+            try entry.dir.copyFile(entry.basename, dst, entry.path, .{});
+        },
+        else => {},
+    };
+}
+
+/// Copy skill `name` from `<src_root>/<name>` to `<dst_root>/<name>`, atomically
+/// replacing any existing copy (stage under `<dst_root>/.wispterm-xfer`, then
+/// rename). All paths absolute. Used for local↔local deploy/import on hosts
+/// without a POSIX shell; both roots are on the same filesystem so the rename is
+/// atomic and a failed copy leaves the live skill untouched.
+pub fn transferLocalToLocal(
+    allocator: std.mem.Allocator,
+    src_root_abs: []const u8,
+    dst_root_abs: []const u8,
+    name: []const u8,
+) !void {
+    try ensureDirAbsolute(dst_root_abs);
+
+    const staging = try std.fs.path.join(allocator, &.{ dst_root_abs, ".wispterm-xfer" });
+    defer allocator.free(staging);
+    std.fs.deleteTreeAbsolute(staging) catch {};
+    defer std.fs.deleteTreeAbsolute(staging) catch {};
+
+    const staged_skill = try std.fs.path.join(allocator, &.{ staging, name });
+    defer allocator.free(staged_skill);
+    try ensureDirAbsolute(staged_skill);
+
+    const src_skill = try std.fs.path.join(allocator, &.{ src_root_abs, name });
+    defer allocator.free(src_skill);
+    {
+        var src = try std.fs.openDirAbsolute(src_skill, .{ .iterate = true });
+        defer src.close();
+        var dst = try std.fs.openDirAbsolute(staged_skill, .{});
+        defer dst.close();
+        try copyTree(allocator, src, dst);
+    } // handles closed before the swap (Windows can't rename an open dir)
+
+    const final = try std.fs.path.join(allocator, &.{ dst_root_abs, name });
+    defer allocator.free(final);
+    std.fs.deleteTreeAbsolute(final) catch {};
+    try std.fs.renameAbsolute(staged_skill, final);
+}
+
+// --- Tests ---
+
+const testing = std.testing;
+
+fn contains(rows: []skill_scan.SkillRow, name: []const u8) bool {
+    for (rows) |r| if (std.mem.eql(u8, r.name, name)) return true;
+    return false;
+}
+
+test "skill_local_fs: aggHashHex is content-sensitive and order-independent" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("s1/refs");
+    try tmp.dir.writeFile(.{ .sub_path = "s1/SKILL.md", .data = "hello" });
+    try tmp.dir.writeFile(.{ .sub_path = "s1/refs/a.md", .data = "AAA" });
+    var s1 = try tmp.dir.openDir("s1", .{ .iterate = true });
+    defer s1.close();
+    const h1 = try aggHashHex(a, s1);
+
+    // Identical content, files created in a different order → identical hash.
+    try tmp.dir.makePath("s2/refs");
+    try tmp.dir.writeFile(.{ .sub_path = "s2/refs/a.md", .data = "AAA" });
+    try tmp.dir.writeFile(.{ .sub_path = "s2/SKILL.md", .data = "hello" });
+    var s2 = try tmp.dir.openDir("s2", .{ .iterate = true });
+    defer s2.close();
+    const h2 = try aggHashHex(a, s2);
+    try testing.expectEqualSlices(u8, &h1, &h2);
+
+    // Changed content → different hash.
+    try tmp.dir.writeFile(.{ .sub_path = "s2/SKILL.md", .data = "hello!" });
+    const h3 = try aggHashHex(a, s2);
+    try testing.expect(!std.mem.eql(u8, &h1, &h3));
+}
+
+test "skill_local_fs: scanRows lists skill dirs, skips hidden and non-skill dirs" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("alpha");
+    try tmp.dir.writeFile(.{ .sub_path = "alpha/SKILL.md", .data = "a" });
+    try tmp.dir.makePath("beta");
+    try tmp.dir.writeFile(.{ .sub_path = "beta/SKILL.md", .data = "b" });
+    try tmp.dir.makePath("noskill");
+    try tmp.dir.writeFile(.{ .sub_path = "noskill/readme.md", .data = "x" });
+    try tmp.dir.makePath(".hidden");
+    try tmp.dir.writeFile(.{ .sub_path = ".hidden/SKILL.md", .data = "h" });
+
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const rows = try scanRows(a, root);
+    defer skill_scan.freeRows(a, rows);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expect(contains(rows, "alpha"));
+    try testing.expect(contains(rows, "beta"));
+    for (rows) |r| {
+        try testing.expect(r.agg_hash != null);
+        var buf: [64]u8 = undefined;
+        const want = try std.fmt.bufPrint(&buf, "{s}/SKILL.md", .{r.name});
+        try testing.expectEqualStrings(want, r.rel_path);
+    }
+}
+
+test "skill_local_fs: scanOutcome on a missing root is reachable-but-empty" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const base = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(base);
+    const missing = try std.fs.path.join(a, &.{ base, "does-not-exist" });
+    defer a.free(missing);
+
+    var outcome = scanOutcome(a, missing);
+    defer outcome.deinit(a);
+    try testing.expect(outcome.reachable);
+    try testing.expectEqual(@as(usize, 0), outcome.rows.len);
+}
+
+test "skill_local_fs: transferLocalToLocal copies and overwrites a skill dir" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("lib/pdf/refs");
+    try tmp.dir.writeFile(.{ .sub_path = "lib/pdf/SKILL.md", .data = "v1" });
+    try tmp.dir.writeFile(.{ .sub_path = "lib/pdf/refs/x.md", .data = "ref" });
+
+    const src_root = try tmp.dir.realpathAlloc(a, "lib");
+    defer a.free(src_root);
+    const base = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(base);
+    const dst_root = try std.fs.path.join(a, &.{ base, "dst" }); // created by transfer
+    defer a.free(dst_root);
+
+    try transferLocalToLocal(a, src_root, dst_root, "pdf");
+
+    {
+        var f = try tmp.dir.openFile("dst/pdf/SKILL.md", .{});
+        defer f.close();
+        const md = try f.readToEndAlloc(a, 100);
+        defer a.free(md);
+        try testing.expectEqualStrings("v1", md);
+    }
+    {
+        var f = try tmp.dir.openFile("dst/pdf/refs/x.md", .{});
+        defer f.close();
+        const rx = try f.readToEndAlloc(a, 100);
+        defer a.free(rx);
+        try testing.expectEqualStrings("ref", rx);
+    }
+
+    // Overwrite with new content.
+    try tmp.dir.writeFile(.{ .sub_path = "lib/pdf/SKILL.md", .data = "v2" });
+    try transferLocalToLocal(a, src_root, dst_root, "pdf");
+    {
+        var f = try tmp.dir.openFile("dst/pdf/SKILL.md", .{});
+        defer f.close();
+        const md2 = try f.readToEndAlloc(a, 100);
+        defer a.free(md2);
+        try testing.expectEqualStrings("v2", md2);
+    }
+}

--- a/src/skill_transfer_cmd.zig
+++ b/src/skill_transfer_cmd.zig
@@ -95,6 +95,46 @@ pub fn absRootExpr(allocator: std.mem.Allocator, abs: []const u8) ![]u8 {
     return buf.toOwnedSlice(allocator);
 }
 
+/// Staging dir name used by the native (scp -r) transfer path on both ends.
+pub const XFER_STAGING = ".wispterm-xfer";
+
+/// `D=<root>; mkdir -p "$D"; rm -rf "$D"/'.wispterm-xfer'; mkdir -p "$D"/'.wispterm-xfer'`
+/// — prepare a fresh remote staging dir for an `scp -r` upload.
+pub fn remoteStagePrepCmd(allocator: std.mem.Allocator, root_expr: []const u8) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    try buf.appendSlice(allocator, "D=");
+    try buf.appendSlice(allocator, root_expr);
+    try buf.appendSlice(allocator, "; mkdir -p \"$D\"; rm -rf \"$D\"/");
+    try appendQuoted(&buf, allocator, XFER_STAGING);
+    try buf.appendSlice(allocator, "; mkdir -p \"$D\"/");
+    try appendQuoted(&buf, allocator, XFER_STAGING);
+    return buf.toOwnedSlice(allocator);
+}
+
+/// `D=<root>; rm -rf "$D"/'<name>' && mv "$D"/'.wispterm-xfer'/'<name>' "$D"/'<name>' && rm -rf "$D"/'.wispterm-xfer'`
+/// — atomically swap the staged skill into place, then remove the staging dir.
+/// The whole chain is `&&`-joined so the command's exit status reflects the
+/// `mv` (the operation that matters): a failed mv propagates non-zero, letting
+/// the caller report failure instead of masking it behind the cleanup `rm`.
+pub fn remoteStageSwapCmd(allocator: std.mem.Allocator, root_expr: []const u8, name: []const u8) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    try buf.appendSlice(allocator, "D=");
+    try buf.appendSlice(allocator, root_expr);
+    try buf.appendSlice(allocator, "; rm -rf \"$D\"/");
+    try appendQuoted(&buf, allocator, name);
+    try buf.appendSlice(allocator, " && mv \"$D\"/");
+    try appendQuoted(&buf, allocator, XFER_STAGING);
+    try buf.append(allocator, '/');
+    try appendQuoted(&buf, allocator, name);
+    try buf.appendSlice(allocator, " \"$D\"/");
+    try appendQuoted(&buf, allocator, name);
+    try buf.appendSlice(allocator, " && rm -rf \"$D\"/");
+    try appendQuoted(&buf, allocator, XFER_STAGING);
+    return buf.toOwnedSlice(allocator);
+}
+
 // --- Tests ---
 
 test "skill_transfer_cmd: homeRootExpr + tarCreateCmd for a $HOME target" {
@@ -139,4 +179,38 @@ test "skill_transfer_cmd: catSkillMdCmd shell-escapes a tricky name" {
     const c = try catSkillMdCmd(a, root, "it's mine");
     defer a.free(c);
     try std.testing.expectEqualStrings("cat '/cfg/skills'/'it'\\''s mine'/'SKILL.md'", c);
+}
+
+test "skill_transfer_cmd: remoteStagePrepCmd makes a fresh staging dir" {
+    const a = std.testing.allocator;
+    const root = try homeRootExpr(a, ".codex/skills");
+    defer a.free(root);
+    const c = try remoteStagePrepCmd(a, root);
+    defer a.free(c);
+    try std.testing.expectEqualStrings(
+        "D=\"$HOME\"/'.codex/skills'; mkdir -p \"$D\"; rm -rf \"$D\"/'.wispterm-xfer'; mkdir -p \"$D\"/'.wispterm-xfer'",
+        c,
+    );
+}
+
+test "skill_transfer_cmd: remoteStageSwapCmd swaps staged skill into place" {
+    const a = std.testing.allocator;
+    const root = try absRootExpr(a, "/cfg/skills");
+    defer a.free(root);
+    const c = try remoteStageSwapCmd(a, root, "pdf");
+    defer a.free(c);
+    try std.testing.expectEqualStrings(
+        "D='/cfg/skills'; rm -rf \"$D\"/'pdf' && mv \"$D\"/'.wispterm-xfer'/'pdf' \"$D\"/'pdf' && rm -rf \"$D\"/'.wispterm-xfer'",
+        c,
+    );
+}
+
+test "skill_transfer_cmd: remoteStageSwapCmd shell-escapes a tricky name" {
+    const a = std.testing.allocator;
+    const root = try homeRootExpr(a, ".claude/skills");
+    defer a.free(root);
+    const c = try remoteStageSwapCmd(a, root, "it's mine");
+    defer a.free(c);
+    try std.testing.expect(std.mem.indexOf(u8, c, "'it'\\''s mine'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, c, "mv \"$D\"/'.wispterm-xfer'/'it'\\''s mine'") != null);
 }

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -760,6 +760,7 @@ comptime {
     _ = @import("skill_registry.zig");
     _ = @import("skill_scan.zig");
     _ = @import("skill_install.zig");
+    _ = @import("skill_local_fs.zig");
     _ = @import("skill_inventory.zig");
     _ = @import("skill_inventory_cache.zig");
     _ = @import("skill_center.zig");

--- a/src/test_posix.zig
+++ b/src/test_posix.zig
@@ -205,3 +205,54 @@ test "run_on_main marshals a task from a worker thread to the draining thread" {
     st.done.wait();
     try std.testing.expectEqual(@as(i32, 42), st.value);
 }
+
+test "skill_local_fs aggHashHex matches the POSIX find|sha256sum recipe byte-for-byte" {
+    const skill_local_fs = @import("skill_local_fs.zig");
+    const a = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // A skill dir with a top-level file, nested files, and a dotfile — exercises
+    // bytewise path sorting and recursion, exactly what the shell pipeline sees.
+    try tmp.dir.makePath("skill/refs");
+    try tmp.dir.writeFile(.{ .sub_path = "skill/SKILL.md", .data = "# title\nbody\n" });
+    try tmp.dir.writeFile(.{ .sub_path = "skill/z.txt", .data = "zzz" });
+    try tmp.dir.writeFile(.{ .sub_path = "skill/refs/a.md", .data = "alpha" });
+    try tmp.dir.writeFile(.{ .sub_path = "skill/refs/b.md", .data = "beta\n" });
+    try tmp.dir.writeFile(.{ .sub_path = "skill/.keep", .data = "" });
+    // A whitespace name: default `xargs` word-splits it, so the shell drops it
+    // from the aggregate — the native scan must drop it too (parity).
+    try tmp.dir.writeFile(.{ .sub_path = "skill/a b.txt", .data = "ws" });
+
+    const skill_abs = try tmp.dir.realpathAlloc(a, "skill");
+    defer a.free(skill_abs);
+
+    // Run the exact recipe the scan command uses for a skill_md target dir.
+    const script = try std.fmt.allocPrint(a,
+        \\HASHCMD="";
+        \\if command -v sha256sum >/dev/null 2>&1; then HASHCMD="sha256sum";
+        \\elif command -v shasum >/dev/null 2>&1; then HASHCMD="shasum -a 256"; fi;
+        \\if [ -z "$HASHCMD" ]; then echo NOHASH; exit 0; fi;
+        \\cd '{s}' && find . -type f | LC_ALL=C sort | xargs $HASHCMD | $HASHCMD | cut -d' ' -f1
+    , .{skill_abs});
+    defer a.free(script);
+
+    const argv = [_][]const u8{ "sh", "-c", script };
+    var child = std.process.Child.init(&argv, a);
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Ignore;
+    try child.spawn();
+    const stdout = child.stdout.?;
+    const raw = try stdout.readToEndAlloc(a, 4096);
+    defer a.free(raw);
+    _ = child.wait() catch {};
+
+    const shell_hex = std.mem.trim(u8, raw, " \t\r\n");
+    if (std.mem.eql(u8, shell_hex, "NOHASH")) return error.SkipZigTest; // no hash tool
+
+    var dir = try tmp.dir.openDir("skill", .{ .iterate = true });
+    defer dir.close();
+    const native = try skill_local_fs.aggHashHex(a, dir);
+
+    try std.testing.expectEqualStrings(shell_hex, &native);
+}


### PR DESCRIPTION
## Problem (Windows, no WSL)

The Skill Center's **local-side** operations (library scan + deploy/import transfer) shelled out to a POSIX shell (`find`/`sha256sum`/`tar`) and a hardcoded `/tmp` staging path — all unavailable on native Windows without WSL (`localPosixExec` → `error.Unreachable`). One root cause produced three reported symptoms:

- **GitHub-installed skills never appeared** — files were written fine via `std.fs`, but the refresh **scan** returned empty, so `model.library` stayed empty.
- **Local sync → "can't connect to the selected server"** — the local→local `tar` failed; `.failed` mapped to the misleading no-conn toast.
- **Server sync → SCP `/tmp/.wispterm-skill.tgz` not found** — the `/tmp` staging path doesn't exist on Windows.

## Fix (native; Linux/macOS path unchanged)

Native `std.fs` equivalents are used **only when no POSIX shell is available** (`!remote_file.localPosixExecSupported()`); Linux/macOS keep the existing POSIX path byte-for-byte.

- **`src/skill_local_fs.zig`** (new) — native library/location scan whose aggregate hash reproduces the shell recipe `find -type f | LC_ALL=C sort | xargs sha256sum | sha256sum` **byte-for-byte** (incl. dropping whitespace/quote/backslash filenames like default `xargs`), plus a local→local directory copy with atomic swap. A posix gold test shells out and proves hash parity.
- **`AppWindow`** — `skillCenterScanOutcome` selects remote-ssh / local-posix / local-native; the three scan jobs + `SkillTransferJob` carry raw local paths; transfer branches to a native path on non-POSIX hosts (local↔local via `std.fs`; local↔remote via `scp -r` into a `.wispterm-xfer` staging dir + ssh stage/swap — no `/tmp`, no local `tar`).
- scp's default **SFTP protocol does not shell-expand** a `"$HOME"`/quoted remote spec, so the absolute remote home is resolved via ssh `printf %s "$HOME"` and scp gets a clean literal path; `remoteStageSwapCmd` is `&&`-joined end-to-end so a failed `mv` reports failure instead of being masked by the cleanup `rm`.
- `platform_dirs.homeDir` resolver; pure, unit-tested stage/swap builders in `skill_transfer_cmd.zig`.

## Verification

`zig build`, `zig build test`, `zig build test-full`, and `zig build -Dtarget=x86_64-windows-gnu` all pass. Reviewed by a multi-agent adversarial pass (3 findings, all fixed). **Needs a real Windows GUI smoke test** of: install-from-GitHub → skill shows; local deploy/import; server (SSH) deploy/import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)