### PR TITLE
[codex] Manage first-party agent tool toggles

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -173,6 +173,13 @@ Use `$skill-name your request` to explicitly load a skill for the next request.
 The loaded skill is stored as a replayable tool result in the chat history, so
 existing conversations stay reproducible even if the skill file changes later.
 
+Open **Skill Center** to inspect prompt skills, imported executable tools, and
+first-party WispTerm Agent tools such as web, terminal, file, docs, and memory
+tools. Imported executable tools keep their existing enable/disable state.
+First-party tool state is stored separately in `agent_tools.json`. Turning a
+built-in tool off hides it from newly built AI request schemas/tool lists, and
+runtime execution rejects stale or hallucinated calls for that disabled tool.
+
 Local slash commands (handled in the panel, without calling the model):
 
 - `/skills` lists discovered local skills.

--- a/docs/ai.html
+++ b/docs/ai.html
@@ -188,7 +188,7 @@ ai-agent-output-limit       = 16384</code></pre>
           <div class="feature">
             <h3>Skill locations</h3>
             <p>WispTerm discovers <code>SKILL.md</code> files under the platform config directory (<code>%APPDATA%\wispterm</code> on Windows, <code>~/Library/Application Support/wispterm</code> on macOS) in <code>skills/</code> and <code>plugins/skills/</code>, plus the same two sub-paths next to the executable and in the current working directory.</p>
-            <p>Skill Center also manages local executable tools. Imported tools are stored under the WispTerm config directory, documented by <code>SKILL.md</code>, and only enabled tools are advertised to AI Agent sessions. A tool can provide <code>--skill</code>, ship a sibling <code>SKILL.md</code>, or let WispTerm draft one with the configured AI profile when no documentation exists.</p>
+            <p>Skill Center also manages Agent tools. Imported executable tools are stored under the WispTerm config directory with a canonical <code>SKILL.md</code> and keep their own enable state. First-party WispTerm tools, including web, terminal, file, docs, and memory tools, appear in the same inventory; their state is stored separately in <code>agent_tools.json</code>. Turning a built-in tool off hides it from newly built AI request tool lists and blocks stale or hallucinated calls at runtime.</p>
           </div>
           <div class="feature">
             <h3>Load a skill</h3>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -168,6 +168,12 @@ WispTerm stores the binary, keeps a canonical `SKILL.md`, and exposes enabled
 tools as AI Agent function tools. If a binary has neither `--skill` nor a
 packaged `SKILL.md`, WispTerm can draft one from limited metadata with your
 configured AI profile and asks you to review it before enabling the tool.
+Imported executable tools keep their existing enable/disable state.
+First-party WispTerm Agent tools, including web, terminal, file, docs, and
+memory tools, appear in the same inventory with separate state in
+`agent_tools.json`. Turning a built-in tool off hides it from newly built AI
+request schemas/tool lists, and runtime execution rejects stale or hallucinated
+calls for that disabled tool.
 
 ## How Do I Generate a Diagnostic Report?
 

--- a/docs/superpowers/plans/2026-06-22-first-party-tool-disable.md
+++ b/docs/superpowers/plans/2026-06-22-first-party-tool-disable.md
@@ -1,0 +1,1393 @@
+# First-Party Agent Tool Disable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Skill Center display WispTerm first-party AI Agent tools and let users turn them off with both schema-level hiding and runtime dispatch rejection.
+
+**Architecture:** Add a focused first-party tool catalog/state module, feed its disabled-tool snapshot into AI request schema generation and runtime dispatch, then add first-party rows to the existing Skill Center mixed entry model. Imported binary tool manifests remain independent; first-party state is persisted in one config-directory JSON file.
+
+**Tech Stack:** Zig 0.15, WispTerm Skill Center model/renderer, AI Agent protocol builders, `platform/dirs.zig`, `platform/atomic_file.zig`, `zig build test`, `zig build test-full`.
+
+---
+
+## File Structure
+
+- Create `src/first_party_tools.zig`: first-party tool catalog, disabled-state parsing, atomic state writes, and pure tests.
+- Modify `src/test_fast.zig` and `src/test_main.zig`: import `first_party_tools.zig` so its tests run in both suites.
+- Modify `src/ai_chat_protocol.zig`: add disabled first-party tool filtering to all tool schema emitters and add drift tests against the catalog.
+- Modify `src/ai_chat_types.zig`: carry a disabled first-party tool name snapshot in `AgentSettings`.
+- Modify `src/ai_chat.zig`: own/reload global disabled first-party state, clone it into `ChatRequest`, and pass it into request params/tool contexts.
+- Modify `src/ai_chat_request.zig`: pass disabled first-party state into leaf tool contexts and block disabled `subagent` before its special handler runs.
+- Modify `src/ai_chat_tools.zig`: reject disabled first-party tool calls before any tool-specific side effect.
+- Modify `src/skill_center.zig`: add first-party tool row data and model tests.
+- Modify `src/AppWindow.zig`: merge first-party rows into Skill Center scan results, toggle persisted state, reload AI state, and render built-in row metadata.
+- Modify `src/i18n.zig`: change Skill Center legend/status text from "enable" to "toggle" in English and Chinese.
+- Modify `docs/ai-agent.md`, `docs/ai.html`, and `docs/faq.md`: document first-party tool enable/disable behavior.
+
+---
+
+### Task 1: First-Party Tool Catalog And State File
+
+**Files:**
+- Create: `src/first_party_tools.zig`
+- Modify: `src/test_fast.zig`
+- Modify: `src/test_main.zig`
+
+- [ ] **Step 1: Write failing tests for catalog and state parsing**
+
+Create `src/first_party_tools.zig` with only imports, type declarations, and these tests. The referenced functions are intentionally missing in this step.
+
+```zig
+const std = @import("std");
+
+test "first_party_tools: active definitions include webread and the local command tool" {
+    const a = std.testing.allocator;
+    const defs = try activeDefinitions(a);
+    defer freeDefinitions(a, defs);
+
+    try std.testing.expect(isKnownActive(defs, "webread"));
+    try std.testing.expect(isKnown(platformLocalCommandNameForTest()));
+}
+
+test "first_party_tools: disabled state json filters unknown and duplicate names" {
+    const a = std.testing.allocator;
+    var disabled = try parseDisabledToolsJson(
+        a,
+        \\{"disabled":["webread","missing_tool","webread","pubmed"]}
+    );
+    defer disabled.deinit(a);
+
+    try std.testing.expect(disabled.contains("webread"));
+    try std.testing.expect(disabled.contains("pubmed"));
+    try std.testing.expect(!disabled.contains("missing_tool"));
+    try std.testing.expectEqual(@as(usize, 2), disabled.names.len);
+}
+
+test "first_party_tools: malformed state falls back to empty when loaded from path" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "agent_tools.json", .data = "not json" });
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    var disabled = loadDisabledToolsFromPath(a, path) catch DisabledTools.empty();
+    defer disabled.deinit(a);
+    try std.testing.expectEqual(@as(usize, 0), disabled.names.len);
+}
+
+test "first_party_tools: toggled state writes and reads atomically" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    var current = DisabledTools.empty();
+    var next = try toggledDisabledTools(a, current, "webread");
+    defer next.deinit(a);
+    try writeDisabledToolsToPath(a, path, next);
+
+    var loaded = try loadDisabledToolsFromPath(a, path);
+    defer loaded.deinit(a);
+    try std.testing.expect(loaded.contains("webread"));
+
+    var enabled_again = try toggledDisabledTools(a, loaded, "webread");
+    defer enabled_again.deinit(a);
+    try std.testing.expect(!enabled_again.contains("webread"));
+}
+```
+
+- [ ] **Step 2: Import the new module in test aggregators**
+
+Add this line to the import block in both `src/test_fast.zig` and `src/test_main.zig`:
+
+```zig
+    _ = @import("first_party_tools.zig");
+```
+
+- [ ] **Step 3: Run the fast test and verify it fails for missing symbols**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: FAIL with errors naming missing declarations such as `activeDefinitions`, `DisabledTools`, or `parseDisabledToolsJson`.
+
+- [ ] **Step 4: Implement the catalog and disabled-state helpers**
+
+Replace `src/first_party_tools.zig` with the tests from Step 1 plus this implementation above the tests:
+
+```zig
+const std = @import("std");
+const platform_atomic_file = @import("platform/atomic_file.zig");
+const platform_dirs = @import("platform/dirs.zig");
+const platform_process = @import("platform/process.zig");
+const platform_pty_command = @import("platform/pty_command.zig");
+
+const MAX_STATE_BYTES: usize = 64 * 1024;
+const STATE_BASENAME = "agent_tools.json";
+
+pub const Category = enum {
+    terminal,
+    file,
+    web,
+    docs,
+    memory,
+    integration,
+    session,
+    agent,
+};
+
+pub const Definition = struct {
+    name: []const u8,
+    label: []const u8,
+    description: []const u8,
+    category: Category,
+    disableable: bool = true,
+};
+
+const static_definitions = [_]Definition{
+    .{ .name = "terminal_list", .label = "terminal_list", .description = "List WispTerm terminal surfaces visible to the agent.", .category = .terminal },
+    .{ .name = "terminal_context", .label = "terminal_context", .description = "Report the current selected terminal write context.", .category = .terminal },
+    .{ .name = "terminal_snapshot", .label = "terminal_snapshot", .description = "Read a bounded text snapshot from terminal surfaces.", .category = .terminal },
+    .{ .name = "terminal_select", .label = "terminal_select", .description = "Select the terminal surface used for subsequent write tools.", .category = .terminal },
+    .{ .name = "ssh_session_exec", .label = "ssh_session_exec", .description = "Run a shell command in an already-open SSH terminal surface.", .category = .terminal },
+    .{ .name = "terminal_repl_exec", .label = "terminal_repl_exec", .description = "Send text to an already-open interactive REPL or agent app.", .category = .terminal },
+    .{ .name = "terminal_answer_prompt", .label = "terminal_answer_prompt", .description = "Answer an approval prompt in an agent terminal surface.", .category = .terminal },
+    .{ .name = "ask_user", .label = "ask_user", .description = "Ask the user a blocking multiple-choice question.", .category = .agent },
+    .{ .name = "read_file", .label = "read_file", .description = "Read a local or remote text file.", .category = .file },
+    .{ .name = "copy_file", .label = "copy_file", .description = "Copy a file between local, WSL, and SSH contexts.", .category = .file },
+    .{ .name = "write_file", .label = "write_file", .description = "Create or overwrite a local or remote text file.", .category = .file },
+    .{ .name = "edit_file", .label = "edit_file", .description = "Replace exact text in a local or remote text file.", .category = .file },
+    .{ .name = "ssh_profile_save", .label = "ssh_profile_save", .description = "Create or update a saved WispTerm SSH profile.", .category = .session },
+    .{ .name = "ssh_profile_connect", .label = "ssh_profile_connect", .description = "Open a new tab from a saved WispTerm SSH profile.", .category = .session },
+    .{ .name = "tab_new", .label = "tab_new", .description = "Open a new WispTerm terminal tab.", .category = .session },
+    .{ .name = "tab_close", .label = "tab_close", .description = "Close a selected terminal tab.", .category = .session },
+    .{ .name = "skill_info", .label = "skill_info", .description = "Load a WispTerm skill by stable name.", .category = .agent },
+    .{ .name = "wispterm_docs", .label = "wispterm_docs", .description = "Read WispTerm's own documentation.", .category = .docs },
+    .{ .name = "websearch", .label = "websearch", .description = "Search the web for current information via Jina.", .category = .web },
+    .{ .name = "webread", .label = "webread", .description = "Read a web page or local document into markdown via Jina Reader.", .category = .web },
+    .{ .name = "pubmed", .label = "pubmed", .description = "Search PubMed biomedical literature.", .category = .web },
+    .{ .name = "subagent", .label = "subagent", .description = "Delegate a self-contained research task to a background subagent.", .category = .agent },
+    .{ .name = "weixin_send_attachment", .label = "weixin_send_attachment", .description = "Send a local file back to the active Weixin conversation.", .category = .integration },
+    .{ .name = "memory_save", .label = "memory_save", .description = "Save a durable long-term memory.", .category = .memory },
+    .{ .name = "memory_recall", .label = "memory_recall", .description = "Read a durable long-term memory.", .category = .memory },
+    .{ .name = "memory_delete", .label = "memory_delete", .description = "Delete a durable long-term memory.", .category = .memory },
+};
+
+pub const DisabledTools = struct {
+    names: [][]u8,
+
+    pub fn empty() DisabledTools {
+        return .{ .names = &.{} };
+    }
+
+    pub fn deinit(self: *DisabledTools, allocator: std.mem.Allocator) void {
+        for (self.names) |name| allocator.free(name);
+        if (self.names.len > 0) allocator.free(self.names);
+        self.* = empty();
+    }
+
+    pub fn contains(self: DisabledTools, name: []const u8) bool {
+        return isDisabledName(self.names, name);
+    }
+};
+
+pub fn platformLocalCommandNameForTest() []const u8 {
+    return platform_process.localCommandToolName();
+}
+
+pub fn activeDefinitions(allocator: std.mem.Allocator) ![]Definition {
+    var list: std.ArrayListUnmanaged(Definition) = .empty;
+    errdefer list.deinit(allocator);
+
+    const local_name = platform_process.localCommandToolName();
+    try list.append(allocator, .{
+        .name = local_name,
+        .label = local_name,
+        .description = platform_process.localCommandToolDescription(),
+        .category = .terminal,
+    });
+
+    for (static_definitions) |definition| try list.append(allocator, definition);
+
+    if (platform_pty_command.wslSessionToolsEnabled()) {
+        const wsl_name = platform_pty_command.wslSessionToolName();
+        try list.append(allocator, .{
+            .name = wsl_name,
+            .label = wsl_name,
+            .description = platform_pty_command.wslSessionToolDescription(),
+            .category = .terminal,
+        });
+    }
+
+    return list.toOwnedSlice(allocator);
+}
+
+pub fn freeDefinitions(allocator: std.mem.Allocator, defs: []Definition) void {
+    allocator.free(defs);
+}
+
+pub fn isKnown(name: []const u8) bool {
+    if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
+    if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
+    for (static_definitions) |definition| {
+        if (std.mem.eql(u8, definition.name, name)) return true;
+    }
+    return false;
+}
+
+pub fn isKnownActive(defs: []const Definition, name: []const u8) bool {
+    for (defs) |definition| {
+        if (std.mem.eql(u8, definition.name, name)) return true;
+    }
+    return false;
+}
+
+pub fn isDisabledName(disabled_names: []const []const u8, name: []const u8) bool {
+    for (disabled_names) |disabled| {
+        if (std.mem.eql(u8, disabled, name)) return true;
+    }
+    return false;
+}
+
+pub fn parseDisabledToolsJson(allocator: std.mem.Allocator, bytes: []const u8) !DisabledTools {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAgentToolsState;
+
+    const disabled_value = parsed.value.object.get("disabled") orelse return DisabledTools.empty();
+    if (disabled_value != .array) return error.InvalidAgentToolsState;
+
+    var list: std.ArrayListUnmanaged([]u8) = .empty;
+    errdefer {
+        for (list.items) |name| allocator.free(name);
+        list.deinit(allocator);
+    }
+
+    for (disabled_value.array.items) |item| {
+        if (item != .string) continue;
+        if (!isKnown(item.string)) continue;
+        if (isDisabledName(list.items, item.string)) continue;
+        try list.append(allocator, try allocator.dupe(u8, item.string));
+    }
+
+    return .{ .names = try list.toOwnedSlice(allocator) };
+}
+
+pub fn loadDisabledToolsFromPath(allocator: std.mem.Allocator, path: []const u8) !DisabledTools {
+    const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_STATE_BYTES) catch |err| switch (err) {
+        error.FileNotFound => return DisabledTools.empty(),
+        else => return err,
+    };
+    defer allocator.free(bytes);
+    return parseDisabledToolsJson(allocator, bytes) catch DisabledTools.empty();
+}
+
+pub fn loadDisabledTools(allocator: std.mem.Allocator) !DisabledTools {
+    const path = platform_dirs.pathInConfigDir(allocator, STATE_BASENAME) catch return DisabledTools.empty();
+    defer allocator.free(path);
+    return loadDisabledToolsFromPath(allocator, path) catch DisabledTools.empty();
+}
+
+pub fn disabledToolsJson(allocator: std.mem.Allocator, disabled: DisabledTools) ![]u8 {
+    const State = struct {
+        disabled: []const []const u8,
+    };
+    return std.json.Stringify.valueAlloc(allocator, State{ .disabled = disabled.names }, .{ .whitespace = .indent_2 });
+}
+
+pub fn writeDisabledToolsToPath(allocator: std.mem.Allocator, path: []const u8, disabled: DisabledTools) !void {
+    const json = try disabledToolsJson(allocator, disabled);
+    defer allocator.free(json);
+    try platform_atomic_file.writeFileReplaceSafe(path, json);
+}
+
+pub fn writeDisabledTools(allocator: std.mem.Allocator, disabled: DisabledTools) !void {
+    const config_dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(config_dir);
+    try std.fs.cwd().makePath(config_dir);
+    const path = try std.fs.path.join(allocator, &.{ config_dir, STATE_BASENAME });
+    defer allocator.free(path);
+    try writeDisabledToolsToPath(allocator, path, disabled);
+}
+
+pub fn toggledDisabledTools(allocator: std.mem.Allocator, current: DisabledTools, name: []const u8) !DisabledTools {
+    if (!isKnown(name)) return error.UnknownFirstPartyTool;
+    var list: std.ArrayListUnmanaged([]u8) = .empty;
+    errdefer {
+        for (list.items) |owned| allocator.free(owned);
+        list.deinit(allocator);
+    }
+
+    var removed = false;
+    for (current.names) |existing| {
+        if (std.mem.eql(u8, existing, name)) {
+            removed = true;
+            continue;
+        }
+        try list.append(allocator, try allocator.dupe(u8, existing));
+    }
+
+    if (!removed) try list.append(allocator, try allocator.dupe(u8, name));
+    return .{ .names = try list.toOwnedSlice(allocator) };
+}
+```
+
+- [ ] **Step 5: Run the fast test and commit**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/first_party_tools.zig src/test_fast.zig src/test_main.zig
+git commit -m "feat: add first-party tool state registry"
+```
+
+---
+
+### Task 2: Filter Disabled First-Party Tools From Request Schemas
+
+**Files:**
+- Modify: `src/ai_chat_protocol.zig`
+
+- [ ] **Step 1: Write failing schema filtering tests**
+
+Add these tests near the existing agent tool schema tests in `src/ai_chat_protocol.zig`:
+
+```zig
+test "disabled first-party tools are omitted from every protocol schema" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"webread"};
+    const params = RequestParams{
+        .model = "m",
+        .system_prompt = "s",
+        .protocol = .chat_completions,
+        .thinking_enabled = false,
+        .reasoning_effort = "",
+        .stream = false,
+        .disabled_first_party_tools = disabled[0..],
+    };
+
+    const chat = try buildRequestJson(a, params, &.{}, true);
+    defer a.free(chat);
+    try std.testing.expect(std.mem.indexOf(u8, chat, "\"name\":\"webread\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, chat, "\"name\":\"websearch\"") != null);
+
+    var responses_params = params;
+    responses_params.protocol = .responses;
+    const responses = try buildRequestJson(a, responses_params, &.{}, true);
+    defer a.free(responses);
+    try std.testing.expect(std.mem.indexOf(u8, responses, "\"name\":\"webread\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, responses, "\"name\":\"websearch\"") != null);
+
+    var anthropic_params = params;
+    anthropic_params.protocol = .anthropic;
+    const anthropic = try buildRequestJson(a, anthropic_params, &.{}, true);
+    defer a.free(anthropic);
+    try std.testing.expect(std.mem.indexOf(u8, anthropic, "\"name\":\"webread\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, anthropic, "\"name\":\"websearch\"") != null);
+}
+
+test "subagent schema also inherits disabled first-party tools" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+    const disabled = [_][]const u8{"webread"};
+
+    try appendToolSchemas(a, &out, .{
+        .include_memory = true,
+        .toolset = .subagent,
+        .disabled_first_party_tools = disabled[0..],
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"webread\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"websearch\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"terminal_snapshot\"") != null);
+}
+
+test "first-party catalog covers every emitted built-in schema tool name" {
+    const a = std.testing.allocator;
+    const names = try collectBuiltinToolNamesForTesting(a, .{ .include_memory = true });
+    defer freeCollectedToolNamesForTesting(a, names);
+
+    for (names) |name| {
+        try std.testing.expect(first_party_tools.isKnown(name));
+    }
+}
+```
+
+- [ ] **Step 2: Run the fast test and verify it fails for missing fields/helpers**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: FAIL because `RequestParams.disabled_first_party_tools`, `ToolSpecOpts.disabled_first_party_tools`, and the collect/free helpers do not exist.
+
+- [ ] **Step 3: Implement schema filtering**
+
+At the top of `src/ai_chat_protocol.zig`, add:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+Extend `RequestParams`:
+
+```zig
+    disabled_first_party_tools: []const []const u8 = &.{},
+```
+
+When calling schema appenders in `buildChatCompletionsRequestJsonForMessages`, `buildResponsesRequestJsonForMessages`, and `buildAnthropicRequestJsonForMessages`, pass the new field:
+
+```zig
+.{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools, .disabled_first_party_tools = params.disabled_first_party_tools }
+```
+
+Extend `ToolSpecOpts`:
+
+```zig
+    disabled_first_party_tools: []const []const u8 = &.{},
+```
+
+In `forEachToolSpec`, change `Filtered.emitTool` to:
+
+```zig
+        fn emitTool(c: Ctx, o: ToolSpecOpts, name: []const u8, description: []const u8, properties: []const u8) anyerror!void {
+            if (o.toolset == .subagent and !subagentToolAllowed(name)) return;
+            if (first_party_tools.isDisabledName(o.disabled_first_party_tools, name)) return;
+            try emit(c, name, description, properties);
+        }
+```
+
+Add these helpers below `dynamicToolNameSeenBefore`:
+
+```zig
+pub fn collectBuiltinToolNamesForTesting(allocator: std.mem.Allocator, opts: ToolSpecOpts) ![][]u8 {
+    const Collector = struct {
+        allocator: std.mem.Allocator,
+        names: std.ArrayListUnmanaged([]u8) = .empty,
+
+        fn emit(self: *@This(), name: []const u8, _: []const u8, _: []const u8) !void {
+            try self.names.append(self.allocator, try self.allocator.dupe(u8, name));
+        }
+    };
+
+    var collector = Collector{ .allocator = allocator };
+    errdefer freeCollectedToolNamesForTesting(allocator, collector.names.items);
+    var no_dynamic = opts;
+    no_dynamic.dynamic_tools = &.{};
+    try forEachToolSpec(*Collector, &collector, no_dynamic, Collector.emit);
+    return collector.names.toOwnedSlice(allocator);
+}
+
+pub fn freeCollectedToolNamesForTesting(allocator: std.mem.Allocator, names: [][]u8) void {
+    for (names) |name| allocator.free(name);
+    allocator.free(names);
+}
+```
+
+- [ ] **Step 4: Run the fast test and commit**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/ai_chat_protocol.zig
+git commit -m "feat: filter disabled first-party tool schemas"
+```
+
+---
+
+### Task 3: Carry Disabled First-Party Tool State Through Agent Requests
+
+**Files:**
+- Modify: `src/ai_chat_types.zig`
+- Modify: `src/ai_chat.zig`
+- Modify: `src/ai_chat_request.zig`
+- Modify: `src/AppWindow.zig`
+
+- [ ] **Step 1: Write failing snapshot ownership test**
+
+Add this test near the dynamic tool snapshot tests in `src/ai_chat.zig`:
+
+```zig
+test "ai chat session request owns first-party disabled tool snapshot" {
+    const a = std.testing.allocator;
+    const saved_settings = g_agent_settings;
+    const saved_disabled = g_first_party_disabled_tools;
+    const saved_disabled_owned = g_first_party_disabled_tools_owned;
+    defer {
+        configureAgent(saved_settings);
+        g_first_party_disabled_tools = saved_disabled;
+        g_first_party_disabled_tools_owned = saved_disabled_owned;
+    }
+
+    g_first_party_disabled_tools = try cloneStringList(a, &[_][]const u8{"webread"});
+    g_first_party_disabled_tools_owned = true;
+
+    var session = try Session.initWithVision(
+        a,
+        "Disabled snapshot",
+        "https://api.example.test",
+        "key",
+        "model",
+        ai_chat_protocol.DEFAULT_PROTOCOL,
+        "",
+        "disabled",
+        "",
+        "false",
+        "true",
+        DEFAULT_VISION,
+    );
+    defer session.deinit();
+
+    session.mutex.lock();
+    try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hello") });
+    const req = try session.buildRequestLocked();
+    session.mutex.unlock();
+    defer req.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), req.disabled_first_party_tools.len);
+    try std.testing.expectEqualStrings("webread", req.disabled_first_party_tools[0]);
+
+    @memcpy(g_first_party_disabled_tools[0], "pubmed");
+    try std.testing.expectEqualStrings("webread", req.disabled_first_party_tools[0]);
+}
+```
+
+- [ ] **Step 2: Run the fast test and verify it fails**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: FAIL because `g_first_party_disabled_tools`, `cloneStringList`, and `ChatRequest.disabled_first_party_tools` do not exist.
+
+- [ ] **Step 3: Add disabled tool state to AgentSettings and ChatRequest**
+
+In `src/ai_chat_types.zig`, extend `AgentSettings`:
+
+```zig
+    disabled_first_party_tools: []const []const u8 = &.{},
+```
+
+In `src/ai_chat.zig`, import the catalog:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+Near the dynamic tool globals, add:
+
+```zig
+threadlocal var g_first_party_disabled_tools: [][]u8 = &.{};
+threadlocal var g_first_party_disabled_tools_owned: bool = false;
+```
+
+Add these helpers near the existing dynamic tool clone/free helpers:
+
+```zig
+fn cloneStringList(allocator: std.mem.Allocator, names: []const []const u8) ![][]u8 {
+    if (names.len == 0) return &.{};
+    const out = try allocator.alloc([]u8, names.len);
+    var written: usize = 0;
+    errdefer {
+        for (out[0..written]) |name| allocator.free(name);
+        allocator.free(out);
+    }
+    for (names) |name| {
+        out[written] = try allocator.dupe(u8, name);
+        written += 1;
+    }
+    return out;
+}
+
+fn freeOwnedStringList(allocator: std.mem.Allocator, names: []const []const u8) void {
+    for (names) |name| allocator.free(name);
+    if (names.len > 0) allocator.free(names);
+}
+
+fn freeFirstPartyDisabledTools(allocator: std.mem.Allocator) void {
+    if (!g_first_party_disabled_tools_owned) return;
+    freeOwnedStringList(allocator, g_first_party_disabled_tools);
+    g_first_party_disabled_tools = &.{};
+    g_first_party_disabled_tools_owned = false;
+}
+
+pub fn reloadFirstPartyToolState(allocator: std.mem.Allocator) void {
+    freeFirstPartyDisabledTools(allocator);
+    var disabled = first_party_tools.loadDisabledTools(allocator) catch {
+        g_first_party_disabled_tools = &.{};
+        g_first_party_disabled_tools_owned = false;
+        return;
+    };
+    g_first_party_disabled_tools = disabled.names;
+    g_first_party_disabled_tools_owned = g_first_party_disabled_tools.len != 0;
+    disabled.names = &.{};
+}
+```
+
+Extend `ChatRequest`:
+
+```zig
+    disabled_first_party_tools: []const []const u8 = &.{},
+```
+
+In `ChatRequest.deinit`, add:
+
+```zig
+        freeOwnedStringList(self.allocator, self.disabled_first_party_tools);
+```
+
+In `ChatRequest.toParams`, add:
+
+```zig
+            .disabled_first_party_tools = self.disabled_first_party_tools,
+```
+
+In `currentAgentSettings`, add:
+
+```zig
+    s.disabled_first_party_tools = g_first_party_disabled_tools;
+```
+
+In `Session.buildRequestLocked`, clone the disabled list after cloning dynamic tools:
+
+```zig
+        const disabled_first_party_tools = try cloneStringList(self.allocator, settings.disabled_first_party_tools);
+        var disabled_first_party_tools_owned = true;
+        errdefer if (disabled_first_party_tools_owned) freeOwnedStringList(self.allocator, disabled_first_party_tools);
+```
+
+Then set the request field:
+
+```zig
+            .disabled_first_party_tools = disabled_first_party_tools,
+```
+
+After request construction succeeds, add:
+
+```zig
+        disabled_first_party_tools_owned = false;
+```
+
+In `src/ai_chat_request.zig`, update `toolContextFromRequest`:
+
+```zig
+    settings.disabled_first_party_tools = request.disabled_first_party_tools;
+```
+
+- [ ] **Step 4: Reload first-party state during app config application**
+
+In `src/AppWindow.zig`, after each existing `ai_chat.configureAgent(...)` call in `AppWindow.init` and `applyReloadedConfig`, add:
+
+```zig
+    ai_chat.reloadFirstPartyToolState(allocator);
+```
+
+- [ ] **Step 5: Run the fast test and commit**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/ai_chat_types.zig src/ai_chat.zig src/ai_chat_request.zig src/AppWindow.zig
+git commit -m "feat: snapshot disabled first-party tools"
+```
+
+---
+
+### Task 4: Reject Disabled First-Party Calls At Runtime
+
+**Files:**
+- Modify: `src/ai_chat_tools.zig`
+- Modify: `src/ai_chat_request.zig`
+
+- [ ] **Step 1: Write failing leaf dispatch test**
+
+Add this test near the existing `executeToolCall` tests in `src/ai_chat_tools.zig`:
+
+```zig
+fn testApproveDisabled(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return false;
+}
+
+fn testCancelledDisabled(_: *anyopaque) bool {
+    return false;
+}
+
+test "executeToolCall rejects disabled first-party tool before dispatch" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    const disabled = [_][]const u8{"webread"};
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = @ptrCast(&dummy),
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .disabled_first_party_tools = disabled[0..] },
+        .approve = testApproveDisabled,
+        .cancelled = testCancelledDisabled,
+    };
+
+    var call = ToolCall{
+        .id = @constCast("call-1"),
+        .name = @constCast("webread"),
+        .arguments = @constCast("{\"url\":\"https://example.com\"}"),
+    };
+
+    const result = try executeToolCall(&ctx, call);
+    defer a.free(result);
+    try std.testing.expectEqualStrings("Tool is disabled: webread", result);
+}
+```
+
+- [ ] **Step 2: Write failing subagent special-case test**
+
+Add this test in `src/ai_chat_request.zig` near the subagent tests:
+
+```zig
+test "executeToolCall rejects disabled subagent before special handler" {
+    const a = std.testing.allocator;
+    var session = try Session.initWithVision(
+        a,
+        "Disabled subagent",
+        "https://api.example.test",
+        "key",
+        "model",
+        ai_chat_protocol.DEFAULT_PROTOCOL,
+        "",
+        "disabled",
+        "",
+        "false",
+        "true",
+        ai_chat.DEFAULT_VISION,
+    );
+    defer session.deinit();
+
+    const disabled = try ai_chat.cloneStringList(a, &[_][]const u8{"subagent"});
+    defer ai_chat.freeOwnedStringList(a, disabled);
+
+    var req = ai_chat.ChatRequest{
+        .allocator = a,
+        .session = &session,
+        .base_url = @constCast(""),
+        .api_key = @constCast(""),
+        .model = @constCast(""),
+        .system_prompt = @constCast(""),
+        .messages = &.{},
+        .thinking_enabled = false,
+        .reasoning_effort = @constCast(""),
+        .stream = false,
+        .agent_enabled = true,
+        .memory_enabled = false,
+        .disabled_first_party_tools = disabled,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .started_ms = 0,
+    };
+
+    var call = ToolCall{
+        .id = @constCast("call-subagent"),
+        .name = @constCast("subagent"),
+        .arguments = @constCast("{\"task\":\"read this\"}"),
+    };
+    const result = try executeToolCall(&req, call);
+    defer a.free(result);
+    try std.testing.expectEqualStrings("Tool is disabled: subagent", result);
+}
+```
+
+If `cloneStringList` and `freeOwnedStringList` are still private after Task 3, make them `pub fn` in `src/ai_chat.zig` in this task so the test can own the request field safely.
+
+- [ ] **Step 3: Run the fast test and verify runtime checks are missing**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: FAIL because disabled first-party calls still execute their existing branches.
+
+- [ ] **Step 4: Implement runtime checks**
+
+In `src/ai_chat_tools.zig`, add:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+At the top of `executeToolCall`, immediately after cancellation:
+
+```zig
+    if (first_party_tools.isDisabledName(ctx.settings.disabled_first_party_tools, call.name)) {
+        return std.fmt.allocPrint(ctx.allocator, "Tool is disabled: {s}", .{call.name});
+    }
+```
+
+In `src/ai_chat_request.zig`, import the catalog:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+At the top of its `executeToolCall` wrapper, before the `subagent` special case:
+
+```zig
+    if (first_party_tools.isDisabledName(request.disabled_first_party_tools, call.name)) {
+        return std.fmt.allocPrint(request.allocator, "Tool is disabled: {s}", .{call.name});
+    }
+```
+
+- [ ] **Step 5: Run the fast test and commit**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/ai_chat_tools.zig src/ai_chat_request.zig src/ai_chat.zig
+git commit -m "feat: reject disabled first-party tool calls"
+```
+
+---
+
+### Task 5: Show And Toggle First-Party Tools In Skill Center
+
+**Files:**
+- Modify: `src/skill_center.zig`
+- Modify: `src/AppWindow.zig`
+- Modify: `src/input.zig`
+- Modify: `src/i18n.zig`
+
+- [ ] **Step 1: Write failing Skill Center model test**
+
+Add this test in `src/skill_center.zig` near the existing mixed entry tests:
+
+```zig
+test "skill_center: setEntries accepts first-party tool rows" {
+    const a = std.testing.allocator;
+    var model = PanelModel.init(a);
+    defer model.deinit();
+
+    const entries = try a.alloc(LibraryEntry, 2);
+    entries[0] = .{ .first_party_tool = .{
+        .name = try a.dupe(u8, "webread"),
+        .description = try a.dupe(u8, "Read web pages"),
+        .enabled = true,
+        .disableable = true,
+    } };
+    entries[1] = .{ .prompt = .{
+        .name = try a.dupe(u8, "pdf"),
+        .rel_path = try a.dupe(u8, "pdf/SKILL.md"),
+        .agg_hash = null,
+    } };
+
+    model.setEntries(entries);
+    try std.testing.expectEqual(@as(usize, 2), model.entryCount());
+    try std.testing.expectEqualStrings("webread", model.selectedEntry().?.name());
+}
+```
+
+- [ ] **Step 2: Write failing AppWindow toggle test**
+
+Add this test in `src/AppWindow.zig` near the existing Skill Center tool toggle tests:
+
+```zig
+test "AppWindow: skill center toggles first-party tool state file" {
+    const allocator = std.testing.allocator;
+    const previous_allocator = g_allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    defer {
+        g_allocator = previous_allocator;
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        platform_dirs.clearTestConfigDirForCurrentThread();
+    }
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    platform_dirs.setTestConfigDirForCurrentThread(root);
+
+    g_allocator = allocator;
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tab_count = 0;
+    active_tab_state.g_active_tab = 0;
+    if (!tab.spawnSkillCenterTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > 0) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+    }
+
+    const session = activeSkillCenter() orelse return error.ExpectedSkillCenterTab;
+    const entries = try allocator.alloc(skill_center.LibraryEntry, 1);
+    entries[0] = .{ .first_party_tool = .{
+        .name = try allocator.dupe(u8, "webread"),
+        .description = try allocator.dupe(u8, "Read web pages"),
+        .enabled = true,
+        .disableable = true,
+    } };
+
+    session.mutex.lock();
+    session.model.setEntries(entries);
+    session.mutex.unlock();
+
+    try std.testing.expect(skillCenterToggleToolEnabled());
+
+    const bytes = try tmp.dir.readFileAlloc(allocator, "agent_tools.json", 4096);
+    defer allocator.free(bytes);
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "\"webread\"") != null);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    switch (session.model.selectedEntry().?) {
+        .first_party_tool => |tool| try std.testing.expect(!tool.enabled),
+        else => return error.ExpectedFirstPartyTool,
+    }
+}
+```
+
+- [ ] **Step 3: Run the full test and verify first-party rows are missing**
+
+Run:
+
+```powershell
+zig build test-full
+```
+
+Expected: FAIL because `LibraryEntry.first_party_tool` and toggle support do not exist.
+
+- [ ] **Step 4: Add first-party row type to Skill Center model**
+
+In `src/skill_center.zig`, import the catalog if needed by tests:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+Add this type after `ToolSkill`:
+
+```zig
+pub const FirstPartyToolSkill = struct {
+    name: []u8,
+    description: []u8,
+    enabled: bool,
+    disableable: bool = true,
+
+    pub fn clone(self: FirstPartyToolSkill, allocator: std.mem.Allocator) !FirstPartyToolSkill {
+        const name = try allocator.dupe(u8, self.name);
+        errdefer allocator.free(name);
+        const description = try allocator.dupe(u8, self.description);
+        return .{
+            .name = name,
+            .description = description,
+            .enabled = self.enabled,
+            .disableable = self.disableable,
+        };
+    }
+
+    pub fn deinit(self: *FirstPartyToolSkill, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.description);
+        self.* = undefined;
+    }
+};
+```
+
+Extend `LibraryEntry`:
+
+```zig
+    first_party_tool: FirstPartyToolSkill,
+```
+
+Update `LibraryEntry.deinit`, `LibraryEntry.clone`, and `LibraryEntry.name` with `.first_party_tool` branches:
+
+```zig
+            .first_party_tool => |*t| t.deinit(allocator),
+```
+
+```zig
+            .first_party_tool => |t| .{ .first_party_tool = try t.clone(allocator) },
+```
+
+```zig
+            .first_party_tool => |t| t.name,
+```
+
+- [ ] **Step 5: Merge first-party definitions into Skill Center scan results**
+
+In `src/AppWindow.zig`, add:
+
+```zig
+const first_party_tools = @import("first_party_tools.zig");
+```
+
+In `SkillLibraryScanJob.run`, after scanning imported tools, load definitions and disabled state:
+
+```zig
+        const first_party_defs = try first_party_tools.activeDefinitions(allocator);
+        defer first_party_tools.freeDefinitions(allocator, first_party_defs);
+        var disabled_first_party = try first_party_tools.loadDisabledTools(allocator);
+        defer disabled_first_party.deinit(allocator);
+```
+
+Change the entry allocation count:
+
+```zig
+        const entries = try allocator.alloc(skill_center.LibraryEntry, prompt_entries.len + tools.len + first_party_defs.len);
+```
+
+After appending imported tools, append first-party rows:
+
+```zig
+        for (first_party_defs) |definition| {
+            entries[filled] = try skillCenterEntryFromFirstPartyTool(allocator, definition, disabled_first_party);
+            filled += 1;
+        }
+```
+
+Add this helper near `skillCenterEntryFromInstalledTool`:
+
+```zig
+fn skillCenterEntryFromFirstPartyTool(
+    allocator: std.mem.Allocator,
+    definition: first_party_tools.Definition,
+    disabled: first_party_tools.DisabledTools,
+) !skill_center.LibraryEntry {
+    const name = try allocator.dupe(u8, definition.name);
+    errdefer allocator.free(name);
+    const description = try allocator.dupe(u8, definition.description);
+    return .{ .first_party_tool = .{
+        .name = name,
+        .description = description,
+        .enabled = !disabled.contains(definition.name),
+        .disableable = definition.disableable,
+    } };
+}
+```
+
+Update `scEntryItemAt`:
+
+```zig
+        .first_party_tool => |t| .{
+            .label = t.name,
+            .marker = "",
+            .kind = "built-in",
+            .enabled = if (t.enabled) "on" else "off",
+            .marker_color = if (t.enabled) .{ 0.3, 0.85, 0.45 } else .{ 0.85, 0.45, 0.35 },
+        },
+```
+
+- [ ] **Step 6: Implement first-party toggling**
+
+Add this helper near `skillCenterApplyToolEnabledByManifestPath`:
+
+```zig
+fn skillCenterApplyFirstPartyEnabledByName(
+    entries: []skill_center.LibraryEntry,
+    name: []const u8,
+    enabled: bool,
+) bool {
+    for (entries) |*entry| {
+        switch (entry.*) {
+            .first_party_tool => |*tool| {
+                if (std.mem.eql(u8, tool.name, name)) {
+                    tool.enabled = enabled;
+                    return true;
+                }
+            },
+            else => {},
+        }
+    }
+    return false;
+}
+```
+
+In `skillCenterToggleToolEnabled`, add state for first-party name before the lock block:
+
+```zig
+    var first_party_name: ?[]u8 = null;
+```
+
+Inside the selected-entry switch, add:
+
+```zig
+            .first_party_tool => |tool| {
+                if (!tool.disableable) return false;
+                first_party_name = allocator.dupe(u8, tool.name) catch return false;
+            },
+```
+
+After the lock block and before imported manifest handling, add:
+
+```zig
+    if (first_party_name) |name| {
+        defer allocator.free(name);
+        var current = first_party_tools.loadDisabledTools(allocator) catch first_party_tools.DisabledTools.empty();
+        defer current.deinit(allocator);
+        const new_enabled = current.contains(name);
+        var next = first_party_tools.toggledDisabledTools(allocator, current, name) catch {
+            session.mutex.lock();
+            skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
+            session.mutex.unlock();
+            markUiDirty();
+            return true;
+        };
+        defer next.deinit(allocator);
+        first_party_tools.writeDisabledTools(allocator, next) catch {
+            session.mutex.lock();
+            skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
+            session.mutex.unlock();
+            markUiDirty();
+            return true;
+        };
+
+        ai_chat.reloadFirstPartyToolState(allocator);
+        session.mutex.lock();
+        if (session.model.entries) |entries| {
+            _ = skillCenterApplyFirstPartyEnabledByName(entries, name, new_enabled);
+        }
+        skillCenterSetStatusLocked(session, if (new_enabled) i18n.s().sc_tool_enabled else i18n.s().sc_tool_disabled);
+        session.mutex.unlock();
+        markUiDirty();
+        return true;
+    }
+```
+
+In `skillCenterToolManifestPath` and imported-tool-only helpers, leave `.first_party_tool` out of path logic so first-party rows cannot accidentally use fake manifests.
+
+- [ ] **Step 7: Update input test expectation and legend strings**
+
+In `src/i18n.zig`, change English:
+
+```zig
+    .sc_legend_v2 = "[space] preview   [↵] deploy   [i] import   [t] import tool   [e] toggle   [g] get   [r] rescan",
+```
+
+Change Chinese:
+
+```zig
+    .sc_legend_v2 = "[space] 预览   [↵] 部署   [i] 导入   [t] 导入工具   [e] 开关   [g] 获取   [r] 重新扫描",
+```
+
+No `README.md` keyboard shortcut update is needed because the binding remains `E`; only the action label changes from enable to toggle.
+
+- [ ] **Step 8: Run the full test and commit**
+
+Run:
+
+```powershell
+zig build test-full
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add src/skill_center.zig src/AppWindow.zig src/input.zig src/i18n.zig
+git commit -m "feat: manage first-party tools in skill center"
+```
+
+---
+
+### Task 6: Documentation Updates
+
+**Files:**
+- Modify: `docs/ai-agent.md`
+- Modify: `docs/ai.html`
+- Modify: `docs/faq.md`
+
+- [ ] **Step 1: Update markdown docs**
+
+In `docs/ai-agent.md`, update the Skill Center paragraph to include first-party tools:
+
+```markdown
+Open **Skill Center** to inspect prompt skills, imported executable tools, and
+first-party WispTerm Agent tools. Imported executable tools and first-party tools
+can be toggled on or off. Off tools stay installed and visible, but WispTerm
+does not advertise them to new Agent requests and rejects stale calls before
+running them.
+```
+
+In `docs/faq.md`, update the Skill Center entry to include the same behavior:
+
+```markdown
+Skill Center also manages Agent tools. Imported executable tools and first-party
+WispTerm tools appear in the same inventory; press `E` to toggle supported tools
+on or off. Disabled tools remain visible but are hidden from new AI requests and
+blocked at runtime if an old conversation tries to call them.
+```
+
+- [ ] **Step 2: Update website copy**
+
+In `docs/ai.html`, replace the Skill Center tool paragraph with:
+
+```html
+            <p>Skill Center also manages Agent tools. Imported executable tools are stored under the WispTerm config directory with a canonical <code>SKILL.md</code>, while first-party WispTerm tools such as <code>webread</code> and <code>websearch</code> appear in the same inventory. Enabled tools are advertised to AI Agent sessions; disabled tools remain visible but are hidden from new requests and blocked if a stale tool call arrives.</p>
+```
+
+- [ ] **Step 3: Run docs-neutral tests and commit**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add docs/ai-agent.md docs/ai.html docs/faq.md
+git commit -m "docs: explain first-party agent tool toggles"
+```
+
+---
+
+### Task 7: Final Verification And Windows Path Safety
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run fast tests**
+
+Run:
+
+```powershell
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full tests**
+
+Run:
+
+```powershell
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Windows checkout safety checks**
+
+In PowerShell from the repository root, run:
+
+```powershell
+$paths = git ls-files
+$reserved = @('CON', 'PRN', 'AUX', 'NUL') + (1..9 | ForEach-Object { "COM$_"; "LPT$_" })
+$violations = [System.Collections.Generic.List[object]]::new()
+$collisions = [System.Collections.Generic.List[object]]::new()
+$seen = @{}
+
+foreach ($path in $paths) {
+    foreach ($part in ($path -split '/')) {
+        $stem = ($part -split '\.')[0].ToUpperInvariant()
+        $reasons = @()
+        if ($part.IndexOfAny([char[]]'<>:"\|?*') -ge 0) { $reasons += 'illegal_char' }
+        if ($part.EndsWith(' ') -or $part.EndsWith('.')) { $reasons += 'trailing_space_or_dot' }
+        if ($reserved -contains $stem) { $reasons += 'reserved_name' }
+        if ($reasons.Count -gt 0) {
+            $violations.Add([pscustomobject]@{ Path = $path; Part = $part; Reasons = ($reasons -join ',') })
+        }
+    }
+
+    $key = $path.ToLowerInvariant()
+    if ($seen.ContainsKey($key) -and $seen[$key] -ne $path) {
+        $collisions.Add([pscustomobject]@{ A = $seen[$key]; B = $path })
+    } else {
+        $seen[$key] = $path
+    }
+}
+
+"tracked_files=$($paths.Count)"
+"windows_name_violations=$($violations.Count)"
+$violations | ForEach-Object { "violation`t$($_.Path)`t$($_.Part)`t$($_.Reasons)" }
+"casefold_collisions=$($collisions.Count)"
+$collisions | ForEach-Object { "collision`t$($_.A)`t$($_.B)" }
+$longest = $paths | Sort-Object Length -Descending | Select-Object -First 1
+"max_path_length=$($longest.Length) $longest"
+```
+
+Expected output includes:
+
+```text
+windows_name_violations=0
+casefold_collisions=0
+```
+
+Then run:
+
+```powershell
+git ls-files -s | Select-String '^120000'
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: only intentional commits are present; no untracked implementation files remain.

--- a/docs/superpowers/specs/2026-06-22-first-party-tool-disable-design.md
+++ b/docs/superpowers/specs/2026-06-22-first-party-tool-disable-design.md
@@ -1,0 +1,182 @@
+# First-Party Agent Tool Disable Design
+
+## Goal
+
+Skill Center should inventory and manage WispTerm's first-party AI Agent tools in
+the same place it already manages prompt skills and imported executable tools.
+Users can turn a first-party tool off, and off means two things:
+
+1. New AI requests do not advertise that tool in their model-facing schema.
+2. If an older request or model response still tries to call that tool, runtime
+   dispatch rejects it before any side effect happens.
+
+The feature includes tools such as `webread`, `websearch`, `pubmed`,
+`wispterm_docs`, terminal tools, file tools, and other built-in Agent function
+tools. Imported binary tools keep their existing manifest-based enable state.
+
+## Ghostty Comparison
+
+Ghostty does not have an AI Agent, Skill Center, or model tool registry. Its
+closest reference is `src/apprt/action.zig`, where application actions are
+centrally enumerated and then routed through platform/runtime layers. WispTerm
+should follow that shape for first-party Agent tools: define the built-in tool
+catalog once, then let Skill Center, schema emission, and runtime dispatch all
+consume that same catalog instead of duplicating tool names.
+
+This keeps WispTerm close to Ghostty's layering principle:
+
+- Command Center launches actions and panels.
+- Skill Center manages reusable AI capabilities.
+- The Agent tool registry owns model-facing tool definitions and dispatch gates.
+
+## Product Behavior
+
+Skill Center list rows can represent three capability kinds:
+
+- `skill`: a prompt skill directory under the local skills library.
+- `tool`: an imported executable tool under `<config>/tools/<id>/`.
+- `first-party`: a built-in WispTerm Agent tool.
+
+First-party tools are shown with `on` or `off`. They are on by default. Pressing
+`E` on a first-party row toggles its state, just like imported binary tools.
+Prompt skill rows remain non-toggleable.
+
+When a tool is off:
+
+- It stays visible in Skill Center and can be toggled back on.
+- It is omitted from Chat Completions, Responses, and Anthropic tool schemas.
+- Runtime dispatch returns a clear tool result such as
+  `Tool is disabled: webread`.
+- Subagents inherit the same disabled set, so `webread` off means it is also off
+  inside the subagent's restricted research toolset.
+
+The memory tools keep the existing `ai-memory-enabled` master switch. If memory
+tools are also represented in Skill Center, the effective rule is:
+`ai-memory-enabled` must be true and the individual memory tool must not be off.
+
+## Data Model
+
+Add a small first-party tool catalog module, for example
+`src/first_party_tools.zig`.
+
+Each tool definition should include:
+
+- `name`: exact function tool name, e.g. `webread`.
+- `label`: row label, usually the same as `name`.
+- `description`: short human-facing summary for preview/status text.
+- `category`: optional grouping such as terminal, file, web, docs, memory, or
+  integration.
+- `disableable`: true for normal tools; false only if a tool must never be
+  hidden for protocol correctness.
+
+The catalog is the source of truth for first-party tool inventory. Existing
+schema text can remain in `ai_chat_protocol.zig` initially, but every emitted
+first-party tool name must be present in the catalog, with tests to catch drift.
+
+## Persistence
+
+Persist first-party tool state under the WispTerm config directory, separate
+from imported executable tool manifests. A compact file such as
+`<config>/agent_tools.json` is sufficient:
+
+```json
+{
+  "disabled": ["webread", "pubmed"]
+}
+```
+
+Unknown names are ignored when reading so old state files remain harmless after
+tools are renamed or removed. Writes should be atomic, using the existing
+`platform/atomic_file.zig` helper. If the file is missing or malformed, WispTerm
+falls back to all first-party tools enabled and reports toggle failures through
+the Skill Center status line rather than breaking AI chat startup.
+
+## Skill Center Integration
+
+The Skill Center scan worker should merge entries in this order before sorting:
+
+1. Prompt skill entries from the local skill library.
+2. Imported executable tool entries from `tool_registry.scanInstalledTools`.
+3. First-party tool entries from the first-party catalog plus persisted state.
+
+Extend `skill_center.LibraryEntry` with a first-party tool variant rather than
+reusing imported binary `ToolSkill`. The first-party row does not have an
+executable path or manifest path, so keeping it distinct avoids fake paths and
+keeps toggle code honest.
+
+The renderer can keep the existing `ListItem.kind` and `ListItem.enabled`
+columns. Use `first-party` or a short label such as `built-in` if the longer
+text does not fit cleanly. The legend should say `[e] toggle` instead of only
+`[e] enable`, because it applies to both on and off transitions.
+
+All Skill Center key handlers that mutate the first-party state must keep the
+existing event-driven render-loop dirtying rule: after consuming the event, set
+`AppWindow.g_force_rebuild = true` and `AppWindow.g_cells_valid = false` at the
+input call site.
+
+## Schema Filtering
+
+Add a disabled-tool lookup to `ai_chat_protocol.ToolSpecOpts`, then make
+`forEachToolSpec` skip first-party tools whose names are disabled. This must
+apply before protocol-specific emitters, so Chat Completions, Responses, and
+Anthropic stay consistent.
+
+Dynamic binary tools keep their current enabled filtering. A disabled
+first-party name also stays reserved, so an imported binary tool cannot become
+callable by taking over a disabled built-in name.
+
+Subagent filtering composes with disabled filtering:
+
+- First check whether the subagent toolset permits the tool.
+- Then check whether the first-party disabled set hides it.
+
+## Runtime Filtering
+
+Extend `ai_chat_types.AgentSettings` and `ai_chat.ChatRequest` with the
+first-party disabled snapshot. Request creation should clone the current
+disabled set just like it already clones dynamic binary tool specs.
+
+At the top of `ai_chat_tools.executeToolCall`, after cancellation and before any
+tool-specific branch, check whether `call.name` is a first-party tool and is
+disabled. If yes, return a plain tool result:
+
+```text
+Tool is disabled: <name>
+```
+
+This prevents side effects from stale tool calls and makes the model-visible
+failure actionable. Imported binary tool dispatch remains controlled by
+`dynamic_binary_tools`, so disabled imported tools are still absent from runtime.
+
+`subagent` is special because it is handled in `ai_chat_request.zig` before the
+leaf tool layer. The top-level `subagent` call itself should be blocked if
+`subagent` is disabled. Once a subagent starts, its derived request inherits the
+same disabled set.
+
+## Testing
+
+Add focused tests for:
+
+- First-party catalog contains every built-in tool emitted by schema generation.
+- Malformed or missing persisted state defaults to all first-party tools on.
+- Skill Center mixed entries include first-party rows with `on/off`.
+- Toggling a first-party row persists state and updates the in-memory row.
+- Disabled `webread` is absent from Chat Completions, Responses, and Anthropic
+  schemas.
+- Disabled `webread` is rejected by `ai_chat_tools.executeToolCall`.
+- Disabled `subagent` is rejected before `runSubagentTaskWithModel`.
+- Subagent schemas inherit disabled first-party tools.
+- Imported binary tool toggling still updates manifest state and does not use
+  the first-party state file.
+
+Run `zig build test` for pure model/protocol coverage. Run `zig build test-full`
+before finishing because Skill Center input tests live only in the full app test
+binary.
+
+## Documentation
+
+Update the AI Agent docs and FAQ to say Skill Center can enable/disable both
+imported executable tools and first-party WispTerm Agent tools. No keyboard
+shortcut README update is required unless the Skill Center key bindings change;
+renaming the legend from enable to toggle is in-panel copy, not a shortcut
+change.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -4355,7 +4355,7 @@ const SkillLibraryScanJob = struct {
             entries[filled] = try skillCenterEntryFromFirstPartyDefinition(
                 allocator,
                 definition,
-                !disabled_first_party.contains(definition.name),
+                !(definition.disableable and disabled_first_party.contains(definition.name)),
             );
             filled += 1;
         }

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -216,6 +216,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
         .memory_enabled = app.ai_memory_enabled,
         .distill_suggest_enabled = app.ai_distill_suggest,
     });
+    ai_chat.reloadFirstPartyToolState(allocator);
     ai_chat.setDefaultWorkingDir(app.ai_agent_working_dir);
     overlays.setSubagentProfileName(app.ai_subagent_profile);
     ai_chat.setSubagentProfileResolver(overlays.resolveSubagentProfileOverride);
@@ -6355,6 +6356,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
         .memory_enabled = cfg.@"ai-memory-enabled",
         .distill_suggest_enabled = cfg.@"ai-distill-suggest",
     });
+    ai_chat.reloadFirstPartyToolState(allocator);
     ai_chat.setDefaultWorkingDir(cfg.@"ai-agent-working-dir");
     overlays.setSubagentProfileName(cfg.@"ai-subagent-profile");
     @import("web_search.zig").setJinaApiKey(cfg.@"jina-api-key");

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -68,6 +68,7 @@ const skill_transfer_cmd = @import("skill_transfer_cmd.zig");
 const tool_import = @import("tool_import.zig");
 const tool_registry = @import("tool_registry.zig");
 const tool_skill_draft = @import("tool_skill_draft.zig");
+const first_party_tools = @import("first_party_tools.zig");
 const ai_chat_request = @import("ai_chat_request.zig");
 const remote_file = @import("platform/remote_file.zig");
 const ssh_connection = @import("ssh_connection.zig");
@@ -461,24 +462,68 @@ test "AppWindow: skill center tool enabled update matches manifest path" {
 
     const manifest_b = switch (entries[1]) {
         .tool => |tool| skillCenterToolManifestPath(std.testing.allocator, tool) orelse return error.ExpectedManifestPath,
-        .prompt => return error.ExpectedSkillCenterTool,
+        else => return error.ExpectedSkillCenterTool,
     };
     defer std.testing.allocator.free(manifest_b);
 
     try std.testing.expect(skillCenterApplyToolEnabledByManifestPath(std.testing.allocator, entries[0..], manifest_b, true));
     switch (entries[0]) {
         .tool => |tool| try std.testing.expect(!tool.enabled),
-        .prompt => return error.ExpectedSkillCenterTool,
+        else => return error.ExpectedSkillCenterTool,
     }
     switch (entries[1]) {
         .tool => |tool| try std.testing.expect(tool.enabled),
-        .prompt => return error.ExpectedSkillCenterTool,
+        else => return error.ExpectedSkillCenterTool,
     }
 
     try std.testing.expect(!skillCenterApplyToolEnabledByManifestPath(std.testing.allocator, entries[0..], "/tmp/tools/missing/manifest.json", false));
     switch (entries[1]) {
         .tool => |tool| try std.testing.expect(tool.enabled),
-        .prompt => return error.ExpectedSkillCenterTool,
+        else => return error.ExpectedSkillCenterTool,
+    }
+}
+
+test "AppWindow: skill center first-party enabled update matches name only" {
+    var entries = [_]skill_center.LibraryEntry{
+        .{ .first_party_tool = .{
+            .name = @constCast("webread"),
+            .description = @constCast("Read web pages."),
+            .enabled = false,
+            .disableable = true,
+        } },
+        .{ .first_party_tool = .{
+            .name = @constCast("pubmed"),
+            .description = @constCast("Search PubMed."),
+            .enabled = false,
+            .disableable = true,
+        } },
+        .{ .tool = .{
+            .name = @constCast("webread"),
+            .executable_path = @constCast("/tmp/tools/webread/bin/webread"),
+            .skill_path = @constCast("/tmp/tools/webread/SKILL.md"),
+            .enabled = false,
+            .approval = .ask,
+        } },
+    };
+
+    try std.testing.expect(skillCenterApplyFirstPartyEnabledByName(entries[0..], "pubmed", true));
+    switch (entries[0]) {
+        .first_party_tool => |tool| try std.testing.expect(!tool.enabled),
+        else => return error.ExpectedFirstPartyTool,
+    }
+    switch (entries[1]) {
+        .first_party_tool => |tool| try std.testing.expect(tool.enabled),
+        else => return error.ExpectedFirstPartyTool,
+    }
+    switch (entries[2]) {
+        .tool => |tool| try std.testing.expect(!tool.enabled),
+        else => return error.ExpectedSkillCenterTool,
+    }
+
+    try std.testing.expect(!skillCenterApplyFirstPartyEnabledByName(entries[0..], "missing", false));
+    switch (entries[1]) {
+        .first_party_tool => |tool| try std.testing.expect(tool.enabled),
+        else => return error.ExpectedFirstPartyTool,
     }
 }
 
@@ -1752,6 +1797,13 @@ fn scEntryItemAt(ctx: *anyopaque, i: usize) skill_center_renderer.ListItem {
             .enabled = if (t.enabled) "on" else "off",
             .marker_color = if (t.enabled) .{ 0.3, 0.85, 0.45 } else .{ 0.85, 0.45, 0.35 },
         },
+        .first_party_tool => |t| .{
+            .label = t.name,
+            .marker = "",
+            .kind = "built-in",
+            .enabled = if (t.enabled) "on" else "off",
+            .marker_color = if (t.enabled) .{ 0.3, 0.85, 0.45 } else .{ 0.85, 0.45, 0.35 },
+        },
     };
 }
 fn scPickerItemAt(ctx: *anyopaque, i: usize) skill_center_renderer.ListItem {
@@ -2683,7 +2735,7 @@ fn skillCenterMarkerFor(model: *const skill_center.PanelModel, name: []const u8,
                     return if (std.mem.eql(u8, lh, th)) .same else .differ;
                 }
             },
-            .tool => {},
+            .tool, .first_party_tool => {},
         }
     }
     return .new_;
@@ -2795,7 +2847,7 @@ fn skillCenterOpenPicker(purpose: skill_center.Purpose) bool {
             const entry = session.model.selectedEntry() orelse return false;
             switch (entry) {
                 .prompt => break :blk "",
-                .tool => return false,
+                .tool, .first_party_tool => return false,
             }
         },
     };
@@ -2851,11 +2903,30 @@ fn skillCenterApplyToolEnabledByManifestPath(
 ) bool {
     for (entries) |*entry| {
         switch (entry.*) {
-            .prompt => {},
+            .prompt, .first_party_tool => {},
             .tool => |*tool| {
                 const path = skillCenterToolManifestPath(allocator, tool.*) orelse continue;
                 defer allocator.free(path);
                 if (std.mem.eql(u8, path, manifest_path)) {
+                    tool.enabled = enabled;
+                    return true;
+                }
+            },
+        }
+    }
+    return false;
+}
+
+fn skillCenterApplyFirstPartyEnabledByName(
+    entries: []skill_center.LibraryEntry,
+    name: []const u8,
+    enabled: bool,
+) bool {
+    for (entries) |*entry| {
+        switch (entry.*) {
+            .prompt, .tool => {},
+            .first_party_tool => |*tool| {
+                if (std.mem.eql(u8, tool.name, name)) {
                     tool.enabled = enabled;
                     return true;
                 }
@@ -3280,10 +3351,52 @@ pub fn skillCenterImportTool() bool {
     return true;
 }
 
+fn skillCenterToolToggleFailed(session: *skill_center.Session) bool {
+    session.mutex.lock();
+    skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+
+fn skillCenterToggleFirstPartyToolEnabled(
+    session: *skill_center.Session,
+    allocator: std.mem.Allocator,
+    name: []const u8,
+) bool {
+    var disabled = first_party_tools.loadDisabledTools(allocator) catch {
+        return skillCenterToolToggleFailed(session);
+    };
+    defer disabled.deinit(allocator);
+
+    const new_enabled = disabled.contains(name);
+    var next = first_party_tools.toggledDisabledTools(allocator, disabled, name) catch {
+        return skillCenterToolToggleFailed(session);
+    };
+    defer next.deinit(allocator);
+
+    first_party_tools.writeDisabledTools(allocator, next) catch {
+        return skillCenterToolToggleFailed(session);
+    };
+
+    ai_chat.reloadFirstPartyToolState(allocator);
+    session.mutex.lock();
+    if (session.model.entries) |entries| {
+        _ = skillCenterApplyFirstPartyEnabledByName(entries, name, new_enabled);
+    }
+    skillCenterSetStatusLocked(session, if (new_enabled) i18n.s().sc_tool_enabled else i18n.s().sc_tool_disabled);
+    session.mutex.unlock();
+    markUiDirty();
+    return true;
+}
+
 pub fn skillCenterToggleToolEnabled() bool {
     const session = activeSkillCenter() orelse return false;
     const allocator = g_allocator orelse return false;
     var manifest_path: ?[]u8 = null;
+    var first_party_name: ?[]u8 = null;
+    var first_party_seen = false;
+    var first_party_disableable = false;
     {
         session.mutex.lock();
         defer session.mutex.unlock();
@@ -3293,49 +3406,43 @@ pub fn skillCenterToggleToolEnabled() bool {
             .tool => |tool| {
                 manifest_path = skillCenterToolManifestPath(allocator, tool);
             },
+            .first_party_tool => |tool| {
+                first_party_seen = true;
+                first_party_disableable = tool.disableable;
+                if (tool.disableable) {
+                    first_party_name = allocator.dupe(u8, tool.name) catch null;
+                }
+            },
         }
     }
+    if (first_party_seen) {
+        if (!first_party_disableable) return skillCenterToolToggleFailed(session);
+        const name = first_party_name orelse return skillCenterToolToggleFailed(session);
+        defer allocator.free(name);
+        return skillCenterToggleFirstPartyToolEnabled(session, allocator, name);
+    }
+
     const path = manifest_path orelse {
-        session.mutex.lock();
-        skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
-        session.mutex.unlock();
-        markUiDirty();
-        return true;
+        return skillCenterToolToggleFailed(session);
     };
     defer allocator.free(path);
 
     const bytes = skill_local_fs.readFileAllocAbsolute(allocator, path, 64 * 1024) catch {
-        session.mutex.lock();
-        skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
-        session.mutex.unlock();
-        markUiDirty();
-        return true;
+        return skillCenterToolToggleFailed(session);
     };
     defer allocator.free(bytes);
     var manifest = tool_registry.parseManifestJson(allocator, bytes) catch {
-        session.mutex.lock();
-        skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
-        session.mutex.unlock();
-        markUiDirty();
-        return true;
+        return skillCenterToolToggleFailed(session);
     };
     defer manifest.deinit(allocator);
 
     const new_enabled = !manifest.enabled;
     const json = skillCenterManifestJsonWithEnabled(allocator, bytes, new_enabled) catch {
-        session.mutex.lock();
-        skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
-        session.mutex.unlock();
-        markUiDirty();
-        return true;
+        return skillCenterToolToggleFailed(session);
     };
     defer allocator.free(json);
     platform_atomic_file.writeFileReplaceSafe(path, json) catch {
-        session.mutex.lock();
-        skillCenterSetStatusLocked(session, i18n.s().sc_tool_toggle_failed);
-        session.mutex.unlock();
-        markUiDirty();
-        return true;
+        return skillCenterToolToggleFailed(session);
     };
 
     ai_chat.reloadDynamicToolSpecs(allocator);
@@ -3676,7 +3783,7 @@ pub fn skillCenterOverlaySelect() bool {
                                             if (s.agg_hash) |h| src_hash_owned = allocator.dupe(u8, h) catch null;
                                         }
                                     },
-                                    .tool => {},
+                                    .tool, .first_party_tool => {},
                                 }
                             }
                         }
@@ -3770,6 +3877,7 @@ pub fn skillCenterPreviewSelected() bool {
                 @memcpy(name_buf[0..name_len], tool.name[0..name_len]);
                 path_owned = allocator.dupe(u8, skill_path) catch null;
             },
+            .first_party_tool => return true,
         }
     }
     const abs = path_owned orelse return true;
@@ -4219,7 +4327,12 @@ const SkillLibraryScanJob = struct {
         const tools = try tool_registry.scanInstalledTools(allocator, job.tools_root);
         defer tool_registry.freeInstalledTools(allocator, tools);
 
-        const entries = try allocator.alloc(skill_center.LibraryEntry, prompt_entries.len + tools.len);
+        const first_party_defs = try first_party_tools.activeDefinitions(allocator);
+        defer first_party_tools.freeDefinitions(allocator, first_party_defs);
+        var disabled_first_party = try first_party_tools.loadDisabledTools(allocator);
+        defer disabled_first_party.deinit(allocator);
+
+        const entries = try allocator.alloc(skill_center.LibraryEntry, prompt_entries.len + tools.len + first_party_defs.len);
         var filled: usize = 0;
         errdefer {
             for (entries[0..filled]) |*entry| entry.deinit(allocator);
@@ -4235,6 +4348,15 @@ const SkillLibraryScanJob = struct {
 
         for (tools) |tool| {
             entries[filled] = try skillCenterEntryFromInstalledTool(allocator, job.tools_root, tool);
+            filled += 1;
+        }
+
+        for (first_party_defs) |definition| {
+            entries[filled] = try skillCenterEntryFromFirstPartyDefinition(
+                allocator,
+                definition,
+                !disabled_first_party.contains(definition.name),
+            );
             filled += 1;
         }
 
@@ -4271,6 +4393,22 @@ fn skillCenterEntryFromInstalledTool(
         .skill_path = skill_path,
         .enabled = tool.enabled,
         .approval = .ask,
+    } };
+}
+
+fn skillCenterEntryFromFirstPartyDefinition(
+    allocator: std.mem.Allocator,
+    definition: first_party_tools.Definition,
+    enabled: bool,
+) !skill_center.LibraryEntry {
+    const name = try allocator.dupe(u8, definition.name);
+    errdefer allocator.free(name);
+    const description = try allocator.dupe(u8, definition.description);
+    return .{ .first_party_tool = .{
+        .name = name,
+        .description = description,
+        .enabled = enabled,
+        .disableable = definition.disableable,
     } };
 }
 

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -29,6 +29,7 @@ const ai_chat_markdown = @import("ai_chat_markdown.zig");
 const weixin_types = @import("weixin/types.zig");
 const ai_loop_store = @import("ai_loop_store.zig");
 const ai_loop_schedule = @import("ai_loop_schedule.zig");
+const first_party_tools = @import("first_party_tools.zig");
 
 pub const AgentSettings = ai_chat_types.AgentSettings;
 pub const AgentPermission = ai_chat_types.AgentPermission;
@@ -172,6 +173,7 @@ pub const ChatRequest = struct {
     memory_enabled: bool = false,
     dynamic_tools: []const ai_chat_protocol.DynamicToolSpec = &.{},
     dynamic_binary_tools: []const ai_chat_types.DynamicBinaryTool = &.{},
+    disabled_first_party_tools: []const []const u8 = &.{},
     copilot: bool = false,
     tool_host: ?ToolHost,
     tool_snapshot: ?ToolSnapshot,
@@ -196,6 +198,7 @@ pub const ChatRequest = struct {
         self.allocator.free(self.messages);
         freeOwnedDynamicToolSpecs(self.allocator, self.dynamic_tools);
         freeOwnedDynamicBinaryTools(self.allocator, self.dynamic_binary_tools);
+        freeOwnedStringList(self.allocator, self.disabled_first_party_tools);
         if (self.tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
         if (self.weixin_reply_context) |*ctx| ctx.deinit(self.allocator);
         if (self.subagent_profile) |profile| profile.deinit(self.allocator);
@@ -213,6 +216,7 @@ pub const ChatRequest = struct {
             .max_tokens = self.max_tokens,
             .memory_enabled = self.memory_enabled,
             .dynamic_tools = self.dynamic_tools,
+            .disabled_first_party_tools = self.disabled_first_party_tools,
             .toolset = self.toolset,
         };
     }
@@ -375,6 +379,8 @@ threadlocal var g_dynamic_tool_specs: []ai_chat_protocol.DynamicToolSpec = &.{};
 threadlocal var g_dynamic_tool_specs_owned: bool = false;
 threadlocal var g_dynamic_binary_tools: []ai_chat_types.DynamicBinaryTool = &.{};
 threadlocal var g_dynamic_binary_tools_owned: bool = false;
+threadlocal var g_first_party_disabled_tools: []const []const u8 = &.{};
+threadlocal var g_first_party_disabled_tools_owned: bool = false;
 
 /// Resolved credentials for the `ai-subagent-profile` config key. Owned
 /// strings; freed by ChatRequest.deinit.
@@ -440,6 +446,27 @@ pub fn setDynamicToolSpecsForTest(specs: []ai_chat_protocol.DynamicToolSpec) voi
 pub fn setDynamicBinaryToolsForTest(tools: []ai_chat_types.DynamicBinaryTool) void {
     g_dynamic_binary_tools = tools;
     g_dynamic_binary_tools_owned = false;
+}
+
+fn freeOwnedStringList(allocator: std.mem.Allocator, list: []const []const u8) void {
+    if (list.len == 0) return;
+    for (list) |item| allocator.free(item);
+    allocator.free(list);
+}
+
+fn cloneStringList(allocator: std.mem.Allocator, list: []const []const u8) ![]const []const u8 {
+    if (list.len == 0) return &.{};
+    const out = try allocator.alloc([]const u8, list.len);
+    var written: usize = 0;
+    errdefer {
+        for (out[0..written]) |item| allocator.free(item);
+        allocator.free(out);
+    }
+    for (list) |item| {
+        out[written] = try allocator.dupe(u8, item);
+        written += 1;
+    }
+    return out;
 }
 
 fn freeDynamicToolSpecsSlice(allocator: std.mem.Allocator, specs: []ai_chat_protocol.DynamicToolSpec) void {
@@ -528,6 +555,13 @@ fn freeDynamicBinaryTools(allocator: std.mem.Allocator) void {
     g_dynamic_binary_tools_owned = false;
 }
 
+fn freeFirstPartyDisabledTools(allocator: std.mem.Allocator) void {
+    if (!g_first_party_disabled_tools_owned) return;
+    freeOwnedStringList(allocator, g_first_party_disabled_tools);
+    g_first_party_disabled_tools = &.{};
+    g_first_party_disabled_tools_owned = false;
+}
+
 const DynamicToolSnapshots = struct {
     specs: []ai_chat_protocol.DynamicToolSpec,
     runtime: []ai_chat_types.DynamicBinaryTool,
@@ -560,6 +594,14 @@ pub fn reloadDynamicToolSpecs(allocator: std.mem.Allocator) void {
     g_dynamic_tool_specs_owned = g_dynamic_tool_specs.len != 0;
     g_dynamic_binary_tools = snapshots.runtime;
     g_dynamic_binary_tools_owned = g_dynamic_binary_tools.len != 0;
+}
+
+pub fn reloadFirstPartyToolState(allocator: std.mem.Allocator) void {
+    var disabled = first_party_tools.loadDisabledTools(allocator) catch return;
+    freeFirstPartyDisabledTools(allocator);
+    g_first_party_disabled_tools = disabled.names;
+    g_first_party_disabled_tools_owned = g_first_party_disabled_tools.len != 0;
+    disabled.names = &.{};
 }
 
 pub fn configureAgent(settings: AgentSettings) void {
@@ -654,6 +696,7 @@ pub fn currentAgentSettings() AgentSettings {
     if (g_default_working_dir_len > 0) s.working_dir = g_default_working_dir_buf[0..g_default_working_dir_len];
     s.dynamic_tools = g_dynamic_tool_specs;
     s.dynamic_binary_tools = g_dynamic_binary_tools;
+    s.disabled_first_party_tools = g_first_party_disabled_tools;
     return s;
 }
 
@@ -3938,6 +3981,9 @@ pub const Session = struct {
         const dynamic_binary_tools = try cloneDynamicBinaryTools(self.allocator, settings.dynamic_binary_tools);
         var dynamic_binary_tools_owned = true;
         errdefer if (dynamic_binary_tools_owned) freeOwnedDynamicBinaryTools(self.allocator, dynamic_binary_tools);
+        const disabled_first_party_tools = try cloneStringList(self.allocator, settings.disabled_first_party_tools);
+        var disabled_first_party_tools_owned = true;
+        errdefer if (disabled_first_party_tools_owned) freeOwnedStringList(self.allocator, disabled_first_party_tools);
 
         req.* = .{
             .allocator = self.allocator,
@@ -3956,6 +4002,7 @@ pub const Session = struct {
             .memory_enabled = settings.memory_enabled,
             .dynamic_tools = dynamic_tools,
             .dynamic_binary_tools = dynamic_binary_tools,
+            .disabled_first_party_tools = disabled_first_party_tools,
             .copilot = self.copilot,
             .tool_host = tool_host,
             .tool_snapshot = tool_snapshot,
@@ -3972,6 +4019,7 @@ pub const Session = struct {
         subagent_profile = null;
         dynamic_tools_owned = false;
         dynamic_binary_tools_owned = false;
+        disabled_first_party_tools_owned = false;
         if (self.copilot and self.bound_surface_id_len > 0) {
             // Inline the write-context seed directly on ChatRequest (the field
             // layout is identical to ToolContext; setWriteContext in
@@ -7675,6 +7723,55 @@ test "ai chat session request owns dynamic binary runtime snapshot" {
     try std.testing.expectEqual(@as(usize, 1), request.dynamic_binary_tools.len);
     try std.testing.expectEqualStrings("fake_tool", request.dynamic_binary_tools[0].function_name);
     try std.testing.expectEqualStrings(executable_text, request.dynamic_binary_tools[0].executable_abs);
+}
+
+test "ai chat session request owns disabled first-party tool snapshot" {
+    const allocator = std.testing.allocator;
+    const saved_settings = currentAgentSettings();
+    const saved_disabled_tools = g_first_party_disabled_tools;
+    const saved_disabled_tools_owned = g_first_party_disabled_tools_owned;
+    defer {
+        configureAgent(saved_settings);
+        g_first_party_disabled_tools = saved_disabled_tools;
+        g_first_party_disabled_tools_owned = saved_disabled_tools_owned;
+    }
+
+    const disabled_name = try allocator.dupe(u8, "webread");
+    defer allocator.free(disabled_name);
+    var disabled = [_][]const u8{disabled_name};
+    g_first_party_disabled_tools = disabled[0..];
+    g_first_party_disabled_tools_owned = false;
+    configureAgent(.{ .enabled = true, .permission = .full });
+
+    const session = try Session.init(
+        allocator,
+        "Test",
+        DEFAULT_BASE_URL,
+        "test-key",
+        DEFAULT_MODEL,
+        DEFAULT_SYSTEM_PROMPT,
+        "enabled",
+        "high",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    session.mutex.lock();
+    try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "hello") });
+    const request = try session.buildRequestLocked();
+    session.mutex.unlock();
+    defer request.deinit();
+
+    @memcpy(disabled_name, "pubmed!");
+    g_first_party_disabled_tools = &.{};
+    g_first_party_disabled_tools_owned = false;
+
+    const json = try ai_chat_request.buildRequestJson(allocator, request);
+    defer allocator.free(json);
+
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"webread\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"websearch\"") != null);
 }
 
 const CopilotBoundSnapshotTestHost = struct {

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -740,7 +740,7 @@ fn forEachToolSpec(
     const Filtered = struct {
         fn emitTool(c: Ctx, o: ToolSpecOpts, name: []const u8, description: []const u8, properties: []const u8) anyerror!void {
             if (o.toolset == .subagent and !subagentToolAllowed(name)) return;
-            if (first_party_tools.isDisabledName(o.disabled_first_party_tools, name)) return;
+            if (first_party_tools.isKnown(name) and first_party_tools.isDisabledName(o.disabled_first_party_tools, name)) return;
             try emit(c, name, description, properties);
         }
     };
@@ -805,7 +805,9 @@ const ToolNameCollectorForTesting = struct {
 pub fn collectBuiltinToolNamesForTesting(allocator: std.mem.Allocator, opts: ToolSpecOpts) ![]const []const u8 {
     var ctx = ToolNameCollectorForTesting{ .allocator = allocator };
     errdefer ctx.names.deinit(allocator);
-    try forEachToolSpec(*ToolNameCollectorForTesting, &ctx, opts, ToolNameCollectorForTesting.emit);
+    var builtin_opts = opts;
+    builtin_opts.dynamic_tools = &.{};
+    try forEachToolSpec(*ToolNameCollectorForTesting, &ctx, builtin_opts, ToolNameCollectorForTesting.emit);
     return ctx.names.toOwnedSlice(allocator);
 }
 
@@ -1726,6 +1728,9 @@ test "collectBuiltinToolNamesForTesting names all active first-party catalog too
     for (definitions) |definition| {
         try std.testing.expect(indexOfToolNameForTesting(names, definition.name) != null);
     }
+    for (names) |name| {
+        try std.testing.expect(first_party_tools.isKnown(name));
+    }
 }
 
 test "agent tool set includes pubmed" {
@@ -1771,6 +1776,44 @@ test "buildRequestJson advertises enabled binary tools" {
     defer a.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"agent_docx_review\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"args\"") != null);
+}
+
+test "disabled first-party list does not hide dynamic binary tools" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"agent_docx_review"};
+    const tools = [_]DynamicToolSpec{.{
+        .name = "agent_docx_review",
+        .description = "Use for DOCX tracked-change review.",
+    }};
+    const params = RequestParams{
+        .model = "m",
+        .system_prompt = "s",
+        .protocol = .chat_completions,
+        .thinking_enabled = false,
+        .reasoning_effort = "",
+        .stream = false,
+        .dynamic_tools = tools[0..],
+        .disabled_first_party_tools = disabled[0..],
+    };
+    const json = try buildRequestJson(a, params, &.{}, true);
+    defer a.free(json);
+
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"agent_docx_review\"") != null);
+}
+
+test "collectBuiltinToolNamesForTesting excludes dynamic binary tools" {
+    const a = std.testing.allocator;
+    const tools = [_]DynamicToolSpec{.{
+        .name = "agent_docx_review",
+        .description = "Use for DOCX tracked-change review.",
+    }};
+    const names = try collectBuiltinToolNamesForTesting(a, .{ .include_memory = true, .dynamic_tools = tools[0..] });
+    defer freeCollectedToolNamesForTesting(a, names);
+
+    try std.testing.expect(indexOfToolNameForTesting(names, "agent_docx_review") == null);
+    for (names) |name| {
+        try std.testing.expect(first_party_tools.isKnown(name));
+    }
 }
 
 test "dynamic binary tools skip built-in tool name collisions" {

--- a/src/ai_chat_protocol.zig
+++ b/src/ai_chat_protocol.zig
@@ -3,6 +3,7 @@
 //! data + an allocator. (Imports the platform tool-description facades that the
 //! tool-schema builders already used.)
 const std = @import("std");
+const first_party_tools = @import("first_party_tools.zig");
 const platform_process = @import("platform/process.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 
@@ -231,6 +232,7 @@ pub const RequestParams = struct {
     memory_enabled: bool = false,
     toolset: Toolset = .full,
     dynamic_tools: []const DynamicToolSpec = &.{},
+    disabled_first_party_tools: []const []const u8 = &.{},
 };
 
 pub fn buildRequestJson(allocator: std.mem.Allocator, params: RequestParams, messages: []const RequestMessage, include_tools: bool) ![]u8 {
@@ -399,7 +401,7 @@ fn buildChatCompletionsRequestJsonForMessages(
         try out.appendSlice(allocator, ",\"stream_options\":{\"include_usage\":true}");
     }
     if (include_tools) {
-        try appendToolSchemas(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools });
+        try appendToolSchemas(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools, .disabled_first_party_tools = params.disabled_first_party_tools });
     }
     try out.append(allocator, '}');
 
@@ -462,7 +464,7 @@ fn buildResponsesRequestJsonForMessages(
     try out.appendSlice(allocator, ",\"stream\":");
     try out.appendSlice(allocator, if (params.stream) "true" else "false");
     if (include_tools) {
-        try appendResponseToolSchemas(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools });
+        try appendResponseToolSchemas(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools, .disabled_first_party_tools = params.disabled_first_party_tools });
     }
     try out.append(allocator, '}');
 
@@ -488,7 +490,7 @@ fn buildAnthropicRequestJsonForMessages(
     try out.appendSlice(allocator, ",\"messages\":[");
     try appendAnthropicMessages(allocator, &out, messages);
     try out.append(allocator, ']');
-    if (include_tools) try appendAnthropicTools(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools });
+    if (include_tools) try appendAnthropicTools(allocator, &out, .{ .include_memory = params.memory_enabled, .toolset = params.toolset, .dynamic_tools = params.dynamic_tools, .disabled_first_party_tools = params.disabled_first_party_tools });
     try out.append(allocator, '}');
     return out.toOwnedSlice(allocator);
 }
@@ -658,6 +660,7 @@ pub const ToolSpecOpts = struct {
     include_memory: bool,
     toolset: Toolset = .full,
     dynamic_tools: []const DynamicToolSpec = &.{},
+    disabled_first_party_tools: []const []const u8 = &.{},
 };
 
 /// Single source of truth for what a subagent may call. Every listed tool is
@@ -737,6 +740,7 @@ fn forEachToolSpec(
     const Filtered = struct {
         fn emitTool(c: Ctx, o: ToolSpecOpts, name: []const u8, description: []const u8, properties: []const u8) anyerror!void {
             if (o.toolset == .subagent and !subagentToolAllowed(name)) return;
+            if (first_party_tools.isDisabledName(o.disabled_first_party_tools, name)) return;
             try emit(c, name, description, properties);
         }
     };
@@ -785,6 +789,28 @@ fn forEachToolSpec(
             );
         }
     }
+}
+
+const ToolNameCollectorForTesting = struct {
+    allocator: std.mem.Allocator,
+    names: std.ArrayListUnmanaged([]const u8) = .empty,
+
+    fn emit(self: *ToolNameCollectorForTesting, name: []const u8, description: []const u8, properties: []const u8) !void {
+        _ = description;
+        _ = properties;
+        try self.names.append(self.allocator, name);
+    }
+};
+
+pub fn collectBuiltinToolNamesForTesting(allocator: std.mem.Allocator, opts: ToolSpecOpts) ![]const []const u8 {
+    var ctx = ToolNameCollectorForTesting{ .allocator = allocator };
+    errdefer ctx.names.deinit(allocator);
+    try forEachToolSpec(*ToolNameCollectorForTesting, &ctx, opts, ToolNameCollectorForTesting.emit);
+    return ctx.names.toOwnedSlice(allocator);
+}
+
+pub fn freeCollectedToolNamesForTesting(allocator: std.mem.Allocator, names: []const []const u8) void {
+    allocator.free(names);
 }
 
 const ToolSchemaEmitter = struct {
@@ -1609,6 +1635,97 @@ test "agent tool set includes webread" {
     const json = try buildRequestJson(a, params, &msgs, true);
     defer a.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"webread\"") != null);
+}
+
+fn requestParamsWithDisabledToolsForTesting(protocol: ApiProtocol, disabled_tools: []const []const u8) RequestParams {
+    return .{
+        .model = "m",
+        .system_prompt = "",
+        .protocol = protocol,
+        .thinking_enabled = false,
+        .reasoning_effort = "",
+        .stream = false,
+        .max_tokens = 8192,
+        .memory_enabled = true,
+        .disabled_first_party_tools = disabled_tools,
+    };
+}
+
+fn expectToolSchemaNameForTesting(json: []const u8, name: []const u8, present: bool) !void {
+    var buf: [128]u8 = undefined;
+    const needle = try std.fmt.bufPrint(&buf, "\"name\":\"{s}\"", .{name});
+    if (present) {
+        try std.testing.expect(std.mem.indexOf(u8, json, needle) != null);
+    } else {
+        try std.testing.expect(std.mem.indexOf(u8, json, needle) == null);
+    }
+}
+
+test "disabled webread is omitted from chat_completions tool schemas" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"webread"};
+    const params = requestParamsWithDisabledToolsForTesting(.chat_completions, disabled[0..]);
+    const json = try buildRequestJson(a, params, &.{}, true);
+    defer a.free(json);
+
+    try expectToolSchemaNameForTesting(json, "webread", false);
+    try expectToolSchemaNameForTesting(json, "websearch", true);
+}
+
+test "disabled webread is omitted from responses tool schemas" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"webread"};
+    const params = requestParamsWithDisabledToolsForTesting(.responses, disabled[0..]);
+    const json = try buildRequestJson(a, params, &.{}, true);
+    defer a.free(json);
+
+    try expectToolSchemaNameForTesting(json, "webread", false);
+    try expectToolSchemaNameForTesting(json, "websearch", true);
+}
+
+test "disabled webread is omitted from anthropic tool schemas" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"webread"};
+    const params = requestParamsWithDisabledToolsForTesting(.anthropic, disabled[0..]);
+    const json = try buildRequestJson(a, params, &.{}, true);
+    defer a.free(json);
+
+    try expectToolSchemaNameForTesting(json, "webread", false);
+    try expectToolSchemaNameForTesting(json, "websearch", true);
+}
+
+test "subagent tool schemas inherit disabled first-party tools" {
+    const a = std.testing.allocator;
+    const disabled = [_][]const u8{"webread"};
+    const names = try collectBuiltinToolNamesForTesting(a, .{
+        .include_memory = true,
+        .toolset = .subagent,
+        .disabled_first_party_tools = disabled[0..],
+    });
+    defer freeCollectedToolNamesForTesting(a, names);
+
+    try std.testing.expect(indexOfToolNameForTesting(names, "webread") == null);
+    try std.testing.expect(indexOfToolNameForTesting(names, "websearch") != null);
+}
+
+fn indexOfToolNameForTesting(names: []const []const u8, target: []const u8) ?usize {
+    for (names, 0..) |name, i| {
+        if (std.mem.eql(u8, name, target)) return i;
+    }
+    return null;
+}
+
+test "collectBuiltinToolNamesForTesting names all active first-party catalog tools" {
+    const a = std.testing.allocator;
+    const definitions = try first_party_tools.activeDefinitions(a);
+    defer first_party_tools.freeDefinitions(a, definitions);
+
+    const names = try collectBuiltinToolNamesForTesting(a, .{ .include_memory = true });
+    defer freeCollectedToolNamesForTesting(a, names);
+
+    for (definitions) |definition| {
+        try std.testing.expect(indexOfToolNameForTesting(names, definition.name) != null);
+    }
 }
 
 test "agent tool set includes pubmed" {

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -9,6 +9,7 @@ const ChatRequest = ai_chat.ChatRequest;
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
 const ai_skill_distill = @import("ai_skill_distill.zig");
 const ai_chat_tools = @import("ai_chat_tools.zig");
+const first_party_tools = @import("first_party_tools.zig");
 const web_search = @import("web_search.zig");
 const web_read = @import("web_read.zig");
 const pubmed = @import("pubmed.zig");
@@ -865,6 +866,9 @@ fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
 }
 
 pub fn executeToolCall(request: *ChatRequest, call: ToolCall) ![]u8 {
+    if (first_party_tools.isKnown(call.name) and first_party_tools.isDisabledName(request.disabled_first_party_tools, call.name)) {
+        return std.fmt.allocPrint(request.allocator, "Tool is disabled: {s}", .{call.name});
+    }
     if (std.mem.eql(u8, call.name, "subagent")) return subagentToolCall(request, call);
     var tool_ctx = toolContextFromRequest(request);
     const result = try ai_chat_tools.executeToolCall(&tool_ctx, call);
@@ -1289,6 +1293,30 @@ test "subagent tool call requires a task argument" {
     const out = try executeToolCall(env.request, call);
     defer a.free(out);
     try std.testing.expectEqualStrings("Missing task", out);
+}
+
+test "executeToolCall rejects disabled subagent before the wrapper special case" {
+    const a = std.testing.allocator;
+    const env = try testSessionAndRequest(a);
+    defer env.session.deinit();
+    defer env.request.deinit();
+
+    const disabled = try a.alloc([]u8, 1);
+    disabled[0] = try a.dupe(u8, "subagent");
+    env.request.disabled_first_party_tools = disabled;
+
+    var call = ToolCall{
+        .id = try a.dupe(u8, "c1"),
+        .name = try a.dupe(u8, "subagent"),
+        .arguments = try a.dupe(u8, "{}"),
+    };
+    defer call.deinit(a);
+
+    const out = try executeToolCall(env.request, call);
+    defer a.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "Tool is disabled: subagent") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Missing task") == null);
 }
 
 test "request-owned dynamic binary tool dispatches through executeToolCall" {

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -844,6 +844,7 @@ fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
     var settings = ai_chat.currentAgentSettings();
     settings.dynamic_tools = request.dynamic_tools;
     settings.dynamic_binary_tools = request.dynamic_binary_tools;
+    settings.disabled_first_party_tools = request.disabled_first_party_tools;
     // Per-conversation override beats the global default.
     if (request.session.workingDirOverride()) |override| settings.working_dir = override;
     return .{

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -10,6 +10,7 @@ const agent_file_copy = @import("agent_file_copy.zig");
 const scp = @import("scp.zig");
 const ToolSshConnection = types.SshConnection;
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
+const first_party_tools = @import("first_party_tools.zig");
 const ToolCall = ai_chat_protocol.ToolCall;
 const ToolContext = types.ToolContext;
 const ToolSurface = types.ToolSurface;
@@ -45,6 +46,9 @@ pub const COPILOT_CONTEXT_LINES: usize = 40;
 
 pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+    if (first_party_tools.isKnown(call.name) and first_party_tools.isDisabledName(ctx.settings.disabled_first_party_tools, call.name)) {
+        return std.fmt.allocPrint(ctx.allocator, "Tool is disabled: {s}", .{call.name});
+    }
     if (std.mem.eql(u8, call.name, "terminal_list")) {
         return terminalListTool(ctx);
     }
@@ -2825,6 +2829,57 @@ test "ask_user tool rejects fewer than two options without asking" {
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "at least 2") != null);
     try std.testing.expectEqual(@as(usize, 0), asker.captured_count); // ask hook never called
+}
+
+test "executeToolCall rejects disabled first-party webread before validating args" {
+    const disabled = [_][]const u8{"webread"};
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = std.testing.allocator,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{
+            .disabled_first_party_tools = disabled[0..],
+        },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast("webread"),
+        .arguments = @constCast("not-json"),
+    });
+    defer std.testing.allocator.free(out);
+
+    try std.testing.expectEqualStrings("Tool is disabled: webread", out);
+}
+
+test "executeToolCall does not treat disabled dynamic names as first-party tools" {
+    const disabled = [_][]const u8{"project_dynamic_tool"};
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = std.testing.allocator,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{
+            .disabled_first_party_tools = disabled[0..],
+        },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast("project_dynamic_tool"),
+        .arguments = @constCast("{}"),
+    });
+    defer std.testing.allocator.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "Unknown tool") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Tool is disabled") == null);
 }
 
 test "isDangerousCommand flags destructive verbs without a Session" {

--- a/src/ai_chat_types.zig
+++ b/src/ai_chat_types.zig
@@ -31,6 +31,7 @@ pub const AgentSettings = struct {
     distill_suggest_enabled: bool = false,
     dynamic_tools: []const ai_chat_protocol.DynamicToolSpec = &.{},
     dynamic_binary_tools: []const DynamicBinaryTool = &.{},
+    disabled_first_party_tools: []const []const u8 = &.{},
 };
 
 pub const DynamicBinaryTool = struct {

--- a/src/first_party_tools.zig
+++ b/src/first_party_tools.zig
@@ -149,7 +149,11 @@ pub fn parseDisabledToolsJson(allocator: std.mem.Allocator, bytes: []const u8) !
         if (item != .string) continue;
         if (!isKnown(item.string)) continue;
         if (isDisabledName(list.items, item.string)) continue;
-        try list.append(allocator, try allocator.dupe(u8, item.string));
+        const owned = try allocator.dupe(u8, item.string);
+        list.append(allocator, owned) catch |err| {
+            allocator.free(owned);
+            return err;
+        };
     }
 
     return .{ .names = try list.toOwnedSlice(allocator) };
@@ -161,13 +165,16 @@ pub fn loadDisabledToolsFromPath(allocator: std.mem.Allocator, path: []const u8)
         else => return err,
     };
     defer allocator.free(bytes);
-    return parseDisabledToolsJson(allocator, bytes) catch DisabledTools.empty();
+    return parseDisabledToolsJson(allocator, bytes) catch |err| switch (err) {
+        error.InvalidAgentToolsState, error.SyntaxError, error.UnexpectedEndOfInput => return DisabledTools.empty(),
+        else => return err,
+    };
 }
 
 pub fn loadDisabledTools(allocator: std.mem.Allocator) !DisabledTools {
-    const path = platform_dirs.pathInConfigDir(allocator, STATE_BASENAME) catch return DisabledTools.empty();
+    const path = try platform_dirs.pathInConfigDir(allocator, STATE_BASENAME);
     defer allocator.free(path);
-    return loadDisabledToolsFromPath(allocator, path) catch DisabledTools.empty();
+    return try loadDisabledToolsFromPath(allocator, path);
 }
 
 pub fn disabledToolsJson(allocator: std.mem.Allocator, disabled: DisabledTools) ![]u8 {
@@ -219,7 +226,7 @@ test "first_party_tools: active definitions include webread and the local comman
     defer freeDefinitions(a, defs);
 
     try std.testing.expect(isKnownActive(defs, "webread"));
-    try std.testing.expect(isKnown(platformLocalCommandNameForTest()));
+    try std.testing.expect(isKnownActive(defs, platformLocalCommandNameForTest()));
 }
 
 test "first_party_tools: disabled state json filters unknown and duplicate names" {
@@ -246,9 +253,65 @@ test "first_party_tools: malformed state falls back to empty when loaded from pa
     const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
     defer a.free(path);
 
-    var disabled = loadDisabledToolsFromPath(a, path) catch DisabledTools.empty();
+    var disabled = try loadDisabledToolsFromPath(a, path);
     defer disabled.deinit(a);
     try std.testing.expectEqual(@as(usize, 0), disabled.names.len);
+}
+
+test "first_party_tools: oversized state file propagates an error" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const bytes = try a.alloc(u8, MAX_STATE_BYTES + 1);
+    defer a.free(bytes);
+    @memset(bytes, ' ');
+    try tmp.dir.writeFile(.{ .sub_path = "agent_tools.json", .data = bytes });
+
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    try std.testing.expectError(error.FileTooBig, loadDisabledToolsFromPath(a, path));
+}
+
+test "first_party_tools: load from path propagates parse allocation failure" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "agent_tools.json", .data = "{\"disabled\":[\"webread\"]}" });
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    var counting = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    var counted = try loadDisabledToolsFromPath(counting.allocator(), path);
+    defer counted.deinit(counting.allocator());
+
+    var fail_index: usize = 0;
+    while (fail_index < counting.alloc_index) : (fail_index += 1) {
+        var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = fail_index });
+        var disabled = loadDisabledToolsFromPath(failing.allocator(), path) catch |err| {
+            try std.testing.expectEqual(error.OutOfMemory, err);
+            try std.testing.expect(failing.has_induced_failure);
+            continue;
+        };
+
+        try std.testing.expect(!failing.has_induced_failure);
+        disabled.deinit(failing.allocator());
+    }
+}
+
+test "first_party_tools: loadDisabledTools propagates config path allocation failure" {
+    platform_dirs.setTestConfigDirForCurrentThread("config-root");
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, loadDisabledTools(failing.allocator()));
+    try std.testing.expect(failing.has_induced_failure);
 }
 
 test "first_party_tools: toggled state writes and reads atomically" {

--- a/src/first_party_tools.zig
+++ b/src/first_party_tools.zig
@@ -213,10 +213,20 @@ pub fn toggledDisabledTools(allocator: std.mem.Allocator, current: DisabledTools
             removed = true;
             continue;
         }
-        try list.append(allocator, try allocator.dupe(u8, existing));
+        const owned = try allocator.dupe(u8, existing);
+        list.append(allocator, owned) catch |err| {
+            allocator.free(owned);
+            return err;
+        };
     }
 
-    if (!removed) try list.append(allocator, try allocator.dupe(u8, name));
+    if (!removed) {
+        const owned = try allocator.dupe(u8, name);
+        list.append(allocator, owned) catch |err| {
+            allocator.free(owned);
+            return err;
+        };
+    }
     return .{ .names = try list.toOwnedSlice(allocator) };
 }
 
@@ -312,6 +322,21 @@ test "first_party_tools: loadDisabledTools propagates config path allocation fai
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
     try std.testing.expectError(error.OutOfMemory, loadDisabledTools(failing.allocator()));
     try std.testing.expect(failing.has_induced_failure);
+}
+
+test "first_party_tools: toggled state frees duplicated name when append fails" {
+    const current = DisabledTools.empty();
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+
+    try std.testing.expectError(error.OutOfMemory, toggledDisabledTools(failing.allocator(), current, "webread"));
+    try std.testing.expect(failing.has_induced_failure);
+
+    var current_names = [_][]u8{@constCast("pubmed")};
+    const current_with_existing = DisabledTools{ .names = current_names[0..] };
+    var failing_existing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 1 });
+
+    try std.testing.expectError(error.OutOfMemory, toggledDisabledTools(failing_existing.allocator(), current_with_existing, "webread"));
+    try std.testing.expect(failing_existing.has_induced_failure);
 }
 
 test "first_party_tools: toggled state writes and reads atomically" {

--- a/src/first_party_tools.zig
+++ b/src/first_party_tools.zig
@@ -1,0 +1,276 @@
+const std = @import("std");
+const platform_atomic_file = @import("platform/atomic_file.zig");
+const platform_dirs = @import("platform/dirs.zig");
+const platform_process = @import("platform/process.zig");
+const platform_pty_command = @import("platform/pty_command.zig");
+
+const MAX_STATE_BYTES: usize = 64 * 1024;
+const STATE_BASENAME = "agent_tools.json";
+
+pub const Category = enum {
+    terminal,
+    file,
+    web,
+    docs,
+    memory,
+    integration,
+    session,
+    agent,
+};
+
+pub const Definition = struct {
+    name: []const u8,
+    label: []const u8,
+    description: []const u8,
+    category: Category,
+    disableable: bool = true,
+};
+
+const static_definitions = [_]Definition{
+    .{ .name = "terminal_list", .label = "terminal_list", .description = "List WispTerm terminal surfaces visible to the agent.", .category = .terminal },
+    .{ .name = "terminal_context", .label = "terminal_context", .description = "Report the current selected terminal write context.", .category = .terminal },
+    .{ .name = "terminal_snapshot", .label = "terminal_snapshot", .description = "Read a bounded text snapshot from terminal surfaces.", .category = .terminal },
+    .{ .name = "terminal_select", .label = "terminal_select", .description = "Select the terminal surface used for subsequent write tools.", .category = .terminal },
+    .{ .name = "ssh_session_exec", .label = "ssh_session_exec", .description = "Run a shell command in an already-open SSH terminal surface.", .category = .terminal },
+    .{ .name = "terminal_repl_exec", .label = "terminal_repl_exec", .description = "Send text to an already-open interactive REPL or agent app.", .category = .terminal },
+    .{ .name = "terminal_answer_prompt", .label = "terminal_answer_prompt", .description = "Answer an approval prompt in an agent terminal surface.", .category = .terminal },
+    .{ .name = "ask_user", .label = "ask_user", .description = "Ask the user a blocking multiple-choice question.", .category = .agent },
+    .{ .name = "read_file", .label = "read_file", .description = "Read a local or remote text file.", .category = .file },
+    .{ .name = "copy_file", .label = "copy_file", .description = "Copy a file between local, WSL, and SSH contexts.", .category = .file },
+    .{ .name = "write_file", .label = "write_file", .description = "Create or overwrite a local or remote text file.", .category = .file },
+    .{ .name = "edit_file", .label = "edit_file", .description = "Replace exact text in a local or remote text file.", .category = .file },
+    .{ .name = "ssh_profile_save", .label = "ssh_profile_save", .description = "Create or update a saved WispTerm SSH profile.", .category = .session },
+    .{ .name = "ssh_profile_connect", .label = "ssh_profile_connect", .description = "Open a new tab from a saved WispTerm SSH profile.", .category = .session },
+    .{ .name = "tab_new", .label = "tab_new", .description = "Open a new WispTerm terminal tab.", .category = .session },
+    .{ .name = "tab_close", .label = "tab_close", .description = "Close a selected terminal tab.", .category = .session },
+    .{ .name = "skill_info", .label = "skill_info", .description = "Load a WispTerm skill by stable name.", .category = .agent },
+    .{ .name = "wispterm_docs", .label = "wispterm_docs", .description = "Read WispTerm's own documentation.", .category = .docs },
+    .{ .name = "websearch", .label = "websearch", .description = "Search the web for current information via Jina.", .category = .web },
+    .{ .name = "webread", .label = "webread", .description = "Read a web page or local document into markdown via Jina Reader.", .category = .web },
+    .{ .name = "pubmed", .label = "pubmed", .description = "Search PubMed biomedical literature.", .category = .web },
+    .{ .name = "subagent", .label = "subagent", .description = "Delegate a self-contained research task to a background subagent.", .category = .agent },
+    .{ .name = "weixin_send_attachment", .label = "weixin_send_attachment", .description = "Send a local file back to the active Weixin conversation.", .category = .integration },
+    .{ .name = "memory_save", .label = "memory_save", .description = "Save a durable long-term memory.", .category = .memory },
+    .{ .name = "memory_recall", .label = "memory_recall", .description = "Read a durable long-term memory.", .category = .memory },
+    .{ .name = "memory_delete", .label = "memory_delete", .description = "Delete a durable long-term memory.", .category = .memory },
+};
+
+pub const DisabledTools = struct {
+    names: [][]u8,
+
+    pub fn empty() DisabledTools {
+        return .{ .names = &.{} };
+    }
+
+    pub fn deinit(self: *DisabledTools, allocator: std.mem.Allocator) void {
+        for (self.names) |name| allocator.free(name);
+        if (self.names.len > 0) allocator.free(self.names);
+        self.* = empty();
+    }
+
+    pub fn contains(self: DisabledTools, name: []const u8) bool {
+        return isDisabledName(self.names, name);
+    }
+};
+
+pub fn platformLocalCommandNameForTest() []const u8 {
+    return platform_process.localCommandToolName();
+}
+
+pub fn activeDefinitions(allocator: std.mem.Allocator) ![]Definition {
+    var list: std.ArrayListUnmanaged(Definition) = .empty;
+    errdefer list.deinit(allocator);
+
+    const local_name = platform_process.localCommandToolName();
+    try list.append(allocator, .{
+        .name = local_name,
+        .label = local_name,
+        .description = platform_process.localCommandToolDescription(),
+        .category = .terminal,
+    });
+
+    for (static_definitions) |definition| try list.append(allocator, definition);
+
+    if (platform_pty_command.wslSessionToolsEnabled()) {
+        const wsl_name = platform_pty_command.wslSessionToolName();
+        try list.append(allocator, .{
+            .name = wsl_name,
+            .label = wsl_name,
+            .description = platform_pty_command.wslSessionToolDescription(),
+            .category = .terminal,
+        });
+    }
+
+    return list.toOwnedSlice(allocator);
+}
+
+pub fn freeDefinitions(allocator: std.mem.Allocator, defs: []Definition) void {
+    allocator.free(defs);
+}
+
+pub fn isKnown(name: []const u8) bool {
+    if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
+    if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
+    for (static_definitions) |definition| {
+        if (std.mem.eql(u8, definition.name, name)) return true;
+    }
+    return false;
+}
+
+pub fn isKnownActive(defs: []const Definition, name: []const u8) bool {
+    for (defs) |definition| {
+        if (std.mem.eql(u8, definition.name, name)) return true;
+    }
+    return false;
+}
+
+pub fn isDisabledName(disabled_names: []const []const u8, name: []const u8) bool {
+    for (disabled_names) |disabled| {
+        if (std.mem.eql(u8, disabled, name)) return true;
+    }
+    return false;
+}
+
+pub fn parseDisabledToolsJson(allocator: std.mem.Allocator, bytes: []const u8) !DisabledTools {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAgentToolsState;
+
+    const disabled_value = parsed.value.object.get("disabled") orelse return DisabledTools.empty();
+    if (disabled_value != .array) return error.InvalidAgentToolsState;
+
+    var list: std.ArrayListUnmanaged([]u8) = .empty;
+    errdefer {
+        for (list.items) |name| allocator.free(name);
+        list.deinit(allocator);
+    }
+
+    for (disabled_value.array.items) |item| {
+        if (item != .string) continue;
+        if (!isKnown(item.string)) continue;
+        if (isDisabledName(list.items, item.string)) continue;
+        try list.append(allocator, try allocator.dupe(u8, item.string));
+    }
+
+    return .{ .names = try list.toOwnedSlice(allocator) };
+}
+
+pub fn loadDisabledToolsFromPath(allocator: std.mem.Allocator, path: []const u8) !DisabledTools {
+    const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_STATE_BYTES) catch |err| switch (err) {
+        error.FileNotFound => return DisabledTools.empty(),
+        else => return err,
+    };
+    defer allocator.free(bytes);
+    return parseDisabledToolsJson(allocator, bytes) catch DisabledTools.empty();
+}
+
+pub fn loadDisabledTools(allocator: std.mem.Allocator) !DisabledTools {
+    const path = platform_dirs.pathInConfigDir(allocator, STATE_BASENAME) catch return DisabledTools.empty();
+    defer allocator.free(path);
+    return loadDisabledToolsFromPath(allocator, path) catch DisabledTools.empty();
+}
+
+pub fn disabledToolsJson(allocator: std.mem.Allocator, disabled: DisabledTools) ![]u8 {
+    const State = struct {
+        disabled: []const []const u8,
+    };
+    return std.json.Stringify.valueAlloc(allocator, State{ .disabled = disabled.names }, .{ .whitespace = .indent_2 });
+}
+
+pub fn writeDisabledToolsToPath(allocator: std.mem.Allocator, path: []const u8, disabled: DisabledTools) !void {
+    const json = try disabledToolsJson(allocator, disabled);
+    defer allocator.free(json);
+    try platform_atomic_file.writeFileReplaceSafe(path, json);
+}
+
+pub fn writeDisabledTools(allocator: std.mem.Allocator, disabled: DisabledTools) !void {
+    const config_dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(config_dir);
+    try std.fs.cwd().makePath(config_dir);
+    const path = try std.fs.path.join(allocator, &.{ config_dir, STATE_BASENAME });
+    defer allocator.free(path);
+    try writeDisabledToolsToPath(allocator, path, disabled);
+}
+
+pub fn toggledDisabledTools(allocator: std.mem.Allocator, current: DisabledTools, name: []const u8) !DisabledTools {
+    if (!isKnown(name)) return error.UnknownFirstPartyTool;
+    var list: std.ArrayListUnmanaged([]u8) = .empty;
+    errdefer {
+        for (list.items) |owned| allocator.free(owned);
+        list.deinit(allocator);
+    }
+
+    var removed = false;
+    for (current.names) |existing| {
+        if (std.mem.eql(u8, existing, name)) {
+            removed = true;
+            continue;
+        }
+        try list.append(allocator, try allocator.dupe(u8, existing));
+    }
+
+    if (!removed) try list.append(allocator, try allocator.dupe(u8, name));
+    return .{ .names = try list.toOwnedSlice(allocator) };
+}
+
+test "first_party_tools: active definitions include webread and the local command tool" {
+    const a = std.testing.allocator;
+    const defs = try activeDefinitions(a);
+    defer freeDefinitions(a, defs);
+
+    try std.testing.expect(isKnownActive(defs, "webread"));
+    try std.testing.expect(isKnown(platformLocalCommandNameForTest()));
+}
+
+test "first_party_tools: disabled state json filters unknown and duplicate names" {
+    const a = std.testing.allocator;
+    var disabled = try parseDisabledToolsJson(a,
+        \\{"disabled":["webread","missing_tool","webread","pubmed"]}
+    );
+    defer disabled.deinit(a);
+
+    try std.testing.expect(disabled.contains("webread"));
+    try std.testing.expect(disabled.contains("pubmed"));
+    try std.testing.expect(!disabled.contains("missing_tool"));
+    try std.testing.expectEqual(@as(usize, 2), disabled.names.len);
+}
+
+test "first_party_tools: malformed state falls back to empty when loaded from path" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "agent_tools.json", .data = "not json" });
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    var disabled = loadDisabledToolsFromPath(a, path) catch DisabledTools.empty();
+    defer disabled.deinit(a);
+    try std.testing.expectEqual(@as(usize, 0), disabled.names.len);
+}
+
+test "first_party_tools: toggled state writes and reads atomically" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const path = try std.fs.path.join(a, &.{ root, "agent_tools.json" });
+    defer a.free(path);
+
+    const current = DisabledTools.empty();
+    var next = try toggledDisabledTools(a, current, "webread");
+    defer next.deinit(a);
+    try writeDisabledToolsToPath(a, path, next);
+
+    var loaded = try loadDisabledToolsFromPath(a, path);
+    defer loaded.deinit(a);
+    try std.testing.expect(loaded.contains("webread"));
+
+    var enabled_again = try toggledDisabledTools(a, loaded, "webread");
+    defer enabled_again.deinit(a);
+    try std.testing.expect(!enabled_again.contains("webread"));
+}

--- a/src/first_party_tools.zig
+++ b/src/first_party_tools.zig
@@ -55,6 +55,18 @@ const static_definitions = [_]Definition{
     .{ .name = "memory_delete", .label = "memory_delete", .description = "Delete a durable long-term memory.", .category = .memory },
 };
 
+const DefinitionLookup = union(enum) {
+    catalog,
+    definitions: []const Definition,
+
+    fn disableable(self: DefinitionLookup, name: []const u8) ?bool {
+        return switch (self) {
+            .catalog => catalogDisableable(name),
+            .definitions => |definitions| definitionDisableable(definitions, name),
+        };
+    }
+};
+
 pub const DisabledTools = struct {
     names: [][]u8,
 
@@ -109,12 +121,24 @@ pub fn freeDefinitions(allocator: std.mem.Allocator, defs: []Definition) void {
 }
 
 pub fn isKnown(name: []const u8) bool {
+    return catalogDisableable(name) != null;
+}
+
+pub fn isDisableable(name: []const u8) bool {
+    return catalogDisableable(name) orelse false;
+}
+
+fn catalogDisableable(name: []const u8) ?bool {
     if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
     if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
-    for (static_definitions) |definition| {
-        if (std.mem.eql(u8, definition.name, name)) return true;
+    return definitionDisableable(&static_definitions, name);
+}
+
+fn definitionDisableable(definitions: []const Definition, name: []const u8) ?bool {
+    for (definitions) |definition| {
+        if (std.mem.eql(u8, definition.name, name)) return definition.disableable;
     }
-    return false;
+    return null;
 }
 
 pub fn isKnownActive(defs: []const Definition, name: []const u8) bool {
@@ -132,6 +156,10 @@ pub fn isDisabledName(disabled_names: []const []const u8, name: []const u8) bool
 }
 
 pub fn parseDisabledToolsJson(allocator: std.mem.Allocator, bytes: []const u8) !DisabledTools {
+    return parseDisabledToolsJsonWithLookup(allocator, bytes, .catalog);
+}
+
+fn parseDisabledToolsJsonWithLookup(allocator: std.mem.Allocator, bytes: []const u8, lookup: DefinitionLookup) !DisabledTools {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, bytes, .{});
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidAgentToolsState;
@@ -147,7 +175,8 @@ pub fn parseDisabledToolsJson(allocator: std.mem.Allocator, bytes: []const u8) !
 
     for (disabled_value.array.items) |item| {
         if (item != .string) continue;
-        if (!isKnown(item.string)) continue;
+        const disableable = lookup.disableable(item.string) orelse continue;
+        if (!disableable) continue;
         if (isDisabledName(list.items, item.string)) continue;
         const owned = try allocator.dupe(u8, item.string);
         list.append(allocator, owned) catch |err| {
@@ -200,7 +229,12 @@ pub fn writeDisabledTools(allocator: std.mem.Allocator, disabled: DisabledTools)
 }
 
 pub fn toggledDisabledTools(allocator: std.mem.Allocator, current: DisabledTools, name: []const u8) !DisabledTools {
-    if (!isKnown(name)) return error.UnknownFirstPartyTool;
+    return toggledDisabledToolsWithLookup(allocator, current, name, .catalog);
+}
+
+fn toggledDisabledToolsWithLookup(allocator: std.mem.Allocator, current: DisabledTools, name: []const u8, lookup: DefinitionLookup) !DisabledTools {
+    const disableable = lookup.disableable(name) orelse return error.UnknownFirstPartyTool;
+    if (!disableable) return error.FirstPartyToolNotDisableable;
     var list: std.ArrayListUnmanaged([]u8) = .empty;
     errdefer {
         for (list.items) |owned| allocator.free(owned);
@@ -237,6 +271,8 @@ test "first_party_tools: active definitions include webread and the local comman
 
     try std.testing.expect(isKnownActive(defs, "webread"));
     try std.testing.expect(isKnownActive(defs, platformLocalCommandNameForTest()));
+    try std.testing.expect(isDisableable("webread"));
+    try std.testing.expect(isDisableable(platformLocalCommandNameForTest()));
 }
 
 test "first_party_tools: disabled state json filters unknown and duplicate names" {
@@ -250,6 +286,23 @@ test "first_party_tools: disabled state json filters unknown and duplicate names
     try std.testing.expect(disabled.contains("pubmed"));
     try std.testing.expect(!disabled.contains("missing_tool"));
     try std.testing.expectEqual(@as(usize, 2), disabled.names.len);
+}
+
+test "first_party_tools: disabled state json filters non-disableable definitions" {
+    const a = std.testing.allocator;
+    const defs = [_]Definition{
+        .{ .name = "sticky_tool", .label = "sticky_tool", .description = "Always on.", .category = .agent, .disableable = false },
+        .{ .name = "switchable_tool", .label = "switchable_tool", .description = "User controlled.", .category = .agent, .disableable = true },
+    };
+    const json =
+        \\{"disabled":["sticky_tool","switchable_tool"]}
+    ;
+    var disabled = try parseDisabledToolsJsonWithLookup(a, json, .{ .definitions = defs[0..] });
+    defer disabled.deinit(a);
+
+    try std.testing.expect(!disabled.contains("sticky_tool"));
+    try std.testing.expect(disabled.contains("switchable_tool"));
+    try std.testing.expectEqual(@as(usize, 1), disabled.names.len);
 }
 
 test "first_party_tools: malformed state falls back to empty when loaded from path" {
@@ -337,6 +390,16 @@ test "first_party_tools: toggled state frees duplicated name when append fails" 
 
     try std.testing.expectError(error.OutOfMemory, toggledDisabledTools(failing_existing.allocator(), current_with_existing, "webread"));
     try std.testing.expect(failing_existing.has_induced_failure);
+}
+
+test "first_party_tools: toggled state rejects non-disableable definitions" {
+    const defs = [_]Definition{
+        .{ .name = "sticky_tool", .label = "sticky_tool", .description = "Always on.", .category = .agent, .disableable = false },
+    };
+    try std.testing.expectError(
+        error.FirstPartyToolNotDisableable,
+        toggledDisabledToolsWithLookup(std.testing.allocator, DisabledTools.empty(), "sticky_tool", .{ .definitions = defs[0..] }),
+    );
 }
 
 test "first_party_tools: toggled state writes and reads atomically" {

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -296,7 +296,7 @@ const en = Strings{
     .sc_overwrite_download = "Overwrite download of",
     .sc_confirm_suffix = "— content differs. [⏎] confirm  [esc] cancel",
 
-    .sc_legend_v2 = "[space] preview   [↵] deploy   [i] import   [t] import tool   [e] enable   [g] get   [r] rescan",
+    .sc_legend_v2 = "[space] preview   [↵] deploy   [i] import   [t] import tool   [e] toggle   [g] get   [r] rescan",
     .sc_legend_import = "[space] preview   [↵] import   [esc] back",
     .sc_busy_loading = "Loading…",
     .sc_tool_import_failed = "Tool import is not available yet",
@@ -500,7 +500,7 @@ const zh_CN = Strings{
     .sc_overwrite_download = "下载覆盖",
     .sc_confirm_suffix = "（内容不同）。 [⏎] 确认  [esc] 取消",
 
-    .sc_legend_v2 = "[space] 预览   [↵] 部署   [i] 导入   [t] 导入工具   [e] 启用   [g] 获取   [r] 重新扫描",
+    .sc_legend_v2 = "[space] 预览   [↵] 部署   [i] 导入   [t] 导入工具   [e] 开关   [g] 获取   [r] 重新扫描",
     .sc_legend_import = "[space] 预览   [↵] 导入   [esc] 返回",
     .sc_busy_loading = "加载中…",
     .sc_tool_import_failed = "工具导入暂不可用",

--- a/src/input.zig
+++ b/src/input.zig
@@ -488,6 +488,98 @@ test "input: skill center tool toggle requests a repaint" {
     _ = AppWindow.skillCenterToggleToolEnabled();
 }
 
+test "input: skill center first-party tool toggle writes state and requests a repaint" {
+    const allocator = std.testing.allocator;
+    const previous_allocator = AppWindow.g_allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    const previous_force_rebuild = AppWindow.g_force_rebuild;
+    const previous_cells_valid = AppWindow.g_cells_valid;
+    defer {
+        AppWindow.g_allocator = previous_allocator;
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        AppWindow.g_force_rebuild = previous_force_rebuild;
+        AppWindow.g_cells_valid = previous_cells_valid;
+        platform_dirs.clearTestConfigDirForCurrentThread();
+    }
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    platform_dirs.setTestConfigDirForCurrentThread(root);
+
+    AppWindow.g_allocator = allocator;
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tab_count = 0;
+    active_tab_state.g_active_tab = 0;
+    if (!tab.spawnSkillCenterTab(allocator)) return error.SkipZigTest;
+    defer {
+        while (tab.g_tab_count > 0) {
+            const idx = tab.g_tab_count - 1;
+            if (tab.g_tabs[idx]) |t| {
+                t.deinit(allocator);
+                allocator.destroy(t);
+                tab.g_tabs[idx] = null;
+            }
+            tab.g_tab_count -= 1;
+        }
+    }
+
+    const session = AppWindow.activeSkillCenter() orelse return error.ExpectedSkillCenterTab;
+    const name = try allocator.dupe(u8, "webread");
+    var name_owned = true;
+    errdefer if (name_owned) allocator.free(name);
+    const description = try allocator.dupe(u8, "Read web pages.");
+    var description_owned = true;
+    errdefer if (description_owned) allocator.free(description);
+    const entries = try allocator.alloc(AppWindow.skill_center.LibraryEntry, 1);
+    var entries_owned = true;
+    errdefer if (entries_owned) allocator.free(entries);
+    entries[0] = .{ .first_party_tool = .{
+        .name = name,
+        .description = description,
+        .enabled = true,
+        .disableable = true,
+    } };
+    session.mutex.lock();
+    session.model.setEntries(entries);
+    entries_owned = false;
+    name_owned = false;
+    description_owned = false;
+    session.mutex.unlock();
+
+    AppWindow.g_force_rebuild = false;
+    AppWindow.g_cells_valid = true;
+    handleKey(.{ .key_code = 0x45, .ctrl = false, .shift = false, .alt = false, .super = false });
+
+    try std.testing.expect(AppWindow.g_force_rebuild);
+    try std.testing.expect(!AppWindow.g_cells_valid);
+
+    const state = try tmp.dir.readFileAlloc(allocator, "agent_tools.json", 4096);
+    defer allocator.free(state);
+    try std.testing.expect(std.mem.indexOf(u8, state, "\"webread\"") != null);
+
+    {
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        const entry = session.model.selectedEntry() orelse return error.ExpectedFirstPartyTool;
+        switch (entry) {
+            .first_party_tool => |tool| try std.testing.expect(!tool.enabled),
+            else => return error.ExpectedFirstPartyTool,
+        }
+    }
+
+    const settings = AppWindow.ai_chat.currentAgentSettings();
+    try std.testing.expectEqual(@as(usize, 1), settings.disabled_first_party_tools.len);
+    try std.testing.expectEqualStrings("webread", settings.disabled_first_party_tools[0]);
+
+    try std.testing.expect(AppWindow.skillCenterToggleToolEnabled());
+}
+
 test "input: skill center tool toggle is blocked while selection overlay is active" {
     const allocator = std.testing.allocator;
     const previous_allocator = AppWindow.g_allocator;
@@ -615,7 +707,7 @@ test "input: skill center tool toggle is blocked while selection overlay is acti
     const entry = session.model.selectedEntry() orelse return error.ExpectedSkillCenterTool;
     switch (entry) {
         .tool => |tool| try std.testing.expect(tool.enabled),
-        .prompt => return error.ExpectedSkillCenterTool,
+        else => return error.ExpectedSkillCenterTool,
     }
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -3100,8 +3100,8 @@ fn handleKey(ev: platform_input.KeyEvent) void {
     }
 
     // Skill Center: ↑/↓ move, space preview/toggle, ⏎ confirm, esc cancel,
-    // d deploy, i import, g get-from-GitHub, r rescan. The URL-input overlay
-    // captures text; the checklist captures space + 'a'.
+    // d deploy, i import, t import tool, e toggle, g get-from-GitHub, r rescan.
+    // The URL-input overlay captures text; the checklist captures space + 'a'.
     if (AppWindow.activeSkillCenter() != null) {
         switch (AppWindow.skillCenterPreviewKind()) {
             .text => {

--- a/src/skill_center.zig
+++ b/src/skill_center.zig
@@ -126,14 +126,41 @@ pub const ToolSkill = struct {
     }
 };
 
+pub const FirstPartyToolSkill = struct {
+    name: []u8,
+    description: []u8,
+    enabled: bool,
+    disableable: bool,
+
+    pub fn clone(self: FirstPartyToolSkill, allocator: std.mem.Allocator) !FirstPartyToolSkill {
+        const name = try allocator.dupe(u8, self.name);
+        errdefer allocator.free(name);
+        const description = try allocator.dupe(u8, self.description);
+        return .{
+            .name = name,
+            .description = description,
+            .enabled = self.enabled,
+            .disableable = self.disableable,
+        };
+    }
+
+    pub fn deinit(self: *FirstPartyToolSkill, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.description);
+        self.* = undefined;
+    }
+};
+
 pub const LibraryEntry = union(enum) {
     prompt: LibrarySkill,
     tool: ToolSkill,
+    first_party_tool: FirstPartyToolSkill,
 
     pub fn deinit(self: *LibraryEntry, allocator: std.mem.Allocator) void {
         switch (self.*) {
             .prompt => |*s| s.deinit(allocator),
             .tool => |*t| t.deinit(allocator),
+            .first_party_tool => |*t| t.deinit(allocator),
         }
         self.* = undefined;
     }
@@ -142,6 +169,7 @@ pub const LibraryEntry = union(enum) {
         return switch (self) {
             .prompt => |s| .{ .prompt = try s.clone(allocator) },
             .tool => |t| .{ .tool = try t.clone(allocator) },
+            .first_party_tool => |t| .{ .first_party_tool = try t.clone(allocator) },
         };
     }
 
@@ -149,6 +177,7 @@ pub const LibraryEntry = union(enum) {
         return switch (self) {
             .prompt => |s| s.name,
             .tool => |t| t.name,
+            .first_party_tool => |t| t.name,
         };
     }
 };
@@ -479,6 +508,7 @@ pub const PanelModel = struct {
         return switch (entry) {
             .prompt => |skill| skill,
             .tool => null,
+            .first_party_tool => null,
         };
     }
 
@@ -491,6 +521,7 @@ pub const PanelModel = struct {
                 tool.enabled = !tool.enabled;
                 return true;
             },
+            .first_party_tool => return false,
         }
     }
 
@@ -931,6 +962,27 @@ test "skill_center: PanelModel holds mixed prompt and tool entries" {
     m.sel_row = 1;
     try std.testing.expectEqualStrings("docx_review", m.selectedEntry().?.name());
     try std.testing.expectEqual(@as(?LibrarySkill, null), m.selected());
+}
+
+test "skill_center: first-party tool entry clones, deinitializes, and reports name" {
+    const a = std.testing.allocator;
+    var entry = LibraryEntry{ .first_party_tool = .{
+        .name = try a.dupe(u8, "webread"),
+        .description = try a.dupe(u8, "Read a web page into markdown."),
+        .enabled = true,
+        .disableable = true,
+    } };
+    defer entry.deinit(a);
+
+    var cloned = try entry.clone(a);
+    defer cloned.deinit(a);
+
+    try std.testing.expectEqualStrings("webread", entry.name());
+    try std.testing.expectEqualStrings("webread", cloned.name());
+    try std.testing.expect(cloned.first_party_tool.enabled);
+    try std.testing.expect(cloned.first_party_tool.disableable);
+    try std.testing.expect(cloned.first_party_tool.name.ptr != entry.first_party_tool.name.ptr);
+    try std.testing.expect(cloned.first_party_tool.description.ptr != entry.first_party_tool.description.ptr);
 }
 
 test "skill_center: toggleSelectedTool flips only selected tool entries" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -99,6 +99,7 @@ test {
     _ = @import("composer_detail_wrap.zig");
     _ = @import("web_search.zig");
     _ = @import("agent_prompt_answer.zig");
+    _ = @import("first_party_tools.zig");
     _ = @import("web_read.zig");
     _ = @import("web_read_cache.zig");
     _ = @import("pubmed.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -679,6 +679,7 @@ comptime {
     _ = @import("config_watcher.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
+    _ = @import("first_party_tools.zig");
     _ = @import("input.zig");
     _ = @import("input/clipboard.zig");
     _ = @import("clipboard_osc52.zig");


### PR DESCRIPTION
## Summary
- Add a first-party Agent tool catalog and persisted disabled state in `agent_tools.json`.
- Show built-in first-party tools in Skill Center and let `[e] toggle` them separately from imported executable tools.
- Hide disabled first-party tools from new request schemas and reject stale runtime calls, including `subagent`.
- Update user docs for built-in Agent tool off behavior.

## Test Plan
- `zig build test`
- `git diff --check`
- Windows checkout path-safety equivalent check: 0 name violations, 0 casefold collisions, no symlinks
- `zig build test-full` skipped per user request