### PR TITLE
ci: manual beta build (signed macOS .app zip + Windows portable)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,262 @@
+name: Build Beta (Windows + macOS)
+
+# Manually-triggered internal/beta build. Produces a macOS (signed and, by
+# default, notarized) .app zip and a Windows portable zip — each as its own
+# workflow ARTIFACT. It does NOT create a GitHub Release, does not touch the
+# "latest" release, and does not feed the in-app auto-updater. Download both
+# artifacts from this run's "Artifacts" section and send them to testers.
+#
+# Reuses the exact signing recipe + secrets from macos-release.yml; the macOS
+# build is zipped instead of packaged into a DMG via WISPTERM_MACOS_PACKAGE_FORMAT=zip.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version label for filenames (default: beta-<short-sha>). Does NOT change the in-app version (that comes from build.zig.zon).'
+        required: false
+        type: string
+      notarize:
+        description: 'Notarize the macOS build with Apple (clean launch, slower). Uncheck for signed-only fast builds (testers right-click -> Open the first time).'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  macos:
+    name: macOS (aarch64, signed)
+    runs-on: macos-15
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-global-cache
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute version label
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          [[ -z "$version" ]] && version="beta-${GITHUB_SHA:0:8}"
+          echo "BETA_VERSION=${version}" >> "${GITHUB_ENV}"
+          echo "macOS beta version: ${version}"
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Cache Zig packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache/p
+            .zig-global-cache
+          key: ${{ runner.os }}-aarch64-zig-0.15.2-${{ hashFiles('build.zig', 'build.zig.zon', 'pkg/**/build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-aarch64-zig-0.15.2-
+
+      - name: Import macOS signing certificate
+        shell: bash
+        env:
+          MAC_CERT_P12_BASE64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="${RUNNER_TEMP}/wispterm-build.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          python3 -c 'import base64, os; open("cert.p12", "wb").write(base64.b64decode(os.environ["MAC_CERT_P12_BASE64"].strip()))'
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security list-keychains -d user -s "${KEYCHAIN_PATH}"
+          security default-keychain -s "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
+          security import cert.p12 -k "${KEYCHAIN_PATH}" -P "${MAC_CERT_PASSWORD}" \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcrun
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+
+          echo "Codesigning identities after import:"
+          security find-identity -v -p codesigning "${KEYCHAIN_PATH}"
+          codesign_identity="$(security find-identity -v -p codesigning "${KEYCHAIN_PATH}" | awk '/Developer ID Application/ {print $2; exit}')"
+          if [[ -z "${codesign_identity}" ]]; then
+            echo "::error::No Developer ID Application identity in keychain. Verify MAC_CERT_P12_BASE64 / MAC_CERT_PASSWORD and that the .p12 includes the private key." >&2
+            exit 1
+          fi
+          {
+            echo "WISPTERM_MACOS_SIGN_IDENTITY=${codesign_identity}"
+            echo "CODESIGN_KEYCHAIN=${KEYCHAIN_PATH}"
+          } >> "${GITHUB_ENV}"
+          rm -f cert.p12
+
+      - name: Store notarization credentials
+        if: ${{ inputs.notarize }}
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool store-credentials "wispterm-notarytool" \
+            --apple-id "${APPLE_ID}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --password "${APPLE_APP_PASSWORD}"
+          echo "WISPTERM_MACOS_NOTARY_PROFILE=wispterm-notarytool" >> "${GITHUB_ENV}"
+
+      - name: Fetch dependencies and build signed .app zip
+        shell: bash
+        env:
+          WISPTERM_MACOS_VERSION: ${{ env.BETA_VERSION }}
+          WISPTERM_MACOS_PACKAGE_FORMAT: zip
+        run: |
+          set -euo pipefail
+          retry() {
+            local name="$1"; shift
+            local attempts=5
+            for (( attempt=1; attempt<=attempts; attempt++ )); do
+              echo "::group::${name} (attempt ${attempt}/${attempts})"
+              if "$@"; then
+                echo "::endgroup::"
+                return 0
+              fi
+              echo "::endgroup::"
+              if (( attempt < attempts )); then
+                local delay=$(( 15 * attempt ))
+                (( delay > 120 )) && delay=120
+                echo "::warning::${name} failed; retrying in ${delay}s"
+                sleep "${delay}"
+              fi
+            done
+            return 1
+          }
+
+          retry "zig dependency fetch" zig build -Doptimize=ReleaseFast --fetch
+          retry "macos packaging" zig build macos-dist \
+            -Doptimize=ReleaseFast \
+            -Dtarget=aarch64-macos
+
+      - name: Validate signed app
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zips=(zig-out/dist/macos/*.zip)
+          zip_path="${zips[0]:-}"
+          if [[ -z "$zip_path" || ! -f "$zip_path" ]]; then
+            echo "no macOS zip produced under zig-out/dist/macos" >&2
+            exit 1
+          fi
+          echo "macOS zip: $zip_path"
+          codesign --verify --strict --verbose=2 "zig-out/bin/WispTerm.app"
+          if [[ "${{ inputs.notarize }}" == "true" ]]; then
+            xcrun stapler validate "zig-out/bin/WispTerm.app"
+          fi
+          echo "MACOS_ZIP=${zip_path}" >> "${GITHUB_ENV}"
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wispterm-macos-aarch64-${{ env.BETA_VERSION }}
+          path: ${{ env.MACOS_ZIP }}
+          if-no-files-found: error
+
+      - name: Clean up keychain
+        if: always()
+        shell: bash
+        run: |
+          if [[ -n "${CODESIGN_KEYCHAIN:-}" && -f "${CODESIGN_KEYCHAIN}" ]]; then
+            security delete-keychain "${CODESIGN_KEYCHAIN}" || true
+          fi
+
+  windows:
+    name: Windows (portable)
+    runs-on: windows-latest
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}\.zig-global-cache
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute version label
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            $version = "beta-" + "${{ github.sha }}".Substring(0, 8)
+          }
+          "BETA_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "Windows beta version: $version"
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Cache Zig packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache/p
+            .zig-global-cache
+          key: ${{ runner.os }}-zig-0.15.2-${{ hashFiles('build.zig', 'build.zig.zon', 'pkg/**/build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-0.15.2-
+
+      - name: Fetch dependencies and build portable
+        shell: pwsh
+        run: |
+          function Invoke-WithRetry {
+            param(
+              [Parameter(Mandatory = $true)][string]$Name,
+              [Parameter(Mandatory = $true)][scriptblock]$Command,
+              [int]$Attempts = 5
+            )
+
+            $exitCode = 1
+            for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+              Write-Host "::group::$Name (attempt $attempt/$Attempts)"
+              & $Command
+              $exitCode = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } elseif ($?) { 0 } else { 1 }
+              Write-Host "::endgroup::"
+
+              if ($exitCode -eq 0) {
+                return
+              }
+
+              if ($attempt -lt $Attempts) {
+                $delay = [Math]::Min(120, 15 * $attempt)
+                Write-Warning "$Name failed with exit code $exitCode. Retrying in $delay seconds..."
+                Start-Sleep -Seconds $delay
+              }
+            }
+
+            exit $exitCode
+          }
+
+          Invoke-WithRetry -Name "zig dependency fetch" -Command { zig build -Doptimize=ReleaseFast --fetch }
+          Invoke-WithRetry -Name "windows packaging" -Command { powershell -ExecutionPolicy Bypass -File .\packaging\windows\package.ps1 -Version "$env:BETA_VERSION" -SkipInstaller }
+
+      - name: Validate and zip portable
+        shell: pwsh
+        run: |
+          $portableExe = "zig-out\dist\portable\wispterm.exe"
+          if (!(Test-Path $portableExe)) {
+            throw "Portable executable not found: $portableExe"
+          }
+          $asset = "wispterm-windows-portable-$env:BETA_VERSION.zip"
+          if (Test-Path $asset) { Remove-Item $asset -Force }
+          Compress-Archive -Path zig-out\dist\portable\* -DestinationPath $asset -Force
+          "WINDOWS_ZIP=$asset" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wispterm-windows-portable-${{ env.BETA_VERSION }}
+          path: ${{ env.WINDOWS_ZIP }}
+          if-no-files-found: error

--- a/packaging/macos/package.sh
+++ b/packaging/macos/package.sh
@@ -8,6 +8,9 @@ sign_identity="${WISPTERM_MACOS_SIGN_IDENTITY:--}"
 notary_profile="${WISPTERM_MACOS_NOTARY_PROFILE:-}"
 entitlements="${WISPTERM_MACOS_ENTITLEMENTS:-"$repo_root/packaging/macos/WispTerm.entitlements"}"
 dist_dir="${WISPTERM_MACOS_DIST_DIR:-"$repo_root/zig-out/dist/macos"}"
+# Output format: "dmg" (default, for releases) or "zip" (internal/beta builds —
+# ship the signed .app as a zip, no DMG).
+package_format="${WISPTERM_MACOS_PACKAGE_FORMAT:-dmg}"
 
 if [[ -z "$version" ]]; then
   version="$(grep -E '^[[:space:]]*\.version[[:space:]]*=' "$repo_root/build.zig.zon" | sed -E 's/.*"([^"]+)".*/\1/')"
@@ -55,13 +58,26 @@ else
   echo "notarization skipped: set WISPTERM_MACOS_NOTARY_PROFILE to submit with notarytool" >&2
 fi
 
-ditto "$app_path" "$staging/WispTerm.app"
-ln -s /Applications "$staging/Applications"
-
 tag_version="$version"
 if [[ "$tag_version" != v* ]]; then
   tag_version="v$tag_version"
 fi
+
+if [[ "$package_format" == "zip" ]]; then
+  # Internal/beta distribution: ship the signed (and, when a notary profile is
+  # set, notarized + stapled) .app as a zip — no DMG. ditto -c -k --keepParent
+  # preserves the bundle and the stapled ticket, so a downloaded + unzipped .app
+  # launches without an online Gatekeeper round-trip.
+  zip_path="$dist_dir/wispterm-macos-$tag_version.zip"
+  rm -f "$zip_path"
+  ditto -c -k --keepParent "$app_path" "$zip_path"
+  echo "$zip_path"
+  exit 0
+fi
+
+ditto "$app_path" "$staging/WispTerm.app"
+ln -s /Applications "$staging/Applications"
+
 dmg_path="$dist_dir/wispterm-macos-$tag_version.dmg"
 rm -f "$dmg_path"
 hdiutil create -volname "WispTerm" -srcfolder "$staging" -ov -format UDZO "$dmg_path" >/dev/null


### PR DESCRIPTION
## 概要

新增手动触发的内测构建 workflow **`beta.yml`**:一次 run 同时构建 **macOS(签名+公证)** 和 **Windows(portable)**,各自作为独立 **artifact** 上传。**不建 GitHub Release、不动 latest、不进自动更新**——从该 run 的 Artifacts 下载两个包,直接发给测试者。

## 怎么用

合并后:仓库 **Actions → Build Beta (Windows + macOS) → Run workflow**(选分支,可选填 version / 是否公证)→ 跑完在该 run 的 **Artifacts** 里下载:
- `wispterm-macos-aarch64-<版本>`(签名+公证的 .app zip)
- `wispterm-windows-portable-<版本>`(Windows portable zip)

## 设计

| Job | Runner | 产物 |
|---|---|---|
| macOS | macos-15 | 复用 `macos-release.yml` 的签名配方 + 现有 secrets(Developer ID + notarytool);`WISPTERM_MACOS_PACKAGE_FORMAT=zip` 出 ditto zip(非 DMG) |
| Windows | windows-latest | `package.ps1` portable → Compress-Archive zip |

- 版本号默认 `beta-<短sha>`(仅文件名;app 内版本仍来自 build.zig.zon)。
- 公证默认开(干净安装);可在 Run workflow 时取消勾选 → 只签名(更快,首次启动右键打开)。
- `package.sh` 加 `WISPTERM_MACOS_PACKAGE_FORMAT=zip` 模式(默认 `dmg`,**正式发布不受影响**)。

## 校验

- `actionlint .github/workflows/beta.yml` 干净。
- `package.sh` zip 模式本地验证通过(产出 zip、bundle 结构正确)。
- 复用 v1.31.0 同款签名 secrets,无需重配。

> 注:真实签名+公证只能在 CI 跑(secrets 仅 CI 可见),首次 dispatch 即实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)