### PR TITLE
feat(settings): apply config changes immediately from the Settings page

### DIFF
--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -4809,6 +4809,15 @@ fn executeSettingsAction(action: SettingsAction) void {
         .close => settingsPageClose(),
     }
     settingsPageReloadCfg();
+
+    // Apply the change to the running terminal right away instead of waiting for
+    // the config-file watcher's debounce (mirrors applyEmbeddedThemeFromPalette).
+    // cycle_theme already applies via cycleThemePreset; the excluded actions open
+    // an editor/confirm dialog or close the page and write nothing to apply.
+    switch (action) {
+        .cycle_theme, .open_raw_config, .restore_defaults, .close => {},
+        else => AppWindow.reloadConfigImmediate(allocator),
+    }
 }
 
 fn writeConfigInt(key: []const u8, value: u32) void {
@@ -4896,6 +4905,9 @@ fn cycleThemePreset(delta: i32) void {
     const next = @mod(current + delta, count);
     applyThemePreset(@intCast(next));
     settingsPageReloadCfg();
+    // Theme rows reach here directly from the focus handlers (not via
+    // executeSettingsAction), so apply the new theme to the terminal immediately.
+    AppWindow.reloadConfigImmediate(allocator);
 }
 
 fn themePresetIsActive(cfg: *const Config, preset: ThemePreset) bool {


### PR DESCRIPTION
## 背景

承接 #242(修复 macOS 配置热重载)。设置面板改完配置后只刷新了**面板自身的显示缓存**(`settingsPageReloadCfg`),应用到运行中终端这一步依赖文件监听器 ~250ms 防抖,改动有迟滞。

## 改动

照搬命令面板切主题的成熟范式(`applyEmbeddedThemeFromPalette`),写完配置后**立即** `AppWindow.reloadConfigImmediate`:

- `executeSettingsAction`:对**写配置**的动作即时应用(字号、光标样式/闪烁、焦点跟随、shell、默认 AI、微信直连、语言、恢复标签页、技能沉淀)。排除不写配置的 `open_raw_config` / `restore_defaults` / `close`。
- `cycleThemePreset`:主题行从焦点处理器**直接调用**(不经 `executeSettingsAction`),单独补上即时应用。

## 验证

- `zig build macos-app -Dtarget=aarch64-macos` 编译通过;`zig build test` 全绿;新构建启动并渲染设置面板无回归。
- `reloadConfigImmediate` 本身已在 #242 端到端验证过(可实时改终端字号)。
- 说明:设置面板的 GUI 键盘 E2E(点开设置→按键改字号)因 WispTerm 在 computer-use 下属终端 tier、键盘输入受限未跑;本改动仅 12 行、建立在已验证原语之上,连线为既有且有单测。

## 权衡

- 与现有 `applyEmbeddedThemeFromPalette` 一样,即时应用会和文件监听器形成一次幂等冗余重载;连续按住 +/− 改字号时每次都会全量重载字形图集(离散点按无影响)。如需对连续改动做合并,可后续在即时应用与防抖之间二选一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)