### PR TITLE
docs: name the integration-layer vs feature-domain boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ A file may be large when it owns one coherent domain object and exposes a clear 
 
 The goal is not small files but code that can be **understood, tested, and changed locally**. Large-but-cohesive is fine; large-but-tangled must be split. New features should prefer focused modules over growing existing hub files. New UI state must live in an explicit state struct or a feature-owned module — never as another top-level `g_*` / `threadlocal` field in `AppWindow.zig`, `input.zig`, or `renderer/overlays.zig`.
 
+### Integration layer vs feature domains
+
+`AppWindow.zig`, `input.zig`, and `renderer/overlays.zig` are an **integration layer**, not terminal "core". They *coordinate* features — AppWindow assembles modules and routes render/input, `input.zig` dispatches events, `overlays.zig` is the overlay facade/registry — but they must **not own feature state**. The **feature domains** own their own state, query/action APIs, and tests: `ai_chat*`, `weixin/*`, the `skill_*` modules, `file_explorer.zig`, the `tmux_*` controllers, and the `remote_*` client/sync code.
+
+When writing new code: feature domains should not depend on `AppWindow` (expose an API, receive context explicitly); `input.zig` only dispatches and returns a `UiEffect` — it must not read a feature's internal `g_*` state; overlays get capabilities through a Host/Context, not by importing `AppWindow.zig`. Prefer explicit context structs, feature-owned query/action APIs, and `UiEffect` returns. **Each time you touch one of these monoliths, lower the matching source-guard ratchet** — that is how the boundary converges. The full layer model and per-edge rules are in [docs/architecture.md](docs/architecture.md#integration-layer-vs-feature-domains) and [docs/decoupling-guide.md §8.5](docs/decoupling-guide.md#85-the-layer-model).
+
 ### Boundary guards (`src/source_guards/`)
 
 Structural debt is frozen mechanically by source-scanning ratchet tests (the same `@embedFile`-scan idiom as `input/dirty_guard.zig`). They run in `zig build test` and, because `test-full` is now a superset of `test`, in the pre-merge gate too. Each freezes a count at today's value; the count may only **shrink**. To add a case you must first remove one elsewhere — or, better, use the pattern the guard points you to.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,9 +27,11 @@ an experimental Linux host.
    platform runtime.
    - `src/AppWindow.zig` — window-level tabs, splits, and the render/input
      routing that drives surfaces. Platform-neutral; calls the host interface.
-     Its orchestration is being decomposed into `src/appwindow/*` (aggregated
-     state structs, the `UiEffect` invalidation boundary, and feature bridges) —
-     see the structural-debt governance in
+     It is an **integration layer** (see below), not terminal core: it
+     coordinates features but must not own their state. Its orchestration is
+     being decomposed into `src/appwindow/*` (aggregated state structs, the
+     `UiEffect` invalidation boundary, and feature bridges) — see the
+     structural-debt governance in
      [docs/decoupling-guide.md §8](decoupling-guide.md#8-structural-debt-governance-axis-b-in-practice).
    - `src/platform/window_backend.zig` — **the host interface** (see below).
    - `src/apprt/win32.zig` — the concrete Win32 host runtime behind the
@@ -140,6 +142,45 @@ Because `test-full` is a superset of `test`, these gate the pre-merge build. The
 cohesion criterion, the remediation roadmap, and the layer model live in
 [docs/decoupling-guide.md §8](decoupling-guide.md#8-structural-debt-governance-axis-b-in-practice);
 the contributor-facing summary is in [`AGENTS.md`](../AGENTS.md).
+
+## Integration layer vs feature domains
+
+A second boundary cuts *across* the core, orthogonal to the platform seam: the
+distinction between the **integration layer** that coordinates features and the
+**feature domains** that own them. The four monoliths above sit on the wrong
+side of it today, which is why they carry the ratchets.
+
+- **Integration layer** — `src/AppWindow.zig`, `src/input.zig`, and
+  `src/renderer/overlays.zig`. These *coordinate*: AppWindow assembles modules
+  and routes render/input, `input.zig` dispatches keyboard/mouse events to
+  whoever should handle them, and `overlays.zig` is the overlay facade/registry.
+  They are **not** the terminal "core" and must **not own feature state**. When
+  they hold a feature's `g_*` globals or reach into a feature's internals, that
+  is the entanglement the ratchets are freezing — not a property of being a host.
+
+- **Feature domains** — each owns its own state, query/action API, and tests:
+  `ai_chat*` (agent/session/tools/streaming), `weixin/*`, the `skill_*` modules,
+  `file_explorer.zig`, the `tmux_*` controllers, and the `remote_*` client/sync
+  code. A domain is responsible for its own behavior; the integration layer only
+  wires it in and asks it to do things.
+
+Guidance for new code (these keep the boundary from re-tangling):
+
+- **Feature domains should not depend on `AppWindow`.** They expose their own
+  API and receive what they need explicitly; they do not reach back through the
+  window for context.
+- **`input.zig` only dispatches.** It decides *who* handles an event and returns
+  a `UiEffect`; it must not read a feature's internal `g_*` state to make that
+  decision.
+- **Overlays get capabilities through a Host/Context**, not by importing
+  `AppWindow.zig` (only narrow types such as `appwindow/ui_effect.zig`).
+- Prefer **explicit context structs**, **feature-owned query/action APIs**, and
+  **`UiEffect` returns** over scattered globals and direct dirty writes.
+- **Each time you touch a monolith, lower the matching source-guard ratchet**
+  (`global_state_guard` / `import_hub_guard` / `side_effect_guard`) — moving one
+  case to the right pattern is how the boundary actually converges. The layer
+  model that names these reverse edges is
+  [docs/decoupling-guide.md §8.5](decoupling-guide.md#85-the-layer-model).
 
 ## Implementing a new host
 

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -373,6 +373,19 @@ The smell is entanglement: presentation mixed with business mutation, input
 dispatch mixed with rendering, global mutable state scattered across facades, a
 file becoming the import hub for unrelated features.
 
+The sharpest case of that entanglement is the **integration layer owning feature
+state**. `AppWindow.zig`, `input.zig`, and `renderer/overlays.zig` are an
+integration layer: they *coordinate* features (module assembly + render/input
+routing, event dispatch, overlay facade/registry) and are **not** terminal
+"core". The **feature domains** are the modules that own their own state and
+behavior — `ai_chat*`, `weixin/*`, the `skill_*` modules, `file_explorer.zig`,
+the `tmux_*` controllers, and the `remote_*` client/sync code. Today the
+integration layer holds feature `g_*` globals, re-exports unrelated feature
+modules, and reaches into feature internals; that is exactly what the §8.2
+ratchets freeze and shrink. Treat each ratchet step as moving one responsibility
+back to the domain that owns it. The architecture-doc summary of this split is
+[architecture.md § Integration layer vs feature domains](architecture.md#integration-layer-vs-feature-domains).
+
 Two numeric signals sit on top of that judgment, neither of which is the goal:
 
 - **> 5,000 lines** — a soft signal to review responsibility, dependency
@@ -513,3 +526,14 @@ The reverse edges worth locking first (the layered-dependency guard in §8.2):
 `renderer/overlays/*` must not import `AppWindow.zig` (only narrow types such as
 `appwindow/ui_effect.zig`); `input/*` must not import a concrete renderer module;
 `ai_chat.zig` must not hold a set of UI-trigger callbacks directly.
+
+Restated as rules for new code, against the integration-layer/feature-domain
+split above: **feature domains must not depend on `AppWindow`** — they expose a
+query/action API and receive context explicitly rather than reaching back
+through the window; **`input/*` only dispatches** — it decides who handles an
+event and returns a `UiEffect`, and must not read a feature's internal `g_*`
+state to do so; **overlays receive capabilities through an injected
+Host/Context**, not by importing `AppWindow.zig`. Prefer explicit context
+structs, feature-owned query/action APIs, and `UiEffect` returns over scattered
+globals — and each time you touch a monolith, lower the matching §8.2 ratchet so
+the boundary converges instead of being re-frozen in place.


### PR DESCRIPTION
Part of the responsibility-boundary refactor (safe batch, task 08): docs only, no code.

Updates `docs/architecture.md`, `AGENTS.md`, and `docs/decoupling-guide.md` to state that `AppWindow.zig`, `input.zig`, and `renderer/overlays.zig` are an **integration layer** (coordinate features, do not own feature state), while `ai_chat*`, `weixin/*`, `skill_*`, `file_explorer.zig`, `tmux_*`, `remote_*` are **feature domains** that own their own state. Adds new-code guidance: domains do not depend on AppWindow; input only dispatches; overlays get capabilities via a Host/Context; prefer explicit context structs, feature-owned query/action APIs, UiEffect returns; lower the matching source-guard ratchet on each touch.

No code changed; superpowers archive untouched; no security-timeline promises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)