### PR TITLE
[codex] fix tmux restore metadata leak

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -55,6 +55,10 @@ const OscParseState = enum { ground, esc, osc_num, osc_semi, osc_title };
 const ImageOscParseState = enum {
     ground,
     esc,
+    /// Swallow tmux/screen title sequences: ESC k <title> ST.
+    screen_title,
+    /// Saw ESC inside a screen-title sequence; next byte may be '\' (ST).
+    screen_title_esc,
     osc_prefix,
     image_osc,
     image_osc_esc,
@@ -1049,12 +1053,34 @@ pub fn feedVtWithWispTermImageFallback(self: *Surface, data: []const u8) void {
                     self.wispterm_image_osc_buf.clearRetainingCapacity();
                     self.wispterm_image_osc_state = .osc_prefix;
                     passthrough_start = i + 1;
+                } else if (byte == 'k') {
+                    // GNU screen/tmux title sequence: ESC k <title> ESC \.
+                    // ghostty-vt doesn't implement ESC k yet; forwarding it
+                    // lets the title payload (often the running command such
+                    // as "ls" or "cd") render as stray pane text.
+                    self.wispterm_image_osc_state = .screen_title;
+                    passthrough_start = i + 1;
                 } else {
                     self.vt_stream.nextSlice("\x1b");
                     self.vt_stream.nextSlice(data[i .. i + 1]);
                     self.wispterm_image_osc_state = .ground;
                     passthrough_start = i + 1;
                 }
+            },
+            .screen_title => switch (byte) {
+                0x07 => {
+                    self.wispterm_image_osc_state = .ground;
+                    passthrough_start = i + 1;
+                },
+                0x1b => {
+                    self.wispterm_image_osc_state = .screen_title_esc;
+                    passthrough_start = i + 1;
+                },
+                else => passthrough_start = i + 1,
+            },
+            .screen_title_esc => {
+                self.wispterm_image_osc_state = if (byte == '\\') .ground else .screen_title;
+                passthrough_start = i + 1;
             },
             .osc_prefix => {
                 const matched = self.wispterm_image_osc_buf.items.len;

--- a/src/appwindow/tmux_bridge.zig
+++ b/src/appwindow/tmux_bridge.zig
@@ -186,10 +186,10 @@ pub const TmuxBridge = struct {
                 return null;
             };
             self.panes.setSurface(pane_id, surface);
-            // Seed the pane's visible screen: tmux doesn't replay it via %output
-            // on attach. `capture-pane -p` (no -J) gives one line per visible row
-            // ≤ pane width, so with size-sync matching the surface to the pane it
-            // paints 1:1 (clear+home prefix in the Session block_end handler).
+            // Seed the pane's primary screen as a fallback: tmux doesn't replay
+            // it via %output on attach. If pane metadata later reports that the
+            // pane is on the alternate screen, onPaneMeta queues an alternate
+            // capture that switches the surface to that screen.
             self.session.capturePane(pane_id) catch {};
             return surface; // ref 1, transferred to the tree
         }
@@ -371,9 +371,13 @@ pub const TmuxBridge = struct {
         }
     }
 
-    fn onPaneMeta(ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8) void {
+    fn onPaneMeta(ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8, alternate_on: bool) void {
         const self: *TmuxBridge = @ptrCast(@alignCast(ctx));
         const p = self.panes.find(pane_id) orelse return;
+        if (alternate_on and !p.alternate_capture_requested) {
+            p.alternate_capture_requested = true;
+            self.session.capturePaneAlternate(pane_id) catch {};
+        }
         const op = p.surface orelse return;
         const s: *Surface = @ptrCast(@alignCast(op));
         if (path.len > 0) s.setCwdPath(path);

--- a/src/appwindow/tmux_controller_windows.zig
+++ b/src/appwindow/tmux_controller_windows.zig
@@ -135,6 +135,18 @@ threadlocal var g_controllers: std.ArrayListUnmanaged(*TmuxController) = .empty;
 const INITIAL_BACKOFF_MS: i64 = 500;
 const MAX_BACKOFF_MS: i64 = 5000;
 
+/// Rewrite the stored `... tmux -CC new -A -s <name>` connect command into its
+/// reconnect form `... tmux -CC attach -t <name>`. After a control-mode session
+/// has once been established, reconnecting with `attach` lets us distinguish a
+/// dropped ssh transport from a remote tmux session the user actually ended.
+/// `"new -A -s"` and `"attach -t"` are the same length, so the output is a
+/// same-size copy; if the needle is absent the command is copied unchanged.
+fn buildAttachCommand(alloc: Allocator, connect_cmd: []const u8) Allocator.Error![]u8 {
+    const out = try alloc.alloc(u8, connect_cmd.len);
+    _ = std.mem.replace(u8, connect_cmd, "new -A -s", "attach -t", out);
+    return out;
+}
+
 const RawTransport = struct {
     stdin_write: HANDLE = INVALID_HANDLE_VALUE,
     stdout_read: HANDLE = INVALID_HANDLE_VALUE,
@@ -322,14 +334,18 @@ pub const TmuxController = struct {
     early: [4096]u8 = undefined,
     early_len: usize = 0,
     handshake_seen: bool = false,
+    /// Sticky: set once any handshake has succeeded. Reconnects after that use
+    /// `attach` (not `new -A`) so a live session is resumed, while a genuinely
+    /// gone session trips `Session.session_gone` and closes the controller.
+    had_handshake: bool = false,
     handshake_tail: [handshake_tail_max]u8 = undefined,
     handshake_tail_len: usize = 0,
     early_debug_chunks: u8 = 0,
     last_cols: u16 = 0,
     last_rows: u16 = 0,
-    /// Pre-handshake transport setup failed; retry login/connect with backoff.
-    /// Once tmux control mode has started, transport exit closes the controller
-    /// instead of re-running `new -A` and recreating a user-killed session.
+    /// A dropped transport reconnects with backoff. Before the first handshake
+    /// it retries the original command; after that it re-attaches the live tmux
+    /// session and closes only if the attach reports the session is gone.
     reconnecting: bool = false,
     closed: bool = false,
     next_retry_ms: i64 = 0,
@@ -366,18 +382,29 @@ pub const TmuxController = struct {
             if (!self.handshake_seen and !handshake) self.logPreHandshakeOutput(chunk);
             if (handshake) {
                 self.handshake_seen = true;
+                self.had_handshake = true;
                 self.backoff_ms = INITIAL_BACKOFF_MS;
                 std.debug.print("tmux: control-mode handshake seen\n", .{});
             }
             self.bridge.session.feed(chunk) catch {};
-            if (self.bridge.session.exited) {
+            if (self.bridge.session.session_gone) {
+                std.debug.print("tmux: remote session gone - closing controller\n", .{});
                 self.closeFromRemoteExit();
+                return;
+            }
+            if (self.bridge.session.exited) {
+                self.markDisconnected();
                 return;
             }
         }
 
-        if (self.bridge.session.exited) {
+        if (self.bridge.session.session_gone) {
+            std.debug.print("tmux: remote session gone - closing controller\n", .{});
             self.closeFromRemoteExit();
+            return;
+        }
+        if (self.bridge.session.exited) {
+            self.markDisconnected();
             return;
         }
 
@@ -418,10 +445,6 @@ pub const TmuxController = struct {
 
     fn markDisconnected(self: *TmuxController) void {
         if (self.reconnecting) return;
-        if (self.handshake_seen) {
-            self.closeFromRemoteExit();
-            return;
-        }
         std.debug.print("tmux: transport lost - reconnecting...\n", .{});
         self.transport.deinit();
         self.handshake_seen = false;
@@ -439,7 +462,18 @@ pub const TmuxController = struct {
     fn tryReconnect(self: *TmuxController) void {
         if (std.time.milliTimestamp() < self.next_retry_ms) return;
 
-        const owned = pty_command.allocCommandLineFromUtf8(self.alloc, self.ssh_cmd) catch {
+        var attach_cmd: ?[]u8 = null;
+        const reconnect_cmd: []const u8 = if (self.had_handshake) blk: {
+            const a = buildAttachCommand(self.alloc, self.ssh_cmd) catch {
+                self.scheduleRetry();
+                return;
+            };
+            attach_cmd = a;
+            break :blk a;
+        } else self.ssh_cmd;
+        defer if (attach_cmd) |a| self.alloc.free(a);
+
+        const owned = pty_command.allocCommandLineFromUtf8(self.alloc, reconnect_cmd) catch {
             self.scheduleRetry();
             return;
         };
@@ -713,4 +747,19 @@ pub fn requestClosePane(surface: *anyopaque) bool {
         }
     }
     return false;
+}
+
+test "buildAttachCommand rewrites the connect command to its attach form" {
+    const alloc = std.testing.allocator;
+    const connect = "ssh.exe -tt xzg@host \"tmux -CC new -A -s wispterm-ngs00\"";
+    const reconnect = try buildAttachCommand(alloc, connect);
+    defer alloc.free(reconnect);
+    try std.testing.expectEqualStrings(
+        "ssh.exe -tt xzg@host \"tmux -CC attach -t wispterm-ngs00\"",
+        reconnect,
+    );
+
+    const other = try buildAttachCommand(alloc, "ssh.exe host \"tmux -CC\"");
+    defer alloc.free(other);
+    try std.testing.expectEqualStrings("ssh.exe host \"tmux -CC\"", other);
 }

--- a/src/tmux/pane.zig
+++ b/src/tmux/pane.zig
@@ -32,6 +32,10 @@ pub const PaneMap = struct {
         /// opaque pointer so `pane.zig` stays Surface-free and unit-testable.
         /// `removePane`/`deinit` never touch it — the tree owns the ref.
         surface: ?*anyopaque = null,
+        /// Set after the bridge has requested an initial alternate-screen seed
+        /// for this pane. Periodic pane metadata refreshes should not keep
+        /// re-capturing a live full-screen TUI.
+        alternate_capture_requested: bool = false,
     };
 
     pub fn init(alloc: Allocator) PaneMap {

--- a/src/tmux/session.zig
+++ b/src/tmux/session.zig
@@ -30,10 +30,13 @@ pub const Session = struct {
     cmds: std.ArrayListUnmanaged(u8) = .empty,
     scratch: std.ArrayListUnmanaged(u8) = .empty,
     windows: std.ArrayListUnmanaged(Window) = .empty,
-    /// FIFO of pane ids awaiting a `capture-pane` reply (Phase 3d scrollback
-    /// seeding). Replies arrive in command order, so the front matches the next
-    /// non-window-list `block_end`.
-    capture_queue: std.ArrayListUnmanaged(usize) = .empty,
+    pane_states: std.ArrayListUnmanaged(PaneState) = .empty,
+    /// FIFO of replies expected from commands we have sent to tmux. Command
+    /// replies arrive in order, but bootstrap reconciliation can enqueue
+    /// capture-pane commands before earlier list-panes replies have arrived; a
+    /// typed FIFO keeps an empty/error list-panes reply from stealing a capture
+    /// seed and leaving a reattached pane blank.
+    reply_queue: std.ArrayListUnmanaged(ReplyKind) = .empty,
     active_window: ?usize = null,
     active_pane: ?usize = null,
     exited: bool = false,
@@ -44,6 +47,32 @@ pub const Session = struct {
     /// a survivable transport drop). Reset by `resetForReconnect`.
     session_gone: bool = false,
     events: EventSink = .{},
+
+    pub const CaptureScreen = enum { primary, alternate };
+
+    const PaneState = struct {
+        pane_id: usize,
+        alternate_on: bool = false,
+        cursor_visible: ?bool = null,
+        cursor_x: ?usize = null,
+        cursor_y: ?usize = null,
+    };
+
+    const CaptureRequest = struct {
+        pane_id: usize,
+        screen: CaptureScreen,
+    };
+
+    const PaneListRequest = struct {
+        restore_cursor_after_metadata: bool = false,
+    };
+
+    const ReplyKind = union(enum) {
+        ignore,
+        window_list,
+        pane_list: PaneListRequest,
+        capture: CaptureRequest,
+    };
 
     pub const Window = struct {
         id: usize,
@@ -71,14 +100,14 @@ pub const Session = struct {
         onWindowClose: *const fn (ctx: *anyopaque, window_id: usize) void = noClose,
         onActiveWindowChanged: *const fn (ctx: *anyopaque, window_id: usize) void = noActiveWindow,
         onActivePaneChanged: *const fn (ctx: *anyopaque, pane_id: usize) void = noActive,
-        onPaneMeta: *const fn (ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8) void = noPaneMeta,
+        onPaneMeta: *const fn (ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8, alternate_on: bool) void = noPaneMeta,
 
         fn noLayout(_: *anyopaque, _: usize, _: *const layout.Node) void {}
         fn noRename(_: *anyopaque, _: usize, _: []const u8) void {}
         fn noClose(_: *anyopaque, _: usize) void {}
         fn noActiveWindow(_: *anyopaque, _: usize) void {}
         fn noActive(_: *anyopaque, _: usize) void {}
-        fn noPaneMeta(_: *anyopaque, _: usize, _: []const u8, _: []const u8) void {}
+        fn noPaneMeta(_: *anyopaque, _: usize, _: []const u8, _: []const u8, _: bool) void {}
     };
 
     pub fn init(alloc: Allocator, sink: PaneSink, cols: u16, rows: u16) Session {
@@ -95,7 +124,8 @@ pub const Session = struct {
         self.parser.deinit();
         self.cmds.deinit(self.alloc);
         self.scratch.deinit(self.alloc);
-        self.capture_queue.deinit(self.alloc);
+        self.reply_queue.deinit(self.alloc);
+        self.pane_states.deinit(self.alloc);
         for (self.windows.items) |*w| w.deinit(self.alloc);
         self.windows.deinit(self.alloc);
     }
@@ -114,14 +144,14 @@ pub const Session = struct {
 
     /// Reset transient stream state for a transport reconnect: the byte parser
     /// (the dropped stream may have left a partial line), the outbound command
-    /// queue, and the pending capture-pane FIFO. The window/pane model is kept —
+    /// queue, and the pending command-reply FIFO. The window/pane model is kept —
     /// the post-reconnect `list-windows` refreshes it and the bridge reuses the
     /// same surfaces by pane id.
     pub fn resetForReconnect(self: *Session) void {
         self.parser.deinit();
         self.parser = control.Parser.init(self.alloc);
         self.cmds.clearRetainingCapacity();
-        self.capture_queue.clearRetainingCapacity();
+        self.reply_queue.clearRetainingCapacity();
         self.exited = false;
         self.session_gone = false;
     }
@@ -140,47 +170,20 @@ pub const Session = struct {
                 self.sink.write(o.pane_id, self.scratch.items);
             },
             .layout_change => |lc| try self.applyLayout(lc.window_id, lc.layout),
-            // A command-reply block. On attach tmux does NOT emit %layout-change,
-            // so the initial windows/layouts are learned from the `list-windows`
-            // reply that arrives here as `@<id> <layout>` lines (Phase 3d
-            // bootstrap). If it is not a window list, check by content whether it
-            // is a `list-panes` reply (`%<id>\t…` shape on every non-empty line);
-            // if so emit onPaneMeta — this must take priority over the capture FIFO
-            // because `start()` enqueues list-panes before any captures but
-            // `capturePane()` may be called during layout reconcile (inside the
-            // earlier list-windows reply) so the queue can already be non-empty
-            // when the list-panes reply lands. Otherwise route to the next queued
-            // `capture-pane` pane sink (FIFO). Anything else is ignored.
-            .block_end => |body| {
-                if (!try self.applyWindowList(body)) {
-                    if (isPaneListReply(body)) {
-                        _ = self.applyPaneList(body); // emits onPaneMeta per line
-                    } else if (self.capture_queue.items.len > 0) {
-                        const pane_id = self.capture_queue.orderedRemove(0);
-                        // Repaint from the top-left, translating LF→CRLF: the
-                        // capture's rows are joined by '\n' only, and the
-                        // terminal's line feed moves down without returning to
-                        // column 0 — without the '\r' each row staircases right.
-                        self.scratch.clearRetainingCapacity();
-                        try self.scratch.appendSlice(self.alloc, "\x1b[2J\x1b[H");
-                        for (body) |c| {
-                            if (c == '\n') {
-                                try self.scratch.appendSlice(self.alloc, "\r\n");
-                            } else {
-                                try self.scratch.append(self.alloc, c);
-                            }
-                        }
-                        self.sink.write(pane_id, self.scratch.items);
-                    }
-                }
-            },
+            // A command-reply block. On attach tmux does NOT emit
+            // %layout-change, so the initial windows/layouts are learned from
+            // the `list-windows` reply. Prefer the command FIFO populated when
+            // commands are queued; fall back to content sniffing only for unit
+            // fixtures or unexpected untracked replies.
+            .block_end => |body| try self.handleBlockEnd(body),
             .block_err => |body| {
                 // A reconnect `attach` to a session the user ended replies with a
                 // `%error` whose body names the failure; flag it so the controller
                 // tears down instead of recreating the session.
                 if (isSessionGoneError(body)) self.session_gone = true;
-                // Keep the capture FIFO aligned if a capture errored.
-                if (self.capture_queue.items.len > 0) _ = self.capture_queue.orderedRemove(0);
+                // Pop the matching command reply, but do not let non-capture
+                // errors consume any later capture seed.
+                _ = self.popReply();
             },
             .window_add => |w| _ = try self.ensureWindow(w.window_id),
             .window_renamed => |w| {
@@ -232,6 +235,138 @@ pub const Session = struct {
         }
     }
 
+    fn enqueueCommand(self: *Session, command: []const u8, reply: ReplyKind) Allocator.Error!void {
+        const old_len = self.cmds.items.len;
+        errdefer self.cmds.items.len = old_len;
+
+        try self.cmds.appendSlice(self.alloc, command);
+        try self.reply_queue.append(self.alloc, reply);
+    }
+
+    fn popReply(self: *Session) ?ReplyKind {
+        if (self.reply_queue.items.len == 0) return null;
+        return self.reply_queue.orderedRemove(0);
+    }
+
+    fn dropLeadingIgnoredReplies(self: *Session) void {
+        while (self.reply_queue.items.len > 0 and std.meta.activeTag(self.reply_queue.items[0]) == .ignore) {
+            _ = self.reply_queue.orderedRemove(0);
+        }
+    }
+
+    fn takeFirstWindowListReply(self: *Session) bool {
+        for (self.reply_queue.items, 0..) |reply, i| {
+            if (std.meta.activeTag(reply) == .window_list) {
+                _ = self.reply_queue.orderedRemove(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn takeFirstPaneListReply(self: *Session) ?PaneListRequest {
+        for (self.reply_queue.items, 0..) |reply, i| {
+            switch (reply) {
+                .pane_list => |req| {
+                    _ = self.reply_queue.orderedRemove(i);
+                    return req;
+                },
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    fn takeNextCaptureReply(self: *Session) ?CaptureRequest {
+        self.dropLeadingIgnoredReplies();
+        if (self.reply_queue.items.len == 0) return null;
+        switch (self.reply_queue.items[0]) {
+            .capture => |cap| {
+                _ = self.reply_queue.orderedRemove(0);
+                return cap;
+            },
+            else => return null,
+        }
+    }
+
+    fn handleBlockEnd(self: *Session, body: []const u8) Allocator.Error!void {
+        // tmux may emit empty replies for commands whose output we do not care
+        // about (for example size refreshes). Do not let those stale ignored
+        // replies offset later list/capture routing.
+        if (std.mem.trim(u8, body, " \r\n\t").len == 0) {
+            if (self.reply_queue.items.len > 0) {
+                switch (self.reply_queue.items[0]) {
+                    .ignore, .window_list, .pane_list => _ = self.popReply(),
+                    .capture => |cap| {
+                        _ = self.popReply();
+                        try self.seedCapturePane(cap.pane_id, cap.screen, body);
+                    },
+                }
+            }
+            return;
+        }
+
+        if (isPaneListReply(body)) {
+            self.dropLeadingIgnoredReplies();
+            const req: PaneListRequest = self.takeFirstPaneListReply() orelse .{};
+            _ = try self.applyPaneList(body, req.restore_cursor_after_metadata);
+            return;
+        }
+
+        if (isWindowListReply(body)) {
+            self.dropLeadingIgnoredReplies();
+            _ = self.takeFirstWindowListReply();
+            _ = try self.applyWindowList(body);
+            return;
+        }
+
+        if (self.takeNextCaptureReply()) |cap| {
+            try self.seedCapturePane(cap.pane_id, cap.screen, body);
+            return;
+        }
+
+        if (self.popReply()) |reply| {
+            switch (reply) {
+                .ignore => {},
+                .window_list => _ = try self.applyWindowList(body),
+                .pane_list => |req| _ = try self.applyPaneList(body, req.restore_cursor_after_metadata),
+                .capture => |cap| try self.seedCapturePane(cap.pane_id, cap.screen, body),
+            }
+            return;
+        }
+
+        if (!try self.applyWindowList(body)) {
+            if (isPaneListReply(body)) _ = try self.applyPaneList(body, false);
+        }
+    }
+
+    fn seedCapturePane(self: *Session, pane_id: usize, screen: CaptureScreen, body: []const u8) Allocator.Error!void {
+        if (isPaneListReply(body)) {
+            _ = try self.applyPaneList(body, false);
+            return;
+        }
+        if (isWindowListReply(body)) {
+            _ = try self.applyWindowList(body);
+            return;
+        }
+
+        // Repaint from the top-left, translating LF→CRLF: the capture's rows
+        // are joined by '\n' only, and the terminal's line feed moves down
+        // without returning to column 0 — without the '\r' each row staircases.
+        self.scratch.clearRetainingCapacity();
+        try self.scratch.appendSlice(self.alloc, if (screen == .alternate) "\x1b[?1049h" else "\x1b[?1049l");
+        try self.scratch.appendSlice(self.alloc, "\x1b[2J\x1b[H");
+        for (body) |c| {
+            if (c == '\n') {
+                try self.scratch.appendSlice(self.alloc, "\r\n");
+            } else {
+                try self.scratch.append(self.alloc, c);
+            }
+        }
+        try self.appendPaneCursorRestore(pane_id, screen, &self.scratch);
+        self.sink.write(pane_id, self.scratch.items);
+    }
+
     fn applyLayout(self: *Session, window_id: usize, layout_str: []const u8) Allocator.Error!void {
         var tree = layout.parse(self.alloc, layout_str) catch return; // ignore malformed layouts
         defer tree.deinit();
@@ -280,28 +415,189 @@ pub const Session = struct {
         return applied;
     }
 
-    /// Parse a `list-panes -s -F "#{pane_id}\t#{pane_current_path}\t#{pane_current_command}"`
-    /// reply body. Each line: `%<id>\t<path>\t<cmd>`. Emits onPaneMeta per line.
+    /// Parse a `list-panes -s -F "#{pane_id}\t#{pane_current_path}\t#{pane_current_command}\t#{alternate_on}\t#{cursor_flag}\t#{cursor_x}\t#{cursor_y}"`
+    /// reply body. Each line:
+    /// `%<id>\t<path>\t<cmd>\t<alternate_on>\t<cursor_flag>\t<cursor_x>\t<cursor_y>`.
+    /// Older three-field fixtures are accepted with `alternate_on=false`.
+    /// Emits onPaneMeta per line.
     /// Returns true if at least one line applied. The caller (block_end) gates
     /// this via `isPaneListReply` so it is only reached when the body is
     /// unambiguously a pane-list; per-line parsing is lenient (skips malformed).
-    fn applyPaneList(self: *Session, body: []const u8) bool {
+    fn applyPaneList(self: *Session, body: []const u8, restore_cursor_after_metadata: bool) Allocator.Error!bool {
         var applied = false;
         var lines = std.mem.splitScalar(u8, body, '\n');
         while (lines.next()) |raw| {
-            // Trim spaces and \r but NOT \t — tabs are the field separator.
-            const line = std.mem.trim(u8, raw, " \r");
-            if (line.len < 2 or line[0] != '%') continue;
-            const t1 = std.mem.indexOfScalar(u8, line, '\t') orelse continue;
-            const id = std.fmt.parseInt(usize, line[1..t1], 10) catch continue;
-            const rest = line[t1 + 1 ..];
-            const t2 = std.mem.indexOfScalar(u8, rest, '\t') orelse continue;
-            const path = rest[0..t2];
-            const cmd = rest[t2 + 1 ..];
-            self.events.onPaneMeta(self.events.ctx, id, path, cmd);
+            const parsed = parsePaneListLine(raw) orelse continue;
+            try self.setPaneState(parsed.id, parsed.state);
+            self.events.onPaneMeta(self.events.ctx, parsed.id, parsed.path, parsed.cmd, parsed.state.alternate_on);
+            if (restore_cursor_after_metadata) try self.writePaneCursorRestore(parsed.id);
             applied = true;
         }
         return applied;
+    }
+
+    fn parsePaneStateFields(
+        alternate_on: []const u8,
+        cursor_flag: ?[]const u8,
+        cursor_x: ?[]const u8,
+        cursor_y: ?[]const u8,
+    ) PaneState {
+        var state: PaneState = .{ .pane_id = 0 };
+        state.alternate_on = std.mem.eql(u8, std.mem.trim(u8, alternate_on, " \r\t"), "1");
+        if (cursor_flag) |field| {
+            const trimmed = std.mem.trim(u8, field, " \r\t");
+            if (std.mem.eql(u8, trimmed, "0")) {
+                state.cursor_visible = false;
+            } else if (std.mem.eql(u8, trimmed, "1")) {
+                state.cursor_visible = true;
+            }
+        }
+        if (cursor_x) |field| {
+            const trimmed = std.mem.trim(u8, field, " \r\t");
+            if (trimmed.len > 0) state.cursor_x = std.fmt.parseInt(usize, trimmed, 10) catch null;
+        }
+        if (cursor_y) |field| {
+            const trimmed = std.mem.trim(u8, field, " \r\t");
+            if (trimmed.len > 0) state.cursor_y = std.fmt.parseInt(usize, trimmed, 10) catch null;
+        }
+        return state;
+    }
+
+    fn parsePaneStateTail(tail: []const u8) PaneState {
+        var fields = std.mem.splitScalar(u8, tail, '\t');
+        const alternate_on = fields.next() orelse return .{ .pane_id = 0 };
+        return parsePaneStateFields(alternate_on, fields.next(), fields.next(), fields.next());
+    }
+
+    const PaneListLine = struct {
+        id: usize,
+        path: []const u8,
+        cmd: []const u8,
+        state: PaneState,
+    };
+
+    fn parsePaneListLine(raw: []const u8) ?PaneListLine {
+        const line = std.mem.trim(u8, raw, " \r\t");
+        if (line.len < 2 or line[0] != '%') return null;
+        if (std.mem.indexOfScalar(u8, line, '\t') != null) {
+            return parseTabbedPaneListLine(line);
+        }
+        return parseWhitespacePaneListLine(line);
+    }
+
+    fn parseTabbedPaneListLine(line: []const u8) ?PaneListLine {
+        const t1 = std.mem.indexOfScalar(u8, line, '\t') orelse return null;
+        const id = std.fmt.parseInt(usize, line[1..t1], 10) catch return null;
+        const rest = line[t1 + 1 ..];
+        const t2 = std.mem.indexOfScalar(u8, rest, '\t') orelse return null;
+        const path = rest[0..t2];
+        const cmd_and_state = rest[t2 + 1 ..];
+        const t3 = std.mem.indexOfScalar(u8, cmd_and_state, '\t');
+        return .{
+            .id = id,
+            .path = path,
+            .cmd = if (t3) |idx| cmd_and_state[0..idx] else cmd_and_state,
+            .state = parsePaneStateTail(if (t3) |idx| cmd_and_state[idx + 1 ..] else ""),
+        };
+    }
+
+    const TokenRange = struct { start: usize, end: usize };
+
+    fn isPaneFieldSpace(c: u8) bool {
+        return c == ' ' or c == '\t' or c == '\r';
+    }
+
+    fn lastTokenBefore(s: []const u8, before: usize) ?TokenRange {
+        var end = @min(before, s.len);
+        while (end > 0 and isPaneFieldSpace(s[end - 1])) end -= 1;
+        if (end == 0) return null;
+        var begin = end;
+        while (begin > 0 and !isPaneFieldSpace(s[begin - 1])) begin -= 1;
+        return .{ .start = begin, .end = end };
+    }
+
+    fn parseWhitespacePaneListLine(line: []const u8) ?PaneListLine {
+        var id_end: usize = 1;
+        while (id_end < line.len and !isPaneFieldSpace(line[id_end])) id_end += 1;
+        if (id_end == line.len) return null;
+        const id = std.fmt.parseInt(usize, line[1..id_end], 10) catch return null;
+
+        const rest = std.mem.trimLeft(u8, line[id_end..], " \r\t");
+        const y = lastTokenBefore(rest, rest.len) orelse return null;
+        const x = lastTokenBefore(rest, y.start) orelse return null;
+        const cursor = lastTokenBefore(rest, x.start) orelse return null;
+        const alternate = lastTokenBefore(rest, cursor.start) orelse return null;
+        const cmd = lastTokenBefore(rest, alternate.start) orelse return null;
+        const path = std.mem.trim(u8, rest[0..cmd.start], " \r\t");
+        if (path.len == 0) return null;
+
+        return .{
+            .id = id,
+            .path = path,
+            .cmd = rest[cmd.start..cmd.end],
+            .state = parsePaneStateFields(
+                rest[alternate.start..alternate.end],
+                rest[cursor.start..cursor.end],
+                rest[x.start..x.end],
+                rest[y.start..y.end],
+            ),
+        };
+    }
+
+    fn setPaneState(self: *Session, pane_id: usize, state: PaneState) Allocator.Error!void {
+        const stored = PaneState{
+            .pane_id = pane_id,
+            .alternate_on = state.alternate_on,
+            .cursor_visible = state.cursor_visible,
+            .cursor_x = state.cursor_x,
+            .cursor_y = state.cursor_y,
+        };
+        for (self.pane_states.items) |*existing| {
+            if (existing.pane_id == pane_id) {
+                existing.* = stored;
+                return;
+            }
+        }
+        try self.pane_states.append(self.alloc, stored);
+    }
+
+    fn findPaneState(self: *const Session, pane_id: usize) ?PaneState {
+        for (self.pane_states.items) |state| {
+            if (state.pane_id == pane_id) return state;
+        }
+        return null;
+    }
+
+    fn activeCaptureScreen(state: PaneState) CaptureScreen {
+        return if (state.alternate_on) .alternate else .primary;
+    }
+
+    fn appendPaneCursorRestore(
+        self: *Session,
+        pane_id: usize,
+        screen: CaptureScreen,
+        out: *std.ArrayListUnmanaged(u8),
+    ) Allocator.Error!void {
+        const state = self.findPaneState(pane_id) orelse return;
+        if (screen != activeCaptureScreen(state)) return;
+
+        if (state.cursor_x) |x| {
+            if (state.cursor_y) |y| {
+                var buf: [48]u8 = undefined;
+                const seq = std.fmt.bufPrint(&buf, "\x1b[{d};{d}H", .{ y + 1, x + 1 }) catch unreachable;
+                try out.appendSlice(self.alloc, seq);
+            }
+        }
+        if (state.cursor_visible) |visible| {
+            try out.appendSlice(self.alloc, if (visible) "\x1b[?25h" else "\x1b[?25l");
+        }
+    }
+
+    fn writePaneCursorRestore(self: *Session, pane_id: usize) Allocator.Error!void {
+        const state = self.findPaneState(pane_id) orelse return;
+        self.scratch.clearRetainingCapacity();
+        try self.appendPaneCursorRestore(pane_id, activeCaptureScreen(state), &self.scratch);
+        if (self.scratch.items.len > 0) self.sink.write(pane_id, self.scratch.items);
     }
 
     fn removeWindowsNotIn(self: *Session, ids: []const usize) void {
@@ -321,18 +617,28 @@ pub const Session = struct {
 
     /// Enqueue a `capture-pane` for a pane and remember it (FIFO) so the reply
     /// can be routed back to the pane's sink to seed its visible screen on
-    /// attach. Plain `-p` (NOT `-J`): each visible row is one line ≤ pane width,
-    /// so writing it to a matched-width surface reproduces the screen 1:1
-    /// without re-wrapping.
+    /// attach. `-e` preserves SGR escapes. No `-J`: each visible row is one
+    /// line <= pane width, so writing it to a matched-width surface reproduces
+    /// the screen 1:1 without re-wrapping.
     pub fn capturePane(self: *Session, pane_id: usize) Allocator.Error!void {
-        var buf: [48]u8 = undefined;
-        const s = std.fmt.bufPrint(&buf, "capture-pane -p -t %{d}\n", .{pane_id}) catch unreachable;
-        try self.cmds.appendSlice(self.alloc, s);
-        try self.capture_queue.append(self.alloc, pane_id);
+        try self.capturePaneScreen(pane_id, .primary);
+    }
+
+    pub fn capturePaneAlternate(self: *Session, pane_id: usize) Allocator.Error!void {
+        try self.capturePaneScreen(pane_id, .alternate);
+    }
+
+    fn capturePaneScreen(self: *Session, pane_id: usize, screen: CaptureScreen) Allocator.Error!void {
+        var buf: [64]u8 = undefined;
+        const s = switch (screen) {
+            .primary => std.fmt.bufPrint(&buf, "capture-pane -p -e -q -t %{d}\n", .{pane_id}) catch unreachable,
+            .alternate => std.fmt.bufPrint(&buf, "capture-pane -p -e -q -a -t %{d}\n", .{pane_id}) catch unreachable,
+        };
+        try self.enqueueCommand(s, .{ .capture = .{ .pane_id = pane_id, .screen = screen } });
     }
 
     /// The `list-panes` format string shared between `start` and `refreshPaneMeta`.
-    const list_panes_cmd = "list-panes -s -F \"#{pane_id}\t#{pane_current_path}\t#{pane_current_command}\"\n";
+    const list_panes_cmd = "list-panes -s -F \"#{pane_id}\t#{pane_current_path}\t#{pane_current_command}\t#{alternate_on}\t#{cursor_flag}\t#{cursor_x}\t#{cursor_y}\"\n";
 
     /// Enqueue the attach bootstrap: tell tmux our client size and ask for the
     /// window list. (Parsing the list-windows reply for complete initial
@@ -340,15 +646,15 @@ pub const Session = struct {
     /// notifications.)
     pub fn start(self: *Session) Allocator.Error!void {
         try self.enqueueResize();
-        try self.cmds.appendSlice(self.alloc, "list-windows -F \"#{window_id}\t#{window_active}\t#{window_layout}\t#{window_name}\"\n");
-        try self.cmds.appendSlice(self.alloc, list_panes_cmd);
+        try self.enqueueCommand("list-windows -F \"#{window_id}\t#{window_active}\t#{window_layout}\t#{window_name}\"\n", .window_list);
+        try self.enqueueCommand(list_panes_cmd, .{ .pane_list = .{ .restore_cursor_after_metadata = true } });
     }
 
     /// Re-query per-pane metadata (cwd + current command). Called periodically
     /// by the controller; cwd/command change infrequently so a coarse cadence
     /// is fine.
     pub fn refreshPaneMeta(self: *Session) Allocator.Error!void {
-        try self.cmds.appendSlice(self.alloc, list_panes_cmd);
+        try self.enqueueCommand(list_panes_cmd, .{ .pane_list = .{} });
     }
 
     pub fn resizeClient(self: *Session, cols: u16, rows: u16) Allocator.Error!void {
@@ -360,11 +666,14 @@ pub const Session = struct {
     fn enqueueResize(self: *Session) Allocator.Error!void {
         var buf: [64]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "refresh-client -C {d}x{d}\n", .{ self.cols, self.rows }) catch unreachable;
-        try self.cmds.appendSlice(self.alloc, s);
+        try self.enqueueCommand(s, .ignore);
     }
 
     /// Queue raw key bytes for a pane as a hex `send-keys` command.
     pub fn sendKeys(self: *Session, pane_id: usize, raw: []const u8) Allocator.Error!void {
+        const old_len = self.cmds.items.len;
+        errdefer self.cmds.items.len = old_len;
+
         var head: [48]u8 = undefined;
         const h = std.fmt.bufPrint(&head, "send-keys -t %{d} -H", .{pane_id}) catch unreachable;
         try self.cmds.appendSlice(self.alloc, h);
@@ -374,6 +683,7 @@ pub const Session = struct {
             try self.cmds.appendSlice(self.alloc, hs);
         }
         try self.cmds.append(self.alloc, '\n');
+        try self.reply_queue.append(self.alloc, .ignore);
     }
 
     pub fn splitPane(self: *Session, pane_id: usize, dir: layout.Dir) Allocator.Error!void {
@@ -383,23 +693,23 @@ pub const Session = struct {
         };
         var buf: [48]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "split-window {s} -t %{d}\n", .{ flag, pane_id }) catch unreachable;
-        try self.cmds.appendSlice(self.alloc, s);
+        try self.enqueueCommand(s, .ignore);
     }
 
     pub fn newWindow(self: *Session) Allocator.Error!void {
-        try self.cmds.appendSlice(self.alloc, "new-window\n");
+        try self.enqueueCommand("new-window\n", .ignore);
     }
 
     pub fn killWindow(self: *Session, id: usize) Allocator.Error!void {
         var buf: [48]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "kill-window -t @{d}\n", .{id}) catch unreachable;
-        try self.cmds.appendSlice(self.alloc, s);
+        try self.enqueueCommand(s, .ignore);
     }
 
     pub fn killPane(self: *Session, pane_id: usize) Allocator.Error!void {
         var buf: [48]u8 = undefined;
         const s = std.fmt.bufPrint(&buf, "kill-pane -t %{d}\n", .{pane_id}) catch unreachable;
-        try self.cmds.appendSlice(self.alloc, s);
+        try self.enqueueCommand(s, .ignore);
     }
 };
 
@@ -413,6 +723,18 @@ const WindowListLine = struct {
 fn parseWindowListLine(line: []const u8) ?WindowListLine {
     if (line.len < 2 or line[0] != '@') return null;
     return parseTabbedWindowListLine(line);
+}
+
+fn isWindowListReply(body: []const u8) bool {
+    var found_any = false;
+    var lines = std.mem.splitScalar(u8, body, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \r\t");
+        if (line.len == 0) continue;
+        if (parseWindowListLine(line) == null) return false;
+        found_any = true;
+    }
+    return found_any;
 }
 
 fn parseTabbedWindowListLine(line: []const u8) ?WindowListLine {
@@ -434,25 +756,27 @@ fn parseTabbedWindowListLine(line: []const u8) ?WindowListLine {
 }
 
 /// Returns true iff `body` is a `list-panes` reply: there is at least one
-/// non-empty line AND every non-empty line matches `%<digits>\t…` (starts with
-/// `%`, has a numeric id before the first `\t`, and contains at least one `\t`).
-/// A single non-matching non-empty line → false. Blank/whitespace-only lines
-/// are ignored. This strict check lets block_end distinguish a pane-list reply
-/// from real capture scrollback (which won't have ALL lines in that shape).
+/// non-empty line AND every non-empty line can be parsed as pane metadata.
+/// Blank/whitespace-only lines are ignored. This strict check lets block_end
+/// distinguish a pane-list reply from real capture scrollback (which won't have
+/// ALL lines in that shape).
 fn isPaneListReply(body: []const u8) bool {
     var found_any = false;
     var lines = std.mem.splitScalar(u8, body, '\n');
     while (lines.next()) |raw| {
         const line = std.mem.trim(u8, raw, " \r\t");
-        if (line.len == 0) continue; // ignore blank lines
-        // Must start with '%' and have at least one '\t'.
-        if (line[0] != '%') return false;
-        const tab = std.mem.indexOfScalar(u8, line, '\t') orelse return false;
-        // The part between '%' and '\t' must be a valid decimal integer (pane id).
-        _ = std.fmt.parseInt(usize, line[1..tab], 10) catch return false;
+        if (line.len == 0) continue;
+        if (Session.parsePaneListLine(line) == null and !hasPaneListPrefix(line)) return false;
         found_any = true;
     }
     return found_any;
+}
+
+fn hasPaneListPrefix(line: []const u8) bool {
+    if (line.len < 3 or line[0] != '%') return false;
+    var i: usize = 1;
+    while (i < line.len and std.ascii.isDigit(line[i])) i += 1;
+    return i > 1 and i < line.len and Session.isPaneFieldSpace(line[i]);
 }
 
 /// True if a `%error` reply body says the attach target no longer exists: the
@@ -690,6 +1014,7 @@ const EventLog = struct {
     last_pane_meta_id: ?usize = null,
     last_pane_meta_path: std.ArrayListUnmanaged(u8) = .empty,
     last_pane_meta_cmd: std.ArrayListUnmanaged(u8) = .empty,
+    last_pane_meta_alternate_on: bool = false,
 
     fn eventSink(self: *EventLog) Session.EventSink {
         return .{
@@ -734,10 +1059,11 @@ const EventLog = struct {
             .split => |s| for (s.children) |*c| countLeaves(c, out),
         }
     }
-    fn onPaneMeta(ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8) void {
+    fn onPaneMeta(ctx: *anyopaque, pane_id: usize, path: []const u8, cmd: []const u8, alternate_on: bool) void {
         const self: *EventLog = @ptrCast(@alignCast(ctx));
         self.pane_meta_count += 1;
         self.last_pane_meta_id = pane_id;
+        self.last_pane_meta_alternate_on = alternate_on;
         self.last_pane_meta_path.clearRetainingCapacity();
         self.last_pane_meta_path.appendSlice(self.alloc, path) catch {};
         self.last_pane_meta_cmd.clearRetainingCapacity();
@@ -886,14 +1212,28 @@ test "capture-pane reply is routed to the pane sink (scrollback seed)" {
     defer s.deinit();
 
     try s.capturePane(5);
-    try std.testing.expect(std.mem.indexOf(u8, s.pendingCommands(), "capture-pane -p -t %5\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, s.pendingCommands(), "capture-pane -p -e -q -t %5\n") != null);
 
     // The capture-pane reply: a %begin/%end block of plain pane content. It is
     // not a window list, so it routes to the queued pane (%5), prefixed with a
-    // clear+home so it paints from the top-left.
+    // primary-screen switch + clear+home so it paints from the top-left.
     try s.feed("%begin 1 1 0\nline-a\nline-b\n%end 1 1 0\n");
     try std.testing.expectEqual(@as(usize, 5), col.last_pane);
-    try std.testing.expectEqualSlices(u8, "\x1b[2J\x1b[Hline-a\r\nline-b", col.buf.items);
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049l\x1b[2J\x1b[Hline-a\r\nline-b", col.buf.items);
+}
+
+test "alternate capture-pane reply enters alternate screen before seeding" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+
+    try s.capturePaneAlternate(5);
+    try std.testing.expect(std.mem.indexOf(u8, s.pendingCommands(), "capture-pane -p -e -q -a -t %5\n") != null);
+
+    try s.feed("%begin 1 1 0\ncodex\nready\n%end 1 1 0\n");
+    try std.testing.expectEqual(@as(usize, 5), col.last_pane);
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049h\x1b[2J\x1b[Hcodex\r\nready", col.buf.items);
 }
 
 test "EventSink default is a silent no-op" {
@@ -915,11 +1255,11 @@ test "list-panes reply drives onPaneMeta per pane" {
     defer s.deinit();
     s.events = log.eventSink();
 
-    // Reply to: list-panes -s -F "#{pane_id}\t#{pane_current_path}\t#{pane_current_command}"
+    // Reply to: list-panes -s -F "#{pane_id}\t#{pane_current_path}\t#{pane_current_command}\t#{alternate_on}"
     try s.feed(
         "%begin 9 9 0\n" ++
-            "%1\t/home/u/proj\tnvim\n" ++
-            "%2\t/var/log\ttail\n" ++
+            "%1\t/home/u/proj\tnvim\t0\n" ++
+            "%2\t/var/log\ttail\t1\n" ++
             "%end 9 9 0\n",
     );
 
@@ -927,6 +1267,52 @@ test "list-panes reply drives onPaneMeta per pane" {
     try std.testing.expectEqual(@as(?usize, 2), log.last_pane_meta_id);
     try std.testing.expectEqualStrings("/var/log", log.last_pane_meta_path.items);
     try std.testing.expectEqualStrings("tail", log.last_pane_meta_cmd.items);
+    try std.testing.expect(log.last_pane_meta_alternate_on);
+}
+
+test "pane cursor state is restored after capture-pane seeding" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var log = EventLog{ .alloc = std.testing.allocator };
+    defer log.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+    s.events = log.eventSink();
+
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{ .restore_cursor_after_metadata = true } });
+    try s.capturePane(5);
+
+    // tmux reports 0-based cursor coordinates. cursor_flag=0 means hidden.
+    try s.feed("%begin 1 1 0\n%5\t/proc\ttop\t0\t0\t12\t7\n%end 1 1 0\n");
+    try std.testing.expectEqual(@as(usize, 5), col.last_pane);
+    try std.testing.expectEqualSlices(u8, "\x1b[8;13H\x1b[?25l", col.buf.items);
+
+    col.buf.clearRetainingCapacity();
+    try s.feed("%begin 2 2 0\nline-a\nline-b\n%end 2 2 0\n");
+    try std.testing.expectEqual(@as(usize, 5), col.last_pane);
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049l\x1b[2J\x1b[Hline-a\r\nline-b\x1b[8;13H\x1b[?25l", col.buf.items);
+}
+
+test "periodic pane metadata records cursor state without injecting it" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var log = EventLog{ .alloc = std.testing.allocator };
+    defer log.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+    s.events = log.eventSink();
+
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{} });
+
+    // A normal refresh should update cached tmux state only; injecting cursor
+    // controls every refresh can race with live pane output.
+    try s.feed("%begin 1 1 0\n%5\t/proc\ttop\t0\t0\t12\t7\n%end 1 1 0\n");
+    try std.testing.expectEqual(@as(usize, 0), col.buf.items.len);
+
+    try s.capturePane(5);
+    try s.feed("%begin 2 2 0\nline-a\n%end 2 2 0\n");
+    try std.testing.expectEqual(@as(usize, 5), col.last_pane);
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049l\x1b[2J\x1b[Hline-a\x1b[8;13H\x1b[?25l", col.buf.items);
 }
 
 test "a pending capture does not steal a list-panes reply (startup ordering)" {
@@ -938,16 +1324,85 @@ test "a pending capture does not steal a list-panes reply (startup ordering)" {
     defer s.deinit();
     s.events = log.eventSink();
 
-    // Captures are queued (as during attach reconcile) BEFORE the list-panes
-    // reply arrives. The reply must be parsed as pane metadata, NOT consumed as
-    // a capture seed, and the capture queue must stay intact.
+    // The list-panes command is queued before captures, but captures may be
+    // queued during the earlier list-windows reconcile before the list-panes
+    // reply arrives. The typed command FIFO must route the reply to pane
+    // metadata, NOT consume a capture seed.
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{ .restore_cursor_after_metadata = true } });
     try s.capturePane(1);
     try s.capturePane(2);
     try s.feed("%begin 7 7 0\n%1\t/home/u\tnvim\n%2\t/var/log\ttail\n%end 7 7 0\n");
 
     try std.testing.expectEqual(@as(usize, 2), log.pane_meta_count);
-    try std.testing.expectEqual(@as(usize, 2), s.capture_queue.items.len); // untouched
+    try std.testing.expectEqual(@as(usize, 2), s.reply_queue.items.len); // captures untouched
     try std.testing.expectEqual(@as(usize, 0), col.buf.items.len); // no capture seed written
+}
+
+test "list-panes reply is parsed even if stale replies precede it" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var log = EventLog{ .alloc = std.testing.allocator };
+    defer log.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+    s.events = log.eventSink();
+
+    try s.reply_queue.append(std.testing.allocator, .ignore);
+    try s.capturePane(44);
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{} });
+
+    try s.feed("%begin 1 1 0\n%44     /data/xzg_data/Plant-Root-Atlas-Project/01.gene-family-analysis zsh 0 1 2 3\n%end 1 1 0\n");
+
+    try std.testing.expectEqual(@as(usize, 1), log.pane_meta_count);
+    try std.testing.expectEqual(@as(?usize, 44), log.last_pane_meta_id);
+    try std.testing.expectEqualStrings("zsh", log.last_pane_meta_cmd.items);
+    try std.testing.expectEqual(@as(usize, 0), col.buf.items.len);
+    try std.testing.expectEqual(@as(usize, 1), s.reply_queue.items.len);
+}
+
+test "pane metadata is never seeded as capture content" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var log = EventLog{ .alloc = std.testing.allocator };
+    defer log.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+    s.events = log.eventSink();
+
+    try s.capturePane(44);
+    try s.feed("%begin 1 1 0\n%44     /data/xzg_data/Plant-Root-Atlas-Project/01.gene-family-analysis zsh 0 1 2 2\n%end 1 1 0\n");
+
+    try std.testing.expectEqual(@as(usize, 1), log.pane_meta_count);
+    try std.testing.expectEqual(@as(?usize, 44), log.last_pane_meta_id);
+    try std.testing.expectEqualStrings("/data/xzg_data/Plant-Root-Atlas-Project/01.gene-family-analysis", log.last_pane_meta_path.items);
+    try std.testing.expectEqualStrings("zsh", log.last_pane_meta_cmd.items);
+    try std.testing.expectEqual(@as(usize, 0), col.buf.items.len);
+    try std.testing.expectEqual(@as(usize, 1), s.reply_queue.items.len);
+}
+
+test "an empty or errored pane-list reply does not consume a later capture" {
+    var col = Collector{ .alloc = std.testing.allocator };
+    defer col.deinit();
+    var s = Session.init(std.testing.allocator, col.sink(), 80, 24);
+    defer s.deinit();
+
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{ .restore_cursor_after_metadata = true } });
+    try s.capturePane(5);
+    try s.feed("%begin 7 7 0\n%end 7 7 0\n");
+    try std.testing.expectEqual(@as(usize, 1), s.reply_queue.items.len);
+    try std.testing.expectEqual(@as(usize, 0), col.buf.items.len);
+
+    try s.feed("%begin 8 8 0\nline-a\n%end 8 8 0\n");
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049l\x1b[2J\x1b[Hline-a", col.buf.items);
+
+    col.buf.clearRetainingCapacity();
+    try s.reply_queue.append(std.testing.allocator, .{ .pane_list = .{ .restore_cursor_after_metadata = true } });
+    try s.capturePane(6);
+    try s.feed("%begin 9 9 0\nboom\n%error 9 9 0\n");
+    try std.testing.expectEqual(@as(usize, 1), s.reply_queue.items.len);
+
+    try s.feed("%begin 10 10 0\nline-b\n%end 10 10 0\n");
+    try std.testing.expectEqualSlices(u8, "\x1b[?1049l\x1b[2J\x1b[Hline-b", col.buf.items);
 }
 
 test "a realistic capture reply is seeded even with pane-list-like ids elsewhere" {
@@ -964,7 +1419,7 @@ test "a realistic capture reply is seeded even with pane-list-like ids elsewhere
     try s.feed("%begin 1 1 0\n$ ls\nfile.txt  %notapaneline\n%end 1 1 0\n");
 
     try std.testing.expectEqual(@as(usize, 0), log.pane_meta_count); // not pane-list
-    try std.testing.expectEqual(@as(usize, 0), s.capture_queue.items.len); // capture consumed
+    try std.testing.expectEqual(@as(usize, 0), s.reply_queue.items.len); // capture consumed
     try std.testing.expect(std.mem.indexOf(u8, col.buf.items, "file.txt") != null); // seeded
 }
 


### PR DESCRIPTION
## Summary

Fixes tmux restore regressions where control-mode metadata could leak into the restored pane as visible text, including the `%44 /data/... zsh 0 1 2 2` line seen after reconnect/restore.

## Root Cause

During tmux control-mode bootstrap, `list-panes` metadata can arrive while capture-pane requests are already queued from layout reconciliation. The previous routing could fall through to the capture seeding path when the reply queue was not aligned exactly, so pane metadata was written into the terminal surface.

## Changes

- Route `list-panes` and `list-windows` replies by content before capture replies, independent of queue alignment.
- Add a defensive guard in capture seeding so tmux metadata is never written as pane content.
- Preserve alternate-screen/cursor state when restoring tmux panes, including `top`-style alternate screen panes.
- Reconnect established tmux controllers with `attach -t` instead of re-running `new -A -s`.
- Swallow tmux/screen `ESC k ... ST` title sequences so command names do not render as stray text.
- Add regression coverage for the exact metadata-leak ordering.

## Validation

- `zig test src\tmux\session.zig`
- `zig build test`
- `zig build test-shared --summary all`
- `zig build --summary all`
- `git diff --check`

`zig build test-full` was attempted but timed out after 184 seconds; leftover `zig` processes were cleaned up.