### PR TITLE
fix: 微信回执提示 /help + 修复会话中心空格无法预览 transcript

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2554,6 +2554,15 @@ pub fn aiHistorySearchFocused() bool {
     return session.focus == .search;
 }
 
+/// True when a plain Space should preview the selected transcript instead of
+/// typing into the Search box (search unfocused, or focused with an empty
+/// query). Keeps "Press Space to load transcript" working from the default
+/// focus while still allowing spaces inside a non-empty query.
+pub fn aiHistorySpacePreviews() bool {
+    const session = activeAiHistory() orelse return false;
+    return session.spacePreviewsTranscript();
+}
+
 pub fn aiHistoryBackspaceFilter() bool {
     const session = activeAiHistory() orelse return false;
     session.mutex.lock();

--- a/src/ai_history_session.zig
+++ b/src/ai_history_session.zig
@@ -807,11 +807,24 @@ pub const Session = struct {
     pub fn typeIntoSearch(self: *Session, codepoint: u21) bool {
         if (self.focus != .search) return false;
         if (codepoint < 0x20 or codepoint == 0x7f) return false;
+        // A leading space is useless as a query prefix, so it stays reserved for
+        // the "Press Space to load transcript" preview shortcut even while the
+        // Search box owns focus. Once the query has content, Space joins it as a
+        // normal multi-word separator.
+        if (codepoint == ' ' and self.filter_len == 0) return false;
         var buf: [4]u8 = undefined;
         const len = std.unicode.utf8Encode(codepoint, &buf) catch return false;
         if (len > self.filter.len - self.filter_len) return false;
         self.appendFilterBytes(buf[0..len]);
         return true;
+    }
+
+    /// Whether a plain Space should preview the selected transcript rather than
+    /// edit the query: true whenever the Search box isn't focused, or it is but
+    /// the query is still empty (mirrors `typeIntoSearch` declining the leading
+    /// space). Lets "Press Space to load transcript" work from the default focus.
+    pub fn spacePreviewsTranscript(self: *const Session) bool {
+        return self.focus != .search or self.filter_len == 0;
     }
 
     /// Number of rows in the combined CATEGORY+DATE list the Filters cursor walks
@@ -2319,6 +2332,24 @@ test "ai_history_session: typeIntoSearch only edits the filter while the search 
     session.focus = .sessions;
     try std.testing.expect(!session.typeIntoSearch('x'));
     try std.testing.expectEqualSlices(u8, "r R", session.filter[0..session.filter_len]);
+}
+
+test "ai_history_session: leading Space is reserved for transcript preview" {
+    var session = Session.init(std.testing.allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    // Default focus is the search box, but a Space on an empty query is NOT
+    // swallowed — it falls through so the input layer can preview the transcript.
+    try std.testing.expect(session.spacePreviewsTranscript());
+    try std.testing.expect(!session.typeIntoSearch(' '));
+    try std.testing.expectEqual(@as(usize, 0), session.filter_len);
+
+    // Once the query has content, Space is a normal separator again.
+    try std.testing.expect(session.typeIntoSearch('a'));
+    try std.testing.expect(!session.spacePreviewsTranscript());
+    try std.testing.expect(session.typeIntoSearch(' '));
+    try std.testing.expect(session.typeIntoSearch('b'));
+    try std.testing.expectEqualSlices(u8, "a b", session.filter[0..session.filter_len]);
 }
 
 test "ai_history_session: scan host replaces rows and marks ready" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -2674,7 +2674,8 @@ fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
     if (AppWindow.activeAiHistory() != null) {
         // aiHistoryInsertCodepoint only consumes the codepoint while the Search box
         // owns focus, so 'r'/Space type into the query there yet stay free to act as
-        // Scan/Preview shortcuts when another panel is focused.
+        // Scan/Preview shortcuts when another panel is focused. A Space on an empty
+        // query is declined (see typeIntoSearch) so it previews the transcript too.
         if (!ev.ctrl and !ev.alt and !ev.super) {
             _ = AppWindow.aiHistoryInsertCodepoint(ev.codepoint);
         }
@@ -3246,7 +3247,7 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
                 _ = AppWindow.aiHistoryScrollTranscript(1 << 30);
                 return .none;
             },
-            0x20 => if (plain and !search_focused) {
+            0x20 => if (plain and AppWindow.aiHistorySpacePreviews()) {
                 _ = AppWindow.aiHistoryPreviewSelectedTranscript();
                 return .none;
             },

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -7,7 +7,7 @@ const approval_reply = @import("approval_reply.zig");
 const question_reply = @import("question_reply.zig");
 const session_list = @import("session_list.zig");
 
-const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。";
+const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。\n发送 /help 查看帮助手册。";
 const AI_BUSY = "副驾正在处理上一条消息，请稍候再发，或发送 /stop 停止当前处理。";
 const ESC = "\x1b";
 const AI_OPEN_TIMEOUT_MS: u32 = 2000;
@@ -549,6 +549,8 @@ test "default text goes to the AI surface with a carriage return" {
     try t.expectEqualStrings("hello world\r", fake.lastInput());
     try t.expectEqualSlices(u8, &FakeControl.aiId(), &fake.last_surface);
     try t.expect(out.expect_ai_progress);
+    // The receipt ack points first-time users at the help manual.
+    try t.expect(std.mem.indexOf(u8, out.text.items, "/help") != null);
 }
 
 test "busy copilot replies with a busy notice and does not start a follow-up" {


### PR DESCRIPTION
## 改动概述

两个小迭代：

### 1. 微信发送信息后提示 `/help`
普通消息的回执 `AI_ACK` 末尾追加一行 `发送 /help 查看帮助手册。`，让用户在发完消息后就能发现帮助入口。

- `src/weixin/agent.zig`

### 2. 修复 session center 空格被搜索框吞掉、无法预览 transcript 的 bug
**根因**：会话中心默认焦点在搜索框（`focus = .search`），`typeIntoSearch` 把空格当普通字符插入搜索词，导致页脚 `Space previews` / 详情区 `Press Space to load transcript` 的提示在默认状态下点不动。

**修复**：
- `typeIntoSearch` 在**查询为空**时不再吞前导空格（前导空格对过滤无意义），保留给预览快捷键；查询非空时空格恢复为多词分隔符。
- 新增 `Session.spacePreviewsTranscript()` 与 `AppWindow.aiHistorySpacePreviews()`。
- `src/input.zig` 空格键判断从 `!search_focused` 改为 `aiHistorySpacePreviews()`。

**效果**：打开会话中心直接按空格即可预览选中会话 transcript；输入关键词过滤后空格仍可用于多词搜索，互不影响。

## 测试
- `zig build test`（fast，含 `ai_history_session`，新增 leading-Space 单测）→ 通过
- `zig build test-full -Dtarget=aarch64-macos`（含 `weixin/agent` 更新断言）→ 通过

## Reviewer notes
- 媒体（图片）消息回执走 `src/weixin/media_inbound.zig` 另一条路径，本 PR 未加 `/help` 提示；如需一致可后续补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)