### PR TITLE
fix(preview): resolve ctrl-click paths under plain tmux over SSH

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -909,6 +909,14 @@ pub fn getCwd(self: *const Surface) ?[]const u8 {
     return null;
 }
 
+/// True when the alternate screen buffer is active. Used as a cheap, local
+/// signal that a full-screen app (notably an attached `tmux`) is running:
+/// plain tmux consumes OSC 7, so the OSC 7-derived cwd goes stale and a live
+/// remote pane-cwd query is preferred for path resolution.
+pub fn isAltScreenActive(self: *const Surface) bool {
+    return self.terminal.screens.active_key == .alternate;
+}
+
 /// Get the platform launch directory for shells that do not report OSC 7.
 pub fn getInitialCwd(self: *const Surface) ?[]const u8 {
     if (self.initial_cwd_path_len > 0)

--- a/src/input/preview_source.zig
+++ b/src/input/preview_source.zig
@@ -233,6 +233,54 @@ fn joinUnixPreviewPath(allocator: std.mem.Allocator, cwd: []const u8, path: []co
     return std.fmt.allocPrint(allocator, "{s}/{s}", .{ base, path });
 }
 
+/// Remote command that prints the working directory of tmux's active pane.
+/// Run over SSH when a relative path is clicked while tmux is attached: plain
+/// tmux consumes OSC 7, so `surface.getCwd()` is frozen at the pre-tmux dir and
+/// can't anchor the relative path. tmux errors (no server, not installed) go to
+/// stderr, leaving stdout empty so the caller falls back to the OSC 7 cwd.
+const TMUX_PANE_CWD_COMMAND = "tmux display-message -p '#{pane_current_path}'";
+
+/// Bound the pane-cwd probe on the UI thread (mirrors the download dir probe):
+/// a hung remote becomes a bounded delay + OSC 7 fallback, never a freeze.
+const TMUX_CWD_PROBE_TIMEOUT_MS = 5_000;
+/// A POSIX path is at most PATH_MAX (~4096); cap stdout there so junk output
+/// can't drive an unbounded read.
+const TMUX_CWD_MAX_STDOUT = 4096;
+
+/// Parse the stdout of `TMUX_PANE_CWD_COMMAND`. Returns the pane's working
+/// directory only when the output is a single, non-empty, absolute Unix path;
+/// otherwise null (tmux not running, command-not-found, unexpanded format, or
+/// error spew) so the caller keeps the OSC 7 cwd. The slice points into `output`.
+fn parseTmuxPaneCwd(output: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, output, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    if (trimmed[0] != '/') return null; // relative result / error text / unexpanded format
+    if (std.mem.indexOfScalar(u8, trimmed, '\n') != null) return null; // multi-line junk
+    return trimmed;
+}
+
+/// Best-effort live cwd for an SSH surface whose OSC 7 cwd may be stale because
+/// plain tmux is attached. Returns an owned absolute path only when tmux is
+/// plausibly attached (alternate screen active) AND the remote query yields a
+/// valid path; otherwise null so the caller uses the OSC 7 cwd. The probe runs
+/// against tmux's *current* client, so with one attached session it targets the
+/// pane the user is looking at; multiple concurrent tmux sessions on the same
+/// host may resolve against the most-recently-active one.
+fn sshPreviewCwd(allocator: std.mem.Allocator, surface: *Surface) ?[]u8 {
+    if (!surface.isAltScreenActive()) return null;
+    const conn = surface.ssh_connection orelse return null;
+    const output = scp.sshExecCappedOpts(
+        allocator,
+        &conn,
+        TMUX_PANE_CWD_COMMAND,
+        TMUX_CWD_MAX_STDOUT,
+        .{ .timeout_ms = TMUX_CWD_PROBE_TIMEOUT_MS },
+    ) orelse return null;
+    defer allocator.free(output);
+    const path = parseTmuxPaneCwd(output) orelse return null;
+    return allocator.dupe(u8, path) catch null;
+}
+
 fn resolveUnixTerminalPath(
     allocator: std.mem.Allocator,
     cwd: ?[]const u8,
@@ -264,6 +312,40 @@ test "preview_source: ssh relative paths require a reported cwd" {
     const relative = try resolveUnixTerminalPath(allocator, "/srv/project/data", "sample.fa", true);
     defer allocator.free(relative);
     try std.testing.expectEqualStrings("/srv/project/data/sample.fa", relative);
+}
+
+test "preview_source: parseTmuxPaneCwd accepts a single absolute path and rejects everything else" {
+    // Happy path: tmux prints the pane's cwd plus a trailing newline. The
+    // surrounding whitespace is trimmed and the absolute path is returned.
+    try std.testing.expectEqualStrings(
+        "/data1/home/xzg/project/Plant-Root-Atlas-Project",
+        parseTmuxPaneCwd("/data1/home/xzg/project/Plant-Root-Atlas-Project\n").?,
+    );
+    // CRLF and leading/trailing spaces are trimmed too.
+    try std.testing.expectEqualStrings(
+        "/srv/data",
+        parseTmuxPaneCwd("  /srv/data\r\n").?,
+    );
+
+    // Empty / whitespace-only output (no tmux value) -> null, caller uses OSC 7.
+    try std.testing.expect(parseTmuxPaneCwd("") == null);
+    try std.testing.expect(parseTmuxPaneCwd("  \r\n") == null);
+    // A relative result can't anchor a cwd -> reject.
+    try std.testing.expect(parseTmuxPaneCwd("project/foo\n") == null);
+    // tmux error spew leaks to stderr, but be defensive if it reaches stdout:
+    // "no server running on /tmp/tmux-1000/default" starts with 'n', not '/'.
+    try std.testing.expect(parseTmuxPaneCwd("no server running on /tmp/tmux-1000/default\n") == null);
+    // Unexpanded format (ancient tmux) doesn't start with '/'.
+    try std.testing.expect(parseTmuxPaneCwd("#{pane_current_path}\n") == null);
+    // Multi-line output is junk, not a single path.
+    try std.testing.expect(parseTmuxPaneCwd("/a\n/b\n") == null);
+}
+
+test "preview_source: tmux pane cwd command queries the active pane path" {
+    try std.testing.expectEqualStrings(
+        "tmux display-message -p '#{pane_current_path}'",
+        TMUX_PANE_CWD_COMMAND,
+    );
 }
 
 test "preview_source: ssh read cap admits head output and beats the default 16 MiB cap" {
@@ -365,7 +447,16 @@ pub fn resolveTerminalPreviewPath(allocator: std.mem.Allocator, surface: *Surfac
 
     return switch (surface.launch_kind) {
         .wsl => try resolveUnixTerminalPath(allocator, surface.getCwd() orelse "~", eff, false),
-        .ssh => try resolveUnixTerminalPath(allocator, surface.getCwd(), eff, true),
+        .ssh => blk: {
+            // Plain tmux consumes OSC 7, so surface.getCwd() can be a stale
+            // pre-tmux dir (the login home). For a relative click, prefer a live
+            // remote pane-cwd query and fall back to the OSC 7 cwd. Absolute/home
+            // paths ignore cwd, so skip the round-trip for them.
+            const remote_cwd: ?[]u8 = if (isUnixAbsoluteOrHome(eff)) null else sshPreviewCwd(allocator, surface);
+            defer if (remote_cwd) |c| allocator.free(c);
+            const cwd: ?[]const u8 = if (remote_cwd) |c| c else surface.getCwd();
+            break :blk try resolveUnixTerminalPath(allocator, cwd, eff, true);
+        },
         .local => blk: {
             if (std.fs.path.isAbsolute(eff) or (eff.len >= 2 and eff[1] == ':')) {
                 break :blk try allocator.dupe(u8, eff);


### PR DESCRIPTION
## Problem

SSH into a server with WispTerm, then start plain `tmux` and `cd` into a subdirectory. Ctrl-clicking a relative filename (e.g. `image.png` from `ls` output) resolves to the wrong path — the login home `/data1/home/xzg/image.png` instead of `~/project/.../image.png` — so the preview pane shows "preview failed".

## Root cause

WispTerm tracks the remote working directory **only** from the **OSC 7** escape sequence the shell emits on each `cd` (`Surface.zig` `updateTitle` → `cwd_path` → `getCwd()`). The `.ssh` branch of `resolveTerminalPreviewPath` resolves relative clicks against that value.

**Plain `tmux` consumes OSC 7** — it captures it for its own `#{pane_current_path}` and never forwards it to the outer terminal. So once `tmux` starts, WispTerm stops receiving cwd updates and `getCwd()` freezes at the last value from before tmux took over (the login home). This is a fundamental plain-tmux + OSC 7 limitation that every terminal hits; the clean fix is tmux control mode (`-CC`), which is separate/in progress.

## Fix

In the `.ssh` resolution path, when a **relative** path is clicked **while tmux is plausibly attached** (terminal on the alternate screen) and the surface is a WispTerm SSH connection, query the live pane cwd over SSH:

```
tmux display-message -p '#{pane_current_path}'
```

and resolve against that real cwd. If the probe yields nothing valid (no tmux, not installed, error spew → stderr), it **falls back to the OSC 7 cwd**, so the normal non-tmux SSH path is unchanged (no regression). The probe is bounded at 5s on the UI thread, mirroring the existing download dir probe (`remotePathIsDirectoryForDownload`).

This fixes preview, download, and ctrl-right-click-open at once, plus `ls subdir/` resolution inside tmux.

### Changes
- `src/Surface.zig` — new `isAltScreenActive()` (cheap local "tmux attached" signal via `terminal.screens.active_key`).
- `src/input/preview_source.zig` — `TMUX_PANE_CWD_COMMAND`, pure `parseTmuxPaneCwd` (accepts a single absolute line only, else null), `sshPreviewCwd` glue, and the `.ssh` branch wiring.

## Testing
- TDD: parser/command tests written first, watched fail to compile, then implemented to green.
- `zig build test-full`: 26/26 steps, 2025/2032 tests pass (7 skipped). Existing `.ssh` resolution tests still green (alt-screen defaults off → behavior unchanged).
- `zig build test` (fast): 1272/1273 (1 skip). `zig build` (native): clean.
- ⚠️ The live remote-query path needs **real-machine GUI verification** (no SSH+tmux server in CI): SSH in, start `tmux`, `cd` into a subdir, ctrl-click a file → resolves under the real cwd.

### Known caveats (documented in code)
- `display-message` targets tmux's *current* client, so multiple concurrent tmux sessions on one host may resolve against the most-recently-active one (still strictly better than the frozen-home behavior today).
- A manually-typed `ssh` in a local tab (no connection metadata) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)