### PR TITLE
test(e2e): assert real overlay state in copilot history test via ui-state

### DIFF
--- a/tests/macos_e2e/conftest.py
+++ b/tests/macos_e2e/conftest.py
@@ -35,8 +35,12 @@ def _accessibility_trusted() -> bool:
         return False
 
 
-@pytest.fixture(scope="session")
-def app():
+def require_macos_gui():
+    """Skip the calling test unless this host can drive a real WispTerm.app via
+    synthetic input: macOS + importable PyObjC + a built app/ctl bundle + granted
+    Accessibility permission. Fixtures that build their own MacDriver (instead of
+    using the `app` fixture) must call this so they skip — rather than fail — when
+    those preconditions are absent."""
     if sys.platform != "darwin":
         pytest.skip("macOS-only E2E harness")
     if not _pyobjc_available():
@@ -54,6 +58,11 @@ def app():
             "Accessibility permission required: grant the terminal running pytest under "
             "System Settings → Privacy & Security → Accessibility, then retry."
         )
+
+
+@pytest.fixture(scope="session")
+def app():
+    require_macos_gui()
 
     from tests.macos_e2e.driver.macos import MacDriver
     driver = MacDriver(app_bundle=APP_BUNDLE, ctl_binary=CTL_BINARY)

--- a/tests/macos_e2e/driver/macos.py
+++ b/tests/macos_e2e/driver/macos.py
@@ -27,6 +27,7 @@ class MacDriver:
         self.home = tempfile.mkdtemp(prefix="wispterm-e2e-")
         self.pid = None
         self.ctl = Ctl(home=self.home, binary=self.ctl_binary)
+        self._kbd_token = 0
 
     @staticmethod
     def _wispterm_pids() -> set:
@@ -47,6 +48,14 @@ class MacDriver:
         os.makedirs(cfg_dir, exist_ok=True)
         with open(os.path.join(cfg_dir, "config"), "w") as f:
             f.write(_CONFIG)
+        # Pre-mark the first-run wizard as already prompted so the AI-setup form
+        # does not auto-open and capture the keyboard on a fresh launch (it has no
+        # AI profile). Without this the form swallows synthetic key input even after
+        # the command palette is opened over it (see startup_tabs.shouldAutoShowAgentForm
+        # / window_state_codec `ai-setup-prompted`). The file lives at
+        # <config_dir>/state (dirs.stateFilePath); unknown keys are tolerated.
+        with open(os.path.join(cfg_dir, "state"), "w") as f:
+            f.write("ai-setup-prompted = 1\n")
 
         env = dict(os.environ)
         env["HOME"] = self.home
@@ -112,11 +121,19 @@ class MacDriver:
         return self.ctl.ui_state()
 
     # ---- real input ----
+    # Space successive keystrokes apart. Text typed through CGEvent's Unicode path
+    # is delivered via the Input Method Kit; posting events back-to-back races IMK
+    # ("error messaging the mach port for IMKCFRunLoopWakeUpReliable") and silently
+    # drops characters, so longer strings arrive mangled or empty. A small inter-key
+    # gap makes delivery reliable (40ms keeps margin for slower/CI machines).
+    _KEY_GAP = 0.04
+
     def key(self, key_name: str, *mods: str) -> None:
         for m in mods:
             if m not in keycodes.MODIFIERS:
                 raise ValueError(f"unknown modifier: {m}")
         quartz_input.key(keycodes.keycode(key_name), quartz_input.mods_to_flags(list(mods)))
+        time.sleep(self._KEY_GAP)
 
     def text(self, s: str) -> None:
         for ch in s:
@@ -124,6 +141,33 @@ class MacDriver:
                 self.key("return")
             else:
                 quartz_input.type_char(ch)
+                time.sleep(self._KEY_GAP)
+
+    def ensure_keyboard_ready(self, pane: str = None, tries: int = 6) -> None:
+        """Warm up the OS keyboard path and block until a keystroke demonstrably
+        reaches the shell, so subsequent real-input assertions are not flaky.
+
+        The Input Method Kit connection is cold on a fresh launch (and goes cold
+        while an instance sits idle); the first CGEvent burst after that is
+        swallowed whole re-establishing it (the "IMKCFRunLoopWakeUpReliable" race),
+        landing nothing in the PTY. A dropped burst leaves no partial text, so
+        retrying is safe. Each round uses a fresh sentinel run as a shell no-op
+        (`:`), so a confirm can only succeed on the current round's keystrokes —
+        never on a previous round's leftover scrollback.
+        """
+        pane = pane or self.primary_pane()
+        for _ in range(tries):
+            self._kbd_token += 1
+            sentinel = f"__wisp_kbd_ready_{self._kbd_token}__"
+            self.focus()
+            self.text(f": {sentinel}")
+            self.key("return")
+            try:
+                self.ctl.wait_for(pane, sentinel, timeout=1.5)
+                return
+            except wait.TimeoutError:
+                continue
+        raise AssertionError("OS keyboard input path never became ready")
 
     def click(self, x: int, y: int, *, count: int = 1) -> None:
         quartz_input.click(x, y, count=count)

--- a/tests/macos_e2e/test_copilot_history.py
+++ b/tests/macos_e2e/test_copilot_history.py
@@ -4,8 +4,58 @@ import time
 
 import pytest
 
-from tests.macos_e2e.conftest import APP_BUNDLE, CTL_BINARY
+from tests.macos_e2e.conftest import APP_BUNDLE, CTL_BINARY, require_macos_gui
+from tests.macos_e2e.driver import wait
 from tests.macos_e2e.driver.macos import MacDriver
+
+
+def _wait_ui(app, predicate, timeout: float = 4.0):
+    """Poll `wisptermctl ui-state` until `predicate(state)` holds. The overlay
+    snapshot is published on a ~200ms render-tick throttle, so a key press is not
+    reflected instantly (mirrors test_ui_state.py::_wait_ui)."""
+    box = {}
+
+    def check():
+        st = app.ui_state()
+        box["last"] = st
+        return st if predicate(st) else None
+
+    try:
+        return wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"ui-state predicate unmet; last={box.get('last')}")
+
+
+# Index of the "Copilot History" command in command_center_state.zig's
+# command_entries (New Session=0, New Copilot=1, Toggle Copilot=2, Manage AI
+# Profiles=3, Copilot History=4). With an empty filter rebuildPaletteScratch lists
+# every entry in declaration order (commandEntryMatches is unconditionally true),
+# so the row sits at this fixed selection index. If the command list is reordered
+# this constant moves with it — the mode=="history" assertion after Enter catches a
+# stale value loudly.
+_COPILOT_HISTORY_INDEX = 4
+
+
+def _select_palette_command(app, target_index: int, timeout: float = 6.0):
+    """Move the commands-mode palette selection down to `target_index`, confirming
+    each step through ui-state. We navigate with arrow keys instead of typing the
+    command name: synthetic IMK text input into an overlay is unreliable on macOS
+    (it silently drops characters / whole bursts), whereas real-keycode arrow events
+    are not. Confirm-and-retry guards against a rare dropped Down, and waiting past
+    the ~200ms publish throttle before re-pressing avoids overshooting."""
+    deadline = time.monotonic() + timeout
+    while True:
+        sel = app.ui_state()["commandPalette"]["selected"]
+        if sel >= target_index:
+            return sel
+        app.key("down")
+        try:
+            _wait_ui(app, lambda s, prev=sel: s["commandPalette"]["selected"] > prev, timeout=1.0)
+        except AssertionError:
+            pass  # key dropped; loop re-reads and presses again
+        if time.monotonic() >= deadline:
+            sel = app.ui_state()["commandPalette"]["selected"]
+            raise AssertionError(f"palette selection stuck at {sel}, want {target_index}")
 
 
 def _session_record(session_id: str, title: str, model: str, updated_at_ms: int, copilot: bool):
@@ -37,6 +87,7 @@ def seeded_app():
     Writing only sessions/*.json (no index.json) exercises the storage layer's
     index-rebuild path on first launch.
     """
+    require_macos_gui()  # this test drives the palette via real keyboard, not just ctl
     driver = MacDriver(app_bundle=APP_BUNDLE, ctl_binary=CTL_BINARY)
     sessions_dir = os.path.join(driver._config_dir(), "agent-history", "sessions")
     os.makedirs(sessions_dir, exist_ok=True)
@@ -62,32 +113,52 @@ def test_copilot_history_input_driven(seeded_app):
     app.focus()
     pane = app.primary_pane()
 
-    # Baseline: app alive and terminal round-trips.
+    # Baseline: app alive and terminal round-trips. (Control-channel inject works
+    # regardless of any overlay, so this is independent of the keyboard path below.)
     app.send_text("echo before-history\n")
     app.wait_for(pane, "before-history", timeout=8)
 
-    # Open command palette (Ctrl+Shift+P), select the "Copilot History" command to
-    # enter history mode (default locale is English).
-    app.key("p", "ctrl", "shift")
-    time.sleep(0.3)
-    app.text("Copilot History")  # filter the command list to the history entry
-    time.sleep(0.3)
-    app.key("return")            # execute -> enters history mode (panel shows seeds)
-    time.sleep(0.3)
+    # Warm up the OS keyboard path before driving the palette with real keys: the
+    # IMK connection is cold on a fresh launch and swallows the first CGEvent burst
+    # whole, which would otherwise drop the Cmd+Shift+P / arrow keys below.
+    app.ensure_keyboard_ready(pane)
 
-    # Exercise the new history-mode input handlers (must not crash / not eat input).
-    app.text("deploy")           # live title filter
-    time.sleep(0.2)
-    app.key("down")              # navigate (skips group headers)
+    # Dismiss any first-launch overlay so the real-keyboard palette binding is not
+    # eaten by it.
+    app.key("escape")
+    _wait_ui(app, lambda s: s["activeOverlay"] == "none")
+
+    # Open the command palette via real keyboard. On macOS the default binding is
+    # Cmd+Shift+P (Ctrl+Shift+P elsewhere); see src/keybind.zig defaults. ui-state
+    # makes the otherwise-invisible overlay actually assertable.
+    app.key("p", "cmd", "shift")
+    st = _wait_ui(app, lambda s: s["activeOverlay"] == "command_palette")
+    assert st["commandPalette"]["mode"] == "commands"
+
+    # Select the "Copilot History" command (by row, see _select_palette_command) and
+    # execute it to enter history mode within the palette.
+    _select_palette_command(app, _COPILOT_HISTORY_INDEX)
+    app.key("return")            # execute -> enters history mode (panel shows seeds)
+    st = _wait_ui(app, lambda s: s["commandPalette"]["mode"] == "history")
+    assert st["activeOverlay"] == "command_palette"
+    source_before = st["commandPalette"]["historySource"]  # "all" on entry
+
+    # Exercise the history-mode input handlers, then assert Tab actually cycled the
+    # source filter (all -> sidebar -> tab) — invisible to get-text, visible here.
+    app.key("down")              # navigate history rows (skips group headers)
     app.key("up")
-    app.key("tab")               # cycle source filter all -> sidebar
+    app.key("tab")               # cycle source filter: all -> sidebar
+    st = _wait_ui(app, lambda s: s["commandPalette"]["historySource"] != source_before)
+    assert st["commandPalette"]["historySource"] != source_before
     app.key("tab")               # -> tab
-    time.sleep(0.2)
-    app.key("escape")            # leave history mode
-    app.key("escape")            # close palette
+
+    # First escape leaves history mode (back to commands), second closes the palette.
+    app.key("escape")
+    _wait_ui(app, lambda s: s["commandPalette"]["mode"] == "commands")
+    app.key("escape")
+    _wait_ui(app, lambda s: s["activeOverlay"] == "none")
 
     # The whole overlay-input flow must leave the app responsive and must NOT have
-    # eaten subsequent terminal input. (Overlay text is unobservable via get-text;
-    # covered by unit tests instead.)
+    # eaten subsequent terminal input.
     app.send_text("echo after-history\n")
     app.wait_for(pane, "after-history", timeout=8)


### PR DESCRIPTION
## What

Converts `tests/macos_e2e/test_copilot_history.py` from a responsiveness-only smoke into a **real overlay-state assertion** using the `wisptermctl ui-state` oracle (merged to main in #300).

The old test opened the palette with `Ctrl+Shift+P` — but the macOS default binding is **`Cmd+Shift+P`** (`src/keybind.zig`), so the palette never actually opened. Every subsequent step (`text("Copilot History")`, `return`, the history filter/nav) ran against the terminal, not the palette. It passed anyway only because it asserted "the app stays responsive" via send-text echo, never that the palette opened or history mode was entered.

## Changes

- **`test_copilot_history.py`**: open the palette with `Cmd+Shift+P`; assert via `ui-state` that `activeOverlay == "command_palette"` and `mode == "commands"`, then that entering the command flips `mode` to `"history"`, that **Tab cycles `commandPalette.historySource`**, and that two Escapes return `activeOverlay` to `"none"`. Adds a `_wait_ui` poll helper (for the ~200ms ui-state publish throttle) and a `require_macos_gui()` guard so the test **skips rather than fails** without Accessibility permission.
- **`conftest.py`**: extract the `app`-fixture preconditions into a shared `require_macos_gui()` so fixtures that build their own `MacDriver` (like `seeded_app`) skip cleanly too.
- **`driver/macos.py`**: port the three #279 harness fixes needed to drive a *fresh* instance with real keys —
  - pre-seed `<config_dir>/state` with `ai-setup-prompted = 1` (the first-run AI-setup form otherwise auto-opens and swallows all keyboard input);
  - add a 40ms inter-key gap (`_KEY_GAP`) — back-to-back CGEvents race IMK and drop characters;
  - add `ensure_keyboard_ready()` — a sentinel warm-up handshake for the cold-IMK first-burst drop.

## Why navigate instead of typing the command name

Synthetic IMK **text** input into an overlay turned out to be unreliable on macOS even after warm-up — a whole-string `app.text()` routinely drops all but the first char, and per-char typing into the overlay was measured at 0/6. Real-keycode **arrow** events, by contrast, are 100% reliable (6/6 in probing). So the test selects "Copilot History" by **row** (`_select_palette_command` navigates Down to its fixed index 4 in `command_center_state.zig`'s `command_entries`, confirming each step via ui-state) rather than typing a filter. With an empty filter `commandEntryMatches` is unconditionally true and `rebuildPaletteScratch` lists entries in declaration order, so the index is stable; the `mode == "history"` assertion validates it (a reorder would fail loudly).

## Verification

Real machine, Accessibility granted:
- copilot test run 5×: **5/5 pass** (no flakiness)
- full macOS e2e suite: **25 passed, 1 skipped** (twice; the skip is the pre-existing, unrelated `test_keybinds`)

No Zig changes — harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)