### PR TITLE
[codex] Increase sidebar status badge spacing

### DIFF
--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -1157,7 +1157,7 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
 
         const close_opacity = tab.g_tab_close_opacity[tab_idx];
         const close_btn_x = sidebar_w - tab.TAB_CLOSE_BTN_W - 4;
-        var right_content_x = close_btn_x - 4;
+        var right_content_x = close_btn_x - titlebar_layout.SIDEBAR_STATUS_CLOSE_GAP;
         // Use aggregate of all panes' visible states so the sidebar badge
         // reflects the most attention-worthy agent across all split panes,
         // not just the focused one.
@@ -1200,8 +1200,9 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
         if (show_agent_badge) {
             const badge_text_w = titlebarTextWidth(detection.badge());
             agent_badge_w = @max(@as(f32, 18), badge_text_w + 10);
-            agent_badge_x = right_content_x - agent_badge_w;
-            right_content_x = agent_badge_x - 6;
+            const badge_layout = titlebar_layout.sidebarStatusBadgeLayout(close_btn_x, agent_badge_w);
+            agent_badge_x = badge_layout.x;
+            right_content_x = badge_layout.next_right_content_x;
         }
 
         const bell_opacity: f32 = if (tab.g_tabs[tab_idx]) |t| (if (t.focusedSurface()) |s| s.bell_opacity else 0) else 0;

--- a/src/renderer/titlebar_layout.zig
+++ b/src/renderer/titlebar_layout.zig
@@ -29,6 +29,22 @@ pub fn clampSidebarWidth(width: f32, min_width: f32, max_for_window: f32) f32 {
     return @max(min_width, @min(max_for_window, width));
 }
 
+pub const SIDEBAR_STATUS_CLOSE_GAP: f32 = 10;
+pub const SIDEBAR_STATUS_LEADING_GAP: f32 = 6;
+
+pub const SidebarStatusBadgeLayout = struct {
+    x: f32,
+    next_right_content_x: f32,
+};
+
+pub fn sidebarStatusBadgeLayout(close_btn_x: f32, badge_w: f32) SidebarStatusBadgeLayout {
+    const x = close_btn_x - SIDEBAR_STATUS_CLOSE_GAP - badge_w;
+    return .{
+        .x = x,
+        .next_right_content_x = x - SIDEBAR_STATUS_LEADING_GAP,
+    };
+}
+
 /// Printable-ASCII passthrough, else '?'.
 pub fn fallbackCodepoint(byte: u8) u32 {
     return if (byte >= 0x20 and byte <= 0x7e) byte else '?';
@@ -62,6 +78,15 @@ test "clampSidebarWidth bounds" {
     try std.testing.expectEqual(@as(f32, 160), clampSidebarWidth(50, 160, 720));
     try std.testing.expectEqual(@as(f32, 720), clampSidebarWidth(900, 160, 720));
     try std.testing.expectEqual(@as(f32, 300), clampSidebarWidth(300, 160, 720));
+}
+
+test "sidebar status badge leaves readable gap before close button" {
+    const close_btn_x: f32 = 184;
+    const badge_w: f32 = 34;
+    const layout = sidebarStatusBadgeLayout(close_btn_x, badge_w);
+
+    try std.testing.expectEqual(@as(f32, 10), close_btn_x - (layout.x + badge_w));
+    try std.testing.expectEqual(@as(f32, close_btn_x - 10 - badge_w - 6), layout.next_right_content_x);
 }
 
 test "fallbackCodepoint maps printable ASCII, else '?'" {


### PR DESCRIPTION
## Summary
- Add a small pure layout helper for the sidebar agent/status badge position.
- Increase the gap between the sidebar status badge and the close button from 4px to 10px.
- Keep the existing 6px gap before earlier right-side content such as bell/title truncation.

## Root Cause
The sidebar tab row anchored the agent/status badge at `close_btn_x - 4`, so short badges like `Full` visually crowd the close icon.

## Validation
- `zig test src/renderer/titlebar_layout.zig --global-cache-dir /tmp/zig-cache`
- `zig fmt --check src/renderer/titlebar_layout.zig src/renderer/titlebar.zig`
- `git diff --check`
- `zig build test`

`zig build test-full` was started and had no reported failures before it was stopped at user direction so CI can run the full gate.