### PR TITLE
[codex] Fix PDF preview drag pan

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -5762,7 +5762,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             // route there) and consumes the event — previews have no terminal
             // grid to select into. Terminal leaves fall through to the surface
             // focus + selection path below, so non-preview clicks are unchanged.
-            // A ready image preview additionally starts a drag-to-pan.
+            // A ready image/PDF preview additionally starts a drag-to-pan.
             if (split_layout.paneAtPoint(ev.x, ev.y)) |hit| {
                 switch (hit.pane) {
                     .preview => |p| {
@@ -6080,8 +6080,8 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
         platform_cursor.set(.ibeam);
         return;
     }
-    // Left-drag pans a ready image preview (the renderer clamps the pan to the
-    // image's overflow each frame).
+    // Left-drag pans a ready image/PDF preview (the renderer clamps the pan to
+    // the raster content's overflow each frame).
     if (g_preview_image_drag.active()) {
         if (g_preview_image_drag.move(xpos, ypos)) AppWindow.g_force_rebuild = true;
         platform_cursor.set(.size_all);

--- a/src/input/preview_image_drag.zig
+++ b/src/input/preview_image_drag.zig
@@ -1,4 +1,4 @@
-//! Left-drag pan state machine for image preview panes. Extracted from
+//! Left-drag pan state machine for raster preview panes. Extracted from
 //! input.zig threadlocals so the drag wiring is testable: the right-dock →
 //! pane migration (PR #185) silently dropped drag-to-pan because the logic
 //! lived only in untested UI glue. input.zig owns one threadlocal instance
@@ -18,12 +18,12 @@ pub fn active(self: *const PreviewImageDrag) bool {
     return self.pane != null;
 }
 
-/// Start a pan drag on `p` if it is a ready image preview. Replaces any stale
+/// Start a pan drag on `p` if it is a ready image/PDF preview. Replaces any stale
 /// drag. The pane is ref'd for the drag's lifetime so a mid-drag tree edit
 /// (e.g. a keyboard close) cannot free it under the cursor. Returns whether
 /// the drag engaged (caller sets the pan cursor).
 pub fn begin(self: *PreviewImageDrag, gpa: Allocator, p: *PreviewPane, x: f64, y: f64) bool {
-    if (p.kind != .image or p.load_status != .ready) return false;
+    if (!p.kind.isRaster() or p.load_status != .ready) return false;
     self.release(gpa);
     self.pane = p.ref();
     self.last_x = x;
@@ -124,6 +124,23 @@ test "PreviewImageDrag: move pans by the mouse delta and updates the anchor" {
     // Same position again: zero delta, no pan change.
     try std.testing.expect(!drag.move(110, 90));
     try std.testing.expectEqual(@as(f32, 10), p.imagePanX());
+
+    drag.release(gpa);
+}
+
+test "PreviewImageDrag: ready PDF panes can be dragged like images" {
+    const gpa = std.testing.allocator;
+    var drag: PreviewImageDrag = .{};
+
+    const p = try PreviewPane.create(gpa);
+    defer p.unref(gpa);
+    p.kind = .pdf;
+    p.load_status = .ready;
+
+    try std.testing.expect(drag.begin(gpa, p, 20, 30));
+    try std.testing.expect(drag.move(12, 44));
+    try std.testing.expectEqual(@as(f32, -8), p.imagePanX());
+    try std.testing.expectEqual(@as(f32, 14), p.imagePanY());
 
     drag.release(gpa);
 }


### PR DESCRIPTION
## Summary
- Allow ready raster preview panes, including PDFs, to start the existing drag-to-pan interaction.
- Keep PNG/image preview behavior unchanged by reusing the same PreviewImageDrag state machine.
- Add a regression test covering PDF drag pan deltas.

## Why
PDF previews already reuse the image preview zoom/pan fields and renderer clamp path, but the mouse-down drag gate only accepted `.image`, so PDFs could zoom but could not be dragged.

## Impact
Users can now drag zoomed PDF previews the same way they drag PNG/image previews.

## Validation
- `git diff --check`
- `zig build test --summary all` (1379 passed, 1 skipped)
- `zig build --summary all` (26/26 steps succeeded)

Note: `zig build test-full` was not run per request to avoid running the full suite for this small change.
