### PR TITLE
[codex] Remove ssh legacy algorithms globals

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -208,8 +208,6 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     g_copilot_hint = app.copilot_hint;
     g_right_click_action = app.right_click_action;
     input.g_url_open_mode = app.url_open_mode;
-    g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
-    tab.g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     g_weixin_notify_forward = app.weixin_notify_forward;
     overlays.g_split_divider_color = app.split_divider_color;
 
@@ -4159,11 +4157,14 @@ pub threadlocal var g_copy_on_select: bool = false;
 pub threadlocal var g_copilot_hint: bool = true;
 threadlocal var g_copilot_shimmer_checked: bool = false;
 pub threadlocal var g_right_click_action: Config.RightClickAction = .copy;
-pub threadlocal var g_ssh_legacy_algorithms: bool = false;
 pub threadlocal var g_desktop_notifications: bool = true;
 pub threadlocal var g_confirm_close_running_program: bool = true;
 pub threadlocal var g_weixin_notify_forward: bool = false;
 threadlocal var g_notif_auth_requested: bool = false;
+
+pub fn sshLegacyAlgorithms() bool {
+    return if (g_app) |app| app.ssh_legacy_algorithms else false;
+}
 
 /// Update cursor blink state based on time (call once per frame)
 fn updateCursorBlink() void {
@@ -4644,11 +4645,9 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     g_copilot_hint = cfg.@"copilot-hint";
     g_right_click_action = cfg.@"right-click-action";
     input.g_url_open_mode = cfg.@"url-open-mode";
-    g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     g_desktop_notifications = cfg.@"desktop-notifications";
     g_confirm_close_running_program = cfg.@"confirm-close-running-program";
     g_weixin_notify_forward = cfg.@"weixin-notify-forward";
-    tab.g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     overlays.g_split_divider_color = cfg.@"split-divider-color";
 
     // --- Background image ---
@@ -6355,6 +6354,7 @@ fn runMainLoop(self: *AppWindow) !void {
             term_rows,
             g_cursor_style,
             g_cursor_blink,
+            sshLegacyAlgorithms(),
         );
 
         switch (startup_tabs.initialTabPlan(.{

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -40,8 +40,6 @@ pub const DEFAULT_PADDING: u32 = 10;
 pub const TAB_CLOSE_BTN_W: f32 = 36;
 pub const TAB_CLOSE_FADE_SPEED: f32 = 6.0;
 
-pub threadlocal var g_ssh_legacy_algorithms: bool = false;
-
 // ============================================================================
 // Tab model — each tab owns a SplitTree of Surfaces
 // ============================================================================
@@ -1619,6 +1617,7 @@ threadlocal var g_restore_cols: u16 = 80;
 threadlocal var g_restore_rows: u16 = 24;
 threadlocal var g_restore_cursor_style: CursorStyle = .block;
 threadlocal var g_restore_cursor_blink: bool = true;
+threadlocal var g_restore_ssh_legacy_algorithms: bool = false;
 const SSH_RESTORE_COMMAND_BUF_SIZE: usize = 4096;
 
 /// Free-function factory passed to SplitTree.fromSnapshot. Reads dimensions
@@ -1640,6 +1639,7 @@ fn surfaceFromSnapImpl(
     const rows: u16 = @max(1, g_restore_rows);
     const cursor_style = g_restore_cursor_style;
     const cursor_blink = g_restore_cursor_blink;
+    const ssh_legacy_algorithms = g_restore_ssh_legacy_algorithms;
 
     switch (snap.*) {
         .local_shell => |sh| {
@@ -1659,7 +1659,7 @@ fn surfaceFromSnapImpl(
         },
         .ssh => |s| {
             var stack_buf: [SSH_RESTORE_COMMAND_BUF_SIZE]u8 = undefined;
-            const command_text = try buildSshRestoreCommand(gpa, &stack_buf, s);
+            const command_text = try buildSshRestoreCommand(gpa, &stack_buf, s, ssh_legacy_algorithms);
 
             var port_buf: [8]u8 = undefined;
             const port_slice = std.fmt.bufPrint(&port_buf, "{}", .{s.port}) catch return error.CommandTooLong;
@@ -1671,7 +1671,7 @@ fn surfaceFromSnapImpl(
             // the native SSH client prompts interactively if key auth fails;
             // the in-app password-autofill flow (which requires password_auth=true)
             // does not engage here.
-            surface.setSshConnection(s.user, s.host, port_slice, "", s.proxy_jump, false, g_ssh_legacy_algorithms);
+            surface.setSshConnection(s.user, s.host, port_slice, "", s.proxy_jump, false, ssh_legacy_algorithms);
             return surface;
         },
     }
@@ -1681,6 +1681,7 @@ fn buildSshRestoreCommand(
     allocator: std.mem.Allocator,
     buf: []u8,
     s: session_persist.SurfaceSnap.SshSnap,
+    ssh_legacy_algorithms: bool,
 ) ![]const u8 {
     // Mirrors the password_auth=false branch: persisted SSH snaps never carry
     // passwords, so restored sessions rely on keys or the native ssh prompt.
@@ -1691,7 +1692,7 @@ fn buildSshRestoreCommand(
         .user = s.user,
         .host = s.host,
         .port = port_slice,
-        .legacy_algorithms = g_ssh_legacy_algorithms,
+        .legacy_algorithms = ssh_legacy_algorithms,
         .proxy_jump = s.proxy_jump,
     }) orelse return error.CommandTooLong;
     var final_len: usize = base.len;
@@ -1719,6 +1720,7 @@ pub fn restoreTab(
     rows: u16,
     cursor_style: CursorStyle,
     cursor_blink: bool,
+    ssh_legacy_algorithms: bool,
 ) bool {
     if (g_tab_count >= MAX_TABS) return false;
 
@@ -1742,6 +1744,7 @@ pub fn restoreTab(
     g_restore_rows = rows;
     g_restore_cursor_style = cursor_style;
     g_restore_cursor_blink = cursor_blink;
+    g_restore_ssh_legacy_algorithms = ssh_legacy_algorithms;
 
     var tree = SplitTree.fromSnapshot(allocator, &snap.tree, &surfaceFromSnap) catch |err| {
         std.debug.print("restoreTab: fromSnapshot failed: {}\n", .{err});
@@ -1891,6 +1894,7 @@ pub fn restoreSessionFromFile(
     rows: u16,
     cursor_style: CursorStyle,
     cursor_blink: bool,
+    ssh_legacy_algorithms: bool,
 ) bool {
     const path = Config.sessionFilePath(allocator) catch return false;
     defer allocator.free(path);
@@ -1902,7 +1906,7 @@ pub fn restoreSessionFromFile(
 
     var rebuilt: usize = 0;
     for (loaded.value.tabs) |*snap| {
-        if (restoreTab(allocator, snap, cols, rows, cursor_style, cursor_blink)) {
+        if (restoreTab(allocator, snap, cols, rows, cursor_style, cursor_blink, ssh_legacy_algorithms)) {
             rebuilt += 1;
         } else {
             std.debug.print("restoreSessionFromFile: skipping failed tab\n", .{});
@@ -1980,7 +1984,7 @@ test "tab: restoreTab routes ai_session_id through the restore hook" {
         .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
         .ai_session_id = "sess-xyz",
     };
-    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false, false));
     try std.testing.expect(Captured.called);
     try std.testing.expectEqualStrings("sess-xyz", Captured.session_id);
     // The hook owns tab creation; restoreTab must not also build a terminal tab.
@@ -1997,7 +2001,7 @@ test "tab: restoreTab skips an ai tab when no restore hook is installed" {
         .tree = .{ .leaf = .{ .surface = .{ .local_shell = .{} } } },
         .ai_session_id = "sess-xyz",
     };
-    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false, false));
 }
 
 test "tab: restoreTab routes ai_history through the restore hook" {
@@ -2026,7 +2030,7 @@ test "tab: restoreTab routes ai_history through the restore hook" {
             .target_name = "Local",
         },
     };
-    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false, false));
     try std.testing.expect(Captured.called);
     try std.testing.expectEqualStrings("local-history", Captured.source_id);
     try std.testing.expectEqual(@as(usize, 0), g_tab_count);
@@ -2046,7 +2050,7 @@ test "tab: restoreTab skips an ai_history tab when no restore hook is installed"
             .target_name = "Local",
         },
     };
-    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false, false));
     try std.testing.expectEqual(@as(usize, 0), g_tab_count);
 }
 
@@ -2250,6 +2254,7 @@ test "tab: SSH restore command accepts the longest persisted connection fields a
             .port = 65535,
             .proxy_jump = proxy_buf[0..],
         },
+        false,
     );
 
     try std.testing.expect(std.mem.indexOf(u8, command, "ssh") != null);
@@ -2421,7 +2426,7 @@ test "tab: restoreTab prioritizes ai_history over ai_session_id" {
         },
     };
 
-    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+    try std.testing.expect(restoreTab(std.testing.allocator, &snap, 80, 24, .block, false, false));
     try std.testing.expect(Captured.history_called);
     try std.testing.expect(!Captured.chat_called);
     try std.testing.expectEqual(@as(usize, 0), g_tab_count);

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3038,7 +3038,7 @@ fn sshConnectionFromProfile(profile: *const SshProfile) ?ssh_connection.SshConne
         .auth_method = auth_method,
         .identity_file = identity_file,
     });
-    conn.legacy_algorithms = AppWindow.g_ssh_legacy_algorithms;
+    conn.legacy_algorithms = AppWindow.sshLegacyAlgorithms();
     return conn;
 }
 
@@ -3468,7 +3468,7 @@ fn connectSshProfileTmux(idx: usize) void {
         .auth_method = conn.auth_method,
         .identity_file = conn.identityFile(),
         .password_auth = conn.password_auth,
-        .legacy_algorithms = AppWindow.g_ssh_legacy_algorithms,
+        .legacy_algorithms = AppWindow.sshLegacyAlgorithms(),
         .proxy_jump = conn.proxyJump(),
         .remote_command = remote,
     }) orelse return;
@@ -3522,7 +3522,7 @@ fn connectSshProfileReturningSurfaceWithCommand(idx: usize, remote_command: []co
         .auth_method = conn.auth_method,
         .identity_file = conn.identityFile(),
         .password_auth = conn.password_auth,
-        .legacy_algorithms = AppWindow.g_ssh_legacy_algorithms,
+        .legacy_algorithms = AppWindow.sshLegacyAlgorithms(),
         .proxy_jump = conn.proxyJump(),
         .remote_command = remote_command,
     }) orelse return null;

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -23,7 +23,7 @@ const Frozen = struct {
 };
 
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 66 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 55 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 48 },
     .{ .name = "ai_chat.zig", .source = @embedFile("../ai_chat.zig"), .ceiling = 20 },
@@ -47,4 +47,9 @@ test "top-level g_* globals in monolith files only shrink" {
         }
     }
     try std.testing.expect(!failed);
+}
+
+test "AppWindow does not mirror ssh legacy config as a global" {
+    try std.testing.expect(std.mem.indexOf(u8, monoliths[0].source, "g_ssh_legacy_algorithms") == null);
+    try std.testing.expect(std.mem.indexOf(u8, @embedFile("../appwindow/tab.zig"), "g_ssh_legacy_algorithms") == null);
 }


### PR DESCRIPTION
## Summary
- Remove the duplicated `g_ssh_legacy_algorithms` globals from `AppWindow.zig` and `appwindow/tab.zig`.
- Read SSH legacy mode from the app config via `AppWindow.sshLegacyAlgorithms()`.
- Pass SSH legacy mode into session restore instead of reading a tab module global.
- Lower the AppWindow global-state guard ceiling from 67 to 66 and guard against reintroducing the old globals.

## Notes
- Stacked on #321 (`codex/shrink-appwindow-import-hub`).
- No SSH security behavior changes; this only removes duplicated config state.

## Validation
- `zig fmt --check build.zig src`
- `zig build test`
- `zig build test-full -Dtarget=native`
- `git diff --check`
