### PR TITLE
refactor(research): move research connectors under src/research

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -231,7 +231,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     ai_chat.setDefaultWorkingDir(app.ai_agent_working_dir);
     overlays.setSubagentProfileName(app.ai_subagent_profile);
     ai_chat.setSubagentProfileResolver(overlays.resolveSubagentProfileOverride);
-    @import("web_search.zig").setJinaApiKey(app.jina_api_key);
+    @import("research/web_search.zig").setJinaApiKey(app.jina_api_key);
     @import("pty.zig").setConsoleHostPreference(app.console_host_preference);
     // Copy shell command from App
     @memcpy(tab.g_shell_cmd_buf[0..app.shell_cmd_len], app.shell_cmd_buf[0..app.shell_cmd_len]);
@@ -4641,7 +4641,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     ai_chat.reloadFirstPartyToolState(allocator);
     ai_chat.setDefaultWorkingDir(cfg.@"ai-agent-working-dir");
     overlays.setSubagentProfileName(cfg.@"ai-subagent-profile");
-    @import("web_search.zig").setJinaApiKey(cfg.@"jina-api-key");
+    @import("research/web_search.zig").setJinaApiKey(cfg.@"jina-api-key");
     @import("pty.zig").setConsoleHostPreference(cfg.@"windows-conpty");
 
     if (g_window == null) return;

--- a/src/ai_chat.zig
+++ b/src/ai_chat.zig
@@ -152,8 +152,8 @@ const ImageBlock = ai_chat_protocol.ImageBlock;
 const ai_chat_title = @import("ai_chat_title.zig");
 const ToolCall = ai_chat_protocol.ToolCall;
 const ai_chat_request = @import("ai_chat_request.zig");
-const web_search = @import("web_search.zig");
-const pubmed = @import("pubmed.zig");
+const web_search = @import("research/web_search.zig");
+const pubmed = @import("research/pubmed.zig");
 const agent_memory = @import("agent_memory.zig");
 
 pub const ChatRequest = struct {

--- a/src/ai_chat_request.zig
+++ b/src/ai_chat_request.zig
@@ -10,9 +10,9 @@ const ai_chat_protocol = @import("ai_chat_protocol.zig");
 const ai_skill_distill = @import("ai_skill_distill.zig");
 const ai_chat_tools = @import("ai_chat_tools.zig");
 const first_party_tools = @import("tools/first_party.zig");
-const web_search = @import("web_search.zig");
-const web_read = @import("web_read.zig");
-const pubmed = @import("pubmed.zig");
+const web_search = @import("research/web_search.zig");
+const web_read = @import("research/web_read.zig");
+const pubmed = @import("research/pubmed.zig");
 const ai_chat_types = @import("ai_chat_types.zig");
 const platform_agent_prompt = @import("platform/agent_prompt.zig");
 

--- a/src/ai_chat_tools.zig
+++ b/src/ai_chat_tools.zig
@@ -33,9 +33,9 @@ const platform_pty_command = @import("platform/pty_command.zig");
 const platform_wsl = @import("platform/wsl.zig");
 const platform_agent_prompt = @import("platform/agent_prompt.zig");
 const ai_agent_access = @import("ai_agent_access.zig");
-const web_search = @import("web_search.zig");
-const web_read = @import("web_read.zig");
-const pubmed = @import("pubmed.zig");
+const web_search = @import("research/web_search.zig");
+const web_read = @import("research/web_read.zig");
+const pubmed = @import("research/pubmed.zig");
 const agent_memory = @import("agent_memory.zig");
 
 /// Number of output lines included in a copilot context block.

--- a/src/research/pubmed.zig
+++ b/src/research/pubmed.zig
@@ -7,7 +7,7 @@
 //! use system proxies. Anonymous access only (no API key); `tool=wispterm` is
 //! sent per NCBI etiquette.
 const std = @import("std");
-const platform_http = @import("platform/http_client.zig");
+const platform_http = @import("../platform/http_client.zig");
 
 const esearch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi";
 const efetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi";

--- a/src/research/web_read.zig
+++ b/src/research/web_read.zig
@@ -6,7 +6,7 @@
 //! Mirrors `web_search.zig`; intentionally does NOT depend on it — the Jina key is
 //! passed in via `Options.api_key` (empty = anonymous).
 const std = @import("std");
-const platform_http = @import("platform/http_client.zig");
+const platform_http = @import("../platform/http_client.zig");
 const web_read_cache = @import("web_read_cache.zig");
 
 const reader_url = "https://r.jina.ai/";

--- a/src/research/web_read_cache.zig
+++ b/src/research/web_read_cache.zig
@@ -3,7 +3,7 @@
 //! markdown lives and reads/writes it. No network, no Jina knowledge. Best-effort:
 //! `read` returns null on any problem; `store` swallows all errors.
 const std = @import("std");
-const platform_atomic_file = @import("platform/atomic_file.zig");
+const platform_atomic_file = @import("../platform/atomic_file.zig");
 
 const cache_dir_name = ".webread_cache";
 const max_cache_file_bytes: usize = 64 * 1024 * 1024;

--- a/src/research/web_search.zig
+++ b/src/research/web_search.zig
@@ -3,7 +3,7 @@
 //! today; a new engine is a new branch in `executeSearch`. HTTP transport goes
 //! through `platform/http_client.zig` so desktop builds can use system proxies.
 const std = @import("std");
-const platform_http = @import("platform/http_client.zig");
+const platform_http = @import("../platform/http_client.zig");
 
 const jina_search_url = "https://s.jina.ai/";
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -218,12 +218,12 @@ test {
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
     _ = @import("composer_detail_wrap.zig");
-    _ = @import("web_search.zig");
+    _ = @import("research/web_search.zig");
     _ = @import("agent_prompt_answer.zig");
     _ = @import("tools/first_party.zig");
-    _ = @import("web_read.zig");
-    _ = @import("web_read_cache.zig");
-    _ = @import("pubmed.zig");
+    _ = @import("research/web_read.zig");
+    _ = @import("research/web_read_cache.zig");
+    _ = @import("research/pubmed.zig");
     _ = @import("ai_loop_schedule.zig");
     _ = @import("ai_skill_distill.zig");
     _ = @import("ai_history/types.zig");


### PR DESCRIPTION
## Summary
- move web search, web read, web read cache, and PubMed connector modules under src/research
- update AI chat, AppWindow, and fast-test imports

## Verification
- zig fmt src build.zig
- zig build test
- zig build test-full -Dtarget=native
- Windows checkout safety check: 0 name violations, 0 casefold collisions, no symlinks