### PR TITLE
diag(ssh-download): instrument SSH download + agent copy_file paths (#268)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -81,6 +81,7 @@ pub const ui_pipeline = @import("renderer/ui_pipeline.zig");
 pub const titlebar = @import("renderer/titlebar.zig");
 pub const input = @import("input.zig");
 pub const overlays = @import("renderer/overlays.zig");
+const preview_diagnostics = @import("preview_diagnostics.zig");
 pub const post_process = @import("renderer/post_process.zig");
 pub const gpu = @import("renderer/gpu/gpu.zig");
 pub const split_layout = @import("appwindow/split_layout.zig");
@@ -6359,6 +6360,11 @@ test "agent surface callbacks reject a surface that is not registered as live" {
 fn agentSshConnectionForSurface(ctx: *anyopaque, surface_id: []const u8) ?Surface.SshConnection {
     _ = ctx;
     if (surface_id.len == 0) return null;
+    // This runs on the agent request worker thread, but `g_tabs`/`g_tab_count`
+    // are thread-local to the UI thread. A worker-thread call therefore sees an
+    // empty tab list and resolves nothing — the root of copy_file's "connection
+    // is unavailable" (#268). Log the tab count actually visible here so a log
+    // capture distinguishes "empty thread-local view" from "surface_id mismatch".
     for (0..tab.g_tab_count) |tab_index| {
         const tab_state = tab.g_tabs[tab_index] orelse continue;
         if (tab_state.kind != .terminal) continue;
@@ -6366,9 +6372,19 @@ fn agentSshConnectionForSurface(ctx: *anyopaque, surface_id: []const u8) ?Surfac
         while (it.next()) |entry| {
             const sfc = entry.surface;
             if (!std.mem.eql(u8, sfc.remote_id[0..], surface_id)) continue;
+            preview_diagnostics.debug("agent-ssh-conn", &.{
+                .{ .key = "stage", .value = "match" },
+                .{ .key = "tabs", .value = if (tab.g_tab_count == 0) "0" else "n" },
+                .{ .key = "has_conn", .value = if (sfc.ssh_connection != null) "true" else "false" },
+            });
             return sfc.ssh_connection; // value copy (or null if not SSH)
         }
     }
+    preview_diagnostics.debug("agent-ssh-conn", &.{
+        .{ .key = "stage", .value = "no-match" },
+        // "0" here means the worker thread sees an empty thread-local tab list.
+        .{ .key = "tabs", .value = if (tab.g_tab_count == 0) "0" else "n" },
+    });
     return null;
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -3372,7 +3372,21 @@ fn handleTerminalSelectionPress(ev: platform_input.MouseButtonEvent, xpos: f64, 
     }
 
     const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
-    switch (terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, primaryOpenMod(ev.ctrl, ev.super), ev.shift, ev.alt)) {
+    const open_mod = primaryOpenMod(ev.ctrl, ev.super);
+    const click_action = terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, open_mod, ev.shift, ev.alt);
+    // Only instrument the SSH download gesture (Ctrl/Cmd+Shift) so the log is not
+    // flooded by every terminal click. This shows whether a click the user
+    // intended as a download even routes to `download_ssh_file`, or falls back to
+    // pass-through because the surface carries no SSH connection metadata (#268).
+    if (open_mod and ev.shift and !ev.alt) {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "click" },
+            .{ .key = "launch", .value = @tagName(clicked_surface.launch_kind) },
+            .{ .key = "has_conn", .value = if (clicked_surface.ssh_connection != null) "true" else "false" },
+            .{ .key = "action", .value = @tagName(click_action) },
+        });
+    }
+    switch (click_action) {
         .download_ssh_file => {
             if (downloadTerminalFileAtCell(clicked_surface, cell_pos)) return;
         },
@@ -3916,17 +3930,47 @@ test "input: remote download path kind command shell-quotes paths" {
 }
 
 fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
-    if (surface.launch_kind != .ssh) return false;
-    const conn = surface.ssh_connection orelse return false;
+    if (surface.launch_kind != .ssh) {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "not-ssh" },
+            .{ .key = "launch", .value = @tagName(surface.launch_kind) },
+        });
+        return false;
+    }
+    const conn = surface.ssh_connection orelse {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "no-conn" },
+        });
+        return false;
+    };
     const allocator = AppWindow.g_allocator orelse return false;
 
-    const path = extractDownloadPathAtCell(allocator, surface, cell_pos) orelse return false;
+    const path = extractDownloadPathAtCell(allocator, surface, cell_pos) orelse {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "no-path" },
+        });
+        return false;
+    };
     defer allocator.free(path);
 
     var ls_prefix_buf: [256]u8 = undefined;
     const ls_prefix = lsPrefixForCell(surface, cell_pos, &ls_prefix_buf);
+    preview_diagnostics.debug("download", &.{
+        .{ .key = "stage", .value = "extract" },
+        .{ .key = "host", .value = conn.host() },
+        .{ .key = "path", .value = path },
+        .{ .key = "ls_prefix", .value = ls_prefix orelse "" },
+    });
 
     const resolved_path = resolveTerminalPreviewPath(allocator, surface, path, ls_prefix) catch |err| {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "resolve-failed" },
+            .{ .key = "path", .value = path },
+            .{ .key = "err", .value = @errorName(err) },
+        });
         if (err == error.CwdUnavailable) {
             file_explorer.setTransferStatusForKind(.download, .failed, "SSH cwd unknown");
             overlays.showSshCwdFallbackPrompt();
@@ -3938,23 +3982,52 @@ fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
     defer allocator.free(resolved_path);
 
     const name = basenameForPreview(resolved_path);
-    if (name.len == 0) return false;
-    const is_dir = remotePathIsDirectoryForDownload(allocator, &conn, resolved_path) orelse false;
+    if (name.len == 0) {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "no-name" },
+            .{ .key = "resolved", .value = resolved_path },
+        });
+        return false;
+    }
+    const dir_probe = remotePathIsDirectoryForDownload(allocator, &conn, resolved_path);
+    const is_dir = dir_probe orelse false;
+    preview_diagnostics.debug("download", &.{
+        .{ .key = "stage", .value = "probe" },
+        .{ .key = "resolved", .value = resolved_path },
+        // Distinguishes "probe ran and said file/dir" from "probe ssh helper
+        // failed" (null) — the latter points at the SSH metadata channel (#268).
+        .{ .key = "probe", .value = if (dir_probe == null) "failed" else if (is_dir) "dir" else "file" },
+    });
 
     var dl_buf: [260]u8 = undefined;
     const dl_path = getDownloadsFolder(&dl_buf);
     if (dl_path.len == 0) {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "no-downloads-folder" },
+        });
         file_explorer.setTransferStatusForKind(.download, .failed, "Download folder missing");
         return true;
     }
 
     var dst_buf: [512]u8 = undefined;
     const dst = platform_local_path.joinInto(dst_buf[0..], dl_path, name) orelse {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "abort" },
+            .{ .key = "reason", .value = "dst-too-long" },
+        });
         file_explorer.setTransferStatusForKind(.download, .failed, "Path too long");
         return true;
     };
 
-    _ = file_explorer.downloadRemotePathToPath(resolved_path, dst, name, &conn, is_dir);
+    const dispatched = file_explorer.downloadRemotePathToPath(resolved_path, dst, name, &conn, is_dir);
+    preview_diagnostics.debug("download", &.{
+        .{ .key = "stage", .value = "dispatch" },
+        .{ .key = "resolved", .value = resolved_path },
+        .{ .key = "dst", .value = dst },
+        .{ .key = "dispatched", .value = if (dispatched) "true" else "false" },
+    });
     return true;
 }
 


### PR DESCRIPTION
## Summary

Diagnostics to root-cause #268 (Ctrl+Shift+Click SSH download + agent `copy_file` both fail with *"connection is unavailable"*, reported as a v1.26.0 regression).

**Key finding from reading the code:** the full `v1.25.0..v1.26.0` diff contains **no change** to the SSH download / `ssh_connection` / `scp` / `copy_file` paths — it's only `preview_diagnostics` logging, the Copilot-sidebar transcript selection, the sidebar-copy fix, and the Windows config-dir bring-up fuse (#263). So the regression cannot be pinned by reading the diff; we need runtime evidence. v1.26.0 added preview diagnostics but never instrumented the **download** path.

This PR is **diagnostics only** (control flow unchanged), gated behind the existing `-Ddebug-console` build. A single log capture will tell us which layer breaks.

## What's instrumented

- **`input.zig` click routing** (`scope=download stage=click`): logs `launch`, `has_conn`, and the chosen `action` for a Ctrl/Cmd+Shift gesture. `has_conn=false` / `action=pass_through` ⇒ the surface carries no SSH connection metadata and the click never reaches the download code.
- **`downloadTerminalFileAtCell`**: every early-exit and the dispatch now log a `reason` (`not-ssh`/`no-conn`/`no-path`/`no-name`/`no-downloads-folder`/`dst-too-long`), the remote `test -d/-e` `probe` result (`file`/`dir`/`failed`), and whether scp was `dispatched`.
- **`agentSshConnectionForSurface`** (`scope=agent-ssh-conn`): logs `match`/`no-match` and `tabs=0|n`. `tabs=0` confirms the agent **worker thread** sees an empty thread-local `g_tabs` — the pending "agent-worker snapshot threading Stage 2" gap (`ToolSurface` carries `is_ssh` but not the `SshConnection`, so the connection is re-resolved live on the worker).

## How the reporter captures it

Run the `-Ddebug-console` build, then:
1. Connect via the SSH profile launcher, `ls` a directory.
2. Ctrl+Shift left-click a filename (reproduces "no reaction").
3. Ask Copilot to `copy_file` a remote file (reproduces "connection is unavailable").
4. Send back the `scope=download` and `scope=agent-ssh-conn` lines from `%APPDATA%\wispterm\wispterm-debug.log`.

## Testing

- `zig build test` — PASS
- `zig build test-full` — PASS
- `zig build -Ddebug-console` (full app build, what the reporter runs) — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gRyaXmGPyvPjstGm5AFQy
