### PR TITLE
fix(skills): show block-scalar descriptions + full-description detail panel in the $ palette

### DIFF
--- a/src/composer_detail_wrap.zig
+++ b/src/composer_detail_wrap.zig
@@ -1,0 +1,136 @@
+//! Wrapping math for the composer suggestion detail panel.
+//!
+//! Splits a suggestion's (already single-line) description into at most
+//! `MAX_LINES` display lines that fit a pixel width, capping the result so the
+//! popup never grows unbounded. Kept free of renderer/font globals so the logic
+//! is unit-testable: callers inject codepoint advances via `advance`.
+
+const std = @import("std");
+
+/// Hard ceiling on rendered detail lines, regardless of the requested cap.
+pub const MAX_LINES: usize = 6;
+
+pub const WrapLine = struct {
+    /// Byte offset where the line's text begins.
+    start: usize,
+    /// Byte offset one past the line's text (excludes any '\n' break).
+    end: usize,
+};
+
+pub const WrapResult = struct {
+    lines: [MAX_LINES]WrapLine,
+    /// Number of populated entries in `lines`.
+    count: usize,
+    /// True when `text` needed more than `max_lines` lines, so the caller should
+    /// render the final line with an overflow ellipsis.
+    truncated: bool,
+};
+
+const CodepointItem = struct { len: usize, advance: f32 };
+
+fn nextCodepoint(text: []const u8, i: usize, advance: *const fn (u21) f32) CodepointItem {
+    const first = text[i];
+    const len = std.unicode.utf8ByteSequenceLength(first) catch 1;
+    if (i + len > text.len) return .{ .len = 1, .advance = advance('?') };
+    const cp = std.unicode.utf8Decode(text[i .. i + len]) catch @as(u21, '?');
+    return .{ .len = len, .advance = advance(cp) };
+}
+
+/// Wrap `text` into at most `min(max_lines, MAX_LINES)` lines no wider than
+/// `max_w`, breaking on width overflow and on '\n'. Width is measured by summing
+/// `advance(codepoint)` (character-level wrapping, matching the renderer's other
+/// wrap helpers — there is no word-boundary logic).
+pub fn wrap(
+    text: []const u8,
+    max_w: f32,
+    max_lines: usize,
+    advance: *const fn (u21) f32,
+) WrapResult {
+    var result = WrapResult{ .lines = undefined, .count = 0, .truncated = false };
+    const limit = @min(max_lines, MAX_LINES);
+    if (limit == 0) {
+        result.truncated = text.len > 0;
+        return result;
+    }
+
+    var line_start: usize = 0;
+    var line_width: f32 = 0;
+    var i: usize = 0;
+    while (i < text.len) {
+        if (text[i] == '\n') {
+            result.lines[result.count] = .{ .start = line_start, .end = i };
+            result.count += 1;
+            i += 1; // drop the break byte itself
+            line_start = i;
+            line_width = 0;
+            if (result.count >= limit) {
+                result.truncated = i < text.len;
+                return result;
+            }
+            continue;
+        }
+
+        const item = nextCodepoint(text, i, advance);
+        if (line_width > 0 and line_width + item.advance > max_w) {
+            result.lines[result.count] = .{ .start = line_start, .end = i };
+            result.count += 1;
+            line_start = i; // re-measure this codepoint on the next line
+            line_width = 0;
+            if (result.count >= limit) {
+                result.truncated = i < text.len;
+                return result;
+            }
+            continue;
+        }
+
+        line_width += item.advance;
+        i += item.len;
+    }
+
+    result.lines[result.count] = .{ .start = line_start, .end = text.len };
+    result.count += 1;
+    return result;
+}
+
+fn asciiAdvance(cp: u21) f32 {
+    return if (cp < 0x80) 1.0 else 2.0;
+}
+
+test "wrap: character-wraps text at the width limit" {
+    const r = wrap("aaabbbccc", 3.0, 6, &asciiAdvance);
+    try std.testing.expectEqual(@as(usize, 3), r.count);
+    try std.testing.expect(!r.truncated);
+    try std.testing.expectEqualStrings("aaa", "aaabbbccc"[r.lines[0].start..r.lines[0].end]);
+    try std.testing.expectEqualStrings("bbb", "aaabbbccc"[r.lines[1].start..r.lines[1].end]);
+    try std.testing.expectEqualStrings("ccc", "aaabbbccc"[r.lines[2].start..r.lines[2].end]);
+}
+
+test "wrap: caps at max_lines and reports truncation" {
+    const r = wrap("aaabbbcccddd", 3.0, 2, &asciiAdvance);
+    try std.testing.expectEqual(@as(usize, 2), r.count);
+    try std.testing.expect(r.truncated);
+}
+
+test "wrap: short text fits without truncation" {
+    const r = wrap("aaabbbcccddd", 3.0, 6, &asciiAdvance);
+    try std.testing.expectEqual(@as(usize, 4), r.count);
+    try std.testing.expect(!r.truncated);
+}
+
+test "wrap: breaks on explicit newlines without emitting the break byte" {
+    const text = "ab\ncd";
+    const r = wrap(text, 100.0, 6, &asciiAdvance);
+    try std.testing.expectEqual(@as(usize, 2), r.count);
+    try std.testing.expect(!r.truncated);
+    try std.testing.expectEqualStrings("ab", text[r.lines[0].start..r.lines[0].end]);
+    try std.testing.expectEqualStrings("cd", text[r.lines[1].start..r.lines[1].end]);
+}
+
+test "wrap: measures multi-byte glyphs by their advance" {
+    const text = "中文a"; // each CJK glyph advances 2.0, 'a' advances 1.0
+    const r = wrap(text, 2.0, 6, &asciiAdvance);
+    try std.testing.expectEqual(@as(usize, 3), r.count);
+    try std.testing.expectEqualStrings("中", text[r.lines[0].start..r.lines[0].end]);
+    try std.testing.expectEqualStrings("文", text[r.lines[1].start..r.lines[1].end]);
+    try std.testing.expectEqualStrings("a", text[r.lines[2].start..r.lines[2].end]);
+}

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -8,6 +8,7 @@ const i18n = @import("../i18n.zig");
 const composer_layout = @import("../ai_chat_composer_layout.zig");
 const scrollbar_model = @import("../ai_chat_scrollbar_model.zig");
 const md = @import("../markdown_text.zig");
+const detail_wrap = @import("../composer_detail_wrap.zig");
 
 // Transcript scrollbar interaction state (one mouse). Set by input.zig,
 // read by the fade computation in renderTranscriptScrollbar.
@@ -62,6 +63,9 @@ const SUGGESTION_MAX_W: f32 = 1120;
 const SUGGESTION_COMMAND_W: f32 = 420;
 const SUGGESTION_PAD_X: f32 = 18;
 const SUGGESTION_COLUMN_GAP: f32 = 34;
+// Vertical padding around the divider that separates the suggestion list from
+// the selected item's full-description detail panel.
+const SUGGESTION_DETAIL_GAP: f32 = 8;
 const MISSING_API_KEY_ACTION_TEXT = "Missing API key. Click to configure";
 
 pub const HitTarget = union(enum) {
@@ -1313,10 +1317,25 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, win
     const popup_y = layout.field_y + layout.field_h + SUGGESTION_GAP;
     const row_h = @round(@max(SUGGESTION_ROW_H, font.g_titlebar_cell_height + 14.0));
     const command_w = @min(@max(SUGGESTION_COMMAND_W, font.g_titlebar_cell_width * 16.0), popup_w * 0.58);
-    const popup_h = SUGGESTION_PAD_Y * 2 + row_h * @as(f32, @floatFromInt(count));
     const popup_bg = mixColor(bg, fg, 0.105);
     const border = mixColor(bg, accent, 0.36);
     const selected = @min(session.suggestion_selected, count - 1);
+
+    // Detail panel: the selected item's full description, wrapped under the
+    // list (capped at detail_wrap.MAX_LINES so the popup never grows unbounded).
+    const detail_w = popup_w - SUGGESTION_PAD_X * 2;
+    const selected_suggestion = ai_chat.composerSuggestionAtForInput(input_text, session.input_cursor, session.skill_suggestions, session.custom_command_suggestions, selected);
+    const detail_desc: []const u8 = if (selected_suggestion) |s| s.description else "";
+    const detail_line_h = lineHeight();
+    const detail = if (detail_desc.len > 0 and detail_w > 0)
+        detail_wrap.wrap(detail_desc, detail_w, detail_wrap.MAX_LINES, &glyphAdvance)
+    else
+        detail_wrap.WrapResult{ .lines = undefined, .count = 0, .truncated = false };
+    const detail_content_h: f32 = @as(f32, @floatFromInt(detail.count)) * detail_line_h;
+    const detail_block: f32 = if (detail.count > 0) detail_content_h + SUGGESTION_DETAIL_GAP * 2 + 1 else 0;
+
+    const list_h = row_h * @as(f32, @floatFromInt(count));
+    const popup_h = SUGGESTION_PAD_Y * 2 + list_h + detail_block;
 
     ui_pipeline.fillQuadAlpha(popup_x, popup_y, popup_w, popup_h, popup_bg, 0.98);
     ui_pipeline.fillQuadAlpha(popup_x, popup_y + popup_h - 1, popup_w, 1, border, 0.78);
@@ -1353,6 +1372,30 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, win
             );
         }
     }
+
+    if (detail.count > 0) {
+        const detail_color = mixColor(bg, fg, 0.72);
+        const content_top = popup_y + SUGGESTION_PAD_Y + detail_content_h;
+        const divider_y = content_top + SUGGESTION_DETAIL_GAP;
+        ui_pipeline.fillQuadAlpha(popup_x + SUGGESTION_PAD_X, divider_y, detail_w, 1, mixColor(bg, fg, 0.16), 0.7);
+
+        for (0..detail.count) |k| {
+            const line_y = content_top - @as(f32, @floatFromInt(k + 1)) * detail_line_h + @round((detail_line_h - font.g_titlebar_cell_height) / 2);
+            const line = detail.lines[k];
+            const is_last = k + 1 == detail.count;
+            // On the truncated final line, hand renderTextLimited the remaining
+            // text so it clips to width and appends its own overflow ellipsis.
+            const slice = if (is_last and detail.truncated)
+                detail_desc[line.start..]
+            else
+                detail_desc[line.start..line.end];
+            _ = titlebar.renderTextLimited(slice, popup_x + SUGGESTION_PAD_X, line_y, detail_color, detail_w);
+        }
+    }
+}
+
+fn glyphAdvance(cp: u21) f32 {
+    return titlebar.titlebarGlyphAdvance(@as(u32, cp));
 }
 
 fn suggestionLabel(buf: []u8, suggestion: ai_chat.ComposerSuggestion) []const u8 {

--- a/src/skill_registry.zig
+++ b/src/skill_registry.zig
@@ -236,10 +236,16 @@ fn parseSkillMeta(
     const frontmatter = frontmatterSlice(bytes) orelse return LookupError.InvalidSkillMarkdown;
 
     var parsed_name: ?[]const u8 = null;
-    var parsed_description: ?[]const u8 = null;
+    var inline_description: ?[]const u8 = null;
+    var folded_description: ?[]u8 = null;
+    errdefer if (folded_description) |d| allocator.free(d);
 
-    var lines = std.mem.splitScalar(u8, frontmatter, '\n');
-    while (lines.next()) |raw_line| {
+    var pos: usize = 0;
+    while (pos < frontmatter.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, frontmatter, pos, '\n') orelse frontmatter.len;
+        const raw_line = frontmatter[pos..line_end];
+        pos = if (line_end < frontmatter.len) line_end + 1 else frontmatter.len;
+
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
 
@@ -250,7 +256,22 @@ fn parseSkillMeta(
         if (std.mem.eql(u8, key, "name")) {
             parsed_name = value;
         } else if (std.mem.eql(u8, key, "description")) {
-            parsed_description = value;
+            if (isBlockScalarHeader(value)) {
+                // YAML block scalar (">" folded / "|" literal): the real text
+                // lives on the following more-indented lines. Fold it into one
+                // line so the single-row suggestion popup and `/skills` listing
+                // (which terminates each entry with "\n") stay intact.
+                const key_indent = leadingWhitespace(raw_line);
+                if (folded_description) |d| allocator.free(d);
+                folded_description = try foldBlockScalar(allocator, frontmatter, &pos, key_indent);
+                inline_description = null;
+            } else {
+                inline_description = value;
+                if (folded_description) |d| {
+                    allocator.free(d);
+                    folded_description = null;
+                }
+            }
         }
     }
 
@@ -258,11 +279,13 @@ fn parseSkillMeta(
         if (name.len == 0) dir_name else name
     else
         dir_name;
-    const description_value = parsed_description orelse "";
 
     const name = try allocator.dupe(u8, name_value);
     errdefer allocator.free(name);
-    const description = try allocator.dupe(u8, description_value);
+    const description: []u8 = if (folded_description) |d| desc: {
+        folded_description = null; // ownership moves into the returned SkillMeta
+        break :desc d;
+    } else try allocator.dupe(u8, inline_description orelse "");
     errdefer allocator.free(description);
     const dir_name_copy = try allocator.dupe(u8, dir_name);
     errdefer allocator.free(dir_name_copy);
@@ -275,6 +298,58 @@ fn parseSkillMeta(
         .dir_name = dir_name_copy,
         .rel_dir = rel_dir,
     };
+}
+
+fn leadingWhitespace(line: []const u8) usize {
+    var i: usize = 0;
+    while (i < line.len and (line[i] == ' ' or line[i] == '\t')) : (i += 1) {}
+    return i;
+}
+
+fn isBlockScalarHeader(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (value[0] != '>' and value[0] != '|') return false;
+    // Permit chomping ("+"/"-") and explicit-indent (digit) indicators only;
+    // a value like ">text" is a plain scalar, not a block scalar header.
+    for (value[1..]) |c| {
+        switch (c) {
+            '-', '+', '0'...'9' => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
+/// Fold the indented body of a YAML block scalar (whose ">"/"|" header was just
+/// consumed) into a single line: content lines joined by single spaces, blank
+/// lines dropped. `pos` starts on the first body line and is left on the first
+/// line that dedents to the key's indent (the next key) or at end of input.
+fn foldBlockScalar(
+    allocator: std.mem.Allocator,
+    frontmatter: []const u8,
+    pos: *usize,
+    key_indent: usize,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    while (pos.* < frontmatter.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, frontmatter, pos.*, '\n') orelse frontmatter.len;
+        const raw_line = frontmatter[pos.*..line_end];
+        const content = std.mem.trim(u8, raw_line, " \t\r");
+
+        if (content.len != 0) {
+            // A non-blank line indented no deeper than the key terminates the
+            // block; leave `pos` on it so the caller parses it as the next key.
+            if (leadingWhitespace(raw_line) <= key_indent) break;
+            if (out.items.len != 0) try out.append(allocator, ' ');
+            try out.appendSlice(allocator, content);
+        }
+
+        pos.* = if (line_end < frontmatter.len) line_end + 1 else frontmatter.len;
+    }
+
+    return out.toOwnedSlice(allocator);
 }
 
 fn frontmatterSlice(bytes: []const u8) ?[]const u8 {
@@ -350,6 +425,61 @@ test "skill_registry: parses CRLF SKILL frontmatter" {
     try std.testing.expectEqual(@as(usize, 1), skills.len);
     try std.testing.expectEqualStrings("pdf", skills[0].name);
     try std.testing.expectEqualStrings("Work with PDF files.", skills[0].description);
+}
+
+test "skill_registry: folds a YAML block scalar description into one line" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("skills/bear");
+    try tmp.dir.writeFile(.{
+        .sub_path = "skills/bear/SKILL.md",
+        .data =
+            "---\n" ++
+            "name: bear\n" ++
+            "description: >\n" ++
+            "  Find papers that argue against a claim.\n" ++
+            "  Sort them by threat level.\n" ++
+            "\n" ++
+            "  Trigger when the user wants counter-evidence.\n" ++
+            "---\n" ++
+            "# Bear\n",
+    });
+
+    const skills = try listSkills(std.testing.allocator, tmp.dir, "skills");
+    defer freeSkillList(std.testing.allocator, skills);
+
+    try std.testing.expectEqual(@as(usize, 1), skills.len);
+    try std.testing.expectEqualStrings("bear", skills[0].name);
+    try std.testing.expectEqualStrings(
+        "Find papers that argue against a claim. Sort them by threat level. Trigger when the user wants counter-evidence.",
+        skills[0].description,
+    );
+}
+
+test "skill_registry: folds a literal block scalar description into one line" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("skills/note");
+    try tmp.dir.writeFile(.{
+        .sub_path = "skills/note/SKILL.md",
+        .data =
+            "---\n" ++
+            "name: note\n" ++
+            "description: |\n" ++
+            "  First line.\n" ++
+            "  Second line.\n" ++
+            "---\n" ++
+            "# Note\n",
+    });
+
+    const skills = try listSkills(std.testing.allocator, tmp.dir, "skills");
+    defer freeSkillList(std.testing.allocator, skills);
+
+    try std.testing.expectEqual(@as(usize, 1), skills.len);
+    try std.testing.expectEqualStrings("note", skills[0].name);
+    try std.testing.expectEqualStrings("First line. Second line.", skills[0].description);
 }
 
 test "skill_registry: listSkills cleans up appended metadata on later error" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -84,6 +84,7 @@ test {
     _ = @import("ai_chat_composer_layout.zig");
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
+    _ = @import("composer_detail_wrap.zig");
     _ = @import("web_search.zig");
     _ = @import("agent_prompt_answer.zig");
     _ = @import("web_read.zig");


### PR DESCRIPTION
## 背景 / 问题

`$` 技能 / `/` 命令的建议弹窗里，凡是 frontmatter 用 YAML 折叠（`>`）或字面量（`|`）块标量写 `description:` 的技能（例如所有 `bear-*`），描述列只显示一个字面量 `>`，看不到内容。此外即使能显示，描述也只截断成一列、长描述无法阅读。

之前的 `codex/skill-suggestion-descriptions` 分支只加了针对单行描述的测试断言、没碰解析器，所以解决不了这个问题——本分支取而代之。

## 改动

**1. 解析块标量描述**（`src/skill_registry.zig`）
- `parseSkillMeta` 原来是朴素的逐行 `key: value` 解析，遇到 `description: >` 就把字面量 `>` 当成值，忽略后面缩进的正文。
- 现在能识别块标量头（`>` / `|`，含 `>-`、`|2` 等修饰符），把缩进正文折叠成**单行**（内容行用空格连接、空行丢弃）。单行保证了单行弹窗和 `- $name: desc\n` 的 `/skills` 列表不被换行破坏；普通单行描述行为不变。

**2. 选中项完整描述详情区**（`src/renderer/ai_chat_renderer.zig` + 新增 `src/composer_detail_wrap.zig`）
- 建议弹窗列表下方新增详情面板，显示**当前选中项**的完整描述，按弹窗宽度自动换行，最多 6 行，超出用 `…` 省略号收尾（复用 `renderTextLimited` 自带的溢出省略号）。
- 技能和斜杠命令都生效；选中项无描述时不画详情区。
- 换行/限高/截断的纯逻辑抽到 `composer_detail_wrap.zig`（只依赖 std、CJK 宽度感知），不依赖字体/GPU 全局态，可独立单测。

## 验证

| 检查 | 结果 |
|---|---|
| `zig test src/skill_registry.zig` | 9/9 通过 |
| `zig test src/composer_detail_wrap.zig`（含 CJK、限高、省略号、换行） | 5/5 通过 |
| `zig build test`（fast 套件） | 通过 |
| `zig build macos-app -Dtarget=aarch64-macos`（编译渲染层） | 通过 |
| 真实 8 个 `bear-*` 技能端到端解析 | 描述全部正确（从 `>` 变成真正摘要） |

## Reviewer 须知

- **视觉布局未截图确认**：开发环境无屏幕录制权限，详情区的像素级布局（分隔线位置、配色、留白）尚未实机截图验证，几何坐标经反复推导、纯逻辑已单测。建议 reviewer 在本地敲 `$` 上下移动看一眼。
- 运行中要看到效果需重新扫描技能（`/reload-skills` 或重启）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)