### PR TITLE
[codex] Add preview diagnostics logging

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -192,3 +192,10 @@ it crashes). To help diagnose a hard-to-reproduce issue — for example a crash
 when opening the WeChat connection, or a freeze when Ctrl+clicking a remote
 file — download it, reproduce the problem, then attach `wispterm-debug.log` (and
 any `crash-*.txt`) to your report.
+
+For Ctrl+click preview/browser issues, the debug log also includes copyable
+single-line records that begin with `preview-diagnostic`. After reproducing the
+problem, paste the nearby `preview-diagnostic` lines into the issue if the full
+log is too large. They cover preview path resolution, async file reads, image
+decode, HTML server startup, SSH browser tunnels, URL routing, and the embedded
+browser panel.

--- a/docs/windows-debug-build.md
+++ b/docs/windows-debug-build.md
@@ -17,5 +17,12 @@ slightly slower than the normal release — use it only to reproduce a problem.
    - any `%APPDATA%\wispterm\crash-*.txt` files, and
    - the text in the console window if the app crashed.
 
+For Ctrl-click preview/browser problems, the debug log also contains copyable
+single-line records beginning with `preview-diagnostic`. After reproducing the
+problem, you can paste just those nearby lines into the GitHub issue if the full
+log is too large. Useful scopes include `preview`, `preview-read`,
+`image-decode`, `html`, `html-server`, `url`, `browser-panel`, and
+`ssh-tunnel`.
+
 Open the folder quickly by pasting `%APPDATA%\wispterm` into the Explorer
 address bar.

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -5,6 +5,7 @@ const Surface = @import("Surface.zig");
 const platform_webview = @import("platform/webview.zig");
 const ssh_tunnel = @import("ssh_tunnel.zig");
 const html_server = @import("html_server.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 const window_backend = @import("platform/window_backend.zig");
 const ui_perf = @import("ui_perf.zig");
 const tab = @import("appwindow/tab.zig");
@@ -159,16 +160,28 @@ pub fn embeddedBrowserAvailable() bool {
     if (!g_availability_checked) {
         g_embedded_browser_available = platform_webview.loaderAvailable();
         g_availability_checked = true;
+        preview_diagnostics.debug("browser-panel", &.{
+            .{ .key = "stage", .value = "loader-check" },
+            .{ .key = "available", .value = if (g_embedded_browser_available) "true" else "false" },
+        });
     }
     return g_embedded_browser_available;
 }
 
 pub fn open(parent: ?window_backend.NativeHandle, url: []const u8) void {
     if (!embeddedBrowserAvailable()) {
+        preview_diagnostics.debug("browser-panel", &.{
+            .{ .key = "stage", .value = "open-unavailable" },
+            .{ .key = "url", .value = url },
+        });
         close();
         return;
     }
 
+    preview_diagnostics.debug("browser-panel", &.{
+        .{ .key = "stage", .value = "open" },
+        .{ .key = "url", .value = url },
+    });
     setUrl(url);
     g_visible = true;
     g_owner_tab = active_tab_state.g_active_tab;
@@ -188,12 +201,29 @@ pub fn openForSurface(allocator: std.mem.Allocator, parent: ?window_backend.Nati
     defer perf.end();
 
     if (!embeddedBrowserAvailable()) {
+        preview_diagnostics.debug("browser-panel", &.{
+            .{ .key = "stage", .value = "open-for-surface-unavailable" },
+            .{ .key = "url", .value = url },
+        });
         close();
         return false;
     }
 
-    const target = externalUrlForSurface(allocator, url, surface) orelse return false;
+    const target = externalUrlForSurface(allocator, url, surface) orelse {
+        preview_diagnostics.debug("browser-panel", &.{
+            .{ .key = "stage", .value = "external-url-failed" },
+            .{ .key = "launch", .value = if (surface) |s| @tagName(s.launch_kind) else "none" },
+            .{ .key = "url", .value = url },
+        });
+        return false;
+    };
     defer allocator.free(target);
+    preview_diagnostics.debug("browser-panel", &.{
+        .{ .key = "stage", .value = "open-for-surface" },
+        .{ .key = "launch", .value = if (surface) |s| @tagName(s.launch_kind) else "none" },
+        .{ .key = "url", .value = url },
+        .{ .key = "target", .value = target },
+    });
 
     open(parent, target);
     return true;
@@ -293,10 +323,25 @@ pub fn sync(parent: window_backend.NativeHandle, window_width: i32, window_heigh
         if (g_browser) |browser| {
             g_last_error = platform_webview.lastError(browser);
             if (platform_webview.failed(g_last_error)) {
+                var err_buf: [32]u8 = undefined;
+                const err_s = std.fmt.bufPrint(&err_buf, "{d}", .{g_last_error}) catch "";
+                preview_diagnostics.debug("browser-panel", &.{
+                    .{ .key = "stage", .value = "create-failed" },
+                    .{ .key = "url", .value = currentUrl() },
+                    .{ .key = "last_error", .value = err_s },
+                });
                 close();
                 return;
             }
+            preview_diagnostics.debug("browser-panel", &.{
+                .{ .key = "stage", .value = "created" },
+                .{ .key = "url", .value = currentUrl() },
+            });
         } else {
+            preview_diagnostics.debug("browser-panel", &.{
+                .{ .key = "stage", .value = "create-null" },
+                .{ .key = "url", .value = currentUrl() },
+            });
             close();
             return;
         }
@@ -306,6 +351,15 @@ pub fn sync(parent: window_backend.NativeHandle, window_width: i32, window_heigh
         platform_webview.setBounds(browser, toWebviewBounds(webview_bounds));
         platform_webview.setVisible(browser, true);
         g_last_error = platform_webview.lastError(browser);
+        if (platform_webview.failed(g_last_error)) {
+            var err_buf: [32]u8 = undefined;
+            const err_s = std.fmt.bufPrint(&err_buf, "{d}", .{g_last_error}) catch "";
+            preview_diagnostics.debug("browser-panel", &.{
+                .{ .key = "stage", .value = "sync-error" },
+                .{ .key = "url", .value = currentUrl() },
+                .{ .key = "last_error", .value = err_s },
+            });
+        }
     }
 }
 
@@ -427,9 +481,22 @@ fn replaceSelectedUrlBeforeEdit() void {
 
 fn navigateCurrentUrl(browser: *platform_webview.Browser) void {
     var url_buf: platform_webview.UrlBuffer = undefined;
-    const url = platform_webview.urlFromUtf8(currentUrl(), &url_buf) orelse return;
+    const url = platform_webview.urlFromUtf8(currentUrl(), &url_buf) orelse {
+        preview_diagnostics.debug("browser-panel", &.{
+            .{ .key = "stage", .value = "url-encode-failed" },
+            .{ .key = "url", .value = currentUrl() },
+        });
+        return;
+    };
     platform_webview.navigate(browser, url);
     g_last_error = platform_webview.lastError(browser);
+    var err_buf: [32]u8 = undefined;
+    const err_s = std.fmt.bufPrint(&err_buf, "{d}", .{g_last_error}) catch "";
+    preview_diagnostics.debug("browser-panel", &.{
+        .{ .key = "stage", .value = "navigate" },
+        .{ .key = "url", .value = currentUrl() },
+        .{ .key = "last_error", .value = err_s },
+    });
 }
 
 pub fn boundsForWindow(window_width: i32, window_height: i32, titlebar_height: f32, left_offset: f32, right_offset: f32) Bounds {

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -4,6 +4,7 @@ const Surface = @import("Surface.zig");
 const model = @import("html_server_model.zig");
 const ssh_tunnel = @import("ssh_tunnel.zig");
 const preview_source = @import("input/preview_source.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const platform_process = @import("platform/process.zig");
 const platform_remote_file = @import("platform/remote_file.zig");
@@ -145,20 +146,51 @@ pub fn stopForSurfaceId(source_surface_id: *const [16]u8) void {
 
 pub fn openForSurface(allocator: std.mem.Allocator, surface: *Surface, path: []const u8, ls_prefix: ?[]const u8) OpenResult {
     if (!model.isHtmlPath(path)) return .{ .err = error.NotHtml };
+    preview_diagnostics.debug("html-server", &.{
+        .{ .key = "stage", .value = "open" },
+        .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+        .{ .key = "path", .value = path },
+        .{ .key = "ls_prefix", .value = ls_prefix orelse "" },
+    });
     const resolved = preview_source.resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "resolve-failed" },
+            .{ .key = "path", .value = path },
+            .{ .key = "err", .value = @errorName(err) },
+        });
         return .{ .err = if (err == error.CwdUnavailable) error.CwdUnavailable else error.PathTooLong };
     };
     defer allocator.free(resolved);
 
     const root = dirname(resolved);
+    preview_diagnostics.debug("html-server", &.{
+        .{ .key = "stage", .value = "resolved" },
+        .{ .key = "path", .value = path },
+        .{ .key = "resolved", .value = resolved },
+        .{ .key = "root", .value = root },
+    });
     const port = ensureServerForSurface(allocator, surface, root) catch |err| return .{ .err = err };
     var url = localUrlForPath(allocator, port, resolved) catch |err| return .{ .err = err };
+    preview_diagnostics.debug("html-server", &.{
+        .{ .key = "stage", .value = "local-url" },
+        .{ .key = "resolved", .value = resolved },
+        .{ .key = "url", .value = url },
+    });
 
     if (surface.launch_kind == .ssh) {
         const tunneled = ssh_tunnel.externalUrlForSurface(allocator, url, surface) orelse {
+            preview_diagnostics.debug("html-server", &.{
+                .{ .key = "stage", .value = "tunnel-failed" },
+                .{ .key = "url", .value = url },
+            });
             allocator.free(url);
             return .{ .err = error.TunnelFailed };
         };
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "tunneled-url" },
+            .{ .key = "local", .value = url },
+            .{ .key = "external", .value = tunneled },
+        });
         allocator.free(url);
         url = tunneled;
     }
@@ -176,6 +208,14 @@ fn ensureServerForSurface(allocator: std.mem.Allocator, surface: *Surface, root:
     pruneExitedServers();
     if (findReusableServerSlot(allocator, surface, root)) |server_slot| {
         const port = g_servers[server_slot].?.port;
+        var port_buf: [16]u8 = undefined;
+        const port_s = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch "";
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "reuse-server" },
+            .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+            .{ .key = "root", .value = root },
+            .{ .key = "port", .value = port_s },
+        });
         stopServersExcept(server_slot);
         return port;
     }
@@ -184,10 +224,32 @@ fn ensureServerForSurface(allocator: std.mem.Allocator, surface: *Surface, root:
     var attempts: usize = 0;
     while (attempts < 8) : (attempts += 1) {
         const port = reserveServerPort() orelse return error.ServerUnavailable;
+        var port_buf: [16]u8 = undefined;
+        const port_s = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch "";
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "spawn-attempt" },
+            .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+            .{ .key = "root", .value = root },
+            .{ .key = "port", .value = port_s },
+        });
         const started = spawnReadyServerForSurface(allocator, surface, root, port) catch |err| {
+            preview_diagnostics.debug("html-server", &.{
+                .{ .key = "stage", .value = "spawn-attempt-failed" },
+                .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+                .{ .key = "root", .value = root },
+                .{ .key = "port", .value = port_s },
+                .{ .key = "err", .value = @errorName(err) },
+            });
             if (err == error.ServerUnavailable or err == error.SpawnFailed or err == error.ServerNotReady) continue;
             return err;
         };
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "spawn-ready" },
+            .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+            .{ .key = "kind", .value = @tagName(started.kind) },
+            .{ .key = "root", .value = root },
+            .{ .key = "port", .value = port_s },
+        });
         const server = Server.init(started.child, surface.launch_kind, started.kind, port, root, surface) orelse {
             var child = started.child;
             stopChild(&child);
@@ -242,7 +304,14 @@ fn serverReachable(allocator: std.mem.Allocator, surface: *Surface, server: *Ser
 
 fn spawnReadyLocal(allocator: std.mem.Allocator, root: []const u8, port: u16) Error!StartedServer {
     if (builtin.os.tag != .windows) {
-        const kind = probeLocalPosix(allocator) orelse return error.ServerUnavailable;
+        const kind = probeLocalPosix(allocator) orelse {
+            preview_diagnostics.debug("html-server", &.{
+                .{ .key = "stage", .value = "probe-failed" },
+                .{ .key = "launch", .value = "local" },
+                .{ .key = "root", .value = root },
+            });
+            return error.ServerUnavailable;
+        };
         var child = try spawnLocal(allocator, root, kind, port);
         if (waitForLocalPortReady(allocator, port, &child)) return .{ .child = child, .kind = kind };
         stopChild(&child);
@@ -258,7 +327,14 @@ fn spawnReadyLocal(allocator: std.mem.Allocator, root: []const u8, port: u16) Er
 }
 
 fn spawnReadyWsl(allocator: std.mem.Allocator, root: []const u8, port: u16) Error!StartedServer {
-    const kind = probeWsl(allocator) orelse return error.ServerUnavailable;
+    const kind = probeWsl(allocator) orelse {
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "probe-failed" },
+            .{ .key = "launch", .value = "wsl" },
+            .{ .key = "root", .value = root },
+        });
+        return error.ServerUnavailable;
+    };
     var child = try spawnWsl(allocator, root, kind, port);
     if (waitForLocalPortReady(allocator, port, &child)) return .{ .child = child, .kind = kind };
     stopChild(&child);
@@ -267,7 +343,16 @@ fn spawnReadyWsl(allocator: std.mem.Allocator, root: []const u8, port: u16) Erro
 
 fn spawnReadySsh(allocator: std.mem.Allocator, surface: *Surface, root: []const u8, port: u16) Error!StartedServer {
     const conn = surface.ssh_connection orelse return error.ServerUnavailable;
-    const kind = probeSsh(allocator, &conn) orelse return error.ServerUnavailable;
+    const kind = probeSsh(allocator, &conn) orelse {
+        preview_diagnostics.debug("html-server", &.{
+            .{ .key = "stage", .value = "probe-failed" },
+            .{ .key = "launch", .value = "ssh" },
+            .{ .key = "root", .value = root },
+            .{ .key = "host", .value = conn.host() },
+            .{ .key = "port", .value = conn.port() },
+        });
+        return error.ServerUnavailable;
+    };
     var child = try spawnSsh(allocator, &conn, root, kind, port);
     if (waitForRemotePortReady(allocator, &conn, kind, port, &child)) return .{ .child = child, .kind = kind };
     stopChild(&child);

--- a/src/input.zig
+++ b/src/input.zig
@@ -54,6 +54,7 @@ const clipboard = @import("input/clipboard.zig");
 const click_tracker = @import("input/click_tracker.zig");
 const hit_test = @import("input/hit_test.zig");
 const preview_source = @import("input/preview_source.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 const ls_path_context = @import("input/ls_path_context.zig");
 const terminal_link_action = @import("input/terminal_link_action.zig");
 const underline_span = @import("input/underline_span.zig");
@@ -3510,7 +3511,17 @@ fn openUrl(surface: *Surface, url: []const u8) bool {
     defer allocator.free(target);
 
     const handle = AppWindow.currentNativeHandle();
-    switch (link_open.destinationForUrlClick(browser_panel.embeddedBrowserAvailable(), g_url_open_mode)) {
+    const embedded_available = browser_panel.embeddedBrowserAvailable();
+    const destination = link_open.destinationForUrlClick(embedded_available, g_url_open_mode);
+    preview_diagnostics.debug("url", &.{
+        .{ .key = "stage", .value = "open" },
+        .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+        .{ .key = "mode", .value = @tagName(g_url_open_mode) },
+        .{ .key = "embedded_available", .value = if (embedded_available) "true" else "false" },
+        .{ .key = "destination", .value = @tagName(destination) },
+        .{ .key = "target", .value = target },
+    });
+    switch (destination) {
         .embedded_browser => {
             if (!browser_panel.openForSurface(allocator, handle, target, surface)) return false;
             if (AppWindow.g_window) |win| {
@@ -3523,6 +3534,11 @@ fn openUrl(surface: *Surface, url: []const u8) bool {
         .system_browser => {
             const external_target = browser_panel.externalUrlForSurface(allocator, target, surface) orelse return false;
             defer allocator.free(external_target);
+            preview_diagnostics.debug("url", &.{
+                .{ .key = "stage", .value = "system-browser" },
+                .{ .key = "target", .value = target },
+                .{ .key = "external", .value = external_target },
+            });
             return platform_open_url.open(allocator, .{ .url = external_target });
         },
     }
@@ -3547,10 +3563,21 @@ fn openHtmlPanelForCell(surface: *Surface, cell_pos: CellPos) bool {
 
     var ls_prefix_buf: [256]u8 = undefined;
     const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+    preview_diagnostics.debug("html", &.{
+        .{ .key = "stage", .value = "click" },
+        .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+        .{ .key = "path", .value = path },
+        .{ .key = "ls_prefix", .value = ls_prefix orelse "" },
+    });
 
     switch (html_server.openForSurface(allocator, surface, path, ls_prefix)) {
         .url => |url| {
             defer allocator.free(url);
+            preview_diagnostics.debug("html", &.{
+                .{ .key = "stage", .value = "open-browser" },
+                .{ .key = "path", .value = path },
+                .{ .key = "url", .value = url },
+            });
             const parent = AppWindow.currentNativeHandle();
             browser_panel.open(parent, url);
             if (AppWindow.g_window) |win| syncPanelGridFromWindow(win);
@@ -3559,6 +3586,11 @@ fn openHtmlPanelForCell(surface: *Surface, cell_pos: CellPos) bool {
             return true;
         },
         .err => |err| {
+            preview_diagnostics.debug("html", &.{
+                .{ .key = "stage", .value = "failed" },
+                .{ .key = "path", .value = path },
+                .{ .key = "err", .value = @errorName(err) },
+            });
             file_explorer.setTransferStatus(.failed, switch (err) {
                 error.CwdUnavailable => "HTML cwd unknown",
                 error.ServerUnavailable => "Install Python 3 in this environment",
@@ -3734,16 +3766,43 @@ fn openPreviewPanelForCell(surface: *Surface, cell_pos: CellPos, shift: bool) bo
     const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
 
     if (markdown_preview.detectKind(path)) |kind| {
-        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch {
+        preview_diagnostics.debug("preview", &.{
+            .{ .key = "stage", .value = "click" },
+            .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+            .{ .key = "kind", .value = @tagName(kind) },
+            .{ .key = "path", .value = path },
+            .{ .key = "ls_prefix", .value = ls_prefix orelse "" },
+        });
+        const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
+            preview_diagnostics.debug("preview", &.{
+                .{ .key = "stage", .value = "resolve-failed" },
+                .{ .key = "kind", .value = @tagName(kind) },
+                .{ .key = "path", .value = path },
+                .{ .key = "err", .value = @errorName(err) },
+            });
             file_explorer.setTransferStatus(.failed, "Preview failed");
             return true;
         };
         defer allocator.free(resolved_path);
 
         const source_kind = terminalPreviewSourceKind(surface) orelse {
+            preview_diagnostics.debug("preview", &.{
+                .{ .key = "stage", .value = "source-kind-failed" },
+                .{ .key = "kind", .value = @tagName(kind) },
+                .{ .key = "path", .value = path },
+                .{ .key = "resolved", .value = resolved_path },
+            });
             file_explorer.setTransferStatus(.failed, "Preview failed");
             return true;
         };
+        preview_diagnostics.debug("preview", &.{
+            .{ .key = "stage", .value = "open-pane" },
+            .{ .key = "kind", .value = @tagName(kind) },
+            .{ .key = "path", .value = path },
+            .{ .key = "resolved", .value = resolved_path },
+            .{ .key = "source", .value = previewSourceKindName(source_kind) },
+            .{ .key = "new_pane", .value = if (shift) "true" else "false" },
+        });
 
         if (shift) {
             return openPreviewNew(kind, basenameForPreview(path), resolved_path, source_kind, false);
@@ -3758,6 +3817,14 @@ fn openPreviewPanelForCell(surface: *Surface, cell_pos: CellPos, shift: bool) bo
     const preview_surface = AppWindow.splitFocusedReturningSurface(.right) orelse return false;
     writeTextToSurfacePty(preview_surface, command);
     return true;
+}
+
+fn previewSourceKindName(kind: markdown_preview_panel.PreviewSourceKind) []const u8 {
+    return switch (kind) {
+        .local => "local",
+        .wsl => "wsl",
+        .remote => "ssh",
+    };
 }
 
 fn buildRemotePathKindCommand(buf: []u8, remote_path: []const u8) ?[]const u8 {

--- a/src/preview_diagnostics.zig
+++ b/src/preview_diagnostics.zig
@@ -1,0 +1,95 @@
+const std = @import("std");
+const build_options = @import("build_options");
+
+const log = std.log.scoped(.preview_diagnostics);
+
+pub const Field = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+pub fn formatCopyLine(buf: []u8, scope: []const u8, fields: []const Field) []const u8 {
+    var len: usize = 0;
+    appendSlice(buf, &len, "preview-diagnostic scope=");
+    appendToken(buf, &len, scope);
+    for (fields) |field| {
+        appendSlice(buf, &len, " ");
+        appendToken(buf, &len, field.key);
+        appendSlice(buf, &len, "=\"");
+        appendEscapedValue(buf, &len, field.value);
+        appendSlice(buf, &len, "\"");
+    }
+    return buf[0..len];
+}
+
+pub fn debug(scope: []const u8, fields: []const Field) void {
+    if (!build_options.debug_console) return;
+    var buf: [1400]u8 = undefined;
+    const line = formatCopyLine(&buf, scope, fields);
+    log.debug("{s}", .{line});
+}
+
+fn appendSlice(buf: []u8, len: *usize, text: []const u8) void {
+    if (len.* >= buf.len) return;
+    const n = @min(buf.len - len.*, text.len);
+    @memcpy(buf[len.*..][0..n], text[0..n]);
+    len.* += n;
+}
+
+fn appendToken(buf: []u8, len: *usize, text: []const u8) void {
+    for (text) |ch| {
+        appendByte(buf, len, if (isTokenByte(ch)) ch else '_');
+    }
+}
+
+fn appendEscapedValue(buf: []u8, len: *usize, text: []const u8) void {
+    for (text) |ch| {
+        const out = if (ch == '\r' or ch == '\n' or ch == '\t')
+            ' '
+        else if (ch == '"')
+            '\''
+        else if (ch < 0x20 or ch == 0x7f)
+            '?'
+        else
+            ch;
+        appendByte(buf, len, out);
+    }
+}
+
+fn appendByte(buf: []u8, len: *usize, byte: u8) void {
+    if (len.* >= buf.len) return;
+    buf[len.*] = byte;
+    len.* += 1;
+}
+
+fn isTokenByte(ch: u8) bool {
+    return (ch >= 'a' and ch <= 'z') or
+        (ch >= 'A' and ch <= 'Z') or
+        (ch >= '0' and ch <= '9') or
+        ch == '_' or
+        ch == '-' or
+        ch == '.';
+}
+
+test "preview_diagnostics: formats a single-line copyable record" {
+    var buf: [256]u8 = undefined;
+    const line = formatCopyLine(&buf, "html", &.{
+        .{ .key = "stage", .value = "open" },
+        .{ .key = "path", .value = "a\"b\nc.htm" },
+    });
+
+    try std.testing.expectEqualStrings(
+        "preview-diagnostic scope=html stage=\"open\" path=\"a'b c.htm\"",
+        line,
+    );
+}
+
+test "preview_diagnostics: truncates without creating multiline output" {
+    var buf: [32]u8 = undefined;
+    const line = formatCopyLine(&buf, "image", &.{
+        .{ .key = "path", .value = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png" },
+    });
+
+    try std.testing.expect(line.len <= buf.len);
+    try std.testing.expect(std.mem.indexOfScalar(u8, line, '\n') == null);
+}

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const markdown_preview = @import("markdown_preview.zig");
 const preview_source = @import("input/preview_source.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 const pdf_preview = @import("pdf_preview.zig");
 const pdf_render = @import("platform/pdf_render.zig");
 const gpu = @import("renderer/gpu/gpu.zig");
@@ -33,6 +34,7 @@ const IMAGE_ZOOM_STEP: f32 = 1.2;
 // single event — a big precise delta can no longer jump straight to the clamp.
 const IMAGE_ZOOM_WHEEL_REF_UNITS: f32 = 120.0;
 const IMAGE_ZOOM_WHEEL_PER_EVENT_MAX: f32 = 1.25;
+threadlocal var g_usize_field_buf: [32]u8 = undefined;
 
 const PreviewJob = struct {
     request_id: u64 = 0,
@@ -273,10 +275,47 @@ fn jobThread(job: *PreviewJob) void {
         return;
     }
     switch (job.read_fn(std.heap.page_allocator, job.source_kind, job.kind, job.path_buf[0..job.path_len])) {
-        .ok => |s| { job.source = s; job.status = .ready; },
-        .ok_truncated => |s| { job.source = s; job.status = .ready; job.truncated = true; },
-        .too_large => job.status = .too_large,
-        .failed => job.status = .failed,
+        .ok => |s| {
+            preview_diagnostics.debug("preview-read", &.{
+                .{ .key = "stage", .value = "ok" },
+                .{ .key = "kind", .value = @tagName(job.kind) },
+                .{ .key = "source", .value = previewSourceKindName(job.source_kind) },
+                .{ .key = "path", .value = job.path_buf[0..job.path_len] },
+                .{ .key = "bytes", .value = usizeField(s.len) },
+            });
+            job.source = s;
+            job.status = .ready;
+        },
+        .ok_truncated => |s| {
+            preview_diagnostics.debug("preview-read", &.{
+                .{ .key = "stage", .value = "ok-truncated" },
+                .{ .key = "kind", .value = @tagName(job.kind) },
+                .{ .key = "source", .value = previewSourceKindName(job.source_kind) },
+                .{ .key = "path", .value = job.path_buf[0..job.path_len] },
+                .{ .key = "bytes", .value = usizeField(s.len) },
+            });
+            job.source = s;
+            job.status = .ready;
+            job.truncated = true;
+        },
+        .too_large => {
+            preview_diagnostics.debug("preview-read", &.{
+                .{ .key = "stage", .value = "too-large" },
+                .{ .key = "kind", .value = @tagName(job.kind) },
+                .{ .key = "source", .value = previewSourceKindName(job.source_kind) },
+                .{ .key = "path", .value = job.path_buf[0..job.path_len] },
+            });
+            job.status = .too_large;
+        },
+        .failed => {
+            preview_diagnostics.debug("preview-read", &.{
+                .{ .key = "stage", .value = "failed" },
+                .{ .key = "kind", .value = @tagName(job.kind) },
+                .{ .key = "source", .value = previewSourceKindName(job.source_kind) },
+                .{ .key = "path", .value = job.path_buf[0..job.path_len] },
+            });
+            job.status = .failed;
+        },
     }
     job.done.store(true, .release);
 }
@@ -312,6 +351,18 @@ fn pdfJobThread(job: *PreviewJob) void {
     job.pdf_out_data = data;
     job.pdf_page_count = rendered.page_count;
     job.status = .ready;
+}
+
+fn previewSourceKindName(kind: PreviewSourceKind) []const u8 {
+    return switch (kind) {
+        .local => "local",
+        .wsl => "wsl",
+        .remote => "ssh",
+    };
+}
+
+fn usizeField(value: usize) []const u8 {
+    return std.fmt.bufPrint(&g_usize_field_buf, "{d}", .{value}) catch "";
 }
 
 fn pdfFailMessage(err: pdf_render.RenderError) []const u8 {

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -7,6 +7,7 @@ const pdf_preview = @import("../pdf_preview.zig");
 const text_wrap = @import("../text_wrap.zig");
 const ui_perf = @import("../ui_perf.zig");
 const PreviewPane = @import("../preview_pane.zig");
+const preview_diagnostics = @import("../preview_diagnostics.zig");
 const preview_close_button = @import("../input/preview_close_button.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
@@ -749,13 +750,33 @@ fn ensureImageTexture(pane: *PreviewPane) bool {
     pane.image_failed = true;
 
     const source = pane.sourceText();
-    if (source.len == 0 or source.len > std.math.maxInt(c_int)) return false;
+    if (source.len == 0 or source.len > std.math.maxInt(c_int)) {
+        var bytes_buf: [32]u8 = undefined;
+        const bytes_s = std.fmt.bufPrint(&bytes_buf, "{d}", .{source.len}) catch "";
+        preview_diagnostics.debug("image-decode", &.{
+            .{ .key = "stage", .value = "invalid-source-size" },
+            .{ .key = "kind", .value = @tagName(pane.kind) },
+            .{ .key = "path", .value = pane.path() },
+            .{ .key = "bytes", .value = bytes_s },
+        });
+        return false;
+    }
 
     var w: c_int = 0;
     var h: c_int = 0;
     var n: c_int = 0;
     const data = c.stbi_load_from_memory(@ptrCast(source.ptr), @intCast(source.len), &w, &h, &n, 4);
-    if (data == null or w <= 0 or h <= 0) return false;
+    if (data == null or w <= 0 or h <= 0) {
+        var bytes_buf: [32]u8 = undefined;
+        const bytes_s = std.fmt.bufPrint(&bytes_buf, "{d}", .{source.len}) catch "";
+        preview_diagnostics.debug("image-decode", &.{
+            .{ .key = "stage", .value = "decode-failed" },
+            .{ .key = "kind", .value = @tagName(pane.kind) },
+            .{ .key = "path", .value = pane.path() },
+            .{ .key = "bytes", .value = bytes_s },
+        });
+        return false;
+    }
     defer c.stbi_image_free(data);
 
     const t = gpu.Texture.create();
@@ -767,6 +788,20 @@ fn ensureImageTexture(pane: *PreviewPane) bool {
     pane.image_width = w;
     pane.image_height = h;
     pane.image_failed = false;
+    var width_buf: [32]u8 = undefined;
+    var height_buf: [32]u8 = undefined;
+    var bytes_buf: [32]u8 = undefined;
+    const width_s = std.fmt.bufPrint(&width_buf, "{d}", .{w}) catch "";
+    const height_s = std.fmt.bufPrint(&height_buf, "{d}", .{h}) catch "";
+    const bytes_s = std.fmt.bufPrint(&bytes_buf, "{d}", .{source.len}) catch "";
+    preview_diagnostics.debug("image-decode", &.{
+        .{ .key = "stage", .value = "ready" },
+        .{ .key = "kind", .value = @tagName(pane.kind) },
+        .{ .key = "path", .value = pane.path() },
+        .{ .key = "bytes", .value = bytes_s },
+        .{ .key = "width", .value = width_s },
+        .{ .key = "height", .value = height_s },
+    });
     return true;
 }
 

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -5,6 +5,7 @@ const builtin = @import("builtin");
 const Surface = @import("Surface.zig");
 const ssh_connection = @import("ssh_connection.zig");
 const browser_url = @import("browser_url.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const ui_perf = @import("ui_perf.zig");
@@ -79,18 +80,48 @@ const SshTunnel = struct {
 
 pub fn externalUrlForSurface(allocator: std.mem.Allocator, url: []const u8, surface: ?*const Surface) ?[]u8 {
     if (sshLoopbackUrl(surface, url)) |request| {
+        var remote_port_buf: [16]u8 = undefined;
+        const remote_port_s = std.fmt.bufPrint(&remote_port_buf, "{d}", .{request.parsed.port}) catch "";
+        preview_diagnostics.debug("ssh-tunnel", &.{
+            .{ .key = "stage", .value = "loopback-url" },
+            .{ .key = "url", .value = url },
+            .{ .key = "host", .value = request.parsed.host },
+            .{ .key = "remote_port", .value = remote_port_s },
+        });
         const local_port = ensureSshTunnel(
             allocator,
             &request.conn,
             request.parsed.port,
             browser_url.localTunnelHost(request.parsed.host),
             browser_url.remoteTunnelHost(request.parsed.host),
-        ) orelse return null;
-        return browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port);
+        ) orelse {
+            preview_diagnostics.debug("ssh-tunnel", &.{
+                .{ .key = "stage", .value = "ensure-failed" },
+                .{ .key = "url", .value = url },
+                .{ .key = "remote_port", .value = remote_port_s },
+            });
+            return null;
+        };
+        var local_port_buf: [16]u8 = undefined;
+        const local_port_s = std.fmt.bufPrint(&local_port_buf, "{d}", .{local_port}) catch "";
+        const target = browser_url.buildLocalTunnelUrl(allocator, request.parsed, local_port) orelse return null;
+        preview_diagnostics.debug("ssh-tunnel", &.{
+            .{ .key = "stage", .value = "rewritten" },
+            .{ .key = "url", .value = url },
+            .{ .key = "remote_port", .value = remote_port_s },
+            .{ .key = "local_port", .value = local_port_s },
+            .{ .key = "target", .value = target },
+        });
+        return target;
     }
 
     if (browser_url.parseHttpUrl(url)) |parsed| {
         if (browser_url.isUnspecifiedHost(parsed.host)) {
+            preview_diagnostics.debug("ssh-tunnel", &.{
+                .{ .key = "stage", .value = "unspecified-host" },
+                .{ .key = "url", .value = url },
+                .{ .key = "host", .value = parsed.host },
+            });
             return browser_url.buildLocalTunnelUrl(allocator, parsed, parsed.port);
         }
     }
@@ -129,16 +160,44 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.Ssh
     pruneExitedTunnels();
 
     if (findReusableTunnel(allocator, conn, remote_port, local_host, remote_host)) |local_port| {
+        var remote_port_buf: [16]u8 = undefined;
+        var local_port_buf: [16]u8 = undefined;
+        const remote_port_s = std.fmt.bufPrint(&remote_port_buf, "{d}", .{remote_port}) catch "";
+        const local_port_s = std.fmt.bufPrint(&local_port_buf, "{d}", .{local_port}) catch "";
+        preview_diagnostics.debug("ssh-tunnel", &.{
+            .{ .key = "stage", .value = "reuse" },
+            .{ .key = "host", .value = conn.host() },
+            .{ .key = "remote_port", .value = remote_port_s },
+            .{ .key = "local_port", .value = local_port_s },
+        });
         return local_port;
     }
 
     const slot = firstEmptySlot() orelse return null;
     const local_port = reservePreferredLocalPort(remote_port) orelse return null;
+    var remote_port_buf: [16]u8 = undefined;
+    var local_port_buf: [16]u8 = undefined;
+    const remote_port_s = std.fmt.bufPrint(&remote_port_buf, "{d}", .{remote_port}) catch "";
+    const local_port_s = std.fmt.bufPrint(&local_port_buf, "{d}", .{local_port}) catch "";
+    preview_diagnostics.debug("ssh-tunnel", &.{
+        .{ .key = "stage", .value = "spawn" },
+        .{ .key = "host", .value = conn.host() },
+        .{ .key = "remote_host", .value = remote_host },
+        .{ .key = "local_host", .value = local_host },
+        .{ .key = "remote_port", .value = remote_port_s },
+        .{ .key = "local_port", .value = local_port_s },
+    });
     const child = spawnSshTunnel(allocator, conn, remote_port, local_port, local_host, remote_host) orelse return null;
 
     g_tunnels[slot] = SshTunnel.init(child, conn, remote_port, local_port, local_host, remote_host);
     if (g_tunnels[slot]) |*tunnel| {
         if (!waitForTunnelReady(allocator, local_host, local_port, &tunnel.child)) {
+            preview_diagnostics.debug("ssh-tunnel", &.{
+                .{ .key = "stage", .value = "ready-failed" },
+                .{ .key = "host", .value = conn.host() },
+                .{ .key = "remote_port", .value = remote_port_s },
+                .{ .key = "local_port", .value = local_port_s },
+            });
             std.debug.print("SSH browser tunnel did not become ready on {s}:{d}\n", .{ local_host, local_port });
             stopTunnelSlot(&g_tunnels[slot]);
             return null;
@@ -148,6 +207,12 @@ fn ensureSshTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.Ssh
     }
 
     std.debug.print("SSH browser tunnel: {s}:{d} -> remote {s}:{d}\n", .{ local_host, local_port, remote_host, remote_port });
+    preview_diagnostics.debug("ssh-tunnel", &.{
+        .{ .key = "stage", .value = "ready" },
+        .{ .key = "host", .value = conn.host() },
+        .{ .key = "remote_port", .value = remote_port_s },
+        .{ .key = "local_port", .value = local_port_s },
+    });
     return local_port;
 }
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -76,6 +76,7 @@ test {
     _ = @import("png_dimensions.zig");
     _ = @import("pdf_preview.zig");
     _ = @import("preview_gallery.zig");
+    _ = @import("preview_diagnostics.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");

--- a/wiki/FAQ-zh.md
+++ b/wiki/FAQ-zh.md
@@ -121,6 +121,11 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\plugins\skills\wispterm-di
 —— 比如打开微信连接时崩溃，或 Ctrl+点击远程文件时卡死 —— 下载它、复现问题，然后把
 `wispterm-debug.log`（以及任何 `crash-*.txt`）附在反馈里。
 
+如果问题是 Ctrl+点击预览或浏览器面板失败，调试日志里还会出现以 `preview-diagnostic`
+开头、可以直接复制的单行记录。复现后，如果完整日志太大，可以只把附近这些
+`preview-diagnostic` 行贴到 issue 里。它们覆盖预览路径解析、异步文件读取、图片解码、
+HTML server 启动、SSH 浏览器隧道、URL 路由和内嵌浏览器面板。
+
 ## 为什么远程在手机上镜像本地终端尺寸？
 
 WispTerm Remote 镜像本地窗口，因为桌面应用是终端状态的唯一真相来源 —— 本地 PTY、VT 状态、

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -151,6 +151,13 @@ opening the WeChat connection, or a freeze when Ctrl+clicking a remote file —
 download it, reproduce the problem, then attach `wispterm-debug.log` (and any
 `crash-*.txt`) to your report.
 
+For Ctrl+click preview/browser issues, the debug log also includes copyable
+single-line records that begin with `preview-diagnostic`. After reproducing the
+problem, paste the nearby `preview-diagnostic` lines into the issue if the full
+log is too large. They cover preview path resolution, async file reads, image
+decode, HTML server startup, SSH browser tunnels, URL routing, and the embedded
+browser panel.
+
 ## Why does remote mirror the local terminal size on phones?
 
 WispTerm Remote mirrors the local window because the desktop app is the source


### PR DESCRIPTION
## Summary
- add debug-console-only `preview-diagnostic` log records for Ctrl-click preview and browser panel flows
- cover preview path resolution, async reads, image decode, HTML server startup, SSH browser tunnels, URL routing, and WebView/browser panel state
- document what users should copy in the debug build docs, FAQ, and wiki FAQ pages

## Impact
Debug builds now give issue reporters a small copyable diagnostic slice when the full `%APPDATA%\wispterm\wispterm-debug.log` is too large. Normal builds keep the diagnostics gated behind `debug_console`.

## Validation
- `zig build test --summary all`
- `zig build test-full --summary all`
- `zig build -Ddebug-console=true --summary all`
- `python3 wiki/check_wiki.py`
- `zig fmt --check src/preview_diagnostics.zig`
- `git diff --check`