### PR TITLE
refactor(renderer): move assistant conversation renderer

### DIFF
--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -63,7 +63,7 @@ is Metal-only on Darwin). Evidence:
 
 - ~**700 raw `gl.*` call sites across 16 files**. Heaviest:
   `gl_init.zig` (123), `titlebar.zig` (113), `overlays.zig` (72),
-  `ai_chat_renderer.zig` (68), `post_process.zig` (66), `cell_renderer.zig`
+  `renderer/assistant/conversation.zig` (68), `post_process.zig` (66), `cell_renderer.zig`
   (62), `markdown_preview_renderer.zig` (44), `background_image.zig` (39),
   `fbo.zig` (33), `image_renderer.zig` (23), `file_explorer_renderer.zig` (17),
   plus the `overlays/` primitives.
@@ -246,7 +246,7 @@ with **A**. **D** is deferred until a macOS SDK environment exists.
   `Renderer.zig:14` shortcut. *Ghostty: `renderer/opengl/`.*
 - **A3** Convert renderer files from raw `gl.*` to `gpu.zig` primitives, and
   **split each file's presentation vs. logic in the same pass** (one touch
-  each): `cell_renderer`, `titlebar`, `overlays`, `ai_chat_renderer`,
+  each): `cell_renderer`, `titlebar`, `overlays`, `renderer/assistant/conversation.zig`,
   `image_renderer`, `post_process`, `background_image`, `fbo`,
   `markdown_preview_renderer`, `file_explorer_renderer`. *Ghostty:
   API-agnostic `renderer/cell.zig`, `cursor.zig`, `image.zig`.*

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -112,7 +112,7 @@ pub const browser_panel = if (build_options.webview)
     @import("browser/panel.zig")
 else
     @import("browser/panel_stub.zig");
-pub const ai_chat_renderer = @import("renderer/ai_chat_renderer.zig");
+pub const assistant_conversation_renderer = @import("renderer/assistant/conversation.zig");
 pub const ai_history_renderer = @import("renderer/ai_history_renderer.zig");
 const skill_center_renderer = @import("renderer/skill_center_renderer.zig");
 const port_forwarding_renderer = @import("renderer/port_forwarding_renderer.zig");
@@ -1728,7 +1728,7 @@ fn renderAiChatFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, le
     if (activeAiChat()) |session| {
         const chat_x = left_panels_w;
         const chat_w = @as(f32, @floatFromInt(fb_width)) - left_panels_w - right_panels_w;
-        ai_chat_renderer.render(
+        assistant_conversation_renderer.render(
             session,
             @floatFromInt(fb_width),
             @floatFromInt(fb_height),
@@ -2024,7 +2024,7 @@ fn renderAiCopilotPanel(fb_width: c_int, fb_height: c_int, titlebar_offset: f32)
     const bounds = ai_sidebar.boundsForWindow(@intCast(fb_width), @intCast(fb_height), titlebar_offset, left, 0);
     const chat_x: f32 = @floatFromInt(bounds.left);
     const chat_w: f32 = @floatFromInt(bounds.right - bounds.left);
-    ai_chat_renderer.render(session, @floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, chat_x, chat_w, true); // copilot sidebar: status shown as a colored dot
+    assistant_conversation_renderer.render(session, @floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset, chat_x, chat_w, true); // copilot sidebar: status shown as a colored dot
     renderAiCopilotCloseButton(bounds, @floatFromInt(fb_height));
 }
 
@@ -2034,7 +2034,7 @@ fn renderAiCopilotCloseButton(bounds: ai_sidebar.Bounds, window_height: f32) voi
         .left = @floatFromInt(bounds.left),
         .right = @floatFromInt(bounds.right),
         .top = @floatFromInt(bounds.top),
-        .height = ai_chat_renderer.HEADER_H,
+        .height = assistant_conversation_renderer.HEADER_H,
     };
     const close = hit_test.panelCloseButtonRect(layout) orelse return;
     const close_x: f32 = @floatCast(close.left);
@@ -5779,13 +5779,13 @@ fn syncAiChatImeCaret(win: *window_backend.Window, session: *ai_chat.Session, ch
     const wh: f32 = @floatFromInt(size.height);
     session.mutex.lock();
     const input_text = session.input();
-    const layout = ai_chat_renderer.inputLayout(chat_x, chat_w, input_text);
-    const cursor = ai_chat_renderer.inputCursorRect(input_text, session.inputCursorLocked(), layout.text_x, layout.text_w);
+    const layout = assistant_conversation_renderer.inputLayout(chat_x, chat_w, input_text);
+    const cursor = assistant_conversation_renderer.inputCursorRect(input_text, session.inputCursorLocked(), layout.text_x, layout.text_w);
     const scrolled_row = session.input_scroll_row;
     const follow_cursor = session.input_scroll_follow_cursor;
     session.mutex.unlock();
     const input_line_h = @round(@max(23.0, font.g_titlebar_cell_height + 8.0));
-    const visible_rows = ai_chat_renderer.inputVisibleRowsForField(layout.field_h);
+    const visible_rows = assistant_conversation_renderer.inputVisibleRowsForField(layout.field_h);
     var first_row = scrolled_row;
     if (follow_cursor) {
         if (cursor.row < first_row) {
@@ -5797,7 +5797,7 @@ fn syncAiChatImeCaret(win: *window_backend.Window, session: *ai_chat.Session, ch
     if (cursor.row < first_row) return;
     const row = cursor.row - first_row;
     const field_top_px = wh - layout.field_y - layout.field_h;
-    const cursor_top_px = field_top_px + ai_chat_renderer.INPUT_FIELD_PAD_TOP + @as(f32, @floatFromInt(row)) * input_line_h;
+    const cursor_top_px = field_top_px + assistant_conversation_renderer.INPUT_FIELD_PAD_TOP + @as(f32, @floatFromInt(row)) * input_line_h;
     const cursor_y = cursor_top_px;
     const h = font.g_titlebar_cell_height;
     window_backend.setImeCaret(

--- a/src/assistant/conversation/layout.zig
+++ b/src/assistant/conversation/layout.zig
@@ -2,7 +2,7 @@
 //!
 //! No GL, font, or platform imports so it can be unit-tested in the fast test
 //! build (mirrors composer_layout.zig / scrollbar_model.zig,
-//! extracted for the same reason — src/renderer/ai_chat_renderer.zig @cImports
+//! extracted for the same reason — src/renderer/assistant/conversation.zig @cImports
 //! OpenGL historically and the font globals are not part of the test build).
 //! Callers pass font-derived metrics (e.g. header_h) and layout constants as
 //! params; this module owns none of them.

--- a/src/assistant/conversation/scrollbar_model.zig
+++ b/src/assistant/conversation/scrollbar_model.zig
@@ -2,7 +2,7 @@
 //!
 //! No GL or platform imports so it can be unit-tested in test_main.zig
 //! (mirrors src/scrollbar_model.zig, which the terminal scrollbar extracted
-//! for the same reason — src/renderer/ai_chat_renderer.zig @cImports OpenGL
+//! for the same reason — src/renderer/assistant/conversation.zig @cImports OpenGL
 //! and is not part of the test build).
 
 const std = @import("std");

--- a/src/input.zig
+++ b/src/input.zig
@@ -2047,8 +2047,8 @@ pub fn cancelTransientMouseState(win: anytype) void {
     g_ai_input_scroll_chat = null;
     g_ai_transcript_scroll_dragging = false;
     g_ai_transcript_scroll_chat = null;
-    AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = false;
-    AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = false;
+    AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_dragging = false;
+    AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_hover = false;
     g_ai_transcript_scroll_panel = .active_chat;
     g_ai_transcript_selecting = false;
     g_ai_transcript_select_chat = null;
@@ -3585,7 +3585,7 @@ fn aiChatInputWrapCols() usize {
     const size = clientSize(win);
     const ww: f32 = @floatFromInt(size.width);
     const panel_w = @max(1.0, ww - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidth());
-    return AppWindow.ai_chat_renderer.inputWrapColumns(panel_w);
+    return AppWindow.assistant_conversation_renderer.inputWrapColumns(panel_w);
 }
 
 /// Wrap columns for the AI copilot sidebar's composer. Mirrors
@@ -3595,7 +3595,7 @@ fn aiCopilotInputWrapCols() usize {
     const win = AppWindow.g_window orelse return std.math.maxInt(usize);
     const size = clientSize(win);
     const panel_w = AppWindow.aiCopilotWidth(size.width);
-    return AppWindow.ai_chat_renderer.inputWrapColumns(panel_w);
+    return AppWindow.assistant_conversation_renderer.inputWrapColumns(panel_w);
 }
 
 fn handleBrowserUrlBarKey(ev: platform_input.KeyEvent) void {
@@ -3839,7 +3839,7 @@ fn aiCopilotHeaderLayout() ?hit_test.PanelHeaderLayout {
         .left = @floatFromInt(bounds.left),
         .right = @floatFromInt(bounds.right),
         .top = @floatFromInt(bounds.top),
-        .height = @floatCast(AppWindow.ai_chat_renderer.HEADER_H),
+        .height = @floatCast(AppWindow.assistant_conversation_renderer.HEADER_H),
     };
 }
 
@@ -5385,7 +5385,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         if (AppWindow.activeAiChat()) |chat| {
             const win = AppWindow.g_window orelse return;
             const fb = window_backend.framebufferSize(win);
-            if (AppWindow.ai_chat_renderer.inputFieldMetricsAt(
+            if (AppWindow.assistant_conversation_renderer.inputFieldMetricsAt(
                 chat,
                 xpos,
                 ypos,
@@ -5541,7 +5541,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                         focusAiCopilot();
                         const chat_x: f32 = @floatFromInt(bounds.left);
                         const chat_w: f32 = @floatFromInt(bounds.right - bounds.left);
-                        if (AppWindow.ai_chat_renderer.stopButtonHitTest(
+                        if (AppWindow.assistant_conversation_renderer.stopButtonHitTest(
                             chat,
                             xpos,
                             ypos,
@@ -5555,7 +5555,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             requestInputRepaint();
                             return;
                         }
-                        if (AppWindow.ai_chat_renderer.missingApiKeyStatusHitTest(
+                        if (AppWindow.assistant_conversation_renderer.missingApiKeyStatusHitTest(
                             chat,
                             xpos,
                             ypos,
@@ -5569,7 +5569,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             requestInputRepaint();
                             return;
                         }
-                        if (AppWindow.ai_chat_renderer.interactionHitTest(
+                        if (AppWindow.assistant_conversation_renderer.interactionHitTest(
                             chat,
                             xpos,
                             ypos,
@@ -5596,7 +5596,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             }
                             return;
                         }
-                        if (AppWindow.ai_chat_renderer.modelLabelHitTest(
+                        if (AppWindow.assistant_conversation_renderer.modelLabelHitTest(
                             chat,
                             xpos,
                             ypos,
@@ -5609,7 +5609,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             requestInputRepaint();
                             return;
                         }
-                        if (AppWindow.ai_chat_renderer.permissionChipHitTest(
+                        if (AppWindow.assistant_conversation_renderer.permissionChipHitTest(
                             xpos,
                             ypos,
                             @floatFromInt(fb.width),
@@ -5620,7 +5620,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             toggleAiAgentPermission();
                             return;
                         }
-                        if (AppWindow.ai_chat_renderer.transcriptScrollbarHitTest(
+                        if (AppWindow.assistant_conversation_renderer.transcriptScrollbarHitTest(
                             chat,
                             xpos,
                             ypos,
@@ -5634,13 +5634,13 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             g_ai_transcript_scroll_chat = chat;
                             g_ai_transcript_scroll_drag_offset = drag_offset;
                             g_ai_transcript_scroll_panel = .copilot_sidebar;
-                            AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = true;
+                            AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_dragging = true;
                             applyAiTranscriptScrollbarDrag(chat, ypos);
                             requestInputRepaint();
                             return;
                         }
                         if (!ev.ctrl and !ev.alt) {
-                            if (AppWindow.ai_chat_renderer.transcriptTextHitTest(
+                            if (AppWindow.assistant_conversation_renderer.transcriptTextHitTest(
                                 chat,
                                 xpos,
                                 ypos,
@@ -5674,7 +5674,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             if (AppWindow.activeAiChat()) |chat| {
                 const win = AppWindow.g_window orelse return;
                 const fb = window_backend.framebufferSize(win);
-                if (AppWindow.ai_chat_renderer.stopButtonHitTest(
+                if (AppWindow.assistant_conversation_renderer.stopButtonHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5688,7 +5688,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     requestInputRepaint();
                     return;
                 }
-                if (AppWindow.ai_chat_renderer.missingApiKeyStatusHitTest(
+                if (AppWindow.assistant_conversation_renderer.missingApiKeyStatusHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5702,7 +5702,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     requestInputRepaint();
                     return;
                 }
-                if (AppWindow.ai_chat_renderer.interactionHitTest(
+                if (AppWindow.assistant_conversation_renderer.interactionHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5729,7 +5729,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     }
                     return;
                 }
-                if (AppWindow.ai_chat_renderer.modelLabelHitTest(
+                if (AppWindow.assistant_conversation_renderer.modelLabelHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5742,7 +5742,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     requestInputRepaint();
                     return;
                 }
-                if (AppWindow.ai_chat_renderer.permissionChipHitTest(
+                if (AppWindow.assistant_conversation_renderer.permissionChipHitTest(
                     xpos,
                     ypos,
                     @floatFromInt(fb.width),
@@ -5753,7 +5753,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     toggleAiAgentPermission();
                     return;
                 }
-                if (AppWindow.ai_chat_renderer.transcriptScrollbarHitTest(
+                if (AppWindow.assistant_conversation_renderer.transcriptScrollbarHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5767,13 +5767,13 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     g_ai_transcript_scroll_chat = chat;
                     g_ai_transcript_scroll_drag_offset = drag_offset;
                     g_ai_transcript_scroll_panel = .active_chat;
-                    AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = true;
+                    AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_dragging = true;
                     applyAiTranscriptScrollbarDrag(chat, ypos);
                     requestInputRepaint();
                     return;
                 }
                 if (!ev.ctrl and !ev.alt) {
-                    if (AppWindow.ai_chat_renderer.transcriptTextHitTest(
+                    if (AppWindow.assistant_conversation_renderer.transcriptTextHitTest(
                         chat,
                         xpos,
                         ypos,
@@ -5793,7 +5793,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                         return;
                     }
                 }
-                if (AppWindow.ai_chat_renderer.inputScrollbarHitTest(
+                if (AppWindow.assistant_conversation_renderer.inputScrollbarHitTest(
                     chat,
                     xpos,
                     ypos,
@@ -5913,7 +5913,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             g_ai_transcript_scroll_dragging = false;
             g_ai_transcript_scroll_chat = null;
             g_ai_transcript_scroll_panel = .active_chat;
-            AppWindow.ai_chat_renderer.g_transcript_scrollbar_dragging = false;
+            AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_dragging = false;
             if (g_ai_transcript_selecting) {
                 if (g_ai_transcript_select_chat) |chat| {
                     if (chat.finishTranscriptSelection() and g_ai_transcript_select_auto_copy) copyAiChatToClipboard(chat);
@@ -6108,7 +6108,7 @@ fn hitTestPlusButton(xpos: f64) bool {
 fn applyAiInputScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) void {
     const win = AppWindow.g_window orelse return;
     const size = clientSize(win);
-    if (AppWindow.ai_chat_renderer.inputScrollbarDragRowAt(
+    if (AppWindow.assistant_conversation_renderer.inputScrollbarDragRowAt(
         chat,
         ypos,
         @floatFromInt(size.width),
@@ -6124,7 +6124,7 @@ fn applyAiInputScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) void {
 
 fn applyAiTranscriptScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) void {
     const geometry = aiTranscriptPanelGeometry(g_ai_transcript_scroll_panel) orelse return;
-    if (AppWindow.ai_chat_renderer.transcriptScrollbarScrollPxAt(
+    if (AppWindow.assistant_conversation_renderer.transcriptScrollbarScrollPxAt(
         chat,
         ypos,
         geometry.window_width,
@@ -6141,7 +6141,7 @@ fn applyAiTranscriptScrollbarDrag(chat: *AppWindow.ai_chat.Session, ypos: f64) v
 
 fn updateAiTranscriptSelectionDrag(chat: *AppWindow.ai_chat.Session, xpos: f64, ypos: f64) void {
     const geometry = aiTranscriptPanelGeometry(g_ai_transcript_select_panel) orelse return;
-    if (AppWindow.ai_chat_renderer.transcriptTextHitTest(
+    if (AppWindow.assistant_conversation_renderer.transcriptTextHitTest(
         chat,
         xpos,
         ypos,
@@ -6214,7 +6214,7 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
     if (AppWindow.g_window) |hover_win| {
         if (AppWindow.activeAiChat()) |chat| {
             const hover_fb = window_backend.framebufferSize(hover_win);
-            const over = AppWindow.ai_chat_renderer.transcriptScrollbarHitTest(
+            const over = AppWindow.assistant_conversation_renderer.transcriptScrollbarHitTest(
                 chat,
                 xpos,
                 ypos,
@@ -6224,12 +6224,12 @@ fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
                 AppWindow.leftPanelsWidth(),
                 @as(f32, @floatFromInt(hover_fb.width)) - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidthForWindow(hover_fb.width),
             ) != null;
-            if (over != AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover) {
-                AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = over;
+            if (over != AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_hover) {
+                AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_hover = over;
                 requestInputRebuild();
             }
-        } else if (AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover) {
-            AppWindow.ai_chat_renderer.g_transcript_scrollbar_hover = false;
+        } else if (AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_hover) {
+            AppWindow.assistant_conversation_renderer.g_transcript_scrollbar_hover = false;
             requestInputRebuild();
         }
     }
@@ -6734,7 +6734,7 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         const left = @as(i32, @intFromFloat(AppWindow.leftPanelsWidth()));
         const right = size.width - @as(i32, @intFromFloat(AppWindow.rightPanelsWidthForWindow(size.width)));
         if (ev.xpos >= left and ev.xpos < right) {
-            if (AppWindow.ai_chat_renderer.inputFieldMetricsAt(
+            if (AppWindow.assistant_conversation_renderer.inputFieldMetricsAt(
                 chat,
                 @floatFromInt(ev.xpos),
                 @floatFromInt(ev.ypos),
@@ -6773,7 +6773,7 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
             if (ev.xpos >= bounds.left and ev.xpos < bounds.right and ev.ypos >= bounds.top and ev.ypos < bounds.bottom) {
                 const chat_x: f32 = @floatFromInt(bounds.left);
                 const chat_w: f32 = @floatFromInt(bounds.right - bounds.left);
-                if (AppWindow.ai_chat_renderer.inputFieldMetricsAt(
+                if (AppWindow.assistant_conversation_renderer.inputFieldMetricsAt(
                     chat,
                     @floatFromInt(ev.xpos),
                     @floatFromInt(ev.ypos),

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -1,14 +1,14 @@
-//! Native renderer for AI Chat sessions.
+//! Native renderer for assistant conversation sessions.
 
 const std = @import("std");
-const AppWindow = @import("../AppWindow.zig");
-const ai_chat = @import("../assistant/conversation/session.zig");
-const ai_model_switch = @import("../assistant/conversation/model_switch.zig");
-const i18n = @import("../i18n.zig");
-const composer_layout = @import("../assistant/conversation/composer_layout.zig");
-const scrollbar_model = @import("../assistant/conversation/scrollbar_model.zig");
-const md = @import("../markdown_text.zig");
-const detail_wrap = @import("../composer_detail_wrap.zig");
+const AppWindow = @import("../../AppWindow.zig");
+const ai_chat = @import("../../assistant/conversation/session.zig");
+const ai_model_switch = @import("../../assistant/conversation/model_switch.zig");
+const i18n = @import("../../i18n.zig");
+const composer_layout = @import("../../assistant/conversation/composer_layout.zig");
+const scrollbar_model = @import("../../assistant/conversation/scrollbar_model.zig");
+const md = @import("../../markdown_text.zig");
+const detail_wrap = @import("../../composer_detail_wrap.zig");
 
 // Transcript scrollbar interaction state (one mouse). Set by input.zig,
 // read by the fade computation in renderTranscriptScrollbar.
@@ -25,8 +25,8 @@ const tableBlockEnd = md.tableBlockEnd;
 
 const font = AppWindow.font;
 const titlebar = AppWindow.titlebar;
-const ui_pipeline = @import("ui_pipeline.zig");
-const ai_chat_layout = @import("../assistant/conversation/layout.zig");
+const ui_pipeline = @import("../ui_pipeline.zig");
+const ai_chat_layout = @import("../../assistant/conversation/layout.zig");
 
 pub const LINE_PAD_X: f32 = 18;
 pub const HEADER_H: f32 = 54;

--- a/src/renderer/gpu/gl_backend_guard.zig
+++ b/src/renderer/gpu/gl_backend_guard.zig
@@ -30,7 +30,7 @@ const gl_context_bypass = "gpu.Context.gl";
 const src_app_window = @embedFile("../../AppWindow.zig");
 const src_font_manager = @embedFile("../../font/manager.zig");
 const src_titlebar = @embedFile("../titlebar.zig");
-const src_ai_chat = @embedFile("../ai_chat_renderer.zig");
+const src_assistant_conversation = @embedFile("../assistant/conversation.zig");
 const src_file_explorer = @embedFile("../file_explorer_renderer.zig");
 const src_markdown = @embedFile("../markdown_preview_renderer.zig");
 const src_overlays = @embedFile("../overlays.zig");
@@ -54,7 +54,7 @@ const glad_free = [_]Entry{
     .{ .name = "AppWindow.zig", .source = src_app_window },
     .{ .name = "font/manager.zig", .source = src_font_manager },
     .{ .name = "renderer/titlebar.zig", .source = src_titlebar },
-    .{ .name = "renderer/ai_chat_renderer.zig", .source = src_ai_chat },
+    .{ .name = "renderer/assistant/conversation.zig", .source = src_assistant_conversation },
     .{ .name = "renderer/file_explorer_renderer.zig", .source = src_file_explorer },
     .{ .name = "renderer/markdown_preview_renderer.zig", .source = src_markdown },
     .{ .name = "renderer/overlays.zig", .source = src_overlays },
@@ -78,7 +78,7 @@ const raw_gl_free = [_]Entry{
     .{ .name = "renderer/post_process.zig", .source = src_post_process },
     .{ .name = "renderer/Renderer.zig", .source = src_renderer },
     .{ .name = "renderer/titlebar.zig", .source = src_titlebar },
-    .{ .name = "renderer/ai_chat_renderer.zig", .source = src_ai_chat },
+    .{ .name = "renderer/assistant/conversation.zig", .source = src_assistant_conversation },
     .{ .name = "renderer/file_explorer_renderer.zig", .source = src_file_explorer },
     .{ .name = "renderer/markdown_preview_renderer.zig", .source = src_markdown },
     .{ .name = "renderer/image_renderer.zig", .source = src_image },


### PR DESCRIPTION
## Summary
- move `src/renderer/ai_chat_renderer.zig` to `src/renderer/assistant/conversation.zig`
- rename the AppWindow re-export to `assistant_conversation_renderer`
- update input call sites, GL backend guard embeds, and active docs/comments

## Validation
- `zig build test`
- `zig build test-full -Dtarget=native`
- `git diff --check`
- Windows checkout safety equivalent: 0 name violations, 0 casefold collisions, no tracked symlinks