### PR TITLE
[codex] Add Surface IO lifecycle state

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -9,6 +9,7 @@
 ///
 /// TabState in main.zig becomes a thin wrapper: `{ surface: *Surface }`.
 const std = @import("std");
+const builtin = @import("builtin");
 const ghostty_vt = @import("ghostty-vt");
 const Pty = @import("pty.zig").Pty;
 const Command = @import("Command.zig");
@@ -29,6 +30,7 @@ const ssh_connection_mod = @import("ssh_connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
 
 const Surface = @This();
+const io_log = std.log.scoped(.surface_io);
 
 // ============================================================================
 // Types
@@ -46,6 +48,43 @@ pub const Selection = struct {
     end_row: usize = 0,
     /// Active selections are rendered and copied; anchor-only clicks are not.
     active: bool = false,
+};
+
+pub const Operation = enum {
+    event_loop,
+    pty_read,
+    pty_write,
+    pty_resize,
+    terminal_resize,
+    thread_spawn,
+    thread_shutdown,
+};
+
+pub const IoFailure = struct {
+    operation: Operation,
+    error_code: anyerror,
+    timestamp_ms: i64,
+};
+
+pub const ExitReason = enum {
+    eof,
+    broken_pipe,
+    user_closed,
+};
+
+pub const ExitInfo = struct {
+    reason: ExitReason,
+    status: ?Command.Exit = null,
+    timestamp_ms: i64,
+};
+
+pub const IoState = union(enum) {
+    starting,
+    running,
+    stopping,
+    stopped,
+    exited: ExitInfo,
+    failed: IoFailure,
 };
 
 /// OSC parser state machine — handles sequences split across PTY reads.
@@ -239,6 +278,11 @@ sync_output_state: sync_output.State = .{},
 
 /// Set when the PTY process has exited.
 exited: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+/// Thread-safe terminal IO lifecycle. `exited` remains as the cheap legacy
+/// stop flag; this carries the reason surfaced to callers and UI.
+io_state_mutex: std.Thread.Mutex = .{},
+io_state: IoState = .starting,
 
 /// Set while the IO writer thread is resizing PTY and terminal state.
 /// The reader thread still drains PTY output during this window, but
@@ -447,6 +491,8 @@ fn finishInit(
     surface.dirty = std.atomic.Value(bool).init(true);
     surface.sync_output_state = .{};
     surface.exited = std.atomic.Value(bool).init(false);
+    surface.io_state_mutex = .{};
+    surface.io_state = .starting;
     surface.resize_in_progress = std.atomic.Value(bool).init(false);
 
     // Desktop-notification state. `allocator.create` returns undefined memory
@@ -523,6 +569,7 @@ fn finishInit(
     // Spawn IO writer thread (xev event loop — handles resize, future messages)
     surface.io_writer_thread = std.Thread.spawn(threading.surface_thread_spawn_config, termio.Thread.threadMain, .{ thread_state, surface }) catch |err| {
         std.debug.print("Failed to spawn IO writer thread: {}\n", .{err});
+        surface.failIo(.thread_spawn, err);
         return err;
     };
     errdefer {
@@ -534,8 +581,11 @@ fn finishInit(
     // Spawn IO reader thread (blocking PTY output loop)
     surface.io_reader_thread = std.Thread.spawn(threading.surface_thread_spawn_config, termio.ReadThread.threadMain, .{surface}) catch |err| {
         std.debug.print("Failed to spawn IO reader thread: {}\n", .{err});
+        surface.failIo(.thread_spawn, err);
         return err;
     };
+
+    surface.setIoRunning();
 
     // The renderer thread is kept as a future integration point, but the actual
     // snapshot/rebuild path still runs on the main thread today. Starting it now
@@ -615,7 +665,7 @@ pub fn deinit(self: *Surface, allocator: std.mem.Allocator) void {
     }
 
     // 2. Signal both IO threads to stop.
-    self.exited.store(true, .release);
+    self.beginStopping();
 
     // Stop the writer thread (xev event loop) via its stop async
     if (self.io_thread_state) |state| {
@@ -634,6 +684,7 @@ pub fn deinit(self: *Surface, allocator: std.mem.Allocator) void {
         thread.join();
         self.io_reader_thread = null;
     }
+    self.markStopped();
     self.remote_client = null;
 
     // Clean up writer thread state and mailbox
@@ -701,6 +752,149 @@ pub fn setSshConnectionValue(self: *Surface, conn: SshConnection) void {
     self.ssh_connection = conn;
 }
 
+pub fn currentIoState(self: *Surface) IoState {
+    self.io_state_mutex.lock();
+    defer self.io_state_mutex.unlock();
+    return self.io_state;
+}
+
+pub fn acceptsInput(self: *Surface) bool {
+    return switch (self.currentIoState()) {
+        .running => true,
+        else => false,
+    };
+}
+
+fn setIoRunning(self: *Surface) void {
+    self.io_state_mutex.lock();
+    defer self.io_state_mutex.unlock();
+    if (self.io_state == .starting) self.io_state = .running;
+}
+
+pub fn beginStopping(self: *Surface) void {
+    self.io_state_mutex.lock();
+    defer self.io_state_mutex.unlock();
+    switch (self.io_state) {
+        .failed, .exited, .stopped => {},
+        else => self.io_state = .stopping,
+    }
+    self.exited.store(true, .release);
+}
+
+pub fn markStopped(self: *Surface) void {
+    self.io_state_mutex.lock();
+    defer self.io_state_mutex.unlock();
+    switch (self.io_state) {
+        .failed, .exited, .stopped => {},
+        else => self.io_state = .stopped,
+    }
+}
+
+pub fn pollExitStatus(self: *Surface) ?Command.Exit {
+    return self.command.wait(false) catch |err| {
+        io_log.warn("process exit poll failed err={s}", .{@errorName(err)});
+        return null;
+    };
+}
+
+pub fn markExited(self: *Surface, reason: ExitReason, status: ?Command.Exit) void {
+    const info: ExitInfo = .{
+        .reason = reason,
+        .status = status,
+        .timestamp_ms = std.time.milliTimestamp(),
+    };
+    var should_notify = false;
+
+    self.io_state_mutex.lock();
+    switch (self.io_state) {
+        .failed, .exited, .stopped => {},
+        .stopping => self.io_state = .stopped,
+        else => {
+            self.io_state = .{ .exited = info };
+            should_notify = true;
+        },
+    }
+    self.exited.store(true, .release);
+    self.io_state_mutex.unlock();
+
+    if (!should_notify) return;
+    io_log.info("surface io exited reason={s}", .{@tagName(reason)});
+    self.requestWriterStop();
+    self.paintIoStatus(.{ .exited = info });
+    window_backend.postWakeup();
+}
+
+pub fn failIo(self: *Surface, operation: Operation, err: anyerror) void {
+    const failure: IoFailure = .{
+        .operation = operation,
+        .error_code = err,
+        .timestamp_ms = std.time.milliTimestamp(),
+    };
+    var should_notify = false;
+
+    self.io_state_mutex.lock();
+    switch (self.io_state) {
+        .failed, .exited, .stopped => {},
+        else => {
+            self.io_state = .{ .failed = failure };
+            should_notify = true;
+        },
+    }
+    self.exited.store(true, .release);
+    self.io_state_mutex.unlock();
+
+    if (!should_notify) return;
+    if (builtin.is_test) {
+        io_log.warn("surface io failed operation={s} err={s}", .{ @tagName(operation), @errorName(err) });
+    } else {
+        io_log.err("surface io failed operation={s} err={s}", .{ @tagName(operation), @errorName(err) });
+    }
+    self.requestWriterStop();
+    if (self.io_reader_thread != null) self.pty.cancelOutputRead();
+    self.paintIoStatus(.{ .failed = failure });
+    window_backend.postWakeup();
+}
+
+fn requestWriterStop(self: *Surface) void {
+    if (self.io_thread_state) |state| {
+        state.stop.notify() catch |err| {
+            io_log.warn("failed to notify io writer stop err={s}", .{@errorName(err)});
+        };
+    }
+}
+
+fn paintIoStatus(self: *Surface, state: IoState) void {
+    self.render_state.mutex.lock();
+    defer self.render_state.mutex.unlock();
+
+    var buf: [256]u8 = undefined;
+    const message = switch (state) {
+        .failed => |failure| std.fmt.bufPrint(
+            &buf,
+            "\r\n[WispTerm] Terminal IO failed during {s}: {s}\r\n",
+            .{ @tagName(failure.operation), @errorName(failure.error_code) },
+        ) catch return,
+        .exited => |info| exited: {
+            if (info.status) |status| switch (status) {
+                .exited => |code| break :exited std.fmt.bufPrint(
+                    &buf,
+                    "\r\n[WispTerm] Process exited with code {d}.\r\n",
+                    .{code},
+                ) catch return,
+                .unknown => {},
+            };
+            break :exited std.fmt.bufPrint(&buf, "\r\n[WispTerm] Process exited.\r\n", .{}) catch return;
+        },
+        else => return,
+    };
+
+    self.terminal.printString(message) catch |err| {
+        io_log.warn("failed to paint io status err={s}", .{@errorName(err)});
+        return;
+    };
+    self.clearSynchronizedOutputLocked();
+}
+
 // ============================================================================
 // Size and Resize
 // ============================================================================
@@ -759,11 +953,10 @@ pub fn setScreenSizeWithPolicy(
         // Terminal rows/cols and pixel dimensions are updated together in
         // the IO thread, under the render-state lock.
         const grid: renderer.size.GridSize = .{ .cols = new_cols, .rows = new_rows };
-        switch (resize_policy) {
+        return switch (resize_policy) {
             .coalesced => self.queueIo(.{ .resize = grid }),
             .immediate => self.queueIo(.{ .resize_immediate = grid }),
-        }
-        return true;
+        };
     }
 
     return false;
@@ -782,13 +975,18 @@ const mailbox_log = std.log.scoped(.mailbox);
 /// NOT enqueued, so we notify the writer thread and retry a bounded number of
 /// times, yielding between attempts to let it drain. If it is still full after
 /// the bound we log a visible warning rather than silently dropping input.
-pub fn queueIo(self: *Surface, msg: termio.Message) void {
+pub fn queueIo(self: *Surface, msg: termio.Message) bool {
+    if (!self.acceptsInput()) {
+        msg.deinit();
+        return false;
+    }
+
     var attempt: usize = 0;
     while (true) {
         switch (self.mailbox.send(msg)) {
             .queued, .coalesced => {
                 self.mailbox.notify();
-                return;
+                return true;
             },
             .full => {
                 // Wake the writer so it drains, then yield and retry. The mutex
@@ -802,7 +1000,7 @@ pub fn queueIo(self: *Surface, msg: termio.Message) void {
                         .{MAILBOX_FULL_RETRIES},
                     );
                     msg.deinit();
-                    return;
+                    return false;
                 }
                 std.Thread.yield() catch {};
             },
@@ -814,8 +1012,9 @@ pub fn queueIo(self: *Surface, msg: termio.Message) void {
 /// This mirrors Ghostty's write-message boundary so local and remote input
 /// share the same PTY write path instead of writing directly to the pipe.
 pub fn queuePtyWrite(self: *Surface, data: []const u8) void {
+    if (!self.acceptsInput()) return;
     const msg = termio.Message.writeReq(self.allocator, data) catch return;
-    self.queueIo(msg);
+    _ = self.queueIo(msg);
 }
 
 pub fn attachRemoteClient(self: *Surface, client: ?*remote.Client) void {
@@ -1451,6 +1650,9 @@ fn vtResponseHarness(surface: *Surface) !void {
     });
     surface.mailbox = try termio.Mailbox.init();
     surface.vt_stream = surface.initVtStream();
+    surface.io_state_mutex = .{};
+    surface.io_state = .running;
+    surface.exited = std.atomic.Value(bool).init(false);
 }
 
 fn vtResponseHarnessDeinit(surface: *Surface) void {
@@ -1484,4 +1686,74 @@ test "kitty keyboard query is answered back to the PTY (issue #302)" {
     surface.vt_stream.nextSlice("\x1b[>1u");
     surface.vt_stream.nextSlice("\x1b[?u");
     try expectPtyResponse(&surface, "\x1b[?1u");
+}
+
+fn ioStateHarness(surface: *Surface) !void {
+    surface.allocator = std.testing.allocator;
+    surface.terminal = try ghostty_vt.Terminal.init(std.testing.allocator, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    surface.render_state = renderer.State.init(&surface.terminal);
+    surface.surface_renderer = Renderer.init(surface);
+    surface.io_state_mutex = .{};
+    surface.io_state = .running;
+    surface.exited = std.atomic.Value(bool).init(false);
+    surface.dirty = std.atomic.Value(bool).init(false);
+    surface.io_thread_state = null;
+    surface.io_writer_thread = null;
+    surface.io_reader_thread = null;
+}
+
+fn ioStateHarnessDeinit(surface: *Surface) void {
+    surface.surface_renderer.deinit();
+    surface.terminal.deinit(std.testing.allocator);
+}
+
+test "Surface failIo records first failure, wakes rendering, and blocks input" {
+    var surface: Surface = undefined;
+    try ioStateHarness(&surface);
+    defer ioStateHarnessDeinit(&surface);
+
+    try std.testing.expect(surface.acceptsInput());
+
+    surface.failIo(.pty_write, error.BrokenPipe);
+    try std.testing.expect(!surface.acceptsInput());
+    try std.testing.expect(surface.exited.load(.acquire));
+    try std.testing.expect(surface.dirty.load(.acquire));
+
+    switch (surface.currentIoState()) {
+        .failed => |failure| {
+            try std.testing.expectEqual(Operation.pty_write, failure.operation);
+            try std.testing.expectEqual(error.BrokenPipe, failure.error_code);
+        },
+        else => return error.ExpectedFailedState,
+    }
+
+    surface.failIo(.pty_resize, error.ResizeFailed);
+    switch (surface.currentIoState()) {
+        .failed => |failure| {
+            try std.testing.expectEqual(Operation.pty_write, failure.operation);
+            try std.testing.expectEqual(error.BrokenPipe, failure.error_code);
+        },
+        else => return error.ExpectedFailedState,
+    }
+}
+
+test "Surface markExited preserves a normal exit as non-failure and blocks input" {
+    var surface: Surface = undefined;
+    try ioStateHarness(&surface);
+    defer ioStateHarnessDeinit(&surface);
+
+    surface.markExited(.eof, .{ .exited = 0 });
+
+    try std.testing.expect(!surface.acceptsInput());
+    try std.testing.expect(surface.exited.load(.acquire));
+    switch (surface.currentIoState()) {
+        .exited => |info| {
+            try std.testing.expectEqual(ExitReason.eof, info.reason);
+            try std.testing.expectEqual(@as(?Command.Exit, .{ .exited = 0 }), info.status);
+        },
+        else => return error.ExpectedExitedState,
+    }
 }

--- a/src/kitty_graphics_unit.zig
+++ b/src/kitty_graphics_unit.zig
@@ -82,6 +82,9 @@ test "wispterm image OSC fallback translates to kitty graphics APC" {
     // needs a real mailbox to receive it instead of writing through garbage.
     surface.mailbox = try termio.Mailbox.init();
     defer surface.mailbox.deinit();
+    surface.io_state_mutex = .{};
+    surface.io_state = .running;
+    surface.exited = std.atomic.Value(bool).init(false);
 
     surface.vt_stream = Surface.VtStream.initAlloc(
         surface.terminal.screens.active.alloc,

--- a/src/termio/ReadThread.zig
+++ b/src/termio/ReadThread.zig
@@ -20,6 +20,8 @@ const read_coalesce = @import("read_coalesce.zig");
 const READ_BUF_SIZE = 64 * 1024;
 
 pub fn threadMain(surface: *Surface) void {
+    defer surface.markStopped();
+
     var buf: [READ_BUF_SIZE]u8 = undefined;
     var resize_pending: std.ArrayListUnmanaged(u8) = .empty;
     defer resize_pending.deinit(surface.allocator);
@@ -28,26 +30,15 @@ pub fn threadMain(surface: *Surface) void {
 
     while (!surface.exited.load(.acquire)) {
         const bytes_read = surface.pty.readOutput(&buf) catch |err| {
-            switch (err) {
-                // Backend interrupted the blocking read. Retry unless we're shutting down.
-                error.ReadInterrupted => continue,
-
-                // Pipe closed — child process exited
-                error.BrokenPipe => {
-                    surface.exited.store(true, .release);
-                    return;
-                },
-
-                // Any other error — exit
-                else => {
-                    std.debug.print("ReadThread: read error: {}\n", .{err});
-                    surface.exited.store(true, .release);
-                    return;
-                },
+            switch (handleReadError(surface, err)) {
+                .retry => continue,
+                .stop => return,
             }
         };
         if (bytes_read == 0) {
-            surface.exited.store(true, .release);
+            if (!surface.exited.load(.acquire)) {
+                surface.markExited(.eof, surface.pollExitStatus());
+            }
             return;
         }
 
@@ -96,12 +87,17 @@ fn drainResizeOutput(
         }
 
         const to_read = @min(available, scratch.len);
-        const bytes_read = surface.pty.readOutput(scratch[0..to_read]) catch |err| switch (err) {
-            error.ReadInterrupted => continue,
-            else => return,
+        const bytes_read = surface.pty.readOutput(scratch[0..to_read]) catch |err| switch (handleReadError(surface, err)) {
+            .retry => continue,
+            .stop => return,
         };
 
-        if (bytes_read == 0) return;
+        if (bytes_read == 0) {
+            if (!surface.exited.load(.acquire)) {
+                surface.markExited(.eof, surface.pollExitStatus());
+            }
+            return;
+        }
 
         const data = scratch[0..bytes_read];
         if (surface.remote_client) |client| {
@@ -142,11 +138,16 @@ fn drainAvailableOutput(
         const to_read = read_coalesce.nextDrainLen(available, scratch.len, pending.items.len);
         if (to_read == 0) return;
 
-        const bytes_read = surface.pty.readOutput(scratch[0..to_read]) catch |err| switch (err) {
-            error.ReadInterrupted => continue,
-            else => return,
+        const bytes_read = surface.pty.readOutput(scratch[0..to_read]) catch |err| switch (handleReadError(surface, err)) {
+            .retry => continue,
+            .stop => return,
         };
-        if (bytes_read == 0) return;
+        if (bytes_read == 0) {
+            if (!surface.exited.load(.acquire)) {
+                surface.markExited(.eof, surface.pollExitStatus());
+            }
+            return;
+        }
 
         const data = scratch[0..bytes_read];
         if (surface.remote_client) |client| {
@@ -174,4 +175,22 @@ fn processOutput(surface: *Surface, data: []const u8) void {
     // pending output on a single frame; per-chunk posts only flood the
     // platform event queue during output bursts.
     if (surface.markOutputDirty()) window_backend.postWakeup();
+}
+
+const ReadErrorAction = enum { retry, stop };
+
+fn handleReadError(surface: *Surface, err: anyerror) ReadErrorAction {
+    if (err == error.ReadInterrupted) {
+        return if (surface.exited.load(.acquire)) .stop else .retry;
+    }
+
+    if (surface.exited.load(.acquire)) return .stop;
+
+    if (err == error.BrokenPipe) {
+        surface.markExited(.broken_pipe, surface.pollExitStatus());
+        return .stop;
+    }
+
+    surface.failIo(.pty_read, err);
+    return .stop;
 }

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -59,6 +59,7 @@ pub fn deinit(self: *Thread) void {
 
 pub fn threadMain(self: *Thread, surface: *Surface) void {
     self.surface = surface;
+    defer surface.markStopped();
 
     // Register mailbox wakeup callback
     surface.mailbox.wakeup.wait(&self.loop, &self.wakeup_c, Thread, self, wakeupCallback);
@@ -67,7 +68,7 @@ pub fn threadMain(self: *Thread, surface: *Surface) void {
     self.stop.wait(&self.loop, &self.stop_c, Thread, self, stopCallback);
 
     // Run the event loop until stop is signaled
-    self.loop.run(.until_done) catch {};
+    self.loop.run(.until_done) catch |err| surface.failIo(.event_loop, err);
 }
 
 fn wakeupCallback(
@@ -76,18 +77,24 @@ fn wakeupCallback(
     _: *xev.Completion,
     r: xev.Async.WaitError!void,
 ) xev.CallbackAction {
-    _ = r catch return .disarm;
     const self = self_opt orelse return .disarm;
+    _ = r catch |err| {
+        if (self.surface) |surface| surface.failIo(.event_loop, err);
+        return .disarm;
+    };
     self.drainMailbox();
     return .rearm;
 }
 
 fn stopCallback(
-    _: ?*Thread,
+    self_opt: ?*Thread,
     loop: *xev.Loop,
     _: *xev.Completion,
-    _: xev.Async.WaitError!void,
+    r: xev.Async.WaitError!void,
 ) xev.CallbackAction {
+    _ = r catch |err| {
+        if (self_opt) |self| if (self.surface) |surface| surface.failIo(.event_loop, err);
+    };
     loop.stop();
     return .disarm;
 }
@@ -96,6 +103,7 @@ fn drainMailbox(self: *Thread) void {
     const surface = self.surface orelse return;
     while (surface.mailbox.pop()) |msg| {
         defer msg.deinit();
+        if (!surface.acceptsInput()) continue;
 
         switch (msg) {
             .resize => |grid| self.handleResize(grid),
@@ -107,10 +115,16 @@ fn drainMailbox(self: *Thread) void {
 }
 
 fn writeToPty(surface: *Surface, data: []const u8) void {
-    surface.pty.writeInput(data) catch {};
+    if (!surface.acceptsInput()) return;
+    surface.pty.writeInput(data) catch |err| {
+        surface.failIo(.pty_write, err);
+        return;
+    };
 }
 
 fn handleResize(self: *Thread, grid: geometry.GridSize) void {
+    const surface = self.surface orelse return;
+    if (!surface.acceptsInput()) return;
     self.coalesce_data = grid;
 
     if (self.coalesce_active) return; // timer already running, it will pick up latest data
@@ -121,10 +135,13 @@ fn handleResize(self: *Thread, grid: geometry.GridSize) void {
 }
 
 fn handleResizeImmediate(self: *Thread, grid: geometry.GridSize) void {
+    const surface = self.surface orelse return;
+    if (!surface.acceptsInput()) return;
+
     // Drop any older coalesced resize so a delayed timer cannot undo the
     // immediate layout change.
     self.coalesce_data = null;
-    applyResize(self.surface.?, grid);
+    applyResize(surface, grid);
 }
 
 fn coalesceCallback(
@@ -133,8 +150,13 @@ fn coalesceCallback(
     _: *xev.Completion,
     r: xev.Timer.RunError!void,
 ) xev.CallbackAction {
-    _ = r catch {
-        if (self_opt) |self| self.coalesce_active = false;
+    _ = r catch |err| {
+        if (self_opt) |self| {
+            self.coalesce_active = false;
+            if (err != error.Canceled) {
+                if (self.surface) |surface| surface.failIo(.event_loop, err);
+            }
+        }
         return .disarm;
     };
     const self = self_opt orelse return .disarm;
@@ -143,25 +165,34 @@ fn coalesceCallback(
 
     if (self.coalesce_data) |grid| {
         self.coalesce_data = null;
-        applyResize(self.surface.?, grid);
+        if (self.surface) |surface| applyResize(surface, grid);
     }
 
     return .disarm;
 }
 
 fn applyResize(surface: *Surface, grid: geometry.GridSize) void {
+    if (!surface.acceptsInput()) return;
+
     // PTY resize first (like Ghostty), then terminal.
     // The ReadThread is concurrently in a blocking PTY read. This keeps
     // backend output draining while resize side effects are emitted.
     surface.resize_in_progress.store(true, .release);
     defer surface.resize_in_progress.store(false, .release);
 
-    surface.pty.setSize(.{ .ws_col = grid.cols, .ws_row = grid.rows }) catch {};
+    surface.pty.setSize(.{ .ws_col = grid.cols, .ws_row = grid.rows }) catch |err| {
+        surface.failIo(.pty_resize, err);
+        return;
+    };
 
     surface.render_state.mutex.lock();
-    defer surface.render_state.mutex.unlock();
 
-    surface.terminal.resize(surface.allocator, grid.cols, grid.rows) catch {};
+    surface.terminal.resize(surface.allocator, grid.cols, grid.rows) catch |err| {
+        surface.render_state.mutex.unlock();
+        surface.failIo(.terminal_resize, err);
+        return;
+    };
+    defer surface.render_state.mutex.unlock();
     surface.terminal.width_px = @intFromFloat(@as(f32, @floatFromInt(grid.cols)) * surface.size.cell.width);
     surface.terminal.height_px = @intFromFloat(@as(f32, @floatFromInt(grid.rows)) * surface.size.cell.height);
 

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -146,6 +146,20 @@ comptime {
         }
     }
 
+    const termio_thread_source = @embedFile("termio/Thread.zig");
+    if (std.mem.indexOf(u8, termio_thread_source, "self.loop.run(.until_done) catch {};") != null or
+        std.mem.indexOf(u8, termio_thread_source, "surface.pty.writeInput(data) catch {};") != null or
+        std.mem.indexOf(u8, termio_thread_source, "surface.pty.setSize(.{ .ws_col = grid.cols, .ws_row = grid.rows }) catch {};") != null or
+        std.mem.indexOf(u8, termio_thread_source, "surface.terminal.resize(surface.allocator, grid.cols, grid.rows) catch {};") != null)
+    {
+        @compileError("termio Thread IO errors must route through Surface.failIo instead of catch {}");
+    }
+
+    const termio_read_source = @embedFile("termio/ReadThread.zig");
+    if (std.mem.indexOf(u8, termio_read_source, "surface.exited.store(true, .release);") != null) {
+        @compileError("ReadThread exits must route through Surface IoState helpers so UI wakeups and reasons stay consistent");
+    }
+
     const update_check_source = @embedFile("update_check.zig");
     if (std.mem.indexOf(u8, update_check_source, "wispterm-windows-portable") != null) {
         @compileError("update_check.zig tests must build concrete release asset names through release_package helpers");


### PR DESCRIPTION
## Summary
- add a Surface-owned IO lifecycle state with failure and exit details
- route writer/read thread IO errors through failIo/markExited instead of silent catch paths
- block post-failure input and wake/render terminal diagnostics immediately

## Root Cause
Surface only exposed a coarse exited flag, so PTY write, resize, event-loop, and read failures could be swallowed or reduced to a background atomic flag without a UI wakeup or durable reason.

## Validation
- zig build test-full