### PR TITLE
test(source-guards): enforce feature boundaries after responsibility split

### DIFF
--- a/src/source_guards/input_feature_boundary_guard.zig
+++ b/src/source_guards/input_feature_boundary_guard.zig
@@ -1,0 +1,54 @@
+//! Input/feature-boundary ratchet. `input.zig` historically reaches directly into
+//! `file_explorer`'s mutable global state (`file_explorer.g_*`) instead of asking
+//! the file_explorer module a query. Round-1 task 04 added query accessors so this
+//! coupling can shrink; this guard freezes the raw `file_explorer.g_` reach-in count
+//! so it may only ratchet DOWN. Future slices should replace each `file_explorer.g_*`
+//! poke with a query call and lower the ceiling — never raise it.
+//!
+//! A second test guards the extracted `input/mouse_dispatch.zig` submodule: it was
+//! split out as a pure dispatch helper and must not depend on the window object, so
+//! its AppWindow import count is frozen at 0. See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const input_source = @embedFile("../input.zig");
+const mouse_dispatch_source = @embedFile("../input/mouse_dispatch.zig");
+
+/// Frozen at the current count; the ratchet may only ratchet DOWN.
+const file_explorer_global_ceiling: usize = 76;
+
+/// The extracted mouse-dispatch helper must not depend on the window object.
+const appwindow_import_ceiling: usize = 0;
+
+fn fileExplorerGlobalReachIns(source: []const u8) usize {
+    return scan.countOccurrences(source, "file_explorer.g_");
+}
+
+fn appWindowImportCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "@import(\"../AppWindow.zig\")");
+}
+
+test "input.zig reaching into file_explorer globals only shrinks" {
+    const count = fileExplorerGlobalReachIns(input_source);
+    if (count > file_explorer_global_ceiling) {
+        std.debug.print(
+            "input_feature_boundary_guard: input.zig touches file_explorer.g_* {d} time(s) " ++
+                "(frozen ceiling {d}). Ask file_explorer a query instead; do not raise the ceiling.\n",
+            .{ count, file_explorer_global_ceiling },
+        );
+        return error.InputReachedFileExplorerGlobals;
+    }
+}
+
+test "input/mouse_dispatch.zig does not import AppWindow" {
+    const count = appWindowImportCount(mouse_dispatch_source);
+    if (count > appwindow_import_ceiling) {
+        std.debug.print(
+            "input_feature_boundary_guard: input/mouse_dispatch.zig imports AppWindow.zig {d} time(s) " ++
+                "(frozen ceiling {d}). Keep this dispatch helper free of the window object.\n",
+            .{ count, appwindow_import_ceiling },
+        );
+        return error.MouseDispatchImportedAppWindow;
+    }
+}

--- a/src/source_guards/layered_dependency_guard.zig
+++ b/src/source_guards/layered_dependency_guard.zig
@@ -1,0 +1,42 @@
+//! Layered-dependency ratchet. `termio/**` is the PTY I/O layer; it must sit
+//! BELOW the renderer in the dependency graph and never reach up into it. After
+//! the round-1 termio extraction it depends on `core/geometry.zig` for the few
+//! shapes it needs instead of importing `renderer/**`, so the `@import("..renderer..")`
+//! count across the termio sources is 0. This freezes that: termio may not grow a
+//! renderer dependency. New termio code must import `core/*` (or a narrower
+//! module), not reach up into the renderer. See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const termio_sources = [_][]const u8{
+    @embedFile("../termio/Thread.zig"),
+    @embedFile("../termio/ReadThread.zig"),
+    @embedFile("../termio/Mailbox.zig"),
+    @embedFile("../termio/message.zig"),
+    @embedFile("../termio/read_coalesce.zig"),
+};
+
+/// termio is a lower layer than the renderer: it may not import it at all.
+const renderer_import_ceiling: usize = 0;
+
+fn rendererImportCount(source: []const u8) usize {
+    // Matches any relative import path that crosses into the renderer tree,
+    // e.g. `@import("../renderer/...")` or `@import("renderer/...")`.
+    return scan.countOccurrences(source, "renderer/");
+}
+
+test "termio does not import the renderer layer" {
+    var total: usize = 0;
+    for (termio_sources) |source| {
+        total += rendererImportCount(source);
+    }
+    if (total > renderer_import_ceiling) {
+        std.debug.print(
+            "layered_dependency_guard: termio/** references the renderer layer {d} time(s) " ++
+                "(frozen ceiling {d}). termio is below the renderer; import core/* instead of reaching up.\n",
+            .{ total, renderer_import_ceiling },
+        );
+        return error.TermioReachedRenderer;
+    }
+}

--- a/src/source_guards/overlay_boundary_guard.zig
+++ b/src/source_guards/overlay_boundary_guard.zig
@@ -1,0 +1,50 @@
+//! Overlay-boundary ratchet. The round-1 overlay split carved pure, unit-testable
+//! submodules (layout math, input mapping, codecs, view-models) out of the heavy
+//! `overlays.zig` graph. Those modules are pure precisely BECAUSE they do not
+//! depend on the window object: they never `@import("../../AppWindow.zig")`. This
+//! freezes that — each extracted pure module must keep its AppWindow import count
+//! at 0, so it stays testable in the fast suite without the GL/Surface graph.
+//!
+//! NOTE: only the already-extracted PURE modules are listed. `overlays.zig`
+//! itself legitimately imports AppWindow and is intentionally excluded.
+//! See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const PureModule = struct {
+    name: []const u8,
+    source: []const u8,
+};
+
+const pure_overlay_modules = [_]PureModule{
+    .{ .name = "command_palette_layout.zig", .source = @embedFile("../renderer/overlays/command_palette_layout.zig") },
+    .{ .name = "command_palette_input.zig", .source = @embedFile("../renderer/overlays/command_palette_input.zig") },
+    .{ .name = "ai_profiles.zig", .source = @embedFile("../renderer/overlays/ai_profiles.zig") },
+    .{ .name = "profile_codec.zig", .source = @embedFile("../renderer/overlays/profile_codec.zig") },
+    .{ .name = "ssh_profiles.zig", .source = @embedFile("../renderer/overlays/ssh_profiles.zig") },
+    .{ .name = "transfer_toast_model.zig", .source = @embedFile("../renderer/overlays/transfer_toast_model.zig") },
+    .{ .name = "update_prompt_model.zig", .source = @embedFile("../renderer/overlays/update_prompt_model.zig") },
+    .{ .name = "whats_new_model.zig", .source = @embedFile("../renderer/overlays/whats_new_model.zig") },
+};
+
+/// Pure overlay submodules must not depend on the window object.
+const appwindow_import_ceiling: usize = 0;
+
+fn appWindowImportCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "@import(\"../../AppWindow.zig\")");
+}
+
+test "extracted pure overlay modules do not import AppWindow" {
+    for (pure_overlay_modules) |module| {
+        const count = appWindowImportCount(module.source);
+        if (count > appwindow_import_ceiling) {
+            std.debug.print(
+                "overlay_boundary_guard: {s} imports AppWindow.zig {d} time(s) " ++
+                    "(frozen ceiling {d}). This module is pure; keep AppWindow out so it stays fast-suite testable.\n",
+                .{ module.name, count, appwindow_import_ceiling },
+            );
+            return error.PureOverlayImportedAppWindow;
+        }
+    }
+}

--- a/src/source_guards/ui_context_adoption_guard.zig
+++ b/src/source_guards/ui_context_adoption_guard.zig
@@ -1,0 +1,29 @@
+//! UI-context boundary ratchet. `ui/context.zig` is the round-1 seam that lets
+//! callers pass UI state explicitly instead of reaching through the window object.
+//! It only depends on `std` and must NOT import `AppWindow.zig` — otherwise it would
+//! re-introduce the very coupling it exists to break. This freezes its AppWindow
+//! import count at 0. See docs/decoupling-guide.md.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const ui_context_source = @embedFile("../ui/context.zig");
+
+/// The UI-context seam must stay independent of the window object.
+const appwindow_import_ceiling: usize = 0;
+
+fn appWindowImportCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "@import(\"../AppWindow.zig\")");
+}
+
+test "ui/context.zig does not import AppWindow" {
+    const count = appWindowImportCount(ui_context_source);
+    if (count > appwindow_import_ceiling) {
+        std.debug.print(
+            "ui_context_adoption_guard: ui/context.zig imports AppWindow.zig {d} time(s) " ++
+                "(frozen ceiling {d}). This seam exists to decouple from the window object; keep AppWindow out.\n",
+            .{ count, appwindow_import_ceiling },
+        );
+        return error.UiContextImportedAppWindow;
+    }
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -69,6 +69,10 @@ test {
     _ = @import("source_guards/global_state_guard.zig");
     _ = @import("source_guards/import_hub_guard.zig");
     _ = @import("source_guards/side_effect_guard.zig");
+    _ = @import("source_guards/layered_dependency_guard.zig");
+    _ = @import("source_guards/overlay_boundary_guard.zig");
+    _ = @import("source_guards/input_feature_boundary_guard.zig");
+    _ = @import("source_guards/ui_context_adoption_guard.zig");
     _ = @import("renderer/overlays/transfer_toast_model.zig");
     _ = @import("renderer/overlays/update_prompt_model.zig");
     _ = @import("renderer/overlays/whats_new_model.zig");


### PR DESCRIPTION
Phase 4 batch 1 (boundary guards): freeze the round-1 decoupling boundaries with minimal anti-regression source guards so they cannot silently regress. Test/guard-only. Each ceiling verified == current actual (green on this tree), failing only on a real future regression.

## New guards (registered in `src/test_fast.zig`)
1. `layered_dependency_guard.zig` — `src/termio/**` must not import the renderer layer. Scans all 5 termio sources for `renderer/`. **ceiling 0, actual 0** (round-1 task 06 moved termio onto core/geometry).
2. `overlay_boundary_guard.zig` — the 8 extracted PURE overlay submodules (command_palette_layout, command_palette_input, ai_profiles, profile_codec, ssh_profiles, transfer_toast_model, update_prompt_model, whats_new_model) must not `@import` AppWindow.zig. **ceiling 0 each**. Deliberately excludes `overlays.zig` and the 5 submodules that legitimately import AppWindow.
3. `input_feature_boundary_guard.zig` — (a) freezes `input.zig` reaching into `file_explorer.g_` internals at the current **ceiling 76** (ratchet-DOWN only; "ask file_explorer a query instead"); (b) `input/mouse_dispatch.zig` must not import AppWindow (**ceiling 0**).
4. `ui_context_adoption_guard.zig` — `ui/context.zig` must not import AppWindow (**ceiling 0**; it is std-only).

## Verification
`zig fmt` clean on all 5 files; `zig build test` (which runs the source_guards) exit 0. No existing guard files edited; `test_main.zig` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)