### PR TITLE
test(input): replace source-string dispatch checks with behavior tests

### DIFF
--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -167,3 +167,37 @@ test "focus_panel actions resolve to a 1-based focus_panel command (late phase o
     // Regression: the shared `else` arm still resolves switch_tab.
     try std.testing.expectEqual(Command{ .switch_tab = 0 }, resolve(.switch_tab_1, .late).?);
 }
+
+// Behavior test (converted from a source-string grep in test_main.zig that
+// asserted input.zig contained a `.copilot_conversation_picker =>` dispatch
+// arm). The dispatch lives here now; assert the real resolver wiring instead of
+// grepping for the arm text.
+test "copilot_conversation_picker resolves to the picker command in the early phase" {
+    try std.testing.expectEqual(
+        Command.copilot_conversation_picker,
+        resolve(.copilot_conversation_picker, .early).?,
+    );
+    // It is an early-phase command, matching the real key-routing order.
+    try std.testing.expectEqual(@as(?Command, null), resolve(.copilot_conversation_picker, .late));
+}
+
+// Behavior test (converted from a source-string grep that asserted keybind.zig
+// contained the literal "copilot_conversation_picker"). Call the keybind catalog
+// directly: the action name must parse to the enum value AND a default binding
+// must exist, so the copilot picker is reachable out of the box. `keybind` is
+// already imported by this module, so this runs in the fast test suite.
+test "copilot_conversation_picker is a real, default-bound keybind action" {
+    try std.testing.expectEqual(
+        keybind.Action.copilot_conversation_picker,
+        keybind.Action.parse("copilot_conversation_picker").?,
+    );
+
+    var bound = false;
+    for (keybind.default_bindings) |binding| {
+        if (binding.action == .copilot_conversation_picker) {
+            bound = true;
+            break;
+        }
+    }
+    try std.testing.expect(bound);
+}

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -5,6 +5,8 @@ const build_options = @import("build_options");
 const std = @import("std");
 const app_metadata = @import("app_metadata.zig");
 const command_center_state = @import("command_center_state.zig");
+const keybind = @import("keybind.zig");
+const command_dispatch = @import("input/command_dispatch.zig");
 
 comptime {
     @setEvalBranchQuota(8_000_000);
@@ -825,11 +827,45 @@ test "command center browser entries do not expose backend implementation names"
     }
 }
 
-test "copilot conversation picker has a keybind action and dispatch" {
-    const kb_src = @embedFile("keybind.zig");
-    try std.testing.expect(std.mem.indexOf(u8, kb_src, "copilot_conversation_picker") != null);
-    const input_src = @embedFile("input.zig");
-    try std.testing.expect(std.mem.indexOf(u8, input_src, ".copilot_conversation_picker =>") != null);
+// Behavior tests (converted from source-string greps): instead of asserting the
+// keybind action *name* appears in keybind.zig and that input.zig contains a
+// `.copilot_conversation_picker =>` dispatch arm, call the real catalog/seam
+// functions and assert what they actually do at runtime. This proves the action
+// is a real, parseable, default-bound keybind and that the extracted dispatch
+// resolver wires it to the copilot picker command — the same facts the greps
+// encoded, but checked through behavior rather than text. The same assertions
+// also live in src/input/command_dispatch.zig so they run in the fast suite
+// (`zig build test`); these copies keep coverage in the full `test-full` binary.
+test "copilot conversation picker is a real, default-bound keybind action" {
+    // The action name resolves to the enum value (the action exists in the catalog).
+    try std.testing.expectEqual(
+        keybind.Action.copilot_conversation_picker,
+        keybind.Action.parse("copilot_conversation_picker").?,
+    );
+
+    // A default keybind binds something to it (so the picker is reachable out of the box).
+    var bound = false;
+    for (keybind.default_bindings) |binding| {
+        if (binding.action == .copilot_conversation_picker) {
+            bound = true;
+            break;
+        }
+    }
+    try std.testing.expect(bound);
+}
+
+test "copilot conversation picker action dispatches to the picker command" {
+    // The extracted dispatch resolver maps the action to the copilot picker
+    // command in the early phase (this replaces grepping input.zig for the arm).
+    try std.testing.expectEqual(
+        command_dispatch.Command.copilot_conversation_picker,
+        command_dispatch.resolve(.copilot_conversation_picker, .early).?,
+    );
+    // It only fires in the early phase, mirroring the real key-routing order.
+    try std.testing.expectEqual(
+        @as(?command_dispatch.Command, null),
+        command_dispatch.resolve(.copilot_conversation_picker, .late),
+    );
 }
 
 test "activeCopilotSession installs the history-change hook" {


### PR DESCRIPTION
Phase 4 batch 1 (behavior tests): convert a behavioral assertion that was encoded as `@embedFile` source-string greps into real tests that call functions and assert results — proving the round-1 dispatch/keybind seam actually works, not just that strings are present. Test-only.

## What
- Converted `test_main.zig`’s `copilot conversation picker has a keybind action and dispatch` (two source greps) into behavior tests:
  - keybind existence/default-binding -> `keybind.Action.parse("copilot_conversation_picker")` + a scan of the `keybind.default_bindings` DATA structure.
  - dispatch wiring -> `input/command_dispatch.resolve(.copilot_conversation_picker, .early)` returns the picker command (`.late` returns null).
- Canonical tests placed in `src/input/command_dispatch.zig` (it is in the FAST `zig build test` graph; `test_main.zig` only runs under test-full), with mirror copies kept in `test_main.zig` for the full binary.

## Honesty
Deeper copilot wiring asserts that need heavy AppWindow/overlay setup were intentionally LEFT as static greps (listed in the commit). Pure layering/import-absence assertions are intentionally kept — only a runtime-behavioral check was converted.

## Verification
Fast suite green (test count +2 confirms the new tests run); a deliberate resolver break confirmed they catch regressions (non-vacuous). `zig fmt` clean. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)