### PR TITLE
ci: gate heavy jobs by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,42 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Decide which jobs need to run from the changed paths. Doc-only changes skip
+  # the zig/windows suites; remote-only changes run just the npm job. Required
+  # checks gated below report "skipped" (which satisfies branch protection)
+  # instead of being filtered out at the `on:` level (which would leave them
+  # pending forever and block the merge).
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      remote: ${{ steps.filter.outputs.remote }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` = anything that isn't pure docs/remote. Single negation glob
+          # so the `some` quantifier means "some changed file is real code".
+          filters: |
+            code:
+              - '!{docs/**,wiki/**,release-notes/**,plans/**,remote/**,**/*.md,*.md}'
+            remote:
+              - 'remote/**'
+
   zig-fast-linux:
     name: Zig fast tests / Linux
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -45,6 +73,8 @@ jobs:
 
   zig-full-mac-arm:
     name: Zig full tests / macOS ARM
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: macos-15
     timeout-minutes: 60
 
@@ -71,6 +101,8 @@ jobs:
 
   remote-ts:
     name: Remote TypeScript
+    needs: changes
+    if: ${{ needs.changes.outputs.remote == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
 
@@ -96,6 +128,8 @@ jobs:
 
   windows-smoke:
     name: Windows smoke
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: windows-2022
     timeout-minutes: 45
 


### PR DESCRIPTION
## What

Add path-based gating to `ci.yml` so doc-only and remote-only PRs no longer run the full CI matrix.

A `changes` job (`dorny/paths-filter`) computes two flags and each job is gated with `if:`:

| Change | Jobs that run |
|---|---|
| `docs/ wiki/ release-notes/ plans/ *.md` only | none of the heavy jobs (incl. the 60-min macOS full-test) |
| `remote/**` only | only **Remote TypeScript** (npm) |
| real code (`src/`, `build.zig`, `tests/`, …) | zig + windows; remote too if touched |
| `workflow_dispatch` | everything (dorny default) |

## Why

Surfaced via #294 — a docs change was triggering the full test suite, including the 60-minute macOS ARM job. CI triggers should be proportional to what actually changed.

## Why not `paths-ignore`

The 4 CI jobs (`Zig fast tests / Linux`, `Zig full tests / macOS ARM`, `Remote TypeScript`, `Windows smoke`) are **required status checks** on `main`. Filtering at the `on:` level would skip the whole workflow, leaving those checks **pending forever** and blocking the merge.

Job-level `if:` avoids this: a job skipped by a conditional reports **Success** ([GitHub-documented behavior](https://docs.github.com/en/repositories/configuring-branches-and-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks)), which satisfies branch protection. Job `name:`s are unchanged, so the required-check contexts still match.

## Reviewer notes

- The `code` filter is a single negation glob so dorny's default `some` quantifier means "some changed file is real code". Verified against picomatch (root `*.md`, nested docs, mixed code+docs PRs).
- Default-from-strict: root non-doc files (e.g. `Dockerfile`, `.gitignore`) still count as code and run zig — intentional, prefer over-running to skipping tests. Loosen by adding to the glob.
- `pull-requests: read` added to `permissions` for dorny's PR file listing.
- Other workflows are unaffected (release workflows are `push: tags`/`workflow_dispatch`; `pages.yml` already filters `docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)