### PR TITLE
fix(termio): do not silently drop terminal writes when the mailbox is full

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -769,10 +769,45 @@ pub fn setScreenSizeWithPolicy(
     return false;
 }
 
+/// Number of notify+yield attempts to give the writer thread a chance to drain
+/// a full mailbox before we give up on a write. Bounded so we never spin.
+const MAILBOX_FULL_RETRIES = 64;
+
+const mailbox_log = std.log.scoped(.mailbox);
+
 /// Send a message to the IO writer thread via the mailbox.
+///
+/// On a full ring, control messages (resize) are accepted by the mailbox via
+/// last-writer-wins/drop-oldest. A WRITE message instead reports `.full` and is
+/// NOT enqueued, so we notify the writer thread and retry a bounded number of
+/// times, yielding between attempts to let it drain. If it is still full after
+/// the bound we log a visible warning rather than silently dropping input.
 pub fn queueIo(self: *Surface, msg: termio.Message) void {
-    self.mailbox.send(msg);
-    self.mailbox.notify();
+    var attempt: usize = 0;
+    while (true) {
+        switch (self.mailbox.send(msg)) {
+            .queued, .coalesced => {
+                self.mailbox.notify();
+                return;
+            },
+            .full => {
+                // Wake the writer so it drains, then yield and retry. The mutex
+                // is released between attempts (send() locks per call), so the
+                // writer's pop() can make progress.
+                self.mailbox.notify();
+                attempt += 1;
+                if (attempt >= MAILBOX_FULL_RETRIES) {
+                    mailbox_log.warn(
+                        "mailbox full after {d} retries; dropping write message to avoid stall",
+                        .{MAILBOX_FULL_RETRIES},
+                    );
+                    msg.deinit();
+                    return;
+                }
+                std.Thread.yield() catch {};
+            },
+        }
+    }
 }
 
 /// Queue bytes to the PTY input pipe through the IO writer thread.

--- a/src/termio/Mailbox.zig
+++ b/src/termio/Mailbox.zig
@@ -7,8 +7,9 @@
 /// Design notes:
 /// - send() + notify() are separate (like Ghostty) so the caller can batch
 ///   sends before one notify
-/// - Drop-oldest on overflow (not blocking) — simpler than Ghostty's
-///   blocking-with-mutex-release, and resize messages are last-writer-wins anyway
+/// - On overflow, control messages (resize) may drop-oldest / last-writer-wins
+///   (resize is idempotent-ish), but WRITE messages are never silently dropped:
+///   send() returns .full and leaves the queue intact so the caller can retry
 /// - Mutex-based, not lock-free — adequate for our SPSC pattern with tiny
 ///   critical sections
 const std = @import("std");
@@ -18,6 +19,17 @@ const Message = @import("message.zig").Message;
 const Mailbox = @This();
 
 const CAPACITY = 64;
+
+/// Outcome of a send() call so the caller can react (e.g. retry on .full).
+pub const SendResult = enum {
+    /// The message was enqueued normally.
+    queued,
+    /// A trailing resize was coalesced into the existing pending resize.
+    coalesced,
+    /// The ring was full and the message could not be enqueued. The queue is
+    /// left intact (nothing dropped); the caller should notify+retry.
+    full,
+};
 
 queue: [CAPACITY]Message = undefined,
 head: usize = 0,
@@ -36,16 +48,37 @@ pub fn deinit(self: *Mailbox) void {
     self.wakeup.deinit();
 }
 
-/// Push a message onto the ring buffer. If full, drops the oldest message.
+/// Whether a message is a control message (idempotent-ish; safe to drop-oldest
+/// on overflow) rather than a payload-bearing write that must not be lost.
+fn isControl(msg: Message) bool {
+    return switch (msg) {
+        .resize, .resize_immediate => true,
+        .write_small, .write_alloc => false,
+    };
+}
+
+/// Push a message onto the ring buffer.
+///
+/// Returns:
+/// - .coalesced if a trailing resize was folded into the pending resize
+/// - .queued on a normal enqueue
+/// - .full if the ring is full and the message is a WRITE: nothing is dropped
+///   and the message is NOT enqueued, so the caller can notify+retry. A full
+///   ring with a CONTROL message drops the oldest entry and returns .queued.
+///
 /// Thread-safe (uses mutex).
-pub fn send(self: *Mailbox, msg: Message) void {
+pub fn send(self: *Mailbox, msg: Message) SendResult {
     self.mutex.lock();
     defer self.mutex.unlock();
 
-    if (self.coalesceTrailingResize(msg)) return;
+    if (self.coalesceTrailingResize(msg)) return .coalesced;
 
     if (self.count == CAPACITY) {
-        // Drop oldest: advance head and release any owned payload.
+        // Never silently drop a write: report .full and leave the queue intact
+        // so the caller can wake the writer thread and retry once it drains.
+        if (!isControl(msg)) return .full;
+
+        // Control message (resize): drop oldest, advance head, release payload.
         self.queue[self.head].deinit();
         self.head = (self.head + 1) % CAPACITY;
         self.count -= 1;
@@ -54,6 +87,7 @@ pub fn send(self: *Mailbox, msg: Message) void {
     self.queue[self.tail] = msg;
     self.tail = (self.tail + 1) % CAPACITY;
     self.count += 1;
+    return .queued;
 }
 
 fn coalesceTrailingResize(self: *Mailbox, msg: Message) bool {
@@ -121,16 +155,23 @@ fn expectResize(msg: Message, cols: u16, rows: u16) !void {
     }
 }
 
-test "Mailbox drops oldest message when full" {
+test "Mailbox returns .full for writes on a full ring without dropping" {
     var mailbox = try Mailbox.init();
     defer mailbox.deinit();
 
-    for (0..CAPACITY + 1) |i| {
-        mailbox.send(writeSmallByte(@intCast(i)));
+    // Fill the ring exactly to capacity.
+    for (0..CAPACITY) |i| {
+        try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte(@intCast(i))));
     }
-
     try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
-    for (1..CAPACITY + 1) |expected| {
+
+    // One more write must NOT be dropped: it is rejected with .full and the
+    // existing queue is left untouched.
+    try std.testing.expectEqual(SendResult.full, mailbox.send(writeSmallByte(0xFF)));
+    try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
+
+    // All original messages are preserved in order; none were dropped.
+    for (0..CAPACITY) |expected| {
         try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, @intCast(expected));
     }
     try std.testing.expect(mailbox.pop() == null);
@@ -140,8 +181,8 @@ test "Mailbox coalesces pending resize messages" {
     var mailbox = try Mailbox.init();
     defer mailbox.deinit();
 
-    mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } });
-    mailbox.send(.{ .resize = .{ .cols = 120, .rows = 40 } });
+    try std.testing.expectEqual(SendResult.queued, mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } }));
+    try std.testing.expectEqual(SendResult.coalesced, mailbox.send(.{ .resize = .{ .cols = 120, .rows = 40 } }));
 
     try std.testing.expectEqual(@as(usize, 1), mailbox.count);
     try expectResize(mailbox.pop() orelse return error.MissingMessage, 120, 40);
@@ -152,14 +193,39 @@ test "Mailbox resize coalescing preserves write messages" {
     var mailbox = try Mailbox.init();
     defer mailbox.deinit();
 
-    mailbox.send(writeSmallByte('a'));
-    mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } });
-    mailbox.send(.{ .resize = .{ .cols = 100, .rows = 30 } });
-    mailbox.send(writeSmallByte('b'));
+    try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte('a')));
+    try std.testing.expectEqual(SendResult.queued, mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } }));
+    try std.testing.expectEqual(SendResult.coalesced, mailbox.send(.{ .resize = .{ .cols = 100, .rows = 30 } }));
+    try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte('b')));
 
     try std.testing.expectEqual(@as(usize, 3), mailbox.count);
     try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'a');
     try expectResize(mailbox.pop() orelse return error.MissingMessage, 100, 30);
     try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'b');
+    try std.testing.expect(mailbox.pop() == null);
+}
+
+test "Mailbox drops oldest control message when full" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    // Fill with writes so the trailing-resize coalesce path is not taken and
+    // each resize lands as a distinct entry until the ring is full.
+    for (0..CAPACITY) |i| {
+        try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte(@intCast(i))));
+    }
+    try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
+
+    // A control (resize) message on a full ring drops the oldest entry and is
+    // enqueued — control is idempotent-ish, unlike writes.
+    try std.testing.expectEqual(SendResult.queued, mailbox.send(.{ .resize = .{ .cols = 10, .rows = 5 } }));
+    try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
+
+    // Oldest write (byte 0) was dropped; remaining writes 1..CAPACITY-1 stay,
+    // followed by the resize.
+    for (1..CAPACITY) |expected| {
+        try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, @intCast(expected));
+    }
+    try expectResize(mailbox.pop() orelse return error.MissingMessage, 10, 5);
     try std.testing.expect(mailbox.pop() == null);
 }


### PR DESCRIPTION
Post-review correctness fix (PR4, minimal). The PTY `Mailbox` is a single fixed ring (64) carrying both control (resize) and real WRITE payloads; on overflow `send()` dropped the oldest message indiscriminately — silently losing user input / paste / agent writes. A test had codified that behavior as the contract.

## What
- `send()` now returns `SendResult { queued, coalesced, full }`.
- On a full ring: control messages (`.resize`/`.resize_immediate`) keep drop-oldest / last-writer-wins; WRITE messages (`.write_small`/`.write_alloc`) return `.full` WITHOUT enqueuing — nothing is dropped, the queue is left intact. (`isControl` is an exhaustive switch, so a new Message variant forces a decision.)
- `Surface.queueIo` handles `.full` with a BOUNDED notify+yield retry (64 attempts, mutex released between attempts so the writer can drain, no unbounded spin / no held lock); if still full after the bound it emits a `std.log.scoped(.mailbox).warn` and frees the message — a visible drop, never silent.
- Replaced the "drops oldest message when full" test with a write-returns-`.full`-without-dropping test; added a control-message-drops-oldest test; kept the resize-coalesce tests.

## Known residual (acceptable for the minimal fix)
A resize arriving on a ring full of 64 writes still drops one oldest write to make room (returning `.queued`) — rejecting the resize instead would leave the terminal mis-sized. Rare edge; the dominant every-write-overflow silent-drop path is fixed.

## Verification
`rg "mailbox.send" src` confirms `Surface.queueIo` is the only call site. `zig build test` + `zig build macos-app -Dtarget=aarch64-macos` + `zig build test-full -Dtarget=aarch64-macos` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)