### PR TITLE
feat(ui): Split Down shortcut + Windows-Terminal-style +/- split chords

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | New session (session launcher) | **Ctrl+Shift+T** | **Cmd+Shift+T** |
 | New window | **Ctrl+Shift+N** | **Cmd+Shift+N** |
 | Toggle tab sidebar | **Ctrl+Shift+B** | **Cmd+Shift+B** |
-| Split to the right | **Ctrl+Shift+O** | **Cmd+Shift+O** |
+| Split to the right | **Ctrl+Shift++** | **Cmd+Shift++** |
+| Split downward | **Ctrl+Shift+-** | **Cmd+Shift+-** |
 | Toggle file explorer sidebar | **Ctrl+Shift+Alt+E** | **Cmd+Shift+Opt+E** |
 | Toggle AI Copilot sidebar (current terminal) | **Ctrl+Shift+A** | **Cmd+Shift+A** |
 | Preview files (Ctrl/Cmd-click in terminal, or double-click in File Explorer) | Ctrl-click | Cmd-click |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,7 +121,8 @@ keybind = global:ctrl+backquote=toggle_quake
 | 新建会话（会话启动器） | **Ctrl+Shift+T** | **Cmd+Shift+T** |
 | 新建窗口 | **Ctrl+Shift+N** | **Cmd+Shift+N** |
 | 切换标签侧边栏 | **Ctrl+Shift+B** | **Cmd+Shift+B** |
-| 向右分屏 | **Ctrl+Shift+O** | **Cmd+Shift+O** |
+| 向右分屏 | **Ctrl+Shift++** | **Cmd+Shift++** |
+| 向下分屏 | **Ctrl+Shift+-** | **Cmd+Shift+-** |
 | 切换文件浏览器侧边栏 | **Ctrl+Shift+Alt+E** | **Cmd+Shift+Opt+E** |
 | 切换 AI Copilot 侧边栏（当前终端） | **Ctrl+Shift+A** | **Cmd+Shift+A** |
 | 预览文件（终端内 Ctrl/Cmd 单击，或文件浏览器中双击） | Ctrl 单击 | Cmd 单击 |

--- a/docs/index.html
+++ b/docs/index.html
@@ -226,7 +226,8 @@ ai-agent-output-limit  = 16384</code></pre>
           <div><span class="label">New window</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>N</kbd></span></div>
           <div><span class="label">Toggle tab sidebar</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>B</kbd></span></div>
           <div><span class="label">Toggle file explorer</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>Alt/Opt</kbd><kbd>E</kbd></span></div>
-          <div><span class="label">Split to the right</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>O</kbd></span></div>
+          <div><span class="label">Split to the right</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>+</kbd></span></div>
+          <div><span class="label">Split downward</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>-</kbd></span></div>
           <div><span class="label">Equalize splits</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>Z</kbd></span></div>
           <div><span class="label">Close panel / tab / window</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>W</kbd></span></div>
           <div><span class="label">Maximize / restore window</span><span class="keys"><kbd>Alt/Opt</kbd><kbd>Enter</kbd></span></div>

--- a/docs/tabs-panels.md
+++ b/docs/tabs-panels.md
@@ -29,8 +29,10 @@ terminals together.
 
 ## Splitting a tab into panels
 
-- **Split the focused panel:** `Ctrl+Shift+O` (`split_right`). The command center
-  also offers `Split Right`, `Split Down`, `Split Left`, and `Split Up`.
+- **Split the focused panel:** `Ctrl+Shift++` splits to the right (`split_right`)
+  and `Ctrl+Shift+-` splits downward (`split_down`), mirroring Windows Terminal.
+  The command center also offers `Split Right`, `Split Down`, `Split Left`, and
+  `Split Up`.
 - **Move focus between panels:** `Alt+←` / `Alt+→` / `Alt+↑` / `Alt+↓`
   (`focus_left` / `focus_right` / `focus_up` / `focus_down`).
 - **Cycle focus:** `Ctrl+Shift+[` (`focus_previous`) and `Ctrl+Shift+]`

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -226,7 +226,8 @@ ai-agent-output-limit  = 16384</code></pre>
           <div><span class="label">新建窗口</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>N</kbd></span></div>
           <div><span class="label">切换标签侧栏</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>B</kbd></span></div>
           <div><span class="label">切换文件浏览器</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>Alt/Opt</kbd><kbd>E</kbd></span></div>
-          <div><span class="label">向右分屏</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>O</kbd></span></div>
+          <div><span class="label">向右分屏</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>+</kbd></span></div>
+          <div><span class="label">向下分屏</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>-</kbd></span></div>
           <div><span class="label">均分分屏尺寸</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>Z</kbd></span></div>
           <div><span class="label">关闭面板 / 标签 / 窗口</span><span class="keys"><kbd>Ctrl/Cmd</kbd><kbd>Shift</kbd><kbd>W</kbd></span></div>
           <div><span class="label">最大化 / 还原窗口</span><span class="keys"><kbd>Alt/Opt</kbd><kbd>Enter</kbd></span></div>

--- a/src/input.zig
+++ b/src/input.zig
@@ -1720,6 +1720,7 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
         .new_window => requestNewWindowFromActiveCwd(),
         .new_session => overlays.sessionLauncherOpen(),
         .split_right => AppWindow.splitFocused(.right),
+        .split_down => AppWindow.splitFocused(.down),
         .toggle_file_explorer => toggleFileExplorer(),
         .toggle_sidebar => toggleSidebar(),
         .toggle_ai_copilot => AppWindow.toggleAiCopilot(),

--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -21,6 +21,7 @@ pub const Command = union(enum) {
     new_window,
     new_session,
     split_right,
+    split_down,
     toggle_file_explorer,
     toggle_sidebar,
     toggle_ai_copilot,
@@ -50,6 +51,7 @@ pub fn resolve(action: keybind.Action, phase: Phase) ?Command {
             .new_window => .new_window,
             .new_session => .new_session,
             .split_right => .split_right,
+            .split_down => .split_down,
             .toggle_file_explorer => .toggle_file_explorer,
             .toggle_sidebar => .toggle_sidebar,
             .toggle_ai_copilot => .toggle_ai_copilot,
@@ -119,6 +121,12 @@ test "early commands resolve only in the early phase" {
     try std.testing.expectEqual(Command.toggle_quake, resolve(.toggle_quake, .early).?);
     try std.testing.expectEqual(Command.split_right, resolve(.split_right, .early).?);
     try std.testing.expectEqual(@as(?Command, null), resolve(.toggle_quake, .late));
+}
+
+test "split_right and split_down resolve in the early phase" {
+    try std.testing.expectEqual(Command.split_right, resolve(.split_right, .early).?);
+    try std.testing.expectEqual(Command.split_down, resolve(.split_down, .early).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.split_down, .late));
 }
 
 test "font size carries the delta" {

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -61,6 +61,7 @@ pub const Action = enum {
     new_window,
     new_session,
     split_right,
+    split_down,
     toggle_file_explorer,
     toggle_sidebar,
     toggle_ai_copilot,
@@ -413,13 +414,18 @@ pub const default_bindings = [_]Binding{
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'N' }, .action = .new_window },
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'B' }, .action = .toggle_sidebar },
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'A' }, .action = .toggle_ai_copilot },
-    .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'O' }, .action = .split_right },
+    // Windows-Terminal-style split chords: Ctrl+Shift++ splits vertically (a pane
+    // to the right), Ctrl+Shift+- splits horizontally (a pane below). These take
+    // the shifted "+" chord that font-size-increase used to share, so font size
+    // keeps only the unshifted Ctrl+= / Ctrl+- chords below.
+    .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = Key.plus }, .action = .split_right },
+    .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = Key.minus }, .action = .split_down },
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true, .alt = true }, .key_code = 'E' }, .action = .toggle_file_explorer },
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'W' }, .action = .close_panel_or_tab },
     .{ .trigger = .{ .mods = .{ .alt = true }, .key_code = Key.enter }, .action = .toggle_maximize },
+    // Font size lives on the unshifted chord (press Ctrl and the "=/+" key
+    // without Shift). The shifted Ctrl+Shift++ chord is now split_right above.
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = Key.plus }, .action = .font_size_increase },
-    // The "+" glyph needs Shift on most layouts, so accept the shifted chord too.
-    .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = Key.plus }, .action = .font_size_increase },
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = Key.minus }, .action = .font_size_decrease },
     .{ .trigger = .{ .mods = .{ .ctrl = true, .shift = true }, .key_code = 'C' }, .action = .copy },
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = 'V' }, .action = .paste },
@@ -550,6 +556,21 @@ test "keybind formats display labels" {
         if (is_macos) "Cmd+P" else "Win+P",
         try formatTrigger(.{ .mods = .{ .win = true }, .key_code = 'P' }, &buf),
     );
+}
+
+test "split right/down use Windows-Terminal-style Ctrl+Shift +/- bindings" {
+    const set = Set.defaults();
+    const is_macos = builtin.target.os.tag == .macos;
+    // Ctrl→Cmd on macOS for non-global app shortcuts.
+    const split_mods: Mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true };
+    // "+" (vertical) opens a pane to the right; "-" (horizontal) opens one below.
+    try std.testing.expectEqual(Action.split_right, set.lookupApp(.{ .mods = split_mods, .key_code = Key.plus }).?);
+    try std.testing.expectEqual(Action.split_down, set.lookupApp(.{ .mods = split_mods, .key_code = Key.minus }).?);
+    // The shifted-plus chord is no longer font increase; font size keeps the
+    // unshifted Ctrl/Cmd +/- chords.
+    const font_mods: Mods = if (is_macos) .{ .win = true } else .{ .ctrl = true };
+    try std.testing.expectEqual(Action.font_size_increase, set.lookupApp(.{ .mods = font_mods, .key_code = Key.plus }).?);
+    try std.testing.expectEqual(Action.font_size_decrease, set.lookupApp(.{ .mods = font_mods, .key_code = Key.minus }).?);
 }
 
 test "keybind parses displayed plus shortcut spelling" {

--- a/src/platform/menu_macos.zig
+++ b/src/platform/menu_macos.zig
@@ -98,7 +98,8 @@ fn buildDefaultMenu() void {
     wispterm_macos_menu_begin_submenu("File");
     wispterm_macos_menu_add_item("New Tab", id(.new_session), "t", ModCtrl | ModShift);
     wispterm_macos_menu_add_item("New Window", id(.new_window), "n", ModCtrl | ModShift);
-    wispterm_macos_menu_add_item("Split Right", id(.split_right), "o", ModCtrl | ModShift);
+    wispterm_macos_menu_add_item("Split Right", id(.split_right), "+", ModCtrl | ModShift);
+    wispterm_macos_menu_add_item("Split Down", id(.split_down), "-", ModCtrl | ModShift);
     wispterm_macos_menu_add_separator();
     wispterm_macos_menu_add_item("Close Tab", id(.close_panel_or_tab), "w", ModCtrl | ModShift);
     wispterm_macos_menu_end_submenu();

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -897,6 +897,7 @@ fn commandEntryKeybindAction(action: CommandAction) ?keybind.Action {
     return switch (action) {
         .new_tab => .new_session,
         .split_right => .split_right,
+        .split_down => .split_down,
         .focus_previous => .focus_previous,
         .focus_next => .focus_next,
         .equalize_splits => .equalize_splits,

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -55,7 +55,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+Shift+P", .kind = .action, .first = .toggle_command_palette, .action = "Command center", .action_zh = "命令中心" },
     .{ .keys = "Ctrl+Shift+T", .kind = .action, .first = .new_session, .action = "New session", .action_zh = "新建会话" },
     .{ .keys = "Ctrl+Shift+B", .kind = .action, .first = .toggle_sidebar, .action = "Toggle sidebar", .action_zh = "切换侧边栏" },
-    .{ .keys = "Ctrl+Shift+O", .kind = .action, .first = .split_right, .action = "Split right", .action_zh = "向右分屏" },
+    .{ .keys = "Ctrl+Shift++ / Ctrl+Shift+-", .kind = .pair, .first = .split_right, .second = .split_down, .action = "Split right / down", .action_zh = "向右 / 向下分屏" },
     .{ .keys = "Ctrl+Shift+Alt+E", .kind = .action, .first = .toggle_file_explorer, .action = "File explorer", .action_zh = "文件浏览器" },
     .{ .keys = "Ctrl/double-click file", .keys_macos = "Cmd/double-click file", .action = "Preview file", .action_zh = "预览文件" },
     .{ .keys = "Ctrl+Shift-click SSH file", .keys_macos = "Cmd+Shift-click SSH file", .action = "Download file", .action_zh = "下载文件" },

--- a/wiki/Keyboard-Shortcuts-zh.md
+++ b/wiki/Keyboard-Shortcuts-zh.md
@@ -35,13 +35,14 @@ keybind = global:ctrl+backquote=toggle_quake
 | `Ctrl+Shift+P` | `toggle_command_palette` | 打开命令中心 |
 | `Ctrl+Shift+T` | `new_session` | 打开会话启动器（shell / Copilot / Sessions） |
 | `Ctrl+Shift+N` | `new_window` | 新建窗口 |
-| `Ctrl+Shift+O` | `split_right` | 分屏当前面板 |
+| `Ctrl+Shift++` | `split_right` | 向右分屏当前面板 |
+| `Ctrl+Shift+-` | `split_down` | 向下分屏当前面板 |
 | `Ctrl+Shift+B` | `toggle_sidebar` | 切换侧边栏 |
 | `Ctrl+Shift+A` | `toggle_ai_copilot` | 在终端上切换 Copilot 侧栏 |
 | `Ctrl+Shift+Alt+E` | `toggle_file_explorer` | 切换文件浏览器 |
 | `Ctrl+Shift+W` | `close_panel_or_tab` | 关闭当前面板/标签 |
 | `Alt+Enter` | `toggle_maximize` | 最大化/还原当前面板 |
-| `Ctrl++`（也可 `Ctrl+Shift++`） | `font_size_increase` | 增大字号 |
+| `Ctrl++`（不按 Shift） | `font_size_increase` | 增大字号 |
 | `Ctrl+-` | `font_size_decrease` | 减小字号 |
 | `Ctrl+Shift+C` | `copy` | 复制选区 |
 | `Ctrl+V` | `paste` | 粘贴 |
@@ -72,7 +73,7 @@ keybind = global:ctrl+backquote=toggle_quake
 所有可绑定的应用级动作：
 
 `toggle_quake`、`toggle_command_palette`、`new_window`、`new_session`、
-`split_right`、`toggle_file_explorer`、`toggle_sidebar`、`toggle_ai_copilot`、
+`split_right`、`split_down`、`toggle_file_explorer`、`toggle_sidebar`、`toggle_ai_copilot`、
 `close_panel_or_tab`、`toggle_maximize`、`font_size_increase`、
 `font_size_decrease`、`copy`、`paste`、`paste_image`、`focus_left`、
 `focus_right`、`focus_up`、`focus_down`、`focus_previous`、`focus_next`、

--- a/wiki/Keyboard-Shortcuts.md
+++ b/wiki/Keyboard-Shortcuts.md
@@ -36,13 +36,14 @@ keybind = global:ctrl+backquote=toggle_quake
 | `Ctrl+Shift+P` | `toggle_command_palette` | Open the command center |
 | `Ctrl+Shift+T` | `new_session` | Open the session launcher (shell / Copilot / Sessions) |
 | `Ctrl+Shift+N` | `new_window` | Open a new window |
-| `Ctrl+Shift+O` | `split_right` | Split the focused panel |
+| `Ctrl+Shift++` | `split_right` | Split the focused panel to the right |
+| `Ctrl+Shift+-` | `split_down` | Split the focused panel downward |
 | `Ctrl+Shift+B` | `toggle_sidebar` | Toggle the sidebar |
 | `Ctrl+Shift+A` | `toggle_ai_copilot` | Toggle the Copilot sidebar on a terminal |
 | `Ctrl+Shift+Alt+E` | `toggle_file_explorer` | Toggle the File Explorer |
 | `Ctrl+Shift+W` | `close_panel_or_tab` | Close the focused panel/tab |
 | `Alt+Enter` | `toggle_maximize` | Maximize/restore the focused panel |
-| `Ctrl++` (also `Ctrl+Shift++`) | `font_size_increase` | Increase font size |
+| `Ctrl++` (press without Shift) | `font_size_increase` | Increase font size |
 | `Ctrl+-` | `font_size_decrease` | Decrease font size |
 | `Ctrl+Shift+C` | `copy` | Copy the selection |
 | `Ctrl+V` | `paste` | Paste |
@@ -77,7 +78,7 @@ Some actions are mouse-only and are not bound through `keybind`:
 Every app-level action you can bind:
 
 `toggle_quake`, `toggle_command_palette`, `new_window`, `new_session`,
-`split_right`, `toggle_file_explorer`, `toggle_sidebar`, `toggle_ai_copilot`,
+`split_right`, `split_down`, `toggle_file_explorer`, `toggle_sidebar`, `toggle_ai_copilot`,
 `close_panel_or_tab`, `toggle_maximize`, `font_size_increase`,
 `font_size_decrease`, `copy`, `paste`, `paste_image`, `focus_left`,
 `focus_right`, `focus_up`, `focus_down`, `focus_previous`, `focus_next`,

--- a/wiki/Tabs-Splits-Panels-zh.md
+++ b/wiki/Tabs-Splits-Panels-zh.md
@@ -24,7 +24,7 @@
 
 ## 创建与切换分屏
 
-- **分屏当前面板：** `Ctrl+Shift+O`（`split_right`）。
+- **分屏当前面板：** `Ctrl+Shift++` 向右分屏（`split_right`），`Ctrl+Shift+-` 向下分屏（`split_down`），与 Windows Terminal 一致。
 - **在面板间移动焦点：** `Alt+←` / `Alt+→` / `Alt+↑` / `Alt+↓`。
 - **循环切换焦点：** `Ctrl+Shift+[`（上一个）与 `Ctrl+Shift+]`（下一个）。
 - **均分大小：** `Ctrl+Shift+Z`（`equalize_splits`）把该标签内所有分屏重置为等比。

--- a/wiki/Tabs-Splits-Panels.md
+++ b/wiki/Tabs-Splits-Panels.md
@@ -28,7 +28,8 @@ unrelated work apart, and splits to see related terminals side by side.
 
 ## Creating & focusing splits
 
-- **Split the current panel:** `Ctrl+Shift+O` (`split_right`).
+- **Split the current panel:** `Ctrl+Shift++` splits to the right (`split_right`)
+  and `Ctrl+Shift+-` splits downward (`split_down`), mirroring Windows Terminal.
 - **Move focus between panels:** `Alt+←` / `Alt+→` / `Alt+↑` / `Alt+↓`.
 - **Cycle focus:** `Ctrl+Shift+[` (previous) and `Ctrl+Shift+]` (next).
 - **Equalize sizes:** `Ctrl+Shift+Z` (`equalize_splits`) resets all splits in


### PR DESCRIPTION
## What

Adds a **Split Down** (horizontal / pane-below) keyboard shortcut and switches both split chords to Windows-Terminal style:

| Action | Shortcut | Was |
|---|---|---|
| Split right (vertical) | `Ctrl+Shift++` | `Ctrl+Shift+O` |
| **Split down (horizontal)** | `Ctrl+Shift+-` | *(none — command center only)* |

`-` opens a pane below, `+` opens one to the right — matching Windows Terminal. On macOS these auto-remap to `Cmd+Shift+±` via the existing Ctrl→Cmd default remap.

## Why / tradeoff

Splitting down already worked from the command palette (`split_down` → `AppWindow.splitFocused(.down)`); it just had no direct key. To take the `+`/`-` chords WT-style, `split_right` moves off `Ctrl+Shift+O` onto `Ctrl+Shift++`, which **reclaims the shifted chord that font-size-increase used to share**. Font size now lives only on the unshifted `Ctrl+=` / `Ctrl+-` (the `Ctrl+Shift++` font variant is removed). This was a deliberate, confirmed choice.

## How

Wires `split_down` through the existing chain:
`keybind.Action` → `command_dispatch.Command` (early phase) → `input.executeCommand` → `AppWindow.splitFocused(.down)`.

Also surfaces it in the command palette shortcut hint, the startup-shortcuts overlay (combined "Split right / down" row), and the macOS menu. Docs kept in sync: embedded `docs/tabs-panels.md`, website HTML, READMEs, and `wiki/` pages.

## Tests

TDD: added resolution + default-binding tests (RED first), then implemented.

- `zig build test` → pass
- `zig build test-full` → pass (Windows cross-compile + posix tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)