### PR TITLE
refactor(core): own GridSize in neutral core/geometry module

### DIFF
--- a/src/core/geometry.zig
+++ b/src/core/geometry.zig
@@ -1,0 +1,11 @@
+/// Neutral grid geometry types shared by the core IO layer and the renderer.
+///
+/// Owning `GridSize` here (rather than under `renderer/`) lets the core IO
+/// layer (termio) size the grid without importing the renderer namespace,
+/// fixing a layer inversion. `renderer/size.zig` re-exports `GridSize` so
+/// existing renderer-side users keep compiling unchanged.
+/// Grid dimensions in cells.
+pub const GridSize = struct {
+    cols: u16 = 80,
+    rows: u16 = 24,
+};

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -1,10 +1,10 @@
 /// Size and dimension types used throughout the renderer.
 /// Modeled after Ghostty's size types in `src/renderer/size.zig`.
 /// Grid dimensions in cells.
-pub const GridSize = struct {
-    cols: u16 = 80,
-    rows: u16 = 24,
-};
+/// Defined in the neutral `core/geometry.zig` module so the core IO layer can
+/// size the grid without importing the renderer namespace. Re-exported here so
+/// existing renderer-side users keep referring to `size.GridSize` unchanged.
+pub const GridSize = @import("../core/geometry.zig").GridSize;
 
 /// Cell dimensions in pixels.
 pub const CellSize = struct {

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -17,7 +17,7 @@
 const std = @import("std");
 const xev = @import("xev");
 const Surface = @import("../Surface.zig");
-const renderer = @import("../renderer.zig");
+const geometry = @import("../core/geometry.zig");
 const window_backend = @import("../platform/window_backend.zig");
 
 const Thread = @This();
@@ -35,7 +35,7 @@ coalesce_c: xev.Completion = .{},
 coalesce_cancel_c: xev.Completion = .{},
 
 /// Pending coalesced resize (latest wins). Writer-thread-only.
-coalesce_data: ?renderer.size.GridSize = null,
+coalesce_data: ?geometry.GridSize = null,
 
 /// Whether the coalesce timer is currently active.
 coalesce_active: bool = false,
@@ -110,7 +110,7 @@ fn writeToPty(surface: *Surface, data: []const u8) void {
     surface.pty.writeInput(data) catch {};
 }
 
-fn handleResize(self: *Thread, grid: renderer.size.GridSize) void {
+fn handleResize(self: *Thread, grid: geometry.GridSize) void {
     self.coalesce_data = grid;
 
     if (self.coalesce_active) return; // timer already running, it will pick up latest data
@@ -120,7 +120,7 @@ fn handleResize(self: *Thread, grid: renderer.size.GridSize) void {
     self.coalesce.run(&self.loop, &self.coalesce_c, COALESCE_MS, Thread, self, coalesceCallback);
 }
 
-fn handleResizeImmediate(self: *Thread, grid: renderer.size.GridSize) void {
+fn handleResizeImmediate(self: *Thread, grid: geometry.GridSize) void {
     // Drop any older coalesced resize so a delayed timer cannot undo the
     // immediate layout change.
     self.coalesce_data = null;
@@ -149,7 +149,7 @@ fn coalesceCallback(
     return .disarm;
 }
 
-fn applyResize(surface: *Surface, grid: renderer.size.GridSize) void {
+fn applyResize(surface: *Surface, grid: geometry.GridSize) void {
     // PTY resize first (like Ghostty), then terminal.
     // The ReadThread is concurrently in a blocking PTY read. This keeps
     // backend output draining while resize side effects are emitted.

--- a/src/termio/message.zig
+++ b/src/termio/message.zig
@@ -4,7 +4,7 @@
 /// The tagged union is trivially extensible — adding a new variant requires
 /// only adding the field here and a switch case in Thread.drainMailbox().
 const std = @import("std");
-const renderer = @import("../renderer.zig");
+const geometry = @import("../core/geometry.zig");
 
 pub const Message = union(enum) {
     pub const WRITE_SMALL_MAX = 256;
@@ -21,11 +21,11 @@ pub const Message = union(enum) {
 
     /// Resize the terminal grid to the given dimensions.
     /// Coalesced with a 25ms timer before applying.
-    resize: renderer.size.GridSize,
+    resize: geometry.GridSize,
 
     /// Resize the terminal grid immediately.
     /// Used for one-shot layout changes where TUI redraw latency is visible.
-    resize_immediate: renderer.size.GridSize,
+    resize_immediate: geometry.GridSize,
 
     /// Write data to the PTY input pipe from the IO writer thread.
     write_small: WriteSmall,


### PR DESCRIPTION
Part of the responsibility-boundary refactor (safe batch, task 06): stop the core IO layer from depending on the renderer namespace.

## What
- New `src/core/geometry.zig` owns `GridSize` (trivial cols/rows u16 struct, no renderer-only deps).
- `src/renderer/size.zig` now re-exports it (`pub const GridSize = @import("../core/geometry.zig").GridSize;`), so every existing renderer-side user keeps compiling unchanged.
- `src/termio/Thread.zig` and `src/termio/message.zig` import `core/geometry` instead of `renderer`. The `renderer` import was used ONLY for `renderer.size.GridSize`, so it is fully removed from both.

## Ratchet
termio -> renderer GridSize references: **2 files / 6 usages -> 0**. `rg -n "@import\(.*renderer" src/termio` now returns nothing.

## Behavior / verification
No resize/semantic/UX change. `zig fmt` clean; `zig build test` (fast native suite) green — the only failure ever seen is the pre-existing load-sensitive flaky timing test `tool_import.zig:715 runArgvProbe is bounded` (also fails on `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)