### PR TITLE
[codex] Add assistant token speed metrics

### DIFF
--- a/src/assistant/conversation/request.zig
+++ b/src/assistant/conversation/request.zig
@@ -683,6 +683,7 @@ fn runChatRequestStreaming(request: *const ChatRequest) !void {
 
     const message_idx = try ai_chat.beginAssistantStream(request.session);
     var usage: ?ApiUsage = null;
+    var first_token_ms: i64 = 0;
     while (true) {
         if (ai_chat.requestCancelled(request)) return error.Canceled;
         const line = reader.takeDelimiter('\n') catch |err| {
@@ -694,9 +695,9 @@ fn runChatRequestStreaming(request: *const ChatRequest) !void {
         } orelse break;
 
         if (ai_chat.requestCancelled(request)) return error.Canceled;
-        if (try ai_chat.applyApiStreamLineToSession(allocator, request.session, message_idx, line, &usage)) break;
+        if (try ai_chat.applyApiStreamLineToSession(allocator, request.session, message_idx, line, &usage, &first_token_ms)) break;
     }
-    ai_chat.finishAssistantStream(request.session, message_idx, request.started_ms, usage);
+    ai_chat.finishAssistantStream(request.session, message_idx, request.started_ms, first_token_ms, usage);
 }
 
 fn networkFailureResult(allocator: std.mem.Allocator, endpoint: []const u8, err: anyerror) !ApiResult {

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -4267,13 +4267,49 @@ fn composeSystemPromptWithMemory(
     return std.fmt.allocPrint(allocator, "{s}\n\n{s}", .{ base, block });
 }
 
-fn allocUsageFooter(allocator: std.mem.Allocator, started_ms: i64, usage: ?ApiUsage) !?[]u8 {
+fn tokenRateTenths(completion_tokens: u64, elapsed_ms: i64) ?u64 {
+    if (completion_tokens == 0 or elapsed_ms <= 0) return null;
+    const elapsed: u128 = @intCast(elapsed_ms);
+    const rate = (@as(u128, completion_tokens) * 10_000 + elapsed / 2) / elapsed;
+    return @intCast(@min(rate, std.math.maxInt(u64)));
+}
+
+fn allocUsageFooter(allocator: std.mem.Allocator, started_ms: i64, first_token_ms: i64, usage: ?ApiUsage) !?[]u8 {
+    return allocUsageFooterAt(allocator, started_ms, first_token_ms, std.time.milliTimestamp(), usage);
+}
+
+fn allocUsageFooterAt(allocator: std.mem.Allocator, started_ms: i64, first_token_ms: i64, finished_ms: i64, usage: ?ApiUsage) !?[]u8 {
     const u = usage orelse return null;
-    var buf: [160]u8 = undefined;
+    var buf: [224]u8 = undefined;
     const text = if (started_ms > 0) blk: {
-        const elapsed_ms: i64 = @max(@as(i64, 0), std.time.milliTimestamp() - started_ms);
+        const elapsed_ms: i64 = @max(@as(i64, 0), finished_ms - started_ms);
         const secs: i64 = @divTrunc(elapsed_ms, 1000);
         const tenths: i64 = @divTrunc(@mod(elapsed_ms, 1000), 100);
+        const first_elapsed_ms: ?i64 = if (first_token_ms > 0) @max(@as(i64, 0), first_token_ms - started_ms) else null;
+        const rate_tenths = tokenRateTenths(u.completion_tokens, elapsed_ms);
+        if (first_elapsed_ms) |first_ms| {
+            const first_secs: i64 = @divTrunc(first_ms, 1000);
+            const first_tenths: i64 = @divTrunc(@mod(first_ms, 1000), 100);
+            if (rate_tenths) |rate| {
+                break :blk std.fmt.bufPrint(
+                    &buf,
+                    "time {d}.{d}s | first {d}.{d}s | {d}.{d} token/s | total {d} | input {d} | output {d} | cache {d}/{d}",
+                    .{ secs, tenths, first_secs, first_tenths, rate / 10, rate % 10, u.total_tokens, u.prompt_tokens, u.completion_tokens, u.prompt_cache_hit_tokens, u.prompt_cache_miss_tokens },
+                ) catch "usage unavailable";
+            }
+            break :blk std.fmt.bufPrint(
+                &buf,
+                "time {d}.{d}s | first {d}.{d}s | total {d} | input {d} | output {d} | cache {d}/{d}",
+                .{ secs, tenths, first_secs, first_tenths, u.total_tokens, u.prompt_tokens, u.completion_tokens, u.prompt_cache_hit_tokens, u.prompt_cache_miss_tokens },
+            ) catch "usage unavailable";
+        }
+        if (rate_tenths) |rate| {
+            break :blk std.fmt.bufPrint(
+                &buf,
+                "time {d}.{d}s | {d}.{d} token/s | total {d} | input {d} | output {d} | cache {d}/{d}",
+                .{ secs, tenths, rate / 10, rate % 10, u.total_tokens, u.prompt_tokens, u.completion_tokens, u.prompt_cache_hit_tokens, u.prompt_cache_miss_tokens },
+            ) catch "usage unavailable";
+        }
         break :blk std.fmt.bufPrint(
             &buf,
             "time {d}.{d}s | total {d} | input {d} | output {d} | cache {d}/{d}",
@@ -4783,7 +4819,7 @@ pub fn appendAssistantResult(session: *Session, result: ApiResult, started_ms: i
         session.setStatusLocked("Out of memory");
         return;
     };
-    var usage_footer = allocUsageFooter(allocator, started_ms, result.usage) catch null;
+    var usage_footer = allocUsageFooter(allocator, started_ms, 0, result.usage) catch null;
     var reasoning_copy: ?[]u8 = null;
     if (result.reasoning) |reasoning| {
         reasoning_copy = allocator.dupe(u8, reasoning) catch null;
@@ -5029,7 +5065,7 @@ fn appendAssistantStreamDelta(session: *Session, message_idx: usize, content_del
     history_change = session.captureHistoryChangeLocked();
 }
 
-pub fn finishAssistantStream(session: *Session, message_idx: usize, started_ms: i64, usage: ?ApiUsage) void {
+pub fn finishAssistantStream(session: *Session, message_idx: usize, started_ms: i64, first_token_ms: i64, usage: ?ApiUsage) void {
     if (session.closing.load(.acquire)) return;
     if (session.stop_requested.load(.acquire)) {
         finishStoppedRequest(session);
@@ -5057,7 +5093,7 @@ pub fn finishAssistantStream(session: *Session, message_idx: usize, started_ms: 
             msg.content = session.allocator.realloc(msg.content, "No response".len) catch msg.content;
             if (msg.content.len == "No response".len) @memcpy(msg.content, "No response");
         }
-        if (allocUsageFooter(session.allocator, started_ms, usage) catch null) |footer| {
+        if (allocUsageFooter(session.allocator, started_ms, first_token_ms, usage) catch null) |footer| {
             if (msg.usage_footer) |old_footer| session.allocator.free(old_footer);
             msg.usage_footer = footer;
         }
@@ -5078,7 +5114,7 @@ pub fn failAssistantStream(session: *Session, message_idx: ?usize, text: []const
     }
     if (message_idx) |idx| {
         appendAssistantStreamDelta(session, idx, text, "") catch {};
-        finishAssistantStream(session, idx, 0, null);
+        finishAssistantStream(session, idx, 0, 0, null);
         return;
     }
 
@@ -5139,6 +5175,7 @@ pub fn applyApiStreamLineToSession(
     message_idx: usize,
     line_raw: []const u8,
     usage_out: *?ApiUsage,
+    first_token_ms: *i64,
 ) !bool {
     const line = std.mem.trim(u8, line_raw, " \t\r");
     if (!std.mem.startsWith(u8, line, "data:")) return false;
@@ -5165,6 +5202,7 @@ pub fn applyApiStreamLineToSession(
         if (std.mem.eql(u8, event_type, "response.output_text.delta")) {
             const content_delta = jsonStringValue(obj.get("delta")) orelse "";
             try appendAssistantStreamDelta(session, message_idx, content_delta, "");
+            if (content_delta.len > 0 and first_token_ms.* == 0) first_token_ms.* = std.time.milliTimestamp();
             return false;
         }
         if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta") or
@@ -5172,6 +5210,7 @@ pub fn applyApiStreamLineToSession(
         {
             const reasoning_delta = jsonStringValue(obj.get("delta")) orelse "";
             try appendAssistantStreamDelta(session, message_idx, "", reasoning_delta);
+            if (reasoning_delta.len > 0 and first_token_ms.* == 0) first_token_ms.* = std.time.milliTimestamp();
             return false;
         }
         if (std.mem.eql(u8, event_type, "response.completed")) {
@@ -5214,6 +5253,7 @@ pub fn applyApiStreamLineToSession(
     else
         "";
     try appendAssistantStreamDelta(session, message_idx, content_delta, reasoning_delta);
+    if ((content_delta.len > 0 or reasoning_delta.len > 0) and first_token_ms.* == 0) first_token_ms.* = std.time.milliTimestamp();
     return false;
 }
 
@@ -6393,7 +6433,7 @@ test "ai chat parses Responses API output text tool calls and usage" {
 }
 
 test "ai chat usage footer includes time token and cache fields" {
-    const footer = try allocUsageFooter(std.testing.allocator, std.time.milliTimestamp() - 2300, .{
+    const footer = try allocUsageFooterAt(std.testing.allocator, 1000, 1800, 3300, .{
         .prompt_tokens = 12,
         .completion_tokens = 34,
         .prompt_cache_hit_tokens = 5,
@@ -6403,6 +6443,8 @@ test "ai chat usage footer includes time token and cache fields" {
     defer if (footer) |text| std.testing.allocator.free(text);
     try std.testing.expect(footer != null);
     try std.testing.expect(std.mem.indexOf(u8, footer.?, "time 2.") != null);
+    try std.testing.expect(std.mem.indexOf(u8, footer.?, "first 0.8s") != null);
+    try std.testing.expect(std.mem.indexOf(u8, footer.?, "14.8 token/s") != null);
     try std.testing.expect(std.mem.indexOf(u8, footer.?, "total 46") != null);
     try std.testing.expect(std.mem.indexOf(u8, footer.?, "input 12") != null);
     try std.testing.expect(std.mem.indexOf(u8, footer.?, "output 34") != null);
@@ -6444,6 +6486,41 @@ test "ai chat appends usage footer to completed assistant message" {
     const footer = session.messages.items[0].usage_footer.?;
     try std.testing.expect(std.mem.indexOf(u8, footer, "total 46") != null);
     try std.testing.expect(std.mem.indexOf(u8, footer, "cache 5/7") != null);
+}
+
+test "ai chat stream records first token timestamp once" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+
+    const message_idx = try beginAssistantStream(&session);
+    var usage: ?ApiUsage = null;
+    var first_token_ms: i64 = 0;
+
+    try std.testing.expect(!try applyApiStreamLineToSession(
+        allocator,
+        &session,
+        message_idx,
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}",
+        &usage,
+        &first_token_ms,
+    ));
+    try std.testing.expect(first_token_ms > 0);
+    const first = first_token_ms;
+
+    try std.testing.expect(!try applyApiStreamLineToSession(
+        allocator,
+        &session,
+        message_idx,
+        "data: {\"choices\":[{\"delta\":{\"content\":\"!\"}}]}",
+        &usage,
+        &first_token_ms,
+    ));
+    try std.testing.expectEqual(first, first_token_ms);
+    try std.testing.expectEqualStrings("hi!", session.messages.items[message_idx].content);
 }
 
 // "ai chat streaming request asks provider to include usage" and


### PR DESCRIPTION
## Summary

- add first-token latency and token/s to assistant response usage footers
- record the first non-empty streaming delta once across Chat Completions and Responses streams
- keep compact completion status unchanged while putting detailed metrics on the assistant message

## Validation

- git diff --cached --check
- zig build test --summary all
- zig build test-shared --summary all
- zig build check-sizes --summary all

## Notes

- `.claude/` is untracked locally and intentionally not included.