### PR TITLE
[codex] Fix Copilot API setup prompt

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3123,6 +3123,29 @@ fn ensureActiveCopilotSession() ?*ai_chat.Session {
     return session;
 }
 
+fn openCopilotApiConfig(session: ?*ai_chat.Session) void {
+    if (session) |s| {
+        overlays.openAiConfigForSession(s);
+    } else {
+        overlays.openAiConfigForMissingCopilotApi();
+    }
+    overlays.showStatusToast("Missing API key. Configure API settings.");
+}
+
+fn ensureActiveCopilotSessionConfigured() ?*ai_chat.Session {
+    const session = ensureActiveCopilotSession() orelse {
+        _ = tab.setActiveCopilotVisible(false);
+        input.blurAiCopilot();
+        openCopilotApiConfig(null);
+        return null;
+    };
+    if (session.missingApiKey()) {
+        openCopilotApiConfig(session);
+        return null;
+    }
+    return session;
+}
+
 /// Input layer getter: the active terminal tab's copilot session, only when the
 /// copilot panel is visible. Used by input routing (next task).
 pub fn activeCopilotSessionForInput() ?*ai_chat.Session {
@@ -3199,10 +3222,12 @@ pub fn newCopilotConversation() void {
     }
     browser_panel.close();
     _ = tab.setActiveCopilotVisible(true);
-    _ = ensureActiveCopilotSession();
+    _ = ensureActiveCopilotSessionConfigured() orelse {
+        markUiDirty();
+        return;
+    };
     input.focusAiCopilot();
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    markUiDirty();
 }
 
 /// The preview pane that currently has split-tree focus, or null if the
@@ -3262,18 +3287,19 @@ pub fn toggleAiCopilot() void {
     if (tab.activeCopilotVisible()) {
         _ = tab.setActiveCopilotVisible(false);
         input.blurAiCopilot();
-        g_force_rebuild = true;
-        g_cells_valid = false;
+        markUiDirty();
         return;
     }
     // Exclusive right slot: close the other right panels first.
     browser_panel.close();
     _ = tab.setActiveCopilotVisible(true);
-    _ = ensureActiveCopilotSession();
+    _ = ensureActiveCopilotSessionConfigured() orelse {
+        markUiDirty();
+        return;
+    };
     input.focusAiCopilot();
     if (g_allocator) |alloc| platform_window_state.setCopilotHintShown(alloc);
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    markUiDirty();
 }
 
 pub fn rightPanelsWidth() f32 {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3766,6 +3766,16 @@ pub fn openAiConfigForSession(session: *AppWindow.ai_chat.Session) void {
     aiState().focus = @intFromEnum(AiField.api_key);
 }
 
+pub fn openAiConfigForMissingCopilotApi() void {
+    loadAiProfiles();
+    if (aiState().profile_count == 0) {
+        openAiFormNew();
+    } else {
+        openAiFormEdit(defaultAiProfileIndex());
+    }
+    aiState().focus = @intFromEnum(AiField.api_key);
+}
+
 fn findAiProfileForSession(name: []const u8, base_url: []const u8, model: []const u8) ?usize {
     if (name.len > 0) {
         for (0..aiState().profile_count) |idx| {
@@ -4268,6 +4278,32 @@ test "default AI profile snapshot normalizes Anthropic URL with default protocol
         ai_chat.ApiProtocol.anthropic,
         defaultAiProfileSnapshotProtocol("https://api.anthropic.com", ""),
     );
+}
+
+test "overlays: missing copilot API opens AI config at API key" {
+    const saved_loaded = aiState().profiles_loaded;
+    const saved_count = aiState().profile_count;
+    const saved_focus = aiState().focus;
+    const saved_list = g_ai_list_visible;
+    const saved_form = g_ai_form_visible;
+    defer {
+        aiState().profiles_loaded = saved_loaded;
+        aiState().profile_count = saved_count;
+        aiState().focus = saved_focus;
+        g_ai_list_visible = saved_list;
+        g_ai_form_visible = saved_form;
+    }
+
+    aiState().profiles_loaded = true;
+    aiState().profile_count = 0;
+    g_ai_list_visible = true;
+    g_ai_form_visible = false;
+
+    openAiConfigForMissingCopilotApi();
+
+    try std.testing.expect(!g_ai_list_visible);
+    try std.testing.expect(g_ai_form_visible);
+    try std.testing.expectEqual(@as(usize, @intFromEnum(AiField.api_key)), aiState().focus);
 }
 
 threadlocal var g_ai_default_name_buf: [256]u8 = undefined;

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -20,10 +20,10 @@ const Frozen = struct {
 };
 
 // Verified against the post-round-1 tree: every direct-write ceiling here
-// already equals the current actual (AppWindow 63, input 81, overlays 12,
+// already equals the current actual (AppWindow 57, input 81, overlays 12,
 // ai_chat 0), so there is no slack to ratchet away this round.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 63 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 57 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 12 },
     .{ .name = "ai_chat.zig", .source = @embedFile("../ai_chat.zig"), .ceiling = 0 },


### PR DESCRIPTION
## Summary
- Open the AI profile/API-key form when Copilot cannot create a configured session
- Route blank API-key Copilot sessions to the existing profile config flow
- Lower the AppWindow dirty-write side-effect guard after converting touched writes to markUiDirty()

## Root Cause
Ctrl+Shift+A marked the Copilot sidebar visible before verifying that a Copilot session existed and had an API key. With no AI profile, session creation returned null and left an empty focused sidebar instead of guiding the user to configuration.

## Validation
- zig build test-full
- zig build test