### PR TITLE
fix(wsl): detect WSL by installed distro; stop spawning wsl.exe for SSH cwds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,7 @@ const linux_system_libraries = [_][]const u8{ "SDL3", "fontconfig" };
 
 const windows_system_libraries = [_][]const u8{
     "user32",
+    "advapi32", // registry access for WSL availability detection
     "gdi32",
     "gdiplus",
     "dwmapi",

--- a/src/App.zig
+++ b/src/App.zig
@@ -178,7 +178,18 @@ fn freeOptStr(allocator: std.mem.Allocator, s: ?[]const u8) void {
 }
 
 pub fn resolveShellCommandLine(out_buf: *platform_pty_command.CommandLineBuffer, cmd: []const u8) usize {
-    return platform_pty_command.resolveShellCommandLine(out_buf, cmd);
+    const len = platform_pty_command.resolveShellCommandLine(out_buf, cmd);
+    // shell=wsl (or any custom command that resolves to wsl.exe) is only honored
+    // when a WSL distro is actually installed. Otherwise fall back to a
+    // guaranteed local shell so the default tab does not spawn a broken wsl.exe
+    // pane that splits would then propagate.
+    if (platform_pty_command.shellFallBackDecision(
+        platform_pty_command.launchKindForCommand(out_buf[0..len :0]),
+        platform_pty_command.wslAvailable(),
+    )) {
+        return platform_pty_command.resolveShellCommandLine(out_buf, platform_pty_command.guaranteedLocalShellCommand());
+    }
+    return len;
 }
 
 /// Initialize the App with configuration.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2966,7 +2966,7 @@ fn clearUiStateOnTabChange() void {
 fn getActiveCwd(cwd_buf: *platform_pty_command.CwdBuffer) platform_pty_command.Cwd {
     if (tab.activeSurface()) |surface| {
         if (surface.getCwd()) |guest_path| {
-            if (platform_wsl.guestPathToNativeCwd(guest_path, cwd_buf)) |cwd| {
+            if (platform_wsl.nativeCwdForLaunchKind(surface.launch_kind, guest_path, cwd_buf)) |cwd| {
                 return platform_pty_command.cwdFromBuffer(cwd_buf, cwd.len);
             }
         }

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -107,10 +107,6 @@ pub const NewAgentLaunchAction = enum {
     connect_default_profile_as_agent,
 };
 
-pub const SESSION_LAUNCHER_ROW_COUNT: usize = platform_pty_command.session_launcher_row_count;
-pub const SESSION_LAUNCHER_ROW_AI_AGENT: usize = platform_pty_command.session_launcher_ai_agent_row;
-pub const SESSION_LAUNCHER_ROW_AI_HISTORY: usize = platform_pty_command.session_launcher_ai_history_row;
-
 pub const State = struct {
     command_palette_visible: bool = false,
     command_palette_selected: usize = 0,

--- a/src/input.zig
+++ b/src/input.zig
@@ -1589,7 +1589,7 @@ fn requestNewWindowFromActiveCwd() void {
     if (AppWindow.activeSurface()) |surface| {
         if (surface.getCwd()) |guest_path| {
             std.debug.print("CWD from OSC 7: {s}\n", .{guest_path});
-            if (platform_wsl.guestPathToNativeCwd(guest_path, &cwd_buf)) |native_cwd| {
+            if (platform_wsl.nativeCwdForLaunchKind(surface.launch_kind, guest_path, &cwd_buf)) |native_cwd| {
                 cwd = native_cwd;
                 var path_u8: [260]u8 = undefined;
                 var display_buf: platform_pty_command.CwdBuffer = undefined;

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -118,46 +118,51 @@ pub fn sessionLauncherDetailForOs(os_tag: std.Target.Os.Tag) []const u8 {
 }
 
 pub fn sessionLauncherRowCount() usize {
-    return session_launcher_row_count;
+    return sessionLauncherRowCountForLayout(sessionLauncherWslRow() != null);
 }
 
-pub const session_launcher_row_count = sessionLauncherRowCountForOs(builtin.os.tag);
+/// Row count given whether a WSL row is shown. Without WSL the launcher is
+/// Shell(0)/SSH(1)/Copilot(2)/Sessions(3); with WSL it is inserted at index 2
+/// and Copilot/Sessions shift down to 3/4.
+pub fn sessionLauncherRowCountForLayout(wsl_present: bool) usize {
+    return if (wsl_present) 5 else 4;
+}
 
 pub fn sessionLauncherRowCountForOs(os_tag: std.Target.Os.Tag) usize {
-    return switch (backendForOs(os_tag)) {
-        .windows => 5,
-        .unsupported => 4,
-    };
+    return sessionLauncherRowCountForLayout(backendForOs(os_tag) == .windows);
 }
 
 pub fn sessionLauncherAiAgentRow() usize {
-    return session_launcher_ai_agent_row;
+    return sessionLauncherAiAgentRowForLayout(sessionLauncherWslRow() != null);
 }
 
-pub const session_launcher_ai_agent_row = sessionLauncherAiAgentRowForOs(builtin.os.tag);
+pub fn sessionLauncherAiAgentRowForLayout(wsl_present: bool) usize {
+    return if (wsl_present) 3 else 2;
+}
 
 pub fn sessionLauncherAiAgentRowForOs(os_tag: std.Target.Os.Tag) usize {
-    return switch (backendForOs(os_tag)) {
-        .windows => 3,
-        .unsupported => 2,
-    };
+    return sessionLauncherAiAgentRowForLayout(backendForOs(os_tag) == .windows);
 }
 
 pub fn sessionLauncherAiHistoryRow() usize {
-    return session_launcher_ai_history_row;
+    return sessionLauncherAiHistoryRowForLayout(sessionLauncherWslRow() != null);
 }
 
-pub const session_launcher_ai_history_row = sessionLauncherAiHistoryRowForOs(builtin.os.tag);
+pub fn sessionLauncherAiHistoryRowForLayout(wsl_present: bool) usize {
+    return if (wsl_present) 4 else 3;
+}
 
 pub fn sessionLauncherAiHistoryRowForOs(os_tag: std.Target.Os.Tag) usize {
-    return switch (backendForOs(os_tag)) {
-        .windows => 4,
-        .unsupported => 3,
-    };
+    return sessionLauncherAiHistoryRowForLayout(backendForOs(os_tag) == .windows);
 }
 
+/// The WSL launcher row index, or null when WSL should not be offered. WSL is
+/// only offered on Windows AND when an installed distribution is detected, so a
+/// machine without WSL never shows the row — and therefore can never create a
+/// `.wsl` surface that splits would propagate.
 pub fn sessionLauncherWslRow() ?usize {
-    return sessionLauncherWslRowForOs(builtin.os.tag);
+    const slot = sessionLauncherWslRowForOs(builtin.os.tag) orelse return null;
+    return if (wslAvailable()) slot else null;
 }
 
 pub fn sessionLauncherWslRowForOs(os_tag: std.Target.Os.Tag) ?usize {
@@ -165,6 +170,21 @@ pub fn sessionLauncherWslRowForOs(os_tag: std.Target.Os.Tag) ?usize {
         .windows => 2,
         .unsupported => null,
     };
+}
+
+/// Whether a usable WSL installation (at least one installed distribution) is
+/// present. Probed once and cached by the platform backend; always false on
+/// non-Windows. Note: on Windows 10/11 the `wsl.exe` stub ships in System32
+/// even with no distro installed, so this checks for an installed distro rather
+/// than the executable's mere existence.
+pub fn wslAvailable() bool {
+    return impl.wslAvailable();
+}
+
+/// Whether a resolved shell command should fall back to a guaranteed local
+/// shell because it targets WSL while no WSL installation is available.
+pub fn shellFallBackDecision(kind: LaunchKind, wsl_available: bool) bool {
+    return kind == .wsl and !wsl_available;
 }
 
 pub fn wslSessionToolsEnabled() bool {
@@ -649,6 +669,29 @@ test "platform pty command exposes session launcher layout by target OS" {
     try std.testing.expect(!wslSessionToolsEnabledForOs(.linux));
     try std.testing.expect(std.mem.indexOf(u8, terminalSelectToolDescriptionForOs(.windows), wslSessionToolName()) != null);
     try std.testing.expect(std.mem.indexOf(u8, terminalSelectToolDescriptionForOs(.linux), wslSessionToolName()) == null);
+}
+
+test "platform pty command derives session launcher layout from WSL presence" {
+    // With a WSL row present: Shell(0) SSH(1) WSL(2) Copilot(3) Sessions(4).
+    try std.testing.expectEqual(@as(usize, 5), sessionLauncherRowCountForLayout(true));
+    try std.testing.expectEqual(@as(usize, 3), sessionLauncherAiAgentRowForLayout(true));
+    try std.testing.expectEqual(@as(usize, 4), sessionLauncherAiHistoryRowForLayout(true));
+
+    // No WSL row: Shell(0) SSH(1) Copilot(2) Sessions(3) — the rows below it
+    // shift up so nothing maps to a hidden/absent WSL slot.
+    try std.testing.expectEqual(@as(usize, 4), sessionLauncherRowCountForLayout(false));
+    try std.testing.expectEqual(@as(usize, 2), sessionLauncherAiAgentRowForLayout(false));
+    try std.testing.expectEqual(@as(usize, 3), sessionLauncherAiHistoryRowForLayout(false));
+}
+
+test "platform pty command falls back from an unavailable WSL shell" {
+    // shell=wsl is only honored when WSL is actually available; otherwise the
+    // default tab must fall back to a guaranteed local shell rather than spawn
+    // a broken wsl.exe pane.
+    try std.testing.expect(shellFallBackDecision(.wsl, false));
+    try std.testing.expect(!shellFallBackDecision(.wsl, true));
+    try std.testing.expect(!shellFallBackDecision(.local, false));
+    try std.testing.expect(!shellFallBackDecision(.ssh, false));
 }
 
 test "platform pty command exposes OpenSSH helper executable names" {

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -157,6 +157,10 @@ pub fn tabCommandForKind(kind: []const u8, current_shell: CommandLine) ![]const 
     return error.InvalidTabKind;
 }
 
+pub fn wslAvailable() bool {
+    return false;
+}
+
 pub fn wslInteractiveCommand(buf: []u8, cwd: ?[]const u8) ?[]const u8 {
     _ = buf;
     _ = cwd;

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -267,6 +267,39 @@ fn appendCommandLineQuotedArg(buf: []u8, pos: *usize, arg: []const u8) bool {
     return true;
 }
 
+threadlocal var g_wsl_available_cached: bool = false;
+threadlocal var g_wsl_available_value: bool = false;
+
+/// Whether WSL has at least one installed distribution.
+///
+/// Detected by reading the per-user `Lxss` registry key that WSL populates when
+/// a distro is registered — NOT by spawning `wsl.exe`. On a machine that only
+/// has the System32 `wsl.exe` stub (WSL feature not installed), running any
+/// `wsl.exe` subcommand pops an interactive "press a key to install WSL" window
+/// and blocks for up to 60s, which would freeze app startup. The registry probe
+/// is silent, non-blocking, and spawns no process. Cached after the first call.
+pub fn wslAvailable() bool {
+    if (g_wsl_available_cached) return g_wsl_available_value;
+    g_wsl_available_cached = true;
+    g_wsl_available_value = probeWslInstalledDistro();
+    return g_wsl_available_value;
+}
+
+fn probeWslInstalledDistro() bool {
+    const advapi32 = windows.advapi32;
+    const subkey = std.unicode.utf8ToUtf16LeStringLiteral("Software\\Microsoft\\Windows\\CurrentVersion\\Lxss");
+    var hkey: windows.HKEY = undefined;
+    if (advapi32.RegOpenKeyExW(windows.HKEY_CURRENT_USER, subkey, 0, windows.KEY_READ, &hkey) != 0) {
+        return false;
+    }
+    defer _ = advapi32.RegCloseKey(hkey);
+    // `DefaultDistribution` (a distro GUID) exists only while at least one distro
+    // is registered; WSL removes it once the last distro is unregistered. Passing
+    // null data/size queries the value's mere existence.
+    const value_name = std.unicode.utf8ToUtf16LeStringLiteral("DefaultDistribution");
+    return advapi32.RegQueryValueExW(hkey, value_name, null, null, null, null) == 0;
+}
+
 pub fn wslInteractiveCommand(buf: []u8, cwd: ?[]const u8) ?[]const u8 {
     var pos: usize = 0;
     if (!appendAscii(buf, &pos, "wsl.exe")) return null;

--- a/src/platform/wsl.zig
+++ b/src/platform/wsl.zig
@@ -72,6 +72,22 @@ fn guestPathToHostPath(guest_path: []const u8, out: *[260]u16) ?usize {
     return guestPathToNativePath(guest_path, out);
 }
 
+/// Convert a surface's reported cwd to a native Windows cwd, but ONLY for WSL
+/// surfaces. SSH surfaces report REMOTE paths (e.g. `/home/...`) that must never
+/// be treated as WSL guest paths: doing so calls `defaultDistroName()`, which
+/// spawns `wsl.exe --list` to resolve a `\\wsl.localhost\<distro>\` path. On a
+/// machine without WSL that pops a blocking "install WSL" window (freeze); on a
+/// machine with WSL it adds first-call latency. Local surfaces already carry
+/// native paths and need no guest conversion here.
+pub fn nativeCwdForLaunchKind(
+    launch_kind: platform_pty_command.LaunchKind,
+    guest_path: []const u8,
+    out: *platform_pty_command.CwdBuffer,
+) ?platform_pty_command.CwdSlice {
+    if (launch_kind != .wsl) return null;
+    return guestPathToNativeCwd(guest_path, out);
+}
+
 pub fn guestPathToNativeCwd(guest_path: []const u8, out: *platform_pty_command.CwdBuffer) ?platform_pty_command.CwdSlice {
     const len = guestPathToNativePath(guest_path, out) orelse return null;
     _ = platform_pty_command.cwdFromBuffer(out, len) orelse return null;
@@ -168,4 +184,18 @@ test "platform WSL exposes converted local paths as UTF-8" {
 
     const local = guestPathToLocalPathUtf8("/mnt/c/Users/me/project", &native_buf, &utf8_buf).?;
     try std.testing.expectEqualStrings("C:\\Users\\me\\project", local);
+}
+
+test "platform WSL only converts cwd for WSL surfaces" {
+    var buf: platform_pty_command.CwdBuffer = undefined;
+
+    // SSH surfaces report REMOTE paths (e.g. /home/...). Treating them as WSL
+    // guest paths would call defaultDistroName() -> spawn `wsl.exe --list`,
+    // which freezes on machines without WSL and lags on machines with it.
+    try std.testing.expect(nativeCwdForLaunchKind(.ssh, "/home/xzg/project", &buf) == null);
+    try std.testing.expect(nativeCwdForLaunchKind(.local, "/home/xzg/project", &buf) == null);
+
+    // A genuine WSL surface still converts a mounted path (the /mnt/ branch
+    // needs no distro probe, so this is spawn-free).
+    try std.testing.expect(nativeCwdForLaunchKind(.wsl, "/mnt/c/Users/me", &buf) != null);
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1970,8 +1970,8 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
             return;
         }
         switch (ev.key) {
-            .arrow_down, .tab => g_session_launcher_selected = (g_session_launcher_selected + 1) % command_center_state.SESSION_LAUNCHER_ROW_COUNT,
-            .arrow_up => g_session_launcher_selected = if (g_session_launcher_selected == 0) command_center_state.SESSION_LAUNCHER_ROW_COUNT - 1 else g_session_launcher_selected - 1,
+            .arrow_down, .tab => g_session_launcher_selected = (g_session_launcher_selected + 1) % platform_pty_command.sessionLauncherRowCount(),
+            .arrow_up => g_session_launcher_selected = if (g_session_launcher_selected == 0) platform_pty_command.sessionLauncherRowCount() - 1 else g_session_launcher_selected - 1,
             .enter => runSessionLauncherRow(g_session_launcher_selected),
             .key_p => {
                 g_session_launcher_selected = 0;
@@ -1988,11 +1988,11 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
                 }
             },
             .key_a => {
-                g_session_launcher_selected = command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT;
+                g_session_launcher_selected = platform_pty_command.sessionLauncherAiAgentRow();
                 runSessionLauncherRow(g_session_launcher_selected);
             },
             .key_h => {
-                g_session_launcher_selected = command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY;
+                g_session_launcher_selected = platform_pty_command.sessionLauncherAiHistoryRow();
                 runSessionLauncherRow(g_session_launcher_selected);
             },
             else => {},
@@ -2149,9 +2149,9 @@ fn runSessionLauncherRow(row: usize) void {
             return;
         }
     }
-    if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT) {
+    if (row == platform_pty_command.sessionLauncherAiAgentRow()) {
         openDefaultAiSession();
-    } else if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY) {
+    } else if (row == platform_pty_command.sessionLauncherAiHistoryRow()) {
         openAiHistorySourcePicker();
     }
 }
@@ -3822,7 +3822,7 @@ fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) Session
     else if (g_ssh_list_visible)
         sshListRowCount()
     else
-        command_center_state.SESSION_LAUNCHER_ROW_COUNT;
+        platform_pty_command.sessionLauncherRowCount();
     const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(row_count)) + bottom_pad);
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
@@ -3884,15 +3884,15 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
     }
 
     if (!g_ssh_form_visible and !g_ai_form_visible) {
-        if (row >= command_center_state.SESSION_LAUNCHER_ROW_COUNT) return null;
+        if (row >= platform_pty_command.sessionLauncherRowCount()) return null;
         g_session_launcher_selected = row;
         if (row == 0) return .local_shell;
         if (row == 1) return .ssh;
         if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
             if (row == wsl_row) return .wsl;
         }
-        if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT) return .ai_chat;
-        if (row == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY) return .ai_history;
+        if (row == platform_pty_command.sessionLauncherAiAgentRow()) return .ai_chat;
+        if (row == platform_pty_command.sessionLauncherAiHistoryRow()) return .ai_history;
         return null;
     }
 
@@ -4111,8 +4111,8 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
             renderSessionRow(layout, window_height, row, "WSL", platform_pty_command.wslLauncherDetail(), g_session_launcher_selected == row);
             row += 1;
         }
-        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT, i18n.s().sl_ai_agent, defaultAiModeLabel(), g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_AGENT);
-        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY, i18n.s().sl_sessions, i18n.s().sl_sessions_detail, g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_AI_HISTORY);
+        renderSessionRow(layout, window_height, platform_pty_command.sessionLauncherAiAgentRow(), i18n.s().sl_ai_agent, defaultAiModeLabel(), g_session_launcher_selected == platform_pty_command.sessionLauncherAiAgentRow());
+        renderSessionRow(layout, window_height, platform_pty_command.sessionLauncherAiHistoryRow(), i18n.s().sl_sessions, i18n.s().sl_sessions_detail, g_session_launcher_selected == platform_pty_command.sessionLauncherAiHistoryRow());
         return;
     }
 


### PR DESCRIPTION
## Problem

On Windows machines **without a usable WSL install** (only the System32 `wsl.exe` stub, or the WSL feature not updated), wispterm could pop a blocking *"press a key to install WSL"* console window and **freeze**; on machines **with** WSL it added noticeable latency to the first SSH session ("先起 wsl 再 ssh").

Two independent code paths were spawning `wsl.exe` implicitly.

### 1. cwd path conversion (the real cause of "Ctrl+Shift+O in an SSH tab pops wsl.exe")
`getActiveCwd` (split / new pane) and `requestNewWindowFromActiveCwd` (new window) fed **any** surface's reported cwd to the WSL guest→native path converter. An SSH surface reports a **remote** path (e.g. `/home/user`), which was treated as a WSL guest path and triggered `defaultDistroName()` → `wsl.exe --list` to resolve a `\\wsl.localhost\<distro>` path.
- Without WSL → blocking install prompt → **freeze**.
- With WSL → `wsl.exe --list` spins up LXSS → **first-SSH lag**.

**Fix:** new `nativeCwdForLaunchKind` only converts a cwd for `.wsl` surfaces.

### 2. WSL availability was never detected
The session launcher always offered WSL on Windows with no detection, and an initial spawn-based probe (`wsl.exe --list`) itself popped the install window at startup.

**Fix:** WSL availability is detected by reading the per-user `Lxss` registry key — no process, no window, non-blocking, cached. It gates:
- the launcher **WSL row + `w` shortcut**,
- the **AI History WSL source** row,
- a **default-shell fallback** (`shell = wsl` resolves to a guaranteed local shell when WSL is unavailable).

With the row hidden and the shell fallback, no `.wsl` surface can be created on a WSL-less machine, so splits never propagate `wsl.exe`.

## Notes
- Launcher row count/indices now derive at runtime from WSL presence instead of comptime OS constants.
- Pure helpers (`sessionLauncher*ForLayout`, `shellFallBackDecision`, `nativeCwdForLaunchKind`) are unit tested.
- The registry probe + launcher wiring are platform glue.

## Testing
- `zig build test` ✅
- `zig build test-full` (windows-gnu) ✅
- ReleaseFast cross-build ✅
- ⚠️ **Windows GUI verification pending** (cross-compiled from WSL): confirm (a) no `wsl.exe` window at startup, (b) SSH-tab Ctrl+Shift+O no longer freezes/pops wsl on a no-WSL machine, (c) no first-SSH lag on a WSL machine, (d) WSL panes still work when WSL is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)