### PR TITLE
fix(input): Ctrl+C copies selection instead of SIGINT (+ input diagnostics)

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -79,6 +79,7 @@ unfocused_split_opacity: f32,
 split_divider_color: ?Config.Color,
 focus_follows_mouse: bool,
 copy_on_select: bool,
+ctrl_c_copies_selection: bool,
 right_click_action: Config.RightClickAction,
 url_open_mode: Config.UrlOpenMode,
 ssh_legacy_algorithms: bool,
@@ -248,6 +249,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: Config) !App {
         .split_divider_color = cfg.@"split-divider-color",
         .focus_follows_mouse = cfg.@"focus-follows-mouse",
         .copy_on_select = cfg.@"copy-on-select",
+        .ctrl_c_copies_selection = cfg.@"ctrl-c-copies-selection",
         .right_click_action = cfg.@"right-click-action",
         .url_open_mode = cfg.@"url-open-mode",
         .ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms",
@@ -477,6 +479,7 @@ pub fn updateConfig(self: *App, cfg: *const Config) void {
     self.split_divider_color = cfg.@"split-divider-color";
     self.focus_follows_mouse = cfg.@"focus-follows-mouse";
     self.copy_on_select = cfg.@"copy-on-select";
+    self.ctrl_c_copies_selection = cfg.@"ctrl-c-copies-selection";
     self.right_click_action = cfg.@"right-click-action";
     self.url_open_mode = cfg.@"url-open-mode";
     self.ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -43,6 +43,7 @@ const quick_terminal = @import("quick_terminal.zig");
 const keybind = @import("keybind.zig");
 const thread_message = @import("appwindow/thread_message.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
+const input_diagnostics = @import("input_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 const hit_test = @import("input/hit_test.zig");
 pub const ai_chat = @import("ai_chat.zig");
@@ -8277,6 +8278,7 @@ fn runMainLoop(self: *AppWindow) !void {
     g_weixin_ui_handle.store(0, .release);
     render_diagnostics.log("shutdown window-loop-ended", .{});
     render_diagnostics.close();
+    input_diagnostics.close();
 
     // Clean up file explorer async state (join background thread, free job)
     file_explorer.deinit();

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -176,6 +176,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     overlays.g_unfocused_split_opacity = app.unfocused_split_opacity;
     g_focus_follows_mouse = app.focus_follows_mouse;
     g_copy_on_select = app.copy_on_select;
+    g_ctrl_c_copies_selection = app.ctrl_c_copies_selection;
     g_right_click_action = app.right_click_action;
     input.g_url_open_mode = app.url_open_mode;
     g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
@@ -4495,6 +4496,7 @@ pub threadlocal var g_focus_follows_mouse: bool = false;
 threadlocal var g_agent_context_surface_id: [16]u8 = undefined;
 threadlocal var g_agent_context_surface_id_len: usize = 0;
 pub threadlocal var g_copy_on_select: bool = false;
+pub threadlocal var g_ctrl_c_copies_selection: bool = true;
 pub threadlocal var g_right_click_action: Config.RightClickAction = .copy;
 pub threadlocal var g_ssh_legacy_algorithms: bool = false;
 pub threadlocal var g_desktop_notifications: bool = true;
@@ -4963,6 +4965,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     overlays.g_unfocused_split_opacity = cfg.@"unfocused-split-opacity";
     g_focus_follows_mouse = cfg.@"focus-follows-mouse";
     g_copy_on_select = cfg.@"copy-on-select";
+    g_ctrl_c_copies_selection = cfg.@"ctrl-c-copies-selection";
     g_right_click_action = cfg.@"right-click-action";
     input.g_url_open_mode = cfg.@"url-open-mode";
     g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -14,6 +14,7 @@ const Pty = @import("pty.zig").Pty;
 const Command = @import("Command.zig");
 const renderer = @import("renderer.zig");
 const termio = @import("termio.zig");
+const input_diagnostics = @import("input_diagnostics.zig");
 const Config = @import("config.zig");
 const Renderer = @import("renderer/Renderer.zig");
 const remote = @import("remote_client.zig");
@@ -779,6 +780,19 @@ pub fn queueIo(self: *Surface, msg: termio.Message) void {
 /// This mirrors Ghostty's write-message boundary so local and remote input
 /// share the same PTY write path instead of writing directly to the pipe.
 pub fn queuePtyWrite(self: *Surface, data: []const u8) void {
+    if (input_diagnostics.enabled()) {
+        // Best-effort, lock-free read of the active mouse-tracking mode so the
+        // log shows whether a write coincides with mouse reporting being on
+        // (e.g. leaked from a mouse-aware TUI like Codex). A torn enum read is
+        // harmless for diagnostics.
+        var tag_buf: [96]u8 = undefined;
+        const tag = std.fmt.bufPrint(&tag_buf, "surface=0x{x} mouse_event={s} mouse_format={s}", .{
+            @intFromPtr(self),
+            @tagName(self.terminal.flags.mouse_event),
+            @tagName(self.terminal.flags.mouse_format),
+        }) catch "surface=?";
+        input_diagnostics.logPtyWrite(tag, data);
+    }
     const msg = termio.Message.writeReq(self.allocator, data) catch return;
     self.queueIo(msg);
 }

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -13,6 +13,7 @@ const windows = std.os.windows;
 const platform_input = @import("../platform/input_events.zig");
 const platform_window = @import("../platform/window.zig");
 const render_diagnostics = @import("../render_diagnostics.zig");
+const uia_probe = @import("../platform/uia_probe.zig");
 const dx_present = @import("win32_dx_present.zig");
 
 // ============================================================================
@@ -186,6 +187,7 @@ const WM_ENTERSIZEMOVE: UINT = 0x0231;
 const WM_EXITSIZEMOVE: UINT = 0x0232;
 const WM_KEYDOWN: UINT = 0x0100;
 const WM_KEYUP: UINT = 0x0101;
+const WM_GETOBJECT: UINT = 0x003D;
 const WM_SYSKEYDOWN: UINT = 0x0104;
 const WM_SYSKEYUP: UINT = 0x0105;
 const WM_CHAR: UINT = 0x0102;
@@ -1695,6 +1697,13 @@ fn wndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.wina
     }
 
     switch (msg) {
+        WM_GETOBJECT => {
+            // UIA probe (Step 1): if a UIA client is inspecting us, answer with a
+            // barebones provider that logs the query. Only active when input
+            // diagnostics are on; otherwise falls through to DefWindowProc.
+            if (uia_probe.handleGetObject(hwnd, wParam, lParam)) |lr| return lr;
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
+        },
         WM_CLOSE => {
             w.close_requested = true;
             return 0;

--- a/src/config.zig
+++ b/src/config.zig
@@ -409,6 +409,12 @@ language: i18n.LanguageSetting = .auto,
 /// program (e.g. Codex) actually receives, e.g. the "selecting text emits ^C"
 /// report. Every PTY write is logged in caret notation (0x03 -> "^C").
 @"wispterm-debug-input": bool = false,
+/// When a terminal selection is active, treat Ctrl+C as "copy the selection"
+/// (and clear it) instead of sending SIGINT (0x03) — matching Windows Terminal.
+/// With no selection, Ctrl+C still interrupts as usual. Also neutralizes
+/// "copy on select" trackpad/clipboard tools that synthesize a Ctrl+C right
+/// after a mouse selection (which otherwise interrupts the running program).
+@"ctrl-c-copies-selection": bool = true,
 /// Present frames through a DXGI flip-model swapchain instead of GDI
 /// SwapBuffers (Windows only). The legacy BLT present goes through the DWM
 /// redirection surface, which on some iGPU drivers (Intel Arc, AMD) produces
@@ -995,6 +1001,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             self.@"wispterm-debug-input" = false;
         } else {
             log.warn("invalid wispterm-debug-input: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "ctrl-c-copies-selection")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"ctrl-c-copies-selection" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"ctrl-c-copies-selection" = false;
+        } else {
+            log.warn("invalid ctrl-c-copies-selection: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "wispterm-d3d-present")) {
         if (std.mem.eql(u8, value, "true")) {
@@ -2287,4 +2301,15 @@ test "config: wispterm-debug-input parses from a config line" {
     try std.testing.expect(cfg.@"wispterm-debug-input");
     cfg.applyKeyValue(allocator, "wispterm-debug-input", "false", ".");
     try std.testing.expect(!cfg.@"wispterm-debug-input");
+}
+
+test "config: ctrl-c-copies-selection defaults true and parses" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    try std.testing.expect(cfg.@"ctrl-c-copies-selection");
+    cfg.applyKeyValue(allocator, "ctrl-c-copies-selection", "false", ".");
+    try std.testing.expect(!cfg.@"ctrl-c-copies-selection");
+    cfg.applyKeyValue(allocator, "ctrl-c-copies-selection", "true", ".");
+    try std.testing.expect(cfg.@"ctrl-c-copies-selection");
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -402,6 +402,13 @@ language: i18n.LanguageSetting = .auto,
 /// the `WISPTERM_RENDER_DIAGNOSTICS=1` env var, but survives restarts and needs
 /// no shell setup — intended for users helping debug resize/DPI render glitches.
 @"wispterm-debug-render": bool = false,
+/// Write input / PTY-write diagnostics to
+/// `%APPDATA%\wispterm\input-diagnostic.log` (Windows). Equivalent to setting
+/// the `WISPTERM_INPUT_DIAGNOSTICS=1` env var, but survives restarts and needs
+/// no shell setup — intended for debugging what keystrokes / mouse reports a
+/// program (e.g. Codex) actually receives, e.g. the "selecting text emits ^C"
+/// report. Every PTY write is logged in caret notation (0x03 -> "^C").
+@"wispterm-debug-input": bool = false,
 /// Present frames through a DXGI flip-model swapchain instead of GDI
 /// SwapBuffers (Windows only). The legacy BLT present goes through the DWM
 /// redirection surface, which on some iGPU drivers (Intel Arc, AMD) produces
@@ -980,6 +987,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             self.@"wispterm-debug-render" = false;
         } else {
             log.warn("invalid wispterm-debug-render: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "wispterm-debug-input")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"wispterm-debug-input" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"wispterm-debug-input" = false;
+        } else {
+            log.warn("invalid wispterm-debug-input: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "wispterm-d3d-present")) {
         if (std.mem.eql(u8, value, "true")) {
@@ -2261,4 +2276,15 @@ test "config: wispterm-debug-render parses from a config line" {
     try std.testing.expect(cfg.@"wispterm-debug-render");
     cfg.applyKeyValue(allocator, "wispterm-debug-render", "false", ".");
     try std.testing.expect(!cfg.@"wispterm-debug-render");
+}
+
+test "config: wispterm-debug-input parses from a config line" {
+    const allocator = std.testing.allocator;
+    var cfg = Config{};
+    defer cfg.deinit(allocator);
+    try std.testing.expect(!cfg.@"wispterm-debug-input");
+    cfg.applyKeyValue(allocator, "wispterm-debug-input", "true", ".");
+    try std.testing.expect(cfg.@"wispterm-debug-input");
+    cfg.applyKeyValue(allocator, "wispterm-debug-input", "false", ".");
+    try std.testing.expect(!cfg.@"wispterm-debug-input");
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -1788,6 +1788,11 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
 }
 
 fn handleKey(ev: platform_input.KeyEvent) void {
+    if (input_diagnostics.enabled()) {
+        input_diagnostics.log("key-event code=0x{x} ctrl={} shift={} alt={} super={} selection_active={}", .{
+            ev.key_code, ev.ctrl, ev.shift, ev.alt, ev.super, activeTerminalSelectionExists(),
+        });
+    }
     overlays.startupShortcutsDismiss();
     const key_event = logicalKeyEvent(ev);
     if (overlays.whatsNewVisible()) {
@@ -2323,6 +2328,10 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 // Shifted Ctrl+letter chords are application shortcuts above.
                 if (!ev.shift) {
                     const ctrl_char: u8 = @intCast(ev.key_code - 0x41 + 1);
+                    if (input_diagnostics.enabled())
+                        input_diagnostics.log("ctrl-key emit byte=0x{x} (Ctrl+{c}) selection_active={}", .{
+                            ctrl_char, @as(u8, @intCast(ev.key_code)), activeTerminalSelectionExists(),
+                        });
                     writeToPty(surface, &[_]u8{ctrl_char});
                     wrote_to_pty = true;
                 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -5236,6 +5236,10 @@ fn reportMouseMotion(surface: *Surface, button: mouse_report.Button, ev: platfor
 }
 
 fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
+    if (input_diagnostics.enabled())
+        input_diagnostics.log("mouse-wheel raw delta={d} x={d} y={d} ctrl={} shift={} alt={}", .{
+            ev.delta, ev.xpos, ev.ypos, ev.ctrl, ev.shift, ev.alt,
+        });
     overlays.startupShortcutsDismiss();
     if (overlays.whatsNewVisible()) {
         overlays.whatsNewHandleScroll(@floatFromInt(ev.delta));
@@ -5373,15 +5377,21 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
     var terminal_input_buf: [512]u8 = undefined;
     var terminal_input_len: usize = 0;
     var sent_to_terminal = false;
+    var dbg_branch: []const u8 = "viewport";
 
     surface.render_state.mutex.lock();
+    const dbg_mode = surface.terminal.flags.mouse_event;
+    const dbg_alt_screen = surface.terminal.screens.active_key == .alternate;
+    const dbg_alt_scroll = surface.terminal.modes.get(.mouse_alternate_scroll);
     if (surface.terminal.flags.mouse_event != .none) {
         for (0..mouseWheelUnits(ev.delta)) |_| {
             if (!appendMouseWheelReport(surface, ev, &terminal_input_buf, &terminal_input_len)) break;
         }
         sent_to_terminal = terminal_input_len > 0;
+        dbg_branch = "report";
     } else if (appendAlternateScrollKeys(surface, ev, &terminal_input_buf, &terminal_input_len)) {
         sent_to_terminal = true;
+        dbg_branch = "altscroll";
     } else {
         // WHEEL_DELTA is 120 per notch. Convert to lines (3 lines per notch, like GLFW).
         const notches = @as(f64, @floatFromInt(ev.delta)) / 120.0;
@@ -5397,6 +5407,11 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         surface.scrollbar_show_time = std.time.milliTimestamp();
     }
     surface.render_state.mutex.unlock();
+
+    if (input_diagnostics.enabled())
+        input_diagnostics.log("mouse-wheel handled mode={s} alt_screen={} alt_scroll_mode={} branch={s} sent_len={d}", .{
+            @tagName(dbg_mode), dbg_alt_screen, dbg_alt_scroll, dbg_branch, terminal_input_len,
+        });
 
     if (g_selecting and !sent_to_terminal) {
         updateDragSelection(surface, @floatFromInt(ev.xpos), @floatFromInt(ev.ypos));

--- a/src/input.zig
+++ b/src/input.zig
@@ -25,6 +25,7 @@ const html_server_model = @import("html_server_model.zig");
 const ai_sidebar = @import("ai_sidebar.zig");
 const ui_perf = AppWindow.ui_perf;
 const render_diagnostics = @import("render_diagnostics.zig");
+const input_diagnostics = @import("input_diagnostics.zig");
 const link_open = @import("link_open.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_local_path = @import("platform/local_path.zig");
@@ -3745,6 +3746,11 @@ fn openInEditorAtRightClick(ev: platform_input.MouseButtonEvent) bool {
 }
 
 fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
+    if (input_diagnostics.enabled()) {
+        input_diagnostics.log("mouse-button {s} {s} x={d} y={d} shift={} ctrl={} alt={} super={}", .{
+            @tagName(ev.button), @tagName(ev.action), ev.x, ev.y, ev.shift, ev.ctrl, ev.alt, ev.super,
+        });
+    }
     if (ev.action == .press) g_close_shortcut_confirm_until_ms = 0;
     if (overlays.whatsNewVisible()) {
         if (ev.button == .left and ev.action == .press) {
@@ -5132,8 +5138,20 @@ fn terminalMouseReportTarget(x_i: i32, y_i: i32) ?*Surface {
 /// Begin a reported press for an event that landed on terminal content.
 /// Returns true if the press was consumed (delivered to the PTY).
 fn beginTerminalMouseReport(ev: platform_input.MouseButtonEvent) bool {
-    const surface = terminalMouseReportTarget(ev.x, ev.y) orelse return false;
+    const surface = terminalMouseReportTarget(ev.x, ev.y) orelse {
+        if (input_diagnostics.enabled())
+            input_diagnostics.log("mouse-report begin: no target (mode none / off terminal) -> local selection", .{});
+        return false;
+    };
     const button = platformMouseButton(ev.button);
+    if (input_diagnostics.enabled()) {
+        surface.render_state.mutex.lock();
+        const mode = surface.terminal.flags.mouse_event;
+        surface.render_state.mutex.unlock();
+        input_diagnostics.log("mouse-report begin: reporting to surface=0x{x} mode={s} button={s}", .{
+            @intFromPtr(surface), @tagName(mode), @tagName(button),
+        });
+    }
     updateFocusFromMouse(ev.x, ev.y);
     _ = sendTerminalMouseReport(surface, .press, button, ev.x, ev.y, .{
         .shift = ev.shift,
@@ -5152,6 +5170,8 @@ fn beginTerminalMouseReport(ev: platform_input.MouseButtonEvent) bool {
 fn finishTerminalMouseReport(ev: platform_input.MouseButtonEvent) bool {
     const active = g_mouse_report_button orelse return false;
     if (active != platformMouseButton(ev.button)) return false;
+    if (input_diagnostics.enabled())
+        input_diagnostics.log("mouse-report finish: release button={s}", .{@tagName(active)});
     const surface = g_mouse_report_surface;
     g_mouse_report_button = null;
     g_mouse_report_surface = null;

--- a/src/input.zig
+++ b/src/input.zig
@@ -66,6 +66,8 @@ const scp = @import("scp.zig");
 const writeToPty = clipboard.writeToPty;
 pub const copyTextToClipboard = clipboard.copyTextToClipboard;
 const activeTerminalSelectionExists = clipboard.activeTerminalSelectionExists;
+const clearActiveTerminalSelection = clipboard.clearActiveTerminalSelection;
+const ctrl_c_selection = @import("input/ctrl_c_selection.zig");
 const handleConfiguredRightClick = clipboard.handleConfiguredRightClick;
 const copyAiChatToClipboard = clipboard.copyAiChatToClipboard;
 const copyAiChatCutToClipboard = clipboard.copyAiChatCutToClipboard;
@@ -2323,6 +2325,25 @@ fn handleKey(ev: platform_input.KeyEvent) void {
         platform_input.key_insert => "\x1b[2~",
         platform_input.key_delete => "\x1b[3~",
         else => blk: {
+            // Windows-Terminal-style: Ctrl+C copies an active selection (and
+            // clears it) instead of sending SIGINT. Also neutralizes external
+            // "copy on select" tools that synthesize a Ctrl+C after a mouse
+            // selection. With no selection, Ctrl+C falls through to 0x03 below.
+            if (ctrl_c_selection.ctrlCCopiesSelection(
+                ev.key_code,
+                ev.ctrl,
+                ev.shift,
+                AppWindow.g_ctrl_c_copies_selection,
+                activeTerminalSelectionExists(),
+            )) {
+                if (input_diagnostics.enabled())
+                    input_diagnostics.log("ctrl-c: active selection -> copy (suppress SIGINT)", .{});
+                copySelectionToClipboard();
+                clearActiveTerminalSelection();
+                AppWindow.g_force_rebuild = true;
+                AppWindow.g_cells_valid = false;
+                break :blk null;
+            }
             // Ctrl+A through Ctrl+Z
             if (ev.ctrl and ev.key_code >= 0x41 and ev.key_code <= 0x5A) {
                 // Shifted Ctrl+letter chords are application shortcuts above.

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -334,6 +334,13 @@ pub fn activeTerminalSelectionExists() bool {
     return surface.selection.active;
 }
 
+/// Clear the active terminal selection (the one copySelectionToClipboard would
+/// copy). Used after a Ctrl+C copy so a second Ctrl+C interrupts as usual.
+pub fn clearActiveTerminalSelection() void {
+    const surface = selectionSurfaceForClipboard() orelse return;
+    surface.selection.active = false;
+}
+
 pub fn handleConfiguredRightClick() void {
     switch (AppWindow.g_right_click_action) {
         .ignore => {},

--- a/src/input/ctrl_c_selection.zig
+++ b/src/input/ctrl_c_selection.zig
@@ -1,0 +1,54 @@
+//! Pure decision for Windows-Terminal-style "Ctrl+C copies the selection".
+//!
+//! On Windows the dominant terminal (Windows Terminal) treats Ctrl+C as COPY
+//! when a selection is active, and only as SIGINT (0x03) when there is no
+//! selection. WispTerm historically always sent 0x03. That bit users whose
+//! "copy on select" trackpad/clipboard tools synthesize a Ctrl+C right after a
+//! mouse selection: in a terminal that Ctrl+C interrupted the running program
+//! instead of copying.
+//!
+//! This module is the pure gate; the caller performs the copy + clears the
+//! selection and suppresses the 0x03 when it returns true.
+
+const std = @import("std");
+
+/// True when an unmodified Ctrl+C should copy the active selection instead of
+/// sending SIGINT. `key_code` is the platform virtual-key code; 0x43 == 'C'.
+pub fn ctrlCCopiesSelection(
+    key_code: usize,
+    ctrl: bool,
+    shift: bool,
+    enabled: bool,
+    selection_active: bool,
+) bool {
+    return enabled and ctrl and !shift and selection_active and key_code == 0x43;
+}
+
+const testing = std.testing;
+
+test "Ctrl+C with active selection copies when enabled" {
+    try testing.expect(ctrlCCopiesSelection(0x43, true, false, true, true));
+}
+
+test "no selection -> still sends SIGINT" {
+    try testing.expect(!ctrlCCopiesSelection(0x43, true, false, true, false));
+}
+
+test "disabled -> never copies (legacy SIGINT behavior)" {
+    try testing.expect(!ctrlCCopiesSelection(0x43, true, false, false, true));
+}
+
+test "Shift+Ctrl+C is a separate chord, not this gate" {
+    try testing.expect(!ctrlCCopiesSelection(0x43, true, true, true, true));
+}
+
+test "other Ctrl+letters are unaffected" {
+    // Ctrl+D (0x44), Ctrl+Z (0x5A), Ctrl+A (0x41) must keep sending their byte.
+    try testing.expect(!ctrlCCopiesSelection(0x44, true, false, true, true));
+    try testing.expect(!ctrlCCopiesSelection(0x5A, true, false, true, true));
+    try testing.expect(!ctrlCCopiesSelection(0x41, true, false, true, true));
+}
+
+test "plain C (no ctrl) is just typing the letter" {
+    try testing.expect(!ctrlCCopiesSelection(0x43, false, false, true, true));
+}

--- a/src/input_diagnostics.zig
+++ b/src/input_diagnostics.zig
@@ -20,9 +20,15 @@ const LOG_BASENAME = "input-diagnostic.log";
 
 threadlocal var g_checked: bool = false;
 threadlocal var g_enabled: bool = false;
-threadlocal var g_file_open: bool = false;
-threadlocal var g_file: std.fs.File = undefined;
-threadlocal var g_start_ms: i64 = 0;
+
+// File state is process-global (not threadlocal): UIA providers and the IO/agent
+// paths can call into the log from threads other than the UI thread, and a
+// threadlocal file opened with truncate would race and clobber the log. A single
+// shared handle guarded by a mutex keeps every line intact and in order.
+var g_mutex: std.Thread.Mutex = .{};
+var g_file_open: bool = false;
+var g_file: std.fs.File = undefined;
+var g_start_ms: i64 = 0;
 
 /// Process-global override flipped on by the `wispterm-debug-input` config key.
 /// Mirrors render_diagnostics: visible to every thread, consulted before the
@@ -54,7 +60,10 @@ pub fn enabled() bool {
 pub fn log(comptime fmt: []const u8, args: anytype) void {
     if (!enabled()) return;
 
-    const file = ensureFile() catch |err| {
+    g_mutex.lock();
+    defer g_mutex.unlock();
+
+    const file = ensureFileLocked() catch |err| {
         std.debug.print("[input-diag] failed to open log: {}\n", .{err});
         std.debug.print("[input-diag] " ++ fmt ++ "\n", args);
         return;
@@ -82,6 +91,8 @@ pub fn logPtyWrite(tag: []const u8, data: []const u8) void {
 }
 
 pub fn close() void {
+    g_mutex.lock();
+    defer g_mutex.unlock();
     if (!g_file_open) return;
     g_file.close();
     g_file_open = false;
@@ -91,7 +102,8 @@ pub fn logFilePath(allocator: std.mem.Allocator) ![]const u8 {
     return platform_dirs.pathInConfigDir(allocator, LOG_BASENAME);
 }
 
-fn ensureFile() !*std.fs.File {
+// Caller must hold g_mutex.
+fn ensureFileLocked() !*std.fs.File {
     if (g_file_open) return &g_file;
 
     const allocator = std.heap.page_allocator;

--- a/src/input_diagnostics.zig
+++ b/src/input_diagnostics.zig
@@ -1,0 +1,233 @@
+//! Opt-in input / PTY-write diagnostics.
+//!
+//! Captures exactly what bytes leave the terminal toward the PTY, plus the
+//! mouse-reporting decisions the input layer makes. Built to investigate the
+//! "selecting text in Codex emits a Ctrl+C (^C)" report: a clean `^C` at the
+//! shell prompt means a literal 0x03 byte reached the PTY, and the cleanest way
+//! to prove what is (or is not) being sent is to render every PTY write in
+//! caret notation (0x03 -> "^C", ESC -> "^[") right at the write funnel.
+//!
+//! Enable with either the `WISPTERM_INPUT_DIAGNOSTICS=1` env var or the
+//! `wispterm-debug-input = true` config key (see `enableFromConfig`). Logs go to
+//! `%APPDATA%\wispterm\input-diagnostic.log` on Windows (and the matching
+//! per-OS config dir elsewhere), mirroring `render_diagnostics.zig`.
+
+const std = @import("std");
+const platform_dirs = @import("platform/dirs.zig");
+
+const ENV_NAME = "WISPTERM_INPUT_DIAGNOSTICS";
+const LOG_BASENAME = "input-diagnostic.log";
+
+threadlocal var g_checked: bool = false;
+threadlocal var g_enabled: bool = false;
+threadlocal var g_file_open: bool = false;
+threadlocal var g_file: std.fs.File = undefined;
+threadlocal var g_start_ms: i64 = 0;
+
+/// Process-global override flipped on by the `wispterm-debug-input` config key.
+/// Mirrors render_diagnostics: visible to every thread, consulted before the
+/// (cached) env-var check so a config opt-in works even after a thread already
+/// evaluated the env var as off.
+var g_config_force = std.atomic.Value(bool).init(false);
+
+/// Force diagnostics on from config. Call once, as early as the config is
+/// available, so the very first input events are captured.
+pub fn enableFromConfig(on: bool) void {
+    if (on) g_config_force.store(true, .seq_cst);
+}
+
+pub fn enabled() bool {
+    if (g_config_force.load(.seq_cst)) return true;
+    if (g_checked) return g_enabled;
+    g_checked = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, ENV_NAME) catch {
+        g_enabled = false;
+        return g_enabled;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    g_enabled = parseEnabledValue(value);
+    return g_enabled;
+}
+
+pub fn log(comptime fmt: []const u8, args: anytype) void {
+    if (!enabled()) return;
+
+    const file = ensureFile() catch |err| {
+        std.debug.print("[input-diag] failed to open log: {}\n", .{err});
+        std.debug.print("[input-diag] " ++ fmt ++ "\n", args);
+        return;
+    };
+
+    const now = std.time.milliTimestamp();
+    const elapsed = if (g_start_ms == 0) 0 else now - g_start_ms;
+    var write_buf: [4096]u8 = undefined;
+    var writer = file.writerStreaming(&write_buf);
+    writer.interface.print("[+{d}ms] ", .{elapsed}) catch return;
+    writer.interface.print(fmt, args) catch return;
+    writer.interface.writeAll("\n") catch return;
+    writer.end() catch return;
+}
+
+/// Log one PTY write as caret notation + hex so it is unambiguous what reached
+/// the child. `tag` names the call site / surface. Cheap no-op when disabled.
+pub fn logPtyWrite(tag: []const u8, data: []const u8) void {
+    if (!enabled()) return;
+    var caret_buf: [256]u8 = undefined;
+    var hex_buf: [256]u8 = undefined;
+    const caret = caretEscape(data, &caret_buf);
+    const hex = hexDump(data, &hex_buf);
+    log("pty-write {s} len={d} caret=\"{s}\" hex={s}", .{ tag, data.len, caret, hex });
+}
+
+pub fn close() void {
+    if (!g_file_open) return;
+    g_file.close();
+    g_file_open = false;
+}
+
+pub fn logFilePath(allocator: std.mem.Allocator) ![]const u8 {
+    return platform_dirs.pathInConfigDir(allocator, LOG_BASENAME);
+}
+
+fn ensureFile() !*std.fs.File {
+    if (g_file_open) return &g_file;
+
+    const allocator = std.heap.page_allocator;
+    const dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+
+    const path = try std.fs.path.join(allocator, &.{ dir, LOG_BASENAME });
+    defer allocator.free(path);
+
+    g_file = try std.fs.createFileAbsolute(path, .{ .truncate = true });
+    g_file_open = true;
+    g_start_ms = std.time.milliTimestamp();
+    var write_buf: [1024]u8 = undefined;
+    var writer = g_file.writerStreaming(&write_buf);
+    writer.interface.print(
+        "WispTerm input diagnostics started timestamp_ms={d} env={s}\n",
+        .{ g_start_ms, ENV_NAME },
+    ) catch {};
+    writer.end() catch {};
+    return &g_file;
+}
+
+fn parseEnabledValue(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.mem.eql(u8, trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+/// Render `data` in caret notation into `out`, returning the written slice.
+/// Control bytes 0x00-0x1f become `^@`..`^_` (so 0x03 -> "^C", ESC -> "^["),
+/// 0x7f becomes "^?", printable ASCII passes through, and any other byte is
+/// shown as `\xHH`. Output is truncated to fit `out` with a trailing "…".
+pub fn caretEscape(data: []const u8, out: []u8) []const u8 {
+    var len: usize = 0;
+    for (data) |b| {
+        // Worst-case glyph is "\xHH" (4 bytes); keep room for a 3-byte "…".
+        if (len + 4 > out.len) {
+            const ell = "…";
+            if (len + ell.len <= out.len) {
+                @memcpy(out[len .. len + ell.len], ell);
+                len += ell.len;
+            }
+            break;
+        }
+        if (b < 0x20) {
+            out[len] = '^';
+            out[len + 1] = b + 64; // 0x00 -> '@', 0x03 -> 'C', 0x1b -> '['
+            len += 2;
+        } else if (b == 0x7f) {
+            out[len] = '^';
+            out[len + 1] = '?';
+            len += 2;
+        } else if (b < 0x7f) {
+            out[len] = b;
+            len += 1;
+        } else {
+            const hex = "0123456789abcdef";
+            out[len] = '\\';
+            out[len + 1] = 'x';
+            out[len + 2] = hex[b >> 4];
+            out[len + 3] = hex[b & 0x0f];
+            len += 4;
+        }
+    }
+    return out[0..len];
+}
+
+/// Render `data` as space-separated two-digit hex into `out`, truncating with
+/// "…" when it would overflow. Returns the written slice.
+pub fn hexDump(data: []const u8, out: []u8) []const u8 {
+    const hex = "0123456789abcdef";
+    var len: usize = 0;
+    for (data, 0..) |b, i| {
+        const need: usize = if (i == 0) 2 else 3; // optional leading space
+        if (len + need > out.len) {
+            const ell = "…";
+            if (len + ell.len <= out.len) {
+                @memcpy(out[len .. len + ell.len], ell);
+                len += ell.len;
+            }
+            break;
+        }
+        if (i != 0) {
+            out[len] = ' ';
+            len += 1;
+        }
+        out[len] = hex[b >> 4];
+        out[len + 1] = hex[b & 0x0f];
+        len += 2;
+    }
+    return out[0..len];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "input diagnostics enabled parser accepts common truthy values" {
+    try std.testing.expect(parseEnabledValue("1"));
+    try std.testing.expect(parseEnabledValue("true"));
+    try std.testing.expect(parseEnabledValue("ON"));
+}
+
+test "input diagnostics enabled parser rejects empty and falsey values" {
+    try std.testing.expect(!parseEnabledValue(""));
+    try std.testing.expect(!parseEnabledValue("0"));
+    try std.testing.expect(!parseEnabledValue("off"));
+}
+
+test "caretEscape renders a bare Ctrl+C as ^C" {
+    var buf: [16]u8 = undefined;
+    try std.testing.expectEqualStrings("^C", caretEscape(&[_]u8{0x03}, &buf));
+}
+
+test "caretEscape renders an SGR mouse press, not a clean ^C" {
+    var buf: [64]u8 = undefined;
+    // ESC [ < 0 ; 2 4 ; 6 M  — what a mouse report actually looks like.
+    const seq = "\x1b[<0;24;6M";
+    try std.testing.expectEqualStrings("^[[<0;24;6M", caretEscape(seq, &buf));
+}
+
+test "caretEscape shows DEL and high bytes distinctly" {
+    var buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("^?\\xff", caretEscape(&[_]u8{ 0x7f, 0xff }, &buf));
+}
+
+test "caretEscape truncates with an ellipsis instead of overflowing" {
+    var buf: [7]u8 = undefined; // room for two "^A" then the 3-byte ellipsis
+    const out = caretEscape(&[_]u8{ 0x01, 0x01, 0x01, 0x01 }, &buf);
+    try std.testing.expectEqualStrings("^A^A…", out);
+}
+
+test "hexDump space-separates bytes" {
+    var buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("1b 5b 4d", hexDump("\x1b[M", &buf));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,6 +13,7 @@ const app_metadata = @import("app_metadata.zig");
 const platform_console = @import("platform/console.zig");
 const font_backend = @import("platform/font_backend.zig");
 const render_diagnostics = @import("render_diagnostics.zig");
+const input_diagnostics = @import("input_diagnostics.zig");
 const window_backend = @import("platform/window_backend.zig");
 const i18n = @import("i18n.zig");
 const ai_chat = @import("ai_chat.zig");
@@ -168,6 +169,7 @@ pub fn main() !void {
     // Honor the config opt-in for render diagnostics before any window/GL
     // exists, so the very first WM_SIZE/WM_DPICHANGED events are captured.
     render_diagnostics.enableFromConfig(cfg.@"wispterm-debug-render");
+    input_diagnostics.enableFromConfig(cfg.@"wispterm-debug-input");
 
     // Present-path selection must be decided before the first window is
     // created (the presenter is built right after the GL context).

--- a/src/platform/conpty_dll.zig
+++ b/src/platform/conpty_dll.zig
@@ -9,6 +9,7 @@
 
 const std = @import("std");
 const policy = @import("console_host_policy.zig");
+const input_diagnostics = @import("../input_diagnostics.zig");
 
 const windows = std.os.windows;
 const HANDLE = windows.HANDLE;
@@ -107,6 +108,10 @@ fn resolveLocked() *const Api {
 
     const dll_present = siblingExists(exe_dir, bundled_dll_name);
     const host_present = siblingExists(exe_dir, bundled_host_name);
+    if (input_diagnostics.enabled())
+        input_diagnostics.log("conpty resolve: preference={s} conpty.dll_present={} OpenConsole.exe_present={} -> choice={s}", .{
+            @tagName(g_preference), dll_present, host_present, @tagName(policy.choose(g_preference, dll_present, host_present)),
+        });
     if (policy.choose(g_preference, dll_present, host_present) == .system) {
         if (g_preference == .auto and (dll_present != host_present)) {
             log.warn(

--- a/src/platform/uia_probe.zig
+++ b/src/platform/uia_probe.zig
@@ -1,0 +1,186 @@
+//! Minimal UI Automation (UIA) probe — Windows only, Step 1 of the root cure.
+//!
+//! We suspect select-translate / copy-on-select tools (有道词典 etc.) read the
+//! selection via UIA on conhost and Windows Terminal — both of which expose a
+//! UIA text provider — and only fall back to injecting Ctrl+C + clobbering the
+//! clipboard when no UIA provider exists (our case). If that's true, the real
+//! fix is to implement a UIA text provider; if those tools never query us over
+//! UIA, that effort would be wasted.
+//!
+//! This module answers `WM_GETOBJECT` with a *barebones* IRawElementProviderSimple
+//! that implements no text pattern yet — it only LOGS every UIA method a client
+//! calls (via input_diagnostics). The point is purely to confirm whether such
+//! tools actually inspect us over UIA, before we build the full provider.
+//!
+//! Everything is gated behind input_diagnostics.enabled(), so normal users get
+//! the unchanged DefWindowProc behavior (no provider advertised).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const windows = std.os.windows;
+const input_diagnostics = @import("../input_diagnostics.zig");
+
+const HWND = windows.HWND;
+const WPARAM = windows.WPARAM;
+const LPARAM = windows.LPARAM;
+const LRESULT = windows.LRESULT;
+const HRESULT = windows.HRESULT;
+const GUID = windows.GUID;
+const HMODULE = windows.HMODULE;
+
+const S_OK: HRESULT = 0;
+const E_NOINTERFACE: HRESULT = @bitCast(@as(u32, 0x80004002));
+
+/// WM_GETOBJECT object id used by UIA (UiaRootObjectId).
+const UiaRootObjectId: i32 = -25;
+const UIA_TextPatternId: i32 = 10014;
+const ProviderOptions_ServerSideProvider: i32 = 1;
+
+const IID_IUnknown = GUID{
+    .Data1 = 0x00000000,
+    .Data2 = 0x0000,
+    .Data3 = 0x0000,
+    .Data4 = .{ 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 },
+};
+const IID_IRawElementProviderSimple = GUID{
+    .Data1 = 0xd6dd68d1,
+    .Data2 = 0x86fd,
+    .Data3 = 0x4332,
+    .Data4 = .{ 0x86, 0x66, 0x9a, 0xbe, 0xde, 0xa2, 0xd2, 0x4c },
+};
+
+/// 24-byte VARIANT (x64). vt=0 is VT_EMPTY, which UIA treats as "unsupported".
+const VARIANT = extern struct {
+    vt: u16,
+    r1: u16,
+    r2: u16,
+    r3: u16,
+    val: [16]u8,
+};
+
+const IRawElementProviderSimple = extern struct {
+    lpVtbl: *const Vtbl,
+
+    const Vtbl = extern struct {
+        QueryInterface: *const fn (*IRawElementProviderSimple, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
+        AddRef: *const fn (*IRawElementProviderSimple) callconv(.winapi) u32,
+        Release: *const fn (*IRawElementProviderSimple) callconv(.winapi) u32,
+        get_ProviderOptions: *const fn (*IRawElementProviderSimple, *i32) callconv(.winapi) HRESULT,
+        GetPatternProvider: *const fn (*IRawElementProviderSimple, i32, *?*anyopaque) callconv(.winapi) HRESULT,
+        GetPropertyValue: *const fn (*IRawElementProviderSimple, i32, *VARIANT) callconv(.winapi) HRESULT,
+        get_HostRawElementProvider: *const fn (*IRawElementProviderSimple, *?*IRawElementProviderSimple) callconv(.winapi) HRESULT,
+    };
+};
+
+fn guidEql(a: *const GUID, b: *const GUID) bool {
+    return a.Data1 == b.Data1 and a.Data2 == b.Data2 and a.Data3 == b.Data3 and
+        std.mem.eql(u8, &a.Data4, &b.Data4);
+}
+
+fn qi(self: *IRawElementProviderSimple, riid: *const GUID, ppv: *?*anyopaque) callconv(.winapi) HRESULT {
+    if (guidEql(riid, &IID_IUnknown) or guidEql(riid, &IID_IRawElementProviderSimple)) {
+        ppv.* = self;
+        input_diagnostics.log("uia QueryInterface -> provider", .{});
+        return S_OK;
+    }
+    input_diagnostics.log("uia QueryInterface other-iid {x:0>8}", .{riid.Data1});
+    ppv.* = null;
+    return E_NOINTERFACE;
+}
+
+fn addRef(self: *IRawElementProviderSimple) callconv(.winapi) u32 {
+    _ = self;
+    return 1; // static singleton: never freed
+}
+
+fn release(self: *IRawElementProviderSimple) callconv(.winapi) u32 {
+    _ = self;
+    return 1;
+}
+
+fn getProviderOptions(self: *IRawElementProviderSimple, ret: *i32) callconv(.winapi) HRESULT {
+    _ = self;
+    ret.* = ProviderOptions_ServerSideProvider;
+    return S_OK;
+}
+
+fn getPatternProvider(self: *IRawElementProviderSimple, patternId: i32, ret: *?*anyopaque) callconv(.winapi) HRESULT {
+    _ = self;
+    input_diagnostics.log("uia GetPatternProvider patternId={d}{s}", .{
+        patternId,
+        if (patternId == UIA_TextPatternId) " (TextPattern — tool wants to read selected text!)" else "",
+    });
+    ret.* = null; // probe: advertise no pattern yet
+    return S_OK;
+}
+
+fn getPropertyValue(self: *IRawElementProviderSimple, propertyId: i32, ret: *VARIANT) callconv(.winapi) HRESULT {
+    _ = self;
+    input_diagnostics.log("uia GetPropertyValue propertyId={d}", .{propertyId});
+    ret.* = std.mem.zeroes(VARIANT); // VT_EMPTY
+    return S_OK;
+}
+
+fn getHostRawElementProvider(self: *IRawElementProviderSimple, ret: *?*IRawElementProviderSimple) callconv(.winapi) HRESULT {
+    _ = self;
+    ret.* = null;
+    if (g_uia.host_from_hwnd) |f| {
+        if (g_hwnd) |h| _ = f(h, ret);
+    }
+    return S_OK;
+}
+
+var g_vtbl = IRawElementProviderSimple.Vtbl{
+    .QueryInterface = qi,
+    .AddRef = addRef,
+    .Release = release,
+    .get_ProviderOptions = getProviderOptions,
+    .GetPatternProvider = getPatternProvider,
+    .GetPropertyValue = getPropertyValue,
+    .get_HostRawElementProvider = getHostRawElementProvider,
+};
+var g_provider = IRawElementProviderSimple{ .lpVtbl = &g_vtbl };
+
+const UiaReturnFn = *const fn (HWND, WPARAM, LPARAM, *IRawElementProviderSimple) callconv(.winapi) LRESULT;
+const UiaHostFn = *const fn (HWND, *?*IRawElementProviderSimple) callconv(.winapi) HRESULT;
+
+extern "kernel32" fn LoadLibraryW(lpLibFileName: [*:0]const u16) callconv(.winapi) ?HMODULE;
+extern "kernel32" fn GetProcAddress(hModule: HMODULE, lpProcName: [*:0]const u8) callconv(.winapi) ?windows.FARPROC;
+
+const Uia = struct {
+    loaded: bool = false,
+    ret_provider: ?UiaReturnFn = null,
+    host_from_hwnd: ?UiaHostFn = null,
+};
+var g_uia: Uia = .{};
+var g_hwnd: ?HWND = null;
+
+fn ensureLoaded() void {
+    if (g_uia.loaded) return;
+    g_uia.loaded = true;
+    const dll = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("uiautomationcore.dll")) orelse {
+        input_diagnostics.log("uia: LoadLibrary uiautomationcore.dll FAILED", .{});
+        return;
+    };
+    if (GetProcAddress(dll, "UiaReturnRawElementProvider")) |p| g_uia.ret_provider = @ptrCast(p);
+    if (GetProcAddress(dll, "UiaHostProviderFromHwnd")) |p| g_uia.host_from_hwnd = @ptrCast(p);
+    input_diagnostics.log("uia: loaded uiautomationcore.dll ret_provider={} host_from_hwnd={}", .{
+        g_uia.ret_provider != null,
+        g_uia.host_from_hwnd != null,
+    });
+}
+
+/// Handle WM_GETOBJECT. Returns the LRESULT when it answered a UIA root query,
+/// or null to let DefWindowProc handle it (non-UIA object ids, or diagnostics
+/// off — i.e. normal users are unaffected).
+pub fn handleGetObject(hwnd: HWND, wParam: WPARAM, lParam: LPARAM) ?LRESULT {
+    if (builtin.os.tag != .windows) return null;
+    if (!input_diagnostics.enabled()) return null;
+    const obj_id: i32 = @truncate(lParam);
+    if (obj_id != UiaRootObjectId) return null;
+    input_diagnostics.log("uia WM_GETOBJECT UiaRootObjectId — a UIA client is inspecting the window", .{});
+    ensureLoaded();
+    g_hwnd = hwnd;
+    const f = g_uia.ret_provider orelse return null;
+    return f(hwnd, wParam, lParam, &g_provider);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -122,6 +122,7 @@ test {
     _ = @import("agent_history.zig");
     _ = @import("render_diagnostics.zig");
     _ = @import("input_diagnostics.zig");
+    _ = @import("input/ctrl_c_selection.zig");
     _ = @import("notification.zig");
     _ = @import("clipboard_osc52.zig");
     _ = @import("renderer/gpu/backend.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -121,6 +121,7 @@ test {
     _ = @import("sync_output.zig");
     _ = @import("agent_history.zig");
     _ = @import("render_diagnostics.zig");
+    _ = @import("input_diagnostics.zig");
     _ = @import("notification.zig");
     _ = @import("clipboard_osc52.zig");
     _ = @import("renderer/gpu/backend.zig");


### PR DESCRIPTION
## Problem

User report: while running **Codex**, selecting text emits a `^C` that interrupts/kills the running command, once per selection (HP laptop).

## Root cause (proven by field logs)

Added opt-in input diagnostics (caret-rendered PTY writes + mouse/keyboard events) and captured the repro. The logs show:

- `mouse_event=none` throughout — **not** a mouse-reporting issue; every drag is a local selection.
- After **every drag-selection** (and never after a same-position click), a real **Ctrl+C key event** arrives: `key-event code=0x11 ctrl=true` then `code=0x43 ctrl=true` **in the same millisecond**, `selection_active=true`, immediately followed by `pty-write … caret="^C" hex=03`.

Same-millisecond `Ctrl`+`C` = software injection (SendInput), i.e. an external **"copy on select"** trackpad/clipboard utility. In a terminal Ctrl+C is SIGINT, so it interrupted Codex. **WispTerm never emits `0x03` on selection** — verified by tracing every mouse PTY-write path.

## Fix

Adopt **Windows Terminal** behavior: when a terminal selection is active, **Ctrl+C copies it (and clears the selection)** instead of sending SIGINT; with no selection it still interrupts. The tool's injected Ctrl+C now copies (its intent) and no longer interrupts.

- New pure `src/input/ctrl_c_selection.zig` (`ctrlCCopiesSelection`) + unit tests.
- `input.zig` intercepts Ctrl+C in the Ctrl+letter path; `clipboard.zig` gains `clearActiveTerminalSelection`.
- Config key **`ctrl-c-copies-selection`** (default **true**), wired like `copy-on-select`, hot-reloadable; set `false` to restore always-interrupt.

## Diagnostics (kept, opt-in, zero cost when off)

`src/input_diagnostics.zig` — `wispterm-debug-input` / `WISPTERM_INPUT_DIAGNOSTICS=1` → `input-diagnostic.log` with caret-notation PTY writes, mouse-button + report decisions, key events. Useful for future input bug reports.

## Verification

`zig build test` ✅ · `zig build test-full` ✅ · windows-gnu ReleaseFast cross-compile → `wispterm.exe` (PE32+ GUI) ✅. Self-contained Win10 compat debug/fix zips were handed to the reporter to confirm in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)