### PR TITLE
[codex] add copilot composer history

### DIFF
--- a/docs/superpowers/plans/2026-06-17-copilot-composer-history.md
+++ b/docs/superpowers/plans/2026-06-17-copilot-composer-history.md
@@ -1,0 +1,70 @@
+# Copilot Composer History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Codex-style Up/Down prompt history recall to the shared AI composer used by Copilot and AI Chat.
+
+**Architecture:** Implement the behavior in `src/ai_chat.zig` on `Session`, reusing existing visual cursor helpers and current-session user messages. Leave `src/input.zig` terminal routing untouched so Ghostty-style PTY arrow behavior remains unchanged.
+
+**Tech Stack:** Zig, existing `Session` unit tests, `zig test src/ai_chat.zig`, `zig build test`.
+
+---
+
+### Task 1: Add Failing Session Tests
+
+**Files:**
+- Modify: `src/ai_chat.zig`
+
+- [ ] **Step 1: Add tests near existing composer cursor tests**
+
+Add tests that construct a `Session`, append `.user` messages, drive `handleKeyWithWrapCols()` with `.arrow_up` and `.arrow_down`, and assert composer text/cursor behavior.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `zig test src/ai_chat.zig`
+
+Expected: the new tests fail because Up at the first row currently returns without recalling history, and Down at the newest history entry does not restore the draft.
+
+### Task 2: Implement Composer History State
+
+**Files:**
+- Modify: `src/ai_chat.zig`
+
+- [ ] **Step 1: Add state to `Session`**
+
+Add fields for whether prompt-history navigation is active, the selected user-message ordinal, and the saved draft buffer/length/cursor.
+
+- [ ] **Step 2: Add locked helper functions**
+
+Add helpers to count user prompts, map user-prompt ordinal to message index, save/clear history navigation state, recall selected prompt into the composer, and decide whether the cursor is on the first or last visual row.
+
+- [ ] **Step 3: Route Up/Down through the helper**
+
+In `handleKeyWithWrapCols()`, keep composer suggestions first. If no suggestion is active, Up/Down should try history navigation at visual boundaries before falling back to `moveInputCursorVertical()`.
+
+- [ ] **Step 4: Clear history navigation on edits**
+
+Clear navigation state from normal composer mutations: append/insert text, deletion, clear input, and explicit input replacement.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run: `zig test src/ai_chat.zig`
+
+Expected: the new tests and existing `ai_chat.zig` tests pass.
+
+### Task 3: Run Project Verification
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Run fast suite**
+
+Run: `zig build test`
+
+Expected: fast platform-independent tests pass.
+
+- [ ] **Step 2: Run full app suite**
+
+Run: `zig build test-full`
+
+Expected: full app tests pass, including input/render-gate compiled paths.

--- a/docs/superpowers/specs/2026-06-17-copilot-composer-history-design.md
+++ b/docs/superpowers/specs/2026-06-17-copilot-composer-history-design.md
@@ -1,0 +1,30 @@
+# Copilot Composer History Design
+
+## Goal
+
+Make the AI composer feel like Codex/shell history: when the Copilot sidebar or AI Chat tab composer is focused, Up/Down can recall previously submitted user prompts without breaking normal multiline editing.
+
+## Behavior
+
+- Up recalls the previous user prompt only when the input cursor is on the first visual row.
+- Down recalls the next user prompt only when the input cursor is on the last visual row.
+- Up/Down inside the middle of a multiline draft keep moving the cursor vertically.
+- Starting history navigation saves the current draft. Moving past the newest history entry restores that draft.
+- Any normal edit to the composer exits history navigation so future history movement starts from the current draft.
+- History source is the current `Session.messages` list, filtered to `role == .user`.
+- Existing `/rewind` remains unchanged: it is a destructive rollback workflow, not prompt recall.
+
+## Architecture
+
+The behavior belongs in `src/ai_chat.zig` on `Session`, because both dedicated AI Chat tabs and terminal-tab Copilot sidebars already route composer keys through `Session.handleKeyWithWrapCols()`. `src/input.zig` already marks the UI dirty after forwarding Copilot/AI Chat keys, so no extra render-gate handling is needed for this change.
+
+The terminal surface path remains unchanged. Ghostty keeps terminal keyboard behavior in its input key encoder: application and normal cursor-key modes produce PTY escape sequences for programs. WispTerm should keep matching that model for terminal surfaces and only apply prompt-history behavior to its own AI composer UI.
+
+## Testing
+
+Add `src/ai_chat.zig` unit tests for:
+
+- Up at the first visual row recalls newest then older user prompts.
+- Down walks forward and restores the saved draft after the newest prompt.
+- Up/Down in the middle of multiline input still moves the cursor vertically.
+- Editing after a recall exits the history navigation state.

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -615,6 +615,11 @@ pub const Session = struct {
     input_scroll_row: usize = 0,
     input_scroll_follow_cursor: bool = true,
     input_select_all: bool = false,
+    composer_history_active: bool = false,
+    composer_history_selected: usize = 0,
+    composer_history_draft_buf: [INPUT_PROMPT_MAX_BYTES]u8 = undefined,
+    composer_history_draft_len: usize = 0,
+    composer_history_draft_cursor: usize = 0,
     suggestion_selected: usize = 0,
     skill_suggestions: []skill_registry.SkillMeta = &.{},
     skill_suggestions_loaded: bool = false,
@@ -1257,6 +1262,7 @@ pub const Session = struct {
 
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.clearComposerHistoryNavigationLocked();
         if (self.input_select_all) {
             self.input_len = 0;
             self.input_cursor = 0;
@@ -1274,6 +1280,7 @@ pub const Session = struct {
     pub fn appendInputText(self: *Session, text: []const u8) void {
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.clearComposerHistoryNavigationLocked();
         if (self.input_select_all) {
             self.input_len = 0;
             self.input_cursor = 0;
@@ -1296,6 +1303,7 @@ pub const Session = struct {
         defer self.mutex.unlock();
         if (!self.input_select_all or self.input_len == 0) return null;
         const text = try allocator.dupe(u8, self.input_buf[0..self.input_len]);
+        self.clearComposerHistoryNavigationLocked();
         self.input_len = 0;
         self.input_cursor = 0;
         self.input_scroll_row = 0;
@@ -1409,6 +1417,7 @@ pub const Session = struct {
         }
         if (ev.ctrl and !ev.alt and ev.key == .key_u) {
             self.mutex.lock();
+            self.clearComposerHistoryNavigationLocked();
             self.input_len = 0;
             self.input_cursor = 0;
             self.input_scroll_row = 0;
@@ -1428,8 +1437,12 @@ pub const Session = struct {
             .delete => self.deleteInput(),
             .arrow_left => self.moveInputCursorLeft(),
             .arrow_right => self.moveInputCursorRight(),
-            .arrow_up => if (!self.moveComposerSuggestionSelection(-1)) self.moveInputCursorVertical(max_cols, -1),
-            .arrow_down => if (!self.moveComposerSuggestionSelection(1)) self.moveInputCursorVertical(max_cols, 1),
+            .arrow_up => if (!self.moveComposerSuggestionSelection(-1)) {
+                if (!self.navigateComposerHistory(max_cols, -1)) self.moveInputCursorVertical(max_cols, -1);
+            },
+            .arrow_down => if (!self.moveComposerSuggestionSelection(1)) {
+                if (!self.navigateComposerHistory(max_cols, 1)) self.moveInputCursorVertical(max_cols, 1);
+            },
             .home => self.moveInputCursorHome(),
             .end => self.moveInputCursorEnd(),
             .tab => _ = self.completeComposerSuggestion(.tab),
@@ -2777,6 +2790,7 @@ pub const Session = struct {
     fn backspaceInput(self: *Session) void {
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.clearComposerHistoryNavigationLocked();
         if (self.input_select_all) {
             self.input_len = 0;
             self.input_cursor = 0;
@@ -2799,6 +2813,7 @@ pub const Session = struct {
     fn deleteInput(self: *Session) void {
         self.mutex.lock();
         defer self.mutex.unlock();
+        self.clearComposerHistoryNavigationLocked();
         if (self.input_select_all) {
             self.input_len = 0;
             self.input_cursor = 0;
@@ -2869,6 +2884,42 @@ pub const Session = struct {
         self.suggestion_selected = 0;
     }
 
+    fn navigateComposerHistory(self: *Session, max_cols_raw: usize, delta: i32) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const prompt_count = self.composerHistoryPromptCountLocked();
+        if (prompt_count == 0 or delta == 0) return false;
+        self.clampInputCursorLocked();
+
+        const max_cols = @max(@as(usize, 1), max_cols_raw);
+        const text = self.input();
+        const current = visualCursorPosition(text, self.input_cursor, max_cols);
+        const rows = inputWrappedLineCount(text, max_cols);
+
+        if (delta < 0) {
+            if (current.row != 0) return false;
+            if (!self.composer_history_active) {
+                self.saveComposerHistoryDraftLocked();
+                self.composer_history_active = true;
+                self.composer_history_selected = prompt_count - 1;
+            } else if (self.composer_history_selected > 0) {
+                self.composer_history_selected -= 1;
+            }
+            return self.restoreComposerHistoryPromptLocked(self.composer_history_selected);
+        }
+
+        if (current.row + 1 < rows or !self.composer_history_active) return false;
+        if (self.composer_history_selected + 1 < prompt_count) {
+            self.composer_history_selected += 1;
+            return self.restoreComposerHistoryPromptLocked(self.composer_history_selected);
+        }
+
+        self.restoreComposerHistoryDraftLocked();
+        self.clearComposerHistoryNavigationLocked();
+        return true;
+    }
+
     fn moveComposerSuggestionSelection(self: *Session, delta: i32) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -2906,6 +2957,7 @@ pub const Session = struct {
         const suffix_len = self.input_len - prefix.token_end;
         if (replacement.len + suffix_len > self.input_buf.len) return false;
 
+        self.clearComposerHistoryNavigationLocked();
         if (replacement.len > prefix.token_end) {
             std.mem.copyBackwards(
                 u8,
@@ -2984,6 +3036,7 @@ pub const Session = struct {
     }
 
     fn clearSubmittedInputLocked(self: *Session) void {
+        self.clearComposerHistoryNavigationLocked();
         self.input_len = 0;
         self.input_cursor = 0;
         self.input_scroll_row = 0;
@@ -2994,6 +3047,11 @@ pub const Session = struct {
 
     /// 用 text 覆盖输入框内容，光标置于末尾。纯缓冲区操作、无 IO。
     fn setInputTextLocked(self: *Session, text: []const u8) void {
+        self.clearComposerHistoryNavigationLocked();
+        self.replaceInputTextLocked(text);
+    }
+
+    fn replaceInputTextLocked(self: *Session, text: []const u8) void {
         self.input_len = 0;
         self.input_cursor = 0;
         self.input_scroll_row = 0;
@@ -3001,6 +3059,55 @@ pub const Session = struct {
         self.suggestion_selected = 0;
         self.clearSelectionLocked();
         self.insertInputBytesLocked(text);
+    }
+
+    fn clearComposerHistoryNavigationLocked(self: *Session) void {
+        self.composer_history_active = false;
+        self.composer_history_selected = 0;
+        self.composer_history_draft_len = 0;
+        self.composer_history_draft_cursor = 0;
+    }
+
+    fn saveComposerHistoryDraftLocked(self: *Session) void {
+        const len = @min(self.input_len, self.composer_history_draft_buf.len);
+        if (len > 0) @memcpy(self.composer_history_draft_buf[0..len], self.input_buf[0..len]);
+        self.composer_history_draft_len = len;
+        self.composer_history_draft_cursor = @min(self.input_cursor, len);
+    }
+
+    fn restoreComposerHistoryDraftLocked(self: *Session) void {
+        const draft = self.composer_history_draft_buf[0..self.composer_history_draft_len];
+        const cursor = self.composer_history_draft_cursor;
+        self.replaceInputTextLocked(draft);
+        self.input_cursor = @min(cursor, self.input_len);
+        self.clampInputCursorLocked();
+        self.input_scroll_follow_cursor = true;
+    }
+
+    fn composerHistoryPromptCountLocked(self: *Session) usize {
+        var n: usize = 0;
+        for (self.messages.items) |msg| {
+            if (msg.role == .user) n += 1;
+        }
+        return n;
+    }
+
+    fn composerHistoryPromptMessageIndexLocked(self: *Session, n: usize) usize {
+        var seen: usize = 0;
+        for (self.messages.items, 0..) |msg, i| {
+            if (msg.role == .user) {
+                if (seen == n) return i;
+                seen += 1;
+            }
+        }
+        return self.messages.items.len;
+    }
+
+    fn restoreComposerHistoryPromptLocked(self: *Session, selected: usize) bool {
+        const idx = self.composerHistoryPromptMessageIndexLocked(selected);
+        if (idx >= self.messages.items.len) return false;
+        self.replaceInputTextLocked(self.messages.items[idx].content);
+        return true;
     }
 
     /// 打开回溯选择器：仅在空闲且至少有一个回溯点时；默认选中最近一条。
@@ -5973,6 +6080,79 @@ test "ai chat input cursor moves vertically across wrapped rows" {
 
     session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 5);
     try std.testing.expectEqual(@as(usize, 7), session.inputCursor());
+}
+
+test "ai chat composer history recalls prompts at visual boundaries" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+    try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "first prompt") });
+    try session.messages.append(allocator, .{ .role = .assistant, .content = try allocator.dupe(u8, "first reply") });
+    try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "second prompt") });
+
+    session.appendInputText("draft");
+    session.handleKey(.{ .key = input_key.Key.home });
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 80);
+    try std.testing.expectEqualStrings("second prompt", session.input());
+    try std.testing.expectEqual(@as(usize, "second prompt".len), session.inputCursor());
+
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 80);
+    try std.testing.expectEqualStrings("first prompt", session.input());
+    try std.testing.expectEqual(@as(usize, "first prompt".len), session.inputCursor());
+
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_down }, 80);
+    try std.testing.expectEqualStrings("second prompt", session.input());
+
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_down }, 80);
+    try std.testing.expectEqualStrings("draft", session.input());
+    try std.testing.expectEqual(@as(usize, 0), session.inputCursor());
+}
+
+test "ai chat composer history preserves multiline vertical editing" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+    try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "previous prompt") });
+
+    session.appendInputText("abc\ndefg\nhi");
+    session.handleKey(.{ .key = input_key.Key.home });
+    session.handleKey(.{ .key = input_key.Key.arrow_down });
+    try std.testing.expectEqual(@as(usize, 4), session.inputCursor());
+
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 80);
+    try std.testing.expectEqualStrings("abc\ndefg\nhi", session.input());
+    try std.testing.expectEqual(@as(usize, 0), session.inputCursor());
+
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 80);
+    try std.testing.expectEqualStrings("previous prompt", session.input());
+}
+
+test "ai chat composer history exits after editing recalled prompt" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+    try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "old prompt") });
+
+    session.appendInputText("draft");
+    session.handleKey(.{ .key = input_key.Key.home });
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_up }, 80);
+    try std.testing.expectEqualStrings("old prompt", session.input());
+
+    session.handleChar('!');
+    try std.testing.expectEqualStrings("old prompt!", session.input());
+
+    session.handleKey(.{ .key = input_key.Key.home });
+    session.handleKeyWithWrapCols(.{ .key = input_key.Key.arrow_down }, 80);
+    try std.testing.expectEqualStrings("old prompt!", session.input());
 }
 
 test "ai chat composer wrapped row count grows with explicit lines and wrapping" {


### PR DESCRIPTION
## Summary
- Add Codex-style Up/Down prompt history navigation to the shared AI composer used by Copilot and AI Chat.
- Preserve normal multiline cursor movement by only recalling history at the first/last visual row boundaries.
- Document the design and implementation plan under docs/superpowers.

## Impact
Copilot users can recall previous prompts from the sidebar composer without changing terminal PTY arrow-key behavior. Dedicated AI Chat tabs get the same composer behavior because they share Session input handling.

## Validation
- zig build test
- zig build test-full
- git diff --check
- Windows checkout path-safety check: 0 name violations, 0 casefold collisions, no tracked symlink output