### PR TITLE
fix(ctl): repair agent-control transport on Windows overlapped sockets

### DIFF
--- a/src/ctl/server.zig
+++ b/src/ctl/server.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const protocol = @import("protocol.zig");
 const control_mod = @import("control.zig");
+const transport = @import("transport.zig");
 
 const MAX_REQUEST_BYTES = 64 * 1024;
 pub const default_rows: u32 = 1000;
@@ -92,7 +93,9 @@ pub const Server = struct {
         var chunk: [4096]u8 = undefined;
         while (buf.items.len < MAX_REQUEST_BYTES) {
             if (self.stop_flag.load(.acquire)) return; // bail promptly on shutdown
-            const n = stream.read(&chunk) catch break; // includes recv timeout (WouldBlock)
+            // posix.recv, not the deprecated Stream.read: the latter is broken on
+            // Windows overlapped sockets (ReadFile + NULL OVERLAPPED). See transport.zig.
+            const n = transport.recv(stream.handle, &chunk) catch break; // includes recv timeout (WouldBlock)
             if (n == 0) break;
             try buf.appendSlice(self.allocator, chunk[0..n]);
             if (std.mem.indexOfScalar(u8, buf.items, '\n') != null) break;
@@ -100,7 +103,7 @@ pub const Server = struct {
         const nl = std.mem.indexOfScalar(u8, buf.items, '\n') orelse buf.items.len;
         const reply = try self.dispatch(buf.items[0..nl]);
         defer self.allocator.free(reply);
-        stream.writeAll(reply) catch {};
+        transport.sendAll(stream.handle, reply) catch {};
     }
 
     /// Parse + authenticate + act. Returns an owned, newline-terminated reply.

--- a/src/ctl/transport.zig
+++ b/src/ctl/transport.zig
@@ -1,0 +1,56 @@
+//! Loopback socket I/O for the agent-control transport — shared by the in-process
+//! server (ctl/server.zig) and the standalone wisptermctl client.
+//!
+//! Why this exists instead of std.net.Stream.read/.writeAll: those are deprecated
+//! and BROKEN on Windows for this use. Zig creates every socket with
+//! WSA_FLAG_OVERLAPPED (std.posix.socket), and Stream.read maps to
+//! `ReadFile(socket, buf, NULL)`. Per Microsoft's docs, calling ReadFile on an
+//! overlapped handle with a NULL OVERLAPPED "can incorrectly report that the read
+//! operation is complete" — in practice it returns 0 bytes immediately. So every
+//! wisptermctl command read the server's reply as 0 bytes and failed with
+//! "malformed response from WispTerm" (the v1.30.0 Windows bug). POSIX uses
+//! `posix.read`, which is why the macOS/Linux round-trip tests never caught it.
+//!
+//! Instead we use plain blocking Winsock recv/send on Windows (synchronous on
+//! overlapped sockets, honors SO_RCVTIMEO) and posix.recv/posix.send on POSIX.
+//! The Windows branch calls ws2_32 directly rather than posix.recv so the lean,
+//! no-libc wisptermctl exe links (posix.recvfrom resolves to a libc symbol on
+//! windows-gnu). Pure std — no GUI deps.
+const std = @import("std");
+const builtin = @import("builtin");
+const ws2_32 = std.os.windows.ws2_32;
+
+const Handle = std.net.Stream.Handle;
+
+pub const Error = error{ RecvFailed, SendFailed };
+
+/// One receive into `buf`. Returns 0 on an orderly peer shutdown. Any failure —
+/// including the SO_RCVTIMEO timeout — maps to error.RecvFailed so a read loop
+/// can `catch break` (matching the previous Stream.read semantics).
+pub fn recv(handle: Handle, buf: []u8) Error!usize {
+    if (builtin.os.tag == .windows) {
+        const len: i32 = @intCast(@min(buf.len, @as(usize, std.math.maxInt(i32))));
+        const rc = ws2_32.recv(handle, buf.ptr, len, 0);
+        if (rc == ws2_32.SOCKET_ERROR) return error.RecvFailed;
+        return @intCast(rc); // rc >= 0; 0 == orderly shutdown
+    } else {
+        return std.posix.recv(handle, buf, 0) catch return error.RecvFailed;
+    }
+}
+
+/// Write every byte of `bytes`, looping over partial sends.
+pub fn sendAll(handle: Handle, bytes: []const u8) Error!void {
+    var i: usize = 0;
+    while (i < bytes.len) {
+        if (builtin.os.tag == .windows) {
+            const len: i32 = @intCast(@min(bytes.len - i, @as(usize, std.math.maxInt(i32))));
+            const rc = ws2_32.send(handle, bytes[i..].ptr, len, 0);
+            if (rc == ws2_32.SOCKET_ERROR) return error.SendFailed;
+            i += @intCast(rc);
+        } else {
+            // MSG.NOSIGNAL: a peer that closed its read end must not raise SIGPIPE
+            // (matches the stdlib POSIX socket writer). Winsock has no SIGPIPE.
+            i += std.posix.send(handle, bytes[i..], std.posix.MSG.NOSIGNAL) catch return error.SendFailed;
+        }
+    }
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -181,6 +181,7 @@ test {
     _ = @import("ctl/control.zig");
     _ = @import("ctl/server.zig");
     _ = @import("ctl/client.zig");
+    _ = @import("ctl/transport.zig");
     _ = @import("ctl/ui_state.zig");
     _ = @import("png_dimensions.zig");
     _ = @import("pdf_preview.zig");

--- a/src/test_posix.zig
+++ b/src/test_posix.zig
@@ -31,13 +31,21 @@ test "ctl server answers a real loopback request and stops cleanly" {
     const ctl_server = @import("ctl/server.zig");
     const protocol = @import("ctl/protocol.zig");
     const control_mod = @import("ctl/control.zig");
+    const transport = @import("ctl/transport.zig");
 
+    // get-text for id "big" returns a payload larger than one recv chunk so the
+    // round-trip exercises sendAll's partial-write loop and multi-recv reassembly
+    // (not just a one-shot small reply).
+    const big_len = 200_000;
     const C = struct {
         fn list_panes(_: *anyopaque, a: std.mem.Allocator) anyerror!?[]u8 {
             return try a.dupe(u8, "{\"activeTab\":0,\"tabs\":[]}");
         }
-        fn get_text(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: ?u32) anyerror!?[]u8 {
-            return null;
+        fn get_text(_: *anyopaque, a: std.mem.Allocator, id: []const u8, _: ?u32) anyerror!?[]u8 {
+            if (!std.mem.eql(u8, id, "big")) return null;
+            const out = try a.alloc(u8, big_len);
+            @memset(out, 'x');
+            return out;
         }
         fn send_text(_: *anyopaque, _: []const u8, _: []const u8) bool {
             return false;
@@ -60,53 +68,63 @@ test "ctl server answers a real loopback request and stops cleanly" {
     try std.testing.expect(srv.port != 0);
 
     const addr = try std.net.Address.parseIp4("127.0.0.1", srv.port);
-    var stream = try std.net.tcpConnectToAddress(addr);
-    defer stream.close();
 
-    const line = try protocol.encodeRequest(std.testing.allocator, .{ .token = "tok", .cmd = .panes });
-    defer std.testing.allocator.free(line);
-    try stream.writeAll(line);
+    // Drive the client side through ctl/transport (posix.recv/posix.send) — the
+    // same code path wisptermctl uses — so this round-trip guards the transport
+    // the Windows v1.30.0 bug lived in, not just the protocol layer.
+    const roundtrip = struct {
+        fn run(a: std.mem.Allocator, ad: std.net.Address, req: protocol.Request, sink: *std.ArrayListUnmanaged(u8)) !void {
+            var stream = try std.net.tcpConnectToAddress(ad);
+            defer stream.close();
+            const line = try protocol.encodeRequest(a, req);
+            defer a.free(line);
+            try transport.sendAll(stream.handle, line);
+            var chunk: [4096]u8 = undefined;
+            while (true) {
+                const n = transport.recv(stream.handle, &chunk) catch break;
+                if (n == 0) break;
+                try sink.appendSlice(a, chunk[0..n]);
+                if (std.mem.indexOfScalar(u8, sink.items, '\n') != null) break;
+            }
+        }
+    }.run;
 
-    var buf: [4096]u8 = undefined;
-    var total: usize = 0;
-    while (total < buf.len) {
-        const n = try stream.read(buf[total..]);
-        if (n == 0) break;
-        total += n;
-        if (std.mem.indexOfScalar(u8, buf[0..total], '\n') != null) break;
-    }
-    try std.testing.expect(std.mem.indexOf(u8, buf[0..total], "\"ok\":true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf[0..total], "activeTab") != null);
+    const alloc = std.testing.allocator;
+
+    var panes: std.ArrayListUnmanaged(u8) = .empty;
+    defer panes.deinit(alloc);
+    try roundtrip(alloc, addr, .{ .token = "tok", .cmd = .panes }, &panes);
+    try std.testing.expect(std.mem.indexOf(u8, panes.items, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, panes.items, "activeTab") != null);
 
     // ui-state round-trips over the same socket protocol as panes.
-    var s_ui = try std.net.tcpConnectToAddress(addr);
-    defer s_ui.close();
-    const ui_line = try protocol.encodeRequest(std.testing.allocator, .{ .token = "tok", .cmd = .ui_state });
-    defer std.testing.allocator.free(ui_line);
-    try s_ui.writeAll(ui_line);
-    var ui_buf: [256]u8 = undefined;
-    const ui_n = try s_ui.read(&ui_buf);
-    try std.testing.expect(std.mem.indexOf(u8, ui_buf[0..ui_n], "activeOverlay") != null);
+    var ui: std.ArrayListUnmanaged(u8) = .empty;
+    defer ui.deinit(alloc);
+    try roundtrip(alloc, addr, .{ .token = "tok", .cmd = .ui_state }, &ui);
+    try std.testing.expect(std.mem.indexOf(u8, ui.items, "activeOverlay") != null);
 
     // spawn round-trips its cwd+command over the wire and replies ok.
-    var s_sp = try std.net.tcpConnectToAddress(addr);
-    defer s_sp.close();
-    const sp_line = try protocol.encodeRequest(std.testing.allocator, .{ .token = "tok", .cmd = .spawn, .data = "claude -r abc", .cwd = "/work" });
-    defer std.testing.allocator.free(sp_line);
-    try s_sp.writeAll(sp_line);
-    var sp_buf: [256]u8 = undefined;
-    const sp_n = try s_sp.read(&sp_buf);
-    try std.testing.expect(std.mem.indexOf(u8, sp_buf[0..sp_n], "\"ok\":true") != null);
+    var sp: std.ArrayListUnmanaged(u8) = .empty;
+    defer sp.deinit(alloc);
+    try roundtrip(alloc, addr, .{ .token = "tok", .cmd = .spawn, .data = "claude -r abc", .cwd = "/work" }, &sp);
+    try std.testing.expect(std.mem.indexOf(u8, sp.items, "\"ok\":true") != null);
+
+    // A large get-text reply round-trips intact: this is what a multi-write
+    // server response + multi-read client looks like, and proves no bytes are
+    // dropped or truncated by the transport.
+    var big: std.ArrayListUnmanaged(u8) = .empty;
+    defer big.deinit(alloc);
+    try roundtrip(alloc, addr, .{ .token = "tok", .cmd = .get_text, .id = "big" }, &big);
+    var big_resp = try protocol.parseResponse(alloc, big.items);
+    defer big_resp.deinit();
+    try std.testing.expect(big_resp.ok);
+    try std.testing.expectEqual(@as(usize, big_len), big_resp.result_text.?.len);
 
     // A bad token is rejected over the wire too.
-    var s2 = try std.net.tcpConnectToAddress(addr);
-    defer s2.close();
-    const bad = try protocol.encodeRequest(std.testing.allocator, .{ .token = "nope", .cmd = .panes });
-    defer std.testing.allocator.free(bad);
-    try s2.writeAll(bad);
-    var buf2: [256]u8 = undefined;
-    const n2 = try s2.read(&buf2);
-    try std.testing.expect(std.mem.indexOf(u8, buf2[0..n2], "unauthorized") != null);
+    var bad: std.ArrayListUnmanaged(u8) = .empty;
+    defer bad.deinit(alloc);
+    try roundtrip(alloc, addr, .{ .token = "nope", .cmd = .panes }, &bad);
+    try std.testing.expect(std.mem.indexOf(u8, bad.items, "unauthorized") != null);
 }
 
 test "ctl server shutdown does not hang on a stalled (newline-less) connection" {

--- a/src/wisptermctl.zig
+++ b/src/wisptermctl.zig
@@ -15,6 +15,7 @@ const std = @import("std");
 const protocol = @import("ctl/protocol.zig");
 const discovery = @import("ctl/discovery.zig");
 const client = @import("ctl/client.zig");
+const transport = @import("ctl/transport.zig");
 
 const ResultKind = enum { raw, text, ok_only };
 
@@ -72,13 +73,16 @@ fn requestOnce(allocator: std.mem.Allocator, info: discovery.Info, req: protocol
 
     const line = try protocol.encodeRequest(allocator, req);
     defer allocator.free(line);
-    try stream.writeAll(line);
+    // posix.send/recv, not the deprecated Stream.write/read: the read path is
+    // broken on Windows overlapped sockets and returned 0 bytes for every reply
+    // ("malformed response from WispTerm"). See ctl/transport.zig.
+    try transport.sendAll(stream.handle, line);
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
     var chunk: [4096]u8 = undefined;
     while (buf.items.len < 16 * 1024 * 1024) {
-        const n = stream.read(&chunk) catch break;
+        const n = transport.recv(stream.handle, &chunk) catch break;
         if (n == 0) break;
         try buf.appendSlice(allocator, chunk[0..n]);
         if (std.mem.indexOfScalar(u8, buf.items, '\n') != null) break;


### PR DESCRIPTION
## 问题

v1.30.0 Windows 上 `wisptermctl` 的**所有**命令都报 `malformed response from WispTerm`（`panes` / `ui-state` / `spawn` 一致）。用户抓包确认：请求合法、token 一致、端口/令牌文件正常刷新，但服务端回 0 字节就关连接。

## 真因（非漏 flush、非协议不对齐）

服务端与客户端都用了**已废弃的 `std.net.Stream.read`**。它在 Windows 上走 `ReadFile(socket, buf, NULL)`，而 Zig 给每个 socket 都加了 `WSA_FLAG_OVERLAPPED`（`std.posix.socket`）。对 overlapped 句柄传 **NULL OVERLAPPED 调 ReadFile** 是微软文档明确的坏用法——"can incorrectly report that the read operation is complete"，实测**立即返回 0 字节**：

- 客户端把回包读成 0 字节 → `parseResponse` 失败 → 打印 `malformed response`。
- 服务端把请求也读成 0 字节 → 根本没读到命令。**两端都坏。**
- POSIX 走 `posix.read`，所以 macOS/Linux 的端到端往返测试一直通过——**socket 往返从没在 Windows 上真正跑过**，bug 因此进了 release。

## 修复

- 新增 `src/ctl/transport.zig`：`recv`/`sendAll` 在 Windows 用普通阻塞 Winsock `ws2_32.recv`/`send`（overlapped socket 上同步工作、遵守 `SO_RCVTIMEO`、且不依赖 libc——`posix.recv` 在 windows-gnu 会拉 libc 符号，破坏 lean 的 wisptermctl exe）；POSIX 用 `posix.recv`/`posix.send`（带 `MSG.NOSIGNAL`）。
- `server.zig` 的 `handleConnection` 与 `wisptermctl.zig` 的 `requestOnce` 改走 transport。
- `test_posix.zig` 端到端往返测试改为驱动真实 transport，并新增 200KB `get-text` 回包断言（覆盖分片发送 + 多次 recv 重组）。

## 验证

- `zig build wisptermctl`（默认 windows-gnu，无 libc）✅、`-Dtarget=aarch64-macos` ✅ 编译通过。
- `zig build test`（快测）✅。
- ctl 端到端 socket 往返测试（含大回包）在 macOS ✅ 全过。
- ⚠️ Windows 运行时的最终确认需一版 Windows 构建（macOS 上无法跑 Windows 二进制）；根因已对照 Zig 源码 + 微软文档坐实，修复用的是 overlapped socket 上正确的 Winsock API。

## 发版注意

**`wispterm.exe`（服务端）和 `wisptermctl.exe`（客户端）两个二进制都要重新构建**才生效——只补客户端不管用。建议出 v1.30.1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)