### PR TITLE
fix(input): enable double/triple/quad-click selection on macOS

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -3203,15 +3203,14 @@ fn selectWordAtCell(surface: *Surface, cell_pos: CellPos) bool {
     return true;
 }
 
-fn selectSentenceAtCell(surface: *Surface, cell_pos: CellPos) bool {
+fn selectLineAtCell(surface: *Surface, cell_pos: CellPos) bool {
     var row_buf: [MAX_SELECTION_COLS]u21 = undefined;
 
     surface.render_state.mutex.lock();
     defer surface.render_state.mutex.unlock();
 
     const row = readViewportRowLocked(surface, cell_pos.row, &row_buf);
-    if (cell_pos.col >= row.len) return false;
-    const range = selection_unit.sentenceRange(row, cell_pos.col) orelse return false;
+    const range = selection_unit.lineRange(row) orelse return false;
     const abs_row = viewportOffsetForSurfaceLocked(surface) + cell_pos.row;
     activateSelection(surface, range.start, abs_row, range.end, abs_row);
     return true;
@@ -3240,6 +3239,75 @@ fn selectParagraphAtCell(surface: *Surface, cell_pos: CellPos) bool {
 
     activateSelection(surface, start_col, vp_off + start_row, end_col, vp_off + end_row);
     return true;
+}
+
+/// Resolve a left-button click in terminal content into focus + selection.
+/// Shared by the normal press path and the macOS double_click fall-through:
+/// the click count comes from click_tracker (time+distance based, identical on
+/// every platform), so 1=drag-select, 2=word, 3=line, 4=paragraph.
+fn handleTerminalSelectionPress(ev: platform_input.MouseButtonEvent, xpos: f64, ypos: f64) void {
+    // Find which surface was clicked and focus it
+    const clicked_surface = split_layout.surfaceAtPoint(@intFromFloat(xpos), @intFromFloat(ypos)) orelse AppWindow.activeSurface() orelse return;
+
+    // Focus the clicked split if different from current focus
+    if (AppWindow.activeTab()) |tb| {
+        const previous_focus = tb.focused;
+        for (0..split_layout.g_split_rect_count) |i| {
+            const rect = split_layout.g_split_rects[i];
+            if (!split_layout.cachedRectIsLive(rect)) continue;
+            if (rect.surface()) |s| {
+                if (s == clicked_surface) {
+                    tb.focused = rect.handle;
+                    break;
+                }
+            }
+        }
+        if (tb.focused != previous_focus) {
+            AppWindow.handleActiveSurfaceChangeWithinTab();
+        }
+    }
+
+    const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
+    switch (terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, primaryOpenMod(ev.ctrl, ev.super), ev.shift, ev.alt)) {
+        .download_ssh_file => {
+            if (downloadTerminalFileAtCell(clicked_surface, cell_pos)) return;
+        },
+        .open_url_or_preview => {
+            if (openUrlAtCell(clicked_surface, cell_pos)) return;
+            if (openHtmlPanelForCell(clicked_surface, cell_pos)) return;
+            if (openPreviewPanelForCell(clicked_surface, cell_pos, ev.shift)) return;
+        },
+        .pass_through => {},
+    }
+
+    clearUrlUnderline();
+    const shift_range_select = ev.shift and !ev.ctrl and !ev.alt;
+    const click_count: u8 = if (shift_range_select) blk: {
+        resetLeftClickCount();
+        break :blk 1;
+    } else nextLeftClickCount(xpos, ypos);
+    switch (click_count) {
+        1 => {
+            // Shift-click extends from the last click anchor, matching
+            // document editor style range selection.
+            if (!(shift_range_select and extendSelectionAtCell(clicked_surface, cell_pos, xpos, ypos))) {
+                startSelectionAtCell(clicked_surface, cell_pos, xpos, ypos);
+            }
+        },
+        2 => {
+            g_selecting = false;
+            if (!selectWordAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+        },
+        3 => {
+            g_selecting = false;
+            if (!selectLineAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+        },
+        4 => {
+            g_selecting = false;
+            if (!selectParagraphAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
+        },
+        else => unreachable,
+    }
 }
 
 fn extractTokenRangeAtCell(allocator: std.mem.Allocator, surface: *Surface, cell_pos: CellPos) ?TokenAtCell {
@@ -3907,7 +3975,10 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         if (beginTerminalMouseReport(ev)) return;
     }
 
-    // Double-click on tab text to rename, elsewhere to maximize
+    // A natively-reported double-click (macOS backend) targets UI chrome:
+    // double-click a tab to rename, the bare titlebar to zoom, or a file-
+    // explorer entry to open it. If it hits none of those, it is a terminal
+    // content double-click and falls through to selection below.
     if (ev.button == .left and ev.action == .double_click) {
         const xpos: f64 = @floatFromInt(ev.x);
         const titlebar_h: f64 = titlebarHeight();
@@ -3924,10 +3995,23 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 // on the macOS traffic-light strip) zooms / unzooms.
                 toggleMaximize();
             }
-        } else if (hitTestSidebarTab(xpos, ypos)) |tab_idx| {
+            return;
+        }
+        if (hitTestSidebarTab(xpos, ypos)) |tab_idx| {
             if (shouldStartSidebarTabRename(xpos, ypos, tab_idx)) {
                 tab.startTabRename(tab_idx);
             }
+            return;
+        }
+        // No chrome hit — this is a double-click in terminal content. The macOS
+        // backend reports the 2nd/3rd/4th click of a multi-click as
+        // double_click (clickCount > 1) rather than press, so they never reach
+        // the press-path selection. Route terminal-content double-clicks
+        // through the same click_tracker path: the opening press already
+        // registered count=1, so this registers 2/3/4 → word/line/paragraph.
+        // Windows/Linux never emit double_click, so their behavior is unchanged.
+        if (split_layout.surfaceAtPoint(ev.x, ev.y) != null) {
+            handleTerminalSelectionPress(ev, xpos, ypos);
         }
         return;
     }
@@ -4391,68 +4475,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 }
             }
 
-            // Find which surface was clicked and focus it
-            const clicked_surface = split_layout.surfaceAtPoint(@intFromFloat(xpos), @intFromFloat(ypos)) orelse AppWindow.activeSurface() orelse return;
-
-            // Focus the clicked split if different from current focus
-            if (AppWindow.activeTab()) |tb| {
-                const previous_focus = tb.focused;
-                for (0..split_layout.g_split_rect_count) |i| {
-                    const rect = split_layout.g_split_rects[i];
-                    if (!split_layout.cachedRectIsLive(rect)) continue;
-                    if (rect.surface()) |s| {
-                        if (s == clicked_surface) {
-                            tb.focused = rect.handle;
-                            break;
-                        }
-                    }
-                }
-                if (tb.focused != previous_focus) {
-                    AppWindow.handleActiveSurfaceChangeWithinTab();
-                }
-            }
-
-            const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
-            switch (terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, primaryOpenMod(ev.ctrl, ev.super), ev.shift, ev.alt)) {
-                .download_ssh_file => {
-                    if (downloadTerminalFileAtCell(clicked_surface, cell_pos)) return;
-                },
-                .open_url_or_preview => {
-                    if (openUrlAtCell(clicked_surface, cell_pos)) return;
-                    if (openHtmlPanelForCell(clicked_surface, cell_pos)) return;
-                    if (openPreviewPanelForCell(clicked_surface, cell_pos, ev.shift)) return;
-                },
-                .pass_through => {},
-            }
-
-            clearUrlUnderline();
-            const shift_range_select = ev.shift and !ev.ctrl and !ev.alt;
-            const click_count: u8 = if (shift_range_select) blk: {
-                resetLeftClickCount();
-                break :blk 1;
-            } else nextLeftClickCount(xpos, ypos);
-            switch (click_count) {
-                1 => {
-                    // Shift-click extends from the last click anchor, matching
-                    // document editor style range selection.
-                    if (!(shift_range_select and extendSelectionAtCell(clicked_surface, cell_pos, xpos, ypos))) {
-                        startSelectionAtCell(clicked_surface, cell_pos, xpos, ypos);
-                    }
-                },
-                2 => {
-                    g_selecting = false;
-                    if (!selectWordAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
-                },
-                3 => {
-                    g_selecting = false;
-                    if (!selectSentenceAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
-                },
-                4 => {
-                    g_selecting = false;
-                    if (!selectParagraphAtCell(clicked_surface, cell_pos)) clearSelectionAtCell(clicked_surface, cell_pos);
-                },
-                else => unreachable,
-            }
+            handleTerminalSelectionPress(ev, xpos, ypos);
         } else {
             // Mouse up
             if (g_preview_image_drag.active()) {

--- a/src/selection_unit.zig
+++ b/src/selection_unit.zig
@@ -76,6 +76,14 @@ pub fn paragraphRange(rows: []const []const u21, row: usize) ?RowRange {
     };
 }
 
+/// Range covering a single row's text, from its first to last non-blank cell.
+/// Used by triple-click to select the whole line. Null for a blank row.
+pub fn lineRange(row: []const u21) ?ColRange {
+    const start = firstNonBlankCol(row) orelse return null;
+    const end = lastNonBlankCol(row) orelse return null;
+    return .{ .start = start, .end = end };
+}
+
 pub fn firstNonBlankCol(row: []const u21) ?usize {
     for (row, 0..) |cp, i| {
         if (!isBlankCodepoint(cp)) return i;
@@ -160,6 +168,16 @@ test "selection unit: paragraph range selects contiguous nonblank rows" {
         .start_col = 2,
         .end_col = 10,
     }, paragraphRange(&rows, 2).?);
+}
+
+test "selection unit: line range spans first to last nonblank cell" {
+    const row = comptime toCodepoints("  hello world  ");
+    try std.testing.expectEqual(ColRange{ .start = 2, .end = 12 }, lineRange(&row).?);
+}
+
+test "selection unit: line range is null for a blank row" {
+    const row = comptime toCodepoints("    ");
+    try std.testing.expect(lineRange(&row) == null);
 }
 
 test "selection unit: clipboard row trim removes trailing terminal blanks only" {


### PR DESCRIPTION
## 问题
macOS 上 WispTerm 的鼠标多击选择（双击选词、三击、四击）完全失效，而 Windows/Linux 正常。

## 根因
macOS 后端 `src/platform/window_macos_bridge.m` 用 `event.clickCount > 1 ? 2 : 0` 编码鼠标按下——只要点击 ≥2 次就一律标成 `double_click`，真实点击次数被压平。这些事件不是 `press`，于是：
- 被 `src/input.zig` 的 `double_click` 分支（标题栏 / tab / 文件浏览器）拦截后直接 `return`，到不了选词逻辑；
- 平台无关的 `click_tracker`（只在 `press` 时计数）在 macOS 永远数不到 2。

Windows/Linux 始终发 `press`，所以 `click_tracker` 正常工作——这解释了为何只有 macOS 缺失。

## 改动（最小修复，不动 bridge / 不动 Windows·Linux 路径）
- `src/selection_unit.zig`：新增 `lineRange`（选整行）+ 单元测试。
- `src/input.zig`：
  - 抽出 `handleTerminalSelectionPress`，让 press 路径与 double_click 兜底共用同一套 `click_tracker` 选择逻辑。
  - `double_click` 分支：命中标题栏 / tab / 文件浏览器各自 `return`（macOS 原有 UI 双击零回归）；落在终端内容区时改走 `click_tracker`——首次 `press` 记为 1，后续 `double_click` 再 register 数到 2/3/4。
  - 三击语义由「选句」改为「选整行」（全平台统一，贴近 macOS Terminal / iTerm2）。

最终行为（三平台一致）：**双击=选词，三击=选整行，四击=选段**。

## 验证
- ✅ `selection_unit` 单元测试 7/7（含新增 `lineRange` 两例）
- ✅ `zig build macos-app -Dtarget=aarch64-macos` 编译通过
- ✅ `zig build test` / `zig build test-macos-ui` 均无 fail/panic
- ✅ 逻辑核实：`release` 路径不 reset click_tracker，双击/三击链路完整

## 注意
- 三击=选整行目前是「单个视觉行」的非空范围；跨软换行的整条逻辑行选择是可选后续增强。
- 发现一个对称问题（本次未改）：标题栏双击最大化、tab 双击重命名只在 macOS 生效（因为只有 macOS 发 `double_click`），Windows/Linux 缺失，建议后续用 `click_tracker` 统一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
