### PR TITLE
fix(config): hot-reload config/font-size on macOS without restart

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1545,6 +1545,23 @@ pub fn setConfigValue(allocator: std.mem.Allocator, key: []const u8, value: []co
     };
     defer if (content.len > 0) allocator.free(content);
 
+    const out = try setConfigValueInContent(allocator, content, key, value);
+    defer allocator.free(out);
+
+    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(out);
+}
+
+/// Pure: return a copy of `content` with `key`'s active value set to `value`.
+/// The first active occurrence is rewritten in place and any later duplicate
+/// occurrences are dropped, so the value the loader applies matches what was just
+/// set — config keys are last-wins during load, so without dropping duplicates a
+/// file with two active `font-size` lines would keep applying the second one and
+/// the Settings page (which only rewrote the first) would appear to do nothing.
+/// Comments and unrelated lines are preserved; the line is appended if the key is
+/// absent. Caller owns the returned slice.
+pub fn setConfigValueInContent(allocator: std.mem.Allocator, content: []const u8, key: []const u8, value: []const u8) ![]u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     defer out.deinit(allocator);
 
@@ -1552,9 +1569,12 @@ pub fn setConfigValue(allocator: std.mem.Allocator, key: []const u8, value: []co
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |line_raw| {
         const line = std.mem.trimRight(u8, line_raw, "\r");
-        if (!replaced and configLineMatchesKey(line, key)) {
-            try out.writer(allocator).print("{s} = {s}\n", .{ key, value });
-            replaced = true;
+        if (configLineMatchesKey(line, key)) {
+            if (!replaced) {
+                try out.writer(allocator).print("{s} = {s}\n", .{ key, value });
+                replaced = true;
+            }
+            // Drop later duplicate active lines for the same key.
         } else if (line.len > 0) {
             try out.appendSlice(allocator, line);
             try out.append(allocator, '\n');
@@ -1568,9 +1588,7 @@ pub fn setConfigValue(allocator: std.mem.Allocator, key: []const u8, value: []co
         try out.writer(allocator).print("{s} = {s}\n", .{ key, value });
     }
 
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(out.items);
+    return out.toOwnedSlice(allocator);
 }
 
 /// Pure: return a copy of `content` with active `key = value` lines for any of
@@ -2020,6 +2038,46 @@ test "config: settings reset strips settings-page keys but preserves everything 
     try std.testing.expect(std.mem.indexOf(u8, stripped, "font-family = JetBrains Mono") != null);
     try std.testing.expect(std.mem.indexOf(u8, stripped, "keybind = ctrl+shift+p=toggle_command_palette") != null);
     try std.testing.expect(std.mem.indexOf(u8, stripped, "quake-mode = true") != null);
+}
+
+test "setConfigValueInContent rewrites first active line and drops duplicates" {
+    const allocator = std.testing.allocator;
+    // Two active font-size lines (as can accumulate in a real config): load is
+    // last-wins, so the Settings page rewriting only the first would never take
+    // effect. The dedupe collapses them to one line carrying the new value.
+    const content =
+        \\# Font
+        \\font-size = 20
+        \\theme = dracula
+        \\font-size = 16
+        \\
+    ;
+    const out = try setConfigValueInContent(allocator, content, "font-size", "24");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings(
+        \\# Font
+        \\font-size = 24
+        \\theme = dracula
+        \\
+    , out);
+}
+
+test "setConfigValueInContent leaves commented lines and appends when key absent" {
+    const allocator = std.testing.allocator;
+    const content =
+        \\# font-size = 13
+        \\theme = dracula
+        \\
+    ;
+    const out = try setConfigValueInContent(allocator, content, "font-size", "18");
+    defer allocator.free(out);
+    // The comment is preserved (not matched) and the active key is appended.
+    try std.testing.expectEqualStrings(
+        \\# font-size = 13
+        \\theme = dracula
+        \\font-size = 18
+        \\
+    , out);
 }
 
 test "config: inline comments after values are ignored" {

--- a/src/config_watcher.zig
+++ b/src/config_watcher.zig
@@ -19,29 +19,44 @@ pub fn init(allocator: std.mem.Allocator) ?ConfigWatcher {
         std.debug.print("ConfigWatcher: failed to get config path: {}\n", .{err});
         return null;
     };
+    return initForPath(allocator, path);
+}
 
-    const dir_path = std.fs.path.dirname(path) orelse {
+/// Watch the directory containing `config_path`. Takes ownership of `config_path`
+/// (freed on failure or in `deinit`). Split out from `init` so tests can point the
+/// watcher at a temporary file instead of the resolved user config path.
+pub fn initForPath(allocator: std.mem.Allocator, config_path: []const u8) ?ConfigWatcher {
+    const dir_path = std.fs.path.dirname(config_path) orelse {
         std.debug.print("ConfigWatcher: failed to get directory from path\n", .{});
-        allocator.free(path);
+        allocator.free(config_path);
         return null;
     };
 
     const watcher = platform_config_watcher.DirectoryWatcher.initPath(dir_path) orelse {
-        allocator.free(path);
+        allocator.free(config_path);
         return null;
     };
-    std.debug.print("ConfigWatcher: watching {s}\\config\n", .{dir_path});
+    std.debug.print("ConfigWatcher: watching {s}\n", .{dir_path});
     return .{
         .watcher = watcher,
         .allocator = allocator,
-        .config_path = path,
-        .last_mtime = configMtime(path),
+        .config_path = config_path,
+        .last_mtime = configMtime(config_path),
     };
 }
 
 /// Non-blocking check: has the config file changed?
+///
+/// mtime is the source of truth. The platform directory watcher is only drained
+/// to keep its event queue armed; its result is intentionally NOT used as a gate.
+/// On macOS a kqueue registered on the *directory* vnode does not fire when an
+/// existing file is rewritten in place (same inode) — which is exactly how the
+/// Settings page (`Config.setConfigValue`) and most editors save the config. So
+/// gating on the event would miss every in-place edit and force an app restart
+/// to pick up changes (the Windows `ReadDirectoryChangesW` backend fires on
+/// last-write/size, which is why this only manifested on macOS).
 pub fn hasChanged(self: *ConfigWatcher) bool {
-    if (!self.watcher.hasChanged()) return false;
+    _ = self.watcher.hasChanged();
     const next_mtime = configMtime(self.config_path);
     if (optionalMtimeEql(self.last_mtime, next_mtime)) return false;
     self.last_mtime = next_mtime;
@@ -70,4 +85,44 @@ test "config watcher wraps platform directory watcher" {
     try std.testing.expect(@hasDecl(ConfigWatcher, "init"));
     try std.testing.expect(@hasDecl(ConfigWatcher, "hasChanged"));
     try std.testing.expect(@hasDecl(ConfigWatcher, "deinit"));
+}
+
+// Regression for the macOS "config changes need a restart" bug: a kqueue on the
+// directory vnode does not fire for an in-place truncate-rewrite of an existing
+// file, so detection must fall back to mtime. This rewrites the SAME inode,
+// exactly like `Config.setConfigValue`, and asserts the change is observed.
+test "config watcher detects in-place rewrite of existing config file" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        const f = try tmp.dir.createFile("config", .{});
+        try f.writeAll("font-size = 16\n");
+        f.close();
+    }
+
+    const dir_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(dir_path);
+    // initForPath takes ownership of this slice (frees it on failure or in deinit).
+    const file_path = try std.fs.path.join(testing.allocator, &.{ dir_path, "config" });
+
+    var watcher = ConfigWatcher.initForPath(testing.allocator, file_path) orelse {
+        // Platform without a directory-watch backend (e.g. Linux): nothing to test.
+        return error.SkipZigTest;
+    };
+    defer watcher.deinit();
+
+    try testing.expect(!watcher.hasChanged());
+
+    // Advance mtime, then truncate-rewrite the SAME file in place.
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    {
+        const f = try tmp.dir.createFile("config", .{ .truncate = true });
+        try f.writeAll("font-size = 24\n");
+        f.close();
+    }
+
+    try testing.expect(watcher.hasChanged());
+    try testing.expect(!watcher.hasChanged());
 }


### PR DESCRIPTION
## 问题

macOS 上修改配置（尤其是字号 font-size）或编辑配置文件后**不重启就不生效**，而 Windows 是即时生效的。

## 根因（两个相互独立）

**1. 配置文件监听器在 macOS 上对原地改写失明**
`ConfigWatcher.hasChanged` 把平台事件当作唯一闸门。macOS 的 kqueue 注册在**目录 vnode** 的 `NOTE_WRITE` 上，而目录 vnode 的 `NOTE_WRITE` **对已存在文件的原地内容改写（同 inode）不触发**——这正是 `setConfigValue`（`createFile(.{.truncate=true})`）和多数编辑器保存配置的方式。结果：原地改写永远检测不到，后面的 mtime 比对被短路掉。Windows 的 `ReadDirectoryChangesW(.last_write,.size)` 会对内容改动触发，所以只在 macOS 暴露。
**修复**：让 mtime 成为权威判据，平台 watcher 事件降级为「排空队列」的辅助。新增 `initForPath` 测试缝 + 复刻原地改写的回归测试。

**2. 重复键导致设置写入无效**
配置加载是**后者覆盖（last-wins）**，但旧 `setConfigValue` 只替换**第一处**匹配行。若配置里有两条 active `font-size`，生效值始终是最后一条，于是即便重载触发了、设置面板点 +/- 也「纹丝不动」。
**修复**：抽出纯函数 `setConfigValueInContent`，**首处改写 + 丢弃后续重复**，使加载的生效值与设置一致。新增回归测试。

## 验证

- 真机 macOS app 端到端：原地改写配置后日志出现 `Config file changed, reloading...`，终端字体实时重算（cell `32x70@20 → 58x127@36 → 19x42@12`）。
- `zig build test` 全绿；所有新测试均用失败注入法确认确实在套件中执行。

## 已知/可选后续（不在本 PR）

- 窗口在后台/空闲时主循环阻塞在 AppKit 事件泵，改动会等到窗口重新获得事件（切回焦点/按键/光标闪烁）才应用；要后台也即时需让文件变更 `postWakeup` 唤醒循环。
- 可选：设置面板写完即时 `reloadConfigImmediate`，去掉 ~250ms 防抖延迟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)