### PR TITLE
[codex] Add progress slash commands for Weixin

### DIFF
--- a/src/assistant/conversation/composer.zig
+++ b/src/assistant/conversation/composer.zig
@@ -184,6 +184,7 @@ pub const SlashCommand = enum {
     memory,
     forget,
     model_switch,
+    btw,
     unknown,
 };
 
@@ -288,6 +289,18 @@ pub const slash_command_entries = [_]SlashCommandEntry{
     .{
         .suggestion = .{ .command = "/model", .description = "switch the model / AI profile" },
         .action = .model_switch,
+    },
+    .{
+        .suggestion = .{ .command = "/btw", .description = "show current progress without adding context" },
+        .action = .btw,
+    },
+    .{
+        .suggestion = .{ .command = "/verbos", .description = "show detailed current progress" },
+        .action = .btw,
+    },
+    .{
+        .suggestion = .{ .command = "/verbose", .description = "show detailed current progress" },
+        .action = .btw,
     },
 };
 
@@ -595,6 +608,9 @@ test "parseSlashCommand recognizes model switch and alias" {
 
 test "parseSlashCommand recognizes exact, unknown, and rejects non-slash" {
     try std.testing.expectEqual(SlashCommand.skills, parseSlashCommand("/skills").?);
+    try std.testing.expectEqual(SlashCommand.btw, parseSlashCommand("/btw").?);
+    try std.testing.expectEqual(SlashCommand.btw, parseSlashCommand("/verbos").?);
+    try std.testing.expectEqual(SlashCommand.btw, parseSlashCommand("/verbose").?);
     try std.testing.expectEqual(SlashCommand.unknown, parseSlashCommand("/help").?);
     try std.testing.expectEqual(@as(?SlashCommand, null), parseSlashCommand("hello"));
     try std.testing.expectEqual(@as(?SlashCommand, null), parseSlashCommand("/has space"));
@@ -610,7 +626,7 @@ test "slash command suggestions filter by prefix" {
     try std.testing.expectEqual(@as(usize, 1), slashCommandSuggestionCountForInput("/sk", 3, &.{}));
     const s = slashCommandSuggestionAtForInput("/sk", 3, 0, &.{}).?;
     try std.testing.expectEqualStrings("/skills", s.command);
-    try std.testing.expectEqual(@as(usize, 17), slashCommandSuggestionCountForInput("/", 1, &.{}));
+    try std.testing.expectEqual(slash_command_entries.len, slashCommandSuggestionCountForInput("/", 1, &.{}));
     try std.testing.expectEqual(@as(usize, 1), slashCommandSuggestionCountForInput("/di", 3, &.{}));
     try std.testing.expectEqualStrings("/distill", slashCommandSuggestionAtForInput("/di", 3, 0, &.{}).?.command);
 }

--- a/src/assistant/conversation/request.zig
+++ b/src/assistant/conversation/request.zig
@@ -457,7 +457,7 @@ pub fn runSubagentTaskWithModel(request: *ChatRequest, task: []const u8, model: 
 
         for (result.tool_calls.?) |tool_call| {
             if (ai_chat.requestCancelled(request)) return error.Canceled;
-            const progress = try std.fmt.allocPrint(allocator, "subagent: running {s} {s}", .{ tool_call.name, tool_call.arguments });
+            const progress = try std.fmt.allocPrint(allocator, "subagent: running {s}", .{tool_call.name});
             defer allocator.free(progress);
             ai_chat.appendProgressMessage(request.session, progress) catch {};
 

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -735,6 +735,7 @@ pub const ComposerSuggestionKind = ai_chat_composer.ComposerSuggestionKind;
 pub const ComposerSuggestion = ai_chat_composer.ComposerSuggestion;
 pub const SlashCommandSuggestion = ai_chat_composer.SlashCommandSuggestion;
 const parseSlashCommand = ai_chat_composer.parseSlashCommand;
+const exactBuiltinCommand = ai_chat_composer.exactBuiltinCommand;
 const composerSuggestionPrefix = ai_chat_composer.composerSuggestionPrefix;
 const slashCommandSuggestionPrefix = ai_chat_composer.slashCommandSuggestionPrefix;
 const suggestionReplacementText = ai_chat_composer.suggestionReplacementText;
@@ -759,6 +760,7 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
         .distill => allocator.dupe(u8, "Use /distill [topic] to preview a reusable skill candidate."),
         .unknown => allocator.dupe(u8, "Unknown command. Use /commands to list commands."),
         .skills => ai_chat_skills.listSkillsForDisplay(allocator),
+        .btw => allocator.dupe(u8, ""),
         // .loop and .watch suppress output and emit their own messages via
         // runLoopCommandLocked; this path is never reached.
         .loop, .watch => allocator.dupe(u8, ""),
@@ -773,6 +775,22 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
 
 fn previewPrompt(p: []const u8) []const u8 {
     return if (p.len > 48) p[0..48] else p;
+}
+
+fn parseBtwArg(input: []const u8) ?[]const u8 {
+    const prompt = std.mem.trim(u8, input, " \t\r\n");
+    if (prompt.len == 0) return null;
+    const tok_end = ai_chat_composer.slashCommandTokenEnd(prompt);
+    const first_tok = prompt[0..tok_end];
+    const command = exactBuiltinCommand(first_tok) orelse return null;
+    if (command != .btw) return null;
+    return std.mem.trim(u8, prompt[tok_end..], " \t\r\n");
+}
+
+fn firstProgressLine(s: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, s, " \t\r\n");
+    const end = std.mem.indexOfScalar(u8, trimmed, '\n') orelse trimmed.len;
+    return std.mem.trim(u8, trimmed[0..end], " \t\r\n");
 }
 
 const LoopTaskListScope = enum { session, all };
@@ -2259,6 +2277,24 @@ pub const Session = struct {
         self.scroll_px = 1_000_000;
     }
 
+    fn allocCurrentProgressLocked(self: *Session) ![]u8 {
+        var i = self.messages.items.len;
+        while (i > 0) : (i -= 1) {
+            const msg = self.messages.items[i - 1];
+            if (msg.role != .tool) continue;
+            const content = firstProgressLine(msg.content);
+            if (std.mem.startsWith(u8, content, "subagent:")) return self.allocator.dupe(u8, content);
+        }
+        const s = std.mem.trim(u8, self.status(), " \t\r\n");
+        if (s.len != 0 and !std.mem.eql(u8, s, "Ready")) return std.fmt.allocPrint(self.allocator, "Status: {s}", .{s});
+        return self.allocator.dupe(u8, "No active progress.");
+    }
+
+    fn runBtwCommandLocked(self: *Session) ?BuiltinResult {
+        _ = parseBtwArg(self.input()) orelse return null;
+        return self.runBuiltinCommandLocked(.btw, "");
+    }
+
     /// Thread-safe wrapper used by the tool layer (worker thread) to post a
     /// transcript note such as a diff. Swallows OOM (best-effort UI message).
     pub fn appendLocalToolMessage(self: *Session, text: []const u8) void {
@@ -2324,6 +2360,13 @@ pub const Session = struct {
     pub fn submit(self: *Session) void {
         var history_change: ?PendingHistoryChange = null;
         self.mutex.lock();
+        if (self.runBtwCommandLocked()) |r| {
+            self.clearPendingWeixinReplyContextLocked();
+            self.mutex.unlock();
+            self.notifyHistoryChange(r.history_change);
+            fireDeferredAction(self, r.deferred);
+            return;
+        }
         if (self.tryAnswerPendingQuestionLocked()) {
             self.mutex.unlock();
             return;
@@ -2723,6 +2766,22 @@ pub const Session = struct {
                 result.deferred = .model_switch_picker;
                 self.clearSubmittedInputLocked();
                 self.setStatusLocked("Ready");
+                result.suppress_output = true;
+            },
+            .btw => {
+                const text = self.allocCurrentProgressLocked() catch {
+                    self.setStatusLocked("Out of memory");
+                    result.suppress_output = true;
+                    return result;
+                };
+                defer self.allocator.free(text);
+                self.appendLocalToolMessageLocked(text) catch {
+                    self.setStatusLocked("Out of memory");
+                    result.suppress_output = true;
+                    return result;
+                };
+                self.clearSubmittedInputLocked();
+                if (!self.request_inflight) self.setStatusLocked("Ready");
                 result.suppress_output = true;
             },
             else => {},
@@ -5425,6 +5484,47 @@ test "ai chat enter submits slash commands instead of completing suggestions" {
 
     for (session.messages.items) |msg| msg.deinit(allocator);
     session.messages.deinit(allocator);
+}
+
+test "/btw emits local progress without adding user context" {
+    const allocator = std.testing.allocator;
+    var session = Session{ .allocator = allocator };
+    defer {
+        if (session.request_thread) |thread| {
+            session.request_thread = null;
+            thread.join();
+        }
+        for (session.messages.items) |msg| msg.deinit(allocator);
+        session.messages.deinit(allocator);
+    }
+    const Noop = struct {
+        fn run() void {}
+    };
+    session.request_thread = try std.Thread.spawn(.{}, Noop.run, .{});
+    session.request_inflight = true;
+
+    try session.messages.append(allocator, .{
+        .role = .tool,
+        .content = try allocator.dupe(u8, "subagent: running web_search"),
+        .persist_to_history = false,
+    });
+    session.appendInputText("/btw 当前进展");
+    session.submit();
+
+    try std.testing.expectEqualStrings("", session.input());
+    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
+    try std.testing.expectEqual(Role.tool, session.messages.items[1].role);
+    try std.testing.expectEqualStrings("subagent: running web_search", session.messages.items[1].content);
+    try std.testing.expect(!session.messages.items[1].persist_to_history);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    const reqs = try session.buildRequestMessagesLocked(null, null);
+    defer {
+        for (reqs) |msg| msg.deinit(allocator);
+        allocator.free(reqs);
+    }
+    try std.testing.expectEqual(@as(usize, 0), reqs.len);
 }
 
 test "/rewind via submit opens picker without adding transcript noise" {

--- a/src/weixin/agent.zig
+++ b/src/weixin/agent.zig
@@ -5,6 +5,7 @@ const control = @import("control.zig");
 const types = @import("types.zig");
 const approval_reply = @import("approval_reply.zig");
 const question_reply = @import("question_reply.zig");
+const reply_progress = @import("reply_progress.zig");
 const session_list = @import("session_list.zig");
 
 const AI_ACK = "信息已收到，开始处理。\n发送 /stop 可停止本次处理。\n发送 /help 查看帮助手册。";
@@ -62,19 +63,23 @@ fn isSwitchCommand(cmd: []const u8) bool {
     return eqIgnoreCase(cmd, "/switch") or eqIgnoreCase(cmd, "/use");
 }
 
+fn isProgressCommand(cmd: []const u8) bool {
+    return eqIgnoreCase(cmd, "/btw") or eqIgnoreCase(cmd, "/verbos") or eqIgnoreCase(cmd, "/verbose");
+}
+
 fn isKnownCommand(cmd: []const u8) bool {
     return eqIgnoreCase(cmd, "/term") or eqIgnoreCase(cmd, "/keys") or
         eqIgnoreCase(cmd, "/ai") or eqIgnoreCase(cmd, "/stop") or
         eqIgnoreCase(cmd, "/models") or eqIgnoreCase(cmd, "/new") or
         eqIgnoreCase(cmd, "/model") or
-        isListCommand(cmd) or isSwitchCommand(cmd);
+        isProgressCommand(cmd) or isListCommand(cmd) or isSwitchCommand(cmd);
 }
 
 /// Commands that are valid with no argument.
 fn isNoArgCommand(cmd: []const u8) bool {
     return eqIgnoreCase(cmd, "/stop") or eqIgnoreCase(cmd, "/models") or
         eqIgnoreCase(cmd, "/new") or eqIgnoreCase(cmd, "/model") or
-        isListCommand(cmd);
+        isProgressCommand(cmd) or isListCommand(cmd);
 }
 
 pub fn route(
@@ -99,6 +104,7 @@ pub fn route(
     if (eqIgnoreCase(cmd, "/models")) return listModelProfiles(ctrl, out);
     if (eqIgnoreCase(cmd, "/new")) return openNewAi(ctrl, parts.arg, out);
     if (eqIgnoreCase(cmd, "/model")) return switchAiModel(ctrl, parts.arg, out);
+    if (isProgressCommand(cmd)) return progressReply(ctrl, out);
     if (cmd.len != 0 and !isKnownCommand(cmd)) {
         return out.set("未知命令。\n\n" ++ helpTextConst);
     }
@@ -301,6 +307,12 @@ fn statusReply(ctrl: control.Control, out: *Reply) !void {
     return out.set("微信直连：在线\n当前会话：默认（发送消息将新建副驾会话）");
 }
 
+fn progressReply(ctrl: control.Control, out: *Reply) !void {
+    const p = reply_progress.progress("", ctrl.latestTranscript());
+    if (p.text.len != 0) return out.set(p.text);
+    return out.set("当前没有进展可显示。");
+}
+
 fn sendTerminal(ctrl: control.Control, text: []const u8, enter: bool, out: *Reply) !void {
     const term = ctrl.findTerminalSurface() orelse return out.set("当前没有可写终端 surface。");
     var buf: std.ArrayListUnmanaged(u8) = .empty;
@@ -315,6 +327,7 @@ const helpTextConst =
     "WispTerm 微信直连命令：\n" ++
     "/ping 验证连接\n/status 查看状态\n/list 列出副驾会话\n" ++
     "/switch <编号> 切换并固定会话\n/ai <内容> 发送给副驾\n" ++
+    "/btw [问题] 立即查看当前进展\n/verbos 查看详细进展\n" ++
     "/models 查看已有 model profile\n/new [profile] 新建独立副驾\n/model <profile> 切换当前副驾模型\n" ++
     "/stop 停止当前 AI 处理\n/term <命令> 发送到终端并回车\n/keys <文本> 发送原始文本\n" ++
     "普通文本默认发送给当前会话。";
@@ -356,6 +369,7 @@ const FakeControl = struct {
     conv_copilot: []const bool = &.{},
     conv_current: ?usize = null,
     pin_called_index: ?usize = null,
+    transcript: []const u8 = "",
 
     /// Bytes captured from the last send_input. send_input borrows its argument
     /// (production consumes it synchronously), so the fake copies for inspection.
@@ -427,8 +441,8 @@ const FakeControl = struct {
         self.len = n;
         return .ok;
     }
-    fn latest_transcript(_: *anyopaque) []const u8 {
-        return "";
+    fn latest_transcript(ctx: *anyopaque) []const u8 {
+        return cast(ctx).transcript;
     }
     fn ai_approval_pending(ctx: *anyopaque) bool {
         return cast(ctx).approval_pending;
@@ -800,6 +814,19 @@ test "/switch with no argument shows usage" {
     defer out.deinit();
     try route(t.allocator, fake.control_iface(), defaultSettings(), "/switch", null, &out);
     try t.expect(std.mem.indexOf(u8, out.text.items, "用法") != null);
+}
+
+test "/btw reports progress without sending input" {
+    var fake = FakeControl{
+        .transcript = "Model:\nGLM\n\nStatus:\nRunning tools...\n\n" ++
+            "You:\nq\n\nTool:\nsubagent: running web_search\n",
+    };
+    var out = Reply.init(t.allocator);
+    defer out.deinit();
+    try route(t.allocator, fake.control_iface(), defaultSettings(), "/btw 当前进展", null, &out);
+    try t.expectEqualStrings("subagent: running web_search", out.text.items);
+    try t.expectEqual(@as(usize, 0), fake.len);
+    try t.expect(!out.expect_ai_progress);
 }
 
 test "/sessions, /ls, /use are aliases" {

--- a/src/weixin/reply_progress.zig
+++ b/src/weixin/reply_progress.zig
@@ -82,6 +82,7 @@ pub fn progress(baseline: []const u8, current: []const u8) Progress {
         return .{ .done = true, .text = "本次处理已停止，未生成新的回复。" };
     }
     if (containsIgnoreCase(status, "running tools") or hasRole(new_msgs, .tool)) {
+        if (latestSubagentProgress(new_msgs)) |detail| return .{ .done = false, .text = detail };
         return .{ .done = false, .text = "还在处理中，工具调用仍在执行。" };
     }
     if (new_msgs.len != 0 or last_assistant != null) {
@@ -200,6 +201,22 @@ fn hasRole(msgs: []const Section, role: Role) bool {
     return false;
 }
 
+fn latestSubagentProgress(msgs: []const Section) ?[]const u8 {
+    var i = msgs.len;
+    while (i > 0) : (i -= 1) {
+        const m = msgs[i - 1];
+        if (m.role != .tool) continue;
+        const content = firstLine(trim(m.content));
+        if (std.mem.startsWith(u8, content, "subagent:")) return content;
+    }
+    return null;
+}
+
+fn firstLine(s: []const u8) []const u8 {
+    const end = std.mem.indexOfScalar(u8, s, '\n') orelse s.len;
+    return trim(s[0..end]);
+}
+
 fn eq(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, a, b);
 }
@@ -251,6 +268,16 @@ test "not done while a tool turn is still streaming" {
     const p = progress(baseline, current);
     try t.expect(!p.done);
     try t.expect(p.text.len != 0);
+}
+
+test "subagent progress beats generic tool-running text" {
+    const baseline = "Model:\nGLM\n\nStatus:\nReady\n\nYou:\nq\n";
+    const current =
+        "Model:\nGLM\n\nStatus:\nRunning tools...\n\n" ++
+        "You:\nq\n\nTool:\nsubagent: running web_search\n";
+    const p = progress(baseline, current);
+    try t.expect(!p.done);
+    try t.expectEqualStrings("subagent: running web_search", p.text);
 }
 
 test "approval section is detected and takes priority over done/tool branches" {


### PR DESCRIPTION
## Summary
- add `/btw`, `/verbos`, and `/verbose` progress commands for Weixin and Copilot
- surface the latest `subagent:` progress line instead of the generic tool-running text
- keep progress lookups local-only so they do not enter future model context

## Why
When Weixin reported “还在处理中，工具调用仍在执行。”, users could not ask for a quick progress detail without sending another prompt into the assistant context.

## Validation
- `zig build test --summary all`
- `zig build test-full --summary all`