### PR TITLE
[codex] harden persisted state writes

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3348,20 +3348,7 @@ fn saveMarkdownDialogPath(
 }
 
 fn writeFilePath(path: []const u8, bytes: []const u8) !void {
-    if (std.fs.path.dirname(path)) |dir| {
-        try std.fs.cwd().makePath(dir);
-    }
-
-    if (std.fs.path.isAbsolute(path)) {
-        var file = try std.fs.createFileAbsolute(path, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(bytes);
-        return;
-    }
-
-    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(bytes);
+    try platform_atomic_file.writeFileReplaceSafe(path, bytes);
 }
 
 fn syncWindowTitlebarHeight(win: *window_backend.Window) f32 {

--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const log = std.log.scoped(.agent_history);
 
@@ -238,11 +239,7 @@ pub fn saveJsonToPath(path: []const u8, json: []const u8) !void {
         };
     }
 
-    var write_buffer: [0]u8 = .{};
-    var atomic = try std.fs.cwd().atomicFile(path, .{ .write_buffer = &write_buffer });
-    defer atomic.deinit();
-    try atomic.file_writer.file.writeAll(json);
-    try atomic.finish();
+    try platform_atomic_file.writeFileReplaceSafe(path, json);
 }
 
 pub fn sortRows(rows: []Row) void {

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 const types = @import("ai_chat_types.zig");
 const agent_file_edit = @import("agent_file_edit.zig");
 const agent_file_copy = @import("agent_file_copy.zig");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const scp = @import("scp.zig");
 const ToolSshConnection = types.SshConnection;
 const ai_chat_protocol = @import("ai_chat_protocol.zig");
@@ -2181,17 +2182,8 @@ fn resolveLocalPath(allocator: std.mem.Allocator, path: []const u8, working_dir:
 }
 
 fn writeLocalFileAtomic(allocator: std.mem.Allocator, resolved: []const u8, content: []const u8) !void {
-    // Ensure parent directory exists.
-    if (std.fs.path.dirname(resolved)) |dir_path| {
-        try std.fs.cwd().makePath(dir_path);
-    }
-    // Use AtomicFile for a safe replace.
-    var write_buffer: [0]u8 = .{};
-    var atomic = try std.fs.cwd().atomicFile(resolved, .{ .write_buffer = &write_buffer });
-    defer atomic.deinit();
-    try atomic.file_writer.file.writeAll(content);
-    try atomic.finish();
-    _ = allocator; // no heap needed beyond the call
+    _ = allocator;
+    try platform_atomic_file.writeFileReplaceSafe(resolved, content);
 }
 
 fn renderReadResult(ctx: *ToolContext, path: []const u8, bytes: []const u8, offset: usize, limit: usize) ![]u8 {

--- a/src/ai_history_cache.zig
+++ b/src/ai_history_cache.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const types = @import("ai_history_types.zig");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const platform_dirs = @import("platform/dirs.zig");
 
 const MAX_CACHE_BYTES = 16 * 1024 * 1024;
@@ -65,12 +66,7 @@ pub fn saveToPath(allocator: std.mem.Allocator, path: []const u8, cache: CacheFi
     const json = try dump(allocator, cache);
     defer allocator.free(json);
 
-    if (std.fs.path.dirname(path)) |dir| try std.fs.cwd().makePath(dir);
-    var write_buffer: [0]u8 = .{};
-    var atomic = try std.fs.cwd().atomicFile(path, .{ .write_buffer = &write_buffer });
-    defer atomic.deinit();
-    try atomic.file_writer.file.writeAll(json);
-    try atomic.finish();
+    try platform_atomic_file.writeFileReplaceSafe(path, json);
 }
 
 pub fn saveDefault(allocator: std.mem.Allocator, cache: CacheFile) !void {

--- a/src/ai_loop_store.zig
+++ b/src/ai_loop_store.zig
@@ -5,6 +5,7 @@
 //! handling + tick), guarded by a mutex for defensive safety.
 const std = @import("std");
 const engine = @import("ai_loop_schedule.zig");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const ai_history_time = @import("ai_history_time.zig");
 
 pub const Task = engine.Task;
@@ -339,9 +340,7 @@ pub const Store = struct {
         const model = engine.FileModel{ .version = 1, .next_id = self.next_id, .tasks = self.tasks.items };
         const bytes = engine.encode(self.allocator, model) catch return;
         defer self.allocator.free(bytes);
-        const file = std.fs.cwd().createFile(self.path, .{ .truncate = true }) catch return;
-        defer file.close();
-        file.writeAll(bytes) catch return;
+        platform_atomic_file.writeFileReplaceSafe(self.path, bytes) catch return;
     }
 };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -23,6 +23,7 @@ const ai_agent_config = @import("ai_agent_config.zig");
 const keybind = @import("keybind.zig");
 const link_open = @import("link_open.zig");
 const console_host_policy = @import("platform/console_host_policy.zig");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 const platform_dirs = @import("platform/dirs.zig");
 const platform_editor = @import("platform/editor.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
@@ -1483,12 +1484,13 @@ pub fn ensureConfigExists(allocator: std.mem.Allocator) void {
         std.fs.cwd().makePath(dir) catch return;
     }
 
-    // Create config file with default template if it doesn't exist
-    if (std.fs.cwd().createFile(path, .{ .exclusive = true })) |file| {
-        file.writeAll(default_config_template) catch {};
-        file.close();
-        log.info("created default config file: {s}", .{path});
-    } else |_| {}
+    std.fs.cwd().access(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            platform_atomic_file.writeFileReplaceSafe(path, default_config_template) catch return;
+            log.info("created default config file: {s}", .{path});
+        },
+        else => return,
+    };
 }
 
 // ============================================================================
@@ -1516,20 +1518,19 @@ pub fn openConfigInEditor(allocator: std.mem.Allocator) void {
         };
     }
 
-    // Create config file with default template if it doesn't exist
-    if (std.fs.cwd().createFile(path, .{ .exclusive = true })) |file| {
-        file.writeAll(default_config_template) catch {};
-        file.close();
-        std.debug.print("[config] created default config file\n", .{});
-    } else |err| switch (err) {
-        error.PathAlreadyExists => {
-            std.debug.print("[config] config file already exists\n", .{});
+    std.fs.cwd().access(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            platform_atomic_file.writeFileReplaceSafe(path, default_config_template) catch |write_err| {
+                std.debug.print("[config] ERROR: failed to create config file: {}\n", .{write_err});
+                return;
+            };
+            std.debug.print("[config] created default config file\n", .{});
         },
         else => {
-            std.debug.print("[config] ERROR: failed to create config file: {}\n", .{err});
+            std.debug.print("[config] ERROR: failed to access config file: {}\n", .{err});
             return;
         },
-    }
+    };
 
     std.debug.print("[config] opening editor with path: {s}\n", .{path});
     if (!platform_editor.openTextFile(allocator, .{ .path = path })) {
@@ -1558,9 +1559,7 @@ pub fn setConfigValue(allocator: std.mem.Allocator, key: []const u8, value: []co
     const out = try setConfigValueInContent(allocator, content, key, value);
     defer allocator.free(out);
 
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(out);
+    try platform_atomic_file.writeFileReplaceSafe(path, out);
 }
 
 /// Pure: return a copy of `content` with `key`'s active value set to `value`.
@@ -1644,9 +1643,7 @@ pub fn removeConfigKeys(allocator: std.mem.Allocator, keys: []const []const u8) 
     const out = try stripConfigKeys(allocator, content, keys);
     defer allocator.free(out);
 
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(out);
+    try platform_atomic_file.writeFileReplaceSafe(path, out);
 }
 
 /// Config keys backing the settings page. "Restore default settings" removes

--- a/src/platform/atomic_file.zig
+++ b/src/platform/atomic_file.zig
@@ -1,17 +1,49 @@
 //! Replace-safe file writes for persisted application state.
 
 const std = @import("std");
+const builtin = @import("builtin");
+
+pub const WriteOptions = struct {
+    mode: std.fs.File.Mode = std.fs.File.default_mode,
+    sync_file: bool = false,
+    sync_parent_dir: bool = false,
+};
 
 /// Write `data` to `path` through `std.fs.AtomicFile`.
 ///
 /// Keeps platform-specific replacement semantics and temporary file cleanup
 /// details out of callers that only need a durable replace-safe write.
 pub fn writeFileReplaceSafe(path: []const u8, data: []const u8) !void {
+    try writeFileReplaceSafeWithOptions(path, data, .{});
+}
+
+/// Same as `writeFileReplaceSafe`, with opt-in sync knobs for state that needs
+/// stronger power-loss durability than the default crash-safe replace.
+pub fn writeFileReplaceSafeWithOptions(path: []const u8, data: []const u8, options: WriteOptions) !void {
     var write_buffer: [0]u8 = .{};
-    var atomic = try std.fs.cwd().atomicFile(path, .{ .write_buffer = &write_buffer });
+    var atomic = try std.fs.cwd().atomicFile(path, .{
+        .mode = options.mode,
+        .make_path = true,
+        .write_buffer = &write_buffer,
+    });
     defer atomic.deinit();
     try atomic.file_writer.file.writeAll(data);
-    try atomic.finish();
+    try atomic.flush();
+    if (options.sync_file) try atomic.file_writer.file.sync();
+    try atomic.renameIntoPlace();
+    if (options.sync_parent_dir) syncParentDir(path);
+}
+
+fn syncParentDir(path: []const u8) void {
+    if (builtin.os.tag == .windows) return;
+    const parent = std.fs.path.dirname(path) orelse ".";
+    var dir = std.fs.cwd().openDir(parent, .{}) catch return;
+    defer dir.close();
+    const rc = std.posix.system.fsync(dir.fd);
+    switch (std.posix.errno(rc)) {
+        .SUCCESS, .INVAL, .ROFS => return,
+        else => return,
+    }
 }
 
 test "platform atomic file replaces existing contents" {
@@ -29,4 +61,55 @@ test "platform atomic file replaces existing contents" {
     const got = try tmp.dir.readFileAlloc(std.testing.allocator, "state.json", 16);
     defer std.testing.allocator.free(got);
     try std.testing.expectEqualStrings("new", got);
+}
+
+test "platform atomic file creates parent directories" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ root, "nested", "state.json" });
+    defer std.testing.allocator.free(path);
+
+    try writeFileReplaceSafe(path, "new");
+
+    const got = try tmp.dir.readFileAlloc(std.testing.allocator, "nested/state.json", 16);
+    defer std.testing.allocator.free(got);
+    try std.testing.expectEqualStrings("new", got);
+}
+
+test "platform atomic file preserves requested file mode" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ root, "secret.json" });
+    defer std.testing.allocator.free(path);
+
+    try writeFileReplaceSafeWithOptions(path, "secret", .{ .mode = 0o600 });
+
+    const stat = try tmp.dir.statFile("secret.json");
+    try std.testing.expectEqual(@as(std.fs.File.Mode, 0o600), stat.mode & 0o777);
+}
+
+test "platform atomic file optional sync path writes successfully" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ root, "durable.json" });
+    defer std.testing.allocator.free(path);
+
+    try writeFileReplaceSafeWithOptions(path, "durable", .{ .sync_file = true, .sync_parent_dir = true });
+
+    const got = try tmp.dir.readFileAlloc(std.testing.allocator, "durable.json", 16);
+    defer std.testing.allocator.free(got);
+    try std.testing.expectEqualStrings("durable", got);
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -27,6 +27,7 @@ const ctl_ui_state = @import("../ctl/ui_state.zig");
 const command_palette_history_view = @import("../command_palette_history_view.zig");
 const command_palette_model = @import("../command_palette_model.zig");
 const agent_history = @import("../agent_history.zig");
+const platform_atomic_file = @import("../platform/atomic_file.zig");
 const platform_dirs = @import("../platform/dirs.zig");
 const platform_open_url = @import("../platform/open_url.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
@@ -4440,9 +4441,10 @@ fn saveAiProfiles(allocator: std.mem.Allocator) void {
         out.append(allocator, '\n') catch return;
     }
 
-    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return;
-    defer file.close();
-    file.writeAll(out.items) catch {};
+    platform_atomic_file.writeFileReplaceSafe(path, out.items) catch {
+        showStatusToast("Failed to save AI profiles");
+        return;
+    };
 }
 
 fn sshProfilesPath(allocator: std.mem.Allocator) ![]const u8 {
@@ -4473,7 +4475,7 @@ fn loadSshProfiles() void {
 const decodeSshProfileLine = profile_codec.decodeSshProfileLine;
 
 fn saveSshProfiles(allocator: std.mem.Allocator) void {
-    _ = saveSshProfilesChecked(allocator);
+    if (!saveSshProfilesChecked(allocator)) showStatusToast("Failed to save SSH profiles");
 }
 
 fn saveSshProfilesChecked(allocator: std.mem.Allocator) bool {
@@ -4494,9 +4496,7 @@ fn saveSshProfilesChecked(allocator: std.mem.Allocator) bool {
         out.append(allocator, '\n') catch return false;
     }
 
-    const file = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return false;
-    defer file.close();
-    file.writeAll(out.items) catch return false;
+    platform_atomic_file.writeFileReplaceSafe(path, out.items) catch return false;
     return true;
 }
 

--- a/src/web_read_cache.zig
+++ b/src/web_read_cache.zig
@@ -3,6 +3,7 @@
 //! markdown lives and reads/writes it. No network, no Jina knowledge. Best-effort:
 //! `read` returns null on any problem; `store` swallows all errors.
 const std = @import("std");
+const platform_atomic_file = @import("platform/atomic_file.zig");
 
 const cache_dir_name = ".webread_cache";
 const max_cache_file_bytes: usize = 64 * 1024 * 1024;
@@ -55,12 +56,7 @@ pub fn read(allocator: std.mem.Allocator, cache_path: []const u8) ?[]u8 {
 /// Best-effort: mkdir -p the parent dir, then atomically write `content`. All errors
 /// are swallowed — caching must never fail the read.
 pub fn store(cache_path: []const u8, content: []const u8) void {
-    if (std.fs.path.dirname(cache_path)) |dir| std.fs.cwd().makePath(dir) catch return;
-    var write_buffer: [0]u8 = .{};
-    var atomic = std.fs.cwd().atomicFile(cache_path, .{ .write_buffer = &write_buffer }) catch return;
-    defer atomic.deinit();
-    atomic.file_writer.file.writeAll(content) catch return;
-    atomic.finish() catch return;
+    platform_atomic_file.writeFileReplaceSafe(cache_path, content) catch return;
 }
 
 test "sha256Hex matches the known empty-input vector" {

--- a/src/weixin/state_store.zig
+++ b/src/weixin/state_store.zig
@@ -1,6 +1,7 @@
 //! Persists the WeChat direct binding to a 0600 JSON file. Secrets never go in
 //! config; they live here in the app state dir.
 const std = @import("std");
+const platform_atomic_file = @import("../platform/atomic_file.zig");
 const types = @import("types.zig");
 
 pub const Loaded = struct {
@@ -21,9 +22,6 @@ const Wire = struct {
 };
 
 pub fn save(allocator: std.mem.Allocator, path: []const u8, binding: types.Binding) !void {
-    if (std.fs.path.dirname(path)) |dir| {
-        std.fs.cwd().makePath(dir) catch {};
-    }
     const wire = Wire{
         .bot_token = binding.bot_token,
         .base_url = binding.base_url,
@@ -34,9 +32,10 @@ pub fn save(allocator: std.mem.Allocator, path: []const u8, binding: types.Bindi
     const json = try std.json.Stringify.valueAlloc(allocator, wire, .{});
     defer allocator.free(json);
 
-    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
-    defer file.close();
-    try file.writeAll(json);
+    try platform_atomic_file.writeFileReplaceSafeWithOptions(path, json, .{
+        .mode = 0o600,
+        .sync_file = true,
+    });
 }
 
 pub fn load(allocator: std.mem.Allocator, path: []const u8) !Loaded {
@@ -50,7 +49,11 @@ pub fn load(allocator: std.mem.Allocator, path: []const u8) !Loaded {
 
     var parsed = std.json.parseFromSlice(Wire, arena.allocator(), data, .{
         .ignore_unknown_fields = true,
-    }) catch return .{ .arena = arena, .binding = .{} };
+    }) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        renameCorrupt(allocator, path);
+        return .{ .arena = arena, .binding = .{} };
+    };
     defer parsed.deinit();
 
     // Copy strings into the arena so they outlive `parsed`
@@ -62,6 +65,18 @@ pub fn load(allocator: std.mem.Allocator, path: []const u8) !Loaded {
         .bot_id = try a.dupe(u8, parsed.value.bot_id),
         .sync_buf = try a.dupe(u8, parsed.value.sync_buf),
     } };
+}
+
+fn renameCorrupt(allocator: std.mem.Allocator, path: []const u8) void {
+    const corrupt = std.fmt.allocPrint(allocator, "{s}.corrupt-{d}", .{ path, std.time.milliTimestamp() }) catch return;
+    defer allocator.free(corrupt);
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.renameAbsolute(path, corrupt) catch {
+            std.fs.cwd().rename(path, corrupt) catch {};
+        };
+    } else {
+        std.fs.cwd().rename(path, corrupt) catch {};
+    }
 }
 
 test "round-trips binding through a file" {
@@ -88,4 +103,35 @@ test "load returns empty binding when file is absent" {
     var loaded = try load(std.testing.allocator, "definitely-not-here-weixin.json");
     defer loaded.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), loaded.binding.bot_token.len);
+}
+
+test "load renames corrupt binding and returns empty" {
+    const allocator = std.testing.allocator;
+    const dir_name = "zig-cache-tmp-weixin-corrupt";
+    std.fs.cwd().deleteTree(dir_name) catch {};
+    defer std.fs.cwd().deleteTree(dir_name) catch {};
+    try std.fs.cwd().makePath(dir_name);
+
+    const path = try std.fs.path.join(allocator, &.{ dir_name, "weixin.json" });
+    defer allocator.free(path);
+
+    try std.fs.cwd().writeFile(.{ .sub_path = path, .data = "{ broken" });
+
+    var loaded = try load(allocator, path);
+    defer loaded.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), loaded.binding.bot_token.len);
+
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(path, .{}));
+
+    var found_corrupt = false;
+    var dir = try std.fs.cwd().openDir(dir_name, .{ .iterate = true });
+    defer dir.close();
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        if (std.mem.startsWith(u8, entry.name, "weixin.json.corrupt-")) {
+            found_corrupt = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_corrupt);
 }


### PR DESCRIPTION
## Summary
- Centralize persisted state writes through platform/atomic_file.zig with parent directory creation, optional file sync, and mode control.
- Move config, profile, agent/cache, and export write paths away from direct truncate writes.
- Make WeChat binding writes 0600 replace-safe and quarantine corrupt JSON as .corrupt-<timestamp> before falling back to an empty binding.

## Why
Crash-safe persistence should leave either the old file or the new file after process failure, not a half-truncated state file. The previous write paths mixed std.fs.atomicFile with direct createFile(... truncate), and WeChat corrupt loads silently returned empty state.

## Validation
- zig test src/platform/atomic_file.zig
- zig test src/agent_history.zig
- zig test src/ai_history_cache.zig
- zig test src/web_read_cache.zig
- zig build test
- zig build test-full
- git diff --check