### PR TITLE
refactor(ai-chat): extract generic MessageStore from Session

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -105,7 +105,7 @@ pub const Message = struct {
     reasoning_collapsed: bool = true,
     reasoning_auto_expand: bool = false,
 
-    fn deinit(self: Message, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: Message, allocator: std.mem.Allocator) void {
         allocator.free(self.content);
         if (self.model_context) |ctx| allocator.free(ctx);
         if (self.reasoning) |reasoning| allocator.free(reasoning);

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -30,6 +30,7 @@ const weixin_types = @import("weixin/types.zig");
 const ai_loop_store = @import("ai_loop_store.zig");
 const ai_loop_schedule = @import("ai_loop_schedule.zig");
 const first_party_tools = @import("first_party_tools.zig");
+const message_store = @import("ai_chat/message_store.zig");
 
 pub const AgentSettings = ai_chat_types.AgentSettings;
 pub const AgentPermission = ai_chat_types.AgentPermission;
@@ -805,7 +806,7 @@ pub fn agentPermission() AgentPermission {
 pub const Session = struct {
     allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},
-    messages: std.ArrayListUnmanaged(Message) = .empty,
+    messages: message_store.MessageStore(Message) = .empty,
     session_id_buf: [64]u8 = undefined,
     session_id_len: usize = 0,
     input_buf: [INPUT_PROMPT_MAX_BYTES]u8 = undefined,
@@ -1132,7 +1133,7 @@ pub const Session = struct {
         // first-turn window; never re-title it. (A half-finished session with no
         // assistant reply keeps auto_title_attempted=false and is still default-
         // titled, so it can be named after its next completed turn.)
-        for (session.messages.items) |restored| {
+        for (session.messages.items()) |restored| {
             if (restored.role == .assistant) {
                 session.auto_title_attempted = true;
                 break;
@@ -1157,7 +1158,7 @@ pub const Session = struct {
             thread.join();
             self.summary_thread = null;
         }
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             msg.deinit(self.allocator);
         }
         self.messages.deinit(self.allocator);
@@ -1491,7 +1492,7 @@ pub const Session = struct {
     pub fn shouldPersistCopilot(self: *Session) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.persist_to_history) return true;
         }
         return false;
@@ -1771,7 +1772,7 @@ pub const Session = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         self.input_select_all = self.input_len > 0;
-        self.transcript_select_all = !self.input_select_all and self.messages.items.len > 0;
+        self.transcript_select_all = !self.input_select_all and self.messages.items().len > 0;
         self.transcript_selection = null;
     }
 
@@ -1792,11 +1793,11 @@ pub const Session = struct {
     pub fn beginTranscriptSelection(self: *Session, message_index: usize, byte_offset: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (message_index >= self.messages.items.len) {
+        if (message_index >= self.messages.items().len) {
             self.clearSelectionLocked();
             return;
         }
-        const msg = self.messages.items[message_index];
+        const msg = self.messages.items()[message_index];
         if (msg.role != .assistant or msg.content.len == 0) {
             self.clearSelectionLocked();
             return;
@@ -1818,8 +1819,8 @@ pub const Session = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         var selection = self.transcript_selection orelse return;
-        if (selection.message_index != message_index or message_index >= self.messages.items.len) return;
-        const msg = self.messages.items[message_index];
+        if (selection.message_index != message_index or message_index >= self.messages.items().len) return;
+        const msg = self.messages.items()[message_index];
         if (msg.role != .assistant) return;
         selection.cursor = byte_offset; // display-text offset; copy path re-clamps
         self.transcript_selection = selection;
@@ -1849,7 +1850,7 @@ pub const Session = struct {
             error.NoSelection => {},
             else => return err,
         }
-        if (self.messages.items.len > 0) {
+        if (self.messages.items().len > 0) {
             return self.allocTranscriptClipboardTextLocked(allocator);
         }
         if (self.input_len > 0) {
@@ -1936,7 +1937,7 @@ pub const Session = struct {
             for (tool_summaries.items) |summary| allocator.free(summary);
             tool_summaries.deinit(allocator);
         }
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.role == .tool) {
                 const summary = try allocRemoteToolSummary(allocator, msg);
                 var summary_owned = true;
@@ -1966,15 +1967,15 @@ pub const Session = struct {
     pub fn allocMessageClipboardText(self: *Session, allocator: std.mem.Allocator, message_index: usize) ![]u8 {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (message_index >= self.messages.items.len) return allocator.dupe(u8, "");
-        return allocator.dupe(u8, self.messages.items[message_index].content);
+        if (message_index >= self.messages.items().len) return allocator.dupe(u8, "");
+        return allocator.dupe(u8, self.messages.items()[message_index].content);
     }
 
     pub fn toggleToolMessageCollapsed(self: *Session, message_index: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (message_index >= self.messages.items.len) return;
-        var msg = &self.messages.items[message_index];
+        if (message_index >= self.messages.items().len) return;
+        var msg = &self.messages.items()[message_index];
         if (msg.role != .tool and !msg.is_context_summary) return;
         msg.content_collapsed = !msg.content_collapsed;
         msg.content_auto_expand = false;
@@ -1983,8 +1984,8 @@ pub const Session = struct {
     pub fn toggleReasoningCollapsed(self: *Session, message_index: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        if (message_index >= self.messages.items.len) return;
-        var msg = &self.messages.items[message_index];
+        if (message_index >= self.messages.items().len) return;
+        var msg = &self.messages.items()[message_index];
         const reasoning = msg.reasoning orelse return;
         if (reasoning.len == 0) return;
         msg.reasoning_collapsed = !msg.reasoning_collapsed;
@@ -2396,7 +2397,7 @@ pub const Session = struct {
             return;
         }
 
-        const message_start = self.messages.items.len;
+        const message_start = self.messages.items().len;
         const invocation = parseSkillInvocation(prompt_raw);
         var skill_preload_content: ?[]u8 = null;
         if (invocation) |parsed| {
@@ -3193,8 +3194,7 @@ pub const Session = struct {
     /// Assumes self.mutex is held. Returns the captured history change for the
     /// caller to notify after unlocking.
     fn clearMessagesLocked(self: *Session) ?PendingHistoryChange {
-        for (self.messages.items) |msg| msg.deinit(self.allocator);
-        self.messages.clearRetainingCapacity();
+        self.messages.clearAndDeinit(self.allocator);
         self.scroll_px = 0;
         self.suggestion_selected = 0;
         self.clearSelectionLocked();
@@ -3562,7 +3562,7 @@ pub const Session = struct {
 
     fn composerHistoryPromptCountLocked(self: *Session) usize {
         var n: usize = 0;
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.role == .user) n += 1;
         }
         return n;
@@ -3570,19 +3570,19 @@ pub const Session = struct {
 
     fn composerHistoryPromptMessageIndexLocked(self: *Session, n: usize) usize {
         var seen: usize = 0;
-        for (self.messages.items, 0..) |msg, i| {
+        for (self.messages.items(), 0..) |msg, i| {
             if (msg.role == .user) {
                 if (seen == n) return i;
                 seen += 1;
             }
         }
-        return self.messages.items.len;
+        return self.messages.items().len;
     }
 
     fn restoreComposerHistoryPromptLocked(self: *Session, selected: usize) bool {
         const idx = self.composerHistoryPromptMessageIndexLocked(selected);
-        if (idx >= self.messages.items.len) return false;
-        self.replaceInputTextLocked(self.messages.items[idx].content);
+        if (idx >= self.messages.items().len) return false;
+        self.replaceInputTextLocked(self.messages.items()[idx].content);
         return true;
     }
 
@@ -3639,14 +3639,14 @@ pub const Session = struct {
         }
         const sel = @min(self.rewind_selected, count - 1);
         const idx = self.rewindPointMessageIndexLocked(sel);
-        if (idx >= self.messages.items.len) {
+        if (idx >= self.messages.items().len) {
             self.rewind_open = false;
             self.mutex.unlock();
             return;
         }
         // insertInputBytesLocked 会立即把字节拷入 input_buf，随后 rollback 才释放
         // messages[idx]，两块缓冲区不重叠，安全。
-        self.setInputTextLocked(self.messages.items[idx].content);
+        self.setInputTextLocked(self.messages.items()[idx].content);
         self.rollbackMessagesFromLocked(idx);
         self.rewind_open = false;
         self.scroll_px = 1_000_000;
@@ -3656,16 +3656,13 @@ pub const Session = struct {
     }
 
     fn rollbackMessagesFromLocked(self: *Session, start: usize) void {
-        while (self.messages.items.len > start) {
-            var msg = self.messages.pop().?;
-            msg.deinit(self.allocator);
-        }
+        self.messages.truncateFrom(self.allocator, start);
     }
 
     /// 对话中 role == .user 的消息条数（回溯点数量）。持锁内部版本。
     fn rewindPointCountLocked(self: *Session) usize {
         var n: usize = 0;
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.role == .user) n += 1;
         }
         return n;
@@ -3682,17 +3679,17 @@ pub const Session = struct {
     /// 调用方需保证 n < rewindPointCountLocked()。找不到返回 messages.items.len。
     fn rewindPointMessageIndexLocked(self: *Session, n: usize) usize {
         var seen: usize = 0;
-        for (self.messages.items, 0..) |msg, i| {
+        for (self.messages.items(), 0..) |msg, i| {
             if (msg.role == .user) {
                 if (seen == n) return i;
                 seen += 1;
             }
         }
-        return self.messages.items.len;
+        return self.messages.items().len;
     }
 
     fn collapseAutoExpandedDetailsLocked(self: *Session) void {
-        for (self.messages.items) |*msg| {
+        for (self.messages.items()) |*msg| {
             if (msg.role == .tool and msg.content_auto_expand) {
                 msg.content_collapsed = true;
                 msg.content_auto_expand = false;
@@ -3707,7 +3704,7 @@ pub const Session = struct {
     fn allocTranscriptClipboardTextLocked(self: *Session, allocator: std.mem.Allocator) ![]u8 {
         var out: std.ArrayListUnmanaged(u8) = .empty;
         errdefer out.deinit(allocator);
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             try appendClipboardSection(allocator, &out, msg.role.label(), msg.content);
             if (msg.reasoning) |reasoning| {
                 if (reasoning.len > 0) try appendClipboardSection(allocator, &out, "Reasoning", reasoning);
@@ -3734,12 +3731,12 @@ pub const Session = struct {
     }
 
     fn appendFullMarkdownExportLocked(self: *Session, allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
-        if (self.messages.items.len == 0) {
+        if (self.messages.items().len == 0) {
             try out.appendSlice(allocator, "No messages yet.\n");
             return;
         }
 
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             const heading = if (msg.role == .tool and msg.tool_name != null and msg.tool_name.?.len > 0)
                 "Tool"
             else
@@ -3757,7 +3754,7 @@ pub const Session = struct {
 
     fn appendCleanMarkdownExportLocked(self: *Session, allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8)) !void {
         var user_count: usize = 0;
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.role == .user and msg.content.len > 0) user_count += 1;
         }
 
@@ -3766,7 +3763,7 @@ pub const Session = struct {
             try out.appendSlice(allocator, "No user input yet.\n\n");
         } else {
             var seen: usize = 0;
-            for (self.messages.items) |msg| {
+            for (self.messages.items()) |msg| {
                 if (msg.role != .user or msg.content.len == 0) continue;
                 if (user_count > 1) {
                     try out.writer(allocator).print("### {d}\n\n", .{seen + 1});
@@ -3778,7 +3775,7 @@ pub const Session = struct {
         }
 
         try out.appendSlice(allocator, "## Final Result\n\n");
-        if (latestAssistantContent(self.messages.items)) |content| {
+        if (latestAssistantContent(self.messages.items())) |content| {
             try appendMarkdownBody(allocator, out, content);
             try out.append(allocator, '\n');
         } else {
@@ -3789,8 +3786,8 @@ pub const Session = struct {
     fn allocTranscriptSelectionTextLocked(self: *Session, allocator: std.mem.Allocator) (error{NoSelection} || std.mem.Allocator.Error)![]u8 {
         const selection = self.transcript_selection orelse return error.NoSelection;
         const range = selection.range() orelse return error.NoSelection;
-        if (selection.message_index >= self.messages.items.len) return error.NoSelection;
-        const msg = self.messages.items[selection.message_index];
+        if (selection.message_index >= self.messages.items().len) return error.NoSelection;
+        const msg = self.messages.items()[selection.message_index];
         if (msg.role != .assistant) return error.NoSelection;
         const display = try markdown_text.allocDisplayText(allocator, msg.content);
         defer allocator.free(display);
@@ -3807,7 +3804,7 @@ pub const Session = struct {
     /// user message (copilot mode); pass null/null for a plain chat.
     fn buildRequestMessagesLocked(self: *Session, copilot_target_idx: ?usize, copilot_ctx: ?[]const u8) ![]RequestMessage {
         var visible_count: usize = 0;
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.role != .tool) {
                 visible_count += 1;
             } else if (msg.replay_to_model) {
@@ -3826,7 +3823,7 @@ pub const Session = struct {
             for (messages[0..written]) |msg| msg.deinit(self.allocator);
         }
 
-        for (self.messages.items, 0..) |msg, idx| {
+        for (self.messages.items(), 0..) |msg, idx| {
             if (msg.role == .tool) {
                 if (!msg.replay_to_model) continue;
                 const id = msg.tool_call_id orelse continue;
@@ -3865,8 +3862,8 @@ pub const Session = struct {
     }
 
     fn allocDistillTurnsLocked(self: *Session) ![]ai_skill_distill.DistillTurn {
-        const turns = try self.allocator.alloc(ai_skill_distill.DistillTurn, self.messages.items.len);
-        for (self.messages.items, 0..) |msg, idx| {
+        const turns = try self.allocator.alloc(ai_skill_distill.DistillTurn, self.messages.items().len);
+        for (self.messages.items(), 0..) |msg, idx| {
             turns[idx] = .{
                 .role = switch (msg.role) {
                     .user => .user,
@@ -3989,10 +3986,10 @@ pub const Session = struct {
                     copilot_ctx = ai_chat_tools.buildCopilotContext(self.allocator, surface.cwd, surface.snapshot) catch null;
                     if (copilot_ctx != null) {
                         // index of the LAST user message in self.messages
-                        var k: usize = self.messages.items.len;
+                        var k: usize = self.messages.items().len;
                         while (k > 0) {
                             k -= 1;
-                            if (self.messages.items[k].role == .user) {
+                            if (self.messages.items()[k].role == .user) {
                                 copilot_target_idx = k;
                                 break;
                             }
@@ -4086,7 +4083,7 @@ pub const Session = struct {
 
     fn toHistoryRecordLocked(self: *Session, allocator: std.mem.Allocator) !agent_history.SessionRecord {
         var persist_count: usize = 0;
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (msg.persist_to_history) persist_count += 1;
         }
 
@@ -4100,7 +4097,7 @@ pub const Session = struct {
             allocator.free(messages);
         }
 
-        for (self.messages.items) |msg| {
+        for (self.messages.items()) |msg| {
             if (!msg.persist_to_history) continue;
 
             var record_msg = agent_history.MessageRecord{
@@ -4523,7 +4520,7 @@ pub fn applyProviderProfile(
 
         var has_summary_user = false;
         var has_summary_assistant = false;
-        for (session.messages.items) |m| switch (m.role) {
+        for (session.messages.items()) |m| switch (m.role) {
             .user => {
                 if (m.content.len > 0) has_summary_user = true;
             },
@@ -4554,13 +4551,13 @@ pub fn applyProviderProfile(
             session.setStatusLocked("Model switched — kept full history");
             break :locked;
         }
-        const boundary = session.messages.items.len;
+        const boundary = session.messages.items().len;
         const turns = session.allocator.alloc(ai_model_switch.TurnMessage, boundary) catch {
             session.setStatusLocked("Model switched — full history saved. Use /resume to reopen it.");
             break :locked;
         };
         defer session.allocator.free(turns);
-        for (session.messages.items, 0..) |m, i| turns[i] = .{ .role = m.role, .content = m.content };
+        for (session.messages.items(), 0..) |m, i| turns[i] = .{ .role = m.role, .content = m.content };
         sreq = buildSummaryRequestLocked(session, turns, boundary, old_model) catch {
             session.setStatusLocked("Model switched — full history saved. Use /resume to reopen it.");
             break :locked;
@@ -4646,7 +4643,7 @@ pub fn applySummaryResult(session: *Session, summary: []const u8, boundary: usiz
         session.notifyHistoryChange(history_change);
     }
     if (session.closing.load(.acquire)) return;
-    if (boundary > session.messages.items.len) {
+    if (boundary > session.messages.items().len) {
         session.setStatusLocked("Ready");
         return; // stale (e.g. /clear happened) — keep raw history
     }
@@ -4666,7 +4663,7 @@ pub fn applySummaryResult(session: *Session, summary: []const u8, boundary: usiz
         session.setStatusLocked("Ready");
         return;
     };
-    new_list.appendSlice(allocator, session.messages.items[boundary..]) catch {
+    new_list.appendSlice(allocator, session.messages.items()[boundary..]) catch {
         // OOM: free the summary we just made, keep raw history intact.
         new_list.items[0].deinit(allocator);
         new_list.deinit(allocator);
@@ -4675,9 +4672,9 @@ pub fn applySummaryResult(session: *Session, summary: []const u8, boundary: usiz
     };
     // Free only the collapsed pre-switch messages; tail structs were copied by
     // value into new_list (pointer ownership moved).
-    for (session.messages.items[0..boundary]) |m| m.deinit(allocator);
+    for (session.messages.items()[0..boundary]) |m| m.deinit(allocator);
     session.messages.deinit(allocator);
-    session.messages = new_list;
+    session.messages = @TypeOf(session.messages).fromList(new_list);
     session.scroll_px = 1_000_000;
     session.setStatusLocked("Context summarized. Use /resume to reopen the full pre-switch conversation.");
     history_change = session.captureHistoryChangeLocked();
@@ -4756,9 +4753,9 @@ pub fn maybeAutoTitle(session: *Session) void {
     session.mutex.lock();
     var spawned_req: ?*ChatRequest = null;
     locked: {
-        const turns = allocator.alloc(ai_chat_title.TurnMessage, session.messages.items.len) catch break :locked;
+        const turns = allocator.alloc(ai_chat_title.TurnMessage, session.messages.items().len) catch break :locked;
         defer allocator.free(turns);
-        for (session.messages.items, 0..) |m, i| {
+        for (session.messages.items(), 0..) |m, i| {
             turns[i] = .{ .role = m.role, .content = m.content };
         }
         const turn = ai_chat_title.extractFirstTurn(turns);
@@ -5027,7 +5024,7 @@ pub fn beginAssistantStream(session: *Session) !usize {
     session.scroll_px = 1_000_000;
     session.setStatusLocked("Streaming...");
     history_change = session.captureHistoryChangeLocked();
-    return session.messages.items.len - 1;
+    return session.messages.items().len - 1;
 }
 
 fn appendAssistantStreamDelta(session: *Session, message_idx: usize, content_delta: []const u8, reasoning_delta: []const u8) !void {
@@ -5042,9 +5039,9 @@ fn appendAssistantStreamDelta(session: *Session, message_idx: usize, content_del
         session.notifyHistoryChange(history_change);
     }
     if (sessionCancelled(session)) return;
-    if (message_idx >= session.messages.items.len) return error.StreamMessageMissing;
+    if (message_idx >= session.messages.items().len) return error.StreamMessageMissing;
 
-    var msg = &session.messages.items[message_idx];
+    var msg = &session.messages.items()[message_idx];
     if (content_delta.len > 0) {
         const old_len = msg.content.len;
         msg.content = try allocator.realloc(msg.content, old_len + content_delta.len);
@@ -5087,8 +5084,8 @@ pub fn finishAssistantStream(session: *Session, message_idx: usize, started_ms: 
         session.setStatusLocked("Stopped");
         return;
     }
-    if (message_idx < session.messages.items.len) {
-        const msg = &session.messages.items[message_idx];
+    if (message_idx < session.messages.items().len) {
+        const msg = &session.messages.items()[message_idx];
         if (msg.content.len == 0 and msg.reasoning == null) {
             msg.content = session.allocator.realloc(msg.content, "No response".len) catch msg.content;
             if (msg.content.len == "No response".len) @memcpy(msg.content, "No response");
@@ -5396,15 +5393,15 @@ test "ai chat enter completes selected slash suggestion before command submit" {
     session.handleKey(.{ .key = input_key.Key.enter });
 
     try std.testing.expectEqualStrings("/commands", session.input());
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
 
     session.handleKey(.{ .key = input_key.Key.enter });
 
     try std.testing.expectEqualStrings("", session.input());
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expectEqual(Role.tool, session.messages.items[0].role);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expectEqual(Role.tool, session.messages.items()[0].role);
 
-    for (session.messages.items) |msg| msg.deinit(allocator);
+    for (session.messages.items()) |msg| msg.deinit(allocator);
     session.messages.deinit(allocator);
 }
 
@@ -5416,11 +5413,11 @@ test "ai chat enter submits slash commands instead of completing suggestions" {
     session.handleKey(.{ .key = input_key.Key.enter });
 
     try std.testing.expectEqualStrings("", session.input());
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expectEqual(Role.tool, session.messages.items[0].role);
-    try std.testing.expect(std.mem.indexOf(u8, session.messages.items[0].content, "/commands - list slash commands") != null);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expectEqual(Role.tool, session.messages.items()[0].role);
+    try std.testing.expect(std.mem.indexOf(u8, session.messages.items()[0].content, "/commands - list slash commands") != null);
 
-    for (session.messages.items) |msg| msg.deinit(allocator);
+    for (session.messages.items()) |msg| msg.deinit(allocator);
     session.messages.deinit(allocator);
 }
 
@@ -5428,7 +5425,7 @@ test "/rewind via submit opens picker without adding transcript noise" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -5441,7 +5438,7 @@ test "/rewind via submit opens picker without adding transcript noise" {
     try std.testing.expect(session.rewind_open);
     try std.testing.expectEqual(@as(usize, 0), session.rewind_selected);
     try std.testing.expectEqualStrings("", session.input());
-    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 2), session.messages.items().len);
 }
 
 test "/clear via submit empties the transcript and shows confirmation" {
@@ -5452,8 +5449,8 @@ test "/clear via submit empties the transcript and shows confirmation" {
     session.appendInputText("/clear");
     session.submit();
     // /clear empties then appends a single confirmation tool message
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expect(std.mem.indexOf(u8, session.messages.items[0].content, "Cleared") != null);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expect(std.mem.indexOf(u8, session.messages.items()[0].content, "Cleared") != null);
 }
 
 var test_export_mode: ?MarkdownExportMode = null;
@@ -5557,7 +5554,7 @@ test "ai chat dollar skill suggestions filter and enter completes with trailing 
 
     try std.testing.expectEqualStrings("$pdf ", session.input());
     try std.testing.expectEqual(@as(usize, "$pdf ".len), session.inputCursor());
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
 }
 
 const WeixinAttachmentCapture = struct {
@@ -5852,7 +5849,7 @@ test "ai_chat: session loads from history record" {
     defer session.deinit();
 
     try std.testing.expectEqualStrings("session-1", session.sessionId());
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
 }
 
 test "ai_chat: loading history record cleans up partial message clone on allocation failure" {
@@ -5979,8 +5976,8 @@ test "ai_chat: progress tool messages are ui-only history" {
 
     try std.testing.expectEqual(@as(usize, 0), capture.calls);
     try std.testing.expect(capture.event == null);
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expect(!session.messages.items[0].persist_to_history);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expect(!session.messages.items()[0].persist_to_history);
 
     session.mutex.lock();
     defer session.mutex.unlock();
@@ -6378,7 +6375,7 @@ test "ai chat appends usage footer to completed assistant message" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -6393,9 +6390,9 @@ test "ai chat appends usage footer to completed assistant message" {
         },
     }, std.time.milliTimestamp() - 2300);
 
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expect(session.messages.items[0].usage_footer != null);
-    const footer = session.messages.items[0].usage_footer.?;
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expect(session.messages.items()[0].usage_footer != null);
+    const footer = session.messages.items()[0].usage_footer.?;
     try std.testing.expect(std.mem.indexOf(u8, footer, "total 46") != null);
     try std.testing.expect(std.mem.indexOf(u8, footer, "cache 5/7") != null);
 }
@@ -6609,7 +6606,7 @@ test "ai chat model context is request-only and hidden from visible history" {
         allocator.free(reqs);
     }
     try std.testing.expectEqual(@as(usize, 1), reqs.len);
-    try std.testing.expect(std.mem.indexOf(u8, session.messages.items[0].content, "/work/") == null);
+    try std.testing.expect(std.mem.indexOf(u8, session.messages.items()[0].content, "/work/") == null);
     try std.testing.expect(std.mem.indexOf(u8, reqs[0].content, "用户通过微信发送了文件：a.pdf") != null);
     try std.testing.expect(std.mem.indexOf(u8, reqs[0].content, "/work/weixin_inbound/a.pdf") != null);
 
@@ -6721,7 +6718,7 @@ test "ai chat composer history recalls prompts at visual boundaries" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "first prompt") });
@@ -6750,7 +6747,7 @@ test "ai chat composer history preserves multiline vertical editing" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "previous prompt") });
@@ -6772,7 +6769,7 @@ test "ai chat composer history exits after editing recalled prompt" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     try session.messages.append(allocator, .{ .role = .user, .content = try allocator.dupe(u8, "old prompt") });
@@ -6923,7 +6920,7 @@ test "ai chat remote snapshot keeps final answer when reasoning is huge (issue 1
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     session.setStatusLocked("Done in 280.9s");
@@ -6952,7 +6949,7 @@ test "ai chat remote snapshot still includes reasoning when it fits" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -6977,7 +6974,7 @@ test "ai chat remote snapshot includes a pending approval section" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     try session.messages.append(allocator, .{
@@ -7011,7 +7008,7 @@ test "ai chat remote snapshot approval section omits the command line when empty
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7033,7 +7030,7 @@ test "ai chat remote snapshot emits a Question section with numbered options" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7064,7 +7061,7 @@ test "ai chat clipboard text exports transcript when input is empty" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7093,7 +7090,7 @@ test "ai chat clipboard text prefers selected assistant answer range" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7117,7 +7114,7 @@ test "ai chat transcript selection clamps to utf8 boundaries" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7138,7 +7135,7 @@ test "ai chat transcript selection copies cleaned markdown text" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7160,7 +7157,7 @@ test "ai chat transcript selection over table is not truncated to raw length" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7184,7 +7181,7 @@ test "ai chat message clipboard exports one bubble" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7208,7 +7205,7 @@ test "ai chat Markdown export includes full transcript details" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     session.copyTitle("Chat Export");
@@ -7241,7 +7238,7 @@ test "ai chat clean Markdown export keeps user inputs and final answer only" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
     session.copyTitle("Clean Export");
@@ -7289,7 +7286,7 @@ test "ai chat stop request suppresses late assistant result" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7302,7 +7299,7 @@ test "ai chat stop request suppresses late assistant result" {
     try std.testing.expect(!session.request_inflight);
     try std.testing.expect(!session.request_stopping);
     try std.testing.expect(!session.stop_requested.load(.acquire));
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
     try std.testing.expectEqualStrings("Stopped", session.status());
 }
 
@@ -7392,7 +7389,7 @@ test "ai chat distill cancel clears pending candidate" {
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     session.distill_candidate = try testDistillCandidate(a);
@@ -7402,8 +7399,8 @@ test "ai chat distill cancel clears pending candidate" {
 
     try std.testing.expect(session.distill_candidate == null);
     try std.testing.expectEqualStrings("", session.input());
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items[0].content, 1, "discarded"));
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items()[0].content, 1, "discarded"));
 }
 
 test "ai chat distill confirm without candidate is local only" {
@@ -7411,7 +7408,7 @@ test "ai chat distill confirm without candidate is local only" {
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     session.appendInputText("/沉淀 确认");
@@ -7419,8 +7416,8 @@ test "ai chat distill confirm without candidate is local only" {
     session.submit();
 
     try std.testing.expect(!session.request_inflight);
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items[0].content, 1, "No distill candidate"));
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items()[0].content, 1, "No distill candidate"));
 }
 
 test "ai chat appends automatic distill suggestion after tool-heavy result" {
@@ -7430,7 +7427,7 @@ test "ai chat appends automatic distill suggestion after tool-heavy result" {
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "fix this") });
@@ -7441,10 +7438,10 @@ test "ai chat appends automatic distill suggestion after tool-heavy result" {
     appendAssistantResult(&session, .{ .content = @constCast("done") }, 0);
 
     try std.testing.expect(session.distill_suggestion_pending);
-    try std.testing.expectEqual(@as(usize, 5), session.messages.items.len);
-    try std.testing.expectEqual(Role.tool, session.messages.items[4].role);
-    try std.testing.expect(!session.messages.items[4].persist_to_history);
-    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items[4].content, 1, "Distill it into a skill"));
+    try std.testing.expectEqual(@as(usize, 5), session.messages.items().len);
+    try std.testing.expectEqual(Role.tool, session.messages.items()[4].role);
+    try std.testing.expect(!session.messages.items()[4].persist_to_history);
+    try std.testing.expect(std.mem.containsAtLeast(u8, session.messages.items()[4].content, 1, "Distill it into a skill"));
 }
 
 test "ai chat skips automatic distill suggestion when disabled" {
@@ -7456,7 +7453,7 @@ test "ai chat skips automatic distill suggestion when disabled" {
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "fix this") });
@@ -7468,8 +7465,8 @@ test "ai chat skips automatic distill suggestion when disabled" {
 
     try std.testing.expect(!session.distill_suggestion_pending);
     // Only the appended assistant message — no extra distill-suggestion tool row.
-    try std.testing.expectEqual(@as(usize, 4), session.messages.items.len);
-    try std.testing.expectEqual(Role.assistant, session.messages.items[3].role);
+    try std.testing.expectEqual(@as(usize, 4), session.messages.items().len);
+    try std.testing.expectEqual(Role.assistant, session.messages.items()[3].role);
 }
 
 test "ai chat escape dismisses pending distill suggestion before rewind" {
@@ -7477,7 +7474,7 @@ test "ai chat escape dismisses pending distill suggestion before rewind" {
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -7496,7 +7493,7 @@ test "ai chat enter on pending distill suggestion requires api key and does not 
     var session = Session{ .allocator = a };
     defer {
         if (session.distill_candidate) |*candidate| candidate.deinit(a);
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "fix this") });
@@ -7514,7 +7511,7 @@ test "ai chat rewind point count and index map user messages" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "first") });
@@ -7533,7 +7530,7 @@ test "ai chat rewind open requires idle and points" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
 
@@ -7561,7 +7558,7 @@ test "ai chat rewind move selection clamps" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "one") });
@@ -7579,7 +7576,7 @@ test "ai chat confirm rewind truncates and restores composer" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "first prompt") });
@@ -7591,7 +7588,7 @@ test "ai chat confirm rewind truncates and restores composer" {
     session.confirmRewind();
 
     // 删除 idx 2 及之后：仅剩前两条。
-    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 2), session.messages.items().len);
     try std.testing.expect(!session.rewind_open);
     try std.testing.expectEqualStrings("second prompt", session.input());
 
@@ -7599,7 +7596,7 @@ test "ai chat confirm rewind truncates and restores composer" {
     session.openRewindPicker(); // 现在 count = 1, selected = 0 (idx 0)
     session.moveRewindSelection(-1);
     session.confirmRewind();
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
     try std.testing.expectEqualStrings("first prompt", session.input());
 }
 
@@ -7617,7 +7614,7 @@ test "ai chat collapse helper only closes auto-expanded details" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7645,18 +7642,18 @@ test "ai chat collapse helper only closes auto-expanded details" {
     session.collapseAutoExpandedDetailsLocked();
     session.mutex.unlock();
 
-    try std.testing.expect(session.messages.items[0].content_collapsed);
-    try std.testing.expect(!session.messages.items[0].content_auto_expand);
-    try std.testing.expect(session.messages.items[1].reasoning_collapsed);
-    try std.testing.expect(!session.messages.items[1].reasoning_auto_expand);
-    try std.testing.expect(!session.messages.items[2].content_collapsed);
+    try std.testing.expect(session.messages.items()[0].content_collapsed);
+    try std.testing.expect(!session.messages.items()[0].content_auto_expand);
+    try std.testing.expect(session.messages.items()[1].reasoning_collapsed);
+    try std.testing.expect(!session.messages.items()[1].reasoning_auto_expand);
+    try std.testing.expect(!session.messages.items()[2].content_collapsed);
 }
 
 test "ai chat cut input returns text and clears when selected" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
-        for (session.messages.items) |msg| msg.deinit(allocator);
+        for (session.messages.items()) |msg| msg.deinit(allocator);
         session.messages.deinit(allocator);
     }
 
@@ -7678,10 +7675,10 @@ test "clearMessages empties transcript but keeps settings" {
     var session = try Session.init(a, "chat", "https://api.example.com", "key", "m1", "sys", "disabled", "", "false", "false");
     defer session.deinit();
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
-    try std.testing.expect(session.messages.items.len > 0);
+    try std.testing.expect(session.messages.items().len > 0);
 
     session.clearMessages();
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
     try std.testing.expectEqualStrings("sys", session.systemPrompt());
     try std.testing.expectEqualStrings("m1", session.model());
 }
@@ -7704,7 +7701,7 @@ test "ai chat double esc opens rewind picker when idle" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -7722,7 +7719,7 @@ test "ai chat slow double esc does not open rewind picker" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -7738,7 +7735,7 @@ test "ai chat esc during generation only stops and does not open picker" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -7758,7 +7755,7 @@ test "ai chat rewind picker arrow and enter via handleKey" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "alpha") });
@@ -7770,7 +7767,7 @@ test "ai chat rewind picker arrow and enter via handleKey" {
     try std.testing.expectEqual(@as(usize, 0), session.rewind_selected);
     session.handleKey(.{ .key = input_key.Key.enter });
     try std.testing.expect(!session.rewind_open);
-    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items().len);
     try std.testing.expectEqualStrings("alpha", session.input());
 }
 
@@ -7778,14 +7775,14 @@ test "ai chat rewind picker esc closes without change" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "keep") });
     session.openRewindPicker();
     session.handleKey(.{ .key = input_key.Key.escape });
     try std.testing.expect(!session.rewind_open);
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
 }
 
 // 清选区是独立动作、不计入双击计时：ESC 清选区后需要重新双击才开选择器。
@@ -7793,7 +7790,7 @@ test "ai chat esc clearing selection does not prime rewind double-tap" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -7818,7 +7815,7 @@ test "ai chat double esc after stop opens rewind picker" {
     const a = std.testing.allocator;
     var session = Session{ .allocator = a };
     defer {
-        for (session.messages.items) |msg| msg.deinit(a);
+        for (session.messages.items()) |msg| msg.deinit(a);
         session.messages.deinit(a);
     }
     try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
@@ -8397,8 +8394,8 @@ test "copilot loop command lists and stops tasks from other sessions" {
     _ = copilot.runBuiltinCommandLocked(.loop, "all");
     copilot.mutex.unlock();
 
-    try std.testing.expect(copilot.messages.items.len > 0);
-    const list_msg = copilot.messages.items[copilot.messages.items.len - 1].content;
+    try std.testing.expect(copilot.messages.items().len > 0);
+    const list_msg = copilot.messages.items()[copilot.messages.items().len - 1].content;
     try std.testing.expect(std.mem.indexOf(u8, list_msg, "legacy copilot task") != null);
     try std.testing.expect(std.mem.indexOf(u8, list_msg, "Old Copilot") != null);
 
@@ -8514,9 +8511,9 @@ test "is_context_summary messages are collapsible" {
         .is_context_summary = true,
         .content_collapsed = true,
     });
-    try std.testing.expect(session.messages.items[0].content_collapsed);
+    try std.testing.expect(session.messages.items()[0].content_collapsed);
     session.toggleToolMessageCollapsed(0);
-    try std.testing.expect(!session.messages.items[0].content_collapsed);
+    try std.testing.expect(!session.messages.items()[0].content_collapsed);
 }
 
 test "applySummaryResult collapses pre-switch messages into one summary card" {
@@ -8530,12 +8527,12 @@ test "applySummaryResult collapses pre-switch messages into one summary card" {
     }
     // boundary = 2 means: collapse the first 2 messages, preserve message[2..].
     applySummaryResult(session, "SUMMARY", 2, "glm-5.2");
-    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
-    try std.testing.expect(session.messages.items[0].is_context_summary);
-    try std.testing.expectEqual(Role.user, session.messages.items[0].role);
-    try std.testing.expect(std.mem.indexOf(u8, session.messages.items[0].content, "SUMMARY") != null);
-    try std.testing.expect(std.mem.indexOf(u8, session.messages.items[0].content, "glm-5.2") != null);
-    try std.testing.expectEqualStrings("u2", session.messages.items[1].content);
+    try std.testing.expectEqual(@as(usize, 2), session.messages.items().len);
+    try std.testing.expect(session.messages.items()[0].is_context_summary);
+    try std.testing.expectEqual(Role.user, session.messages.items()[0].role);
+    try std.testing.expect(std.mem.indexOf(u8, session.messages.items()[0].content, "SUMMARY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, session.messages.items()[0].content, "glm-5.2") != null);
+    try std.testing.expectEqualStrings("u2", session.messages.items()[1].content);
     try std.testing.expect(std.mem.indexOf(u8, session.status(), "/resume") != null);
 }
 
@@ -8544,8 +8541,8 @@ test "applySummaryResult is a no-op when boundary exceeds message count" {
     defer session.deinit();
     try session.messages.append(std.testing.allocator, .{ .role = .user, .content = try std.testing.allocator.dupe(u8, "only") });
     applySummaryResult(session, "S", 5, "X"); // stale boundary (e.g. after /clear)
-    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    try std.testing.expectEqualStrings("only", session.messages.items[0].content);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items().len);
+    try std.testing.expectEqualStrings("only", session.messages.items()[0].content);
 }
 
 test "failSummaryResult keeps raw history and points to resume" {
@@ -8558,9 +8555,9 @@ test "failSummaryResult keeps raw history and points to resume" {
         });
     }
     failSummaryResult(session);
-    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
-    try std.testing.expectEqualStrings("u1", session.messages.items[0].content);
-    try std.testing.expectEqualStrings("a1", session.messages.items[1].content);
+    try std.testing.expectEqual(@as(usize, 2), session.messages.items().len);
+    try std.testing.expectEqualStrings("u1", session.messages.items()[0].content);
+    try std.testing.expectEqualStrings("a1", session.messages.items()[1].content);
     try std.testing.expect(std.mem.indexOf(u8, session.status(), "/resume") != null);
 }
 

--- a/src/ai_chat/message_store.zig
+++ b/src/ai_chat/message_store.zig
@@ -1,0 +1,250 @@
+//! Owns the AI Chat session's ordered message list.
+//!
+//! Extracted from the `ai_chat.Session` god-object so the "what messages does
+//! this session hold, and how do we append/truncate them?" responsibility lives
+//! in one std-only, unit-testable place instead of being spread across ~150
+//! `self.messages.items` / `.append` / `.pop` references in ai_chat.zig.
+//!
+//! To avoid a circular import (ai_chat.zig defines `Message`, and a non-generic
+//! store here would have to import ai_chat.zig back for that type) this module is
+//! GENERIC over the message type, mirroring the pattern used by
+//! input/mouse_dispatch.zig's `TerminalMouseReportState(comptime SurfacePtr)`.
+//!
+//! This module owns NO I/O: it never touches a PTY, a surface mutex, the
+//! renderer, or AppWindow. It is a pure container over the allocator the caller
+//! hands in on each mutating call (matching `std.ArrayListUnmanaged`'s shape so
+//! existing call sites keep their `append(allocator, msg)` / `deinit(allocator)`
+//! ergonomics unchanged).
+//!
+//! `Message` must expose `fn deinit(self: Message, allocator: std.mem.Allocator)`
+//! so the store can free owned entries on `truncateFrom` / `deinitAll`.
+
+const std = @import("std");
+
+/// A message list keyed by insertion order. `Message` is supplied by the caller
+/// (ai_chat.zig passes its own `Message` struct) to keep this module free of any
+/// dependency on the session module.
+pub fn MessageStore(comptime Message: type) type {
+    return struct {
+        const Self = @This();
+
+        /// Backing storage. Public so the rare call site that must move a freshly
+        /// built list in wholesale (e.g. the context-summary fold) can assign
+        /// `store.list = new_list` without the store re-allocating. Prefer the
+        /// methods below for everything else.
+        list: std.ArrayListUnmanaged(Message) = .empty,
+
+        /// An empty store. Equivalent to `.{}` but reads intentionally at call
+        /// sites that construct a Session.
+        pub const empty: Self = .{};
+
+        /// Wrap an already-populated `ArrayListUnmanaged` (ownership moves in).
+        pub fn fromList(list: std.ArrayListUnmanaged(Message)) Self {
+            return .{ .list = list };
+        }
+
+        /// Append one message to the tail. Signature mirrors
+        /// `std.ArrayListUnmanaged.append` so existing call sites are unchanged.
+        pub fn append(self: *Self, allocator: std.mem.Allocator, msg: Message) std.mem.Allocator.Error!void {
+            return self.list.append(allocator, msg);
+        }
+
+        /// Remove and return the tail message, or null if empty. Mirrors
+        /// `std.ArrayListUnmanaged.pop`. The caller owns the returned message and
+        /// is responsible for freeing it.
+        pub fn pop(self: *Self) ?Message {
+            return self.list.pop();
+        }
+
+        /// Number of messages currently held.
+        pub fn len(self: *const Self) usize {
+            return self.list.items.len;
+        }
+
+        /// The backing slice. Mutating an element through this slice (e.g.
+        /// `store.items()[i].content = ...` or `&store.items()[i]`) is valid; the
+        /// slice aliases the backing buffer until the next structural change.
+        pub fn items(self: *const Self) []Message {
+            return self.list.items;
+        }
+
+        /// The message at `index`, or null when out of bounds. Pure read; the
+        /// returned value is a copy of the struct (its owned slices still alias
+        /// the store's allocations).
+        pub fn at(self: *const Self, index: usize) ?Message {
+            if (index >= self.list.items.len) return null;
+            return self.list.items[index];
+        }
+
+        /// Drop and `deinit` every message at or after `index`, leaving the head
+        /// `[0, index)` intact. Capacity is retained. No-op when `index` is past
+        /// the end. This is the structural primitive behind /clear-tail and the
+        /// rewind picker's "fold from here" behavior.
+        pub fn truncateFrom(self: *Self, allocator: std.mem.Allocator, index: usize) void {
+            while (self.list.items.len > index) {
+                if (self.list.pop()) |msg| {
+                    msg.deinit(allocator);
+                } else break;
+            }
+        }
+
+        /// `deinit` every held message and empty the list, keeping capacity. The
+        /// store stays usable afterward.
+        pub fn clearAndDeinit(self: *Self, allocator: std.mem.Allocator) void {
+            for (self.list.items) |msg| msg.deinit(allocator);
+            self.list.clearRetainingCapacity();
+        }
+
+        /// Empty the list keeping capacity, WITHOUT freeing the messages. The
+        /// caller has already taken ownership of the elements elsewhere. Mirrors
+        /// `std.ArrayListUnmanaged.clearRetainingCapacity`.
+        pub fn clearRetainingCapacity(self: *Self) void {
+            self.list.clearRetainingCapacity();
+        }
+
+        /// Release the backing buffer. Does NOT free the individual messages —
+        /// callers that own message contents must drain them first (the existing
+        /// ai_chat.zig teardown loops free each message, then call this).
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+            self.list.deinit(allocator);
+        }
+    };
+}
+
+// --- tests -----------------------------------------------------------------
+
+/// Minimal message stand-in: owns a heap string so we can exercise the
+/// store's free-on-truncate contract without pulling in ai_chat.Message.
+const TestMsg = struct {
+    content: []u8,
+
+    fn make(allocator: std.mem.Allocator, text: []const u8) TestMsg {
+        return .{ .content = allocator.dupe(u8, text) catch unreachable };
+    }
+
+    fn deinit(self: TestMsg, allocator: std.mem.Allocator) void {
+        allocator.free(self.content);
+    }
+};
+
+const TestStore = MessageStore(TestMsg);
+
+test "append increments len and at returns the right item" {
+    const a = std.testing.allocator;
+    var store: TestStore = .empty;
+    defer {
+        store.clearAndDeinit(a);
+        store.deinit(a);
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), store.len());
+    try std.testing.expect(store.at(0) == null);
+
+    try store.append(a, TestMsg.make(a, "first"));
+    try store.append(a, TestMsg.make(a, "second"));
+
+    try std.testing.expectEqual(@as(usize, 2), store.len());
+    try std.testing.expectEqualStrings("first", store.at(0).?.content);
+    try std.testing.expectEqualStrings("second", store.at(1).?.content);
+    try std.testing.expect(store.at(2) == null);
+}
+
+test "items() exposes the backing slice and allows mutation" {
+    const a = std.testing.allocator;
+    var store: TestStore = .empty;
+    defer {
+        store.clearAndDeinit(a);
+        store.deinit(a);
+    }
+
+    try store.append(a, TestMsg.make(a, "x"));
+    try std.testing.expectEqual(@as(usize, 1), store.items().len);
+
+    // Mutating through the slice must reach the stored element.
+    a.free(store.items()[0].content);
+    store.items()[0].content = a.dupe(u8, "y") catch unreachable;
+    try std.testing.expectEqualStrings("y", store.at(0).?.content);
+}
+
+test "pop returns and detaches the tail" {
+    const a = std.testing.allocator;
+    var store: TestStore = .empty;
+    defer {
+        store.clearAndDeinit(a);
+        store.deinit(a);
+    }
+
+    try store.append(a, TestMsg.make(a, "keep"));
+    try store.append(a, TestMsg.make(a, "drop"));
+
+    const popped = store.pop().?;
+    try std.testing.expectEqualStrings("drop", popped.content);
+    popped.deinit(a); // caller owns it now
+    try std.testing.expectEqual(@as(usize, 1), store.len());
+    try std.testing.expectEqualStrings("keep", store.at(0).?.content);
+
+    // Drain the rest, freeing each popped message (caller owns it), so the
+    // empty-store branch is exercised without leaking.
+    const last = store.pop().?;
+    last.deinit(a);
+    try std.testing.expect(store.pop() == null);
+    try std.testing.expectEqual(@as(usize, 0), store.len());
+}
+
+test "truncateFrom frees the tail and keeps the head" {
+    const a = std.testing.allocator;
+    var store: TestStore = .empty;
+    defer {
+        store.clearAndDeinit(a);
+        store.deinit(a);
+    }
+
+    try store.append(a, TestMsg.make(a, "0"));
+    try store.append(a, TestMsg.make(a, "1"));
+    try store.append(a, TestMsg.make(a, "2"));
+    try store.append(a, TestMsg.make(a, "3"));
+
+    store.truncateFrom(a, 2);
+    try std.testing.expectEqual(@as(usize, 2), store.len());
+    try std.testing.expectEqualStrings("0", store.at(0).?.content);
+    try std.testing.expectEqualStrings("1", store.at(1).?.content);
+
+    // Out-of-range index is a no-op.
+    store.truncateFrom(a, 99);
+    try std.testing.expectEqual(@as(usize, 2), store.len());
+
+    // Truncating from 0 empties everything (and frees it).
+    store.truncateFrom(a, 0);
+    try std.testing.expectEqual(@as(usize, 0), store.len());
+}
+
+test "clearAndDeinit empties and frees while keeping the store usable" {
+    const a = std.testing.allocator;
+    var store: TestStore = .empty;
+    defer store.deinit(a);
+
+    try store.append(a, TestMsg.make(a, "a"));
+    try store.append(a, TestMsg.make(a, "b"));
+    store.clearAndDeinit(a);
+    try std.testing.expectEqual(@as(usize, 0), store.len());
+
+    // Reusable afterward.
+    try store.append(a, TestMsg.make(a, "c"));
+    try std.testing.expectEqual(@as(usize, 1), store.len());
+    store.clearAndDeinit(a);
+}
+
+test "fromList adopts an existing ArrayList" {
+    const a = std.testing.allocator;
+    var raw: std.ArrayListUnmanaged(TestMsg) = .empty;
+    try raw.append(a, TestMsg.make(a, "adopted"));
+
+    var store = TestStore.fromList(raw);
+    defer {
+        store.clearAndDeinit(a);
+        store.deinit(a);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), store.len());
+    try std.testing.expectEqualStrings("adopted", store.at(0).?.content);
+}

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -1242,7 +1242,7 @@ test "subagent loop rejects disallowed tools, returns the final report, accumula
     defer env.session.mutex.unlock();
     var saw_running = false;
     var saw_done = false;
-    for (env.session.messages.items) |msg| {
+    for (env.session.messages.items()) |msg| {
         if (msg.role != .tool) continue;
         if (std.mem.indexOf(u8, msg.content, "subagent: running write_file") != null) saw_running = true;
         if (std.mem.indexOf(u8, msg.content, "subagent: done (2 rounds, 15 tokens)") != null) saw_done = true;

--- a/src/renderer/ai_chat_renderer.zig
+++ b/src/renderer/ai_chat_renderer.zig
@@ -348,7 +348,7 @@ pub fn render(
     const viewport_bottom_top_px = window_height - transcript_bottom;
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
@@ -368,7 +368,7 @@ pub fn render(
     const transcript_selected = session.transcript_select_all;
     var cursor_top = transcript_top + gravity_offset - session.scroll_px;
 
-    for (session.messages.items, 0..) |msg, message_index| {
+    for (session.messages.items(), 0..) |msg, message_index| {
         const block_h = messageBlockHeight(msg, content_w);
         if (rendersAsCard(msg)) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
@@ -470,7 +470,7 @@ pub fn interactionHitTest(
     }
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
@@ -485,7 +485,7 @@ pub fn interactionHitTest(
     const gravity_offset = @max(0.0, transcript_h - content_h);
     var cursor_top = transcript_top + gravity_offset - scroll_px;
 
-    for (session.messages.items, 0..) |msg, message_index| {
+    for (session.messages.items(), 0..) |msg, message_index| {
         const block_h = messageBlockHeight(msg, content_w);
         if (rendersAsCard(msg)) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
@@ -549,7 +549,7 @@ pub fn transcriptTextHitTest(
     const content_x = x + LINE_PAD_X;
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
@@ -566,7 +566,7 @@ pub fn transcriptTextHitTest(
     const py: f32 = @floatCast(ypos);
     var cursor_top = transcript_top + gravity_offset - scroll_px;
 
-    for (session.messages.items, 0..) |msg, message_index| {
+    for (session.messages.items(), 0..) |msg, message_index| {
         const block_h = messageBlockHeight(msg, content_w);
         if (msg.role == .assistant and sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
             const bubble = bubbleGeometry(msg.role, content_x, content_w);
@@ -821,7 +821,7 @@ fn transcriptLayoutLocked(
     const content_w = w - LINE_PAD_X * 2;
 
     var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         content_h += messageBlockHeight(msg, content_w);
         if (msg.reasoning) |reasoning| {
             if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
@@ -1318,7 +1318,7 @@ fn firstLine(text: []const u8) []const u8 {
 
 fn renderRewindPicker(session: *ai_chat.Session, layout: InputLayout) void {
     var total: usize = 0;
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         if (msg.role == .user) total += 1;
     }
     if (total == 0) return;
@@ -1371,7 +1371,7 @@ fn renderRewindPicker(session: *ai_chat.Session, layout: InputLayout) void {
     );
 
     var ord: usize = 0; // 用户消息序号（0 = 最早）
-    for (session.messages.items) |msg| {
+    for (session.messages.items()) |msg| {
         if (msg.role != .user) continue;
         const this_ord = ord;
         ord += 1;

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -185,6 +185,7 @@ test {
     _ = @import("appwindow/resize_throttle.zig");
     _ = @import("termio/read_coalesce.zig");
     _ = @import("ai_chat_protocol.zig");
+    _ = @import("ai_chat/message_store.zig");
     _ = @import("weixin/types.zig");
     _ = @import("weixin/ilink_codec.zig");
     _ = @import("weixin/ilink_client.zig");


### PR DESCRIPTION
Phase 4 batch 2 (task 8): second cut on the `ai_chat.Session` god-object (~8.8k lines) after Composer — pull message storage into its own unit-tested module.

## What
- New `src/ai_chat/message_store.zig`: a generic `MessageStore(comptime Message)` owning the ordered message list with named ops (append, len, at, items(), clearAndDeinit, truncateFrom, fromList). Made generic over the message type to avoid a circular import back to ai_chat.zig for `Message` (mirrors `input/mouse_dispatch.zig`). Imports neither AppWindow nor renderer (satisfies the layered/overlay/ui_context guards). 6 unit tests.
- `Session`: the raw `messages: std.ArrayListUnmanaged(Message)` field becomes `messages: MessageStore(Message)`. Three structural ops now route through named store ops: clear-all -> clearAndDeinit, rewind/rollback tail-drop -> truncateFrom (replacing a manual pop+deinit loop), context-summary fold -> fromList. Delegating methods keep append/pop/deinit signature-compatible so ~141 call sites are untouched; ~153 bare `.messages.items` reads became `.messages.items()`.

## Verification
Behavior identical (no tool-runner / approval / protocol / security / renderer change). `zig build test` green; pure MessageStore tests run in the fast suite (deep ai_chat integration runs under the macOS-ARM full suite in CI). Only failure ever seen is the pre-existing `tool_import runArgvProbe` timing flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)