### PR TITLE
Add `wisptermctl spawn`: open a new tab in the running instance (#307)

### DIFF
--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -57,9 +57,22 @@ wisptermctl send-text -t <surface-id> "<text>"
 wisptermctl wait-for -t <surface-id> "<substring>" [--timeout SECONDS]
     Poll get-text until the output contains <substring> (default 60s).
     Exit 0 on match, 2 on timeout.
+
+wisptermctl spawn [--cwd DIR] [-- program args...]
+    Open a NEW tab in the running instance (no separate window). --cwd sets
+    its working directory (default: the active tab's cwd). Everything after
+    `--` is the command to run (default: your configured shell). The tab is
+    queued and created on the next UI tick; `ok` means "accepted".
 ```
 
 Surface ids come from `wisptermctl panes` (the `id` field).
+
+### Example: jump to a saved session in its own tab
+
+```sh
+wisptermctl spawn --cwd "F:\1_Bio-analysis" -- claude -r 1b42b2ea
+wisptermctl spawn --cwd /home/me/code            # just a shell in that dir
+```
 
 ### Example: run a test in another pane and read the result
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -5031,7 +5031,27 @@ pub fn clearWeixinTranscriptCache() void {
 
 pub fn enableAgentControl() void {
     control_api.setUiStateBuilder(overlays.buildUiStateJson);
+    control_api.setSpawnHandler(ctlSpawnTab);
     control_api.enable();
+}
+
+/// UI-thread handler for `wisptermctl spawn`: open a new terminal tab. `cwd`
+/// empty = inherit the active tab's cwd; `command` empty = the configured shell.
+fn ctlSpawnTab(cwd_path: []const u8, command: []const u8) void {
+    const allocator = g_allocator orelse return;
+    var cwd_buf: platform_pty_command.CwdBuffer = undefined;
+    const cwd = if (cwd_path.len != 0)
+        platform_pty_command.cwdFromUtf8(&cwd_buf, cwd_path)
+    else
+        getActiveCwd(&cwd_buf);
+
+    const ok = if (command.len != 0) blk: {
+        const command_line = platform_pty_command.allocCommandLineFromUtf8(allocator, command) catch break :blk false;
+        defer platform_pty_command.freeCommandLine(allocator, command_line);
+        break :blk tab.spawnTabWithCommandAndCwd(allocator, term_cols, term_rows, platform_pty_command.commandLineFromOwned(command_line), g_cursor_style, g_cursor_blink, cwd);
+    } else tab.spawnTabWithCwd(allocator, term_cols, term_rows, g_cursor_style, g_cursor_blink, cwd);
+
+    if (ok) clearUiStateOnTabChange();
 }
 
 /// The Control the agent-control server drives. Backed by process-global state,
@@ -6511,6 +6531,9 @@ fn runMainLoop(self: *AppWindow) !void {
         rememberWindowedPosition(win);
         // Fire any due /loop or /watch tasks (UI thread: tab.g_tabs is populated).
         ai_loop_store.tick(std.time.milliTimestamp());
+        // Open any tabs requested via `wisptermctl spawn` (queued by the ctl
+        // server thread, created here on the UI thread).
+        control_api.drainSpawnQueue();
 
         // Handle bells, notifications, and OSC 52 clipboard writes staged by
         // the IO threads. This runs before the render gate: background-tab
@@ -6951,6 +6974,7 @@ fn runMainLoop(self: *AppWindow) !void {
     clearWeixinTranscriptCache();
     control_api.clearPanesCache();
     control_api.clearUiStateCache();
+    control_api.clearSpawnQueue();
     markdown_preview_renderer.deinit();
     browser_panel.deinit();
 

--- a/src/appwindow/control_api.zig
+++ b/src/appwindow/control_api.zig
@@ -6,6 +6,7 @@ const remote = @import("../remote_client.zig");
 const remote_snapshot = @import("../remote_snapshot.zig");
 const ctl_control = @import("../ctl/control.zig");
 const surface_registry = @import("../surface_registry.zig");
+const window_backend = @import("../platform/window_backend.zig");
 const active_tab_state = @import("active_tab.zig");
 const tab = @import("tab.zig");
 const surface_snapshots = @import("surface_snapshots.zig");
@@ -33,6 +34,23 @@ var g_build_ui_state_json: ?BuildUiStateJsonFn = null;
 
 pub fn setUiStateBuilder(builder: BuildUiStateJsonFn) void {
     g_build_ui_state_json = builder;
+}
+
+// --- spawn (new-tab) queue: server thread enqueues, UI thread drains ---
+// Tab creation touches threadlocal tab state + GPU resources, so it can't run on
+// the ctl server thread. The server copies cwd+command into this queue and wakes
+// the UI loop; drainSpawnQueue() (render tick) does the actual spawn.
+pub const SpawnFn = *const fn (cwd: []const u8, command: []const u8) void;
+var g_spawn_handler: ?SpawnFn = null;
+var g_spawn_mutex: std.Thread.Mutex = .{};
+const SpawnItem = struct { cwd: []u8, command: []u8 }; // page_allocator-owned
+var g_spawn_queue: std.ArrayListUnmanaged(SpawnItem) = .empty;
+// ponytail: bounded so a wedged UI thread can't grow this without limit; 32
+// queued tab spawns is far past any real burst. Raise if it ever bites.
+const MAX_SPAWN_QUEUE = 32;
+
+pub fn setSpawnHandler(h: SpawnFn) void {
+    g_spawn_handler = h;
 }
 
 pub fn enable() void {
@@ -82,11 +100,64 @@ fn ctlUiState(ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!?[]u8 {
     return try allocator.dupe(u8, g_ctl_ui_state_json);
 }
 
+/// Server thread: queue a new-tab request for the UI thread, then wake it.
+/// Returns false if no handler is wired up or the queue is full.
+fn ctlSpawn(ctx: *anyopaque, cwd: []const u8, command: []const u8) bool {
+    _ = ctx;
+    if (g_spawn_handler == null) return false;
+    if (!enqueueSpawn(cwd, command)) return false;
+    window_backend.postWakeup();
+    return true;
+}
+
+fn enqueueSpawn(cwd: []const u8, command: []const u8) bool {
+    const a = std.heap.page_allocator;
+    g_spawn_mutex.lock();
+    defer g_spawn_mutex.unlock();
+    if (g_spawn_queue.items.len >= MAX_SPAWN_QUEUE) return false;
+    const cwd_owned = a.dupe(u8, cwd) catch return false;
+    errdefer a.free(cwd_owned);
+    const cmd_owned = a.dupe(u8, command) catch return false;
+    errdefer a.free(cmd_owned);
+    g_spawn_queue.append(a, .{ .cwd = cwd_owned, .command = cmd_owned }) catch return false;
+    return true;
+}
+
+/// UI thread: spawn every queued tab. Called from the render loop. No-op when
+/// the queue is empty or no handler is registered.
+pub fn drainSpawnQueue() void {
+    const handler = g_spawn_handler orelse return;
+    const a = std.heap.page_allocator;
+    g_spawn_mutex.lock();
+    var items = g_spawn_queue; // move ownership out; process unlocked
+    g_spawn_queue = .empty;
+    g_spawn_mutex.unlock();
+    defer items.deinit(a);
+    for (items.items) |item| {
+        handler(item.cwd, item.command);
+        a.free(item.cwd);
+        a.free(item.command);
+    }
+}
+
+pub fn clearSpawnQueue() void {
+    const a = std.heap.page_allocator;
+    g_spawn_mutex.lock();
+    defer g_spawn_mutex.unlock();
+    for (g_spawn_queue.items) |item| {
+        a.free(item.cwd);
+        a.free(item.command);
+    }
+    g_spawn_queue.deinit(a);
+    g_spawn_queue = .empty;
+}
+
 const ctl_vtable = ctl_control.Control.VTable{
     .list_panes = ctlListPanes,
     .get_text = ctlGetText,
     .send_text = ctlSendText,
     .ui_state = ctlUiState,
+    .spawn = ctlSpawn,
 };
 
 /// The Control the agent-control server drives. Backed by process-global state,
@@ -264,4 +335,34 @@ test "ctl surface callbacks reject an unregistered id without dereferencing" {
     const c = control();
     try std.testing.expect((try c.getText(std.testing.allocator, "missing", null)) == null);
     try std.testing.expect(!c.sendText("missing", "x"));
+}
+
+var g_test_spawn_log: std.ArrayListUnmanaged(u8) = .empty;
+fn testSpawnHandler(cwd: []const u8, command: []const u8) void {
+    g_test_spawn_log.appendSlice(std.testing.allocator, cwd) catch {};
+    g_test_spawn_log.append(std.testing.allocator, '|') catch {};
+    g_test_spawn_log.appendSlice(std.testing.allocator, command) catch {};
+    g_test_spawn_log.append(std.testing.allocator, ';') catch {};
+}
+
+test "spawn queue enqueues and drains in order to the handler" {
+    defer {
+        g_test_spawn_log.deinit(std.testing.allocator);
+        g_test_spawn_log = .empty;
+        g_spawn_handler = null;
+        clearSpawnQueue();
+    }
+    // No handler → reject (don't accumulate undrained work).
+    g_spawn_handler = null;
+    try std.testing.expect(!ctlSpawn(&g_ctl_ctx, "/a", "bash"));
+
+    setSpawnHandler(testSpawnHandler);
+    try std.testing.expect(enqueueSpawn("/a", "bash"));
+    try std.testing.expect(enqueueSpawn("", "claude -r x"));
+    drainSpawnQueue();
+    try std.testing.expectEqualStrings("/a|bash;|claude -r x;", g_test_spawn_log.items);
+
+    g_spawn_mutex.lock();
+    defer g_spawn_mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 0), g_spawn_queue.items.len);
 }

--- a/src/ctl/client.zig
+++ b/src/ctl/client.zig
@@ -9,6 +9,9 @@ pub const Action = union(enum) {
     send_text: struct { id: []const u8, data: []const u8 }, // data still escaped
     wait_for: struct { id: []const u8, pattern: []const u8, timeout_ms: u32 },
     ui_state,
+    // command is the argv tail after `--` (joined with spaces by the caller);
+    // empty = open a plain shell tab.
+    spawn: struct { cwd: []const u8, command: []const []const u8 },
     help,
 };
 
@@ -80,6 +83,10 @@ pub fn parseArgs(args: []const []const u8) !Action {
         const text = positionalAfterFlags(args) orelse return error.MissingText;
         return .{ .send_text = .{ .id = id, .data = text } };
     }
+    if (std.mem.eql(u8, cmd, "spawn")) {
+        const cwd = (try flagValue(args, "--cwd")) orelse "";
+        return .{ .spawn = .{ .cwd = cwd, .command = argsAfterDoubleDash(args) } };
+    }
     if (std.mem.eql(u8, cmd, "wait-for")) {
         const id = (try flagValue(args, "-t")) orelse return error.MissingTarget;
         const pat = positionalAfterFlags(args) orelse return error.MissingText;
@@ -123,6 +130,15 @@ fn positionalAfterFlags(args: []const []const u8) ?[]const u8 {
         return args[i];
     }
     return null;
+}
+
+/// Everything after a literal `--` (the program + its args for `spawn`). Empty
+/// slice when there is no `--` or nothing follows it.
+fn argsAfterDoubleDash(args: []const []const u8) []const []const u8 {
+    for (args, 0..) |a, i| {
+        if (std.mem.eql(u8, a, "--")) return args[i + 1 ..];
+    }
+    return &.{};
 }
 
 fn isKnownFlag(a: []const u8) bool {
@@ -182,6 +198,20 @@ test "parseArgs covers every command and required-flag errors" {
 
 test "parseArgs maps ui-state to its no-arg action" {
     try t.expectEqual(Action.ui_state, try parseArgs(&.{"ui-state"}));
+}
+
+test "parseArgs spawn: cwd + command tail after --" {
+    const a = try parseArgs(&.{ "spawn", "--cwd", "F:\\proj", "--", "claude", "-r", "abc" });
+    try t.expectEqualStrings("F:\\proj", a.spawn.cwd);
+    try t.expectEqual(@as(usize, 3), a.spawn.command.len);
+    try t.expectEqualStrings("claude", a.spawn.command[0]);
+    try t.expectEqualStrings("abc", a.spawn.command[2]);
+}
+
+test "parseArgs spawn: bare (no cwd, no command) is a plain shell tab" {
+    const a = try parseArgs(&.{"spawn"});
+    try t.expectEqualStrings("", a.spawn.cwd);
+    try t.expectEqual(@as(usize, 0), a.spawn.command.len);
 }
 
 test "parseArgs: large --timeout does not overflow u32 (clamps)" {

--- a/src/ctl/control.zig
+++ b/src/ctl/control.zig
@@ -18,6 +18,10 @@ pub const Control = struct {
         /// Allocator-owned overlay/UI semantic-state JSON object, or null if not
         /// yet published. Complements list_panes (topology) with the overlay layer.
         ui_state: *const fn (ctx: *anyopaque, allocator: std.mem.Allocator) anyerror!?[]u8,
+        /// Queue a new terminal tab (UI thread spawns it). `command`/`cwd` empty
+        /// = default shell / active tab's cwd. Returns false if it could not be
+        /// queued (e.g. the spawn handler isn't wired up, or the queue is full).
+        spawn: *const fn (ctx: *anyopaque, cwd: []const u8, command: []const u8) bool,
     };
 
     pub fn listPanes(self: Control, allocator: std.mem.Allocator) anyerror!?[]u8 {
@@ -31,6 +35,9 @@ pub const Control = struct {
     }
     pub fn uiState(self: Control, allocator: std.mem.Allocator) anyerror!?[]u8 {
         return self.vtable.ui_state(self.ctx, allocator);
+    }
+    pub fn spawn(self: Control, cwd: []const u8, command: []const u8) bool {
+        return self.vtable.spawn(self.ctx, cwd, command);
     }
 };
 
@@ -51,9 +58,12 @@ test "Control forwards to the vtable" {
         fn ui_state(_: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
             return try a.dupe(u8, "{\"activeOverlay\":\"none\"}");
         }
+        fn spawn(_: *anyopaque, cwd: []const u8, _: []const u8) bool {
+            return std.mem.eql(u8, cwd, "/ok");
+        }
         var dummy: u8 = 0;
         fn iface() Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state, .spawn = spawn } };
         }
     };
     const c = Fake.iface();
@@ -69,4 +79,6 @@ test "Control forwards to the vtable" {
     try t.expect((try c.getText(t.allocator, "gone", null)) == null);
     try t.expect(c.sendText("live", "x"));
     try t.expect(!c.sendText("gone", "x"));
+    try t.expect(c.spawn("/ok", "bash"));
+    try t.expect(!c.spawn("/nope", "bash"));
 }

--- a/src/ctl/protocol.zig
+++ b/src/ctl/protocol.zig
@@ -4,7 +4,7 @@
 //! '\n'-terminated.
 const std = @import("std");
 
-pub const Cmd = enum { panes, get_text, send_text, ui_state };
+pub const Cmd = enum { panes, get_text, send_text, ui_state, spawn };
 
 pub fn cmdToStr(c: Cmd) []const u8 {
     return switch (c) {
@@ -12,6 +12,7 @@ pub fn cmdToStr(c: Cmd) []const u8 {
         .get_text => "get-text",
         .send_text => "send-text",
         .ui_state => "ui-state",
+        .spawn => "spawn",
     };
 }
 
@@ -20,6 +21,7 @@ pub fn cmdFromStr(s: []const u8) ?Cmd {
     if (std.mem.eql(u8, s, "get-text")) return .get_text;
     if (std.mem.eql(u8, s, "send-text")) return .send_text;
     if (std.mem.eql(u8, s, "ui-state")) return .ui_state;
+    if (std.mem.eql(u8, s, "spawn")) return .spawn;
     return null;
 }
 
@@ -28,7 +30,8 @@ pub const Request = struct {
     cmd: Cmd,
     id: []const u8 = "",
     recent: ?u32 = null,
-    data: []const u8 = "",
+    data: []const u8 = "", // send-text input, or spawn's command line
+    cwd: []const u8 = "", // spawn working directory ("" = inherit active tab's)
 };
 
 /// Build one newline-terminated JSON request line. Caller owns the result.
@@ -47,9 +50,13 @@ pub fn encodeRequest(allocator: std.mem.Allocator, req: Request) ![]u8 {
         try out.appendSlice(allocator, ",\"recent\":");
         try out.print(allocator, "{d}", .{n});
     }
-    if (req.cmd == .send_text) {
+    if (req.cmd == .send_text or req.cmd == .spawn) {
         try out.appendSlice(allocator, ",\"data\":");
         try writeJsonString(allocator, &out, req.data);
+    }
+    if (req.cwd.len != 0) {
+        try out.appendSlice(allocator, ",\"cwd\":");
+        try writeJsonString(allocator, &out, req.cwd);
     }
     try out.appendSlice(allocator, "}\n");
     return out.toOwnedSlice(allocator);
@@ -79,6 +86,7 @@ pub fn parseRequest(allocator: std.mem.Allocator, line: []const u8) !ParsedReque
     req.token = stringField(obj, "token") orelse "";
     req.id = stringField(obj, "id") orelse "";
     req.data = stringField(obj, "data") orelse "";
+    req.cwd = stringField(obj, "cwd") orelse "";
     if (obj.get("recent")) |v| {
         // Clamp to u32 range: a huge value must not panic (@intCast) the server
         // thread — and parseRequest runs BEFORE token auth, so this is reachable
@@ -197,6 +205,25 @@ test "parseRequest clamps an out-of-u32 recent instead of panicking" {
     var pr = try parseRequest(t.allocator, "{\"token\":\"x\",\"cmd\":\"get-text\",\"id\":\"s\",\"recent\":5000000000}");
     defer pr.deinit();
     try t.expectEqual(@as(?u32, std.math.maxInt(u32)), pr.value.recent);
+}
+
+test "spawn round-trips command + cwd" {
+    const line = try encodeRequest(t.allocator, .{ .token = "x", .cmd = .spawn, .data = "claude -r abc", .cwd = "F:\\proj" });
+    defer t.allocator.free(line);
+    var pr = try parseRequest(t.allocator, line);
+    defer pr.deinit();
+    try t.expectEqual(Cmd.spawn, pr.value.cmd);
+    try t.expectEqualStrings("claude -r abc", pr.value.data);
+    try t.expectEqualStrings("F:\\proj", pr.value.cwd);
+}
+
+test "spawn with empty cwd omits the field" {
+    const line = try encodeRequest(t.allocator, .{ .token = "x", .cmd = .spawn, .data = "bash" });
+    defer t.allocator.free(line);
+    try t.expect(std.mem.indexOf(u8, line, "cwd") == null);
+    var pr = try parseRequest(t.allocator, line);
+    defer pr.deinit();
+    try t.expectEqualStrings("", pr.value.cwd);
 }
 
 test "ui-state command round-trips through cmd<->str and encode/parse" {

--- a/src/ctl/server.zig
+++ b/src/ctl/server.zig
@@ -139,6 +139,13 @@ pub const Server = struct {
                     return protocol.encodeError(self.allocator, "surface not found");
                 return protocol.encodeOk(self.allocator);
             },
+            .spawn => {
+                // Queued for the UI thread (tab creation is not thread-safe here);
+                // ok means "accepted", not "tab is already visible".
+                if (!self.control.spawn(req.cwd, req.data))
+                    return protocol.encodeError(self.allocator, "spawn queue full or unavailable");
+                return protocol.encodeOk(self.allocator);
+            },
         }
     }
 };
@@ -173,6 +180,9 @@ const t = std.testing;
 const FakeControl = struct {
     sent: std.ArrayListUnmanaged(u8) = .empty,
     ui_published: bool = true,
+    spawned_cwd: std.ArrayListUnmanaged(u8) = .empty,
+    spawned_cmd: std.ArrayListUnmanaged(u8) = .empty,
+    spawn_ok: bool = true,
     fn list_panes(ctx: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
         _ = ctx;
         return try a.dupe(u8, "{\"tabs\":[]}");
@@ -193,8 +203,15 @@ const FakeControl = struct {
         self.sent.appendSlice(t.allocator, data) catch return false;
         return true;
     }
+    fn spawn(ctx: *anyopaque, cwd: []const u8, command: []const u8) bool {
+        const self: *FakeControl = @ptrCast(@alignCast(ctx));
+        if (!self.spawn_ok) return false;
+        self.spawned_cwd.appendSlice(t.allocator, cwd) catch return false;
+        self.spawned_cmd.appendSlice(t.allocator, command) catch return false;
+        return true;
+    }
     fn iface(self: *FakeControl) control_mod.Control {
-        return .{ .ctx = self, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
+        return .{ .ctx = self, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state, .spawn = spawn } };
     }
 };
 
@@ -250,6 +267,27 @@ test "dispatch panes / get-text / send-text happy + missing paths" {
     defer t.allocator.free(sr);
     try t.expect(std.mem.indexOf(u8, sr, "\"ok\":true") != null);
     try t.expectEqualStrings("echo hi\n", fc.sent.items);
+}
+
+test "dispatch spawn forwards cwd+command and reports queue-full" {
+    var fc = FakeControl{};
+    defer fc.sent.deinit(t.allocator);
+    defer fc.spawned_cwd.deinit(t.allocator);
+    defer fc.spawned_cmd.deinit(t.allocator);
+    var srv = fakeServer(&fc);
+
+    const s = try protocol.encodeRequest(t.allocator, .{ .token = "secret", .cmd = .spawn, .data = "claude -r abc", .cwd = "/work" });
+    defer t.allocator.free(s);
+    const sr = try srv.dispatch(s);
+    defer t.allocator.free(sr);
+    try t.expect(std.mem.indexOf(u8, sr, "\"ok\":true") != null);
+    try t.expectEqualStrings("/work", fc.spawned_cwd.items);
+    try t.expectEqualStrings("claude -r abc", fc.spawned_cmd.items);
+
+    fc.spawn_ok = false;
+    const sr2 = try srv.dispatch(s);
+    defer t.allocator.free(sr2);
+    try t.expect(std.mem.indexOf(u8, sr2, "spawn queue full") != null);
 }
 
 test "dispatch ui-state returns the published overlay JSON" {

--- a/src/test_posix.zig
+++ b/src/test_posix.zig
@@ -45,9 +45,12 @@ test "ctl server answers a real loopback request and stops cleanly" {
         fn ui_state(_: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
             return try a.dupe(u8, "{\"activeOverlay\":\"none\"}");
         }
+        fn spawn(_: *anyopaque, cwd: []const u8, _: []const u8) bool {
+            return std.mem.eql(u8, cwd, "/work"); // accept only the expected request
+        }
         var dummy: u8 = 0;
         fn iface() control_mod.Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state, .spawn = spawn } };
         }
     };
 
@@ -85,6 +88,16 @@ test "ctl server answers a real loopback request and stops cleanly" {
     const ui_n = try s_ui.read(&ui_buf);
     try std.testing.expect(std.mem.indexOf(u8, ui_buf[0..ui_n], "activeOverlay") != null);
 
+    // spawn round-trips its cwd+command over the wire and replies ok.
+    var s_sp = try std.net.tcpConnectToAddress(addr);
+    defer s_sp.close();
+    const sp_line = try protocol.encodeRequest(std.testing.allocator, .{ .token = "tok", .cmd = .spawn, .data = "claude -r abc", .cwd = "/work" });
+    defer std.testing.allocator.free(sp_line);
+    try s_sp.writeAll(sp_line);
+    var sp_buf: [256]u8 = undefined;
+    const sp_n = try s_sp.read(&sp_buf);
+    try std.testing.expect(std.mem.indexOf(u8, sp_buf[0..sp_n], "\"ok\":true") != null);
+
     // A bad token is rejected over the wire too.
     var s2 = try std.net.tcpConnectToAddress(addr);
     defer s2.close();
@@ -113,9 +126,12 @@ test "ctl server shutdown does not hang on a stalled (newline-less) connection" 
         fn ui_state(_: *anyopaque, _: std.mem.Allocator) anyerror!?[]u8 {
             return null;
         }
+        fn spawn(_: *anyopaque, _: []const u8, _: []const u8) bool {
+            return false;
+        }
         var dummy: u8 = 0;
         fn iface() control_mod.Control {
-            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state } };
+            return .{ .ctx = &dummy, .vtable = &.{ .list_panes = list_panes, .get_text = get_text, .send_text = send_text, .ui_state = ui_state, .spawn = spawn } };
         }
     };
 

--- a/src/wisptermctl.zig
+++ b/src/wisptermctl.zig
@@ -7,6 +7,7 @@
 //!   wisptermctl get-text  -t <surface-id> [--recent N]
 //!   wisptermctl send-text -t <surface-id> "<text with \n \t \xNN escapes>"
 //!   wisptermctl wait-for  -t <surface-id> "<substring>" [--timeout SECONDS]
+//!   wisptermctl spawn     [--cwd DIR] [-- program args...]
 //!
 //! Lean by design: imports only ctl/* + platform/dirs.zig (std/builtin), so it
 //! links without any GUI/SDL dependencies.
@@ -51,6 +52,11 @@ pub fn main() !void {
             const data = try client.decodeEscapes(allocator, s.data);
             defer allocator.free(data);
             try runOnce(allocator, info, .{ .token = info.token, .cmd = .send_text, .id = s.id, .data = data }, .ok_only);
+        },
+        .spawn => |sp| {
+            const command = try std.mem.join(allocator, " ", sp.command);
+            defer allocator.free(command);
+            try runOnce(allocator, info, .{ .token = info.token, .cmd = .spawn, .data = command, .cwd = sp.cwd }, .ok_only);
         },
         .wait_for => |w| try runWaitFor(allocator, info, w),
         .help => try stdoutAll(USAGE),
@@ -170,6 +176,12 @@ const USAGE =
     \\  wisptermctl wait-for -t <surface-id> "<substring>" [--timeout SECONDS]
     \\      Poll get-text until the output contains <substring> (default 60s).
     \\      Exit 0 on match, 2 on timeout.
+    \\  wisptermctl spawn [--cwd DIR] [-- program args...]
+    \\      Open a new tab in the running instance. --cwd sets its working
+    \\      directory (default: the active tab's cwd). Everything after `--` is
+    \\      the command to run (default: your configured shell). Examples:
+    \\        wisptermctl spawn --cwd "F:\proj" -- claude -r 1b42b2ea
+    \\        wisptermctl spawn --cwd /home/me/code
     \\
     \\Enable in WispTerm config:  agent-control-enabled = true
     \\Surface ids come from `wisptermctl panes`.


### PR DESCRIPTION
Closes #307.

## What

Extends the existing `wisptermctl` control API with a `spawn` command so an external tool (e.g. a "session index") can reuse the running WispTerm instance and open a **new tab** with a `--cwd` and a startup command — no separate window.

```sh
wisptermctl spawn --cwd "F:\1_Bio-analysis" -- claude -r 1b42b2ea   # the issue's use case
wisptermctl spawn --cwd /home/me/code                              # just a shell in that dir
wisptermctl spawn                                                  # new tab, active tab's cwd
```

This is the issue's priority‑1 option (CLI, WezTerm‑style `cli spawn`), and answers the follow‑up comment asking for a "new conversation" command.

## How

Tab creation is **UI‑thread‑only** (it touches threadlocal tab state + GPU resources). Unlike `get-text`/`send-text` — which pin a live `Surface` via `surface_registry` and run on the ctl server thread — the server thread can't create a tab directly. So:

- Server thread `ctlSpawn` copies `cwd`+`command` into a bounded (cap 32) mutex‑guarded owned queue, then `window_backend.postWakeup()`s the UI loop.
- The render loop calls `control_api.drainSpawnQueue()` (next to the `/loop` tick), moves the queue out under the lock, and spawns each tab on the UI thread via `tab.spawnTabWithCommandAndCwd` / `spawnTabWithCwd`.
- `ok` means **"queued"**, not "tab is visible"; no new surface‑id is returned (call `panes` afterward if you need it).

Reuses the existing `agent-control-enabled` gate, token auth, and discovery file — **no new config or transport**. The ctl `Control` vtable gains a `spawn` fn (updated in all test fakes).

## Design notes

- **Fire‑and‑forget** rather than a synchronous id‑returning handshake — covers the click‑to‑jump use case and avoids the cross‑thread UAF hazards that bit the agent‑worker path. Chain a `panes` call if you need the spawned surface id.
- **`--` required** before the command (matches WezTerm); a command without `--` falls back to a plain shell.
- Does **not** raise/focus the OS window — the new tab just becomes active. Possible follow‑up.

## Testing

- `zig build test`, `zig build test-full`, `zig build` (app), `zig build wisptermctl` — all green.
- Unit tests: protocol round‑trip, arg parsing, server dispatch, queue enqueue/drain.
- A real over‑the‑socket `spawn` assertion added to the posix loopback test.
- Native + Windows `wisptermctl` binaries smoke‑tested (help shows `spawn`; no‑instance path exits cleanly).
- GUI verification pending (new tab actually appearing) — same as the rest of the wisptermctl API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)