### PR TITLE
refactor(input): query file_explorer accessors instead of g_* reads

### DIFF
--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -196,6 +196,38 @@ pub fn isVisibleForActiveTab() bool {
     return g_visible and owner == active_tab_state.g_active_tab;
 }
 
+/// Narrow, read-only queries used by the input layer so it does not have to
+/// reach into file-explorer globals directly. These preserve the exact
+/// semantics of the underlying `g_*` reads.
+pub fn isFocused() bool {
+    return g_focused;
+}
+
+/// Current inline-operation mode (rename / new file / new dir / confirm delete).
+pub fn opMode() OpMode {
+    return g_op_mode;
+}
+
+/// True when any inline file operation is active (not `.none`).
+pub fn hasActiveOp() bool {
+    return g_op_mode != .none;
+}
+
+/// True when the panel is showing the agent-history view rather than files.
+pub fn isAgentHistoryPanel() bool {
+    return g_panel_mode == .agent_history;
+}
+
+/// True when the panel is showing the file-tree view (not agent history).
+pub fn isFilesPanel() bool {
+    return g_panel_mode == .files;
+}
+
+/// True when the explorer is browsing a remote (SSH) location.
+pub fn isRemoteMode() bool {
+    return g_mode == .remote;
+}
+
 pub fn openForActiveTab() void {
     g_visible = true;
     g_owner_tab = active_tab_state.g_active_tab;
@@ -2247,6 +2279,48 @@ test "file_explorer: switching to agent history clears file op state" {
     try std.testing.expectEqual(@as(u8, 0), g_input_len);
     try std.testing.expectEqual(@as(f32, 77), g_scroll_offset);
     try std.testing.expectEqual(@as(f32, 12), g_history_scroll_offset);
+}
+
+test "file_explorer: narrow query accessors reflect global state" {
+    const prev_focused = g_focused;
+    const prev_op_mode = g_op_mode;
+    const prev_panel_mode = g_panel_mode;
+    const prev_mode = g_mode;
+    defer {
+        g_focused = prev_focused;
+        g_op_mode = prev_op_mode;
+        g_panel_mode = prev_panel_mode;
+        g_mode = prev_mode;
+    }
+
+    g_focused = true;
+    try std.testing.expect(isFocused());
+    g_focused = false;
+    try std.testing.expect(!isFocused());
+
+    g_op_mode = .none;
+    try std.testing.expect(!hasActiveOp());
+    try std.testing.expectEqual(OpMode.none, opMode());
+    g_op_mode = .rename;
+    try std.testing.expect(hasActiveOp());
+    try std.testing.expectEqual(OpMode.rename, opMode());
+    g_op_mode = .confirm_delete;
+    try std.testing.expect(hasActiveOp());
+    try std.testing.expectEqual(OpMode.confirm_delete, opMode());
+
+    g_panel_mode = .files;
+    try std.testing.expect(isFilesPanel());
+    try std.testing.expect(!isAgentHistoryPanel());
+    g_panel_mode = .agent_history;
+    try std.testing.expect(isAgentHistoryPanel());
+    try std.testing.expect(!isFilesPanel());
+
+    g_mode = .remote;
+    try std.testing.expect(isRemoteMode());
+    g_mode = .local;
+    try std.testing.expect(!isRemoteMode());
+    g_mode = .wsl;
+    try std.testing.expect(!isRemoteMode());
 }
 
 test "file_explorer: syncPanelForTabKind resets focus and mode" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -2651,7 +2651,7 @@ fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
         return .none;
     }
     // File explorer inline editing
-    if (file_explorer.g_focused and file_explorer.isVisibleForActiveTab() and file_explorer.g_op_mode != .none and file_explorer.g_op_mode != .confirm_delete) {
+    if (file_explorer.isFocused() and file_explorer.isVisibleForActiveTab() and file_explorer.hasActiveOp() and file_explorer.opMode() != .confirm_delete) {
         if (!ev.ctrl and !ev.alt) file_explorer.inputChar(ev.codepoint);
         return .none;
     }
@@ -3127,7 +3127,7 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
         return .none;
     }
     // File explorer key handling (when focused and in operation mode)
-    if (file_explorer.g_focused and file_explorer.isVisibleForActiveTab()) {
+    if (file_explorer.isFocused() and file_explorer.isVisibleForActiveTab()) {
         if (handleFileExplorerKey(ev)) {
             // Navigation/edits change what the panel draws; request a frame so it
             // updates immediately (same rationale as the wheel-scroll path).
@@ -4008,7 +4008,7 @@ fn applyExplorerWidthFromMouse(xpos: f64) void {
 }
 
 fn handleFileExplorerKey(ev: platform_input.KeyEvent) bool {
-    if (file_explorer.g_panel_mode == .agent_history) {
+    if (file_explorer.isAgentHistoryPanel()) {
         return handleAgentHistoryKey(ev);
     }
 
@@ -4019,7 +4019,7 @@ fn handleFileExplorerKey(ev: platform_input.KeyEvent) bool {
     const key_down = platform_input.key_down;
 
     // In input mode (rename/new file/new dir)
-    if (file_explorer.g_op_mode != .none) {
+    if (file_explorer.hasActiveOp()) {
         switch (ev.key_code) {
             key_escape => {
                 file_explorer.cancelOp();
@@ -4091,7 +4091,7 @@ fn handleFileExplorerKey(ev: platform_input.KeyEvent) bool {
         },
         0x53 => { // 'S' key: Ctrl/Cmd+S = download selected file
             if ((ev.ctrl or ev.super) and !ev.alt and !ev.shift) {
-                if (file_explorer.g_mode == .remote) {
+                if (file_explorer.isRemoteMode()) {
                     // Download to user's Downloads folder
                     var dl_buf: [260]u8 = undefined;
                     const dl_path = getDownloadsFolder(&dl_buf);
@@ -4104,7 +4104,7 @@ fn handleFileExplorerKey(ev: platform_input.KeyEvent) bool {
             return false;
         },
         0x55 => { // 'U' = upload file; Shift+U = upload folder
-            if (file_explorer.g_mode == .remote and !ev.ctrl and !ev.alt and !ev.super) {
+            if (file_explorer.isRemoteMode() and !ev.ctrl and !ev.alt and !ev.super) {
                 if (ev.shift) {
                     openFolderDialogAndUpload();
                 } else {
@@ -4208,13 +4208,13 @@ fn handleFileExplorerPress(xpos: f64, ypos: f64, ctrl: bool, shift: bool, alt: b
         return;
     }
 
-    if (file_explorer.g_panel_mode == .agent_history) {
+    if (file_explorer.isAgentHistoryPanel()) {
         handleAgentHistoryPress(xpos, ypos);
         return;
     }
 
     // Cancel any active op on click elsewhere in the panel
-    if (file_explorer.g_op_mode != .none) {
+    if (file_explorer.hasActiveOp()) {
         file_explorer.cancelOp();
     }
 
@@ -5533,7 +5533,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 closeFileExplorerPanel();
                 return;
             }
-            if (file_explorer.g_panel_mode == .files and hitTestFileExplorerRefreshButton(xpos, ypos)) {
+            if (file_explorer.isFilesPanel() and hitTestFileExplorerRefreshButton(xpos, ypos)) {
                 file_explorer.refresh();
                 requestInputRepaint();
                 return;
@@ -5587,7 +5587,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
 
             if (over_browser_url_bar) {
                 file_explorer.g_focused = false;
-                if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+                if (file_explorer.hasActiveOp()) file_explorer.cancelOp();
                 browser_panel.focusUrlBar();
                 markBrowserUrlBarDirty();
                 return;
@@ -5600,7 +5600,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
 
             if (hitTestBrowserPanel(xpos, ypos)) {
                 file_explorer.g_focused = false;
-                if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+                if (file_explorer.hasActiveOp()) file_explorer.cancelOp();
                 browser_panel.blurUrlBar();
                 markBrowserUrlBarDirty();
                 browser_panel.focus();
@@ -5615,7 +5615,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
 
             // Clicking outside file explorer unfocuses it
             file_explorer.g_focused = false;
-            if (file_explorer.g_op_mode != .none) file_explorer.cancelOp();
+            if (file_explorer.hasActiveOp()) file_explorer.cancelOp();
 
             if (AppWindow.activeAiHistory() != null) {
                 if (AppWindow.aiHistoryHandleMousePress(xpos, ypos)) return;


### PR DESCRIPTION
Part of the responsibility-boundary refactor (task 04, final task of round 1): make `input.zig` ASK `file_explorer` narrow questions instead of reaching into its threadlocal globals. Minimal first slice — only the simplest PRODUCTION read sites.

## What
- `src/file_explorer.zig`: 6 narrow read-only query accessors (each mirrors the exact semantics of the underlying global) + a unit test:
  `isFocused()` ← g_focused; `opMode()` ← g_op_mode; `hasActiveOp()` ← g_op_mode != .none; `isAgentHistoryPanel()` ← g_panel_mode == .agent_history; `isFilesPanel()` ← g_panel_mode == .files; `isRemoteMode()` ← g_mode == .remote.
- `src/input.zig`: 12 production read sites migrated from `file_explorer.g_*` to accessors (inline-edit guard, key/mouse dispatch focus checks, op-mode/panel-mode guards, remote upload/download gates, click-elsewhere cancel paths). file_explorer remains the sole state owner.

## Ratchet
Production `file_explorer.g_*` READ references in `input.zig`: **24 -> 12**. Raw `g_` references: 86 -> 74. No write sites and no test-fixture save/restore blocks were touched.

## Scope / what remains
First slice. The remaining 12 production reads need richer accessors (entry-array access, selection payload, scroll offsets, and a `previewSourceKind()` that owns the g_mode + ssh-conn assembly) — future slices.

## Verification
Byte-for-byte behavior-preserving (no local/remote/wsl, upload/download, or selection change). `zig fmt` clean; `zig build test` green — only failure is the pre-existing `tool_import.zig:715 runArgvProbe` timing flake (fails on main too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)