### PR TITLE
fix(ai-chat): 修复 $ 技能/工具建议列表过多时顶部显示不全

### DIFF
--- a/src/ai_chat_layout.zig
+++ b/src/ai_chat_layout.zig
@@ -182,6 +182,50 @@ pub fn questionLayout(cell_h: f32, n_options: usize, max_visible_options: usize)
     };
 }
 
+/// Visible window for the composer's `$`/`/` suggestion list. Row 0 renders at
+/// the top and the list grows downward, while the whole popup grows *upward*
+/// from the input field — so when there are more suggestions than fit between
+/// the input and the chat header, the list must cap its row count and scroll to
+/// keep the selection in view. Without this the popup overflowed the top of the
+/// window and clipped the first suggestions off-screen.
+pub const SuggestionWindow = struct {
+    /// Rows actually drawn (1..=count; 0 only when count == 0).
+    visible: usize,
+    /// Index of the first (topmost) drawn row.
+    first: usize,
+    /// Pixel height of the drawn rows (visible * row_h).
+    list_h: f32,
+};
+
+/// `avail_list_h` is the vertical space the list rows may occupy (the caller
+/// reserves padding and the detail panel separately). `selected` is clamped
+/// into range, so callers may pass a stale index safely.
+pub fn composerSuggestionWindow(
+    count: usize,
+    selected: usize,
+    row_h: f32,
+    avail_list_h: f32,
+) SuggestionWindow {
+    if (count == 0 or row_h <= 0) return .{ .visible = 0, .first = 0, .list_h = 0 };
+    // Always keep at least one row so a tiny window can still show (and reach)
+    // the selection.
+    const fit_f = @floor(avail_list_h / row_h);
+    const fit: usize = if (fit_f >= 1) @intFromFloat(fit_f) else 1;
+    const visible = @min(fit, count);
+    const sel = @min(selected, count - 1);
+    const first: usize = if (count <= visible)
+        0
+    else if (sel < visible)
+        0
+    else
+        @min(sel - visible + 1, count - visible);
+    return .{
+        .visible = visible,
+        .first = first,
+        .list_h = row_h * @as(f32, @floatFromInt(visible)),
+    };
+}
+
 test "pointInRect inside, edges, outside" {
     const r = Rect{ .x = 0, .top_px = 0, .w = 20, .h = 20 };
     try std.testing.expect(pointInRect(10, 10, r));
@@ -296,4 +340,58 @@ test "questionLayout clamps visible options to the row cap (rest scroll)" {
     const exact5 = questionLayout(18, 5, 5);
     try std.testing.expectApproxEqAbs(exact5.height, capped.height, 0.001);
     try std.testing.expect(few.height < capped.height);
+}
+
+test "composerSuggestionWindow shows everything when it fits" {
+    // 5 rows of 28px fit in 1000px → no scrolling, no cap.
+    const w = composerSuggestionWindow(5, 0, 28, 1000);
+    try std.testing.expectEqual(@as(usize, 5), w.visible);
+    try std.testing.expectEqual(@as(usize, 0), w.first);
+    try std.testing.expectApproxEqAbs(@as(f32, 140), w.list_h, 0.001);
+}
+
+test "composerSuggestionWindow caps rows to the available height" {
+    // 25 suggestions, but only 140px of room → 5 rows. This is the bug: before
+    // the cap the popup grew to 25*28=700px and clipped the top off-screen.
+    const w = composerSuggestionWindow(25, 0, 28, 140);
+    try std.testing.expectEqual(@as(usize, 5), w.visible);
+    try std.testing.expectEqual(@as(usize, 0), w.first);
+    try std.testing.expectApproxEqAbs(@as(f32, 140), w.list_h, 0.001);
+}
+
+test "composerSuggestionWindow scrolls to keep the selection visible" {
+    // Window of 5 over 25 items. Selecting item 10 puts it on the bottom row.
+    const mid = composerSuggestionWindow(25, 10, 28, 140);
+    try std.testing.expectEqual(@as(usize, 5), mid.visible);
+    try std.testing.expectEqual(@as(usize, 6), mid.first); // 10 - 5 + 1
+
+    // Selection inside the first window keeps first at 0.
+    const near_top = composerSuggestionWindow(25, 3, 28, 140);
+    try std.testing.expectEqual(@as(usize, 0), near_top.first);
+
+    // Selecting the last item clamps first at count - visible (no overscroll).
+    const last = composerSuggestionWindow(25, 24, 28, 140);
+    try std.testing.expectEqual(@as(usize, 20), last.first);
+    try std.testing.expectEqual(@as(usize, 24), last.first + last.visible - 1);
+}
+
+test "composerSuggestionWindow always keeps at least one row" {
+    // A window shorter than a single row still shows the selected suggestion.
+    const w = composerSuggestionWindow(25, 12, 28, 5);
+    try std.testing.expectEqual(@as(usize, 1), w.visible);
+    try std.testing.expectEqual(@as(usize, 12), w.first);
+}
+
+test "composerSuggestionWindow handles an empty list" {
+    const w = composerSuggestionWindow(0, 0, 28, 500);
+    try std.testing.expectEqual(@as(usize, 0), w.visible);
+    try std.testing.expectEqual(@as(usize, 0), w.first);
+    try std.testing.expectApproxEqAbs(@as(f32, 0), w.list_h, 0.001);
+}
+
+test "composerSuggestionWindow clamps an out-of-range selection" {
+    // A stale selected index beyond the list must not panic or overscroll.
+    const w = composerSuggestionWindow(25, 999, 28, 140);
+    try std.testing.expectEqual(@as(usize, 20), w.first);
+    try std.testing.expectEqual(@as(usize, 5), w.visible);
 }

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -66,6 +66,9 @@ const SUGGESTION_COLUMN_GAP: f32 = 34;
 // Vertical padding around the divider that separates the suggestion list from
 // the selected item's full-description detail panel.
 const SUGGESTION_DETAIL_GAP: f32 = 8;
+// Gap kept between the top of the suggestion popup and the chat header bar, so a
+// long skill/tool list caps its row count instead of growing under the header.
+const SUGGESTION_TOP_GAP: f32 = 8;
 const MISSING_API_KEY_ACTION_TEXT = "Missing API key. Click to configure";
 
 pub const HitTarget = union(enum) {
@@ -386,7 +389,7 @@ pub fn render(
     if (session.rewind_open) {
         renderRewindPicker(session, layout);
     } else {
-        renderComposerSuggestions(session, layout, window_width);
+        renderComposerSuggestions(session, layout, window_width, header_y);
     }
 }
 
@@ -1336,7 +1339,7 @@ fn renderRewindPicker(session: *ai_chat.Session, layout: InputLayout) void {
     }
 }
 
-fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, window_width: f32) void {
+fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, window_width: f32, ceiling_y: f32) void {
     const input_text = session.input();
     const count = ai_chat.composerSuggestionCountForInput(input_text, session.input_cursor, session.skill_suggestions, session.custom_command_suggestions);
     if (count == 0) return;
@@ -1367,7 +1370,12 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, win
     const detail_content_h: f32 = @as(f32, @floatFromInt(detail.count)) * detail_line_h;
     const detail_block: f32 = if (detail.count > 0) detail_content_h + SUGGESTION_DETAIL_GAP * 2 + 1 else 0;
 
-    const list_h = row_h * @as(f32, @floatFromInt(count));
+    // The popup grows *upward* from the input field; cap the visible rows to the
+    // space below the chat header so a long skill/tool list can never overflow
+    // the top of the window. Overflow scrolls to keep the selection in view.
+    const avail_list_h = ceiling_y - SUGGESTION_TOP_GAP - popup_y - SUGGESTION_PAD_Y * 2 - detail_block;
+    const win = ai_chat_layout.composerSuggestionWindow(count, selected, row_h, avail_list_h);
+    const list_h = win.list_h;
     const popup_h = SUGGESTION_PAD_Y * 2 + list_h + detail_block;
 
     ui_pipeline.fillQuadAlpha(popup_x, popup_y, popup_w, popup_h, popup_bg, 0.98);
@@ -1377,8 +1385,10 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, win
     ui_pipeline.fillQuadAlpha(popup_x + popup_w - 1, popup_y, 1, popup_h, mixColor(bg, fg, 0.16), 0.72);
 
     const top = popup_y + popup_h - SUGGESTION_PAD_Y;
-    for (0..count) |i| {
-        const row_y = top - @as(f32, @floatFromInt(i + 1)) * row_h;
+    var row: usize = 0;
+    while (row < win.visible) : (row += 1) {
+        const i = win.first + row;
+        const row_y = top - @as(f32, @floatFromInt(row + 1)) * row_h;
         if (i == selected) {
             ui_pipeline.fillQuadAlpha(popup_x + 5, row_y + 4, popup_w - 10, row_h - 8, mixColor(bg, accent, 0.20), 0.90);
             ui_pipeline.fillQuadAlpha(popup_x + 5, row_y + 4, 3, row_h - 8, accent, 0.82);
@@ -1404,6 +1414,22 @@ fn renderComposerSuggestions(session: *ai_chat.Session, layout: InputLayout, win
                 popup_x + popup_w - SUGGESTION_PAD_X - desc_x,
             );
         }
+    }
+
+    // Scrollbar shown only while the list is windowed, so the user can tell more
+    // suggestions exist above/below and where the selection sits.
+    if (count > win.visible and win.visible > 0) {
+        const sb_w: f32 = 3;
+        const sb_x = popup_x + popup_w - sb_w - 4;
+        ui_pipeline.fillQuadAlpha(sb_x, top - list_h, sb_w, list_h, mixColor(bg, fg, 0.14), 0.5);
+        const count_f: f32 = @floatFromInt(count);
+        const vis_f: f32 = @floatFromInt(win.visible);
+        const first_f: f32 = @floatFromInt(win.first);
+        const thumb_h = @max(20.0, @round(list_h * vis_f / count_f));
+        const max_scroll = count_f - vis_f;
+        const scroll_frac = if (max_scroll > 0) first_f / max_scroll else 0;
+        const thumb_top = top - (list_h - thumb_h) * scroll_frac;
+        ui_pipeline.fillQuadAlpha(sb_x, thumb_top - thumb_h, sb_w, thumb_h, mixColor(bg, accent, 0.5), 0.85);
     }
 
     if (detail.count > 0) {


### PR DESCRIPTION
## 问题

AI Chat 输入框里用 `$` 触发的技能/工具建议列表，在技能/工具较多时**顶部显示不全**——最上面的几项被裁出窗口外（见用户截图：`$websearch` 只剩底部一条）。

## 根因

`renderComposerSuggestions`（`src/renderer/ai_chat_renderer.zig`）把所有匹配项**一次性渲染**：

```zig
const list_h = row_h * @as(f32, @floatFromInt(count)); // 无上限
```

弹窗在 y-up 坐标里从输入框**向上生长**，`popup_h` 随项数线性增长，项数一多就顶穿窗口上沿，最上面的项被裁掉。命令面板（`overlays.zig`）早已用"按高度封顶 + 跟随选中滚动 + 滚动条"解决了同类问题，而 composer 建议列表缺失这套逻辑。

## 改动

- **`src/ai_chat_layout.zig`**：新增纯函数 `composerSuggestionWindow`（及 `SuggestionWindow`）——按可用高度封顶可见行数、跟随选中项滚动；这是个无 GL/字体依赖的纯逻辑函数，配套 7 个单元测试纳入 fast 测试套件。
- **`src/renderer/ai_chat_renderer.zig`**：把"聊天头部下沿"作为上限 `ceiling_y` 传入 `renderComposerSuggestions`，据此算出可用高度，只渲染可见窗口；列表被裁剪时画一条细滚动条提示还有更多项、并指示当前位置。

行为与同属 `$` 功能的命令面板保持一致。

## 验证

- `zig build test`（快速套件，含 7 个新增窗口数学用例）— 通过 (exit 0)
- `zig build test-full`（含跨目标完整 app 测试二进制编译）— 通过 (exit 0)
- `zig build macos-app -Dtarget=aarch64-macos`（渲染器实际参与编译）— 通过 (exit 0)

## 评审要点

- 选择项导航是键盘驱动（上下/Tab/Enter，且循环），无逐行鼠标命中测试，因此渲染端做"裁剪+跟随选中滚动"即可，未触及点击映射。
- 可用高度为负（极小窗口）时，纯函数兜底至少渲染 1 行，保证选中项始终可见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
