### PR TITLE
[codex] Fix SSH profile file helpers

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -7663,6 +7663,7 @@ fn makeAgentToolSurface(
     focused: bool,
 ) anyerror!ai_chat.ToolSurface {
     const snapshot = buildRemoteSurfaceSnapshot(allocator, surface, remote_snapshot.agent_max_history_rows) catch try allocator.dupe(u8, "");
+    const ssh_conn = if (surface.launch_kind == .ssh) surface.ssh_connection else null;
     return ai_chat.ToolSurface.initOwned(
         allocator,
         surface.remote_id[0..],
@@ -7672,8 +7673,9 @@ fn makeAgentToolSurface(
         .{
             .tab_index = tab_index,
             .focused = focused,
-            .is_ssh = surface.launch_kind == .ssh and surface.ssh_connection != null,
+            .is_ssh = surface.launch_kind == .ssh,
             .is_wsl = surface.launch_kind == .wsl,
+            .ssh_connection = ssh_conn,
             .agent_app = surface.agent_detection.app,
             .agent_state = surface.agent_detection.state,
             .agent_confidence = surface.agent_detection.confidence,

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -2230,6 +2230,7 @@ fn resolveFileTarget(ctx: *ToolContext, surface_id: ?[]const u8) !FileTarget {
         return .{ .err = try allocNoSurfaceError(ctx.allocator, snapshot, sid) };
     };
     if (!surface.is_ssh) return .local;
+    if (surface.ssh_connection) |conn| return .{ .remote = conn };
     if (ctx.sshConnectionForSurface(surface.id)) |conn| return .{ .remote = conn };
     return .{ .err = try std.fmt.allocPrint(ctx.allocator, "Surface {s} is an SSH terminal but its connection is unavailable.", .{surface.id}) };
 }
@@ -2243,6 +2244,9 @@ fn resolveCopyEndpoint(ctx: *ToolContext, surface_id: ?[]const u8) !CopyEndpoint
         return .{ .err = try allocNoSurfaceError(ctx.allocator, snapshot, sid) };
     };
     if (surface.is_ssh) {
+        if (surface.ssh_connection) |conn| {
+            return .{ .ssh = .{ .surface = surface, .conn = conn } };
+        }
         if (ctx.sshConnectionForSurface(surface.id)) |conn| {
             return .{ .ssh = .{ .surface = surface, .conn = conn } };
         }
@@ -4182,6 +4186,74 @@ test "copy_file copies a local artifact into wispterm-files by default" {
     try std.testing.expectEqualStrings("artifact-bytes", copied);
     try std.testing.expect(std.mem.indexOf(u8, out, "local_path=") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "wispterm-files") != null);
+}
+
+test "file tool resolution uses ssh connection carried by the request snapshot" {
+    const a = std.testing.allocator;
+    const conn = ToolSshConnection.fromParts(.{
+        .user = "alice",
+        .host = "example.test",
+        .port = "2222",
+        .proxy_jump = "jump.example.test",
+    });
+    var surfaces = try a.alloc(ToolSurface, 1);
+    surfaces[0] = .{
+        .id = try a.dupe(u8, "ssh-surface"),
+        .title = try a.dupe(u8, "SSH"),
+        .cwd = try a.dupe(u8, "/home/alice"),
+        .snapshot = try a.dupe(u8, "$ "),
+        .tab_index = 0,
+        .focused = true,
+        .is_ssh = true,
+        .is_wsl = false,
+        .ssh_connection = conn,
+        .agent_app = .none,
+        .agent_state = .none,
+        .agent_confidence = 0,
+        .ptr = @ptrFromInt(1),
+    };
+    const snapshot = ToolSnapshot{ .surfaces = surfaces, .active_tab = 0 };
+    defer snapshot.deinit(a);
+
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = snapshot,
+        .settings = .{},
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    const target = try resolveFileTarget(&ctx, "ssh-surface");
+    switch (target) {
+        .remote => |remote| {
+            try std.testing.expectEqualStrings("alice", remote.user());
+            try std.testing.expectEqualStrings("example.test", remote.host());
+            try std.testing.expectEqualStrings("2222", remote.port());
+            try std.testing.expectEqualStrings("jump.example.test", remote.proxyJump());
+        },
+        .err => |msg| {
+            defer a.free(msg);
+            return error.TestExpectedEqual;
+        },
+        .local => return error.TestExpectedEqual,
+    }
+
+    const endpoint = try resolveCopyEndpoint(&ctx, "ssh-surface");
+    switch (endpoint) {
+        .ssh => |remote| {
+            try std.testing.expectEqualStrings("ssh-surface", remote.surface.id);
+            try std.testing.expectEqualStrings("alice", remote.conn.user());
+            try std.testing.expectEqualStrings("example.test", remote.conn.host());
+        },
+        .err => |msg| {
+            defer a.free(msg);
+            return error.TestExpectedEqual;
+        },
+        else => return error.TestExpectedEqual,
+    }
 }
 
 test "write_file creates a local file in full permission mode" {

--- a/src/ai_chat_types.zig
+++ b/src/ai_chat_types.zig
@@ -52,6 +52,7 @@ pub const ToolSurface = struct {
     focused: bool,
     is_ssh: bool,
     is_wsl: bool,
+    ssh_connection: ?SshConnection = null,
     agent_app: agent_detector.App = .none,
     agent_state: agent_detector.State = .none,
     agent_confidence: u8 = 0,
@@ -69,6 +70,7 @@ pub const ToolSurface = struct {
         focused: bool,
         is_ssh: bool,
         is_wsl: bool,
+        ssh_connection: ?SshConnection = null,
         agent_app: agent_detector.App = .none,
         agent_state: agent_detector.State = .none,
         agent_confidence: u8 = 0,
@@ -101,6 +103,7 @@ pub const ToolSurface = struct {
             .focused = meta.focused,
             .is_ssh = meta.is_ssh,
             .is_wsl = meta.is_wsl,
+            .ssh_connection = meta.ssh_connection,
             .agent_app = meta.agent_app,
             .agent_state = meta.agent_state,
             .agent_confidence = meta.agent_confidence,
@@ -126,6 +129,7 @@ pub const ToolSurface = struct {
             .focused = self.focused,
             .is_ssh = self.is_ssh,
             .is_wsl = self.is_wsl,
+            .ssh_connection = self.ssh_connection,
             .agent_app = self.agent_app,
             .agent_state = self.agent_state,
             .agent_confidence = self.agent_confidence,
@@ -340,12 +344,19 @@ test "ToolSurface.initOwned dupes borrowed strings and adopts the owned snapshot
     const a = std.testing.allocator;
     var dummy: u8 = 0;
     const snapshot = try a.dupe(u8, "snap");
+    const conn = SshConnection.fromParts(.{
+        .user = "alice",
+        .host = "example.test",
+        .port = "2222",
+        .proxy_jump = "jump.example.test",
+    });
     const id_src = "surface-1";
     const ts = try ToolSurface.initOwned(a, id_src, "title-1", "/work", snapshot, .{
         .tab_index = 3,
         .focused = true,
-        .is_ssh = false,
+        .is_ssh = true,
         .is_wsl = true,
+        .ssh_connection = conn,
         .ptr = @ptrCast(&dummy),
     });
     defer ts.deinit(a);
@@ -357,7 +368,13 @@ test "ToolSurface.initOwned dupes borrowed strings and adopts the owned snapshot
     try std.testing.expect(ts.snapshot.ptr == snapshot.ptr); // ownership moved, no copy
     try std.testing.expectEqual(@as(usize, 3), ts.tab_index);
     try std.testing.expect(ts.focused);
+    try std.testing.expect(ts.is_ssh);
     try std.testing.expect(ts.is_wsl);
+    const stored = ts.ssh_connection orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("alice", stored.user());
+    try std.testing.expectEqualStrings("example.test", stored.host());
+    try std.testing.expectEqualStrings("2222", stored.port());
+    try std.testing.expectEqualStrings("jump.example.test", stored.proxyJump());
 }
 
 test "ToolSurface.initOwned frees the snapshot and earlier dupes when an allocation fails" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -4250,9 +4250,8 @@ fn handleTerminalSelectionPress(ev: platform_input.MouseButtonEvent, xpos: f64, 
     const open_mod = primaryOpenMod(ev.ctrl, ev.super);
     const click_action = terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, open_mod, ev.shift, ev.alt);
     // Only instrument the SSH download gesture (Ctrl/Cmd+Shift) so the log is not
-    // flooded by every terminal click. This shows whether a click the user
-    // intended as a download even routes to `download_ssh_file`, or falls back to
-    // pass-through because the surface carries no SSH connection metadata (#268).
+    // flooded by every terminal click. This shows whether a download gesture
+    // routed to `download_ssh_file` and whether the surface had SSH metadata.
     if (open_mod and ev.shift and !ev.alt) {
         preview_diagnostics.debug("download", &.{
             .{ .key = "stage", .value = "click" },
@@ -4818,7 +4817,8 @@ fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
             .{ .key = "stage", .value = "abort" },
             .{ .key = "reason", .value = "no-conn" },
         });
-        return false;
+        file_explorer.setTransferStatusForKind(.download, .failed, "SSH connection unavailable");
+        return true;
     };
     const allocator = AppWindow.g_allocator orelse return false;
 
@@ -4866,13 +4866,20 @@ fn downloadTerminalFileAtCell(surface: *Surface, cell_pos: CellPos) bool {
         return false;
     }
     const dir_probe = remotePathIsDirectoryForDownload(allocator, &conn, resolved_path);
-    const is_dir = dir_probe orelse false;
+    const is_dir = dir_probe orelse {
+        preview_diagnostics.debug("download", &.{
+            .{ .key = "stage", .value = "probe-failed" },
+            .{ .key = "resolved", .value = resolved_path },
+        });
+        file_explorer.setTransferStatusForKind(.download, .failed, "SSH helper unavailable");
+        return true;
+    };
     preview_diagnostics.debug("download", &.{
         .{ .key = "stage", .value = "probe" },
         .{ .key = "resolved", .value = resolved_path },
         // Distinguishes "probe ran and said file/dir" from "probe ssh helper
         // failed" (null) — the latter points at the SSH metadata channel (#268).
-        .{ .key = "probe", .value = if (dir_probe == null) "failed" else if (is_dir) "dir" else "file" },
+        .{ .key = "probe", .value = if (is_dir) "dir" else "file" },
     });
 
     var dl_buf: [260]u8 = undefined;

--- a/src/input/terminal_link_action.zig
+++ b/src/input/terminal_link_action.zig
@@ -27,7 +27,8 @@ pub fn primaryOpenMod(ctrl: bool, super: bool) bool {
 }
 
 pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, has_ssh_conn: bool, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
-    if (mod and shift and !alt and launch_kind == .ssh and has_ssh_conn) return .download_ssh_file;
+    _ = has_ssh_conn;
+    if (mod and shift and !alt and launch_kind == .ssh) return .download_ssh_file;
     if (mod and !shift and !alt) return .open_url_or_preview;
     return .pass_through;
 }
@@ -96,7 +97,7 @@ test "terminal path click action maps ctrl shift ssh to download" {
         terminalPathClickAction(.ssh, true, true, true, false),
     );
     try std.testing.expectEqual(
-        TerminalPathClickAction.pass_through,
+        TerminalPathClickAction.download_ssh_file,
         terminalPathClickAction(.ssh, false, true, true, false),
     );
     try std.testing.expectEqual(

--- a/src/platform/remote_file.zig
+++ b/src/platform/remote_file.zig
@@ -159,6 +159,14 @@ pub fn sshExecCaptureFull(allocator: std.mem.Allocator, conn: anytype, command: 
     argc += 1;
     argv_buf[argc] = "ConnectTimeout=8";
     argc += 1;
+    argv_buf[argc] = "-o";
+    argc += 1;
+    argv_buf[argc] = "ServerAliveInterval=5";
+    argc += 1;
+    argv_buf[argc] = "-o";
+    argc += 1;
+    argv_buf[argc] = "ServerAliveCountMax=2";
+    argc += 1;
     if (conn.usesPasswordAuth()) {
         argv_buf[argc] = "-o";
         argc += 1;

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -33,6 +33,8 @@ const SshTunnel = struct {
     host_len: usize = 0,
     ssh_port_buf: [16]u8 = undefined,
     ssh_port_len: usize = 0,
+    proxy_jump_buf: [256]u8 = undefined,
+    proxy_jump_len: usize = 0,
 
     fn init(child: std.process.Child, conn: *const ssh_connection.SshConnection, remote_port: u16, local_port: u16, local_host: []const u8, remote_host: []const u8) SshTunnel {
         var tunnel: SshTunnel = .{
@@ -45,6 +47,7 @@ const SshTunnel = struct {
         tunnel.user_len = copyBounded(tunnel.user_buf[0..], conn.user());
         tunnel.host_len = copyBounded(tunnel.host_buf[0..], conn.host());
         tunnel.ssh_port_len = copyBounded(tunnel.ssh_port_buf[0..], conn.port());
+        tunnel.proxy_jump_len = copyBounded(tunnel.proxy_jump_buf[0..], conn.proxyJump());
         return tunnel;
     }
 
@@ -54,7 +57,8 @@ const SshTunnel = struct {
             std.mem.eql(u8, self.remoteHost(), remote_host) and
             std.mem.eql(u8, self.user(), conn.user()) and
             std.mem.eql(u8, self.host(), conn.host()) and
-            std.mem.eql(u8, self.sshPort(), conn.port());
+            std.mem.eql(u8, self.sshPort(), conn.port()) and
+            std.mem.eql(u8, self.proxyJump(), conn.proxyJump());
     }
 
     fn localHost(self: *const SshTunnel) []const u8 {
@@ -75,6 +79,10 @@ const SshTunnel = struct {
 
     fn sshPort(self: *const SshTunnel) []const u8 {
         return self.ssh_port_buf[0..self.ssh_port_len];
+    }
+
+    fn proxyJump(self: *const SshTunnel) []const u8 {
+        return self.proxy_jump_buf[0..self.proxy_jump_len];
     }
 };
 
@@ -466,6 +474,26 @@ test "ssh_tunnel configures browser tunnel helper as hidden background process" 
     try std.testing.expectEqual(std.process.Child.StdIo.Ignore, child.stdout_behavior);
     try std.testing.expectEqual(std.process.Child.StdIo.Inherit, child.stderr_behavior);
     try std.testing.expect(child.create_no_window);
+}
+
+test "ssh_tunnel cache key distinguishes proxy jump" {
+    const child = std.process.Child.init(&.{"ssh.exe"}, std.testing.allocator);
+    const conn_a = ssh_connection.SshConnection.fromParts(.{
+        .user = "alice",
+        .host = "example.test",
+        .port = "2222",
+        .proxy_jump = "jump-a.example.test",
+    });
+    const conn_b = ssh_connection.SshConnection.fromParts(.{
+        .user = "alice",
+        .host = "example.test",
+        .port = "2222",
+        .proxy_jump = "jump-b.example.test",
+    });
+    const tunnel = SshTunnel.init(child, &conn_a, 8888, 50123, "127.0.0.1", "127.0.0.1");
+
+    try std.testing.expect(tunnel.matches(&conn_a, 8888, "127.0.0.1", "127.0.0.1"));
+    try std.testing.expect(!tunnel.matches(&conn_b, 8888, "127.0.0.1", "127.0.0.1"));
 }
 
 test "reservePreferredLocalPort returns the preferred port when it is free" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -19,6 +19,18 @@ const build_options = @import("build_options");
 const std = @import("std");
 const app_metadata = @import("app_metadata.zig");
 
+test "input ssh download surfaces missing connection and helper probe failures" {
+    const input_source = @embedFile("input.zig");
+    try std.testing.expect(std.mem.indexOf(u8, input_source, "\"SSH connection unavailable\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, input_source, "\"SSH helper unavailable\"") != null);
+}
+
+test "remote file ssh helpers include short keepalive options" {
+    const remote_file_source = @embedFile("platform/remote_file.zig");
+    try std.testing.expect(std.mem.indexOf(u8, remote_file_source, "\"ServerAliveInterval=5\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, remote_file_source, "\"ServerAliveCountMax=2\"") != null);
+}
+
 test {
     _ = @import("input/command_dispatch.zig");
     _ = @import("input/click_tracker.zig");


### PR DESCRIPTION
## Summary
- Carry SSH connection metadata in AI tool snapshots so worker-thread file tools can resolve SSH surfaces without scanning UI-thread tab state.
- Route SSH Ctrl+Shift+Click downloads by launch kind and surface missing-connection/helper-probe failures as visible transfer errors.
- Add SSH helper keepalive coverage and include ProxyJump in browser tunnel reuse keys.

## Root Cause
Agent file tools resolved SSH connections through a host callback that can run on the agent request worker thread, where UI-thread tab state is unavailable. SSH download clicks also depended on connection metadata before entering the download handler, causing missing metadata to look like a no-op instead of a diagnosable failure.

## Validation
- `zig build test`
- `zig build test-full`
