### PR TITLE
fix(macos): stop quit from ringing the system bell

### DIFF
--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -194,8 +194,18 @@ static atomic_bool g_quit_pending = false;
     // the close_requested flag and exits cleanly; App.run() then drains the
     // quit flag and breaks out of its idle loop. We return Cancel so AppKit
     // doesn't tear NSApp down underneath us — zig owns the actual shutdown.
+    //
+    // Only message WispTerm's own terminal windows. -[NSApplication windows]
+    // also returns AppKit's borderless helper windows (e.g. TUINSWindow from
+    // the text-input / Touch Bar subsystem), which have no close button and so
+    // are not closable. Sending -performClose: to a non-closable window makes
+    // AppKit emit the system alert sound, so quitting (Dock menu Quit, ⌘Q, menu
+    // Quit — all routed here) would ring a bell. Gating on our delegate class
+    // skips those helper windows; our terminal windows all carry it (and are
+    // closable), so the intended shutdown is unchanged.
     NSArray<NSWindow *> *snapshot = [[NSApp windows] copy];
     for (NSWindow *win in snapshot) {
+        if (![win.delegate isKindOfClass:[WispTermMacWindowDelegate class]]) continue;
         [win performClose:nil];
     }
     [snapshot release];


### PR DESCRIPTION
## 问题

macOS 上退出 WispTerm——右击 Dock 图标 → 退出,以及 `⌘Q`、菜单栏 Quit(三者都经 `-applicationShouldTerminate:`)——会发出一声系统警告音("叮")。

## 根因

`-applicationShouldTerminate:` 对 `-[NSApplication windows]` 里的**每一个**窗口调用 `-performClose:`。而 `-[NSApplication windows]` 除了 WispTerm 的终端主窗口(普通 `NSWindow`,含 `NSWindowStyleMaskClosable`)外,还包含 AppKit 文本输入 / Touch Bar 子系统创建的 borderless 辅助窗口 `TUINSWindow`(无关闭按钮、不可关闭)。

`-performClose:` 的 Cocoa 契约是:当目标窗口没有关闭按钮或不可关闭时,它**不关窗、改为发出系统警告音**(`NSBeep`)。对 `TUINSWindow` 调用 `-performClose:` 正是响铃来源。

同源旁证:该文件的 `-performKeyEquivalent:` / `-doCommandBySelector:` 早已为消除按键场景的 system beep 做过类似规避,唯独退出路径漏了。

## 修复

退出循环按 delegate 类过滤,只对挂着 `WispTermMacWindowDelegate` 的窗口(即 WispTerm 自己的终端窗口,全部 closable)调用 `-performClose:`,跳过 AppKit 辅助窗口:

```objc
for (NSWindow *win in snapshot) {
    if (![win.delegate isKindOfClass:[WispTermMacWindowDelegate class]]) continue;
    [win performClose:nil];
}
```

## 验证

- `zig build macos-app` 编译通过
- 运行时用 lldb 给 `NSBeep` 下断点统计命中次数,走 **1 → 2 → 2**:
  - 直调 `NSBeep()` = 1(断点有效)
  - 对 `TUINSWindow` 调 `-performClose:` = 2(确定性复现根因)
  - 调修复后的真实 `-applicationShouldTerminate:` = **仍为 2**(退出路径不再触发 `NSBeep`)
- 修复版进程随退出流程干净结束(退出逻辑未受影响)
- `zig build test-macos-ui` 通过(`EXIT=0`,无 fail/panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
