### PR TITLE
[codex] add remote file edit helper

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -396,6 +396,13 @@ test "desktop executable emission defaults to implemented platform backends" {
     try std.testing.expect(defaultEmitDesktopExe(PlatformFeatures.forOs(.macos)));
 }
 
+test "standalone filetool build contract is declared" {
+    const source = @embedFile("build.zig");
+    try expectSourceContains(source, ".name = \"wispterm-filetool\"");
+    try expectSourceContains(source, "src/wispterm_filetool.zig");
+    try expectSourceContains(source, "b.step(\"wispterm-filetool\"");
+}
+
 test "shared compile checks default to platforms without desktop backends" {
     try std.testing.expect(!defaultEmitSharedCompileChecks(PlatformFeatures.forOs(.windows)));
     try std.testing.expect(!defaultEmitSharedCompileChecks(PlatformFeatures.forOs(.linux)));
@@ -628,6 +635,19 @@ pub fn build(b: *std.Build) void {
         const wisptermctl_step = b.step("wisptermctl", "Build the standalone wisptermctl CLI client (separate artifact; not bundled with the app)");
         wisptermctl_step.dependOn(&b.addInstallArtifact(ctl_exe, .{}).step);
     }
+
+    const filetool_mod = b.createModule(.{
+        .root_source_file = b.path("src/wispterm_filetool.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const filetool_exe = b.addExecutable(.{
+        .name = "wispterm-filetool",
+        .root_module = filetool_mod,
+    });
+    if (platform.supports_gui_subsystem) filetool_exe.subsystem = .Console;
+    const filetool_step = b.step("wispterm-filetool", "Build the standalone remote-side file edit helper");
+    filetool_step.dependOn(&b.addInstallArtifact(filetool_exe, .{}).step);
 
     b.installDirectory(.{
         .source_dir = b.path("plugins"),

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -136,6 +136,8 @@ The AI agent can read and edit files directly:
 
 To edit a file on a remote SSH server, the agent passes the `surface_id` of an open SSH terminal tab; the operation runs on that host over the existing connection. Local files (no `surface_id`) resolve relative paths against the conversation's working directory. Writes and edits display a diff and, depending on the permission level (confirm / auto / full), may ask you to approve before applying.
 
+SSH `edit_file` can use the optional `wispterm-filetool` helper on the remote host so the exact-string replacement is checked and applied server-side. Build it separately with `zig build wispterm-filetool -Dtarget=<remote-target>` and put `zig-out/bin/wispterm-filetool` on the remote server's `PATH`. If the helper is missing, WispTerm automatically falls back to the legacy SSH read/apply/write path.
+
 ## Long-term memory
 
 Copilot keeps two tiers of long-term memory under the config directory

--- a/src/agent/remote_filetool.zig
+++ b/src/agent/remote_filetool.zig
@@ -1,0 +1,250 @@
+//! Wire protocol and local implementation for the standalone wispterm-filetool.
+const std = @import("std");
+const file_edit = @import("file_edit.zig");
+
+pub const tool_name = "wispterm-filetool";
+pub const edit_check_command = "edit-check";
+pub const edit_count_command = "edit-count";
+pub const edit_apply_command = "edit-apply";
+pub const helper_unavailable_exit_code: u8 = 127;
+pub const max_request_bytes: usize = 2 * file_edit.MAX_FILE_BYTES + 4096;
+
+const EditRequest = struct {
+    old_string: []u8,
+    new_string: []u8,
+    replace_all: bool,
+
+    fn deinit(self: *EditRequest, allocator: std.mem.Allocator) void {
+        allocator.free(self.old_string);
+        allocator.free(self.new_string);
+        self.* = undefined;
+    }
+};
+
+pub fn encodeEditRequestAlloc(
+    allocator: std.mem.Allocator,
+    old_string: []const u8,
+    new_string: []const u8,
+    replace_all: bool,
+) ![]u8 {
+    const encoder = std.base64.standard.Encoder;
+    const old_b64 = try allocator.alloc(u8, encoder.calcSize(old_string.len));
+    defer allocator.free(old_b64);
+    _ = encoder.encode(old_b64, old_string);
+
+    const new_b64 = try allocator.alloc(u8, encoder.calcSize(new_string.len));
+    defer allocator.free(new_b64);
+    _ = encoder.encode(new_b64, new_string);
+
+    return std.fmt.allocPrint(
+        allocator,
+        "replace_all={d}\nold_b64={s}\nnew_b64={s}\n",
+        .{ @intFromBool(replace_all), old_b64, new_b64 },
+    );
+}
+
+pub fn handleEditCheckAlloc(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    request_bytes: []const u8,
+    include_diff: bool,
+) ![]u8 {
+    var request = parseEditRequestAlloc(allocator, request_bytes) catch return errorResponseAlloc(allocator, "BadRequest");
+    defer request.deinit(allocator);
+
+    const old_content = readWholeFileAlloc(allocator, path) catch |err| return fileIoErrorAlloc(allocator, err, "ReadFailed");
+    defer allocator.free(old_content);
+
+    const outcome = file_edit.applyEdit(allocator, old_content, request.old_string, request.new_string, request.replace_all) catch |err| {
+        return editErrorResponseAlloc(allocator, err);
+    };
+    defer allocator.free(outcome.new_content);
+
+    if (!include_diff) return okHeaderAlloc(allocator, outcome.occurrences);
+
+    const diff = file_edit.unifiedDiffAlloc(allocator, path, old_content, outcome.new_content) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer allocator.free(diff);
+
+    return std.fmt.allocPrint(allocator, "ok occurrences={d}\n{s}", .{ outcome.occurrences, diff });
+}
+
+pub fn handleEditApplyAlloc(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    request_bytes: []const u8,
+) ![]u8 {
+    var request = parseEditRequestAlloc(allocator, request_bytes) catch return errorResponseAlloc(allocator, "BadRequest");
+    defer request.deinit(allocator);
+
+    const old_content = readWholeFileAlloc(allocator, path) catch |err| return fileIoErrorAlloc(allocator, err, "ReadFailed");
+    defer allocator.free(old_content);
+
+    const outcome = file_edit.applyEdit(allocator, old_content, request.old_string, request.new_string, request.replace_all) catch |err| {
+        return editErrorResponseAlloc(allocator, err);
+    };
+    defer allocator.free(outcome.new_content);
+
+    writeFileAtomic(allocator, path, outcome.new_content) catch |err| return fileIoErrorAlloc(allocator, err, "WriteFailed");
+    return okHeaderAlloc(allocator, outcome.occurrences);
+}
+
+fn parseEditRequestAlloc(allocator: std.mem.Allocator, request_bytes: []const u8) !EditRequest {
+    var replace_all: ?bool = null;
+    var old_b64: ?[]const u8 = null;
+    var new_b64: ?[]const u8 = null;
+
+    var it = std.mem.splitScalar(u8, request_bytes, '\n');
+    while (it.next()) |line| {
+        if (line.len == 0) continue;
+        if (std.mem.eql(u8, line, "replace_all=0")) {
+            replace_all = false;
+        } else if (std.mem.eql(u8, line, "replace_all=1")) {
+            replace_all = true;
+        } else if (std.mem.startsWith(u8, line, "old_b64=")) {
+            old_b64 = line["old_b64=".len..];
+        } else if (std.mem.startsWith(u8, line, "new_b64=")) {
+            new_b64 = line["new_b64=".len..];
+        } else {
+            return error.BadRequest;
+        }
+    }
+
+    const old_encoded = old_b64 orelse return error.BadRequest;
+    const new_encoded = new_b64 orelse return error.BadRequest;
+    var request = EditRequest{
+        .old_string = try decodeBase64Alloc(allocator, old_encoded),
+        .new_string = &[_]u8{},
+        .replace_all = replace_all orelse return error.BadRequest,
+    };
+    errdefer allocator.free(request.old_string);
+    request.new_string = try decodeBase64Alloc(allocator, new_encoded);
+    return request;
+}
+
+fn decodeBase64Alloc(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
+    const decoder = std.base64.standard.Decoder;
+    const size = try decoder.calcSizeForSlice(encoded);
+    const decoded = try allocator.alloc(u8, size);
+    errdefer allocator.free(decoded);
+    try decoder.decode(decoded, encoded);
+    return decoded;
+}
+
+fn readWholeFileAlloc(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.fs.openFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    return file.readToEndAlloc(allocator, file_edit.MAX_FILE_BYTES);
+}
+
+fn createWriteFile(path: []const u8) !std.fs.File {
+    if (std.fs.path.isAbsolute(path)) return std.fs.createFileAbsolute(path, .{ .truncate = true });
+    return std.fs.cwd().createFile(path, .{ .truncate = true });
+}
+
+fn renameFile(old_path: []const u8, new_path: []const u8) !void {
+    if (std.fs.path.isAbsolute(old_path) and std.fs.path.isAbsolute(new_path)) {
+        return std.fs.renameAbsolute(old_path, new_path);
+    }
+    return std.fs.cwd().rename(old_path, new_path);
+}
+
+fn deleteFileBestEffort(path: []const u8) void {
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.deleteFileAbsolute(path) catch {};
+    } else {
+        std.fs.cwd().deleteFile(path) catch {};
+    }
+}
+
+fn writeFileAtomic(allocator: std.mem.Allocator, path: []const u8, content: []const u8) !void {
+    const tmp = try std.fmt.allocPrint(allocator, "{s}.wispterm.tmp", .{path});
+    defer allocator.free(tmp);
+    errdefer deleteFileBestEffort(tmp);
+
+    var file = try createWriteFile(tmp);
+    errdefer file.close();
+    try file.writeAll(content);
+    file.close();
+
+    try renameFile(tmp, path);
+}
+
+fn okHeaderAlloc(allocator: std.mem.Allocator, occurrences: usize) ![]u8 {
+    return std.fmt.allocPrint(allocator, "ok occurrences={d}\n", .{occurrences});
+}
+
+fn editErrorResponseAlloc(allocator: std.mem.Allocator, err: anyerror) ![]u8 {
+    return switch (err) {
+        error.EmptyOld => errorResponseAlloc(allocator, "EmptyOld"),
+        error.NotFound => errorResponseAlloc(allocator, "NotFound"),
+        error.NotUnique => errorResponseAlloc(allocator, "NotUnique"),
+        error.OutOfMemory => error.OutOfMemory,
+        else => errorResponseAlloc(allocator, @errorName(err)),
+    };
+}
+
+fn fileIoErrorAlloc(allocator: std.mem.Allocator, err: anyerror, fallback_code: []const u8) ![]u8 {
+    return switch (err) {
+        error.FileTooBig => errorResponseAlloc(allocator, "TooLarge"),
+        error.OutOfMemory => error.OutOfMemory,
+        else => errorResponseAlloc(allocator, fallback_code),
+    };
+}
+
+fn errorResponseAlloc(allocator: std.mem.Allocator, code: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "error {s}\n", .{code});
+}
+
+test "remote filetool encodes edit requests without putting content in argv" {
+    const a = std.testing.allocator;
+    const request = try encodeEditRequestAlloc(a, "old\ntext", "new\ntext", true);
+    defer a.free(request);
+
+    try std.testing.expect(std.mem.indexOf(u8, request, "replace_all=1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, request, "old=old") == null);
+    try std.testing.expect(std.mem.indexOf(u8, request, "new=new") == null);
+}
+
+test "remote filetool check returns a diff and apply edits the file" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "demo.txt", .data = "alpha\nbeta\ngamma\n" });
+    const path = try tmp.dir.realpathAlloc(a, "demo.txt");
+    defer a.free(path);
+    const request = try encodeEditRequestAlloc(a, "beta", "BETA", false);
+    defer a.free(request);
+
+    const check = try handleEditCheckAlloc(a, path, request, true);
+    defer a.free(check);
+    try std.testing.expect(std.mem.startsWith(u8, check, "ok occurrences=1\n"));
+    try std.testing.expect(std.mem.indexOf(u8, check, "-beta\n+BETA\n") != null);
+
+    const apply = try handleEditApplyAlloc(a, path, request);
+    defer a.free(apply);
+    try std.testing.expectEqualStrings("ok occurrences=1\n", apply);
+
+    const after = try tmp.dir.readFileAlloc(a, "demo.txt", 1024);
+    defer a.free(after);
+    try std.testing.expectEqualStrings("alpha\nBETA\ngamma\n", after);
+}
+
+test "remote filetool redacted check returns only the count" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "secret.txt", .data = "alpha\nbeta\n" });
+    const path = try tmp.dir.realpathAlloc(a, "secret.txt");
+    defer a.free(path);
+    const request = try encodeEditRequestAlloc(a, "beta", "BETA", false);
+    defer a.free(request);
+
+    const check = try handleEditCheckAlloc(a, path, request, false);
+    defer a.free(check);
+    try std.testing.expectEqualStrings("ok occurrences=1\n", check);
+}

--- a/src/agent_tools/files.zig
+++ b/src/agent_tools/files.zig
@@ -449,6 +449,66 @@ pub fn editFile(ctx: *ToolContext, path: []const u8, old_string: []const u8, new
     };
     defer ctx.allocator.free(resolved);
 
+    const gate = gateForFileTarget(ctx, target, resolved, true);
+    if (target == .remote) {
+        switch (try tryRemoteEditFile(ctx, &target.remote.conn, resolved, old_string, new_string, replace_all, gate)) {
+            .done => |out| return out,
+            .fallback => {},
+        }
+    }
+
+    return legacyEditFile(ctx, target, resolved, old_string, new_string, replace_all, gate);
+}
+
+const RemoteEditAttempt = union(enum) {
+    done: []u8,
+    fallback,
+};
+
+fn tryRemoteEditFile(
+    ctx: *ToolContext,
+    conn: *const ToolSshConnection,
+    resolved: []const u8,
+    old_string: []const u8,
+    new_string: []const u8,
+    replace_all: bool,
+    gate: tool_access.Gate,
+) !RemoteEditAttempt {
+    var check = scp.sshRemoteEditCheck(ctx.allocator, conn, resolved, old_string, new_string, replace_all, !gate.blacklisted);
+    switch (check) {
+        .unavailable => return .fallback,
+        .edit_error => |msg| return .{ .done = msg },
+        .failed => |msg| return .{ .done = msg },
+        .ok => |ok| {
+            defer check.deinit(ctx.allocator);
+            if (gate.blacklisted) {
+                const note = try std.fmt.allocPrint(ctx.allocator, "edit_file {s}: protected path - diff hidden ({d} change(s))", .{ resolved, ok.occurrences });
+                defer ctx.allocator.free(note);
+                ctx.emitNote(note);
+            } else {
+                ctx.emitNote(ok.diff);
+            }
+
+            if (tool_access.approvalRequired(ctx.settings.permission, gate)) {
+                const reason = try std.fmt.allocPrint(ctx.allocator, "Edit {s} ({d} change(s))", .{ resolved, ok.occurrences });
+                defer ctx.allocator.free(reason);
+                if (!ctx.requestApproval("edit_file", resolved, reason)) {
+                    return .{ .done = try tool_output.deniedResult(ctx.allocator, resolved, "operator rejected file edit") };
+                }
+            }
+
+            const apply = scp.sshRemoteEditApply(ctx.allocator, conn, resolved, old_string, new_string, replace_all);
+            switch (apply) {
+                .unavailable => return .{ .done = try std.fmt.allocPrint(ctx.allocator, "wispterm-filetool disappeared before applying {s}; retry the edit to use the legacy fallback.", .{resolved}) },
+                .ok => |occurrences| return .{ .done = try std.fmt.allocPrint(ctx.allocator, "Edited {s} ({d} change(s)).", .{ resolved, occurrences }) },
+                .edit_error => |msg| return .{ .done = msg },
+                .failed => |msg| return .{ .done = msg },
+            }
+        },
+    }
+}
+
+fn legacyEditFile(ctx: *ToolContext, target: FileTarget, resolved: []const u8, old_string: []const u8, new_string: []const u8, replace_all: bool, gate: tool_access.Gate) ![]u8 {
     var old_content: []u8 = undefined;
     if (target == .remote) {
         old_content = scp.sshReadFile(ctx.allocator, &target.remote.conn, resolved, agent_file_edit.MAX_FILE_BYTES) orelse
@@ -472,8 +532,6 @@ pub fn editFile(ctx: *ToolContext, path: []const u8, old_string: []const u8, new
         };
     };
     defer ctx.allocator.free(outcome.new_content);
-
-    const gate = gateForFileTarget(ctx, target, resolved, true);
 
     // Do not disclose a protected file's content in the diff; show a redacted note.
     if (gate.blacklisted) {
@@ -795,6 +853,17 @@ test "edit_file applies a unique replacement to a local file" {
     const after = try tmp.dir.readFileAlloc(a, "e.txt", 1024);
     defer a.free(after);
     try std.testing.expectEqualStrings("alpha\nBETA\ngamma\n", after);
+}
+
+test "edit_file SSH path tries wispterm-filetool before legacy fallback" {
+    const source = @embedFile("files.zig");
+    const start = std.mem.indexOf(u8, source, "pub fn editFile") orelse return error.MissingEditFile;
+    const body = source[start..];
+    const end = std.mem.indexOf(u8, body, "fn fakeApprove") orelse return error.MissingEditFileEnd;
+    const edit_body = body[0..end];
+    try std.testing.expect(std.mem.indexOf(u8, edit_body, "tryRemoteEditFile") != null);
+    try std.testing.expect(std.mem.indexOf(u8, edit_body, "legacyEditFile") != null);
+    try std.testing.expect(std.mem.indexOf(u8, edit_body, "sshRemoteEditCheck") != null);
 }
 
 test "read_file with an unknown surface_id returns a no-surface error" {

--- a/src/ssh/scp.zig
+++ b/src/ssh/scp.zig
@@ -11,6 +11,7 @@ const SshConnection = ssh_connection.SshConnection;
 const platform_dirs = @import("../platform/dirs.zig");
 const platform_process = @import("../platform/process.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
+const remote_filetool = @import("../agent/remote_filetool.zig");
 
 /// Result of a transfer operation.
 pub const TransferResult = enum { ok, failed, spawn_error, cancelled };
@@ -652,6 +653,159 @@ pub fn buildRemoteWriteCommand(buf: *[2048]u8, path: []const u8, tmp: []const u8
     return buf[0..pos];
 }
 
+fn buildRemoteFiletoolCommand(buf: *[2048]u8, command: []const u8, path: []const u8) ?[]const u8 {
+    var pos: usize = 0;
+    if (!appendSlice(buf, &pos, "command -v ")) return null;
+    if (!appendSlice(buf, &pos, remote_filetool.tool_name)) return null;
+    if (!appendSlice(buf, &pos, " >/dev/null 2>&1 || exit 127; exec ")) return null;
+    if (!appendSlice(buf, &pos, remote_filetool.tool_name)) return null;
+    if (!appendSlice(buf, &pos, " ")) return null;
+    if (!appendSlice(buf, &pos, command)) return null;
+    if (!appendSlice(buf, &pos, " -- ")) return null;
+    if (!appendShellQuote(buf, &pos, path)) return null;
+    return buf[0..pos];
+}
+
+const RemoteFiletoolOk = struct {
+    occurrences: usize,
+    diff: []const u8,
+};
+
+fn parseRemoteFiletoolOk(output: []const u8) ?RemoteFiletoolOk {
+    const prefix = "ok occurrences=";
+    if (!std.mem.startsWith(u8, output, prefix)) return null;
+    const line_end = std.mem.indexOfScalar(u8, output, '\n') orelse return null;
+    const occurrences = std.fmt.parseUnsigned(usize, output[prefix.len..line_end], 10) catch return null;
+    return .{ .occurrences = occurrences, .diff = output[line_end + 1 ..] };
+}
+
+fn parseRemoteFiletoolError(output: []const u8) ?[]const u8 {
+    const prefix = "error ";
+    if (!std.mem.startsWith(u8, output, prefix)) return null;
+    const line_end = std.mem.indexOfScalar(u8, output, '\n') orelse output.len;
+    return output[prefix.len..line_end];
+}
+
+fn remoteFiletoolErrorAlloc(allocator: std.mem.Allocator, path: []const u8, code: []const u8) ![]u8 {
+    if (std.mem.eql(u8, code, "EmptyOld")) return allocator.dupe(u8, "old_string must not be empty.");
+    if (std.mem.eql(u8, code, "NotFound")) return std.fmt.allocPrint(allocator, "old_string not found in {s}.", .{path});
+    if (std.mem.eql(u8, code, "NotUnique")) return std.fmt.allocPrint(allocator, "old_string is not unique in {s}; pass replace_all=true or add more context.", .{path});
+    if (std.mem.eql(u8, code, "TooLarge")) return std.fmt.allocPrint(allocator, "File {s} is too large (>= {d} bytes).", .{ path, @import("../agent/file_edit.zig").MAX_FILE_BYTES });
+    if (std.mem.eql(u8, code, "BadRequest")) return allocator.dupe(u8, "wispterm-filetool received a malformed edit request.");
+    if (std.mem.eql(u8, code, "ReadFailed")) return std.fmt.allocPrint(allocator, "Failed to read remote file {s} for editing.", .{path});
+    if (std.mem.eql(u8, code, "WriteFailed")) return std.fmt.allocPrint(allocator, "Failed to write remote file {s}.", .{path});
+    return std.fmt.allocPrint(allocator, "wispterm-filetool failed for {s}: {s}", .{ path, code });
+}
+
+pub const RemoteEditCheckResult = union(enum) {
+    unavailable,
+    ok: struct {
+        occurrences: usize,
+        diff: []u8,
+    },
+    edit_error: []u8,
+    failed: []u8,
+
+    pub fn deinit(self: RemoteEditCheckResult, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .ok => |ok| allocator.free(ok.diff),
+            .edit_error, .failed => |msg| allocator.free(msg),
+            .unavailable => {},
+        }
+    }
+};
+
+pub const RemoteEditApplyResult = union(enum) {
+    unavailable,
+    ok: usize,
+    edit_error: []u8,
+    failed: []u8,
+
+    pub fn deinit(self: RemoteEditApplyResult, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .edit_error, .failed => |msg| allocator.free(msg),
+            .unavailable, .ok => {},
+        }
+    }
+};
+
+pub fn sshRemoteEditCheck(
+    allocator: std.mem.Allocator,
+    conn: *const SshConnection,
+    path: []const u8,
+    old_string: []const u8,
+    new_string: []const u8,
+    replace_all: bool,
+    include_diff: bool,
+) RemoteEditCheckResult {
+    const command_name = if (include_diff) remote_filetool.edit_check_command else remote_filetool.edit_count_command;
+    const request = remote_filetool.encodeEditRequestAlloc(allocator, old_string, new_string, replace_all) catch return .{
+        .failed = allocator.dupe(u8, "Failed to encode remote edit request.") catch return .unavailable,
+    };
+    defer allocator.free(request);
+
+    var cmd_buf: [2048]u8 = undefined;
+    const command = buildRemoteFiletoolCommand(&cmd_buf, command_name, path) orelse return .{
+        .failed = allocator.dupe(u8, "Failed to build wispterm-filetool command.") catch return .unavailable,
+    };
+
+    var cap = sshExecStdinCapture(allocator, conn, command, request, remote_filetool.max_request_bytes) orelse return .{
+        .failed = allocator.dupe(u8, "Failed to run wispterm-filetool.") catch return .unavailable,
+    };
+    defer cap.deinit(allocator);
+
+    if (cap.exit_code == remote_filetool.helper_unavailable_exit_code and cap.stdout.len == 0) return .unavailable;
+    if (parseRemoteFiletoolOk(cap.stdout)) |ok| {
+        const diff = allocator.dupe(u8, ok.diff) catch return .{
+            .failed = allocator.dupe(u8, "Failed to copy wispterm-filetool response.") catch return .unavailable,
+        };
+        return .{ .ok = .{ .occurrences = ok.occurrences, .diff = diff } };
+    }
+    if (parseRemoteFiletoolError(cap.stdout)) |code| {
+        return .{ .edit_error = remoteFiletoolErrorAlloc(allocator, path, code) catch return .unavailable };
+    }
+    return .{ .failed = remoteFiletoolFailureAlloc(allocator, "wispterm-filetool check failed", cap) catch return .unavailable };
+}
+
+pub fn sshRemoteEditApply(
+    allocator: std.mem.Allocator,
+    conn: *const SshConnection,
+    path: []const u8,
+    old_string: []const u8,
+    new_string: []const u8,
+    replace_all: bool,
+) RemoteEditApplyResult {
+    const request = remote_filetool.encodeEditRequestAlloc(allocator, old_string, new_string, replace_all) catch return .{
+        .failed = allocator.dupe(u8, "Failed to encode remote edit request.") catch return .unavailable,
+    };
+    defer allocator.free(request);
+
+    var cmd_buf: [2048]u8 = undefined;
+    const command = buildRemoteFiletoolCommand(&cmd_buf, remote_filetool.edit_apply_command, path) orelse return .{
+        .failed = allocator.dupe(u8, "Failed to build wispterm-filetool command.") catch return .unavailable,
+    };
+
+    var cap = sshExecStdinCapture(allocator, conn, command, request, 4096) orelse return .{
+        .failed = allocator.dupe(u8, "Failed to run wispterm-filetool.") catch return .unavailable,
+    };
+    defer cap.deinit(allocator);
+
+    if (cap.exit_code == remote_filetool.helper_unavailable_exit_code and cap.stdout.len == 0) return .unavailable;
+    if (parseRemoteFiletoolOk(cap.stdout)) |ok| return .{ .ok = ok.occurrences };
+    if (parseRemoteFiletoolError(cap.stdout)) |code| {
+        return .{ .edit_error = remoteFiletoolErrorAlloc(allocator, path, code) catch return .unavailable };
+    }
+    return .{ .failed = remoteFiletoolFailureAlloc(allocator, "wispterm-filetool apply failed", cap) catch return .unavailable };
+}
+
+fn remoteFiletoolFailureAlloc(allocator: std.mem.Allocator, label: []const u8, cap: SshStdinCapture) ![]u8 {
+    const stderr = std.mem.trim(u8, cap.stderr, " \t\r\n");
+    if (stderr.len > 0) return std.fmt.allocPrint(allocator, "{s}: {s}", .{ label, stderr });
+    const stdout = std.mem.trim(u8, cap.stdout, " \t\r\n");
+    if (stdout.len > 0) return std.fmt.allocPrint(allocator, "{s}: {s}", .{ label, stdout });
+    return std.fmt.allocPrint(allocator, "{s} (exit={?})", .{ label, cap.exit_code });
+}
+
 /// Read a remote file via `ssh ... cat`. Returns owned bytes, null on
 /// failure — including files larger than `max_bytes`, mirroring the local
 /// read_file cap. Failing outright (instead of truncating) matters: a
@@ -671,19 +825,39 @@ pub fn sshWriteFile(allocator: std.mem.Allocator, conn: *const SshConnection, pa
     return sshExecStdin(allocator, conn, cmd, content);
 }
 
+pub const SshStdinCapture = struct {
+    stdout: []u8,
+    stderr: []u8,
+    exit_code: ?u8,
+
+    pub fn deinit(self: *SshStdinCapture, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+        self.* = undefined;
+    }
+};
+
 /// Run `ssh user@host "<command>"` piping `stdin_bytes` to the remote stdin.
 /// Returns true on exit code 0. Mirrors `sshExec`'s askpass env setup.
 fn sshExecStdin(allocator: std.mem.Allocator, conn: *const SshConnection, command: []const u8, stdin_bytes: []const u8) bool {
+    var cap = sshExecStdinCapture(allocator, conn, command, stdin_bytes, 4096) orelse return false;
+    defer cap.deinit(allocator);
+    const ok = cap.exit_code == 0;
+    if (!ok) logProcessFailure("sshExecStdin failed", cap.stderr);
+    return ok;
+}
+
+fn sshExecStdinCapture(allocator: std.mem.Allocator, conn: *const SshConnection, command: []const u8, stdin_bytes: []const u8, max_stdout_bytes: usize) ?SshStdinCapture {
     var askpass_path: ?[]const u8 = null;
     defer if (askpass_path) |p| allocator.free(p);
     var env_map: ?std.process.EnvMap = null;
     defer if (env_map) |*map| map.deinit();
 
     if (conn.usesPasswordAuth()) {
-        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return false;
-        env_map = std.process.getEnvMap(allocator) catch return false;
+        askpass_path = platform_process.ensureSshAskPassScript(allocator) orelse return null;
+        env_map = std.process.getEnvMap(allocator) catch return null;
         if (env_map) |*map| {
-            platform_process.putSshAskPassEnv(map, askpass_path.?, conn.password()) catch return false;
+            platform_process.putSshAskPassEnv(map, askpass_path.?, conn.password()) catch return null;
         }
     }
 
@@ -710,32 +884,59 @@ fn sshExecStdin(allocator: std.mem.Allocator, conn: *const SshConnection, comman
 
     var child = std.process.Child.init(argv_buf[0..argc], allocator);
     child.stdin_behavior = .Pipe;
-    child.stdout_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
     if (env_map) |*map| child.env_map = map;
     child.create_no_window = true;
     child.spawn() catch |err| {
         std.debug.print("sshExecStdin: spawn failed: {}\n", .{err});
-        return false;
+        return null;
     };
 
+    var write_ok = true;
     if (child.stdin) |stdin| {
         var in = stdin;
-        platform_process.writeAllToPipe(in, stdin_bytes) catch {};
+        platform_process.writeAllToPipe(in, stdin_bytes) catch {
+            write_ok = false;
+        };
         in.close();
         child.stdin = null;
+    } else {
+        write_ok = false;
     }
 
-    var stderr_output: ?[]u8 = null;
-    defer if (stderr_output) |stderr| allocator.free(stderr);
-    if (child.stderr) |stderr| {
-        stderr_output = stderr.readToEndAlloc(allocator, 16 * 1024) catch null;
+    var stdout_output: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer stdout_output.deinit(allocator);
+    if (child.stdout) |stdout| {
+        var out = stdout;
+        child.stdout = null;
+        defer out.close();
+        const drain = drainCapped(out, allocator, &stdout_output, max_stdout_bytes, true) catch return null;
+        if (drain == .exceeded) {
+            _ = child.kill() catch {};
+            return null;
+        }
     }
 
-    const term = child.wait() catch return false;
-    return switch (term) {
-        .Exited => |code| code == 0,
-        else => false,
+    const stderr_output = if (child.stderr) |stderr| blk: {
+        var err_file = stderr;
+        child.stderr = null;
+        defer err_file.close();
+        break :blk err_file.readToEndAlloc(allocator, SSH_EXEC_MAX_STDERR_BYTES) catch return null;
+    } else allocator.dupe(u8, "") catch return null;
+    errdefer allocator.free(stderr_output);
+
+    const term = child.wait() catch return null;
+    const exit_code = switch (term) {
+        .Exited => |code| code,
+        else => null,
+    };
+    if (!write_ok and exit_code == 0) return null;
+
+    return .{
+        .stdout = stdout_output.toOwnedSlice(allocator) catch return null,
+        .stderr = stderr_output,
+        .exit_code = exit_code,
     };
 }
 
@@ -1191,6 +1392,21 @@ test "buildRemoteWriteCommand builds an atomic temp+mv" {
     var buf: [2048]u8 = undefined;
     const cmd = buildRemoteWriteCommand(&buf, "/tmp/a.txt", "/tmp/a.txt.tmp").?;
     try std.testing.expectEqualStrings("cat > '/tmp/a.txt.tmp' && mv -- '/tmp/a.txt.tmp' '/tmp/a.txt'", cmd);
+}
+
+test "buildRemoteFiletoolCommand probes PATH and quotes the path" {
+    var buf: [2048]u8 = undefined;
+    const cmd = buildRemoteFiletoolCommand(&buf, "edit-check", "/tmp/it's here.txt").?;
+    try std.testing.expectEqualStrings(
+        "command -v wispterm-filetool >/dev/null 2>&1 || exit 127; exec wispterm-filetool edit-check -- '/tmp/it'\\''s here.txt'",
+        cmd,
+    );
+}
+
+test "parseRemoteFiletoolOk splits count and diff" {
+    const parsed = parseRemoteFiletoolOk("ok occurrences=2\n--- a/f\n+++ b/f\n").?;
+    try std.testing.expectEqual(@as(usize, 2), parsed.occurrences);
+    try std.testing.expectEqualStrings("--- a/f\n+++ b/f\n", parsed.diff);
 }
 
 /// Test stand-in for a pipe: serves `data` in chunks of at most `chunk` bytes.

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -186,6 +186,7 @@ test {
     _ = @import("agent/config.zig");
     _ = @import("agent/access.zig");
     _ = @import("agent/file_edit.zig");
+    _ = @import("agent/remote_filetool.zig");
     _ = @import("agent/file_copy.zig");
     _ = @import("ssh/connection.zig");
     _ = @import("tmux/control.zig");

--- a/src/wispterm_filetool.zig
+++ b/src/wispterm_filetool.zig
@@ -1,0 +1,79 @@
+//! wispterm-filetool — tiny remote-side helper for WispTerm SSH file edits.
+const std = @import("std");
+const remote_filetool = @import("agent/remote_filetool.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len == 2 and std.mem.eql(u8, args[1], "--help")) {
+        try stdoutAll(USAGE);
+        return;
+    }
+    const parsed = parseArgs(args[1..]) orelse {
+        try stderrAll(USAGE);
+        std.process.exit(2);
+    };
+
+    var stdin = std.fs.File.stdin();
+    const request = stdin.readToEndAlloc(allocator, remote_filetool.max_request_bytes) catch {
+        try stdoutAll("error BadRequest\n");
+        std.process.exit(1);
+    };
+    defer allocator.free(request);
+
+    const out = if (std.mem.eql(u8, parsed.command, remote_filetool.edit_check_command))
+        try remote_filetool.handleEditCheckAlloc(allocator, parsed.path, request, true)
+    else if (std.mem.eql(u8, parsed.command, remote_filetool.edit_count_command))
+        try remote_filetool.handleEditCheckAlloc(allocator, parsed.path, request, false)
+    else if (std.mem.eql(u8, parsed.command, remote_filetool.edit_apply_command))
+        try remote_filetool.handleEditApplyAlloc(allocator, parsed.path, request)
+    else {
+        try stderrAll(USAGE);
+        std.process.exit(2);
+    };
+    defer allocator.free(out);
+
+    try stdoutAll(out);
+    if (!std.mem.startsWith(u8, out, "ok ")) std.process.exit(1);
+}
+
+const ParsedArgs = struct {
+    command: []const u8,
+    path: []const u8,
+};
+
+fn parseArgs(args: []const []const u8) ?ParsedArgs {
+    if (args.len != 3) return null;
+    if (!std.mem.eql(u8, args[1], "--")) return null;
+    return .{ .command = args[0], .path = args[2] };
+}
+
+fn stdoutAll(s: []const u8) !void {
+    try std.fs.File.stdout().deprecatedWriter().writeAll(s);
+}
+
+fn stderrAll(s: []const u8) !void {
+    try std.fs.File.stderr().deprecatedWriter().writeAll(s);
+}
+
+const USAGE =
+    \\wispterm-filetool — remote-side helper for WispTerm SSH edit_file
+    \\
+    \\Usage:
+    \\  wispterm-filetool edit-check -- <path>
+    \\  wispterm-filetool edit-count -- <path>
+    \\  wispterm-filetool edit-apply -- <path>
+    \\
+;
+
+test "wispterm-filetool parses command separator and path" {
+    const args = [_][]const u8{ "edit-check", "--", "/tmp/a b.txt" };
+    const parsed = parseArgs(&args).?;
+    try std.testing.expectEqualStrings("edit-check", parsed.command);
+    try std.testing.expectEqualStrings("/tmp/a b.txt", parsed.path);
+}


### PR DESCRIPTION
## Summary

- Add a standalone `wispterm-filetool` helper for server-side SSH `edit_file` exact-string edits.
- Prefer the helper for SSH edits when it is available on the remote `PATH`, with automatic fallback to the existing SSH read/apply/write path when it is missing.
- Document how to build and install the optional helper on a remote host.

## Why

SSH `edit_file` previously had to read the remote file into WispTerm to compute and apply the replacement, then write the full file back. The helper keeps the check/apply step on the server when users opt in by installing it.

## Validation

- `git diff --cached --check`
- `zig build test`
- `zig build test-full`
- `zig build wispterm-filetool -Dtarget=x86_64-linux-gnu`
- `zig test build.zig`
- `zig test src/wispterm_filetool.zig`
- Windows checkout path safety check: 0 violations, 0 case-fold collisions, 0 symlinks
