### PR TITLE
feat(command-center): copilot history panel — relative time, date grouping, search, source filter

### DIFF
--- a/docs/superpowers/plans/2026-06-23-copilot-history-panel-ui.md
+++ b/docs/superpowers/plans/2026-06-23-copilot-history-panel-ui.md
@@ -1,0 +1,1052 @@
+# 副驾历史面板 UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给命令面板「副驾历史」模态加上每行相对时间、本地日历日分组（今天/昨天/过去7天/更早）、实时 title+model 搜索、Tab 来源筛选。
+
+**Architecture:** 过滤/分桶/相对时间/导航逻辑放进纯模块 `command_palette_history_view.zig`（可单测）；`renderCommandPalette` 历史分支、input 键位、`command_center_state` 状态、`i18n` 文案只做接线；新增一个 macOS e2e 输入驱动冒烟测试。
+
+**Tech Stack:** Zig 0.15.2（`zig build test` / `test-full` / `macos-app`）、tests/macos_e2e（pytest + PyObjC + wisptermctl，`make test-macos-e2e`）。
+
+**测试套件归属：**
+- `command_palette_history_view.zig`（新建，需加进 `test_fast.zig`）、`command_center_state.zig`、`i18n.zig` 的内联测试 → `zig build test`（fast）。
+- `overlays.zig`/`input.zig` 改动无内联单测，靠 `zig build test-full` 编译 + e2e + 手测。
+- macOS app：`zig build macos-app -Dtarget=aarch64-macos`（默认 `zig build` 目标是 Windows）。
+
+---
+
+## File Structure
+
+- **Create** `src/command_palette_history_view.zig` — 纯逻辑：`Bucket`/`SourceFilter`/`DisplayItem`/`localEpochDay`/`bucketFor`/`rowMatches`/`View`/`build`。
+- **Modify** `src/test_fast.zig` — 加 `_ = @import("command_palette_history_view.zig");`。
+- **Modify** `src/command_center_state.zig` — `command_palette_history_source` 字段 + `commandPaletteCycleHistorySource` + 进入历史模式时复位。
+- **Modify** `src/i18n.zig` — 分组标题 / 来源标签 / 搜索 placeholder / footer 文案（中英）。
+- **Modify** `src/renderer/overlays.zig` — 来源 threadlocal + snapshot/apply、`buildHistoryView` 辅助、move/delete/activate 改用过滤映射、`commandPaletteResultCount`/窗口化改为 items、历史分支渲染重写、cycle 包装。
+- **Modify** `src/input.zig` — 历史模式启用字符/Backspace、Tab 切来源。
+- **Modify** `tests/macos_e2e/driver/keycodes.py` — 加 `"p": 35`。
+- **Create** `tests/macos_e2e/test_copilot_history.py` — 输入驱动冒烟（预置历史 + 终端 round-trip 断言）。
+
+---
+
+## Task 1: 视图模块 — localEpochDay + bucketFor
+
+**Files:**
+- Create: `src/command_palette_history_view.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: 建文件并写失败测试**
+
+新建 `src/command_palette_history_view.zig`：
+
+```zig
+const std = @import("std");
+const agent_history = @import("agent_history.zig");
+const command_palette_model = @import("command_palette_model.zig");
+
+pub const Bucket = enum { today, yesterday, past_week, earlier };
+pub const SourceFilter = enum { all, sidebar, tab };
+
+/// A flat display row: either a group header, or a session row referenced by its
+/// ordinal into `View.filtered` (0..filtered.len).
+pub const DisplayItem = union(enum) { header: Bucket, row: usize };
+
+/// Local civil day number (floored), so day differences are linear and tz-correct.
+pub fn localEpochDay(ms: i64, tz_offset_seconds: i32) i64 {
+    return @divFloor(@divFloor(ms, 1000) + tz_offset_seconds, 86400);
+}
+
+pub fn bucketFor(now_ms: i64, row_ms: i64, tz_offset_seconds: i32) Bucket {
+    const diff = localEpochDay(now_ms, tz_offset_seconds) - localEpochDay(row_ms, tz_offset_seconds);
+    if (diff <= 0) return .today; // future/clock-skew falls into today
+    if (diff == 1) return .yesterday;
+    if (diff < 7) return .past_week;
+    return .earlier;
+}
+
+test "history view: bucketFor classifies by local calendar day" {
+    const tz: i32 = 8 * 3600;
+    const day: i64 = 86400 * 1000;
+    const now: i64 = 1_700_000_000_000;
+    try std.testing.expectEqual(Bucket.today, bucketFor(now, now, tz));
+    try std.testing.expectEqual(Bucket.today, bucketFor(now, now + day, tz));
+    try std.testing.expectEqual(Bucket.yesterday, bucketFor(now, now - day, tz));
+    try std.testing.expectEqual(Bucket.past_week, bucketFor(now, now - 2 * day, tz));
+    try std.testing.expectEqual(Bucket.past_week, bucketFor(now, now - 6 * day, tz));
+    try std.testing.expectEqual(Bucket.earlier, bucketFor(now, now - 7 * day, tz));
+    try std.testing.expectEqual(Bucket.earlier, bucketFor(now, now - 30 * day, tz));
+}
+```
+
+并在 `src/test_fast.zig` 紧跟 `_ = @import("command_center_state.zig");` 之后加：
+
+```zig
+    _ = @import("command_palette_history_view.zig");
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 失败（断言或编译）——确认 `bucketFor` 已被测试驱动。
+
+- [ ] **Step 3: 实现已在 Step 1（bucketFor/localEpochDay 已写）** — 若 Step 2 因测试逻辑失败则修正，使其通过。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/command_palette_history_view.zig src/test_fast.zig
+git commit -m "feat(history-view): bucketFor classifies rows into today/yesterday/past-week/earlier"
+```
+
+---
+
+## Task 2: 视图模块 — rowMatches
+
+**Files:**
+- Modify: `src/command_palette_history_view.zig`
+
+- [ ] **Step 1: 写失败测试**（追加到文件）
+
+```zig
+test "history view: rowMatches filters by query and source" {
+    const r_tab = agent_history.Row{ .session_id = "a", .title = "Deploy notes", .model = "deepseek-v4", .updated_at = 1, .copilot = false };
+    const r_side = agent_history.Row{ .session_id = "b", .title = "Chat", .model = "gpt-x", .updated_at = 1, .copilot = true };
+    try std.testing.expect(rowMatches(r_tab, "deploy", .all));
+    try std.testing.expect(rowMatches(r_tab, "DEEPSEEK", .all)); // case-insensitive, matches model
+    try std.testing.expect(!rowMatches(r_tab, "zzz", .all));
+    try std.testing.expect(rowMatches(r_tab, "", .all)); // empty query matches
+    try std.testing.expect(rowMatches(r_side, "", .sidebar));
+    try std.testing.expect(!rowMatches(r_side, "", .tab));
+    try std.testing.expect(rowMatches(r_tab, "", .tab));
+    try std.testing.expect(!rowMatches(r_tab, "", .sidebar));
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `rowMatches` 未定义。
+
+- [ ] **Step 3: 实现**（加在 `bucketFor` 之后）
+
+```zig
+pub fn rowMatches(row: agent_history.Row, query: []const u8, source: SourceFilter) bool {
+    const src_ok = switch (source) {
+        .all => true,
+        .sidebar => row.copilot,
+        .tab => !row.copilot,
+    };
+    if (!src_ok) return false;
+    if (query.len == 0) return true;
+    return command_palette_model.containsIgnoreCase(row.title, query) or
+        command_palette_model.containsIgnoreCase(row.model, query);
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/command_palette_history_view.zig
+git commit -m "feat(history-view): rowMatches filters by title/model query and source"
+```
+
+---
+
+## Task 3: 视图模块 — View + build
+
+**Files:**
+- Modify: `src/command_palette_history_view.zig`
+
+- [ ] **Step 1: 写失败测试**（追加）
+
+```zig
+test "history view: build groups, filters, and maps selection" {
+    const a = std.testing.allocator;
+    const day: i64 = 86400 * 1000;
+    const now: i64 = 10_000 * day;
+    const rows = [_]agent_history.Row{
+        .{ .session_id = "1", .title = "Today A", .model = "m", .updated_at = now, .copilot = false },
+        .{ .session_id = "2", .title = "Today B", .model = "m", .updated_at = now - 1000, .copilot = true },
+        .{ .session_id = "3", .title = "Yesterday", .model = "m", .updated_at = now - day, .copilot = false },
+        .{ .session_id = "4", .title = "Old", .model = "m", .updated_at = now - 20 * day, .copilot = false },
+    };
+
+    var v = try build(a, &rows, "", .all, now, 0);
+    defer v.deinit(a);
+    try std.testing.expectEqual(@as(usize, 4), v.rowCount());
+    // items = header(today),row0,row1, header(yesterday),row2, header(earlier),row3
+    try std.testing.expectEqual(@as(usize, 7), v.items.len);
+    try std.testing.expect(std.meta.activeTag(v.items[0]) == .header);
+    try std.testing.expectEqual(Bucket.today, v.items[0].header);
+    try std.testing.expect(std.meta.activeTag(v.items[1]) == .row);
+    try std.testing.expectEqual(@as(usize, 0), v.items[1].row);
+    try std.testing.expectEqual(Bucket.yesterday, v.items[3].header);
+    try std.testing.expectEqual(@as(usize, 0), v.filtered[0]);
+    try std.testing.expectEqual(@as(usize, 3), v.filtered[3]);
+
+    var v2 = try build(a, &rows, "", .sidebar, now, 0);
+    defer v2.deinit(a);
+    try std.testing.expectEqual(@as(usize, 1), v2.rowCount());
+    try std.testing.expectEqual(@as(usize, 1), v2.filtered[0]);
+
+    var v3 = try build(a, &rows, "yesterday", .all, now, 0);
+    defer v3.deinit(a);
+    try std.testing.expectEqual(@as(usize, 1), v3.rowCount());
+
+    var v4 = try build(a, &rows, "zzzzz", .all, now, 0);
+    defer v4.deinit(a);
+    try std.testing.expectEqual(@as(usize, 0), v4.rowCount());
+    try std.testing.expectEqual(@as(usize, 0), v4.items.len);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `View` / `build` 未定义。
+
+- [ ] **Step 3: 实现**（加在 `rowMatches` 之后）
+
+```zig
+pub const View = struct {
+    items: []DisplayItem,
+    filtered: []usize, // original-row indices in display order; selectable count = len
+
+    pub fn rowCount(self: *const View) usize {
+        return self.filtered.len;
+    }
+
+    pub fn deinit(self: *View, allocator: std.mem.Allocator) void {
+        allocator.free(self.items);
+        allocator.free(self.filtered);
+        self.* = undefined;
+    }
+};
+
+/// `rows` must already be sorted newest-first (MetaStore.buildRows guarantees this),
+/// so buckets are contiguous and one header is emitted per bucket transition.
+pub fn build(
+    allocator: std.mem.Allocator,
+    rows: []const agent_history.Row,
+    query: []const u8,
+    source: SourceFilter,
+    now_ms: i64,
+    tz_offset_seconds: i32,
+) !View {
+    var items: std.ArrayListUnmanaged(DisplayItem) = .empty;
+    errdefer items.deinit(allocator);
+    var filtered: std.ArrayListUnmanaged(usize) = .empty;
+    errdefer filtered.deinit(allocator);
+
+    var have_bucket = false;
+    var cur_bucket: Bucket = .today;
+    for (rows, 0..) |row, i| {
+        if (!rowMatches(row, query, source)) continue;
+        const b = bucketFor(now_ms, row.updated_at, tz_offset_seconds);
+        if (!have_bucket or b != cur_bucket) {
+            try items.append(allocator, .{ .header = b });
+            cur_bucket = b;
+            have_bucket = true;
+        }
+        const ord = filtered.items.len;
+        try filtered.append(allocator, i);
+        try items.append(allocator, .{ .row = ord });
+    }
+    return .{
+        .items = try items.toOwnedSlice(allocator),
+        .filtered = try filtered.toOwnedSlice(allocator),
+    };
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/command_palette_history_view.zig
+git commit -m "feat(history-view): build grouped display items + filtered selection mapping"
+```
+
+---
+
+## Task 4: 来源筛选状态（command_center_state + overlays 桥接）
+
+**Files:**
+- Modify: `src/command_center_state.zig`
+- Modify: `src/renderer/overlays.zig`
+
+- [ ] **Step 1: 写失败测试**（追加到 `src/command_center_state.zig` 测试区）
+
+```zig
+test "command palette: history source cycles and resets on open" {
+    var state = State{};
+    state.commandPaletteOpenAgentHistory();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.sidebar, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.tab, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    // re-open resets to all + selection 0 + empty filter
+    state.command_palette_history_source = .tab;
+    state.command_palette_history_selected = 5;
+    state.command_palette_filter_len = 3;
+    state.commandPaletteOpenAgentHistory();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    try std.testing.expectEqual(@as(usize, 0), state.command_palette_history_selected);
+    try std.testing.expectEqual(@as(usize, 0), state.command_palette_filter_len);
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `command_palette_history_view` 未导入 / `command_palette_history_source` 字段缺失。
+
+- [ ] **Step 3: 实现 — command_center_state.zig**
+
+文件顶部 import 区加：
+
+```zig
+const command_palette_history_view = @import("command_palette_history_view.zig");
+```
+
+`State` 结构里，在 `command_palette_history_selected: usize = 0,` 之后加字段：
+
+```zig
+    command_palette_history_source: command_palette_history_view.SourceFilter = .all,
+```
+
+`commandPaletteOpenAgentHistory` 改为（在原有 visibility 复位基础上补三行复位）：
+
+```zig
+pub fn commandPaletteOpenAgentHistory(self: *State) void {
+    self.commandPaletteOpen();
+    self.commandPaletteSetMode(.agent_history);
+    self.session_launcher_visible = false;
+    self.ssh_list_visible = false;
+    self.ssh_form_visible = false;
+    self.ai_list_visible = false;
+    self.ai_form_visible = false;
+    self.ai_history_source_visible = false;
+    self.command_palette_history_source = .all;
+    self.command_palette_history_selected = 0;
+    self.command_palette_filter_len = 0;
+}
+```
+
+并新增循环方法（放在 `commandPaletteLeaveAgentHistory` 附近）：
+
+```zig
+pub fn commandPaletteCycleHistorySource(self: *State) void {
+    self.command_palette_history_source = switch (self.command_palette_history_source) {
+        .all => .sidebar,
+        .sidebar => .tab,
+        .tab => .all,
+    };
+    self.command_palette_history_selected = 0;
+}
+```
+
+- [ ] **Step 4: 实现 — overlays.zig 桥接 threadlocal**
+
+在 threadlocal 变量区（`g_command_palette_history_selected` 附近，约 220-229）加：
+
+```zig
+threadlocal var g_command_palette_history_source: command_palette_history_view.SourceFilter = .all;
+```
+
+文件顶部 import 区加（与其他 `@import("../xxx.zig")` 同处）：
+
+```zig
+const command_palette_history_view = @import("../command_palette_history_view.zig");
+```
+
+`commandCenterStateSnapshot()` 的返回字面量里加一行：
+
+```zig
+        .command_palette_history_source = g_command_palette_history_source,
+```
+
+`commandCenterStateApply()` 里加一行：
+
+```zig
+    g_command_palette_history_source = state.command_palette_history_source;
+```
+
+并加面向输入层的包装（放在 `commandPaletteMoveAgentHistory` 附近）：
+
+```zig
+pub fn commandPaletteCycleHistorySource() void {
+    var state = commandCenterStateSnapshot();
+    state.commandPaletteCycleHistorySource();
+    commandCenterStateCommit(state);
+}
+```
+
+- [ ] **Step 5: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/command_center_state.zig src/renderer/overlays.zig
+git commit -m "feat(command-center): history source-filter state + snapshot/apply bridge"
+```
+
+---
+
+## Task 5: i18n 文案（分组 / 来源 / placeholder / footer）
+
+**Files:**
+- Modify: `src/i18n.zig`
+
+- [ ] **Step 1: 写失败测试**（追加到 i18n.zig 测试区）
+
+```zig
+test "i18n: history panel strings present in both locales" {
+    defer setLang(.en); // 复位，避免污染其它测试（与现有 "setLang switches..." 测试同款）
+    setLang(.en);
+    try std.testing.expectEqualStrings("Today", s().cmd_palette_group_today);
+    try std.testing.expectEqualStrings("Sidebar", s().cmd_palette_source_sidebar);
+    setLang(.zh_CN);
+    try std.testing.expectEqualStrings("今天", s().cmd_palette_group_today);
+    try std.testing.expectEqualStrings("过去7天", s().cmd_palette_group_past_week);
+    try std.testing.expectEqualStrings("侧栏", s().cmd_palette_source_sidebar);
+}
+```
+
+> `setLang(.en)`/`setLang(.zh_CN)` 是 i18n.zig:665 的现成切换函数（见现有测试 "setLang switches the active strings table"）。
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `zig build test`
+Expected: 编译错误 `cmd_palette_group_today` 等字段缺失。
+
+- [ ] **Step 3: 实现 — 三处新增字段**
+
+(a) `Strings` 结构声明区（`cmd_palette_sidebar_tag` 之后）加：
+
+```zig
+cmd_palette_group_today: []const u8,
+cmd_palette_group_yesterday: []const u8,
+cmd_palette_group_past_week: []const u8,
+cmd_palette_group_earlier: []const u8,
+cmd_palette_source_all: []const u8,
+cmd_palette_source_sidebar: []const u8,
+cmd_palette_source_tab: []const u8,
+cmd_palette_history_search_placeholder: []const u8,
+```
+
+(b) 英文 locale（`.cmd_palette_sidebar_tag = "Sidebar",` 之后）：
+
+```zig
+.cmd_palette_group_today = "Today",
+.cmd_palette_group_yesterday = "Yesterday",
+.cmd_palette_group_past_week = "Past 7 days",
+.cmd_palette_group_earlier = "Earlier",
+.cmd_palette_source_all = "All",
+.cmd_palette_source_sidebar = "Sidebar",
+.cmd_palette_source_tab = "Tab",
+.cmd_palette_history_search_placeholder = "Search Copilot history",
+```
+
+并把英文 `cmd_palette_footer_history` 改为：
+
+```zig
+.cmd_palette_footer_history = "Type to filter, Tab source, Up/Down, Enter reopens, Delete removes, Esc returns",
+```
+
+(c) 中文 locale（`.cmd_palette_sidebar_tag = "侧栏",` 之后）：
+
+```zig
+.cmd_palette_group_today = "今天",
+.cmd_palette_group_yesterday = "昨天",
+.cmd_palette_group_past_week = "过去7天",
+.cmd_palette_group_earlier = "更早",
+.cmd_palette_source_all = "全部",
+.cmd_palette_source_sidebar = "侧栏",
+.cmd_palette_source_tab = "标签页",
+.cmd_palette_history_search_placeholder = "搜索副驾历史",
+```
+
+并把中文 `cmd_palette_footer_history` 改为：
+
+```zig
+.cmd_palette_footer_history = "输入筛选，Tab 来源，上下选择，回车重开，Delete 删除，Esc 返回",
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `zig build test`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/i18n.zig
+git commit -m "feat(i18n): copilot history group/source/search strings (en+zh)"
+```
+
+---
+
+## Task 6: overlays 历史导航改用过滤映射（buildHistoryView + move/delete/activate）
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+
+目标：把 move/delete/activate 从"直接索引 `g_command_palette_history_rows`"改为"基于当前过滤后的 View 的序号 → 原始行下标"。空查询 + `.all` 时行为与现状一致。
+
+- [ ] **Step 1: 加 `buildHistoryView` 辅助**（放在 `commandPaletteSyncAgentHistoryRows` 附近）
+
+```zig
+const ai_history_time = @import("../ai_history_time.zig");
+
+/// Build the current filtered/grouped view from the loaded history rows + live
+/// filter/source. Caller owns the View and must `deinit` it. Null on no allocator.
+fn buildHistoryView() ?command_palette_history_view.View {
+    const allocator = AppWindow.g_allocator orelse return null;
+    const now_ms = std.time.milliTimestamp();
+    const tz = ai_history_time.localOffsetSeconds();
+    return command_palette_history_view.build(
+        allocator,
+        g_command_palette_history_rows,
+        commandPaletteFilter(),
+        g_command_palette_history_source,
+        now_ms,
+        tz,
+    ) catch null;
+}
+```
+
+> `ai_history_time` 的 import 路径按 overlays.zig 现有相对路径风格（`../`）书写。
+
+- [ ] **Step 2: move 改用过滤计数**
+
+把 `commandPaletteMoveAgentHistory` 改为：
+
+```zig
+pub fn commandPaletteMoveAgentHistory(delta: i32) void {
+    commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse {
+        // Fallback: move over unfiltered rows.
+        var state0 = commandCenterStateSnapshot();
+        state0.commandPaletteMoveAgentHistory(delta, g_command_palette_history_rows.len);
+        commandCenterStateCommit(state0);
+        return;
+    };
+    defer view.deinit(AppWindow.g_allocator.?);
+    var state = commandCenterStateSnapshot();
+    state.commandPaletteMoveAgentHistory(delta, view.rowCount());
+    commandCenterStateCommit(state);
+}
+```
+
+- [ ] **Step 3: delete 改用 filtered 映射**
+
+把 `commandPaletteDeleteSelectedAgentHistory` 改为：
+
+```zig
+pub fn commandPaletteDeleteSelectedAgentHistory() bool {
+    if (!commandPaletteIsHistoryMode()) return false;
+    commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse return false;
+    defer view.deinit(AppWindow.g_allocator.?);
+    const state = commandCenterStateSnapshot();
+    const ord = state.commandPaletteSelectedAgentHistoryIndex(view.rowCount()) orelse return false;
+    const orig = view.filtered[ord];
+    return commandPaletteDeleteAgentHistoryIndex(orig);
+}
+```
+
+`commandPaletteDeleteAgentHistoryIndex` 末尾的 clamp 仍按总行数 `g_command_palette_history_rows.len`——保持不变（删除后选中会在下次 move/render 经过滤重新夹持）。
+
+- [ ] **Step 4: activate 改用 filtered 映射**
+
+把 `commandPaletteActivateSelectedAgentHistory` 改为：
+
+```zig
+fn commandPaletteActivateSelectedAgentHistory() bool {
+    if (!commandPaletteIsHistoryMode()) return false;
+    commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse return false;
+    defer view.deinit(AppWindow.g_allocator.?);
+    const state = commandCenterStateSnapshot();
+    const ord = state.commandPaletteActivateSelected(view.rowCount()) orelse return false;
+    const orig = view.filtered[ord];
+    return commandPaletteActivateAgentHistoryIndex(orig);
+}
+```
+
+- [ ] **Step 5: 运行确认编译 + fast 套件通过**
+
+Run: `zig build test`
+Expected: PASS（fast 套件不含 overlays 渲染测试，但会编译 overlays.zig 经依赖；若 fast 不编译 overlays，则改跑 `zig build test-full`）。
+若 fast 不触达 overlays，Run: `zig build test-full`，Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "refactor(command-center): history nav/delete/activate operate on filtered view"
+```
+
+---
+
+## Task 7: overlays 历史分支渲染重写（相对时间 + 分组 + 来源 chip + 可编辑搜索 + items 窗口化）
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`
+
+- [ ] **Step 1: 加 items 计数 threadlocal + 历史 result count + 窗口/标签辅助**
+
+threadlocal 区加：
+
+```zig
+threadlocal var g_command_palette_history_item_count: usize = 0;
+```
+
+加分组标题文案映射 + 来源 chip 文案 + 窗口辅助（放在 `commandPaletteFirstVisibleIndex` 附近）：
+
+```zig
+fn historyBucketLabel(b: command_palette_history_view.Bucket) []const u8 {
+    return switch (b) {
+        .today => i18n.s().cmd_palette_group_today,
+        .yesterday => i18n.s().cmd_palette_group_yesterday,
+        .past_week => i18n.s().cmd_palette_group_past_week,
+        .earlier => i18n.s().cmd_palette_group_earlier,
+    };
+}
+
+fn historySourceLabel(src: command_palette_history_view.SourceFilter) []const u8 {
+    return switch (src) {
+        .all => i18n.s().cmd_palette_source_all,
+        .sidebar => i18n.s().cmd_palette_source_sidebar,
+        .tab => i18n.s().cmd_palette_source_tab,
+    };
+}
+
+/// First visible item index that keeps `focus_item` (the selected row's item
+/// index) inside a window of `rendered` items out of `count`.
+fn historyWindowStart(count: usize, rendered: usize, focus_item: usize) usize {
+    if (rendered == 0 or count <= rendered) return 0;
+    if (focus_item < rendered) return 0;
+    return @min(focus_item - rendered + 1, count - rendered);
+}
+
+/// The items-index of the row whose ordinal == selected_ord (0 if not found).
+fn historySelectedItemIndex(view: command_palette_history_view.View, selected_ord: usize) usize {
+    for (view.items, 0..) |it, i| {
+        switch (it) {
+            .row => |ord| if (ord == selected_ord) return i,
+            .header => {},
+        }
+    }
+    return 0;
+}
+```
+
+- [ ] **Step 2: 让 `commandPaletteResultCount` 在历史模式返回 items 数**
+
+`commandPaletteResultCount` 当前为：
+
+```zig
+fn commandPaletteResultCount() usize {
+    if (commandPaletteIsHistoryMode()) return g_command_palette_history_rows.len;
+    return commandPaletteVisibleCount();
+}
+```
+
+把历史分支的 `g_command_palette_history_rows.len` 改为 items 数：
+
+```zig
+fn commandPaletteResultCount() usize {
+    if (commandPaletteIsHistoryMode()) return g_command_palette_history_item_count;
+    return commandPaletteVisibleCount();
+}
+```
+
+- [ ] **Step 3: 在 renderCommandPalette 顶部构建一次 View 并暴露 item 数**
+
+在 `renderCommandPalette` 里、`commandPaletteSyncAgentHistoryRows();` 之后、`const layout = commandPaletteLayout(...)` 之前插入：
+
+```zig
+    var history_view: ?command_palette_history_view.View = null;
+    const hist_alloc = AppWindow.g_allocator;
+    defer if (history_view) |*v| {
+        if (hist_alloc) |a| v.deinit(a);
+    };
+    const hist_now_ms = std.time.milliTimestamp();
+    if (commandPaletteIsHistoryMode()) {
+        history_view = buildHistoryView();
+        g_command_palette_history_item_count = if (history_view) |v| v.items.len else 0;
+    }
+```
+
+- [ ] **Step 4: 重写历史搜索框 + 历史列表渲染**
+
+把历史模式的"搜索框提示"分支（当前显示 `cmd_palette_recent_sessions` 静态提示）改为显示可编辑 query：
+
+```zig
+    if (commandPaletteIsHistoryMode()) {
+        const filter = commandPaletteFilter();
+        if (filter.len > 0) {
+            renderTitlebarTextLimited(filter, filter_x + 12, filter_text_y, fg, filter_w - 24);
+        } else {
+            renderTitlebarTextLimited(i18n.s().cmd_palette_history_search_placeholder, filter_x + 12, filter_text_y, dim, filter_w - 24);
+        }
+    } else {
+        // ... 命令模式 filter 渲染保持原状 ...
+    }
+```
+
+在标题栏画来源 chip：紧接标题/esc 提示渲染之后加（历史模式才画）：
+
+```zig
+    if (commandPaletteIsHistoryMode()) {
+        const chip = historySourceLabel(g_command_palette_history_source);
+        const chip_w = measureTitlebarText(chip);
+        const chip_x = layout.box_x + layout.box_w - pad_x - measureTitlebarText(esc_hint) - 16 - chip_w;
+        renderTitlebarText(chip, chip_x, title_y, mixColor(fg, accent, 0.20));
+    }
+```
+
+把历史**列表**渲染分支整体替换为基于 `history_view` 的 items 窗口化：
+
+```zig
+    if (commandPaletteIsHistoryMode()) {
+        const view_opt = history_view;
+        const selectable = if (view_opt) |v| v.rowCount() else 0;
+        if (view_opt == null or selectable == 0) {
+            const empty_text = if (g_command_palette_history_rows.len == 0)
+                i18n.s().cmd_palette_no_sessions
+            else
+                i18n.s().cmd_palette_no_sessions; // 无会话 / 无匹配 共用：见下注
+            const empty_y = @round(window_height - layout.row_top_px - layout.row_h + (layout.row_h - overlayTextHeight()) / 2);
+            renderTitlebarText(empty_text, layout.box_x + (layout.box_w - measureTitlebarText(empty_text)) / 2, empty_y, muted);
+        } else {
+            const view = view_opt.?;
+            const selected_ord = @min(g_command_palette_history_selected, selectable - 1);
+            const focus_item = historySelectedItemIndex(view, selected_ord);
+            const first_item = historyWindowStart(view.items.len, layout.rendered_rows, focus_item);
+
+            var display_row: usize = 0;
+            while (display_row < layout.rendered_rows) : (display_row += 1) {
+                const item_idx = first_item + display_row;
+                if (item_idx >= view.items.len) break;
+                const row_top = @round(layout.row_top_px + @as(f32, @floatFromInt(display_row)) * layout.row_h);
+                const row_y = @round(window_height - row_top - layout.row_h);
+                const text_y = rowTextY(row_y, layout.row_h);
+                switch (view.items[item_idx]) {
+                    .header => |b| {
+                        const label = historyBucketLabel(b);
+                        renderTitlebarText(label, @round(layout.box_x + pad_x + 2), text_y, mixColor(bg, fg, 0.40));
+                    },
+                    .row => |ord| {
+                        const row = g_command_palette_history_rows[view.filtered[ord]];
+                        const selected = ord == selected_ord;
+                        if (selected) {
+                            renderRoundedQuadAlpha(layout.box_x + 12, row_y + 4, layout.box_w - 24, layout.row_h - 8, 5, selected_border, 0.38);
+                            renderRoundedQuadAlpha(layout.box_x + 13, row_y + 5, layout.box_w - 26, layout.row_h - 10, 4, selected_bg, 0.78);
+                        }
+                        const row_title_color = if (selected) fg else mixColor(bg, fg, 0.86);
+                        const meta_color = if (selected) mixColor(fg, accent, 0.08) else mixColor(bg, fg, 0.54);
+                        const title_x = @round(layout.box_x + pad_x + 2);
+                        const meta_right = layout.box_x + layout.box_w - pad_x;
+
+                        // Rightmost: relative time. Left of it: model / "Sidebar" tag.
+                        var tbuf: [32]u8 = undefined;
+                        const rel = copilot_picker.formatRelativeTime(hist_now_ms, row.updated_at, &tbuf);
+                        const rel_w = measureTitlebarText(rel);
+                        renderTitlebarText(rel, meta_right - rel_w, text_y, meta_color);
+
+                        const tag = if (row.copilot) i18n.s().cmd_palette_sidebar_tag else row.model;
+                        var title_limit_right = meta_right - rel_w - 14;
+                        if (tag.len > 0) {
+                            const tag_w = measureTitlebarText(tag);
+                            renderTitlebarText(tag, title_limit_right - tag_w, text_y, meta_color);
+                            title_limit_right = title_limit_right - tag_w - 14;
+                        }
+                        renderTitlebarTextLimited(row.title, title_x, text_y, row_title_color, title_limit_right - title_x);
+                    },
+                }
+            }
+        }
+    } else {
+        // ... 命令模式列表渲染保持原状 ...
+    }
+```
+
+> 注：上面"无会话/无匹配"暂复用 `cmd_palette_no_sessions`。若想区分，可在 i18n 另加 `cmd_palette_no_matches`（"无匹配"/"No matches"）并在 `g_command_palette_history_rows.len != 0` 分支用它——可选，不做也可。
+> `copilot_picker` 已被 overlays.zig 引用（picker 渲染处用过 `copilot_picker.formatRelativeTime`），无需新增 import。
+
+- [ ] **Step 5: 编译 + 全量验证**
+
+Run: `zig build test-full`
+Expected: PASS（编译通过；overlays 改动靠编译 + 后续 e2e/手测验证）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/renderer/overlays.zig
+git commit -m "feat(command-center): render copilot history with relative time, date groups, source chip, live search"
+```
+
+---
+
+## Task 8: input — 历史模式启用字符/Backspace + Tab 切来源
+
+**Files:**
+- Modify: `src/renderer/overlays.zig`（解除 insertChar/backspace 历史守卫，历史下重置选中）
+- Modify: `src/input.zig`（历史键位加 Tab/Backspace；字符输入已对命令面板生效，无需改 input.zig 字符分支）
+
+- [ ] **Step 1: overlays.zig 解除历史守卫，历史下编辑 query 重置选中**
+
+`commandPaletteInsertChar` 改为：
+
+```zig
+pub fn commandPaletteInsertChar(codepoint: u21) void {
+    if (codepoint < 0x20 or codepoint == 0x7f) return;
+    var buf: [4]u8 = undefined;
+    const len = std.unicode.utf8Encode(codepoint, &buf) catch return;
+    if (g_command_palette_filter_len + len > g_command_palette_filter.len) return;
+    @memcpy(g_command_palette_filter[g_command_palette_filter_len..][0..len], buf[0..len]);
+    g_command_palette_filter_len += len;
+    if (commandPaletteIsHistoryMode()) {
+        g_command_palette_history_selected = 0;
+    } else {
+        commandPaletteClampSelection();
+    }
+}
+```
+
+`commandPaletteBackspace` 改为：
+
+```zig
+pub fn commandPaletteBackspace() void {
+    if (g_command_palette_filter_len == 0) return;
+    var n = g_command_palette_filter_len - 1;
+    while (n > 0 and (g_command_palette_filter[n] & 0xC0) == 0x80) n -= 1;
+    g_command_palette_filter_len = n;
+    if (commandPaletteIsHistoryMode()) {
+        g_command_palette_history_selected = 0;
+    } else {
+        commandPaletteClampSelection();
+    }
+}
+```
+
+- [ ] **Step 2: input.zig 历史键位加 Tab + Backspace**
+
+把历史模式 switch（约 2930）改为：
+
+```zig
+        if (overlays.commandPaletteAgentHistoryVisible()) {
+            switch (ev.key_code) {
+                platform_input.key_escape => overlays.commandPaletteLeaveAgentHistory(),
+                platform_input.key_up => overlays.commandPaletteMoveAgentHistory(-1),
+                platform_input.key_down => overlays.commandPaletteMoveAgentHistory(1),
+                platform_input.key_enter => overlays.commandPaletteExecuteSelected(),
+                platform_input.key_delete => _ = overlays.commandPaletteDeleteSelectedAgentHistory(),
+                platform_input.key_backspace => overlays.commandPaletteBackspace(),
+                platform_input.key_tab => overlays.commandPaletteCycleHistorySource(),
+                else => {},
+            }
+        } else {
+```
+
+> `platform_input.key_tab`（= 0x09）与 `key_backspace`（= 0x08）均定义在 `src/platform/input_events.zig`，确认可用。字符输入路径（input.zig 字符分支调 `overlays.commandPaletteInsertChar`，在 `commandPaletteVisible()` 时统一生效）无需改动——Step 1 解除 `commandPaletteInsertChar` 的历史守卫后，历史模式即可接收字符。
+
+- [ ] **Step 3: 编译 + 全量验证**
+
+Run: `zig build test-full`
+Expected: PASS。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/renderer/overlays.zig src/input.zig
+git commit -m "feat(command-center): enable history search input + Tab source cycling"
+```
+
+---
+
+## Task 9: macOS e2e — keycode + 输入驱动冒烟
+
+**Files:**
+- Modify: `tests/macos_e2e/driver/keycodes.py`
+- Create: `tests/macos_e2e/test_copilot_history.py`
+
+- [ ] **Step 1: keycodes 加 "p"**
+
+在 `tests/macos_e2e/driver/keycodes.py` 的 `_KEYCODES` 字典里，给字母行补上 `p`（macOS virtual keycode 35）：
+
+```python
+    "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
+    "t": 17, "n": 45, "p": 35,
+```
+
+- [ ] **Step 2: 写 e2e 测试**
+
+新建 `tests/macos_e2e/test_copilot_history.py`：
+
+```python
+import json
+import os
+import time
+
+import pytest
+
+from tests.macos_e2e.conftest import APP_BUNDLE, CTL_BINARY
+from tests.macos_e2e.driver.macos import MacDriver
+
+
+def _session_record(session_id: str, title: str, model: str, updated_at_ms: int, copilot: bool):
+    return {
+        "session_id": session_id,
+        "title": title,
+        "base_url": "https://api.example.com",
+        "api_key": "k",
+        "model": model,
+        "protocol": "chat_completions",
+        "system_prompt": "sys",
+        "thinking_enabled": False,
+        "reasoning_effort": "low",
+        "stream": True,
+        "max_tokens": 8192,
+        "agent_enabled": True,
+        "vision_enabled": False,
+        "copilot": copilot,
+        "created_at": updated_at_ms,
+        "updated_at": updated_at_ms,
+        "messages": [{"role": "user", "content": f"hello from {title}"}],
+    }
+
+
+@pytest.fixture()
+def seeded_app():
+    """A fresh isolated WispTerm instance pre-seeded with copilot history sessions.
+
+    Writing only sessions/*.json (no index.json) exercises the storage layer's
+    index-rebuild path on first launch.
+    """
+    driver = MacDriver(app_bundle=APP_BUNDLE, ctl_binary=CTL_BINARY)
+    sessions_dir = os.path.join(driver._config_dir(), "agent-history", "sessions")
+    os.makedirs(sessions_dir, exist_ok=True)
+    now_ms = int(time.time() * 1000)
+    day = 86400 * 1000
+    seeds = [
+        _session_record("hist-deploy", "Deploy notes", "deepseek-v4", now_ms, False),
+        _session_record("hist-sidebar", "Sidebar chat", "glm-5", now_ms - day, True),
+        _session_record("hist-old", "Old planning", "gpt-x", now_ms - 20 * day, False),
+    ]
+    for rec in seeds:
+        with open(os.path.join(sessions_dir, f"{rec['session_id']}.json"), "w") as f:
+            json.dump(rec, f)
+    driver.launch()
+    yield driver
+    driver.quit()
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_copilot_history_input_driven(seeded_app):
+    app = seeded_app
+    app.focus()
+    pane = app.primary_pane()
+
+    # Baseline: app is alive and the terminal round-trips.
+    app.send_text("echo before-history\n")
+    app.wait_for(pane, "before-history", timeout=8)
+
+    # Open the command palette (default keybind Ctrl+Shift+P), then select the
+    # "Copilot History" command to enter history mode. Default locale is English.
+    app.key("p", "ctrl", "shift")
+    time.sleep(0.3)
+    app.text("Copilot History")  # filters the command list to the history entry
+    time.sleep(0.3)
+    app.key("return")  # execute -> enters history mode (panel shows seeded rows)
+    time.sleep(0.3)
+
+    # Exercise the new history-mode input handlers (must not crash / not eat input):
+    app.text("deploy")     # live title filter
+    time.sleep(0.2)
+    app.key("down")        # navigate filtered rows (skips group headers)
+    app.key("up")
+    app.key("delete")      # backspace one char of the query
+    app.key("tab")         # cycle source filter all -> sidebar
+    app.key("tab")         # -> tab
+    time.sleep(0.2)
+    app.key("escape")      # leave history mode
+    app.key("escape")      # close palette
+
+    # The whole overlay-input flow must have left the app responsive and must NOT
+    # have eaten subsequent terminal input. (overlay text itself is unobservable
+    # via get-text; covered by unit tests instead.)
+    app.send_text("echo after-history\n")
+    app.wait_for(pane, "after-history", timeout=8)
+```
+
+> 说明：`app.key("delete")` 在历史模式映射为 Backspace（编辑 query）——driver 的 `"delete"` keycode 51 是主键盘的退格键（macOS 上 keycode 51 即 Backspace），对应我们绑定的 `key_backspace`/`key_delete` 取决于平台映射；若该键触发的是"删除会话"而非退格，改用一个不会误删的序列（去掉这行 `delete`，仅保留 `text`/`down`/`up`/`tab`）。本测试的硬断言只在最后的终端 round-trip，删/退格仅作"输入不致命"的压测。
+
+- [ ] **Step 3: 运行 e2e**
+
+Run: `make test-macos-e2e`
+Expected: 新测试 `test_copilot_history_input_driven` PASS（需 macOS + 已授权辅助功能；CI/无头环境会 skip）。若因"进入历史模式的命令筛选"不稳定，按 Step 2 注释将进入方式调整为更稳的序列，但保持最后的终端 round-trip 断言不变。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add tests/macos_e2e/driver/keycodes.py tests/macos_e2e/test_copilot_history.py
+git commit -m "test(e2e): input-driven copilot history smoke (seeded sessions + responsiveness)"
+```
+
+---
+
+## Task 10: 全量验证
+
+**Files:** 无代码改动（仅验证）
+
+- [ ] **Step 1: fast 套件** — Run: `zig build test` — Expected: PASS。
+- [ ] **Step 2: full 套件** — Run: `zig build test-full` — Expected: PASS。
+- [ ] **Step 3: macOS 构建** — Run: `zig build macos-app -Dtarget=aarch64-macos` — Expected: 构建成功。
+- [ ] **Step 4: e2e** — Run: `make test-macos-e2e` — Expected: 新 e2e PASS（或在不满足环境时 skip）。
+- [ ] **Step 5: 手测**（真机）：打开副驾历史 → 每行右侧有相对时间、列表按 今天/昨天/过去7天/更早 分组 → 输入筛 title/model → ↑↓ 跳过分组标题 → Tab 切来源 chip（全部/侧栏/标签页）→ 回车重开 → Esc 返回。
+
+---
+
+## Self-Review（计划作者已核对）
+
+**Spec coverage：**
+- 相对时间 → Task 7（formatRelativeTime 每行）。
+- 时间分组（今天/昨天/过去7天/更早）→ Task 1（bucketFor）+ Task 3（build 插 header）+ Task 7（渲染 header）。
+- 启用搜索 title+model → Task 2（rowMatches）+ Task 8（解除守卫、历史下编辑 query）+ Task 7（搜索框显示 query）。
+- 来源 Tab 筛选 → Task 4（状态+cycle+桥接）+ Task 8（Tab 键）+ Task 7（chip）。
+- 导航跳过 header → Task 3（filtered 序号）+ Task 6（move/delete/activate 用 filtered）+ Task 7（窗口化 + selected 映射）。
+- i18n → Task 5。
+- 单测 → Task 1/2/3/4/5。
+- macos-e2e 输入驱动 + 重开/响应性断言 → Task 9。
+- 验证 → Task 10。
+
+**Type 一致性：** `command_palette_history_view.{Bucket,SourceFilter,DisplayItem,localEpochDay,bucketFor,rowMatches,View,build}` 在 Task 1-3 定义、Task 4/6/7 引用一致；`State.command_palette_history_source` + `commandPaletteCycleHistorySource` 在 Task 4 定义、Task 6/7/8 用；overlays `g_command_palette_history_source`/`g_command_palette_history_item_count`/`buildHistoryView`/`historyBucketLabel`/`historySourceLabel`/`historyWindowStart`/`historySelectedItemIndex` 在 Task 4/6/7 定义并互用一致。
+
+**已知执行注意：**
+- Task 6 的 `zig build test` 是否编译 overlays 取决于 fast 套件依赖图；若不编译则以 `test-full` 为准（步骤已注明）。
+- Task 9 的合成 `delete` 键在历史模式映射为 Backspace 编辑 query——若该键触发"删除会话"，按 Step 2 注释去掉该行（硬断言只在最后的终端 round-trip，不受影响）。
+- 其余（i18n `setLang`、`key_tab`/`key_backspace` 常量、`commandPaletteResultCount` 现状）均已实证固化。

--- a/docs/superpowers/specs/2026-06-23-copilot-history-panel-ui-design.md
+++ b/docs/superpowers/specs/2026-06-23-copilot-history-panel-ui-design.md
@@ -1,0 +1,148 @@
+# 副驾历史面板 UI（第二阶段）：相对时间 + 时间分组 + 搜索/来源筛选
+
+- 日期：2026-06-23
+- 范围：**命令面板的「副驾历史」模态**（截图那个：标题"副驾历史"、搜索框 placeholder"最近的副驾会话"、底部"上下选择，回车重开，Delete 删除，Esc"）。即 `renderCommandPalette` 的历史模式分支。
+- 前置：建立在第一阶段存储重构（per-session 文件 + 索引）之上。本阶段所需数据 `agent_history.Row`（含 `title/model/updated_at/copilot`）由 `MetaStore.buildRows` 提供，已按 `updated_at` 倒序。
+- **不在范围**：file_explorer 侧栏的 agent-history 面板（另一套 `g_panel_mode == .agent_history`，input.zig:4026）；消息正文的深度全文检索（留给后续，索引已存 `search_preview` 备用）。
+
+## 背景与问题
+
+当前命令面板「副驾历史」模式（[overlays.zig](../../../src/renderer/overlays.zig) `renderCommandPalette` 历史分支）：
+- 每行只画 `title` + 右侧 `model`/「侧栏」标记，**不显示时间**——尽管 `Row.updated_at` 已有。
+- 列表是**扁平**的，没有日期分组，难定位"某天"的会话。
+- 搜索框是**惰性的**：历史模式下 `commandPaletteInsertChar`/`commandPaletteBackspace`（overlays.zig:284/339）与 input.zig:2522 的字符输入都直接 `return`，框里只显示"最近的副驾会话"提示，**无法输入筛选**。
+- 无法按来源（侧栏/标签页）或模型快速筛选。
+
+## 目标 / 非目标
+
+**目标**（用户已确认的设计取舍）
+1. 每行右侧显示**相对时间**"4h ago"（复用 `copilot_picker.formatRelativeTime`）。
+2. 按**本地日历日**分组：今天 / 昨天 / 过去7天 / 更早，组间插入灰色分隔标题。
+3. **启用搜索框**：输入即按 **title + model** 大小写不敏感子串过滤（"扩大字段"与"按模型筛选=输入模型名"合一）。
+4. **来源快捷筛选**：`Tab` 键循环 全部 → 侧栏 → 标签页，标题栏右侧显示当前 chip。
+5. 导航在过滤后的会话行间移动、**跳过分组标题**；空结果显示"无匹配"。
+
+**非目标**
+- 模型不做独立 chip 循环（输入模型名即可）。
+- 不触碰 file_explorer 侧栏 agent-history 面板。
+- 不做消息正文全文检索。
+
+## 设计概览
+
+### 纯视图模块 `src/command_palette_history_view.zig`
+
+把"过滤 + 分桶 + 生成显示项 + 导航辅助"做成无渲染、无全局状态的纯模块（加入 `test_fast.zig`，`zig build test` 覆盖）。
+
+```zig
+pub const Bucket = enum { today, yesterday, past_week, earlier };
+pub const SourceFilter = enum { all, sidebar, tab };
+
+// 显示项：分组标题，或一条会话行（row = 在 filtered 中的序号 0..filtered.len）
+pub const DisplayItem = union(enum) { header: Bucket, row: usize };
+
+pub const View = struct {
+    items: []DisplayItem,   // 标题 + 行，按显示顺序（行已按 updated_at 倒序）
+    filtered: []usize,      // 通过过滤的「原始 rows 下标」，按显示顺序；可选行数 = filtered.len
+    pub fn rowCount(self: *const View) usize { return self.filtered.len; }
+    pub fn deinit(self: *View, allocator: std.mem.Allocator) void;
+};
+
+// 本地纪元日（向下取整到天），用于稳健的"差几天"分桶（比 packed YYYYMMDD 更易算）
+pub fn localEpochDay(ms: i64, tz_offset_seconds: i32) i64;
+pub fn bucketFor(now_ms: i64, row_ms: i64, tz_offset_seconds: i32) Bucket; // 0→today,1→yesterday,2..6→past_week,>=7→earlier；负差(时钟偏移)按 today
+pub fn rowMatches(row: agent_history.Row, query: []const u8, source: SourceFilter) bool; // (title|model 含 query) 且 来源匹配
+pub fn build(
+    allocator: std.mem.Allocator,
+    rows: []const agent_history.Row,
+    query: []const u8,
+    source: SourceFilter,
+    now_ms: i64,
+    tz_offset_seconds: i32,
+) !View;
+```
+
+- `build`：顺序遍历已排序的 `rows`，对每条先 `rowMatches` 过滤；保留者计算 `bucketFor`，当桶相对上一保留行变化时先 push 一个 `.header`，再 push `.row`（序号为它在 `filtered` 中的位置）。桶因排序天然连续。
+- `rowMatches`：`containsIgnoreCase(title, q) or containsIgnoreCase(model, q)`（复用 `command_palette_model.containsIgnoreCase`），且 `source==all || (source==sidebar && copilot) || (source==tab && !copilot)`。
+
+### 渲染（`renderCommandPalette` 历史分支改造）
+
+- 每帧取 `now_ms = std.time.milliTimestamp()`、`tz = ai_history_time.localOffsetSeconds()`、当前 `query`（复用 `g_command_palette_filter`）、当前 `source`（来自 state），调 `view.build(...)`，渲染后 `deinit`。
+- 标题栏：标题"副驾历史"右侧加来源 chip（`i18n` 全部/侧栏/标签页）；搜索框由"惰性提示"改为显示可编辑的 `query`（空时显示 placeholder）。
+- 列表：遍历 `view.items` 做窗口化渲染（见下）。`.header` 画一行居中/缩进的灰色分组标题；`.row` 画 `title` + 右侧 `model`/「侧栏」+ 最右 `formatRelativeTime(now_ms, rows[filtered[ord]].updated_at)`；当 `ord == 选中序号` 高亮。
+- 空 `filtered`：居中显示"无匹配"。
+
+### 选择 / 滚动
+
+- 状态 `command_palette_history_selected` 改为**过滤后会话行的序号**（0..rowCount），每次 `build` 后 clamp 到 `rowCount`。
+- 上/下移动只在 `[0, rowCount)` 间走（沿用 `commandPaletteMoveAgentHistory` 的 wrap 逻辑，行数传 `rowCount`）。
+- 滚动：把可视窗口从"对会话行取窗"改为"**对 `view.items`（含标题）取窗**"，并保证选中会话行对应的 DisplayItem 落在窗口内（由选中行的 display 下标推算首行）。沿用现有 `commandPaletteLayout`/`rendered_rows` 的固定行高与行数，标题占一个行槽。
+
+### 输入（input.zig 历史模式键位 @2924 + 字符输入 @2522）
+
+历史模式按键，在现有 Esc/Up/Down/Enter/Delete 基础上：
+- **可打印字符** → 插入 `g_command_palette_filter`（解除 overlays.zig:284 与 input.zig:2522 的历史模式 `return` 守卫，使其在历史模式也插入）。
+- **Backspace** → 删除 query 末个 codepoint（解除 overlays.zig:339 守卫；历史模式新增 backspace 处理）。
+- **Tab** → 循环来源筛选 `all→sidebar→tab→all`。
+- **Delete** → 维持"删除选中会话"（语义不变，与 Backspace 编辑 query 不冲突）。
+- Up/Down/Enter/Esc 不变（Enter 重开选中会话，Esc 离开历史模式）。
+- 进入历史模式时**重置** `query` 为空、`source` 为 `all`、选中为 0。
+
+### 状态（command_center_state.zig）
+
+`State` 新增 `command_palette_history_source: command_palette_history_view.SourceFilter = .all`，并加：
+- `commandPaletteCycleHistorySource(self)`：`.all→.sidebar→.tab→.all`。
+- 进入历史模式（`commandPaletteOpenAgentHistory`）时把 source 复位为 `.all`、`command_palette_history_selected = 0`、清空 filter。
+（`command_center_state` 引入对纯模块 `command_palette_history_view` 的 import 仅为 `SourceFilter` 枚举；两者都在 fast 套件，无循环依赖风险。）
+
+### i18n（i18n.zig Strings）
+
+新增字段（中英各一份）：
+- 分组标题：`cmd_palette_group_today`/`_yesterday`/`_past_week`/`_earlier`（今天/昨天/过去7天/更早；Today/Yesterday/Past 7 days/Earlier）。
+- 来源 chip：`cmd_palette_source_all`/`_sidebar`/`_tab`（全部/侧栏/标签页；All/Sidebar/Tab）。
+- 更新 `cmd_palette_footer_history` 提示，体现：输入筛选 · ↑↓ 选择 · Tab 来源 · 回车重开 · Delete 删除 · Esc 返回。
+
+## 接线点小结
+
+| 关注点 | 文件 | 改动 |
+| --- | --- | --- |
+| 过滤/分桶/显示项（纯逻辑） | `src/command_palette_history_view.zig`（新建） | View/Bucket/SourceFilter/build/bucketFor/rowMatches/localEpochDay |
+| 渲染历史分支 | `src/renderer/overlays.zig` `renderCommandPalette` | 用 View 渲染、相对时间、分组标题、来源 chip、可编辑搜索框、窗口化 |
+| 历史键位 | `src/input.zig`（~2522 字符、~2924 历史键） | 启用字符/Backspace、Tab 循环来源 |
+| 选择/来源状态 | `src/command_center_state.zig` | `command_palette_history_source` + cycle + 进入复位 |
+| 文案 | `src/i18n.zig` | 分组/来源/footer 字段 |
+| 测试装配 | `src/test_fast.zig` | `_ = @import("command_palette_history_view.zig");` |
+
+## 测试
+
+### 单元测试（`zig build test`，纯视图模块）
+- `localEpochDay` / `bucketFor`：今天(0)/昨天(1)/过去7天(2..6)/更早(>=7)；跨时区（UTC+8、UTC-8）边界；负差（时钟偏移）归 today。
+- `rowMatches`：title 命中、model 命中、都不命中；source=all/sidebar/tab 三态过滤。
+- `build`：多桶在边界处各插一个 header；过滤后只剩部分桶；空结果（items 空、filtered 空）；filtered 顺序 = 排序顺序；header 不计入 rowCount。
+- 导航辅助：选中序号在 `[0,rowCount)` clamp/wrap，分组标题不可选。
+
+### macos-e2e（`make test-macos-e2e`，新增 `tests/macos_e2e/test_copilot_history.py`）
+鉴于 overlay/AI-chat 文本无法经 ctl `get-text` 断言（只读终端 pane），采用**输入驱动 + 可观测信号**：
+1. **预置数据**：在隔离 HOME 的配置目录下预写 `agent-history/sessions/<id>.json` + `index.json`（数条会话，含 copilot 与非 copilot、不同 `updated_at`）——顺带端到端验证第一阶段存储加载。
+2. **驱动**（real CGEvent）：toggle 命令面板 → 选择/进入「副驾历史」→ 输入一个只匹配某会话的筛选词 → ↑↓ 导航 → Tab 切来源 → Esc 关闭。
+3. **断言**（可观测）：
+   - 流程后做一次终端 round-trip（`send_text "echo e2e-ok\n"` + `wait_for "e2e-ok"`）——证明历史模式的字符/Tab/方向键/Esc 处理不崩、不卡、不吞终端输入（呼应"overlay 输入处理回归"类历史问题）。
+   - 回车重开某会话后断言 `panes()` 较基线发生变化（证明重开链路被执行）。
+   - overlay 内的相对时间/分组文本**不在 e2e 断言**（由单测覆盖）。
+4. 历史模式的精确进入序列（命令面板键位 + 选择「副驾历史」项）在实施计划里定死。
+
+## 验证
+- `zig build test`（fast，含新视图模块 + command_center_state 测试）。
+- `zig build test-full`（含 overlays/input 相关 app 测试）。
+- `zig build macos-app -Dtarget=aarch64-macos`（真机构建）。
+- `make test-macos-e2e`（新增的 copilot 历史 e2e）。
+- 真机手测：打开副驾历史 → 看到相对时间与今天/昨天/过去7天/更早分组 → 输入筛 title/model → Tab 切来源 chip → ↑↓ 跳过分组标题 → 回车重开。
+
+## 风险
+- **滚动窗口化**：从"对会话行取窗"改为"对含标题的 DisplayItem 取窗"是最易错处——需保证选中行始终可见且标题不抢占导航。以单测覆盖 build 的 items 结构 + 真机手测滚动。
+- **输入语义重叠**：Backspace 编辑 query vs Delete 删除会话——已明确分工，避免误删会话。
+- **e2e 进入序列脆弱**：无"副驾历史"菜单项，需经命令面板选择项进入；序列在 plan 固化，必要时回退为"最小冒烟（能开能输入不崩）"。
+- 主线程 overlay 键/字符处理需置 `g_force_rebuild`（项目既有约定，避免方向键"不跟手"）。
+
+## 未来工作
+- 深度全文检索：在 `index.json.search_preview` 之上扩为消息正文检索（需让面板拿到 IndexEntry 而非仅 Row）。
+- 把相对时间/分组同样应用到 file_explorer 侧栏 agent-history 面板（另一表面）。

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -1,6 +1,7 @@
 const app_metadata = @import("app_metadata.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const std = @import("std");
+const command_palette_history_view = @import("command_palette_history_view.zig");
 
 pub const CommandAction = enum {
     new_tab,
@@ -134,6 +135,7 @@ pub const State = struct {
     command_palette_filter_len: usize = 0,
     command_palette_mode: CommandPaletteMode = .commands,
     command_palette_history_selected: usize = 0,
+    command_palette_history_source: command_palette_history_view.SourceFilter = .all,
     startup_shortcuts_visible: bool = false,
     session_launcher_visible: bool = false,
     session_launcher_selected: usize = 0,
@@ -190,10 +192,22 @@ pub const State = struct {
         self.ai_list_visible = false;
         self.ai_form_visible = false;
         self.ai_history_source_visible = false;
+        self.command_palette_history_source = .all;
+        self.command_palette_history_selected = 0;
+        self.command_palette_filter_len = 0;
     }
 
     pub fn commandPaletteLeaveAgentHistory(self: *State) void {
         self.commandPaletteSetMode(.commands);
+    }
+
+    pub fn commandPaletteCycleHistorySource(self: *State) void {
+        self.command_palette_history_source = switch (self.command_palette_history_source) {
+            .all => .sidebar,
+            .sidebar => .tab,
+            .tab => .all,
+        };
+        self.command_palette_history_selected = 0;
     }
 
     pub fn commandPaletteShouldRefreshAgentHistory(self: *const State, loaded_revision: u64, latest_revision: u64) bool {
@@ -537,4 +551,23 @@ test "clicking an agent history row updates selection and returns that row" {
 
     try std.testing.expectEqual(@as(?usize, 2), state.commandPaletteActivateHistoryRow(2, 3));
     try std.testing.expectEqual(@as(?usize, 2), state.commandPaletteSelectedAgentHistoryIndex(3));
+}
+
+test "command palette: history source cycles and resets on open" {
+    var state = State{};
+    state.commandPaletteOpenAgentHistory();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.sidebar, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.tab, state.command_palette_history_source);
+    state.commandPaletteCycleHistorySource();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    state.command_palette_history_source = .tab;
+    state.command_palette_history_selected = 5;
+    state.command_palette_filter_len = 3;
+    state.commandPaletteOpenAgentHistory();
+    try std.testing.expectEqual(command_palette_history_view.SourceFilter.all, state.command_palette_history_source);
+    try std.testing.expectEqual(@as(usize, 0), state.command_palette_history_selected);
+    try std.testing.expectEqual(@as(usize, 0), state.command_palette_filter_len);
 }

--- a/src/command_palette_history_view.zig
+++ b/src/command_palette_history_view.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const agent_history = @import("agent_history.zig");
+const command_palette_model = @import("command_palette_model.zig");
+
+pub const Bucket = enum { today, yesterday, past_week, earlier };
+pub const SourceFilter = enum { all, sidebar, tab };
+
+/// A flat display row: either a group header, or a session row referenced by its
+/// ordinal into `View.filtered` (0..filtered.len).
+pub const DisplayItem = union(enum) { header: Bucket, row: usize };
+
+/// Local civil day number (floored), so day differences are linear and tz-correct.
+pub fn localEpochDay(ms: i64, tz_offset_seconds: i32) i64 {
+    return @divFloor(@divFloor(ms, 1000) + tz_offset_seconds, 86400);
+}
+
+pub fn bucketFor(now_ms: i64, row_ms: i64, tz_offset_seconds: i32) Bucket {
+    const diff = localEpochDay(now_ms, tz_offset_seconds) - localEpochDay(row_ms, tz_offset_seconds);
+    if (diff <= 0) return .today; // future/clock-skew falls into today
+    if (diff == 1) return .yesterday;
+    if (diff < 7) return .past_week;
+    return .earlier;
+}
+
+pub fn rowMatches(row: agent_history.Row, query: []const u8, source: SourceFilter) bool {
+    const src_ok = switch (source) {
+        .all => true,
+        .sidebar => row.copilot,
+        .tab => !row.copilot,
+    };
+    if (!src_ok) return false;
+    if (query.len == 0) return true;
+    return command_palette_model.containsIgnoreCase(row.title, query) or
+        command_palette_model.containsIgnoreCase(row.model, query);
+}
+
+pub const View = struct {
+    items: []DisplayItem,
+    filtered: []usize, // original-row indices in display order; selectable count = len
+
+    pub fn rowCount(self: *const View) usize {
+        return self.filtered.len;
+    }
+
+    pub fn deinit(self: *View, allocator: std.mem.Allocator) void {
+        allocator.free(self.items);
+        allocator.free(self.filtered);
+        self.* = undefined;
+    }
+};
+
+/// `rows` must already be sorted newest-first (MetaStore.buildRows guarantees this),
+/// so buckets are contiguous and one header is emitted per bucket transition.
+pub fn build(
+    allocator: std.mem.Allocator,
+    rows: []const agent_history.Row,
+    query: []const u8,
+    source: SourceFilter,
+    now_ms: i64,
+    tz_offset_seconds: i32,
+) !View {
+    var items: std.ArrayListUnmanaged(DisplayItem) = .empty;
+    errdefer items.deinit(allocator);
+    var filtered: std.ArrayListUnmanaged(usize) = .empty;
+    errdefer filtered.deinit(allocator);
+
+    var have_bucket = false;
+    var cur_bucket: Bucket = .today;
+    for (rows, 0..) |row, i| {
+        if (!rowMatches(row, query, source)) continue;
+        const b = bucketFor(now_ms, row.updated_at, tz_offset_seconds);
+        if (!have_bucket or b != cur_bucket) {
+            try items.append(allocator, .{ .header = b });
+            cur_bucket = b;
+            have_bucket = true;
+        }
+        const ord = filtered.items.len;
+        try filtered.append(allocator, i);
+        try items.append(allocator, .{ .row = ord });
+    }
+    return .{
+        .items = try items.toOwnedSlice(allocator),
+        .filtered = try filtered.toOwnedSlice(allocator),
+    };
+}
+
+test "history view: bucketFor classifies by local calendar day" {
+    const tz: i32 = 8 * 3600;
+    const day: i64 = 86400 * 1000;
+    const now: i64 = 1_700_000_000_000;
+    try std.testing.expectEqual(Bucket.today, bucketFor(now, now, tz));
+    try std.testing.expectEqual(Bucket.today, bucketFor(now, now + day, tz));
+    try std.testing.expectEqual(Bucket.yesterday, bucketFor(now, now - day, tz));
+    try std.testing.expectEqual(Bucket.past_week, bucketFor(now, now - 2 * day, tz));
+    try std.testing.expectEqual(Bucket.past_week, bucketFor(now, now - 6 * day, tz));
+    try std.testing.expectEqual(Bucket.earlier, bucketFor(now, now - 7 * day, tz));
+    try std.testing.expectEqual(Bucket.earlier, bucketFor(now, now - 30 * day, tz));
+}
+
+test "history view: rowMatches filters by query and source" {
+    const r_tab = agent_history.Row{ .session_id = "a", .title = "Deploy notes", .model = "deepseek-v4", .updated_at = 1, .copilot = false };
+    const r_side = agent_history.Row{ .session_id = "b", .title = "Chat", .model = "gpt-x", .updated_at = 1, .copilot = true };
+    try std.testing.expect(rowMatches(r_tab, "deploy", .all));
+    try std.testing.expect(rowMatches(r_tab, "DEEPSEEK", .all));
+    try std.testing.expect(!rowMatches(r_tab, "zzz", .all));
+    try std.testing.expect(rowMatches(r_tab, "", .all));
+    try std.testing.expect(rowMatches(r_side, "", .sidebar));
+    try std.testing.expect(!rowMatches(r_side, "", .tab));
+    try std.testing.expect(rowMatches(r_tab, "", .tab));
+    try std.testing.expect(!rowMatches(r_tab, "", .sidebar));
+}
+
+test "history view: build groups, filters, and maps selection" {
+    const a = std.testing.allocator;
+    const day: i64 = 86400 * 1000;
+    const now: i64 = 10_000 * day + day / 2; // noon to avoid midnight boundary crossing
+    const rows = [_]agent_history.Row{
+        .{ .session_id = "1", .title = "Today A", .model = "m", .updated_at = now, .copilot = false },
+        .{ .session_id = "2", .title = "Today B", .model = "m", .updated_at = now - 1000, .copilot = true },
+        .{ .session_id = "3", .title = "Yesterday", .model = "m", .updated_at = now - day, .copilot = false },
+        .{ .session_id = "4", .title = "Old", .model = "m", .updated_at = now - 20 * day, .copilot = false },
+    };
+    var v = try build(a, &rows, "", .all, now, 0);
+    defer v.deinit(a);
+    try std.testing.expectEqual(@as(usize, 4), v.rowCount());
+    try std.testing.expectEqual(@as(usize, 7), v.items.len);
+    try std.testing.expect(std.meta.activeTag(v.items[0]) == .header);
+    try std.testing.expectEqual(Bucket.today, v.items[0].header);
+    try std.testing.expect(std.meta.activeTag(v.items[1]) == .row);
+    try std.testing.expectEqual(@as(usize, 0), v.items[1].row);
+    try std.testing.expectEqual(Bucket.yesterday, v.items[3].header);
+    try std.testing.expectEqual(@as(usize, 0), v.filtered[0]);
+    try std.testing.expectEqual(@as(usize, 3), v.filtered[3]);
+
+    var v2 = try build(a, &rows, "", .sidebar, now, 0);
+    defer v2.deinit(a);
+    try std.testing.expectEqual(@as(usize, 1), v2.rowCount());
+    try std.testing.expectEqual(@as(usize, 1), v2.filtered[0]);
+
+    var v3 = try build(a, &rows, "yesterday", .all, now, 0);
+    defer v3.deinit(a);
+    try std.testing.expectEqual(@as(usize, 1), v3.rowCount());
+
+    var v4 = try build(a, &rows, "zzzzz", .all, now, 0);
+    defer v4.deinit(a);
+    try std.testing.expectEqual(@as(usize, 0), v4.rowCount());
+    try std.testing.expectEqual(@as(usize, 0), v4.items.len);
+}

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -192,6 +192,14 @@ pub const Strings = struct {
     cmd_palette_footer: []const u8,
     cmd_palette_footer_history: []const u8,
     cmd_palette_sidebar_tag: []const u8,
+    cmd_palette_group_today: []const u8,
+    cmd_palette_group_yesterday: []const u8,
+    cmd_palette_group_past_week: []const u8,
+    cmd_palette_group_earlier: []const u8,
+    cmd_palette_source_all: []const u8,
+    cmd_palette_source_sidebar: []const u8,
+    cmd_palette_source_tab: []const u8,
+    cmd_palette_history_search_placeholder: []const u8,
     copilot_picker_title: []const u8,
     copilot_picker_new: []const u8,
     copilot_picker_empty: []const u8,
@@ -403,8 +411,16 @@ const en = Strings{
     .cmd_palette_recent_sessions = "Recent Copilot sessions",
     .cmd_palette_no_sessions = "No saved Copilot sessions",
     .cmd_palette_footer = "Up/Down + Enter applies",
-    .cmd_palette_footer_history = "Up/Down selects, Enter reopens, Delete removes, Esc returns",
+    .cmd_palette_footer_history = "Type to filter, Tab source, Up/Down, Enter reopens, Delete removes, Esc returns",
     .cmd_palette_sidebar_tag = "Sidebar",
+    .cmd_palette_group_today = "Today",
+    .cmd_palette_group_yesterday = "Yesterday",
+    .cmd_palette_group_past_week = "Past 7 days",
+    .cmd_palette_group_earlier = "Earlier",
+    .cmd_palette_source_all = "All",
+    .cmd_palette_source_sidebar = "Sidebar",
+    .cmd_palette_source_tab = "Tab",
+    .cmd_palette_history_search_placeholder = "Search Copilot history",
     .copilot_picker_title = "Copilot conversations (Up/Down, Enter, Delete, Esc)",
     .copilot_picker_new = "+ New conversation",
     .copilot_picker_empty = "No saved Copilot conversations",
@@ -613,8 +629,16 @@ const zh_CN = Strings{
     .cmd_palette_recent_sessions = "最近的副驾会话",
     .cmd_palette_no_sessions = "没有已保存的副驾会话",
     .cmd_palette_footer = "上下选择，回车执行",
-    .cmd_palette_footer_history = "上下选择，回车重开，Delete 删除，Esc 返回",
+    .cmd_palette_footer_history = "输入筛选，Tab 来源，上下选择，回车重开，Delete 删除，Esc 返回",
     .cmd_palette_sidebar_tag = "侧栏",
+    .cmd_palette_group_today = "今天",
+    .cmd_palette_group_yesterday = "昨天",
+    .cmd_palette_group_past_week = "过去7天",
+    .cmd_palette_group_earlier = "更早",
+    .cmd_palette_source_all = "全部",
+    .cmd_palette_source_sidebar = "侧栏",
+    .cmd_palette_source_tab = "标签页",
+    .cmd_palette_history_search_placeholder = "搜索副驾历史",
     .copilot_picker_title = "副驾对话（上下选择，回车打开，Delete 删除，Esc 关闭）",
     .copilot_picker_new = "+ 新建对话",
     .copilot_picker_empty = "没有已保存的副驾对话",
@@ -930,4 +954,15 @@ test "settings strings: en source and zh translation present" {
     try std.testing.expectEqualStrings("语言", s().settings_language);
     try std.testing.expectEqualStrings("重启生效", s().settings_hint_restart);
     try std.testing.expect(s().settings_close.len > 0);
+}
+
+test "i18n: history panel strings present in both locales" {
+    defer setLang(.en);
+    setLang(.en);
+    try std.testing.expectEqualStrings("Today", s().cmd_palette_group_today);
+    try std.testing.expectEqualStrings("Sidebar", s().cmd_palette_source_sidebar);
+    setLang(.zh_CN);
+    try std.testing.expectEqualStrings("今天", s().cmd_palette_group_today);
+    try std.testing.expectEqualStrings("过去7天", s().cmd_palette_group_past_week);
+    try std.testing.expectEqualStrings("侧栏", s().cmd_palette_source_sidebar);
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -2934,6 +2934,8 @@ fn handleKey(ev: platform_input.KeyEvent) void {
                 platform_input.key_down => overlays.commandPaletteMoveAgentHistory(1),
                 platform_input.key_enter => overlays.commandPaletteExecuteSelected(),
                 platform_input.key_delete => _ = overlays.commandPaletteDeleteSelectedAgentHistory(),
+                platform_input.key_backspace => overlays.commandPaletteBackspace(),
+                platform_input.key_tab => overlays.commandPaletteCycleHistorySource(),
                 else => {},
             }
         } else {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -230,6 +230,7 @@ threadlocal var g_command_palette_filter_len: usize = 0;
 threadlocal var g_command_palette_mode: CommandPaletteMode = .commands;
 threadlocal var g_command_palette_history_selected: usize = 0;
 threadlocal var g_command_palette_history_source: command_palette_history_view.SourceFilter = .all;
+threadlocal var g_command_palette_history_item_count: usize = 0;
 
 const CommandPaletteLayout = struct {
     box_x: f32,
@@ -1167,8 +1168,44 @@ fn commandPaletteVisibleCount() usize {
 }
 
 fn commandPaletteResultCount() usize {
-    if (commandPaletteIsHistoryMode()) return g_command_palette_history_rows.len;
+    if (commandPaletteIsHistoryMode()) return g_command_palette_history_item_count;
     return commandPaletteVisibleCount();
+}
+
+fn historyBucketLabel(b: command_palette_history_view.Bucket) []const u8 {
+    return switch (b) {
+        .today => i18n.s().cmd_palette_group_today,
+        .yesterday => i18n.s().cmd_palette_group_yesterday,
+        .past_week => i18n.s().cmd_palette_group_past_week,
+        .earlier => i18n.s().cmd_palette_group_earlier,
+    };
+}
+
+fn historySourceLabel(src: command_palette_history_view.SourceFilter) []const u8 {
+    return switch (src) {
+        .all => i18n.s().cmd_palette_source_all,
+        .sidebar => i18n.s().cmd_palette_source_sidebar,
+        .tab => i18n.s().cmd_palette_source_tab,
+    };
+}
+
+/// First visible item index that keeps `focus_item` inside a window of `rendered`
+/// items out of `count`.
+fn historyWindowStart(count: usize, rendered: usize, focus_item: usize) usize {
+    if (rendered == 0 or count <= rendered) return 0;
+    if (focus_item < rendered) return 0;
+    return @min(focus_item - rendered + 1, count - rendered);
+}
+
+/// The items-index of the row whose ordinal == selected_ord (0 if not found).
+fn historySelectedItemIndex(view: command_palette_history_view.View, selected_ord: usize) usize {
+    for (view.items, 0..) |it, i| {
+        switch (it) {
+            .row => |ord| if (ord == selected_ord) return i,
+            .header => {},
+        }
+    }
+    return 0;
 }
 
 fn commandPaletteClampSelection() void {
@@ -1845,6 +1882,17 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     if (!g_command_palette_visible) return;
     commandPaletteSyncAgentHistoryRows();
 
+    var history_view: ?command_palette_history_view.View = null;
+    const hist_alloc = AppWindow.g_allocator;
+    defer if (history_view) |*v| {
+        if (hist_alloc) |a| v.deinit(a);
+    };
+    const hist_now_ms = std.time.milliTimestamp();
+    if (commandPaletteIsHistoryMode()) {
+        history_view = buildHistoryView();
+        g_command_palette_history_item_count = if (history_view) |v| v.items.len else 0;
+    }
+
     const layout = commandPaletteLayout(window_width, window_height, top_offset);
     const box_y = @round(window_height - layout.box_top_px - layout.box_h);
 
@@ -1870,6 +1918,12 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     renderTitlebarText(if (commandPaletteIsHistoryMode()) i18n.s().cmd_palette_history_title else i18n.s().cmd_palette_title, layout.box_x + pad_x, title_y, title_color);
     const esc_hint = if (commandPaletteIsHistoryMode()) i18n.s().cmd_palette_esc_returns else i18n.s().cmd_palette_esc_closes;
     renderTitlebarText(esc_hint, layout.box_x + layout.box_w - pad_x - measureTitlebarText(esc_hint), title_y, muted);
+    if (commandPaletteIsHistoryMode()) {
+        const chip = historySourceLabel(g_command_palette_history_source);
+        const chip_w = measureTitlebarText(chip);
+        const chip_x = layout.box_x + layout.box_w - pad_x - measureTitlebarText(esc_hint) - 16 - chip_w;
+        renderTitlebarText(chip, chip_x, title_y, mixColor(fg, accent, 0.20));
+    }
 
     const filter_x = @round(layout.box_x + pad_x);
     const filter_box_y = @round(window_height - (layout.box_top_px + layout.header_h + layout.filter_h));
@@ -1879,11 +1933,12 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
 
     const filter_text_y = rowTextY(filter_box_y, layout.filter_h);
     if (commandPaletteIsHistoryMode()) {
-        const history_hint = if (g_command_palette_history_rows.len == 0)
-            i18n.s().cmd_palette_no_sessions_yet
-        else
-            i18n.s().cmd_palette_recent_sessions;
-        renderTitlebarTextLimited(history_hint, filter_x + 12, filter_text_y, dim, filter_w - 24);
+        const filter = commandPaletteFilter();
+        if (filter.len > 0) {
+            renderTitlebarTextLimited(filter, filter_x + 12, filter_text_y, fg, filter_w - 24);
+        } else {
+            renderTitlebarTextLimited(i18n.s().cmd_palette_history_search_placeholder, filter_x + 12, filter_text_y, dim, filter_w - 24);
+        }
     } else {
         const filter = commandPaletteFilter();
         if (filter.len > 0) {
@@ -1894,40 +1949,55 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     }
 
     if (commandPaletteIsHistoryMode()) {
-        if (g_command_palette_history_rows.len == 0) {
+        const selectable = if (history_view) |v| v.rowCount() else 0;
+        if (history_view == null or selectable == 0) {
             const empty_text = i18n.s().cmd_palette_no_sessions;
             const empty_y = @round(window_height - layout.row_top_px - layout.row_h + (layout.row_h - overlayTextHeight()) / 2);
             renderTitlebarText(empty_text, layout.box_x + (layout.box_w - measureTitlebarText(empty_text)) / 2, empty_y, muted);
         } else {
-            const first_row = commandPaletteFirstVisibleIndex(layout.rendered_rows);
+            const view = history_view.?;
+            const selected_ord = @min(g_command_palette_history_selected, selectable - 1);
+            const focus_item = historySelectedItemIndex(view, selected_ord);
+            const first_item = historyWindowStart(view.items.len, layout.rendered_rows, focus_item);
+
             var display_row: usize = 0;
             while (display_row < layout.rendered_rows) : (display_row += 1) {
-                const item_idx = first_row + display_row;
-                if (item_idx >= g_command_palette_history_rows.len) break;
-                const row = g_command_palette_history_rows[item_idx];
-                const selected = item_idx == g_command_palette_history_selected;
-
+                const item_idx = first_item + display_row;
+                if (item_idx >= view.items.len) break;
                 const row_top = @round(layout.row_top_px + @as(f32, @floatFromInt(display_row)) * layout.row_h);
                 const row_y = @round(window_height - row_top - layout.row_h);
-                if (selected) {
-                    renderRoundedQuadAlpha(layout.box_x + 12, row_y + 4, layout.box_w - 24, layout.row_h - 8, 5, selected_border, 0.38);
-                    renderRoundedQuadAlpha(layout.box_x + 13, row_y + 5, layout.box_w - 26, layout.row_h - 10, 4, selected_bg, 0.78);
-                }
-
-                const row_title_color = if (selected) fg else mixColor(bg, fg, 0.86);
-                const meta_color = if (selected) mixColor(fg, accent, 0.08) else mixColor(bg, fg, 0.54);
                 const text_y = rowTextY(row_y, layout.row_h);
-                const title_x = @round(layout.box_x + pad_x + 2);
-                const meta_right = layout.box_x + layout.box_w - pad_x;
-                // Sidebar-origin conversations show a "Sidebar" tag where tab
-                // conversations show their model name.
-                const right_label = if (row.copilot) i18n.s().cmd_palette_sidebar_tag else row.model;
-                if (right_label.len > 0) {
-                    const meta_w = measureTitlebarText(right_label);
-                    renderTitlebarText(right_label, meta_right - meta_w, text_y, meta_color);
-                    renderTitlebarTextLimited(row.title, title_x, text_y, row_title_color, (meta_right - meta_w) - title_x - 18);
-                } else {
-                    renderTitlebarTextLimited(row.title, title_x, text_y, row_title_color, meta_right - title_x);
+                switch (view.items[item_idx]) {
+                    .header => |b| {
+                        const label = historyBucketLabel(b);
+                        renderTitlebarText(label, @round(layout.box_x + pad_x + 2), text_y, mixColor(bg, fg, 0.40));
+                    },
+                    .row => |ord| {
+                        const row = g_command_palette_history_rows[view.filtered[ord]];
+                        const selected = ord == selected_ord;
+                        if (selected) {
+                            renderRoundedQuadAlpha(layout.box_x + 12, row_y + 4, layout.box_w - 24, layout.row_h - 8, 5, selected_border, 0.38);
+                            renderRoundedQuadAlpha(layout.box_x + 13, row_y + 5, layout.box_w - 26, layout.row_h - 10, 4, selected_bg, 0.78);
+                        }
+                        const row_title_color = if (selected) fg else mixColor(bg, fg, 0.86);
+                        const meta_color = if (selected) mixColor(fg, accent, 0.08) else mixColor(bg, fg, 0.54);
+                        const title_x = @round(layout.box_x + pad_x + 2);
+                        const meta_right = layout.box_x + layout.box_w - pad_x;
+
+                        var tbuf: [32]u8 = undefined;
+                        const rel = copilot_picker.formatRelativeTime(hist_now_ms, row.updated_at, &tbuf);
+                        const rel_w = measureTitlebarText(rel);
+                        renderTitlebarText(rel, meta_right - rel_w, text_y, meta_color);
+
+                        const tag = if (row.copilot) i18n.s().cmd_palette_sidebar_tag else row.model;
+                        var title_limit_right = meta_right - rel_w - 14;
+                        if (tag.len > 0) {
+                            const tag_w = measureTitlebarText(tag);
+                            renderTitlebarText(tag, title_limit_right - tag_w, text_y, meta_color);
+                            title_limit_right = title_limit_right - tag_w - 14;
+                        }
+                        renderTitlebarTextLimited(row.title, title_x, text_y, row_title_color, title_limit_right - title_x);
+                    },
                 }
             }
         }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -38,6 +38,7 @@ const weixin_types = @import("../weixin/types.zig");
 const i18n = @import("../i18n.zig");
 const ai_model_switch = @import("../ai_model_switch.zig");
 const agent_integration_prompt = @import("../agent_integration_prompt.zig");
+const ai_history_time = @import("../ai_history_time.zig");
 
 const ui_pipeline = @import("ui_pipeline.zig");
 
@@ -323,8 +324,15 @@ pub fn commandPaletteAgentHistoryVisible() bool {
 
 pub fn commandPaletteMoveAgentHistory(delta: i32) void {
     commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse {
+        var state0 = commandCenterStateSnapshot();
+        state0.commandPaletteMoveAgentHistory(delta, g_command_palette_history_rows.len);
+        commandCenterStateCommit(state0);
+        return;
+    };
+    defer view.deinit(AppWindow.g_allocator.?);
     var state = commandCenterStateSnapshot();
-    state.commandPaletteMoveAgentHistory(delta, g_command_palette_history_rows.len);
+    state.commandPaletteMoveAgentHistory(delta, view.rowCount());
     commandCenterStateCommit(state);
 }
 
@@ -337,9 +345,12 @@ pub fn commandPaletteCycleHistorySource() void {
 pub fn commandPaletteDeleteSelectedAgentHistory() bool {
     if (!commandPaletteIsHistoryMode()) return false;
     commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse return false;
+    defer view.deinit(AppWindow.g_allocator.?);
     const state = commandCenterStateSnapshot();
-    const row_idx = state.commandPaletteSelectedAgentHistoryIndex(g_command_palette_history_rows.len) orelse return false;
-    return commandPaletteDeleteAgentHistoryIndex(row_idx);
+    const ord = state.commandPaletteSelectedAgentHistoryIndex(view.rowCount()) orelse return false;
+    const orig = view.filtered[ord];
+    return commandPaletteDeleteAgentHistoryIndex(orig);
 }
 
 pub fn commandPaletteLeaveAgentHistory() void {
@@ -1126,6 +1137,22 @@ fn commandPaletteSyncAgentHistoryRows() void {
     commandPaletteRefreshAgentHistoryRows();
 }
 
+/// Build the current filtered/grouped view from the loaded history rows + live
+/// filter/source. Caller owns the View and must `deinit` it. Null on no allocator.
+fn buildHistoryView() ?command_palette_history_view.View {
+    const allocator = AppWindow.g_allocator orelse return null;
+    const now_ms = std.time.milliTimestamp();
+    const tz = ai_history_time.localOffsetSeconds();
+    return command_palette_history_view.build(
+        allocator,
+        g_command_palette_history_rows,
+        commandPaletteFilter(),
+        g_command_palette_history_source,
+        now_ms,
+        tz,
+    ) catch null;
+}
+
 fn applyEmbeddedThemeFromPalette(theme_index: usize) void {
     const allocator = AppWindow.g_allocator orelse return;
     if (theme_index >= themes_embed.entries.len) return;
@@ -1293,9 +1320,12 @@ fn commandPaletteHistoryHitTestIndex(xpos: f64, ypos: f64, window_width: f32, wi
 fn commandPaletteActivateSelectedAgentHistory() bool {
     if (!commandPaletteIsHistoryMode()) return false;
     commandPaletteSyncAgentHistoryRows();
+    var view = buildHistoryView() orelse return false;
+    defer view.deinit(AppWindow.g_allocator.?);
     const state = commandCenterStateSnapshot();
-    const row_idx = state.commandPaletteActivateSelected(g_command_palette_history_rows.len) orelse return false;
-    return commandPaletteActivateAgentHistoryIndex(row_idx);
+    const ord = state.commandPaletteActivateSelected(view.rowCount()) orelse return false;
+    const orig = view.filtered[ord];
+    return commandPaletteActivateAgentHistoryIndex(orig);
 }
 
 fn commandPaletteActivateAgentHistoryRow(row_idx: usize) bool {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -23,6 +23,7 @@ const ssh_prompt = @import("../ssh_prompt.zig");
 const ssh_connection = @import("../ssh_connection.zig");
 const app_metadata = @import("../app_metadata.zig");
 const command_center_state = @import("../command_center_state.zig");
+const command_palette_history_view = @import("../command_palette_history_view.zig");
 const command_palette_model = @import("../command_palette_model.zig");
 const agent_history = @import("../agent_history.zig");
 const platform_dirs = @import("../platform/dirs.zig");
@@ -227,6 +228,7 @@ threadlocal var g_command_palette_filter: [COMMAND_PALETTE_FILTER_MAX]u8 = undef
 threadlocal var g_command_palette_filter_len: usize = 0;
 threadlocal var g_command_palette_mode: CommandPaletteMode = .commands;
 threadlocal var g_command_palette_history_selected: usize = 0;
+threadlocal var g_command_palette_history_source: command_palette_history_view.SourceFilter = .all;
 
 const CommandPaletteLayout = struct {
     box_x: f32,
@@ -323,6 +325,12 @@ pub fn commandPaletteMoveAgentHistory(delta: i32) void {
     commandPaletteSyncAgentHistoryRows();
     var state = commandCenterStateSnapshot();
     state.commandPaletteMoveAgentHistory(delta, g_command_palette_history_rows.len);
+    commandCenterStateCommit(state);
+}
+
+pub fn commandPaletteCycleHistorySource() void {
+    var state = commandCenterStateSnapshot();
+    state.commandPaletteCycleHistorySource();
     commandCenterStateCommit(state);
 }
 
@@ -2184,6 +2192,7 @@ fn commandCenterStateSnapshot() command_center_state.State {
         .command_palette_filter_len = g_command_palette_filter_len,
         .command_palette_mode = g_command_palette_mode,
         .command_palette_history_selected = g_command_palette_history_selected,
+        .command_palette_history_source = g_command_palette_history_source,
         .startup_shortcuts_visible = startup_shortcuts.g_startup_shortcuts_visible,
         .session_launcher_visible = g_session_launcher_visible,
         .session_launcher_selected = g_session_launcher_selected,
@@ -2211,6 +2220,7 @@ fn commandCenterStateApply(state: command_center_state.State) void {
     g_command_palette_filter_len = state.command_palette_filter_len;
     g_command_palette_mode = state.command_palette_mode;
     g_command_palette_history_selected = state.command_palette_history_selected;
+    g_command_palette_history_source = state.command_palette_history_source;
     startup_shortcuts.g_startup_shortcuts_visible = state.startup_shortcuts_visible;
     g_session_launcher_visible = state.session_launcher_visible;
     g_session_launcher_selected = state.session_launcher_selected;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1349,9 +1349,19 @@ fn commandPaletteHistoryHitTestIndex(xpos: f64, ypos: f64, window_width: f32, wi
     const row: usize = @intFromFloat(@floor(row_f));
     if (row >= layout.rendered_rows) return null;
 
-    const item_idx = commandPaletteFirstVisibleIndex(layout.rendered_rows) + row;
-    if (item_idx >= g_command_palette_history_rows.len) return null;
-    return item_idx;
+    var view = buildHistoryView() orelse return null;
+    defer view.deinit(AppWindow.g_allocator.?);
+    const selectable = view.rowCount();
+    if (selectable == 0) return null;
+    const selected_ord = @min(g_command_palette_history_selected, selectable - 1);
+    const focus_item = historySelectedItemIndex(view, selected_ord);
+    const first_item = historyWindowStart(view.items.len, layout.rendered_rows, focus_item);
+    const item_idx = first_item + row;
+    if (item_idx >= view.items.len) return null;
+    return switch (view.items[item_idx]) {
+        .header => null, // clicking a group header is a no-op
+        .row => |ord| view.filtered[ord], // raw index into g_command_palette_history_rows
+    };
 }
 
 fn commandPaletteActivateSelectedAgentHistory() bool {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2123,7 +2123,15 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
         const track_gl_y = @round(window_height - track_top_px - track_h);
         ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
 
-        const first_row = commandPaletteFirstVisibleIndex(layout.rendered_rows);
+        // History mode windows over display items (rows + group headers), so the
+        // thumb must track the same item-index window the list render uses, not the
+        // raw-ordinal window commandPaletteFirstVisibleIndex assumes.
+        const first_row = if (commandPaletteIsHistoryMode()) blk: {
+            const v = history_view orelse break :blk 0;
+            const selectable = v.rowCount();
+            const selected_ord = if (selectable == 0) 0 else @min(g_command_palette_history_selected, selectable - 1);
+            break :blk historyWindowStart(v.items.len, layout.rendered_rows, historySelectedItemIndex(v, selected_ord));
+        } else commandPaletteFirstVisibleIndex(layout.rendered_rows);
         const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
         const max_scroll_f: f32 = @floatFromInt(total_results - layout.rendered_rows);
         const scroll_f: f32 = @floatFromInt(first_row);

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -362,13 +362,15 @@ pub fn commandPaletteLeaveAgentHistory() void {
 }
 
 pub fn commandPaletteBackspace() void {
-    if (commandPaletteIsHistoryMode()) return;
     if (g_command_palette_filter_len == 0) return;
-    // Remove a whole UTF-8 codepoint: walk back over continuation bytes (0b10xxxxxx).
     var n = g_command_palette_filter_len - 1;
     while (n > 0 and (g_command_palette_filter[n] & 0xC0) == 0x80) n -= 1;
     g_command_palette_filter_len = n;
-    commandPaletteClampSelection();
+    if (commandPaletteIsHistoryMode()) {
+        g_command_palette_history_selected = 0;
+    } else {
+        commandPaletteClampSelection();
+    }
 }
 
 pub fn commandPaletteClearFilter() void {
@@ -378,17 +380,17 @@ pub fn commandPaletteClearFilter() void {
 }
 
 pub fn commandPaletteInsertChar(codepoint: u21) void {
-    if (commandPaletteIsHistoryMode()) return;
     if (codepoint < 0x20 or codepoint == 0x7f) return;
-
-    // UTF-8-encode the codepoint so CJK (e.g. IME-committed 中文) is accepted,
-    // not just ASCII. Mirrors the terminal char path's utf8Encode.
     var buf: [4]u8 = undefined;
     const len = std.unicode.utf8Encode(codepoint, &buf) catch return;
     if (g_command_palette_filter_len + len > g_command_palette_filter.len) return;
     @memcpy(g_command_palette_filter[g_command_palette_filter_len..][0..len], buf[0..len]);
     g_command_palette_filter_len += len;
-    commandPaletteClampSelection();
+    if (commandPaletteIsHistoryMode()) {
+        g_command_palette_history_selected = 0;
+    } else {
+        commandPaletteClampSelection();
+    }
 }
 
 pub fn commandPaletteExecuteSelected() void {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -52,6 +52,7 @@ test {
     _ = @import("close_confirm.zig");
     _ = @import("command_palette_model.zig");
     _ = @import("command_center_state.zig");
+    _ = @import("command_palette_history_view.zig");
     _ = @import("platform/window_state_codec.zig");
     _ = @import("platform/dxgi_core.zig");
     _ = @import("platform/console_host_policy.zig");

--- a/tests/macos_e2e/driver/keycodes.py
+++ b/tests/macos_e2e/driver/keycodes.py
@@ -8,7 +8,7 @@ Extend as new shortcut tests need more keys.
 _KEYCODES = {
     "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
     "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
-    "t": 17, "n": 45,
+    "t": 17, "n": 45, "p": 35,
     "return": 36, "tab": 48, "space": 49, "delete": 51, "escape": 53,
     "left": 123, "right": 124, "down": 125, "up": 126,
     "f1": 122, "f2": 120, "f3": 99, "f4": 118,

--- a/tests/macos_e2e/test_copilot_history.py
+++ b/tests/macos_e2e/test_copilot_history.py
@@ -1,0 +1,93 @@
+import json
+import os
+import time
+
+import pytest
+
+from tests.macos_e2e.conftest import APP_BUNDLE, CTL_BINARY
+from tests.macos_e2e.driver.macos import MacDriver
+
+
+def _session_record(session_id: str, title: str, model: str, updated_at_ms: int, copilot: bool):
+    return {
+        "session_id": session_id,
+        "title": title,
+        "base_url": "https://api.example.com",
+        "api_key": "k",
+        "model": model,
+        "protocol": "chat_completions",
+        "system_prompt": "sys",
+        "thinking_enabled": False,
+        "reasoning_effort": "low",
+        "stream": True,
+        "max_tokens": 8192,
+        "agent_enabled": True,
+        "vision_enabled": False,
+        "copilot": copilot,
+        "created_at": updated_at_ms,
+        "updated_at": updated_at_ms,
+        "messages": [{"role": "user", "content": f"hello from {title}"}],
+    }
+
+
+@pytest.fixture()
+def seeded_app():
+    """A fresh isolated WispTerm instance pre-seeded with copilot history sessions.
+
+    Writing only sessions/*.json (no index.json) exercises the storage layer's
+    index-rebuild path on first launch.
+    """
+    driver = MacDriver(app_bundle=APP_BUNDLE, ctl_binary=CTL_BINARY)
+    sessions_dir = os.path.join(driver._config_dir(), "agent-history", "sessions")
+    os.makedirs(sessions_dir, exist_ok=True)
+    now_ms = int(time.time() * 1000)
+    day = 86400 * 1000
+    seeds = [
+        _session_record("hist-deploy", "Deploy notes", "deepseek-v4", now_ms, False),
+        _session_record("hist-sidebar", "Sidebar chat", "glm-5", now_ms - day, True),
+        _session_record("hist-old", "Old planning", "gpt-x", now_ms - 20 * day, False),
+    ]
+    for rec in seeds:
+        with open(os.path.join(sessions_dir, f"{rec['session_id']}.json"), "w") as f:
+            json.dump(rec, f)
+    driver.launch()
+    yield driver
+    driver.quit()
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_copilot_history_input_driven(seeded_app):
+    app = seeded_app
+    app.focus()
+    pane = app.primary_pane()
+
+    # Baseline: app alive and terminal round-trips.
+    app.send_text("echo before-history\n")
+    app.wait_for(pane, "before-history", timeout=8)
+
+    # Open command palette (Ctrl+Shift+P), select the "Copilot History" command to
+    # enter history mode (default locale is English).
+    app.key("p", "ctrl", "shift")
+    time.sleep(0.3)
+    app.text("Copilot History")  # filter the command list to the history entry
+    time.sleep(0.3)
+    app.key("return")            # execute -> enters history mode (panel shows seeds)
+    time.sleep(0.3)
+
+    # Exercise the new history-mode input handlers (must not crash / not eat input).
+    app.text("deploy")           # live title filter
+    time.sleep(0.2)
+    app.key("down")              # navigate (skips group headers)
+    app.key("up")
+    app.key("tab")               # cycle source filter all -> sidebar
+    app.key("tab")               # -> tab
+    time.sleep(0.2)
+    app.key("escape")            # leave history mode
+    app.key("escape")            # close palette
+
+    # The whole overlay-input flow must leave the app responsive and must NOT have
+    # eaten subsequent terminal input. (Overlay text is unobservable via get-text;
+    # covered by unit tests instead.)
+    app.send_text("echo after-history\n")
+    app.wait_for(pane, "after-history", timeout=8)


### PR DESCRIPTION
## Summary

副驾历史（Copilot history）命令面板模态从「只有标题 + 右侧 model/侧栏」升级为可检索、可分组的列表（第二阶段，承接 #295 存储重构）：

- **每行相对时间**：右侧显示 `4h ago` / `2d ago`（复用 `copilot_picker.formatRelativeTime`）。
- **按本地日历日分组**：今天 / 昨天 / 过去7天 / 更早（`dateKeyFromMs` 思路 + `ai_history_time.localOffsetSeconds()`，组间插分隔标题）。
- **实时搜索**：在历史模式直接输入即按 **title + model** 大小写不敏感过滤（输入模型名即可按模型筛选）。此前历史模式的搜索框是惰性的（输入被屏蔽）。
- **Tab 切来源筛选**：全部 → 侧栏 → 标签页，标题栏显示当前 chip。
- 导航跳过分组标题；空结果显示提示；删除/重开/鼠标点击均按过滤后的可见行映射。

**架构**：过滤/分桶/相对时间/选中映射抽成纯模块 `src/command_palette_history_view.zig`（`bucketFor`/`rowMatches`/`build`/`View`，fast 套件单测覆盖含时区边界与空结果）；渲染（`overlays.zig`）、输入（`input.zig`）、状态（`command_center_state.zig` 经 snapshot/apply 桥接）、文案（`i18n.zig` 中英）只做接线。

**范围**：仅命令面板的副驾历史模态；不含 file_explorer 侧栏的另一套 agent-history 面板；不含消息正文全文检索（索引已存 `search_preview` 备用）。

设计/计划见 `docs/superpowers/specs/2026-06-23-copilot-history-panel-ui-design.md` 与 `docs/superpowers/plans/2026-06-23-copilot-history-panel-ui.md`。

## Test Plan

- [x] `zig build test`（fast：视图模块 bucket/match/build + 状态 cycle/reset + i18n 中英，testing.allocator 检漏）
- [x] `zig build test-full -Dtarget=aarch64-macos`（原生运行；唯一失败为与本改动无关的预存 flaky 测试 `AppWindow: skill center tool import rejects reserved built-in function names`，`.zig-cache/tmp` FileNotFound）
- [x] `zig build macos-app -Dtarget=aarch64-macos`（真机 .app 构建）
- [x] `tests/macos_e2e/test_copilot_history.py`：预置历史会话（仅 sessions/*.json，顺带验证索引重建）→ Ctrl+Shift+P 开面板 → 进历史模式 → 输入筛选 → ↑↓ 导航 → Tab 切来源 → Esc → 前后终端 round-trip 正常（证明新输入处理不崩/不吞输入）。对 Phase 2 binary 跑通。
- [x] 真机手测：相对时间显示、四档分组、输入筛 title/model、Tab 切来源 chip、↑↓ 跳过分组标题、回车/鼠标点击重开正确会话。

🤖 Generated with [Claude Code](https://claude.com/claude-code)