### PR TITLE
refactor(agent-history): per-session file storage + index (lazy, debounced, migrated)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-copilot-history-storage-redesign.md
+++ b/docs/superpowers/plans/2026-06-23-copilot-history-storage-redesign.md
@@ -1,0 +1,1490 @@
+# 副驾历史存储重构 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把副驾历史的单文件 `agent-history.json` 存储改为「每会话一个 `sessions/<id>.json` + 派生 `index.json`」目录布局，运行时索引驱动、正文懒加载、写入去抖，去掉 8MB 加载死线。
+
+**Architecture:** 在 `agent_history.zig` 增加纯函数（索引结构、单记录 JSON 读写、文件名净化、搜索预览、索引 IO、由索引投影 Row）；新建 `agent_history_store.zig` 的 `MetaStore`（持目录、内存索引、`pending` 待写记录、迁移/重建/flush）；`MetaStore` 替换全局 `g_agent_history` 指向的类型；`AppWindow.zig` 与 `file_explorer.zig` 的调用点改为指向 `MetaStore`（方法同名，签名基本不变）。旧 `agent_history.Store` 仅保留为「单 blob 解析器」供迁移与原有测试使用，不删。
+
+**Tech Stack:** Zig（`std.json` / `std.fs` 原子写 / `std.testing.tmpDir`），项目既有 `flush_scheduler.FlushScheduler`、`platform_dirs` 测试隔离钩子。
+
+**测试套件归属：**
+- `agent_history.zig`、`agent_history_store.zig`（新增，需加进 `test_fast.zig`）、`file_explorer.zig` 的内联测试 → `zig build test`（fast 套件）。
+- `platform/dirs.zig`、`AppWindow.zig` 的内联测试 → `zig build test-full`。
+- macOS 真机构建验证：`zig build macos-app -Dtarget=aarch64-macos`（默认 `zig build` 目标是 Windows）。
+
+---
+
+## File Structure
+
+- **Modify** `src/platform/dirs.zig` — 新增 `agentHistoryDir` / `agentHistoryDirFromEnvForOs`（目录路径）。
+- **Modify** `src/agent_history.zig` — 新增 `IndexEntry`/`IndexFile`、索引 IO、`sanitizeSessionFileName`、`buildSearchPreview`、`recordToIndexEntry`、单记录 JSON 读写、`buildRowsFromEntries`/`buildCopilotRowsFromEntries` 及 free/clone 辅助。现有 `Store` 与其测试保持不动。
+- **Create** `src/agent_history_store.zig` — `MetaStore`（目录后端 + 内存索引 + pending + 迁移/重建/flush）。
+- **Modify** `src/test_fast.zig` — 增加 `_ = @import("agent_history_store.zig");`。
+- **Modify** `src/AppWindow.zig` — 全局类型、`ensureGlobalAgentHistoryStore`、flush 函数、3 处内联测试。
+- **Modify** `src/file_explorer.zig` — `syncAgentHistoryRows` 形参类型、3 处内联测试。
+
+---
+
+## Task 1: dirs.zig 新增 agent-history 目录路径
+
+**Files:**
+- Modify: `src/platform/dirs.zig`（在 `agentHistoryPath` 之后，约第 205 行）
+
+- [ ] **Step 1: 写失败测试**（追加到 `src/platform/dirs.zig` 末尾的 test 区）
+
+```zig
+test "agentHistoryDir resolves under config dir (macos)" {
+    const a = std.testing.allocator;
+    const p = try agentHistoryDirFromEnvForOs(a, .macos, .{ .home = "/Users/x" });
+    defer a.free(p);
+    try std.testing.expectEqualStrings("/Users/x/Library/Application Support/wispterm/agent-history", p);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test-full`
+Expected: 编译错误 `agentHistoryDirFromEnvForOs` 未定义。
+
+- [ ] **Step 3: 实现**（紧跟现有 `agentHistoryPathFromEnvForOs` 之后插入）
+
+```zig
+pub fn agentHistoryDir(allocator: std.mem.Allocator) ![]const u8 {
+    return pathInConfigDir(allocator, "agent-history");
+}
+
+pub fn agentHistoryDirFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "agent-history");
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test-full`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/platform/dirs.zig
+git commit -m "feat(dirs): add agentHistoryDir for per-session history layout"
+```
+
+---
+
+## Task 2: agent_history.zig 索引结构与 IO
+
+**Files:**
+- Modify: `src/agent_history.zig`（结构定义放在 `Row`（第 50 行）之后；函数放在文件下半部公共函数区，如 `freeRows`（第 369 行）附近）
+
+- [ ] **Step 1: 写失败测试**（追加到 `agent_history.zig` 的 test 区，例如第 1021 行测试之后）
+
+```zig
+test "agent_history: index file round-trips" {
+    const allocator = std.testing.allocator;
+    var entries = [_]IndexEntry{
+        .{ .session_id = "s1", .title = "T1", .model = "m1", .created_at = 1, .updated_at = 2, .copilot = false, .message_count = 3, .search_preview = "t1 hello" },
+        .{ .session_id = "s2", .title = "T2", .model = "m2", .created_at = 5, .updated_at = 6, .copilot = true, .message_count = 0, .search_preview = "" },
+    };
+    const json = try dumpIndex(allocator, .{ .version = INDEX_VERSION, .entries = &entries });
+    defer allocator.free(json);
+
+    var parsed = try parseIndex(allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(INDEX_VERSION, parsed.value.version);
+    try std.testing.expectEqual(@as(usize, 2), parsed.value.entries.len);
+    try std.testing.expectEqualStrings("s2", parsed.value.entries[1].session_id);
+    try std.testing.expect(parsed.value.entries[1].copilot);
+    try std.testing.expectEqual(@as(u32, 3), parsed.value.entries[0].message_count);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `IndexEntry` / `dumpIndex` / `parseIndex` / `INDEX_VERSION` 未定义。
+
+- [ ] **Step 3: 实现**（结构放在第 50 行 `Row` 之后）
+
+```zig
+pub const INDEX_VERSION: u32 = 1;
+
+pub const IndexEntry = struct {
+    session_id: []const u8,
+    title: []const u8,
+    model: []const u8,
+    created_at: i64,
+    updated_at: i64,
+    copilot: bool = false,
+    message_count: u32 = 0,
+    search_preview: []const u8 = "",
+};
+
+pub const IndexFile = struct {
+    version: u32 = INDEX_VERSION,
+    entries: []IndexEntry = &.{},
+};
+```
+
+并在公共函数区（如 `freeRows` 之后）加入：
+
+```zig
+pub fn dumpIndex(allocator: std.mem.Allocator, index: IndexFile) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, index, .{});
+}
+
+pub fn parseIndex(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(IndexFile) {
+    return std.json.parseFromSlice(IndexFile, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+}
+
+pub fn cloneIndexEntry(allocator: std.mem.Allocator, input: IndexEntry) !IndexEntry {
+    const session_id = try allocator.dupe(u8, input.session_id);
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, input.title);
+    errdefer allocator.free(title);
+    const model = try allocator.dupe(u8, input.model);
+    errdefer allocator.free(model);
+    const search_preview = try allocator.dupe(u8, input.search_preview);
+    errdefer allocator.free(search_preview);
+    return .{
+        .session_id = session_id,
+        .title = title,
+        .model = model,
+        .created_at = input.created_at,
+        .updated_at = input.updated_at,
+        .copilot = input.copilot,
+        .message_count = input.message_count,
+        .search_preview = search_preview,
+    };
+}
+
+pub fn freeOwnedIndexEntry(allocator: std.mem.Allocator, entry: *IndexEntry) void {
+    allocator.free(entry.session_id);
+    allocator.free(entry.title);
+    allocator.free(entry.model);
+    allocator.free(entry.search_preview);
+    entry.* = undefined;
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history.zig
+git commit -m "feat(agent_history): add IndexEntry/IndexFile and JSON round-trip"
+```
+
+---
+
+## Task 3: 文件名净化 sanitizeSessionFileName
+
+**Files:**
+- Modify: `src/agent_history.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "agent_history: sanitizeSessionFileName keeps safe ids and hashes unsafe ones" {
+    const allocator = std.testing.allocator;
+
+    const safe = try sanitizeSessionFileName(allocator, "session-1719000000000-3");
+    defer allocator.free(safe);
+    try std.testing.expectEqualStrings("session-1719000000000-3.json", safe);
+
+    const unsafe1 = try sanitizeSessionFileName(allocator, "会話/x");
+    defer allocator.free(unsafe1);
+    const unsafe2 = try sanitizeSessionFileName(allocator, "会話/x");
+    defer allocator.free(unsafe2);
+    try std.testing.expect(std.mem.endsWith(u8, unsafe1, ".json"));
+    try std.testing.expect(std.mem.indexOfScalar(u8, unsafe1, '/') == null);
+    try std.testing.expectEqualStrings(unsafe1, unsafe2); // deterministic
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `sanitizeSessionFileName` 未定义。
+
+- [ ] **Step 3: 实现**（公共函数区）
+
+```zig
+fn isSafeFileChar(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or
+        (c >= 'a' and c <= 'z') or
+        (c >= '0' and c <= '9') or
+        c == '.' or c == '_' or c == '-';
+}
+
+pub fn sanitizeSessionFileName(allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
+    var all_safe = session_id.len > 0;
+    for (session_id) |c| {
+        if (!isSafeFileChar(c)) {
+            all_safe = false;
+            break;
+        }
+    }
+    if (all_safe) {
+        return std.fmt.allocPrint(allocator, "{s}.json", .{session_id});
+    }
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    for (session_id) |c| {
+        try buf.append(allocator, if (isSafeFileChar(c)) c else '_');
+    }
+    const h = std.hash.Wyhash.hash(0, session_id);
+    return std.fmt.allocPrint(allocator, "{s}-{x}.json", .{ buf.items, h });
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history.zig
+git commit -m "feat(agent_history): add filesystem-safe session filename mapping"
+```
+
+---
+
+## Task 4: 搜索预览 buildSearchPreview + recordToIndexEntry
+
+**Files:**
+- Modify: `src/agent_history.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "agent_history: recordToIndexEntry derives bounded lowercase preview" {
+    const allocator = std.testing.allocator;
+    var store = Store.init(allocator);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1",
+        .title = "Hello World",
+        .base_url = "https://api.example.com",
+        .api_key = "k",
+        .model = "m1",
+        .system_prompt = "sys",
+        .thinking_enabled = false,
+        .reasoning_effort = "low",
+        .stream = true,
+        .agent_enabled = true,
+        .created_at = 1,
+        .updated_at = 2,
+        .messages = &[_]MessageRecord{
+            .{ .role = .user, .content = "First Question" },
+        },
+    });
+
+    var entry = try recordToIndexEntry(allocator, store.records.items[0]);
+    defer freeOwnedIndexEntry(allocator, &entry);
+
+    try std.testing.expectEqual(@as(u32, 1), entry.message_count);
+    try std.testing.expect(entry.search_preview.len <= SEARCH_PREVIEW_MAX);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(entry.search_preview));
+    try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "hello world") != null);
+    try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "first question") != null);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `recordToIndexEntry` / `SEARCH_PREVIEW_MAX` 未定义。
+
+- [ ] **Step 3: 实现**（公共函数区）
+
+```zig
+pub const SEARCH_PREVIEW_MAX = 200;
+
+fn lowerAsciiByte(c: u8) u8 {
+    return if (c >= 'A' and c <= 'Z') c + 32 else c;
+}
+
+pub fn buildSearchPreview(allocator: std.mem.Allocator, record: SessionRecord) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(allocator);
+
+    for (record.title) |c| try buf.append(allocator, lowerAsciiByte(c));
+    for (record.messages) |m| {
+        if (buf.items.len >= SEARCH_PREVIEW_MAX) break;
+        try buf.append(allocator, ' ');
+        for (m.content) |c| {
+            if (buf.items.len >= SEARCH_PREVIEW_MAX) break;
+            try buf.append(allocator, lowerAsciiByte(c));
+        }
+    }
+
+    // Back off to a valid UTF-8 prefix (lowercasing only touched ASCII bytes).
+    var n = @min(buf.items.len, SEARCH_PREVIEW_MAX);
+    while (n > 0 and !std.unicode.utf8ValidateSlice(buf.items[0..n])) n -= 1;
+    buf.shrinkRetainingCapacity(n);
+    return buf.toOwnedSlice(allocator);
+}
+
+pub fn recordToIndexEntry(allocator: std.mem.Allocator, record: SessionRecord) !IndexEntry {
+    const session_id = try allocator.dupe(u8, record.session_id);
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, record.title);
+    errdefer allocator.free(title);
+    const model = try allocator.dupe(u8, record.model);
+    errdefer allocator.free(model);
+    const search_preview = try buildSearchPreview(allocator, record);
+    errdefer allocator.free(search_preview);
+    return .{
+        .session_id = session_id,
+        .title = title,
+        .model = model,
+        .created_at = record.created_at,
+        .updated_at = record.updated_at,
+        .copilot = record.copilot,
+        .message_count = @intCast(record.messages.len),
+        .search_preview = search_preview,
+    };
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history.zig
+git commit -m "feat(agent_history): derive index entry + bounded search preview from record"
+```
+
+---
+
+## Task 5: 单会话记录 JSON 读写
+
+**Files:**
+- Modify: `src/agent_history.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "agent_history: single record JSON round-trips" {
+    const allocator = std.testing.allocator;
+    var store = Store.init(allocator);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1",
+        .title = "Title",
+        .base_url = "https://api.example.com",
+        .api_key = "k",
+        .model = "m1",
+        .system_prompt = "sys",
+        .thinking_enabled = true,
+        .reasoning_effort = "high",
+        .stream = false,
+        .agent_enabled = true,
+        .copilot = true,
+        .created_at = 7,
+        .updated_at = 9,
+        .messages = &[_]MessageRecord{
+            .{ .role = .user, .content = "hi" },
+            .{ .role = .assistant, .content = "yo" },
+        },
+    });
+
+    const json = try recordToJson(allocator, store.records.items[0]);
+    defer allocator.free(json);
+
+    var rec = try recordFromJson(allocator, json);
+    defer freeOwnedRecord(allocator, &rec);
+
+    try std.testing.expectEqualStrings("s1", rec.session_id);
+    try std.testing.expect(rec.copilot);
+    try std.testing.expectEqual(@as(usize, 2), rec.messages.len);
+    try std.testing.expectEqualStrings("yo", rec.messages[1].content);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `recordToJson` / `recordFromJson` 未定义。
+
+- [ ] **Step 3: 实现**（公共函数区；`MAX_SESSION_BYTES` 顶部常量）
+
+在第 5 行 `MAX_HISTORY_BYTES` 附近添加：
+
+```zig
+pub const MAX_SESSION_BYTES = 32 * 1024 * 1024;
+```
+
+公共函数区添加：
+
+```zig
+pub fn recordToJson(allocator: std.mem.Allocator, record: SessionRecord) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, record, .{});
+}
+
+pub fn recordFromJson(allocator: std.mem.Allocator, bytes: []const u8) !SessionRecord {
+    var parsed = try std.json.parseFromSlice(SessionRecord, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+    return cloneRecord(allocator, parsed.value);
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history.zig
+git commit -m "feat(agent_history): single-record JSON serialize/deserialize"
+```
+
+---
+
+## Task 6: 由索引投影 Row（含排序与 copilot 过滤）
+
+**Files:**
+- Modify: `src/agent_history.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "agent_history: buildRowsFromEntries sorts desc and filters copilot" {
+    const allocator = std.testing.allocator;
+    var entries = [_]IndexEntry{
+        .{ .session_id = "a", .title = "A", .model = "m", .created_at = 1, .updated_at = 1, .copilot = false },
+        .{ .session_id = "b", .title = "B", .model = "m", .created_at = 2, .updated_at = 3, .copilot = true },
+        .{ .session_id = "c", .title = "C", .model = "m", .created_at = 2, .updated_at = 2, .copilot = false },
+    };
+
+    const rows = try buildRowsFromEntries(allocator, &entries);
+    defer freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 3), rows.len);
+    try std.testing.expectEqualStrings("b", rows[0].session_id); // updated_at=3 first
+    try std.testing.expectEqualStrings("c", rows[1].session_id);
+
+    const co = try buildCopilotRowsFromEntries(allocator, &entries);
+    defer freeRows(allocator, co);
+    try std.testing.expectEqual(@as(usize, 1), co.len);
+    try std.testing.expectEqualStrings("b", co[0].session_id);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `buildRowsFromEntries` / `buildCopilotRowsFromEntries` 未定义。
+
+- [ ] **Step 3: 实现**（公共函数区；复用现有私有 `cloneRow`/`freeOwnedRow`/`sortRows`）
+
+```zig
+pub fn buildRowsFromEntries(allocator: std.mem.Allocator, entries: []const IndexEntry) ![]Row {
+    const rows = try allocator.alloc(Row, entries.len);
+    var initialized: usize = 0;
+    errdefer {
+        while (initialized > 0) {
+            initialized -= 1;
+            freeOwnedRow(allocator, &rows[initialized]);
+        }
+        allocator.free(rows);
+    }
+    for (entries, 0..) |e, i| {
+        rows[i] = try cloneRow(allocator, .{
+            .session_id = e.session_id,
+            .title = e.title,
+            .model = e.model,
+            .updated_at = e.updated_at,
+            .copilot = e.copilot,
+        });
+        initialized += 1;
+    }
+    sortRows(rows);
+    return rows;
+}
+
+pub fn buildCopilotRowsFromEntries(allocator: std.mem.Allocator, entries: []const IndexEntry) ![]Row {
+    var list: std.ArrayListUnmanaged(Row) = .empty;
+    errdefer {
+        for (list.items) |*r| freeOwnedRow(allocator, r);
+        list.deinit(allocator);
+    }
+    for (entries) |e| {
+        if (!e.copilot) continue;
+        const row = try cloneRow(allocator, .{
+            .session_id = e.session_id,
+            .title = e.title,
+            .model = e.model,
+            .updated_at = e.updated_at,
+            .copilot = e.copilot,
+        });
+        list.append(allocator, row) catch |err| {
+            var owned = row;
+            freeOwnedRow(allocator, &owned);
+            return err;
+        };
+    }
+    const rows = try list.toOwnedSlice(allocator);
+    sortRows(rows);
+    return rows;
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history.zig
+git commit -m "feat(agent_history): project sorted rows from index entries"
+```
+
+---
+
+## Task 7: MetaStore 骨架（open 空目录 / buildRows / deinit）
+
+**Files:**
+- Create: `src/agent_history_store.zig`
+- Modify: `src/test_fast.zig`（加入 import）
+
+- [ ] **Step 1: 写失败测试**（写在新文件 `src/agent_history_store.zig` 内联 test）
+
+```zig
+const std = @import("std");
+const agent_history = @import("agent_history.zig");
+
+pub const MAX_INDEX_BYTES = 32 * 1024 * 1024;
+const MIGRATION_MAX_BYTES = 1 << 30;
+
+pub const MetaStore = struct {
+    allocator: std.mem.Allocator,
+    dir: []u8,
+    entries: std.ArrayListUnmanaged(agent_history.IndexEntry) = .empty,
+    pending: std.ArrayListUnmanaged(agent_history.SessionRecord) = .empty,
+    index_dirty: bool = false,
+};
+
+test "MetaStore: open empty dir yields no rows" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 0), rows.len);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+先把新文件加入 fast 套件：在 `src/test_fast.zig` 第 137 行 `_ = @import("agent_history.zig");` 之后加入：
+
+```zig
+    _ = @import("agent_history_store.zig");
+```
+
+Run: `zig build test`
+Expected: 编译错误 `MetaStore.open` / `buildRows` / `deinit` 未定义。
+
+- [ ] **Step 3: 实现**（在 `MetaStore` 结构体内补方法 + 私有路径辅助）
+
+```zig
+    pub fn open(allocator: std.mem.Allocator, dir_in: []const u8) !MetaStore {
+        var self = MetaStore{ .allocator = allocator, .dir = try allocator.dupe(u8, dir_in) };
+        errdefer self.deinit();
+
+        try std.fs.cwd().makePath(self.dir);
+        const sessions = try self.sessionsDirPath(allocator);
+        defer allocator.free(sessions);
+        try std.fs.cwd().makePath(sessions);
+        return self;
+    }
+
+    pub fn deinit(self: *MetaStore) void {
+        for (self.entries.items) |*e| agent_history.freeOwnedIndexEntry(self.allocator, e);
+        self.entries.deinit(self.allocator);
+        for (self.pending.items) |*r| agent_history.freeOwnedRecord(self.allocator, r);
+        self.pending.deinit(self.allocator);
+        self.allocator.free(self.dir);
+        self.* = undefined;
+    }
+
+    fn sessionsDirPath(self: *const MetaStore, allocator: std.mem.Allocator) ![]u8 {
+        return std.fs.path.join(allocator, &.{ self.dir, "sessions" });
+    }
+
+    fn indexPath(self: *const MetaStore, allocator: std.mem.Allocator) ![]u8 {
+        return std.fs.path.join(allocator, &.{ self.dir, "index.json" });
+    }
+
+    fn sessionFilePath(self: *const MetaStore, allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
+        const fname = try agent_history.sanitizeSessionFileName(allocator, session_id);
+        defer allocator.free(fname);
+        const sessions = try self.sessionsDirPath(allocator);
+        defer allocator.free(sessions);
+        return std.fs.path.join(allocator, &.{ sessions, fname });
+    }
+
+    pub fn buildRows(self: *const MetaStore, allocator: std.mem.Allocator) ![]agent_history.Row {
+        return agent_history.buildRowsFromEntries(allocator, self.entries.items);
+    }
+
+    pub fn buildCopilotRows(self: *const MetaStore, allocator: std.mem.Allocator) ![]agent_history.Row {
+        return agent_history.buildCopilotRowsFromEntries(allocator, self.entries.items);
+    }
+
+    fn entryIndex(self: *const MetaStore, session_id: []const u8) ?usize {
+        for (self.entries.items, 0..) |e, i| {
+            if (std.mem.eql(u8, e.session_id, session_id)) return i;
+        }
+        return null;
+    }
+
+    fn pendingIndex(self: *const MetaStore, session_id: []const u8) ?usize {
+        for (self.pending.items, 0..) |r, i| {
+            if (std.mem.eql(u8, r.session_id, session_id)) return i;
+        }
+        return null;
+    }
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig src/test_fast.zig
+git commit -m "feat(agent_history_store): MetaStore skeleton with dir + index-backed rows"
+```
+
+---
+
+## Task 8: MetaStore upsert / cloneRecordBySessionId（pending 路径）
+
+**Files:**
+- Modify: `src/agent_history_store.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "MetaStore: upsert is visible via rows and clone before flush (pending)" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+
+    try store.upsertRecord(.{
+        .session_id = "s1",
+        .title = "T",
+        .base_url = "https://api.example.com",
+        .api_key = "k",
+        .model = "m",
+        .system_prompt = "sys",
+        .thinking_enabled = false,
+        .reasoning_effort = "low",
+        .stream = true,
+        .agent_enabled = true,
+        .created_at = 1,
+        .updated_at = 2,
+        .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hi" }},
+    });
+
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("s1", rows[0].session_id);
+
+    var rec = (try store.cloneRecordBySessionId(allocator, "s1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expectEqualStrings("hi", rec.messages[0].content);
+
+    try std.testing.expect((try store.cloneRecordBySessionId(allocator, "nope")) == null);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `upsertRecord` / `cloneRecordBySessionId` 未定义。
+
+- [ ] **Step 3: 实现**（MetaStore 内）
+
+```zig
+    pub fn upsertRecord(self: *MetaStore, input: anytype) !void {
+        var cloned = try agent_history.cloneRecord(self.allocator, input);
+        errdefer agent_history.freeOwnedRecord(self.allocator, &cloned);
+
+        var new_entry = try agent_history.recordToIndexEntry(self.allocator, cloned);
+        errdefer agent_history.freeOwnedIndexEntry(self.allocator, &new_entry);
+
+        // Reserve space FIRST: these are the only fallible ops. After this point
+        // every transfer below is infallible, so ownership moves out of `cloned`/
+        // `new_entry` without leaving the errdefers able to double-free them.
+        try self.entries.ensureUnusedCapacity(self.allocator, 1);
+        try self.pending.ensureUnusedCapacity(self.allocator, 1);
+
+        if (self.entryIndex(cloned.session_id)) |i| {
+            agent_history.freeOwnedIndexEntry(self.allocator, &self.entries.items[i]);
+            self.entries.items[i] = new_entry;
+        } else {
+            self.entries.appendAssumeCapacity(new_entry);
+        }
+
+        if (self.pendingIndex(cloned.session_id)) |i| {
+            agent_history.freeOwnedRecord(self.allocator, &self.pending.items[i]);
+            self.pending.items[i] = cloned;
+        } else {
+            self.pending.appendAssumeCapacity(cloned);
+        }
+        self.index_dirty = true;
+        // Reached the end with no error → errdefers do not run; `cloned`/`new_entry`
+        // are now owned by self.pending / self.entries.
+    }
+
+    pub fn cloneRecordBySessionId(
+        self: *const MetaStore,
+        allocator: std.mem.Allocator,
+        session_id: []const u8,
+    ) !?agent_history.SessionRecord {
+        if (self.pendingIndex(session_id)) |i| {
+            return try agent_history.cloneRecord(allocator, self.pending.items[i]);
+        }
+        const path = try self.sessionFilePath(allocator, session_id);
+        defer allocator.free(path);
+        const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_INDEX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return null,
+        };
+        defer allocator.free(bytes);
+        return try agent_history.recordFromJson(allocator, bytes);
+    }
+```
+
+> 所有权说明：`errdefer` 仅覆盖到两个 `ensureUnusedCapacity`（最后的可失败步骤）之前；其后的 `appendAssumeCapacity`/下标赋值不可失败，函数遂走到末尾正常返回（无 error），`errdefer` 不触发，`cloned`/`new_entry` 干净地移交给 `pending`/`entries`，由 `deinit` 释放——不存在双重释放。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS（在 `testing.allocator` 下无泄漏/双释放）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig
+git commit -m "feat(agent_history_store): upsert into index+pending, lazy clone by id"
+```
+
+---
+
+## Task 9: MetaStore flush（落盘会话文件 + 索引）与冷读
+
+**Files:**
+- Modify: `src/agent_history_store.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "MetaStore: flush writes files and index, reopen reads cold from disk" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    {
+        var store = try MetaStore.open(allocator, root);
+        defer store.deinit();
+        try store.upsertRecord(.{
+            .session_id = "s1",
+            .title = "T",
+            .base_url = "https://api.example.com",
+            .api_key = "k",
+            .model = "m",
+            .system_prompt = "sys",
+            .thinking_enabled = false,
+            .reasoning_effort = "low",
+            .stream = true,
+            .agent_enabled = true,
+            .created_at = 1,
+            .updated_at = 2,
+            .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hi" }},
+        });
+        try store.flush();
+        try std.testing.expectEqual(@as(usize, 0), store.pending.items.len);
+    }
+
+    // Reopen: index loaded, no pending, body read lazily from file.
+    var store2 = try MetaStore.open(allocator, root);
+    defer store2.deinit();
+    const rows = try store2.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+
+    var rec = (try store2.cloneRecordBySessionId(allocator, "s1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expectEqualStrings("hi", rec.messages[0].content);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 失败——`open` 尚不加载 index（reopen 后 rows.len==0），或 `flush` 未定义。
+
+- [ ] **Step 3: 实现**：加入 `flush` / `writeSessionFile` / `writeIndex`，并在 `open` 中接入「加载 index」分支。
+
+MetaStore 内新增：
+
+```zig
+    fn writeSessionFile(self: *const MetaStore, record: agent_history.SessionRecord) !void {
+        const json = try agent_history.recordToJson(self.allocator, record);
+        defer self.allocator.free(json);
+        const path = try self.sessionFilePath(self.allocator, record.session_id);
+        defer self.allocator.free(path);
+        try agent_history.saveJsonToPath(path, json);
+    }
+
+    fn writeIndex(self: *MetaStore) !void {
+        const json = try agent_history.dumpIndex(self.allocator, .{
+            .version = agent_history.INDEX_VERSION,
+            .entries = self.entries.items,
+        });
+        defer self.allocator.free(json);
+        const path = try self.indexPath(self.allocator);
+        defer self.allocator.free(path);
+        try agent_history.saveJsonToPath(path, json);
+    }
+
+    pub fn flush(self: *MetaStore) !void {
+        if (!self.index_dirty and self.pending.items.len == 0) return;
+        for (self.pending.items) |record| {
+            try self.writeSessionFile(record);
+        }
+        for (self.pending.items) |*r| agent_history.freeOwnedRecord(self.allocator, r);
+        self.pending.clearRetainingCapacity();
+        try self.writeIndex();
+        self.index_dirty = false;
+    }
+
+    fn loadIndexFromDisk(self: *MetaStore) !bool {
+        const path = try self.indexPath(self.allocator);
+        defer self.allocator.free(path);
+        const bytes = std.fs.cwd().readFileAlloc(self.allocator, path, MAX_INDEX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return false,
+        };
+        defer self.allocator.free(bytes);
+        var parsed = agent_history.parseIndex(self.allocator, bytes) catch return false;
+        defer parsed.deinit();
+        if (parsed.value.version != agent_history.INDEX_VERSION) return false;
+        for (parsed.value.entries) |e| {
+            const cloned = try agent_history.cloneIndexEntry(self.allocator, e);
+            self.entries.append(self.allocator, cloned) catch |err| {
+                var owned = cloned;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+        return true;
+    }
+```
+
+并把 `open` 改为（在 `makePath(sessions)` 之后、`return self` 之前）：
+
+```zig
+        if (try self.loadIndexFromDisk()) return self;
+        return self;
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig
+git commit -m "feat(agent_history_store): debounced flush to per-session files + index; load index on open"
+```
+
+---
+
+## Task 10: MetaStore deleteBySessionId
+
+**Files:**
+- Modify: `src/agent_history_store.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "MetaStore: delete removes entry, pending and on-disk file" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1", .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+        .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+        .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+        .messages = &[_]agent_history.MessageRecord{},
+    });
+    try store.flush();
+
+    try std.testing.expect(store.deleteBySessionId("s1"));
+    try std.testing.expect(!store.deleteBySessionId("s1"));
+    try store.flush();
+
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 0), rows.len);
+
+    var reopened = try MetaStore.open(allocator, root);
+    defer reopened.deinit();
+    try std.testing.expect((try reopened.cloneRecordBySessionId(allocator, "s1")) == null);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `deleteBySessionId` 未定义。
+
+- [ ] **Step 3: 实现**（MetaStore 内）
+
+```zig
+    pub fn deleteBySessionId(self: *MetaStore, session_id: []const u8) bool {
+        const idx = self.entryIndex(session_id) orelse return false;
+
+        if (self.sessionFilePath(self.allocator, session_id)) |path| {
+            defer self.allocator.free(path);
+            std.fs.cwd().deleteFile(path) catch {};
+        } else |_| {}
+
+        var removed = self.entries.orderedRemove(idx);
+        agent_history.freeOwnedIndexEntry(self.allocator, &removed);
+
+        if (self.pendingIndex(session_id)) |pi| {
+            var r = self.pending.orderedRemove(pi);
+            agent_history.freeOwnedRecord(self.allocator, &r);
+        }
+        self.index_dirty = true;
+        return true;
+    }
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig
+git commit -m "feat(agent_history_store): delete entry + pending + on-disk session file"
+```
+
+---
+
+## Task 11: MetaStore.open 从会话文件重建索引（容错）
+
+**Files:**
+- Modify: `src/agent_history_store.zig`
+
+- [ ] **Step 1: 写失败测试**
+
+```zig
+test "MetaStore: rebuilds index from session files when index missing/corrupt; skips bad files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    // Seed two good session files via a first store, then drop index.json.
+    {
+        var store = try MetaStore.open(allocator, root);
+        defer store.deinit();
+        inline for (.{ "s1", "s2" }) |sid| {
+            try store.upsertRecord(.{
+                .session_id = sid, .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+                .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+                .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+                .messages = &[_]agent_history.MessageRecord{},
+            });
+        }
+        try store.flush();
+    }
+    // open(allocator, root) uses dir == root, so index.json is at root/index.json
+    // and session files live under root/sessions/.
+    try tmp.dir.deleteFile("index.json");
+    // Drop a corrupt session file that must be skipped on rebuild.
+    try tmp.dir.writeFile(.{ .sub_path = "sessions/broken.json", .data = "{ not json" });
+
+    var rebuilt = try MetaStore.open(allocator, root);
+    defer rebuilt.deinit();
+    const rows = try rebuilt.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 失败——`open` 在缺 index 时不重建（rows.len==0），`rebuildIndexFromSessions` 未定义。
+
+- [ ] **Step 3: 实现**：加入 `rebuildIndexFromSessions`，并在 `open` 的 `loadIndexFromDisk` 之后接入。
+
+MetaStore 内新增：
+
+```zig
+    fn rebuildIndexFromSessions(self: *MetaStore) !void {
+        const sessions = try self.sessionsDirPath(self.allocator);
+        defer self.allocator.free(sessions);
+        var dir = std.fs.cwd().openDir(sessions, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return,
+            else => return err,
+        };
+        defer dir.close();
+        var it = dir.iterate();
+        while (try it.next()) |ent| {
+            if (ent.kind != .file) continue;
+            if (!std.mem.endsWith(u8, ent.name, ".json")) continue;
+            const bytes = dir.readFileAlloc(self.allocator, ent.name, agent_history.MAX_SESSION_BYTES) catch continue;
+            defer self.allocator.free(bytes);
+            var rec = agent_history.recordFromJson(self.allocator, bytes) catch continue;
+            defer agent_history.freeOwnedRecord(self.allocator, &rec);
+            const entry = try agent_history.recordToIndexEntry(self.allocator, rec);
+            self.entries.append(self.allocator, entry) catch |err| {
+                var owned = entry;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+    }
+```
+
+把 `open` 中的尾段改为：
+
+```zig
+        if (try self.loadIndexFromDisk()) return self;
+
+        try self.rebuildIndexFromSessions();
+        if (self.entries.items.len > 0) {
+            self.index_dirty = true;
+            try self.flush(); // persist freshly rebuilt index.json
+        }
+        return self;
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig
+git commit -m "feat(agent_history_store): rebuild index from session files, skip corrupt ones"
+```
+
+---
+
+## Task 12: MetaStore.open 从旧单文件迁移
+
+**Files:**
+- Modify: `src/agent_history_store.zig`
+
+- [ ] **Step 1: 写失败测试**（迁移依赖 `agent_history.defaultPath`，用 `setTestConfigDirForCurrentThread` 把 config dir 指到 tmp，使旧文件与新目录同根）
+
+```zig
+const platform_dirs = @import("platform/dirs.zig");
+
+test "MetaStore: migrates legacy single file to dir layout, idempotently, keeps .bak" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    platform_dirs.setTestConfigDirForCurrentThread(root);
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    // Build a legacy agent-history.json with two records via the old Store.
+    {
+        var legacy = agent_history.Store.init(allocator);
+        defer legacy.deinit();
+        try legacy.upsertRecord(.{
+            .session_id = "old-1", .title = "Old1", .base_url = "u", .api_key = "k", .model = "m",
+            .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+            .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2, .copilot = true,
+            .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hey" }},
+        });
+        try legacy.upsertRecord(.{
+            .session_id = "old-2", .title = "Old2", .base_url = "u", .api_key = "k", .model = "m",
+            .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+            .stream = true, .agent_enabled = true, .created_at = 3, .updated_at = 4,
+            .messages = &[_]agent_history.MessageRecord{},
+        });
+        try legacy.saveDefault();
+    }
+
+    const dir = try platform_dirs.agentHistoryDir(allocator);
+    defer allocator.free(dir);
+
+    var store = try MetaStore.open(allocator, dir);
+    defer store.deinit();
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+
+    // Legacy renamed to .bak (original no longer accessible).
+    const legacy_path = try agent_history.defaultPath(allocator);
+    defer allocator.free(legacy_path);
+    const legacy_exists = if (std.fs.cwd().access(legacy_path, .{})) |_| true else |_| false;
+    try std.testing.expect(!legacy_exists);
+    const bak_path = try std.fmt.allocPrint(allocator, "{s}.bak", .{legacy_path});
+    defer allocator.free(bak_path);
+    const bak_exists = if (std.fs.cwd().access(bak_path, .{})) |_| true else |_| false;
+    try std.testing.expect(bak_exists);
+
+    // Body recoverable from disk.
+    var rec = (try store.cloneRecordBySessionId(allocator, "old-1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expect(rec.copilot);
+
+    // Idempotent: a second open does not re-migrate (no legacy present anymore).
+    var store2 = try MetaStore.open(allocator, dir);
+    defer store2.deinit();
+    const rows2 = try store2.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows2);
+    try std.testing.expectEqual(@as(usize, 2), rows2.len);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 失败——`open` 不迁移（rows.len==0），`migrateLegacy` 未定义。
+
+- [ ] **Step 3: 实现**：加入 `migrateLegacy`，并在 `open` 的重建分支之后、`return self` 之前接入。
+
+MetaStore 内新增：
+
+```zig
+    fn migrateLegacy(self: *MetaStore) !bool {
+        const legacy = try agent_history.defaultPath(self.allocator);
+        defer self.allocator.free(legacy);
+
+        const bytes = std.fs.cwd().readFileAlloc(self.allocator, legacy, MIGRATION_MAX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        defer self.allocator.free(bytes);
+
+        var store = agent_history.Store.fromJsonStringLenient(self.allocator, bytes) catch return false;
+        defer store.deinit();
+
+        for (store.records.items) |record| {
+            try self.writeSessionFile(record);
+            const entry = try agent_history.recordToIndexEntry(self.allocator, record);
+            self.entries.append(self.allocator, entry) catch |err| {
+                var owned = entry;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+        self.index_dirty = true;
+        try self.flush(); // writes index.json (session files already written above)
+
+        // Only after success: keep the original as a non-destructive backup.
+        const bak = try std.fmt.allocPrint(self.allocator, "{s}.bak", .{legacy});
+        defer self.allocator.free(bak);
+        std.fs.cwd().rename(legacy, bak) catch |err| {
+            std.log.scoped(.agent_history).warn("legacy history rename to .bak failed: {}", .{err});
+        };
+        return true;
+    }
+```
+
+把 `open` 尾段改为：
+
+```zig
+        if (try self.loadIndexFromDisk()) return self;
+
+        try self.rebuildIndexFromSessions();
+        if (self.entries.items.len > 0) {
+            self.index_dirty = true;
+            try self.flush();
+            return self;
+        }
+
+        _ = try self.migrateLegacy();
+        return self;
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/agent_history_store.zig
+git commit -m "feat(agent_history_store): one-time idempotent migration from legacy single file"
+```
+
+---
+
+## Task 13: 接入 AppWindow（切换全局类型 + flush + 内联测试）
+
+**Files:**
+- Modify: `src/AppWindow.zig`（import；`g_agent_history` 类型 @1368；`ensureGlobalAgentHistoryStore` @5564；`flushAgentHistoryStoreIfDirty` @5659；内联测试 @1161/@1224/@1332）
+
+- [ ] **Step 1: 改全局类型与 import**
+
+在 AppWindow.zig 顶部 import 区（`agent_history` 已 import 处附近）加：
+
+```zig
+const agent_history_store = @import("agent_history_store.zig");
+```
+
+第 1368 行改为：
+
+```zig
+pub var g_agent_history: ?*agent_history_store.MetaStore = null;
+```
+
+- [ ] **Step 2: 改 ensureGlobalAgentHistoryStore（@5564）**
+
+```zig
+fn ensureGlobalAgentHistoryStore(allocator: std.mem.Allocator) !void {
+    g_agent_history_mutex.lock();
+    defer g_agent_history_mutex.unlock();
+
+    if (g_agent_history != null) return;
+
+    const store = try allocator.create(agent_history_store.MetaStore);
+    errdefer allocator.destroy(store);
+    const dir = try platform_dirs.agentHistoryDir(allocator);
+    defer allocator.free(dir);
+    store.* = try agent_history_store.MetaStore.open(allocator, dir);
+    g_agent_history = store;
+    g_flush_scheduler.reset();
+    g_agent_history_revision = 0;
+}
+```
+
+- [ ] **Step 3: 改 flushAgentHistoryStoreIfDirty（@5659 整函数替换）**
+
+```zig
+fn flushAgentHistoryStoreIfDirty(force: bool) void {
+    const now = std.time.milliTimestamp();
+    g_agent_history_mutex.lock();
+    defer g_agent_history_mutex.unlock();
+
+    if (!g_flush_scheduler.shouldFlush(force, now)) return;
+    const store = g_agent_history orelse return;
+    store.flush() catch |err| {
+        log.warn("failed to flush agent history store: {}", .{err});
+        g_flush_scheduler.failFlush(std.time.milliTimestamp());
+        return;
+    };
+    g_flush_scheduler.beginFlush();
+}
+```
+
+- [ ] **Step 4: 改三处内联测试（@1161 / @1224 / @1332）**
+
+把每处的：
+
+```zig
+    var store = agent_history.Store.init(allocator);
+    defer store.deinit();
+    g_agent_history = &store;
+```
+
+改为（每处函数体开头增加 tmp 目录变量；注意三处都在各自 test 内）：
+
+```zig
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const hist_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(hist_root);
+    var store = try agent_history_store.MetaStore.open(allocator, hist_root);
+    defer store.deinit();
+    g_agent_history = &store;
+```
+
+这三处测试随后调用的 `store.upsertRecord(...)`、`store.cloneRecordBySessionId(...)`、以及通过 hook 走 `g_agent_history.?.cloneRecordBySessionId` 方法名均不变，pending 路径保证 flush 前即可读回。
+
+- [ ] **Step 5: 运行确认通过**
+
+Run: `zig build test-full`
+Expected: PASS（AppWindow 测试在 full 套件）。若编译报 `snapshotAgentHistoryRowsForCommandPalette`/`deleteAiChatHistorySessionId` 等处类型不符，确认它们调用的 `buildRows`/`deleteBySessionId`/`cloneRecordBySessionId` 名称与 MetaStore 一致（应一致，无需改）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/AppWindow.zig
+git commit -m "refactor(AppWindow): back global agent history with MetaStore (dir + lazy bodies)"
+```
+
+---
+
+## Task 14: 接入 file_explorer（形参类型 + 内联测试）
+
+**Files:**
+- Modify: `src/file_explorer.zig`（import；`syncAgentHistoryRows` @320；内联测试 @2538/@2567/@2613）
+
+- [ ] **Step 1: 加 import + 改形参类型**
+
+顶部 import 区加：
+
+```zig
+const agent_history_store = @import("agent_history_store.zig");
+```
+
+第 320 行改为：
+
+```zig
+pub fn syncAgentHistoryRows(store: *const agent_history_store.MetaStore) void {
+```
+
+（函数体内 `store.buildRows(allocator)` 保持不变——MetaStore 同名 const 方法。）
+
+- [ ] **Step 2: 改三处内联测试**
+
+每处把：
+
+```zig
+    var store = agent_history.Store.init(allocator);
+    defer store.deinit();
+```
+
+改为：
+
+```zig
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const hist_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(hist_root);
+    var store = try agent_history_store.MetaStore.open(allocator, hist_root);
+    defer store.deinit();
+```
+
+随后的 `store.upsertRecord(...)`、`syncAgentHistoryRows(&store)`、`store.deleteBySessionId(...)` 名称/语义不变；buildRows 从内存索引取值，upsert/delete 即时更新索引，无需 flush。
+
+- [ ] **Step 3: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS（file_explorer 在 fast 套件）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/file_explorer.zig
+git commit -m "refactor(file_explorer): sync history rows from MetaStore"
+```
+
+---
+
+## Task 15: 全量验证与真机迁移冒烟
+
+**Files:** 无代码改动（仅验证）
+
+- [ ] **Step 1: fast 套件**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 2: full 套件（macOS）**
+
+Run: `zig build test-full`
+Expected: PASS。
+
+- [ ] **Step 3: macOS 真机构建**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`
+Expected: 构建成功，产出 .app。
+
+- [ ] **Step 4: 迁移冒烟（手动）**
+
+1. 准备：确保 `~/Library/Application Support/wispterm/agent-history.json`（旧单文件）存在（可用上一个版本运行产生，或手工放置一个有效旧 JSON）。
+2. 启动新构建的 app，打开「副驾历史」面板，确认历史条目与旧版一致。
+3. 检查目录：`~/Library/Application Support/wispterm/agent-history/index.json` 与 `agent-history/sessions/*.json` 已生成；`agent-history.json.bak` 存在；原 `agent-history.json` 已不在。
+4. 新建一个副驾会话、删除一条历史，确认 `sessions/` 与 `index.json` 随之增删。
+5. 重启 app，确认列表内容稳定（走 index 加载路径）。
+
+- [ ] **Step 5: 收尾提交（如有验证期间的小修）**
+
+```bash
+git add -A
+git commit -m "test: verify history storage migration end-to-end"
+```
+
+---
+
+## Self-Review（计划作者已核对）
+
+**Spec coverage：**
+- 多文件布局 / index → Task 2,7,9。
+- 去 8MB 死线（按会话文件读、迁移用大上限）→ Task 5(`MAX_SESSION_BYTES`),12(`MIGRATION_MAX_BYTES`)。
+- 索引派生可重建 / 损坏容错 → Task 11。
+- 索引驱动 + 懒加载 → Task 7,8(`cloneRecordBySessionId` pending→disk),9(冷读)。
+- 去抖写入（pending + flush）→ Task 8,9,13(flush 接 scheduler)。
+- 迁移幂等 + `.bak` 不删 → Task 12。
+- 文件名安全 → Task 3。
+- 搜索预览（检索基础）→ Task 4。
+- 调用点接入（AppWindow / file_explorer）→ Task 13,14。
+- 验证（fast/full/macos-app/真机迁移）→ Task 15。
+
+**Type 一致性：** `MetaStore.{open,deinit,buildRows,buildCopilotRows,cloneRecordBySessionId,upsertRecord,deleteBySessionId,flush}` 在 Task 7–10 定义、Task 13–14 调用一致；`agent_history.{IndexEntry,IndexFile,INDEX_VERSION,dumpIndex,parseIndex,cloneIndexEntry,freeOwnedIndexEntry,recordToIndexEntry,buildSearchPreview,SEARCH_PREVIEW_MAX,recordToJson,recordFromJson,MAX_SESSION_BYTES,sanitizeSessionFileName,buildRowsFromEntries,buildCopilotRowsFromEntries}` 在 Task 2–6 定义、Task 7–12 引用一致。`pending` 与 `entries` 均为 `ArrayListUnmanaged`，线性查找辅助 `entryIndex`/`pendingIndex` 在 Task 7 定义、后续复用。
+
+**Placeholder 扫描：** 无 TBD/TODO；每个 code step 均给出完整代码与精确命令；Task 11/12 的路径与断言已按 `open(root)` 实际布局写实（无「执行时再改」遗留）。

--- a/docs/superpowers/specs/2026-06-23-copilot-history-storage-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-23-copilot-history-storage-redesign-design.md
@@ -40,11 +40,11 @@
 | 列表（侧栏） | `file_explorer.zig:332` `syncAgentHistoryRows` → `buildRows` | 从内存全量构造 Row | 从索引构造 Row（不读正文） |
 | 列表（命令面板） | `AppWindow.zig:5985` `snapshotAgentHistoryRowsForCommandPalette` → `buildRows` | 同上 | 同上 |
 | 列表（Copilot picker） | `agent_history buildCopilotRows`（经 overlays） | 从内存筛 copilot | 从索引筛 copilot |
-| 写入（AI 历史变更） | `AppWindow.zig:5615` `saveAiHistoryChangeEvent` → `upsertRecord` | upsert 内存 + 标整库 dirty | upsert：立即原子写该会话文件 + 更新内存 entry + 标索引脏 |
+| 写入（AI 历史变更） | `AppWindow.zig:5615` `saveAiHistoryChangeEvent` → `upsertRecord` | upsert 内存 + 标整库 dirty | upsert：更新内存 entry + 暂存「待写记录」+ `markDirty`（去抖，**不立即写盘**） |
 | 写入（关闭前持久化打开的标签） | `AppWindow.zig:5642` `persistOpenAiChatTabsToHistoryStore` → `upsertRecord` | 同上 | 同上 |
-| 恢复 | `AppWindow.zig:1199 / 1273` `cloneRecordBySessionId` | 从内存克隆完整记录 | **读该会话文件**返回完整记录 |
-| 删除 | `AppWindow.zig:5972` `deleteAiChatHistorySessionId` → `deleteBySessionId` | 内存删除 + 标 dirty | 内存索引删除 + 删该会话文件 + 标索引脏 |
-| 落盘 | `AppWindow.zig:5659` `flushAgentHistoryStoreIfDirty` → `saveDefault` | 整库重写 | 仅在索引脏时重写 `index.json`（会话文件已在 upsert 时落盘） |
+| 恢复 | `AppWindow.zig:1199 / 1273` `cloneRecordBySessionId` | 从内存克隆完整记录 | 先查内存暂存，未命中则**读该会话文件**返回完整记录 |
+| 删除 | `AppWindow.zig:5972` `deleteAiChatHistorySessionId` → `deleteBySessionId` | 内存删除 + 标 dirty | 内存索引删除 + 删该会话文件 + 移除暂存 + 标脏 |
+| 落盘 | `AppWindow.zig:5659` `flushAgentHistoryStoreIfDirty` → `saveDefault` | 整库重写 | 节流 flush：写所有「待写」会话文件 + 重写 `index.json`，清空暂存 |
 
 `session_id` 形如 `session-{毫秒}-{计数}`（[ai_chat.zig:4183](../../../src/ai_chat.zig#L4183)），纯 ASCII、可直接作文件名（非法字符做净化兜底，见下）。
 
@@ -104,25 +104,27 @@ pub const IndexFile = struct {
 ```zig
 pub const MetaStore = struct {
     allocator,
-    dir: []const u8,                 // <config>/agent-history
-    entries: std.ArrayListUnmanaged(IndexEntry),
-    index_dirty: bool,               // index.json 待重写（会话文件在 upsert 时已落盘）
+    dir: []const u8,                                  // <config>/agent-history
+    entries: std.ArrayListUnmanaged(IndexEntry),      // 全部会话元数据（常驻）
+    pending: std.StringHashMapUnmanaged(SessionRecord),// 改动未落盘的完整记录（去抖期间暂存）
+    index_dirty: bool,                                // index.json 需重写
 
     pub fn open(allocator, dir) !MetaStore;          // 载入/重建索引（不读正文）
     pub fn buildRows(self, allocator) ![]Row;        // 从 entries 投影，已按 updated_at 倒序
     pub fn buildCopilotRows(self, allocator) ![]Row; // 仅 copilot==true
-    pub fn getRecord(self, allocator, id) !?SessionRecord; // 懒读 sessions/<id>.json
-    pub fn upsertRecord(self, input) !void;          // 立即原子写会话文件 + 更新内存 entry + index_dirty=true
-    pub fn deleteBySessionId(self, id) bool;         // 删文件 + 删 entry + index_dirty=true
-    pub fn flush(self) !void;                        // 若 index_dirty 则重写 index.json
+    // 完整记录：先查 pending，未命中则懒读 sessions/<id>.json（保留旧方法名以少改调用点）
+    pub fn cloneRecordBySessionId(self, allocator, id) !?SessionRecord;
+    pub fn upsertRecord(self, input) !void;          // 更新 entry + 存入 pending + index_dirty=true（不写盘）
+    pub fn deleteBySessionId(self, id) bool;         // 删文件 + 删 entry + 移除 pending + index_dirty=true
+    pub fn flush(self) !void;                         // 写所有 pending 会话文件 + 重写 index.json + 清空 pending
     pub fn deinit(self) void;
 };
 ```
 
-- `cloneRecordBySessionId` 调用点改为 `getRecord`（懒读文件）。其余调用点签名几乎不变。
-- `upsertRecord` 立即把完整 `SessionRecord` 原子写入 `sessions/<id>.json`，并刷新内存里对应 `IndexEntry`、置 `index_dirty`。正文不在内存久留，仅 `IndexEntry` 常驻。
+- 生产调用点签名基本不变：`cloneRecordBySessionId` 保留同名（内部先查 `pending` 再读盘）；`buildRows`/`buildCopilotRows`/`upsertRecord`/`deleteBySessionId`/`deinit` 同名同义。新增 `dir` 参数仅出现在 `open`。
+- `upsertRecord` 把完整 `SessionRecord` 克隆进 `pending` 并刷新对应 `IndexEntry`、置 `index_dirty`、`markDirty`；**不立即写盘**。只有「改动未落盘」的少量记录短暂常驻，flush 后清空，冷会话始终懒加载。
 
-> 决策记录：`upsertRecord` 立即落该会话文件（原子写），`flush` 仅按需重写索引。理由：单会话文件小、写入频率低，需被 flush_scheduler 节流的是「索引重写」而非「正文」；正文不在内存久留，符合懒加载初衷，崩溃面也最小。
+> 决策记录：写盘走 flush_scheduler 去抖（沿用现有 350ms 防抖），`upsertRecord` 仅更新内存并暂存。理由：AI 流式回复会高频触发 upsert，若每次立即整写会话文件则一次回复内 O(n²) 写盘；去抖把多次变更合并为一次落盘。代价是改动记录在 flush 前短暂驻留内存——量小且 flush 后释放，仍符合懒加载初衷。
 
 ## 迁移（旧单文件 → 新布局）
 
@@ -148,11 +150,11 @@ pub const MetaStore = struct {
 
 ## 并发与落盘
 
-- 沿用 `g_agent_history_mutex` 保护 `MetaStore`，以及 `flush_scheduler.FlushScheduler`（`markDirty`/`shouldFlush`/`beginFlush`/`deferFlush`/`failFlush`/`reset`）。
-- `upsertRecord`：持锁内原子写会话文件 + 更新内存 entry + `index_dirty = true` + `markAgentHistoryDirtyLocked()`（驱动索引 flush 节流）。
-- `deleteBySessionId`：持锁内删文件 + 删 entry + `index_dirty = true` + 标脏。
-- `flushAgentHistoryStoreIfDirty`：仅当 `index_dirty` 时重写 `index.json`（会话文件已在 upsert 时落盘）。`failFlush`/`deferFlush` 语义不变。
-- 关闭路径 `deinitGlobalAgentHistoryStore` 仍 `force` flush 一次，确保索引落盘。
+- 沿用 `g_agent_history_mutex` 保护 `MetaStore`，以及 `flush_scheduler.FlushScheduler`（`markDirty`/`shouldFlush`/`beginFlush`/`deferFlush`/`failFlush`/`reset`，350ms 去抖）。
+- `upsertRecord`：持锁内更新内存 entry + 克隆进 `pending` + `markAgentHistoryDirtyLocked()`（标脏并驱动去抖），**不写盘**。
+- `deleteBySessionId`：持锁内删会话文件 + 删 entry + 移除 `pending` 项 + 标脏。
+- `flushAgentHistoryStoreIfDirty`：沿用现有「持锁判定 `shouldFlush`」门控；判定通过后在锁内调 `MetaStore.flush()`（逐个原子写 `pending` 会话文件 + 原子写 `index.json`），成功 `beginFlush`、失败 `failFlush`。flush 经 350ms 去抖且只写少量脏文件，锁内写盘耗时可忽略，换取实现简单与 pending 所有权清晰（无需在「移出 pending 后写失败」时回填）。
+- 关闭路径 `deinitGlobalAgentHistoryStore` 仍 `force` flush 一次，确保 pending 与索引全部落盘。
 
 ## 容错与可重建
 

--- a/docs/superpowers/specs/2026-06-23-copilot-history-storage-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-23-copilot-history-storage-redesign-design.md
@@ -1,0 +1,200 @@
+# 副驾历史存储重构：单文件 → 每会话一文件 + 索引（懒加载）
+
+- 日期：2026-06-23
+- 范围：**仅存储架构层**。副驾历史面板的 UI 优化（日期显示、时间分组、启用搜索/来源/模型筛选）作为**第二阶段单独 spec**，本轮不做。
+- 触发：用户反馈「copilot history 管理很差——单文件、不利于检索；8MB 上限有丢历史风险」。本轮把单文件存储拆成每会话一文件 + 元数据索引，并改为索引驱动、正文懒加载，为后续检索打地基。
+
+## 背景与问题
+
+当前副驾会话（含侧栏 Copilot 与 AI Chat 标签页）统一存放在 `agent_history.Store`，落盘为**单个 JSON 文件** `<config>/agent-history.json`：
+
+- **8MB 致命上限**：[loadFromPath](../../../src/agent_history.zig#L286) 用 `readFileAlloc(..., MAX_HISTORY_BYTES = 8MB)`。一旦文件超过 8MB，读取直接报错并经 `else` 分支 `return err`；调用方 [ensureGlobalAgentHistoryStore](../../../src/AppWindow.zig#L5564) 用 `try` 传播，导致**整库加载失败、历史全空**。
+- **整文件重写**：每次 flush 调 `saveDefault` → `saveToPath`，把整库（所有会话的所有消息正文）原子重写一遍。会话越多越慢。
+- **不利于检索**：所有正文塞在一个 JSON 里，想搜消息内容必须整体解析；列表渲染也要先把整库读进内存解析。
+- **一坏全丢**：单文件 JSON 局部损坏时，`fromJsonStringLenient` 只能整体回退为空库。
+
+注：经与用户确认，**当前消息内容是完整保存的**，没有截断 bug；本轮不涉及「部分记录」问题，只解决存储结构。
+
+## 目标 / 非目标
+
+**目标**
+1. 去掉 8MB 全局读取死线，历史规模不再有全局上限。
+2. 每会话独立成文件，单文件损坏只影响该会话，其余可正常加载。
+3. 维护一份轻量**元数据索引** `index.json`，让列表与（元数据级）检索无需读取所有正文。
+4. 运行时改为**索引驱动 + 正文懒加载**：启动只载入索引；打开某会话时才读它的正文文件。
+5. 写入精细化：只重写改动过的会话文件 + 索引，不再整库重写。
+6. 从旧单文件**一次性、幂等、可回滚**地迁移到新布局。
+
+**非目标（本轮明确不做）**
+- 副驾历史面板的 UI（日期、时间分组、搜索框启用、来源/模型筛选）—— 第二阶段 spec。
+- 消息正文的全文检索（FTS）。本轮只在索引里存**有界搜索预览文本**，为后续检索留接口，不实现深度全文搜索。
+- 引入 SQLite 或任何新的第三方/ C 依赖。
+
+## 现状速览（改造半径）
+
+生产代码里真正触碰 `Store` 的调用点（其余 `*.buildRows`/`upsertRecord` 命中均为 `agent_history.zig` 内联测试）：
+
+| 调用点 | 文件:行 | 当前行为 | 重构后 |
+| --- | --- | --- | --- |
+| 加载 | `AppWindow.zig:5572` `ensureGlobalAgentHistoryStore` → `loadDefault` | 读整库进内存 | 只读 `index.json`（缺失/损坏则扫描会话文件重建） |
+| 列表（侧栏） | `file_explorer.zig:332` `syncAgentHistoryRows` → `buildRows` | 从内存全量构造 Row | 从索引构造 Row（不读正文） |
+| 列表（命令面板） | `AppWindow.zig:5985` `snapshotAgentHistoryRowsForCommandPalette` → `buildRows` | 同上 | 同上 |
+| 列表（Copilot picker） | `agent_history buildCopilotRows`（经 overlays） | 从内存筛 copilot | 从索引筛 copilot |
+| 写入（AI 历史变更） | `AppWindow.zig:5615` `saveAiHistoryChangeEvent` → `upsertRecord` | upsert 内存 + 标整库 dirty | upsert：立即原子写该会话文件 + 更新内存 entry + 标索引脏 |
+| 写入（关闭前持久化打开的标签） | `AppWindow.zig:5642` `persistOpenAiChatTabsToHistoryStore` → `upsertRecord` | 同上 | 同上 |
+| 恢复 | `AppWindow.zig:1199 / 1273` `cloneRecordBySessionId` | 从内存克隆完整记录 | **读该会话文件**返回完整记录 |
+| 删除 | `AppWindow.zig:5972` `deleteAiChatHistorySessionId` → `deleteBySessionId` | 内存删除 + 标 dirty | 内存索引删除 + 删该会话文件 + 标索引脏 |
+| 落盘 | `AppWindow.zig:5659` `flushAgentHistoryStoreIfDirty` → `saveDefault` | 整库重写 | 仅在索引脏时重写 `index.json`（会话文件已在 upsert 时落盘） |
+
+`session_id` 形如 `session-{毫秒}-{计数}`（[ai_chat.zig:4183](../../../src/ai_chat.zig#L4183)），纯 ASCII、可直接作文件名（非法字符做净化兜底，见下）。
+
+## 磁盘布局
+
+```
+<config>/agent-history/                # 新目录
+  index.json                           # 版本化元数据索引（派生缓存，可重建）
+  sessions/
+    session-1719000000000-3.json       # 每会话一个完整 SessionRecord（权威源）
+    ...
+```
+
+- 旧文件 `<config>/agent-history.json` 在迁移完成后改名为 `<config>/agent-history.json.bak`（**保留不删**），作为回滚与审计依据。
+- 平台路径：在 `src/platform/dirs.zig` 新增 `agentHistoryDir(allocator)`（返回 `<config>/agent-history`）；现有 `agentHistoryPath`（返回旧单文件路径）保留，仅用于迁移检测与 `.bak` 重命名。
+
+## 数据结构
+
+会话文件（权威源，复用现有 `SessionRecord` 序列化，单条记录而非数组）：
+
+```zig
+// sessions/<id>.json  ← 直接是一个 SessionRecord 的 JSON（已含 messages 全文）
+```
+
+索引 `index.json`（派生缓存，可由会话文件重建）：
+
+```zig
+pub const IndexEntry = struct {
+    session_id: []const u8,
+    title: []const u8,
+    model: []const u8,
+    created_at: i64,
+    updated_at: i64,
+    copilot: bool = false,
+    message_count: u32 = 0,
+    // 有界搜索预览：title + 首条/末条消息截断拼接，小写归一。
+    // 仅供元数据级检索与列表预览；深度全文检索为后续工作。
+    search_preview: []const u8 = "",
+};
+
+pub const IndexFile = struct {
+    version: u32 = 1,
+    entries: []IndexEntry = &.{},
+};
+```
+
+`Row`（现有结构，列表渲染用）从 `IndexEntry` 直接投影，字段一一对应，无需读正文。
+
+## 运行时内存模型：索引驱动 + 正文懒加载
+
+新存储抽象（暂名 `MetaStore`，落点见「模块划分」）：
+
+- 内存常驻：`entries: []IndexEntry`（全部会话的元数据，远小于正文）。
+- **不**常驻：任何 `messages` 正文。
+- 接口（替换现 `Store` 的对外语义，保持调用点改动最小）：
+
+```zig
+pub const MetaStore = struct {
+    allocator,
+    dir: []const u8,                 // <config>/agent-history
+    entries: std.ArrayListUnmanaged(IndexEntry),
+    index_dirty: bool,               // index.json 待重写（会话文件在 upsert 时已落盘）
+
+    pub fn open(allocator, dir) !MetaStore;          // 载入/重建索引（不读正文）
+    pub fn buildRows(self, allocator) ![]Row;        // 从 entries 投影，已按 updated_at 倒序
+    pub fn buildCopilotRows(self, allocator) ![]Row; // 仅 copilot==true
+    pub fn getRecord(self, allocator, id) !?SessionRecord; // 懒读 sessions/<id>.json
+    pub fn upsertRecord(self, input) !void;          // 立即原子写会话文件 + 更新内存 entry + index_dirty=true
+    pub fn deleteBySessionId(self, id) bool;         // 删文件 + 删 entry + index_dirty=true
+    pub fn flush(self) !void;                        // 若 index_dirty 则重写 index.json
+    pub fn deinit(self) void;
+};
+```
+
+- `cloneRecordBySessionId` 调用点改为 `getRecord`（懒读文件）。其余调用点签名几乎不变。
+- `upsertRecord` 立即把完整 `SessionRecord` 原子写入 `sessions/<id>.json`，并刷新内存里对应 `IndexEntry`、置 `index_dirty`。正文不在内存久留，仅 `IndexEntry` 常驻。
+
+> 决策记录：`upsertRecord` 立即落该会话文件（原子写），`flush` 仅按需重写索引。理由：单会话文件小、写入频率低，需被 flush_scheduler 节流的是「索引重写」而非「正文」；正文不在内存久留，符合懒加载初衷，崩溃面也最小。
+
+## 迁移（旧单文件 → 新布局）
+
+`MetaStore.open` 启动时：
+
+1. 若 `agent-history/index.json` 存在且 `version` 匹配 → 直接载入。
+2. 否则若 `agent-history/sessions/` 存在 → **扫描重建索引**（解析每个 `*.json` 取元数据；解析失败的文件记日志跳过）。
+3. 否则若旧单文件 `agent-history.json` 存在 → **执行迁移**：
+   - 用**大上限/流式**读取旧文件（迁移路径不受 8MB 限制；用 `std.fs` 直接读全量或分段，避免 `readFileAlloc` 的小上限）。
+   - 用现有 `Store.fromJsonStringLenient` 解析为记录集合。
+   - 逐条原子写 `sessions/<sanitized_id>.json`，并累积 `IndexEntry`。
+   - 原子写 `index.json`。
+   - **全部成功后**才把旧文件 `rename` 为 `agent-history.json.bak`。任一步失败：保留旧文件、清理半成品目录、记日志并降级为空索引（下次启动重试），绝不删除旧数据。
+4. 否则（全新用户）→ 空索引。
+
+迁移幂等：以 `.bak` 是否已生成 + 目录是否存在为判据；重复启动不会重复迁移或覆盖。
+
+## 文件名安全与防碰撞
+
+- 合法字符集 `[A-Za-z0-9._-]`。`session_id` 现状全部满足。
+- 不满足时（历史遗留/异常 id）：将非法字符替换为 `_`，并在末尾追加 `-{wyhash十六进制}`，保证唯一且可逆映射（真实 `session_id` 同时存在于文件内 `SessionRecord.session_id` 与 `IndexEntry.session_id`，文件名仅作存储键）。
+- 删除/读取通过 `IndexEntry.session_id` → 文件名映射函数定位，映射函数为纯函数、可单测。
+
+## 并发与落盘
+
+- 沿用 `g_agent_history_mutex` 保护 `MetaStore`，以及 `flush_scheduler.FlushScheduler`（`markDirty`/`shouldFlush`/`beginFlush`/`deferFlush`/`failFlush`/`reset`）。
+- `upsertRecord`：持锁内原子写会话文件 + 更新内存 entry + `index_dirty = true` + `markAgentHistoryDirtyLocked()`（驱动索引 flush 节流）。
+- `deleteBySessionId`：持锁内删文件 + 删 entry + `index_dirty = true` + 标脏。
+- `flushAgentHistoryStoreIfDirty`：仅当 `index_dirty` 时重写 `index.json`（会话文件已在 upsert 时落盘）。`failFlush`/`deferFlush` 语义不变。
+- 关闭路径 `deinitGlobalAgentHistoryStore` 仍 `force` flush 一次，确保索引落盘。
+
+## 容错与可重建
+
+- **权威/派生分离**：会话文件权威，`index.json` 派生。索引缺失、版本不符、JSON 损坏 → 一律扫描会话文件重建，不阻塞启动。
+- 单个会话文件解析失败 → 记日志跳过该会话，其余正常（替代旧「一坏全丢」）。
+- `getRecord` 对损坏/缺失文件返回 `null` 并记日志，调用方（恢复 hook）按现有 `error.ExpectedHistoryRecord` 路径优雅降级。
+
+## 模块划分（保持可隔离、可单测）
+
+- `src/agent_history.zig`：保留 `SessionRecord`/`MessageRecord`/`Row` 与 clone/free/序列化纯函数；新增单会话 `SessionRecord` 的 JSON 读写纯函数；新增 `IndexEntry`/`IndexFile` 及其 JSON 读写、`recordToIndexEntry`、`sanitizeFileName`、`buildSearchPreview` 等纯函数。
+- 新文件 `src/agent_history_store.zig`（或同名命名空间）：`MetaStore`（持目录、entries、flush 逻辑、迁移、重建）。文件 IO 与全局状态解耦——所有路径/序列化/迁移逻辑写成接收 `dir`/`allocator` 的纯函数，便于用临时目录单测。
+- `src/platform/dirs.zig`：新增 `agentHistoryDir` + `agentHistoryDirFromEnvForOs`（与现有 `*FromEnvForOs` 风格一致，供路径单测）。
+- `src/AppWindow.zig`：`ensureGlobalAgentHistoryStore` 改为 `MetaStore.open(dir)`；`cloneRecordBySessionId` 调用点改 `getRecord`；flush 路径改为索引落盘；其余调用点签名保持。
+
+## 测试计划（TDD）
+
+纯逻辑用 `testing.allocator` + `std.testing.tmpDir`，尽量进 `zig build test` 快速套件；涉及 app 绑定的走 `test-full`。
+
+1. 文件名净化/防碰撞：合法 id 原样、非法字符替换、碰撞追加 hash、映射可逆。
+2. 单会话 JSON 往返：`SessionRecord` 写入再读出，字段（含 messages）一致。
+3. 索引往返与投影：`recordToIndexEntry` 字段映射；`buildRows`/`buildCopilotRows` 排序（updated_at 倒序）与 copilot 过滤。
+4. 索引重建：删掉 `index.json`，由 `sessions/*.json` 扫描重建，entries 与原一致。
+5. 版本不符 → 重建：`index.json` 写入旧版本号，open 时触发重建。
+6. 损坏容错：写入一个坏 `sessions/x.json`，open 仍成功且跳过它；坏 `index.json` 触发重建。
+7. 迁移：构造旧 `agent-history.json`（多记录，含 copilot 与非 copilot），open 后 → 生成 `sessions/*` + `index.json`，旧文件变 `.bak`；再次 open 幂等（不重复迁移）。
+8. 迁移失败回滚：注入写失败，旧文件保留、无 `.bak`、降级空索引。
+9. upsert/delete：upsert 新会话→文件存在 + 索引含之；upsert 同 id→覆盖且 entry 更新；delete→文件与 entry 同时移除。
+10. 懒加载：`buildRows` 不读正文（可用「仅索引存在、正文文件被改名」仍能列出、`getRecord` 才失败 来佐证）。
+11. 8MB 回归：构造 > 8MB 的总量（多会话），新布局可全量加载（旧路径会失败）。
+
+## 验证
+
+- 按项目惯例，默认 `zig build` 目标是 Windows；macOS 验证用 `zig build test-full` + `zig build macos-app -Dtarget=aarch64-macos`；纯逻辑可先用 `zig build test`。
+- 真机冒烟：旧版本产生的 `agent-history.json` 在新版本首启后被迁移为目录布局，副驾历史列表内容不变，旧文件留有 `.bak`；新增/删除/重开会话后目录与索引正确更新。
+
+## 风险与回滚
+
+- **数据安全第一**：迁移只在全部成功后改名旧文件，且只改名不删除；任何异常都保留 `agent-history.json` 原样。
+- 回滚：删除 `agent-history/` 目录、把 `agent-history.json.bak` 改回 `agent-history.json`，即恢复旧版可读状态（旧版本读新目录会得到空库，但数据未丢，仍在 `.bak`）。
+- 索引与会话文件不一致风险：通过「会话文件权威 + 索引可重建」消解；任何疑似不一致，删 `index.json` 重启即重建。
+
+## 未来工作（不在本轮）
+
+1. **第二阶段 UI spec**：副驾历史面板显示相对时间（复用 [formatRelativeTime](../../../src/copilot_picker.zig#L101)）、按时间分组标题（今天/昨天/过去7天/更早）、启用搜索框（title+model）、Tab 来源筛选（全部/侧栏/标签页）、模型筛选。本轮的 `index.json` + `search_preview` 即为其检索基础。
+2. **深度全文检索**：在索引 `search_preview` 之上扩展为完整正文检索（按需扫描会话文件或建倒排）。

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -25,6 +25,7 @@ const memory_debug = @import("memory_debug.zig");
 const surface_registry = @import("surface_registry.zig");
 const agent_detector = @import("agent_detector.zig");
 const agent_history = @import("agent_history.zig");
+const agent_history_store = @import("agent_history_store.zig");
 const close_confirm = @import("close_confirm.zig");
 const font_backend = @import("platform/font_backend.zig");
 const platform_display = @import("platform/display.zig");
@@ -1158,7 +1159,11 @@ test "AppWindow: open AI chat tabs are persisted to agent history before session
     tab.g_tab_count = 0;
     active_tab_state.g_active_tab = 0;
 
-    var store = agent_history.Store.init(allocator);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const hist_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(hist_root);
+    var store = try agent_history_store.MetaStore.open(allocator, hist_root);
     defer store.deinit();
     g_agent_history = &store;
 
@@ -1221,7 +1226,11 @@ test "AppWindow: terminal tab copilot sessions are persisted to agent history be
     tab.g_tab_count = 0;
     active_tab_state.g_active_tab = 0;
 
-    var store = agent_history.Store.init(allocator);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const hist_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(hist_root);
+    var store = try agent_history_store.MetaStore.open(allocator, hist_root);
     defer store.deinit();
     g_agent_history = &store;
 
@@ -1329,7 +1338,11 @@ test "AppWindow: copilot restore hook rehydrates a copilot session by id" {
         g_allocator = previous_alloc;
     }
 
-    var store = agent_history.Store.init(allocator);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const hist_root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(hist_root);
+    var store = try agent_history_store.MetaStore.open(allocator, hist_root);
     defer store.deinit();
     g_agent_history = &store;
     g_allocator = allocator;
@@ -1365,7 +1378,7 @@ test "AppWindow: copilot restore hook rehydrates a copilot session by id" {
 // App pointer for requestNewWindow
 pub threadlocal var g_app: ?*App = null;
 var g_agent_history_mutex: std.Thread.Mutex = .{};
-pub var g_agent_history: ?*agent_history.Store = null;
+pub var g_agent_history: ?*agent_history_store.MetaStore = null;
 var g_flush_scheduler: flush_scheduler.FlushScheduler = .{};
 var g_agent_history_revision: u64 = 0;
 
@@ -5567,9 +5580,11 @@ fn ensureGlobalAgentHistoryStore(allocator: std.mem.Allocator) !void {
 
     if (g_agent_history != null) return;
 
-    const store = try allocator.create(agent_history.Store);
+    const store = try allocator.create(agent_history_store.MetaStore);
     errdefer allocator.destroy(store);
-    store.* = try agent_history.loadDefault(allocator);
+    const dir = try platform_dirs.agentHistoryDir(allocator);
+    defer allocator.free(dir);
+    store.* = try agent_history_store.MetaStore.open(allocator, dir);
     g_agent_history = store;
     g_flush_scheduler.reset();
     g_agent_history_revision = 0;
@@ -5658,51 +5673,17 @@ fn markAgentHistoryDirtyLocked() void {
 
 fn flushAgentHistoryStoreIfDirty(force: bool) void {
     const now = std.time.milliTimestamp();
-    var json: ?[]u8 = null;
-    var path: ?[]const u8 = null;
-    var snapshot_allocator: ?std.mem.Allocator = null;
-
     g_agent_history_mutex.lock();
-    if (!g_flush_scheduler.shouldFlush(force, now)) {
-        g_agent_history_mutex.unlock();
-        return;
-    }
+    defer g_agent_history_mutex.unlock();
 
-    const store = g_agent_history orelse {
-        g_agent_history_mutex.unlock();
-        return;
-    };
-    snapshot_allocator = store.allocator;
-    json = store.toJsonString(store.allocator) catch |err| {
-        log.warn("failed to snapshot agent history store for flush: {}", .{err});
-        g_flush_scheduler.deferFlush(now);
-        g_agent_history_mutex.unlock();
-        return;
-    };
-    path = agent_history.defaultPath(store.allocator) catch |err| {
-        log.warn("failed to resolve agent history path for flush: {}", .{err});
-        store.allocator.free(json.?);
-        g_flush_scheduler.deferFlush(now);
-        g_agent_history_mutex.unlock();
+    if (!g_flush_scheduler.shouldFlush(force, now)) return;
+    const store = g_agent_history orelse return;
+    store.flush() catch |err| {
+        log.warn("failed to flush agent history store: {}", .{err});
+        g_flush_scheduler.failFlush(std.time.milliTimestamp());
         return;
     };
     g_flush_scheduler.beginFlush();
-    g_agent_history_mutex.unlock();
-
-    agent_history.saveJsonToPath(path.?, json.?) catch |err| {
-        log.warn("failed to flush agent history store: {}", .{err});
-        g_agent_history_mutex.lock();
-        g_flush_scheduler.failFlush(std.time.milliTimestamp());
-        snapshot_allocator.?.free(path.?);
-        snapshot_allocator.?.free(json.?);
-        g_agent_history_mutex.unlock();
-        return;
-    };
-
-    g_agent_history_mutex.lock();
-    snapshot_allocator.?.free(path.?);
-    snapshot_allocator.?.free(json.?);
-    g_agent_history_mutex.unlock();
 }
 
 fn spawnTabWithCwd(allocator: std.mem.Allocator, cwd: platform_pty_command.Cwd) bool {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -434,6 +434,51 @@ fn isSafeFileChar(c: u8) bool {
         c == '.' or c == '_' or c == '-';
 }
 
+pub const SEARCH_PREVIEW_MAX = 200;
+
+fn lowerAsciiByte(c: u8) u8 {
+    return if (c >= 'A' and c <= 'Z') c + 32 else c;
+}
+
+pub fn buildSearchPreview(allocator: std.mem.Allocator, record: SessionRecord) ![]u8 {
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    for (record.title) |c| try buf.append(allocator, lowerAsciiByte(c));
+    for (record.messages) |m| {
+        if (buf.items.len >= SEARCH_PREVIEW_MAX) break;
+        try buf.append(allocator, ' ');
+        for (m.content) |c| {
+            if (buf.items.len >= SEARCH_PREVIEW_MAX) break;
+            try buf.append(allocator, lowerAsciiByte(c));
+        }
+    }
+    var n = @min(buf.items.len, SEARCH_PREVIEW_MAX);
+    while (n > 0 and !std.unicode.utf8ValidateSlice(buf.items[0..n])) n -= 1;
+    buf.shrinkRetainingCapacity(n);
+    return buf.toOwnedSlice(allocator);
+}
+
+pub fn recordToIndexEntry(allocator: std.mem.Allocator, record: SessionRecord) !IndexEntry {
+    const session_id = try allocator.dupe(u8, record.session_id);
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, record.title);
+    errdefer allocator.free(title);
+    const model = try allocator.dupe(u8, record.model);
+    errdefer allocator.free(model);
+    const search_preview = try buildSearchPreview(allocator, record);
+    errdefer allocator.free(search_preview);
+    return .{
+        .session_id = session_id,
+        .title = title,
+        .model = model,
+        .created_at = record.created_at,
+        .updated_at = record.updated_at,
+        .copilot = record.copilot,
+        .message_count = @intCast(record.messages.len),
+        .search_preview = search_preview,
+    };
+}
+
 pub fn sanitizeSessionFileName(allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
     var all_safe = session_id.len > 0;
     for (session_id) |c| {
@@ -1136,6 +1181,25 @@ test "agent_history: sanitizeSessionFileName keeps safe ids and hashes unsafe on
     try std.testing.expect(std.mem.endsWith(u8, unsafe1, ".json"));
     try std.testing.expect(std.mem.indexOfScalar(u8, unsafe1, '/') == null);
     try std.testing.expectEqualStrings(unsafe1, unsafe2);
+}
+
+test "agent_history: recordToIndexEntry derives bounded lowercase preview" {
+    const allocator = std.testing.allocator;
+    var store = Store.init(allocator);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1", .title = "Hello World", .base_url = "https://api.example.com",
+        .api_key = "k", .model = "m1", .system_prompt = "sys", .thinking_enabled = false,
+        .reasoning_effort = "low", .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+        .messages = &[_]MessageRecord{.{ .role = .user, .content = "First Question" }},
+    });
+    var entry = try recordToIndexEntry(allocator, store.records.items[0]);
+    defer freeOwnedIndexEntry(allocator, &entry);
+    try std.testing.expectEqual(@as(u32, 1), entry.message_count);
+    try std.testing.expect(entry.search_preview.len <= SEARCH_PREVIEW_MAX);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(entry.search_preview));
+    try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "hello world") != null);
+    try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "first question") != null);
 }
 
 fn expectLenientParseOutOfMemory(json: []const u8) !void {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const platform_dirs = @import("platform/dirs.zig");
 const log = std.log.scoped(.agent_history);
 
-const MAX_HISTORY_BYTES = 8 * 1024 * 1024;
 pub const MAX_SESSION_BYTES = 32 * 1024 * 1024;
 const DEFAULT_PROTOCOL = "chat_completions";
 
@@ -299,25 +298,6 @@ pub fn cloneRecord(allocator: std.mem.Allocator, input: anytype) !SessionRecord 
         .updated_at = input.updated_at,
         .messages = messages,
     };
-}
-
-pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) !Store {
-    const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_HISTORY_BYTES) catch |err| switch (err) {
-        error.FileNotFound => return Store.init(allocator),
-        else => {
-            log.warn("failed to read {s}: {}", .{ path, err });
-            return err;
-        },
-    };
-    defer allocator.free(bytes);
-
-    return Store.fromJsonStringLenient(allocator, bytes);
-}
-
-pub fn loadDefault(allocator: std.mem.Allocator) !Store {
-    const path = try defaultPath(allocator);
-    defer allocator.free(path);
-    return loadFromPath(allocator, path);
 }
 
 pub fn freeOwnedRecord(allocator: std.mem.Allocator, record: *SessionRecord) void {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -458,6 +458,19 @@ pub fn buildSearchPreview(allocator: std.mem.Allocator, record: SessionRecord) !
     return buf.toOwnedSlice(allocator);
 }
 
+pub fn recordToJson(allocator: std.mem.Allocator, record: SessionRecord) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, record, .{});
+}
+
+pub fn recordFromJson(allocator: std.mem.Allocator, bytes: []const u8) !SessionRecord {
+    var parsed = try std.json.parseFromSlice(SessionRecord, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+    return cloneRecord(allocator, parsed.value);
+}
+
 pub fn recordToIndexEntry(allocator: std.mem.Allocator, record: SessionRecord) !IndexEntry {
     const session_id = try allocator.dupe(u8, record.session_id);
     errdefer allocator.free(session_id);
@@ -1200,6 +1213,27 @@ test "agent_history: recordToIndexEntry derives bounded lowercase preview" {
     try std.testing.expect(std.unicode.utf8ValidateSlice(entry.search_preview));
     try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "hello world") != null);
     try std.testing.expect(std.mem.indexOf(u8, entry.search_preview, "first question") != null);
+}
+
+test "agent_history: single record JSON round-trips" {
+    const allocator = std.testing.allocator;
+    var store = Store.init(allocator);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1", .title = "Title", .base_url = "https://api.example.com",
+        .api_key = "k", .model = "m1", .system_prompt = "sys", .thinking_enabled = true,
+        .reasoning_effort = "high", .stream = false, .agent_enabled = true, .copilot = true,
+        .created_at = 7, .updated_at = 9,
+        .messages = &[_]MessageRecord{ .{ .role = .user, .content = "hi" }, .{ .role = .assistant, .content = "yo" } },
+    });
+    const json = try recordToJson(allocator, store.records.items[0]);
+    defer allocator.free(json);
+    var rec = try recordFromJson(allocator, json);
+    defer freeOwnedRecord(allocator, &rec);
+    try std.testing.expectEqualStrings("s1", rec.session_id);
+    try std.testing.expect(rec.copilot);
+    try std.testing.expectEqual(@as(usize, 2), rec.messages.len);
+    try std.testing.expectEqualStrings("yo", rec.messages[1].content);
 }
 
 fn expectLenientParseOutOfMemory(json: []const u8) !void {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -3,6 +3,7 @@ const platform_dirs = @import("platform/dirs.zig");
 const log = std.log.scoped(.agent_history);
 
 const MAX_HISTORY_BYTES = 8 * 1024 * 1024;
+pub const MAX_SESSION_BYTES = 32 * 1024 * 1024;
 const DEFAULT_PROTOCOL = "chat_completions";
 
 pub const MessageRole = enum {
@@ -47,6 +48,24 @@ pub const Row = struct {
     model: []const u8,
     updated_at: i64,
     copilot: bool = false,
+};
+
+pub const INDEX_VERSION: u32 = 1;
+
+pub const IndexEntry = struct {
+    session_id: []const u8,
+    title: []const u8,
+    model: []const u8,
+    created_at: i64,
+    updated_at: i64,
+    copilot: bool = false,
+    message_count: u32 = 0,
+    search_preview: []const u8 = "",
+};
+
+pub const IndexFile = struct {
+    version: u32 = INDEX_VERSION,
+    entries: []IndexEntry = &.{},
 };
 
 const PersistedStore = struct {
@@ -366,6 +385,46 @@ pub fn freeOwnedMessage(allocator: std.mem.Allocator, message: *MessageRecord) v
 pub fn freeRows(allocator: std.mem.Allocator, rows: []Row) void {
     for (rows) |*row| freeOwnedRow(allocator, row);
     allocator.free(rows);
+}
+
+pub fn dumpIndex(allocator: std.mem.Allocator, index: IndexFile) ![]u8 {
+    return std.json.Stringify.valueAlloc(allocator, index, .{});
+}
+
+pub fn parseIndex(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(IndexFile) {
+    return std.json.parseFromSlice(IndexFile, allocator, bytes, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+}
+
+pub fn cloneIndexEntry(allocator: std.mem.Allocator, input: IndexEntry) !IndexEntry {
+    const session_id = try allocator.dupe(u8, input.session_id);
+    errdefer allocator.free(session_id);
+    const title = try allocator.dupe(u8, input.title);
+    errdefer allocator.free(title);
+    const model = try allocator.dupe(u8, input.model);
+    errdefer allocator.free(model);
+    const search_preview = try allocator.dupe(u8, input.search_preview);
+    errdefer allocator.free(search_preview);
+    return .{
+        .session_id = session_id,
+        .title = title,
+        .model = model,
+        .created_at = input.created_at,
+        .updated_at = input.updated_at,
+        .copilot = input.copilot,
+        .message_count = input.message_count,
+        .search_preview = search_preview,
+    };
+}
+
+pub fn freeOwnedIndexEntry(allocator: std.mem.Allocator, entry: *IndexEntry) void {
+    allocator.free(entry.session_id);
+    allocator.free(entry.title);
+    allocator.free(entry.model);
+    allocator.free(entry.search_preview);
+    entry.* = undefined;
 }
 
 fn dupeOptionalString(allocator: std.mem.Allocator, value: ?[]const u8) !?[]const u8 {
@@ -1019,6 +1078,23 @@ test "agent_history: old record without copilot field defaults to false" {
     defer store.deinit();
     try std.testing.expectEqual(@as(usize, 1), store.records.items.len);
     try std.testing.expect(!store.records.items[0].copilot);
+}
+
+test "agent_history: index file round-trips" {
+    const allocator = std.testing.allocator;
+    var entries = [_]IndexEntry{
+        .{ .session_id = "s1", .title = "T1", .model = "m1", .created_at = 1, .updated_at = 2, .copilot = false, .message_count = 3, .search_preview = "t1 hello" },
+        .{ .session_id = "s2", .title = "T2", .model = "m2", .created_at = 5, .updated_at = 6, .copilot = true, .message_count = 0, .search_preview = "" },
+    };
+    const json = try dumpIndex(allocator, .{ .version = INDEX_VERSION, .entries = &entries });
+    defer allocator.free(json);
+    var parsed = try parseIndex(allocator, json);
+    defer parsed.deinit();
+    try std.testing.expectEqual(INDEX_VERSION, parsed.value.version);
+    try std.testing.expectEqual(@as(usize, 2), parsed.value.entries.len);
+    try std.testing.expectEqualStrings("s2", parsed.value.entries[1].session_id);
+    try std.testing.expect(parsed.value.entries[1].copilot);
+    try std.testing.expectEqual(@as(u32, 3), parsed.value.entries[0].message_count);
 }
 
 fn expectLenientParseOutOfMemory(json: []const u8) !void {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -458,6 +458,56 @@ pub fn buildSearchPreview(allocator: std.mem.Allocator, record: SessionRecord) !
     return buf.toOwnedSlice(allocator);
 }
 
+pub fn buildRowsFromEntries(allocator: std.mem.Allocator, entries: []const IndexEntry) ![]Row {
+    const rows = try allocator.alloc(Row, entries.len);
+    var initialized: usize = 0;
+    errdefer {
+        while (initialized > 0) {
+            initialized -= 1;
+            freeOwnedRow(allocator, &rows[initialized]);
+        }
+        allocator.free(rows);
+    }
+    for (entries, 0..) |e, i| {
+        rows[i] = try cloneRow(allocator, .{
+            .session_id = e.session_id,
+            .title = e.title,
+            .model = e.model,
+            .updated_at = e.updated_at,
+            .copilot = e.copilot,
+        });
+        initialized += 1;
+    }
+    sortRows(rows);
+    return rows;
+}
+
+pub fn buildCopilotRowsFromEntries(allocator: std.mem.Allocator, entries: []const IndexEntry) ![]Row {
+    var list: std.ArrayListUnmanaged(Row) = .empty;
+    errdefer {
+        for (list.items) |*r| freeOwnedRow(allocator, r);
+        list.deinit(allocator);
+    }
+    for (entries) |e| {
+        if (!e.copilot) continue;
+        const row = try cloneRow(allocator, .{
+            .session_id = e.session_id,
+            .title = e.title,
+            .model = e.model,
+            .updated_at = e.updated_at,
+            .copilot = e.copilot,
+        });
+        list.append(allocator, row) catch |err| {
+            var owned = row;
+            freeOwnedRow(allocator, &owned);
+            return err;
+        };
+    }
+    const rows = try list.toOwnedSlice(allocator);
+    sortRows(rows);
+    return rows;
+}
+
 pub fn recordToJson(allocator: std.mem.Allocator, record: SessionRecord) ![]u8 {
     return std.json.Stringify.valueAlloc(allocator, record, .{});
 }
@@ -1234,6 +1284,24 @@ test "agent_history: single record JSON round-trips" {
     try std.testing.expect(rec.copilot);
     try std.testing.expectEqual(@as(usize, 2), rec.messages.len);
     try std.testing.expectEqualStrings("yo", rec.messages[1].content);
+}
+
+test "agent_history: buildRowsFromEntries sorts desc and filters copilot" {
+    const allocator = std.testing.allocator;
+    var entries = [_]IndexEntry{
+        .{ .session_id = "a", .title = "A", .model = "m", .created_at = 1, .updated_at = 1, .copilot = false },
+        .{ .session_id = "b", .title = "B", .model = "m", .created_at = 2, .updated_at = 3, .copilot = true },
+        .{ .session_id = "c", .title = "C", .model = "m", .created_at = 2, .updated_at = 2, .copilot = false },
+    };
+    const rows = try buildRowsFromEntries(allocator, &entries);
+    defer freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 3), rows.len);
+    try std.testing.expectEqualStrings("b", rows[0].session_id);
+    try std.testing.expectEqualStrings("c", rows[1].session_id);
+    const co = try buildCopilotRowsFromEntries(allocator, &entries);
+    defer freeRows(allocator, co);
+    try std.testing.expectEqual(@as(usize, 1), co.len);
+    try std.testing.expectEqualStrings("b", co[0].session_id);
 }
 
 fn expectLenientParseOutOfMemory(json: []const u8) !void {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -427,6 +427,33 @@ pub fn freeOwnedIndexEntry(allocator: std.mem.Allocator, entry: *IndexEntry) voi
     entry.* = undefined;
 }
 
+fn isSafeFileChar(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or
+        (c >= 'a' and c <= 'z') or
+        (c >= '0' and c <= '9') or
+        c == '.' or c == '_' or c == '-';
+}
+
+pub fn sanitizeSessionFileName(allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
+    var all_safe = session_id.len > 0;
+    for (session_id) |c| {
+        if (!isSafeFileChar(c)) {
+            all_safe = false;
+            break;
+        }
+    }
+    if (all_safe) {
+        return std.fmt.allocPrint(allocator, "{s}.json", .{session_id});
+    }
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    for (session_id) |c| {
+        try buf.append(allocator, if (isSafeFileChar(c)) c else '_');
+    }
+    const h = std.hash.Wyhash.hash(0, session_id);
+    return std.fmt.allocPrint(allocator, "{s}-{x}.json", .{ buf.items, h });
+}
+
 fn dupeOptionalString(allocator: std.mem.Allocator, value: ?[]const u8) !?[]const u8 {
     if (value) |slice| return try allocator.dupe(u8, slice);
     return null;
@@ -1095,6 +1122,20 @@ test "agent_history: index file round-trips" {
     try std.testing.expectEqualStrings("s2", parsed.value.entries[1].session_id);
     try std.testing.expect(parsed.value.entries[1].copilot);
     try std.testing.expectEqual(@as(u32, 3), parsed.value.entries[0].message_count);
+}
+
+test "agent_history: sanitizeSessionFileName keeps safe ids and hashes unsafe ones" {
+    const allocator = std.testing.allocator;
+    const safe = try sanitizeSessionFileName(allocator, "session-1719000000000-3");
+    defer allocator.free(safe);
+    try std.testing.expectEqualStrings("session-1719000000000-3.json", safe);
+    const unsafe1 = try sanitizeSessionFileName(allocator, "会話/x");
+    defer allocator.free(unsafe1);
+    const unsafe2 = try sanitizeSessionFileName(allocator, "会話/x");
+    defer allocator.free(unsafe2);
+    try std.testing.expect(std.mem.endsWith(u8, unsafe1, ".json"));
+    try std.testing.expect(std.mem.indexOfScalar(u8, unsafe1, '/') == null);
+    try std.testing.expectEqualStrings(unsafe1, unsafe2);
 }
 
 fn expectLenientParseOutOfMemory(json: []const u8) !void {

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -18,6 +18,7 @@ pub const MetaStore = struct {
         const sessions = try self.sessionsDirPath(allocator);
         defer allocator.free(sessions);
         try std.fs.cwd().makePath(sessions);
+        if (try self.loadIndexFromDisk()) return self;
         return self;
     }
 
@@ -109,6 +110,58 @@ pub const MetaStore = struct {
         defer allocator.free(bytes);
         return try agent_history.recordFromJson(allocator, bytes);
     }
+
+    fn writeSessionFile(self: *const MetaStore, record: agent_history.SessionRecord) !void {
+        const json = try agent_history.recordToJson(self.allocator, record);
+        defer self.allocator.free(json);
+        const path = try self.sessionFilePath(self.allocator, record.session_id);
+        defer self.allocator.free(path);
+        try agent_history.saveJsonToPath(path, json);
+    }
+
+    fn writeIndex(self: *MetaStore) !void {
+        const json = try agent_history.dumpIndex(self.allocator, .{
+            .version = agent_history.INDEX_VERSION,
+            .entries = self.entries.items,
+        });
+        defer self.allocator.free(json);
+        const path = try self.indexPath(self.allocator);
+        defer self.allocator.free(path);
+        try agent_history.saveJsonToPath(path, json);
+    }
+
+    pub fn flush(self: *MetaStore) !void {
+        if (!self.index_dirty and self.pending.items.len == 0) return;
+        for (self.pending.items) |record| {
+            try self.writeSessionFile(record);
+        }
+        for (self.pending.items) |*r| agent_history.freeOwnedRecord(self.allocator, r);
+        self.pending.clearRetainingCapacity();
+        try self.writeIndex();
+        self.index_dirty = false;
+    }
+
+    fn loadIndexFromDisk(self: *MetaStore) !bool {
+        const path = try self.indexPath(self.allocator);
+        defer self.allocator.free(path);
+        const bytes = std.fs.cwd().readFileAlloc(self.allocator, path, MAX_INDEX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return false,
+        };
+        defer self.allocator.free(bytes);
+        var parsed = agent_history.parseIndex(self.allocator, bytes) catch return false;
+        defer parsed.deinit();
+        if (parsed.value.version != agent_history.INDEX_VERSION) return false;
+        for (parsed.value.entries) |e| {
+            const cloned = try agent_history.cloneIndexEntry(self.allocator, e);
+            self.entries.append(self.allocator, cloned) catch |err| {
+                var owned = cloned;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+        return true;
+    }
 };
 
 test "MetaStore: open empty dir yields no rows" {
@@ -146,4 +199,32 @@ test "MetaStore: upsert is visible via rows and clone before flush (pending)" {
     defer agent_history.freeOwnedRecord(allocator, &rec);
     try std.testing.expectEqualStrings("hi", rec.messages[0].content);
     try std.testing.expect((try store.cloneRecordBySessionId(allocator, "nope")) == null);
+}
+
+test "MetaStore: flush writes files and index, reopen reads cold from disk" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    {
+        var store = try MetaStore.open(allocator, root);
+        defer store.deinit();
+        try store.upsertRecord(.{
+            .session_id = "s1", .title = "T", .base_url = "https://api.example.com", .api_key = "k", .model = "m",
+            .system_prompt = "sys", .thinking_enabled = false, .reasoning_effort = "low", .stream = true,
+            .agent_enabled = true, .created_at = 1, .updated_at = 2,
+            .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hi" }},
+        });
+        try store.flush();
+        try std.testing.expectEqual(@as(usize, 0), store.pending.items.len);
+    }
+    var store2 = try MetaStore.open(allocator, root);
+    defer store2.deinit();
+    const rows = try store2.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    var rec = (try store2.cloneRecordBySessionId(allocator, "s1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expectEqualStrings("hi", rec.messages[0].content);
 }

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -19,6 +19,12 @@ pub const MetaStore = struct {
         defer allocator.free(sessions);
         try std.fs.cwd().makePath(sessions);
         if (try self.loadIndexFromDisk()) return self;
+
+        try self.rebuildIndexFromSessions();
+        if (self.entries.items.len > 0) {
+            self.index_dirty = true;
+            try self.flush();
+        }
         return self;
     }
 
@@ -178,6 +184,31 @@ pub const MetaStore = struct {
         self.index_dirty = true;
         return true;
     }
+
+    fn rebuildIndexFromSessions(self: *MetaStore) !void {
+        const sessions = try self.sessionsDirPath(self.allocator);
+        defer self.allocator.free(sessions);
+        var dir = std.fs.cwd().openDir(sessions, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return,
+            else => return err,
+        };
+        defer dir.close();
+        var it = dir.iterate();
+        while (try it.next()) |ent| {
+            if (ent.kind != .file) continue;
+            if (!std.mem.endsWith(u8, ent.name, ".json")) continue;
+            const bytes = dir.readFileAlloc(self.allocator, ent.name, agent_history.MAX_SESSION_BYTES) catch continue;
+            defer self.allocator.free(bytes);
+            var rec = agent_history.recordFromJson(self.allocator, bytes) catch continue;
+            defer agent_history.freeOwnedRecord(self.allocator, &rec);
+            const entry = try agent_history.recordToIndexEntry(self.allocator, rec);
+            self.entries.append(self.allocator, entry) catch |err| {
+                var owned = entry;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+    }
 };
 
 test "MetaStore: open empty dir yields no rows" {
@@ -269,4 +300,32 @@ test "MetaStore: delete removes entry, pending and on-disk file" {
     var reopened = try MetaStore.open(allocator, root);
     defer reopened.deinit();
     try std.testing.expect((try reopened.cloneRecordBySessionId(allocator, "s1")) == null);
+}
+
+test "MetaStore: rebuilds index from session files when index missing/corrupt; skips bad files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    {
+        var store = try MetaStore.open(allocator, root);
+        defer store.deinit();
+        inline for (.{ "s1", "s2" }) |sid| {
+            try store.upsertRecord(.{
+                .session_id = sid, .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+                .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+                .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+                .messages = &[_]agent_history.MessageRecord{},
+            });
+        }
+        try store.flush();
+    }
+    try tmp.dir.deleteFile("index.json");
+    try tmp.dir.writeFile(.{ .sub_path = "sessions/broken.json", .data = "{ not json" });
+    var rebuilt = try MetaStore.open(allocator, root);
+    defer rebuilt.deinit();
+    const rows = try rebuilt.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
 }

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -21,14 +21,17 @@ pub const MetaStore = struct {
         try std.fs.cwd().makePath(sessions);
         if (try self.loadIndexFromDisk()) return self;
 
+        // Complete (or start) migration before trusting on-disk session files: a
+        // crash mid-migration can leave a partial sessions/ dir with the legacy
+        // file still present, and rebuilding from those partial files would
+        // silently drop the un-migrated records. migrateLegacy is idempotent.
+        if (try self.migrateLegacy()) return self;
+
         try self.rebuildIndexFromSessions();
         if (self.entries.items.len > 0) {
             self.index_dirty = true;
             try self.flush();
-            return self;
         }
-
-        _ = try self.migrateLegacy();
         return self;
     }
 
@@ -361,6 +364,63 @@ test "MetaStore: rebuilds index from session files when index missing/corrupt; s
     const rows = try rebuilt.buildRows(allocator);
     defer agent_history.freeRows(allocator, rows);
     try std.testing.expectEqual(@as(usize, 2), rows.len);
+}
+
+test "MetaStore: completes an interrupted migration when legacy file still present" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    platform_dirs.setTestConfigDirForCurrentThread(root);
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    // Legacy file with three records.
+    {
+        var legacy = agent_history.Store.init(allocator);
+        defer legacy.deinit();
+        inline for (.{ "old-1", "old-2", "old-3" }) |sid| {
+            try legacy.upsertRecord(.{
+                .session_id = sid, .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+                .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+                .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+                .messages = &[_]agent_history.MessageRecord{},
+            });
+        }
+        try legacy.saveDefault();
+    }
+
+    // Simulate a crashed migration: a partial sessions/ dir (only old-1 written),
+    // NO index.json, legacy file still present.
+    try tmp.dir.makePath("agent-history/sessions");
+    {
+        var one = agent_history.Store.init(allocator);
+        defer one.deinit();
+        try one.upsertRecord(.{
+            .session_id = "old-1", .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+            .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+            .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+            .messages = &[_]agent_history.MessageRecord{},
+        });
+        const json = try agent_history.recordToJson(allocator, one.records.items[0]);
+        defer allocator.free(json);
+        try tmp.dir.writeFile(.{ .sub_path = "agent-history/sessions/old-1.json", .data = json });
+    }
+
+    const dir = try platform_dirs.agentHistoryDir(allocator);
+    defer allocator.free(dir);
+    var store = try MetaStore.open(allocator, dir);
+    defer store.deinit();
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    // Migration must complete: all THREE records present (not just the partial old-1).
+    try std.testing.expectEqual(@as(usize, 3), rows.len);
+
+    // Legacy file renamed to .bak (migration finished).
+    const legacy_path = try agent_history.defaultPath(allocator);
+    defer allocator.free(legacy_path);
+    const legacy_exists = if (std.fs.cwd().access(legacy_path, .{})) |_| true else |_| false;
+    try std.testing.expect(!legacy_exists);
 }
 
 test "MetaStore: migrates legacy single file to dir layout, idempotently, keeps .bak" {

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const agent_history = @import("agent_history.zig");
+const platform_dirs = @import("platform/dirs.zig");
 
 pub const MAX_INDEX_BYTES = 32 * 1024 * 1024;
 const MIGRATION_MAX_BYTES = 1 << 30;
@@ -24,7 +25,10 @@ pub const MetaStore = struct {
         if (self.entries.items.len > 0) {
             self.index_dirty = true;
             try self.flush();
+            return self;
         }
+
+        _ = try self.migrateLegacy();
         return self;
     }
 
@@ -209,6 +213,35 @@ pub const MetaStore = struct {
             };
         }
     }
+
+    fn migrateLegacy(self: *MetaStore) !bool {
+        const legacy = try agent_history.defaultPath(self.allocator);
+        defer self.allocator.free(legacy);
+        const bytes = std.fs.cwd().readFileAlloc(self.allocator, legacy, MIGRATION_MAX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        defer self.allocator.free(bytes);
+        var store = agent_history.Store.fromJsonStringLenient(self.allocator, bytes) catch return false;
+        defer store.deinit();
+        for (store.records.items) |record| {
+            try self.writeSessionFile(record);
+            const entry = try agent_history.recordToIndexEntry(self.allocator, record);
+            self.entries.append(self.allocator, entry) catch |err| {
+                var owned = entry;
+                agent_history.freeOwnedIndexEntry(self.allocator, &owned);
+                return err;
+            };
+        }
+        self.index_dirty = true;
+        try self.flush();
+        const bak = try std.fmt.allocPrint(self.allocator, "{s}.bak", .{legacy});
+        defer self.allocator.free(bak);
+        std.fs.cwd().rename(legacy, bak) catch |err| {
+            std.log.scoped(.agent_history).warn("legacy history rename to .bak failed: {}", .{err});
+        };
+        return true;
+    }
 };
 
 test "MetaStore: open empty dir yields no rows" {
@@ -328,4 +361,54 @@ test "MetaStore: rebuilds index from session files when index missing/corrupt; s
     const rows = try rebuilt.buildRows(allocator);
     defer agent_history.freeRows(allocator, rows);
     try std.testing.expectEqual(@as(usize, 2), rows.len);
+}
+
+test "MetaStore: migrates legacy single file to dir layout, idempotently, keeps .bak" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    platform_dirs.setTestConfigDirForCurrentThread(root);
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+    {
+        var legacy = agent_history.Store.init(allocator);
+        defer legacy.deinit();
+        try legacy.upsertRecord(.{
+            .session_id = "old-1", .title = "Old1", .base_url = "u", .api_key = "k", .model = "m",
+            .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+            .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2, .copilot = true,
+            .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hey" }},
+        });
+        try legacy.upsertRecord(.{
+            .session_id = "old-2", .title = "Old2", .base_url = "u", .api_key = "k", .model = "m",
+            .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+            .stream = true, .agent_enabled = true, .created_at = 3, .updated_at = 4,
+            .messages = &[_]agent_history.MessageRecord{},
+        });
+        try legacy.saveDefault();
+    }
+    const dir = try platform_dirs.agentHistoryDir(allocator);
+    defer allocator.free(dir);
+    var store = try MetaStore.open(allocator, dir);
+    defer store.deinit();
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 2), rows.len);
+    const legacy_path = try agent_history.defaultPath(allocator);
+    defer allocator.free(legacy_path);
+    const legacy_exists = if (std.fs.cwd().access(legacy_path, .{})) |_| true else |_| false;
+    try std.testing.expect(!legacy_exists);
+    const bak_path = try std.fmt.allocPrint(allocator, "{s}.bak", .{legacy_path});
+    defer allocator.free(bak_path);
+    const bak_exists = if (std.fs.cwd().access(bak_path, .{})) |_| true else |_| false;
+    try std.testing.expect(bak_exists);
+    var rec = (try store.cloneRecordBySessionId(allocator, "old-1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expect(rec.copilot);
+    var store2 = try MetaStore.open(allocator, dir);
+    defer store2.deinit();
+    const rows2 = try store2.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows2);
+    try std.testing.expectEqual(@as(usize, 2), rows2.len);
 }

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -162,6 +162,22 @@ pub const MetaStore = struct {
         }
         return true;
     }
+
+    pub fn deleteBySessionId(self: *MetaStore, session_id: []const u8) bool {
+        const idx = self.entryIndex(session_id) orelse return false;
+        if (self.sessionFilePath(self.allocator, session_id)) |path| {
+            defer self.allocator.free(path);
+            std.fs.cwd().deleteFile(path) catch {};
+        } else |_| {}
+        var removed = self.entries.orderedRemove(idx);
+        agent_history.freeOwnedIndexEntry(self.allocator, &removed);
+        if (self.pendingIndex(session_id)) |pi| {
+            var r = self.pending.orderedRemove(pi);
+            agent_history.freeOwnedRecord(self.allocator, &r);
+        }
+        self.index_dirty = true;
+        return true;
+    }
 };
 
 test "MetaStore: open empty dir yields no rows" {
@@ -227,4 +243,30 @@ test "MetaStore: flush writes files and index, reopen reads cold from disk" {
     var rec = (try store2.cloneRecordBySessionId(allocator, "s1")) orelse return error.Missing;
     defer agent_history.freeOwnedRecord(allocator, &rec);
     try std.testing.expectEqualStrings("hi", rec.messages[0].content);
+}
+
+test "MetaStore: delete removes entry, pending and on-disk file" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1", .title = "T", .base_url = "u", .api_key = "k", .model = "m",
+        .system_prompt = "s", .thinking_enabled = false, .reasoning_effort = "low",
+        .stream = true, .agent_enabled = true, .created_at = 1, .updated_at = 2,
+        .messages = &[_]agent_history.MessageRecord{},
+    });
+    try store.flush();
+    try std.testing.expect(store.deleteBySessionId("s1"));
+    try std.testing.expect(!store.deleteBySessionId("s1"));
+    try store.flush();
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 0), rows.len);
+    var reopened = try MetaStore.open(allocator, root);
+    defer reopened.deinit();
+    try std.testing.expect((try reopened.cloneRecordBySessionId(allocator, "s1")) == null);
 }

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -67,6 +67,48 @@ pub const MetaStore = struct {
         }
         return null;
     }
+
+    pub fn upsertRecord(self: *MetaStore, input: anytype) !void {
+        var cloned = try agent_history.cloneRecord(self.allocator, input);
+        errdefer agent_history.freeOwnedRecord(self.allocator, &cloned);
+        var new_entry = try agent_history.recordToIndexEntry(self.allocator, cloned);
+        errdefer agent_history.freeOwnedIndexEntry(self.allocator, &new_entry);
+
+        try self.entries.ensureUnusedCapacity(self.allocator, 1);
+        try self.pending.ensureUnusedCapacity(self.allocator, 1);
+
+        if (self.entryIndex(cloned.session_id)) |i| {
+            agent_history.freeOwnedIndexEntry(self.allocator, &self.entries.items[i]);
+            self.entries.items[i] = new_entry;
+        } else {
+            self.entries.appendAssumeCapacity(new_entry);
+        }
+        if (self.pendingIndex(cloned.session_id)) |i| {
+            agent_history.freeOwnedRecord(self.allocator, &self.pending.items[i]);
+            self.pending.items[i] = cloned;
+        } else {
+            self.pending.appendAssumeCapacity(cloned);
+        }
+        self.index_dirty = true;
+    }
+
+    pub fn cloneRecordBySessionId(
+        self: *const MetaStore,
+        allocator: std.mem.Allocator,
+        session_id: []const u8,
+    ) !?agent_history.SessionRecord {
+        if (self.pendingIndex(session_id)) |i| {
+            return try agent_history.cloneRecord(allocator, self.pending.items[i]);
+        }
+        const path = try self.sessionFilePath(allocator, session_id);
+        defer allocator.free(path);
+        const bytes = std.fs.cwd().readFileAlloc(allocator, path, MAX_INDEX_BYTES) catch |err| switch (err) {
+            error.FileNotFound => return null,
+            else => return null,
+        };
+        defer allocator.free(bytes);
+        return try agent_history.recordFromJson(allocator, bytes);
+    }
 };
 
 test "MetaStore: open empty dir yields no rows" {
@@ -80,4 +122,28 @@ test "MetaStore: open empty dir yields no rows" {
     const rows = try store.buildRows(allocator);
     defer agent_history.freeRows(allocator, rows);
     try std.testing.expectEqual(@as(usize, 0), rows.len);
+}
+
+test "MetaStore: upsert is visible via rows and clone before flush (pending)" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+    try store.upsertRecord(.{
+        .session_id = "s1", .title = "T", .base_url = "https://api.example.com", .api_key = "k", .model = "m",
+        .system_prompt = "sys", .thinking_enabled = false, .reasoning_effort = "low", .stream = true,
+        .agent_enabled = true, .created_at = 1, .updated_at = 2,
+        .messages = &[_]agent_history.MessageRecord{.{ .role = .user, .content = "hi" }},
+    });
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 1), rows.len);
+    try std.testing.expectEqualStrings("s1", rows[0].session_id);
+    var rec = (try store.cloneRecordBySessionId(allocator, "s1")) orelse return error.Missing;
+    defer agent_history.freeOwnedRecord(allocator, &rec);
+    try std.testing.expectEqualStrings("hi", rec.messages[0].content);
+    try std.testing.expect((try store.cloneRecordBySessionId(allocator, "nope")) == null);
 }

--- a/src/agent_history_store.zig
+++ b/src/agent_history_store.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const agent_history = @import("agent_history.zig");
+
+pub const MAX_INDEX_BYTES = 32 * 1024 * 1024;
+const MIGRATION_MAX_BYTES = 1 << 30;
+
+pub const MetaStore = struct {
+    allocator: std.mem.Allocator,
+    dir: []u8,
+    entries: std.ArrayListUnmanaged(agent_history.IndexEntry) = .empty,
+    pending: std.ArrayListUnmanaged(agent_history.SessionRecord) = .empty,
+    index_dirty: bool = false,
+
+    pub fn open(allocator: std.mem.Allocator, dir_in: []const u8) !MetaStore {
+        var self = MetaStore{ .allocator = allocator, .dir = try allocator.dupe(u8, dir_in) };
+        errdefer self.deinit();
+        try std.fs.cwd().makePath(self.dir);
+        const sessions = try self.sessionsDirPath(allocator);
+        defer allocator.free(sessions);
+        try std.fs.cwd().makePath(sessions);
+        return self;
+    }
+
+    pub fn deinit(self: *MetaStore) void {
+        for (self.entries.items) |*e| agent_history.freeOwnedIndexEntry(self.allocator, e);
+        self.entries.deinit(self.allocator);
+        for (self.pending.items) |*r| agent_history.freeOwnedRecord(self.allocator, r);
+        self.pending.deinit(self.allocator);
+        self.allocator.free(self.dir);
+        self.* = undefined;
+    }
+
+    fn sessionsDirPath(self: *const MetaStore, allocator: std.mem.Allocator) ![]u8 {
+        return std.fs.path.join(allocator, &.{ self.dir, "sessions" });
+    }
+
+    fn indexPath(self: *const MetaStore, allocator: std.mem.Allocator) ![]u8 {
+        return std.fs.path.join(allocator, &.{ self.dir, "index.json" });
+    }
+
+    fn sessionFilePath(self: *const MetaStore, allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
+        const fname = try agent_history.sanitizeSessionFileName(allocator, session_id);
+        defer allocator.free(fname);
+        const sessions = try self.sessionsDirPath(allocator);
+        defer allocator.free(sessions);
+        return std.fs.path.join(allocator, &.{ sessions, fname });
+    }
+
+    pub fn buildRows(self: *const MetaStore, allocator: std.mem.Allocator) ![]agent_history.Row {
+        return agent_history.buildRowsFromEntries(allocator, self.entries.items);
+    }
+
+    pub fn buildCopilotRows(self: *const MetaStore, allocator: std.mem.Allocator) ![]agent_history.Row {
+        return agent_history.buildCopilotRowsFromEntries(allocator, self.entries.items);
+    }
+
+    fn entryIndex(self: *const MetaStore, session_id: []const u8) ?usize {
+        for (self.entries.items, 0..) |e, i| {
+            if (std.mem.eql(u8, e.session_id, session_id)) return i;
+        }
+        return null;
+    }
+
+    fn pendingIndex(self: *const MetaStore, session_id: []const u8) ?usize {
+        for (self.pending.items, 0..) |r, i| {
+            if (std.mem.eql(u8, r.session_id, session_id)) return i;
+        }
+        return null;
+    }
+};
+
+test "MetaStore: open empty dir yields no rows" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    var store = try MetaStore.open(allocator, root);
+    defer store.deinit();
+    const rows = try store.buildRows(allocator);
+    defer agent_history.freeRows(allocator, rows);
+    try std.testing.expectEqual(@as(usize, 0), rows.len);
+}

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -317,7 +317,7 @@ pub fn syncPanelForTerminalTarget(target: TerminalPanelTarget, force: bool) void
     }
 }
 
-pub fn syncAgentHistoryRows(store: *const agent_history.Store) void {
+pub fn syncAgentHistoryRows(store: anytype) void {
     const allocator = std.heap.page_allocator;
     const selected_index_copy = g_history_selected;
     const selected_session_id_copy = if (g_history_selected) |selected|

--- a/src/platform/dirs.zig
+++ b/src/platform/dirs.zig
@@ -212,6 +212,18 @@ pub fn agentHistoryPathFromEnvForOs(
     return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "agent-history.json");
 }
 
+pub fn agentHistoryDir(allocator: std.mem.Allocator) ![]const u8 {
+    return pathInConfigDir(allocator, "agent-history");
+}
+
+pub fn agentHistoryDirFromEnvForOs(
+    allocator: std.mem.Allocator,
+    os_tag: std.Target.Os.Tag,
+    env: Env,
+) ![]const u8 {
+    return pathInConfigDirFromEnvForOs(allocator, os_tag, env, "agent-history");
+}
+
 pub fn aiHistoryCachePath(allocator: std.mem.Allocator) ![]const u8 {
     return pathInConfigDir(allocator, "ai_history_cache.json");
 }
@@ -710,4 +722,11 @@ test "platform dirs resolve home directory per OS" {
     try std.testing.expectEqualStrings("/home/alice", linux);
 
     try std.testing.expectError(error.NoHomeDir, homeDirFromEnvForOs(allocator, .linux, .{}));
+}
+
+test "agentHistoryDir resolves under config dir (macos)" {
+    const a = std.testing.allocator;
+    const p = try agentHistoryDirFromEnvForOs(a, .macos, .{ .home = "/Users/x" });
+    defer a.free(p);
+    try std.testing.expectEqualStrings("/Users/x/Library/Application Support/wispterm/agent-history", p);
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -135,6 +135,7 @@ test {
     _ = @import("ime_caret.zig");
     _ = @import("sync_output.zig");
     _ = @import("agent_history.zig");
+    _ = @import("agent_history_store.zig");
     _ = @import("render_diagnostics.zig");
     _ = @import("diag_log.zig");
     _ = @import("notification.zig");


### PR DESCRIPTION
## Summary

副驾历史（Copilot history）存储从**单文件**重构为**目录布局**，去掉会导致历史丢失的 8MB 加载死线，并为后续检索/UI 打基础。

- **磁盘布局**：`agent-history.json`（单文件，整库重写）→ `agent-history/` 目录：每会话一个权威文件 `sessions/<id>.json` + 派生缓存 `index.json`。
- **运行时**：索引驱动 + 正文懒加载——启动只读 `index.json` 即可列表/检索；打开某会话才读它的文件。
- **写入去抖**：`upsertRecord` 更新内存索引 + 暂存 `pending` 完整记录，由现有 `flush_scheduler`（350ms 去抖）批量落盘，避免 AI 流式回复期间 O(n²) 整文件重写。
- **迁移**：旧单文件首启**一次性、幂等**迁移到目录布局，原文件改名 `.bak`（只备份不删，可回滚）。修复了「迁移中途崩溃 → 重建抢先短路 → 未迁移会话不可见」的竞态（`open()` 先补完迁移再 rebuild）。
- **容错**：会话文件为权威源，`index.json` 缺失/版本不符/损坏则扫描重建；单个会话文件损坏只跳过该条，不再「一坏全丢」。
- **检索基础**：`index.json` 每条带有界 `search_preview`，供后续历史面板搜索/分组使用。
- 文件名对非法字符做净化 + wyhash 防碰撞；清理了重构后不再使用的 8MB 上限加载路径。

UI 面板优化（日期显示、时间分组、启用搜索/来源/模型筛选）作为**第二阶段**单独进行——本 PR 仅做存储层。

设计与实施文档见 `docs/superpowers/specs/2026-06-23-copilot-history-storage-redesign-design.md` 与 `docs/superpowers/plans/2026-06-23-copilot-history-storage-redesign.md`。

## Test Plan

- [x] `zig build test`（fast 套件，含 agent_history / agent_history_store 内联测试，testing.allocator 检漏）
- [x] `zig build test-full`（含 AppWindow / platform/dirs 测试）
- [x] `zig build macos-app -Dtarget=aarch64-macos`（真机 .app 构建）
- [x] 单测覆盖：索引往返、文件名净化、搜索预览、单记录 JSON 往返、Row 排序/copilot 过滤、flush 冷读、删除、索引重建（跳过损坏）、幂等迁移、迁移中途崩溃恢复
- [x] 真机迁移冒烟：旧 `agent-history.json` 升级后被迁移为目录布局、列表内容不变、留有 `.bak`；新建/删除/重开会话后 `sessions/` 与 `index.json` 正确增删；重启列表稳定

🤖 Generated with [Claude Code](https://claude.com/claude-code)