### PR TITLE
[codex] fix copilot sidebar markdown export

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -156,8 +156,8 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     }.cb);
     // `/export [full|clean]` writes the active AI Chat transcript as Markdown.
     ai_chat.setMarkdownExportTrigger(struct {
-        fn cb(mode: ai_chat.MarkdownExportMode) void {
-            exportActiveAiChatMarkdown(mode);
+        fn cb(session: *ai_chat.Session, mode: ai_chat.MarkdownExportMode) void {
+            exportAiChatMarkdown(session, mode);
         }
     }.cb);
     // `/model [name]` switches the active session's profile (and summarizes the
@@ -1274,6 +1274,48 @@ test "AppWindow: terminal tab copilot sessions are persisted to agent history be
     defer agent_history.freeOwnedRecord(allocator, &restored);
 
     try std.testing.expect(restored.copilot);
+}
+
+test "AppWindow: markdown export target includes visible copilot sidebar" {
+    const allocator = std.testing.allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    defer {
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+    }
+
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tab_count = 0;
+    active_tab_state.g_active_tab = 0;
+
+    var copilot = ai_chat.Session{ .allocator = allocator, .copilot = true };
+    var terminal_tab = tab.TabState{
+        .kind = .terminal,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = null,
+        .ai_history_session = null,
+        .copilot_session = &copilot,
+        .copilot_visible = true,
+    };
+    tab.g_tabs[0] = &terminal_tab;
+    tab.g_tab_count = 1;
+    try std.testing.expectEqual(&copilot, activeMarkdownExportSession().?);
+
+    var chat = ai_chat.Session{ .allocator = allocator };
+    var chat_tab = tab.TabState{
+        .kind = .ai_chat,
+        .tree = .empty,
+        .focused = .root,
+        .ai_chat_session = &chat,
+        .ai_history_session = null,
+        .copilot_session = null,
+    };
+    tab.g_tabs[0] = &chat_tab;
+    try std.testing.expectEqual(&chat, activeMarkdownExportSession().?);
 }
 
 test "AppWindow: copilot restore hook rehydrates a copilot session by id" {
@@ -5110,12 +5152,21 @@ fn localHomeForAiHistory(allocator: std.mem.Allocator) ![]u8 {
     return error.NoHomeDirectory;
 }
 
+fn activeMarkdownExportSession() ?*ai_chat.Session {
+    if (activeAiChat()) |session| return session;
+    return activeCopilotSessionForInput();
+}
+
 pub fn exportActiveAiChatMarkdown(mode: ai_chat.MarkdownExportMode) void {
-    const allocator = g_allocator orelse return;
-    const session = activeAiChat() orelse {
-        overlays.showStatusToast("Open a Copilot tab first");
+    const session = activeMarkdownExportSession() orelse {
+        overlays.showStatusToast("Open a Copilot tab or sidebar first");
         return;
     };
+    exportAiChatMarkdown(session, mode);
+}
+
+fn exportAiChatMarkdown(session: *ai_chat.Session, mode: ai_chat.MarkdownExportMode) void {
+    const allocator = g_allocator orelse return;
 
     const markdown = session.allocMarkdownExport(allocator, mode) catch |err| {
         log.warn("failed to render AI chat Markdown export: {}", .{err});

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -363,7 +363,9 @@ fn fireDeferredAction(session: *Session, action: DeferredAction) void {
         // Targets the session that submitted `/model` (copilot sidebar OR a tab),
         // not the active tab — they can differ.
         .model_switch_picker => if (g_model_switch_trigger) |t| t(session),
-        .export_markdown => |mode| if (g_markdown_export_trigger) |t| t(mode),
+        // Targets the session that submitted `/export` (copilot sidebar OR a tab),
+        // not the active tab — they can differ.
+        .export_markdown => |mode| if (g_markdown_export_trigger) |t| t(session, mode),
     }
 }
 
@@ -376,7 +378,7 @@ var g_default_working_dir_len: usize = 0;
 var g_session_id_counter = std.atomic.Value(u64).init(1);
 var g_session_resume_trigger: ?*const fn () void = null;
 var g_copilot_picker_trigger: ?*const fn () void = null;
-var g_markdown_export_trigger: ?*const fn (MarkdownExportMode) void = null;
+var g_markdown_export_trigger: ?*const fn (*Session, MarkdownExportMode) void = null;
 var g_model_switch_trigger: ?*const fn (*Session) void = null;
 threadlocal var g_dynamic_tool_specs: []ai_chat_protocol.DynamicToolSpec = &.{};
 threadlocal var g_dynamic_tool_specs_owned: bool = false;
@@ -442,7 +444,7 @@ pub fn setModelSwitchTrigger(cb: ?*const fn (*Session) void) void {
 /// Wire the callback that `/export [full|clean]` fires to write the conversation
 /// Markdown. Fired AFTER the session mutex unlocks, because the export reads the
 /// session under the SAME mutex (`allocMarkdownExport`) and would otherwise deadlock.
-pub fn setMarkdownExportTrigger(cb: ?*const fn (MarkdownExportMode) void) void {
+pub fn setMarkdownExportTrigger(cb: ?*const fn (*Session, MarkdownExportMode) void) void {
     g_markdown_export_trigger = cb;
 }
 threadlocal var g_tool_host: ?ToolHost = null;
@@ -5368,23 +5370,33 @@ test "/clear via submit empties the transcript and shows confirmation" {
 }
 
 var test_export_mode: ?MarkdownExportMode = null;
-fn testExportHook(mode: MarkdownExportMode) void {
+var test_export_session: ?*Session = null;
+fn testExportHook(session: *Session, mode: MarkdownExportMode) void {
+    test_export_session = session;
     test_export_mode = mode;
 }
 
-test "/export via submit fires the export trigger with parsed mode" {
+test "/export via submit fires the export trigger with submitting session and parsed mode" {
     const a = std.testing.allocator;
     setMarkdownExportTrigger(testExportHook);
     defer setMarkdownExportTrigger(null);
     var session = try Session.init(a, "chat", "https://api.example.com", "key", "m1", "sys", "false", "", "false", "false");
     defer session.deinit();
     test_export_mode = null;
+    test_export_session = null;
     session.appendInputText("/export full");
     session.submit();
+    try std.testing.expectEqual(session, test_export_session.?);
     try std.testing.expectEqual(MarkdownExportMode.full, test_export_mode.?);
+
+    var copilot = try Session.init(a, "copilot", "https://api.example.com", "key", "m1", "sys", "false", "", "false", "false");
+    defer copilot.deinit();
+    copilot.copilot = true;
     test_export_mode = null;
-    session.appendInputText("/export");
-    session.submit();
+    test_export_session = null;
+    copilot.appendInputText("/export");
+    copilot.submit();
+    try std.testing.expectEqual(copilot, test_export_session.?);
     try std.testing.expectEqual(MarkdownExportMode.clean, test_export_mode.?);
 }
 


### PR DESCRIPTION
## Summary

Fix Copilot sidebar Markdown export so `/export` and command-driven export can target a sidebar Copilot session, not only a dedicated AI Chat tab.

## Root Cause

The `/export` deferred action only carried the export mode into the AppWindow callback. AppWindow then looked up `activeAiChat()`, which is null for a terminal tab with a visible Copilot sidebar, causing the "Open a Copilot tab first" toast.

## Changes

- Pass the submitting `ai_chat.Session` through the Markdown export callback.
- Reuse the given session for slash-command export.
- Let manual export choose the active AI Chat tab first, then the visible Copilot sidebar session.
- Add regression coverage for both callback routing and AppWindow export target selection.

## Validation

- `zig build test-full`
- `zig build test`
