### PR TITLE
[codex] Add active-tab UI screenshot tool

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -594,7 +594,7 @@ pub fn build(b: *std.Build) void {
 
         if (target.result.os.tag == .windows) {
             const askpass_mod = b.createModule(.{
-                .root_source_file = b.path("src/ssh_askpass.zig"),
+                .root_source_file = b.path("src/ssh/askpass.zig"),
                 .target = target,
                 .optimize = optimize,
             });

--- a/docs/superpowers/plans/2026-06-28-active-tab-ui-screenshot.md
+++ b/docs/superpowers/plans/2026-06-28-active-tab-ui-screenshot.md
@@ -1,0 +1,1120 @@
+# Active-tab UI Screenshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `ui_screenshot` first-party agent tool that captures the active WispTerm tab or focused active-tab panel to a local PNG path, so WeChat-triggered agents can send it back with `weixin_send_attachment`.
+
+**Architecture:** The agent tool parses `target` and optional `surface_id`, then calls a new optional `ToolHost.uiScreenshot` callback. The real AppWindow host marshals to the UI thread, resolves an active-tab framebuffer rectangle, reads the current visible framebuffer through a backend readback primitive, writes a PNG under `wispterm-files`, and returns path/size metadata. V1 supports the OpenGL backend used by the primary Windows target; the Metal backend returns `UnsupportedReadback` instead of pretending to work.
+
+**Tech Stack:** Zig 0.15.2, WispTerm `ToolHost`, `appwindow/agent_requests.zig`, `thread_message.zig`, OpenGL `ReadPixels`, stdlib CRC/Adler hashing, pure PNG writer.
+
+---
+
+## Ghostty Comparison
+
+Ghostty has no WeChat or AI screenshot tool. Its relevant precedent is renderer layering: `src/renderer/generic.zig` documents a hierarchy where `GraphicsAPI` owns render `Target`s and frame/render-pass objects, while terminal state remains separate. `src/renderer/opengl/Target.zig` wraps an OpenGL framebuffer as a render target. WispTerm should follow that split: `remote_snapshot.zig` remains terminal text/VT state, while `ui_screenshot` lives at the AppWindow/render-host boundary.
+
+## File Structure
+
+- Create `src/appwindow/png_writer.zig`: pure PNG encoder for RGBA8 data, row flipping, and tests. Uses stdlib `std.hash.crc.Crc32` and `std.hash.Adler32`; no new build dependency.
+- Create `src/agent_tools/ui_screenshot.zig`: argument parsing, target defaults, host callback call, and text result formatting.
+- Modify `src/assistant/conversation/types.zig`: add `UiScreenshotTarget`, `UiScreenshotResult`, and optional `ToolHost.uiScreenshot`.
+- Modify `src/agent_tools/mod.zig`: dispatch `ui_screenshot` to the new leaf module and add focused tests.
+- Modify `src/tools/first_party.zig`: add catalog entry.
+- Modify `src/assistant/conversation/protocol.zig`: advertise schema to all supported model protocols.
+- Create `src/renderer/gpu/opengl/readback.zig`: OpenGL `ReadPixels` RGBA readback.
+- Create `src/renderer/gpu/metal/readback.zig`: explicit unsupported readback for macOS/Metal v1.
+- Modify `src/renderer/gpu/opengl/api.zig`, `src/renderer/gpu/metal/api.zig`, `src/renderer/gpu/gpu.zig`: export `readback`.
+- Modify `src/appwindow/thread_message.zig`: add `agent_ui_screenshot` message tag.
+- Modify `src/appwindow/agent_requests.zig`: add synchronous UI-thread screenshot request bridge.
+- Modify `src/AppWindow.zig`: install the host callback, handle the message, resolve capture rectangles, call readback/PNG writer, and return metadata.
+- Modify `src/test_fast.zig`: include `appwindow/png_writer.zig`.
+
+## Task 1: Pure PNG Writer
+
+**Files:**
+- Create: `src/appwindow/png_writer.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Write failing tests for PNG encoding and row flipping**
+
+Create `src/appwindow/png_writer.zig` with only tests and stub signatures:
+
+```zig
+const std = @import("std");
+const png_dimensions = @import("../preview/png_dimensions.zig");
+
+pub const Image = struct {
+    width: u32,
+    height: u32,
+    rgba: []const u8,
+};
+
+pub fn encodeRgba(allocator: std.mem.Allocator, image: Image) ![]u8 {
+    _ = allocator;
+    _ = image;
+    return error.Unimplemented;
+}
+
+pub fn flipRgbaRows(allocator: std.mem.Allocator, bottom_up: []const u8, width: u32, height: u32) ![]u8 {
+    _ = allocator;
+    _ = bottom_up;
+    _ = width;
+    _ = height;
+    return error.Unimplemented;
+}
+
+test "png_writer encodes RGBA8 PNG with expected dimensions" {
+    const rgba = [_]u8{
+        255, 0, 0, 255,
+        0, 255, 0, 255,
+        0, 0, 255, 255,
+        255, 255, 255, 255,
+    };
+    const png = try encodeRgba(std.testing.allocator, .{
+        .width = 2,
+        .height = 2,
+        .rgba = &rgba,
+    });
+    defer std.testing.allocator.free(png);
+
+    try std.testing.expect(std.mem.startsWith(u8, png, "\x89PNG\r\n\x1a\n"));
+    const dims = png_dimensions.parse(png) orelse return error.MissingPngDimensions;
+    try std.testing.expectEqual(@as(u32, 2), dims.width);
+    try std.testing.expectEqual(@as(u32, 2), dims.height);
+    try std.testing.expect(std.mem.endsWith(u8, png, "IEND\xaeB`\x82"));
+}
+
+test "png_writer flips OpenGL bottom-up RGBA rows into PNG top-down rows" {
+    const bottom_up = [_]u8{
+        1, 1, 1, 255, 2, 2, 2, 255,
+        3, 3, 3, 255, 4, 4, 4, 255,
+    };
+    const top_down = try flipRgbaRows(std.testing.allocator, &bottom_up, 2, 2);
+    defer std.testing.allocator.free(top_down);
+
+    try std.testing.expectEqualSlices(u8, &[_]u8{
+        3, 3, 3, 255, 4, 4, 4, 255,
+        1, 1, 1, 255, 2, 2, 2, 255,
+    }, top_down);
+}
+
+test "png_writer rejects RGBA buffers with the wrong size" {
+    try std.testing.expectError(error.InvalidImageBuffer, encodeRgba(std.testing.allocator, .{
+        .width = 2,
+        .height = 2,
+        .rgba = &[_]u8{0} ** 15,
+    }));
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+zig test src/appwindow/png_writer.zig
+```
+
+Expected: failure with `Unimplemented` from `encodeRgba` or `flipRgbaRows`.
+
+- [ ] **Step 3: Implement the minimal PNG writer**
+
+Replace the stubs in `src/appwindow/png_writer.zig` with:
+
+```zig
+const std = @import("std");
+const png_dimensions = @import("../preview/png_dimensions.zig");
+
+const png_signature = "\x89PNG\r\n\x1a\n";
+const max_deflate_block: usize = 65_535;
+
+pub const Error = error{
+    InvalidImageDimensions,
+    InvalidImageBuffer,
+} || std.mem.Allocator.Error;
+
+pub const Image = struct {
+    width: u32,
+    height: u32,
+    rgba: []const u8,
+};
+
+fn checkedRgbaLen(width: u32, height: u32) Error!usize {
+    if (width == 0 or height == 0) return error.InvalidImageDimensions;
+    const pixels = std.math.mul(usize, width, height) catch return error.InvalidImageDimensions;
+    return std.math.mul(usize, pixels, 4) catch return error.InvalidImageDimensions;
+}
+
+fn appendU32(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, value: u32) !void {
+    var buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &buf, value, .big);
+    try out.appendSlice(allocator, &buf);
+}
+
+fn appendChunk(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, kind: *const [4]u8, data: []const u8) !void {
+    try appendU32(out, allocator, @intCast(data.len));
+    try out.appendSlice(allocator, kind);
+    try out.appendSlice(allocator, data);
+
+    var crc_bytes = try allocator.alloc(u8, kind.len + data.len);
+    defer allocator.free(crc_bytes);
+    @memcpy(crc_bytes[0..4], kind);
+    @memcpy(crc_bytes[4..], data);
+    try appendU32(out, allocator, std.hash.crc.Crc32.hash(crc_bytes));
+}
+
+fn appendZlibStored(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, payload: []const u8) !void {
+    try out.appendSlice(allocator, &.{ 0x78, 0x01 });
+    var remaining = payload;
+    while (remaining.len > 0) {
+        const n = @min(remaining.len, max_deflate_block);
+        const final: u8 = if (n == remaining.len) 1 else 0;
+        try out.append(allocator, final);
+
+        var len_buf: [2]u8 = undefined;
+        const len16: u16 = @intCast(n);
+        std.mem.writeInt(u16, &len_buf, len16, .little);
+        try out.appendSlice(allocator, &len_buf);
+        std.mem.writeInt(u16, &len_buf, ~len16, .little);
+        try out.appendSlice(allocator, &len_buf);
+
+        try out.appendSlice(allocator, remaining[0..n]);
+        remaining = remaining[n..];
+    }
+    try appendU32(out, allocator, std.hash.Adler32.hash(payload));
+}
+
+pub fn encodeRgba(allocator: std.mem.Allocator, image: Image) ![]u8 {
+    const expected = try checkedRgbaLen(image.width, image.height);
+    if (image.rgba.len != expected) return error.InvalidImageBuffer;
+
+    const row_bytes = @as(usize, image.width) * 4;
+    const filtered_len = (@as(usize, image.height) * (row_bytes + 1));
+    var filtered = try std.ArrayListUnmanaged(u8).initCapacity(allocator, filtered_len);
+    defer filtered.deinit(allocator);
+    for (0..image.height) |row| {
+        try filtered.append(allocator, 0);
+        const start = row * row_bytes;
+        try filtered.appendSlice(allocator, image.rgba[start .. start + row_bytes]);
+    }
+
+    var idat = std.ArrayListUnmanaged(u8).empty;
+    defer idat.deinit(allocator);
+    try appendZlibStored(&idat, allocator, filtered.items);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, png_signature);
+
+    var ihdr: [13]u8 = undefined;
+    std.mem.writeInt(u32, ihdr[0..4], image.width, .big);
+    std.mem.writeInt(u32, ihdr[4..8], image.height, .big);
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    ihdr[10] = 0;
+    ihdr[11] = 0;
+    ihdr[12] = 0;
+    try appendChunk(&out, allocator, "IHDR", &ihdr);
+    try appendChunk(&out, allocator, "IDAT", idat.items);
+    try appendChunk(&out, allocator, "IEND", &.{});
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn flipRgbaRows(allocator: std.mem.Allocator, bottom_up: []const u8, width: u32, height: u32) ![]u8 {
+    const expected = try checkedRgbaLen(width, height);
+    if (bottom_up.len != expected) return error.InvalidImageBuffer;
+    const row_bytes = @as(usize, width) * 4;
+    const out = try allocator.alloc(u8, bottom_up.len);
+    errdefer allocator.free(out);
+    for (0..height) |row| {
+        const src_row = @as(usize, height) - 1 - row;
+        @memcpy(out[row * row_bytes .. (row + 1) * row_bytes], bottom_up[src_row * row_bytes .. (src_row + 1) * row_bytes]);
+    }
+    return out;
+}
+```
+
+- [ ] **Step 4: Add the pure module to the fast suite**
+
+In `src/test_fast.zig`, add this import near the other `appwindow/*` imports:
+
+```zig
+    _ = @import("appwindow/png_writer.zig");
+```
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run:
+
+```bash
+zig test src/appwindow/png_writer.zig
+zig build test
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/appwindow/png_writer.zig src/test_fast.zig
+git commit -m "feat(agent): add pure png writer for ui screenshots"
+```
+
+## Task 2: Agent Tool Types, Schema, and Dispatch
+
+**Files:**
+- Modify: `src/assistant/conversation/types.zig`
+- Create: `src/agent_tools/ui_screenshot.zig`
+- Modify: `src/agent_tools/mod.zig`
+- Modify: `src/tools/first_party.zig`
+- Modify: `src/assistant/conversation/protocol.zig`
+
+- [ ] **Step 1: Write failing protocol/catalog tests**
+
+In `src/assistant/conversation/protocol.zig`, add:
+
+```zig
+test "agent tool set includes ui_screenshot" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("show me the screen") }};
+    const params = RequestParams{ .model = "m", .system_prompt = "", .protocol = .chat_completions, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const json = try buildRequestJson(a, params, &msgs, true);
+    defer a.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"ui_screenshot\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"target\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"surface_id\"") != null);
+}
+```
+
+In `src/agent_tools/mod.zig`, add:
+
+```zig
+test "executeToolCall ui_screenshot reports missing host clearly" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null, .working_dir = "/work" },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("call-shot"),
+        .name = @constCast("ui_screenshot"),
+        .arguments = @constCast("{}"),
+    });
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No UI screenshot host") != null);
+}
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+zig test src/assistant/conversation/protocol.zig --test-filter ui_screenshot
+zig test src/agent_tools/mod.zig --test-filter ui_screenshot
+```
+
+Expected: protocol test fails because the schema is absent; tool test fails because dispatch returns `Unknown tool`.
+
+- [ ] **Step 3: Add shared types and optional host callback**
+
+In `src/assistant/conversation/types.zig`, after `ToolClosedTab`, add:
+
+```zig
+pub const UiScreenshotTarget = enum {
+    focused_panel,
+    active_tab,
+
+    pub fn label(self: UiScreenshotTarget) []const u8 {
+        return switch (self) {
+            .focused_panel => "focused_panel",
+            .active_tab => "active_tab",
+        };
+    }
+};
+
+pub const UiScreenshotResult = struct {
+    path: []u8,
+    width: u32,
+    height: u32,
+    target: UiScreenshotTarget,
+
+    pub fn deinit(self: UiScreenshotResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+    }
+};
+```
+
+Then add this field at the end of `ToolHost`:
+
+```zig
+    uiScreenshot: ?*const fn (*anyopaque, std.mem.Allocator, UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!UiScreenshotResult = null,
+```
+
+- [ ] **Step 4: Create the agent tool leaf module**
+
+Create `src/agent_tools/ui_screenshot.zig`:
+
+```zig
+//! Agent UI screenshot tool.
+const std = @import("std");
+const types = @import("../assistant/conversation/types.zig");
+
+const ToolContext = types.ToolContext;
+const UiScreenshotTarget = types.UiScreenshotTarget;
+
+fn parseTarget(text: ?[]const u8) ?UiScreenshotTarget {
+    const raw = std.mem.trim(u8, text orelse "focused_panel", " \t\r\n");
+    if (raw.len == 0 or std.ascii.eqlIgnoreCase(raw, "focused_panel") or std.ascii.eqlIgnoreCase(raw, "focused")) return .focused_panel;
+    if (std.ascii.eqlIgnoreCase(raw, "active_tab") or std.ascii.eqlIgnoreCase(raw, "tab")) return .active_tab;
+    return null;
+}
+
+pub fn run(ctx: *ToolContext, target_text: ?[]const u8, surface_id: ?[]const u8) ![]u8 {
+    if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+    const target = parseTarget(target_text) orelse return ctx.allocator.dupe(u8, "Invalid target; expected focused_panel or active_tab.");
+    const host = ctx.tool_host orelse return ctx.allocator.dupe(u8, "No UI screenshot host is available.");
+    const callback = host.uiScreenshot orelse return ctx.allocator.dupe(u8, "No UI screenshot host is available.");
+    const result = callback(host.ctx, ctx.allocator, target, surface_id, ctx.settings.working_dir) catch |err| {
+        return std.fmt.allocPrint(ctx.allocator, "ui_screenshot failed: {s}", .{@errorName(err)});
+    };
+    defer result.deinit(ctx.allocator);
+    return std.fmt.allocPrint(
+        ctx.allocator,
+        "screenshot path={s} width={d} height={d} target={s}",
+        .{ result.path, result.width, result.height, result.target.label() },
+    );
+}
+
+test "ui_screenshot target parser accepts defaults and aliases" {
+    try std.testing.expectEqual(UiScreenshotTarget.focused_panel, parseTarget(null).?);
+    try std.testing.expectEqual(UiScreenshotTarget.focused_panel, parseTarget("focused").?);
+    try std.testing.expectEqual(UiScreenshotTarget.active_tab, parseTarget("tab").?);
+    try std.testing.expect(parseTarget("pane") == null);
+}
+```
+
+- [ ] **Step 5: Dispatch the tool**
+
+In `src/agent_tools/mod.zig`, add the import:
+
+```zig
+const agent_ui_screenshot = @import("ui_screenshot.zig");
+```
+
+In `executeToolCall`, after `terminal_snapshot` or near other terminal observation tools, add:
+
+```zig
+    if (std.mem.eql(u8, call.name, "ui_screenshot")) {
+        const args = tool_args.parse(ctx.allocator, call.arguments);
+        defer if (args) |parsed| parsed.deinit();
+        const target = if (args) |parsed| tool_args.string(parsed.value, "target") else null;
+        const surface_id = if (args) |parsed| tool_args.string(parsed.value, "surface_id") else null;
+        return agent_ui_screenshot.run(ctx, target, surface_id);
+    }
+```
+
+- [ ] **Step 6: Add catalog and schema entries**
+
+In `src/tools/first_party.zig`, add:
+
+```zig
+    .{ .name = "ui_screenshot", .label = "ui_screenshot", .description = "Capture the active WispTerm tab or focused active-tab panel as a local PNG file.", .category = .terminal },
+```
+
+In `src/assistant/conversation/protocol.zig`, in `forEachToolSpec` after `terminal_snapshot`, add:
+
+```zig
+    try Filtered.emitTool(ctx, opts, "ui_screenshot", "Capture a PNG screenshot of the active WispTerm tab or the focused panel in the active tab. Use target=focused_panel for the panel the user is looking at, or target=active_tab for the whole visible active tab. In a dedicated AI/Copilot tab, focused_panel falls back to active_tab. The tool returns a local PNG path; when the request came from Weixin, call weixin_send_attachment with kind=image and that path.", "{\"target\":{\"type\":\"string\",\"description\":\"Optional: focused_panel (default) or active_tab.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Optional terminal surface id from terminal_list. Only valid for terminal panels in the active tab.\"}}");
+```
+
+- [ ] **Step 7: Add a fake-host success test**
+
+In `src/agent_tools/mod.zig`, add:
+
+```zig
+test "executeToolCall ui_screenshot calls host and formats path" {
+    const Fake = struct {
+        fn collectSnapshot(_: *anyopaque, allocator: std.mem.Allocator) anyerror!ToolSnapshot {
+            return .{ .surfaces = try allocator.alloc(ToolSurface, 0), .active_tab = 0 };
+        }
+        fn surfaceSnapshot(_: *anyopaque, allocator: std.mem.Allocator, _: []const u8, _: *anyopaque) anyerror![]u8 {
+            return allocator.dupe(u8, "");
+        }
+        fn writeSurface(_: *anyopaque, _: []const u8, _: *anyopaque, _: []const u8) bool {
+            return false;
+        }
+        fn unsupportedSpawn(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: ?[]const u8) anyerror!ToolSurface {
+            return error.Unsupported;
+        }
+        fn unsupportedClose(_: *anyopaque, _: std.mem.Allocator, _: ?usize, _: ?[]const u8, _: ?[]const u8) anyerror!ToolClosedTab {
+            return error.Unsupported;
+        }
+        fn unsupportedSaveSsh(_: *anyopaque, _: std.mem.Allocator, _: SshProfileSaveArgs) anyerror!SavedSshProfile {
+            return error.Unsupported;
+        }
+        fn unsupportedConnectSsh(_: *anyopaque, _: std.mem.Allocator, _: []const u8) anyerror!ToolSurface {
+            return error.Unsupported;
+        }
+        fn shot(_: *anyopaque, allocator: std.mem.Allocator, target: types.UiScreenshotTarget, surface_id: ?[]const u8, working_dir: ?[]const u8) anyerror!types.UiScreenshotResult {
+            try std.testing.expectEqual(types.UiScreenshotTarget.active_tab, target);
+            try std.testing.expectEqualStrings("abc", surface_id.?);
+            try std.testing.expectEqualStrings("/work", working_dir.?);
+            return .{
+                .path = try allocator.dupe(u8, "/work/wispterm-files/ui-screenshot-1.png"),
+                .width = 10,
+                .height = 20,
+                .target = target,
+            };
+        }
+        var dummy: u8 = 0;
+        fn host() ToolHost {
+            return .{
+                .ctx = &dummy,
+                .collectSnapshot = collectSnapshot,
+                .surfaceSnapshot = surfaceSnapshot,
+                .writeSurface = writeSurface,
+                .spawnTab = unsupportedSpawn,
+                .closeTab = unsupportedClose,
+                .saveSshProfile = unsupportedSaveSsh,
+                .connectSshProfile = unsupportedConnectSsh,
+                .uiScreenshot = shot,
+            };
+        }
+    };
+
+    const a = std.testing.allocator;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &Fake.dummy,
+        .tool_host = Fake.host(),
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null, .working_dir = "/work" },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("call-shot"),
+        .name = @constCast("ui_screenshot"),
+        .arguments = @constCast("{\"target\":\"active_tab\",\"surface_id\":\"abc\"}"),
+    });
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "path=/work/wispterm-files/ui-screenshot-1.png") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "width=10") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "height=20") != null);
+}
+```
+
+- [ ] **Step 8: Run tests and verify they pass**
+
+Run:
+
+```bash
+zig test src/agent_tools/ui_screenshot.zig
+zig test src/agent_tools/mod.zig --test-filter ui_screenshot
+zig test src/assistant/conversation/protocol.zig --test-filter ui_screenshot
+zig build test
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/assistant/conversation/types.zig src/agent_tools/ui_screenshot.zig src/agent_tools/mod.zig src/tools/first_party.zig src/assistant/conversation/protocol.zig
+git commit -m "feat(agent): add ui_screenshot tool surface"
+```
+
+## Task 3: GPU Readback Primitive
+
+**Files:**
+- Create: `src/renderer/gpu/opengl/readback.zig`
+- Create: `src/renderer/gpu/metal/readback.zig`
+- Modify: `src/renderer/gpu/opengl/api.zig`
+- Modify: `src/renderer/gpu/metal/api.zig`
+- Modify: `src/renderer/gpu/gpu.zig`
+
+- [ ] **Step 1: Add the OpenGL readback module**
+
+Create `src/renderer/gpu/opengl/readback.zig`:
+
+```zig
+//! OpenGL framebuffer readback helpers.
+const std = @import("std");
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+
+pub fn readRgba(allocator: std.mem.Allocator, x: i32, y: i32, width: u32, height: u32) ![]u8 {
+    if (width == 0 or height == 0) return error.InvalidReadbackRect;
+    const pixels = std.math.mul(usize, @as(usize, width), @as(usize, height)) catch return error.InvalidReadbackRect;
+    const len = std.math.mul(usize, pixels, 4) catch return error.InvalidReadbackRect;
+    const out = try allocator.alloc(u8, len);
+    errdefer allocator.free(out);
+    const gl = Context.gl;
+    gl.PixelStorei.?(c.GL_PACK_ALIGNMENT, 1);
+    gl.ReadPixels.?(
+        x,
+        y,
+        @intCast(width),
+        @intCast(height),
+        c.GL_RGBA,
+        c.GL_UNSIGNED_BYTE,
+        out.ptr,
+    );
+    return out;
+}
+```
+
+- [ ] **Step 2: Add the Metal unsupported module**
+
+Create `src/renderer/gpu/metal/readback.zig`:
+
+```zig
+//! Metal framebuffer readback is not wired in v1.
+const std = @import("std");
+
+pub fn readRgba(allocator: std.mem.Allocator, x: i32, y: i32, width: u32, height: u32) ![]u8 {
+    _ = allocator;
+    _ = x;
+    _ = y;
+    _ = width;
+    _ = height;
+    return error.UnsupportedReadback;
+}
+
+test "metal readback reports unsupported" {
+    try std.testing.expectError(error.UnsupportedReadback, readRgba(std.testing.allocator, 0, 0, 1, 1));
+}
+```
+
+- [ ] **Step 3: Export readback through backend APIs**
+
+In `src/renderer/gpu/opengl/api.zig`, add:
+
+```zig
+pub const readback = @import("readback.zig");
+```
+
+In `src/renderer/gpu/metal/api.zig`, add:
+
+```zig
+pub const readback = @import("readback.zig");
+```
+
+In `src/renderer/gpu/gpu.zig`, add:
+
+```zig
+pub const readback = impl.readback;
+```
+
+- [ ] **Step 4: Run compile tests**
+
+Run:
+
+```bash
+zig build test
+zig build test-full
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/gpu/opengl/readback.zig src/renderer/gpu/metal/readback.zig src/renderer/gpu/opengl/api.zig src/renderer/gpu/metal/api.zig src/renderer/gpu/gpu.zig
+git commit -m "feat(renderer): add framebuffer readback primitive"
+```
+
+## Task 4: AppWindow Screenshot Helpers
+
+**Files:**
+- Create: `src/appwindow/ui_screenshot.zig`
+- Modify: `src/test_fast.zig`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `src/appwindow/ui_screenshot.zig`:
+
+```zig
+//! Pure helpers for active-tab UI screenshot capture.
+const std = @import("std");
+const agent_file_copy = @import("../agent/file_copy.zig");
+
+pub const Rect = struct {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+};
+
+pub fn clampRect(rect: Rect, fb_width: u32, fb_height: u32) ?Rect {
+    _ = rect;
+    _ = fb_width;
+    _ = fb_height;
+    return null;
+}
+
+pub fn glReadY(rect: Rect, fb_height: u32) i32 {
+    _ = rect;
+    _ = fb_height;
+    return 0;
+}
+
+pub fn outputPath(allocator: std.mem.Allocator, working_dir: []const u8, now_ms: i64) ![]u8 {
+    _ = allocator;
+    _ = working_dir;
+    _ = now_ms;
+    return error.Unimplemented;
+}
+
+test "ui_screenshot clamps rectangles to framebuffer bounds" {
+    const r = clampRect(.{ .x = -5, .y = 10, .width = 20, .height = 20 }, 100, 100).?;
+    try std.testing.expectEqual(@as(i32, 0), r.x);
+    try std.testing.expectEqual(@as(i32, 10), r.y);
+    try std.testing.expectEqual(@as(u32, 15), r.width);
+    try std.testing.expectEqual(@as(u32, 20), r.height);
+    try std.testing.expect(clampRect(.{ .x = 200, .y = 0, .width = 10, .height = 10 }, 100, 100) == null);
+}
+
+test "ui_screenshot converts top-left rect y to OpenGL read y" {
+    const r = Rect{ .x = 10, .y = 20, .width = 30, .height = 40 };
+    try std.testing.expectEqual(@as(i32, 40), glReadY(r, 100));
+}
+
+test "ui_screenshot output path uses wispterm-files and a png basename" {
+    const path = try outputPath(std.testing.allocator, "/work/project", 1234);
+    defer std.testing.allocator.free(path);
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/work/project", agent_file_copy.DEFAULT_DIR, "ui-screenshot-1234.png" });
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, path);
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+zig test src/appwindow/ui_screenshot.zig
+```
+
+Expected: failure from stubbed `clampRect` or `outputPath`.
+
+- [ ] **Step 3: Implement helpers**
+
+Replace stubs in `src/appwindow/ui_screenshot.zig` with:
+
+```zig
+pub fn clampRect(rect: Rect, fb_width: u32, fb_height: u32) ?Rect {
+    if (rect.width == 0 or rect.height == 0 or fb_width == 0 or fb_height == 0) return null;
+    const x0 = @max(rect.x, 0);
+    const y0 = @max(rect.y, 0);
+    const x1 = @min(rect.x + @as(i32, @intCast(rect.width)), @as(i32, @intCast(fb_width)));
+    const y1 = @min(rect.y + @as(i32, @intCast(rect.height)), @as(i32, @intCast(fb_height)));
+    if (x1 <= x0 or y1 <= y0) return null;
+    return .{
+        .x = x0,
+        .y = y0,
+        .width = @intCast(x1 - x0),
+        .height = @intCast(y1 - y0),
+    };
+}
+
+pub fn glReadY(rect: Rect, fb_height: u32) i32 {
+    return @as(i32, @intCast(fb_height)) - rect.y - @as(i32, @intCast(rect.height));
+}
+
+pub fn outputPath(allocator: std.mem.Allocator, working_dir: []const u8, now_ms: i64) ![]u8 {
+    if (working_dir.len == 0) return error.MissingWorkingDir;
+    const name = try std.fmt.allocPrint(allocator, "ui-screenshot-{d}.png", .{now_ms});
+    defer allocator.free(name);
+    if (!agent_file_copy.isSafeDestinationName(name)) return error.UnsafeDestinationName;
+    const dir = try std.fs.path.join(allocator, &.{ working_dir, agent_file_copy.DEFAULT_DIR });
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, name });
+}
+```
+
+- [ ] **Step 4: Add the helper module to the fast suite**
+
+In `src/test_fast.zig`, add near other appwindow imports:
+
+```zig
+    _ = @import("appwindow/ui_screenshot.zig");
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+zig test src/appwindow/ui_screenshot.zig
+zig build test
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/appwindow/ui_screenshot.zig src/test_fast.zig
+git commit -m "feat(appwindow): add screenshot helper utilities"
+```
+
+## Task 5: UI-thread Screenshot Bridge and Capture
+
+**Files:**
+- Modify: `src/appwindow/thread_message.zig`
+- Modify: `src/appwindow/agent_requests.zig`
+- Modify: `src/AppWindow.zig`
+
+- [ ] **Step 1: Write failing bridge tests**
+
+In `src/appwindow/thread_message.zig`, extend `Tag` with:
+
+```zig
+    agent_ui_screenshot,
+```
+
+Do not add it to `offset` yet.
+
+Run:
+
+```bash
+zig test src/appwindow/thread_message.zig
+```
+
+Expected: compile failure because `offset` switch is missing `.agent_ui_screenshot`.
+
+- [ ] **Step 2: Add thread message offset**
+
+In `src/appwindow/thread_message.zig`, add:
+
+```zig
+        .agent_ui_screenshot => 0x58,
+```
+
+Run:
+
+```bash
+zig test src/appwindow/thread_message.zig
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Add request bridge types and callback**
+
+In `src/appwindow/agent_requests.zig`, extend `Host`:
+
+```zig
+    captureUiScreenshot: *const fn (std.mem.Allocator, ai_chat.UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!ai_chat.UiScreenshotResult,
+```
+
+Add the request type:
+
+```zig
+pub const AgentUiScreenshotRequest = struct {
+    allocator: std.mem.Allocator,
+    target: ai_chat.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+    result: ?ai_chat.UiScreenshotResult = null,
+    err: ?anyerror = null,
+};
+```
+
+Add the post helper:
+
+```zig
+fn postAgentUiScreenshot(native_handle: window_backend.NativeHandle, request: *AgentUiScreenshotRequest) void {
+    postAgentRequest(native_handle, .agent_ui_screenshot, @intFromPtr(request));
+}
+```
+
+Add the public callback:
+
+```zig
+pub fn uiScreenshot(
+    ctx: *anyopaque,
+    allocator: std.mem.Allocator,
+    target: ai_chat.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+) anyerror!ai_chat.UiScreenshotResult {
+    const host = try installedHost();
+    const native_handle = host.nativeHandleForContext(ctx) orelse return error.WindowUnavailable;
+    var request = AgentUiScreenshotRequest{
+        .allocator = allocator,
+        .target = target,
+        .surface_id = surface_id,
+        .working_dir = working_dir,
+    };
+    if (host.currentNativeHandle()) |current| {
+        if (current == native_handle) {
+            handleUiScreenshotRequest(&request, host);
+        } else {
+            postAgentUiScreenshot(native_handle, &request);
+        }
+    } else {
+        postAgentUiScreenshot(native_handle, &request);
+    }
+    if (request.err) |err| return err;
+    return request.result orelse error.ScreenshotFailed;
+}
+```
+
+Add the UI-thread handler:
+
+```zig
+pub fn handleUiScreenshotRequest(request: *AgentUiScreenshotRequest, host: Host) void {
+    request.result = host.captureUiScreenshot(
+        request.allocator,
+        request.target,
+        request.surface_id,
+        request.working_dir,
+    ) catch |err| {
+        request.err = err;
+        return;
+    };
+}
+```
+
+- [ ] **Step 4: Wire AppWindow message dispatch and ToolHost install**
+
+In `src/AppWindow.zig`, add imports near existing appwindow imports:
+
+```zig
+const appwindow_ui_screenshot = @import("appwindow/ui_screenshot.zig");
+const png_writer = @import("appwindow/png_writer.zig");
+```
+
+In `onPlatformMessage`, add:
+
+```zig
+        .agent_ui_screenshot => agent_requests.handleUiScreenshotRequest(@ptrFromInt(decoded.ptr), agent_host),
+```
+
+In `installAgentToolHost`, add:
+
+```zig
+        .uiScreenshot = agent_requests.uiScreenshot,
+```
+
+In `agentRequestHost`, add:
+
+```zig
+        .captureUiScreenshot = agentRequestCaptureUiScreenshot,
+```
+
+- [ ] **Step 5: Add AppWindow rectangle resolution and capture implementation**
+
+In `src/AppWindow.zig`, near `agentRequestSaveSshProfile`, add:
+
+```zig
+fn activeTabFullRect(fb_width: i32, fb_height: i32) appwindow_ui_screenshot.Rect {
+    return .{
+        .x = 0,
+        .y = 0,
+        .width = @intCast(@max(fb_width, 0)),
+        .height = @intCast(@max(fb_height, 0)),
+    };
+}
+
+fn activeTabPanelRect(target: ai_chat.UiScreenshotTarget, surface_id: ?[]const u8, fb_width: i32, fb_height: i32) !appwindow_ui_screenshot.Rect {
+    if (target == .active_tab) return activeTabFullRect(fb_width, fb_height);
+    const active = activeTab() orelse return activeTabFullRect(fb_width, fb_height);
+    if (active.kind != .terminal) return activeTabFullRect(fb_width, fb_height);
+
+    if (surface_id) |sid_raw| {
+        const sid = std.mem.trim(u8, sid_raw, " \t\r\n");
+        if (sid.len == 0 or std.ascii.eqlIgnoreCase(sid, "focused") or std.ascii.eqlIgnoreCase(sid, "active") or std.ascii.eqlIgnoreCase(sid, "current")) {
+            return activeTabPanelRect(.focused_panel, null, fb_width, fb_height);
+        }
+        for (0..split_layout.g_split_rect_count) |i| {
+            const r = split_layout.g_split_rects[i];
+            if (!split_layout.cachedRectIsLive(r)) continue;
+            if (r.pane.surface()) |surface| {
+                if (std.mem.eql(u8, surface.remote_id[0..], sid)) {
+                    return .{ .x = r.x, .y = r.y, .width = @intCast(@max(r.width, 0)), .height = @intCast(@max(r.height, 0)) };
+                }
+            }
+        }
+        return error.SurfaceNotInActiveTab;
+    }
+
+    for (0..split_layout.g_split_rect_count) |i| {
+        const r = split_layout.g_split_rects[i];
+        if (!split_layout.cachedRectIsLive(r)) continue;
+        if (r.handle == active.focused) {
+            return .{ .x = r.x, .y = r.y, .width = @intCast(@max(r.width, 0)), .height = @intCast(@max(r.height, 0)) };
+        }
+    }
+    return activeTabFullRect(fb_width, fb_height);
+}
+
+fn writeScreenshotFile(path: []const u8, png: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        if (parent.len > 0) try std.fs.cwd().makePath(parent);
+    }
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.fs.createFileAbsolute(path, .{ .truncate = true })
+    else
+        try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(png);
+}
+
+fn agentRequestCaptureUiScreenshot(
+    allocator: std.mem.Allocator,
+    target: ai_chat.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+) anyerror!ai_chat.UiScreenshotResult {
+    const win = g_window orelse return error.WindowUnavailable;
+    if (window_backend.isMinimized(win)) return error.WindowUnavailable;
+    const wd = working_dir orelse return error.MissingWorkingDir;
+    const fb = window_backend.framebufferSize(win);
+    if (fb.width <= 0 or fb.height <= 0) return error.WindowUnavailable;
+    const effective_target: ai_chat.UiScreenshotTarget = blk: {
+        if (target != .focused_panel) break :blk target;
+        const active = activeTab() orelse break :blk .active_tab;
+        break :blk if (active.kind == .terminal) .focused_panel else .active_tab;
+    };
+
+    const requested = try activeTabPanelRect(target, surface_id, fb.width, fb.height);
+    const rect = appwindow_ui_screenshot.clampRect(requested, @intCast(fb.width), @intCast(fb.height)) orelse return error.InvalidReadbackRect;
+    const read_y = appwindow_ui_screenshot.glReadY(rect, @intCast(fb.height));
+    const bottom_up = try gpu.readback.readRgba(allocator, rect.x, read_y, rect.width, rect.height);
+    defer allocator.free(bottom_up);
+    const top_down = try png_writer.flipRgbaRows(allocator, bottom_up, rect.width, rect.height);
+    defer allocator.free(top_down);
+    const png = try png_writer.encodeRgba(allocator, .{ .width = rect.width, .height = rect.height, .rgba = top_down });
+    defer allocator.free(png);
+
+    const path = try appwindow_ui_screenshot.outputPath(allocator, wd, std.time.milliTimestamp());
+    errdefer allocator.free(path);
+    try writeScreenshotFile(path, png);
+    return .{
+        .path = path,
+        .width = rect.width,
+        .height = rect.height,
+        .target = effective_target,
+    };
+}
+```
+
+- [ ] **Step 6: Run compile tests and source guards**
+
+Run:
+
+```bash
+zig build test
+zig build test-full
+```
+
+Expected: both pass, with no source-guard ceiling increases. Guard failures are fixed by moving helper code into `src/appwindow/ui_screenshot.zig` with explicit inputs.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/appwindow/thread_message.zig src/appwindow/agent_requests.zig src/AppWindow.zig
+git commit -m "feat(agent): capture active tab ui screenshots"
+```
+
+## Task 6: End-to-end Verification and Documentation Check
+
+**Files:**
+- Read-only unless verification exposes a compile/test failure.
+
+- [ ] **Step 1: Run the fast suite**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run the full suite**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run the Windows checkout safety check if files were added**
+
+Use the command documented in `docs/development.md#windows-checkout-safety`.
+
+Expected: no reserved names, illegal characters, case-fold collisions, symlinks, or excessive path lengths.
+
+- [ ] **Step 4: Manual Windows smoke**
+
+Build/run WispTerm on Windows, open an agent session, and ask:
+
+```text
+Call ui_screenshot with target=focused_panel and report the returned path.
+```
+
+Expected: tool result contains `path=...wispterm-files...png`, nonzero `width`, nonzero `height`, and the file opens as a PNG.
+
+- [ ] **Step 5: Manual split smoke**
+
+Open a terminal tab with two split panels. Ask the agent:
+
+```text
+Call terminal_list, then call ui_screenshot for each active-tab surface_id.
+```
+
+Expected: each screenshot path exists and each image dimensions match its panel rectangle rather than the full window.
+
+- [ ] **Step 6: Manual Copilot/AI chat tab smoke**
+
+Switch to a dedicated AI chat/Copilot tab and ask:
+
+```text
+Call ui_screenshot with target=focused_panel.
+```
+
+Expected: tool succeeds and reports `target=active_tab`.
+
+- [ ] **Step 7: Manual WeChat smoke**
+
+From WeChat, ask the agent:
+
+```text
+请截一张当前界面的图发给我。
+```
+
+Expected: the agent calls `ui_screenshot`, then `weixin_send_attachment(kind=image, path=<returned path>)`, and the image arrives in WeChat.
+
+- [ ] **Step 8: Metal/macOS behavior check**
+
+On macOS, call:
+
+```text
+Call ui_screenshot with target=active_tab.
+```
+
+Expected for v1: clear tool result containing `UnsupportedReadback`. This is deliberate until Metal readback is wired.
+
+- [ ] **Step 9: Final status**
+
+If all required checks pass, report:
+
+```text
+Implemented ui_screenshot for active-tab OpenGL screenshots. Verified zig build test and zig build test-full. Manual Windows smoke passed. Metal/macOS returns UnsupportedReadback in v1.
+```
+
+Do not claim macOS screenshot support until Metal readback has a real implementation.

--- a/docs/superpowers/plans/2026-06-28-active-tab-ui-screenshot.md
+++ b/docs/superpowers/plans/2026-06-28-active-tab-ui-screenshot.md
@@ -1118,3 +1118,15 @@ Implemented ui_screenshot for active-tab OpenGL screenshots. Verified zig build 
 ```
 
 Do not claim macOS screenshot support until Metal readback has a real implementation.
+
+## Follow-up (2026-06-28): Metal readback implemented
+
+The Metal backend now has a real readback, so macOS is supported too. The
+drawable can't be read after `frame_end` presents+releases it, so the capture
+happens inside `frame_end`: on frames the caller arms via
+`gpu.state.armUiScreenshotCapture()` (no-op on OpenGL), the rendered drawable is
+blitted into a shared CPU buffer and the GPU is waited on; `metal/readback.zig`
+then crops it, swaps BGRA→RGBA, and flips to GL bottom-up so the AppWindow path
+is backend-agnostic. `metal_layer.framebufferOnly` is `NO` to allow the blit.
+Verified `zig build test-metal`, `macos-app -Dtarget=aarch64-macos`, and
+`test-full -Dtarget=aarch64-macos`.

--- a/docs/superpowers/specs/2026-06-28-active-tab-ui-screenshot-design.md
+++ b/docs/superpowers/specs/2026-06-28-active-tab-ui-screenshot-design.md
@@ -1,0 +1,130 @@
+# Active-tab UI screenshot tool
+
+**Date:** 2026-06-28
+**Status:** Design - approved by user, pending spec review
+
+## Problem
+
+When a request comes from WeChat, the agent can inspect terminal text through
+`terminal_snapshot`, but the user sometimes needs to see the actual WispTerm UI:
+split layout, preview panes, Copilot/AI chat screens, overlays, and the visual
+state of a panel. Text snapshots do not cover that.
+
+The first version only needs to capture what the user can currently see in the
+active window. Capturing non-active tabs would require hidden rendering or tab
+switching and is intentionally out of scope.
+
+## Ghostty reference
+
+Ghostty has no comparable WeChat or AI tool surface, and the GitHub tree search
+shows no terminal screenshot/capture tool. The relevant alignment is
+architectural: Ghostty keeps VT terminal state separate from the host renderer.
+WispTerm should do the same. Screenshot capture belongs at the UI/render host
+boundary, not in `remote_snapshot.zig`, libghostty-vt state, or terminal text
+serialization.
+
+## Decision
+
+Add a first-party agent tool named `ui_screenshot`.
+
+The tool captures a PNG from the active WispTerm tab and returns the local file
+path plus basic metadata. It does not send anything to WeChat itself; the agent
+can call the existing `weixin_send_attachment(kind=image, path=...)` tool when
+the current request came from WeChat.
+
+Parameters:
+
+```json
+{
+  "target": "focused_panel | active_tab",
+  "surface_id": "optional"
+}
+```
+
+Defaults:
+
+- `target` defaults to `focused_panel`.
+- `surface_id` is optional and only applies to terminal panels in the active tab.
+- Aliases `focused`, `active`, and `current` resolve the same way terminal tools
+  already resolve focused surfaces.
+
+## Behavior
+
+- Terminal active tab:
+  - `focused_panel` captures the focused split panel.
+  - `focused_panel + surface_id` captures that terminal panel if it is in the
+    active tab.
+  - `active_tab` captures the active tab's visible content area, including
+    split panels, preview panes, the Copilot sidebar, and overlays that are
+    currently drawn.
+- Dedicated Copilot or AI chat tab:
+  - `focused_panel` falls back to `active_tab`.
+  - The PNG captures the visible AI chat page.
+- Unsupported or unavailable state:
+  - No window, minimized window, or zero framebuffer size returns a clear tool
+    error.
+  - A `surface_id` outside the active tab returns a clear "not in active tab"
+    error and lists active-tab terminal surfaces when available.
+
+## Architecture
+
+The agent tool layer runs off the UI thread, but framebuffer access must happen
+on the UI thread with the render context current. The tool therefore routes
+through a new `ToolHost` callback:
+
+```zig
+uiScreenshot(ctx, allocator, target, surface_id) !UiScreenshotResult
+```
+
+The real AppWindow host implements the callback by marshaling a synchronous UI
+thread request, mirroring the existing agent tab-control and WeChat control
+bridges. The UI thread handler:
+
+1. Ensures there is a freshly rendered frame for the active tab.
+2. Computes the capture rectangle:
+   - `active_tab`: visible tab/content area in framebuffer pixels.
+   - `focused_panel`: the matching `split_layout.g_split_rects` rectangle.
+3. Reads pixels from the current framebuffer.
+4. Flips rows from GL bottom-left order into PNG top-left order.
+5. Writes a PNG into the existing local agent/WispTerm files area.
+6. Returns `{ path, width, height, target }`.
+
+PNG encoding should use existing vendored/native capability, not a new
+dependency. Prefer a tiny local encoder wrapper around the available platform or
+vendored PNG path; add the minimum module needed only if no reusable writer
+exists.
+
+## Tool integration
+
+- `src/tools/first_party.zig`: add `ui_screenshot` under `.terminal` or
+  `.integration` (the tool is UI-level but mainly serves agent observation).
+- `src/assistant/conversation/protocol.zig`: advertise the schema.
+- `src/agent_tools/mod.zig`: parse arguments and call the `ToolHost` callback.
+- `src/assistant/conversation/types.zig`: add result/callback types.
+- AppWindow side: add the UI-thread request/handler and screenshot implementation
+  in a feature-owned module where practical, with only the narrow bridge in
+  `AppWindow.zig`.
+
+## Non-goals
+
+- No non-active tab screenshot.
+- No hidden/offscreen re-render of arbitrary tabs.
+- No automatic WeChat send inside `ui_screenshot`.
+- No screenshot history browser or UI button.
+- No OCR or image analysis. The model only receives a file path unless it asks
+  to send or inspect the image through existing channels.
+
+## Testing
+
+- Unit test argument parsing and target defaults in the agent tool layer.
+- Unit test active-tab surface matching: active-tab surface succeeds,
+  non-active-tab surface is rejected.
+- Unit test schema emission includes `ui_screenshot` and its parameters.
+- Source-scan or small pure test for row-flip/rectangle clamping.
+- Manual smoke on the real app:
+  - terminal single panel: `focused_panel`;
+  - terminal split: each active-tab panel by `surface_id`;
+  - `active_tab` with Copilot sidebar open;
+  - dedicated AI chat/Copilot tab falls back from `focused_panel` to
+    `active_tab`;
+  - WeChat flow: `ui_screenshot` then `weixin_send_attachment`.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -47,6 +47,7 @@ const render_diagnostics = @import("render_diagnostics.zig");
 const ime_caret = @import("ime_caret.zig");
 const hit_test = @import("input/hit_test.zig");
 pub const ai_chat = @import("assistant/conversation/session.zig");
+const ai_chat_types = @import("assistant/conversation/types.zig");
 const ai_history_cache = @import("terminal_agents/sessions/cache.zig");
 const ai_history_resume = @import("terminal_agents/sessions/resume.zig");
 const ai_loop_store = @import("assistant/loop/store.zig");
@@ -99,6 +100,8 @@ const control_api = @import("appwindow/control_api.zig");
 const remote_sync = @import("appwindow/remote_sync.zig");
 const weixin_bridge = @import("appwindow/weixin_bridge.zig");
 const agent_requests = @import("appwindow/agent_requests.zig");
+const appwindow_ui_screenshot = @import("appwindow/ui_screenshot.zig");
+const png_writer = @import("appwindow/png_writer.zig");
 const ui_effect = @import("appwindow/ui_effect.zig");
 pub const UiEffect = ui_effect.UiEffect;
 pub const background_image = @import("renderer/background_image.zig");
@@ -5058,6 +5061,200 @@ fn agentRequestSaveSshProfile(allocator: std.mem.Allocator, args: ai_chat.SshPro
     return overlays.agentSaveSshProfile(allocator, args);
 }
 
+const AgentUiScreenshotCapture = struct {
+    rect: appwindow_ui_screenshot.Rect,
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]const u8 = null,
+};
+
+const LiveUiScreenshotRect = struct {
+    rect: appwindow_ui_screenshot.Rect,
+    surface_id: ?[]const u8 = null,
+};
+
+fn fullUiScreenshotCapture(fb_width: u32, fb_height: u32) AgentUiScreenshotCapture {
+    return .{
+        .rect = .{ .x = 0, .y = 0, .width = fb_width, .height = fb_height },
+        .target = .active_tab,
+    };
+}
+
+fn splitRectToUiScreenshotRect(rect: split_layout.SplitRect) ?appwindow_ui_screenshot.Rect {
+    if (rect.width <= 0 or rect.height <= 0) return null;
+    return .{
+        .x = rect.x,
+        .y = rect.y,
+        .width = @intCast(rect.width),
+        .height = @intCast(rect.height),
+    };
+}
+
+fn liveUiScreenshotRectForHandle(handle: SplitTree.Node.Handle) ?LiveUiScreenshotRect {
+    for (0..split_layout.g_split_rect_count) |i| {
+        const rect = split_layout.g_split_rects[i];
+        if (rect.handle != handle) continue;
+        if (!split_layout.cachedRectIsLive(rect)) continue;
+        return .{
+            .rect = splitRectToUiScreenshotRect(rect) orelse return null,
+            .surface_id = if (rect.surface()) |surface| surface.remote_id[0..] else null,
+        };
+    }
+    return null;
+}
+
+fn liveUiScreenshotRectForSurfaceId(surface_id: []const u8) ?LiveUiScreenshotRect {
+    for (0..split_layout.g_split_rect_count) |i| {
+        const rect = split_layout.g_split_rects[i];
+        if (!split_layout.cachedRectIsLive(rect)) continue;
+        const surface = rect.surface() orelse continue;
+        if (std.mem.eql(u8, surface.remote_id[0..], surface_id)) {
+            return .{
+                .rect = splitRectToUiScreenshotRect(rect) orelse continue,
+                .surface_id = surface.remote_id[0..],
+            };
+        }
+    }
+    return null;
+}
+
+fn isFocusedUiScreenshotSelector(surface_id: []const u8) bool {
+    return surface_id.len == 0 or
+        std.ascii.eqlIgnoreCase(surface_id, "focused") or
+        std.ascii.eqlIgnoreCase(surface_id, "active") or
+        std.ascii.eqlIgnoreCase(surface_id, "current");
+}
+
+fn resolveAgentUiScreenshotCapture(
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    fb_width: u32,
+    fb_height: u32,
+) anyerror!AgentUiScreenshotCapture {
+    const full = fullUiScreenshotCapture(fb_width, fb_height);
+    const id = if (surface_id) |raw| std.mem.trim(u8, raw, " \t\r\n") else "";
+    const focused_selector = isFocusedUiScreenshotSelector(id);
+    switch (target) {
+        .active_tab => {
+            if (focused_selector) return full;
+            const active_tab = tab.activeTab() orelse return error.SurfaceNotInActiveTab;
+            if (active_tab.kind != .terminal) return error.SurfaceNotInActiveTab;
+            const live = liveUiScreenshotRectForSurfaceId(id) orelse return error.SurfaceNotInActiveTab;
+            return .{ .rect = full.rect, .target = .active_tab, .surface_id = live.surface_id };
+        },
+        .focused_panel => {
+            const active_tab = tab.activeTab() orelse {
+                if (focused_selector) return full;
+                return error.SurfaceNotInActiveTab;
+            };
+            if (active_tab.kind != .terminal) {
+                if (focused_selector) return full;
+                return error.SurfaceNotInActiveTab;
+            }
+
+            if (focused_selector) {
+                const live = liveUiScreenshotRectForHandle(active_tab.focused) orelse return full;
+                return .{ .rect = live.rect, .target = .focused_panel, .surface_id = live.surface_id };
+            }
+
+            const live = liveUiScreenshotRectForSurfaceId(id) orelse return error.SurfaceNotInActiveTab;
+            return .{ .rect = live.rect, .target = .focused_panel, .surface_id = live.surface_id };
+        },
+    }
+}
+
+fn ensureAbsoluteDir(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        error.FileNotFound => {
+            const parent = std.fs.path.dirname(path) orelse return err;
+            try ensureAbsoluteDir(parent);
+            std.fs.makeDirAbsolute(path) catch |err2| switch (err2) {
+                error.PathAlreadyExists => {},
+                else => return err2,
+            };
+        },
+        else => return err,
+    };
+}
+
+fn writeUiScreenshotFile(path: []const u8, bytes: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        if (parent.len > 0) {
+            if (std.fs.path.isAbsolute(parent)) {
+                try ensureAbsoluteDir(parent);
+            } else {
+                try std.fs.cwd().makePath(parent);
+            }
+        }
+    }
+
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.fs.createFileAbsolute(path, .{ .truncate = true })
+    else
+        try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(bytes);
+}
+
+fn agentRequestCaptureUiScreenshot(
+    allocator: std.mem.Allocator,
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+) anyerror!ai_chat_types.UiScreenshotResult {
+    const win = g_window orelse return error.WindowUnavailable;
+    if (window_backend.isMinimized(win)) return error.WindowUnavailable;
+
+    const fb = window_backend.framebufferSize(win);
+    if (fb.width <= 0 or fb.height <= 0) return error.WindowUnavailable;
+    const fb_width: u32 = @intCast(fb.width);
+    const fb_height: u32 = @intCast(fb.height);
+
+    const wd = working_dir orelse return error.MissingWorkingDir;
+    if (wd.len == 0) return error.MissingWorkingDir;
+
+    const capture = try resolveAgentUiScreenshotCapture(target, surface_id, fb_width, fb_height);
+    const rect = appwindow_ui_screenshot.clampRect(capture.rect, fb_width, fb_height) orelse return error.WindowUnavailable;
+
+    const bottom_up = try gpu.readback.readRgba(
+        allocator,
+        rect.x,
+        appwindow_ui_screenshot.glReadY(rect, fb_height),
+        rect.width,
+        rect.height,
+    );
+    defer allocator.free(bottom_up);
+
+    const top_down = try png_writer.flipRgbaRows(allocator, bottom_up, rect.width, rect.height);
+    defer allocator.free(top_down);
+
+    const png = try png_writer.encodeRgba(allocator, .{
+        .width = rect.width,
+        .height = rect.height,
+        .rgba = top_down,
+    });
+    defer allocator.free(png);
+
+    var result_surface_id: ?[]u8 = null;
+    errdefer if (result_surface_id) |id| allocator.free(id);
+    if (capture.surface_id) |id| {
+        result_surface_id = try allocator.dupe(u8, id);
+    }
+
+    const path = try appwindow_ui_screenshot.outputPath(allocator, wd, std.time.milliTimestamp());
+    errdefer allocator.free(path);
+    try writeUiScreenshotFile(path, png);
+
+    return .{
+        .path = path,
+        .mime = "image/png",
+        .width = rect.width,
+        .height = rect.height,
+        .target = capture.target,
+        .surface_id = result_surface_id,
+    };
+}
+
 fn agentRequestHost() agent_requests.Host {
     return .{
         .nativeHandleForContext = agentRequestNativeHandle,
@@ -5067,6 +5264,7 @@ fn agentRequestHost() agent_requests.Host {
         .closeTabByIndex = agentRequestCloseTabByIndex,
         .connectSshProfile = agentRequestConnectSshProfile,
         .saveSshProfile = agentRequestSaveSshProfile,
+        .captureUiScreenshot = agentRequestCaptureUiScreenshot,
     };
 }
 
@@ -5205,6 +5403,7 @@ fn onPlatformMessage(msg: window_backend.MessageId, wParam: window_backend.WordP
         .agent_ssh_save => agent_requests.handleSshSaveRequest(@ptrFromInt(decoded.ptr), agent_host),
         .agent_tab_new => agent_requests.handleTabNewRequest(@ptrFromInt(decoded.ptr), agent_host),
         .agent_tab_close => agent_requests.handleTabCloseRequest(@ptrFromInt(decoded.ptr), agent_host),
+        .agent_ui_screenshot => agent_requests.handleUiScreenshotRequest(@ptrFromInt(decoded.ptr), agent_host),
         .remote_ai_input => remote_sync.handleAiInputRequest(@ptrFromInt(decoded.ptr), remoteSyncHost()),
         .remote_open_ai_agent => remote_sync.handleAiAgentOpenRequest(@ptrFromInt(decoded.ptr), remoteSyncHost()),
         .weixin_control => weixin_bridge.handleControlRequest(@ptrFromInt(decoded.ptr), weixinBridgeHost()),
@@ -5224,6 +5423,7 @@ fn installAgentToolHost(self: *AppWindow) void {
         .saveSshProfile = agent_requests.saveSshProfile,
         .connectSshProfile = agent_requests.connectSshProfile,
         .sshConnectionForSurface = surface_snapshots.agentSshConnectionForSurface,
+        .uiScreenshot = agent_requests.uiScreenshot,
     });
 }
 
@@ -6530,6 +6730,7 @@ fn runMainLoop(self: *AppWindow) !void {
         const fb_width: c_int = fb.width;
         const fb_height: c_int = fb.height;
         if (window_backend.isMinimized(win) or fb_width <= 0 or fb_height <= 0) {
+            agent_requests.failPendingUiScreenshots(error.WindowUnavailable);
             const timeout_ms = render_gate.computeBlockTimeoutMs(.{
                 .visibility = .hidden,
                 .cursor_blink_enabled = false,
@@ -6557,7 +6758,7 @@ fn runMainLoop(self: *AppWindow) !void {
         });
 
         const signals = render_gate.RenderSignals{
-            .force_rebuild = g_force_rebuild or !g_cells_valid or pendingResizeActive() or windowState().layout_resize_immediate,
+            .force_rebuild = g_force_rebuild or !g_cells_valid or pendingResizeActive() or windowState().layout_resize_immediate or agent_requests.hasPendingUiScreenshot(),
             .any_surface_dirty = anyVisibleSurfaceDirty(),
             .cursor_blink_due = blink.due,
             .ai_streaming = aiStreamingActive(),
@@ -6868,6 +7069,7 @@ fn runMainLoop(self: *AppWindow) !void {
         logSwapDiagnosticsIfChanged(win, fb_width, fb_height);
         forceOpaqueBackbufferForPresent();
         gpu.state.endFrame();
+        agent_requests.capturePendingUiScreenshots(agentRequestHost());
         window_backend.swapBuffers(win);
         if (windowState().takePresentBringupSettlement()) {
             platform_window_state.settleD3dBringup(allocator);
@@ -6898,6 +7100,8 @@ fn runMainLoop(self: *AppWindow) !void {
             platform_window_state.blockD3dBringup(allocator, build_options.app_version);
         }
     }
+
+    agent_requests.failPendingUiScreenshots(error.WindowUnavailable);
 
     // Save window position + size for next session
     if (g_window) |w| {
@@ -7043,6 +7247,91 @@ test "appwindow: render gate ignores background-tab surface dirty" {
     clearVisibleSurfaceDirty();
     try std.testing.expect(!active_surface.dirty.load(.acquire));
     try std.testing.expect(background_surface.dirty.load(.acquire));
+}
+
+test "appwindow: ui screenshot focused_panel uses focused non-terminal split rect" {
+    const allocator = std.testing.allocator;
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_tab_count = tab.g_tab_count;
+    const saved_tab0 = tab.g_tabs[0];
+    const saved_split_rect_count = split_layout.g_split_rect_count;
+    const saved_split_rect0: split_layout.SplitRect = if (saved_split_rect_count > 0) split_layout.g_split_rects[0] else undefined;
+
+    var surface: Surface = undefined;
+    surface.ref_count = 1;
+    var active_tab_v = tab.TabState{ .tree = try SplitTree.init(allocator, &surface) };
+    defer active_tab_v.tree.deinit();
+
+    tab.g_tabs[0] = &active_tab_v;
+    tab.g_tab_count = 1;
+    active_tab_state.g_active_tab = 0;
+    split_layout.g_split_rect_count = 0;
+    defer {
+        if (saved_split_rect_count > 0) split_layout.g_split_rects[0] = saved_split_rect0;
+        split_layout.g_split_rect_count = saved_split_rect_count;
+        tab.g_tabs[0] = saved_tab0;
+        tab.g_tab_count = saved_tab_count;
+        active_tab_state.g_active_tab = saved_active;
+    }
+
+    const preview = tab.splitIntoPreview(allocator) orelse return error.SplitIntoPreviewFailed;
+    try std.testing.expect(tab.focusPreviewPane(preview));
+    const focused_pane = switch (active_tab_v.tree.nodes[active_tab_v.focused.idx()]) {
+        .leaf => |pane| pane,
+        .split => return error.FocusedIsSplit,
+    };
+
+    split_layout.g_split_rects[0] = .{
+        .x = 11,
+        .y = 22,
+        .width = 33,
+        .height = 44,
+        .cols = 0,
+        .rows = 0,
+        .pane = focused_pane,
+        .handle = active_tab_v.focused,
+    };
+    split_layout.g_split_rect_count = 1;
+
+    const capture = try resolveAgentUiScreenshotCapture(.focused_panel, null, 100, 100);
+    try std.testing.expectEqual(ai_chat_types.UiScreenshotTarget.focused_panel, capture.target);
+    try std.testing.expectEqual(appwindow_ui_screenshot.Rect{ .x = 11, .y = 22, .width = 33, .height = 44 }, capture.rect);
+}
+
+test "appwindow: ui screenshot explicit surface id errors on non-terminal active tab" {
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_tab_count = tab.g_tab_count;
+    const saved_tab0 = tab.g_tabs[0];
+
+    var active_tab_v = tab.TabState{ .kind = .ai_chat, .tree = .empty };
+    tab.g_tabs[0] = &active_tab_v;
+    tab.g_tab_count = 1;
+    active_tab_state.g_active_tab = 0;
+    defer {
+        tab.g_tabs[0] = saved_tab0;
+        tab.g_tab_count = saved_tab_count;
+        active_tab_state.g_active_tab = saved_active;
+    }
+
+    try std.testing.expectError(
+        error.SurfaceNotInActiveTab,
+        resolveAgentUiScreenshotCapture(.focused_panel, "surface-123", 100, 100),
+    );
+    try std.testing.expectError(
+        error.SurfaceNotInActiveTab,
+        resolveAgentUiScreenshotCapture(.active_tab, "surface-123", 100, 100),
+    );
+}
+
+test "appwindow: ui screenshot reports unavailable window before missing working dir" {
+    const saved_window = g_window;
+    g_window = null;
+    defer g_window = saved_window;
+
+    try std.testing.expectError(
+        error.WindowUnavailable,
+        agentRequestCaptureUiScreenshot(std.testing.allocator, .active_tab, null, null),
+    );
 }
 
 test "appwindow: ai history content width accounts for right panels" {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -5061,6 +5061,46 @@ fn agentRequestSaveSshProfile(allocator: std.mem.Allocator, args: ai_chat.SshPro
     return overlays.agentSaveSshProfile(allocator, args);
 }
 
+const AgentTerminalFocusTarget = struct {
+    surface: *Surface,
+    tab_index: usize,
+};
+
+fn focusAgentTerminalSurfaceById(surface_id_raw: []const u8) ?AgentTerminalFocusTarget {
+    const surface_id = std.mem.trim(u8, surface_id_raw, " \t\r\n");
+    if (surface_id.len == 0) return null;
+
+    for (0..tab.g_tab_count) |tab_index| {
+        const tab_state = tab.g_tabs[tab_index] orelse continue;
+        if (tab_state.kind != .terminal) continue;
+        var it = tab_state.tree.surfaces();
+        while (it.next()) |entry| {
+            if (!std.mem.eql(u8, entry.surface.remote_id[0..], surface_id)) continue;
+
+            if (active_tab_state.g_active_tab != tab_index) {
+                switchTab(tab_index);
+            }
+            tab_state.focused = entry.handle;
+            handleActiveSurfaceChangeWithinTab();
+            return .{
+                .surface = entry.surface,
+                .tab_index = tab_index,
+            };
+        }
+    }
+    return null;
+}
+
+fn agentRequestFocusTerminalSurface(allocator: std.mem.Allocator, surface_id: []const u8) anyerror!ai_chat.ToolSurface {
+    const target = focusAgentTerminalSurfaceById(surface_id) orelse return error.SurfaceNotFound;
+    return surface_snapshots.makeAgentToolSurface(
+        allocator,
+        target.surface,
+        target.tab_index,
+        true,
+    );
+}
+
 const AgentUiScreenshotCapture = struct {
     rect: appwindow_ui_screenshot.Rect,
     target: ai_chat_types.UiScreenshotTarget,
@@ -5272,6 +5312,7 @@ fn agentRequestHost() agent_requests.Host {
         .connectSshProfile = agentRequestConnectSshProfile,
         .saveSshProfile = agentRequestSaveSshProfile,
         .captureUiScreenshot = agentRequestCaptureUiScreenshot,
+        .focusTerminalSurface = agentRequestFocusTerminalSurface,
     };
 }
 
@@ -5411,6 +5452,7 @@ fn onPlatformMessage(msg: window_backend.MessageId, wParam: window_backend.WordP
         .agent_tab_new => agent_requests.handleTabNewRequest(@ptrFromInt(decoded.ptr), agent_host),
         .agent_tab_close => agent_requests.handleTabCloseRequest(@ptrFromInt(decoded.ptr), agent_host),
         .agent_ui_screenshot => agent_requests.handleUiScreenshotRequest(@ptrFromInt(decoded.ptr), agent_host),
+        .agent_terminal_focus => agent_requests.handleTerminalFocusRequest(@ptrFromInt(decoded.ptr), agent_host),
         .remote_ai_input => remote_sync.handleAiInputRequest(@ptrFromInt(decoded.ptr), remoteSyncHost()),
         .remote_open_ai_agent => remote_sync.handleAiAgentOpenRequest(@ptrFromInt(decoded.ptr), remoteSyncHost()),
         .weixin_control => weixin_bridge.handleControlRequest(@ptrFromInt(decoded.ptr), weixinBridgeHost()),
@@ -5431,6 +5473,7 @@ fn installAgentToolHost(self: *AppWindow) void {
         .connectSshProfile = agent_requests.connectSshProfile,
         .sshConnectionForSurface = surface_snapshots.agentSshConnectionForSurface,
         .uiScreenshot = agent_requests.uiScreenshot,
+        .focusTerminal = agent_requests.focusTerminal,
     });
 }
 
@@ -7334,6 +7377,68 @@ test "appwindow: ui screenshot explicit surface id errors on non-terminal active
         error.SurfaceNotInActiveTab,
         resolveAgentUiScreenshotCapture(.active_tab, "surface-123", 100, 100),
     );
+}
+
+test "appwindow: agent terminal focus activates the owning tab and split" {
+    const allocator = std.testing.allocator;
+    const id_a = "00000000000000a1";
+    const id_b = "00000000000000b2";
+    const id_c = "00000000000000c3";
+
+    var surface_a: Surface = undefined;
+    surface_a.ref_count = 1;
+    @memcpy(surface_a.remote_id[0..], id_a);
+    var surface_b: Surface = undefined;
+    surface_b.ref_count = 1;
+    @memcpy(surface_b.remote_id[0..], id_b);
+    var surface_c: Surface = undefined;
+    surface_c.ref_count = 1;
+    @memcpy(surface_c.remote_id[0..], id_c);
+
+    var tab0_v = tab.TabState{ .tree = try SplitTree.init(allocator, &surface_a) };
+    defer tab0_v.tree.deinit();
+
+    var left = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var right = session_persist.NodeSnap{ .leaf = .{ .surface = .{ .local_shell = .{} } } };
+    var root = session_persist.NodeSnap{ .split = .{ .layout = .horizontal, .ratio = 0.5, .left = &left, .right = &right } };
+    const Stub = struct {
+        var idx: usize = 0;
+        var surfaces: [2]*Surface = undefined;
+        fn make(_: *const session_persist.SurfaceSnap, _: std.mem.Allocator) ?*Surface {
+            const surface = surfaces[idx];
+            idx += 1;
+            return surface;
+        }
+    };
+    Stub.idx = 0;
+    Stub.surfaces = .{ &surface_b, &surface_c };
+    var tab1_v = tab.TabState{
+        .tree = try SplitTree.fromSnapshot(allocator, &root, Stub.make),
+        .focused = @enumFromInt(1),
+    };
+    defer tab1_v.tree.arena.deinit();
+
+    const saved_active = active_tab_state.g_active_tab;
+    const saved_tab_count = tab.g_tab_count;
+    const saved_tab0 = tab.g_tabs[0];
+    const saved_tab1 = tab.g_tabs[1];
+    defer {
+        tab.g_tabs[0] = saved_tab0;
+        tab.g_tabs[1] = saved_tab1;
+        tab.g_tab_count = saved_tab_count;
+        active_tab_state.g_active_tab = saved_active;
+    }
+
+    tab.g_tabs[0] = &tab0_v;
+    tab.g_tabs[1] = &tab1_v;
+    tab.g_tab_count = 2;
+    active_tab_state.g_active_tab = 0;
+
+    const target = focusAgentTerminalSurfaceById(id_c) orelse return error.FocusTargetMissing;
+    try std.testing.expect(target.surface == &surface_c);
+    try std.testing.expectEqual(@as(usize, 1), target.tab_index);
+    try std.testing.expectEqual(@as(usize, 1), active_tab_state.g_active_tab);
+    try std.testing.expectEqual(@as(SplitTree.Node.Handle.Backing, 2), @intFromEnum(tab1_v.focused));
 }
 
 test "appwindow: ui screenshot base dir falls back to exports dir" {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -5196,6 +5196,13 @@ fn writeUiScreenshotFile(path: []const u8, bytes: []const u8) !void {
     try file.writeAll(bytes);
 }
 
+fn agentUiScreenshotBaseDir(allocator: std.mem.Allocator, working_dir: ?[]const u8) ![]const u8 {
+    if (working_dir) |wd| {
+        if (wd.len > 0) return allocator.dupe(u8, wd);
+    }
+    return platform_dirs.exportsDir(allocator);
+}
+
 fn agentRequestCaptureUiScreenshot(
     allocator: std.mem.Allocator,
     target: ai_chat_types.UiScreenshotTarget,
@@ -5210,8 +5217,8 @@ fn agentRequestCaptureUiScreenshot(
     const fb_width: u32 = @intCast(fb.width);
     const fb_height: u32 = @intCast(fb.height);
 
-    const wd = working_dir orelse return error.MissingWorkingDir;
-    if (wd.len == 0) return error.MissingWorkingDir;
+    const output_base = try agentUiScreenshotBaseDir(allocator, working_dir);
+    defer allocator.free(output_base);
 
     const capture = try resolveAgentUiScreenshotCapture(target, surface_id, fb_width, fb_height);
     const rect = appwindow_ui_screenshot.clampRect(capture.rect, fb_width, fb_height) orelse return error.WindowUnavailable;
@@ -5241,7 +5248,7 @@ fn agentRequestCaptureUiScreenshot(
         result_surface_id = try allocator.dupe(u8, id);
     }
 
-    const path = try appwindow_ui_screenshot.outputPath(allocator, wd, std.time.milliTimestamp());
+    const path = try appwindow_ui_screenshot.outputPath(allocator, output_base, std.time.milliTimestamp());
     errdefer allocator.free(path);
     try writeUiScreenshotFile(path, png);
 
@@ -7327,6 +7334,22 @@ test "appwindow: ui screenshot explicit surface id errors on non-terminal active
         error.SurfaceNotInActiveTab,
         resolveAgentUiScreenshotCapture(.active_tab, "surface-123", 100, 100),
     );
+}
+
+test "appwindow: ui screenshot base dir falls back to exports dir" {
+    const allocator = std.testing.allocator;
+    platform_dirs.setTestConfigDirForCurrentThread("/tmp/wispterm-test-config");
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    const fallback = try agentUiScreenshotBaseDir(allocator, null);
+    defer allocator.free(fallback);
+    const expected = try std.fs.path.join(allocator, &.{ "/tmp/wispterm-test-config", "exports" });
+    defer allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, fallback);
+
+    const explicit = try agentUiScreenshotBaseDir(allocator, "/work/project");
+    defer allocator.free(explicit);
+    try std.testing.expectEqualStrings("/work/project", explicit);
 }
 
 test "appwindow: ui screenshot reports unavailable window before missing working dir" {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -6778,6 +6778,12 @@ fn runMainLoop(self: *AppWindow) !void {
         }
         if (blink.due) g_gate_last_blink_render = gate_now;
 
+        // A pending ui_screenshot is captured from this frame's framebuffer right
+        // after endFrame. The Metal backend can't read a presented+released
+        // drawable, so arm an in-frame capture before we render+endFrame. No-op
+        // on OpenGL (it reads the live back buffer post-endFrame).
+        if (agent_requests.hasPendingUiScreenshot()) gpu.state.armUiScreenshotCapture();
+
         gpu.gl_init.g_draw_call_count = 0;
         overlays.updateFps();
 

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -389,9 +389,11 @@ test "executeToolCall ui_screenshot calls host and formats path" {
             try std.testing.expectEqualStrings("/work", working_dir.?);
             return .{
                 .path = try allocator.dupe(u8, "/work/wispterm-files/ui-screenshot-1.png"),
+                .mime = "image/png",
                 .width = 10,
                 .height = 20,
                 .target = target,
+                .surface_id = try allocator.dupe(u8, "abc"),
             };
         }
         var dummy: u8 = 0;
@@ -427,8 +429,10 @@ test "executeToolCall ui_screenshot calls host and formats path" {
     });
     defer a.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "path=/work/wispterm-files/ui-screenshot-1.png") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "mime=image/png") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "width=10") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "height=20") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "surface_id=abc") != null);
 }
 
 const FakeApprover = struct {

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -28,6 +28,7 @@ const agent_files = @import("files.zig");
 const agent_exec = @import("exec.zig");
 const agent_dynamic = @import("dynamic.zig");
 const agent_weixin = @import("weixin.zig");
+const agent_ui_screenshot = @import("ui_screenshot.zig");
 
 // ---------------------------------------------------------------------------
 // Tool dispatch
@@ -49,6 +50,13 @@ pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
         defer if (args) |parsed| parsed.deinit();
         const surface_id = if (args) |parsed| tool_args.string(parsed.value, "surface_id") else null;
         return terminal_tools.snapshot(ctx, surface_id);
+    }
+    if (std.mem.eql(u8, call.name, "ui_screenshot")) {
+        const args = tool_args.parse(ctx.allocator, call.arguments);
+        defer if (args) |parsed| parsed.deinit();
+        const target = if (args) |parsed| tool_args.string(parsed.value, "target") else null;
+        const surface_id = if (args) |parsed| tool_args.string(parsed.value, "surface_id") else null;
+        return agent_ui_screenshot.run(ctx, target, surface_id);
     }
     if (std.mem.eql(u8, call.name, "terminal_select")) {
         const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
@@ -329,6 +337,98 @@ fn fakeApprove(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool 
 }
 fn fakeCancelled(_: *anyopaque) bool {
     return false;
+}
+
+test "executeToolCall ui_screenshot reports missing host clearly" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null, .working_dir = "/work" },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("call-shot"),
+        .name = @constCast("ui_screenshot"),
+        .arguments = @constCast("{}"),
+    });
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No UI screenshot host") != null);
+}
+
+test "executeToolCall ui_screenshot calls host and formats path" {
+    const Fake = struct {
+        fn collectSnapshot(_: *anyopaque, allocator: std.mem.Allocator) anyerror!ToolSnapshot {
+            return .{ .surfaces = try allocator.alloc(ToolSurface, 0), .active_tab = 0 };
+        }
+        fn surfaceSnapshot(_: *anyopaque, allocator: std.mem.Allocator, _: []const u8, _: *anyopaque) anyerror![]u8 {
+            return allocator.dupe(u8, "");
+        }
+        fn writeSurface(_: *anyopaque, _: []const u8, _: *anyopaque, _: []const u8) bool {
+            return false;
+        }
+        fn unsupportedSpawn(_: *anyopaque, _: std.mem.Allocator, _: []const u8, _: ?[]const u8) anyerror!ToolSurface {
+            return error.Unsupported;
+        }
+        fn unsupportedClose(_: *anyopaque, _: std.mem.Allocator, _: ?usize, _: ?[]const u8, _: ?[]const u8) anyerror!ToolClosedTab {
+            return error.Unsupported;
+        }
+        fn unsupportedSaveSsh(_: *anyopaque, _: std.mem.Allocator, _: SshProfileSaveArgs) anyerror!SavedSshProfile {
+            return error.Unsupported;
+        }
+        fn unsupportedConnectSsh(_: *anyopaque, _: std.mem.Allocator, _: []const u8) anyerror!ToolSurface {
+            return error.Unsupported;
+        }
+        fn shot(_: *anyopaque, allocator: std.mem.Allocator, target: types.UiScreenshotTarget, surface_id: ?[]const u8, working_dir: ?[]const u8) anyerror!types.UiScreenshotResult {
+            try std.testing.expectEqual(types.UiScreenshotTarget.active_tab, target);
+            try std.testing.expectEqualStrings("abc", surface_id.?);
+            try std.testing.expectEqualStrings("/work", working_dir.?);
+            return .{
+                .path = try allocator.dupe(u8, "/work/wispterm-files/ui-screenshot-1.png"),
+                .width = 10,
+                .height = 20,
+                .target = target,
+            };
+        }
+        var dummy: u8 = 0;
+        fn host() ToolHost {
+            return .{
+                .ctx = &dummy,
+                .collectSnapshot = collectSnapshot,
+                .surfaceSnapshot = surfaceSnapshot,
+                .writeSurface = writeSurface,
+                .spawnTab = unsupportedSpawn,
+                .closeTab = unsupportedClose,
+                .saveSshProfile = unsupportedSaveSsh,
+                .connectSshProfile = unsupportedConnectSsh,
+                .uiScreenshot = shot,
+            };
+        }
+    };
+
+    const a = std.testing.allocator;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &Fake.dummy,
+        .tool_host = Fake.host(),
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null, .working_dir = "/work" },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("call-shot"),
+        .name = @constCast("ui_screenshot"),
+        .arguments = @constCast("{\"target\":\"active_tab\",\"surface_id\":\"abc\"}"),
+    });
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "path=/work/wispterm-files/ui-screenshot-1.png") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "width=10") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "height=20") != null);
 }
 
 const FakeApprover = struct {

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -64,6 +64,12 @@ pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
         const surface_id = tool_args.string(args.value, "surface_id") orelse return ctx.allocator.dupe(u8, "Missing surface_id");
         return terminal_tools.select(ctx, surface_id);
     }
+    if (std.mem.eql(u8, call.name, "terminal_focus")) {
+        const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const surface_id = tool_args.string(args.value, "surface_id") orelse return ctx.allocator.dupe(u8, "Missing surface_id");
+        return terminal_tools.focus(ctx, surface_id);
+    }
     if (std.mem.eql(u8, call.name, platform_process.localCommandToolName())) {
         const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
         defer args.deinit();
@@ -358,6 +364,27 @@ test "executeToolCall ui_screenshot reports missing host clearly" {
     });
     defer a.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "No UI screenshot host") != null);
+}
+
+test "executeToolCall terminal_focus reports missing host clearly" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .access_rules = null },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("call-focus"),
+        .name = @constCast("terminal_focus"),
+        .arguments = @constCast("{\"surface_id\":\"surface-2\"}"),
+    });
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No terminal focus host") != null);
 }
 
 test "executeToolCall ui_screenshot calls host and formats path" {

--- a/src/agent_tools/terminal.zig
+++ b/src/agent_tools/terminal.zig
@@ -165,6 +165,33 @@ pub fn select(ctx: *ToolContext, surface_id: []const u8) ![]u8 {
     );
 }
 
+pub fn focus(ctx: *ToolContext, surface_id: []const u8) ![]u8 {
+    const host = ctx.tool_host orelse return ctx.allocator.dupe(u8, "No terminal focus host is available.");
+    const callback = host.focusTerminal orelse return ctx.allocator.dupe(u8, "No terminal focus host is available.");
+    const surface = callback(host.ctx, ctx.allocator, surface_id) catch |err| {
+        return std.fmt.allocPrint(ctx.allocator, "terminal_focus failed: {s}", .{@errorName(err)});
+    };
+    defer surface.deinit(ctx.allocator);
+    if (ctx.tool_snapshot) |*snapshot_value| {
+        snapshot_value.active_tab = surface.tab_index;
+        for (snapshot_value.surfaces) |*existing| {
+            existing.focused = std.mem.eql(u8, existing.id, surface.id);
+        }
+    }
+    return std.fmt.allocPrint(
+        ctx.allocator,
+        "focused surface_id={s} tab={d} focused={} kind={s} title=\"{s}\" cwd=\"{s}\"",
+        .{
+            surface.id,
+            surface.tab_index + 1,
+            surface.focused,
+            surfaceKind(surface),
+            surface.title,
+            surface.cwd,
+        },
+    );
+}
+
 pub fn collectToolSnapshot(ctx: *const ToolContext) !ToolSnapshot {
     if (ctx.tool_snapshot) |snapshot_value| {
         return snapshot_value.clone(ctx.allocator);

--- a/src/agent_tools/ui_screenshot.zig
+++ b/src/agent_tools/ui_screenshot.zig
@@ -1,0 +1,36 @@
+//! Agent UI screenshot tool.
+const std = @import("std");
+const types = @import("../assistant/conversation/types.zig");
+
+const ToolContext = types.ToolContext;
+const UiScreenshotTarget = types.UiScreenshotTarget;
+
+fn parseTarget(text: ?[]const u8) ?UiScreenshotTarget {
+    const raw = std.mem.trim(u8, text orelse "focused_panel", " \t\r\n");
+    if (raw.len == 0 or std.ascii.eqlIgnoreCase(raw, "focused_panel") or std.ascii.eqlIgnoreCase(raw, "focused")) return .focused_panel;
+    if (std.ascii.eqlIgnoreCase(raw, "active_tab") or std.ascii.eqlIgnoreCase(raw, "tab")) return .active_tab;
+    return null;
+}
+
+pub fn run(ctx: *ToolContext, target_text: ?[]const u8, surface_id: ?[]const u8) ![]u8 {
+    if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+    const target = parseTarget(target_text) orelse return ctx.allocator.dupe(u8, "Invalid target; expected focused_panel or active_tab.");
+    const host = ctx.tool_host orelse return ctx.allocator.dupe(u8, "No UI screenshot host is available.");
+    const callback = host.uiScreenshot orelse return ctx.allocator.dupe(u8, "No UI screenshot host is available.");
+    const result = callback(host.ctx, ctx.allocator, target, surface_id, ctx.settings.working_dir) catch |err| {
+        return std.fmt.allocPrint(ctx.allocator, "ui_screenshot failed: {s}", .{@errorName(err)});
+    };
+    defer result.deinit(ctx.allocator);
+    return std.fmt.allocPrint(
+        ctx.allocator,
+        "screenshot path={s} width={d} height={d} target={s}",
+        .{ result.path, result.width, result.height, result.target.label() },
+    );
+}
+
+test "ui_screenshot target parser accepts defaults and aliases" {
+    try std.testing.expectEqual(UiScreenshotTarget.focused_panel, parseTarget(null).?);
+    try std.testing.expectEqual(UiScreenshotTarget.focused_panel, parseTarget("focused").?);
+    try std.testing.expectEqual(UiScreenshotTarget.active_tab, parseTarget("tab").?);
+    try std.testing.expect(parseTarget("pane") == null);
+}

--- a/src/agent_tools/ui_screenshot.zig
+++ b/src/agent_tools/ui_screenshot.zig
@@ -21,10 +21,17 @@ pub fn run(ctx: *ToolContext, target_text: ?[]const u8, surface_id: ?[]const u8)
         return std.fmt.allocPrint(ctx.allocator, "ui_screenshot failed: {s}", .{@errorName(err)});
     };
     defer result.deinit(ctx.allocator);
+    if (result.surface_id) |result_surface_id| {
+        return std.fmt.allocPrint(
+            ctx.allocator,
+            "screenshot path={s} mime={s} width={d} height={d} target={s} surface_id={s}",
+            .{ result.path, result.mime, result.width, result.height, result.target.label(), result_surface_id },
+        );
+    }
     return std.fmt.allocPrint(
         ctx.allocator,
-        "screenshot path={s} width={d} height={d} target={s}",
-        .{ result.path, result.width, result.height, result.target.label() },
+        "screenshot path={s} mime={s} width={d} height={d} target={s}",
+        .{ result.path, result.mime, result.width, result.height, result.target.label() },
     );
 }
 

--- a/src/appwindow/agent_requests.zig
+++ b/src/appwindow/agent_requests.zig
@@ -34,6 +34,7 @@ pub const Host = struct {
     connectSshProfile: *const fn ([]const u8) SshConnectResult,
     saveSshProfile: *const fn (std.mem.Allocator, ai_chat.SshProfileSaveArgs) anyerror!ai_chat.SavedSshProfile,
     captureUiScreenshot: *const fn (std.mem.Allocator, ai_chat_types.UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!ai_chat_types.UiScreenshotResult,
+    focusTerminalSurface: *const fn (std.mem.Allocator, []const u8) anyerror!ai_chat.ToolSurface,
 };
 
 pub const AgentSshConnectRequest = struct {
@@ -81,6 +82,13 @@ pub const AgentUiScreenshotRequest = struct {
     next: ?*AgentUiScreenshotRequest = null,
 };
 
+pub const AgentTerminalFocusRequest = struct {
+    allocator: std.mem.Allocator,
+    surface_id: []const u8,
+    result: ?ai_chat.ToolSurface = null,
+    err: ?anyerror = null,
+};
+
 var g_host: ?Host = null;
 threadlocal var pending_ui_screenshot_head: ?*AgentUiScreenshotRequest = null;
 threadlocal var pending_ui_screenshot_tail: ?*AgentUiScreenshotRequest = null;
@@ -115,6 +123,10 @@ fn postAgentSshSave(native_handle: window_backend.NativeHandle, request: *AgentS
 
 fn postAgentUiScreenshot(native_handle: window_backend.NativeHandle, request: *AgentUiScreenshotRequest) bool {
     return thread_message.postPointer(native_handle, .agent_ui_screenshot, @intFromPtr(request));
+}
+
+fn postAgentTerminalFocus(native_handle: window_backend.NativeHandle, request: *AgentTerminalFocusRequest) void {
+    postAgentRequest(native_handle, .agent_terminal_focus, @intFromPtr(request));
 }
 
 fn destroyUiScreenshotRequest(request: *AgentUiScreenshotRequest) void {
@@ -382,6 +394,29 @@ pub fn uiScreenshot(
     return waitUiScreenshotRequest(request, allocator);
 }
 
+pub fn focusTerminal(ctx: *anyopaque, allocator: std.mem.Allocator, surface_id: []const u8) anyerror!ai_chat.ToolSurface {
+    const host = try installedHost();
+    const native_handle = host.nativeHandleForContext(ctx) orelse return error.WindowUnavailable;
+
+    var request = AgentTerminalFocusRequest{
+        .allocator = allocator,
+        .surface_id = surface_id,
+    };
+
+    if (host.currentNativeHandle()) |current| {
+        if (current == native_handle) {
+            handleTerminalFocusRequest(&request, host);
+        } else {
+            postAgentTerminalFocus(native_handle, &request);
+        }
+    } else {
+        postAgentTerminalFocus(native_handle, &request);
+    }
+
+    if (request.err) |err| return err;
+    return request.result orelse error.SurfaceNotFound;
+}
+
 fn agentTabCommand(kind_raw: []const u8, command_raw: ?[]const u8) anyerror!?[]const u8 {
     return platform_pty_command.tabCommandForKind(kind_raw, command_raw, tab.getShellCmd());
 }
@@ -537,4 +572,11 @@ pub fn handleUiScreenshotRequest(request: *AgentUiScreenshotRequest, host: Host)
         return;
     }
     enqueueUiScreenshotRequest(request);
+}
+
+pub fn handleTerminalFocusRequest(request: *AgentTerminalFocusRequest, host: Host) void {
+    request.result = host.focusTerminalSurface(request.allocator, request.surface_id) catch |err| {
+        request.err = err;
+        return;
+    };
 }

--- a/src/appwindow/agent_requests.zig
+++ b/src/appwindow/agent_requests.zig
@@ -8,12 +8,16 @@ const std = @import("std");
 
 const Surface = @import("../Surface.zig");
 const ai_chat = @import("../assistant/conversation/session.zig");
+const ai_chat_types = @import("../assistant/conversation/types.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
 const window_backend = @import("../platform/window_backend.zig");
 const active_tab_state = @import("active_tab.zig");
 const surface_snapshots = @import("surface_snapshots.zig");
 const tab = @import("tab.zig");
 const thread_message = @import("thread_message.zig");
+
+const ui_screenshot_timeout_ns = 30 * std.time.ns_per_s;
+const ui_screenshot_request_allocator = std.heap.page_allocator;
 
 pub const SshConnectResult = union(enum) {
     connected: *Surface,
@@ -29,6 +33,7 @@ pub const Host = struct {
     closeTabByIndex: *const fn (usize) void,
     connectSshProfile: *const fn ([]const u8) SshConnectResult,
     saveSshProfile: *const fn (std.mem.Allocator, ai_chat.SshProfileSaveArgs) anyerror!ai_chat.SavedSshProfile,
+    captureUiScreenshot: *const fn (std.mem.Allocator, ai_chat_types.UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!ai_chat_types.UiScreenshotResult,
 };
 
 pub const AgentSshConnectRequest = struct {
@@ -62,7 +67,23 @@ pub const AgentTabCloseRequest = struct {
     err: ?anyerror = null,
 };
 
+pub const AgentUiScreenshotRequest = struct {
+    allocator: std.mem.Allocator,
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]u8,
+    working_dir: ?[]u8,
+    result: ?ai_chat_types.UiScreenshotResult = null,
+    err: ?anyerror = null,
+    mutex: std.Thread.Mutex = .{},
+    cond: std.Thread.Condition = .{},
+    done: bool = false,
+    abandoned: bool = false,
+    next: ?*AgentUiScreenshotRequest = null,
+};
+
 var g_host: ?Host = null;
+threadlocal var pending_ui_screenshot_head: ?*AgentUiScreenshotRequest = null;
+threadlocal var pending_ui_screenshot_tail: ?*AgentUiScreenshotRequest = null;
 
 pub fn setHost(host: Host) void {
     g_host = host;
@@ -90,6 +111,156 @@ fn postAgentSshConnect(native_handle: window_backend.NativeHandle, request: *Age
 
 fn postAgentSshSave(native_handle: window_backend.NativeHandle, request: *AgentSshSaveRequest) void {
     postAgentRequest(native_handle, .agent_ssh_save, @intFromPtr(request));
+}
+
+fn postAgentUiScreenshot(native_handle: window_backend.NativeHandle, request: *AgentUiScreenshotRequest) bool {
+    return thread_message.postPointer(native_handle, .agent_ui_screenshot, @intFromPtr(request));
+}
+
+fn destroyUiScreenshotRequest(request: *AgentUiScreenshotRequest) void {
+    if (request.surface_id) |surface_id| ui_screenshot_request_allocator.free(surface_id);
+    if (request.working_dir) |working_dir| ui_screenshot_request_allocator.free(working_dir);
+    ui_screenshot_request_allocator.destroy(request);
+}
+
+fn createUiScreenshotRequest(
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+) !*AgentUiScreenshotRequest {
+    const request = try ui_screenshot_request_allocator.create(AgentUiScreenshotRequest);
+    errdefer ui_screenshot_request_allocator.destroy(request);
+
+    const surface_id_copy = if (surface_id) |value|
+        try ui_screenshot_request_allocator.dupe(u8, value)
+    else
+        null;
+    errdefer if (surface_id_copy) |value| ui_screenshot_request_allocator.free(value);
+
+    const working_dir_copy = if (working_dir) |value|
+        try ui_screenshot_request_allocator.dupe(u8, value)
+    else
+        null;
+    errdefer if (working_dir_copy) |value| ui_screenshot_request_allocator.free(value);
+
+    request.* = .{
+        .allocator = ui_screenshot_request_allocator,
+        .target = target,
+        .surface_id = surface_id_copy,
+        .working_dir = working_dir_copy,
+    };
+    return request;
+}
+
+fn cloneUiScreenshotResult(allocator: std.mem.Allocator, result: ai_chat_types.UiScreenshotResult) !ai_chat_types.UiScreenshotResult {
+    const path = try allocator.dupe(u8, result.path);
+    errdefer allocator.free(path);
+
+    const surface_id = if (result.surface_id) |value|
+        try allocator.dupe(u8, value)
+    else
+        null;
+    errdefer if (surface_id) |value| allocator.free(value);
+
+    return .{
+        .path = path,
+        .mime = result.mime,
+        .width = result.width,
+        .height = result.height,
+        .target = result.target,
+        .surface_id = surface_id,
+    };
+}
+
+fn waitUiScreenshotRequest(
+    request: *AgentUiScreenshotRequest,
+    allocator: std.mem.Allocator,
+) anyerror!ai_chat_types.UiScreenshotResult {
+    request.mutex.lock();
+    while (!request.done) {
+        request.cond.timedWait(&request.mutex, ui_screenshot_timeout_ns) catch |err| switch (err) {
+            error.Timeout => {
+                if (request.done) break;
+                request.abandoned = true;
+                request.mutex.unlock();
+                return error.WindowUnavailable;
+            },
+        };
+    }
+    const request_err = request.err;
+    const request_result = request.result;
+    request.mutex.unlock();
+    defer destroyUiScreenshotRequest(request);
+
+    if (request_err) |err| return err;
+    var result = request_result orelse return error.ScreenshotFailed;
+    defer result.deinit(ui_screenshot_request_allocator);
+    return cloneUiScreenshotResult(allocator, result);
+}
+
+fn completeUiScreenshotRequest(
+    request: *AgentUiScreenshotRequest,
+    result: ?ai_chat_types.UiScreenshotResult,
+    err: ?anyerror,
+) void {
+    request.mutex.lock();
+    if (request.abandoned) {
+        request.mutex.unlock();
+        if (result) |owned_result| {
+            var mutable = owned_result;
+            mutable.deinit(ui_screenshot_request_allocator);
+        }
+        destroyUiScreenshotRequest(request);
+        return;
+    }
+    request.result = result;
+    request.err = err;
+    request.done = true;
+    request.cond.signal();
+    request.mutex.unlock();
+}
+
+fn enqueueUiScreenshotRequest(request: *AgentUiScreenshotRequest) void {
+    request.next = null;
+    if (pending_ui_screenshot_tail) |tail| {
+        tail.next = request;
+    } else {
+        pending_ui_screenshot_head = request;
+    }
+    pending_ui_screenshot_tail = request;
+}
+
+fn popUiScreenshotRequest() ?*AgentUiScreenshotRequest {
+    const request = pending_ui_screenshot_head orelse return null;
+    pending_ui_screenshot_head = request.next;
+    if (pending_ui_screenshot_head == null) pending_ui_screenshot_tail = null;
+    request.next = null;
+    return request;
+}
+
+pub fn hasPendingUiScreenshot() bool {
+    return pending_ui_screenshot_head != null;
+}
+
+pub fn failPendingUiScreenshots(err: anyerror) void {
+    while (popUiScreenshotRequest()) |request| {
+        completeUiScreenshotRequest(request, null, err);
+    }
+}
+
+pub fn capturePendingUiScreenshots(host: Host) void {
+    while (popUiScreenshotRequest()) |request| {
+        const result = host.captureUiScreenshot(
+            request.allocator,
+            request.target,
+            request.surface_id,
+            request.working_dir,
+        ) catch |err| {
+            completeUiScreenshotRequest(request, null, err);
+            continue;
+        };
+        completeUiScreenshotRequest(request, result, null);
+    }
 }
 
 pub fn spawnTab(ctx: *anyopaque, allocator: std.mem.Allocator, kind: []const u8, command: ?[]const u8) anyerror!ai_chat.ToolSurface {
@@ -185,6 +356,30 @@ pub fn saveSshProfile(ctx: *anyopaque, allocator: std.mem.Allocator, args: ai_ch
 
     if (request.err) |err| return err;
     return request.result orelse error.SaveFailed;
+}
+
+pub fn uiScreenshot(
+    ctx: *anyopaque,
+    allocator: std.mem.Allocator,
+    target: ai_chat_types.UiScreenshotTarget,
+    surface_id: ?[]const u8,
+    working_dir: ?[]const u8,
+) anyerror!ai_chat_types.UiScreenshotResult {
+    const host = try installedHost();
+    const native_handle = host.nativeHandleForContext(ctx) orelse return error.WindowUnavailable;
+
+    if (host.currentNativeHandle()) |current| {
+        if (current == native_handle) {
+            return error.ScreenshotRequiresWorkerThread;
+        }
+    }
+
+    const request = try createUiScreenshotRequest(target, surface_id, working_dir);
+    if (!postAgentUiScreenshot(native_handle, request)) {
+        destroyUiScreenshotRequest(request);
+        return error.WindowUnavailable;
+    }
+    return waitUiScreenshotRequest(request, allocator);
 }
 
 fn agentTabCommand(kind_raw: []const u8, command_raw: ?[]const u8) anyerror!?[]const u8 {
@@ -330,4 +525,16 @@ pub fn handleSshSaveRequest(request: *AgentSshSaveRequest, host: Host) void {
         request.err = err;
         return;
     };
+}
+
+pub fn handleUiScreenshotRequest(request: *AgentUiScreenshotRequest, host: Host) void {
+    _ = host;
+    request.mutex.lock();
+    const abandoned = request.abandoned;
+    request.mutex.unlock();
+    if (abandoned) {
+        destroyUiScreenshotRequest(request);
+        return;
+    }
+    enqueueUiScreenshotRequest(request);
 }

--- a/src/appwindow/png_writer.zig
+++ b/src/appwindow/png_writer.zig
@@ -1,0 +1,226 @@
+const std = @import("std");
+
+const png_signature = "\x89PNG\r\n\x1a\n";
+const max_deflate_block: usize = 65_535;
+
+const png_dimensions = struct {
+    const Dimensions = struct { width: u32, height: u32 };
+
+    fn parse(data: []const u8) ?Dimensions {
+        if (data.len < 24) return null;
+        if (!std.mem.eql(u8, data[0..8], png_signature)) return null;
+        if (std.mem.readInt(u32, data[8..12], .big) != 13) return null;
+        if (!std.mem.eql(u8, data[12..16], "IHDR")) return null;
+        return .{
+            .width = std.mem.readInt(u32, data[16..20], .big),
+            .height = std.mem.readInt(u32, data[20..24], .big),
+        };
+    }
+};
+
+pub const Error = error{
+    InvalidImageDimensions,
+    InvalidImageBuffer,
+    InvalidPngChunkLength,
+} || std.mem.Allocator.Error;
+
+pub const Image = struct {
+    width: u32,
+    height: u32,
+    rgba: []const u8,
+};
+
+fn checkedRgbaLen(width: u32, height: u32) Error!usize {
+    if (width == 0 or height == 0) return error.InvalidImageDimensions;
+    const row_bytes = try checkedRowBytes(width);
+    return std.math.mul(usize, row_bytes, @as(usize, height)) catch return error.InvalidImageDimensions;
+}
+
+fn checkedRowBytes(width: u32) Error!usize {
+    return std.math.mul(usize, @as(usize, width), 4) catch return error.InvalidImageDimensions;
+}
+
+fn checkedFilteredLen(width: u32, height: u32) Error!usize {
+    const row_bytes = try checkedRowBytes(width);
+    const row_len = std.math.add(usize, row_bytes, 1) catch return error.InvalidImageDimensions;
+    return std.math.mul(usize, @as(usize, height), row_len) catch return error.InvalidImageDimensions;
+}
+
+fn checkedZlibStoredLen(payload_len: usize) Error!usize {
+    const block_numerator = std.math.add(usize, payload_len, max_deflate_block - 1) catch return error.InvalidPngChunkLength;
+    const blocks = block_numerator / max_deflate_block;
+    const block_headers = std.math.mul(usize, blocks, 5) catch return error.InvalidPngChunkLength;
+    const with_headers = std.math.add(usize, payload_len, block_headers) catch return error.InvalidPngChunkLength;
+    return std.math.add(usize, with_headers, 6) catch return error.InvalidPngChunkLength;
+}
+
+fn appendU32(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, value: u32) !void {
+    var buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &buf, value, .big);
+    try out.appendSlice(allocator, &buf);
+}
+
+fn appendChunk(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, kind: *const [4]u8, data: []const u8) !void {
+    if (data.len > std.math.maxInt(u32)) return error.InvalidPngChunkLength;
+    try appendU32(out, allocator, @intCast(data.len));
+    try out.appendSlice(allocator, kind);
+    try out.appendSlice(allocator, data);
+
+    var hasher = std.hash.crc.Crc32.init();
+    hasher.update(kind);
+    hasher.update(data);
+    try appendU32(out, allocator, hasher.final());
+}
+
+fn appendZlibStored(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, payload: []const u8) !void {
+    try out.appendSlice(allocator, &.{ 0x78, 0x01 });
+    var remaining = payload;
+    while (remaining.len > 0) {
+        const n = @min(remaining.len, max_deflate_block);
+        const final: u8 = if (n == remaining.len) 1 else 0;
+        try out.append(allocator, final);
+
+        var len_buf: [2]u8 = undefined;
+        const len16: u16 = @intCast(n);
+        std.mem.writeInt(u16, &len_buf, len16, .little);
+        try out.appendSlice(allocator, &len_buf);
+        std.mem.writeInt(u16, &len_buf, ~len16, .little);
+        try out.appendSlice(allocator, &len_buf);
+
+        try out.appendSlice(allocator, remaining[0..n]);
+        remaining = remaining[n..];
+    }
+    try appendU32(out, allocator, std.hash.Adler32.hash(payload));
+}
+
+pub fn encodeRgba(allocator: std.mem.Allocator, image: Image) Error![]u8 {
+    const expected = try checkedRgbaLen(image.width, image.height);
+    if (image.rgba.len != expected) return error.InvalidImageBuffer;
+
+    const row_bytes = try checkedRowBytes(image.width);
+    const filtered_len = try checkedFilteredLen(image.width, image.height);
+    if (try checkedZlibStoredLen(filtered_len) > std.math.maxInt(u32)) return error.InvalidPngChunkLength;
+    var filtered = try std.ArrayListUnmanaged(u8).initCapacity(allocator, filtered_len);
+    defer filtered.deinit(allocator);
+    for (0..image.height) |row| {
+        try filtered.append(allocator, 0);
+        const start = row * row_bytes;
+        try filtered.appendSlice(allocator, image.rgba[start .. start + row_bytes]);
+    }
+
+    var idat = std.ArrayListUnmanaged(u8).empty;
+    defer idat.deinit(allocator);
+    try appendZlibStored(&idat, allocator, filtered.items);
+
+    var out = std.ArrayListUnmanaged(u8).empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, png_signature);
+
+    var ihdr: [13]u8 = undefined;
+    std.mem.writeInt(u32, ihdr[0..4], image.width, .big);
+    std.mem.writeInt(u32, ihdr[4..8], image.height, .big);
+    ihdr[8] = 8;
+    ihdr[9] = 6;
+    ihdr[10] = 0;
+    ihdr[11] = 0;
+    ihdr[12] = 0;
+    try appendChunk(&out, allocator, "IHDR", &ihdr);
+    try appendChunk(&out, allocator, "IDAT", idat.items);
+    try appendChunk(&out, allocator, "IEND", &.{});
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn flipRgbaRows(allocator: std.mem.Allocator, bottom_up: []const u8, width: u32, height: u32) Error![]u8 {
+    const expected = try checkedRgbaLen(width, height);
+    if (bottom_up.len != expected) return error.InvalidImageBuffer;
+    const row_bytes = try checkedRowBytes(width);
+    const out = try allocator.alloc(u8, bottom_up.len);
+    errdefer allocator.free(out);
+    for (0..height) |row| {
+        const src_row = @as(usize, height) - 1 - row;
+        @memcpy(out[row * row_bytes .. (row + 1) * row_bytes], bottom_up[src_row * row_bytes .. (src_row + 1) * row_bytes]);
+    }
+    return out;
+}
+
+test "png_writer encodes RGBA8 PNG with expected dimensions" {
+    const rgba = [_]u8{
+        255, 0,   0,   255,
+        0,   255, 0,   255,
+        0,   0,   255, 255,
+        255, 255, 255, 255,
+    };
+    const png = try encodeRgba(std.testing.allocator, .{
+        .width = 2,
+        .height = 2,
+        .rgba = &rgba,
+    });
+    defer std.testing.allocator.free(png);
+
+    try std.testing.expect(std.mem.startsWith(u8, png, "\x89PNG\r\n\x1a\n"));
+    const dims = png_dimensions.parse(png) orelse return error.MissingPngDimensions;
+    try std.testing.expectEqual(@as(u32, 2), dims.width);
+    try std.testing.expectEqual(@as(u32, 2), dims.height);
+    try std.testing.expect(std.mem.endsWith(u8, png, "IEND\xaeB`\x82"));
+}
+
+test "png_writer flips OpenGL bottom-up RGBA rows into PNG top-down rows" {
+    const bottom_up = [_]u8{
+        1, 1, 1, 255, 2, 2, 2, 255,
+        3, 3, 3, 255, 4, 4, 4, 255,
+    };
+    const top_down = try flipRgbaRows(std.testing.allocator, &bottom_up, 2, 2);
+    defer std.testing.allocator.free(top_down);
+
+    try std.testing.expectEqualSlices(u8, &[_]u8{
+        3, 3, 3, 255, 4, 4, 4, 255,
+        1, 1, 1, 255, 2, 2, 2, 255,
+    }, top_down);
+}
+
+test "png_writer rejects RGBA buffers with the wrong size" {
+    try std.testing.expectError(error.InvalidImageBuffer, encodeRgba(std.testing.allocator, .{
+        .width = 2,
+        .height = 2,
+        .rgba = &[_]u8{0} ** 15,
+    }));
+}
+
+test "png_writer emits valid chunk CRCs and stored zlib payload" {
+    const rgba = [_]u8{
+        10, 20, 30, 255,
+        40, 50, 60, 255,
+    };
+    const png = try encodeRgba(std.testing.allocator, .{
+        .width = 1,
+        .height = 2,
+        .rgba = &rgba,
+    });
+    defer std.testing.allocator.free(png);
+
+    var offset: usize = png_signature.len;
+    inline for (.{ "IHDR", "IDAT", "IEND" }) |kind| {
+        const len = std.mem.readInt(u32, png[offset..][0..4], .big);
+        const chunk_kind = png[offset + 4 ..][0..4];
+        const data = png[offset + 8 ..][0..len];
+        const crc = std.mem.readInt(u32, png[offset + 8 + len ..][0..4], .big);
+
+        try std.testing.expectEqualStrings(kind, chunk_kind);
+        var hasher = std.hash.crc.Crc32.init();
+        hasher.update(chunk_kind);
+        hasher.update(data);
+        try std.testing.expectEqual(hasher.final(), crc);
+
+        if (std.mem.eql(u8, kind, "IDAT")) {
+            try std.testing.expectEqualSlices(u8, &.{ 0x78, 0x01, 0x01, 10, 0, 245, 255 }, data[0..7]);
+            try std.testing.expectEqualSlices(u8, &[_]u8{
+                0, 10, 20, 30, 255,
+                0, 40, 50, 60, 255,
+            }, data[7..17]);
+            try std.testing.expectEqual(std.hash.Adler32.hash(data[7..17]), std.mem.readInt(u32, data[17..21], .big));
+        }
+
+        offset += 12 + len;
+    }
+    try std.testing.expectEqual(png.len, offset);
+}

--- a/src/appwindow/thread_message.zig
+++ b/src/appwindow/thread_message.zig
@@ -10,6 +10,7 @@ pub const Tag = enum(u8) {
     remote_open_ai_agent,
     weixin_control,
     agent_ui_screenshot,
+    agent_terminal_focus,
 };
 
 pub const Decoded = struct {
@@ -27,6 +28,7 @@ fn offset(tag: Tag) u32 {
         .agent_ssh_save => 0x56,
         .weixin_control => 0x57,
         .agent_ui_screenshot => 0x58,
+        .agent_terminal_focus => 0x59,
     };
 }
 

--- a/src/appwindow/thread_message.zig
+++ b/src/appwindow/thread_message.zig
@@ -9,6 +9,7 @@ pub const Tag = enum(u8) {
     remote_ai_input,
     remote_open_ai_agent,
     weixin_control,
+    agent_ui_screenshot,
 };
 
 pub const Decoded = struct {
@@ -25,6 +26,7 @@ fn offset(tag: Tag) u32 {
         .remote_open_ai_agent => 0x55,
         .agent_ssh_save => 0x56,
         .weixin_control => 0x57,
+        .agent_ui_screenshot => 0x58,
     };
 }
 

--- a/src/appwindow/ui_screenshot.zig
+++ b/src/appwindow/ui_screenshot.zig
@@ -1,0 +1,120 @@
+//! Pure helpers for active-tab UI screenshot capture.
+const std = @import("std");
+const destination_policy = struct {
+    const DEFAULT_DIR = "wispterm-files";
+
+    fn isSafeDestinationName(name: []const u8) bool {
+        if (name.len == 0) return false;
+        if (std.mem.eql(u8, name, ".") or std.mem.eql(u8, name, "..")) return false;
+        for (name) |ch| {
+            if (ch == '/' or ch == '\\' or ch == ':') return false;
+        }
+        return true;
+    }
+};
+
+pub const Rect = struct {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+};
+
+pub fn clampRect(rect: Rect, fb_width: u32, fb_height: u32) ?Rect {
+    if (rect.width == 0 or rect.height == 0 or fb_width == 0 or fb_height == 0) return null;
+    const x0 = @max(@as(i64, rect.x), 0);
+    const y0 = @max(@as(i64, rect.y), 0);
+    const x1 = @min(@as(i64, rect.x) + @as(i64, rect.width), @as(i64, fb_width));
+    const y1 = @min(@as(i64, rect.y) + @as(i64, rect.height), @as(i64, fb_height));
+    if (x1 <= x0 or y1 <= y0) return null;
+    return .{
+        .x = @intCast(x0),
+        .y = @intCast(y0),
+        .width = @intCast(x1 - x0),
+        .height = @intCast(y1 - y0),
+    };
+}
+
+/// Converts a clamped top-left rect to OpenGL readback Y.
+pub fn glReadY(rect: Rect, fb_height: u32) i32 {
+    const y = @as(i64, fb_height) - @as(i64, rect.y) - @as(i64, rect.height);
+    return @intCast(std.math.clamp(y, 0, std.math.maxInt(i32)));
+}
+
+pub fn outputPath(allocator: std.mem.Allocator, working_dir: []const u8, now_ms: i64) ![]u8 {
+    if (working_dir.len == 0) return error.MissingWorkingDir;
+    const name = try std.fmt.allocPrint(allocator, "ui-screenshot-{d}.png", .{now_ms});
+    defer allocator.free(name);
+    if (!destination_policy.isSafeDestinationName(name)) return error.UnsafeDestinationName;
+    const dir = try std.fs.path.join(allocator, &.{ working_dir, destination_policy.DEFAULT_DIR });
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, name });
+}
+
+test "ui_screenshot clamps rectangles to framebuffer bounds" {
+    const r = clampRect(.{ .x = -5, .y = 10, .width = 20, .height = 20 }, 100, 100).?;
+    try std.testing.expectEqual(@as(i32, 0), r.x);
+    try std.testing.expectEqual(@as(i32, 10), r.y);
+    try std.testing.expectEqual(@as(u32, 15), r.width);
+    try std.testing.expectEqual(@as(u32, 20), r.height);
+    try std.testing.expect(clampRect(.{ .x = 200, .y = 0, .width = 10, .height = 10 }, 100, 100) == null);
+}
+
+test "ui_screenshot rejects empty framebuffer or rect" {
+    try std.testing.expect(clampRect(.{ .x = 0, .y = 0, .width = 1, .height = 1 }, 0, 1) == null);
+    try std.testing.expect(clampRect(.{ .x = 0, .y = 0, .width = 1, .height = 1 }, 1, 0) == null);
+    try std.testing.expect(clampRect(.{ .x = 0, .y = 0, .width = 0, .height = 1 }, 1, 1) == null);
+    try std.testing.expect(clampRect(.{ .x = 0, .y = 0, .width = 1, .height = 0 }, 1, 1) == null);
+}
+
+test "ui_screenshot clips right and bottom edges" {
+    const r = clampRect(.{ .x = 80, .y = 70, .width = 50, .height = 50 }, 100, 100).?;
+    try std.testing.expectEqual(@as(i32, 80), r.x);
+    try std.testing.expectEqual(@as(i32, 70), r.y);
+    try std.testing.expectEqual(@as(u32, 20), r.width);
+    try std.testing.expectEqual(@as(u32, 30), r.height);
+}
+
+test "ui_screenshot rejects fully above or left rectangles" {
+    try std.testing.expect(clampRect(.{ .x = -20, .y = 0, .width = 10, .height = 10 }, 100, 100) == null);
+    try std.testing.expect(clampRect(.{ .x = 0, .y = -20, .width = 10, .height = 10 }, 100, 100) == null);
+}
+
+test "ui_screenshot handles very large bounds without trapping" {
+    const clipped = clampRect(.{
+        .x = std.math.maxInt(i32) - 1,
+        .y = 0,
+        .width = std.math.maxInt(u32),
+        .height = std.math.maxInt(u32),
+    }, std.math.maxInt(u32), std.math.maxInt(u32)).?;
+    try std.testing.expectEqual(@as(i32, std.math.maxInt(i32) - 1), clipped.x);
+    try std.testing.expectEqual(@as(i32, 0), clipped.y);
+    try std.testing.expectEqual(@as(u32, 2_147_483_649), clipped.width);
+    try std.testing.expectEqual(@as(u32, std.math.maxInt(u32)), clipped.height);
+
+    try std.testing.expect(clampRect(.{
+        .x = std.math.maxInt(i32),
+        .y = 0,
+        .width = std.math.maxInt(u32),
+        .height = 1,
+    }, 1, 1) == null);
+    try std.testing.expectEqual(@as(i32, std.math.maxInt(i32)), glReadY(.{ .x = 0, .y = -1, .width = 1, .height = 0 }, std.math.maxInt(u32)));
+    try std.testing.expectEqual(@as(i32, 0), glReadY(.{ .x = 0, .y = 10, .width = 1, .height = std.math.maxInt(u32) }, 1));
+}
+
+test "ui_screenshot converts top-left rect y to OpenGL read y" {
+    const r = Rect{ .x = 10, .y = 20, .width = 30, .height = 40 };
+    try std.testing.expectEqual(@as(i32, 40), glReadY(r, 100));
+}
+
+test "ui_screenshot output path uses wispterm-files and a png basename" {
+    const path = try outputPath(std.testing.allocator, "/work/project", 1234);
+    defer std.testing.allocator.free(path);
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ "/work/project", destination_policy.DEFAULT_DIR, "ui-screenshot-1234.png" });
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, path);
+}
+
+test "ui_screenshot output path rejects empty working dir" {
+    try std.testing.expectError(error.MissingWorkingDir, outputPath(std.testing.allocator, "", 1234));
+}

--- a/src/assistant/conversation/protocol.zig
+++ b/src/assistant/conversation/protocol.zig
@@ -750,6 +750,7 @@ fn forEachToolSpec(
     try Filtered.emitTool(ctx, opts, "terminal_snapshot", "Read a bounded text snapshot from one terminal surface or all surfaces.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Optional surface id from terminal_list.\"}}");
     try Filtered.emitTool(ctx, opts, "ui_screenshot", "Capture a PNG screenshot of the active WispTerm tab or the focused panel in the active tab. Use target=focused_panel for the panel the user is looking at, or target=active_tab for the whole visible active tab. In a dedicated AI/Copilot tab, focused_panel falls back to active_tab. The tool returns a local PNG path; when the request came from Weixin, call weixin_send_attachment with kind=image and that path.", "{\"target\":{\"type\":\"string\",\"description\":\"Optional: focused_panel (default) or active_tab.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Optional terminal surface id from terminal_list. Only valid for terminal panels in the active tab.\"}}");
     try Filtered.emitTool(ctx, opts, "terminal_select", platform_pty_command.terminalSelectToolDescription(), "{\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list to make the current agent write context.\"}}");
+    try Filtered.emitTool(ctx, opts, "terminal_focus", "Focus and activate a terminal surface in the WispTerm UI by surface_id. Use this before ui_screenshot when the user asks for a screenshot of a tab or panel that is not currently focused. This changes UI focus only; use terminal_select separately before terminal writes.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list to focus in the visible UI.\"}}");
     try Filtered.emitTool(ctx, opts, platform_process.localCommandToolName(), platform_process.localCommandToolDescription(), "{\"command\":{\"type\":\"string\"},\"cwd\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}");
     try Filtered.emitTool(ctx, opts, "ssh_session_exec", "Run a POSIX shell command in the selected already-open SSH terminal surface. The surface_id must match the current terminal_select context. Use only when the surface is at a shell prompt and the command returns; for R, Python, Codex, Claude Code, other REPLs, or launching full-screen agent apps, use terminal_repl_exec.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Selected surface id from terminal_select.\"},\"command\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}");
     if (platform_pty_command.wslSessionToolsEnabled()) {
@@ -2055,6 +2056,7 @@ test "agent tool set includes ui_screenshot" {
     const json = try buildRequestJson(a, params, &msgs, true);
     defer a.free(json);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"ui_screenshot\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_focus\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"target\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"surface_id\"") != null);
 }
@@ -2067,9 +2069,9 @@ test "subagentToolAllowed accepts exactly the research tools" {
     };
     for (allowed) |name| try std.testing.expect(subagentToolAllowed(name));
     const denied = [_][]const u8{
-        "subagent",           "memory_save", "ssh_session_exec", "write_file",
-        "edit_file",          "tab_new",     "tab_close",        "terminal_select",
-        "terminal_repl_exec",
+        "subagent",       "memory_save",        "ssh_session_exec", "write_file",
+        "edit_file",      "tab_new",            "tab_close",        "terminal_select",
+        "terminal_focus", "terminal_repl_exec",
     };
     for (denied) |name| try std.testing.expect(!subagentToolAllowed(name));
 }

--- a/src/assistant/conversation/protocol.zig
+++ b/src/assistant/conversation/protocol.zig
@@ -748,6 +748,7 @@ fn forEachToolSpec(
     try Filtered.emitTool(ctx, opts, "terminal_list", "List WispTerm terminal surfaces visible to the agent, including the current agent-selected write context. Before any terminal write, use terminal_select to choose the intended surface_id; use focused=true only as a default hint.", "{}");
     try Filtered.emitTool(ctx, opts, "terminal_context", "Report the current selected terminal write context/binding without changing it. Use this to verify which terminal Copilot or the agent will write to.", "{}");
     try Filtered.emitTool(ctx, opts, "terminal_snapshot", "Read a bounded text snapshot from one terminal surface or all surfaces.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Optional surface id from terminal_list.\"}}");
+    try Filtered.emitTool(ctx, opts, "ui_screenshot", "Capture a PNG screenshot of the active WispTerm tab or the focused panel in the active tab. Use target=focused_panel for the panel the user is looking at, or target=active_tab for the whole visible active tab. In a dedicated AI/Copilot tab, focused_panel falls back to active_tab. The tool returns a local PNG path; when the request came from Weixin, call weixin_send_attachment with kind=image and that path.", "{\"target\":{\"type\":\"string\",\"description\":\"Optional: focused_panel (default) or active_tab.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Optional terminal surface id from terminal_list. Only valid for terminal panels in the active tab.\"}}");
     try Filtered.emitTool(ctx, opts, "terminal_select", platform_pty_command.terminalSelectToolDescription(), "{\"surface_id\":{\"type\":\"string\",\"description\":\"Surface id from terminal_list to make the current agent write context.\"}}");
     try Filtered.emitTool(ctx, opts, platform_process.localCommandToolName(), platform_process.localCommandToolDescription(), "{\"command\":{\"type\":\"string\"},\"cwd\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}");
     try Filtered.emitTool(ctx, opts, "ssh_session_exec", "Run a POSIX shell command in the selected already-open SSH terminal surface. The surface_id must match the current terminal_select context. Use only when the surface is at a shell prompt and the command returns; for R, Python, Codex, Claude Code, other REPLs, or launching full-screen agent apps, use terminal_repl_exec.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Selected surface id from terminal_select.\"},\"command\":{\"type\":\"string\"},\"timeout_ms\":{\"type\":\"integer\"}}");
@@ -2045,6 +2046,17 @@ test "terminal_answer_prompt appears in the tool schema" {
     const json = out.items;
     try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_answer_prompt\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "approve_all") != null);
+}
+
+test "agent tool set includes ui_screenshot" {
+    const a = std.testing.allocator;
+    var msgs = [_]RequestMessage{.{ .role = .user, .content = @constCast("show me the screen") }};
+    const params = RequestParams{ .model = "m", .system_prompt = "", .protocol = .chat_completions, .thinking_enabled = false, .reasoning_effort = "", .stream = false };
+    const json = try buildRequestJson(a, params, &msgs, true);
+    defer a.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"ui_screenshot\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"target\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"surface_id\"") != null);
 }
 
 test "subagentToolAllowed accepts exactly the research tools" {

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -176,6 +176,29 @@ pub const ToolClosedTab = struct {
     }
 };
 
+pub const UiScreenshotTarget = enum {
+    focused_panel,
+    active_tab,
+
+    pub fn label(self: UiScreenshotTarget) []const u8 {
+        return switch (self) {
+            .focused_panel => "focused_panel",
+            .active_tab => "active_tab",
+        };
+    }
+};
+
+pub const UiScreenshotResult = struct {
+    path: []u8,
+    width: u32,
+    height: u32,
+    target: UiScreenshotTarget,
+
+    pub fn deinit(self: UiScreenshotResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+    }
+};
+
 pub const SshProfileSaveArgs = struct {
     name: []const u8 = "",
     host: []const u8,
@@ -219,6 +242,7 @@ pub const ToolHost = struct {
     /// null for local/WSL/unknown surfaces. Only the real AppWindow host sets
     /// this; others leave it null (file tools then treat the target as local).
     sshConnectionForSurface: ?*const fn (*anyopaque, []const u8) ?SshConnection = null,
+    uiScreenshot: ?*const fn (*anyopaque, std.mem.Allocator, UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!UiScreenshotResult = null,
 };
 
 pub const WeixinReplyContext = struct {

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -190,12 +190,15 @@ pub const UiScreenshotTarget = enum {
 
 pub const UiScreenshotResult = struct {
     path: []u8,
+    mime: []const u8 = "image/png",
     width: u32,
     height: u32,
     target: UiScreenshotTarget,
+    surface_id: ?[]u8 = null,
 
     pub fn deinit(self: UiScreenshotResult, allocator: std.mem.Allocator) void {
         allocator.free(self.path);
+        if (self.surface_id) |surface_id| allocator.free(surface_id);
     }
 };
 

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -246,6 +246,7 @@ pub const ToolHost = struct {
     /// this; others leave it null (file tools then treat the target as local).
     sshConnectionForSurface: ?*const fn (*anyopaque, []const u8) ?SshConnection = null,
     uiScreenshot: ?*const fn (*anyopaque, std.mem.Allocator, UiScreenshotTarget, ?[]const u8, ?[]const u8) anyerror!UiScreenshotResult = null,
+    focusTerminal: ?*const fn (*anyopaque, std.mem.Allocator, []const u8) anyerror!ToolSurface = null,
 };
 
 pub const WeixinReplyContext = struct {

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -54,6 +54,7 @@ const common_tools_before_wsl =
     \\Terminal tools:
     \\- Use `terminal_list` before terminal writes, then `terminal_select`.
     \\- Use `terminal_context` to inspect the selected write context.
+    \\- Use `terminal_focus` before `ui_screenshot` when the requested tab or panel is not focused.
     \\- Use `ssh_session_exec` at an open SSH shell prompt.
     \\- Use `ssh_profile_save` / `ssh_profile_connect` for saved SSH details.
 ;

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -29,7 +29,7 @@ const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 
 /// Reserved message id for the synchronous-send shim (see `sendMessage`).
-/// Distinct from the app-message range thread_message uses (wm_app + 0x51..0x57)
+/// Distinct from the app-message range thread_message uses (wm_app + 0x51..0x58)
 /// and from `hotkey_message`, so it never collides with a real posted message.
 pub const sync_message: MessageId = wm_app + 0x7e;
 

--- a/src/platform/window_macos.zig
+++ b/src/platform/window_macos.zig
@@ -29,7 +29,7 @@ const wm_close: u32 = 0x0010;
 const wm_app: u32 = 0x8000;
 
 /// Reserved message id for the synchronous-send shim (see `sendMessage`).
-/// Distinct from the app-message range thread_message uses (wm_app + 0x51..0x58)
+/// Distinct from the app-message range thread_message uses (wm_app + 0x51..0x59)
 /// and from `hotkey_message`, so it never collides with a real posted message.
 pub const sync_message: MessageId = wm_app + 0x7e;
 

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -32,5 +32,6 @@ pub const Texture = impl.Texture;
 pub const Buffer = impl.Buffer;
 pub const Pipeline = impl.Pipeline;
 pub const Framebuffer = impl.Framebuffer;
+pub const readback = impl.readback;
 pub const state = impl.render_state;
 pub const vertex = impl.vertex;

--- a/src/renderer/gpu/metal/api.zig
+++ b/src/renderer/gpu/metal/api.zig
@@ -14,6 +14,7 @@ pub const Buffer = @import("Buffer.zig");
 pub const Texture = @import("Texture.zig");
 pub const Pipeline = @import("Pipeline.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
+pub const readback = @import("readback.zig");
 pub const shaders = @import("shaders.zig");
 pub const render_state = @import("render_state.zig");
 pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/metal/bridge.m
+++ b/src/renderer/gpu/metal/bridge.m
@@ -91,6 +91,31 @@ static _Thread_local int wispterm_metal_sc_h = 0;
 static _Thread_local int wispterm_metal_drawable_w = 0;
 static _Thread_local int wispterm_metal_drawable_h = 0;
 
+// Agent ui_screenshot capture (macOS). The Zig readback runs AFTER frame_end has
+// presented + released the drawable, so the drawable is gone by then. Instead, on
+// frames the caller arms (wispterm_metal_arm_capture), frame_end blits the just-
+// rendered drawable into this shared buffer before present and waits for the GPU,
+// so the bytes are CPU-readable when readback.zig asks. BGRA8, top-down (Metal
+// origin top-left); the Zig side converts to RGBA bottom-up to match GL readback.
+static _Thread_local bool wispterm_metal_capture_armed = false;
+static _Thread_local id<MTLBuffer> wispterm_metal_capture_buffer = nil;
+static _Thread_local int wispterm_metal_capture_w = 0;
+static _Thread_local int wispterm_metal_capture_h = 0;
+static _Thread_local int wispterm_metal_capture_row_stride = 0; // bytes per row (256-aligned)
+
+void wispterm_metal_arm_capture(void) {
+    wispterm_metal_capture_armed = true;
+}
+
+const unsigned char *wispterm_metal_capture_pixels(void) {
+    if (wispterm_metal_capture_buffer == nil) return NULL;
+    return (const unsigned char *)[wispterm_metal_capture_buffer contents];
+}
+
+int wispterm_metal_capture_width(void) { return wispterm_metal_capture_w; }
+int wispterm_metal_capture_height(void) { return wispterm_metal_capture_h; }
+int wispterm_metal_capture_stride(void) { return wispterm_metal_capture_row_stride; }
+
 void wispterm_metal_set_viewport(int x, int y, int w, int h) {
     wispterm_metal_vp_x = x;
     wispterm_metal_vp_y = y;
@@ -323,7 +348,13 @@ bool wispterm_metal_context_init(void *layer, WispTermMetalContext *out, char *e
         [metal_layer retain];
         metal_layer.device = device;
         metal_layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-        metal_layer.framebufferOnly = YES;
+        // NO (not YES) so the drawable texture can be a blit source for the
+        // agent ui_screenshot readback (see wispterm_metal_frame_end capture
+        // path). ponytail: tiny per-frame cost (loses some drawable lossless
+        // compression); the expensive blit+wait is still gated by the capture
+        // arm flag, so steady-state perf is unaffected. Gate framebufferOnly by
+        // the arm flag too only if drawable bandwidth ever shows up in a profile.
+        metal_layer.framebufferOnly = NO;
         metal_layer.opaque = YES;
         metal_layer.contentsScale = 1.0;
         metal_layer.drawableSize = CGSizeMake(64.0, 64.0);
@@ -916,6 +947,47 @@ bool wispterm_metal_frame_end(WispTermMetalContext *ctx, char *error_buf, size_t
         id<CAMetalDrawable> drawable = (id<CAMetalDrawable>)ctx->drawable;
 
         [encoder endEncoding];
+
+        // Agent ui_screenshot: on armed frames, blit the just-rendered drawable
+        // into a shared CPU-readable buffer in the SAME command buffer, then wait
+        // below so readback.zig can read it after frame_end returns. Gated by the
+        // arm flag, so non-capture frames keep the async (no-wait) fast path.
+        bool captured_this_frame = false;
+        if (wispterm_metal_capture_armed && drawable != nil) {
+            id<MTLTexture> tex = drawable.texture;
+            NSUInteger w = tex.width;
+            NSUInteger h = tex.height;
+            NSUInteger stride = (w * 4 + 255) & ~((NSUInteger)255); // 256-align (macOS blit req)
+            NSUInteger needed = stride * h;
+            id<MTLDevice> device = (id<MTLDevice>)ctx->device;
+            if (w > 0 && h > 0 && device != nil) {
+                if (wispterm_metal_capture_buffer == nil ||
+                    wispterm_metal_capture_buffer.length < needed) {
+                    if (wispterm_metal_capture_buffer != nil) [wispterm_metal_capture_buffer release];
+                    wispterm_metal_capture_buffer =
+                        [device newBufferWithLength:needed options:MTLResourceStorageModeShared];
+                }
+                if (wispterm_metal_capture_buffer != nil) {
+                    id<MTLBlitCommandEncoder> blit = [command_buffer blitCommandEncoder];
+                    [blit copyFromTexture:tex
+                              sourceSlice:0
+                              sourceLevel:0
+                             sourceOrigin:MTLOriginMake(0, 0, 0)
+                               sourceSize:MTLSizeMake(w, h, 1)
+                                 toBuffer:wispterm_metal_capture_buffer
+                        destinationOffset:0
+                   destinationBytesPerRow:stride
+                 destinationBytesPerImage:needed];
+                    [blit endEncoding];
+                    wispterm_metal_capture_w = (int)w;
+                    wispterm_metal_capture_h = (int)h;
+                    wispterm_metal_capture_row_stride = (int)stride;
+                    captured_this_frame = true;
+                }
+            }
+        }
+        wispterm_metal_capture_armed = false;
+
         if (drawable != nil) [command_buffer presentDrawable:drawable];
 
         // Report GPU errors asynchronously rather than blocking the render
@@ -931,6 +1003,9 @@ bool wispterm_metal_frame_end(WispTermMetalContext *ctx, char *error_buf, size_t
             }
         }];
         [command_buffer commit];
+        // Capture frames must block until the blit finishes so the shared buffer
+        // is populated before readback.zig reads it. Rare (agent-triggered) only.
+        if (captured_this_frame) [command_buffer waitUntilCompleted];
         wispterm_metal_set_error(error_buf, error_buf_len, "");
 
         [encoder release];

--- a/src/renderer/gpu/metal/readback.zig
+++ b/src/renderer/gpu/metal/readback.zig
@@ -1,0 +1,15 @@
+//! Metal framebuffer readback is not wired in v1.
+const std = @import("std");
+
+pub fn readRgba(allocator: std.mem.Allocator, x: i32, y: i32, width: u32, height: u32) ![]u8 {
+    _ = allocator;
+    _ = x;
+    _ = y;
+    _ = width;
+    _ = height;
+    return error.UnsupportedReadback;
+}
+
+test "metal readback reports unsupported" {
+    try std.testing.expectError(error.UnsupportedReadback, readRgba(std.testing.allocator, 0, 0, 1, 1));
+}

--- a/src/renderer/gpu/metal/readback.zig
+++ b/src/renderer/gpu/metal/readback.zig
@@ -1,15 +1,102 @@
-//! Metal framebuffer readback is not wired in v1.
+//! Metal framebuffer readback.
+//!
+//! Metal has no `glReadPixels`-style read of the live back buffer, and by the
+//! time the agent ui_screenshot path calls this the drawable is already
+//! presented and released (see `bridge.m` frame_end). So the capture is done
+//! inside frame_end on armed frames: the rendered drawable is blitted into a
+//! shared CPU buffer and the GPU is waited on. `readRgba` then crops that buffer
+//! to the requested rect, converts BGRA8 -> RGBA8, and flips rows into the GL
+//! bottom-up order the OpenGL backend's `readRgba` returns (AppWindow flips it
+//! back to top-down for PNG, so both backends look identical to the caller).
 const std = @import("std");
 
+extern fn wispterm_metal_capture_pixels() ?[*]const u8;
+extern fn wispterm_metal_capture_width() c_int;
+extern fn wispterm_metal_capture_height() c_int;
+extern fn wispterm_metal_capture_stride() c_int;
+
 pub fn readRgba(allocator: std.mem.Allocator, x: i32, y: i32, width: u32, height: u32) ![]u8 {
-    _ = allocator;
-    _ = x;
-    _ = y;
-    _ = width;
-    _ = height;
-    return error.UnsupportedReadback;
+    if (width == 0 or height == 0) return error.InvalidReadbackRect;
+
+    const src_ptr = wispterm_metal_capture_pixels() orelse return error.UnsupportedReadback;
+    const img_w = std.math.cast(u32, wispterm_metal_capture_width()) orelse return error.UnsupportedReadback;
+    const img_h = std.math.cast(u32, wispterm_metal_capture_height()) orelse return error.UnsupportedReadback;
+    const stride = std.math.cast(usize, wispterm_metal_capture_stride()) orelse return error.UnsupportedReadback;
+    if (img_w == 0 or img_h == 0 or stride == 0) return error.UnsupportedReadback;
+
+    const pixels = std.math.mul(usize, width, height) catch return error.InvalidReadbackRect;
+    const len = std.math.mul(usize, pixels, 4) catch return error.InvalidReadbackRect;
+    const out = try allocator.alloc(u8, len);
+    errdefer allocator.free(out);
+
+    const src = src_ptr[0 .. stride * img_h];
+    try extractRgbaBottomUp(src, stride, img_w, img_h, x, y, width, height, out);
+    return out;
 }
 
-test "metal readback reports unsupported" {
-    try std.testing.expectError(error.UnsupportedReadback, readRgba(std.testing.allocator, 0, 0, 1, 1));
+/// Crop `src` (BGRA8, top-down, `stride` bytes/row, `img_w`x`img_h`) to the
+/// `w`x`h` rect whose lower-left is at GL coords (`x`, `gl_y`) measured from the
+/// image bottom, writing RGBA8 in GL bottom-up order into `out`. Pure so the
+/// row-flip + channel-swap is unit-testable without a Metal device.
+fn extractRgbaBottomUp(
+    src: []const u8,
+    stride: usize,
+    img_w: u32,
+    img_h: u32,
+    x: i32,
+    gl_y: i32,
+    w: u32,
+    h: u32,
+    out: []u8,
+) !void {
+    if (x < 0 or gl_y < 0) return error.InvalidReadbackRect;
+    const xu: u32 = @intCast(x);
+    const yu: u32 = @intCast(gl_y);
+    if (xu + w > img_w or yu + h > img_h) return error.InvalidReadbackRect;
+    std.debug.assert(out.len == @as(usize, w) * @as(usize, h) * 4);
+
+    var row: u32 = 0;
+    while (row < h) : (row += 1) {
+        // GL bottom-up row `row` -> top-down image row (origin top-left).
+        const img_row = img_h - 1 - (yu + row);
+        const src_row = src[@as(usize, img_row) * stride ..];
+        const dst_row = out[@as(usize, row) * w * 4 ..];
+        var col: u32 = 0;
+        while (col < w) : (col += 1) {
+            const s = src_row[@as(usize, xu + col) * 4 ..][0..4]; // BGRA
+            const d = dst_row[@as(usize, col) * 4 ..][0..4];
+            d[0] = s[2]; // R
+            d[1] = s[1]; // G
+            d[2] = s[0]; // B
+            d[3] = s[3]; // A
+        }
+    }
+}
+
+test "extractRgbaBottomUp swaps BGRA->RGBA and flips to bottom-up" {
+    // 2x2 BGRA top-down image, stride padded past the 8 used bytes.
+    const stride: usize = 16;
+    var src = [_]u8{0} ** (stride * 2);
+    // top row:    left = B,G,R,A = 10,20,30,40 ; right = 11,21,31,41
+    src[0..4].* = .{ 10, 20, 30, 40 };
+    src[4..8].* = .{ 11, 21, 31, 41 };
+    // bottom row: left = 12,22,32,42 ; right = 13,23,33,43
+    src[stride + 0 .. stride + 4].* = .{ 12, 22, 32, 42 };
+    src[stride + 4 .. stride + 8].* = .{ 13, 23, 33, 43 };
+
+    var out: [2 * 2 * 4]u8 = undefined;
+    try extractRgbaBottomUp(&src, stride, 2, 2, 0, 0, 2, 2, &out);
+
+    // out row 0 = GL bottom row = image bottom row, RGBA (R,G,B,A from BGRA).
+    try std.testing.expectEqualSlices(u8, &.{ 32, 22, 12, 42, 33, 23, 13, 43 }, out[0..8]);
+    // out row 1 = image top row.
+    try std.testing.expectEqualSlices(u8, &.{ 30, 20, 10, 40, 31, 21, 11, 41 }, out[8..16]);
+}
+
+test "extractRgbaBottomUp rejects out-of-bounds rect" {
+    var src = [_]u8{0} ** 16;
+    var out: [4]u8 = undefined;
+    try std.testing.expectError(error.InvalidReadbackRect, extractRgbaBottomUp(&src, 8, 2, 2, 2, 0, 1, 1, &out));
+    try std.testing.expectError(error.InvalidReadbackRect, extractRgbaBottomUp(&src, 8, 2, 2, 0, 2, 1, 1, &out));
+    try std.testing.expectError(error.InvalidReadbackRect, extractRgbaBottomUp(&src, 8, 2, 2, -1, 0, 1, 1, &out));
 }

--- a/src/renderer/gpu/metal/render_state.zig
+++ b/src/renderer/gpu/metal/render_state.zig
@@ -23,6 +23,7 @@ threadlocal var scratch_error: [256]u8 = @splat(0);
 
 extern fn wispterm_metal_frame_begin(ctx: *Context.Handles, r: f32, g: f32, b: f32, a: f32, error_buf: [*]u8, error_buf_len: usize) bool;
 extern fn wispterm_metal_frame_end(ctx: *Context.Handles, error_buf: [*]u8, error_buf_len: usize) bool;
+extern fn wispterm_metal_arm_capture() void;
 // Viewport/scissor are encoder state: the renderer records them here per pane,
 // and the C bridge applies them on the active `MTLRenderCommandEncoder` before
 // each draw (with the GL bottom-left → Metal top-left y-flip and a clamp to the
@@ -112,6 +113,15 @@ pub fn restoreScissor(s: ScissorState) void {
 
 pub fn isFrameActive() bool {
     return frame_active;
+}
+
+/// Arm a one-shot ui_screenshot capture for the frame currently being rendered.
+/// frame_end blits the drawable into a CPU-readable buffer and waits for the GPU
+/// so `gpu.readback.readRgba` can read it right after the frame. Must be called
+/// before `endFrame` of the target frame. No-op on the OpenGL backend (its
+/// readback reads the live back buffer directly).
+pub fn armUiScreenshotCapture() void {
+    wispterm_metal_arm_capture();
 }
 
 pub fn isBlendEnabled() bool {

--- a/src/renderer/gpu/metal/test.zig
+++ b/src/renderer/gpu/metal/test.zig
@@ -7,9 +7,14 @@ const Framebuffer = @import("Framebuffer.zig");
 const Pipeline = @import("Pipeline.zig");
 const Texture = @import("Texture.zig");
 const gl_init = @import("gl_init.zig");
+const readback = @import("readback.zig");
 const render_state = @import("render_state.zig");
 const shaders = @import("shaders.zig");
 const vertex = @import("vertex.zig");
+
+test {
+    _ = readback;
+}
 
 test "Context.init creates a usable Metal backend context" {
     try Context.init(null);

--- a/src/renderer/gpu/metal/test.zig
+++ b/src/renderer/gpu/metal/test.zig
@@ -167,6 +167,53 @@ test "render_state batches multiple Metal draws into one presented frame" {
     try std.testing.expect(!render_state.isFrameActive());
 }
 
+test "armed ui screenshot capture reads back the rendered frame" {
+    try Context.init(null);
+    defer Context.deinit();
+
+    // Fullscreen triangle rendered solid orange (R!=B so the channel swap is
+    // actually exercised); the readback must return that pixel as RGBA
+    // (origin-correct + BGRA->RGBA swap), proving the in-frame blit + shared
+    // buffer + readback path works on a real Metal device.
+    const vs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\vertex float4 vertex_main(uint vertex_id [[vertex_id]]) {
+        \\    float2 positions[3] = {
+        \\        float2(-1.0, -1.0),
+        \\        float2( 3.0, -1.0),
+        \\        float2(-1.0,  3.0),
+        \\    };
+        \\    return float4(positions[vertex_id], 0.0, 1.0);
+        \\}
+    ;
+    const fs: [*c]const u8 =
+        \\#include <metal_stdlib>
+        \\using namespace metal;
+        \\fragment float4 fragment_main() {
+        \\    return float4(1.0, 0.5, 0.0, 1.0);
+        \\}
+    ;
+
+    var pipeline = Pipeline.init(vs, fs, 0);
+    defer pipeline.deinit();
+
+    render_state.clear(0, 0, 0, 1);
+    render_state.armUiScreenshotCapture();
+    pipeline.drawArrays(c.GL_TRIANGLES, 0, 3);
+    try std.testing.expect(Pipeline.lastDrawSucceeded());
+    render_state.endFrame();
+
+    // Standalone layer is 64x64 (Context.init). Read a 1x1 at the origin.
+    const px = try readback.readRgba(std.testing.allocator, 0, 0, 1, 1);
+    defer std.testing.allocator.free(px);
+    try std.testing.expectEqual(@as(usize, 4), px.len);
+    try std.testing.expect(px[0] >= 254); // R ~ 255
+    try std.testing.expect(px[1] >= 126 and px[1] <= 130); // G ~ 128
+    try std.testing.expect(px[2] <= 1); // B ~ 0
+    try std.testing.expectEqual(@as(u8, 255), px[3]); // A
+}
+
 test "viewport and scissor apply to the encoder without breaking draws" {
     try Context.init(null);
     defer Context.deinit();

--- a/src/renderer/gpu/opengl/api.zig
+++ b/src/renderer/gpu/opengl/api.zig
@@ -14,6 +14,7 @@ pub const Buffer = @import("Buffer.zig");
 pub const Texture = @import("Texture.zig");
 pub const Pipeline = @import("Pipeline.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
+pub const readback = @import("readback.zig");
 pub const shaders = @import("shaders.zig");
 pub const render_state = @import("render_state.zig");
 pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/opengl/readback.zig
+++ b/src/renderer/gpu/opengl/readback.zig
@@ -1,0 +1,37 @@
+//! OpenGL framebuffer readback helpers.
+const std = @import("std");
+const Context = @import("Context.zig");
+const c = @import("c.zig").c;
+
+pub fn readRgba(allocator: std.mem.Allocator, x: i32, y: i32, width: u32, height: u32) ![]u8 {
+    if (width == 0 or height == 0) return error.InvalidReadbackRect;
+    const gl_width = std.math.cast(c.GLsizei, width) orelse return error.InvalidReadbackRect;
+    const gl_height = std.math.cast(c.GLsizei, height) orelse return error.InvalidReadbackRect;
+    const pixels = std.math.mul(usize, @as(usize, width), @as(usize, height)) catch return error.InvalidReadbackRect;
+    const len = std.math.mul(usize, pixels, 4) catch return error.InvalidReadbackRect;
+    const out = try allocator.alloc(u8, len);
+    errdefer allocator.free(out);
+    const gl = Context.gl;
+    gl.PixelStorei.?(c.GL_PACK_ALIGNMENT, 1);
+    gl.ReadPixels.?(
+        x,
+        y,
+        gl_width,
+        gl_height,
+        c.GL_RGBA,
+        c.GL_UNSIGNED_BYTE,
+        out.ptr,
+    );
+    return out;
+}
+
+test "readRgba rejects invalid rectangles before GL access" {
+    const max_glsizei = std.math.cast(u32, std.math.maxInt(c.GLsizei)) orelse return error.SkipZigTest;
+    if (max_glsizei == std.math.maxInt(u32)) return error.SkipZigTest;
+    const too_large = max_glsizei + 1;
+
+    try std.testing.expectError(error.InvalidReadbackRect, readRgba(std.testing.allocator, 0, 0, 0, 1));
+    try std.testing.expectError(error.InvalidReadbackRect, readRgba(std.testing.allocator, 0, 0, 1, 0));
+    try std.testing.expectError(error.InvalidReadbackRect, readRgba(std.testing.allocator, 0, 0, too_large, 1));
+    try std.testing.expectError(error.InvalidReadbackRect, readRgba(std.testing.allocator, 0, 0, 1, too_large));
+}

--- a/src/renderer/gpu/opengl/render_state.zig
+++ b/src/renderer/gpu/opengl/render_state.zig
@@ -26,6 +26,11 @@ pub fn endFrame() void {
     notifyPreChange();
 }
 
+/// No-op: the OpenGL `readback.readRgba` reads the live back buffer with
+/// `glReadPixels` directly (the buffer is still intact between endFrame and
+/// swapBuffers). Only the Metal backend needs an armed in-frame capture.
+pub fn armUiScreenshotCapture() void {}
+
 pub fn setBlendEnabled(enabled: bool) void {
     notifyPreChange();
     if (enabled) Context.gl.Enable.?(c.GL_BLEND) else Context.gl.Disable.?(c.GL_BLEND);

--- a/src/ssh/askpass.zig
+++ b/src/ssh/askpass.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
-const platform_process = @import("../platform/process.zig");
+
+const ssh_askpass_password_env = "WISPTERM_SSH_PASSWORD";
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const password = std.process.getEnvVarOwned(allocator, platform_process.SSH_ASKPASS_PASSWORD_ENV) catch |err| switch (err) {
+    const password = std.process.getEnvVarOwned(allocator, ssh_askpass_password_env) catch |err| switch (err) {
         error.EnvironmentVariableNotFound => return,
         else => return err,
     };

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -202,6 +202,7 @@ test {
     _ = @import("appwindow/active_tab.zig");
     _ = @import("appwindow/frame_latency.zig");
     _ = @import("appwindow/frame_scheduler.zig");
+    _ = @import("appwindow/png_writer.zig");
     _ = @import("appwindow/render_gate.zig");
     _ = @import("appwindow/ui_effect.zig");
     _ = @import("appwindow/window_state.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -204,6 +204,7 @@ test {
     _ = @import("appwindow/frame_scheduler.zig");
     _ = @import("appwindow/png_writer.zig");
     _ = @import("appwindow/render_gate.zig");
+    _ = @import("appwindow/ui_screenshot.zig");
     _ = @import("appwindow/ui_effect.zig");
     _ = @import("appwindow/window_state.zig");
     _ = @import("appwindow/remote_state.zig");

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -32,6 +32,7 @@ const static_definitions = [_]Definition{
     .{ .name = "terminal_snapshot", .label = "terminal_snapshot", .description = "Read a bounded text snapshot from terminal surfaces.", .category = .terminal },
     .{ .name = "ui_screenshot", .label = "ui_screenshot", .description = "Capture the active WispTerm tab or focused active-tab panel as a local PNG file.", .category = .terminal },
     .{ .name = "terminal_select", .label = "terminal_select", .description = "Select the terminal surface used for subsequent write tools.", .category = .terminal },
+    .{ .name = "terminal_focus", .label = "terminal_focus", .description = "Focus a terminal surface in the visible WispTerm UI.", .category = .terminal },
     .{ .name = "ssh_session_exec", .label = "ssh_session_exec", .description = "Run a shell command in an already-open SSH terminal surface.", .category = .terminal },
     .{ .name = "terminal_repl_exec", .label = "terminal_repl_exec", .description = "Send text to an already-open interactive REPL or agent app.", .category = .terminal },
     .{ .name = "terminal_answer_prompt", .label = "terminal_answer_prompt", .description = "Answer an approval prompt in an agent terminal surface.", .category = .terminal },

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -30,6 +30,7 @@ const static_definitions = [_]Definition{
     .{ .name = "terminal_list", .label = "terminal_list", .description = "List WispTerm terminal surfaces visible to the agent.", .category = .terminal },
     .{ .name = "terminal_context", .label = "terminal_context", .description = "Report the current selected terminal write context.", .category = .terminal },
     .{ .name = "terminal_snapshot", .label = "terminal_snapshot", .description = "Read a bounded text snapshot from terminal surfaces.", .category = .terminal },
+    .{ .name = "ui_screenshot", .label = "ui_screenshot", .description = "Capture the active WispTerm tab or focused active-tab panel as a local PNG file.", .category = .terminal },
     .{ .name = "terminal_select", .label = "terminal_select", .description = "Select the terminal surface used for subsequent write tools.", .category = .terminal },
     .{ .name = "ssh_session_exec", .label = "ssh_session_exec", .description = "Run a shell command in an already-open SSH terminal surface.", .category = .terminal },
     .{ .name = "terminal_repl_exec", .label = "terminal_repl_exec", .description = "Send text to an already-open interactive REPL or agent app.", .category = .terminal },


### PR DESCRIPTION
## Summary
- Add `ui_screenshot` as a first-party agent tool for active-tab/focused-panel PNG capture.
- Add OpenGL framebuffer readback, pure PNG encoding, and AppWindow pre-swap capture plumbing.
- Keep Metal/macOS as explicit `UnsupportedReadback` for V1.

## Validation
- `zig build test --summary all`
- `zig build test-full --summary all`
- `git diff --check`
- Windows path-safety: official PowerShell script unavailable in this Linux/WSL environment; equivalent git/awk checks passed.

## Notes
- No live Windows GUI or WeChat smoke was possible from this environment.
