### PR TITLE
fix: scroll all centered-box overlays on short windows (#233)

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -5198,6 +5198,11 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         AppWindow.g_force_rebuild = true;
         return;
     }
+    if (overlays.settingsPageVisible()) {
+        overlays.settingsPageHandleScroll(@floatFromInt(ev.delta));
+        AppWindow.g_force_rebuild = true;
+        return;
+    }
     if (tab.g_sidebar_visible and ev.xpos >= 0 and ev.xpos < @as(i32, @intFromFloat(titlebar.sidebarWidth()))) return;
     if (hitTestBrowserPanel(@floatFromInt(ev.xpos), @floatFromInt(ev.ypos))) return;
     // Scroll in file explorer

--- a/src/input.zig
+++ b/src/input.zig
@@ -5203,6 +5203,12 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         AppWindow.g_force_rebuild = true;
         return;
     }
+    if (overlays.commandPaletteVisible()) {
+        overlays.commandPaletteHandleScroll(@floatFromInt(ev.delta));
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
     if (tab.g_sidebar_visible and ev.xpos >= 0 and ev.xpos < @as(i32, @intFromFloat(titlebar.sidebarWidth()))) return;
     if (hitTestBrowserPanel(@floatFromInt(ev.xpos), @floatFromInt(ev.ypos))) return;
     // Scroll in file explorer

--- a/src/input.zig
+++ b/src/input.zig
@@ -5209,6 +5209,18 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         AppWindow.g_cells_valid = false;
         return;
     }
+    if (overlays.sessionLauncherVisible()) {
+        overlays.sessionLauncherHandleScroll(@floatFromInt(ev.delta));
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
+    if (jupyter_picker.isVisible()) {
+        jupyter_picker.move(if (ev.delta > 0) -1 else 1);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        return;
+    }
     if (tab.g_sidebar_visible and ev.xpos >= 0 and ev.xpos < @as(i32, @intFromFloat(titlebar.sidebarWidth()))) return;
     if (hitTestBrowserPanel(@floatFromInt(ev.xpos), @floatFromInt(ev.ypos))) return;
     // Scroll in file explorer

--- a/src/jupyter_picker.zig
+++ b/src/jupyter_picker.zig
@@ -39,6 +39,15 @@ pub fn nextIndex(selected: usize, delta: i32, n: usize) usize {
     return @intCast(ni);
 }
 
+/// First row to render so the selected row stays visible when the list is taller
+/// than the window. Mirrors the scroll-follow helpers used by the overlays.
+pub fn firstVisible(selected: usize, visible_rows: usize, n: usize) usize {
+    if (visible_rows == 0 or n <= visible_rows) return 0;
+    const sel = @min(selected, n - 1);
+    if (sel < visible_rows) return 0;
+    return @min(sel - visible_rows + 1, n - visible_rows);
+}
+
 pub fn show(urls: []const []const u8) void {
     g_count = @min(urls.len, MAX_URLS);
     for (0..g_count) |i| {
@@ -58,6 +67,17 @@ pub fn hide() void {
     g_visible = false;
     g_count = 0;
     g_selected = 0;
+}
+
+test "firstVisible keeps the selected row within the visible window" {
+    // Everything fits → no scroll.
+    try std.testing.expectEqual(@as(usize, 0), firstVisible(5, 10, 8));
+    // Selection inside the first window → pinned to top.
+    try std.testing.expectEqual(@as(usize, 0), firstVisible(2, 4, 16));
+    // Selecting the last row scrolls so it is the bottom visible row.
+    try std.testing.expectEqual(@as(usize, 12), firstVisible(15, 4, 16));
+    // Mid-list selection.
+    try std.testing.expectEqual(@as(usize, 5), firstVisible(8, 4, 16));
 }
 
 test "nextIndex clamps at both ends" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1429,9 +1429,16 @@ pub fn renderJupyterPicker(window_width: f32, window_height: f32) void {
     const row_h: f32 = @max(28.0, font.g_titlebar_cell_height + 12);
     const box_w: f32 = @min(window_width - 80, 720);
     const title_h: f32 = row_h;
-    const box_h: f32 = title_h + row_h * @as(f32, @floatFromInt(n)) + 16;
+    const bottom_pad: f32 = 16;
+    // Clamp the row count to what fits the window, then scroll to keep the
+    // selected server visible (the list is keyboard/wheel navigable).
+    const usable_h = @max(row_h, window_height - 32.0 - title_h - bottom_pad);
+    const fit: usize = @intFromFloat(@max(1.0, @floor(usable_h / row_h)));
+    const visible = @min(n, fit);
+    const scroll = jupyter_picker.firstVisible(jupyter_picker.selectedIndex(), visible, n);
+    const box_h: f32 = title_h + row_h * @as(f32, @floatFromInt(visible)) + bottom_pad;
     const box_x = @round((window_width - box_w) / 2);
-    const box_top = @round((window_height - box_h) / 2);
+    const box_top = @round(@max(16.0, (window_height - box_h) / 2));
     const box_y = @round(window_height - box_top - box_h);
 
     ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.30);
@@ -1441,15 +1448,35 @@ pub fn renderJupyterPicker(window_width: f32, window_height: f32) void {
     const title_y = @round(box_y + box_h - title_h + (title_h - font.g_titlebar_cell_height) / 2);
     _ = titlebar.renderTextLimited("Select a Jupyter server (Up/Down, Enter, Esc)", box_x + 16, title_y, mixColor(bg, fg, 0.6), box_w - 32);
 
-    var i: usize = 0;
-    while (i < n) : (i += 1) {
-        const row_top_px = box_top + title_h + row_h * @as(f32, @floatFromInt(i));
+    var display: usize = 0;
+    while (display < visible) : (display += 1) {
+        const i = scroll + display;
+        if (i >= n) break;
+        const row_top_px = box_top + title_h + row_h * @as(f32, @floatFromInt(display));
         const row_y = @round(window_height - row_top_px - row_h);
         if (i == jupyter_picker.selectedIndex()) {
             renderRoundedQuadAlpha(box_x + 8, row_y + 3, box_w - 16, row_h - 6, 5, sel_bg, 0.6);
         }
         const ty = @round(row_y + (row_h - font.g_titlebar_cell_height) / 2);
         _ = titlebar.renderTextLimited(jupyter_picker.urlAt(i), box_x + 18, ty, text_color, box_w - 36);
+    }
+
+    // Scrollbar thumb when the list is taller than the window.
+    if (n > visible and visible > 0) {
+        const total_f: f32 = @floatFromInt(n);
+        const vis_f: f32 = @floatFromInt(visible);
+        const track_h = row_h * vis_f;
+        const track_top_px = box_top + title_h;
+        const sb_w: f32 = 3;
+        const sb_x = box_x + box_w - sb_w - 6;
+        const track_gl_y = @round(window_height - track_top_px - track_h);
+        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
+        const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
+        const max_scroll_f: f32 = @floatFromInt(n - visible);
+        const scroll_f: f32 = @floatFromInt(scroll);
+        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
+        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
     }
 }
 
@@ -1868,6 +1895,12 @@ const SessionLayout = struct {
     header_h: f32,
     first_row_top_px: f32,
     row_h: f32,
+    /// Total rows in the active mode.
+    row_count: usize,
+    /// Rows that fit in the box for the current window height.
+    visible_rows: usize,
+    /// Index of the first rendered row (scroll offset, selection-following).
+    scroll: usize,
 };
 
 pub threadlocal var g_session_launcher_visible: bool = false;
@@ -2182,6 +2215,26 @@ pub fn sessionLauncherHandleKey(ev: input_key.KeyEvent) void {
         },
         .enter => runSshFormFocusAction(),
         else => {},
+    }
+}
+
+/// Mouse-wheel handling for the session launcher. Scrolls by moving the active
+/// mode's selected/focused row (the view follows it), clamped at the ends so the
+/// wheel never wraps. Positive delta scrolls toward the top, mirroring
+/// whatsNewHandleScroll().
+pub fn sessionLauncherHandleScroll(delta_y: f64) void {
+    if (!sessionLauncherVisible()) return;
+    const step: i32 = if (delta_y > 0) -1 else if (delta_y < 0) 1 else 0;
+    if (step == 0) return;
+    const count = sessionActiveRowCount();
+    if (count == 0) return;
+    const sel = sessionActiveSelectionPtr();
+    if (step < 0) {
+        if (sel.* == 0) return;
+        sel.* -= 1;
+    } else {
+        if (sel.* + 1 >= count) return;
+        sel.* += 1;
     }
 }
 
@@ -4067,15 +4120,9 @@ fn sessionDesiredBoxWidth() f32 {
     return desired;
 }
 
-fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) SessionLayout {
-    const content_height = @max(1, window_height - top_offset);
-    const min_box_w: f32 = if (g_ssh_form_visible or g_ssh_list_visible or g_ai_form_visible or g_ai_list_visible) 460 else 360;
-    const max_box_w = @max(260.0, @min(760.0, window_width - 48.0));
-    const box_w: f32 = @round(@min(@max(min_box_w, sessionDesiredBoxWidth()), max_box_w));
-    const row_h = overlayRowHeight(38);
-    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
-    const bottom_pad = @round(@max(20.0, overlayTextHeight() * 0.55));
-    const row_count: usize = if (g_ai_form_visible)
+/// Total rows in the currently active session-launcher mode.
+fn sessionActiveRowCount() usize {
+    return if (g_ai_form_visible)
         AI_FIELD_COUNT + 3
     else if (g_ai_list_visible)
         aiListRowCount()
@@ -4087,7 +4134,71 @@ fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) Session
         sshListRowCount()
     else
         platform_pty_command.sessionLauncherRowCount();
-    const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(row_count)) + bottom_pad);
+}
+
+/// Selected/focused row of the currently active session-launcher mode.
+fn sessionActiveSelection() usize {
+    return if (g_ai_form_visible)
+        g_ai_focus
+    else if (g_ai_list_visible)
+        g_ai_list_selected
+    else if (g_ai_history_source_visible)
+        g_ai_history_source_selected
+    else if (g_ssh_form_visible)
+        g_ssh_focus
+    else if (g_ssh_list_visible)
+        g_ssh_list_selected
+    else
+        g_session_launcher_selected;
+}
+
+/// Mutable pointer to the active mode's selection (for the mouse wheel).
+fn sessionActiveSelectionPtr() *usize {
+    return if (g_ai_form_visible)
+        &g_ai_focus
+    else if (g_ai_list_visible)
+        &g_ai_list_selected
+    else if (g_ai_history_source_visible)
+        &g_ai_history_source_selected
+    else if (g_ssh_form_visible)
+        &g_ssh_focus
+    else if (g_ssh_list_visible)
+        &g_ssh_list_selected
+    else
+        &g_session_launcher_selected;
+}
+
+/// Rows that fit within the box for the given window height. Mirrors
+/// commandPaletteRowCapacity().
+fn sessionRowCapacity(content_height: f32, base_h: f32, row_h: f32, row_count: usize) usize {
+    if (row_count == 0) return 0;
+    const usable_h = @max(row_h, content_height - 32.0 - base_h);
+    if (usable_h <= row_h) return 1;
+    const fit: usize = @intFromFloat(@max(1.0, @floor(usable_h / row_h)));
+    return @min(row_count, fit);
+}
+
+/// First row to render so the selected row stays visible. Mirrors
+/// commandPaletteFirstVisibleIndex().
+fn sessionFirstVisibleRow(selection: usize, visible_rows: usize, row_count: usize) usize {
+    if (visible_rows == 0 or row_count <= visible_rows) return 0;
+    const sel = @min(selection, row_count - 1);
+    if (sel < visible_rows) return 0;
+    return @min(sel - visible_rows + 1, row_count - visible_rows);
+}
+
+fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) SessionLayout {
+    const content_height = @max(1, window_height - top_offset);
+    const min_box_w: f32 = if (g_ssh_form_visible or g_ssh_list_visible or g_ai_form_visible or g_ai_list_visible) 460 else 360;
+    const max_box_w = @max(260.0, @min(760.0, window_width - 48.0));
+    const box_w: f32 = @round(@min(@max(min_box_w, sessionDesiredBoxWidth()), max_box_w));
+    const row_h = overlayRowHeight(38);
+    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
+    const bottom_pad = @round(@max(20.0, overlayTextHeight() * 0.55));
+    const row_count = sessionActiveRowCount();
+    const visible_rows = sessionRowCapacity(content_height, header_h + bottom_pad, row_h, row_count);
+    const scroll = sessionFirstVisibleRow(sessionActiveSelection(), visible_rows, row_count);
+    const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + bottom_pad);
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
     return .{
@@ -4098,6 +4209,9 @@ fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) Session
         .header_h = header_h,
         .first_row_top_px = box_top_px + header_h,
         .row_h = row_h,
+        .row_count = row_count,
+        .visible_rows = visible_rows,
+        .scroll = scroll,
     };
 }
 
@@ -4107,7 +4221,9 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
     const y: f32 = @floatCast(ypos);
     if (x < layout.box_x or x > layout.box_x + layout.box_w) return null;
     if (y < layout.first_row_top_px) return null;
-    const row: usize = @intFromFloat(@floor((y - layout.first_row_top_px) / layout.row_h));
+    const visible_index: usize = @intFromFloat(@floor((y - layout.first_row_top_px) / layout.row_h));
+    if (visible_index >= layout.visible_rows) return null;
+    const row = visible_index + layout.scroll;
 
     if (g_ai_history_source_visible) {
         if (row >= aiHistorySourceRowCount()) return null;
@@ -4189,7 +4305,11 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
 }
 
 fn renderSessionRow(layout: SessionLayout, window_height: f32, row: usize, left: []const u8, right: []const u8, selected: bool) void {
-    const row_top = @round(layout.first_row_top_px + @as(f32, @floatFromInt(row)) * layout.row_h);
+    // Skip rows scrolled out of view above or below the visible window.
+    if (row < layout.scroll) return;
+    const visible_index = row - layout.scroll;
+    if (visible_index >= layout.visible_rows) return;
+    const row_top = @round(layout.first_row_top_px + @as(f32, @floatFromInt(visible_index)) * layout.row_h);
     const row_y = @round(window_height - row_top - layout.row_h);
     const x = layout.box_x + 18;
     const w = layout.box_w - 36;
@@ -4293,6 +4413,26 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.18);
     renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 11, border_color, 0.24);
     renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 10, panel_color, 0.96);
+
+    // Scrollbar indicator when more rows exist than fit (short windows or long
+    // lists). The list scrolls via keyboard/click selection-follow and the wheel.
+    if (layout.row_count > layout.visible_rows and layout.visible_rows > 0) {
+        const total_f: f32 = @floatFromInt(layout.row_count);
+        const vis_f: f32 = @floatFromInt(layout.visible_rows);
+        const track_h = layout.row_h * vis_f;
+        const track_top_px = layout.first_row_top_px;
+        const sb_w: f32 = 3;
+        const sb_x = layout.box_x + layout.box_w - sb_w - 7;
+        const track_gl_y = @round(window_height - track_top_px - track_h);
+        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
+
+        const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
+        const max_scroll_f: f32 = @floatFromInt(layout.row_count - layout.visible_rows);
+        const scroll_f: f32 = @floatFromInt(layout.scroll);
+        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
+        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
+    }
 
     const title = sessionLauncherTitle();
     const hint = sessionLauncherHint();
@@ -5396,6 +5536,57 @@ test "overlays: command center mouse wheel moves selection without wrapping" {
     g_command_palette_selected = count - 1;
     commandPaletteHandleScroll(-1);
     try std.testing.expectEqual(count - 1, g_command_palette_selected);
+}
+
+test "overlays: session launcher caps rows and scrolls to keep selection visible on short windows" {
+    const row_h = overlayRowHeight(38);
+    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
+    const bottom_pad = @round(@max(20.0, overlayTextHeight() * 0.55));
+    const base_h = header_h + bottom_pad;
+
+    // The tallest mode is the AI form (12 fields + 3 action rows = 15 rows).
+    const total: usize = AI_FIELD_COUNT + 3;
+
+    // A tall window fits every row.
+    try std.testing.expectEqual(total, sessionRowCapacity(2000, base_h, row_h, total));
+
+    // The reported short window cannot fit all rows.
+    const short_vis = sessionRowCapacity(522, base_h, row_h, total);
+    try std.testing.expect(short_vis >= 1);
+    try std.testing.expect(short_vis < total);
+
+    // Selection near the top keeps the list pinned to the top.
+    try std.testing.expectEqual(@as(usize, 0), sessionFirstVisibleRow(0, short_vis, total));
+
+    // Selecting the last row scrolls just far enough to reveal it.
+    const scroll = sessionFirstVisibleRow(total - 1, short_vis, total);
+    try std.testing.expectEqual(total - short_vis, scroll);
+    try std.testing.expect(total - 1 >= scroll);
+    try std.testing.expect(total - 1 < scroll + short_vis);
+}
+
+test "overlays: session launcher mouse wheel moves selection without wrapping" {
+    sessionLauncherOpen();
+    defer sessionLauncherClose();
+
+    const count = platform_pty_command.sessionLauncherRowCount();
+    try std.testing.expect(count >= 2);
+
+    g_session_launcher_selected = 0;
+    sessionLauncherHandleScroll(-1);
+    try std.testing.expectEqual(@as(usize, 1), g_session_launcher_selected);
+
+    sessionLauncherHandleScroll(1);
+    try std.testing.expectEqual(@as(usize, 0), g_session_launcher_selected);
+
+    // At the top, scrolling up does not wrap.
+    sessionLauncherHandleScroll(1);
+    try std.testing.expectEqual(@as(usize, 0), g_session_launcher_selected);
+
+    // At the bottom, scrolling down does not wrap.
+    g_session_launcher_selected = count - 1;
+    sessionLauncherHandleScroll(-1);
+    try std.testing.expectEqual(count - 1, g_session_launcher_selected);
 }
 
 test "overlays: active download toast can be clicked for interruption" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -4423,6 +4423,10 @@ const SettingsLayout = struct {
     footer_h: f32,
     row_top_px: f32,
     row_h: f32,
+    /// Number of rows that fit in the box for the current window height.
+    visible_rows: usize,
+    /// Index of the first rendered row (scroll offset).
+    scroll: usize,
 };
 
 pub threadlocal var g_settings_visible: bool = false;
@@ -4492,13 +4496,34 @@ pub fn settingsPageExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_hei
     return true;
 }
 
+/// Number of settings rows that fit within the box for the given window height,
+/// leaving room for the header and footer. Mirrors commandPaletteRowCapacity().
+fn settingsRowCapacity(content_height: f32, base_h: f32, row_h: f32) usize {
+    const usable_h = @max(row_h, content_height - 32.0 - base_h);
+    if (usable_h <= row_h) return 1;
+    const count_f = @floor(usable_h / row_h);
+    const count: usize = @intFromFloat(@max(1.0, count_f));
+    return @min(count, SETTINGS_ROW_COUNT);
+}
+
+/// First row to render so the focused row stays visible (scroll offset).
+/// Mirrors commandPaletteFirstVisibleIndex().
+fn settingsFirstVisibleRow(visible_rows: usize) usize {
+    if (visible_rows == 0 or SETTINGS_ROW_COUNT <= visible_rows) return 0;
+    const focus = @min(g_settings_focus, SETTINGS_ROW_COUNT - 1);
+    if (focus < visible_rows) return 0;
+    return @min(focus - visible_rows + 1, SETTINGS_ROW_COUNT - visible_rows);
+}
+
 fn settingsLayout(window_width: f32, window_height: f32, top_offset: f32) SettingsLayout {
     const content_height = @max(1, window_height - top_offset);
     const box_w = @round(@min(@max(420, window_width - 48), 760));
     const row_h = overlayRowHeight(42);
     const header_h = @round(18 + overlayLineHeight() * 2 + 12);
     const footer_h = @round(@max(52.0, overlayTextHeight() + 28.0));
-    const box_h = @round(header_h + row_h * SETTINGS_ROW_COUNT + footer_h);
+    const visible_rows = settingsRowCapacity(content_height, header_h + footer_h, row_h);
+    const scroll = settingsFirstVisibleRow(visible_rows);
+    const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h);
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
     const row_top_px = @round(box_top_px + header_h);
@@ -4511,6 +4536,8 @@ fn settingsLayout(window_width: f32, window_height: f32, top_offset: f32) Settin
         .footer_h = footer_h,
         .row_top_px = row_top_px,
         .row_h = row_h,
+        .visible_rows = visible_rows,
+        .scroll = scroll,
     };
 }
 
@@ -4526,7 +4553,9 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, 
 
     if (x < layout.box_x + 18 or x > layout.box_x + layout.box_w - 18) return null;
     if (y < layout.row_top_px) return null;
-    const row: usize = @intFromFloat(@floor((y - layout.row_top_px) / layout.row_h));
+    const visible_index: usize = @intFromFloat(@floor((y - layout.row_top_px) / layout.row_h));
+    if (visible_index >= layout.visible_rows) return null;
+    const row = visible_index + layout.scroll;
     if (row >= SETTINGS_ROW_COUNT) return null;
     g_settings_focus = row;
 
@@ -4733,7 +4762,11 @@ fn languageSettingText(setting: i18n.LanguageSetting) []const u8 {
 }
 
 fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, title: []const u8, value: []const u8, hint: []const u8, clickable: bool, selected: bool) void {
-    const row_y = @round(@as(f32, @floatFromInt(row)) * layout.row_h);
+    // Skip rows scrolled out of view above or below the visible window.
+    if (row < layout.scroll) return;
+    const visible_index = row - layout.scroll;
+    if (visible_index >= layout.visible_rows) return;
+    const row_y = @round(@as(f32, @floatFromInt(visible_index)) * layout.row_h);
     const y_top_px = layout.row_top_px + row_y;
     const gl_y = @round(window_height - y_top_px - layout.row_h);
     const x = layout.box_x + 18;
@@ -4833,6 +4866,38 @@ pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 9, i18n.s().settings_raw_config, i18n.s().settings_value_open, i18n.s().settings_hint_advanced_editor, true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 9);
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 10, i18n.s().settings_restore_defaults, "Enter", "", true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 10);
     renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 11, i18n.s().settings_close, "Esc", "", true, g_settings_focus == SETTINGS_CONTROL_ROW_START + 11);
+
+    // Scrollbar indicator when not all rows fit (short windows). The list is
+    // scrolled via keyboard/click focus-follow and the mouse wheel.
+    if (layout.visible_rows < SETTINGS_ROW_COUNT) {
+        const total: f32 = @floatFromInt(SETTINGS_ROW_COUNT);
+        const vis: f32 = @floatFromInt(layout.visible_rows);
+        const track_h = layout.row_h * vis;
+        const track_top_px = layout.row_top_px;
+        const sb_w: f32 = 3;
+        const sb_x = layout.box_x + layout.box_w - sb_w - 7;
+        const track_gl_y = @round(window_height - track_top_px - track_h);
+        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
+
+        const thumb_h = @max(24.0, @round(track_h * vis / total));
+        const max_scroll_f: f32 = @floatFromInt(SETTINGS_ROW_COUNT - layout.visible_rows);
+        const scroll_f: f32 = @floatFromInt(layout.scroll);
+        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
+        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
+    }
+}
+
+/// Mouse-wheel handling for the settings page. The list scrolls by moving the
+/// focused row (which the view follows), matching the keyboard navigation model.
+/// Positive delta scrolls toward the top, mirroring whatsNewHandleScroll().
+pub fn settingsPageHandleScroll(delta_y: f64) void {
+    if (!g_settings_visible) return;
+    if (delta_y > 0) {
+        if (g_settings_focus > 0) g_settings_focus -= 1;
+    } else if (delta_y < 0) {
+        if (g_settings_focus + 1 < SETTINGS_ROW_COUNT) g_settings_focus += 1;
+    }
 }
 
 // ============================================================================
@@ -5231,6 +5296,36 @@ test "macOS UI smoke: settings toggles WeChat direct" {
     defer allocator.free(content);
 
     try std.testing.expect(std.mem.indexOf(u8, content, "weixin-direct-enabled = true") != null);
+}
+
+test "overlays: settings page caps visible rows and scrolls to keep focus visible on short windows" {
+    const row_h = overlayRowHeight(42);
+    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
+    const footer_h = @round(@max(52.0, overlayTextHeight() + 28.0));
+    const base_h = header_h + footer_h;
+
+    // A tall window fits every row, so no scrolling is needed.
+    try std.testing.expectEqual(SETTINGS_ROW_COUNT, settingsRowCapacity(2000, base_h, row_h));
+
+    // The reported short window (~522px tall) cannot fit all rows.
+    const short_rows = settingsRowCapacity(522, base_h, row_h);
+    try std.testing.expect(short_rows >= 1);
+    try std.testing.expect(short_rows < SETTINGS_ROW_COUNT);
+
+    const saved_focus = g_settings_focus;
+    defer g_settings_focus = saved_focus;
+
+    // Focus near the top keeps the list pinned to the top.
+    g_settings_focus = 0;
+    try std.testing.expectEqual(@as(usize, 0), settingsFirstVisibleRow(short_rows));
+
+    // Focusing the last row (the close action that was clipped in the report)
+    // scrolls just far enough to reveal it as the bottom visible row.
+    g_settings_focus = SETTINGS_ROW_COUNT - 1;
+    const scroll = settingsFirstVisibleRow(short_rows);
+    try std.testing.expectEqual(SETTINGS_ROW_COUNT - short_rows, scroll);
+    try std.testing.expect(g_settings_focus >= scroll);
+    try std.testing.expect(g_settings_focus < scroll + short_rows);
 }
 
 test "overlays: active download toast can be clicked for interruption" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -288,6 +288,26 @@ pub fn commandPaletteMove(delta: i32) void {
     g_command_palette_selected = @intCast(next);
 }
 
+/// Mouse-wheel handling for the command center. The list scrolls by moving the
+/// selection (which the view follows via commandPaletteFirstVisibleIndex),
+/// matching the keyboard Up/Down model. Positive delta scrolls toward the top,
+/// mirroring whatsNewHandleScroll(). Clamps at the ends so the wheel never wraps.
+pub fn commandPaletteHandleScroll(delta_y: f64) void {
+    if (!g_command_palette_visible) return;
+    const step: i32 = if (delta_y > 0) -1 else if (delta_y < 0) 1 else 0;
+    if (step == 0) return;
+    if (commandPaletteIsHistoryMode()) {
+        commandPaletteMoveAgentHistory(step);
+        return;
+    }
+    const count = commandPaletteVisibleCount();
+    if (count == 0) return;
+    if (step < 0) {
+        if (g_command_palette_selected == 0) return;
+    } else if (g_command_palette_selected + 1 >= count) return;
+    commandPaletteMove(step);
+}
+
 pub fn commandPaletteAgentHistoryVisible() bool {
     return commandPaletteIsHistoryMode();
 }
@@ -1737,6 +1757,29 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
                 }
             }
         }
+    }
+
+    // Scrollbar indicator when more results exist than fit (short windows or
+    // long result lists). The list scrolls via keyboard/click selection-follow
+    // and the mouse wheel.
+    const total_results = commandPaletteResultCount();
+    if (total_results > layout.rendered_rows and layout.rendered_rows > 0) {
+        const total_f: f32 = @floatFromInt(total_results);
+        const vis_f: f32 = @floatFromInt(layout.rendered_rows);
+        const track_h = layout.row_h * vis_f;
+        const track_top_px = layout.row_top_px;
+        const sb_w: f32 = 3;
+        const sb_x = layout.box_x + layout.box_w - sb_w - 7;
+        const track_gl_y = @round(window_height - track_top_px - track_h);
+        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
+
+        const first_row = commandPaletteFirstVisibleIndex(layout.rendered_rows);
+        const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
+        const max_scroll_f: f32 = @floatFromInt(total_results - layout.rendered_rows);
+        const scroll_f: f32 = @floatFromInt(first_row);
+        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
+        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
     }
 
     const footer = if (commandPaletteIsHistoryMode()) i18n.s().cmd_palette_footer_history else i18n.s().cmd_palette_footer;
@@ -5326,6 +5369,33 @@ test "overlays: settings page caps visible rows and scrolls to keep focus visibl
     try std.testing.expectEqual(SETTINGS_ROW_COUNT - short_rows, scroll);
     try std.testing.expect(g_settings_focus >= scroll);
     try std.testing.expect(g_settings_focus < scroll + short_rows);
+}
+
+test "overlays: command center mouse wheel moves selection without wrapping" {
+    commandPaletteOpen();
+    defer commandPaletteClose();
+
+    // Default command mode with an empty filter lists many commands.
+    const count = commandPaletteVisibleCount();
+    try std.testing.expect(count >= 2);
+
+    g_command_palette_selected = 0;
+    // Positive delta scrolls toward the top; negative toward the bottom
+    // (mirrors whatsNewHandleScroll / the wheel sign convention).
+    commandPaletteHandleScroll(-1);
+    try std.testing.expectEqual(@as(usize, 1), g_command_palette_selected);
+
+    commandPaletteHandleScroll(1);
+    try std.testing.expectEqual(@as(usize, 0), g_command_palette_selected);
+
+    // At the top, scrolling up does not wrap to the bottom.
+    commandPaletteHandleScroll(1);
+    try std.testing.expectEqual(@as(usize, 0), g_command_palette_selected);
+
+    // At the bottom, scrolling down does not wrap to the top.
+    g_command_palette_selected = count - 1;
+    commandPaletteHandleScroll(-1);
+    try std.testing.expectEqual(count - 1, g_command_palette_selected);
 }
 
 test "overlays: active download toast can be clicked for interruption" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1080,6 +1080,14 @@ fn overlayTextHeight() f32 {
     return @max(1.0, font.g_titlebar_cell_height);
 }
 
+/// Clamp an overlay box height so the centered panel never paints past the
+/// content area on very short windows. The *RowCapacity helpers already size the
+/// box to fit in the common case; this guards the degenerate case where even the
+/// header + one row + footer exceeds the window.
+fn clampOverlayBoxHeight(box_h: f32, content_height: f32) f32 {
+    return @max(1.0, @min(box_h, content_height - 32.0));
+}
+
 fn overlayLineHeight() f32 {
     return @round(@max(24.0, overlayTextHeight() + 8.0));
 }
@@ -1132,7 +1140,7 @@ fn commandPaletteLayout(window_width: f32, window_height: f32, top_offset: f32) 
     const max_rows = commandPaletteRowCapacity(content_height, base_h, row_h);
     const rendered_rows = @min(visible_count, max_rows);
     const row_area_h = row_h * @as(f32, @floatFromInt(@max(rendered_rows, 1)));
-    const box_h = @round(base_h + row_area_h);
+    const box_h = @round(clampOverlayBoxHeight(base_h + row_area_h, content_height));
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
     const row_top_px = @round(box_top_px + header_h + filter_h + 12);
@@ -1436,7 +1444,7 @@ pub fn renderJupyterPicker(window_width: f32, window_height: f32) void {
     const fit: usize = @intFromFloat(@max(1.0, @floor(usable_h / row_h)));
     const visible = @min(n, fit);
     const scroll = jupyter_picker.firstVisible(jupyter_picker.selectedIndex(), visible, n);
-    const box_h: f32 = title_h + row_h * @as(f32, @floatFromInt(visible)) + bottom_pad;
+    const box_h: f32 = clampOverlayBoxHeight(title_h + row_h * @as(f32, @floatFromInt(visible)) + bottom_pad, window_height);
     const box_x = @round((window_width - box_w) / 2);
     const box_top = @round(@max(16.0, (window_height - box_h) / 2));
     const box_y = @round(window_height - box_top - box_h);
@@ -4198,7 +4206,7 @@ fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) Session
     const row_count = sessionActiveRowCount();
     const visible_rows = sessionRowCapacity(content_height, header_h + bottom_pad, row_h, row_count);
     const scroll = sessionFirstVisibleRow(sessionActiveSelection(), visible_rows, row_count);
-    const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + bottom_pad);
+    const box_h = @round(clampOverlayBoxHeight(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + bottom_pad, content_height));
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
     return .{
@@ -4706,7 +4714,7 @@ fn settingsLayout(window_width: f32, window_height: f32, top_offset: f32) Settin
     const footer_h = @round(@max(52.0, overlayTextHeight() + 28.0));
     const visible_rows = settingsRowCapacity(content_height, header_h + footer_h, row_h);
     const scroll = settingsFirstVisibleRow(visible_rows);
-    const box_h = @round(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h);
+    const box_h = @round(clampOverlayBoxHeight(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h, content_height));
     const box_x = @round(@max(16, (window_width - box_w) / 2));
     const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
     const row_top_px = @round(box_top_px + header_h);
@@ -5587,6 +5595,27 @@ test "overlays: session launcher mouse wheel moves selection without wrapping" {
     g_session_launcher_selected = count - 1;
     sessionLauncherHandleScroll(-1);
     try std.testing.expectEqual(count - 1, g_session_launcher_selected);
+}
+
+test "overlays: short-window overlay boxes stay within the window" {
+    // A window far too short to hold the full box must still keep the panel
+    // inside the content area (never paint past the bottom edge).
+    {
+        const layout = settingsLayout(800, 120, 0);
+        try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
+    }
+    {
+        sessionLauncherOpen();
+        defer sessionLauncherClose();
+        const layout = sessionLayout(800, 120, 0);
+        try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
+    }
+    {
+        commandPaletteOpen();
+        defer commandPaletteClose();
+        const layout = commandPaletteLayout(800, 120, 0);
+        try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
+    }
 }
 
 test "overlays: active download toast can be clicked for interruption" {

--- a/src/renderer/skill_center_renderer.zig
+++ b/src/renderer/skill_center_renderer.zig
@@ -87,6 +87,15 @@ pub fn bodyVisibleCapacity(window_height: f32, titlebar_offset: f32, cell_h: f32
     return @intFromFloat(@max(0.0, @floor(usable / rowHeight(cell_h))));
 }
 
+/// Scroll offset that keeps the selected row visible, for lists that have only a
+/// selection (no stored scroll). Mirrors the overlay scroll-follow helpers.
+fn firstVisibleForSelection(selected: usize, visible: usize, total: usize) usize {
+    if (visible == 0 or total <= visible) return 0;
+    const sel = @min(selected, total - 1);
+    if (sel < visible) return 0;
+    return @min(sel - visible + 1, total - visible);
+}
+
 fn clampScroll(requested: usize, total: usize, visible: usize) usize {
     if (total <= visible) return 0;
     return @min(requested, total - visible);
@@ -238,13 +247,20 @@ fn renderList(
     // Title line.
     const title_y = yTextFromTop(draw, window_height, body_top + 8);
     _ = draw.renderTextLimited(lv.title, content_x + PAD_X, title_y, muted, content_w - PAD_X * 2);
-    const list_top = body_top + rowHeight(draw.cell_h);
-
     const row_h = rowHeight(draw.cell_h);
+    const list_top = body_top + row_h;
+
+    // Clamp rows to what fits below the title and above the legend, then scroll
+    // to keep the selected row visible (the list is keyboard navigable).
+    const usable = window_height - list_top - legendHeight(draw.cell_h);
+    const cap: usize = if (usable <= 0) 0 else @intFromFloat(@max(0.0, @floor(usable / row_h)));
+    const scroll = firstVisibleForSelection(lv.sel, cap, lv.len);
+
     const marker_w: f32 = 110;
-    var i: usize = 0;
-    while (i < lv.len) : (i += 1) {
-        const row_top_px = list_top + @as(f32, @floatFromInt(i)) * row_h;
+    var rendered: usize = 0;
+    var i: usize = scroll;
+    while (i < lv.len and rendered < cap) : (i += 1) {
+        const row_top_px = list_top + @as(f32, @floatFromInt(rendered)) * row_h;
         const row_y = yFromTop(window_height, row_top_px, row_h);
         if (i == lv.sel) {
             draw.fillQuadAlpha(content_x, row_y, content_w, row_h, selected_bg, 0.55);
@@ -258,6 +274,24 @@ fn renderList(
             const mx = content_x + content_w - PAD_X - marker_w;
             _ = draw.renderTextLimited(item.marker, mx, text_y, item.marker_color, marker_w);
         }
+        rendered += 1;
+    }
+
+    // Scrollbar thumb when the list is taller than the visible area.
+    if (lv.len > cap and cap > 0) {
+        const total_f: f32 = @floatFromInt(lv.len);
+        const vis_f: f32 = @floatFromInt(cap);
+        const track_h = row_h * vis_f;
+        const sb_w: f32 = 3;
+        const sb_x = content_x + content_w - sb_w - 4;
+        const track_gl_y = yFromTop(window_height, list_top, track_h);
+        draw.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(muted, fg, 0.2), 0.30);
+        const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
+        const max_scroll_f: f32 = @floatFromInt(lv.len - cap);
+        const scroll_f: f32 = @floatFromInt(scroll);
+        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+        const thumb_gl_y = yFromTop(window_height, list_top + thumb_offset, thumb_h);
+        draw.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
     }
 }
 
@@ -373,6 +407,13 @@ fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w
 }
 
 // --- Tests ---
+
+test "skill_center_renderer: firstVisibleForSelection keeps selection in view" {
+    try std.testing.expectEqual(@as(usize, 0), firstVisibleForSelection(5, 10, 8));
+    try std.testing.expectEqual(@as(usize, 0), firstVisibleForSelection(2, 4, 16));
+    try std.testing.expectEqual(@as(usize, 12), firstVisibleForSelection(15, 4, 16));
+    try std.testing.expectEqual(@as(usize, 5), firstVisibleForSelection(8, 4, 16));
+}
 
 test "skill_center_renderer: clampScroll keeps scroll within range" {
     try std.testing.expectEqual(@as(usize, 0), clampScroll(5, 3, 10));


### PR DESCRIPTION
Fixes #233.

## Problem
Overlay panels that draw a **centered box with a vertical list/menu/form** computed a fixed box height with no clamp to the window and no scrolling. On a short window the bottom rows were drawn off-screen and couldn't be reached or clicked. Reported for Settings; the same bug affected Command Center, the SSH/New-Session launcher, and more.

## Audited every overlay
A parallel audit of all centered-box list/menu/form renderers classified each as already-OK or needs-fix. Fixed (all mirroring the existing command-palette pattern: `*RowCapacity` clamp + selection-follow scroll + mouse wheel + scrollbar thumb):

| Overlay | What was wrong |
|---|---|
| **Settings** | fixed `box_h`, no scroll |
| **Command Center** | clamped + keyboard scroll already; **added wheel + scrollbar** |
| **Session launcher** — SSH list, New Session menu, AI provider list, SSH form, AI form, AI-history picker (all share `sessionLayout`) | fixed `box_h`, no scroll |
| **Jupyter server picker** | `box_h = title + row*n + 16`, no clamp |
| **Skill Center `.list`** (import/install/server pickers) | looped all rows, no cap/scroll |

Already correct (verified, untouched): What's New, AI history sessions, port-forward list, Skill Center main matrix, AI-chat transcript/input, file explorer, rewind picker, confirms/toasts, startup-shortcuts card, resize indicator.

## How it works
Each fixed overlay now: clamps visible rows to the window, scrolls so the selected/focused row stays visible, skips off-screen rows in render, maps clicks through the scroll offset in its hit-test, draws a scrollbar thumb, and scrolls with the mouse wheel (clamped — no wrap). `clampOverlayBoxHeight()` additionally keeps the panel inside the window on degenerately short windows.

## Review
Ran an adversarial multi-agent review of the fixes; it confirmed one residual (box height not clamped on extremely short windows) which is fixed in the final commit, and refuted the other finding.

## Tests
TDD throughout — each scroll helper has a unit test, verified RED→GREEN (incl. temporarily reverting each to confirm the test fails):
`settingsRowCapacity`/`settingsFirstVisibleRow`, `commandPaletteHandleScroll` (no-wrap), `sessionRowCapacity`/`sessionFirstVisibleRow`, `sessionLauncherHandleScroll` (no-wrap), `jupyter_picker.firstVisible`, `skill_center_renderer.firstVisibleForSelection`, and a box-stays-in-window clamp test.

- App test binary run natively: **1980/1986 passed, 6 skipped** (macOS-gated).
- `zig build test-full` (windows-gnu compile) and `zig build test` (fast): green.

## Note
Real GUI verification on Windows is still pending (the GL GUI can't be driven headlessly here). Settings was GUI-confirmed by the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)