### PR TITLE
fix(clipboard): implement image paste on macOS and Linux

### DIFF
--- a/src/platform/clipboard_linux.zig
+++ b/src/platform/clipboard_linux.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const c = @import("../apprt/sdl.zig").c;
+const platform_dirs = @import("dirs.zig");
 
 pub const Owner = struct {
     native_window: ?usize = null,
@@ -28,10 +29,34 @@ pub fn readText(allocator: std.mem.Allocator, owner: Owner) ?[]u8 {
 }
 
 pub fn readImageAsPngTemp(allocator: std.mem.Allocator, owner: Owner) ?[]u8 {
-    _ = allocator;
     _ = owner;
-    // Image paste is deferred on Linux.
-    return null;
+    // Most Linux screenshot tools and browsers expose pasted images as
+    // image/png on the clipboard. Pull that target through SDL's clipboard
+    // data provider and spill it to a temp file the terminal can reference.
+    var size: usize = 0;
+    const raw = c.SDL_GetClipboardData("image/png", &size) orelse return null;
+    defer c.SDL_free(raw);
+    if (size == 0) return null;
+
+    const bytes = @as([*]const u8, @ptrCast(raw))[0..size];
+    return writeClipboardPngTemp(allocator, bytes);
+}
+
+fn writeClipboardPngTemp(allocator: std.mem.Allocator, bytes: []const u8) ?[]u8 {
+    const dir = platform_dirs.tempDir(allocator) catch return null;
+    defer allocator.free(dir);
+
+    const ts = std.time.milliTimestamp();
+    const path = std.fmt.allocPrint(allocator, "{s}/wispterm-clipboard-{d}.png", .{ dir, ts }) catch return null;
+    var keep_path = false;
+    defer if (!keep_path) allocator.free(path);
+
+    const file = std.fs.createFileAbsolute(path, .{ .truncate = true }) catch return null;
+    defer file.close();
+    file.writeAll(bytes) catch return null;
+
+    keep_path = true;
+    return path;
 }
 
 pub fn normalizeText(allocator: std.mem.Allocator, text: []const u8) ![]u8 {

--- a/src/platform/clipboard_macos.zig
+++ b/src/platform/clipboard_macos.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform_dirs = @import("dirs.zig");
 
 pub const Owner = struct {
     native_window: ?usize = null,
@@ -6,6 +7,7 @@ pub const Owner = struct {
 
 extern fn wispterm_macos_clipboard_write_text(text: [*:0]const u8) bool;
 extern fn wispterm_macos_clipboard_copy_text() ?[*:0]u8;
+extern fn wispterm_macos_clipboard_image_png_path(dir: [*:0]const u8) ?[*:0]u8;
 extern fn wispterm_macos_services_free(ptr: ?*anyopaque) void;
 
 pub fn windowOwner(native_window: usize) Owner {
@@ -29,9 +31,15 @@ pub fn readText(allocator: std.mem.Allocator, owner: Owner) ?[]u8 {
 }
 
 pub fn readImageAsPngTemp(allocator: std.mem.Allocator, owner: Owner) ?[]u8 {
-    _ = allocator;
     _ = owner;
-    return null;
+    const dir = platform_dirs.tempDir(allocator) catch return null;
+    defer allocator.free(dir);
+    const dir_z = allocator.dupeZ(u8, dir) catch return null;
+    defer allocator.free(dir_z);
+
+    const raw = wispterm_macos_clipboard_image_png_path(dir_z.ptr) orelse return null;
+    defer wispterm_macos_services_free(raw);
+    return allocator.dupe(u8, std.mem.span(raw)) catch null;
 }
 
 pub fn normalizeText(allocator: std.mem.Allocator, text: []const u8) ![]u8 {

--- a/src/platform/services_macos_bridge.m
+++ b/src/platform/services_macos_bridge.m
@@ -76,6 +76,61 @@ char *wispterm_macos_clipboard_copy_text(void) {
     }
 }
 
+// Read an image off the general pasteboard, transcode it to PNG, and write it
+// to `<dir>/wispterm-clipboard-<ms>.png`. Returns the malloc'd path (free with
+// wispterm_macos_services_free) or NULL when the clipboard holds no image.
+char *wispterm_macos_clipboard_image_png_path(const char *dir) {
+    @autoreleasepool {
+        if (dir == NULL) return NULL;
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+
+        // Prefer a ready-made PNG (some apps put image/png directly on the board).
+        NSData *png = [pasteboard dataForType:NSPasteboardTypePNG];
+        if (png == nil) {
+            // Fall back to TIFF (the native macOS screenshot format) or any
+            // NSImage object, then transcode to PNG via NSBitmapImageRep.
+            NSData *tiff = [pasteboard dataForType:NSPasteboardTypeTIFF];
+            if (tiff == nil) {
+                NSArray *images = [pasteboard readObjectsForClasses:@[[NSImage class]]
+                                                            options:nil];
+                if (images.count > 0) {
+                    NSImage *image = images.firstObject;
+                    tiff = [image TIFFRepresentation];
+                }
+            }
+            if (tiff != nil) {
+                NSBitmapImageRep *rep = [NSBitmapImageRep imageRepWithData:tiff];
+                if (rep != nil) {
+                    png = [rep representationUsingType:NSBitmapImageFileTypePNG
+                                            properties:@{}];
+                }
+            }
+        }
+        if (png == nil) return NULL;
+
+        NSString *dir_str = [NSString stringWithUTF8String:dir];
+        if (dir_str == nil) return NULL;
+        long long ms = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+        NSString *name = [NSString stringWithFormat:@"wispterm-clipboard-%lld.png", ms];
+        NSString *path = [dir_str stringByAppendingPathComponent:name];
+
+        if (![png writeToFile:path atomically:YES]) return NULL;
+        return wispterm_macos_copy_nsstring(path);
+    }
+}
+
+// Place raw PNG bytes on the general pasteboard as image/png. Used by the
+// native clipboard smoke tests to stage an image for the paste path.
+bool wispterm_macos_clipboard_write_image_png(const char *bytes, int32_t len) {
+    @autoreleasepool {
+        if (bytes == NULL || len <= 0) return false;
+        NSData *data = [NSData dataWithBytes:bytes length:(NSUInteger)len];
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        [pasteboard clearContents];
+        return [pasteboard setData:data forType:NSPasteboardTypePNG];
+    }
+}
+
 void wispterm_macos_cursor_set(uint32_t shape) {
     @autoreleasepool {
         switch (shape) {

--- a/src/test_macos_services.zig
+++ b/src/test_macos_services.zig
@@ -35,6 +35,37 @@ test "macOS clipboard round-trips UTF-8 text through NSPasteboard" {
     try std.testing.expectEqualStrings("wispterm mac clipboard", text_value);
 }
 
+extern fn wispterm_macos_clipboard_write_image_png(bytes: [*]const u8, len: i32) bool;
+
+// A valid 1x1 RGBA PNG, generated with a real PNG encoder.
+const sample_png = [_]u8{
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0xf8, 0xcf, 0xc0, 0xf0,
+    0x1f, 0x00, 0x05, 0x00, 0x01, 0xff, 0x56, 0xc7, 0x2f, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+    0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+};
+
+test "macOS clipboard reads a pasted image as a temp PNG file" {
+    try std.testing.expect(wispterm_macos_clipboard_write_image_png(&sample_png, @intCast(sample_png.len)));
+
+    const owner = clipboard.windowOwner(0);
+    const path = clipboard.readImageAsPngTemp(std.testing.allocator, owner) orelse return error.ExpectedClipboardImage;
+    defer std.testing.allocator.free(path);
+    defer std.fs.deleteFileAbsolute(path) catch {};
+
+    try std.testing.expect(std.fs.path.isAbsolute(path));
+    try std.testing.expect(std.mem.endsWith(u8, path, ".png"));
+
+    const data = try std.fs.cwd().readFileAlloc(std.testing.allocator, path, 1024 * 1024);
+    defer std.testing.allocator.free(data);
+
+    // The PNG signature must survive the clipboard round-trip, and for a
+    // ready-made image/png the bytes pass through verbatim.
+    try std.testing.expect(std.mem.startsWith(u8, data, "\x89PNG\r\n\x1a\n"));
+    try std.testing.expectEqualSlices(u8, &sample_png, data);
+}
+
 test "macOS display and text services return native answers" {
     try std.testing.expect(display.isPointOnAnyDisplay(0, 0));
     try std.testing.expectEqual(@as(?bool, true), text.nativeOrdinalIgnoreCaseUtf8Equal("WispTerm", "wispterm"));


### PR DESCRIPTION
## 问题

macOS 下 `Cmd+Shift+V` 无法把剪贴板里的图片(如截图)粘贴进终端里的 Claude TUI,Windows 正常。根因:`readImageAsPngTemp` 只在 Windows 实现了,macOS 和 Linux 都是空桩 `return null`,所以即使剪贴板里确实有图(其它 App 能贴),粘贴动作也静默无操作。

```zig
// 修复前 src/platform/clipboard_macos.zig
pub fn readImageAsPngTemp(...) ?[]u8 {
    _ = allocator; _ = owner;
    return null;   // 永远读不到图
}
```

## 改动

- **macOS**:新增 `wispterm_macos_clipboard_image_png_path()` 桥接,从 `NSPasteboard` 取图(优先 `NSPasteboardTypePNG`,否则读 `TIFF`/`NSImage` 用 `NSBitmapImageRep` 转 PNG),写临时文件返回路径;在 `clipboard_macos.zig` 中接入(对齐 `readText` 写法)。
- **Linux**:用 SDL3 `SDL_GetClipboardData("image/png", …)` 读图并落临时 PNG 文件。
- **测试**:新增真实走 `NSPasteboard` 的图片往返冒烟测试,并加了一个写图桥接辅助函数为测试铺数据。

下游(本地键入路径 / SSH 自动 `scp` 上传)原本就有,未改动。

## 测试

- `zig build test-macos-services` → **60/60 passed**(新测试真实往返:写 PNG 进 `NSPasteboard` → `readImageAsPngTemp` → 落临时文件 → 读回 → 断言 PNG 签名 + 字节一致)
- `zig build macos-app -Dtarget=aarch64-macos` → 成功(ObjC 桥接编译 + 链接进 app)
- `zig build test-full` → **145/147 passed, 2 skipped**,无失败(含 Windows 目标编译)

## 已知限制

- Linux 端因本机为 macOS 且依赖需联网下载,未能在本地交叉编译验证;代码已按 SDL3 API 与仓库现有写法逐行核对,建议在 Linux 机器上 `zig build` 跑一次确认。
- Linux 端目前只处理 `image/png`(主流截图工具/浏览器均提供该类型);其它 MIME 类型暂不支持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)