### PR TITLE
[codex] fix root-cause issue cluster

### DIFF
--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -3959,14 +3959,17 @@ pub const Session = struct {
 
         const settings = currentAgentSettings();
         const agent_enabled = self.agent_enabled or settings.enabled;
-        const tool_host = if (agent_enabled) currentToolHost() else null;
+        var tool_host = if (agent_enabled) currentToolHost() else null;
         var tool_snapshot: ?ToolSnapshot = null;
         errdefer if (tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
         if (tool_host) |host| {
             // The tab model is thread-local to the UI thread. Capture the agent
             // view before spawning the request worker so tools do not read an
             // empty thread-local copy from the background thread.
-            tool_snapshot = host.collectSnapshot(host.ctx, self.allocator) catch null;
+            tool_snapshot = host.collectSnapshot(host.ctx, self.allocator) catch blk: {
+                tool_host = null;
+                break :blk null;
+            };
         }
 
         var weixin_ctx: ?WeixinReplyContext = null;
@@ -4732,7 +4735,7 @@ fn buildTitleRequestLocked(session: *Session, turn: ai_chat_title.FirstTurn) !*C
         .thinking_enabled = false,
         .reasoning_effort = reasoning_effort,
         .stream = false,
-        .max_tokens = 64,
+        .max_tokens = 512,
         .agent_enabled = false,
         .copilot = false,
         .tool_host = null,
@@ -6200,6 +6203,30 @@ test "ai_chat: applyGeneratedTitle ignores empty model output" {
     defer session.deinit();
     applyGeneratedTitle(session, "   \n  ");
     try std.testing.expectEqualStrings(DEFAULT_NAME, session.title());
+}
+
+test "ai_chat: title request leaves enough budget for reasoning providers" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(
+        allocator,
+        DEFAULT_NAME,
+        "https://api.example.com",
+        "secret",
+        "model-a",
+        "system",
+        "enabled",
+        "high",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+
+    session.mutex.lock();
+    const req = try buildTitleRequestLocked(session, .{ .user = "hello", .assistant = "world" });
+    session.mutex.unlock();
+    defer req.deinit();
+
+    try std.testing.expect(req.max_tokens >= 256);
 }
 
 test "ai chat endpoint normalization" {

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -16,6 +16,8 @@ const pubmed = @import("pubmed.zig");
 const ai_chat_types = @import("ai_chat_types.zig");
 const platform_agent_prompt = @import("platform/agent_prompt.zig");
 
+const title_log = std.log.scoped(.ai_title);
+
 // Type aliases from ai_chat_protocol
 const RequestMessage = ai_chat_protocol.RequestMessage;
 const ToolCall = ai_chat_protocol.ToolCall;
@@ -105,11 +107,27 @@ pub fn titleThreadMain(req: *ChatRequest) void {
     const allocator = req.allocator;
     if (session.closing.load(.acquire)) return;
 
-    const result = runChatRequestForMessages(req, req.messages, false) catch return;
+    const result = runChatRequestForMessages(req, req.messages, false) catch |err| {
+        title_log.warn("title request failed: {}", .{err});
+        return;
+    };
     defer result.deinit(allocator);
     if (session.closing.load(.acquire)) return;
+    if (result.api_error) {
+        const preview = result.content[0..@min(result.content.len, 160)];
+        title_log.warn("title request API error: {s}", .{preview});
+        return;
+    }
 
-    ai_chat.applyGeneratedTitle(session, result.content);
+    const content = std.mem.trim(u8, result.content, " \t\r\n");
+    if (content.len > 0) {
+        ai_chat.applyGeneratedTitle(session, result.content);
+    } else if (result.reasoning) |reasoning| {
+        title_log.warn("title request returned empty content; trying reasoning fallback", .{});
+        ai_chat.applyGeneratedTitle(session, reasoning);
+    } else {
+        title_log.warn("title request returned empty content", .{});
+    }
 }
 
 /// Background worker for the post-model-switch context summary. Owns `sreq`

--- a/src/ai_chat_title.zig
+++ b/src/ai_chat_title.zig
@@ -226,10 +226,20 @@ fn trimIncompleteUtf8(s: []const u8) []const u8 {
     return s[0..i]; // incomplete tail
 }
 
-fn looksLikeApiErrorJson(s: []const u8) bool {
+fn startsWithIgnoreCase(haystack: []const u8, prefix: []const u8) bool {
+    return haystack.len >= prefix.len and std.ascii.eqlIgnoreCase(haystack[0..prefix.len], prefix);
+}
+
+fn looksLikeApiErrorText(s: []const u8) bool {
     const trimmed = std.mem.trim(u8, s, " \t\r\n");
-    return std.mem.startsWith(u8, trimmed, "{") and
-        std.mem.indexOf(u8, trimmed, "\"error\"") != null;
+    if (std.mem.startsWith(u8, trimmed, "{")) {
+        return std.mem.indexOf(u8, trimmed, "\"error\"") != null or
+            std.mem.indexOf(u8, trimmed, "\"code\"") != null or
+            std.mem.indexOf(u8, trimmed, "\"message\"") != null;
+    }
+    return startsWithIgnoreCase(trimmed, "<html") or
+        startsWithIgnoreCase(trimmed, "<!doctype") or
+        startsWithIgnoreCase(trimmed, "http ");
 }
 
 /// Clean a raw model response into a display title written into `out`
@@ -241,7 +251,7 @@ fn looksLikeApiErrorJson(s: []const u8) bool {
 pub fn cleanTitle(raw: []const u8, out: []u8) ?[]const u8 {
     std.debug.assert(out.len >= max_title_bytes);
     const trimmed_raw = std.mem.trim(u8, raw, " \t\r\n");
-    if (looksLikeApiErrorJson(trimmed_raw)) return null;
+    if (looksLikeApiErrorText(trimmed_raw)) return null;
 
     var line = trimmed_raw;
     if (std.mem.indexOfScalar(u8, line, '\n')) |nl| line = line[0..nl];
@@ -302,6 +312,13 @@ test "cleanTitle: rejects raw API error JSON" {
         "{\"error\":{\"message\":\"thinking options type cannot be disabled when reasoning_effort is set\"}}",
         &buf,
     ) == null);
+}
+
+test "cleanTitle: rejects nonstandard API error bodies" {
+    var buf: [max_title_bytes]u8 = undefined;
+    try std.testing.expect(cleanTitle("{\"code\":400,\"message\":\"bad request\"}", &buf) == null);
+    try std.testing.expect(cleanTitle("<html><body>upstream error</body></html>", &buf) == null);
+    try std.testing.expect(cleanTitle("HTTP 502 Bad Gateway", &buf) == null);
 }
 
 test "cleanTitle: clamps to max_title_bytes on UTF-8 boundary" {

--- a/src/appwindow/surface_snapshots.zig
+++ b/src/appwindow/surface_snapshots.zig
@@ -178,30 +178,29 @@ test "agent surface callbacks reject a surface that is not registered as live" {
 pub fn agentSshConnectionForSurface(ctx: *anyopaque, surface_id: []const u8) ?Surface.SshConnection {
     _ = ctx;
     if (surface_id.len == 0) return null;
-    // This runs on the agent request worker thread, but `g_tabs`/`g_tab_count`
-    // are thread-local to the UI thread. A worker-thread call therefore sees an
-    // empty tab list and resolves nothing — the root of copy_file's "connection
-    // is unavailable" (#268). Log the tab count actually visible here so a log
-    // capture distinguishes "empty thread-local view" from "surface_id mismatch".
-    for (0..tab.g_tab_count) |tab_index| {
-        const tab_state = tab.g_tabs[tab_index] orelse continue;
-        if (tab_state.kind != .terminal) continue;
-        var it = tab_state.tree.surfaces();
-        while (it.next()) |entry| {
-            const sfc = entry.surface;
-            if (!std.mem.eql(u8, sfc.remote_id[0..], surface_id)) continue;
-            preview_diagnostics.debug("agent-ssh-conn", &.{
-                .{ .key = "stage", .value = "match" },
-                .{ .key = "tabs", .value = if (tab.g_tab_count == 0) "0" else "n" },
-                .{ .key = "has_conn", .value = if (sfc.ssh_connection != null) "true" else "false" },
-            });
-            return sfc.ssh_connection; // value copy (or null if not SSH)
-        }
-    }
+    const ptr = surface_registry.acquireById(surface_id) orelse {
+        preview_diagnostics.debug("agent-ssh-conn", &.{.{ .key = "stage", .value = "no-match" }});
+        return null;
+    };
+    defer surface_registry.release();
+    const surface: *Surface = @ptrCast(@alignCast(ptr));
     preview_diagnostics.debug("agent-ssh-conn", &.{
-        .{ .key = "stage", .value = "no-match" },
-        // "0" here means the worker thread sees an empty thread-local tab list.
-        .{ .key = "tabs", .value = if (tab.g_tab_count == 0) "0" else "n" },
+        .{ .key = "stage", .value = "match" },
+        .{ .key = "has_conn", .value = if (surface.ssh_connection != null) "true" else "false" },
     });
-    return null;
+    return surface.ssh_connection; // value copy (or null if not SSH)
+}
+
+test "agent SSH connection resolver rejects unregistered surface id" {
+    try std.testing.expect(agentSshConnectionForSurface(undefined, "missing") == null);
+}
+
+test "agent SSH connection resolver uses registry source" {
+    const source = @embedFile("surface_snapshots.zig");
+    const start = std.mem.indexOf(u8, source, "pub fn agentSshConnectionForSurface") orelse return error.MissingAgentSshResolver;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "test \"agent SSH") orelse return error.MissingAgentSshResolverEnd;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, "surface_registry.acquireById") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "tab.g_") == null);
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2689,7 +2689,7 @@ fn runSessionLauncherRow(row: usize) void {
         openLocalShellSession();
     } else if (row == 1) {
         openSshList();
-    } else if (row == command_center_state.SESSION_LAUNCHER_ROW_TMUX) {
+    } else if (row == platform_pty_command.sessionLauncherTmuxRow()) {
         openTmuxSshPicker();
         return;
     } else if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
@@ -4903,7 +4903,7 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
         g_session_launcher_selected = row;
         if (row == 0) return .local_shell;
         if (row == 1) return .ssh;
-        if (row == command_center_state.SESSION_LAUNCHER_ROW_TMUX) return .tmux;
+        if (row == platform_pty_command.sessionLauncherTmuxRow()) return .tmux;
         if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
             if (row == wsl_row) return .wsl;
         }
@@ -5189,7 +5189,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
         row += 1;
         renderSessionRow(layout, window_height, row, "SSH", i18n.s().sl_v_connect_server, g_session_launcher_selected == row);
         row += 1;
-        renderSessionRow(layout, window_height, command_center_state.SESSION_LAUNCHER_ROW_TMUX, "tmux", "Alive session", g_session_launcher_selected == command_center_state.SESSION_LAUNCHER_ROW_TMUX);
+        renderSessionRow(layout, window_height, platform_pty_command.sessionLauncherTmuxRow(), "tmux", "Alive session", g_session_launcher_selected == platform_pty_command.sessionLauncherTmuxRow());
         row += 1;
         if (platform_pty_command.sessionLauncherWslRow()) |wsl_row| {
             row = wsl_row;

--- a/src/source_guards/overlay_boundary_guard.zig
+++ b/src/source_guards/overlay_boundary_guard.zig
@@ -12,6 +12,8 @@
 const std = @import("std");
 const scan = @import("scan.zig");
 
+const overlays_source = @embedFile("../renderer/overlays.zig");
+
 const PureModule = struct {
     name: []const u8,
     source: []const u8,
@@ -35,6 +37,10 @@ fn appWindowImportCount(source: []const u8) usize {
     return scan.countOccurrences(source, "@import(\"../../AppWindow.zig\")");
 }
 
+fn staleSessionLauncherTmuxRowCount(source: []const u8) usize {
+    return scan.countOccurrences(source, "command_center_state.SESSION_LAUNCHER_ROW_TMUX");
+}
+
 test "extracted pure overlay modules do not import AppWindow" {
     for (pure_overlay_modules) |module| {
         const count = appWindowImportCount(module.source);
@@ -46,5 +52,17 @@ test "extracted pure overlay modules do not import AppWindow" {
             );
             return error.PureOverlayImportedAppWindow;
         }
+    }
+}
+
+test "session launcher uses runtime tmux row layout" {
+    const count = staleSessionLauncherTmuxRowCount(overlays_source);
+    if (count > 0) {
+        std.debug.print(
+            "overlay_boundary_guard: renderer/overlays.zig uses the compile-time tmux launcher row {d} time(s). " ++
+                "Use platform_pty_command.sessionLauncherTmuxRow() so WSL-less Windows shifts rows correctly.\n",
+            .{count},
+        );
+        return error.SessionLauncherUsedStaticTmuxRow;
     }
 }

--- a/src/ssh_tunnel.zig
+++ b/src/ssh_tunnel.zig
@@ -16,6 +16,7 @@ const MAX_LOCAL_HOST_BYTES = 32;
 const MAX_ACTIVE_TUNNELS = 32;
 const TUNNEL_READY_TIMEOUT_MS = 8000;
 const TUNNEL_READY_POLL_NS = 50 * std.time.ns_per_ms;
+const TUNNEL_HTTP_PROBE_TIMEOUT_MS = 1000;
 
 threadlocal var g_tunnels: [MAX_ACTIVE_TUNNELS]?SshTunnel = [_]?SshTunnel{null} ** MAX_ACTIVE_TUNNELS;
 
@@ -232,7 +233,7 @@ fn findReusableTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.
             stopTunnelSlot(slot);
             continue;
         }
-        if (!canConnectToLocalPort(allocator, tunnel.localHost(), tunnel.local_port)) {
+        if (!localHttpReadyOnce(allocator, tunnel.localHost(), tunnel.local_port)) {
             stopTunnelSlot(slot);
             continue;
         }
@@ -371,30 +372,56 @@ fn waitForTunnelReady(allocator: std.mem.Allocator, local_host: []const u8, loca
 
     const deadline = std.time.milliTimestamp() + TUNNEL_READY_TIMEOUT_MS;
     while (std.time.milliTimestamp() < deadline) {
-        if (canConnectToLocalPort(allocator, local_host, local_port)) return true;
+        if (localHttpReadyOnce(allocator, local_host, local_port)) return true;
         if (childHasExited(child)) return false;
         std.Thread.sleep(TUNNEL_READY_POLL_NS);
     }
     return false;
 }
 
-fn canConnectToLocalPort(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
-    if (std.mem.eql(u8, local_host, "127.0.0.1") or std.mem.eql(u8, local_host, "localhost")) {
-        const address = std.net.Address.parseIp4("127.0.0.1", local_port) catch return false;
-        var stream = std.net.tcpConnectToAddress(address) catch {
-            if (!std.mem.eql(u8, local_host, "localhost")) return false;
-            return canConnectToLocalHostName(allocator, local_host, local_port);
-        };
-        stream.close();
-        return true;
-    }
-    return canConnectToLocalHostName(allocator, local_host, local_port);
+fn localHttpReadyOnce(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
+    var stream = connectToLocalPort(allocator, local_host, local_port) orelse return false;
+    defer stream.close();
+    setReadTimeout(stream.handle, TUNNEL_HTTP_PROBE_TIMEOUT_MS);
+    stream.writeAll("GET / HTTP/1.0\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n") catch return false;
+    var buf: [512]u8 = undefined;
+    const n = stream.read(&buf) catch return false;
+    return httpProbeReady(buf[0..n]);
 }
 
-fn canConnectToLocalHostName(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) bool {
-    var stream = std.net.tcpConnectToHost(allocator, local_host, local_port) catch return false;
-    stream.close();
-    return true;
+fn httpProbeReady(response: []const u8) bool {
+    return std.mem.startsWith(u8, response, "HTTP/");
+}
+
+fn setReadTimeout(handle: std.net.Stream.Handle, ms: u32) void {
+    if (builtin.os.tag == .windows) {
+        const ws2 = std.os.windows.ws2_32;
+        const timeout: u32 = ms;
+        _ = ws2.setsockopt(handle, ws2.SOL.SOCKET, ws2.SO.RCVTIMEO, @ptrCast(&timeout), @sizeOf(u32));
+    } else {
+        const tv = std.posix.timeval{
+            .sec = @intCast(ms / 1000),
+            .usec = @intCast((ms % 1000) * 1000),
+        };
+        std.posix.setsockopt(handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+    }
+}
+
+fn connectToLocalPort(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) ?std.net.Stream {
+    if (std.mem.eql(u8, local_host, "127.0.0.1") or std.mem.eql(u8, local_host, "localhost")) {
+        const address = std.net.Address.parseIp4("127.0.0.1", local_port) catch return null;
+        const stream = std.net.tcpConnectToAddress(address) catch {
+            if (!std.mem.eql(u8, local_host, "localhost")) return null;
+            return connectToLocalHostName(allocator, local_host, local_port);
+        };
+        return stream;
+    }
+    return connectToLocalHostName(allocator, local_host, local_port);
+}
+
+fn connectToLocalHostName(allocator: std.mem.Allocator, local_host: []const u8, local_port: u16) ?std.net.Stream {
+    const stream = std.net.tcpConnectToHost(allocator, local_host, local_port) catch return null;
+    return stream;
 }
 
 fn childHasExited(child: *const std.process.Child) bool {
@@ -486,6 +513,13 @@ test "ssh_tunnel cache key distinguishes proxy jump" {
 
     try std.testing.expect(tunnel.matches(&conn_a, 8888, "127.0.0.1", "127.0.0.1"));
     try std.testing.expect(!tunnel.matches(&conn_b, 8888, "127.0.0.1", "127.0.0.1"));
+}
+
+test "ssh_tunnel HTTP probe requires a response status line" {
+    try std.testing.expect(httpProbeReady("HTTP/1.0 302 Found\r\nLocation: /\r\n\r\n"));
+    try std.testing.expect(httpProbeReady("HTTP/1.1 404 Not Found\r\n\r\n"));
+    try std.testing.expect(!httpProbeReady(""));
+    try std.testing.expect(!httpProbeReady("SSH-2.0-OpenSSH\r\n"));
 }
 
 test "reservePreferredLocalPort returns the preferred port when it is free" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -31,6 +31,65 @@ test "remote file ssh helpers include short keepalive options" {
     try std.testing.expect(std.mem.indexOf(u8, remote_file_source, "\"ServerAliveCountMax=2\"") != null);
 }
 
+test "ai title worker rejects API error results" {
+    const source = @embedFile("ai_chat_request.zig");
+    const start = std.mem.indexOf(u8, source, "pub fn titleThreadMain") orelse return error.MissingTitleWorker;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "pub fn summaryThreadMain") orelse return error.MissingSummaryWorker;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, "result.api_error") != null);
+}
+
+test "ai title request does not use the old 64 token budget" {
+    const source = @embedFile("ai_chat.zig");
+    const start = std.mem.indexOf(u8, source, "fn buildTitleRequestLocked") orelse return error.MissingTitleRequestBuilder;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "// titleThreadMain has moved") orelse return error.MissingTitleRequestEnd;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, ".max_tokens = 64") == null);
+}
+
+test "ssh browser tunnel readiness probes HTTP through the tunnel" {
+    const source = @embedFile("ssh_tunnel.zig");
+    {
+        const start = std.mem.indexOf(u8, source, "fn waitForTunnelReady") orelse return error.MissingTunnelReady;
+        const rest = source[start..];
+        const end = std.mem.indexOf(u8, rest, "fn childHasExited") orelse return error.MissingTunnelReadyEnd;
+        const body = rest[0..end];
+        try std.testing.expect(std.mem.indexOf(u8, body, "localHttpReadyOnce") != null);
+        try std.testing.expect(std.mem.indexOf(u8, body, "canConnectToLocalPort") == null);
+    }
+    {
+        const start = std.mem.indexOf(u8, source, "fn findReusableTunnel") orelse return error.MissingTunnelReuse;
+        const rest = source[start..];
+        const end = std.mem.indexOf(u8, rest, "fn spawnSshTunnel") orelse return error.MissingTunnelReuseEnd;
+        const body = rest[0..end];
+        try std.testing.expect(std.mem.indexOf(u8, body, "localHttpReadyOnce") != null);
+        try std.testing.expect(std.mem.indexOf(u8, body, "canConnectToLocalPort") == null);
+    }
+}
+
+test "agent SSH connection resolver uses the surface registry, not tab threadlocals" {
+    const source = @embedFile("appwindow/surface_snapshots.zig");
+    const start = std.mem.indexOf(u8, source, "pub fn agentSshConnectionForSurface") orelse return error.MissingAgentSshResolver;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "test \"agent SSH") orelse return error.MissingAgentSshResolverEnd;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, "surface_registry.acquireById") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "tab.g_") == null);
+}
+
+test "agent request disables worker snapshot fallback when UI capture fails" {
+    const source = @embedFile("ai_chat.zig");
+    const start = std.mem.indexOf(u8, source, "fn buildRequestLocked") orelse return error.MissingBuildRequestLocked;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "var weixin_ctx") orelse return error.MissingBuildRequestSnapshotEnd;
+    const body = rest[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, body, "host.collectSnapshot") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "catch null") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "tool_host = null") != null);
+}
+
 test {
     _ = @import("input/command_dispatch.zig");
     _ = @import("input/effects.zig");


### PR DESCRIPTION

## Summary

Fixes #335, fixes #320, fixes #319, fixes #311, fixes #309, fixes #308.

- Use the runtime session-launcher tmux row everywhere, so WSL-less Windows layouts no longer overlap tmux and Copilot rows.
- Make AI auto-title failures diagnosable and safer: reject API error results, reject nonstandard error bodies, increase the title token budget, and avoid worker-side snapshot recapture after UI snapshot failure.
- Require SSH browser tunnels to return an HTTP status line before marking them ready or reusable.
- Resolve agent SSH connections through `surface_registry.acquireById` instead of worker-thread `tab.g_*` threadlocals.

## Root Cause

The fixed issues were all already traced to shared integration assumptions: fixed launcher row constants despite runtime WSL availability, silent title-worker error handling plus a tiny title budget, TCP-only tunnel readiness that accepted half-ready `ssh -L` sockets, and worker threads reading UI-thread threadlocal tab state.

## Validation

- `zig build test`
- `zig build test-full`
- `git diff --check`
