### PR TITLE
[codex] cover skill suggestion descriptions

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -4958,6 +4958,7 @@ test "ai chat dollar skill suggestions filter and enter completes with trailing 
     const suggestion = session.composerSuggestionAt(1).?;
     try std.testing.expectEqual(ComposerSuggestionKind.skill, suggestion.kind);
     try std.testing.expectEqualStrings("pdf", suggestion.text);
+    try std.testing.expectEqualStrings("Work with PDF files.", suggestion.description);
 
     // Navigate down once to select the "pdf" skill (index 1) and then confirm.
     session.handleKey(.{ .key = input_key.Key.arrow_down });

--- a/src/ai_chat_composer.zig
+++ b/src/ai_chat_composer.zig
@@ -470,6 +470,7 @@ test "skill suggestions filter by prefix against a fixture" {
     const sug = skillSuggestionAtForPrefix("$b", &test_skills, 1).?;
     try std.testing.expectEqual(ComposerSuggestionKind.skill, sug.kind);
     try std.testing.expectEqualStrings("build", sug.text);
+    try std.testing.expectEqualStrings("build something", sug.description);
 }
 
 test "parseSkillInvocation splits name and prompt" {


### PR DESCRIPTION
## Summary
- add regression coverage that `$` skill suggestions expose the skill frontmatter description
- cover both pure composer suggestion filtering and the Session path that loads metadata from SKILL.md

## Why
The composer already carries `SkillMeta.description` through to the renderer, but this behavior was not explicitly covered. The tests lock the requested display behavior so skills do not regress to blank descriptions while tools continue showing descriptions.

## Validation
- `git diff --cached --check`
- `zig test src/ai_chat_composer.zig`
- `zig build test`
- `zig build test-full`