### PR TITLE
fix(win): ensure bring-up crash fuse persists on a fresh profile (#259)

### DIFF
--- a/src/platform/window_state.zig
+++ b/src/platform/window_state.zig
@@ -52,6 +52,12 @@ fn savePersisted(allocator: std.mem.Allocator, state: codec.PersistedState) void
     defer allocator.free(path);
     var buf: [384]u8 = undefined;
     const content = codec.format(&buf, state) catch return;
+    // Create the config directory first: on a first-ever launch it does not
+    // exist yet (Config.ensureConfigExists only runs later, in the window
+    // loop), and the bring-up crash fuse writes its marker through here before
+    // then — without this, createFile fails and the marker is silently lost,
+    // so the fuse never engages and the app crashes again (issue #259).
+    if (std.fs.path.dirname(path)) |dir| std.fs.cwd().makePath(dir) catch {};
     if (std.fs.cwd().createFile(path, .{})) |file| {
         defer file.close();
         file.writeAll(content) catch {};
@@ -195,4 +201,29 @@ pub fn blockD3dBringup(allocator: std.mem.Allocator, version: []const u8) void {
     var buf: [dxgi_core.bringup_marker_max_len]u8 = undefined;
     const marker = dxgi_core.bringupBlockedMarker(&buf, version) catch return;
     recordD3dBringup(allocator, marker);
+}
+
+test "savePersisted creates the config directory on a fresh profile" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Point the config dir at a not-yet-created nested subdirectory, mirroring
+    // a first-ever launch where %APPDATA%\wispterm has never existed. The
+    // bring-up crash fuse writes its marker here *before* the window loop runs
+    // ensureConfigExists, so savePersisted must create the directory itself or
+    // the marker is silently lost and the fuse never engages (issue #259).
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const config_dir = try std.fs.path.join(allocator, &.{ base, "missing", "wispterm" });
+    defer allocator.free(config_dir);
+
+    platform_dirs.setTestConfigDirForCurrentThread(config_dir);
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    recordD3dBringup(allocator, "probing:9.9.9");
+
+    var buf: [codec.bringup_max_len]u8 = undefined;
+    try std.testing.expectEqualStrings("probing:9.9.9", d3dBringup(allocator, &buf));
 }


### PR DESCRIPTION
## Problem (issue #259)

On some Win11 machines WispTerm opens as a **black frame, then crashes** on launch; force-quitting and reopening recovers. The portable v1.25.0 build is affected.

### Root cause

The DXGI flip-model present path (`wispterm-d3d-present`, default **on**) runs driver code (`wglDX*NV` interop + `D3D11CreateDevice`) during bring-up. On weak iGPU / buggy-ICD Win11 drivers this **crashes the process** instead of returning an error — the black-frame-then-crash symptom.

A **bring-up crash fuse** already guards this: a `probing:<version>` marker is written to the state file before the first window, cleared after the first successful present. A leftover marker on the next launch means the last bring-up died, so the app falls back to GDI `SwapBuffers` from frame 0. **This is why force-quit + reopen recovers.**

But the fuse marker is written by `savePersisted`, which used `createFile` (no parent-dir creation), and it runs *before* the window loop calls `Config.ensureConfigExists`. On a **first-ever launch** (`%APPDATA%\wispterm` not created yet) the write **failed silently** (error swallowed by `else |_| {}`), so the fuse never engaged — the app could keep crashing instead of self-healing on the second launch.

The codebase already knows this ordering gap: `ctl/discovery.zig` works around the same "config dir created later" problem with its own `makePath`. `window_state.savePersisted` was the one path that didn't.

## Fix

Create the config directory before writing the state file in `savePersisted`, mirroring `ctl/discovery.zig`:

```zig
if (std.fs.path.dirname(path)) |dir| std.fs.cwd().makePath(dir) catch {};
```

This guarantees **"at most one crash, then reopen recovers"** on every machine, instead of a possible crash loop on a fresh profile.

This is the low-risk, isolated mitigation. The deeper question — whether the flip path should default on for weak iGPUs, or probe adapter capability before the first present — is left for a separate change.

## Testing (TDD)

- Added regression test `savePersisted creates the config directory on a fresh profile` (points the config dir at a not-yet-created nested subdir; asserts the bring-up marker persists). Confirmed it **fails before** the fix (marker silently lost → reads back empty) and **passes after**.
- `zig build test` (fast suite) — green
- `zig build test-full` (full suite, where `window_state.zig` is registered) — green (exit 0, 0 failures)

GUI verification on an affected Win11 machine still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LWwrGFFoagLD87V5XAtgL