### PR TITLE
test(macos-e2e): cover tabs, splits, paste, click, resize, OSC title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           # so the `some` quantifier means "some changed file is real code".
           filters: |
             code:
-              - '!{docs/**,wiki/**,release-notes/**,plans/**,remote/**,**/*.md,*.md}'
+              - '!{docs/**,wiki/**,release-notes/**,plans/**,remote/**,tests/macos_e2e/**,**/*.md,*.md}'
             remote:
               - 'remote/**'
 

--- a/tests/macos_e2e/driver/keycodes.py
+++ b/tests/macos_e2e/driver/keycodes.py
@@ -9,6 +9,7 @@ _KEYCODES = {
     "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
     "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
     "t": 17, "n": 45, "p": 35,
+    "equal": 24,  # the "=/+" key; with Shift the OS yields "+", which the app maps to Key.plus
     "return": 36, "tab": 48, "space": 49, "delete": 51, "escape": 53,
     "left": 123, "right": 124, "down": 125, "up": 126,
     "f1": 122, "f2": 120, "f3": 99, "f4": 118,

--- a/tests/macos_e2e/test_click.py
+++ b/tests/macos_e2e/test_click.py
@@ -1,0 +1,84 @@
+"""A real left-click inside the terminal viewport reaches the PTY as a mouse report.
+
+The click analog of test_shift_enter: a probe enables xterm mouse reporting
+(1000) with SGR encoding (1006), signals readiness, then blocks reading the next
+bytes. A single CGEvent left-click in the terminal body must arrive as an SGR
+press report (`ESC [ < ... M`), proving the synthetic click routes through
+AppKit -> input.zig mouse_report -> Surface -> PTY.
+
+Coordinate-tolerant by design: any point inside the grid produces a report, so
+the target is the window's content center (below the tab bar), derived from the
+window's AX position/size — no per-cell geometry needed.
+"""
+import os
+import sys
+
+import pytest
+
+from tests.macos_e2e.driver import osascript
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+_PROBE = r'''
+import os, sys, termios, tty, select
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(1, b"\x1b[?1000h\x1b[?1006h")   # enable mouse tracking + SGR encoding
+    os.write(1, b"MOUSEREADY\r\n")
+    r, _, _ = select.select([fd], [], [], 10)
+    data = os.read(fd, 64) if r else b""
+finally:
+    os.write(1, b"\x1b[?1006l\x1b[?1000l")    # disable, leave the terminal clean
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+os.write(1, b"MOUSE=" + data.hex().encode() + b"\r\n")
+'''
+
+# An SGR mouse report opens with "ESC [ <" — its hex prefix proves the click
+# reached the surface as a report rather than being dropped or echoed as text.
+_SGR_PREFIX = b"\x1b[<".hex()  # "1b5b3c"
+
+
+def _win_pair(app, prop):
+    """Read a 2-element window property (size/position) as (a, b). `as string`
+    concatenates the list with no separator ({1006,639} -> "1006639"), so the
+    script must join the items explicitly."""
+    out = osascript.run(
+        'tell application "System Events"\n'
+        f'  tell (first process whose unix id is {app.pid})\n'
+        f'    set v to {prop} of window 1\n'
+        '    return ((item 1 of v) as string) & "," & ((item 2 of v) as string)\n'
+        '  end tell\n'
+        'end tell'
+    )
+    a, b = (int(n) for n in out.split(","))
+    return a, b
+
+
+def _window_rect(app):
+    """(x, y, w, h) of the test window in screen points (AX == CGEvent space)."""
+    px, py = _win_pair(app, "position")
+    w, h = _win_pair(app, "size")
+    return px, py, w, h
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_left_click_reaches_pty_as_mouse_report(app, pane):
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.send_text("\x03", pane)  # clean prompt before launching the probe
+
+    probe_path = os.path.join(app.home, "mouse_probe.py")
+    with open(probe_path, "w") as f:
+        f.write(_PROBE)
+
+    app.send_text("/usr/bin/python3 ~/mouse_probe.py\n", pane)
+    app.wait_for(pane, "MOUSEREADY", timeout=15)
+
+    # Click the content center — safely below the tab bar, inside the grid.
+    x, y, w, h = _window_rect(app)
+    app.click(x + w // 2, y + int(h * 0.6))
+
+    app.wait_for(pane, f"MOUSE={_SGR_PREFIX}", timeout=15)

--- a/tests/macos_e2e/test_paste.py
+++ b/tests/macos_e2e/test_paste.py
@@ -1,0 +1,38 @@
+"""Cmd+V paste delivers the system clipboard into the focused terminal.
+
+Complements test_keybinds' Cmd+C copy (xfail): copy reads the clipboard, this
+writes it (via pbcopy) and asserts a real Cmd+V keystroke routes the clipboard
+text through the app's paste action into the PTY, where it lands on the prompt
+line and is visible through get-text.
+
+macOS remaps the Ctrl+V paste default to Cmd+V (keybind.zig's ctrl->win
+migration). The marker carries no newline, so it sits on the command line rather
+than executing; a trailing Ctrl-C clears it so the shared shell stays clean.
+"""
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+_MARKER = "PHANTTY_PASTE_MARKER_42"
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_cmd_v_pastes_clipboard_into_pty(app, pane):
+    subprocess.run(["pbcopy"], input=_MARKER, text=True, check=True)
+
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    # Abort any partial line left by earlier real-keyboard tests (session-scoped shell).
+    app.send_text("\x03", pane)
+    time.sleep(0.3)
+
+    app.key("v", "cmd")
+    try:
+        app.wait_for(pane, _MARKER, timeout=8)
+    finally:
+        app.send_text("\x03", pane)  # clear the pasted line off the prompt

--- a/tests/macos_e2e/test_resize.py
+++ b/tests/macos_e2e/test_resize.py
@@ -1,0 +1,78 @@
+"""Resizing the window re-sizes the PTY (TIOCSWINSZ + SIGWINCH reaches the shell).
+
+The #171 redraw bugs lived on the resize path; this asserts the load-bearing half
+of it — that a window resize actually propagates new dimensions to the child PTY,
+which `stty size` (run inside the shell) reports back. It checks the dimensions
+*changed*, not exact cells: cell metrics depend on font/DPI, but "resize the
+window -> the shell sees a different size" is the invariant that matters.
+
+The shell is session-scoped, so the window is restored to its original size.
+"""
+import re
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.driver import osascript, wait
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+
+def _window_size(app) -> tuple:
+    """Current (w, h). `as string` joins a list with no separator, so the script
+    must delimit the items itself ({1006,639} -> "1006639" otherwise)."""
+    out = osascript.run(
+        'tell application "System Events"\n'
+        f'  tell (first process whose unix id is {app.pid})\n'
+        '    set v to size of window 1\n'
+        '    return ((item 1 of v) as string) & "," & ((item 2 of v) as string)\n'
+        '  end tell\n'
+        'end tell'
+    )
+    w, h = (int(n) for n in out.split(","))
+    return w, h
+
+
+def _set_size(app, w: int, h: int) -> None:
+    osascript.run(
+        'tell application "System Events"\n'
+        f'  tell (first process whose unix id is {app.pid})\n'
+        f'    set size of window 1 to {{{w}, {h}}}\n'
+        '  end tell\n'
+        'end tell'
+    )
+
+
+def _pty_size(app, pane: str, tag: str) -> tuple:
+    """Run `stty size` in the shell and read back (rows, cols). A unique tag in the
+    marker means the regex matches only THIS call's output, never stale scrollback
+    or the echoed command line. Aborts any partial prompt line first."""
+    app.send_text("\x03", pane)
+    time.sleep(0.2)
+    # The marker is built by the shell from two literals so the typed command line
+    # ("...W''SZ...") can't itself match the assembled "WSZ<tag> R C" output.
+    app.send_text(f"echo W''SZ{tag} $(stty size)\n", pane)
+
+    pat = re.compile(rf"WSZ{tag} (\d+) (\d+)")
+
+    def check():
+        m = pat.search(app.get_text(pane))
+        return (int(m.group(1)), int(m.group(2))) if m else None
+
+    return wait.wait_until(check, timeout=8, interval=0.2)
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_window_resize_propagates_to_pty(app, pane):
+    w0, h0 = _window_size(app)
+
+    before = _pty_size(app, pane, "A")
+    try:
+        _set_size(app, w0 - 160, h0 - 120)
+        time.sleep(0.5)  # let AppKit resize -> surface reflow -> SIGWINCH settle
+        after = _pty_size(app, pane, "B")
+        assert after != before, f"PTY size unchanged after window resize: {before} -> {after}"
+    finally:
+        _set_size(app, w0, h0)

--- a/tests/macos_e2e/test_splits.py
+++ b/tests/macos_e2e/test_splits.py
@@ -1,0 +1,62 @@
+"""Split a pane with a real keystroke; `panes()` sees the new surface.
+
+The split sibling of test_tabs: tab topology was the cross-tab axis, this is the
+within-tab one. `Cmd+Shift+=` (split_right; macOS remaps the ctrl+shift+plus
+default, and the OS turns the "=" key + Shift into "+", which the app maps to
+Key.plus) adds a surface to the active tab via AppWindow.splitFocused. Until
+synthetic input reached the app this could only be asserted as a static mocked
+shape (test_panes); here a real key drives the change.
+
+Self-restoring: the `app` fixture is session-scoped, so the new split is closed
+(Cmd+Shift+W -> confirm overlay -> Enter, like test_tabs) to leave one surface.
+"""
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.driver import wait
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+
+def _active_surface_count(app) -> int:
+    panes = app.ctl.panes()
+    tabs = panes.get("tabs", [])
+    active = panes.get("activeTab", 0)
+    tab = next((t for t in tabs if t.get("index") == active and t.get("surfaces")), None)
+    if tab is None:
+        tab = next((t for t in tabs if t.get("surfaces")), None)
+    return len(tab.get("surfaces", [])) if tab else 0
+
+
+def _wait_surfaces(app, n: int, timeout: float = 6.0):
+    box = {}
+
+    def check():
+        box["last"] = _active_surface_count(app)
+        return True if box["last"] == n else None
+
+    try:
+        wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"expected {n} surfaces in active tab, last saw {box.get('last')}")
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_split_adds_surface_to_active_tab(app, pane):
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.key("escape")  # dismiss any startup overlay
+    base = _active_surface_count(app)
+
+    # Cmd+Shift+= -> split_right: a second surface joins the active tab.
+    app.key("equal", "cmd", "shift")
+    _wait_surfaces(app, base + 1)
+
+    # Cleanup: closing a focused terminal split is confirm-guarded; Enter accepts.
+    app.key("w", "cmd", "shift")
+    time.sleep(0.3)
+    app.key("return")
+    _wait_surfaces(app, base)

--- a/tests/macos_e2e/test_tabs.py
+++ b/tests/macos_e2e/test_tabs.py
@@ -1,0 +1,78 @@
+"""Tab lifecycle through the real GUI — the path #279 unblocked.
+
+`panes()` exposes tab topology but, until synthetic input reached the app, no
+test could *drive* it: tabs could only be asserted as a static shape (see
+test_panes' mocked JSON). This presses real keys to create and close a tab and
+watches `panes()` react, which is exactly the menu/keyboard→tab-count path that
+#279 reported broken.
+
+Self-restoring: the `app` fixture is session-scoped, so the test must end on the
+same tab count it started with or it pollutes every later test's `primary_pane`.
+"""
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.driver import wait
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+
+def _tab_count(app) -> int:
+    return len(app.ctl.panes().get("tabs", []))
+
+
+def _wait_tabs(app, n: int, timeout: float = 6.0):
+    """panes is published on a render-tick throttle, so a keystroke is not
+    reflected instantly; poll until the count settles (or fail with the last)."""
+    box = {}
+
+    def check():
+        box["last"] = _tab_count(app)
+        return True if box["last"] == n else None
+
+    try:
+        wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"expected {n} tabs, last saw {box.get('last')}")
+
+
+def _wait_overlay(app, value: str, timeout: float = 4.0):
+    box = {}
+
+    def check():
+        box["last"] = app.ui_state().get("activeOverlay")
+        return True if box["last"] == value else None
+
+    try:
+        wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"expected overlay {value!r}, last saw {box.get('last')!r}")
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_new_tab_and_close_via_keyboard(app, pane):
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+
+    # Clean baseline: dismiss any startup overlay, record the tab count.
+    app.key("escape")
+    _wait_overlay(app, "none")
+    base = _tab_count(app)
+
+    # Cmd+Shift+T opens the session launcher (default new_session; macOS remaps
+    # the ctrl+shift default to cmd+shift). Its first row ("New Session",
+    # pre-selected) is action new_tab — Enter creates a plain terminal tab.
+    app.key("t", "cmd", "shift")
+    _wait_overlay(app, "session_launcher")
+    app.key("return")
+    _wait_tabs(app, base + 1)
+
+    # Cleanup: closing a focused terminal tab is guarded by a confirm overlay
+    # (close_confirm.decideClose -> .confirm_terminal); Enter accepts it.
+    app.key("w", "cmd", "shift")
+    time.sleep(0.3)  # let the confirm overlay come up before accepting
+    app.key("return")
+    _wait_tabs(app, base)

--- a/tests/macos_e2e/test_window_title.py
+++ b/tests/macos_e2e/test_window_title.py
@@ -1,0 +1,67 @@
+"""OSC window-title escape -> surface title, asserted through the control channel.
+
+A program inside the terminal sets its title with `ESC ] 0 ; <text> BEL`; the app
+parses that PTY output (Surface.scanForOscTitle -> updateTitle) and exposes it as
+the focused surface's `title` in `panes()`. This walks the whole chain (program ->
+PTY -> terminal parser -> control_api title serialization), a path `panes()`
+carried but no test asserted.
+
+The escape bytes live in an on-disk script (like test_shift_enter's probe), not in
+the command line: `wisptermctl send-text` decodes only `\\xNN` (not octal) and a
+raw ESC injected at the prompt is swallowed by the shell's line editor, so neither
+survives the input path. Run by an ASCII command, the script emits the bytes to
+PTY *output* where the terminal parses them. `sleep` holds the shell off the next
+prompt so macOS /etc/zshrc's precmd can't reset the title before the (throttled)
+panes snapshot reflects it.
+"""
+import os
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.driver import wait
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only E2E harness")
+
+_MARKER = "PHANTTY_E2E_TITLE"
+_SCRIPT = (
+    "import sys, time\n"
+    f'sys.stdout.write("\\x1b]0;{_MARKER}\\x07")\n'
+    "sys.stdout.flush()\n"
+    "time.sleep(4)\n"
+)
+
+
+def _focused_title(app, pane: str) -> str:
+    for tab in app.ctl.panes().get("tabs", []):
+        for s in tab.get("surfaces", []):
+            if s.get("id") == pane:
+                return s.get("title", "")
+    return ""
+
+
+@pytest.mark.e2e
+@pytest.mark.macos_only
+def test_osc_title_sets_surface_title(app, pane):
+    script_path = os.path.join(app.home, "osc_title_probe.py")
+    with open(script_path, "w") as f:
+        f.write(_SCRIPT)
+
+    # The `app` fixture is session-scoped: earlier real-keyboard tests can leave a
+    # partial command on this shell's prompt line. Ctrl-C aborts it so our command
+    # runs from a clean prompt rather than getting concatenated onto stray input.
+    app.send_text("\x03", pane)
+    time.sleep(0.3)
+    app.send_text("/usr/bin/python3 ~/osc_title_probe.py\n", pane)
+
+    box = {}
+
+    def check():
+        box["last"] = _focused_title(app, pane)
+        return True if _MARKER in box["last"] else None
+
+    try:
+        wait.wait_until(check, timeout=8.0, interval=0.2)
+    except wait.TimeoutError:
+        raise AssertionError(f"OSC title not reflected in panes; last title={box.get('last')!r}")


### PR DESCRIPTION
## What

Adds six real-GUI e2e tests under `tests/macos_e2e/`, exercising user input paths that the harness could already drive (once #279 unblocked synthetic input) but that had no assertions:

| Test | Path covered |
|------|--------------|
| `test_tabs` | `Cmd+Shift+T`→Enter creates a tab, `Cmd+Shift+W`→Enter (confirm overlay) closes it; asserted via `panes()` tab count |
| `test_splits` | `Cmd+Shift+=` (`split_right`) adds a surface to the active tab; `panes()` surface count |
| `test_paste` | `pbcopy` + real `Cmd+V` routes the system clipboard into the PTY |
| `test_click` | a CGEvent left-click in the terminal body arrives as an SGR mouse report (`ESC [ < … M`) — the click analog of `test_shift_enter` |
| `test_resize` | System Events resizes the window; `stty size` confirms PTY dimensions change (the #171 resize-propagation path) |
| `test_window_title` | a program's OSC `0` escape sets the focused surface title in `panes()` (PTY output → Surface parser → control_api) |

Also adds keycode `"equal"` (24) to the driver, and **excludes `tests/macos_e2e/**` from `ci.yml`'s `code` path filter**.

## Why

- These were the gaps flagged after the existing suite: real keyboard text/keys, command palette, and menu reads were covered, but tab/split topology, paste, mouse, resize→PTY, and OSC title were not.
- **CI exclusion:** this suite needs Accessibility permission + a real window server to synthesize CGEvents, so it runs *nowhere* in CI (runners can't grant `AXIsProcessTrusted()`; `conftest` skips). A pure-e2e change was triggering the full zig/windows build matrix for jobs that don't cover it. The `some`-quantifier filter still triggers zig CI when an e2e change is bundled with real code.

## Notes for reviewers

- Stateful tests **self-restore** (the `app` fixture is session-scoped) and clear the shared shell line with Ctrl-C before running, since earlier real-keyboard tests can leave partial input on the prompt.
- A few harness quirks are documented inline where they bit: `wisptermctl send-text` decodes only `\xNN` (not octal) and a raw ESC at the prompt is eaten by ZLE (hence the on-disk OSC probe); `(size of window 1) as string` concatenates with no separator (script joins items explicitly); `split_right` matches by the `+` char → `Key.plus`.
- Verified locally: `make test-macos-e2e` → **38 passed, 1 xfailed** (was 32 passed before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)