### PR TITLE
fix(termio): split payload/control lanes so resize never evicts a queued write

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -127,7 +127,10 @@ pub const VtHandler = struct {
     /// the handler's terminal pointer, which aliases `&surface.terminal`.
     fn writePtyResponse(handler: *InnerHandler, data: [:0]const u8) void {
         const surface: *Surface = @fieldParentPtr("terminal", handler.terminal);
-        surface.queuePtyWrite(data);
+        surface.queuePtyWrite(data) catch |err| mailbox_log.warn(
+            "dropped terminal query reply ({d} bytes): {s}",
+            .{ data.len, @errorName(err) },
+        );
     }
 
     pub fn deinit(self: *VtHandler) void {
@@ -775,47 +778,72 @@ const MAILBOX_FULL_RETRIES = 64;
 
 const mailbox_log = std.log.scoped(.mailbox);
 
-/// Send a message to the IO writer thread via the mailbox.
-///
-/// On a full ring, control messages (resize) are accepted by the mailbox via
-/// last-writer-wins/drop-oldest. A WRITE message instead reports `.full` and is
-/// NOT enqueued, so we notify the writer thread and retry a bounded number of
-/// times, yielding between attempts to let it drain. If it is still full after
-/// the bound we log a visible warning rather than silently dropping input.
+/// Failure modes of queuePtyWrite. A caller MUST handle these — there is no
+/// silent-drop path. A fire-and-forget caller may `catch |e| log...` but the
+/// outcome is always surfaced.
+pub const QueueWriteError = error{
+    /// The owning surface has already exited (PTY process gone); writes are
+    /// pointless and the IO writer thread is tearing down.
+    SurfaceExited,
+    /// The payload ring stayed full across the bounded notify+retry window;
+    /// the write was NOT delivered and NOT dropped behind the caller's back.
+    BackpressureTimeout,
+    /// Allocating the heap copy for a large write failed.
+    OutOfMemory,
+};
+
+/// Queue a resize (control-lane) message to the IO writer thread. Infallible:
+/// resize uses the mailbox's last-writer-wins control fields, which never
+/// occupy a payload slot and can never report `.full`. Writes must NOT go
+/// through here — use queuePtyWrite, which surfaces backpressure.
 pub fn queueIo(self: *Surface, msg: termio.Message) void {
-    var attempt: usize = 0;
-    while (true) {
-        switch (self.mailbox.send(msg)) {
-            .queued, .coalesced => {
-                self.mailbox.notify();
-                return;
-            },
-            .full => {
-                // Wake the writer so it drains, then yield and retry. The mutex
-                // is released between attempts (send() locks per call), so the
-                // writer's pop() can make progress.
-                self.mailbox.notify();
-                attempt += 1;
-                if (attempt >= MAILBOX_FULL_RETRIES) {
-                    mailbox_log.warn(
-                        "mailbox full after {d} retries; dropping write message to avoid stall",
-                        .{MAILBOX_FULL_RETRIES},
-                    );
-                    msg.deinit();
-                    return;
-                }
-                std.Thread.yield() catch {};
-            },
-        }
+    switch (msg) {
+        .resize => |grid| self.mailbox.setResize(grid),
+        .resize_immediate => |grid| self.mailbox.setImmediateResize(grid),
+        .write_small, .write_alloc => unreachable, // use queuePtyWrite
     }
+    self.mailbox.notify();
 }
 
 /// Queue bytes to the PTY input pipe through the IO writer thread.
 /// This mirrors Ghostty's write-message boundary so local and remote input
 /// share the same PTY write path instead of writing directly to the pipe.
-pub fn queuePtyWrite(self: *Surface, data: []const u8) void {
-    const msg = termio.Message.writeReq(self.allocator, data) catch return;
-    self.queueIo(msg);
+///
+/// On a full payload ring we notify the writer and retry a bounded number of
+/// times, yielding between attempts to let it drain (the mutex is released
+/// between attempts). If it is still full after the bound we RETURN
+/// `error.BackpressureTimeout` rather than discarding the bytes and pretending
+/// success — the caller decides how loud to be. We NEVER use msg.deinit() to
+/// implicitly mean "delivered".
+pub fn queuePtyWrite(self: *Surface, data: []const u8) QueueWriteError!void {
+    if (self.exited.load(.acquire)) return error.SurfaceExited;
+
+    const msg = termio.Message.writeReq(self.allocator, data) catch
+        return error.OutOfMemory;
+
+    var attempt: usize = 0;
+    while (true) {
+        switch (self.mailbox.sendWrite(msg)) {
+            .queued => {
+                self.mailbox.notify();
+                return;
+            },
+            .full => {
+                // Wake the writer so it drains, then yield and retry. The mutex
+                // is released between attempts (sendWrite locks per call), so
+                // the writer's popWrite() can make progress.
+                self.mailbox.notify();
+                attempt += 1;
+                if (attempt >= MAILBOX_FULL_RETRIES) {
+                    // The bytes were never enqueued; free our copy and report
+                    // the backpressure instead of silently dropping input.
+                    msg.deinit();
+                    return error.BackpressureTimeout;
+                }
+                std.Thread.yield() catch {};
+            },
+        }
+    }
 }
 
 pub fn attachRemoteClient(self: *Surface, client: ?*remote.Client) void {
@@ -827,7 +855,10 @@ pub fn attachRemoteClient(self: *Surface, client: ?*remote.Client) void {
 
 fn remoteWrite(ctx: *anyopaque, data: []const u8) void {
     const surface: *Surface = @ptrCast(@alignCast(ctx));
-    surface.queuePtyWrite(data);
+    surface.queuePtyWrite(data) catch |err| mailbox_log.warn(
+        "dropped remote write ({d} bytes): {s}",
+        .{ data.len, @errorName(err) },
+    );
 }
 
 /// Get the padding for rendering. Returns the computed padding
@@ -1462,7 +1493,7 @@ fn vtResponseHarnessDeinit(surface: *Surface) void {
 fn expectPtyResponse(surface: *Surface, expected: []const u8) !void {
     // The popped message owns the bytes; assert while it is still in scope so
     // the slice into write_small.data stays valid.
-    const msg = surface.mailbox.pop() orelse return error.NoPtyResponse;
+    const msg = surface.mailbox.popWrite() orelse return error.NoPtyResponse;
     switch (msg) {
         .write_small => |*w| try std.testing.expectEqualStrings(expected, w.data[0..w.len]),
         else => return error.UnexpectedMessage,
@@ -1484,4 +1515,65 @@ test "kitty keyboard query is answered back to the PTY (issue #302)" {
     surface.vt_stream.nextSlice("\x1b[>1u");
     surface.vt_stream.nextSlice("\x1b[?u");
     try expectPtyResponse(&surface, "\x1b[?1u");
+}
+
+// queuePtyWrite only touches surface.allocator, surface.mailbox, and the
+// exited flag, so a tiny harness is enough to exercise its outcome contract.
+fn writeOutcomeHarness(surface: *Surface) !void {
+    surface.allocator = std.testing.allocator;
+    surface.mailbox = try termio.Mailbox.init();
+    surface.exited = std.atomic.Value(bool).init(false);
+}
+
+fn writeOutcomeHarnessDeinit(surface: *Surface) void {
+    surface.mailbox.deinit();
+}
+
+test "queuePtyWrite returns SurfaceExited on an exited surface" {
+    var surface: Surface = undefined;
+    try writeOutcomeHarness(&surface);
+    defer writeOutcomeHarnessDeinit(&surface);
+
+    surface.exited.store(true, .release);
+    try std.testing.expectError(error.SurfaceExited, surface.queuePtyWrite("hello"));
+}
+
+test "queuePtyWrite returns BackpressureTimeout when the payload ring stays full" {
+    var surface: Surface = undefined;
+    try writeOutcomeHarness(&surface);
+    defer writeOutcomeHarnessDeinit(&surface);
+
+    // Saturate the payload ring directly so every queuePtyWrite retry sees a
+    // full ring (no writer thread is draining it in this harness).
+    while (true) {
+        var small: termio.Message.WriteSmall = .{ .len = 1 };
+        small.data[0] = 'x';
+        if (surface.mailbox.sendWrite(.{ .write_small = small }) == .full) break;
+    }
+
+    // The write is neither delivered nor silently dropped — it is reported.
+    try std.testing.expectError(error.BackpressureTimeout, surface.queuePtyWrite("y"));
+
+    // The original queued writes are untouched: the full ring evicted nothing.
+    var drained: usize = 0;
+    while (surface.mailbox.popWrite()) |msg| {
+        msg.deinit();
+        drained += 1;
+    }
+    try std.testing.expect(drained > 0);
+}
+
+test "queuePtyWrite enqueues a write onto the payload ring on success" {
+    var surface: Surface = undefined;
+    try writeOutcomeHarness(&surface);
+    defer writeOutcomeHarnessDeinit(&surface);
+
+    try surface.queuePtyWrite("ok");
+
+    const msg = surface.mailbox.popWrite() orelse return error.MissingMessage;
+    defer msg.deinit();
+    switch (msg) {
+        .write_small => |*w| try std.testing.expectEqualStrings("ok", w.data[0..w.len]),
+        else => return error.UnexpectedMessage,
+    }
 }

--- a/src/appwindow/control_api.zig
+++ b/src/appwindow/control_api.zig
@@ -64,7 +64,13 @@ fn ctlSendText(ctx: *anyopaque, id: []const u8, data: []const u8) bool {
     const ptr = surface_registry.acquireById(id) orelse return false;
     defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(ptr));
-    surface.queuePtyWrite(data);
+    surface.queuePtyWrite(data) catch |err| {
+        std.log.scoped(.control).warn(
+            "dropped control write ({d} bytes): {s}",
+            .{ data.len, @errorName(err) },
+        );
+        return false;
+    };
     return true;
 }
 

--- a/src/appwindow/surface_snapshots.zig
+++ b/src/appwindow/surface_snapshots.zig
@@ -158,7 +158,13 @@ pub fn agentWriteSurface(ctx: *anyopaque, surface_id: []const u8, surface_ptr: *
     if (!surface_registry.acquire(surface_ptr, surface_id)) return false;
     defer surface_registry.release();
     const surface: *Surface = @ptrCast(@alignCast(surface_ptr));
-    surface.queuePtyWrite(data);
+    surface.queuePtyWrite(data) catch |err| {
+        std.log.scoped(.agent).warn(
+            "dropped agent write ({d} bytes): {s}",
+            .{ data.len, @errorName(err) },
+        );
+        return false;
+    };
     return true;
 }
 

--- a/src/appwindow/weixin_bridge.zig
+++ b/src/appwindow/weixin_bridge.zig
@@ -204,7 +204,13 @@ pub fn handleControlRequest(req: *WeixinRequest, host: Host) void {
                 return;
             }
             const surface = weixinTerminalSurfaceFromId(req.surface_id) orelse return;
-            surface.queuePtyWrite(req.bytes);
+            surface.queuePtyWrite(req.bytes) catch |err| {
+                std.log.scoped(.weixin).warn(
+                    "dropped weixin input ({d} bytes): {s}",
+                    .{ req.bytes.len, @errorName(err) },
+                );
+                return;
+            };
             req.sent = true;
         },
         .latest_transcript => {

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -54,9 +54,19 @@ fn mutatePasteData(data: []u8, bracketed: bool) void {
     }
 }
 
+const pty_write_log = std.log.scoped(.pty_write);
+
 /// Write data to the PTY's input pipe (us -> child stdin).
+///
+/// This is the keyboard/paste input boundary, so it is intentionally
+/// fire-and-forget: there is no caller positioned to recover from backpressure.
+/// queuePtyWrite still surfaces its outcome — on failure we log a visible
+/// warning instead of silently swallowing input.
 pub fn writeToPty(surface: *Surface, data: []const u8) void {
-    surface.queuePtyWrite(data);
+    surface.queuePtyWrite(data) catch |err| pty_write_log.warn(
+        "dropped {d} bytes of input: {s}",
+        .{ data.len, @errorName(err) },
+    );
 }
 
 pub fn writePasteToPty(surface: *Surface, allocator: std.mem.Allocator, data: []const u8) void {

--- a/src/termio/Mailbox.zig
+++ b/src/termio/Mailbox.zig
@@ -1,42 +1,59 @@
-/// SPSC mailbox: fixed-capacity ring buffer with mutex + xev.Async wakeup.
+/// Termio mailbox: a payload/control split with mutex + xev.Async wakeup.
 ///
-/// The main thread pushes messages via send(), then calls notify() to wake
-/// the IO writer thread's xev event loop. The writer thread pops messages
-/// via pop() in its wakeup callback.
+/// The main thread enqueues messages, then calls notify() to wake the IO
+/// writer thread's xev event loop. The writer thread drains the mailbox in its
+/// wakeup callback.
+///
+/// Two separately governed lanes share one mutex and one wakeup:
+///
+///   PAYLOAD lane — terminal writes (`write_small` / `write_alloc`).
+///     A fixed-capacity, order-preserving ring (CAPACITY 64). This is the
+///     stream of bytes destined for the child PTY; order matters and nothing
+///     may be silently dropped. When the ring is full, sendWrite() returns
+///     `.full` and the queue is left intact — the caller wakes the writer and
+///     retries. A resize storm can NEVER displace a queued write because resize
+///     no longer occupies a ring slot.
+///
+///   CONTROL lane — resize requests (coalesced + immediate).
+///     Two last-writer-wins fields, not a queue: `pending_resize` and
+///     `pending_immediate_resize`. Resize is inherently a "latest geometry
+///     wins" operation (and the writer thread additionally coalesces the
+///     non-immediate one behind a 25ms timer), so a single overwriting slot per
+///     kind is sufficient. setResize()/setImmediateResize() never fail.
 ///
 /// Design notes:
-/// - send() + notify() are separate (like Ghostty) so the caller can batch
-///   sends before one notify
-/// - On overflow the ring is full for EVERY message kind: send() returns .full
-///   and the queue is left intact — an already-queued payload (a real terminal
-///   write) is never evicted to make room, not even for a control message.
-///   Trailing resizes still coalesce (last-writer-wins) before the full check,
-///   so rapid resize streams do not grow the queue
-/// - Mutex-based, not lock-free — adequate for our SPSC pattern with tiny
-///   critical sections
+/// - send + notify are separate (like Ghostty) so the caller can batch sends
+///   before one notify.
+/// - Mutex-based, not lock-free — adequate for our pattern with tiny critical
+///   sections.
 const std = @import("std");
 const xev = @import("xev");
 const Message = @import("message.zig").Message;
+const geometry = @import("../core/geometry.zig");
 
 const Mailbox = @This();
 
 const CAPACITY = 64;
 
-/// Outcome of a send() call so the caller can react (e.g. retry on .full).
+/// Outcome of a sendWrite() call so the caller can react (e.g. retry on .full).
 pub const SendResult = enum {
-    /// The message was enqueued normally.
+    /// The write was enqueued onto the payload ring.
     queued,
-    /// A trailing resize was coalesced into the existing pending resize.
-    coalesced,
-    /// The ring was full and the message could not be enqueued. The queue is
-    /// left intact (nothing dropped); the caller should notify+retry.
+    /// The payload ring was full and the write could not be enqueued. The queue
+    /// is left intact (nothing dropped); the caller should notify+retry.
     full,
 };
 
+// PAYLOAD lane — order-preserving write ring.
 queue: [CAPACITY]Message = undefined,
 head: usize = 0,
 tail: usize = 0,
 count: usize = 0,
+
+// CONTROL lane — last-writer-wins resize fields (NOT ring slots).
+pending_resize: ?geometry.GridSize = null,
+pending_immediate_resize: ?geometry.GridSize = null,
+
 mutex: std.Thread.Mutex = .{},
 wakeup: xev.Async,
 
@@ -47,28 +64,34 @@ pub fn init() !Mailbox {
 }
 
 pub fn deinit(self: *Mailbox) void {
+    // Free any heap-owned payload still queued (write_alloc) so teardown does
+    // not leak. Resize fields own nothing.
+    while (self.popWrite()) |msg| msg.deinit();
     self.wakeup.deinit();
 }
 
-/// Push a message onto the ring buffer.
+/// Enqueue a terminal write (`write_small` / `write_alloc`) onto the payload
+/// ring, preserving order.
 ///
 /// Returns:
-/// - .coalesced if a trailing resize was folded into the pending resize
-/// - .queued on a normal enqueue
+/// - .queued on a normal enqueue.
 /// - .full if the ring is full: the message is NOT enqueued and NOTHING is
-///   dropped (no message kind evicts an already-queued payload), so the caller
-///   can notify+retry once the writer drains.
+///   dropped, so the caller can notify+retry once the writer drains.
+///
+/// Asserts the message is a write variant — resize must go through
+/// setResize()/setImmediateResize(), which can never fail and never occupy a
+/// ring slot.
 ///
 /// Thread-safe (uses mutex).
-pub fn send(self: *Mailbox, msg: Message) SendResult {
+pub fn sendWrite(self: *Mailbox, msg: Message) SendResult {
+    switch (msg) {
+        .write_small, .write_alloc => {},
+        .resize, .resize_immediate => unreachable, // use setResize/setImmediateResize
+    }
+
     self.mutex.lock();
     defer self.mutex.unlock();
 
-    if (self.coalesceTrailingResize(msg)) return .coalesced;
-
-    // Full means full for every message kind. Never evict an already-queued
-    // payload (a real terminal write) to make room — not even for a control
-    // message; the caller (Surface.queueIo) wakes the writer and retries.
     if (self.count == CAPACITY) return .full;
 
     self.queue[self.tail] = msg;
@@ -77,32 +100,36 @@ pub fn send(self: *Mailbox, msg: Message) SendResult {
     return .queued;
 }
 
-fn coalesceTrailingResize(self: *Mailbox, msg: Message) bool {
-    const latest = switch (msg) {
-        .resize => |grid| grid,
-        else => return false,
-    };
+/// Record a coalesced resize request (last-writer-wins). Never fails; never
+/// occupies a payload ring slot. The previous pending value is simply
+/// overwritten — resize is inherently "latest geometry wins".
+///
+/// Thread-safe (uses mutex).
+pub fn setResize(self: *Mailbox, grid: geometry.GridSize) void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    self.pending_resize = grid;
+}
 
-    if (self.count == 0) return false;
-    const idx = if (self.tail == 0) CAPACITY - 1 else self.tail - 1;
-    switch (self.queue[idx]) {
-        .resize => {
-            self.queue[idx] = .{ .resize = latest };
-            return true;
-        },
-        else => return false,
-    }
+/// Record an immediate resize request (last-writer-wins). Never fails; never
+/// occupies a payload ring slot.
+///
+/// Thread-safe (uses mutex).
+pub fn setImmediateResize(self: *Mailbox, grid: geometry.GridSize) void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    self.pending_immediate_resize = grid;
 }
 
 /// Wake the IO writer thread's xev event loop.
-/// Call after one or more send() calls.
+/// Call after one or more send/set calls.
 pub fn notify(self: *Mailbox) void {
     self.wakeup.notify() catch {};
 }
 
-/// Pop a message from the ring buffer. Returns null if empty.
+/// Pop the next queued write from the payload ring. Returns null if empty.
 /// Thread-safe (uses mutex).
-pub fn pop(self: *Mailbox) ?Message {
+pub fn popWrite(self: *Mailbox) ?Message {
     self.mutex.lock();
     defer self.mutex.unlock();
 
@@ -112,6 +139,28 @@ pub fn pop(self: *Mailbox) ?Message {
     self.head = (self.head + 1) % CAPACITY;
     self.count -= 1;
     return msg;
+}
+
+/// Atomically read and clear the pending coalesced resize.
+/// Returns null if none pending. Thread-safe (uses mutex).
+pub fn takePendingResize(self: *Mailbox) ?geometry.GridSize {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    const grid = self.pending_resize;
+    self.pending_resize = null;
+    return grid;
+}
+
+/// Atomically read and clear the pending immediate resize.
+/// Returns null if none pending. Thread-safe (uses mutex).
+pub fn takePendingImmediateResize(self: *Mailbox) ?geometry.GridSize {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    const grid = self.pending_immediate_resize;
+    self.pending_immediate_resize = null;
+    return grid;
 }
 
 fn writeSmallByte(byte: u8) Message {
@@ -131,86 +180,121 @@ fn expectWriteByte(msg: Message, byte: u8) !void {
     }
 }
 
-fn expectResize(msg: Message, cols: u16, rows: u16) !void {
-    defer msg.deinit();
-    switch (msg) {
-        .resize => |grid| {
-            try std.testing.expectEqual(cols, grid.cols);
-            try std.testing.expectEqual(rows, grid.rows);
-        },
-        else => return error.UnexpectedMessage,
-    }
-}
-
-test "Mailbox returns .full for writes on a full ring without dropping" {
+test "payload ring returns .full without dropping queued writes" {
     var mailbox = try Mailbox.init();
     defer mailbox.deinit();
 
     // Fill the ring exactly to capacity.
     for (0..CAPACITY) |i| {
-        try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte(@intCast(i))));
+        try std.testing.expectEqual(SendResult.queued, mailbox.sendWrite(writeSmallByte(@intCast(i))));
     }
     try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
 
     // One more write must NOT be dropped: it is rejected with .full and the
     // existing queue is left untouched.
-    try std.testing.expectEqual(SendResult.full, mailbox.send(writeSmallByte(0xFF)));
+    try std.testing.expectEqual(SendResult.full, mailbox.sendWrite(writeSmallByte(0xFF)));
     try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
 
     // All original messages are preserved in order; none were dropped.
     for (0..CAPACITY) |expected| {
-        try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, @intCast(expected));
+        try expectWriteByte(mailbox.popWrite() orelse return error.MissingMessage, @intCast(expected));
     }
-    try std.testing.expect(mailbox.pop() == null);
+    try std.testing.expect(mailbox.popWrite() == null);
 }
 
-test "Mailbox coalesces pending resize messages" {
+test "64 queued writes then a resize: resize evicts nothing" {
     var mailbox = try Mailbox.init();
     defer mailbox.deinit();
 
-    try std.testing.expectEqual(SendResult.queued, mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } }));
-    try std.testing.expectEqual(SendResult.coalesced, mailbox.send(.{ .resize = .{ .cols = 120, .rows = 40 } }));
-
-    try std.testing.expectEqual(@as(usize, 1), mailbox.count);
-    try expectResize(mailbox.pop() orelse return error.MissingMessage, 120, 40);
-    try std.testing.expect(mailbox.pop() == null);
-}
-
-test "Mailbox resize coalescing preserves write messages" {
-    var mailbox = try Mailbox.init();
-    defer mailbox.deinit();
-
-    try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte('a')));
-    try std.testing.expectEqual(SendResult.queued, mailbox.send(.{ .resize = .{ .cols = 80, .rows = 24 } }));
-    try std.testing.expectEqual(SendResult.coalesced, mailbox.send(.{ .resize = .{ .cols = 100, .rows = 30 } }));
-    try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte('b')));
-
-    try std.testing.expectEqual(@as(usize, 3), mailbox.count);
-    try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'a');
-    try expectResize(mailbox.pop() orelse return error.MissingMessage, 100, 30);
-    try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, 'b');
-    try std.testing.expect(mailbox.pop() == null);
-}
-
-test "resize on a full mailbox never evicts queued writes" {
-    var mailbox = try Mailbox.init();
-    defer mailbox.deinit();
-
-    // Fill the ring exactly to capacity with real terminal writes.
+    // Fill the payload ring exactly to capacity with real terminal writes.
     for (0..CAPACITY) |i| {
-        try std.testing.expectEqual(SendResult.queued, mailbox.send(writeSmallByte(@intCast(i))));
+        try std.testing.expectEqual(SendResult.queued, mailbox.sendWrite(writeSmallByte(@intCast(i))));
     }
     try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
 
-    // A control (resize) message on a full ring is rejected with .full — it must
-    // NOT evict a queued write to make room. The caller (Surface.queueIo)
-    // notifies the writer and retries once space frees.
-    try std.testing.expectEqual(SendResult.full, mailbox.send(.{ .resize = .{ .cols = 10, .rows = 5 } }));
+    // A resize on a full ring goes to the control lane (last-writer-wins). It
+    // cannot occupy a payload slot, so it evicts NOTHING.
+    mailbox.setResize(.{ .cols = 10, .rows = 5 });
     try std.testing.expectEqual(@as(usize, CAPACITY), mailbox.count);
 
     // Every queued write survives, in order; none were dropped for the resize.
     for (0..CAPACITY) |expected| {
-        try expectWriteByte(mailbox.pop() orelse return error.MissingMessage, @intCast(expected));
+        try expectWriteByte(mailbox.popWrite() orelse return error.MissingMessage, @intCast(expected));
     }
-    try std.testing.expect(mailbox.pop() == null);
+    try std.testing.expect(mailbox.popWrite() == null);
+
+    // The resize is still pending, last-writer-wins.
+    const grid = mailbox.takePendingResize() orelse return error.MissingResize;
+    try std.testing.expectEqual(@as(u16, 10), grid.cols);
+    try std.testing.expectEqual(@as(u16, 5), grid.rows);
+}
+
+test "interleaved writes and resizes: write order exact, resize last-writer-wins" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    // Interleave writes with resizes. Writes go to the ordered ring; resizes
+    // overwrite the single pending field.
+    const sequence = "ghostty-mailbox";
+    var resize_n: u16 = 0;
+    for (sequence) |byte| {
+        try std.testing.expectEqual(SendResult.queued, mailbox.sendWrite(writeSmallByte(byte)));
+        resize_n += 1;
+        mailbox.setResize(.{ .cols = resize_n, .rows = resize_n });
+    }
+
+    // The popped write byte sequence is EXACTLY the sent order — resizes did
+    // not perturb the payload lane at all.
+    try std.testing.expectEqual(@as(usize, sequence.len), mailbox.count);
+    for (sequence) |byte| {
+        try expectWriteByte(mailbox.popWrite() orelse return error.MissingMessage, byte);
+    }
+    try std.testing.expect(mailbox.popWrite() == null);
+
+    // The resize ends last-writer-wins: only the final geometry survives.
+    const grid = mailbox.takePendingResize() orelse return error.MissingResize;
+    try std.testing.expectEqual(@as(u16, sequence.len), grid.cols);
+    try std.testing.expectEqual(@as(u16, sequence.len), grid.rows);
+}
+
+test "pending resize is last-writer-wins and clears on take" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    mailbox.setResize(.{ .cols = 80, .rows = 24 });
+    mailbox.setResize(.{ .cols = 120, .rows = 40 });
+
+    const grid = mailbox.takePendingResize() orelse return error.MissingResize;
+    try std.testing.expectEqual(@as(u16, 120), grid.cols);
+    try std.testing.expectEqual(@as(u16, 40), grid.rows);
+
+    // Taking again yields null — the field was cleared.
+    try std.testing.expect(mailbox.takePendingResize() == null);
+}
+
+test "pending immediate resize is last-writer-wins and clears on take" {
+    var mailbox = try Mailbox.init();
+    defer mailbox.deinit();
+
+    mailbox.setImmediateResize(.{ .cols = 100, .rows = 30 });
+    mailbox.setImmediateResize(.{ .cols = 132, .rows = 50 });
+
+    const grid = mailbox.takePendingImmediateResize() orelse return error.MissingResize;
+    try std.testing.expectEqual(@as(u16, 132), grid.cols);
+    try std.testing.expectEqual(@as(u16, 50), grid.rows);
+
+    try std.testing.expect(mailbox.takePendingImmediateResize() == null);
+
+    // Coalesced and immediate fields are independent lanes.
+    try std.testing.expect(mailbox.takePendingResize() == null);
+}
+
+test "deinit frees heap-owned write_alloc payload left in the ring" {
+    // A leak here would fail the testing allocator. The ring keeps the owning
+    // write_alloc, and deinit must drain+free it.
+    var mailbox = try Mailbox.init();
+    const owned = try std.testing.allocator.dupe(u8, "x" ** (Message.WRITE_SMALL_MAX + 1));
+    const msg: Message = .{ .write_alloc = .{ .allocator = std.testing.allocator, .data = owned } };
+    try std.testing.expectEqual(SendResult.queued, mailbox.sendWrite(msg));
+    mailbox.deinit();
 }

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -92,16 +92,36 @@ fn stopCallback(
     return .disarm;
 }
 
+/// Drain the mailbox: apply the control lane (resizes) first, then flush every
+/// queued payload write.
+///
+/// Order rationale: resize is last-writer-wins on both lanes and the coalesced
+/// resize is additionally deferred behind a 25ms timer, so strict resize/write
+/// interleaving is neither possible nor meaningful — only the latest geometry
+/// can win regardless of when writes land relative to it. We therefore apply
+/// the pending immediate resize (which grows/shrinks the grid now), arm/refresh
+/// the coalesce timer for the pending coalesced resize, and then drain all
+/// queued writes in their exact enqueue order via popWrite(). Writes can never
+/// be evicted by a resize because they live on a separate ordered lane.
 fn drainMailbox(self: *Thread) void {
     const surface = self.surface orelse return;
-    while (surface.mailbox.pop()) |msg| {
-        defer msg.deinit();
 
+    // Control lane: immediate resize applies now; coalesced resize feeds the
+    // 25ms timer (handleResize preserves last-writer-wins + the coalesce gate).
+    if (surface.mailbox.takePendingImmediateResize()) |grid| {
+        self.handleResizeImmediate(grid);
+    }
+    if (surface.mailbox.takePendingResize()) |grid| {
+        self.handleResize(grid);
+    }
+
+    // Payload lane: flush every queued write in order.
+    while (surface.mailbox.popWrite()) |msg| {
+        defer msg.deinit();
         switch (msg) {
-            .resize => |grid| self.handleResize(grid),
-            .resize_immediate => |grid| self.handleResizeImmediate(grid),
             .write_small => |payload| writeToPty(surface, payload.data[0..payload.len]),
             .write_alloc => |payload| writeToPty(surface, payload.data),
+            .resize, .resize_immediate => unreachable, // resize never enters the payload ring
         }
     }
 }


### PR DESCRIPTION
First-priority reliability fix from the review: TermIO must never silently drop terminal write input. Replaces the single mixed 64-slot ring with a proper payload/control split and makes `queuePtyWrite` report its outcome.

## What
- **Mailbox = two lanes, one mutex+wakeup.** PAYLOAD = an order-preserving 64-slot write ring (`sendWrite` → `.queued`/`.full`; `.full` leaves the queue intact, evicts nothing; `popWrite` drains FIFO). CONTROL = last-writer-wins fields `pending_resize` / `pending_immediate_resize` (`setResize`/`setImmediateResize` never fail, `takePending*` read+clear) — resize occupies NO ring slot, so a resize storm can never displace a queued write. `deinit` frees any queued `write_alloc`.
- **Thread.drainMailbox**: apply pending immediate resize (now) + coalesced resize (via the unchanged `handleResize` 25ms timer), then flush all queued writes in order. Resize arms in the write loop are `unreachable`. Resize coalescing / `resize_immediate` semantics are observably unchanged.
- **`Surface.queuePtyWrite(data) QueueWriteError!void`** (`{ SurfaceExited, BackpressureTimeout, OutOfMemory }`): checks `exited`, allocates, then bounded notify+retry on `.full`; on exhaustion it frees its own un-enqueued copy and returns `BackpressureTimeout` — **never `msg.deinit()`-as-success, never a silent drop**. `queueIo` is now resize-only (infallible). All 6 write call sites surface the outcome (try / catch+log / return false).

## Acceptance (per review)
64 writes + 1 resize → all 64 writes preserved in order ✓ · interleaved write/resize → exact write byte order, resize LWW ✓ · full ring → `.full` + `BackpressureTimeout`, nothing dropped ✓ · write on exited surface → `SurfaceExited` ✓ · no path uses `msg.deinit()` to mean delivered ✓.

## Verification
`zig build test` + `zig build test-full -Dtarget=aarch64-macos` (runs the termio/Surface tests) + `zig build macos-app -Dtarget=aarch64-macos` all real-exit 0 (independently re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)