### PR TITLE
feat(ctl): add wisptermctl ui-state command for overlay semantics

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -7937,6 +7937,13 @@ var g_ctl_panes_json: []u8 = &.{}; // page_allocator-owned latest panes JSON
 // sync). The timestamp must be touched atomically to avoid a data race.
 var g_ctl_panes_last_ms = std.atomic.Value(i64).init(0);
 
+// Overlay semantic state for `ui-state`, published the same way as panes: the UI
+// thread serializes the threadlocal command-center globals on the render tick,
+// the ctl server thread only ever reads this buffer under the mutex.
+var g_ctl_ui_state_mutex: std.Thread.Mutex = .{};
+var g_ctl_ui_state_json: []u8 = &.{}; // page_allocator-owned latest ui-state JSON
+var g_ctl_ui_state_last_ms = std.atomic.Value(i64).init(0);
+
 const ctl_default_rows: u32 = 1000;
 
 pub fn enableAgentControl() void {
@@ -7972,10 +7979,19 @@ fn ctlSendText(ctx: *anyopaque, id: []const u8, data: []const u8) bool {
     return true;
 }
 
+fn ctlUiState(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!?[]u8 {
+    _ = ctx;
+    g_ctl_ui_state_mutex.lock();
+    defer g_ctl_ui_state_mutex.unlock();
+    if (g_ctl_ui_state_json.len == 0) return null;
+    return try allocator.dupe(u8, g_ctl_ui_state_json);
+}
+
 const ctl_vtable = ctl_control.Control.VTable{
     .list_panes = ctlListPanes,
     .get_text = ctlGetText,
     .send_text = ctlSendText,
+    .ui_state = ctlUiState,
 };
 
 /// The Control the agent-control server drives. Backed by process-global state,
@@ -8008,6 +8024,32 @@ fn syncCtlPanes(allocator: std.mem.Allocator) void {
     defer g_ctl_panes_mutex.unlock();
     if (g_ctl_panes_json.len != 0) std.heap.page_allocator.free(g_ctl_panes_json);
     g_ctl_panes_json = owned;
+}
+
+fn clearCtlUiStateCache() void {
+    g_ctl_ui_state_mutex.lock();
+    defer g_ctl_ui_state_mutex.unlock();
+    if (g_ctl_ui_state_json.len != 0) std.heap.page_allocator.free(g_ctl_ui_state_json);
+    g_ctl_ui_state_json = &.{};
+}
+
+/// UI-thread: publish a fresh overlay ui-state JSON snapshot (throttled). Called
+/// from the render loop next to syncCtlPanes. No-op unless ctl is enabled.
+fn syncCtlUiState(allocator: std.mem.Allocator) void {
+    if (!g_agent_control_enabled.load(.acquire)) return;
+    const now = std.time.milliTimestamp();
+    if (now - g_ctl_ui_state_last_ms.load(.monotonic) < 200) return;
+    g_ctl_ui_state_last_ms.store(now, .monotonic);
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    overlays.buildUiStateJson(allocator, &out) catch return;
+
+    const owned = std.heap.page_allocator.dupe(u8, out.items) catch return;
+    g_ctl_ui_state_mutex.lock();
+    defer g_ctl_ui_state_mutex.unlock();
+    if (g_ctl_ui_state_json.len != 0) std.heap.page_allocator.free(g_ctl_ui_state_json);
+    g_ctl_ui_state_json = owned;
 }
 
 test "ctl surface callbacks reject an unregistered id without dereferencing" {
@@ -9987,6 +10029,7 @@ fn runMainLoop(self: *AppWindow) !void {
             const split_count = computeSplitLayout(active_tab, content_x, content_y, content_w, content_h, font.cell_width, font.cell_height);
             syncRemoteLayout(allocator);
             syncCtlPanes(allocator);
+            syncCtlUiState(allocator);
             syncImeCaretPosition(win, split_count);
             if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and active_tab.kind != .skill_center and active_tab.kind != .port_forwarding and synchronizedOutputPendingForVisibleSplits(split_count)) {
                 // Block instead of spinning at ~1kHz: the IO thread posts a
@@ -10315,6 +10358,7 @@ fn runMainLoop(self: *AppWindow) !void {
     weixin_qr_panel.deinit();
     clearWeixinTranscriptCache();
     clearCtlPanesCache();
+    clearCtlUiStateCache();
     markdown_preview_renderer.deinit();
     browser_panel.deinit();
 

--- a/src/ctl/client.zig
+++ b/src/ctl/client.zig
@@ -8,6 +8,7 @@ pub const Action = union(enum) {
     get_text: struct { id: []const u8, recent: ?u32 },
     send_text: struct { id: []const u8, data: []const u8 }, // data still escaped
     wait_for: struct { id: []const u8, pattern: []const u8, timeout_ms: u32 },
+    ui_state,
     help,
 };
 
@@ -68,6 +69,7 @@ pub fn parseArgs(args: []const []const u8) !Action {
     const cmd = args[0];
     if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "-h") or std.mem.eql(u8, cmd, "--help")) return .help;
     if (std.mem.eql(u8, cmd, "panes")) return .panes;
+    if (std.mem.eql(u8, cmd, "ui-state")) return .ui_state;
     if (std.mem.eql(u8, cmd, "get-text")) {
         const id = (try flagValue(args, "-t")) orelse return error.MissingTarget;
         const recent = if (try flagValue(args, "--recent")) |r| try std.fmt.parseInt(u32, r, 10) else null;
@@ -176,6 +178,10 @@ test "parseArgs covers every command and required-flag errors" {
     try t.expectEqual(Action.help, try parseArgs(&.{"--help"}));
     // Unknown command is an error (non-zero exit), not silent help.
     try t.expectError(error.UnknownCommand, parseArgs(&.{"bogus"}));
+}
+
+test "parseArgs maps ui-state to its no-arg action" {
+    try t.expectEqual(Action.ui_state, try parseArgs(&.{"ui-state"}));
 }
 
 test "parseArgs: large --timeout does not overflow u32 (clamps)" {

--- a/src/ctl/control.zig
+++ b/src/ctl/control.zig
@@ -15,6 +15,9 @@ pub const Control = struct {
         get_text: *const fn (ctx: *anyopaque, allocator: std.mem.Allocator, id: []const u8, recent: ?u32) anyerror!?[]u8,
         /// Queue raw bytes to surface `id`. Returns false if no live surface.
         send_text: *const fn (ctx: *anyopaque, id: []const u8, data: []const u8) bool,
+        /// Allocator-owned overlay/UI semantic-state JSON object, or null if not
+        /// yet published. Complements list_panes (topology) with the overlay layer.
+        ui_state: *const fn (ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!?[]u8,
     };
 
     pub fn listPanes(self: Control, allocator: std.mem.Allocator) anyerror!?[]u8 {
@@ -25,6 +28,9 @@ pub const Control = struct {
     }
     pub fn sendText(self: Control, id: []const u8, data: []const u8) bool {
         return self.vtable.send_text(self.ctx, id, data);
+    }
+    pub fn uiState(self: Control, allocator: std.mem.Allocator) anyerror!?[]u8 {
+        return self.vtable.ui_state(self.ctx, allocator);
     }
 };
 
@@ -42,15 +48,21 @@ test "Control forwards to the vtable" {
         fn send_text(_: *anyopaque, id: []const u8, _: []const u8) bool {
             return std.mem.eql(u8, id, "live");
         }
+        fn ui_state(_: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
+            return try a.dupe(u8, "{\"activeOverlay\":\"none\"}");
+        }
         var dummy: u8 = 0;
         fn iface() Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
         }
     };
     const c = Fake.iface();
     const panes = (try c.listPanes(t.allocator)).?;
     defer t.allocator.free(panes);
     try t.expectEqualStrings("{\"tabs\":[]}", panes);
+    const ui = (try c.uiState(t.allocator)).?;
+    defer t.allocator.free(ui);
+    try t.expectEqualStrings("{\"activeOverlay\":\"none\"}", ui);
     const text = (try c.getText(t.allocator, "live", null)).?;
     defer t.allocator.free(text);
     try t.expectEqualStrings("hello", text);

--- a/src/ctl/protocol.zig
+++ b/src/ctl/protocol.zig
@@ -4,13 +4,14 @@
 //! '\n'-terminated.
 const std = @import("std");
 
-pub const Cmd = enum { panes, get_text, send_text };
+pub const Cmd = enum { panes, get_text, send_text, ui_state };
 
 pub fn cmdToStr(c: Cmd) []const u8 {
     return switch (c) {
         .panes => "panes",
         .get_text => "get-text",
         .send_text => "send-text",
+        .ui_state => "ui-state",
     };
 }
 
@@ -18,6 +19,7 @@ pub fn cmdFromStr(s: []const u8) ?Cmd {
     if (std.mem.eql(u8, s, "panes")) return .panes;
     if (std.mem.eql(u8, s, "get-text")) return .get_text;
     if (std.mem.eql(u8, s, "send-text")) return .send_text;
+    if (std.mem.eql(u8, s, "ui-state")) return .ui_state;
     return null;
 }
 
@@ -195,6 +197,16 @@ test "parseRequest clamps an out-of-u32 recent instead of panicking" {
     var pr = try parseRequest(t.allocator, "{\"token\":\"x\",\"cmd\":\"get-text\",\"id\":\"s\",\"recent\":5000000000}");
     defer pr.deinit();
     try t.expectEqual(@as(?u32, std.math.maxInt(u32)), pr.value.recent);
+}
+
+test "ui-state command round-trips through cmd<->str and encode/parse" {
+    try t.expectEqual(Cmd.ui_state, cmdFromStr("ui-state").?);
+    try t.expectEqualStrings("ui-state", cmdToStr(.ui_state));
+    const line = try encodeRequest(t.allocator, .{ .token = "tok", .cmd = .ui_state });
+    defer t.allocator.free(line);
+    var pr = try parseRequest(t.allocator, line);
+    defer pr.deinit();
+    try t.expectEqual(Cmd.ui_state, pr.value.cmd);
 }
 
 test "parseRequest rejects unknown command and non-object" {

--- a/src/ctl/server.zig
+++ b/src/ctl/server.zig
@@ -120,6 +120,12 @@ pub const Server = struct {
                 defer self.allocator.free(json);
                 return protocol.encodeOkRawJson(self.allocator, json);
             },
+            .ui_state => {
+                const json = (try self.control.uiState(self.allocator)) orelse
+                    return protocol.encodeError(self.allocator, "ui-state not available");
+                defer self.allocator.free(json);
+                return protocol.encodeOkRawJson(self.allocator, json);
+            },
             .get_text => {
                 if (req.id.len == 0) return protocol.encodeError(self.allocator, "missing id");
                 const text = (try self.control.getText(self.allocator, req.id, req.recent)) orelse
@@ -166,9 +172,15 @@ const t = std.testing;
 
 const FakeControl = struct {
     sent: std.ArrayListUnmanaged(u8) = .empty,
+    ui_published: bool = true,
     fn list_panes(ctx: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
         _ = ctx;
         return try a.dupe(u8, "{\"tabs\":[]}");
+    }
+    fn ui_state(ctx: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
+        const self: *FakeControl = @ptrCast(@alignCast(ctx));
+        if (!self.ui_published) return null;
+        return try a.dupe(u8, "{\"activeOverlay\":\"command_palette\"}");
     }
     fn get_text(ctx: *anyopaque, a: std.mem.Allocator, id: []const u8, _: ?u32) anyerror!?[]u8 {
         _ = ctx;
@@ -182,7 +194,7 @@ const FakeControl = struct {
         return true;
     }
     fn iface(self: *FakeControl) control_mod.Control {
-        return .{ .ctx = self, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text } };
+        return .{ .ctx = self, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
     }
 };
 
@@ -238,6 +250,29 @@ test "dispatch panes / get-text / send-text happy + missing paths" {
     defer t.allocator.free(sr);
     try t.expect(std.mem.indexOf(u8, sr, "\"ok\":true") != null);
     try t.expectEqualStrings("echo hi\n", fc.sent.items);
+}
+
+test "dispatch ui-state returns the published overlay JSON" {
+    var fc = FakeControl{};
+    defer fc.sent.deinit(t.allocator);
+    var srv = fakeServer(&fc);
+    const u = try protocol.encodeRequest(t.allocator, .{ .token = "secret", .cmd = .ui_state });
+    defer t.allocator.free(u);
+    const ur = try srv.dispatch(u);
+    defer t.allocator.free(ur);
+    try t.expect(std.mem.indexOf(u8, ur, "\"ok\":true") != null);
+    try t.expect(std.mem.indexOf(u8, ur, "activeOverlay") != null);
+}
+
+test "dispatch ui-state reports unavailable when nothing is published" {
+    var fc = FakeControl{ .ui_published = false };
+    defer fc.sent.deinit(t.allocator);
+    var srv = fakeServer(&fc);
+    const u = try protocol.encodeRequest(t.allocator, .{ .token = "secret", .cmd = .ui_state });
+    defer t.allocator.free(u);
+    const ur = try srv.dispatch(u);
+    defer t.allocator.free(ur);
+    try t.expect(std.mem.indexOf(u8, ur, "ui-state not available") != null);
 }
 
 test "dispatch surfaces a malformed line as an error reply" {

--- a/src/ctl/ui_state.zig
+++ b/src/ctl/ui_state.zig
@@ -1,0 +1,147 @@
+//! Pure serializer for the wisptermctl `ui-state` command: derives the topmost
+//! active overlay and emits the overlay-layer semantic-state JSON. std-only so it
+//! unit-tests fast and stays decoupled from the renderer's threadlocal globals —
+//! overlays.zig snapshots those into Fields, AppWindow publishes the JSON to the
+//! ctl thread. Complements `panes` (tab/split/focus topology) with the overlay
+//! layer (which modal is up, selection, filter) that panes does not cover.
+const std = @import("std");
+
+pub const Mode = enum { commands, history };
+pub const HistorySource = enum { all, sidebar, tab };
+
+pub const Fields = struct {
+    command_palette_visible: bool = false,
+    command_palette_mode: Mode = .commands,
+    command_palette_selected: usize = 0,
+    command_palette_visible_count: usize = 0,
+    command_palette_filter: []const u8 = "",
+    history_selected: usize = 0,
+    history_source: HistorySource = .all,
+    session_launcher_visible: bool = false,
+    session_launcher_selected: usize = 0,
+    settings_visible: bool = false,
+    ai_form_visible: bool = false,
+    ssh_form_visible: bool = false,
+    ai_list_visible: bool = false,
+    ssh_list_visible: bool = false,
+    ai_history_source_visible: bool = false,
+    startup_shortcuts_visible: bool = false,
+};
+
+/// The single overlay currently capturing input, topmost-first. Session-launcher
+/// sub-forms outrank the bare launcher; the command palette is lowest.
+pub fn activeOverlay(f: Fields) []const u8 {
+    if (f.ai_form_visible) return "ai_form";
+    if (f.ssh_form_visible) return "ssh_form";
+    if (f.settings_visible) return "settings";
+    if (f.ai_list_visible) return "ai_list";
+    if (f.ssh_list_visible) return "ssh_list";
+    if (f.ai_history_source_visible) return "ai_history_source";
+    if (f.session_launcher_visible) return "session_launcher";
+    if (f.startup_shortcuts_visible) return "startup_shortcuts";
+    if (f.command_palette_visible) return "command_palette";
+    return "none";
+}
+
+fn modeStr(m: Mode) []const u8 {
+    return switch (m) {
+        .commands => "commands",
+        .history => "history",
+    };
+}
+
+fn sourceStr(s: HistorySource) []const u8 {
+    return switch (s) {
+        .all => "all",
+        .sidebar => "sidebar",
+        .tab => "tab",
+    };
+}
+
+fn appendJsonString(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), s: []const u8) !void {
+    const enc = try std.json.Stringify.valueAlloc(allocator, std.json.Value{ .string = s }, .{});
+    defer allocator.free(enc);
+    try out.appendSlice(allocator, enc);
+}
+
+fn appendBool(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), b: bool) !void {
+    try out.appendSlice(allocator, if (b) "true" else "false");
+}
+
+/// Serialize the overlay layer as one JSON object. Caller owns `out`.
+pub fn writeJson(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), f: Fields) !void {
+    try out.appendSlice(allocator, "{\"activeOverlay\":");
+    try appendJsonString(allocator, out, activeOverlay(f));
+
+    try out.appendSlice(allocator, ",\"commandPalette\":{\"visible\":");
+    try appendBool(allocator, out, f.command_palette_visible);
+    try out.appendSlice(allocator, ",\"mode\":");
+    try appendJsonString(allocator, out, modeStr(f.command_palette_mode));
+    try out.print(allocator, ",\"selected\":{d},\"visibleCount\":{d}", .{ f.command_palette_selected, f.command_palette_visible_count });
+    try out.appendSlice(allocator, ",\"filter\":");
+    try appendJsonString(allocator, out, f.command_palette_filter);
+    try out.print(allocator, ",\"historySelected\":{d},\"historySource\":", .{f.history_selected});
+    try appendJsonString(allocator, out, sourceStr(f.history_source));
+    try out.append(allocator, '}');
+
+    try out.appendSlice(allocator, ",\"sessionLauncher\":{\"visible\":");
+    try appendBool(allocator, out, f.session_launcher_visible);
+    try out.print(allocator, ",\"selected\":{d}}}", .{f.session_launcher_selected});
+
+    try out.appendSlice(allocator, ",\"settingsVisible\":");
+    try appendBool(allocator, out, f.settings_visible);
+    try out.appendSlice(allocator, ",\"aiFormVisible\":");
+    try appendBool(allocator, out, f.ai_form_visible);
+    try out.appendSlice(allocator, ",\"sshFormVisible\":");
+    try appendBool(allocator, out, f.ssh_form_visible);
+    try out.appendSlice(allocator, ",\"aiListVisible\":");
+    try appendBool(allocator, out, f.ai_list_visible);
+    try out.appendSlice(allocator, ",\"sshListVisible\":");
+    try appendBool(allocator, out, f.ssh_list_visible);
+    try out.appendSlice(allocator, ",\"aiHistorySourceVisible\":");
+    try appendBool(allocator, out, f.ai_history_source_visible);
+    try out.appendSlice(allocator, ",\"startupShortcutsVisible\":");
+    try appendBool(allocator, out, f.startup_shortcuts_visible);
+    try out.append(allocator, '}');
+}
+
+// ---- tests ----
+const t = std.testing;
+
+test "activeOverlay picks the topmost overlay, sub-forms above the bare launcher" {
+    try t.expectEqualStrings("none", activeOverlay(.{}));
+    try t.expectEqualStrings("command_palette", activeOverlay(.{ .command_palette_visible = true }));
+    // A session-launcher sub-form (ai_form) outranks both the launcher and palette.
+    try t.expectEqualStrings("ai_form", activeOverlay(.{
+        .command_palette_visible = true,
+        .session_launcher_visible = true,
+        .ai_form_visible = true,
+    }));
+    try t.expectEqualStrings("session_launcher", activeOverlay(.{ .session_launcher_visible = true }));
+    try t.expectEqualStrings("settings", activeOverlay(.{ .settings_visible = true }));
+}
+
+test "writeJson emits overlay fields with a JSON-escaped filter" {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(t.allocator);
+    try writeJson(t.allocator, &out, .{
+        .command_palette_visible = true,
+        .command_palette_mode = .history,
+        .command_palette_selected = 2,
+        .command_palette_visible_count = 9,
+        .command_palette_filter = "de\"p",
+        .history_source = .sidebar,
+    });
+    const s = out.items;
+    try t.expect(std.mem.indexOf(u8, s, "\"activeOverlay\":\"command_palette\"") != null);
+    try t.expect(std.mem.indexOf(u8, s, "\"mode\":\"history\"") != null);
+    try t.expect(std.mem.indexOf(u8, s, "\"selected\":2") != null);
+    try t.expect(std.mem.indexOf(u8, s, "\"visibleCount\":9") != null);
+    try t.expect(std.mem.indexOf(u8, s, "\"historySource\":\"sidebar\"") != null);
+    // The double-quote in the filter must be escaped, not break the JSON.
+    try t.expect(std.mem.indexOf(u8, s, "\"filter\":\"de\\\"p\"") != null);
+    // Result must be parseable JSON.
+    var parsed = try std.json.parseFromSlice(std.json.Value, t.allocator, s, .{});
+    defer parsed.deinit();
+    try t.expect(parsed.value == .object);
+}

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -23,6 +23,7 @@ const ssh_prompt = @import("../ssh_prompt.zig");
 const ssh_connection = @import("../ssh_connection.zig");
 const app_metadata = @import("../app_metadata.zig");
 const command_center_state = @import("../command_center_state.zig");
+const ctl_ui_state = @import("../ctl/ui_state.zig");
 const command_palette_history_view = @import("../command_palette_history_view.zig");
 const command_palette_model = @import("../command_palette_model.zig");
 const agent_history = @import("../agent_history.zig");
@@ -2303,6 +2304,43 @@ const SSH_PROMPT_SCAN_MAX_COLS: usize = 4096;
 
 pub fn sessionLauncherVisible() bool {
     return commandCenterStateSnapshot().sessionLauncherVisible();
+}
+
+/// Serialize the overlay layer (which modal is up, selection, filter) for the
+/// wisptermctl `ui-state` command. Reads threadlocal command-center globals, so
+/// it must run on the UI thread — AppWindow's render-tick publisher calls it and
+/// hands the JSON to the ctl server thread. Complements `panes` (topology).
+pub fn buildUiStateJson(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
+    const st = commandCenterStateSnapshot();
+    const history_mode = st.commandPaletteIsHistoryMode();
+    // commandPaletteVisibleCount() rebuilds the filtered-results scratch, so only
+    // pay for it when the palette is showing the command list.
+    const visible_count: usize = if (st.command_palette_visible and !history_mode)
+        commandPaletteVisibleCount()
+    else
+        0;
+    try ctl_ui_state.writeJson(allocator, out, .{
+        .command_palette_visible = st.command_palette_visible,
+        .command_palette_mode = if (history_mode) .history else .commands,
+        .command_palette_selected = st.command_palette_selected,
+        .command_palette_visible_count = visible_count,
+        .command_palette_filter = commandPaletteFilter(),
+        .history_selected = st.command_palette_history_selected,
+        .history_source = switch (st.command_palette_history_source) {
+            .all => .all,
+            .sidebar => .sidebar,
+            .tab => .tab,
+        },
+        .session_launcher_visible = st.session_launcher_visible,
+        .session_launcher_selected = st.session_launcher_selected,
+        .settings_visible = st.settings_visible,
+        .ai_form_visible = st.ai_form_visible,
+        .ssh_form_visible = st.ssh_form_visible,
+        .ai_list_visible = st.ai_list_visible,
+        .ssh_list_visible = st.ssh_list_visible,
+        .ai_history_source_visible = st.ai_history_source_visible,
+        .startup_shortcuts_visible = st.startup_shortcuts_visible,
+    });
 }
 
 fn commandCenterStateSnapshot() command_center_state.State {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -85,6 +85,7 @@ test {
     _ = @import("ctl/control.zig");
     _ = @import("ctl/server.zig");
     _ = @import("ctl/client.zig");
+    _ = @import("ctl/ui_state.zig");
     _ = @import("png_dimensions.zig");
     _ = @import("pdf_preview.zig");
     _ = @import("preview_gallery.zig");

--- a/src/test_posix.zig
+++ b/src/test_posix.zig
@@ -44,9 +44,12 @@ test "ctl server answers a real loopback request and stops cleanly" {
         fn send_text(_: *anyopaque, _: []const u8, _: []const u8) bool {
             return false;
         }
+        fn ui_state(_: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
+            return try a.dupe(u8, "{\"activeOverlay\":\"none\"}");
+        }
         var dummy: u8 = 0;
         fn iface() control_mod.Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
         }
     };
 
@@ -74,6 +77,16 @@ test "ctl server answers a real loopback request and stops cleanly" {
     try std.testing.expect(std.mem.indexOf(u8, buf[0..total], "\"ok\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf[0..total], "activeTab") != null);
 
+    // ui-state round-trips over the same socket protocol as panes.
+    var s_ui = try std.net.tcpConnectToAddress(addr);
+    defer s_ui.close();
+    const ui_line = try protocol.encodeRequest(std.testing.allocator, .{ .token = "tok", .cmd = .ui_state });
+    defer std.testing.allocator.free(ui_line);
+    try s_ui.writeAll(ui_line);
+    var ui_buf: [256]u8 = undefined;
+    const ui_n = try s_ui.read(&ui_buf);
+    try std.testing.expect(std.mem.indexOf(u8, ui_buf[0..ui_n], "activeOverlay") != null);
+
     // A bad token is rejected over the wire too.
     var s2 = try std.net.tcpConnectToAddress(addr);
     defer s2.close();
@@ -99,9 +112,12 @@ test "ctl server shutdown does not hang on a stalled (newline-less) connection" 
         fn send_text(_: *anyopaque, _: []const u8, _: []const u8) bool {
             return false;
         }
+        fn ui_state(_: *anyopaque, _: std.mem.Allocator) anyerror!?[]u8 {
+            return null;
+        }
         var dummy: u8 = 0;
         fn iface() control_mod.Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
         }
     };
 

--- a/src/wisptermctl.zig
+++ b/src/wisptermctl.zig
@@ -45,6 +45,7 @@ pub fn main() !void {
 
     switch (action) {
         .panes => try runOnce(allocator, info, .{ .token = info.token, .cmd = .panes }, .raw),
+        .ui_state => try runOnce(allocator, info, .{ .token = info.token, .cmd = .ui_state }, .raw),
         .get_text => |g| try runOnce(allocator, info, .{ .token = info.token, .cmd = .get_text, .id = g.id, .recent = g.recent }, .text),
         .send_text => |s| {
             const data = try client.decodeEscapes(allocator, s.data);
@@ -159,6 +160,9 @@ const USAGE =
         \\Usage:
         \\  wisptermctl panes
         \\      List tabs/panes as JSON (id, title, cwd, cols/rows, cursor, focus, geometry).
+        \\  wisptermctl ui-state
+        \\      Print overlay UI state as JSON (active overlay, command-palette
+        \\      selection/filter/mode, session launcher, settings visibility).
         \\  wisptermctl get-text -t <surface-id> [--recent N]
         \\      Print a surface's terminal text. --recent N prepends N scrollback rows.
         \\  wisptermctl send-text -t <surface-id> "<text>"

--- a/tests/macos_e2e/driver/ctl.py
+++ b/tests/macos_e2e/driver/ctl.py
@@ -27,6 +27,11 @@ class Ctl:
     def panes(self) -> dict:
         return json.loads(self._run(["panes"]))
 
+    def ui_state(self) -> dict:
+        # Overlay semantic layer (active overlay, command-palette selection/filter,
+        # session launcher, settings) — complements `panes` (topology).
+        return json.loads(self._run(["ui-state"]))
+
     def get_text(self, pane: str, recent=None) -> str:
         args = ["get-text", "-t", pane]
         if recent is not None:

--- a/tests/macos_e2e/driver/macos.py
+++ b/tests/macos_e2e/driver/macos.py
@@ -107,6 +107,10 @@ class MacDriver:
     def primary_pane(self) -> str:
         return primary_pane_id(self.ctl.panes())
 
+    def ui_state(self) -> dict:
+        # Overlay semantic state (active overlay, command-palette selection/filter).
+        return self.ctl.ui_state()
+
     # ---- real input ----
     def key(self, key_name: str, *mods: str) -> None:
         for m in mods:

--- a/tests/macos_e2e/test_ui_state.py
+++ b/tests/macos_e2e/test_ui_state.py
@@ -1,0 +1,71 @@
+"""E2E coverage for `wisptermctl ui-state` — the overlay semantic oracle.
+
+`panes` exposes tab/split/focus topology; `ui-state` adds the overlay layer
+(which modal is up, command-palette selection/filter/mode) that `get-text` and
+`panes` cannot see. Before this, overlay flows could only assert "the app stays
+responsive" (see test_copilot_history); now they can assert the actual state.
+"""
+import pytest
+
+from tests.macos_e2e.driver import wait
+
+
+def _wait_ui(app, predicate, timeout: float = 4.0):
+    """Poll ui-state until `predicate(state)` holds (the snapshot is published on
+    a ~200ms render-tick throttle, so a key press is not reflected instantly)."""
+    box = {}
+
+    def check():
+        st = app.ui_state()
+        box["last"] = st
+        return st if predicate(st) else None
+
+    try:
+        return wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"ui-state predicate unmet; last={box.get('last')}")
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_ui_state_reports_overlay_shape(app, pane):
+    """Full ctl path (build -> publish -> socket -> parse) yields a well-formed
+    overlay snapshot, independent of synthetic input working."""
+    st = app.ui_state()
+    assert "activeOverlay" in st
+    cp = st["commandPalette"]
+    assert set(["visible", "mode", "selected", "visibleCount", "filter"]).issubset(cp)
+    assert isinstance(cp["visible"], bool)
+    assert st["activeOverlay"] == "none" or isinstance(st["activeOverlay"], str)
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_command_palette_overlay_state_is_observable(app, pane):
+    """Real keyboard drives the command palette; ui-state makes the otherwise
+    invisible overlay selection/filter assertable."""
+    app.focus()
+    # Dismiss any startup overlay so we have a clean baseline.
+    app.key("escape")
+    _wait_ui(app, lambda s: s["activeOverlay"] == "none")
+
+    # Open the command palette via real keyboard. On macOS the default binding is
+    # Cmd+Shift+P (Ctrl+Shift+P elsewhere); see keybind.zig defaults.
+    app.key("p", "cmd", "shift")
+    st = _wait_ui(app, lambda s: s["activeOverlay"] == "command_palette")
+    assert st["commandPalette"]["visible"] is True
+    assert st["commandPalette"]["mode"] == "commands"
+    # Unfiltered, the palette lists many commands.
+    assert st["commandPalette"]["visibleCount"] >= 2
+
+    # Arrow navigation moves the selection — invisible to get-text, visible here.
+    app.key("down")
+    _wait_ui(app, lambda s: s["commandPalette"]["selected"] == 1)
+
+    # Typing filters the list; the filter text is reflected in ui-state.
+    app.text("s")
+    _wait_ui(app, lambda s: s["commandPalette"]["filter"] == "s")
+
+    # Escape closes it; overlay returns to none.
+    app.key("escape")
+    _wait_ui(app, lambda s: s["activeOverlay"] == "none")


### PR DESCRIPTION
## What

Adds a new `wisptermctl ui-state` command that exports the **overlay semantic layer** — the part of the UI that `panes` (tab/split/focus topology) and `get-text` (terminal text) cannot observe: which modal is up, and the command-palette selection / filter / mode.

This is the missing **semantic oracle** for macOS UI E2E tests. Until now, overlay flows could only assert "the app stays responsive" (see `test_copilot_history`); they could not assert the actual overlay state.

### Example output

```json
{"activeOverlay":"command_palette",
 "commandPalette":{"visible":true,"mode":"commands","selected":1,
                   "visibleCount":9,"filter":"s","historySelected":0,"historySource":"all"},
 "sessionLauncher":{"visible":false,"selected":0},
 "settingsVisible":false,"aiFormVisible":false,"sshFormVisible":false,
 "aiListVisible":false,"sshListVisible":false,"aiHistorySourceVisible":false,
 "startupShortcutsVisible":false}
```

## How

Reuses the proven `syncCtlPanes` pattern: the ctl server runs on a separate thread, so the UI thread serializes the threadlocal command-center state on the render tick into a process-global buffer (`g_ctl_ui_state_json`), and the ctl thread reads it under a mutex. Zero cross-thread reads of threadlocal state.

Serialization (active-overlay precedence + JSON) lives in a new pure std-only module `src/ctl/ui_state.zig`, so it unit-tests fast and stays decoupled from the renderer. `overlays.zig` only snapshots State → `Fields` and delegates.

## Layers touched

- `ctl/protocol.zig`, `ctl/client.zig`, `ctl/control.zig`, `ctl/server.zig` — `ui-state` command through every layer (each with unit tests)
- `ctl/ui_state.zig` *(new)* — pure serializer: active-overlay precedence + `writeJson`
- `renderer/overlays.zig` — `buildUiStateJson` (snapshot → Fields → delegate)
- `AppWindow.zig` — publish machinery (`ctlUiState` / `syncCtlUiState` / cache clear; vtable + render-tick wiring)
- `wisptermctl.zig` — CLI arm + help
- `tests/macos_e2e/` — `ctl.py`/`macos.py` wrappers + `test_ui_state.py` *(new)*

## Verification

- `zig build test` (fast): all ctl + ui_state unit tests pass.
- `zig build test-full -Dtarget=aarch64-macos`: full app compiles; 2309/2314 pass. The one failure is the pre-existing, known-flaky `skill center tool import` test (FileNotFound on `.zig-cache/tmp` at `AppWindow.zig:796`), unrelated to this change. The ui-state socket round-trip in `test_posix.zig` passes.
- macOS E2E `test_ui_state.py`: **2/2 pass on the real GUI** — full `build → publish → socket → parse` path, plus a real `Cmd+Shift+P` opening the command palette with ui-state reflecting `activeOverlay` / `selected` / `filter`.
- Full macOS E2E suite: 25 passed, 1 skipped — no regressions.

## Note / follow-up

While writing the E2E test, ui-state immediately paid off by exposing that `test_copilot_history.py` opens the command palette with `Ctrl+Shift+P` — but on macOS the binding is `Cmd+Shift+P` (Ctrl→Cmd migration, `keybind.zig:487`). That test's palette/history-navigation steps are therefore no-ops; it passes only because it asserts responsiveness. Tracked as a separate follow-up (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
