### PR TITLE
fix(ai-chat): auto-title every profile, not just one named "DeepSeek"

### DIFF
--- a/src/agent_history.zig
+++ b/src/agent_history.zig
@@ -37,6 +37,9 @@ pub const SessionRecord = struct {
     agent_enabled: bool,
     vision_enabled: bool = false,
     copilot: bool = false,
+    /// True once the user manually renamed the chat; defaults false for records
+    /// written before this field existed (std.json fills the default).
+    title_is_custom: bool = false,
     created_at: i64,
     updated_at: i64,
     messages: []MessageRecord,
@@ -291,6 +294,7 @@ pub fn cloneRecord(allocator: std.mem.Allocator, input: anytype) !SessionRecord 
         .agent_enabled = input.agent_enabled,
         .vision_enabled = if (@hasField(@TypeOf(input), "vision_enabled")) input.vision_enabled else false,
         .copilot = if (@hasField(@TypeOf(input), "copilot")) input.copilot else false,
+        .title_is_custom = if (@hasField(@TypeOf(input), "title_is_custom")) input.title_is_custom else false,
         .created_at = input.created_at,
         .updated_at = input.updated_at,
         .messages = messages,

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -870,6 +870,11 @@ pub const Session = struct {
     distill_last_suggested_turn_count: usize = 0,
     distill_inflight: bool = false,
     auto_title_attempted: bool = false,
+    /// True once the user has manually renamed the chat (via the tab rename UI).
+    /// Auto-title checks this instead of comparing the title to a hardcoded
+    /// default name, so every profile — not just one literally named "DeepSeek"
+    /// — gets an auto-generated title on its first turn.
+    title_is_custom: bool = false,
     closing: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     stop_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     scroll_px: f32 = 0,
@@ -1107,6 +1112,7 @@ pub const Session = struct {
         session.max_tokens = record.max_tokens;
         session.vision_enabled = record.vision_enabled;
         session.copilot = record.copilot;
+        session.title_is_custom = record.title_is_custom;
         session.created_at_ms = record.created_at;
         session.updated_at_ms = record.updated_at;
         for (record.messages) |msg| {
@@ -1454,21 +1460,26 @@ pub const Session = struct {
         };
     }
 
+    /// Explicit (user-driven) rename. Marks the title as custom so a later
+    /// auto-title never overwrites the user's choice.
     pub fn setTitle(self: *Session, title_text: []const u8) void {
         var history_change: ?PendingHistoryChange = null;
         self.mutex.lock();
         self.copyTitle(title_text);
+        self.title_is_custom = true;
         history_change = self.captureHistoryChangeLocked();
         self.mutex.unlock();
         self.notifyHistoryChange(history_change);
     }
 
-    /// Set the title only if it is still the default name. Returns true if it
-    /// changed. Used by auto-title so a concurrent manual rename always wins.
-    pub fn setTitleIfDefault(self: *Session, title_text: []const u8) bool {
+    /// Set the title only if the user has not manually renamed the chat. Returns
+    /// true if it changed. Used by auto-title so a concurrent manual rename
+    /// always wins. Leaves `title_is_custom` false: an auto-generated title is
+    /// not a user choice, and `auto_title_attempted` already prevents re-firing.
+    pub fn setTitleIfNotCustom(self: *Session, title_text: []const u8) bool {
         var history_change: ?PendingHistoryChange = null;
         self.mutex.lock();
-        if (!std.mem.eql(u8, self.title_buf[0..self.title_len], DEFAULT_NAME)) {
+        if (self.title_is_custom) {
             self.mutex.unlock();
             return false;
         }
@@ -4157,6 +4168,7 @@ pub const Session = struct {
             .agent_enabled = self.agent_enabled,
             .vision_enabled = self.vision_enabled,
             .copilot = self.copilot,
+            .title_is_custom = self.title_is_custom,
             .created_at = self.created_at_ms,
             .updated_at = self.updated_at_ms,
             .messages = messages,
@@ -4479,13 +4491,13 @@ pub fn finishStoppedRequest(session: *Session) void {
 }
 
 /// Clean a raw model title response and apply it to the session, but only if the
-/// title is still the default (a manual rename in the meantime always wins) and
-/// the session is not closing.
+/// user has not manually renamed it (a manual rename in the meantime always
+/// wins) and the session is not closing.
 pub fn applyGeneratedTitle(session: *Session, raw: []const u8) void {
     if (session.closing.load(.acquire)) return;
     var buf: [ai_chat_title.max_title_bytes]u8 = undefined;
     const cleaned = ai_chat_title.cleanTitle(raw, &buf) orelse return;
-    _ = session.setTitleIfDefault(cleaned);
+    _ = session.setTitleIfNotCustom(cleaned);
 }
 
 /// Swap the live session to a different provider/model (session-only; does not
@@ -4767,8 +4779,7 @@ pub fn maybeAutoTitle(session: *Session) void {
         const gate = ai_chat_title.TitleGate{
             .attempted = session.auto_title_attempted,
             .has_api_key = session.api_key_len > 0,
-            .title = session.title_buf[0..session.title_len],
-            .default_name = DEFAULT_NAME,
+            .is_custom = session.title_is_custom,
         };
         if (!ai_chat_title.shouldAutoTitle(gate, turn)) break :locked;
 
@@ -6166,11 +6177,11 @@ test "ai_chat: applyGeneratedTitle cleans and sets title when still default" {
     try std.testing.expectEqualStrings("Deploy the App", session.title());
 }
 
-test "ai_chat: applyGeneratedTitle leaves a renamed title untouched" {
+test "ai_chat: applyGeneratedTitle leaves a user-renamed title untouched" {
     const allocator = std.testing.allocator;
     const session = try Session.init(
         allocator,
-        "My Custom Name",
+        DEFAULT_NAME,
         "https://api.example.com",
         "secret",
         "model-a",
@@ -6181,8 +6192,67 @@ test "ai_chat: applyGeneratedTitle leaves a renamed title untouched" {
         "true",
     );
     defer session.deinit();
+    // A manual rename (setTitle) marks the title custom; auto-title must not win.
+    session.setTitle("My Custom Name");
+    try std.testing.expect(session.title_is_custom);
     applyGeneratedTitle(session, "Generated Title");
     try std.testing.expectEqualStrings("My Custom Name", session.title());
+}
+
+test "ai_chat: applyGeneratedTitle titles a non-DeepSeek profile (glm-5.2 regression)" {
+    // Regression for the hardcoded `title == "DeepSeek"` gate: a fresh session
+    // whose default title is its profile name (here an Anthropic glm-5.2 chat)
+    // must still receive an auto-generated title. The name is no longer compared
+    // against a single hardcoded default.
+    const allocator = std.testing.allocator;
+    const session = try Session.init(
+        allocator,
+        "glm-5.2",
+        "https://open.bigmodel.cn/api/anthropic",
+        "secret",
+        "glm-5.2",
+        "system",
+        "enabled",
+        "high",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+    try std.testing.expect(!session.title_is_custom);
+    applyGeneratedTitle(session, "Greeting Exchange");
+    try std.testing.expectEqualStrings("Greeting Exchange", session.title());
+}
+
+test "ai_chat: title_is_custom survives a history record round trip" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(
+        allocator,
+        "glm-5.2",
+        "https://open.bigmodel.cn/api/anthropic",
+        "secret",
+        "glm-5.2",
+        "system",
+        "enabled",
+        "high",
+        "false",
+        "true",
+    );
+    defer session.deinit();
+    try std.testing.expect(!session.title_is_custom);
+
+    session.setTitle("Renamed By User");
+    try std.testing.expect(session.title_is_custom);
+
+    var record = try session.toHistoryRecord(allocator);
+    defer agent_history.freeOwnedRecord(allocator, &record);
+    try std.testing.expect(record.title_is_custom);
+
+    const restored = try Session.initFromHistoryRecord(allocator, record);
+    defer restored.deinit();
+    try std.testing.expect(restored.title_is_custom);
+    // And a restored, user-renamed chat must not be auto-titled over.
+    applyGeneratedTitle(restored, "Auto Title");
+    try std.testing.expectEqualStrings("Renamed By User", restored.title());
 }
 
 test "ai_chat: applyGeneratedTitle ignores empty model output" {

--- a/src/ai_chat_title.zig
+++ b/src/ai_chat_title.zig
@@ -108,36 +108,51 @@ test "extractFirstTurn: null when user missing" {
 pub const TitleGate = struct {
     attempted: bool,
     has_api_key: bool,
-    title: []const u8,
-    default_name: []const u8,
+    /// True once the user has manually renamed the chat. Auto-title must never
+    /// overwrite a user-chosen name. This replaces the old `title == "DeepSeek"`
+    /// check, which only ever fired for sessions literally named after the
+    /// original default profile — every other profile (glm-5.2, GPT-5, any
+    /// renamed one) silently lost auto-title.
+    is_custom: bool,
 };
 
 /// Auto-title fires only when: not attempted yet, an API key is configured, the
-/// title is still the default (user has not renamed), and a first turn exists.
+/// user has not manually renamed the chat, and a first turn exists.
 pub fn shouldAutoTitle(gate: TitleGate, turn: ?FirstTurn) bool {
     if (gate.attempted) return false;
     if (!gate.has_api_key) return false;
-    if (!std.mem.eql(u8, gate.title, gate.default_name)) return false;
+    if (gate.is_custom) return false;
     return turn != null;
 }
 
-test "shouldAutoTitle: fires on first turn with default title and key" {
+test "shouldAutoTitle: fires on first turn when not renamed and key present" {
     const turn = FirstTurn{ .user = "u", .assistant = "a" };
     try std.testing.expect(shouldAutoTitle(.{
         .attempted = false,
         .has_api_key = true,
-        .title = "DeepSeek",
-        .default_name = "DeepSeek",
+        .is_custom = false,
     }, turn));
 }
 
-test "shouldAutoTitle: blocked when title not default" {
+test "shouldAutoTitle: fires regardless of the profile name (glm-5.2 regression)" {
+    // Regression for the hardcoded `title == "DeepSeek"` gate: a session whose
+    // default title is its profile name (e.g. an Anthropic-protocol glm-5.2
+    // chat) must still auto-title. The name is irrelevant now — only whether
+    // the user manually renamed it (is_custom) matters.
+    const turn = FirstTurn{ .user = "hi", .assistant = "Hi! How can I help?" };
+    try std.testing.expect(shouldAutoTitle(.{
+        .attempted = false,
+        .has_api_key = true,
+        .is_custom = false,
+    }, turn));
+}
+
+test "shouldAutoTitle: blocked when the user has renamed the chat" {
     const turn = FirstTurn{ .user = "u", .assistant = "a" };
     try std.testing.expect(!shouldAutoTitle(.{
         .attempted = false,
         .has_api_key = true,
-        .title = "My chat",
-        .default_name = "DeepSeek",
+        .is_custom = true,
     }, turn));
 }
 
@@ -146,20 +161,17 @@ test "shouldAutoTitle: blocked when attempted / no key / no turn" {
     const base = TitleGate{
         .attempted = false,
         .has_api_key = true,
-        .title = "DeepSeek",
-        .default_name = "DeepSeek",
+        .is_custom = false,
     };
     try std.testing.expect(!shouldAutoTitle(.{
         .attempted = true,
         .has_api_key = base.has_api_key,
-        .title = base.title,
-        .default_name = base.default_name,
+        .is_custom = base.is_custom,
     }, turn));
     try std.testing.expect(!shouldAutoTitle(.{
         .attempted = base.attempted,
         .has_api_key = false,
-        .title = base.title,
-        .default_name = base.default_name,
+        .is_custom = base.is_custom,
     }, turn));
     try std.testing.expect(!shouldAutoTitle(base, null));
 }


### PR DESCRIPTION
## 问题

非 DeepSeek 的 AI 会话(尤其 glm-5.2 这种 anthropic 协议的 profile)新建对话后**标题永远不会自动生成**,一直停留在 profile 名;而 DeepSeek 会话能正常起标题(如 "Greeting Exchange")。

## 根因

自动起标题的门禁把「会话是否还是默认名」**写死成了字符串 `"DeepSeek"`**:

- `shouldAutoTitle` 要求 `session.title == DEFAULT_NAME`("DeepSeek")才发标题请求
- `setTitleIfDefault` 又要求 `title == "DeepSeek"` 才写入标题

而新建会话的标题取自 profile 名。于是只有恰好叫 "DeepSeek" 的 profile 能过门禁,glm-5.2 / GPT-5 / 任何改过名的 profile 全部被挡。

这跟模型/协议无关:标题请求本来就用会话自身的模型与协议(实测 glm-5.2 的 anthropic 标题请求能正常返回真实标题),纯粹是这道名字门禁的问题。

## 改动

用 `title_is_custom` 布尔标记替代字符串比较:

- 新增 `Session.title_is_custom`(默认 `false`)
- 用户手动改名(`setTitle`,唯一作用于 AI 会话的调用点是 tab 改名)置 `true`
- 门禁 `shouldAutoTitle` 与写入路径(`setTitleIfDefault` → 重命名为 `setTitleIfNotCustom`)改为判 `is_custom`
- 标题仍由会话自身的模型生成(未引入 subagent)
- 标记持久化进 `SessionRecord`,沿用 `@hasField` 向后兼容(旧记录默认 `false`),手动改过名的会话恢复后不会被自动标题覆盖

## 验证

- `zig build test-full -Dtarget=aarch64-macos`:全部通过(含新增的 glm-5.2 回归测试、用户改名不被覆盖、持久化往返测试)
- 真机验证:新版构建中新建 glm-5.2 对话发消息后,标题自动生成("Greeting"),修复生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)