### PR TITLE
[codex] Add Mailbox core tests

### DIFF
--- a/src/termio/Mailbox.zig
+++ b/src/termio/Mailbox.zig
@@ -42,6 +42,8 @@ pub fn send(self: *Mailbox, msg: Message) void {
     self.mutex.lock();
     defer self.mutex.unlock();
 
+    if (self.coalesceTrailingResize(msg)) return;
+
     if (self.count == CAPACITY) {
         // Drop oldest: advance head and release any owned payload.
         self.queue[self.head].deinit();
@@ -52,6 +54,23 @@ pub fn send(self: *Mailbox, msg: Message) void {
     self.queue[self.tail] = msg;
     self.tail = (self.tail + 1) % CAPACITY;
     self.count += 1;
+}
+
+fn coalesceTrailingResize(self: *Mailbox, msg: Message) bool {
+    const latest = switch (msg) {
+        .resize => |grid| grid,
+        else => return false,
+    };
+
+    if (self.count == 0) return false;
+    const idx = if (self.tail == 0) CAPACITY - 1 else self.tail - 1;
+    switch (self.queue[idx]) {
+        .resize => {
+            self.queue[idx] = .{ .resize = latest };
+            return true;
+        },
+        else => return false,
+    }
 }
 
 /// Wake the IO writer thread's xev event loop.
@@ -72,4 +91,75 @@ pub fn pop(self: *Mailbox) ?Message {
     self.head = (self.head + 1) % CAPACITY;
     self.count -= 1;
     return msg;
+}
+
+fn writeSmallByte(byte: u8) Message {
+    var payload: Message.WriteSmall = .{ .len = 1 };
+    payload.data[0] = byte;
+    return .{ .write_small = payload };
+}
+
+fn expectWriteByte(msg: Message, byte: u8) !void {
+    defer msg.deinit();
+    switch (msg) {
+        .write_small => |payload| {
+            try std.testing.expectEqual(@as(u16, 1), payload.len);
+            try std.testing.expectEqual(byte, payload.data[0]);
+        },
+        else => return error.UnexpectedMessage,
+    }
+}
+
+fn expectResize(msg: Message, cols: u16, rows: u16) !void {
+    defer msg.deinit();
+    switch (msg) {
+        .resize => |grid| {
+            try std.testing.expectEqual(cols, grid.cols);
+            try std.testing.expectEqual(rows, grid.rows);
+        },
+        else => return error.UnexpectedMessage,
+    }
+}
+
+test "Mailbox drops oldest message when full" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    for (0..CAPACITY + 1) |i| {
+        mailbox.send(writeSmallByte(@intCast(i)));
+    }
+
+    try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
+    for (1..CAPACITY + 1) |expected| {
+        try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, @intCast(expected));
+    }
+    try std.testing.expect(mailbox.pop() == null);
+}
+
+test "Mailbox coalesces pending resize messages" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } });
+    mailbox.send(.{ .resize = .{ .cols = 120, .rows = 40 } });
+
+    try std.testing.expectEqual(@as(usize, 1), mailbox.count);
+    try expectResize(mailbox.pop() orelse return error.MissingMessage, 120, 40);
+    try std.testing.expect(mailbox.pop() == null);
+}
+
+test "Mailbox resize coalescing preserves write messages" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    mailbox.send(writeSmallByte('a'));
+    mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } });
+    mailbox.send(.{ .resize = .{ .cols = 100, .rows = 30 } });
+    mailbox.send(writeSmallByte('b'));
+
+    try std.testing.expectEqual(@as(usize, 3), mailbox.count);
+    try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'a');
+    try expectResize(mailbox.pop() orelse return error.MissingMessage, 100, 30);
+    try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'b');
+    try std.testing.expect(mailbox.pop() == null);
 }

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -644,6 +644,7 @@ comptime {
     _ = @import("renderer/ai_history_renderer.zig");
     _ = @import("agent_detector.zig");
     _ = @import("Surface.zig");
+    _ = @import("termio/Mailbox.zig");
     _ = @import("agent_prompt_answer.zig");
     _ = @import("App.zig");
     _ = @import("AppWindow.zig");


### PR DESCRIPTION
## Summary
- Add test-full coverage for termio Mailbox ring-buffer behavior.
- Cover queue overflow drop-oldest behavior, trailing resize coalescing, and preserving write messages around coalesced resize controls.
- Implement the minimal trailing resize coalescing needed for the documented last-writer-wins control path.

## Validation
- zig fmt --check build.zig src
- git diff --check origin/main...HEAD
- zig build test
- zig build test-full -Dtarget=native