### PR TITLE
fix(file-dialog): honor filter types + save extension on macOS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -675,6 +675,69 @@ verification in progress.
 | Draggable titlebar | ⚠️ only via traffic-light gaps until D8.4a |
 | Embedded browser panel | ❌ disabled (D5 — no WKWebView backend yet) |
 
+### Silent platform stubs — audit 2026-06-15
+
+A code audit of every `src/platform/*` facade for the clipboard image-paste
+shape (facade wired, but a platform's `backendForOs` resolves to a
+`*_unsupported`/no-op impl, so the capability silently does nothing with no
+error surfaced). macOS items are the priority (active port); Linux items fold
+into the Linux-host work below.
+
+**macOS:**
+- [x] Clipboard image paste (`readImageAsPngTemp`) — fixed (PR #228).
+- [x] File dialog type filters + save default-extension — fixed: `file_dialog_macos.zig`
+      derives `NSOpenPanel`/`NSSavePanel.allowedFileTypes` from the filter
+      patterns and auto-appends the save extension (previously `_ = request.filters`).
+- [ ] **Remote-relay client (`remote_transport`)** — macOS **and** Linux resolve to
+      `.unsupported` (`remote_transport.zig:11-14`); with `remote-enabled = true`
+      the relay never connects — `remote_client.zig:321` errors, only a
+      `std.debug.print` to stderr, then a perpetual 2s reconnect loop. No UI
+      error. Add `remote_transport_posix.zig` (macOS `NSURLSessionWebSocketTask`
+      bridge like `http_client_macos_bridge.m`; Linux minimal RFC6455 over
+      `std.net` + `std.crypto.tls`), route `.macos|.linux → .posix`. **HIGH.**
+- [ ] **Single-instance session lock (`session_lock`)** — macOS+Linux use
+      `session_lock_local_process` whose `reserveSessionKey` always returns
+      success (`:11-15`); no cross-process lock (Windows uses a named mutex), so
+      a double-launched/restored session key isn't detected. Add
+      `session_lock_posix.zig` (`flock`/`O_CREAT|O_EXCL` lockfile). **MEDIUM.**
+- [ ] **Process memory HUD (`memory`)** — macOS+Linux → `memory_unsupported`
+      (`queryProcess` null); the debug memory overlay line is blank. Add
+      `memory_macos.zig` (`task_info`/`TASK_VM_INFO`) and `memory_linux.zig`
+      (`/proc/self/status`). **LOW** (developer diagnostic only).
+- [ ] **Cooperative blocking-thread shutdown (`thread_control`)** — macOS+Linux →
+      `thread_control_unsupported` (no-op); a WeChat login/poll worker stuck in a
+      long-poll is force-killed at quit instead of cooperatively cancelled
+      (`weixin/controller.zig:397`). Add `thread_control_posix.zig`
+      (`pthread_kill` interrupt + timed join). **LOW** (only with WeChat).
+
+**Linux (in addition to the deferred Linux host below):**
+- [ ] **Quake-mode global hotkey** — `global_hotkey_unsupported.register()` →
+      false; `quake-mode` never binds a system-wide hotkey, and the
+      "already registered by another app" print (`AppWindow.zig:6532`) is
+      misleading. Add `global_hotkey_linux.zig` (X11 `XGrabKey` / Wayland
+      global-shortcuts portal), mirroring the macOS Carbon path.
+- [ ] **Live config reload** — `config_watcher_unsupported.initPath()` → null;
+      config edits need a full restart ("Config watcher not available",
+      `AppWindow.zig:7749`). Add `config_watcher_linux.zig` (inotify), mirroring
+      `config_watcher_macos.zig` (kqueue `EVFILT_VNODE`).
+- [ ] **Auto-update asset detection** — `update_package.zig:48-60` has no
+      `.linux` arm, so the update check can never match a Linux asset →
+      `state.failed`. Add `update_package_linux.zig`.
+- [ ] **Font family enumeration** — `font_discovery_linux.zig:119` returns an
+      empty list; any font picker/auto-complete is blank (exact `font-family`
+      still works). Implement via fontconfig `FcFontList`.
+- [ ] **Off-screen window guard** — `display_portable.isPointOnAnyDisplay`
+      always returns true; a restored window can open off-screen on Linux. Add
+      an SDL3 `SDL_GetDisplayBounds` containment check.
+
+**Doc corrections found in the same audit (code already done; text stale):**
+- Embedded browser on macOS appears implemented (`webview_macos.zig` + WKWebView;
+  `build.zig` maps macOS → webkit), but D5 (504-514) and the status table (676)
+  still say "❌ disabled" — verify on-device and flip to ✅.
+- Desktop notifications on macOS/Linux are implemented
+  (`notifications_macos.zig` UNUserNotificationCenter; Linux `notify-send`), but
+  D4 (486-492) still reads "bell + window attention only" — update the caveat.
+
 ### Linux — deferred
 
 Postponed in favor of the macOS port. The groundwork already exists (Phase A

--- a/src/platform/file_dialog_macos.zig
+++ b/src/platform/file_dialog_macos.zig
@@ -24,8 +24,14 @@ pub const SaveRequest = struct {
     filters: []const Filter,
 };
 
-extern fn wispterm_macos_open_file_dialog(title: [*:0]const u8) ?[*:0]u8;
-extern fn wispterm_macos_save_file_dialog(title: [*:0]const u8, initial_dir: ?[*:0]const u8, default_filename: ?[*:0]const u8) ?[*:0]u8;
+extern fn wispterm_macos_open_file_dialog(title: [*:0]const u8, allowed_exts: ?[*:0]const u8) ?[*:0]u8;
+extern fn wispterm_macos_save_file_dialog(
+    title: [*:0]const u8,
+    initial_dir: ?[*:0]const u8,
+    default_filename: ?[*:0]const u8,
+    allowed_exts: ?[*:0]const u8,
+    default_ext: ?[*:0]const u8,
+) ?[*:0]u8;
 extern fn wispterm_macos_pick_folder_dialog(title: [*:0]const u8) ?[*:0]u8;
 extern fn wispterm_macos_services_free(ptr: ?*anyopaque) void;
 
@@ -35,10 +41,16 @@ pub fn windowOwner(native_window: usize) Owner {
 
 pub fn openFile(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
     _ = request.owner;
-    _ = request.filters;
     const title = allocator.dupeZ(u8, request.title) catch return null;
     defer allocator.free(title);
-    const raw = wispterm_macos_open_file_dialog(title.ptr) orelse return null;
+
+    const allowed = joinAllowedExtensions(allocator, request.filters);
+    defer if (allowed) |a| allocator.free(a);
+
+    const raw = wispterm_macos_open_file_dialog(
+        title.ptr,
+        if (allowed) |a| a.ptr else null,
+    ) orelse return null;
     defer wispterm_macos_services_free(raw);
     return allocator.dupe(u8, std.mem.span(raw)) catch null;
 }
@@ -55,8 +67,6 @@ pub fn pickFolder(allocator: std.mem.Allocator, request: OpenRequest) ?[]u8 {
 
 pub fn saveFile(allocator: std.mem.Allocator, request: SaveRequest) ?[]u8 {
     _ = request.owner;
-    _ = request.default_extension;
-    _ = request.filters;
     const title = allocator.dupeZ(u8, request.title) catch return null;
     defer allocator.free(title);
     const initial_dir = if (request.initial_dir) |dir| allocator.dupeZ(u8, dir) catch return null else null;
@@ -64,11 +74,109 @@ pub fn saveFile(allocator: std.mem.Allocator, request: SaveRequest) ?[]u8 {
     const default_filename = if (request.default_filename) |name| allocator.dupeZ(u8, name) catch return null else null;
     defer if (default_filename) |name| allocator.free(name);
 
+    const allowed = joinAllowedExtensions(allocator, request.filters);
+    defer if (allowed) |a| allocator.free(a);
+    const default_ext = if (request.default_extension) |ext| allocator.dupeZ(u8, ext) catch return null else null;
+    defer if (default_ext) |ext| allocator.free(ext);
+
     const raw = wispterm_macos_save_file_dialog(
         title.ptr,
         if (initial_dir) |dir| dir.ptr else null,
         if (default_filename) |name| name.ptr else null,
+        if (allowed) |a| a.ptr else null,
+        if (default_ext) |ext| ext.ptr else null,
     ) orelse return null;
     defer wispterm_macos_services_free(raw);
     return allocator.dupe(u8, std.mem.span(raw)) catch null;
+}
+
+/// Convert dialog filter patterns ("*.md", "*.png;*.jpg", "*.*") into a
+/// ';'-joined, deduplicated, NUL-terminated list of bare extensions the bridge
+/// hands to NSOpenPanel/NSSavePanel.allowedFileTypes. Wildcard-only filters
+/// ("*.*", "*") contribute nothing, so an all-files request yields null (no
+/// type restriction) — matching the Windows backend, which defaults to the
+/// first concrete filter and treats "*.*" as unrestricted.
+fn joinAllowedExtensions(allocator: std.mem.Allocator, filters: []const Filter) ?[:0]u8 {
+    return joinAllowedExtensionsImpl(allocator, filters) catch null;
+}
+
+fn joinAllowedExtensionsImpl(allocator: std.mem.Allocator, filters: []const Filter) !?[:0]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    for (filters) |filter| {
+        var it = std.mem.tokenizeAny(u8, filter.pattern, ";,");
+        while (it.next()) |token| {
+            const ext = extensionFromPattern(token) orelse continue;
+            if (containsExtension(out.items, ext)) continue;
+            if (out.items.len > 0) try out.append(allocator, ';');
+            try out.appendSlice(allocator, ext);
+        }
+    }
+
+    if (out.items.len == 0) {
+        out.deinit(allocator);
+        return null;
+    }
+    return try out.toOwnedSliceSentinel(allocator, 0);
+}
+
+/// Extract a bare extension from one glob token, or null when the token is a
+/// wildcard (`*`, `*.*`) or otherwise carries no concrete extension.
+fn extensionFromPattern(token: []const u8) ?[]const u8 {
+    var t = std.mem.trim(u8, token, " \t");
+    if (std.mem.startsWith(u8, t, "*.")) {
+        t = t[2..];
+    } else if (std.mem.startsWith(u8, t, ".")) {
+        t = t[1..];
+    } else if (std.mem.eql(u8, t, "*")) {
+        return null;
+    }
+    if (t.len == 0) return null;
+    // Still wildcarded (e.g. "*" left from "*.*") → not a concrete extension.
+    if (std.mem.indexOfAny(u8, t, "*?") != null) return null;
+    return t;
+}
+
+fn containsExtension(joined: []const u8, ext: []const u8) bool {
+    var it = std.mem.tokenizeScalar(u8, joined, ';');
+    while (it.next()) |part| {
+        if (std.mem.eql(u8, part, ext)) return true;
+    }
+    return false;
+}
+
+test "macOS file dialog derives allowed extensions from filter patterns" {
+    const a = std.testing.allocator;
+
+    {
+        const filters = [_]Filter{
+            .{ .name = "Markdown (*.md)", .pattern = "*.md" },
+            .{ .name = "All Files (*.*)", .pattern = "*.*" },
+        };
+        const exts = joinAllowedExtensions(a, &filters) orelse return error.ExpectedExtensions;
+        defer a.free(exts);
+        try std.testing.expectEqualStrings("md", exts);
+    }
+    {
+        const filters = [_]Filter{.{ .name = "Images", .pattern = "*.png;*.jpg;*.jpeg" }};
+        const exts = joinAllowedExtensions(a, &filters) orelse return error.ExpectedExtensions;
+        defer a.free(exts);
+        try std.testing.expectEqualStrings("png;jpg;jpeg", exts);
+    }
+    {
+        // All-files-only → no type restriction.
+        const filters = [_]Filter{.{ .name = "All Files", .pattern = "*.*" }};
+        try std.testing.expect(joinAllowedExtensions(a, &filters) == null);
+    }
+    {
+        // Duplicate extensions across filters collapse to one.
+        const filters = [_]Filter{
+            .{ .name = "MD", .pattern = "*.md" },
+            .{ .name = "MD bare", .pattern = "md" },
+        };
+        const exts = joinAllowedExtensions(a, &filters) orelse return error.ExpectedExtensions;
+        defer a.free(exts);
+        try std.testing.expectEqualStrings("md", exts);
+    }
 }

--- a/src/platform/services_macos_bridge.m
+++ b/src/platform/services_macos_bridge.m
@@ -345,13 +345,36 @@ static bool wispterm_macos_install_hotkey_handler(void) {
     return status == noErr;
 }
 
-char *wispterm_macos_open_file_dialog(const char *title) {
+// Parse a ';'-joined list of bare extensions (e.g. "md" or "png;jpg") into the
+// NSArray<NSString *> that NSOpenPanel/NSSavePanel.allowedFileTypes expects, or
+// nil when there is nothing to constrain.
+static NSArray<NSString *> *wispterm_macos_allowed_file_types(const char *exts) {
+    if (exts == NULL) return nil;
+    NSString *joined = [NSString stringWithUTF8String:exts];
+    if (joined == nil || joined.length == 0) return nil;
+    NSMutableArray<NSString *> *out = [NSMutableArray array];
+    for (NSString *raw in [joined componentsSeparatedByString:@";"]) {
+        NSString *ext = [raw stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if (ext.length == 0 || [ext isEqualToString:@"*"]) continue;
+        if (![out containsObject:ext]) [out addObject:ext];
+    }
+    return out.count > 0 ? out : nil;
+}
+
+char *wispterm_macos_open_file_dialog(const char *title, const char *allowed_exts) {
     @autoreleasepool {
         NSOpenPanel *panel = [NSOpenPanel openPanel];
         panel.canChooseFiles = YES;
         panel.canChooseDirectories = NO;
         panel.allowsMultipleSelection = NO;
         if (title != NULL) panel.title = [NSString stringWithUTF8String:title];
+        NSArray<NSString *> *types = wispterm_macos_allowed_file_types(allowed_exts);
+        if (types != nil) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            panel.allowedFileTypes = types;
+#pragma clang diagnostic pop
+        }
         if ([panel runModal] != NSModalResponseOK) return NULL;
         return wispterm_macos_copy_nsstring(panel.URL.path);
     }
@@ -369,7 +392,7 @@ char *wispterm_macos_pick_folder_dialog(const char *title) {
     }
 }
 
-char *wispterm_macos_save_file_dialog(const char *title, const char *initial_dir, const char *default_filename) {
+char *wispterm_macos_save_file_dialog(const char *title, const char *initial_dir, const char *default_filename, const char *allowed_exts, const char *default_ext) {
     @autoreleasepool {
         NSSavePanel *panel = [NSSavePanel savePanel];
         if (title != NULL) panel.title = [NSString stringWithUTF8String:title];
@@ -378,6 +401,27 @@ char *wispterm_macos_save_file_dialog(const char *title, const char *initial_dir
             if (dir != nil) panel.directoryURL = [NSURL fileURLWithPath:dir];
         }
         if (default_filename != NULL) panel.nameFieldStringValue = [NSString stringWithUTF8String:default_filename];
+
+        // Restrict to the filter extensions (auto-appends when the user omits
+        // one); make sure the requested default extension is the primary type.
+        NSMutableArray<NSString *> *types = [NSMutableArray array];
+        NSArray<NSString *> *filter_types = wispterm_macos_allowed_file_types(allowed_exts);
+        if (filter_types != nil) [types addObjectsFromArray:filter_types];
+        if (default_ext != NULL) {
+            NSString *ext = [[NSString stringWithUTF8String:default_ext]
+                stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            if (ext.length > 0 && ![ext isEqualToString:@"*"]) {
+                [types removeObject:ext];
+                [types insertObject:ext atIndex:0];
+            }
+        }
+        if (types.count > 0) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            panel.allowedFileTypes = types;
+#pragma clang diagnostic pop
+        }
+
         if ([panel runModal] != NSModalResponseOK) return NULL;
         return wispterm_macos_copy_nsstring(panel.URL.path);
     }


### PR DESCRIPTION
## 问题(审计发现的 macOS 静默桩 · 小修)

macOS 文件对话框把 `request.filters` 和 `default_extension` 直接丢弃(`_ = request.filters`),导致:
- Open/Save 面板不按类型收窄,全文件平铺;
- "保存 Copilot Markdown"不自动补 `.md`,能存成无扩展名文件。

而 Windows(`lpstrFilter`/`lpstrDefExt`)和 Linux(zenity)都正常。和之前剪贴板图片粘贴同型——facade 接好了、macOS 悄悄空转。

## 改动

- **[file_dialog_macos.zig](src/platform/file_dialog_macos.zig)**:从 filter 的 `*.md` / `*.png;*.jpg` / `*.*` 模式中解析出去重的扩展名列表(纯函数 `joinAllowedExtensions`,有单测),连同默认扩展名传给桥接。`*.*`/`*` 只读不约束(与 Windows 行为一致)。
- **[services_macos_bridge.m](src/platform/services_macos_bridge.m)**:用扩展名设置 `NSOpenPanel`/`NSSavePanel.allowedFileTypes`;Save 面板会自动补默认扩展名。
- **[TODO.md](TODO.md)**:记录 2026-06-15 facade 审计发现的其余静默桩——
  - macOS:`remote_transport`(高)、`session_lock`(中)、`memory`/`thread_control`(低);
  - Linux:Quake 全局热键、配置热重载、自动更新资产识别、字体族枚举、屏幕内检查;
  - 另附两处文档过时纠正(macOS 嵌入浏览器/桌面通知其实已实现)。

## 测试

- `zig build test-macos-services` → **61/61 passed**(含新增 `joinAllowedExtensions` 单测:`*.md`→`md`、`*.png;*.jpg;*.jpeg`→去重、`*.*`→无约束、跨 filter 去重)
- `zig build macos-app -Dtarget=aarch64-macos` → RC=0(桥接新签名链接进真实 app)
- `zig build test-full` → RC=0(含 Windows 目标,无回归)

## 限制

对话框是交互式 `runModal`,无法自动化"真实点开看 `.md` 自动补全";纯解析逻辑已单测,桥接已编译链接。建议在你的 Mac 上点一次"保存 Copilot Markdown"确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)