### PR TITLE
feat(remote): implement WebSocket transport on macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -54,6 +54,7 @@ const macos_objective_c_sources = [_][]const u8{
     "src/platform/menu_macos_bridge.m",
     "src/platform/http_client_macos_bridge.m",
     "src/platform/pdf_render_macos_bridge.m",
+    "src/platform/remote_transport_macos_bridge.m",
 };
 
 const MacosBundleMetadata = struct {
@@ -828,6 +829,11 @@ pub fn build(b: *std.Build) void {
         });
         macos_services_test_mod.addCSourceFile(.{
             .file = b.path("src/platform/text_macos_bridge.m"),
+            .flags = &.{},
+            .language = .objective_c,
+        });
+        macos_services_test_mod.addCSourceFile(.{
+            .file = b.path("src/platform/remote_transport_macos_bridge.m"),
             .flags = &.{},
             .language = .objective_c,
         });

--- a/src/platform/remote_transport.zig
+++ b/src/platform/remote_transport.zig
@@ -3,18 +3,21 @@ const builtin = @import("builtin");
 
 pub const Backend = enum {
     windows,
+    macos,
     unsupported,
 };
 
 pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
+        .macos => .macos,
         else => .unsupported,
     };
 }
 
 const impl = switch (backendForOs(builtin.os.tag)) {
     .windows => @import("remote_transport_windows.zig"),
+    .macos => @import("remote_transport_macos.zig"),
     .unsupported => @import("remote_transport_unsupported.zig"),
 };
 
@@ -55,5 +58,5 @@ test "platform remote transport exposes websocket API" {
 test "platform remote transport selects backend per OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
     try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
-    try std.testing.expectEqual(Backend.unsupported, backendForOs(.macos));
+    try std.testing.expectEqual(Backend.macos, backendForOs(.macos));
 }

--- a/src/platform/remote_transport_macos.zig
+++ b/src/platform/remote_transport_macos.zig
@@ -1,0 +1,103 @@
+const std = @import("std");
+
+pub const io_chunk_size = 16 * 1024;
+
+pub const WebSocketHandle = *opaque {};
+
+pub const Endpoint = struct {
+    secure: bool,
+    host: []const u8,
+    port: u16,
+    object_name: []const u8,
+};
+
+pub const BufferType = enum {
+    utf8_message,
+    utf8_fragment,
+    close,
+    other,
+};
+
+pub const ReceiveResult = struct {
+    bytes_read: usize,
+    buffer_type: BufferType,
+};
+
+pub const Handles = struct {
+    websocket: ?WebSocketHandle = null,
+    // The consumer calls close() twice — once before joining the receive thread
+    // (to unblock it) and once after (remote_client.zig). The first call only
+    // tears the socket down so the in-flight receive can finish; the second
+    // frees the native connection once no thread can touch it anymore.
+    torn_down: bool = false,
+
+    pub fn close(self: *Handles) void {
+        const ws = self.websocket orelse return;
+        if (!self.torn_down) {
+            self.torn_down = true;
+            wispterm_macos_ws_shutdown(ws);
+        } else {
+            wispterm_macos_ws_free(ws);
+            self.websocket = null;
+        }
+    }
+};
+
+const connect_timeout_seconds: f64 = 10.0;
+
+extern fn wispterm_macos_ws_connect(
+    secure: bool,
+    host: [*:0]const u8,
+    port: u16,
+    object_name: [*:0]const u8,
+    timeout_seconds: f64,
+) ?WebSocketHandle;
+extern fn wispterm_macos_ws_shutdown(websocket: WebSocketHandle) void;
+extern fn wispterm_macos_ws_free(websocket: WebSocketHandle) void;
+extern fn wispterm_macos_ws_send(websocket: WebSocketHandle, bytes: [*]const u8, len: usize) bool;
+extern fn wispterm_macos_ws_receive(
+    websocket: WebSocketHandle,
+    buffer: [*]u8,
+    buffer_len: usize,
+    out_type: *i32,
+) isize;
+
+pub fn connect(allocator: std.mem.Allocator, endpoint: Endpoint) !Handles {
+    const host_z = allocator.dupeZ(u8, endpoint.host) catch return error.OutOfMemory;
+    defer allocator.free(host_z);
+    const object_z = allocator.dupeZ(u8, endpoint.object_name) catch return error.OutOfMemory;
+    defer allocator.free(object_z);
+
+    const websocket = wispterm_macos_ws_connect(
+        endpoint.secure,
+        host_z.ptr,
+        endpoint.port,
+        object_z.ptr,
+        connect_timeout_seconds,
+    ) orelse return error.RemoteTransportConnectFailed;
+
+    return .{ .websocket = websocket };
+}
+
+pub fn receive(websocket: WebSocketHandle, buffer: []u8) !ReceiveResult {
+    var out_type: i32 = 0;
+    const n = wispterm_macos_ws_receive(websocket, buffer.ptr, buffer.len, &out_type);
+    if (n < 0) return error.RemoteTransportReceiveFailed;
+    return .{
+        .bytes_read = @intCast(n),
+        .buffer_type = decodeBufferType(out_type),
+    };
+}
+
+pub fn sendUtf8(websocket: WebSocketHandle, message: []const u8) bool {
+    return wispterm_macos_ws_send(websocket, message.ptr, message.len);
+}
+
+fn decodeBufferType(raw: i32) BufferType {
+    return switch (raw) {
+        0 => .utf8_message,
+        1 => .utf8_fragment,
+        2 => .close,
+        else => .other,
+    };
+}

--- a/src/platform/remote_transport_macos_bridge.m
+++ b/src/platform/remote_transport_macos_bridge.m
@@ -1,0 +1,205 @@
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// A live WebSocket connection. Obj-C objects are retained into this C struct
+// (the bridge is compiled without ARC, matching the other *_macos_bridge.m
+// files), so they survive across the connect/send/receive/close C calls.
+typedef struct WispWsConn {
+    NSURLSession *session;
+    NSURLSessionWebSocketTask *task;
+    // Remainder of an oversized message awaiting delivery: NSURLSession hands us
+    // whole messages, but the caller's buffer is io_chunk_size, so a larger
+    // message is sliced into utf8_fragment chunks across successive receives.
+    NSMutableData *pending;
+    bool pending_is_text;
+} WispWsConn;
+
+// dispatch objects are ARC-managed when OS_OBJECT_USE_OBJC is set; otherwise we
+// must release them ourselves (mirrors http_client_macos_bridge.m).
+static void wispterm_ws_release_semaphore(dispatch_semaphore_t sema) {
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(sema);
+#else
+    (void)sema;
+#endif
+}
+
+// Copy the head of conn->pending into the caller buffer, fragmenting text
+// messages that exceed it. out_type: 0=utf8_message (final), 1=utf8_fragment,
+// 3=other (binary; the consumer ignores these, so deliver one chunk and drop).
+static long wispterm_ws_emit_pending(WispWsConn *conn, char *buffer, size_t buffer_len, int32_t *out_type) {
+    NSUInteger total = conn->pending.length;
+    NSUInteger take = (total < buffer_len) ? total : buffer_len;
+    if (take > 0) memcpy(buffer, conn->pending.bytes, take);
+
+    BOOL is_final = (take == total);
+    if (conn->pending_is_text) {
+        *out_type = is_final ? 0 : 1;
+    } else {
+        *out_type = 3;
+    }
+
+    if (is_final || !conn->pending_is_text) {
+        [conn->pending setLength:0];
+    } else {
+        [conn->pending replaceBytesInRange:NSMakeRange(0, take) withBytes:NULL length:0];
+    }
+    return (long)take;
+}
+
+void *wispterm_macos_ws_connect(bool secure, const char *host, uint16_t port, const char *object_name, double timeout_seconds) {
+    @autoreleasepool {
+        if (host == NULL || object_name == NULL) return NULL;
+        NSString *host_str = [NSString stringWithUTF8String:host];
+        NSString *object_str = [NSString stringWithUTF8String:object_name];
+        if (host_str == nil || object_str == nil) return NULL;
+
+        NSString *scheme = secure ? @"wss" : @"ws";
+        NSString *url_str = [NSString stringWithFormat:@"%@://%@:%u%@", scheme, host_str, (unsigned)port, object_str];
+        NSURL *url = [NSURL URLWithString:url_str];
+        if (url == nil) return NULL;
+
+        NSTimeInterval timeout = timeout_seconds > 0 ? (NSTimeInterval)timeout_seconds : 10.0;
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        config.timeoutIntervalForRequest = timeout;
+        config.timeoutIntervalForResource = timeout;
+        NSURLSession *session = [NSURLSession sessionWithConfiguration:config];
+        NSURLSessionWebSocketTask *task = [session webSocketTaskWithURL:url];
+        if (task == nil) return NULL;
+        [task resume];
+
+        // Validate the handshake with a ping/pong before reporting success so a
+        // dead endpoint surfaces as a connect error (like the Windows upgrade
+        // handshake) rather than a silently-broken socket.
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        __block BOOL ok = NO;
+        [task sendPingWithPongReceiveHandler:^(NSError *error) {
+            ok = (error == nil);
+            dispatch_semaphore_signal(sema);
+        }];
+        int64_t wait_ns = (int64_t)((timeout + 5.0) * NSEC_PER_SEC);
+        long wait_result = dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, wait_ns));
+        wispterm_ws_release_semaphore(sema);
+
+        if (wait_result != 0 || !ok) {
+            [task cancel];
+            [session invalidateAndCancel];
+            return NULL;
+        }
+
+        WispWsConn *conn = calloc(1, sizeof(WispWsConn));
+        if (conn == NULL) {
+            [task cancel];
+            [session invalidateAndCancel];
+            return NULL;
+        }
+        conn->session = [session retain];
+        conn->task = [task retain];
+        conn->pending = [[NSMutableData alloc] init];
+        conn->pending_is_text = false;
+        return conn;
+    }
+}
+
+bool wispterm_macos_ws_send(void *handle, const char *bytes, size_t len) {
+    @autoreleasepool {
+        WispWsConn *conn = (WispWsConn *)handle;
+        if (conn == NULL || conn->task == nil) return false;
+
+        NSData *data = [NSData dataWithBytes:(bytes != NULL ? bytes : "") length:len];
+        NSString *text = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
+        NSURLSessionWebSocketMessage *msg = (text != nil)
+            ? [[[NSURLSessionWebSocketMessage alloc] initWithString:text] autorelease]
+            : [[[NSURLSessionWebSocketMessage alloc] initWithData:data] autorelease];
+
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        __block BOOL ok = NO;
+        [conn->task sendMessage:msg completionHandler:^(NSError *error) {
+            ok = (error == nil);
+            dispatch_semaphore_signal(sema);
+        }];
+        // Block until the send resolves (mirrors the synchronous Windows send);
+        // the handler always fires, so the semaphore is safe to release after.
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        wispterm_ws_release_semaphore(sema);
+        return ok;
+    }
+}
+
+long wispterm_macos_ws_receive(void *handle, char *buffer, size_t buffer_len, int32_t *out_type) {
+    @autoreleasepool {
+        WispWsConn *conn = (WispWsConn *)handle;
+        if (conn == NULL || buffer == NULL || buffer_len == 0 || out_type == NULL) return -1;
+
+        // Drain a buffered remainder from a previous oversized message first.
+        if (conn->pending.length > 0) {
+            return wispterm_ws_emit_pending(conn, buffer, buffer_len, out_type);
+        }
+
+        dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+        __block NSData *payload = nil;
+        __block BOOL is_text = NO;
+        __block BOOL failed = NO;
+        [conn->task receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage *message, NSError *error) {
+            if (error != nil || message == nil) {
+                failed = YES;
+            } else if (message.type == NSURLSessionWebSocketMessageTypeString) {
+                is_text = YES;
+                payload = [[message.string dataUsingEncoding:NSUTF8StringEncoding] retain];
+            } else {
+                is_text = NO;
+                payload = [message.data retain];
+            }
+            dispatch_semaphore_signal(sema);
+        }];
+        // Block until a message arrives or the socket is torn down (close()
+        // cancels the task, which completes this receive with an error).
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        wispterm_ws_release_semaphore(sema);
+
+        if (failed) return -1;
+        if (payload == nil) {
+            *out_type = 3;
+            return 0;
+        }
+
+        conn->pending_is_text = is_text;
+        [conn->pending setData:payload];
+        [payload release];
+        return wispterm_ws_emit_pending(conn, buffer, buffer_len, out_type);
+    }
+}
+
+// Tear the socket down (idempotent). Unblocks an in-flight receive but does NOT
+// free the connection — the receive thread may still be running; the caller
+// frees via wispterm_macos_ws_free after joining it.
+void wispterm_macos_ws_shutdown(void *handle) {
+    @autoreleasepool {
+        WispWsConn *conn = (WispWsConn *)handle;
+        if (conn == NULL) return;
+        if (conn->task != nil) {
+            [conn->task cancelWithCloseCode:NSURLSessionWebSocketCloseCodeNormalClosure reason:nil];
+        }
+        if (conn->session != nil) {
+            [conn->session invalidateAndCancel];
+        }
+    }
+}
+
+void wispterm_macos_ws_free(void *handle) {
+    @autoreleasepool {
+        WispWsConn *conn = (WispWsConn *)handle;
+        if (conn == NULL) return;
+        [conn->task release];
+        [conn->session release];
+        [conn->pending release];
+        conn->task = nil;
+        conn->session = nil;
+        conn->pending = nil;
+        free(conn);
+    }
+}

--- a/src/test_macos_services.zig
+++ b/src/test_macos_services.zig
@@ -11,6 +11,7 @@ const global_hotkey = @import("platform/global_hotkey.zig");
 const global_hotkey_macos = @import("platform/global_hotkey_macos.zig");
 const notifications = @import("platform/notifications.zig");
 const open_url = @import("platform/open_url.zig");
+const remote_transport = @import("platform/remote_transport.zig");
 const text = @import("platform/text.zig");
 const update_package = @import("platform/update_package.zig");
 
@@ -64,6 +65,22 @@ test "macOS clipboard reads a pasted image as a temp PNG file" {
     // ready-made image/png the bytes pass through verbatim.
     try std.testing.expect(std.mem.startsWith(u8, data, "\x89PNG\r\n\x1a\n"));
     try std.testing.expectEqualSlices(u8, &sample_png, data);
+}
+
+test "macOS remote transport selects the native backend and fails closed on a dead endpoint" {
+    try std.testing.expectEqualStrings("macos", @tagName(remote_transport.backendForOs(.macos)));
+
+    // Nothing is listening on this loopback port, so connect must fail promptly
+    // and tear the native session down cleanly (exercises the connect + shutdown
+    // path of the NSURLSessionWebSocketTask bridge; full duplex needs a live
+    // relay server and is verified on-device).
+    const result = remote_transport.connect(std.testing.allocator, .{
+        .secure = false,
+        .host = "127.0.0.1",
+        .port = 9,
+        .object_name = "/ws",
+    });
+    try std.testing.expectError(error.RemoteTransportConnectFailed, result);
 }
 
 test "macOS display and text services return native answers" {


### PR DESCRIPTION
## 问题(审计发现的 macOS 静默桩 · 大修)

`remote_transport` 在 macOS(和 Linux)都落到 `.unsupported`,`remote-enabled = true` 时中继**永远连不上**:[remote_client.zig:321](src/remote_client.zig:321) 报错 → 只打印 stderr → 每 2s 无限重连,UI 无任何提示。设备同步 / 远程镜像 / agent-open 全部静默失效。这是审计里最高危的一项。本 PR 实现 **macOS** 侧;Linux 仍记录在 TODO。

## 实现

- **[remote_transport_macos_bridge.m](src/platform/remote_transport_macos_bridge.m)**:`NSURLSessionWebSocketTask` 桥接(手动 retain/release,与 [http_client_macos_bridge.m](src/platform/http_client_macos_bridge.m) 一致)。
  - `connect` 用 ping/pong 校验握手,死端点立刻返回错误(对齐 Windows 的 upgrade 握手语义),而不是留一个静默坏 socket;
  - `send`/`receive` 用 `dispatch_semaphore` 阻塞,镜像 Windows 的同步 API;
  - 超过消费方 `io_chunk_size`(16K)缓冲区的入站消息,切成 `utf8_fragment` 分片投递(对齐 WinHTTP 的分片契约)。
- **[remote_transport_macos.zig](src/platform/remote_transport_macos.zig)**:镜像 Windows API 表面;**两段式 close**(先 shutdown 解除接收线程阻塞、保留 conn,join 之后第二次 close 才 free),与 [remote_client.zig:372](src/remote_client.zig:372) 的「close 在 join 之前」顺序匹配,避免接收线程访问已释放内存。
- **[remote_transport.zig](src/platform/remote_transport.zig)**:`.macos` 路由到新后端。
- **build.zig**:桥接编译进 app + services 测试模块。

## 测试

- `zig build test-macos-services` → **63/63 passed**,含新增冒烟测试:连接 `127.0.0.1:9`(无监听)→ 快速返回 `error.RemoteTransportConnectFailed` 且会话干净拆除(509ms,真机运行了 connect+shutdown 路径)
- `zig build macos-app -Dtarget=aarch64-macos` → RC=0(桥接链接进真实 app)
- `zig build test-full` → RC=0(Windows 目标,无回归)
- `zig build test-full -Dtarget=aarch64-macos` → RC=0(macOS 目标全量,无 undefined/duplicate symbol)

## ⚠️ 验证限制(重要)

这块几乎全是实时 socket I/O,**本机没有完整验证路径**:已运行时验证的只有「连接失败 + 拆除」一条路径。**成功连接 + 收发全双工需要一台真实运行的 relay 服务器,必须在你的 Mac 上真机验证**。建议:配 `remote-enabled = true` 指向你的中继服务,确认能连上、能收发、断开后能干净重连、退出不崩。

🤖 Generated with [Claude Code](https://claude.com/claude-code)