### PR TITLE
fix(input): make Shift+Enter insert a newline in Kitty-protocol TUIs (#302)

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -107,10 +107,27 @@ pub const VtHandler = struct {
     surface: *Surface,
 
     pub fn init(terminal: *ghostty_vt.Terminal, surface: *Surface) VtHandler {
+        var inner = terminal.vtHandler();
+        // Answer terminal query sequences by writing the reply back to the PTY.
+        // This notably includes the Kitty keyboard protocol query (`CSI ? u`):
+        // full-screen TUIs (Claude Code, Codex, …) probe for protocol support
+        // and, without a reply, conclude it is unsupported and never enable it —
+        // leaving Shift+Enter indistinguishable from Enter. See issue #302.
+        inner.effects.write_pty = &writePtyResponse;
         return .{
-            .inner = terminal.vtHandler(),
+            .inner = inner,
             .surface = surface,
         };
+    }
+
+    /// Forward a terminal-generated response (Kitty keyboard query, DSR, mode
+    /// reports, …) to the PTY. Invoked on the IO reader thread while parsing
+    /// output; `queuePtyWrite` copies the bytes and hands them to the IO writer
+    /// thread, so this is safe from here. The owning Surface is recovered from
+    /// the handler's terminal pointer, which aliases `&surface.terminal`.
+    fn writePtyResponse(handler: *InnerHandler, data: [:0]const u8) void {
+        const surface: *Surface = @fieldParentPtr("terminal", handler.terminal);
+        surface.queuePtyWrite(data);
     }
 
     pub fn deinit(self: *VtHandler) void {
@@ -1398,4 +1415,49 @@ test "Surface exposes init and initVirtual (forces analysis of the shared finish
     // allocator, cols, rows, pty, scrollback_limit, cursor_style, cursor_blink
     try std.testing.expectEqual(@as(usize, 7), info.params.len);
     try std.testing.expect(info.params[3].type.? == Pty);
+}
+
+// Build just enough of a Surface to drive the VT stream and capture the bytes
+// the terminal writes back to the PTY (no real PTY or IO threads).
+fn vtResponseHarness(surface: *Surface) !void {
+    surface.allocator = std.testing.allocator;
+    surface.terminal = try ghostty_vt.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    surface.mailbox = try termio.Mailbox.init();
+    surface.vt_stream = surface.initVtStream();
+}
+
+fn vtResponseHarnessDeinit(surface: *Surface) void {
+    surface.vt_stream.deinit();
+    surface.mailbox.deinit();
+    surface.terminal.deinit(std.testing.allocator);
+}
+
+fn expectPtyResponse(surface: *Surface, expected: []const u8) !void {
+    // The popped message owns the bytes; assert while it is still in scope so
+    // the slice into write_small.data stays valid.
+    const msg = surface.mailbox.pop() orelse return error.NoPtyResponse;
+    switch (msg) {
+        .write_small => |*w| try std.testing.expectEqualStrings(expected, w.data[0..w.len]),
+        else => return error.UnexpectedMessage,
+    }
+}
+
+test "kitty keyboard query is answered back to the PTY (issue #302)" {
+    var surface: Surface = undefined;
+    try vtResponseHarness(&surface);
+    defer vtResponseHarnessDeinit(&surface);
+
+    // crossterm/Claude Code probe support with `CSI ? u`. With no flags pushed
+    // yet the terminal must report 0 so the app knows the protocol exists.
+    surface.vt_stream.nextSlice("\x1b[?u");
+    try expectPtyResponse(&surface, "\x1b[?0u");
+
+    // After the app pushes the disambiguate flag, the query reflects it — this
+    // is the round-trip that makes the app actually turn the protocol on.
+    surface.vt_stream.nextSlice("\x1b[>1u");
+    surface.vt_stream.nextSlice("\x1b[?u");
+    try expectPtyResponse(&surface, "\x1b[?1u");
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -2877,6 +2877,28 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
     return true;
 }
 
+/// Encode a special terminal key (Enter/Backspace/Tab) honoring the Kitty
+/// keyboard protocol when the foreground app enabled it, otherwise returning
+/// the supplied legacy bytes. This is what lets Shift+Enter reach Claude
+/// Code/Codex as a distinct "insert newline" sequence (issue #302).
+fn terminalSpecialKeySeq(
+    surface: *Surface,
+    ev: platform_input.KeyEvent,
+    key: anytype,
+    buf: []u8,
+    legacy: []const u8,
+) []const u8 {
+    const ghostty_vt = @import("ghostty-vt");
+    const opts = ghostty_vt.input.KeyEncodeOptions.fromTerminal(&surface.terminal);
+    const mods: ghostty_vt.input.KeyMods = .{
+        .shift = ev.shift,
+        .ctrl = ev.ctrl,
+        .alt = ev.alt,
+        .super = ev.super,
+    };
+    return input_shortcuts.kittyKeyEncode(opts, key, mods, buf) orelse legacy;
+}
+
 fn handleKey(ev: platform_input.KeyEvent) void {
     overlays.startupShortcutsDismiss();
     const key_event = logicalKeyEvent(ev);
@@ -3453,10 +3475,14 @@ fn handleKey(ev: platform_input.KeyEvent) void {
     // not for modifier-only keys or key combos that don't produce PTY output.
     var wrote_to_pty = false;
 
+    // Scratch buffer for Kitty keyboard protocol key encoding. Only used by the
+    // Enter/Backspace/Tab arms below; harmless otherwise.
+    var kitty_buf: [128]u8 = undefined;
+
     const seq: ?[]const u8 = switch (ev.key_code) {
-        platform_input.key_enter => "\r",
-        platform_input.key_backspace => "\x7f",
-        platform_input.key_tab => if (ev.shift) "\x1b[Z" else "\t",
+        platform_input.key_enter => terminalSpecialKeySeq(surface, ev, .enter, &kitty_buf, "\r"),
+        platform_input.key_backspace => terminalSpecialKeySeq(surface, ev, .backspace, &kitty_buf, "\x7f"),
+        platform_input.key_tab => terminalSpecialKeySeq(surface, ev, .tab, &kitty_buf, if (ev.shift) "\x1b[Z" else "\t"),
         platform_input.key_escape => "\x1b",
         platform_input.key_up, platform_input.key_down, platform_input.key_right, platform_input.key_left => input_shortcuts.terminalArrowSequence(key_event, surface.terminal.modes.get(.cursor_keys)),
         platform_input.key_home => "\x1b[H",

--- a/src/input_shortcuts.zig
+++ b/src/input_shortcuts.zig
@@ -1,6 +1,41 @@
 const std = @import("std");
+const ghostty_vt = @import("ghostty-vt");
 
 const input_key = @import("input/key.zig");
+
+/// Encode a "special" terminal key (Enter, Tab, Backspace, …) using the Kitty
+/// keyboard protocol when the running application has enabled it.
+///
+/// Full-screen TUIs such as Claude Code and Codex push Kitty keyboard flags so
+/// they can tell a modified press apart from a bare one. With the protocol
+/// active this returns the disambiguated CSI-u sequence — e.g. Shift+Enter
+/// becomes "\x1b[13;2u" instead of the legacy "\r" — letting those apps treat
+/// it as "insert newline" rather than "submit" (issue #302).
+///
+/// Returns the encoded bytes (written into `buf`) when the protocol is active,
+/// or null when it is disabled, in which case the caller falls back to the
+/// historical legacy byte(s) so plain shells and non-Kitty apps are completely
+/// unaffected. A bare Enter still encodes as "\r" even while the protocol is on.
+pub fn kittyKeyEncode(
+    opts: ghostty_vt.input.KeyEncodeOptions,
+    key: ghostty_vt.input.Key,
+    mods: ghostty_vt.input.KeyMods,
+    buf: []u8,
+) ?[]const u8 {
+    // Diverge from legacy encoding only when the app opted into the Kitty
+    // keyboard protocol; otherwise signal the caller to keep existing behavior.
+    if (opts.kitty_flags.int() == 0) return null;
+
+    var writer: std.Io.Writer = .fixed(buf);
+    ghostty_vt.input.encodeKey(&writer, .{
+        .action = .press,
+        .key = key,
+        .mods = mods,
+    }, opts) catch return null;
+
+    const encoded = writer.buffered();
+    return if (encoded.len == 0) null else encoded;
+}
 
 pub fn terminalArrowSequence(ev: input_key.KeyEvent, cursor_keys: bool) ?[]const u8 {
     const modifier: u8 = 1 +
@@ -56,4 +91,43 @@ test "terminal arrow sequence handles modifiers" {
         terminalArrowSequence(.{ .key = input_key.Key.arrow_right, .ctrl = true }, false).?,
     );
     try std.testing.expect(terminalArrowSequence(.{ .key = input_key.Key.key_a, .alt = true }, false) == null);
+}
+
+const kitty_disambiguate: ghostty_vt.input.KeyEncodeOptions = .{
+    .kitty_flags = .{ .disambiguate = true },
+};
+
+test "kittyKeyEncode returns null when the Kitty keyboard protocol is disabled" {
+    var buf: [64]u8 = undefined;
+    // Protocol off (default options): caller must fall back to legacy bytes,
+    // so Shift+Enter stays a bare Enter for plain shells.
+    try std.testing.expect(kittyKeyEncode(.{}, .enter, .{ .shift = true }, &buf) == null);
+}
+
+test "kittyKeyEncode encodes Shift+Enter as CSI u when the protocol is active" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "\x1b[13;2u",
+        kittyKeyEncode(kitty_disambiguate, .enter, .{ .shift = true }, &buf).?,
+    );
+}
+
+test "kittyKeyEncode keeps a bare Enter as \\r while the protocol is active" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "\r",
+        kittyKeyEncode(kitty_disambiguate, .enter, .{}, &buf).?,
+    );
+}
+
+test "kittyKeyEncode disambiguates Shift+Tab and Shift+Backspace when active" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "\x1b[9;2u",
+        kittyKeyEncode(kitty_disambiguate, .tab, .{ .shift = true }, &buf).?,
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[127;2u",
+        kittyKeyEncode(kitty_disambiguate, .backspace, .{ .shift = true }, &buf).?,
+    );
 }

--- a/src/kitty_graphics_unit.zig
+++ b/src/kitty_graphics_unit.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const ghostty_vt = @import("ghostty-vt");
 const Surface = @import("Surface.zig");
+const termio = @import("termio.zig");
 
 test "kitty graphics APC transmit and display creates image placement" {
     const allocator = std.testing.allocator;
@@ -75,6 +76,12 @@ test "wispterm image OSC fallback translates to kitty graphics APC" {
     surface.wispterm_image_osc_state = .ground;
     surface.wispterm_image_osc_buf = .empty;
     defer surface.wispterm_image_osc_buf.deinit(allocator);
+
+    // The terminal now answers queries/transmissions back to the PTY (issue
+    // #302), and a kitty graphics transmit emits an "OK" reply, so the surface
+    // needs a real mailbox to receive it instead of writing through garbage.
+    surface.mailbox = try termio.Mailbox.init();
+    defer surface.mailbox.deinit();
 
     surface.vt_stream = Surface.VtStream.initAlloc(
         surface.terminal.screens.active.alloc,

--- a/tests/macos_e2e/test_shift_enter.py
+++ b/tests/macos_e2e/test_shift_enter.py
@@ -1,0 +1,79 @@
+"""#302 acceptance: a real Shift+Enter keystroke must reach a full-screen TUI as
+the Kitty keyboard sequence ``CSI 13 ; 2 u`` (so it means "insert newline"),
+distinct from a bare Enter's ``\\r`` ("submit").
+
+This drives the whole chain through the real GUI: CGEvent keystroke -> AppKit ->
+input.zig encoder -> Surface -> PTY, and -- because the probe first *queries*
+Kitty support -- it also exercises the terminal's query response (``effects.
+write_pty``) that lets the app turn the protocol on in the first place. Both
+halves of the fix are asserted; a regression in either fails the test instead of
+hanging (the raw-mode reads are guarded by ``select``).
+"""
+import os
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+# A raw-mode probe run inside the terminal's shell. It (1) queries Kitty keyboard
+# support and captures the reply, (2) enables the protocol, (3) signals the test
+# to press the key, then (4) dumps the next key's exact bytes. Output is hex so it
+# survives screen scraping with no control characters to confuse the matcher.
+_PROBE = r'''
+import os, sys, termios, tty, select
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+
+def read(timeout):
+    r, _, _ = select.select([fd], [], [], timeout)
+    return os.read(fd, 64) if r else b""
+
+try:
+    tty.setraw(fd)
+    os.write(1, b"\x1b[?u")           # query Kitty keyboard flags
+    qresp = read(5)                   # terminal must answer "CSI ? <flags> u"
+    os.write(1, b"\x1b[>1u")          # push the "disambiguate" flag
+    os.write(1, b"KITTYREADY\r\n")    # tell the test to press the key now
+    keybytes = read(10)              # capture the next keystroke's encoding
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.write(1, b"\x1b[<u")           # pop the flag, leave the terminal clean
+os.write(1, b"QRESP=" + qresp.hex().encode()
+         + b" KEYBYTES=" + keybytes.hex().encode() + b"\r\n")
+'''
+
+# Shift+Enter under the protocol encodes as CSI 13 ; 2 u (Enter keycode 13,
+# Shift modifier 2), NOT a bare CR.
+_SHIFT_ENTER = b"\x1b[13;2u".hex()  # "1b5b31333b3275"
+# A Kitty keyboard query reply is "CSI ? <flags> u"; its "\x1b[?" prefix is enough
+# to prove the terminal answered the probe rather than staying silent.
+_QUERY_REPLY_PREFIX = b"\x1b[?".hex()  # "1b5b3f"
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_shift_enter_sends_kitty_csi_u(app, pane):
+    app.ensure_keyboard_ready(pane)
+
+    probe_path = os.path.join(app.home, "kitty_shift_enter_probe.py")
+    with open(probe_path, "w") as f:
+        f.write(_PROBE)
+
+    # Run the probe and wait until it has answered the query, enabled the
+    # protocol, and is blocked reading the next key.
+    app.text("/usr/bin/python3 ~/kitty_shift_enter_probe.py")
+    app.key("return")
+    app.wait_for(pane, "KITTYREADY", timeout=15)
+
+    # The behavior under test: a single real Shift+Enter keystroke.
+    app.key("return", "shift")
+
+    app.wait_for(pane, f"KEYBYTES={_SHIFT_ENTER}", timeout=15)
+
+    # Same line also proves the query round-trip (Part A): without a write_pty
+    # reply the app could never have learned the protocol was supported.
+    screen = app.get_text(pane)
+    assert f"QRESP={_QUERY_REPLY_PREFIX}" in screen, (
+        f"terminal did not answer the Kitty keyboard query; screen:\n{screen}"
+    )


### PR DESCRIPTION
## Summary

Fixes #302 — Shift+Enter now inserts a newline (instead of submitting) in Kitty-keyboard-protocol TUIs such as Claude Code and Codex.

## Root cause (two compounding defects)

1. **No query responses.** WispTerm uses ghostty-vt's read-only VT handler but never set `effects.write_pty`, so it answered *no* terminal queries — including the Kitty keyboard probe `CSI ? u`. Apps (crossterm's `supports_keyboard_enhancement`, Claude Code) probe for support, get silence, and never enable the protocol.
2. **Modifier-blind Enter encoding.** The hand-rolled key encoder mapped `key_enter => "\r"` unconditionally, ignoring modifiers and the active Kitty flags.

ghostty-vt already ships a complete Kitty keyboard encoder; WispTerm was bypassing it.

## Fix

- **`Surface.zig`** — wire `VtHandler.write_pty` to forward terminal responses to the PTY via the IO-writer mailbox, so the Kitty keyboard (and DSR/mode) queries are answered and the protocol negotiates.
- **`input_shortcuts.zig` / `input.zig`** — encode Enter/Backspace/Tab via ghostty-vt's `encodeKey` when the protocol is active → Shift+Enter = `\x1b[13;2u`, plain Enter still `\r`. **The protocol-off path is byte-identical**, so plain shells are unaffected.
- **`kitty_graphics_unit.zig`** — give the partial-`Surface` test a real mailbox (a graphics transmit now emits an OK reply through write_pty).

Works for the reported **Windows → SSH → Linux → Claude Code** setup: Win32 delivers Shift+Enter with `shift=true`, and WispTerm *is* the emulator, so the remote app's query/push flow back to WispTerm's terminal.

## Tests

- `input_shortcuts`: `kittyKeyEncode` units (Shift+Enter/Tab/Backspace CSI u, gating, plain Enter stays `\r`).
- `Surface`: a Kitty keyboard query round-trips a reply to the PTY mailbox.
- `tests/macos_e2e/test_shift_enter.py`: a **real** Shift+Enter keystroke reaches a raw-mode probe as `\x1b[13;2u` through the live GUI app (also asserts the query was answered).

## Verification

- `zig build test` (fast): ✅
- `zig build test-full -Dtarget=aarch64-macos`: ✅ (the only failure is the known-flaky skill-center `.zig-cache/tmp` test)
- macOS e2e on the rebuilt app: `test_shift_enter_sends_kitty_csi_u` ✅, `test_real_keyboard_text_reaches_pty` ✅ (no regression to plain Enter/text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
