### PR TITLE
feat(ai-chat): show status as a colored dot instead of text

### DIFF
--- a/docs/superpowers/specs/2026-06-22-ai-chat-status-dot-design.md
+++ b/docs/superpowers/specs/2026-06-22-ai-chat-status-dot-design.md
@@ -1,0 +1,115 @@
+# AI Chat 状态指示:文字 → 彩色圆点
+
+日期:2026-06-22
+
+## 背景与问题
+
+AI Chat 面板头部最右侧显示一段状态文字(`Ready` / `Done` / `Thinking…` 等),
+空闲态由 `statusActionRect` 预留约 280px(`STATUS_SLOT_W`),请求进行中则显示
+一个 104px 宽的 `Esc Stop` 按钮。在窄的 copilot 侧边栏里,这块文字占用过多横向
+空间(模型名在窄面板下已经被隐藏)。
+
+目标:用红/绿/黄三色圆点表示状态,大幅压缩占用,同时保留关键信息与取消能力。
+
+代码现状:
+- 渲染:`src/renderer/ai_chat_renderer.zig` `render()` 第 213–224 行
+  (`if (request_inflight) renderStopButton(...) else 渲染状态文字`)。
+- 状态是纯字符串 `Session.status_buf: [512]u8`,没有严重级别枚举。
+- 取消请求:进行中按 `Esc` 即触发 `stopRequest()`(`src/ai_chat.zig:1472`),
+  以及点击 `Esc Stop` 按钮(`input.zig:4438/4578` 调 `stopButtonHitTest` → `stopRequest`)。
+- 主题色:`Config.Theme.palette: [16]Color`(`Color = [3]f32`),标准 ANSI:
+  `palette[1]`=红、`palette[2]`=绿、`palette[3]`=黄。
+
+## 目标 / 非目标
+
+目标:
+- 状态指示从文字改为固定在头部最右角的彩色圆点(直径约 9px,垂直居中)。
+- 圆点颜色映射请求生命周期三态:绿=正常完整、黄=进行中、红=停止/出错。
+- 用主题自带 ANSI 色,换主题自动适配。
+- 进行中的黄点可点击停止(复用现有点击热区),`Esc` 仍可取消。
+- 出错(红)时在圆点旁保留简短错误文字,保证可操作提示(如 Missing API key)不丢失。
+
+非目标:
+- 不改任何状态字符串本身、不改 agent 行为。
+- 不动模型名 / Agent·Chat / 权限 chip(Ask/Auto/Full)这三块,只替换最右侧状态块。
+- 不引入悬停 tooltip(终端 UI 无现成机制)。
+
+## 状态 → 颜色映射
+
+| 颜色 | 语义 | 触发条件 |
+|---|---|---|
+| 🟢 绿 `palette[2]` | 正常完整 | 空闲且状态为 Ready / Done(含 Done in X.Xs) / Cleared / Model switched / Context summarized / Distill preview ready(默认归类) |
+| 🟡 黄 `palette[3]` | 进行中 | `request_inflight`(Thinking / Streaming / Running tools / Searching / Reading / Summarizing / Distilling / Stopping);以及空闲态下的 Approval needed、Waiting for your answer |
+| 🔴 红 `palette[1]` | 停止 / 出错 | `missingApiKey()`;以及空闲态下的 Stopped、Out of memory、Could not…、Failed…、Summary unavailable… |
+
+## 设计
+
+### 1. 状态分级:`Session.statusKind()`
+
+在 `src/ai_chat.zig` 新增:
+
+```zig
+pub const StatusKind = enum { ready, busy, stopped }; // ready→绿, busy→黄, stopped→红
+
+/// 调用方需已持有 session.mutex(与 status() 一致)。
+pub fn statusKind(self: *const Session) StatusKind {
+    if (self.missingApiKey()) return .stopped;
+    if (self.request_inflight) return .busy;
+    const s = self.status();
+    if (isErrorStatus(s)) return .stopped;          // Out of memory / Could not / Failed / unavailable / Stopped
+    if (isWaitingStatus(s)) return .busy;           // Approval needed / Waiting for your answer
+    return .ready;
+}
+```
+
+`isErrorStatus` / `isWaitingStatus` 用前缀/相等匹配已知字符串;未知空闲串默认 `.ready`(绿)。
+逻辑主要靠标志位(`missingApiKey` / `request_inflight`),字符串匹配只覆盖少量空闲态。
+可单测,不依赖渲染。
+
+### 2. 圆点绘制图元:`fillDot`
+
+代码无圆形图元(全是 `fillQuad`)。在 `ai_chat_renderer.zig` 加私有辅助:
+按圆方程逐行堆 `fillQuadAlpha` 近似实心圆盘(直径约 9px → ~9 行,开销可忽略),
+得到真正的圆点而非方块,且不依赖字体字形。颜色取主题 ANSI 色。
+
+### 3. 渲染替换(`render()` 213–224 行)
+
+新逻辑(始终走同一分支,不再按 inflight 二选一):
+- 计算 `kind = session.statusKind()`,选 `dot_color = palette[1/2/3]`。
+- 圆点固定画在头部最右角(`x + w - LINE_PAD_X` 处,垂直居中),所有状态位置一致,便于一眼定位。
+- 若 `kind == .stopped`(红):在圆点左侧渲染简短状态文字(`session.status()`,
+  缺 key 时用 `MISSING_API_KEY_ACTION_TEXT`),文字向左展开,宽度受 `statusActionRect` 同款夹取规则约束,避免与权限 chip 重叠。
+- 绿 / 黄:仅圆点,无文字。
+
+### 4. 点击停止(黄点)
+
+复用现有 `stopButtonHitTest` + `input.zig` 调用链(命中即 `stopRequest()`)。
+做法:把 `stopButtonRect` 的几何改成圆点所在位置的一个便于点击的方形热区
+(略大于视觉圆点,如 ~24–28px 方块),并保持仅在 `request_inflight` 时命中。
+`input.zig` 两处调用点(4438/4578)无需改动。`Esc` 取消路径不变。
+
+### 5. 出错文字点击(红点)
+
+`missingApiKeyStatusHitTest` 继续有效(红态文字仍渲染,点击可跳配置)。
+其命中矩形需跟随新的红态文字位置;沿用 `statusActionRect` 计算即可。
+
+## 测试
+
+- 单测(`zig build test` 快速套件,macOS 可链接通过):
+  `Session.statusKind()` 覆盖 ready / busy(inflight + waiting)/ stopped(error + missingApiKey)各分支。
+- UI 渲染回归:`zig build test-macos-ui`(布局/热区相关,见 `ai_chat_layout.zig` 的 `stopButtonRect` 测试,需同步更新)。
+- 真机抽查:窄 copilot 侧边栏下三态圆点位置一致、黄点可点击停止、红态文字可见且可点。
+
+## 触及文件
+
+- `src/ai_chat.zig`:新增 `StatusKind` + `statusKind()` + 分类辅助;单测。
+- `src/renderer/ai_chat_renderer.zig`:`fillDot` 辅助;改写 `render()` 状态块;
+  调整 `stopButtonRect`/相关常量为圆点热区;红态文字位置。
+- `src/ai_chat_layout.zig`:同步 `stopButtonRect` 几何与其测试。
+- (input.zig 预期无需改动,验证为准。)
+
+## 取舍记录
+
+- 绿/黄态丢失精确文字(如 "Done in 3.2s"),换取空间——符合"空间小"诉求。
+- 进行中不再有 `Esc Stop` 文案提示,靠黄点可点击 + Esc 兜底;接受可发现性下降。
+- 错误态保留文字,因其常含可操作信息,是最需要文字的场景。

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -851,6 +851,7 @@ fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, le
             titlebar_offset,
             chat_x,
             chat_w,
+            false, // full tab: status shown as text + Esc Stop button
         );
     }
 }
@@ -1108,7 +1109,7 @@ fn renderAiCopilotPanel(fb_width: c_int, fb_height: c_int, titlebar_offset: f32)
     const bounds = ai_sidebar.boundsForWindow(@intCast(fb_width), @intCast(fb_height), titlebar_offset, left, 0);
     const chat_x: f32 = @floatFromInt(bounds.left);
     const chat_w: f32 = @floatFromInt(bounds.right - bounds.left);
-    ai_chat_renderer.render(session, @floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, chat_x, chat_w);
+    ai_chat_renderer.render(session, @floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, chat_x, chat_w, true); // copilot sidebar: status shown as a colored dot
     renderAiCopilotCloseButton(bounds, @floatFromInt(fb_height));
 }
 

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -1223,6 +1223,31 @@ pub const Session = struct {
         return self.status_buf[0..self.status_len];
     }
 
+    /// Severity of the current status, for the header status dot.
+    /// ready → green, busy → yellow, stopped → red.
+    pub const StatusKind = enum { ready, busy, stopped };
+
+    /// Classify the current status for the header dot. Caller must hold
+    /// `mutex` (mirrors `status()` / `missingApiKey()`, which don't lock).
+    pub fn statusKind(self: *const Session) StatusKind {
+        if (self.missingApiKey()) return .stopped;
+        if (self.request_inflight) return .busy;
+        const s = self.status();
+        // Stopped / error states → red.
+        if (std.mem.eql(u8, s, "Stopped") or
+            std.mem.startsWith(u8, s, "Out of memory") or
+            std.mem.startsWith(u8, s, "Could not") or
+            std.mem.startsWith(u8, s, "Failed") or
+            std.mem.startsWith(u8, s, "Missing API key") or
+            std.mem.indexOf(u8, s, "unavailable") != null)
+            return .stopped;
+        // Awaiting the user → yellow (mid-task, your turn).
+        if (std.mem.eql(u8, s, "Approval needed") or
+            std.mem.startsWith(u8, s, "Waiting"))
+            return .busy;
+        return .ready;
+    }
+
     pub fn requestState(self: *Session) RequestState {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -6919,6 +6944,67 @@ test "ai chat escape stops in-flight request" {
     try std.testing.expect(session.request_stopping);
     try std.testing.expect(session.stop_requested.load(.acquire));
     try std.testing.expectEqualStrings("Stopping...", session.status());
+}
+
+test "statusKind: missing api key maps to stopped" {
+    var session = Session{ .allocator = std.testing.allocator };
+    // A freshly-constructed session has no API key.
+    try std.testing.expect(session.missingApiKey());
+    try std.testing.expectEqual(Session.StatusKind.stopped, session.statusKind());
+}
+
+test "statusKind: idle error and stopped states map to stopped" {
+    var session = Session{ .allocator = std.testing.allocator };
+    session.copyApiKey("k");
+    const errors = [_][]const u8{
+        "Stopped",
+        "Out of memory",
+        "Could not prepare request",
+        "Could not run command",
+        "Failed to start request thread",
+        "Summary unavailable — kept full history",
+        "Missing API key. Edit the Copilot profile or set DEEPSEEK_API_KEY.",
+    };
+    for (errors) |s| {
+        session.setStatus(s);
+        try std.testing.expectEqual(Session.StatusKind.stopped, session.statusKind());
+    }
+}
+
+test "statusKind: inflight maps to busy" {
+    var session = Session{ .allocator = std.testing.allocator };
+    session.copyApiKey("k");
+    session.request_inflight = true;
+    session.setStatus("Thinking...");
+    try std.testing.expectEqual(Session.StatusKind.busy, session.statusKind());
+}
+
+test "statusKind: idle waiting states map to busy" {
+    var session = Session{ .allocator = std.testing.allocator };
+    session.copyApiKey("k");
+    const waiting = [_][]const u8{ "Approval needed", "Waiting for your answer" };
+    for (waiting) |s| {
+        session.setStatus(s);
+        try std.testing.expectEqual(Session.StatusKind.busy, session.statusKind());
+    }
+}
+
+test "statusKind: idle normal states map to ready" {
+    var session = Session{ .allocator = std.testing.allocator };
+    session.copyApiKey("k");
+    const ready = [_][]const u8{
+        "Ready",
+        "Done",
+        "Done in 3.2s",
+        "Cleared",
+        "Model switched",
+        "Context summarized",
+        "Distill preview ready",
+    };
+    for (ready) |s| {
+        session.setStatus(s);
+        try std.testing.expectEqual(Session.StatusKind.ready, session.statusKind());
+    }
 }
 
 fn testDistillCandidate(allocator: std.mem.Allocator) !ai_skill_distill.Candidate {

--- a/src/input.zig
+++ b/src/input.zig
@@ -4443,6 +4443,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             @floatCast(titlebarHeight()),
                             chat_x,
                             chat_w,
+                            true, // copilot sidebar: dot hit-box
                         )) {
                             chat.stopRequest();
                             AppWindow.g_force_rebuild = true;
@@ -4457,6 +4458,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             @floatCast(titlebarHeight()),
                             chat_x,
                             chat_w,
+                            true, // copilot sidebar: error text left of dot
                         )) {
                             overlays.openAiConfigForSession(chat);
                             AppWindow.g_force_rebuild = true;
@@ -4583,6 +4585,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     @floatCast(titlebarHeight()),
                     AppWindow.leftPanelsWidth(),
                     @as(f32, @floatFromInt(fb.width)) - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidthForWindow(fb.width),
+                    false, // full tab: Esc Stop button hit-box
                 )) {
                     chat.stopRequest();
                     AppWindow.g_force_rebuild = true;
@@ -4597,6 +4600,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     @floatCast(titlebarHeight()),
                     AppWindow.leftPanelsWidth(),
                     @as(f32, @floatFromInt(fb.width)) - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidthForWindow(fb.width),
+                    false, // full tab: status text hit-box
                 )) {
                     overlays.openAiConfigForSession(chat);
                     AppWindow.g_force_rebuild = true;

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -36,9 +36,13 @@ pub const INPUT_FIELD_PAD_TOP: f32 = composer_layout.Field.pad_top;
 const PERMISSION_CHIP_W: f32 = 104;
 const PERMISSION_CHIP_H: f32 = 24;
 const STATUS_SLOT_W: f32 = 280;
-// Status dot: a small colored disc anchored in the top-right header slot.
-// STATUS_DOT_HIT is the (larger) clickable square that stops an in-flight
-// request when the dot is busy/yellow.
+// Wide panels (a full AI-chat tab) show the status as text plus an "Esc Stop"
+// button while a request runs.
+const STOP_BUTTON_W: f32 = 104;
+const STOP_BUTTON_H: f32 = 28;
+// The narrow copilot sidebar (compact mode) collapses the status into a small
+// colored disc instead. STATUS_DOT_HIT is the (larger) clickable square that
+// stops an in-flight request when the dot is busy/yellow.
 const STATUS_DOT_D: f32 = 9;
 const STATUS_DOT_HIT: f32 = 28;
 const MODE_SLOT_W: f32 = 76;
@@ -162,6 +166,7 @@ pub fn render(
     titlebar_offset: f32,
     chat_x: f32,
     chat_w: f32,
+    compact: bool,
 ) void {
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -212,26 +217,40 @@ pub fn render(
     };
     ui_pipeline.fillQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, perm_alpha);
 
-    // Status indicator: a colored dot in a fixed top-right slot.
-    //   green  (palette[2]) = ready / done / idle
-    //   yellow (palette[3]) = in progress; the dot doubles as the click target
-    //                         to stop the request (Esc also works)
-    //   red    (palette[1]) = stopped / error; the dot keeps its actionable
-    //                         status text alongside it (e.g. "Missing API key")
-    const status_kind = session.statusKind();
-    const dot_color = switch (status_kind) {
-        .ready => AppWindow.g_theme.palette[2],
-        .busy => AppWindow.g_theme.palette[3],
-        .stopped => AppWindow.g_theme.palette[1],
-    };
-    if (status_kind == .stopped) {
-        const status_text = if (session.missingApiKey()) MISSING_API_KEY_ACTION_TEXT else session.status();
-        const status_rect = statusActionRect(x, w, top, status_text);
-        _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, dot_color, status_rect.w);
-        ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, dot_color, 0.34);
+    if (compact) {
+        // Narrow copilot sidebar: collapse the status into a colored dot.
+        //   green  (palette[2]) = ready / done / idle
+        //   yellow (palette[3]) = in progress; the dot doubles as the click
+        //                         target to stop the request (Esc also works)
+        //   red    (palette[1]) = stopped / error; the dot keeps its actionable
+        //                         status text alongside it (e.g. "Missing API key")
+        const status_kind = session.statusKind();
+        const dot_color = switch (status_kind) {
+            .ready => AppWindow.g_theme.palette[2],
+            .busy => AppWindow.g_theme.palette[3],
+            .stopped => AppWindow.g_theme.palette[1],
+        };
+        if (status_kind == .stopped) {
+            const status_text = if (session.missingApiKey()) MISSING_API_KEY_ACTION_TEXT else session.status();
+            const status_rect = statusActionRect(x, w, top, status_text, true);
+            _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, dot_color, status_rect.w);
+            ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, dot_color, 0.34);
+        }
+        const dot_hit = statusDotRect(x, w, top);
+        fillDot(dot_hit.x + dot_hit.w / 2, header_y + HEADER_H / 2, STATUS_DOT_D, dot_color);
+    } else if (session.request_inflight) {
+        // Wide tab: keep the original status text / "Esc Stop" button.
+        renderStopButton(stopButtonRect(x, w, top), window_height, session.request_stopping);
+    } else {
+        const missing_api_key = session.missingApiKey();
+        const status_text = if (missing_api_key) MISSING_API_KEY_ACTION_TEXT else session.status();
+        const status_color = if (missing_api_key) mixColor(fg, accent, 0.22) else mixColor(bg, fg, 0.62);
+        const status_rect = statusActionRect(x, w, top, status_text, false);
+        _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, status_color, STATUS_SLOT_W);
+        if (missing_api_key) {
+            ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, accent, 0.34);
+        }
     }
-    const dot_hit = statusDotRect(x, w, top);
-    fillDot(dot_hit.x + dot_hit.w / 2, header_y + HEADER_H / 2, STATUS_DOT_D, dot_color);
 
     const input_text = session.input();
     const layout = inputLayout(x, w, input_text);
@@ -585,6 +604,7 @@ pub fn stopButtonHitTest(
     titlebar_offset: f32,
     chat_x: f32,
     chat_w: f32,
+    compact: bool,
 ) bool {
     _ = window_width;
     session.mutex.lock();
@@ -594,7 +614,7 @@ pub fn stopButtonHitTest(
 
     const x = @round(chat_x);
     const w = @round(@max(1.0, chat_w));
-    const rect = statusDotRect(x, w, titlebar_offset);
+    const rect = if (compact) statusDotRect(x, w, titlebar_offset) else stopButtonRect(x, w, titlebar_offset);
     return pointInRect(@floatCast(xpos), @floatCast(ypos), rect);
 }
 
@@ -655,6 +675,7 @@ pub fn missingApiKeyStatusHitTest(
     titlebar_offset: f32,
     chat_x: f32,
     chat_w: f32,
+    compact: bool,
 ) bool {
     _ = window_width;
     session.mutex.lock();
@@ -664,7 +685,7 @@ pub fn missingApiKeyStatusHitTest(
 
     const x = @round(chat_x);
     const w = @round(@max(1.0, chat_w));
-    const rect = statusActionRect(x, w, titlebar_offset, MISSING_API_KEY_ACTION_TEXT);
+    const rect = statusActionRect(x, w, titlebar_offset, MISSING_API_KEY_ACTION_TEXT, compact);
     return pointInRect(@floatCast(xpos), @floatCast(ypos), rect);
 }
 
@@ -1235,11 +1256,37 @@ fn fillDot(cx: f32, cy: f32, diameter: f32, color: [3]f32) void {
     }
 }
 
-fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8) Rect {
-    // Error text sits to the LEFT of the status dot (which owns the far-right
-    // corner) and is clamped to the space right of the permission chip, so long
-    // status text can't overlap the dot or the chip on a narrow panel.
-    const right = statusDotRect(x, w, titlebar_offset).x - 8;
+// Wide-tab "Esc Stop" button geometry (text mode). The compact sidebar uses
+// statusDotRect instead.
+fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
+    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STOP_BUTTON_W, STOP_BUTTON_H, HEADER_H);
+}
+
+fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) void {
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const y = window_height - rect.top_px - rect.h;
+    const fill = if (stopping) mixColor(bg, fg, 0.12) else mixColor(bg, accent, 0.20);
+    const stroke = if (stopping) mixColor(bg, fg, 0.42) else accent;
+    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, rect.h, fill, 0.92);
+    ui_pipeline.fillQuadAlpha(rect.x, y + rect.h - 1, rect.w, 1, stroke, 0.70);
+    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, 1, mixColor(bg, fg, 0.20), 0.70);
+
+    const icon_size: f32 = 8;
+    const icon_x = rect.x + 12;
+    const icon_y = y + @round((rect.h - icon_size) / 2);
+    ui_pipeline.fillQuad(icon_x, icon_y, icon_size, icon_size, if (stopping) mixColor(bg, fg, 0.62) else mixColor(fg, accent, 0.10));
+
+    const label = if (stopping) "Stopping" else "Esc Stop";
+    _ = titlebar.renderTextLimited(label, rect.x + 28, y + @round((rect.h - font.g_titlebar_cell_height) / 2), if (stopping) mixColor(bg, fg, 0.72) else fg, rect.w - 34);
+}
+
+fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8, compact: bool) Rect {
+    // Wide tab: text owns the far-right corner. Compact sidebar: text sits to
+    // the LEFT of the status dot. Either way it is clamped to the space right of
+    // the permission chip so it can't overlap the chip/dot on a narrow panel.
+    const right = if (compact) statusDotRect(x, w, titlebar_offset).x - 8 else x + w - LINE_PAD_X;
     const avail = @max(1.0, right - (permissionChipX(x, w) + PERMISSION_CHIP_W + 12));
     const status_w = @min(@min(measureText(text), STATUS_SLOT_W), avail);
     return .{

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -36,8 +36,11 @@ pub const INPUT_FIELD_PAD_TOP: f32 = composer_layout.Field.pad_top;
 const PERMISSION_CHIP_W: f32 = 104;
 const PERMISSION_CHIP_H: f32 = 24;
 const STATUS_SLOT_W: f32 = 280;
-const STOP_BUTTON_W: f32 = 104;
-const STOP_BUTTON_H: f32 = 28;
+// Status dot: a small colored disc anchored in the top-right header slot.
+// STATUS_DOT_HIT is the (larger) clickable square that stops an in-flight
+// request when the dot is busy/yellow.
+const STATUS_DOT_D: f32 = 9;
+const STATUS_DOT_HIT: f32 = 28;
 const MODE_SLOT_W: f32 = 76;
 const INPUT_SCROLLBAR_GUTTER: f32 = 10;
 const INPUT_SCROLLBAR_W: f32 = 4;
@@ -163,7 +166,6 @@ pub fn render(
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
-    const muted = mixColor(bg, fg, 0.62);
     const panel = mixColor(bg, fg, 0.045);
     const line = mixColor(bg, fg, 0.18);
 
@@ -210,18 +212,26 @@ pub fn render(
     };
     ui_pipeline.fillQuadAlpha(chip_x, header_y + 8, PERMISSION_CHIP_W - 8, 1, accent, perm_alpha);
 
-    if (session.request_inflight) {
-        renderStopButton(stopButtonRect(x, w, top), window_height, session.request_stopping);
-    } else {
-        const missing_api_key = session.missingApiKey();
-        const status_text = if (missing_api_key) MISSING_API_KEY_ACTION_TEXT else session.status();
-        const status_color = if (missing_api_key) mixColor(fg, accent, 0.22) else muted;
+    // Status indicator: a colored dot in a fixed top-right slot.
+    //   green  (palette[2]) = ready / done / idle
+    //   yellow (palette[3]) = in progress; the dot doubles as the click target
+    //                         to stop the request (Esc also works)
+    //   red    (palette[1]) = stopped / error; the dot keeps its actionable
+    //                         status text alongside it (e.g. "Missing API key")
+    const status_kind = session.statusKind();
+    const dot_color = switch (status_kind) {
+        .ready => AppWindow.g_theme.palette[2],
+        .busy => AppWindow.g_theme.palette[3],
+        .stopped => AppWindow.g_theme.palette[1],
+    };
+    if (status_kind == .stopped) {
+        const status_text = if (session.missingApiKey()) MISSING_API_KEY_ACTION_TEXT else session.status();
         const status_rect = statusActionRect(x, w, top, status_text);
-        _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, status_color, STATUS_SLOT_W);
-        if (missing_api_key) {
-            ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, accent, 0.34);
-        }
+        _ = titlebar.renderTextLimited(status_text, status_rect.x, header_y + 10, dot_color, status_rect.w);
+        ui_pipeline.fillQuadAlpha(status_rect.x, header_y + 8, status_rect.w, 1, dot_color, 0.34);
     }
+    const dot_hit = statusDotRect(x, w, top);
+    fillDot(dot_hit.x + dot_hit.w / 2, header_y + HEADER_H / 2, STATUS_DOT_D, dot_color);
 
     const input_text = session.input();
     const layout = inputLayout(x, w, input_text);
@@ -584,7 +594,7 @@ pub fn stopButtonHitTest(
 
     const x = @round(chat_x);
     const w = @round(@max(1.0, chat_w));
-    const rect = stopButtonRect(x, w, titlebar_offset);
+    const rect = statusDotRect(x, w, titlebar_offset);
     return pointInRect(@floatCast(xpos), @floatCast(ypos), rect);
 }
 
@@ -1203,15 +1213,33 @@ fn permissionChipX(x: f32, w: f32) f32 {
     return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, status_reserve, 12, PERMISSION_CHIP_W);
 }
 
-fn stopButtonRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
-    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STOP_BUTTON_W, STOP_BUTTON_H, HEADER_H);
+// Clickable square centered on the status dot. When a request is in flight the
+// dot is yellow and clicking this square stops it (mirrors the old stop button;
+// Esc still works). Reuses the generic header-button geometry.
+fn statusDotRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
+    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STATUS_DOT_HIT, STATUS_DOT_HIT, HEADER_H);
+}
+
+// Filled disc approximated by stacked 1px scanlines (no circle primitive exists;
+// the UI is quad-based). `cx`/`cy` are the center in the renderer's y-up draw
+// space; `diameter` in px.
+fn fillDot(cx: f32, cy: f32, diameter: f32, color: [3]f32) void {
+    const r = diameter / 2;
+    const r_i: i32 = @intFromFloat(@floor(r));
+    var dy: i32 = -r_i;
+    while (dy <= r_i) : (dy += 1) {
+        const fy: f32 = @floatFromInt(dy);
+        const half_w = @sqrt(@max(0.0, r * r - fy * fy));
+        if (half_w < 0.5) continue;
+        ui_pipeline.fillQuad(@round(cx - half_w), cy + fy, @round(half_w * 2), 1, color);
+    }
 }
 
 fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8) Rect {
-    // Keep status to the right of the permission chip; clamp its width to the
-    // space available there so long status text can't overlap the chip on a
-    // narrow panel.
-    const right = x + w - LINE_PAD_X;
+    // Error text sits to the LEFT of the status dot (which owns the far-right
+    // corner) and is clamped to the space right of the permission chip, so long
+    // status text can't overlap the dot or the chip on a narrow panel.
+    const right = statusDotRect(x, w, titlebar_offset).x - 8;
     const avail = @max(1.0, right - (permissionChipX(x, w) + PERMISSION_CHIP_W + 12));
     const status_w = @min(@min(measureText(text), STATUS_SLOT_W), avail);
     return .{
@@ -1220,26 +1248,6 @@ fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8) Rect
         .w = @max(1.0, status_w),
         .h = 32,
     };
-}
-
-fn renderStopButton(rect: HeaderButtonRect, window_height: f32, stopping: bool) void {
-    const bg = AppWindow.g_theme.background;
-    const fg = AppWindow.g_theme.foreground;
-    const accent = AppWindow.g_theme.cursor_color;
-    const y = window_height - rect.top_px - rect.h;
-    const fill = if (stopping) mixColor(bg, fg, 0.12) else mixColor(bg, accent, 0.20);
-    const stroke = if (stopping) mixColor(bg, fg, 0.42) else accent;
-    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, rect.h, fill, 0.92);
-    ui_pipeline.fillQuadAlpha(rect.x, y + rect.h - 1, rect.w, 1, stroke, 0.70);
-    ui_pipeline.fillQuadAlpha(rect.x, y, rect.w, 1, mixColor(bg, fg, 0.20), 0.70);
-
-    const icon_size: f32 = 8;
-    const icon_x = rect.x + 12;
-    const icon_y = y + @round((rect.h - icon_size) / 2);
-    ui_pipeline.fillQuad(icon_x, icon_y, icon_size, icon_size, if (stopping) mixColor(bg, fg, 0.62) else mixColor(fg, accent, 0.10));
-
-    const label = if (stopping) "Stopping" else "Esc Stop";
-    _ = titlebar.renderTextLimited(label, rect.x + 28, y + @round((rect.h - font.g_titlebar_cell_height) / 2), if (stopping) mixColor(bg, fg, 0.72) else fg, rect.w - 34);
 }
 
 fn permissionDisplayName(permission: ai_chat.AgentPermission) []const u8 {


### PR DESCRIPTION
## 背景

AI 聊天头部最右侧的状态(`Ready` 文字 / `Esc Stop` 按钮,约 280px 宽)在**窄的 copilot 侧边栏**里太占横向空间。改为按面板宽度自适应。

## 最终行为(宽窄自适应)

| 场景 | 状态指示 |
|---|---|
| 📝 **全屏 AI chat tab(宽)** | 保留原来的状态文字(Ready / Done in X.Xs / …)+ `Esc Stop` 按钮 |
| 🟢 **copilot 侧边栏(窄)** | 收成一个固定在右上角的 9px 彩色圆点 |

> 第一版把圆点用到了所有场景,但在宽 tab 里既丢了可读文字又在右上角显示不全;后续提交 `65cbe4d` 改为只在侧边栏用圆点。

圆点配色(取主题 ANSI 调色板,换主题自动适配),映射请求生命周期:

| 圆点 | 含义 | 行为 |
|---|---|---|
| 🟢 绿 `palette[2]` | 就绪 / 完成 / 空闲 | 纯圆点 |
| 🟡 黄 `palette[3]` | 进行中 | 纯圆点,**可点击停止**(Esc 仍可用) |
| 🔴 红 `palette[1]` | 停止 / 出错 | 圆点 **+ 保留旁边的简短错误文字**(如 `Missing API key. Click to configure`) |

## 实现要点
- `src/ai_chat.zig`:新增可单测的 `Session.StatusKind` + `statusKind()`(标志位优先,空闲态按状态串分类)+ 6 个单测。
- `src/renderer/ai_chat_renderer.zig`:`render()` 加 `compact` 参数分支;新增 `fillDot()`(逐行堆 quad 画实心圆盘,代码库无圆形图元);命中测试 `stopButtonHitTest`/`missingApiKeyStatusHitTest` 与 `statusActionRect` 都按 `compact` 区分几何。
- `compact` 标志由两个 render 调用点显式传入(tab=false / 侧边栏=true),不靠脆弱的宽度阈值。
- `ai_chat_layout.zig` 未改动(通用几何函数,传不同尺寸即可)。

## 验证
- TDD:先写 `statusKind()` 失败测试 → 实现 → 通过。
- `zig build test-full -Dtarget=aarch64-macos`:**EXIT=0**,整个 app 编译通过、全部测试通过。
- 启动 macOS 构建,真机确认 copilot 侧边栏显示干净的绿色圆点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)