### PR TITLE
feat: ratchet structural debt + document cohesion/coupling rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,38 @@ Windows is the **primary and default development target** (`x86_64-windows-gnu`)
 
 WispTerm is split into a platform-agnostic **core** (terminal state, IO, rendering) and a per-platform **host** (window, event loop, input) that drives the core through a narrow surface API. The host interface is `src/platform/window_backend.zig`; OS facilities go through capability facades in `src/platform/`. The named contract — what the host implements, what services it supplies, and the invariants that keep the seam intact — is documented in [docs/architecture.md](docs/architecture.md). Read it before touching the platform boundary or starting a port.
 
+## Cohesion and coupling
+
+These are the **primary** architectural criteria. File length is a symptom, not the rule.
+
+A file may be large when it owns one coherent domain object and exposes a clear API. Ghostty-style large terminal-core files are acceptable because their responsibilities are narrow and their state ownership is explicit — Ghostty ships `terminal/PageList.zig` (~14.8k lines), `terminal/Terminal.zig` (~13.3k), `config/Config.zig` (~10.9k), and `terminal/Screen.zig` (~10.5k) with no scattered module globals. The smell we guard against is **responsibility entanglement**: UI presentation mixed with business mutation, input dispatch mixed with rendering, global mutable state scattered across facades, and one file becoming an import hub for unrelated features. WispTerm's largest files are smaller than Ghostty's yet harder to change because they carry all of those at once.
+
+The goal is not small files but code that can be **understood, tested, and changed locally**. Large-but-cohesive is fine; large-but-tangled must be split. New features should prefer focused modules over growing existing hub files. New UI state must live in an explicit state struct or a feature-owned module — never as another top-level `g_*` / `threadlocal` field in `AppWindow.zig`, `input.zig`, or `renderer/overlays.zig`.
+
+### Boundary guards (`src/source_guards/`)
+
+Structural debt is frozen mechanically by source-scanning ratchet tests (the same `@embedFile`-scan idiom as `input/dirty_guard.zig`). They run in `zig build test` and, because `test-full` is now a superset of `test`, in the pre-merge gate too. Each freezes a count at today's value; the count may only **shrink**. To add a case you must first remove one elsewhere — or, better, use the pattern the guard points you to.
+
+| Guard | Freezes | Today's ceiling | Escape hatch |
+|---|---|---|---|
+| `file_size_guard` | lines in any `src/**/*.zig` | < **10,000** (also `zig build check-sizes`) | split by responsibility; never raise the limit |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the four monoliths | AppWindow **67**, input **55**, overlays **48**, ai_chat **20** | put new state in a state struct (`appwindow/state.zig`, …) |
+| `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | **29** | import the real module directly, not via `AppWindow.X` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the four monoliths | AppWindow **63**, input **81**, overlays **12**, ai_chat **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
+
+The 10,000-line guard is a **runaway tripwire, not a health metric**: `check-sizes` prevents uncontrolled growth, it does not certify architectural health. A file under it can still be tangled; treat any file over **5,000 lines** as a signal to review responsibility, dependency direction, state ownership, and test boundaries. The four boundary ratchets — not the line count — are the primary enforcement mechanism.
+
+A fifth guard — a **layered-dependency** check (e.g. `renderer/overlays/*` must not import `AppWindow.zig`; `input/*` must not import a concrete renderer) — is the documented next step; it needs per-edge allowlists and lands once the boundaries it asserts have converged. The layer model and the full remediation roadmap (state structs first, then import-hub, then per-domain file splits) live in [docs/decoupling-guide.md](docs/decoupling-guide.md).
+
 ## Hard Rules
 
 When changing application **keyboard shortcuts** (bindings in `src/input.zig` and related input paths), **update `README.md`** so the [Keyboard shortcuts](README.md#keyboard-shortcuts) section stays accurate. Also update user-visible shortcut text in `src/renderer/overlays.zig` (startup overlay, command palette entries) when those strings describe the same bindings.
 
-The main render loop is **event-driven** (`src/appwindow/render_gate.zig`): a frame is drawn only when `frameNeedsRender` is true, and `overlays.anyOverlayActive()` deliberately excludes statically-open overlays (command palette / command center, session launcher / new session, settings page) to keep idle CPU low. Therefore, any **overlay or panel key/char handler** in `src/input.zig` (`handleKey`/`handleChar`) that mutates UI state — selection index, filter text, focus — **must set `AppWindow.g_force_rebuild = true; AppWindow.g_cells_valid = false;`** after consuming the event (the handler functions in `src/renderer/overlays.zig` do not self-dirty; set the two globals at the call site, as the existing overlay branches do). Omit it and the change repaints only on the next incidental wake (cursor blink ~530ms, mouse move), so arrow-key navigation visibly lags ("不跟手") identically on Windows and macOS — it is shared logic, not platform code. The cross-thread analogue for a worker thread is `window_backend.postWakeup()`; `markUiDirty()` in `AppWindow.zig` is private, which is why `input.zig` writes the two globals directly. These `input.zig` tests run only in the full app test binary (`zig build test-full`, and `zig build test-macos-ui` on macOS); the fast `zig build test` suite does **not** compile `input.zig`.
+The main render loop is **event-driven** (`src/appwindow/render_gate.zig`): a frame is drawn only when `frameNeedsRender` is true, and `overlays.anyOverlayActive()` deliberately excludes statically-open overlays (command palette / command center, session launcher / new session, settings page) to keep idle CPU low. Therefore, any **overlay or panel key/char handler** in `src/input.zig` (`handleKey`/`handleChar`) that mutates UI state — selection index, filter text, focus — **must request a repaint**, or the change paints only on the next incidental wake (cursor blink ~530ms, mouse move) and navigation visibly lags ("不跟手") identically on Windows and macOS — it is shared logic, not platform code.
+
+The mechanism is the **UI-effect boundary**, not a direct global write. Input dispatch returns a `UiEffect` (`src/appwindow/ui_effect.zig`: `consumed` / `needs_rebuild` / `cells_invalid` / `wake_backend`), and `input.zig` lands it through `requestInputRepaint()` / `requestInputRebuild()` / `applyInputEffect()`, which funnel into the single sink `AppWindow.applyUiEffect` — the only place that touches `g_force_rebuild` / `g_cells_valid` (and `window_backend.postWakeup()` for a worker thread, via `UiEffect{ .wake_backend = true }`). New or converted handlers **must return/route a `UiEffect`** and **must not write `AppWindow.g_force_rebuild` / `AppWindow.g_cells_valid` directly**: `src/input/dirty_guard.zig` enforces this on the converted regions of `input.zig`, and `src/source_guards/side_effect_guard.zig` freezes the remaining direct-write count per monolith so it can only shrink. Legacy direct writes survive only where already counted by that ratchet.
+
+These `input.zig` compiled tests run only in the full app test binary (`zig build test-full`, and `zig build test-macos-ui` on macOS); the fast `zig build test` suite does **not** compile `input.zig` (the source-scan guards `@embedFile` it as text instead). Because `test-full` now also runs the fast suite, those guards gate the pre-merge build.
 
 When publishing a new **desktop app version**, keep the desktop version surfaces synchronized before tagging or releasing: `build.zig.zon`, matching tests, release notes under `release-notes/`, package `version.txt` output, `wispterm.exe --version`, and the command center `Version` entry. The compiled desktop app reads its version from `build.zig.zon` through `build_options.app_version`; do not hard-code a second desktop version constant.
 
@@ -44,7 +71,7 @@ Tests have two steps. `zig build test` is the fast inner loop: it builds and run
 
 To quantify input responsiveness — e.g. the overlay arrow-key "feel" gated by the event-driven render loop (see the Hard Rule above) — use the opt-in frame-latency probe. Enable it with `wispterm-debug-render = true` in the config file, or `WISPTERM_RENDER_DIAGNOSTICS=1` **in the app process's own environment**. On macOS, `open Foo.app` launches via launchd and does **not** inherit your shell env, so either use the config key or run the bundle binary directly (`WISPTERM_RENDER_DIAGNOSTICS=1 ./zig-out/bin/WispTerm.app/Contents/MacOS/WispTerm`). The log lands at `%APPDATA%\wispterm\render-diagnostic.log` (Windows) / `~/Library/Application Support/wispterm/render-diagnostic.log` (macOS); `grep frame-latency` it while navigating.
 
-Two line kinds: `frame-latency input->present count=N p50/p95/max=..ms` is genuine same-iteration input→present latency (the CPU pipeline wake → process → layout → draw-submit; it excludes the inherent ~1–2 frame vblank/compositor latency, so healthy is single-digit ms). `frame-latency STALL input->present=..ms iters=K (...)` is an input that painted nothing in its own loop iteration — a no-render key (bare modifier / unfocused), or a handler that forgot to mark the UI dirty — and is kept out of the p50/p95 stats. **A STALL that fires the instant you press a navigation key inside an overlay means a handler is missing its `g_force_rebuild` (the event-driven Hard Rule regression); a sporadic STALL on stray non-navigation keys is harmless.** Pure stats live in `src/appwindow/frame_latency.zig` (unit-tested, in the fast suite); the main-loop wiring + the input→render-gate regression tests are in `src/AppWindow.zig` / `src/input.zig`.
+Two line kinds: `frame-latency input->present count=N p50/p95/max=..ms` is genuine same-iteration input→present latency (the CPU pipeline wake → process → layout → draw-submit; it excludes the inherent ~1–2 frame vblank/compositor latency, so healthy is single-digit ms). `frame-latency STALL input->present=..ms iters=K (...)` is an input that painted nothing in its own loop iteration — a no-render key (bare modifier / unfocused), or a handler that forgot to mark the UI dirty — and is kept out of the p50/p95 stats. **A STALL that fires the instant you press a navigation key inside an overlay means a handler is missing its repaint `UiEffect` (the event-driven Hard Rule regression); a sporadic STALL on stray non-navigation keys is harmless.** Pure stats live in `src/appwindow/frame_latency.zig` (unit-tested, in the fast suite); the main-loop wiring + the input→render-gate regression tests are in `src/AppWindow.zig` / `src/input.zig`.
 
 ## Windows UI Automation
 
@@ -79,10 +106,18 @@ src/                         # Desktop terminal application
 │                            #   _unsupported/_posix stubs — PTY/process, window/input
 │                            #   backends, font discovery, clipboard, file dialogs,
 │                            #   remote transport, embedded browser, updater, etc.
-├── appwindow/               # Tab and split-tree helpers for AppWindow
+├── appwindow/               # AppWindow decomposition: aggregated state model
+│                            #   (state.zig / window_state / remote_state), feature
+│                            #   bridges (weixin/agent/remote_sync), control API,
+│                            #   surface snapshots, the UiEffect boundary, tab/split
+├── input/                   # Input pipeline split out of input.zig: command
+│                            #   dispatch, UiEffect helpers, hit-test, preview/path,
+│                            #   plus source-scan guards (dirty/overlay effect)
 ├── apprt/                   # Win32/windowing support code
 ├── font/                    # Font manager, atlas, embedded fallback, sprite glyphs
 ├── renderer/                # OpenGL renderer, cell renderer, overlays, titlebar, panels
+├── source_guards/           # Cross-cutting architecture ratchets: file-size backstop
+│                            #   + global-state / import-hub / side-effect freezes
 └── termio/                  # PTY read/write threads and terminal IO mailbox
 
 remote/                      # WispTerm-specific web remote console and relay

--- a/build.zig
+++ b/build.zig
@@ -713,6 +713,29 @@ pub fn build(b: *std.Build) void {
     }
     test_step.dependOn(&b.addRunArtifact(fast_tests).step);
 
+    // The fast suite carries the architecture guards (src/source_guards/* plus
+    // the existing input/overlay guards), so make the pre-merge gate a superset
+    // of the fast loop instead of silently skipping them. Previously test-full
+    // did not run the fast tests at all.
+    test_full_step.dependOn(test_step);
+
+    // Standalone file-size backstop: `zig build check-sizes`. The fast suite
+    // also exercises it; this is the quick, dependency-free command. Runs from
+    // the repo root so the test can walk src/.
+    const check_sizes_mod = b.createModule(.{
+        .root_source_file = b.path("src/source_guards/file_size_guard.zig"),
+        .target = b.resolveTargetQuery(.{}),
+        .optimize = optimize,
+    });
+    const check_sizes_tests = b.addTest(.{
+        .name = "wispterm-check-sizes",
+        .root_module = check_sizes_mod,
+    });
+    const run_check_sizes = b.addRunArtifact(check_sizes_tests);
+    run_check_sizes.setCwd(b.path("."));
+    const check_sizes_step = b.step("check-sizes", "Fail if any src/*.zig crosses the file-size backstop");
+    check_sizes_step.dependOn(&run_check_sizes.step);
+
     // Posix-native libc-linked tests: file I/O, libc (localtime), fork, plus the
     // socketpair virtual-PTY and tmux pane I/O bridge tests. Runs on any
     // non-Windows host. Added to test-full so the store tests (ai_loop_store)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,10 @@ an experimental Linux host.
    platform runtime.
    - `src/AppWindow.zig` — window-level tabs, splits, and the render/input
      routing that drives surfaces. Platform-neutral; calls the host interface.
+     Its orchestration is being decomposed into `src/appwindow/*` (aggregated
+     state structs, the `UiEffect` invalidation boundary, and feature bridges) —
+     see the structural-debt governance in
+     [docs/decoupling-guide.md §8](decoupling-guide.md#8-structural-debt-governance-axis-b-in-practice).
    - `src/platform/window_backend.zig` — **the host interface** (see below).
    - `src/apprt/win32.zig` — the concrete Win32 host runtime behind the
      `window_backend` facade. The macOS host uses AppKit, and the experimental
@@ -109,6 +113,33 @@ comptime guards, so a violation fails the build or `zig build test`:
 Scope note: these platform-leakage checks apply to the desktop app, build, and
 shared Zig code. The `remote/` web console and packaged `plugins/` content are
 out of scope.
+
+## Internal-architecture invariants
+
+Beyond the platform seam, a second set of invariants keeps the core itself
+maintainable. **Cohesion and coupling — not file length — are the criteria**: a
+file should own one coherent responsibility with explicit state ownership. Large
+files are acceptable when they stay cohesive (Ghostty ships 10k–15k-line core
+files that do); the smell is tangled responsibility, not size. These are
+enforced by source-scan ratchet tests in `src/source_guards/` that freeze
+today's structural debt so it can only **shrink**:
+
+- **`file_size_guard`** — no `src/**/*.zig` over 10,000 lines (a runaway
+  backstop; also `zig build check-sizes`).
+- **`global_state_guard`** — the top-level `g_*` / `threadlocal` count in
+  `AppWindow.zig` / `input.zig` / `renderer/overlays.zig` / `ai_chat.zig` may
+  only shrink; new state belongs in an explicit state struct.
+- **`import_hub_guard`** — `AppWindow.zig`'s `pub const X = @import(...)`
+  re-export count may only shrink; import the real module directly, not via
+  `AppWindow.X`.
+- **`side_effect_guard`** — direct `g_force_rebuild` / `g_cells_valid` writes in
+  those files may only shrink; route UI invalidation through the `UiEffect`
+  boundary (`AppWindow.applyUiEffect`).
+
+Because `test-full` is a superset of `test`, these gate the pre-merge build. The
+cohesion criterion, the remediation roadmap, and the layer model live in
+[docs/decoupling-guide.md §8](decoupling-guide.md#8-structural-debt-governance-axis-b-in-practice);
+the contributor-facing summary is in [`AGENTS.md`](../AGENTS.md).
 
 ## Implementing a new host
 

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -88,23 +88,30 @@ renderer has **no platform-runtime leakage** (no win32/DirectWrite/WebView2 —
 true ✅), but the **GPU API itself is not behind an interface** (false ❌). The
 two claims are split in the updated roadmap.
 
-**Gap 2 — Several files conflate presentation with business logic (Axis B).**
+**Gap 2 — Several UI files conflate presentation with business logic (Axis B).**
 
-Large files mix *what a feature does* with *how it is drawn / how input is
-routed*, which makes the logic hard to test and hard to reuse under a different
-host:
+These are WispTerm's largest files. None crosses the 10,000-line backstop, yet
+each is hard to change because it carries several roles at once — the problem is
+entanglement, not raw size. For contrast, Ghostty's largest files are *bigger*
+(`terminal/PageList.zig` ~14.8k lines, `terminal/Terminal.zig` ~13.3k,
+`config/Config.zig` ~10.9k, `terminal/Screen.zig` ~10.5k) but each owns one
+coherent domain object with explicit state ownership and no scattered module
+globals, so they stay tractable. WispTerm's files are smaller and harder.
 
-| File | Size | What is tangled |
+| File | Lines | What is tangled |
 |------|------|-----------------|
-| `src/ai_chat.zig` | 248 KB | AI conversation/state/protocol logic + UI state |
-| `src/renderer/overlays.zig` | 171 KB | Many unrelated overlay renderers in one module |
-| `src/AppWindow.zig` | 149 KB / 3,742 ln | Window orchestration + GL binding + tab/split + input routing |
-| `src/input.zig` | 136 KB / 3,462 ln | Platform input handling + keybind parsing + command dispatch |
-| `src/renderer/ai_chat_renderer.zig` | 73 KB | Chat rendering (also a heavy `gl.*` site) |
+| `src/ai_chat.zig` | ~8,760 | agent config + dynamic tools + global callbacks + session lifecycle + summary/title generation + streaming + test hooks |
+| `src/renderer/overlays.zig` | ~7,670 | overlay facade + per-overlay state + input handling + layout + rendering, for many unrelated overlays in one module |
+| `src/AppWindow.zig` | ~7,090 | window orchestration + 123 imports (29 re-exported as a hub) + 67 top-level `g_*` globals + render/input routing |
+| `src/input.zig` | ~7,040 | platform events + mouse selection + panel swap + preview + AI copilot + browser + terminal mouse report + repaint side effects |
 
-These are not bugs; they are accreted responsibility. The roadmap decomposes
-them along the presentation/logic line, touching each file once (see
-[§4](#4-execution-strategy-approach-c)).
+These are accreted responsibility, not bugs. The `feat/ui-state-debt` refactor
+(PR #310) started the decomposition: it pulled `AppWindow.zig` from 10,521 down
+to ~7,090 lines, introduced the `UiEffect` boundary and the `appwindow/` state
+structs, and extracted feature bridge/control/snapshot modules — each locked by
+a source-scan guard. The remaining work, and the ratchets that now stop these
+files regrowing, are in
+[§8 — structural-debt governance](#8-structural-debt-governance-axis-b-in-practice).
 
 ---
 
@@ -256,14 +263,24 @@ with **A**. **D** is deferred until a macOS SDK environment exists.
 ### Phase B — Presentation/logic separation (non-renderer files)
 *Verifiable on Windows; runs in parallel with A.*
 
-- **B1** `input.zig` (3,462 ln): extract keybind parsing and command dispatch
-  from platform input-event handling into pure, unit-testable modules
-  (continuing `input_shortcuts.zig` / `keybind.zig`). *Ghostty: `input/` +
-  `Binding.zig` are separate from apprt input.*
-- **B2** `ai_chat.zig` (248 KB): separate conversation/state/protocol logic
-  from UI state; split into independently testable sub-modules.
-- **B3** `AppWindow.zig` (3,742 ln): layer tab/split orchestration, render
-  orchestration, and input routing (GL binding already removed in A2).
+> **Status (ui-state-debt P1–P3 landed, PR #310).** The `UiEffect` boundary
+> (`appwindow/ui_effect.zig` + `AppWindow.applyUiEffect`) and the `appwindow/`
+> state structs (`state.zig` / `window_state.zig` / `remote_state.zig`) exist,
+> and `AppWindow.zig` shed its weixin/agent/remote-sync/control/snapshot glue
+> into `appwindow/*` (10,521 → ~7,090 lines). B1/B3 are **in progress**, not
+> done. The per-file decomposition that remains and the ratchets that keep these
+> files from regrowing are in [§8](#8-structural-debt-governance-axis-b-in-practice).
+
+- **B1** `input.zig` (~7,040 ln): continue extracting the input pipeline by
+  concern (dispatch, selection, panel drag, preview, terminal mouse report) and
+  route every repaint through `UiEffect`. *Ghostty: `input/` + `Binding.zig` are
+  separate from apprt input.*
+- **B2** `ai_chat.zig` (~8,760 ln): separate agent config / session / protocol /
+  tools / streaming / summary-title from UI callbacks; inject a `Host` interface
+  instead of holding global UI triggers. Split into testable sub-modules.
+- **B3** `AppWindow.zig` (~7,090 ln): keep reducing it toward an orchestration
+  root — lifecycle, main loop, module assembly — and stop using it as the import
+  hub (GL binding already removed in A2).
 - **B4** Add unit tests for the extracted pure logic (runnable locally with
   `zig test` — see the test-execution note in project memory).
 
@@ -337,3 +354,162 @@ that gets real runtime coverage on Linux.
 
 > `remote/` is out of scope for the Ghostty comparison and for these
 > platform-leakage checks (per `AGENTS.md`, `ROADMAP.md`, and `KNOWN_ISSUES.md`).
+
+---
+
+## 8. Structural-debt governance (Axis B in practice)
+
+Axis B used to be a roadmap aspiration. It is now governed mechanically so the
+monolith UI files cannot quietly regrow while they are being decomposed. This
+section is the playbook the `AGENTS.md` "Cohesion and coupling" section points
+to.
+
+### 8.1 The criterion
+
+Cohesion and coupling — **not** line count — decide whether a file is too big. A
+file is fine when it owns one coherent responsibility, exposes a clear API, has
+explicit state ownership, a stable dependency direction, and real test coverage.
+The smell is entanglement: presentation mixed with business mutation, input
+dispatch mixed with rendering, global mutable state scattered across facades, a
+file becoming the import hub for unrelated features.
+
+Two numeric signals sit on top of that judgment, neither of which is the goal:
+
+- **> 5,000 lines** — a soft signal to review responsibility, dependency
+  direction, import fan-in/out, state ownership, and test boundaries. Not
+  enforced.
+- **≥ 10,000 lines** — a hard backstop (`file_size_guard`). A *runaway tripwire,
+  not a health certificate*: a file well under it can still be tangled, and one
+  approaching it has usually already lost cohesion. `check-sizes` prevents
+  uncontrolled growth; it does not certify architectural health.
+
+### 8.2 The boundary guards (`src/source_guards/`)
+
+These are the primary enforcement mechanism. Each is a source-scan test (the
+`@embedFile`-and-count idiom of `input/dirty_guard.zig`) that **freezes a count
+at today's value; the count may only shrink**. Adding a new occurrence fails the
+gate — you must first remove one, or use the pattern the guard names.
+
+| Guard | Freezes | Today's ceiling | Escape hatch |
+|---|---|---|---|
+| `file_size_guard` | lines in any `src/**/*.zig` (whole tree, future files too) | < 10,000 | split by responsibility; never raise the limit |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the four monoliths | AppWindow 67, input 55, overlays 48, ai_chat 20 | new state → an explicit state struct (`appwindow/state.zig`, …) |
+| `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | 29 | import the real module directly, not via `AppWindow.X` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the four monoliths | AppWindow 63, input 81, overlays 12, ai_chat 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
+
+They run in `zig build test` and — since `test-full` is now a superset of `test`
+— in the pre-merge gate. The file-size backstop is also a standalone command,
+`zig build check-sizes`.
+
+**Next guard (documented, not yet mechanized): layered-dependency.** A scan that
+forbids reverse imports across the layer model in §8.5 — e.g. `renderer/overlays/*`
+importing `AppWindow.zig`, or `input/*` importing a concrete renderer. It needs
+per-edge allowlists seeded from current violations, so it lands once those edges
+have converged rather than freezing the violations in place.
+
+### 8.3 Remediation priority
+
+Decompose in this order. The point of the ordering is to *freeze new debt first*
+and *move state before functions*, so the work never makes the files larger on
+the way to making them smaller.
+
+1. **Freeze new debt (done — the §8.2 ratchets).** No new `g_*` in the monoliths,
+   no new `AppWindow` re-export hub entry, no new direct dirty write, no file
+   over 10k. New input paths return a `UiEffect` / result; new overlays own their
+   state/input/render modules.
+2. **Finish the side-effect boundary.** Extend `UiEffect` returns from input to
+   every overlay handler, command palette, confirm modal, settings page, and
+   session launcher, so all repaint/rebuild/wake requests flow through
+   `AppWindow.applyUiEffect`. Ratchet `side_effect_guard` down as each converts.
+3. **Split state before functions.** Move scattered globals into explicit state
+   owners (`AppWindow.State`, `InputState`, `OverlayState`, `AiChatState`,
+   `RemoteState`, `BrowserState`, `PreviewState`) and ratchet `global_state_guard`
+   down. Moving functions before state only manufactures more imports.
+4. **Dismantle the import hub.** Stop routing unrelated modules through
+   `AppWindow`; convert callers to direct imports / narrow interfaces and ratchet
+   `import_hub_guard` down.
+5. **Split the big files by domain** (§8.4), in the order overlays → input →
+   ai_chat → AppWindow: overlays decompose naturally by feature; input by event
+   type and consumer; ai_chat needs its `Host`/`State`/`Session` boundaries
+   designed first; AppWindow thins out last, once its dependencies have boundaries.
+
+### 8.4 Per-file target decomposition
+
+Targets, not a mandate to hit a line number. The aim is local understandability.
+
+**`AppWindow.zig` → an orchestration root**, not a god-window. It should own
+window lifecycle, the main loop, platform-window binding, and module assembly —
+a *composer* that initializes the pieces and passes state in. Candidate splits:
+`appwindow/lifecycle.zig`, `appwindow/main_loop.zig`, `appwindow/render_bridge.zig`,
+`appwindow/state.zig`, `appwindow/actions.zig`, `appwindow/agent_bridge.zig`,
+`appwindow/remote_bridge.zig` (joining the existing `ui_effect.zig`,
+`weixin_bridge.zig`, `remote_sync.zig`, `surface_snapshots.zig`,
+`control_api.zig`). Crucially, stop adding `pub const X = @import(...)` re-exports.
+
+**`input.zig` → an input pipeline.** Split by event scenario rather than size:
+`input/pipeline.zig` (entry/dispatch), `input/key_dispatch.zig`,
+`input/mouse_dispatch.zig`, `input/selection.zig`, `input/panel_drag.zig`,
+`input/terminal_mouse.zig`, `input/overlay_dispatch.zig`,
+`input/browser_dispatch.zig`, `input/preview_dispatch.zig`, plus the existing
+`input/command_dispatch.zig` / `input/effects.zig`. Handlers should return a
+result instead of poking globals:
+
+```zig
+pub const InputResult = struct {
+    consumed: bool = false,
+    action: ?InputAction = null,
+    effect: UiEffect = .none,
+};
+```
+
+**`renderer/overlays.zig` → facade + registry.** `overlays.zig` keeps only the
+facade/registry; each overlay moves to its own module/dir
+(`command_palette/`, `settings/`, `confirm/`, `session_launcher/`,
+`ssh_profiles/`, `ai_profiles/`, `toasts/`, `update_prompt/`) with a uniform
+trio — `state.zig`, `input.zig`, `render.zig` (`+ layout.zig`/`model.zig` as
+needed) — behind a uniform interface:
+
+```zig
+pub fn visible(state: *const State) bool
+pub fn handleKey(state: *State, ev: KeyEvent) UiEffect
+pub fn handleMouse(state: *State, ev: MouseEvent) UiEffect
+pub fn render(ctx: *RenderContext, state: *const State) void
+```
+
+**`ai_chat.zig` → an agent domain.** Split by domain, not by slicing:
+`ai_chat/session.zig`, `ai_chat/settings.zig`, `ai_chat/tool_state.zig`,
+`ai_chat/access.zig`, `ai_chat/stream.zig`, `ai_chat/summary.zig`,
+`ai_chat/title.zig`, `ai_chat/memory.zig`, `ai_chat/slash_commands.zig`,
+`ai_chat/host.zig`, `ai_chat/test_support.zig`. Collapse the scattered global UI
+callbacks into one injected `Host` interface:
+
+```zig
+pub const Host = struct {
+    resume_session: ?*const fn (...) void = null,
+    open_copilot_picker: ?*const fn (...) void = null,
+    export_markdown: ?*const fn (...) void = null,
+    switch_model: ?*const fn (...) void = null,
+};
+```
+
+`AppWindow` injects the `Host`; `ai_chat` stops reaching back for window details.
+
+### 8.5 The layer model
+
+The dependency direction these guards defend. Imports should flow downward only:
+
+- **`platform/*`** — platform capabilities only; never imports app business.
+- **core / domain** (terminal state, IO, `ai_chat/*` domain) — no UI/renderer
+  imports.
+- **`input/*`** — produces actions/effects; does not render directly.
+- **`renderer/*`** — renders view state; does not perform business mutation.
+- **`appwindow/*`** — orchestration; does not carry concrete feature business.
+- **`ai_chat/*`** — owns agent/session/protocol/tools; does not know window
+  details (reaches the UI only through an injected `Host`).
+- **`remote/*`** — an independent security boundary; does not reach into
+  main-app state (also out of scope for the Ghostty/platform-leakage checks).
+
+The reverse edges worth locking first (the layered-dependency guard in §8.2):
+`renderer/overlays/*` must not import `AppWindow.zig` (only narrow types such as
+`appwindow/ui_effect.zig`); `input/*` must not import a concrete renderer module;
+`ai_chat.zig` must not hold a set of UI-trigger callbacks directly.

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,6 +60,25 @@ Test-Path .\zig-out\bin\wispterm.exe
 Get-Item .\zig-out\bin\wispterm.exe
 ```
 
+### Tests and structural guards
+
+```bash
+zig build test         # fast inner loop: platform-independent logic (src/test_fast.zig)
+zig build test-full    # complete pre-merge gate; a SUPERSET of `zig build test`
+zig build check-sizes  # the file-size backstop on its own
+```
+
+`zig build test` is sub-second when cached and does not recompile the heavy app
+binary; `zig build test-full` is the gate to run before finishing a change and
+now also runs the fast suite.
+
+Architecture is enforced by source-scan ratchet tests under `src/source_guards/`
+(file size, top-level `g_*` globals, `AppWindow` import-hub re-exports, and
+direct UI dirty-writes). Each freezes today's count so it can only **shrink** —
+adding a new occurrence fails the gate. The cohesion/coupling rationale and the
+frozen ceilings are in [`../AGENTS.md`](../AGENTS.md) and
+[decoupling-guide.md §8](decoupling-guide.md#8-structural-debt-governance-axis-b-in-practice).
+
 ## Why The UI Is Custom Drawn
 
 WispTerm's main terminal UI is intentionally custom drawn instead of composed

--- a/src/source_guards/file_size_guard.zig
+++ b/src/source_guards/file_size_guard.zig
@@ -1,0 +1,69 @@
+//! File-size backstop. A single Zig source file crossing `max_lines` fails the
+//! test gate. This is a coarse "runaway" tripwire, NOT a health metric: a file
+//! well under the limit can still be tangled. Cohesion/coupling — reviewed via
+//! the other `source_guards/` ratchets and the architecture docs — is the real
+//! criterion. See AGENTS.md and docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+/// Hard ceiling. Crossing it fails the gate. Chosen as the line `AppWindow.zig`
+/// was pulled back under (10,469 → 7,091) during the ui-state-debt refactor;
+/// the whole tree currently sits below it, so there is no exemption list.
+pub const max_lines: usize = 10_000;
+
+/// Count source lines as `wc -l` does: the number of newline bytes.
+pub fn lineCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "\n");
+}
+
+pub fn exceedsLimit(line_count: usize) bool {
+    return line_count > max_lines;
+}
+
+test "exceedsLimit triggers strictly above the limit" {
+    try std.testing.expect(!exceedsLimit(max_lines));
+    try std.testing.expect(exceedsLimit(max_lines + 1));
+    try std.testing.expect(!exceedsLimit(0));
+}
+
+test "lineCount counts newlines" {
+    try std.testing.expectEqual(@as(usize, 3), lineCount("a\nb\nc\n"));
+    try std.testing.expectEqual(@as(usize, 0), lineCount(""));
+}
+
+// The live backstop: every `.zig` under `src/` must stay under `max_lines`.
+// Covers future files too (it iterates the tree, not a fixed list). Skips
+// silently when `src/` is not reachable from the CWD so it never produces a
+// false failure when the test binary is run from an unexpected directory; it
+// only ever FAILS on a genuinely oversized file found on disk.
+test "no src/*.zig file exceeds the line backstop" {
+    const gpa = std.testing.allocator;
+    var dir = std.fs.cwd().openDir("src", .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var offenders = std.ArrayList(u8).empty;
+    defer offenders.deinit(gpa);
+
+    var walker = try dir.walk(gpa);
+    defer walker.deinit();
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".zig")) continue;
+        const source = try dir.readFileAlloc(gpa, entry.path, 16 * 1024 * 1024);
+        defer gpa.free(source);
+        const lines = lineCount(source);
+        if (exceedsLimit(lines)) {
+            try offenders.writer(gpa).print("  src/{s}: {d} lines (> {d})\n", .{ entry.path, lines, max_lines });
+        }
+    }
+
+    if (offenders.items.len != 0) {
+        std.debug.print(
+            "\nfile_size_guard: source file(s) crossed the {d}-line backstop:\n{s}" ++
+                "Split by responsibility (see docs/decoupling-guide.md), do not raise the limit.\n",
+            .{ max_lines, offenders.items },
+        );
+        return error.FileExceedsLineBackstop;
+    }
+}

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -1,0 +1,50 @@
+//! Global-state ratchet. The four monolith UI files accreted ~190 top-level
+//! `g_*` globals (state scattered across facades, hostile to isolation and to
+//! future multi-window work). This freezes each file's count at today's value:
+//! it may only shrink. New mutable UI state must land in an explicit state
+//! struct (e.g. `appwindow/state.zig`) or a feature-owned module, never as a
+//! fresh top-level global in one of these hubs. See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const global_prefixes = [_][]const u8{
+    "var g_",
+    "pub var g_",
+    "threadlocal var g_",
+    "pub threadlocal var g_",
+};
+
+const Frozen = struct {
+    name: []const u8,
+    source: []const u8,
+    /// Frozen at the current count; the ratchet may only ratchet DOWN.
+    ceiling: usize,
+};
+
+const monoliths = [_]Frozen{
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 55 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 48 },
+    .{ .name = "ai_chat.zig", .source = @embedFile("../ai_chat.zig"), .ceiling = 20 },
+};
+
+fn globalCount(source: []const u8) usize {
+    return scan.countTopLevelDecls(source, &global_prefixes);
+}
+
+test "top-level g_* globals in monolith files only shrink" {
+    var failed = false;
+    for (monoliths) |m| {
+        const count = globalCount(m.source);
+        if (count > m.ceiling) {
+            std.debug.print(
+                "global_state_guard: {s} has {d} top-level g_* globals (frozen ceiling {d}). " ++
+                    "Move new state into a state struct; do not raise the ceiling.\n",
+                .{ m.name, count, m.ceiling },
+            );
+            failed = true;
+        }
+    }
+    try std.testing.expect(!failed);
+}

--- a/src/source_guards/import_hub_guard.zig
+++ b/src/source_guards/import_hub_guard.zig
@@ -1,0 +1,31 @@
+//! Import-hub ratchet. `AppWindow.zig` re-exports whole modules via
+//! `pub const X = @import(...)`, which lets unrelated code reach them as
+//! `AppWindow.X` and quietly turns the window object into the import hub for the
+//! whole app (123 imports today). This freezes the re-export count: it may only
+//! shrink. New code must import the real module directly
+//! (`@import("appwindow/tab.zig")`), not add another forward through
+//! `AppWindow`. See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const app_window = @embedFile("../AppWindow.zig");
+
+/// Frozen at the current count; the ratchet may only ratchet DOWN.
+const reexport_ceiling: usize = 29;
+
+fn reexportCount(source: []const u8) usize {
+    return scan.countTopLevelLinesContaining(source, "pub const ", "= @import(");
+}
+
+test "AppWindow module re-exports only shrink" {
+    const count = reexportCount(app_window);
+    if (count > reexport_ceiling) {
+        std.debug.print(
+            "import_hub_guard: AppWindow.zig re-exports {d} modules via `pub const X = @import(...)` " ++
+                "(frozen ceiling {d}). Import the real module directly; do not add another AppWindow forward.\n",
+            .{ count, reexport_ceiling },
+        );
+        return error.ImportHubGrew;
+    }
+}

--- a/src/source_guards/scan.zig
+++ b/src/source_guards/scan.zig
@@ -1,0 +1,76 @@
+//! Shared source-scanning primitives for the cross-cutting `source_guards/`
+//! ratchet tests. Pure `std`-only helpers so they live in the fast suite and
+//! can be unit-tested against synthetic inputs.
+
+const std = @import("std");
+
+/// Count non-overlapping occurrences of `needle` in `haystack`. An empty needle
+/// counts as zero so callers never divide by it.
+pub fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
+    if (needle.len == 0) return 0;
+    var count: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, haystack, i, needle)) |pos| {
+        count += 1;
+        i = pos + needle.len;
+    }
+    return count;
+}
+
+/// Count source lines that begin (with no leading indentation) with any of
+/// `prefixes`. Indented lines never match, so this only sees top-level decls.
+pub fn countTopLevelDecls(source: []const u8, prefixes: []const []const u8) usize {
+    var count: usize = 0;
+    var lines = std.mem.splitScalar(u8, source, '\n');
+    while (lines.next()) |line| {
+        for (prefixes) |prefix| {
+            if (std.mem.startsWith(u8, line, prefix)) {
+                count += 1;
+                break;
+            }
+        }
+    }
+    return count;
+}
+
+/// Count top-level lines that begin with `start_prefix` (no leading
+/// indentation) and also contain `substr` somewhere on the line.
+pub fn countTopLevelLinesContaining(source: []const u8, start_prefix: []const u8, substr: []const u8) usize {
+    var count: usize = 0;
+    var lines = std.mem.splitScalar(u8, source, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.startsWith(u8, line, start_prefix) and std.mem.indexOf(u8, line, substr) != null) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+test "countOccurrences counts non-overlapping needles" {
+    try std.testing.expectEqual(@as(usize, 2), countOccurrences("g_x = true; g_x = false;", "g_x = "));
+    try std.testing.expectEqual(@as(usize, 2), countOccurrences("aaaa", "aa"));
+    try std.testing.expectEqual(@as(usize, 0), countOccurrences("abc", "x"));
+    try std.testing.expectEqual(@as(usize, 0), countOccurrences("abc", ""));
+}
+
+test "countTopLevelDecls matches only unindented prefix lines" {
+    const src =
+        \\var g_foo = 1;
+        \\    var g_bar = 2;
+        \\pub var g_baz = 3;
+        \\threadlocal var g_qux = 4;
+        \\fn notAGlobal() void {}
+    ;
+    const prefixes = [_][]const u8{ "var g_", "pub var g_", "threadlocal var g_", "pub threadlocal var g_" };
+    try std.testing.expectEqual(@as(usize, 3), countTopLevelDecls(src, &prefixes));
+}
+
+test "countTopLevelLinesContaining requires unindented start prefix and substring" {
+    const src =
+        \\pub const A = @import("a.zig");
+        \\const B = @import("b.zig");
+        \\pub const C = foo.Bar;
+        \\    pub const D = @import("d.zig");
+    ;
+    try std.testing.expectEqual(@as(usize, 1), countTopLevelLinesContaining(src, "pub const ", "= @import("));
+}

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -1,0 +1,48 @@
+//! Side-effect ratchet. UI invalidation must converge on the effect boundary:
+//! input/overlay/command handlers return a `UiEffect`, and `AppWindow.applyUiEffect`
+//! is the one place that maps it onto the `g_force_rebuild` / `g_cells_valid`
+//! dirty globals (plus `window_backend.postWakeup()`). This freezes the number
+//! of DIRECT writes to those globals per monolith file at today's value; it may
+//! only shrink. New handlers must return an effect, not poke the globals.
+//!
+//! `input/dirty_guard.zig` already locks the converted regions of `input.zig`
+//! function-by-function; this is the whole-file backstop across all four hubs.
+//! See AGENTS.md (the render-gate Hard Rule) and docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const Frozen = struct {
+    name: []const u8,
+    source: []const u8,
+    /// Frozen at the current count; the ratchet may only ratchet DOWN.
+    ceiling: usize,
+};
+
+const monoliths = [_]Frozen{
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 63 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 12 },
+    .{ .name = "ai_chat.zig", .source = @embedFile("../ai_chat.zig"), .ceiling = 0 },
+};
+
+fn directWriteCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "g_force_rebuild = ") +
+        scan.countOccurrences(source, "g_cells_valid = ");
+}
+
+test "direct dirty-global writes in monolith files only shrink" {
+    var failed = false;
+    for (monoliths) |m| {
+        const count = directWriteCount(m.source);
+        if (count > m.ceiling) {
+            std.debug.print(
+                "side_effect_guard: {s} has {d} direct dirty-global writes (frozen ceiling {d}). " ++
+                    "Return a UiEffect and land it through AppWindow.applyUiEffect; do not raise the ceiling.\n",
+                .{ m.name, count, m.ceiling },
+            );
+            failed = true;
+        }
+    }
+    try std.testing.expect(!failed);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -58,6 +58,13 @@ test {
     _ = @import("renderer/overlays/session_launcher.zig");
     _ = @import("renderer/overlays/state.zig");
     _ = @import("renderer/overlays/state_guard.zig");
+    // Cross-cutting architecture ratchets (file size + global-state / import-hub /
+    // side-effect freezes). See docs/decoupling-guide.md.
+    _ = @import("source_guards/scan.zig");
+    _ = @import("source_guards/file_size_guard.zig");
+    _ = @import("source_guards/global_state_guard.zig");
+    _ = @import("source_guards/import_hub_guard.zig");
+    _ = @import("source_guards/side_effect_guard.zig");
     _ = @import("renderer/overlays/transfer_toast_model.zig");
     _ = @import("renderer/overlays/update_prompt_model.zig");
     _ = @import("renderer/overlays/whats_new_model.zig");


### PR DESCRIPTION
## What

Institutionalizes **cohesion/coupling as the architecture criterion** — line
count is only a coarse backstop (Ghostty itself ships cohesive 10k–15k-line core
files such as `PageList.zig`/`Terminal.zig`/`Config.zig`). It freezes today's
structural debt mechanically so it can only shrink, and writes down the
criterion, the remediation roadmap, and the layer model.

WispTerm's largest files are *smaller* than Ghostty's yet harder to change
because they carry tangled responsibilities + scattered globals + import-hub
duties at once. This PR adds guards + docs only — **no business refactor**.

## Guards (`src/source_guards/`, source-scan ratchets in the fast suite)

Each freezes the current count; the count may only **shrink**. Adding a new
occurrence fails the gate.

| Guard | Freezes | Today's ceiling |
|---|---|---|
| `file_size_guard` | lines in any `src/**/*.zig` (future files too) | < 10,000 (also `zig build check-sizes`) |
| `global_state_guard` | top-level `g_*`/`threadlocal` in the 4 monoliths | AppWindow 67 / input 55 / overlays 48 / ai_chat 20 |
| `import_hub_guard` | `AppWindow` `pub const X = @import(...)` re-exports | 29 |
| `side_effect_guard` | direct `g_force_rebuild`/`g_cells_valid` writes | AppWindow 63 / input 81 / overlays 12 / ai_chat 0 |

`file_size_guard` was proven to fail on a real >10,000-line fixture (then
removed). The ratchets were seeded by measuring the real counts via a RED run.

## Build

- New `zig build check-sizes` (the file-size backstop standalone).
- `test-full` now depends on `test`, so these guards — and the pre-existing fast
  guards (`dirty_guard`, etc.) — gate the pre-merge build. **Previously
  `test-full` did not run the fast suite at all.** (On Windows, `test-full` now
  also runs the fast suite — a few extra seconds.)

## Docs

- **AGENTS.md** — new `## Cohesion and coupling` section (criterion + guard table
  + >5k review / 10k hard stop); rewrote the event-driven Hard Rule from the
  manual `g_force_rebuild` write to the `UiEffect` boundary; refreshed the
  `appwindow/` / `input/` / `source_guards/` structure entries.
- **docs/decoupling-guide.md** — fixed the stale §1 audit line counts (AppWindow
  3,742 → ~7,090, etc.); noted ui-state-debt (PR #310) progress in §5 Phase B;
  added **§8 structural-debt governance** (guard toolkit, 5-level remediation
  priority, per-file decomposition targets, layer model).
- **docs/architecture.md** — AppWindow internal-decomposition note + an
  Internal-architecture invariants section.
- **docs/development.md** — documents `test` / `test-full` / `check-sizes` + the guards.

## Verification

`zig build test`, `zig build test-full`, `zig build check-sizes` all green.

## Scope / follow-ups

- Deliberately untouched: `docs/superpowers/`, `remote/`, README user-facing content.
- Documented but **not yet mechanized**: a 5th **layered-dependency** guard
  (reverse-import bans, e.g. `renderer/overlays/*` ↛ `AppWindow.zig`) — needs
  per-edge allowlists once those boundaries converge.
- Ghostty line figures come from a static scan; adjust if the pinned snapshot differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkUzyQDomuYLJC6rG13qCW
