### PR TITLE
test(source-guards): lower responsibility-boundary ratchets after split

### DIFF
--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -23,9 +23,13 @@ const Frozen = struct {
 };
 
 const monoliths = [_]Frozen{
+    // Ceilings re-tightened to the current actual after the round-1
+    // responsibility split. input.zig dropped 55->52 (lost the 3 g_mouse_report_*
+    // globals via the mouse_dispatch slice); overlays.zig dropped 48->47.
+    // AppWindow (67) and ai_chat (20) were already at their actual.
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
-    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 55 },
-    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 48 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 52 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 47 },
     .{ .name = "ai_chat.zig", .source = @embedFile("../ai_chat.zig"), .ceiling = 20 },
 };
 

--- a/src/source_guards/import_hub_guard.zig
+++ b/src/source_guards/import_hub_guard.zig
@@ -12,6 +12,8 @@ const scan = @import("scan.zig");
 const app_window = @embedFile("../AppWindow.zig");
 
 /// Frozen at the current count; the ratchet may only ratchet DOWN.
+/// Verified post-round-1: AppWindow re-exports 18 modules today, so the
+/// ceiling already equals the actual and has no slack to lower this round.
 const reexport_ceiling: usize = 18;
 
 fn reexportCount(source: []const u8) usize {

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,6 +19,9 @@ const Frozen = struct {
     ceiling: usize,
 };
 
+// Verified against the post-round-1 tree: every direct-write ceiling here
+// already equals the current actual (AppWindow 63, input 81, overlays 12,
+// ai_chat 0), so there is no slack to ratchet away this round.
 const monoliths = [_]Frozen{
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 63 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },


### PR DESCRIPTION
Phase 4 batch 1 (ratchet lowering): prove the round-1 responsibility splits reduced debt, not just relocated it, by tightening guard ceilings to the current actual values. Test/guard-only — no production code touched.

## What
- `global_state_guard.zig`: `input.zig` **55 -> 52** (round-1 removed the 3 `g_mouse_report_*` globals via the mouse_dispatch slice + close-confirm global); `renderer/overlays.zig` **48 -> 47**.
- All other ceilings already equalled their current actual and were LEFT UNCHANGED (no slack), with comments recording the post-round-1 verification as a baseline: global_state AppWindow 67 / ai_chat 20; side_effect AppWindow 63 / input 81 / overlays 12 / ai_chat 0; import_hub reexport 18. `file_size_guard` untouched (intentional wide backstop).

## Verification
Actuals computed by replicating the scan.zig algorithms. `zig fmt` clean; `zig build test` green with the tighter ceilings (only failure is the pre-existing `tool_import runArgvProbe` timing flake, also red on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)