### PR TITLE
test(macos-e2e): P1 harness — real-input→PTY verification, ui-state failure dumps, determinism

### DIFF
--- a/tests/macos_e2e/.gitignore
+++ b/tests/macos_e2e/.gitignore
@@ -1,0 +1,1 @@
+_artifacts/

--- a/tests/macos_e2e/conftest.py
+++ b/tests/macos_e2e/conftest.py
@@ -76,3 +76,66 @@ def pane(app):
     """Per-test convenience: focus + return the active surface id."""
     app.focus()
     return app.primary_pane()
+
+
+# ---- failure diagnostics --------------------------------------------------
+import json
+import re
+
+ARTIFACTS_DIR = os.path.join(os.path.dirname(__file__), "_artifacts")
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """On a GUI test's failure, dump the oracles that explain *why* — panes
+    topology, terminal text, window geometry, overlay ui-state, and a screenshot
+    — so a red run is diagnosable without re-running locally. Best-effort: a
+    dump that itself fails never overrides the real test failure."""
+    outcome = yield
+    rep = outcome.get_result()
+    if rep.when != "call" or not rep.failed:
+        return
+    app = getattr(item, "funcargs", {}).get("app")
+    if app is None:
+        return  # not a GUI test (no `app` fixture) — nothing to dump
+    _dump_failure_artifacts(item, app)
+
+
+def _dump_failure_artifacts(item, app):
+    out_dir = os.path.join(ARTIFACTS_DIR, re.sub(r"[^A-Za-z0-9_.-]", "_", item.nodeid))
+    os.makedirs(out_dir, exist_ok=True)
+    written = []
+
+    def _try(name, fn):
+        try:
+            fn(os.path.join(out_dir, name))
+            written.append(name)
+        except Exception as e:
+            with open(os.path.join(out_dir, name + ".error"), "w") as f:
+                f.write(repr(e))
+
+    def _json(path, obj):
+        with open(path, "w") as f:
+            json.dump(obj, f, indent=2, ensure_ascii=False)
+
+    def _text(path, s):
+        with open(path, "w") as f:
+            f.write(s)
+
+    _try("panes.json", lambda p: _json(p, app.ctl.panes()))
+    _try("ui-state.json", lambda p: _json(p, app.ui_state()))
+    try:
+        pane = app.primary_pane()
+    except Exception:
+        pane = None
+    if pane:
+        _try("text.txt", lambda p: _text(p, app.get_text(pane)))
+    _try("window.txt", lambda p: _text(
+        p, "".join(f"{a}={app.window_attr(a)}\n" for a in ("size", "position"))))
+
+    def _shot(p):
+        if not app.screenshot(p):
+            raise RuntimeError("screencapture unavailable (Screen Recording permission?)")
+    _try("screen.png", _shot)
+
+    print(f"\n[e2e] failure artifacts for {item.nodeid} -> {out_dir} ({', '.join(written) or 'none'})")

--- a/tests/macos_e2e/driver/macos.py
+++ b/tests/macos_e2e/driver/macos.py
@@ -12,10 +12,23 @@ from .base import ItemState
 from .ctl import Ctl
 from .panes import primary_pane_id
 
+# Deterministic base config for E2E: isolate the control channel, suppress
+# network/update side effects, fix the font, and pin the locale to English so
+# command-palette entries are matched by their English names regardless of the
+# host language. The initial grid (window-width/height = cols/rows in CELLS, see
+# config.zig / App.zig) is appended per-launch.
+#
+# NOTE: we deliberately do NOT set `cursor-style-blink = false`. The blink timer
+# is what keeps the render loop ticking while otherwise idle, and ui-state is
+# published on the render tick; with blink off, the publish that should report a
+# freshly-opened overlay can lag past the assertion window, so ui-state-based
+# overlay tests flake (verified by bisection). We don't golden-diff screenshots,
+# so a blinking cursor costs us nothing here.
 _CONFIG = (
     "agent-control-enabled = true\n"
     "auto-update-check = false\n"
     "font-size = 14\n"
+    "language = en\n"
 )
 
 
@@ -46,8 +59,13 @@ class MacDriver:
     def launch(self, *, cols: int = 80, rows: int = 24) -> None:
         cfg_dir = self._config_dir()
         os.makedirs(cfg_dir, exist_ok=True)
+        # window-width/height are the initial terminal grid in CELLS, so the
+        # cross-platform launch(cols, rows) contract maps straight onto them and
+        # the window starts at a deterministic size (no longer ignored).
         with open(os.path.join(cfg_dir, "config"), "w") as f:
             f.write(_CONFIG)
+            f.write(f"window-width = {cols}\n")
+            f.write(f"window-height = {rows}\n")
         # Pre-mark the first-run wizard as already prompted so the AI-setup form
         # does not auto-open and capture the keyboard on a fresh launch (it has no
         # AI profile). Without this the form swallows synthetic key input even after
@@ -196,3 +214,33 @@ class MacDriver:
 
     def read_clipboard(self) -> str:
         return osascript.run(osascript.clipboard_script())
+
+    def screenshot(self, path: str) -> bool:
+        """Best-effort PNG capture of the test instance's frontmost window for
+        failure triage. Returns False (never raises) if capture is unavailable —
+        e.g. Screen Recording permission not granted on CI — so a diagnostic dump
+        never masks the original test failure. Captures the WispTerm window by id
+        when resolvable, else falls back to the full screen."""
+        try:
+            self.focus()
+            win_id = self._frontmost_window_id()
+            cmd = ["/usr/sbin/screencapture", "-x"]
+            if win_id is not None:
+                cmd += ["-l", str(win_id), "-o"]
+            cmd.append(path)
+            subprocess.run(cmd, timeout=10, check=True)
+            return os.path.exists(path)
+        except Exception:
+            return False
+
+    def _frontmost_window_id(self):
+        """CoreGraphics window id of our pid's on-screen window, or None."""
+        try:
+            import Quartz
+            opts = Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements
+            for w in Quartz.CGWindowListCopyWindowInfo(opts, Quartz.kCGNullWindowID) or []:
+                if w.get("kCGWindowOwnerPID") == self.pid and w.get("kCGWindowLayer", 1) == 0:
+                    return w.get("kCGWindowNumber")
+        except Exception:
+            pass
+        return None

--- a/tests/macos_e2e/test_keybinds.py
+++ b/tests/macos_e2e/test_keybinds.py
@@ -1,22 +1,37 @@
-import time
 import pytest
-
-# Blocked: a test-launched WispTerm instance does not act on synthetic keyboard
-# events (they reach -keyDown: but never drive the PTY/keybinding). See issue
-# #279. Kept (skipped) so the intended real-input coverage is ready to re-enable
-# once the app processes synthetic input under automation.
-pytestmark = pytest.mark.skip(
-    reason="blocked by #279: app does not process synthetic keyboard actions in a test-launched instance"
-)
 
 
 @pytest.mark.e2e
+@pytest.mark.macos_only
+def test_real_keyboard_text_reaches_pty(app, pane):
+    """#279 acceptance: the real-input chain end to end — synthetic keystrokes ->
+    AppKit -> input.zig -> surface -> PTY -> shell — asserted by the typed
+    command's output appearing in the terminal. Unlike send-text (control
+    channel), this exercises the actual OS keyboard path the #279 skip claimed was
+    broken under automation."""
+    app.ensure_keyboard_ready(pane)
+    marker = "real-input-ok-9417"
+    app.text(f"echo {marker}\n")
+    app.wait_for(pane, marker, timeout=8)
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "WispTerm terminals have no Cmd+A select-all (keybind.zig binds only "
+        "Cmd+C=copy on macOS); copying a selection needs a mouse triple-click + "
+        "click-coordinate helper not yet in the driver. NOT blocked by #279 — real "
+        "key input reaches the PTY (see test_real_keyboard_text_reaches_pty). "
+        "strict=True flips this to a failure if select-all/copy ever starts working."
+    ),
+)
 def test_cmd_c_copies_selection(app, pane):
-    marker = "copy-me-e2e"
+    app.ensure_keyboard_ready(pane)
+    marker = "copy-me-e2e-3382"
     app.text(marker)
     app.wait_for(pane, marker, timeout=8)
-    app.key("a", "cmd")                   # Select All
-    time.sleep(0.2)
-    app.key("c", "cmd")                   # Copy
-    time.sleep(0.2)
+    app.key("a", "cmd")   # Select All (no such binding in the terminal)
+    app.key("c", "cmd")   # Copy
     assert marker in app.read_clipboard()


### PR DESCRIPTION
## What

Three macOS UI E2E harness improvements (P1), built on the `ui-state` overlay oracle from #300. Harness-only — no `.zig` changes.

### 1. Failure auto-dump
A `pytest_runtest_makereport` hook (`conftest.py`) dumps the diagnostic oracles on **any** GUI-test failure, so a red run is explainable without re-running locally:
- `panes.json` (topology), `text.txt` (terminal text), `window.txt` (geometry), `ui-state.json` (overlay state), and a best-effort `screen.png`.
- Written to `tests/macos_e2e/_artifacts/<test>/` (gitignored); the path is printed.
- Adds `MacDriver.screenshot()` (`screencapture`, targets the WispTerm window by CoreGraphics id when resolvable). Best-effort: if Screen Recording permission is absent it degrades to a `.png.error` note and never masks the original failure.

### 2. Determinism
- `launch(cols, rows)` now writes `window-width`/`window-height` — which are the **initial terminal grid in cells** (`App.zig:237`) — so the window starts at a fixed, deterministic size instead of the params being silently ignored (verified: grid comes up exactly 80×24).
- Pins `language = en` so command-palette entries are matched by their English names regardless of host locale.

> **Deliberately NOT** setting `cursor-style-blink = false`. The blink timer is what keeps the render loop ticking while otherwise idle, and `ui-state` is published on the render tick — with blink off, the publish that should report a freshly-opened overlay lags past the assertion window, so ui-state-based overlay tests flake. Bisected. We don't golden-diff screenshots, so a blinking cursor costs nothing here. (Possible latent ui-state freshness gap worth a later look, but input events normally wake the loop, so impact is limited.)

### 3. Real keyboard → PTY + strict-xfail
- Drops the stale module-level `#279` skip in `test_keybinds.py`.
- Adds `test_real_keyboard_text_reaches_pty`: synthetic keys → AppKit → `input.zig` → surface → PTY → shell, asserted by the typed command's output appearing in the terminal (not via the control channel). **This is the #279 acceptance** — it passes on the real GUI, so the old "test instance doesn't process synthetic keyboard input" claim is false on current `main`.
- Converts `test_cmd_c_copies_selection` from `skip` to `xfail(strict=True)` with the accurate blocker: WispTerm terminals have no `Cmd+A` select-all (`keybind.zig` binds only `Cmd+C` on macOS); copying needs a mouse triple-click + click-coordinate helper not yet in the driver. `strict=True` flips it to a failure if select-all/copy ever starts working.

## Verification

Run on a real macOS GUI (Accessibility granted):
- Full `tests/macos_e2e` suite: **26 passed, 1 xfailed** (previously 25 passed, 1 skipped).
- `test_real_keyboard_text_reaches_pty` passes; `test_cmd_c_copies_selection` xfails (strict, as designed).
- Determinism config verified stable: `test_ui_state.py` 2/2 across repeated runs and within the full suite; grid measured at 80×24.
- Failure-dump hook verified with a throwaway failing test: `panes.json` / `text.txt` / `window.txt` / `ui-state.json` written, screenshot degraded to `.error` (no Screen Recording permission on this host) — original failure preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
