### PR TITLE
fix(macos): bind Copy to Cmd+C only, not Cmd+Shift+C

### DIFF
--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -148,9 +148,11 @@ pub const Set = struct {
                     b.trigger.mods.win = true;
                 }
             }
-            // Plain Cmd+C alongside Cmd+Shift+C, matching the macOS copy
-            // convention (Cmd+Shift+C still works as the historic muscle memory).
-            set.appendIfRoom(.{ .trigger = .{ .mods = .{ .win = true }, .key_code = 'C' }, .action = .copy });
+            // Copy is just Cmd+C on macOS. Windows/Linux keep Ctrl+Shift+C
+            // because Ctrl+C is the terminal's SIGINT and can't double as copy;
+            // Cmd+C has no such conflict, so the migrated Cmd+Shift+C is replaced
+            // by the single conventional shortcut rather than kept alongside it.
+            set.replaceTrigger(.copy, .{ .mods = .{ .win = true }, .key_code = 'C' });
         }
         return set;
     }
@@ -485,6 +487,28 @@ test "keybind defaults include global quake and command palette" {
         .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }).?);
+}
+
+test "copy default: macOS binds Cmd+C only, other platforms keep Ctrl+Shift+C" {
+    const set = Set.defaults();
+    if (builtin.target.os.tag == .macos) {
+        // macOS copy is the single conventional Cmd+C.
+        try std.testing.expectEqual(@as(?Action, .copy), set.lookupApp(.{
+            .mods = .{ .win = true },
+            .key_code = 'C',
+        }));
+        // The migrated Cmd+Shift+C is intentionally dropped (not bound).
+        try std.testing.expectEqual(@as(?Action, null), set.lookupApp(.{
+            .mods = .{ .win = true, .shift = true },
+            .key_code = 'C',
+        }));
+    } else {
+        // Elsewhere copy stays Ctrl+Shift+C — Ctrl+C is the terminal's SIGINT.
+        try std.testing.expectEqual(@as(?Action, .copy), set.lookupApp(.{
+            .mods = .{ .ctrl = true, .shift = true },
+            .key_code = 'C',
+        }));
+    }
 }
 
 test "keybind overriding an action removes its old default trigger" {

--- a/src/platform/menu_macos.zig
+++ b/src/platform/menu_macos.zig
@@ -117,7 +117,7 @@ fn buildDefaultMenu() void {
 
     // Edit.
     wispterm_macos_menu_begin_submenu("Edit");
-    wispterm_macos_menu_add_item("Copy", id(.copy), "c", AppMod | ModShift);
+    wispterm_macos_menu_add_item("Copy", id(.copy), "c", AppMod);
     wispterm_macos_menu_add_item("Paste", id(.paste), "v", AppMod);
     wispterm_macos_menu_add_item("Paste Image", id(.paste_image), "v", AppMod | ModShift);
     wispterm_macos_menu_end_submenu();


### PR DESCRIPTION
Follow-up to #271, which was merged before this commit landed, so the macOS copy refinement is not yet in `main`.

## What

On macOS, `Set.defaults()` previously bound copy to **both** `Cmd+Shift+C` (migrated from the Ctrl default) and `Cmd+C`. Windows/Linux keep `Ctrl+Shift+C` because `Ctrl+C` is the terminal's SIGINT and can't double as copy — but macOS has no such conflict on `Cmd+C`, so copy should be the single conventional `Cmd+C`.

## Changes

- **`keybind.zig`** — macOS copy is now just `Cmd+C` (`replaceTrigger` instead of appending `Cmd+C` alongside the migrated `Cmd+Shift+C`). Other platforms unchanged (`Ctrl+Shift+C`).
- **`menu_macos.zig`** — Edit ▸ Copy key equivalent drops Shift → shows `⌘C`.
- **`keybind.zig` test** — pins the per-platform copy default (`Cmd+C` on macOS, `Ctrl+Shift+C` elsewhere). The existing menu drift-guard test (from #271) keeps the menu modifier in sync with `firstForAction(.copy)`.

## Note

`main` after #271 is self-consistent (menu `⌘⇧C` ↔ keybind `Cmd+Shift+C`, drift-guard passes); this PR is purely the copy refinement, not a fix for a broken state.

## Verification

- `zig build test` (fast, incl. keybind copy test) ✓
- `zig build test-macos-menu` (drift guard: menu `⌘C` ↔ keybind `Cmd+C`) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)