### PR TITLE
refactor(ui): introduce minimal UiContext DI seam

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -100,6 +100,7 @@ const weixin_bridge = @import("appwindow/weixin_bridge.zig");
 const agent_requests = @import("appwindow/agent_requests.zig");
 const ui_effect = @import("appwindow/ui_effect.zig");
 pub const UiEffect = ui_effect.UiEffect;
+const ui_context = @import("ui/context.zig");
 pub const fbo = @import("renderer/fbo.zig");
 pub const background_image = @import("renderer/background_image.zig");
 pub const file_explorer = @import("file_explorer.zig");
@@ -2984,6 +2985,55 @@ pub fn applyUiEffect(effect: UiEffect) void {
     if (effect.needs_rebuild) g_force_rebuild = true;
     if (effect.cells_invalid) g_cells_valid = false;
     if (effect.wake_backend) window_backend.postWakeup();
+}
+
+// --- UiContext dependency-injection seam -----------------------------------
+//
+// These thin wrappers exist so `uiContext()` can hand out fn-pointers with
+// stable signatures. They route to the existing UI-thread plumbing
+// (`applyUiEffect`, `g_force_rebuild`, `overlays.showStatusToast`) so behavior
+// is preserved exactly; the seam just gives call sites a way to depend on a
+// small capability set instead of the AppWindow globals directly.
+
+fn uiCtxRequestRepaint() void {
+    markUiDirty();
+}
+
+fn uiCtxRequestRebuild() void {
+    // Land the rebuild through the effect boundary rather than poking
+    // g_force_rebuild directly, matching the side-effect ratchet.
+    applyUiEffect(.{ .needs_rebuild = true });
+}
+
+fn uiCtxShowToast(msg: []const u8) void {
+    overlays.showStatusToast(msg);
+}
+
+/// Construct a `UiContext` wired to this window's existing capabilities.
+///
+/// First dependency-injection seam: a path away from the AppWindow service
+/// locator. The fn-pointers wrap existing UI-thread plumbing, so callers get
+/// the same behavior they would by calling those functions directly.
+pub fn uiContext() ui_context.UiContext {
+    return .{
+        .allocator = g_allocator orelse std.heap.page_allocator,
+        .requestRepaint = uiCtxRequestRepaint,
+        .requestRebuild = uiCtxRequestRebuild,
+        .showToast = uiCtxShowToast,
+    };
+}
+
+test "AppWindow: uiContext constructs and exposes wired capabilities" {
+    const ctx = uiContext();
+    // The constructed seam must expose the exact wrapper fns, so callers route
+    // through the existing UI-thread plumbing (applyUiEffect / showStatusToast).
+    try std.testing.expect(ctx.requestRepaint == uiCtxRequestRepaint);
+    try std.testing.expect(ctx.requestRebuild == uiCtxRequestRebuild);
+    try std.testing.expect(ctx.showToast == uiCtxShowToast);
+
+    // A constructed allocator must always be present (fallback when g_allocator
+    // is unset), so callers can allocate without a null check.
+    try std.testing.expect(@TypeOf(ctx.allocator) == std.mem.Allocator);
 }
 
 /// Tick all preview panes across every tab. Returns true if any pane

--- a/src/ui/context.zig
+++ b/src/ui/context.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+/// Dependency-injection seam for UI-thread capabilities.
+///
+/// `UiContext` is an INTERFACE-ONLY struct: it carries no business logic and
+/// owns no state. It exists so call sites can depend on a small, explicit set
+/// of capabilities (repaint / rebuild / toast) instead of reaching into the
+/// `AppWindow` service locator (its ~67 `g_*` globals). The fn-pointers are
+/// wired by `AppWindow.uiContext()` to thin wrappers around existing plumbing,
+/// so behavior is preserved exactly.
+pub const UiContext = struct {
+    allocator: std.mem.Allocator,
+    requestRepaint: *const fn () void,
+    requestRebuild: *const fn () void,
+    showToast: *const fn (msg: []const u8) void,
+};
+
+test "ui context is constructible from no-op pointers" {
+    const Noop = struct {
+        fn repaint() void {}
+        fn rebuild() void {}
+        fn toast(msg: []const u8) void {
+            _ = msg;
+        }
+    };
+
+    const ctx = UiContext{
+        .allocator = std.testing.allocator,
+        .requestRepaint = Noop.repaint,
+        .requestRebuild = Noop.rebuild,
+        .showToast = Noop.toast,
+    };
+
+    // Invoking the pointers must be safe and side-effect-free here.
+    ctx.requestRepaint();
+    ctx.requestRebuild();
+    ctx.showToast("hello");
+}


### PR DESCRIPTION
Part of the responsibility-boundary refactor (safe batch, task 05): establish a dependency-injection seam instead of growing the AppWindow service locator (~67 g_* globals). Skeleton only — no full migration.

## What
- New `src/ui/context.zig`: interface-only `UiContext` struct (`allocator` + `requestRepaint`/`requestRebuild`/`showToast` fn-pointers). No business logic.
- `AppWindow.uiContext()` constructor wires the pointers to EXISTING plumbing: `markUiDirty()`, `applyUiEffect(.{ .needs_rebuild = true })`, `overlays.showStatusToast()`; allocator from `g_allocator`.
- Seam proven via a construction test (no existing call site re-routed — lowest-risk option for the trickiest task in the batch).

## Guard note
First attempt wired rebuild via a direct `g_force_rebuild = true`, which tripped `side_effect_guard` (AppWindow dirty-global-write ceiling 63 -> 66). Fixed by routing through `applyUiEffect` as the guard prescribes — the frozen count stays at baseline 63.

## Verification
`zig fmt` clean; `zig build test` green (modulo the unrelated pre-existing `tool_import runArgvProbe` timing flake). No AppWindow re-export expansion; no mass mechanical edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)