### PR TITLE
refactor(research): own reserved research command metadata

### DIFF
--- a/src/ai_chat_composer.zig
+++ b/src/ai_chat_composer.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const skill_registry = @import("skill/registry.zig");
 const input_text = @import("ai_chat_input_text.zig");
+const research_commands = @import("research/commands.zig");
 
 /// Max bytes the composer input buffer can hold. Mirrors
 /// `ai_chat.INPUT_PROMPT_MAX_BYTES` exactly so the editable buffer semantics
@@ -186,23 +187,16 @@ pub const SlashCommand = enum {
     unknown,
 };
 
-pub const WebCommand = enum { websearch, webread, pubmed };
+pub const WebCommand = research_commands.Command;
 
 /// Reserved `$`-prefixed commands shown in the same dropdown as skills.
-pub const ReservedWebCommand = struct { name: []const u8, description: []const u8 };
-pub const reserved_web_commands = [_]ReservedWebCommand{
-    .{ .name = "websearch", .description = "search the web (Jina)" },
-    .{ .name = "webread", .description = "read a web page or local file (Jina)" },
-    .{ .name = "pubmed", .description = "search PubMed (NCBI)" },
-};
+pub const ReservedWebCommand = research_commands.Entry;
+pub const reserved_web_commands = research_commands.entries;
 
 /// Match the first whitespace-delimited token against a reserved `$` command.
 /// `token` is e.g. "$websearch" (the value of `first_tok` in Session.submit).
 pub fn parseWebCommand(token: []const u8) ?WebCommand {
-    if (std.mem.eql(u8, token, "$websearch")) return .websearch;
-    if (std.mem.eql(u8, token, "$webread")) return .webread;
-    if (std.mem.eql(u8, token, "$pubmed")) return .pubmed;
-    return null;
+    return research_commands.parseToken(token);
 }
 
 pub const ComposerSuggestionKind = enum {

--- a/src/research/commands.zig
+++ b/src/research/commands.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub const Command = enum {
+    websearch,
+    webread,
+    pubmed,
+};
+
+pub const Entry = struct {
+    name: []const u8,
+    description: []const u8,
+    command: Command,
+};
+
+pub const entries = [_]Entry{
+    .{ .name = "websearch", .description = "search the web (Jina)", .command = .websearch },
+    .{ .name = "webread", .description = "read a web page or local file (Jina)", .command = .webread },
+    .{ .name = "pubmed", .description = "search PubMed (NCBI)", .command = .pubmed },
+};
+
+pub fn parseToken(token: []const u8) ?Command {
+    if (std.mem.eql(u8, token, "$websearch")) return .websearch;
+    if (std.mem.eql(u8, token, "$webread")) return .webread;
+    if (std.mem.eql(u8, token, "$pubmed")) return .pubmed;
+    return null;
+}
+
+test "research commands parse only full dollar-prefixed tokens" {
+    try std.testing.expectEqual(Command.websearch, parseToken("$websearch").?);
+    try std.testing.expectEqual(Command.webread, parseToken("$webread").?);
+    try std.testing.expectEqual(Command.pubmed, parseToken("$pubmed").?);
+    try std.testing.expectEqual(@as(?Command, null), parseToken("$websearchx"));
+    try std.testing.expectEqual(@as(?Command, null), parseToken("websearch"));
+    try std.testing.expectEqual(@as(?Command, null), parseToken("/websearch"));
+}
+
+test "research commands expose composer suggestions" {
+    try std.testing.expectEqual(@as(usize, 3), entries.len);
+    try std.testing.expectEqual(Command.websearch, entries[0].command);
+    try std.testing.expectEqualStrings("websearch", entries[0].name);
+    try std.testing.expectEqual(Command.pubmed, entries[2].command);
+    try std.testing.expectEqualStrings("pubmed", entries[2].name);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -218,6 +218,7 @@ test {
     _ = @import("ai_chat_input_text.zig");
     _ = @import("ai_chat_composer.zig");
     _ = @import("composer_detail_wrap.zig");
+    _ = @import("research/commands.zig");
     _ = @import("research/web_search.zig");
     _ = @import("agent_prompt_answer.zig");
     _ = @import("tools/first_party.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -686,6 +686,7 @@ comptime {
     _ = @import("config_watcher.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
+    _ = @import("research/commands.zig");
     _ = @import("tools/first_party.zig");
     _ = @import("input.zig");
     _ = @import("input/clipboard.zig");


### PR DESCRIPTION
## Summary
- add src/research/commands.zig as the owner for // metadata and parsing
- keep ai_chat_composer API-compatible by re-exporting the research command types/list/parser
- add commands.zig to fast/full test aggregators

## Verification
- zig fmt src build.zig
- zig build test
- zig build test-full -Dtarget=native
- Windows checkout safety check: 0 name violations, 0 casefold collisions, no symlinks