### PR TITLE
fix(clipboard): copy soft-wrapped lines as a single line

### DIFF
--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -427,8 +427,14 @@ pub fn copySelectionToClipboard() void {
         std.mem.swap(usize, &start_col, &end_col);
     }
 
-    var text: std.ArrayListUnmanaged(u8) = .empty;
-    defer text.deinit(allocator);
+    // Collect each selected row's text plus its soft-wrap flag, then join.
+    // Soft-wrapped rows (a visually wrapped logical line, e.g. a long path)
+    // must copy back as a single line — see selection_unit.joinSelectionRows.
+    var rows: std.ArrayListUnmanaged(selection_unit.SelectionRow) = .empty;
+    defer {
+        for (rows.items) |r| allocator.free(r.text);
+        rows.deinit(allocator);
+    }
 
     // Lock while reading terminal cells
     surface.render_state.mutex.lock();
@@ -442,7 +448,7 @@ pub fn copySelectionToClipboard() void {
         row_end_col = @min(row_end_col, grid_cols - 1);
         if (row_start_col > row_end_col) continue;
 
-        const row_text_start = text.items.len;
+        var row_buf: std.ArrayListUnmanaged(u8) = .empty;
         var col: usize = row_start_col;
         while (col <= row_end_col) : (col += 1) {
             const cell_data = screen.pages.getCell(.{ .screen = .{
@@ -457,11 +463,11 @@ pub fn copySelectionToClipboard() void {
 
             const cp = cell_data.cell.codepoint();
             if (cp == 0 or cp == ' ') {
-                text.append(allocator, ' ') catch continue;
+                row_buf.append(allocator, ' ') catch continue;
             } else {
                 var buf: [4]u8 = undefined;
                 const len = std.unicode.utf8Encode(@intCast(cp), &buf) catch continue;
-                text.appendSlice(allocator, buf[0..len]) catch continue;
+                row_buf.appendSlice(allocator, buf[0..len]) catch continue;
 
                 // Append grapheme cluster continuation codepoints (emoji ZWJ sequences, etc.)
                 if (cell_data.cell.hasGrapheme()) {
@@ -469,26 +475,44 @@ pub fn copySelectionToClipboard() void {
                     if (page.lookupGrapheme(cell_data.cell)) |extra_cps| {
                         for (extra_cps) |ecp| {
                             const elen = std.unicode.utf8Encode(@intCast(ecp), &buf) catch continue;
-                            text.appendSlice(allocator, buf[0..elen]) catch {};
+                            row_buf.appendSlice(allocator, buf[0..elen]) catch {};
                         }
                     }
                 }
             }
         }
-        text.items.len = row_text_start + selection_unit.trimTrailingClipboardSpaces(text.items[row_text_start..]).len;
-        if (row < end_row) {
-            text.appendSlice(allocator, "\r\n") catch {};
-        }
+
+        // Read the soft-wrap flag in the same .screen coordinate space as the
+        // cells above so it stays correct when the viewport is scrolled.
+        const wraps_next = wn: {
+            const pin = screen.pages.pin(.{ .screen = .{
+                .x = 0,
+                .y = @intCast(row),
+            } }) orelse break :wn false;
+            break :wn pin.rowAndCell().row.wrap;
+        };
+
+        const owned = row_buf.toOwnedSlice(allocator) catch {
+            row_buf.deinit(allocator);
+            continue;
+        };
+        rows.append(allocator, .{ .text = owned, .wraps_next = wraps_next }) catch {
+            allocator.free(owned);
+            continue;
+        };
     }
     surface.render_state.mutex.unlock();
 
-    if (text.items.len == 0) return;
+    const text = selection_unit.joinSelectionRows(allocator, rows.items) catch return;
+    defer allocator.free(text);
 
-    if (copyTextToClipboard(text.items)) {
-        overlays.showCopyToast(text.items.len);
+    if (text.len == 0) return;
+
+    if (copyTextToClipboard(text)) {
+        overlays.showCopyToast(text.len);
         AppWindow.g_force_rebuild = true;
         AppWindow.g_cells_valid = false;
-        std.debug.print("Copied {} bytes to clipboard\n", .{text.items.len});
+        std.debug.print("Copied {} bytes to clipboard\n", .{text.len});
     }
 }
 

--- a/src/selection_unit.zig
+++ b/src/selection_unit.zig
@@ -102,6 +102,49 @@ pub fn trimTrailingClipboardSpaces(row: []const u8) []const u8 {
     return row[0..end];
 }
 
+/// One selected terminal row, ready to be joined into clipboard text.
+pub const SelectionRow = struct {
+    /// The selected span of this row as UTF-8 text. Trailing terminal blanks
+    /// are NOT pre-trimmed; `joinSelectionRows` decides whether to trim.
+    text: []const u8,
+    /// True when this row is soft-wrapped: the next selected row is a visual
+    /// continuation of the same logical line (ghostty `Row.wrap`).
+    wraps_next: bool,
+};
+
+/// Join selected terminal rows into clipboard text.
+///
+/// A soft-wrapped row (`wraps_next`) is a continuation of one logical line, so
+/// it is concatenated to the following row with no separator and without
+/// trimming trailing blanks — a visually wrapped line such as a long path
+/// copies back as a single line. A row that ends a logical line is joined to
+/// the next with "\r\n" after trimming trailing terminal blanks, and the final
+/// row is trimmed with no trailing separator. This matches Windows Terminal and
+/// Ghostty (whose `selectionString` "unwraps soft-wrapped edges").
+pub fn joinSelectionRows(
+    allocator: std.mem.Allocator,
+    rows: []const SelectionRow,
+) std.mem.Allocator.Error![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    for (rows, 0..) |r, i| {
+        const is_last = i + 1 == rows.len;
+        if (!is_last and r.wraps_next) {
+            // Soft wrap: this row continues onto the next, so join with no
+            // separator and keep trailing content verbatim.
+            try out.appendSlice(allocator, r.text);
+        } else {
+            // Hard line end (or the final row): trim trailing terminal blanks,
+            // and break to the next line unless this is the last row.
+            try out.appendSlice(allocator, trimTrailingClipboardSpaces(r.text));
+            if (!is_last) try out.appendSlice(allocator, "\r\n");
+        }
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
 pub fn isWordCodepoint(cp: u21) bool {
     return !isBlankCodepoint(cp) and !isWordDelimiter(cp);
 }
@@ -172,6 +215,77 @@ test "selection unit: clipboard row trim removes trailing terminal blanks only" 
         trimTrailingClipboardSpaces("           -cwd ~/cc-agent/yard \\     "),
     );
     try std.testing.expectEqualStrings("", trimTrailingClipboardSpaces("     \t  "));
+}
+
+test "join selection rows: soft-wrapped line copies as one line" {
+    // The reported bug: a long path that visually wraps must copy as a single
+    // line, not split at the wrap boundary.
+    const rows = [_]SelectionRow{
+        .{ .text = "~/project/Plant-Root-Atlas-Project/06.trajectory_analysis/result/pl", .wraps_next = true },
+        .{ .text = "ot/marker_gene_grouped_panels/combinations/Osa_Sly_Gma_Cri_Ath_ref_cri", .wraps_next = false },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings(
+        "~/project/Plant-Root-Atlas-Project/06.trajectory_analysis/result/plot/marker_gene_grouped_panels/combinations/Osa_Sly_Gma_Cri_Ath_ref_cri",
+        joined,
+    );
+}
+
+test "join selection rows: hard line breaks keep CRLF separators" {
+    const rows = [_]SelectionRow{
+        .{ .text = "line one", .wraps_next = false },
+        .{ .text = "line two", .wraps_next = false },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("line one\r\nline two", joined);
+}
+
+test "join selection rows: trims hard-break and final rows but preserves soft-wrap content" {
+    const rows = [_]SelectionRow{
+        // Soft wrap: trailing spaces are part of the logical line — keep them.
+        .{ .text = "abc   ", .wraps_next = true },
+        // Hard break: trailing terminal blanks trimmed, CRLF added.
+        .{ .text = "def   ", .wraps_next = false },
+        // Final row: trailing blanks trimmed, no separator.
+        .{ .text = "ghi   ", .wraps_next = false },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("abc   def\r\nghi", joined);
+}
+
+test "join selection rows: single row trims trailing blanks without separator" {
+    const rows = [_]SelectionRow{
+        .{ .text = "hello   ", .wraps_next = false },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("hello", joined);
+}
+
+test "join selection rows: wraps_next on the final selected row is ignored" {
+    // Selection ends exactly at a soft-wrap boundary: there is no next row to
+    // join to, so the final row is trimmed like any line end.
+    const rows = [_]SelectionRow{
+        .{ .text = "foo", .wraps_next = true },
+        .{ .text = "bar   ", .wraps_next = true },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("foobar", joined);
+}
+
+test "join selection rows: mixes soft wrap and hard breaks" {
+    const rows = [_]SelectionRow{
+        .{ .text = "aaa", .wraps_next = true },
+        .{ .text = "bbb", .wraps_next = false },
+        .{ .text = "ccc", .wraps_next = false },
+    };
+    const joined = try joinSelectionRows(std.testing.allocator, &rows);
+    defer std.testing.allocator.free(joined);
+    try std.testing.expectEqualStrings("aaabbb\r\nccc", joined);
 }
 
 fn toCodepoints(comptime text: []const u8) [text.len]u21 {


### PR DESCRIPTION
## Summary

Selecting and copying a line that only *visually* wraps across terminal rows (e.g. a long path in the shell prompt) produced multiple clipboard lines with a `\r\n` injected at each wrap boundary. It now copies back as a single continuous line, matching Windows Terminal and Ghostty.

## Root cause

`copySelectionToClipboard` (`src/input/clipboard.zig`) inserted `\r\n` between **every** selected row, ignoring ghostty's `Row.wrap` soft-wrap flag. The ctrl+click path-token detector (`preview_token.zig`) was already wrap-aware, but the actual clipboard copy path was not — which is why this looked "fixed before" yet still split wrapped lines.

## Changes

- New pure, unit-tested `selection_unit.joinSelectionRows` + `SelectionRow`:
  - soft-wrapped row → joined with **no separator**, trailing blanks kept verbatim
  - hard line end → `\r\n` after trimming trailing terminal blanks
  - final row → trimmed, no trailing separator
- `copySelectionToClipboard` rewritten to collect each row's text and its `.screen`-coordinate `Row.wrap` flag (read in the same coordinate space as the cells, so it stays correct when the viewport is scrolled), then join via the helper.

## Tests

- 6 new unit tests in `selection_unit.zig` (soft wrap, hard breaks, trim policy, single row, wrap-at-final-row, mixed). Written test-first (confirmed red with an old-behavior stub, then green).
- `zig build test` ✅ and `zig build test-full` ✅ (exit 0).

## Verification pending

GUI smoke test (select a wrapped path, Ctrl+C / right-click copy, paste → single line) — requires real rendering + system clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)