### PR TITLE
refactor: extract shared ASCII case-insensitive text matching

### DIFF
--- a/src/ai_history_types.zig
+++ b/src/ai_history_types.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const text_search = @import("text_search.zig");
 
 pub const ProviderId = enum {
     codex,
@@ -144,28 +145,11 @@ pub fn lessRecent(_: void, lhs: SessionMeta, rhs: SessionMeta) bool {
 
 pub fn metadataMatches(meta: SessionMeta, query: []const u8) bool {
     if (query.len == 0) return true;
-    return containsIgnoreCase(meta.title, query) or
-        containsIgnoreCase(meta.summary, query) or
-        containsIgnoreCase(meta.project_dir, query) or
-        containsIgnoreCase(meta.session_id, query) or
-        containsIgnoreCase(meta.source_path, query);
-}
-
-fn containsIgnoreCase(haystack: []const u8, query: []const u8) bool {
-    if (query.len == 0) return true;
-    if (query.len > haystack.len) return false;
-    var i: usize = 0;
-    while (i + query.len <= haystack.len) : (i += 1) {
-        var matched = true;
-        for (query, 0..) |qch, j| {
-            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(qch)) {
-                matched = false;
-                break;
-            }
-        }
-        if (matched) return true;
-    }
-    return false;
+    return text_search.containsIgnoreCase(meta.title, query) or
+        text_search.containsIgnoreCase(meta.summary, query) or
+        text_search.containsIgnoreCase(meta.project_dir, query) or
+        text_search.containsIgnoreCase(meta.session_id, query) or
+        text_search.containsIgnoreCase(meta.source_path, query);
 }
 
 test "ai_history_types: provider labels are stable" {

--- a/src/browser_panel.zig
+++ b/src/browser_panel.zig
@@ -10,6 +10,7 @@ const window_backend = @import("platform/window_backend.zig");
 const ui_perf = @import("ui_perf.zig");
 const tab = @import("appwindow/tab.zig");
 const active_tab_state = @import("appwindow/active_tab.zig");
+const text_search = @import("text_search.zig");
 
 pub const DEFAULT_WIDTH: f32 = 720;
 pub const MIN_WIDTH: f32 = 360;
@@ -526,16 +527,11 @@ fn normalizeUrlInput(allocator: std.mem.Allocator, input: []const u8) ?[]u8 {
 }
 
 fn defaultsToHttp(input: []const u8) bool {
-    return startsWithIgnoreCase(input, "localhost") or
-        startsWithIgnoreCase(input, "127.") or
-        startsWithIgnoreCase(input, "0.0.0.0") or
-        startsWithIgnoreCase(input, "[::1]") or
+    return text_search.startsWithIgnoreCase(input, "localhost") or
+        text_search.startsWithIgnoreCase(input, "127.") or
+        text_search.startsWithIgnoreCase(input, "0.0.0.0") or
+        text_search.startsWithIgnoreCase(input, "[::1]") or
         std.mem.indexOfScalar(u8, input, ':') != null;
-}
-
-fn startsWithIgnoreCase(text: []const u8, prefix: []const u8) bool {
-    if (text.len < prefix.len) return false;
-    return std.ascii.eqlIgnoreCase(text[0..prefix.len], prefix);
 }
 
 fn copyBounded(dest: []u8, text: []const u8) usize {

--- a/src/ssh_prompt.zig
+++ b/src/ssh_prompt.zig
@@ -1,29 +1,8 @@
 const std = @import("std");
-
-fn lowerAscii(ch: u8) u8 {
-    return if (ch >= 'A' and ch <= 'Z') ch + 32 else ch;
-}
-
-fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
-    if (needle.len == 0) return true;
-    if (needle.len > haystack.len) return false;
-
-    var start: usize = 0;
-    while (start + needle.len <= haystack.len) : (start += 1) {
-        var matched = true;
-        for (needle, 0..) |needle_ch, i| {
-            if (lowerAscii(haystack[start + i]) != lowerAscii(needle_ch)) {
-                matched = false;
-                break;
-            }
-        }
-        if (matched) return true;
-    }
-    return false;
-}
+const text_search = @import("text_search.zig");
 
 pub fn containsPasswordPromptText(text: []const u8) bool {
-    return containsIgnoreCase(text, "password:");
+    return text_search.containsIgnoreCase(text, "password:");
 }
 
 test "ssh prompt detects OpenSSH password prompt" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -152,6 +152,7 @@ test {
     _ = @import("ai_history_resume.zig");
     _ = @import("ai_history_session.zig");
     _ = @import("browser_url.zig");
+    _ = @import("text_search.zig");
     _ = @import("ssh_prompt.zig");
     _ = @import("selection_unit.zig");
     _ = @import("scrollbar_model.zig");

--- a/src/text_search.zig
+++ b/src/text_search.zig
@@ -1,0 +1,80 @@
+//! Pure ASCII case-insensitive text matching helpers.
+//!
+//! Extracted from duplicated local copies (ssh_prompt, ai_history_types,
+//! browser_panel, ...). Semantics deliberately match those originals exactly so
+//! call-site behavior is unchanged:
+//!   * `containsIgnoreCase`: empty needle matches anything (returns true); a
+//!     needle longer than the haystack never matches (returns false).
+//!   * `startsWithIgnoreCase`: an empty prefix always matches; a prefix longer
+//!     than the haystack never matches.
+//!
+//! ASCII only — no Unicode case folding. Comparisons go through `std.ascii`.
+
+const std = @import("std");
+
+/// Returns true if `needle` appears anywhere in `haystack`, comparing bytes
+/// case-insensitively over ASCII A-Z/a-z. An empty `needle` returns true; a
+/// `needle` longer than `haystack` returns false.
+pub fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+
+    var start: usize = 0;
+    while (start + needle.len <= haystack.len) : (start += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[start .. start + needle.len], needle)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Returns true if `haystack` begins with `prefix`, comparing bytes
+/// case-insensitively over ASCII A-Z/a-z. An empty `prefix` returns true; a
+/// `prefix` longer than `haystack` returns false.
+pub fn startsWithIgnoreCase(haystack: []const u8, prefix: []const u8) bool {
+    if (prefix.len > haystack.len) return false;
+    return std.ascii.eqlIgnoreCase(haystack[0..prefix.len], prefix);
+}
+
+test "containsIgnoreCase empty needle matches anything" {
+    try std.testing.expect(containsIgnoreCase("", ""));
+    try std.testing.expect(containsIgnoreCase("anything", ""));
+}
+
+test "containsIgnoreCase ascii lower match" {
+    try std.testing.expect(containsIgnoreCase("hello world", "world"));
+    try std.testing.expect(containsIgnoreCase("password:", "password:"));
+}
+
+test "containsIgnoreCase ascii upper match" {
+    try std.testing.expect(containsIgnoreCase("HELLO WORLD", "WORLD"));
+    try std.testing.expect(containsIgnoreCase("Password:", "password:"));
+}
+
+test "containsIgnoreCase mixed case match" {
+    try std.testing.expect(containsIgnoreCase("HeLLo WoRLd", "hello"));
+    try std.testing.expect(containsIgnoreCase("root@example.com's Password:", "password:"));
+}
+
+test "containsIgnoreCase not found" {
+    try std.testing.expect(!containsIgnoreCase("hello world", "xyz"));
+    try std.testing.expect(!containsIgnoreCase("hi", "hello"));
+}
+
+test "containsIgnoreCase needle longer than haystack" {
+    try std.testing.expect(!containsIgnoreCase("ab", "abc"));
+    try std.testing.expect(!containsIgnoreCase("", "x"));
+}
+
+test "startsWithIgnoreCase prefix match" {
+    try std.testing.expect(startsWithIgnoreCase("localhost:3000", "localhost"));
+    try std.testing.expect(startsWithIgnoreCase("LOCALHOST", "localhost"));
+    try std.testing.expect(startsWithIgnoreCase("LocalHost", "LOCAL"));
+    try std.testing.expect(startsWithIgnoreCase("anything", ""));
+}
+
+test "startsWithIgnoreCase non-match" {
+    try std.testing.expect(!startsWithIgnoreCase("example.com", "localhost"));
+    try std.testing.expect(!startsWithIgnoreCase("127", "127.0.0.1"));
+    try std.testing.expect(!startsWithIgnoreCase("abc", "abcd"));
+}


### PR DESCRIPTION
Part of the responsibility-boundary refactor (safe batch, task 07): de-duplicate case-insensitive text matching into one pure module.

## What
- New `src/text_search.zig` with `containsIgnoreCase` and `startsWithIgnoreCase` (built on `std.ascii.eqlIgnoreCase`), edge cases matched exactly to the prior local copies (empty needle/prefix -> true; longer-than-haystack -> false). 8 unit tests, registered in `src/test_fast.zig`.
- Migrated 3 non-overlay call sites to the shared module and deleted their local copies: `ssh_prompt.zig`, `ai_history_types.zig`, `browser_panel.zig`.
- Overlay/command-palette copies (`command_palette_model.zig`, `renderer/overlays.zig`, `renderer/ai_history_renderer.zig`) intentionally left untouched (separate overlay pilot).

## Behavior / verification
No sort/filter/fuzzy ordering changed; no Unicode case folding introduced. `zig fmt` clean; `zig build test` green (modulo the unrelated pre-existing `tool_import runArgvProbe` timing flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)