### PR TITLE
[codex] document AI command reference

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -187,7 +187,13 @@ Local slash commands (handled in the panel, without calling the model):
 - `/reload-skills` confirms that future skill calls will read from disk again.
 - `/reload-commands` rescans the custom `commands/` directory.
 - `/clear` clears the current conversation context (keeps the tab and profile).
+- `/rewind` opens a picker for an earlier user prompt so you can edit and
+  continue from that point.
 - `/resume` opens the saved-conversation history picker.
+- `/cwd` shows the effective working directory for the conversation.
+  `/cwd <path>` sets a per-conversation directory override after resolving it
+  to an existing absolute directory. `/cwd reset`, `/cwd default`, and
+  `/cwd clear` remove the override and return to the default.
 - `/model` opens the saved-profile picker; `/model <name>` switches directly.
   `/模型` is the Chinese alias.
 - `/permission` shows the agent tool permission; `/permission ask`,
@@ -198,8 +204,38 @@ Local slash commands (handled in the panel, without calling the model):
   `ask`.
 - `/export` writes the conversation to Markdown (clean by default; `/export full`
   includes reasoning, tool details, and usage).
+- `/loop <interval> <count> <prompt>` repeats a prompt after each fixed
+  interval, then stops after `count` successful sends. The interval is an
+  integer plus `s`, `m`, `h`, or `d`, for example `/loop 30m 8 check CI`.
+  `/loop` lists this session's loop tasks, `/loop all` lists all loop tasks from
+  Copilot, and `/loop stop <id>` or `/loop stop all` cancels tasks.
+- `/watch <HH:MM> <prompt>` sends a prompt every day at that local time.
+  `/watch <YYYY-MM-DD HH:MM> <prompt>` sends a one-shot prompt at that local
+  time. `/watch` lists this session's watch tasks, `/watch all` lists all watch
+  tasks from Copilot, and `/watch stop <id>` or `/watch stop all` cancels
+  tasks.
+- `/remember <fact>` saves a long-term memory in the project tier when a
+  working directory is set, otherwise in the global tier. `/记住` is the Chinese
+  alias.
+- `/memory` lists remembered facts. `/记忆` is the Chinese alias.
+- `/forget <name>` deletes a remembered fact by name. `/忘记` is the Chinese
+  alias.
 - `/distill [topic]` or `/沉淀 [主题]` previews a reusable local skill distilled
   from the current conversation.
+
+Reserved `$` lookup commands run in the panel and append a local tool message
+without submitting a normal AI turn:
+
+- `$websearch <query>` searches the web through Jina Search. It requires
+  `jina-api-key` in the WispTerm config.
+- `$webread <url | file path>` reads a web page or local file into Markdown
+  through Jina Reader. It uses `jina-api-key` when set, but anonymous reads are
+  allowed. Local-file conversions are cached by content under `.webread_cache`.
+- `$pubmed <query>` searches NCBI PubMed and returns article metadata and
+  abstracts. It does not require an API key.
+
+The agent can also call the `websearch`, `webread`, and `pubmed` tools on its
+own when those first-party tools are enabled in Skill Center.
 
 ## Skill Distillation
 

--- a/docs/ai.html
+++ b/docs/ai.html
@@ -196,7 +196,12 @@ ai-agent-output-limit       = 16384</code></pre>
           </div>
           <div class="feature">
             <h3>Slash commands</h3>
-            <p><code>/model</code> switches saved profiles, <code>/skills</code> lists discovered skills, <code>/commands</code> lists local AI commands, and <code>/reload-skills</code> refreshes future skill calls from disk.</p>
+            <p><code>/commands</code> lists the current command set. Common commands include <code>/model</code> for profile switching, <code>/cwd</code> for the conversation working directory, <code>/permission</code> for agent approval mode, <code>/export</code> for Markdown, <code>/distill</code> for reusable skills, and <code>/remember</code> / <code>/memory</code> / <code>/forget</code> for long-term memory.</p>
+            <p><code>/loop</code> repeats a prompt on an interval and <code>/watch</code> schedules daily or one-shot prompts. <code>/clear</code>, <code>/rewind</code>, <code>/resume</code>, <code>/skills</code>, <code>/reload-skills</code>, and <code>/reload-commands</code> cover conversation lifecycle and local command refresh.</p>
+          </div>
+          <div class="feature">
+            <h3>Lookup shortcuts</h3>
+            <p>Type <code>$websearch &lt;query&gt;</code>, <code>$webread &lt;url | file path&gt;</code>, or <code>$pubmed &lt;query&gt;</code> to run a read-only lookup from the composer without starting a normal AI turn. <code>$websearch</code> uses the configured <code>jina-api-key</code>; <code>$webread</code> can read anonymously; <code>$pubmed</code> uses NCBI PubMed anonymously.</p>
           </div>
           <div class="feature">
             <h3>Command center paths</h3>

--- a/docs/ai.zh.html
+++ b/docs/ai.zh.html
@@ -196,7 +196,12 @@ ai-agent-output-limit       = 16384</code></pre>
           </div>
           <div class="feature">
             <h3>Slash Commands</h3>
-            <p><code>/model</code> 切换已保存 profile，<code>/skills</code> 列出已发现 Skills，<code>/commands</code> 列出本地 AI 命令，<code>/reload-skills</code> 让后续 Skill 调用从磁盘重新读取。</p>
+            <p><code>/commands</code> 会列出当前命令集合。常用命令包括：用 <code>/model</code> 切换 profile，用 <code>/cwd</code> 设置本次对话工作目录，用 <code>/permission</code> 切换 Agent 审批模式，用 <code>/export</code> 导出 Markdown，用 <code>/distill</code> 沉淀可复用 Skill，以及用 <code>/remember</code> / <code>/memory</code> / <code>/forget</code> 管理长期记忆。</p>
+            <p><code>/loop</code> 可以按固定间隔重复发送 prompt，<code>/watch</code> 可以按每日时间或一次性时间发送 prompt。<code>/clear</code>、<code>/rewind</code>、<code>/resume</code>、<code>/skills</code>、<code>/reload-skills</code> 和 <code>/reload-commands</code> 用于管理对话生命周期与本地命令刷新。</p>
+          </div>
+          <div class="feature">
+            <h3>查询快捷命令</h3>
+            <p>在输入框中使用 <code>$websearch &lt;query&gt;</code>、<code>$webread &lt;url | file path&gt;</code> 或 <code>$pubmed &lt;query&gt;</code>，可以不发起普通 AI 回合，直接执行只读查询并把结果写入对话。<code>$websearch</code> 使用配置中的 <code>jina-api-key</code>；<code>$webread</code> 可匿名读取；<code>$pubmed</code> 匿名使用 NCBI PubMed。</p>
           </div>
           <div class="feature">
             <h3>命令面板入口</h3>


### PR DESCRIPTION
## Summary

- document missing AI/Copilot slash commands in the embedded AI agent docs
- add `/loop`, `/watch`, `/cwd`, `/rewind`, memory command, and `$` lookup command coverage
- update English and Chinese AI website pages with the same command families

## Why

WispTerm's in-app docs tool reads the formal docs, not release notes or internal plans. Commands such as `/loop`, `/watch`, `$websearch`, `$webread`, and `$pubmed` were implemented but hard to discover through normal user documentation.

## Validation

- `git diff --check --cached`
- `git show --check --stat --oneline HEAD`
- `rg -n '/loop|/watch|\$websearch|\$webread|\$pubmed' docs/ai-agent.md docs/ai.html docs/ai.zh.html`
