### PR TITLE
Remove thin dead-code wrappers

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -459,14 +459,12 @@ test "AppWindow: skill center tool enabled update matches manifest path" {
             .executable_path = @constCast("/tmp/tools/tool_a/bin/tool_a"),
             .skill_path = @constCast("/tmp/tools/tool_a/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
         .{ .tool = .{
             .name = @constCast("tool_b"),
             .executable_path = @constCast("/tmp/tools/tool_b/bin/tool_b"),
             .skill_path = @constCast("/tmp/tools/tool_b/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
     };
 
@@ -512,7 +510,6 @@ test "AppWindow: skill center first-party enabled update matches name only" {
             .executable_path = @constCast("/tmp/tools/webread/bin/webread"),
             .skill_path = @constCast("/tmp/tools/webread/SKILL.md"),
             .enabled = false,
-            .approval = .ask,
         } },
     };
 
@@ -684,7 +681,6 @@ test "AppWindow: skill center import picker allows empty library and blocks tool
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -752,7 +748,6 @@ test "AppWindow: skill center tool toggle failure uses toggle status" {
         .executable_path = executable_path,
         .skill_path = null,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -6263,7 +6258,7 @@ fn runMainLoop(self: *AppWindow) !void {
     // - So total subtracted from fb_height: 54 + 20 = 74
     //   Wait, let me recalculate...
     //   Actually: content_h = fb_height - (10+34) - 10 = fb_height - 54
-    //   Then setScreenSize: avail_h = content_h - 20 = fb_height - 74
+    //   Then setScreenSizeWithPolicy: avail_h = content_h - 20 = fb_height - 74
     //
     // Actually there might be edge extension for top/bottom too. Let me just match exactly:
     // For a full-window single split (at all edges):
@@ -6273,7 +6268,7 @@ fn runMainLoop(self: *AppWindow) !void {
     //
     // Looking at the code: only left/right edges get extension, not top/bottom.
     // So:
-    //   setScreenSize(pw=fb_width, ph=fb_height-54, explicit_padding)
+    //   setScreenSizeWithPolicy(pw=fb_width, ph=fb_height-54, explicit_padding)
     //   avail_w = fb_width - 10 - 22 = fb_width - 32
     //   avail_h = (fb_height - 54) - 10 - 10 = fb_height - 74
     const titlebar_height = currentTitlebarHeight();

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -719,17 +719,6 @@ pub const ResizePolicy = enum {
 /// on the IO thread via queueIo() with 25ms coalescing.
 ///
 /// Returns true if the grid dimensions changed (resize was queued).
-pub fn setScreenSize(
-    self: *Surface,
-    screen_width: u32,
-    screen_height: u32,
-    cell_width: f32,
-    cell_height: f32,
-    explicit_padding: renderer.size.Padding,
-) bool {
-    return self.setScreenSizeWithPolicy(screen_width, screen_height, cell_width, cell_height, explicit_padding, .coalesced);
-}
-
 pub fn setScreenSizeWithPolicy(
     self: *Surface,
     screen_width: u32,

--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -32,16 +32,6 @@ pub const CategoryCounts = struct {
     subagent: usize = 0,
 };
 
-pub fn categoryMatches(category: CategoryFilter, provider: ProviderId) bool {
-    return switch (category) {
-        .all => true,
-        .codex => provider == .codex,
-        .claude => provider == .claude,
-        .reasonix => provider == .reasonix,
-        .subagent => false,
-    };
-}
-
 pub fn isSubagentSession(meta: SessionMeta) bool {
     const title = std.mem.trimLeft(u8, meta.title, " \t\r\n");
     return std.mem.startsWith(u8, title, "You are");
@@ -234,15 +224,37 @@ test "ai_history_types: recent sort is descending with session id tie break" {
     try std.testing.expectEqualStrings("b", rows[2].session_id);
 }
 
-test "ai_history_types: categoryMatches respects provider" {
-    try std.testing.expect(categoryMatches(.all, .codex));
-    try std.testing.expect(categoryMatches(.all, .claude));
-    try std.testing.expect(categoryMatches(.codex, .codex));
-    try std.testing.expect(!categoryMatches(.codex, .claude));
-    try std.testing.expect(categoryMatches(.claude, .claude));
-    try std.testing.expect(!categoryMatches(.claude, .codex));
-    try std.testing.expect(categoryMatches(.reasonix, .reasonix));
-    try std.testing.expect(!categoryMatches(.reasonix, .codex));
+test "ai_history_types: categoryMatchesMeta respects provider" {
+    const codex: SessionMeta = .{
+        .provider = .codex,
+        .session_id = "codex",
+        .title = "Codex task",
+        .source_path = "codex.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const claude: SessionMeta = .{
+        .provider = .claude,
+        .session_id = "claude",
+        .title = "Claude task",
+        .source_path = "claude.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    const reasonix: SessionMeta = .{
+        .provider = .reasonix,
+        .session_id = "reasonix",
+        .title = "Reasonix task",
+        .source_path = "reasonix.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+
+    try std.testing.expect(categoryMatchesMeta(.all, codex));
+    try std.testing.expect(categoryMatchesMeta(.all, claude));
+    try std.testing.expect(categoryMatchesMeta(.codex, codex));
+    try std.testing.expect(!categoryMatchesMeta(.codex, claude));
+    try std.testing.expect(categoryMatchesMeta(.claude, claude));
+    try std.testing.expect(!categoryMatchesMeta(.claude, codex));
+    try std.testing.expect(categoryMatchesMeta(.reasonix, reasonix));
+    try std.testing.expect(!categoryMatchesMeta(.reasonix, codex));
 }
 
 test "ai_history_types: You are titles are classified as subagent metadata" {

--- a/src/appwindow/skill_center_actions.zig
+++ b/src/appwindow/skill_center_actions.zig
@@ -1888,7 +1888,6 @@ fn skillCenterEntryFromInstalledTool(
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = tool.enabled,
-        .approval = .ask,
     } };
 }
 

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -512,45 +512,6 @@ fn copyRootPathOnly(path: []const u8) void {
     g_root_path_len = len;
 }
 
-/// Enter remote mode with the given SSH connection.
-pub fn enterRemoteMode(conn: *const ssh_connection.SshConnection, remote_cwd: []const u8) void {
-    g_async_context_id +%= 1;
-    g_mode = .remote;
-    g_ssh_conn = conn.*;
-    g_has_ssh_conn = true;
-    if (remote_cwd.len > 0) {
-        setRoot(remote_cwd);
-    } else {
-        g_root_path_len = 0;
-        rescanRemote();
-    }
-}
-
-/// Switch back to local mode.
-pub fn enterLocalMode() void {
-    g_async_context_id +%= 1;
-    g_pending_async_list = null;
-    g_loading = false;
-    g_mode = .local;
-    g_has_ssh_conn = false;
-    g_entry_count = 0;
-    g_root_path_len = 0;
-}
-
-/// Enter WSL mode. Paths are Linux-style and listed via the platform backend.
-pub fn enterWslMode(wsl_cwd: []const u8) void {
-    g_async_context_id +%= 1;
-    g_pending_async_list = null;
-    g_loading = false;
-    g_mode = .wsl;
-    g_has_ssh_conn = false;
-    if (wsl_cwd.len > 0) {
-        setRoot(wsl_cwd);
-    } else {
-        setRoot("~");
-    }
-}
-
 pub fn setRoot(path: []const u8) void {
     g_async_context_id +%= 1;
     const len = @min(path.len, g_root_path.len);
@@ -1695,17 +1656,6 @@ pub fn uploadFolder(local_path: []const u8) void {
     _ = startTransferJob(.upload, &g_ssh_conn, local_path, dst, name, scp.transferDirWithControl);
 }
 
-pub fn uploadLocalFileToRemoteSpec(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
-    return uploadLocalPathToRemoteSpecWithTransferFns(
-        local_path,
-        dst_spec,
-        display_name,
-        conn,
-        scp.transferWithControl,
-        scp.transferDirWithControl,
-    );
-}
-
 fn uploadLocalFileToRemoteSpecWithTransfer(local_path: []const u8, dst_spec: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, transfer_fn: TransferFn) bool {
     return startTransferJob(.upload, conn, local_path, dst_spec, display_name, transfer_fn);
 }
@@ -1740,10 +1690,6 @@ pub fn uploadLocalFileToRemoteSpecWithCompletion(
     completion: TransferCompletion,
 ) bool {
     return startTransferJobWithCompletion(.upload, conn, local_path, dst_spec, display_name, pickUploadTransferFn(local_path), completion);
-}
-
-pub fn downloadRemoteFileToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection) bool {
-    return downloadRemotePathToPath(remote_path, local_path, display_name, conn, false);
 }
 
 pub fn downloadRemotePathToPath(remote_path: []const u8, local_path: []const u8, display_name: []const u8, conn: *const ssh_connection.SshConnection, is_dir: bool) bool {

--- a/src/html_server.zig
+++ b/src/html_server.zig
@@ -113,10 +113,6 @@ const Server = struct {
             std.mem.eql(u8, self.sshPort(), conn.port()) and
             std.mem.eql(u8, self.proxyJump(), conn.proxyJump());
     }
-
-    fn matchesSurface(self: *const Server, surface: *const Surface) bool {
-        return surfaceIdsEqual(&self.source_surface_id, &surface.remote_id);
-    }
 };
 
 threadlocal var g_servers: [MAX_SERVERS]?Server = [_]?Server{null} ** MAX_SERVERS;
@@ -128,13 +124,6 @@ pub fn deinit() void {
 
 pub fn stopAll() void {
     for (&g_servers) |*slot| stopServer(slot);
-}
-
-pub fn stopForSurface(surface: *const Surface) void {
-    for (&g_servers) |*slot| {
-        const server = if (slot.*) |*server| server else continue;
-        if (server.matchesSurface(surface)) stopServer(slot);
-    }
 }
 
 pub fn stopForSurfaceId(source_surface_id: *const [16]u8) void {
@@ -857,9 +846,9 @@ test "html_server: public stop API shape stays stable" {
 }
 
 test "html_server: public surface stop API shape stays stable" {
-    const info = @typeInfo(@TypeOf(stopForSurface)).@"fn";
+    const info = @typeInfo(@TypeOf(stopForSurfaceId)).@"fn";
     try std.testing.expectEqual(@as(usize, 1), info.params.len);
-    try std.testing.expect(info.params[0].type.? == *const Surface);
+    try std.testing.expect(info.params[0].type.? == *const [16]u8);
     try std.testing.expect(info.return_type.? == void);
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -572,7 +572,6 @@ test "input: skill center tool toggle requests a repaint" {
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
     session.mutex.lock();
     session.model.setEntries(entries);
@@ -763,7 +762,6 @@ test "input: skill center tool toggle is blocked while selection overlay is acti
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = true,
-        .approval = .ask,
     } };
 
     const picker_labels = try allocator.alloc([]u8, 1);
@@ -924,7 +922,6 @@ test "input: skill center deploy and import keys ignore selected tool rows" {
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = false,
-        .approval = .ask,
     } };
 
     session.mutex.lock();
@@ -1319,7 +1316,6 @@ test "input: skill center main actions are blocked while import list overlay is 
         .executable_path = executable_path,
         .skill_path = skill_path,
         .enabled = true,
-        .approval = .ask,
     } };
 
     var import_target = try AppWindow.skill_center.Target.dupe(allocator, "local", "Local", .claude, true);
@@ -2270,13 +2266,6 @@ pub fn copyRemoteSessionKeyToClipboard() bool {
 // ============================================================================
 // Shared helpers (used by input + cell_renderer)
 // ============================================================================
-
-/// Get the viewport's absolute row offset into the scrollback.
-/// Row 0 on screen corresponds to absolute row `viewportOffset()`.
-pub fn viewportOffset() usize {
-    const surface = AppWindow.activeSurface() orelse return 0;
-    return viewportOffsetForSurface(surface);
-}
 
 pub const ScrollbarState = struct {
     total: usize,
@@ -4564,7 +4553,7 @@ fn handleTerminalSelectionPress(ev: platform_input.MouseButtonEvent, xpos: f64, 
 
     const cell_pos = mouseToSurfaceCell(clicked_surface, xpos, ypos);
     const open_mod = primaryOpenMod(ev.ctrl, ev.super);
-    const click_action = terminalPathClickAction(clicked_surface.launch_kind, clicked_surface.ssh_connection != null, open_mod, ev.shift, ev.alt);
+    const click_action = terminalPathClickAction(clicked_surface.launch_kind, open_mod, ev.shift, ev.alt);
     // Only instrument the SSH download gesture (Ctrl/Cmd+Shift) so the log is not
     // flooded by every terminal click. This shows whether a download gesture
     // routed to `download_ssh_file` and whether the surface had SSH metadata.
@@ -4878,7 +4867,7 @@ fn updateInteractiveUnderlineAtMouse(xpos: f64, ypos: f64, ctrl: bool, shift: bo
     const allocator = AppWindow.g_allocator orelse return;
     const cell_pos = mouseToSurfaceCell(surface, xpos, ypos);
 
-    const action = terminalPathClickAction(surface.launch_kind, surface.ssh_connection != null, primaryOpenMod(ctrl, super), shift, alt);
+    const action = terminalPathClickAction(surface.launch_kind, primaryOpenMod(ctrl, super), shift, alt);
     const token = extractInteractiveUnderlineRangeAtCell(allocator, surface, cell_pos, action) orelse {
         clearUrlUnderline();
         return;

--- a/src/input/terminal_link_action.zig
+++ b/src/input/terminal_link_action.zig
@@ -26,8 +26,7 @@ pub fn primaryOpenMod(ctrl: bool, super: bool) bool {
     return if (builtin.target.os.tag == .macos) super else ctrl;
 }
 
-pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, has_ssh_conn: bool, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
-    _ = has_ssh_conn;
+pub fn terminalPathClickAction(launch_kind: platform_pty_command.LaunchKind, mod: bool, shift: bool, alt: bool) TerminalPathClickAction {
     if (mod and shift and !alt and launch_kind == .ssh) return .download_ssh_file;
     if (mod and !shift and !alt) return .open_url_or_preview;
     return .pass_through;
@@ -94,19 +93,15 @@ test "primary open modifier is Cmd on macOS, Ctrl elsewhere" {
 test "terminal path click action maps ctrl shift ssh to download" {
     try std.testing.expectEqual(
         TerminalPathClickAction.download_ssh_file,
-        terminalPathClickAction(.ssh, true, true, true, false),
-    );
-    try std.testing.expectEqual(
-        TerminalPathClickAction.download_ssh_file,
-        terminalPathClickAction(.ssh, false, true, true, false),
+        terminalPathClickAction(.ssh, true, true, false),
     );
     try std.testing.expectEqual(
         TerminalPathClickAction.pass_through,
-        terminalPathClickAction(.wsl, false, true, true, false),
+        terminalPathClickAction(.wsl, true, true, false),
     );
     try std.testing.expectEqual(
         TerminalPathClickAction.open_url_or_preview,
-        terminalPathClickAction(.ssh, true, true, false, false),
+        terminalPathClickAction(.ssh, true, false, false),
     );
 }
 

--- a/src/preview_pane.zig
+++ b/src/preview_pane.zig
@@ -166,8 +166,6 @@ pub fn scrollBy(self: *PreviewPane, delta: f32) void {
     self.scroll_offset = @max(0, @min(self.max_scroll, self.scroll_offset + delta));
 }
 
-pub fn isContentTruncated(self: *const PreviewPane) bool { return self.content_truncated; }
-
 pub fn zoomImageBySteps(self: *PreviewPane, steps: usize, zoom_in: bool) bool {
     if (!self.kind.isRaster()) return false;
     var next = self.image_zoom;
@@ -735,12 +733,12 @@ test "PreviewPane: truncated text read is ready and flags content as truncated" 
     try std.testing.expect(p.beginAsyncLoadWith(.text, "big.log", "big.log", .local, fakeTruncatedReadOk));
     drainJobs(p);
     try std.testing.expectEqual(LoadStatus.ready, p.load_status);
-    try std.testing.expect(p.isContentTruncated());
+    try std.testing.expect(p.content_truncated);
     try std.testing.expectEqualStrings("line1\nline2\n", p.sourceText());
 
     // Loading new content clears the truncated flag.
     p.open(.markdown, "b.md", "b.md", "# hi");
-    try std.testing.expect(!p.isContentTruncated());
+    try std.testing.expect(!p.content_truncated);
 }
 
 test "PreviewPane: scrollBy clamps to the renderer-reported max_scroll" {

--- a/src/render_diagnostics.zig
+++ b/src/render_diagnostics.zig
@@ -69,10 +69,6 @@ pub fn close() void {
     g_file_open = false;
 }
 
-pub fn logFilePath(allocator: std.mem.Allocator) ![]const u8 {
-    return platform_dirs.pathInConfigDir(allocator, LOG_BASENAME);
-}
-
 fn ensureFile() !*std.fs.File {
     if (g_file_open) return &g_file;
 

--- a/src/scp.zig
+++ b/src/scp.zig
@@ -620,10 +620,7 @@ fn buildUploadCommand(buf: *[2048]u8, remote_path: []const u8, local_path: []con
 }
 
 fn buildDownloadCommand(buf: *[2048]u8, remote_path: []const u8) ?[]const u8 {
-    var pos: usize = 0;
-    if (!appendSlice(buf, &pos, "cat -- ")) return null;
-    if (!appendShellQuote(buf, &pos, remote_path)) return null;
-    return buf[0..pos];
+    return buildRemoteReadCommand(buf, remote_path);
 }
 
 /// Build `cat -- '<path>'` to stream a remote file's bytes to stdout.

--- a/src/skill_center.zig
+++ b/src/skill_center.zig
@@ -92,16 +92,11 @@ pub fn freeLibrary(allocator: std.mem.Allocator, lib: []LibrarySkill) void {
     allocator.free(lib);
 }
 
-pub const ToolApproval = enum {
-    ask,
-};
-
 pub const ToolSkill = struct {
     name: []u8,
     executable_path: []u8,
     skill_path: ?[]u8,
     enabled: bool,
-    approval: ToolApproval = .ask,
 
     pub fn clone(self: ToolSkill, allocator: std.mem.Allocator) !ToolSkill {
         const name = try allocator.dupe(u8, self.name);
@@ -114,7 +109,6 @@ pub const ToolSkill = struct {
             .executable_path = executable_path,
             .skill_path = skill_path,
             .enabled = self.enabled,
-            .approval = self.approval,
         };
     }
 
@@ -949,7 +943,6 @@ test "skill_center: PanelModel holds mixed prompt and tool entries" {
         .executable_path = try a.dupe(u8, "/tmp/tools/docx_review/bin/docx-review"),
         .skill_path = try a.dupe(u8, "/tmp/tools/docx_review/SKILL.md"),
         .enabled = true,
-        .approval = .ask,
     } };
 
     var m = PanelModel.init(a);
@@ -998,7 +991,6 @@ test "skill_center: toggleSelectedTool flips only selected tool entries" {
         .executable_path = try a.dupe(u8, "/tmp/tools/docx_review/bin/docx-review"),
         .skill_path = null,
         .enabled = false,
-        .approval = .ask,
     } };
 
     var m = PanelModel.init(a);
@@ -1026,7 +1018,6 @@ test "skill_center: setEntries and setLibrary clamp selection" {
         .executable_path = try a.dupe(u8, "/tmp/tool"),
         .skill_path = null,
         .enabled = true,
-        .approval = .ask,
     } };
     m.setEntries(entries);
     try std.testing.expectEqual(@as(usize, 0), m.sel_row);

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -420,14 +420,6 @@ fn isLocalPortAvailable(port: u16) bool {
     return true;
 }
 
-fn reserveLocalPort() ?u16 {
-    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return null;
-    var server = address.listen(.{}) catch return null;
-    const port = server.listen_address.getPort();
-    server.deinit();
-    return if (port == 0) null else port;
-}
-
 fn sshDestination(buf: *[MAX_SSH_DEST_BYTES]u8, conn: *const ssh_connection.SshConnection) ?[]const u8 {
     const user = conn.user();
     const host = conn.host();
@@ -497,18 +489,24 @@ test "ssh_tunnel cache key distinguishes proxy jump" {
 }
 
 test "reservePreferredLocalPort returns the preferred port when it is free" {
-    const preferred = reserveLocalPort() orelse return error.SkipZigTest;
+    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return error.SkipZigTest;
+    var server = address.listen(.{}) catch return error.SkipZigTest;
+    const preferred = server.listen_address.getPort();
+    server.deinit();
+    if (preferred == 0) return error.SkipZigTest;
+
     const selected = reservePreferredLocalPort(preferred) orelse return error.SkipZigTest;
     try std.testing.expectEqual(preferred, selected);
 }
 
 test "reservePreferredLocalPort skips an occupied preferred port" {
-    const preferred = reserveLocalPort() orelse return error.SkipZigTest;
-    if (preferred == std.math.maxInt(u16)) return error.SkipZigTest;
-
-    const address = std.net.Address.parseIp4("127.0.0.1", preferred) catch return error.SkipZigTest;
+    const address = std.net.Address.parseIp4("127.0.0.1", 0) catch return error.SkipZigTest;
     var server = address.listen(.{}) catch return error.SkipZigTest;
     defer server.deinit();
+
+    const preferred = server.listen_address.getPort();
+    if (preferred == 0) return error.SkipZigTest;
+    if (preferred == std.math.maxInt(u16)) return error.SkipZigTest;
 
     const selected = reservePreferredLocalPort(preferred) orelse return error.SkipZigTest;
     try std.testing.expect(selected > preferred);

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -220,10 +220,6 @@ pub fn evaluateReleaseForPackage(current_version: []const u8, release: ReleaseIn
     };
 }
 
-pub fn evaluateRelease(current_version: []const u8, release: ReleaseInfo) CheckResult {
-    return evaluateReleaseForPackage(current_version, release, .{ .platform = .unsupported });
-}
-
 pub fn formatStatusMessage(buf: []u8, result: CheckResult) ![]const u8 {
     return switch (result.state) {
         .idle => std.fmt.bufPrint(buf, "", .{}),
@@ -264,19 +260,6 @@ fn copyExact(buf: []u8, value: []const u8) ?[]const u8 {
     if (buf.len < value.len) return null;
     @memcpy(buf[0..value.len], value);
     return buf[0..value.len];
-}
-
-pub fn fetchLatestRelease(
-    allocator: std.mem.Allocator,
-    current_version: []const u8,
-    buffers: CheckResultBuffers,
-) CheckResult {
-    return fetchLatestReleaseForPackage(
-        allocator,
-        current_version,
-        .{ .platform = .unsupported },
-        buffers,
-    );
 }
 
 pub fn fetchLatestReleaseForPackage(

--- a/src/update_install.zig
+++ b/src/update_install.zig
@@ -24,10 +24,6 @@ pub fn downloadDestPath(allocator: std.mem.Allocator, asset_name: []const u8) ![
     return try std.fs.path.join(allocator, &.{ downloads, asset_name });
 }
 
-fn siblingTempPath(allocator: std.mem.Allocator, path: []const u8, suffix: []const u8) ![]u8 {
-    return try std.mem.concat(allocator, u8, &.{ path, suffix });
-}
-
 /// Download `url` to `dest_path`, overwriting any existing file with that name.
 /// Writes to a `.part` sibling first and renames into place so a failed or
 /// interrupted download never leaves a truncated file at `dest_path`.
@@ -44,7 +40,7 @@ pub fn downloadAssetAccept(allocator: std.mem.Allocator, url: []const u8, dest_p
         try std.fs.cwd().makePath(dir_path);
     }
 
-    const temp_path = try siblingTempPath(allocator, dest_path, ".part");
+    const temp_path = try std.mem.concat(allocator, u8, &.{ dest_path, ".part" });
     defer allocator.free(temp_path);
     std.fs.deleteFileAbsolute(temp_path) catch |err| switch (err) {
         error.FileNotFound => {},

--- a/src/web_read_cache.zig
+++ b/src/web_read_cache.zig
@@ -11,11 +11,8 @@ const max_cache_file_bytes: usize = 64 * 1024 * 1024;
 pub fn sha256Hex(bytes: []const u8, out: *[64]u8) []const u8 {
     var digest: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
-    const hex = "0123456789abcdef";
-    for (digest, 0..) |b, i| {
-        out[i * 2] = hex[b >> 4];
-        out[i * 2 + 1] = hex[b & 0x0f];
-    }
+    const hex = std.fmt.bytesToHex(digest, .lower);
+    @memcpy(out, &hex);
     return out[0..64];
 }
 


### PR DESCRIPTION
## Summary
- Remove zero-caller mode/transfer wrappers and stale public stop/resize/getter APIs.
- Drop the single-value Skill Center approval field and no-package update-check wrappers.
- Keep test coverage by moving assertions to production APIs or direct fields, and replace small duplicate implementations with existing helpers/stdlib.

## Validation
- `zig build test`
- `zig build test-full -Dtarget=native`
- `git diff --check`

Stacked on #315 / `dead-code-pr-c-test-only-helpers`.