### PR TITLE
feat(skill-center): add WSL as a deploy/sync target on Windows

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1812,12 +1812,15 @@ fn downloadSelectedSkillsToLibrary(
     return .{ .installed = installed, .overwritten = overwritten, .failed = failed };
 }
 
-/// ExecHost over a location: local POSIX, or SSH when a conn is present.
+/// ExecHost over a location: local POSIX, SSH when a conn is present, or the
+/// default WSL distro (`wsl.exe --exec sh -lc`) when `is_wsl` is set.
 const SkillLocExec = struct {
     conn: ?ssh_connection.SshConnection,
+    is_wsl: bool = false,
     fn exec(ctx: *anyopaque, allocator: std.mem.Allocator, command: []const u8) anyerror![]u8 {
         const self: *SkillLocExec = @ptrCast(@alignCast(ctx));
         if (self.conn) |c| return remote_file.sshExecCapture(allocator, c, command);
+        if (self.is_wsl) return remote_file.wslExec(allocator, command) orelse error.RemoteExecFailed;
         return remote_file.localPosixExec(allocator, command, 4 * 1024 * 1024);
     }
     fn host(self: *SkillLocExec) skill_scan.ExecHost {
@@ -1845,20 +1848,27 @@ fn skillCenterLocalRootPath(allocator: std.mem.Allocator, software: skill_center
 
 /// Scan a skills endpoint, picking the right backend:
 ///   - remote (conn set): the POSIX `find`/`sha256sum` command over SSH.
+///   - WSL (`is_wsl`): the same command via `wsl.exe --exec sh -lc`.
 ///   - local on a POSIX host: the same command via `sh -c` (preserves the
 ///     existing Linux/macOS hashes).
 ///   - local on a non-POSIX host (Windows, no WSL): a native `std.fs` scan whose
 ///     aggregate hash matches the POSIX recipe byte-for-byte.
-/// `root_expr` is the shell root expression (for the SSH/POSIX paths);
+/// `root_expr` is the shell root expression (for the SSH/POSIX/WSL paths);
 /// `local_path` is the raw absolute root (for the native path; null when remote).
 fn skillCenterScanOutcome(
     allocator: std.mem.Allocator,
     root_expr: []const u8,
     local_path: ?[]const u8,
     conn: ?ssh_connection.SshConnection,
+    is_wsl: bool,
 ) skill_scan.ScanOutcome {
     if (conn) |c| {
         var le = SkillLocExec{ .conn = c };
+        return skill_scan.scanLocation(allocator, root_expr, le.host()) catch
+            return .{ .reachable = false, .rows = &.{} };
+    }
+    if (is_wsl) {
+        var le = SkillLocExec{ .conn = null, .is_wsl = true };
         return skill_scan.scanLocation(allocator, root_expr, le.host()) catch
             return .{ .reachable = false, .rows = &.{} };
     }
@@ -1871,10 +1881,14 @@ fn skillCenterScanOutcome(
     return skill_local_fs.scanOutcome(allocator, lp);
 }
 
-/// Adapts skill_transfer.Ops onto local/ssh/scp. conn null → a local-only target.
+/// Adapts skill_transfer.Ops onto local/ssh/scp/WSL. conn null + !is_wsl → a
+/// local-only target; is_wsl → both endpoints reached via `wsl.exe` (see
+/// `wslSkillTransfer`, where the library lives under /mnt/<drive> and the target
+/// under $HOME, so the copy primitive is never invoked).
 /// `err_buf`/`err_len` capture the last ssh error summary for the UI toast.
 const SkillTransferCtx = struct {
     conn: ?ssh_connection.SshConnection,
+    is_wsl: bool = false,
     // Sized off ssh_error.MAX (+ margin) so a summary never gets re-truncated here.
     err_buf: [ssh_error.MAX + 40]u8 = undefined,
     err_len: usize = 0,
@@ -1889,11 +1903,22 @@ const SkillTransferCtx = struct {
     }
 
     fn localExec(ctx: *anyopaque, allocator: std.mem.Allocator, command: []const u8) bool {
-        _ = ctx;
+        const self: *SkillTransferCtx = @ptrCast(@alignCast(ctx));
+        // A WSL transfer runs every step (tar/extract/cleanup) over `wslExec`;
+        // skill_transfer only calls localExec for the LOCAL_TMP cleanup, whose
+        // path lives in the WSL /tmp and is already removed by the remoteExec
+        // `rm`. A no-op keeps that ignored cleanup from spuriously failing.
+        if (self.is_wsl) return true;
         return remote_file.localPosixExecOk(allocator, command);
     }
     fn remoteExec(ctx: *anyopaque, allocator: std.mem.Allocator, command: []const u8) bool {
         const self: *SkillTransferCtx = @ptrCast(@alignCast(ctx));
+        if (self.is_wsl) {
+            // Default WSL distro; stdout discarded (only exit status matters).
+            const out = remote_file.wslExec(allocator, command) orelse return false;
+            allocator.free(out);
+            return true;
+        }
         const c = self.conn orelse return false;
         // stdout is discarded; remoteExec only cares about exit status + stderr.
         var cap = remote_file.sshExecCaptureFull(allocator, c, command) catch return false;
@@ -1963,7 +1988,7 @@ fn skillCenterMakeImportState(allocator: std.mem.Allocator, model: *const skill_
     };
 }
 
-fn skillCenterAddMachine(allocator: std.mem.Allocator, labels: *std.ArrayListUnmanaged([]u8), targets: *std.ArrayListUnmanaged(skill_center.Target), machine_id: []const u8, machine_label: []const u8, is_local: bool) !void {
+fn skillCenterAddMachine(allocator: std.mem.Allocator, labels: *std.ArrayListUnmanaged([]u8), targets: *std.ArrayListUnmanaged(skill_center.Target), machine_id: []const u8, machine_label: []const u8, is_local: bool, is_wsl: bool) !void {
     const sws = [_]skill_center.Software{ .claude, .codex };
     for (sws) |sw| {
         const sw_label = switch (sw) {
@@ -1978,6 +2003,7 @@ fn skillCenterAddMachine(allocator: std.mem.Allocator, labels: *std.ArrayListUnm
             return e;
         };
         var tgt = try skill_center.Target.dupe(allocator, machine_id, machine_label, sw, is_local);
+        tgt.is_wsl = is_wsl;
         targets.append(allocator, tgt) catch |e| {
             tgt.deinit(allocator);
             return e;
@@ -1985,7 +2011,7 @@ fn skillCenterAddMachine(allocator: std.mem.Allocator, labels: *std.ArrayListUnm
     }
 }
 
-/// Build a target picker over {local, ssh profiles} × {claude, codex}.
+/// Build a target picker over {local, WSL (Windows), ssh profiles} × {claude, codex}.
 fn skillCenterBuildPicker(allocator: std.mem.Allocator, purpose: skill_center.Purpose, skill_name: []const u8) !skill_center.PickerState {
     var labels: std.ArrayListUnmanaged([]u8) = .empty;
     var targets: std.ArrayListUnmanaged(skill_center.Target) = .empty;
@@ -1995,7 +2021,13 @@ fn skillCenterBuildPicker(allocator: std.mem.Allocator, purpose: skill_center.Pu
         for (targets.items) |*t| t.deinit(allocator);
         targets.deinit(allocator);
     }
-    try skillCenterAddMachine(allocator, &labels, &targets, "local", i18n.s().sc_local, true);
+    try skillCenterAddMachine(allocator, &labels, &targets, "local", i18n.s().sc_local, true, false);
+    // The default WSL distro, only when one is actually installed (registry
+    // probe — never spawns wsl.exe, so a WSL-less machine never pops the
+    // "install WSL" window). Hidden on non-Windows hosts (wslAvailable false).
+    if (platform_pty_command.wslAvailable()) {
+        try skillCenterAddMachine(allocator, &labels, &targets, "wsl", i18n.s().sc_wsl, false, true);
+    }
     const names = overlays.sshProfileNames(allocator) catch &[_][]u8{};
     defer {
         for (names) |n| allocator.free(n);
@@ -2004,7 +2036,7 @@ fn skillCenterBuildPicker(allocator: std.mem.Allocator, purpose: skill_center.Pu
     for (names) |nm| {
         const id = try std.fmt.allocPrint(allocator, "ssh:{s}", .{nm});
         defer allocator.free(id);
-        try skillCenterAddMachine(allocator, &labels, &targets, id, nm, false);
+        try skillCenterAddMachine(allocator, &labels, &targets, id, nm, false, false);
     }
     const name_copy = try allocator.dupe(u8, skill_name);
     errdefer allocator.free(name_copy);
@@ -2044,7 +2076,7 @@ pub fn skillCenterImport() bool {
 fn skillCenterOpenImportList(allocator: std.mem.Allocator, target: skill_center.Target) void {
     const session = activeSkillCenter() orelse return;
     const conn = skillCenterTargetConn(target);
-    if (!target.is_local and conn == null) {
+    if (target.requiresSshConn() and conn == null) {
         overlays.showStatusToast(i18n.s().sc_toast_no_conn);
         return;
     }
@@ -2076,7 +2108,7 @@ fn skillCenterOpenImportList(allocator: std.mem.Allocator, target: skill_center.
 fn skillCenterRunTransfer(allocator: std.mem.Allocator, is_import: bool, target: skill_center.Target, name: []const u8) void {
     const session = activeSkillCenter() orelse return;
     const conn = skillCenterTargetConn(target);
-    if (!target.is_local and conn == null) {
+    if (target.requiresSshConn() and conn == null) {
         overlays.showStatusToast(i18n.s().sc_toast_no_conn);
         return;
     }
@@ -2112,6 +2144,7 @@ fn skillCenterRunTransfer(allocator: std.mem.Allocator, is_import: bool, target:
     job.* = .{
         .is_import = is_import,
         .conn = conn,
+        .is_wsl = target.is_wsl,
         .lib_root = lib_root,
         .tgt_root = tgt_root,
         .tgt_is_local = target.is_local,
@@ -2156,7 +2189,7 @@ fn skillCenterPreviewServerSkill(allocator: std.mem.Allocator) void {
     defer target.deinit(allocator); // only need conn + software here
 
     const conn = skillCenterTargetConn(target);
-    if (!target.is_local and conn == null) {
+    if (target.requiresSshConn() and conn == null) {
         overlays.showStatusToast(i18n.s().sc_toast_no_conn);
         allocator.free(name);
         return;
@@ -2183,7 +2216,7 @@ fn skillCenterPreviewServerSkill(allocator: std.mem.Allocator) void {
         if (local_md_path) |p| allocator.free(p);
         return;
     };
-    job.* = .{ .conn = conn, .name = name, .cmd = cmd, .local_md_path = local_md_path };
+    job.* = .{ .conn = conn, .is_wsl = target.is_wsl, .name = name, .cmd = cmd, .local_md_path = local_md_path };
     if (!session.startOp(.{ .ctx = job, .run = SkillPreviewJob.run, .destroy = SkillPreviewJob.destroy }, window_backend.postWakeup, i18n.s().sc_busy_loading)) {
         SkillPreviewJob.destroy(@ptrCast(job), allocator);
         overlays.showStatusToast(i18n.s().sc_toast_op_busy);
@@ -2219,7 +2252,7 @@ fn skillCenterArmConfirm(allocator: std.mem.Allocator, is_import: bool, target: 
 fn skillCenterDeployDecide(allocator: std.mem.Allocator, target: skill_center.Target, name: []const u8, src_hash: ?[]const u8) void {
     const session = activeSkillCenter() orelse return;
     const conn = skillCenterTargetConn(target);
-    if (!target.is_local and conn == null) {
+    if (target.requiresSshConn() and conn == null) {
         overlays.showStatusToast(i18n.s().sc_toast_no_conn);
         return;
     }
@@ -2804,7 +2837,7 @@ const SkillLibraryScanJob = struct {
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror![]skill_center.LibrarySkill {
         const job: *SkillLibraryScanJob = @ptrCast(@alignCast(ctx));
-        const outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, null);
+        const outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, null, false);
         // Move the scanned rows into the library list (frees the rows slice).
         return skill_center.libraryFromRows(allocator, outcome.rows);
     }
@@ -2826,7 +2859,7 @@ const SkillImportScanJob = struct {
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillImportScanJob = @ptrCast(@alignCast(ctx));
-        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn);
+        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn, job.target.is_wsl);
         const tgt = job.target.clone(allocator) catch {
             outcome.deinit(allocator);
             return .failed;
@@ -2856,7 +2889,7 @@ const SkillDeployScanJob = struct {
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillDeployScanJob = @ptrCast(@alignCast(ctx));
-        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn);
+        var outcome = skillCenterScanOutcome(allocator, job.root_expr, job.local_path, job.conn, job.target.is_wsl);
         // A genuinely unreachable target (SSH failure) → fail fast, as the old
         // scan-error path did; a reachable-but-empty target deploys via `.direct`.
         if (!outcome.reachable) {
@@ -2902,6 +2935,7 @@ const SkillDeployScanJob = struct {
 const SkillTransferJob = struct {
     is_import: bool,
     conn: ?ssh_connection.SshConnection,
+    is_wsl: bool,
     lib_root: []u8, // owned shell expr (POSIX path)
     tgt_root: []u8, // owned shell expr (POSIX path)
     tgt_is_local: bool,
@@ -2912,8 +2946,10 @@ const SkillTransferJob = struct {
 
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillTransferJob = @ptrCast(@alignCast(ctx));
-        var tctx = SkillTransferCtx{ .conn = job.conn };
-        const ok = if (remote_file.localPosixExecSupported()) blk: {
+        var tctx = SkillTransferCtx{ .conn = job.conn, .is_wsl = job.is_wsl };
+        const ok = if (job.is_wsl)
+            wslSkillTransfer(allocator, job, &tctx)
+        else if (remote_file.localPosixExecSupported()) blk: {
             // POSIX local host: the proven tar-over-scp dance (Linux/macOS).
             const lib_ep = skill_transfer.Endpoint{ .root_expr = job.lib_root, .is_local = true };
             const tgt_ep = skill_transfer.Endpoint{ .root_expr = job.tgt_root, .is_local = job.tgt_is_local };
@@ -2937,6 +2973,31 @@ const SkillTransferJob = struct {
         allocator.destroy(job);
     }
 };
+
+/// Transfer a skill to/from the default WSL distro. Both endpoints are visible
+/// to a single `wsl.exe` shell — the library on the Windows filesystem reached
+/// at `/mnt/<drive>/…`, the target under `$HOME` — so the whole transfer runs
+/// inside WSL with no host↔guest file copy: tar-create + extract over `wslExec`
+/// (see `SkillTransferCtx` and the both-remote case of `skill_transfer`).
+/// `job.lib_path` is a native Windows path that must be converted to its guest
+/// `/mnt` form before `tar -C` can read it. Returns true on full success.
+fn wslSkillTransfer(allocator: std.mem.Allocator, job: *SkillTransferJob, tctx: *SkillTransferCtx) bool {
+    const guest_lib = (platform_wsl.hostPathToGuestPathAlloc(allocator, job.lib_path) catch null) orelse {
+        tctx.noteErr("library is not on a mounted drive");
+        return false;
+    };
+    defer allocator.free(guest_lib);
+    const lib_root = skill_transfer_cmd.absRootExpr(allocator, guest_lib) catch return false;
+    defer allocator.free(lib_root);
+
+    // Both endpoints remote (is_local = false) → skill_transfer skips its copy
+    // primitive and runs tar-create + extract entirely over wslExec.
+    const lib_ep = skill_transfer.Endpoint{ .root_expr = lib_root, .is_local = false };
+    const tgt_ep = skill_transfer.Endpoint{ .root_expr = job.tgt_root, .is_local = false };
+    const from = if (job.is_import) tgt_ep else lib_ep;
+    const to = if (job.is_import) lib_ep else tgt_ep;
+    return skill_transfer.transfer(allocator, tctx.ops(), from, to, job.name) == .ok;
+}
 
 /// Transfer a skill without a POSIX shell (native Windows, no WSL):
 ///   - local↔local: a native `std.fs` directory copy with atomic swap.
@@ -3073,6 +3134,7 @@ fn nativeImportFromRemote(
 /// Background op: read one skill's SKILL.md (local or via ssh) for preview.
 const SkillPreviewJob = struct {
     conn: ?ssh_connection.SshConnection,
+    is_wsl: bool,
     name: []u8, // owned — becomes the preview title
     cmd: []u8, // owned — `cat <root>/'<name>'/'SKILL.md'`
     local_md_path: ?[]u8, // owned absolute SKILL.md path for a LOCAL target (native read)
@@ -3080,14 +3142,15 @@ const SkillPreviewJob = struct {
     fn run(ctx: *anyopaque, allocator: std.mem.Allocator) skill_center.OpResult {
         const job: *SkillPreviewJob = @ptrCast(@alignCast(ctx));
         // Local target on a non-POSIX host (Windows): read SKILL.md natively;
-        // `cat` via localPosixExec is unavailable. Remote/posix use the shell cmd.
-        const content = if (job.conn == null and !remote_file.localPosixExecSupported())
+        // `cat` via localPosixExec is unavailable. Remote/posix/WSL use the shell
+        // cmd (WSL via `wsl.exe`, see SkillLocExec).
+        const content = if (job.conn == null and !job.is_wsl and !remote_file.localPosixExecSupported())
             blk: {
                 const p = job.local_md_path orelse return .failed;
                 break :blk skill_local_fs.readFileAllocAbsolute(allocator, p, 1024 * 1024) catch return .failed;
             }
         else blk: {
-            var le = SkillLocExec{ .conn = job.conn };
+            var le = SkillLocExec{ .conn = job.conn, .is_wsl = job.is_wsl };
             const host = le.host();
             break :blk host.exec(host.ctx, allocator, job.cmd) catch return .failed;
         };

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -62,6 +62,7 @@ pub const Strings = struct {
 
     // —— Skill Center 面板 ——
     sc_local: []const u8,
+    sc_wsl: []const u8,
     sc_scanning: []const u8,
     sc_no_server: []const u8,
     sc_cached: []const u8,
@@ -261,6 +262,7 @@ const en = Strings{
     .pf_form_legend = "[up/down] move   [left/right/space] change   [enter] save   [esc] cancel",
 
     .sc_local = "Local",
+    .sc_wsl = "WSL",
     .sc_scanning = "No skills found. Scanning…",
     .sc_no_server = "(no server)",
     .sc_cached = "(cached)",
@@ -455,6 +457,7 @@ const zh_CN = Strings{
     .pf_form_legend = "[上/下] 切换字段   [左/右 或 空格] 切换选项   [enter] 保存   [esc] 取消",
 
     .sc_local = "本地",
+    .sc_wsl = "WSL",
     .sc_scanning = "未发现技能，扫描中…",
     .sc_no_server = "（无服务器）",
     .sc_cached = "（缓存）",

--- a/src/skill_center.zig
+++ b/src/skill_center.zig
@@ -23,10 +23,16 @@ pub const Software = enum {
 
 /// A deploy/import destination: a machine × a software root.
 pub const Target = struct {
-    machine_id: []u8, // owned: "local" or "ssh:<profile>"
+    machine_id: []u8, // owned: "local", "ssh:<profile>", or "wsl"
     machine_label: []u8, // owned display name
     software: Software,
     is_local: bool,
+    /// A WSL distro reached on the Windows host via `wsl.exe --exec sh -lc`.
+    /// Mutually exclusive with `is_local`/SSH: a WSL target is neither local nor
+    /// an SSH connection, so guards must check this before falling back to a
+    /// "needs an SSH connection" error. `dupe` defaults it false; `clone`
+    /// preserves it.
+    is_wsl: bool = false,
 
     pub fn dupe(
         allocator: std.mem.Allocator,
@@ -41,7 +47,16 @@ pub const Target = struct {
         return .{ .machine_id = id, .machine_label = label, .software = software, .is_local = is_local };
     }
     pub fn clone(self: Target, allocator: std.mem.Allocator) !Target {
-        return dupe(allocator, self.machine_id, self.machine_label, self.software, self.is_local);
+        var t = try dupe(allocator, self.machine_id, self.machine_label, self.software, self.is_local);
+        t.is_wsl = self.is_wsl;
+        return t;
+    }
+    /// True when reaching this target requires an SSH connection (i.e. it is a
+    /// remote SSH profile, not the local host and not a WSL distro). Centralizes
+    /// the picker/scan/transfer guards so a WSL target is never rejected for
+    /// "no connection".
+    pub fn requiresSshConn(self: Target) bool {
+        return !self.is_local and !self.is_wsl;
     }
     pub fn deinit(self: *Target, allocator: std.mem.Allocator) void {
         allocator.free(self.machine_id);
@@ -814,6 +829,34 @@ test "startOp rejects a second op while one is in flight" {
     OpTestCtx.destroy(@ptrCast(ctx), a);
     // let the dummy thread be joinable at destroy
     session.op_done.store(true, .release);
+}
+
+test "Target.clone preserves the WSL discriminator" {
+    const a = std.testing.allocator;
+    var t = try Target.dupe(a, "wsl", "WSL", .claude, false);
+    t.is_wsl = true;
+    defer t.deinit(a);
+    var c = try t.clone(a);
+    defer c.deinit(a);
+    try std.testing.expect(c.is_wsl);
+    try std.testing.expectEqualStrings("wsl", c.machine_id);
+    try std.testing.expect(!c.is_local);
+}
+
+test "Target.requiresSshConn is true only for non-local non-WSL targets" {
+    const a = std.testing.allocator;
+    var local = try Target.dupe(a, "local", "Local", .claude, true);
+    defer local.deinit(a);
+    try std.testing.expect(!local.requiresSshConn());
+
+    var ssh = try Target.dupe(a, "ssh:web", "web", .codex, false);
+    defer ssh.deinit(a);
+    try std.testing.expect(ssh.requiresSshConn());
+
+    var wsl = try Target.dupe(a, "wsl", "WSL", .claude, false);
+    wsl.is_wsl = true;
+    defer wsl.deinit(a);
+    try std.testing.expect(!wsl.requiresSshConn());
 }
 
 test "importScanResult: unreachable source becomes failed (not an empty import list)" {

--- a/src/skill_transfer.zig
+++ b/src/skill_transfer.zig
@@ -124,6 +124,24 @@ test "skill_transfer: local→remote deploy does create-local, copy, extract-rem
     try std.testing.expect(std.mem.indexOf(u8, rec.remote_cmds.items[0], "tar -xzf") != null);
 }
 
+test "skill_transfer: remote→remote (WSL) tars and extracts without a host copy" {
+    // The WSL deploy path treats BOTH endpoints as remote (reachable from one
+    // `wsl.exe` shell): the library under /mnt/<drive> and the target under
+    // $HOME. With from.is_local == to.is_local, transfer must skip the copy
+    // primitive entirely and run tar-create + extract over remoteExec.
+    const a = std.testing.allocator;
+    var rec = Recorder{ .allocator = a };
+    defer rec.deinit();
+    const from = Endpoint{ .root_expr = "'/mnt/c/lib/skills'", .is_local = false };
+    const to = Endpoint{ .root_expr = "\"$HOME\"/'.claude/skills'", .is_local = false };
+    try std.testing.expectEqual(Result.ok, transfer(a, rec.ops(), from, to, "pdf"));
+    try std.testing.expectEqual(@as(usize, 0), rec.copies);
+    try std.testing.expect(std.mem.startsWith(u8, rec.remote_cmds.items[0], "tar -czf"));
+    try std.testing.expect(std.mem.indexOf(u8, rec.remote_cmds.items[1], "tar -xzf") != null);
+    // The staged tarball is cleaned up on the remote (WSL /tmp).
+    try std.testing.expect(std.mem.indexOf(u8, rec.remote_cmds.items[2], "rm -f") != null);
+}
+
 test "skill_transfer: remote→local import does create-remote, copy, extract-local" {
     const a = std.testing.allocator;
     var rec = Recorder{ .allocator = a };


### PR DESCRIPTION
## Problem

The Skill Center **Deploy to…** / **Sync** picker enumerated only `local` + saved SSH profiles × {Claude Code, Codex}. WSL distro enumeration was a sanctioned v1 deferral, so on Windows there was **no WSL row** at all — even though most setups run Claude Code/Codex skills inside WSL.

## Change

Adds a single **`WSL`** machine (the **default** WSL distro) to the deploy/import/preview picker, reached via `wsl.exe --exec sh -lc`.

- **No freeze risk** — the WSL row appears only when the registry-based `wslAvailable()` probe is true (a silent per-user `Lxss` read, never a `wsl.exe` spawn), so a WSL-less machine never pops the blocking *"install WSL"* window (the #223 hazard). Hidden entirely on non-Windows.
- **`Target.is_wsl`** — a third endpoint kind beyond local/SSH, with a `requiresSshConn()` helper that centralizes the old `!is_local and conn == null` guards so a WSL target is never rejected for "no connection".
- **WSL exec branch** in `SkillLocExec` / `SkillTransferCtx` / scan / preview via the existing `wslExec`.
- **`wslSkillTransfer`** — the whole transfer runs inside one WSL shell: the library is reached at `/mnt/<drive>/…` (`hostPathToGuestPathAlloc`) and the target under `$HOME`, both endpoints `is_local=false`, so `skill_transfer.transfer` skips its copy primitive — **no host↔guest file copy**. Fresh distros with no `~/.claude/skills` deploy cleanly (scan guards with `[ -d "$R" ]` → reachable-empty → `.direct`).

Default distro only; per-distro rows (`wsl -d <distro>`) remain deferred.

## Tests

- TDD: `Target.is_wsl` clone-preservation + `requiresSshConn` unit tests; a `skill_transfer` remote→remote no-copy characterization test (locks the contract the WSL path relies on).
- ✅ `zig build test` (fast) · ✅ `zig build` (native) · ✅ `zig build test-full` (windows-gnu app-test binary)
- ✅ 5-dimension adversarial review (mem-safety / freeze-gating / transfer / scan-preview / UI-i18n): **0 findings**

## Not covered

- **Multi-distro** listing — deferred (matches how AI History / Sessions and the rest of the app treat WSL as the default distro).
- **GUI click-through on Windows** still pending — no Linux GUI backend, and WSL targets only exist on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
