### PR TITLE
fix(skill-center): native SKILL.md preview on Windows (no shell cat)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2161,12 +2161,20 @@ fn skillCenterPreviewServerSkill(allocator: std.mem.Allocator) void {
         allocator.free(name);
         return;
     };
+    // Absolute SKILL.md path for a LOCAL target so the worker can read it
+    // natively on a non-POSIX host; null for remote (uses the ssh cat cmd).
+    const local_md_path: ?[]u8 = if (target.is_local) blk: {
+        const root = skillCenterLocalRootPath(allocator, target.software) orelse break :blk null;
+        defer allocator.free(root);
+        break :blk std.fs.path.join(allocator, &.{ root, name, "SKILL.md" }) catch null;
+    } else null;
     const job = allocator.create(SkillPreviewJob) catch {
         allocator.free(name);
         allocator.free(cmd);
+        if (local_md_path) |p| allocator.free(p);
         return;
     };
-    job.* = .{ .conn = conn, .name = name, .cmd = cmd };
+    job.* = .{ .conn = conn, .name = name, .cmd = cmd, .local_md_path = local_md_path };
     if (!session.startOp(.{ .ctx = job, .run = SkillPreviewJob.run, .destroy = SkillPreviewJob.destroy }, window_backend.postWakeup, i18n.s().sc_busy_loading)) {
         SkillPreviewJob.destroy(@ptrCast(job), allocator);
         overlays.showStatusToast(i18n.s().sc_toast_op_busy);
@@ -2378,9 +2386,9 @@ pub fn skillCenterPreviewSelected() bool {
     defer allocator.free(lib_dir);
     const abs = std.fs.path.join(allocator, &.{ lib_dir, rp }) catch return true;
     defer allocator.free(abs);
-    const command = skill_center.catCommand(allocator, abs) catch return true;
-    defer allocator.free(command);
-    const text = remote_file.localPosixExec(allocator, command, 1024 * 1024) catch null;
+    // Read the library file directly (no shell): the library is always a local
+    // absolute path, and `cat` via localPosixExec is unavailable on Windows.
+    const text = skill_local_fs.readFileAllocAbsolute(allocator, abs, 1024 * 1024) catch null;
     if (text) |t| {
         defer allocator.free(t);
         openSkillMdInPreviewLeaf(allocator, name_buf[0..name_len], t);
@@ -3024,12 +3032,22 @@ const SkillPreviewJob = struct {
     conn: ?ssh_connection.SshConnection,
     name: []u8, // owned — becomes the preview title
     cmd: []u8, // owned — `cat <root>/'<name>'/'SKILL.md'`
+    local_md_path: ?[]u8, // owned absolute SKILL.md path for a LOCAL target (native read)
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillPreviewJob = @ptrCast(@alignCast(ctx));
-        var le = SkillLocExec{ .conn = job.conn };
-        const host = le.host();
-        const content = host.exec(host.ctx, allocator, job.cmd) catch return .failed;
+        // Local target on a non-POSIX host (Windows): read SKILL.md natively;
+        // `cat` via localPosixExec is unavailable. Remote/posix use the shell cmd.
+        const content = if (job.conn == null and !remote_file.localPosixExecSupported())
+            blk: {
+                const p = job.local_md_path orelse return .failed;
+                break :blk skill_local_fs.readFileAllocAbsolute(allocator, p, 1024 * 1024) catch return .failed;
+            }
+        else blk: {
+            var le = SkillLocExec{ .conn = job.conn };
+            const host = le.host();
+            break :blk host.exec(host.ctx, allocator, job.cmd) catch return .failed;
+        };
         const title = allocator.dupe(u8, job.name) catch {
             allocator.free(content);
             return .failed;
@@ -3040,6 +3058,7 @@ const SkillPreviewJob = struct {
         const job: *SkillPreviewJob = @ptrCast(@alignCast(ctx));
         allocator.free(job.name);
         allocator.free(job.cmd);
+        if (job.local_md_path) |p| allocator.free(p);
         allocator.destroy(job);
     }
 };

--- a/src/skill_local_fs.zig
+++ b/src/skill_local_fs.zig
@@ -233,6 +233,15 @@ pub fn transferLocalToLocal(
     try std.fs.renameAbsolute(staged_skill, final);
 }
 
+/// Read an absolute local file into an owned buffer (capped at `max_bytes`).
+/// Used to preview a local skill's SKILL.md without a shell — `cat` via
+/// localPosixExec is unavailable on native Windows. Works on every platform.
+pub fn readFileAllocAbsolute(allocator: std.mem.Allocator, abs_path: []const u8, max_bytes: usize) ![]u8 {
+    var file = try std.fs.openFileAbsolute(abs_path, .{});
+    defer file.close();
+    return file.readToEndAlloc(allocator, max_bytes);
+}
+
 // --- Tests ---
 
 const testing = std.testing;
@@ -312,6 +321,18 @@ test "skill_local_fs: scanOutcome on a missing root is reachable-but-empty" {
     defer outcome.deinit(a);
     try testing.expect(outcome.reachable);
     try testing.expectEqual(@as(usize, 0), outcome.rows.len);
+}
+
+test "skill_local_fs: readFileAllocAbsolute reads a file by absolute path" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "SKILL.md", .data = "# hi\nbody\n" });
+    const abs = try tmp.dir.realpathAlloc(a, "SKILL.md");
+    defer a.free(abs);
+    const text = try readFileAllocAbsolute(a, abs, 1024);
+    defer a.free(text);
+    try testing.expectEqualStrings("# hi\nbody\n", text);
 }
 
 test "skill_local_fs: transferLocalToLocal copies and overwrites a skill dir" {


### PR DESCRIPTION
## Problem

On Windows (no WSL), previewing a skill's SKILL.md failed with **"Couldn't read SKILL.md"**. Both preview paths read the file by shelling out `cat` via `remote_file.localPosixExec`, which returns `error.Unreachable` on native Windows — the same root cause as the scan/transfer cross-platform fix (#220).

- **Library preview** (`skillCenterPreviewSelected`) → the `sc_toast_read_failed` toast the user saw.
- **Import-list preview** of a *local* target (`SkillPreviewJob`) → same flaw.

## Fix

A local absolute file needs no shell on any platform — read it directly with `std.fs`:

- **`skill_local_fs.readFileAllocAbsolute`** — open + `readToEndAlloc` by absolute path (unit-tested).
- **`skillCenterPreviewSelected`** (library) — reads `<lib>/<name>/SKILL.md` natively instead of `cat` via `localPosixExec`.
- **`SkillPreviewJob`** — for a **local** target on a non-POSIX host, reads the absolute SKILL.md path natively; remote (SSH) and POSIX hosts keep the existing `cat` path unchanged.

## Verification

`zig build`, `zig build test`, `zig build test-full`, `zig build -Dtarget=x86_64-windows-gnu` all pass. **Needs a Windows GUI smoke test**: preview a library skill, and (optional) preview a local import-target skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)