### PR TITLE
refactor(renderer): move terminal agent sessions renderer

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -113,7 +113,7 @@ pub const browser_panel = if (build_options.webview)
 else
     @import("browser/panel_stub.zig");
 pub const assistant_conversation_renderer = @import("renderer/assistant/conversation.zig");
-pub const ai_history_renderer = @import("renderer/ai_history_renderer.zig");
+pub const terminal_agent_sessions_renderer = @import("renderer/terminal_agents/sessions.zig");
 const skill_center_renderer = @import("renderer/skill_center_renderer.zig");
 const port_forwarding_renderer = @import("renderer/port_forwarding_renderer.zig");
 const ai_sidebar = @import("assistant/sidebar/panel.zig");
@@ -1752,7 +1752,7 @@ fn renderAiHistoryFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int
     titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     file_explorer_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     if (active_tab.ai_history_session) |session| {
-        const draw: ai_history_renderer.DrawContext = .{
+        const draw: terminal_agent_sessions_renderer.DrawContext = .{
             .bg = g_theme.background,
             .fg = g_theme.foreground,
             .accent = g_theme.cursor_color,
@@ -1764,7 +1764,7 @@ fn renderAiHistoryFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_int
         };
         session.mutex.lock();
         defer session.mutex.unlock();
-        ai_history_renderer.render(
+        terminal_agent_sessions_renderer.render(
             draw,
             session,
             @floatFromInt(fb_width),
@@ -2916,10 +2916,10 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
     const left = leftPanelsWidth();
     const right = rightPanelsWidthForWindow(fb.width);
     const width = @as(f32, @floatFromInt(fb.width)) - left - right;
-    const visible_rows = ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight(), font.g_titlebar_cell_height);
+    const visible_rows = terminal_agent_sessions_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight(), font.g_titlebar_cell_height);
 
     session.mutex.lock();
-    const hit = ai_history_renderer.interactionHitTest(
+    const hit = terminal_agent_sessions_renderer.interactionHitTest(
         session,
         @floatFromInt(fb.width),
         @floatFromInt(fb.height),
@@ -3015,7 +3015,7 @@ fn tickAllPreviewPanes() bool {
 fn aiHistoryListVisibleRowsForWindow() usize {
     const win = g_window orelse return 1;
     const fb = window_backend.framebufferSize(win);
-    return ai_history_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight(), font.g_titlebar_cell_height);
+    return terminal_agent_sessions_renderer.listVisibleCapacity(@floatFromInt(fb.height), currentTitlebarHeight(), font.g_titlebar_cell_height);
 }
 
 /// Number of day rows (excluding the pinned "All dates") visible in the DATE
@@ -3024,8 +3024,8 @@ fn aiHistoryDateDaySlotsForWindow() usize {
     const win = g_window orelse return 0;
     const fb = window_backend.framebufferSize(win);
     const cell_h = font.g_titlebar_cell_height;
-    const lc = ai_history_renderer.leftColumnLayout(currentTitlebarHeight(), cell_h);
-    const cap = ai_history_renderer.dateVisibleCapacity(@floatFromInt(fb.height), lc.date_rows_top, cell_h);
+    const lc = terminal_agent_sessions_renderer.leftColumnLayout(currentTitlebarHeight(), cell_h);
+    const cap = terminal_agent_sessions_renderer.dateVisibleCapacity(@floatFromInt(fb.height), lc.date_rows_top, cell_h);
     return if (cap > 1) cap - 1 else 0;
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -6713,7 +6713,7 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
         const left_f = AppWindow.leftPanelsWidth();
         const right_f = @as(f32, @floatFromInt(size.width)) - AppWindow.rightPanelsWidthForWindow(size.width);
         const content_w = @max(0, right_f - left_f);
-        const layout = AppWindow.ai_history_renderer.computeLayout(left_f, content_w);
+        const layout = AppWindow.terminal_agent_sessions_renderer.computeLayout(left_f, content_w);
         const x: f32 = @floatFromInt(ev.xpos);
         if (x >= layout.detail_x and x < layout.detail_x + layout.detail_w) {
             const units: i32 = @intCast(mouseWheelUnits(ev.delta));

--- a/src/renderer/terminal_agents/sessions.zig
+++ b/src/renderer/terminal_agents/sessions.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const ai_history_session = @import("../terminal_agents/sessions/session.zig");
-const types = @import("../terminal_agents/sessions/types.zig");
-const i18n = @import("../i18n.zig");
-const text_search = @import("../text_search.zig");
-const panel_draw = @import("panel_draw.zig");
+const ai_history_session = @import("../../terminal_agents/sessions/session.zig");
+const types = @import("../../terminal_agents/sessions/types.zig");
+const i18n = @import("../../i18n.zig");
+const text_search = @import("../../text_search.zig");
+const panel_draw = @import("../panel_draw.zig");
 
 const HEADER_H: f32 = 54;
 const FILTER_H: f32 = 42;
@@ -820,7 +820,7 @@ fn rectContains(x: f32, y: f32, left: f32, top: f32, width: f32, height: f32) bo
         y >= top and y < top + height;
 }
 
-test "ai_history_renderer: left count column fits three digit counts" {
+test "terminal agent sessions renderer: left count column fits three digit counts" {
     const Advance = struct {
         fn twentyPx(_: u32) f32 {
             return 20;
@@ -830,7 +830,7 @@ test "ai_history_renderer: left count column fits three digit counts" {
     try std.testing.expectEqual(@as(f32, 60), countColumnWidth("896", Advance.twentyPx));
 }
 
-test "ai_history_renderer: list row lines never overlap as ui font grows" {
+test "terminal agent sessions renderer: list row lines never overlap as ui font grows" {
     const cell_heights = [_]f32{ 12, 16, 18, 22, 28, 32, 40 };
     for (cell_heights) |cell_h| {
         const lines = rowTextLayout(cell_h);
@@ -842,13 +842,13 @@ test "ai_history_renderer: list row lines never overlap as ui font grows" {
     }
 }
 
-test "ai_history_renderer: hit test maps list rows" {
+test "terminal agent sessions renderer: hit test maps list rows" {
     const layout = computeLayout(0, 1000);
     const hit = hitTest(layout, layout.list_x + 10, 120, 100, 24, 5);
     try std.testing.expectEqual(@as(usize, 0), hit.row);
 }
 
-test "ai_history_renderer: layout keeps a readable detail column" {
+test "terminal agent sessions renderer: layout keeps a readable detail column" {
     const layout = computeLayout(0, 1200);
     try std.testing.expect(layout.left_w >= 180);
     try std.testing.expect(layout.list_w >= 260);
@@ -857,7 +857,7 @@ test "ai_history_renderer: layout keeps a readable detail column" {
     try std.testing.expectEqual(layout.list_x + layout.list_w, layout.detail_x);
 }
 
-test "ai_history_renderer: narrow layout stays inside available width" {
+test "terminal agent sessions renderer: narrow layout stays inside available width" {
     const layout = computeLayout(10, 300);
     try std.testing.expect(layout.left_w >= 0);
     try std.testing.expect(layout.list_w >= 0);
@@ -867,7 +867,7 @@ test "ai_history_renderer: narrow layout stays inside available width" {
     try std.testing.expect(layout.detail_x + layout.detail_w <= 310.001);
 }
 
-test "ai_history_renderer: zero width layout has no columns" {
+test "terminal agent sessions renderer: zero width layout has no columns" {
     const layout = computeLayout(20, 0);
     try std.testing.expectEqual(@as(f32, 0), layout.left_w);
     try std.testing.expectEqual(@as(f32, 0), layout.list_w);
@@ -877,7 +877,7 @@ test "ai_history_renderer: zero width layout has no columns" {
     try std.testing.expectEqual(@as(f32, 20), layout.detail_x);
 }
 
-test "ai_history_renderer: interaction hit test maps buttons and row offset" {
+test "terminal agent sessions renderer: interaction hit test maps buttons and row offset" {
     const FakeSession = struct {
         date_offset: usize = 0,
         fn visibleCount(_: @This()) usize {
@@ -927,7 +927,7 @@ fn collectWrapped(text: []const u8, max_w: f32, out: *std.ArrayList([]const u8))
     while (it.next()) |line| try out.append(std.testing.allocator, line);
 }
 
-test "ai_history_renderer: LineWrap hard-wraps when text exceeds width" {
+test "terminal agent sessions renderer: LineWrap hard-wraps when text exceeds width" {
     var lines: std.ArrayList([]const u8) = .empty;
     defer lines.deinit(std.testing.allocator);
     // max_w 35 fits three 10px glyphs (30) but not four (40).
@@ -938,7 +938,7 @@ test "ai_history_renderer: LineWrap hard-wraps when text exceeds width" {
     try std.testing.expectEqualStrings("g", lines.items[2]);
 }
 
-test "ai_history_renderer: LineWrap breaks on explicit newlines" {
+test "terminal agent sessions renderer: LineWrap breaks on explicit newlines" {
     var lines: std.ArrayList([]const u8) = .empty;
     defer lines.deinit(std.testing.allocator);
     try collectWrapped("ab\n\ncd", 1000, &lines);
@@ -948,7 +948,7 @@ test "ai_history_renderer: LineWrap breaks on explicit newlines" {
     try std.testing.expectEqualStrings("cd", lines.items[2]);
 }
 
-test "ai_history_renderer: LineWrap prefers a space boundary when wrapping" {
+test "terminal agent sessions renderer: LineWrap prefers a space boundary when wrapping" {
     var lines: std.ArrayList([]const u8) = .empty;
     defer lines.deinit(std.testing.allocator);
     // "ab cd ef" at max_w 55: "ab cd " would need 60px, so break at the first space.
@@ -958,7 +958,7 @@ test "ai_history_renderer: LineWrap prefers a space boundary when wrapping" {
     try std.testing.expectEqualStrings("cd ef", lines.items[1]);
 }
 
-test "ai_history_renderer: LineWrap always advances past an oversized glyph" {
+test "terminal agent sessions renderer: LineWrap always advances past an oversized glyph" {
     var lines: std.ArrayList([]const u8) = .empty;
     defer lines.deinit(std.testing.allocator);
     // max_w smaller than one glyph must still emit one glyph per line, not loop.
@@ -966,13 +966,13 @@ test "ai_history_renderer: LineWrap always advances past an oversized glyph" {
     try std.testing.expectEqual(@as(usize, 3), lines.items.len);
 }
 
-test "ai_history_renderer: LineWrap counts wrapped lines" {
+test "terminal agent sessions renderer: LineWrap counts wrapped lines" {
     try std.testing.expectEqual(@as(usize, 3), wrappedLineCount("abcdefg", 35, tenPxAdvance));
     try std.testing.expectEqual(@as(usize, 1), wrappedLineCount("ab", 1000, tenPxAdvance));
     try std.testing.expectEqual(@as(usize, 0), wrappedLineCount("", 1000, tenPxAdvance));
 }
 
-test "ai_history_renderer: transcriptLineTotal counts a role line plus wrapped content per message" {
+test "terminal agent sessions renderer: transcriptLineTotal counts a role line plus wrapped content per message" {
     const Msg = struct { content: []const u8 };
     const msgs = [_]Msg{
         .{ .content = "abcdefg" }, // 1 role + 3 wrapped = 4
@@ -982,14 +982,14 @@ test "ai_history_renderer: transcriptLineTotal counts a role line plus wrapped c
     try std.testing.expectEqual(@as(usize, 7), transcriptLineTotal(&msgs, 35, tenPxAdvance));
 }
 
-test "ai_history_renderer: clampScroll keeps scroll within the scrollable range" {
+test "terminal agent sessions renderer: clampScroll keeps scroll within the scrollable range" {
     try std.testing.expectEqual(@as(usize, 0), clampScroll(5, 3, 10)); // everything fits
     try std.testing.expectEqual(@as(usize, 2), clampScroll(5, 12, 10)); // clamped to max
     try std.testing.expectEqual(@as(usize, 1), clampScroll(1, 12, 10)); // within range
     try std.testing.expectEqual(@as(usize, 0), clampScroll(0, 12, 10));
 }
 
-test "ai_history_renderer: left column layout is ordered top to bottom" {
+test "terminal agent sessions renderer: left column layout is ordered top to bottom" {
     const lc = leftColumnLayout(40, 16);
     try std.testing.expect(lc.source_name_top < lc.status_label_top);
     try std.testing.expect(lc.status_label_top < lc.status_value_top);
@@ -1000,7 +1000,7 @@ test "ai_history_renderer: left column layout is ordered top to bottom" {
     try std.testing.expectEqual(lc.retry_text_top - BUTTON_PAD_Y, refreshButtonTop(40, 16));
 }
 
-test "ai_history_renderer: interaction hit test maps category rows" {
+test "terminal agent sessions renderer: interaction hit test maps category rows" {
     const FakeSession = struct {
         date_offset: usize = 0,
         fn visibleCount(_: @This()) usize {
@@ -1051,7 +1051,7 @@ test "ai_history_renderer: interaction hit test maps category rows" {
     );
 }
 
-test "ai_history_renderer: interaction hit test maps date rows" {
+test "terminal agent sessions renderer: interaction hit test maps date rows" {
     const FakeSession = struct {
         date_offset: usize = 0,
         fn visibleCount(_: @This()) usize {

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -680,7 +680,7 @@ comptime {
     _ = @import("terminal_agents/sessions/cache.zig");
     _ = @import("terminal_agents/sessions/resume.zig");
     _ = @import("terminal_agents/sessions/session.zig");
-    _ = @import("renderer/ai_history_renderer.zig");
+    _ = @import("renderer/terminal_agents/sessions.zig");
     _ = @import("terminal_agents/detector.zig");
     _ = @import("Surface.zig");
     _ = @import("termio/Mailbox.zig");


### PR DESCRIPTION
## Summary
- move `src/renderer/ai_history_renderer.zig` to `src/renderer/terminal_agents/sessions.zig`
- rename the AppWindow re-export to `terminal_agent_sessions_renderer`
- update input call sites, test imports, and renderer test names

## Validation
- `zig build test`
- `zig build test-full -Dtarget=native`
- `git diff --check`
- Windows checkout safety equivalent: 0 name violations, 0 casefold collisions, no tracked symlinks