### PR TITLE
ci(remote): build production client and server artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
+      # Production emit: typecheck alone does not validate the Vite client
+      # bundle or the tsc server emit (build:docker = build + build:server).
+      - run: npm run build:docker
 
   windows-smoke:
     name: Windows smoke


### PR DESCRIPTION
Post-review CI gap (PR6). The Remote CI job ran `npm run typecheck` + `npm test` but never emitted the production build, so a broken Vite client bundle or `tsc` server emit could pass CI.

## What
- Added `npm run build:docker` to the Remote job (= `vite build` + `tsc -p tsconfig.server.json`), after typecheck/test.

TypeScript `--noEmit` typecheck does not validate the bundler, static assets, or the server emit; this closes that gap. The new step runs on the Remote TypeScript job which is already a required status check on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)