### PR TITLE
Remove test-only public helpers

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -459,14 +459,12 @@ test "AppWindow: skill center tool enabled update matches manifest path" {
             .executable_path = @constCast("/tmp/tools/tool_a/bin/tool_a"),
             .skill_path = @constCast("/tmp/tools/tool_a/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
         .{ .tool = .{
             .name = @constCast("tool_b"),
             .executable_path = @constCast("/tmp/tools/tool_b/bin/tool_b"),
             .skill_path = @constCast("/tmp/tools/tool_b/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
     };
 
@@ -512,7 +510,6 @@ test "AppWindow: skill center first-party enabled update matches name only" {
             .executable_path = @constCast("/tmp/tools/webread/bin/webread"),
             .skill_path = @constCast("/tmp/tools/webread/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
     };
 
@@ -684,7 +681,6 @@ test "AppWindow: skill center import picker allows empty library and blocks tool
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -752,7 +748,6 @@ test "AppWindow: skill center tool toggle failure uses toggle status" {
         .executable_path = executable_path,
         .skill_path = null,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -6263,7 +6258,7 @@ fn runMainLoop(self: *AppWindow) !void {
     // - So total subtracted from fb_height: 54 + 20 = 74
     //   Wait, let me recalculate...
     //   Actually: content_h = fb_height - (10+34) - 10 = fb_height - 54
-    //   Then setScreenSize: avail_h = content_h - 20 = fb_height - 74
+    //   Then setScreenSizeWithPolicy: avail_h = content_h - 20 = fb_height - 74
     //
     // Actually there might be edge extension for top/bottom too. Let me just match exactly:
     // For a full-window single split (at all edges):
@@ -6273,7 +6268,7 @@ fn runMainLoop(self: *AppWindow) !void {
     //
     // Looking at the code: only left/right edges get extension, not top/bottom.
     // So:
-    //   setScreenSize(pw=fb_width, ph=fb_height-54, explicit_padding)
+    //   setScreenSizeWithPolicy(pw=fb_width, ph=fb_height-54, explicit_padding)
     //   avail_w = fb_width - 10 - 22 = fb_width - 32
     //   avail_h = (fb_height - 54) - 10 - 10 = fb_height - 74
     const titlebar_height = currentTitlebarHeight();

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -719,17 +719,6 @@ pub const ResizePolicy = enum {
 /// on the IO thread via queueIo() with 25ms coalescing.
 ///
 /// Returns true if the grid dimensions changed (resize was queued).
-pub fn setScreenSize(
-    self: *Surface,
-    screen_width: u32,
-    screen_height: u32,
-    cell_width: f32,
-    cell_height: f32,
-    explicit_padding: renderer.size.Padding,
-) bool {
-    return self.setScreenSizeWithPolicy(screen_width, screen_height, cell_width, cell_height, explicit_padding, .coalesced);
-}
-
 pub fn setScreenSizeWithPolicy(
     self: *Surface,
     screen_width: u32,

--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -32,16 +32,6 @@ pub const CategoryCounts = struct {
     subagent: usize = 0,
 };
 
-pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
-    return switch (category) {
-        .all => true,
-        .codex => provider == .codex,
-        .claude => provider == .claude,
-        .reasonix => provider == .reasonix,
-        .subagent => false,
-    };
-}
-
 pub fn isSubagentSession(meta: SessionMeta) bool {
     const title = std.mem.trimLeft(u8, meta.title, " \t\r\n");
     return std.mem.startsWith(u8, title, "You are");
@@ -234,15 +224,37 @@ test "ai_history_types: recent sort is descending with session id tie break" {
     try std.testing.expectEqualStrings("b", rows[2].session_id);
 }
 
-test "ai_history_types: categoryMatches respects provider" {
-    try std.testing.expect(categoryMatches(.all, .codex));
-    try std.testing.expect(categoryMatches(.all, .claude));
-    try std.testing.expect(categoryMatches(.codex, .codex));
-    try std.testing.expect(!categoryMatches(.codex, .claude));
-    try std.testing.expect(categoryMatches(.claude, .claude));
-    try std.testing.expect(!categoryMatches(.claude, .codex));
-    try std.testing.expect(categoryMatches(.reasonix, .reasonix));
-    try std.testing.expect(!categoryMatches(.reasonix, .codex));
+test "ai_history_types: categoryMatchesMeta respects provider" {
+    const codex: SessionMeta = .{
+        .provider = .codex,
+        .session_id = "codex",
+        .title = "Codex task",
+        .source_path = "codex.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const claude: SessionMeta = .{
+        .provider = .claude,
+        .session_id = "claude",
+        .title = "Claude task",
+        .source_path = "claude.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    const reasonix: SessionMeta = .{
+        .provider = .reasonix,
+        .session_id = "reasonix",
+        .title = "Reasonix task",
+        .source_path = "reasonix.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+
+    try std.testing.expect(categoryMatchesMeta(.all, codex));
+    try std.testing.expect(categoryMatchesMeta(.all, claude));
+    try std.testing.expect(categoryMatchesMeta(.codex, codex));
+    try std.testing.expect(!categoryMatchesMeta(.codex, claude));
+    try std.testing.expect(categoryMatchesMeta(.claude, claude));
+    try std.testing.expect(!categoryMatchesMeta(.claude, codex));
+    try std.testing.expect(categoryMatchesMeta(.reasonix, reasonix));
+    try std.testing.expect(!categoryMatchesMeta(.reasonix, codex));
 }
 
 test "ai_history_types: You are titles are classified as subagent metadata" {

--- a/src/appwindow/control_api.zig
+++ b/src/appwindow/control_api.zig
@@ -142,13 +142,6 @@ pub fn syncUiState(allocator: std.mem.Allocator) void {
     g_ctl_ui_state_json = owned;
 }
 
-pub fn buildPanesJson(allocator: std.mem.Allocator) ![]u8 {
-    var out: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer out.deinit(allocator);
-    try appendPanesJson(allocator, &out);
-    return out.toOwnedSlice(allocator);
-}
-
 /// Lightweight panes listing for the agent-control API. Mirrors
 /// buildRemoteLayoutJson's terminal branch but omits the heavy per-surface
 /// scrollback snapshot (that is get-text's job) and adds the surface cwd.
@@ -254,10 +247,11 @@ test "control api panes json includes empty tab topology" {
     active_tab_state.g_active_tab = 0;
     tab.g_tab_count = 0;
 
-    const json = try buildPanesJson(std.testing.allocator);
-    defer std.testing.allocator.free(json);
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(std.testing.allocator);
+    try appendPanesJson(std.testing.allocator, &out);
 
-    try std.testing.expectEqualStrings("{\"activeTab\":0,\"tabs\":[]}", json);
+    try std.testing.expectEqualStrings("{\"activeTab\":0,\"tabs\":[]}", out.items);
 }
 
 test "ctl surface callbacks reject an unregistered id without dereferencing" {

--- a/src/appwindow/skill_center_actions.zig
+++ b/src/appwindow/skill_center_actions.zig
@@ -1888,7 +1888,6 @@ fn skillCenterEntryFromInstalledTool(
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = tool.enabled,
-        .approval = .ask,
     } };
 }
 

--- a/src/command_center_state.zig
+++ b/src/command_center_state.zig
@@ -301,49 +301,58 @@ pub fn historyRowsNeedCleanup(previous: State, next: State) bool {
         (!next.command_palette_visible or next.command_palette_mode != .agent_history);
 }
 
-pub fn findCommandAction(title: []const u8) ?CommandAction {
-    for (command_entries) |entry| {
-        if (std.mem.eql(u8, entry.title, title)) return entry.action;
-    }
-    return null;
-}
-
 pub fn resolveNewAgentLaunch(has_profiles: bool) NewAgentLaunchAction {
     return if (has_profiles) .connect_default_profile_as_agent else .open_form;
 }
 
+fn expectCommandEntry(title: []const u8, action: CommandAction) !void {
+    for (command_entries) |entry| {
+        if (std.mem.eql(u8, entry.title, title)) {
+            try std.testing.expectEqual(action, entry.action);
+            return;
+        }
+    }
+    return error.CommandEntryNotFound;
+}
+
+fn expectNoCommandEntry(title: []const u8) !void {
+    for (command_entries) |entry| {
+        if (std.mem.eql(u8, entry.title, title)) return error.UnexpectedCommandEntry;
+    }
+}
+
 test "command center includes New Copilot action" {
-    try std.testing.expectEqual(CommandAction.new_agent, findCommandAction("New Copilot"));
+    try expectCommandEntry("New Copilot", .new_agent);
 }
 
 test "command center exposes Toggle Copilot" {
-    try std.testing.expectEqual(CommandAction.toggle_ai_copilot, findCommandAction("Toggle Copilot"));
+    try expectCommandEntry("Toggle Copilot", .toggle_ai_copilot);
 }
 
 test "command center includes Manage AI Profiles action" {
-    try std.testing.expectEqual(CommandAction.manage_ai_profiles, findCommandAction("Manage AI Profiles"));
+    try expectCommandEntry("Manage AI Profiles", .manage_ai_profiles);
 }
 
 test "command center includes Copilot History action" {
-    try std.testing.expectEqual(CommandAction.select_agent_history, findCommandAction("Copilot History"));
+    try expectCommandEntry("Copilot History", .select_agent_history);
 }
 
 test "command catalog no longer has a Load Copilot Conversation entry" {
-    try std.testing.expectEqual(@as(?CommandAction, null), findCommandAction("Load Copilot Conversation"));
+    try expectNoCommandEntry("Load Copilot Conversation");
 }
 
 test "command center includes update check actions" {
-    try std.testing.expectEqual(CommandAction.check_for_updates, findCommandAction("Check for Updates"));
-    try std.testing.expectEqual(CommandAction.download_update, findCommandAction("Download Update"));
-    try std.testing.expectEqual(CommandAction.open_latest_release, findCommandAction("Open Latest Release"));
+    try expectCommandEntry("Check for Updates", .check_for_updates);
+    try expectCommandEntry("Download Update", .download_update);
+    try expectCommandEntry("Open Latest Release", .open_latest_release);
 }
 
-test "findCommandAction resolves What's New" {
-    try std.testing.expectEqual(CommandAction.show_whats_new, findCommandAction("What's New"));
+test "command center includes What's New action" {
+    try expectCommandEntry("What's New", .show_whats_new);
 }
 
 test "command center includes Skill Center action" {
-    try std.testing.expectEqual(CommandAction.open_skill_center, findCommandAction("Skill Center"));
+    try expectCommandEntry("Skill Center", .open_skill_center);
     for (command_entries) |entry| {
         if (entry.action == .open_skill_center) {
             try std.testing.expect(std.mem.indexOf(u8, entry.detail, "tools") != null or std.mem.indexOf(u8, entry.detail, "Tools") != null);
@@ -365,15 +374,15 @@ test "Skill Center is on the default first command center page" {
 }
 
 test "command center includes Port Forwarding action" {
-    try std.testing.expectEqual(CommandAction.open_port_forwarding, findCommandAction("Port Forwarding"));
+    try expectCommandEntry("Port Forwarding", .open_port_forwarding);
 }
 
-test "findCommandAction resolves Open Jupyter" {
-    try std.testing.expectEqual(CommandAction.open_jupyter_panel, findCommandAction("Open Jupyter"));
+test "command center includes Open Jupyter action" {
+    try expectCommandEntry("Open Jupyter", .open_jupyter_panel);
 }
 
-test "findCommandAction resolves Load OpenSSH Config" {
-    try std.testing.expectEqual(CommandAction.load_openssh_config, findCommandAction("Load OpenSSH Config"));
+test "command center includes Load OpenSSH Config action" {
+    try expectCommandEntry("Load OpenSSH Config", .load_openssh_config);
 }
 
 test "Load OpenSSH Config is not on the default first command center page" {
@@ -388,16 +397,16 @@ test "Load OpenSSH Config is not on the default first command center page" {
 }
 
 test "command center includes Copilot Markdown export actions" {
-    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown, findCommandAction("Export Copilot Markdown"));
-    try std.testing.expectEqual(CommandAction.export_ai_chat_markdown_clean, findCommandAction("Export Copilot Markdown Clean"));
+    try expectCommandEntry("Export Copilot Markdown", .export_ai_chat_markdown);
+    try expectCommandEntry("Export Copilot Markdown Clean", .export_ai_chat_markdown_clean);
 }
 
 test "command center includes WeChat direct actions" {
-    try std.testing.expectEqual(CommandAction.connect_wechat, findCommandAction("Connect WeChat"));
-    try std.testing.expectEqual(CommandAction.start_wechat, findCommandAction("WeChat: Start"));
-    try std.testing.expectEqual(CommandAction.stop_wechat, findCommandAction("WeChat: Stop"));
-    try std.testing.expectEqual(CommandAction.wechat_status, findCommandAction("WeChat: Status"));
-    try std.testing.expectEqual(CommandAction.unbind_wechat, findCommandAction("WeChat: Unbind"));
+    try expectCommandEntry("Connect WeChat", .connect_wechat);
+    try expectCommandEntry("WeChat: Start", .start_wechat);
+    try expectCommandEntry("WeChat: Stop", .stop_wechat);
+    try expectCommandEntry("WeChat: Status", .wechat_status);
+    try expectCommandEntry("WeChat: Unbind", .unbind_wechat);
 }
 
 test "command center browser text is backend neutral" {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -512,45 +512,6 @@ fn copyRootPathOnly(path: []const u8) void {
     g_root_path_len = len;
 }
 
-/// Enter remote mode with the given SSH connection.
-pub fn enterRemoteMode(conn: *const ssh_connection.SshConnection, remote_cwd: []const u8) void {
-    g_async_context_id +%= 1;
-    g_mode = .remote;
-    g_ssh_conn = conn.*;
-    g_has_ssh_conn = true;
-    if (remote_cwd.len > 0) {
-        setRoot(remote_cwd);
-    } else {
-        g_root_path_len = 0;
-        rescanRemote();
-    }
-}
-
-/// Switch back to local mode.
-pub fn enterLocalMode() void {
-    g_async_context_id +%= 1;
-    g_pending_async_list = null;
-    g_loading = false;
-    g_mode = .local;
-    g_has_ssh_conn = false;
-    g_entry_count = 0;
-    g_root_path_len = 0;
-}
-
-/// Enter WSL mode. Paths are Linux-style and listed via the platform backend.
-pub fn enterWslMode(wsl_cwd: []const u8) void {
-    g_async_context_id +%= 1;
-    g_pending_async_list = null;
-    g_loading = false;
-    g_mode = .wsl;
-    g_has_ssh_conn = false;
-    if (wsl_cwd.len > 0) {
-        setRoot(wsl_cwd);
-    } else {
-        setRoot("~");
-    }
-}
-
 pub fn setRoot(path: []const u8) void {
     g_async_context_id +%= 1;
     const len = @min(path.len, g_root_path.len);
@@ -1695,17 +1656,6 @@ pub fn uploadFolder(local_path: []const u8) void {
     _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, name, scp.transferDirWithControl);
 }
 
-pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
-    return uploadLocalPathToRemoteSpecWithTransferFns(
-        local_path,
-        dst_spec,
-        display_name,
-        conn,
-        scp.transferWithControl,
-        scp.transferDirWithControl,
-    );
-}
-
 fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, transfer_fn: TransferFn) bool {
     return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
@@ -1740,10 +1690,6 @@ pub fn uploadLocalFileToRemoteSpecWithCompletion(
     completion: TransferCompletion,
 ) bool {
     return startTransferJobWithCompletion(.upload, conn, local_path, dst_spec, display_name, pickUploadTransferFn(local_path), completion);
-}
-
-pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
-    return downloadRemotePathToPath(remote_path, local_path, display_name, conn, false);
 }
 
 pub fn downloadRemotePathToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, is_dir: bool) bool {

--- a/src/first_party_tools.zig
+++ b/src/first_party_tools.zig
@@ -85,10 +85,6 @@ pub const DisabledTools = struct {
     }
 };
 
-pub fn platformLocalCommandNameForTest() []const u8 {
-    return platform_process.localCommandToolName();
-}
-
 pub fn activeDefinitions(allocator: std.mem.Allocator) ![]Definition {
     var list: std.ArrayListUnmanaged(Definition) = .empty;
     errdefer list.deinit(allocator);
@@ -124,10 +120,6 @@ pub fn isKnown(name: []const u8) bool {
     return catalogDisableable(name) != null;
 }
 
-pub fn isDisableable(name: []const u8) bool {
-    return catalogDisableable(name) orelse false;
-}
-
 fn catalogDisableable(name: []const u8) ?bool {
     if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
     if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
@@ -141,7 +133,7 @@ fn definitionDisableable(definitions: []const Definition, name: []const u8) ?boo
     return null;
 }
 
-pub fn isKnownActive(defs: []const Definition, name: []const u8) bool {
+fn catalogContains(defs: []const Definition, name: []const u8) bool {
     for (defs) |definition| {
         if (std.mem.eql(u8, definition.name, name)) return true;
     }
@@ -268,11 +260,12 @@ test "first_party_tools: active definitions include webread and the local comman
     const a = std.testing.allocator;
     const defs = try activeDefinitions(a);
     defer freeDefinitions(a, defs);
+    const local_name = platform_process.localCommandToolName();
 
-    try std.testing.expect(isKnownActive(defs, "webread"));
-    try std.testing.expect(isKnownActive(defs, platformLocalCommandNameForTest()));
-    try std.testing.expect(isDisableable("webread"));
-    try std.testing.expect(isDisableable(platformLocalCommandNameForTest()));
+    try std.testing.expect(catalogContains(defs, "webread"));
+    try std.testing.expect(catalogContains(defs, local_name));
+    try std.testing.expectEqual(@as(?bool, true), catalogDisableable("webread"));
+    try std.testing.expectEqual(@as(?bool, true), catalogDisableable(local_name));
 }
 
 test "first_party_tools: disabled state json filters unknown and duplicate names" {

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -113,10 +113,6 @@ const Server = struct {
             std.mem.eql(u8, self.sshPort(), conn.port()) and
             std.mem.eql(u8, self.proxyJump(), conn.proxyJump());
     }
-
-    fn matchesSurface(self: *const Server, surface: *const Surface) bool {
-        return surfaceIdsEqual(&self.source_surface_id, &surface.remote_id);
-    }
 };
 
 threadlocal var g_servers: [MAX_SERVERS]?Server = [_]?Server{null} ** MAX_SERVERS;
@@ -128,13 +124,6 @@ pub fn deinit() void {
 
 pub fn stopAll() void {
     for (&g_servers) |*slot| stopServer(slot);
-}
-
-pub fn stopForSurface(surface: *const Surface) void {
-    for (&g_servers) |*slot| {
-        const server = if (slot.*) |*server| server else continue;
-        if (server.matchesSurface(surface)) stopServer(slot);
-    }
 }
 
 pub fn stopForSurfaceId(source_surface_id: *const [16]u8) void {
@@ -857,9 +846,9 @@ test "html_server: public stop API shape stays stable" {
 }
 
 test "html_server: public surface stop API shape stays stable" {
-    const info = @typeInfo(@TypeOf(stopForSurface)).@"fn";
+    const info = @typeInfo(@TypeOf(stopForSurfaceId)).@"fn";
     try std.testing.expectEqual(@as(usize, 1), info.params.len);
-    try std.testing.expect(info.params[0].type.? == *const Surface);
+    try std.testing.expect(info.params[0].type.? == *const [16]u8);
     try std.testing.expect(info.return_type.? == void);
 }
 

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -200,10 +200,6 @@ pub fn openForSurface(allocator: std.mem.Allocator, surface: *Surface, path: []c
     return .{ .url = url };
 }
 
-pub fn commandForKindForTest(allocator: std.mem.Allocator, kind: model.ServerKind, port: u16) ![]u8 {
-    return serverCommandForKindAlloc(allocator, kind, port);
-}
-
 fn ensureServerForSurface(allocator: std.mem.Allocator, surface: *Surface, root: []const u8, file_name: []const u8) Error!u16 {
     if (root.len == 0 or root.len > MAX_ROOT_BYTES) return error.PathTooLong;
 
@@ -888,19 +884,35 @@ test "html_server: non-html model check rejects markdown" {
 }
 
 test "html_server: command builder emits python and node server commands" {
-    const py3 = try commandForKindForTest(std.testing.allocator, .python3, 49152);
+    const py3 = try serverCommandForKindAlloc(std.testing.allocator, .python3, 49152);
     defer std.testing.allocator.free(py3);
     try std.testing.expect(std.mem.indexOf(u8, py3, "python3 -m http.server 49152 --bind 127.0.0.1") != null);
 
-    const py2 = try commandForKindForTest(std.testing.allocator, .python2, 49153);
+    const py2 = try serverCommandForKindAlloc(std.testing.allocator, .python2, 49153);
     defer std.testing.allocator.free(py2);
     try std.testing.expect(std.mem.indexOf(u8, py2, "SimpleHTTPServer") != null);
     try std.testing.expect(std.mem.indexOf(u8, py2, "49153") != null);
 
-    const node = try commandForKindForTest(std.testing.allocator, .node_inline, 49154);
+    const node = try serverCommandForKindAlloc(std.testing.allocator, .node_inline, 49154);
     defer std.testing.allocator.free(node);
     try std.testing.expect(std.mem.indexOf(u8, node, "node -e") != null);
     try std.testing.expect(std.mem.indexOf(u8, node, "49154") != null);
+}
+
+test "html_server: server probe order prefers python before node" {
+    const script = serverProbeScript();
+    const python3 = std.mem.indexOf(u8, script, "echo python3").?;
+    const python = std.mem.indexOf(u8, script, "command -v python ").?;
+    const python2 = std.mem.indexOf(u8, script, "command -v python2").?;
+    const node = std.mem.indexOf(u8, script, "command -v node").?;
+    const npx = std.mem.indexOf(u8, script, "command -v npx").?;
+    try std.testing.expect(python3 < python);
+    try std.testing.expect(python < python2);
+    try std.testing.expect(python2 < node);
+    try std.testing.expect(node < npx);
+    try std.testing.expectEqual(model.ServerKind.python3, probeOutputToKind("python3\n").?);
+    try std.testing.expectEqual(model.ServerKind.node_inline, probeOutputToKind("node\n").?);
+    try std.testing.expectEqual(@as(?model.ServerKind, null), probeOutputToKind("none\n"));
 }
 
 test "html_server: remote ready probe verifies an HTTP response" {

--- a/src/html_server_model.zig
+++ b/src/html_server_model.zig
@@ -10,30 +10,9 @@ pub const ServerKind = enum {
     npx_http_server,
 };
 
-pub const Probe = struct {
-    python3: bool = false,
-    py_launcher_python3: bool = false,
-    python_is_python3: bool = false,
-    python_is_python2: bool = false,
-    python2: bool = false,
-    node: bool = false,
-    npx_http_server: bool = false,
-};
-
 pub fn isHtmlPath(path: []const u8) bool {
     if (std.mem.startsWith(u8, path, "http://") or std.mem.startsWith(u8, path, "https://")) return false;
     return endsWithIgnoreCase(path, ".html") or endsWithIgnoreCase(path, ".htm");
-}
-
-pub fn chooseServerKind(probe: Probe) ?ServerKind {
-    if (probe.python3) return .python3;
-    if (probe.py_launcher_python3) return .py_launcher_python3;
-    if (probe.python_is_python3) return .python3_via_python;
-    if (probe.python2) return .python2;
-    if (probe.python_is_python2) return .python2_via_python;
-    if (probe.node) return .node_inline;
-    if (probe.npx_http_server) return .npx_http_server;
-    return null;
 }
 
 pub fn percentEncodeSegment(allocator: std.mem.Allocator, segment: []const u8) ![]u8 {
@@ -77,17 +56,6 @@ test "html_server_model: detects html path suffixes only" {
     try std.testing.expect(!isHtmlPath("README.md"));
     try std.testing.expect(!isHtmlPath("html"));
     try std.testing.expect(!isHtmlPath("https://example.com/index.html"));
-}
-
-test "html_server_model: server candidate ordering prefers target python before node" {
-    try std.testing.expectEqual(ServerKind.python3, chooseServerKind(.{ .python3 = true, .node = true }).?);
-    try std.testing.expectEqual(ServerKind.py_launcher_python3, chooseServerKind(.{ .py_launcher_python3 = true, .node = true }).?);
-    try std.testing.expectEqual(ServerKind.python3_via_python, chooseServerKind(.{ .python_is_python3 = true, .python2 = true }).?);
-    try std.testing.expectEqual(ServerKind.python2, chooseServerKind(.{ .python2 = true, .node = true }).?);
-    try std.testing.expectEqual(ServerKind.python2_via_python, chooseServerKind(.{ .python_is_python2 = true, .node = true }).?);
-    try std.testing.expectEqual(ServerKind.node_inline, chooseServerKind(.{ .node = true, .npx_http_server = true }).?);
-    try std.testing.expectEqual(ServerKind.npx_http_server, chooseServerKind(.{ .npx_http_server = true }).?);
-    try std.testing.expectEqual(@as(?ServerKind, null), chooseServerKind(.{}));
 }
 
 test "html_server_model: percent-encodes path segment for URL" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -572,7 +572,6 @@ test "input: skill center tool toggle requests a repaint" {
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
     session.mutex.lock();
     session.model.setEntries(entries);
@@ -763,7 +762,6 @@ test "input: skill center tool toggle is blocked while selection overlay is acti
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = true,
-        .approval = .ask,
     } };
 
     const picker_labels = try allocator.alloc([]u8, 1);
@@ -924,7 +922,6 @@ test "input: skill center deploy and import keys ignore selected tool rows" {
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -1319,7 +1316,6 @@ test "input: skill center main actions are blocked while import list overlay is 
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = true,
-        .approval = .ask,
     } };
 
     var import_target = try AppWindow.skill_center.Target.dupe(allocator, "local", "Local", .claude, true);
@@ -2270,13 +2266,6 @@ pub fn copyRemoteSessionKeyToClipboard() bool {
 // ============================================================================
 // Shared helpers (used by input + cell_renderer)
 // ============================================================================
-
-/// Get the viewport's absolute row offset into the scrollback.
-/// Row 0 on screen corresponds to absolute row `viewportOffset()`.
-pub fn viewportOffset() usize {
-    const surface = AppWindow.activeSurface() orelse return 0;
-    return viewportOffsetForSurface(surface);
-}
 
 pub const ScrollbarState = struct {
     total: usize,
@@ -4564,7 +4553,7 @@ fn handleTerminalSelectionPress(ev: platform_input.MouseButtonEvent, xpos: f64, 
 
     const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
     const open_mod = primaryOpenMod(ev.ctrl, ev.super);
-    const click_action = terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, open_mod, ev.shift, ev.alt);
+    const click_action = terminalPathClickAction(clicked_surface.launch_kind, open_mod, ev.shift, ev.alt);
     // Only instrument the SSH download gesture (Ctrl/Cmd+Shift) so the log is not
     // flooded by every terminal click. This shows whether a download gesture
     // routed to `download_ssh_file` and whether the surface had SSH metadata.
@@ -4878,7 +4867,7 @@ fn updateInteractiveUnderlineAtMouse(xpos: f64, ypos: f64, ctrl: bool, shift: bo
     const allocator = AppWindow.g_allocator orelse return;
     const cell_pos = mouseToSurfaceCell(surface, xpos, ypos);
 
-    const action = terminalPathClickAction(surface.launch_kind, surface.ssh_connection != null, primaryOpenMod(ctrl, super), shift, alt);
+    const action = terminalPathClickAction(surface.launch_kind, primaryOpenMod(ctrl, super), shift, alt);
     const token = extractInteractiveUnderlineRangeAtCell(allocator, surface, cell_pos, action) orelse {
         clearUrlUnderline();
         return;

--- a/src/input/effects.zig
+++ b/src/input/effects.zig
@@ -17,26 +17,6 @@ pub inline fn rebuildOnly() UiEffect {
     return rebuild_only;
 }
 
-pub inline fn consumedOnly() UiEffect {
-    return UiEffect.consumed_only;
-}
-
-pub inline fn repaintIf(changed: bool) UiEffect {
-    return if (changed) repaint() else UiEffect.none;
-}
-
-pub inline fn rebuildIf(changed: bool) UiEffect {
-    return if (changed) rebuildOnly() else UiEffect.none;
-}
-
-pub inline fn mergeRepaint(effect: UiEffect, changed: bool) UiEffect {
-    return if (changed) effect.merge(repaint()) else effect;
-}
-
-pub inline fn mergeRebuild(effect: UiEffect, changed: bool) UiEffect {
-    return if (changed) effect.merge(rebuildOnly()) else effect;
-}
-
 pub inline fn fromDirtyFlags(force_rebuild: bool, cells_valid: bool) UiEffect {
     return .{
         .consumed = true,
@@ -52,26 +32,6 @@ test "input effects expose repaint and rebuild-only semantics" {
     try std.testing.expect(repaint_effect.cells_invalid);
 
     const rebuild_effect = rebuildOnly();
-    try std.testing.expect(rebuild_effect.consumed);
-    try std.testing.expect(rebuild_effect.needs_rebuild);
-    try std.testing.expect(!rebuild_effect.cells_invalid);
-}
-
-test "input effects conditional helpers preserve none when unchanged" {
-    try std.testing.expectEqual(UiEffect.none, repaintIf(false));
-    try std.testing.expectEqual(UiEffect.none, rebuildIf(false));
-    try std.testing.expect(repaintIf(true).cells_invalid);
-    try std.testing.expect(!rebuildIf(true).cells_invalid);
-}
-
-test "input effects merge helpers add only requested invalidation" {
-    const base = UiEffect.consumed_only;
-    const repaint_effect = mergeRepaint(base, true);
-    try std.testing.expect(repaint_effect.consumed);
-    try std.testing.expect(repaint_effect.needs_rebuild);
-    try std.testing.expect(repaint_effect.cells_invalid);
-
-    const rebuild_effect = mergeRebuild(base, true);
     try std.testing.expect(rebuild_effect.consumed);
     try std.testing.expect(rebuild_effect.needs_rebuild);
     try std.testing.expect(!rebuild_effect.cells_invalid);

--- a/src/input/terminal_link_action.zig
+++ b/src/input/terminal_link_action.zig
@@ -26,8 +26,7 @@ pub fn primaryOpenMod(ctrl: bool, super: bool) bool {
     return if (builtin.target.os.tag == .macos) super else ctrl;
 }
 
-pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, has_ssh_conn: bool, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
-    _ = has_ssh_conn;
+pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
     if (mod and shift and !alt and launch_kind == .ssh) return .download_ssh_file;
     if (mod and !shift and !alt) return .open_url_or_preview;
     return .pass_through;
@@ -94,19 +93,15 @@ test "primary open modifier is Cmd on macOS, Ctrl elsewhere" {
 test "terminal path click action maps ctrl shift ssh to download" {
     try std.testing.expectEqual(
         TerminalPathClickAction.download_ssh_file,
-        terminalPathClickAction(.ssh, true, true, true, false),
-    );
-    try std.testing.expectEqual(
-        TerminalPathClickAction.download_ssh_file,
-        terminalPathClickAction(.ssh, false, true, true, false),
+        terminalPathClickAction(.ssh, true, true, false),
     );
     try std.testing.expectEqual(
         TerminalPathClickAction.pass_through,
-        terminalPathClickAction(.wsl, false, true, true, false),
+        terminalPathClickAction(.wsl, true, true, false),
     );
     try std.testing.expectEqual(
         TerminalPathClickAction.open_url_or_preview,
-        terminalPathClickAction(.ssh, true, true, false, false),
+        terminalPathClickAction(.ssh, true, false, false),
     );
 }
 

--- a/src/port_forward_rule.zig
+++ b/src/port_forward_rule.zig
@@ -132,10 +132,6 @@ pub fn parsePort(text: []const u8) ?u16 {
     return @intCast(value);
 }
 
-pub fn freeRules(allocator: std.mem.Allocator, rules: []Rule) void {
-    allocator.free(rules);
-}
-
 pub fn encodeRules(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), rules: []const Rule) !void {
     try out.appendSlice(allocator, "# WispTerm port forwarding rules. Fields are hex encoded: name, profile, direction, local_host, local_port, remote_host, remote_port, enabled, auto_start.\n");
     for (rules) |rule| {
@@ -160,21 +156,6 @@ pub fn encodeRules(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8
         try appendHexField(allocator, out, if (rule.auto_start) "true" else "false");
         try out.append(allocator, '\n');
     }
-}
-
-pub fn decodeRules(allocator: std.mem.Allocator, content: []const u8) ![]Rule {
-    var rules: std.ArrayListUnmanaged(Rule) = .empty;
-    errdefer rules.deinit(allocator);
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line_raw| {
-        const line = std.mem.trimRight(u8, line_raw, "\r");
-        if (line.len == 0 or line[0] == '#') continue;
-        if (decodeRuleLine(line)) |rule| {
-            try rules.append(allocator, rule);
-        }
-    }
-    return rules.toOwnedSlice(allocator);
 }
 
 pub fn decodeRuleLine(line: []const u8) ?Rule {
@@ -304,7 +285,7 @@ test "port_forward_rule: forward specs match ssh -L and -R semantics" {
     try std.testing.expectEqualStrings("-L", rule.direction.flag());
 }
 
-test "port_forward_rule: storage round trips two rules" {
+test "port_forward_rule: storage encodes two rules" {
     var rules = [_]Rule{
         defaultReverseProxy("devbox"),
         defaultReverseProxy("lab"),
@@ -319,15 +300,10 @@ test "port_forward_rule: storage round trips two rules" {
     defer out.deinit(std.testing.allocator);
     try encodeRules(std.testing.allocator, &out, rules[0..]);
 
-    var decoded = try decodeRules(std.testing.allocator, out.items);
-    defer freeRules(std.testing.allocator, decoded);
-
-    try std.testing.expectEqual(@as(usize, 2), decoded.len);
-    try std.testing.expectEqual(Direction.reverse, decoded[0].direction);
-    try std.testing.expectEqualStrings("devbox", decoded[0].profileName());
-    try std.testing.expectEqual(Direction.local, decoded[1].direction);
-    try std.testing.expectEqualStrings("Jupyter", decoded[1].name());
-    try std.testing.expect(!decoded[1].auto_start);
+    try std.testing.expect(std.mem.startsWith(u8, out.items, "# WispTerm port forwarding rules."));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "646576626F78") != null); // devbox
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "4A757079746572") != null); // Jupyter
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "66616C7365") != null); // false
 }
 
 test "port_forward_rule: decoder rejects extra fields" {

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -166,8 +166,6 @@ pub fn scrollBy(self: *PreviewPane, delta: f32) void {
     self.scroll_offset = @max(0, @min(self.max_scroll, self.scroll_offset + delta));
 }
 
-pub fn isContentTruncated(self: *const PreviewPane) bool { return self.content_truncated; }
-
 pub fn zoomImageBySteps(self: *PreviewPane, steps: usize, zoom_in: bool) bool {
     if (!self.kind.isRaster()) return false;
     var next = self.image_zoom;
@@ -735,12 +733,12 @@ test "PreviewPane: truncated text read is ready and flags content as truncated" 
     try std.testing.expect(p.beginAsyncLoadWith(.text, "big.log", "big.log", .local, fakeTruncatedReadOk));
     drainJobs(p);
     try std.testing.expectEqual(LoadStatus.ready, p.load_status);
-    try std.testing.expect(p.isContentTruncated());
+    try std.testing.expect(p.content_truncated);
     try std.testing.expectEqualStrings("line1\nline2\n", p.sourceText());
 
     // Loading new content clears the truncated flag.
     p.open(.markdown, "b.md", "b.md", "# hi");
-    try std.testing.expect(!p.isContentTruncated());
+    try std.testing.expect(!p.content_truncated);
 }
 
 test "PreviewPane: scrollBy clamps to the renderer-reported max_scroll" {

--- a/src/render_diagnostics.zig
+++ b/src/render_diagnostics.zig
@@ -69,10 +69,6 @@ pub fn close() void {
     g_file_open = false;
 }
 
-pub fn logFilePath(allocator: std.mem.Allocator) ![]const u8 {
-    return platform_dirs.pathInConfigDir(allocator, LOG_BASENAME);
-}
-
 fn ensureFile() !*std.fs.File {
     if (g_file_open) return &g_file;
 

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -620,10 +620,7 @@ fn buildUploadCommand(buf: *[2048]u8, remote_path: []const u8, local_path: []con
 }
 
 fn buildDownloadCommand(buf: *[2048]u8, remote_path: []const u8) ?[]const u8 {
-    var pos: usize = 0;
-    if (!appendSlice(buf, &pos, "cat -- ")) return null;
-    if (!appendShellQuote(buf, &pos, remote_path)) return null;
-    return buf[0..pos];
+    return buildRemoteReadCommand(buf, remote_path);
 }
 
 /// Build `cat -- '<path>'` to stream a remote file's bytes to stdout.

--- a/src/selection_unit.zig
+++ b/src/selection_unit.zig
@@ -5,13 +5,6 @@ pub const ColRange = struct {
     end: usize,
 };
 
-pub const RowRange = struct {
-    start_row: usize,
-    end_row: usize,
-    start_col: usize,
-    end_col: usize,
-};
-
 pub const default_word_delimiters = "\\ :;~`!@#$%^&*()=+|[]{}'\",<>?";
 
 pub fn wordRange(row: []const u21, col: usize) ?ColRange {
@@ -24,56 +17,6 @@ pub fn wordRange(row: []const u21, col: usize) ?ColRange {
     while (end + 1 < row.len and isWordCodepoint(row[end + 1])) : (end += 1) {}
 
     return .{ .start = start, .end = end };
-}
-
-pub fn sentenceRange(row: []const u21, col: usize) ?ColRange {
-    if (col >= row.len) return null;
-    const first = firstNonBlankCol(row) orelse return null;
-    const last = lastNonBlankCol(row) orelse return null;
-    if (col < first or col > last) return null;
-
-    var start: usize = 0;
-    var cursor = col;
-    while (cursor > 0) {
-        cursor -= 1;
-        if (isSentenceTerminator(row[cursor])) {
-            start = cursor + 1;
-            while (start <= last and isSentenceCloser(row[start])) : (start += 1) {}
-            break;
-        }
-    }
-    while (start <= last and isBlankCodepoint(row[start])) : (start += 1) {}
-
-    var end = last;
-    cursor = col;
-    while (cursor <= last) : (cursor += 1) {
-        if (isSentenceTerminator(row[cursor])) {
-            end = cursor;
-            while (end + 1 <= last and isSentenceCloser(row[end + 1])) : (end += 1) {}
-            break;
-        }
-    }
-    while (end > start and isBlankCodepoint(row[end])) : (end -= 1) {}
-
-    if (start > end) return null;
-    return .{ .start = start, .end = end };
-}
-
-pub fn paragraphRange(rows: []const []const u21, row: usize) ?RowRange {
-    if (row >= rows.len or rowIsBlank(rows[row])) return null;
-
-    var start_row = row;
-    while (start_row > 0 and !rowIsBlank(rows[start_row - 1])) : (start_row -= 1) {}
-
-    var end_row = row;
-    while (end_row + 1 < rows.len and !rowIsBlank(rows[end_row + 1])) : (end_row += 1) {}
-
-    return .{
-        .start_row = start_row,
-        .end_row = end_row,
-        .start_col = firstNonBlankCol(rows[start_row]) orelse 0,
-        .end_col = lastNonBlankCol(rows[end_row]) orelse 0,
-    };
 }
 
 /// Range covering a single row's text, from its first to last non-blank cell.
@@ -169,17 +112,6 @@ fn isBlankCodepoint(cp: u21) bool {
     return cp == 0 or cp <= 0x20;
 }
 
-fn isSentenceTerminator(cp: u21) bool {
-    return cp == '.' or cp == '!' or cp == '?';
-}
-
-fn isSentenceCloser(cp: u21) bool {
-    return switch (cp) {
-        '"', '\'', ')', ']', '}' => true,
-        else => false,
-    };
-}
-
 test "selection unit: word range selects an alphanumeric token" {
     const row = comptime toCodepoints("alpha beta_42.");
     try std.testing.expectEqual(ColRange{ .start = 6, .end = 13 }, wordRange(&row, 8).?);
@@ -192,25 +124,6 @@ test "selection unit: word range uses configured delimiter set" {
     try std.testing.expectEqual(ColRange{ .start = 38, .end = 41 }, wordRange(&row, 40).?);
     try std.testing.expect(wordRange(&row, 26) == null);
     try std.testing.expect(wordRange(&row, 37) == null);
-}
-
-test "selection unit: sentence range trims surrounding whitespace and includes terminator" {
-    const row = comptime toCodepoints("  first sentence. second one!  ");
-    try std.testing.expectEqual(ColRange{ .start = 18, .end = 28 }, sentenceRange(&row, 23).?);
-}
-
-test "selection unit: paragraph range selects contiguous nonblank rows" {
-    const row0 = comptime toCodepoints("");
-    const row1 = comptime toCodepoints("  first line");
-    const row2 = comptime toCodepoints("second line  ");
-    const row3 = comptime toCodepoints("   ");
-    const rows = [_][]const u21{ &row0, &row1, &row2, &row3 };
-    try std.testing.expectEqual(RowRange{
-        .start_row = 1,
-        .end_row = 2,
-        .start_col = 2,
-        .end_col = 10,
-    }, paragraphRange(&rows, 2).?);
 }
 
 test "selection unit: line range spans first to last nonblank cell" {

--- a/src/session_persist.zig
+++ b/src/session_persist.zig
@@ -158,48 +158,6 @@ pub fn countLeaves(node: *const NodeSnap) u32 {
     };
 }
 
-/// Return a pointer to the Nth leaf in pre-order, or null if out of range.
-pub fn leafByIndex(root: *const NodeSnap, target: u32) ?*const NodeSnap {
-    var idx: u32 = 0;
-    return walk(root, target, &idx);
-}
-
-fn walk(node: *const NodeSnap, target: u32, idx: *u32) ?*const NodeSnap {
-    return switch (node.*) {
-        .leaf => blk: {
-            if (idx.* == target) break :blk node;
-            idx.* += 1;
-            break :blk null;
-        },
-        .split => |sp| blk: {
-            if (walk(sp.left, target, idx)) |found| break :blk found;
-            if (walk(sp.right, target, idx)) |found| break :blk found;
-            break :blk null;
-        },
-    };
-}
-
-/// Return the pre-order leaf index of the given leaf node, or null if not in tree.
-pub fn indexOfLeaf(root: *const NodeSnap, target: *const NodeSnap) ?u32 {
-    var idx: u32 = 0;
-    return findIndex(root, target, &idx);
-}
-
-fn findIndex(node: *const NodeSnap, target: *const NodeSnap, idx: *u32) ?u32 {
-    return switch (node.*) {
-        .leaf => blk: {
-            if (node == target) break :blk idx.*;
-            idx.* += 1;
-            break :blk null;
-        },
-        .split => |sp| blk: {
-            if (findIndex(sp.left, target, idx)) |found| break :blk found;
-            if (findIndex(sp.right, target, idx)) |found| break :blk found;
-            break :blk null;
-        },
-    };
-}
-
 test "session_persist: empty Session compiles and has expected defaults" {
     const empty: Session = .{ .tabs = &.{} };
     try std.testing.expectEqual(@as(u32, SCHEMA_VERSION), empty.version);
@@ -582,29 +540,6 @@ test "session_persist: normalize() clamps ratio above 1" {
         else => return error.UnexpectedLeaf,
     };
     try std.testing.expect(sp.ratio <= 0.95);
-}
-
-test "session_persist: leafByIndexPreOrder walks pre-order" {
-    var l1 = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
-    var l2 = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
-    var l3 = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
-    var inner = NodeSnap{ .split = .{ .layout = .vertical, .ratio = 0.5, .left = &l1, .right = &l2 } };
-    var root = NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &inner, .right = &l3 } };
-
-    try std.testing.expectEqual(@as(u32, 3), countLeaves(&root));
-    try std.testing.expectEqual(@as(?*const NodeSnap, &l1), leafByIndex(&root, 0));
-    try std.testing.expectEqual(@as(?*const NodeSnap, &l2), leafByIndex(&root, 1));
-    try std.testing.expectEqual(@as(?*const NodeSnap, &l3), leafByIndex(&root, 2));
-    try std.testing.expectEqual(@as(?*const NodeSnap, null), leafByIndex(&root, 3));
-}
-
-test "session_persist: indexOfLeafBySurfaceAddress finds leaf in pre-order" {
-    var l1 = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{ .cwd = "/A" } } } };
-    var l2 = NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{ .cwd = "/B" } } } };
-    var root = NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &l1, .right = &l2 } };
-
-    try std.testing.expectEqual(@as(?u32, 0), indexOfLeaf(&root, &l1));
-    try std.testing.expectEqual(@as(?u32, 1), indexOfLeaf(&root, &l2));
 }
 
 /// Escape a path so that wrapping it in single quotes (`'...'`) produces a

--- a/src/skill_center.zig
+++ b/src/skill_center.zig
@@ -92,16 +92,11 @@ pub fn freeLibrary(allocator: std.mem.Allocator, lib: []LibrarySkill) void {
     allocator.free(lib);
 }
 
-pub const ToolApproval = enum {
-    ask,
-};
-
 pub const ToolSkill = struct {
     name: []u8,
     executable_path: []u8,
     skill_path: ?[]u8,
     enabled: bool,
-    approval: ToolApproval = .ask,
 
     pub fn clone(self: ToolSkill, allocator: std.mem.Allocator) !ToolSkill {
         const name = try allocator.dupe(u8, self.name);
@@ -114,7 +109,6 @@ pub const ToolSkill = struct {
             .executable_path = executable_path,
             .skill_path = skill_path,
             .enabled = self.enabled,
-            .approval = self.approval,
         };
     }
 
@@ -949,7 +943,6 @@ test "skill_center: PanelModel holds mixed prompt and tool entries" {
         .executable_path = try a.dupe(u8, "/tmp/tools/docx_review/bin/docx-review"),
         .skill_path = try a.dupe(u8, "/tmp/tools/docx_review/SKILL.md"),
         .enabled = true,
-        .approval = .ask,
     } };
 
     var m = PanelModel.init(a);
@@ -998,7 +991,6 @@ test "skill_center: toggleSelectedTool flips only selected tool entries" {
         .executable_path = try a.dupe(u8, "/tmp/tools/docx_review/bin/docx-review"),
         .skill_path = null,
         .enabled = false,
-        .approval = .ask,
     } };
 
     var m = PanelModel.init(a);
@@ -1026,7 +1018,6 @@ test "skill_center: setEntries and setLibrary clamp selection" {
         .executable_path = try a.dupe(u8, "/tmp/tool"),
         .skill_path = null,
         .enabled = true,
-        .approval = .ask,
     } };
     m.setEntries(entries);
     try std.testing.expectEqual(@as(usize, 0), m.sel_row);

--- a/src/split_tree.zig
+++ b/src/split_tree.zig
@@ -1155,7 +1155,7 @@ fn dimensions(self: *const SplitTree, current: Node.Handle) struct {
 ///
 /// Splits are always binary; ratios are clamped to [0.05, 0.95] for safety.
 /// Pre-order traversal: root first, then left subtree, then right subtree.
-/// Pre-order leaf order matches session_persist.leafByIndex semantics, so
+/// Pre-order leaf order matches persisted focused-leaf indexes, so
 /// `focused_leaf` from a TabSnap can be resolved against the resulting nodes.
 pub fn fromSnapshot(
     gpa: Allocator,

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -420,14 +420,6 @@ fn isLocalPortAvailable(port: u16) bool {
     return true;
 }
 
-fn reserveLocalPort() ?u16 {
-    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return null;
-    var server = address.listen(.{}) catch return null;
-    const port = server.listen_address.getPort();
-    server.deinit();
-    return if (port == 0) null else port;
-}
-
 fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const ssh_connection.SshConnection) ?[]const u8 {
     const user = conn.user();
     const host = conn.host();
@@ -497,18 +489,24 @@ test "ssh_tunnel cache key distinguishes proxy jump" {
 }
 
 test "reservePreferredLocalPort returns the preferred port when it is free" {
-    const preferred = reserveLocalPort() orelse return error.SkipZigTest;
+    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return error.SkipZigTest;
+    var server = address.listen(.{}) catch return error.SkipZigTest;
+    const preferred = server.listen_address.getPort();
+    server.deinit();
+    if (preferred == 0) return error.SkipZigTest;
+
     const selected = reservePreferredLocalPort(preferred) orelse return error.SkipZigTest;
     try std.testing.expectEqual(preferred, selected);
 }
 
 test "reservePreferredLocalPort skips an occupied preferred port" {
-    const preferred = reserveLocalPort() orelse return error.SkipZigTest;
-    if (preferred == std.math.maxInt(u16)) return error.SkipZigTest;
-
-    const address = std.net.Address.parseIp4("127.0.0.1", preferred) catch return error.SkipZigTest;
+    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return error.SkipZigTest;
     var server = address.listen(.{}) catch return error.SkipZigTest;
     defer server.deinit();
+
+    const preferred = server.listen_address.getPort();
+    if (preferred == 0) return error.SkipZigTest;
+    if (preferred == std.math.maxInt(u16)) return error.SkipZigTest;
 
     const selected = reservePreferredLocalPort(preferred) orelse return error.SkipZigTest;
     try std.testing.expect(selected > preferred);

--- a/src/tool_import.zig
+++ b/src/tool_import.zig
@@ -113,27 +113,6 @@ pub fn sha256FileHex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     return hex;
 }
 
-/// Install a binary tool package and return the installed directory path as an
-/// owned string. The caller owns the returned path and must free it.
-pub fn installToolPackage(
-    allocator: std.mem.Allocator,
-    tools_root: []const u8,
-    source_binary_path: []const u8,
-    function_name: []const u8,
-    skill_md: []const u8,
-    enabled: bool,
-) ![]u8 {
-    return installToolPackageWithSource(
-        allocator,
-        tools_root,
-        source_binary_path,
-        source_binary_path,
-        function_name,
-        skill_md,
-        enabled,
-    );
-}
-
 pub fn installToolPackageWithSource(
     allocator: std.mem.Allocator,
     tools_root: []const u8,
@@ -617,9 +596,10 @@ test "tool_import: installToolPackage stages package with manifest and binary" {
     const tools_root = try tmp.dir.realpathAlloc(a, "tools");
     defer a.free(tools_root);
 
-    const installed = try installToolPackage(
+    const installed = try installToolPackageWithSource(
         a,
         tools_root,
+        source_path,
         source_path,
         "docx",
         "---\nname: docx\ndescription: DOCX helper\n---\nUse docs.\n",
@@ -648,9 +628,10 @@ test "tool_import: installToolPackage stages package with manifest and binary" {
     try std.testing.expectEqualStrings("bin/docx", manifest.executable);
     try std.testing.expectEqualStrings(source_path, manifest.source_path);
 
-    try std.testing.expectError(error.ToolAlreadyExists, installToolPackage(
+    try std.testing.expectError(error.ToolAlreadyExists, installToolPackageWithSource(
         a,
         tools_root,
+        source_path,
         source_path,
         "docx",
         "---\nname: docx\n---\nUse docs.\n",
@@ -798,9 +779,10 @@ test "tool_import: installToolPackage rejects reserved built-in function names" 
     const tools_root = try tmp.dir.realpathAlloc(a, "tools");
     defer a.free(tools_root);
 
-    try std.testing.expectError(error.ReservedToolName, installToolPackage(
+    try std.testing.expectError(error.ReservedToolName, installToolPackageWithSource(
         a,
         tools_root,
+        source_path,
         source_path,
         "read_file",
         "---\nname: read_file\n---\nReserved.\n",
@@ -827,9 +809,10 @@ test "tool_import: installToolPackage preserves executable bits through restrict
 
     const old_umask = setProcessUmask(0o077);
     defer _ = setProcessUmask(old_umask);
-    const installed = try installToolPackage(
+    const installed = try installToolPackageWithSource(
         a,
         tools_root,
+        source_path,
         source_path,
         "runme",
         "---\nname: runme\n---\nUse runme.\n",

--- a/src/tool_registry.zig
+++ b/src/tool_registry.zig
@@ -287,26 +287,6 @@ pub fn freeInstalledTools(allocator: std.mem.Allocator, tools: []InstalledTool) 
     allocator.free(tools);
 }
 
-pub fn enabledSnapshot(allocator: std.mem.Allocator, tools: []const InstalledTool) ![]InstalledTool {
-    var list: std.ArrayListUnmanaged(InstalledTool) = .empty;
-    errdefer freeInstalledToolsBuilder(allocator, &list);
-
-    for (tools) |tool| {
-        if (!tool.enabled) continue;
-        const copy = try copyInstalledTool(allocator, tool);
-        list.append(allocator, copy) catch |err| {
-            copy.deinit(allocator);
-            return err;
-        };
-    }
-
-    return list.toOwnedSlice(allocator);
-}
-
-pub fn freeEnabledSnapshot(allocator: std.mem.Allocator, tools: []InstalledTool) void {
-    freeInstalledTools(allocator, tools);
-}
-
 pub fn dynamicSpecsFromInstalled(allocator: std.mem.Allocator, tools: []const InstalledTool) ![]ai_chat_protocol.DynamicToolSpec {
     var list: std.ArrayListUnmanaged(ai_chat_protocol.DynamicToolSpec) = .empty;
     errdefer {
@@ -451,28 +431,6 @@ fn hasWindowsDrivePrefix(path: []const u8) bool {
     return path.len >= 2 and std.ascii.isAlphabetic(path[0]) and path[1] == ':';
 }
 
-fn copyInstalledTool(allocator: std.mem.Allocator, tool: InstalledTool) !InstalledTool {
-    const id = try allocator.dupe(u8, tool.id);
-    errdefer allocator.free(id);
-    const function_name = try allocator.dupe(u8, tool.function_name);
-    errdefer allocator.free(function_name);
-    const executable_abs = try allocator.dupe(u8, tool.executable_abs);
-    errdefer allocator.free(executable_abs);
-    const skill_md = try allocator.dupe(u8, tool.skill_md);
-    errdefer allocator.free(skill_md);
-    const description = try allocator.dupe(u8, tool.description);
-    errdefer allocator.free(description);
-
-    return .{
-        .id = id,
-        .function_name = function_name,
-        .enabled = tool.enabled,
-        .executable_abs = executable_abs,
-        .skill_md = skill_md,
-        .description = description,
-    };
-}
-
 fn freeInstalledToolsBuilder(allocator: std.mem.Allocator, list: *std.ArrayListUnmanaged(InstalledTool)) void {
     for (list.items) |*tool| tool.deinit(allocator);
     list.deinit(allocator);
@@ -611,33 +569,6 @@ test "tool_registry: scanInstalledTools propagates OutOfMemory from tool reads" 
     var failing_allocator = std.testing.FailingAllocator.init(a, .{ .fail_index = 0 });
     try std.testing.expectError(error.OutOfMemory, scanInstalledTools(failing_allocator.allocator(), tools_root));
     try std.testing.expect(failing_allocator.has_induced_failure);
-}
-
-test "tool_registry: enabledToolSchemas skips disabled tools" {
-    const a = std.testing.allocator;
-    const enabled = InstalledTool{
-        .id = try a.dupe(u8, "docx"),
-        .function_name = try a.dupe(u8, "docx"),
-        .enabled = true,
-        .executable_abs = try a.dupe(u8, "/tmp/tools/docx/bin/docx"),
-        .skill_md = try a.dupe(u8, "---\nname: docx\n---\nUse for DOCX review."),
-        .description = try a.dupe(u8, "DOCX review"),
-    };
-    defer enabled.deinit(a);
-    const disabled = InstalledTool{
-        .id = try a.dupe(u8, "off"),
-        .function_name = try a.dupe(u8, "off"),
-        .enabled = false,
-        .executable_abs = try a.dupe(u8, "/tmp/tools/off/bin/off"),
-        .skill_md = try a.dupe(u8, "---\nname: off\n---\nOff."),
-        .description = try a.dupe(u8, "Off"),
-    };
-    defer disabled.deinit(a);
-    const list = [_]InstalledTool{ enabled, disabled };
-    const snapshot = try enabledSnapshot(a, list[0..]);
-    defer freeEnabledSnapshot(a, snapshot);
-    try std.testing.expectEqual(@as(usize, 1), snapshot.len);
-    try std.testing.expectEqualStrings("docx", snapshot[0].function_name);
 }
 
 test "tool_registry: dynamic snapshots include specs and runtime paths for enabled tools" {

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -220,10 +220,6 @@ pub fn evaluateReleaseForPackage(current_version: []const u8, release: ReleaseIn
     };
 }
 
-pub fn evaluateRelease(current_version: []const u8, release: ReleaseInfo) CheckResult {
-    return evaluateReleaseForPackage(current_version, release, .{ .platform = .unsupported });
-}
-
 pub fn formatStatusMessage(buf: []u8, result: CheckResult) ![]const u8 {
     return switch (result.state) {
         .idle => std.fmt.bufPrint(buf, "", .{}),
@@ -264,19 +260,6 @@ fn copyExact(buf: []u8, value: []const u8) ?[]const u8 {
     if (buf.len < value.len) return null;
     @memcpy(buf[0..value.len], value);
     return buf[0..value.len];
-}
-
-pub fn fetchLatestRelease(
-    allocator: std.mem.Allocator,
-    current_version: []const u8,
-    buffers: CheckResultBuffers,
-) CheckResult {
-    return fetchLatestReleaseForPackage(
-        allocator,
-        current_version,
-        .{ .platform = .unsupported },
-        buffers,
-    );
 }
 
 pub fn fetchLatestReleaseForPackage(

--- a/src/update_install.zig
+++ b/src/update_install.zig
@@ -24,10 +24,6 @@ pub fn downloadDestPath(allocator: std.mem.Allocator, asset_name: []const u8) ![
     return try std.fs.path.join(allocator, &.{ downloads, asset_name });
 }
 
-fn siblingTempPath(allocator: std.mem.Allocator, path: []const u8, suffix: []const u8) ![]u8 {
-    return try std.mem.concat(allocator, u8, &.{ path, suffix });
-}
-
 /// Download `url` to `dest_path`, overwriting any existing file with that name.
 /// Writes to a `.part` sibling first and renames into place so a failed or
 /// interrupted download never leaves a truncated file at `dest_path`.
@@ -44,7 +40,7 @@ pub fn downloadAssetAccept(allocator: std.mem.Allocator, url: []const u8, dest_p
         try std.fs.cwd().makePath(dir_path);
     }
 
-    const temp_path = try siblingTempPath(allocator, dest_path, ".part");
+    const temp_path = try std.mem.concat(allocator, u8, &.{ dest_path, ".part" });
     defer allocator.free(temp_path);
     std.fs.deleteFileAbsolute(temp_path) catch |err| switch (err) {
         error.FileNotFound => {},

--- a/src/web_read_cache.zig
+++ b/src/web_read_cache.zig
@@ -11,11 +11,8 @@ const max_cache_file_bytes: usize = 64 * 1024 * 1024;
 pub fn sha256Hex(bytes: []const u8, out: *[64]u8) []const u8 {
     var digest: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
-    const hex = "0123456789abcdef";
-    for (digest, 0..) |b, i| {
-        out[i * 2] = hex[b >> 4];
-        out[i * 2 + 1] = hex[b & 0x0f];
-    }
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    @memcpy(out, &hex);
     return out[0..64];
 }
 


### PR DESCRIPTION
## Summary

Remove test-only public helpers after PR-B while keeping behavior coverage on real production APIs.

- remove sentence/paragraph selection helpers and tests
- remove enabledSnapshot/input-effect/session leaf helper APIs
- replace command-center, control API, tool import, first-party tools, html server, and port-forward tests with direct production-path coverage

## Stack

Base: dead-code-pr-b-fossil-wrappers (#314)

## Validation

- zig build test
- zig build test-full -Dtarget=native
- git diff --check
- Windows path/symlink safety checks
