### PR TITLE
fix: free restored tmux controllers at quit to stop GPA leaks

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -292,6 +292,16 @@ pub fn deinit(self: *AppWindow) void {
         }
     }
 
+    // Tear down this thread's tmux control-mode controllers. They are
+    // thread-local and persist across transport drops (reconnect-with-backoff,
+    // no auto-teardown), so quit is the only place they are freed — closing
+    // each transport PTY detaches (not kills) the remote tmux session, the
+    // persistence we want. Must run AFTER dumpSessionToFile above, which reads
+    // the live controllers' profile names to persist them, and BEFORE the tab
+    // cleanup below: destroy closes every pane's virtual controller (EOF'ing the
+    // Surfaces) without freeing the Surfaces, which the tab teardown then owns.
+    tmux_controller.shutdownAll(self.allocator);
+
     // Clean up all tabs
     for (0..tab.g_tab_count) |ti| {
         if (tab.g_tabs[ti]) |t| {
@@ -349,6 +359,17 @@ test "AppWindow: current backend window handle is exposed through platform facad
 test "AppWindow: native handle bit conversion stays in platform backend" {
     const source = @embedFile("AppWindow.zig");
     try std.testing.expect(std.mem.indexOf(u8, source, "builtin." ++ "os.tag") == null);
+}
+
+// deinit runs on the same thread as runMainLoop (first window → main thread,
+// spawned window → its worker thread), so it is the only place the thread-local
+// tmux controller list can be freed. A restored persistent tmux session
+// allocates a TmuxController/TmuxBridge/Session there; without this teardown
+// call they leak at clean exit (GPA reports ~14 leaks). Guard the wiring.
+test "AppWindow: deinit tears down tmux controllers so restored sessions don't leak" {
+    const source = @embedFile("AppWindow.zig");
+    // Split the needle so this assertion does not match its own literal.
+    try std.testing.expect(std.mem.indexOf(u8, source, "tmux_controller." ++ "shutdownAll") != null);
 }
 
 test "AppWindow: platform window callbacks use backend-neutral names" {


### PR DESCRIPTION
## Problem

On a debug build, quitting WispTerm cleanly (after `WispTerm exiting...`) leaked ~14 GPA allocations when a persistent tmux session had been restored. `tmux_controller.shutdownAll` was defined and exported but **never called from any exit path** — the PR #216 note claimed "shutdownAll cleans up at quit", but the wiring was never added.

Leaked allocations all trace back to `tmux_controller_posix.start`:
- the `TmuxController` + the thread-local `g_controllers` list backing
- `TmuxBridge.create` and per-pane `FactoryCtx.make` (PaneMap / Surfaces)
- the session `cmds` / `scratch` / `capture_queue` / `windows` buffers
- the `profile_name` / `ssh_cmd` dups

## Fix

Wire `tmux_controller.shutdownAll(self.allocator)` into `AppWindow.deinit`. Placement is deliberate:

- **after** `dumpSessionToFile` — it reads the live controllers' profile names (via the active-profiles hook) to persist them for next-launch restore;
- **before** the tab cleanup loop — `destroy` closes each pane's virtual controller (EOF'ing the Surfaces) without freeing the Surfaces; the tabs own that teardown.

`deinit` runs on the same thread as `runMainLoop` (first window → main thread, spawned window → its worker thread), so the thread-local controller list is freed on the correct thread; no `is_last_window` gate is needed. `shutdownAll`/`destroy` themselves were already complete — the only defect was the missing call.

Debug-only (release lets the OS reclaim at exit), but worth fixing to pass GPA leak detection.

## Verification

- `zig build test-full -Dtarget=aarch64-macos` — green (`27/27 steps, 1974/1978 passed`). Adds a source-assertion regression test guarding the wiring.
- End-to-end against a **real local tmux control-mode session** (handshake + reconciled panes), same clean-exit path:

  | binary | `error(gpa): … leaked` |
  |---|---|
  | unpatched | **13** |
  | patched | **0** |

  The unpatched leak stacks match the report exactly (`tmux_controller_posix.start`, `TmuxBridge.create`, `FactoryCtx.make`, `g_controllers` append).

🤖 Generated with [Claude Code](https://claude.com/claude-code)