### PR TITLE
[codex] Support right-click tab rename

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -1743,6 +1743,40 @@ test "input: overlay navigation drives the render gate to repaint" {
     try std.testing.expect(render_gate.frameNeedsRender(signals));
 }
 
+test "input: right-clicking a sidebar tab starts tab rename" {
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    const previous_sidebar = tab.g_sidebar_visible;
+    const previous_sidebar_width = titlebar.g_sidebar_width;
+    defer {
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        tab.g_sidebar_visible = previous_sidebar;
+        titlebar.g_sidebar_width = previous_sidebar_width;
+        tab.g_tab_rename_active = false;
+        tab.g_tab_rename_idx = 0;
+    }
+
+    var first = tab.TabState{ .kind = .skill_center, .tree = .empty };
+    var second = tab.TabState{ .kind = .skill_center, .tree = .empty };
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tabs[0] = &first;
+    tab.g_tabs[1] = &second;
+    tab.g_tab_count = 2;
+    active_tab_state.g_active_tab = 0;
+    tab.g_sidebar_visible = true;
+    titlebar.g_sidebar_width = 220;
+    tab.g_tab_rename_active = false;
+
+    const y: i32 = @intFromFloat(titlebarHeight() + titlebar.sidebarHeaderHeight() + 6 + titlebar.sidebarRowHeight() / 2);
+    handleMouseButton(.{ .button = .right, .action = .release, .x = 24, .y = y });
+
+    try std.testing.expect(tab.g_tab_rename_active);
+    try std.testing.expectEqual(@as(usize, 0), tab.g_tab_rename_idx);
+}
+
 test "macOS UI smoke: Cmd+Shift+B toggles the tab sidebar" {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
 
@@ -3710,12 +3744,12 @@ fn hitTestSidebarTabCloseButton(xpos: f64, ypos: f64, tab_idx: usize) bool {
     return hit_test.sidebarTabCloseButton(sidebarLayout(), xpos, ypos, tab_idx);
 }
 
-fn shouldStartSidebarTabRename(xpos: f64, ypos: f64, tab_idx: usize) bool {
-    if (tab_idx >= tab.g_tab_count) return false;
-    const layout = sidebarLayout();
-    if (hit_test.sidebarPlusButton(layout, xpos, ypos)) return false;
-    if (hit_test.sidebarResizeHandle(layout, xpos, ypos)) return false;
-    if (hit_test.sidebarTabCloseButton(layout, xpos, ypos, tab_idx)) return false;
+fn handleSidebarTabRenameGesture(xpos: f64, ypos: f64) bool {
+    if (hitTestSidebarTab(xpos, ypos) == null) return false;
+    if (hit_test.sidebarTabRenameTarget(sidebarLayout(), xpos, ypos)) |tab_idx| {
+        tab.startTabRename(tab_idx);
+        requestInputRepaint();
+    }
     return true;
 }
 
@@ -5355,12 +5389,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
             }
             return;
         }
-        if (hitTestSidebarTab(xpos, ypos)) |tab_idx| {
-            if (shouldStartSidebarTabRename(xpos, ypos, tab_idx)) {
-                tab.startTabRename(tab_idx);
-            }
-            return;
-        }
+        if (handleSidebarTabRenameGesture(xpos, ypos)) return;
         // No chrome hit — this is a double-click in terminal content. The macOS
         // backend reports the 2nd/3rd/4th click of a multi-click as
         // double_click (clickCount > 1) rather than press, so they never reach
@@ -5404,6 +5433,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
     // Ctrl+right-click (Cmd on macOS) over a local terminal opens the file under
     // the cursor in the OS default app; otherwise follow the configured action.
     if (ev.button == .right and ev.action == .release) {
+        if (handleSidebarTabRenameGesture(@floatFromInt(ev.x), @floatFromInt(ev.y))) return;
         if (openInEditorAtRightClick(ev)) return;
         handleConfiguredRightClick();
         return;

--- a/src/input/hit_test.zig
+++ b/src/input/hit_test.zig
@@ -81,6 +81,14 @@ pub fn sidebarTabCloseButton(l: SidebarLayout, x: f64, y: f64, tab_idx: usize) b
     return x >= close_x and x < close_x + l.close_btn_w;
 }
 
+pub fn sidebarTabRenameTarget(l: SidebarLayout, x: f64, y: f64) ?usize {
+    const tab_idx = sidebarTabAt(l, x, y) orelse return null;
+    if (sidebarPlusButton(l, x, y)) return null;
+    if (sidebarResizeHandle(l, x, y)) return null;
+    if (sidebarTabCloseButton(l, x, y, tab_idx)) return null;
+    return tab_idx;
+}
+
 /// True if (x, y) is within the horizontal resize-hit band around the sidebar
 /// right edge and below the titlebar.
 pub fn sidebarResizeHandle(l: SidebarLayout, x: f64, y: f64) bool {
@@ -184,6 +192,13 @@ test "sidebarTabCloseButton: only on its own hovered row, needs >1 tab" {
     var one = sample;
     one.tab_count = 1;
     try std.testing.expect(!sidebarTabCloseButton(one, 170, 80, 0)); // single tab: no close
+}
+
+test "sidebarTabRenameTarget: accepts row body and rejects controls" {
+    try std.testing.expectEqual(@as(?usize, 0), sidebarTabRenameTarget(sample, 24, 80));
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabRenameTarget(sample, 170, 80)); // close button
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabRenameTarget(sample, 200, 100)); // resize handle
+    try std.testing.expectEqual(@as(?usize, null), sidebarTabRenameTarget(sample, 10, 50)); // header
 }
 
 test "sidebarResizeHandle: band around the right edge" {


### PR DESCRIPTION
## Summary
- Reuse the existing sidebar tab rename gesture for right-click release events.
- Move tab rename hit testing into the pure sidebar hit-test helper so close, resize, and header regions stay excluded.
- Add regression coverage for right-click tab rename and rename-target geometry.

## Why
Users could rename a sidebar tab by double-clicking it, but plain right-clicks always fell through to the configured terminal right-click action. The root cause was that the right-click branch did not check sidebar tab chrome before terminal/editor handling.

## Impact
Right-clicking a sidebar tab now starts inline tab rename. Right-clicking tab controls or terminal content keeps the existing behavior.

## Validation
- `git diff --check`
- `zig build test-full --summary all`