### PR TITLE
feat(feishu): international (Lark) region + group @-mention support

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -421,6 +421,10 @@ pub fn startFeishu(self: *App, cfg: *const Config) void {
         return;
     }
 
+    // Select the API region (China feishu.cn vs international larksuite.com) before
+    // any network call. Process-wide singleton — see feishu_types.apiBase().
+    feishu_types.setRegion(cfg.@"feishu-international");
+
     const creds = feishu_types.Credentials{ .app_id = app_id, .app_secret = app_secret };
     const binding_cfg = feishu_binding.Config{
         .allowed_user = cfg.@"feishu-allowed-user" orelse "",

--- a/src/config.zig
+++ b/src/config.zig
@@ -368,6 +368,11 @@ language: i18n.LanguageSetting = .auto,
 /// Enables the Feishu (Lark) long-connection channel.
 @"feishu-enabled": bool = false,
 
+/// Use the international Lark platform (open.larksuite.com) instead of the
+/// China Feishu platform (open.feishu.cn, default). An app belongs to exactly
+/// one region — credentials are not interchangeable.
+@"feishu-international": bool = false,
+
 /// Feishu app_id. Falls back to env FEISHU_APP_ID when empty.
 @"feishu-app-id": ?[]const u8 = null,
 
@@ -959,6 +964,14 @@ fn applyKeyValue(self: *Config, allocator: std.mem.Allocator, key: []const u8, v
             self.@"feishu-enabled" = false;
         } else {
             log.warn("invalid feishu-enabled: {s}", .{value});
+        }
+    } else if (std.mem.eql(u8, key, "feishu-international")) {
+        if (std.mem.eql(u8, value, "true")) {
+            self.@"feishu-international" = true;
+        } else if (std.mem.eql(u8, value, "false")) {
+            self.@"feishu-international" = false;
+        } else {
+            log.warn("invalid feishu-international: {s}", .{value});
         }
     } else if (std.mem.eql(u8, key, "feishu-app-id")) {
         self.@"feishu-app-id" = self.dupeString(allocator, value) orelse return;
@@ -2013,6 +2026,20 @@ test "config: feishu-enabled parses true/false (regression: field needs a parse 
     // Invalid value leaves the previous state untouched.
     cfg.applyKeyValue(allocator, "feishu-enabled", "maybe", ".");
     try std.testing.expectEqual(false, cfg.@"feishu-enabled");
+}
+
+test "config: feishu-international parses true/false (regression: field needs a parse handler)" {
+    const allocator = std.testing.allocator;
+    var cfg: Config = .{};
+
+    try std.testing.expectEqual(false, cfg.@"feishu-international");
+    cfg.applyKeyValue(allocator, "feishu-international", "true", ".");
+    try std.testing.expectEqual(true, cfg.@"feishu-international");
+    cfg.applyKeyValue(allocator, "feishu-international", "false", ".");
+    try std.testing.expectEqual(false, cfg.@"feishu-international");
+    // Invalid value leaves the previous state untouched.
+    cfg.applyKeyValue(allocator, "feishu-international", "maybe", ".");
+    try std.testing.expectEqual(false, cfg.@"feishu-international");
 }
 
 test "config: auto update check option parses true false" {

--- a/src/feishu/binding.zig
+++ b/src/feishu/binding.zig
@@ -1,4 +1,4 @@
-//! 飞书入站过滤 + event_id 去重。M2 p2p-only；群聊 @ 留 M3。
+//! 飞书入站过滤 + event_id 去重。私聊全收；群聊仅响应 @ 机器人的消息。
 const std = @import("std");
 const types = @import("types.zig");
 
@@ -8,12 +8,15 @@ pub const Config = struct {
 };
 
 /// 决定是否处理该消息。
-/// - group → false（v1 仅 p2p；群聊 @ 是 M3）
+/// - group 且未 @ 机器人 → false（群聊仅响应 @ 机器人的消息，避免刷屏）
 /// - sender_open_id 空 → false
 /// - allowed_user 非空且不匹配 → false
 /// - 否则 true
-pub fn shouldHandle(msg: types.IncomingMessage, cfg: Config) bool {
-    if (msg.chat_type == .group) return false;
+///
+/// bot_open_id 为机器人自身 open_id（controller 在 start 时经 getBotOpenId 获取）。
+/// 为空时（获取失败的降级）群聊一律 false，私聊不受影响。
+pub fn shouldHandle(msg: types.IncomingMessage, cfg: Config, bot_open_id: []const u8) bool {
+    if (msg.chat_type == .group and !msg.mentionsOpenId(bot_open_id)) return false;
     if (msg.sender_open_id.len == 0) return false;
     if (cfg.allowed_user.len != 0 and !std.mem.eql(u8, msg.sender_open_id, cfg.allowed_user)) return false;
     return true;
@@ -64,28 +67,45 @@ pub const Dedup = struct {
 
 const t = std.testing;
 
+const bot = "ou_bot"; // 测试用机器人 open_id
+
 test "shouldHandle: p2p with sender → true" {
-    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_abc" }, .{}));
+    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_abc" }, .{}, bot));
 }
 
-test "shouldHandle: group → false" {
-    try t.expect(!shouldHandle(.{ .chat_type = .group, .sender_open_id = "ou_abc" }, .{}));
+test "shouldHandle: group without @bot → false" {
+    try t.expect(!shouldHandle(.{ .chat_type = .group, .sender_open_id = "ou_abc" }, .{}, bot));
+}
+
+test "shouldHandle: group @bot → true" {
+    const m = [_]types.Mention{.{ .key = "@_user_1", .open_id = bot }};
+    try t.expect(shouldHandle(.{ .chat_type = .group, .sender_open_id = "ou_abc", .mentions = &m }, .{}, bot));
+}
+
+test "shouldHandle: group @someone-else → false" {
+    const m = [_]types.Mention{.{ .key = "@_user_1", .open_id = "ou_other" }};
+    try t.expect(!shouldHandle(.{ .chat_type = .group, .sender_open_id = "ou_abc", .mentions = &m }, .{}, bot));
+}
+
+test "shouldHandle: group @bot but empty bot_open_id (degraded) → false" {
+    const m = [_]types.Mention{.{ .key = "@_user_1", .open_id = bot }};
+    try t.expect(!shouldHandle(.{ .chat_type = .group, .sender_open_id = "ou_abc", .mentions = &m }, .{}, ""));
 }
 
 test "shouldHandle: empty sender → false" {
-    try t.expect(!shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "" }, .{}));
+    try t.expect(!shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "" }, .{}, bot));
 }
 
 test "shouldHandle: allowlist hit → true" {
-    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_abc" }, .{ .allowed_user = "ou_abc" }));
+    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_abc" }, .{ .allowed_user = "ou_abc" }, bot));
 }
 
 test "shouldHandle: allowlist miss → false" {
-    try t.expect(!shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_xyz" }, .{ .allowed_user = "ou_abc" }));
+    try t.expect(!shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_xyz" }, .{ .allowed_user = "ou_abc" }, bot));
 }
 
 test "shouldHandle: empty allowlist → any user passes" {
-    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_anyone" }, .{ .allowed_user = "" }));
+    try t.expect(shouldHandle(.{ .chat_type = .p2p, .sender_open_id = "ou_anyone" }, .{ .allowed_user = "" }, bot));
 }
 
 test "Dedup: first seen=false, after markSeen seen=true" {

--- a/src/feishu/codec.zig
+++ b/src/feishu/codec.zig
@@ -45,6 +45,15 @@ const Sender = struct {
     sender_id: SenderId = .{},
 };
 
+// event.message.mentions[].id.open_id —— 被 @ 者的 open_id。
+const RawMentionId = struct {
+    open_id: []const u8 = "",
+};
+const RawMention = struct {
+    key: []const u8 = "",
+    id: RawMentionId = .{},
+};
+
 const Message = struct {
     message_id: []const u8 = "",
     chat_id: []const u8 = "",
@@ -52,6 +61,8 @@ const Message = struct {
     message_type: []const u8 = "",
     /// content 是一段 JSON 字符串，其值本身又是 JSON。
     content: []const u8 = "",
+    /// 群聊 @ 列表；私聊一般缺失（→ 空数组）。
+    mentions: []const RawMention = &.{},
 };
 
 const Event = struct {
@@ -97,6 +108,17 @@ pub fn parseReceiveV1(arena: std.mem.Allocator, payload_json: []const u8) !types
         text = inner.text;
     }
 
+    // 映射 mentions（borrow arena），并从 text 中剥除 @ 占位符。
+    var mentions: []const types.Mention = &.{};
+    if (env.event.message.mentions.len > 0) {
+        const out = try arena.alloc(types.Mention, env.event.message.mentions.len);
+        for (env.event.message.mentions, 0..) |m, i| {
+            out[i] = .{ .key = m.key, .open_id = m.id.open_id };
+        }
+        mentions = out;
+    }
+    text = try stripMentions(arena, text, mentions);
+
     return .{
         .event_id = env.header.event_id,
         .message_id = env.event.message.message_id,
@@ -105,7 +127,20 @@ pub fn parseReceiveV1(arena: std.mem.Allocator, payload_json: []const u8) !types
         .chat_type = types.ChatType.fromString(env.event.message.chat_type),
         .message_type = env.event.message.message_type,
         .text = text,
+        .mentions = mentions,
     };
+}
+
+/// 从 text 中移除所有 @ 占位符（mentions[].key，如 "@_user_1"）并 trim 首尾空白。
+/// mentions 为空时原样返回（私聊常见路径，零分配）。返回的切片借 arena。
+pub fn stripMentions(arena: std.mem.Allocator, text: []const u8, mentions: []const types.Mention) ![]const u8 {
+    if (mentions.len == 0) return text;
+    var cur: []const u8 = text;
+    for (mentions) |m| {
+        if (m.key.len == 0) continue;
+        cur = try std.mem.replaceOwned(u8, arena, cur, m.key, "");
+    }
+    return std.mem.trim(u8, cur, " \t\r\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -365,6 +400,58 @@ test "parseReceiveV1: non-text (image) — text is empty, other fields set" {
     try std.testing.expectEqualStrings("image", msg.message_type);
     // 非 text 类型，text 应为空。
     try std.testing.expectEqualStrings("", msg.text);
+}
+
+test "parseReceiveV1: group @ message — mentions parsed and placeholder stripped" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+
+    // 群聊 @ 机器人：text 含占位符 @_user_1，mentions 给出被 @ 者 open_id。
+    const json =
+        \\{
+        \\  "schema":"2.0",
+        \\  "header":{"event_id":"ev-g1","event_type":"im.message.receive_v1"},
+        \\  "event":{
+        \\    "sender":{"sender_id":{"open_id":"ou_alice"}},
+        \\    "message":{
+        \\      "message_id":"om_g1",
+        \\      "chat_id":"oc_group1",
+        \\      "chat_type":"group",
+        \\      "message_type":"text",
+        \\      "content":"{\"text\":\"@_user_1 帮我看下日志\"}",
+        \\      "mentions":[{"key":"@_user_1","id":{"open_id":"ou_bot"},"name":"小助手"}]
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    const msg = try parseReceiveV1(arena.allocator(), json);
+
+    try std.testing.expectEqual(types.ChatType.group, msg.chat_type);
+    try std.testing.expectEqual(@as(usize, 1), msg.mentions.len);
+    try std.testing.expectEqualStrings("ou_bot", msg.mentions[0].open_id);
+    try std.testing.expect(msg.mentionsOpenId("ou_bot"));
+    // 占位符 @_user_1 已被剥除并 trim。
+    try std.testing.expectEqualStrings("帮我看下日志", msg.text);
+}
+
+test "stripMentions: multiple placeholders removed and trimmed; empty mentions is a no-op" {
+    const a = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const al = arena.allocator();
+
+    const mentions = [_]types.Mention{
+        .{ .key = "@_user_1", .open_id = "ou_bot" },
+        .{ .key = "@_user_2", .open_id = "ou_alice" },
+    };
+    const out = try stripMentions(al, "@_user_1 @_user_2 部署一下", &mentions);
+    try std.testing.expectEqualStrings("部署一下", out);
+
+    // 无 mentions：原样返回。
+    const same = try stripMentions(al, "纯私聊文本", &.{});
+    try std.testing.expectEqualStrings("纯私聊文本", same);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/feishu/controller.zig
+++ b/src/feishu/controller.zig
@@ -297,6 +297,9 @@ pub const Controller = struct {
     app_secret_buf: []u8,
 
     token_cache: rest.TokenCache = .{},
+    // 机器人自身 open_id（start 时经 getBotOpenId 获取），群聊用它判断是否被 @。
+    // 空 = 获取失败的降级（群聊不响应，私聊照常）。owned by allocator。
+    bot_open_id_buf: []u8 = &.{},
     dedup: binding_mod.Dedup,
 
     // longconn ownership — addr stable because Controller is heap-allocated.
@@ -357,6 +360,7 @@ pub const Controller = struct {
         self.stop();
         self.dedup.deinit();
         self.token_cache.deinit(self.allocator);
+        if (self.bot_open_id_buf.len != 0) self.allocator.free(self.bot_open_id_buf);
         self.allocator.free(self.app_id_buf);
         self.allocator.free(self.app_secret_buf);
         self.allocator.destroy(self);
@@ -368,9 +372,29 @@ pub const Controller = struct {
         if (self.running) return;
         try self.progress.start();
         errdefer self.progress.stop();
+
+        // Best-effort：拿机器人自身 open_id，供群聊判断是否被 @。失败不致命
+        // （群聊 @ 失效，私聊照常）。仅在尚未取得时获取，避免 start 重试时泄漏。
+        if (self.bot_open_id_buf.len == 0) self.resolveBotOpenId();
+
         try self.conn.start(self.creds, onEvent, self);
         self.running = true;
         log.info("feishu controller started", .{});
+    }
+
+    /// Best-effort fetch of the bot's own open_id for group @-mention detection.
+    /// Errors are logged, never propagated — p2p must work even if this fails.
+    fn resolveBotOpenId(self: *Controller) void {
+        const token = self.token_cache.get(self.allocator, self.creds) catch |err| {
+            log.warn("feishu: token fetch before getBotOpenId failed: {s}; group @ disabled", .{@errorName(err)});
+            return;
+        };
+        const id = rest.getBotOpenId(self.allocator, token) catch |err| {
+            log.warn("feishu: getBotOpenId failed: {s}; group @ disabled", .{@errorName(err)});
+            return;
+        };
+        self.bot_open_id_buf = id; // owned by self.allocator; freed in destroy
+        log.info("feishu: bot open_id resolved; group @-mention enabled", .{});
     }
 
     /// Signals stop and joins both the longconn thread and the progress worker.
@@ -419,8 +443,8 @@ pub const Controller = struct {
             // Continue — a dedup failure is not fatal; worst case we process once.
         };
 
-        // Step 3: binding filter
-        if (!binding_mod.shouldHandle(msg, self.cfg)) {
+        // Step 3: binding filter (group messages require an @-mention of the bot)
+        if (!binding_mod.shouldHandle(msg, self.cfg, self.bot_open_id_buf)) {
             log.debug("onEvent: message filtered by binding.shouldHandle", .{});
             return;
         }
@@ -700,6 +724,39 @@ fn buildPayload(
     , .{ event_id, sender_open_id, chat_id, chat_type, content_escaped });
 }
 
+// Synthetic group receive_v1 payload whose text @-mentions `bot_open_id`
+// (placeholder @_user_1). Mirrors buildPayload but chat_type=group + mentions[].
+fn buildGroupAtPayload(
+    alloc: std.mem.Allocator,
+    event_id: []const u8,
+    chat_id: []const u8,
+    sender_open_id: []const u8,
+    bot_open_id: []const u8,
+    text: []const u8,
+) ![]u8 {
+    const inner_content = try std.fmt.allocPrint(alloc, "{{\"text\":\"@_user_1 {s}\"}}", .{text});
+    defer alloc.free(inner_content);
+    const content_escaped = try std.json.Stringify.valueAlloc(alloc, inner_content, .{});
+    defer alloc.free(content_escaped);
+    return std.fmt.allocPrint(alloc,
+        \\{{
+        \\  "schema":"2.0",
+        \\  "header":{{"event_id":"{s}","event_type":"im.message.receive_v1"}},
+        \\  "event":{{
+        \\    "sender":{{"sender_id":{{"open_id":"{s}"}}}},
+        \\    "message":{{
+        \\      "message_id":"om_g1",
+        \\      "chat_id":"{s}",
+        \\      "chat_type":"group",
+        \\      "message_type":"text",
+        \\      "content":{s},
+        \\      "mentions":[{{"key":"@_user_1","id":{{"open_id":"{s}"}}}}]
+        \\    }}
+        \\  }}
+        \\}}
+    , .{ event_id, sender_open_id, chat_id, content_escaped, bot_open_id });
+}
+
 /// Create a controller wired to a fake control + ack capture (no network).
 fn makeTestCtrl(fake: *FakeControl, ack: *AckCapture) !*Controller {
     const ctrl = try Controller.create(
@@ -788,7 +845,48 @@ test "onEvent binding filter: group message is ignored" {
 
     Controller.onEvent(ctrl, payload);
 
-    // Group messages must be filtered by binding.shouldHandle → no ack.
+    // Group message with no @-mention of the bot → filtered by shouldHandle → no ack.
+    try t.expectEqual(@as(usize, 0), ack.calls);
+    try t.expectEqual(@as(usize, 0), fake.last_input.items.len);
+}
+
+test "onEvent: group message that @-mentions the bot is handled (placeholder stripped)" {
+    var fake = FakeControl{};
+    defer fake.deinit();
+    var ack = AckCapture{};
+    defer ack.deinit();
+
+    const ctrl = try makeTestCtrl(&fake, &ack);
+    defer ctrl.destroy();
+    // Simulate start() having resolved the bot's open_id (owned; freed by destroy).
+    ctrl.bot_open_id_buf = try t.allocator.dupe(u8, "ou_bot");
+
+    const payload = try buildGroupAtPayload(t.allocator, "ev-g1", "oc_group1", "ou_alice", "ou_bot", "部署服务");
+    defer t.allocator.free(payload);
+
+    Controller.onEvent(ctrl, payload);
+
+    // route ran → sendInput got the text with the @ placeholder stripped.
+    try t.expect(std.mem.indexOf(u8, fake.last_input.items, "部署服务") != null);
+    try t.expect(std.mem.indexOf(u8, fake.last_input.items, "@_user_1") == null);
+}
+
+test "onEvent: group message @-mentioning someone else is ignored" {
+    var fake = FakeControl{};
+    defer fake.deinit();
+    var ack = AckCapture{};
+    defer ack.deinit();
+
+    const ctrl = try makeTestCtrl(&fake, &ack);
+    defer ctrl.destroy();
+    ctrl.bot_open_id_buf = try t.allocator.dupe(u8, "ou_bot");
+
+    // @ targets another user, not the bot → must be ignored.
+    const payload = try buildGroupAtPayload(t.allocator, "ev-g2", "oc_group1", "ou_alice", "ou_someone_else", "随便聊聊");
+    defer t.allocator.free(payload);
+
+    Controller.onEvent(ctrl, payload);
+
     try t.expectEqual(@as(usize, 0), ack.calls);
     try t.expectEqual(@as(usize, 0), fake.last_input.items.len);
 }

--- a/src/feishu/media.zig
+++ b/src/feishu/media.zig
@@ -4,10 +4,12 @@
 //! 上传依赖 multipart/form-data；核心编码抽为纯函数 buildMultipart 以便离线测试。
 
 const std = @import("std");
+const types = @import("types.zig");
 
 const log = std.log.scoped(.feishu_media);
 
-const BASE = "https://open.feishu.cn";
+// API base host (open.feishu.cn vs open.larksuite.com) is resolved at runtime
+// from the configured region — see types.apiBase().
 
 // ---------------------------------------------------------------------------
 // multipart/form-data — pure, offline-testable
@@ -105,7 +107,8 @@ pub fn uploadImage(alloc: std.mem.Allocator, token: []const u8, image_bytes: []c
 
     const ct = try std.fmt.allocPrint(a, "multipart/form-data; boundary={s}", .{mp.boundary});
 
-    const resp_bytes = try httpsPostMultipart(alloc, a, BASE ++ "/open-apis/im/v1/images", token, mp.body, ct);
+    const url = try std.fmt.allocPrint(a, "{s}/open-apis/im/v1/images", .{types.apiBase()});
+    const resp_bytes = try httpsPostMultipart(alloc, a, url, token, mp.body, ct);
 
     const Resp = struct {
         code: i64 = -1,
@@ -150,7 +153,8 @@ pub fn uploadFile(
 
     const ct = try std.fmt.allocPrint(a, "multipart/form-data; boundary={s}", .{mp.boundary});
 
-    const resp_bytes = try httpsPostMultipart(alloc, a, BASE ++ "/open-apis/im/v1/files", token, mp.body, ct);
+    const url = try std.fmt.allocPrint(a, "{s}/open-apis/im/v1/files", .{types.apiBase()});
+    const resp_bytes = try httpsPostMultipart(alloc, a, url, token, mp.body, ct);
 
     const Resp = struct {
         code: i64 = -1,
@@ -196,8 +200,8 @@ pub fn downloadResource(
     };
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/im/v1/messages/{s}/resources/{s}?type={s}",
-        .{ message_id, file_key, kind_str },
+        "{s}/open-apis/im/v1/messages/{s}/resources/{s}?type={s}",
+        .{ types.apiBase(), message_id, file_key, kind_str },
     );
 
     // httpsGetWithBearer returns bytes owned by arena `a`; dupe into the

--- a/src/feishu/rest.zig
+++ b/src/feishu/rest.zig
@@ -12,7 +12,8 @@ const types = @import("types.zig");
 
 const log = std.log.scoped(.feishu_rest);
 
-const BASE = "https://open.feishu.cn";
+// API base host (open.feishu.cn vs open.larksuite.com) is resolved at runtime
+// from the configured region — see types.apiBase().
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-testable without network)
@@ -57,7 +58,8 @@ pub fn tenantAccessToken(alloc: std.mem.Allocator, creds: types.Credentials) !To
         .app_secret = creds.app_secret,
     }, .{});
 
-    const resp = try httpsPost(alloc, a, BASE ++ "/open-apis/auth/v3/tenant_access_token/internal", body);
+    const url = try std.fmt.allocPrint(a, "{s}/open-apis/auth/v3/tenant_access_token/internal", .{types.apiBase()});
+    const resp = try httpsPost(alloc, a, url, body);
 
     const Resp = struct {
         code: i64 = -1,
@@ -148,7 +150,8 @@ pub fn discoverWsEndpoint(alloc: std.mem.Allocator, creds: types.Credentials) !W
         .AppSecret = creds.app_secret,
     }, .{});
 
-    const resp = try httpsPost(alloc, a, BASE ++ "/callback/ws/endpoint", body);
+    const url = try std.fmt.allocPrint(a, "{s}/callback/ws/endpoint", .{types.apiBase()});
+    const resp = try httpsPost(alloc, a, url, body);
 
     const ClientConfig = struct {
         PingInterval: i64 = 0,
@@ -228,8 +231,8 @@ pub fn sendMessage(
 
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/im/v1/messages?receive_id_type={s}",
-        .{receive_id_type},
+        "{s}/open-apis/im/v1/messages?receive_id_type={s}",
+        .{ types.apiBase(), receive_id_type },
     );
 
     try httpsPostWithBearer(alloc, a, url, token, body_str);
@@ -305,7 +308,8 @@ pub fn createStreamingCard(alloc: std.mem.Allocator, token: []const u8, card_jso
         .data = card_json,
     }, .{});
 
-    const resp = try httpsReqWithBearer(alloc, a, .POST, BASE ++ "/open-apis/cardkit/v1/cards", token, body);
+    const url = try std.fmt.allocPrint(a, "{s}/open-apis/cardkit/v1/cards", .{types.apiBase()});
+    const resp = try httpsReqWithBearer(alloc, a, .POST, url, token, body);
 
     const Data = struct { card_id: []const u8 = "" };
     const Resp = struct {
@@ -347,8 +351,8 @@ pub fn sendCardMessage(
     }, .{});
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/im/v1/messages?receive_id_type={s}",
-        .{receive_id_type},
+        "{s}/open-apis/im/v1/messages?receive_id_type={s}",
+        .{ types.apiBase(), receive_id_type },
     );
     const resp = try httpsReqWithBearer(alloc, a, .POST, url, token, body_str);
 
@@ -390,8 +394,8 @@ pub fn streamCardContent(
 
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/cardkit/v1/cards/{s}/elements/{s}/content",
-        .{ card_id, element_id },
+        "{s}/open-apis/cardkit/v1/cards/{s}/elements/{s}/content",
+        .{ types.apiBase(), card_id, element_id },
     );
     const body = try buildStreamBody(a, content, sequence);
     _ = try httpsReqWithBearer(alloc, a, .PUT, url, token, body);
@@ -410,8 +414,8 @@ pub fn closeStreaming(
 
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/cardkit/v1/cards/{s}/settings",
-        .{card_id},
+        "{s}/open-apis/cardkit/v1/cards/{s}/settings",
+        .{ types.apiBase(), card_id },
     );
     const body = try buildCloseBody(a, sequence);
     _ = try httpsReqWithBearer(alloc, a, .PATCH, url, token, body);
@@ -437,8 +441,8 @@ pub fn patchMessageCard(
 
     const url = try std.fmt.allocPrint(
         a,
-        BASE ++ "/open-apis/im/v1/messages/{s}",
-        .{message_id},
+        "{s}/open-apis/im/v1/messages/{s}",
+        .{ types.apiBase(), message_id },
     );
     // content field must be card_json serialized as a JSON string value.
     const body = try std.json.Stringify.valueAlloc(a, .{ .content = card_json }, .{});
@@ -455,7 +459,8 @@ pub fn getBotOpenId(alloc: std.mem.Allocator, token: []const u8) ![]u8 {
     defer arena.deinit();
     const a = arena.allocator();
 
-    const resp = try httpsGetWithBearer(alloc, a, BASE ++ "/open-apis/bot/v3/info", token);
+    const url = try std.fmt.allocPrint(a, "{s}/open-apis/bot/v3/info", .{types.apiBase()});
+    const resp = try httpsGetWithBearer(alloc, a, url, token);
 
     const BotInfo = struct {
         open_id: []const u8 = "",

--- a/src/feishu/types.zig
+++ b/src/feishu/types.zig
@@ -8,6 +8,33 @@ pub const Credentials = struct {
     app_secret: []const u8,
 };
 
+/// Open API region. A Feishu/Lark app belongs to exactly one region — China
+/// (open.feishu.cn) vs international Lark (open.larksuite.com) — and credentials
+/// are not interchangeable. So the region is a process singleton, set once at
+/// controller startup from config (feishu-international).
+/// ponytail: set-once global models the one-region-per-process reality, so rest.zig
+/// and media.zig read it directly instead of threading a base host through every call.
+var g_international: bool = false;
+
+/// Sets the API region. Call once from App.startFeishu before any network call.
+pub fn setRegion(international: bool) void {
+    g_international = international;
+}
+
+/// Returns the Open API base host (scheme + host, no trailing slash) for the
+/// configured region.
+pub fn apiBase() []const u8 {
+    return if (g_international) "https://open.larksuite.com" else "https://open.feishu.cn";
+}
+
+test "apiBase switches between Feishu and Lark hosts" {
+    defer setRegion(false); // restore default so other tests see China region
+    setRegion(false);
+    try std.testing.expectEqualStrings("https://open.feishu.cn", apiBase());
+    setRegion(true);
+    try std.testing.expectEqualStrings("https://open.larksuite.com", apiBase());
+}
+
 /// 会话类型：单聊或群聊。
 pub const ChatType = enum {
     p2p,
@@ -18,6 +45,12 @@ pub const ChatType = enum {
         if (std.mem.eql(u8, s, "group")) return .group;
         return .p2p;
     }
+};
+
+/// 群聊 @ 提及项。key 是 text 中的占位符（如 "@_user_1"），open_id 是被 @ 者。
+pub const Mention = struct {
+    key: []const u8 = "",
+    open_id: []const u8 = "",
 };
 
 /// im.message.receive_v1 规范化后的消息结构体。
@@ -34,9 +67,35 @@ pub const IncomingMessage = struct {
     chat_type: ChatType = .p2p,
     /// event.message.message_type（text / image / post / …）
     message_type: []const u8 = "",
-    /// 已从 content JSON 串解析出的纯文本；非 text 类型可为空
+    /// 已从 content JSON 串解析出的纯文本；非 text 类型可为空。
+    /// 群聊消息已剥除 @ 占位符（见 codec.stripMentions）。
     text: []const u8 = "",
+    /// event.message.mentions —— 群聊 @ 列表；私聊一般为空。
+    mentions: []const Mention = &.{},
+
+    /// 该消息是否 @ 了给定 open_id（用于群聊判断是否 @ 了机器人本身）。
+    pub fn mentionsOpenId(self: IncomingMessage, open_id: []const u8) bool {
+        if (open_id.len == 0) return false;
+        for (self.mentions) |m| {
+            if (std.mem.eql(u8, m.open_id, open_id)) return true;
+        }
+        return false;
+    }
 };
+
+test "mentionsOpenId matches a mentioned open_id, ignores empty/absent" {
+    const m = [_]Mention{
+        .{ .key = "@_user_1", .open_id = "ou_bot" },
+        .{ .key = "@_user_2", .open_id = "ou_alice" },
+    };
+    const msg = IncomingMessage{ .chat_type = .group, .mentions = &m };
+    try std.testing.expect(msg.mentionsOpenId("ou_bot"));
+    try std.testing.expect(msg.mentionsOpenId("ou_alice"));
+    try std.testing.expect(!msg.mentionsOpenId("ou_stranger"));
+    try std.testing.expect(!msg.mentionsOpenId("")); // empty bot id never matches
+    const empty = IncomingMessage{ .chat_type = .p2p };
+    try std.testing.expect(!empty.mentionsOpenId("ou_bot"));
+}
 
 test "ChatType.fromString" {
     try std.testing.expectEqual(ChatType.group, ChatType.fromString("group"));

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -238,6 +238,7 @@ pub const Strings = struct {
     // —— 飞书凭证表单 ——
     feishu_form_title: []const u8,
     feishu_form_enabled: []const u8,
+    feishu_form_international: []const u8,
     feishu_form_app_id: []const u8,
     feishu_form_app_secret: []const u8,
     feishu_form_secret_set_hint: []const u8,
@@ -464,6 +465,7 @@ const en = Strings{
 
     .feishu_form_title = "Feishu bot config",
     .feishu_form_enabled = "Enabled",
+    .feishu_form_international = "International (Lark)",
     .feishu_form_app_id = "App ID",
     .feishu_form_app_secret = "App Secret",
     .feishu_form_secret_set_hint = "already set — leave blank to keep",
@@ -690,6 +692,7 @@ const zh_CN = Strings{
 
     .feishu_form_title = "飞书 bot 配置",
     .feishu_form_enabled = "启用",
+    .feishu_form_international = "国际版 (Lark)",
     .feishu_form_app_id = "App ID",
     .feishu_form_app_secret = "App Secret",
     .feishu_form_secret_set_hint = "已设置，留空保留",

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2588,11 +2588,10 @@ fn sessionLauncherHandleKeyImpl(ev: input_key.KeyEvent) void {
         switch (ev.key) {
             .tab, .arrow_down => feishuConfig().focusNextRow(),
             .arrow_up => feishuConfig().focusPrevRow(),
-            .arrow_left, .arrow_right => if (feishuConfig().focus == feishu_config.ENABLED_ROW) feishuConfig().toggleEnabled(),
+            .arrow_left, .arrow_right => feishuConfig().toggleFocusedBool(),
             .enter => switch (feishuConfig().focus) {
                 feishu_config.SAVE_ROW => saveFeishuConfig(),
-                feishu_config.ENABLED_ROW => feishuConfig().toggleEnabled(),
-                else => {},
+                else => feishuConfig().toggleFocusedBool(), // toggle rows flip; field rows no-op
             },
             .backspace => if (feishuConfig().focusedField()) |f| feishuConfig().backspace(f),
             .escape => closeFeishuConfigForm(),
@@ -3968,6 +3967,7 @@ fn openFeishuConfigForm() void {
         var cfg = Config.load(allocator) catch Config{};
         defer cfg.deinit(allocator);
         st.enabled = cfg.@"feishu-enabled"; // reflect current enable state in the form's toggle row
+        st.international = cfg.@"feishu-international"; // reflect current region in the form's toggle row
         if (cfg.@"feishu-app-id") |id| st.setValue(.app_id, id); // app-id prefilled; secret never prefilled
         feishuForm().secret_already_set = cfg.@"feishu-app-secret" != null; // boolean only — secret value never read into the form
     }
@@ -3986,6 +3986,7 @@ fn saveFeishuConfig() void {
     if (AppWindow.g_allocator) |allocator| {
         const st = feishuConfig();
         Config.setConfigValue(allocator, "feishu-enabled", if (st.enabled) "true" else "false") catch {};
+        Config.setConfigValue(allocator, "feishu-international", if (st.international) "true" else "false") catch {};
         const app_id = st.value(.app_id);
         if (app_id.len > 0) Config.setConfigValue(allocator, "feishu-app-id", app_id) catch {};
         const secret = st.value(.app_secret);
@@ -4986,7 +4987,7 @@ fn sessionHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, t
         if (row >= FEISHU_ROW_COUNT) return null;
         feishuConfig().focus = row;
         if (row == feishu_config.SAVE_ROW) return .feishu_save;
-        if (row == feishu_config.ENABLED_ROW) feishuConfig().toggleEnabled(); // click toggles enable
+        feishuConfig().toggleFocusedBool(); // toggle rows flip on click; field rows no-op
         return null;
     }
 
@@ -5184,10 +5185,13 @@ fn renderFeishuConfigForm(layout: SessionLayout, window_height: f32) void {
     // Row 0: enabled toggle (shows current on/off so the user knows the state before flipping)
     renderSessionRow(layout, window_height, feishu_config.ENABLED_ROW, i18n.s().feishu_form_enabled, boolText(st.enabled), st.focus == feishu_config.ENABLED_ROW);
 
-    // Row 1: app_id (plain text)
-    renderSessionFieldValue(layout, window_height, 1, i18n.s().feishu_form_app_id, st.value(.app_id), false, st.focus == 1);
+    // Row 1: international (Lark) toggle — picks open.larksuite.com over open.feishu.cn
+    renderSessionRow(layout, window_height, feishu_config.INTERNATIONAL_ROW, i18n.s().feishu_form_international, boolText(st.international), st.focus == feishu_config.INTERNATIONAL_ROW);
 
-    // Row 2: app_secret (masked)
+    // Row 2: app_id (plain text)
+    renderSessionFieldValue(layout, window_height, feishu_config.APP_ID_ROW, i18n.s().feishu_form_app_id, st.value(.app_id), false, st.focus == feishu_config.APP_ID_ROW);
+
+    // Row 3: app_secret (masked)
     const secret = st.value(.app_secret);
     var dot_buf: [feishu_config.FEISHU_FIELD_MAX * 3]u8 = undefined; // • is 3 UTF-8 bytes; mask by codepoint count
     const secret_display: []const u8 = if (secret.len > 0) blk: {
@@ -5202,9 +5206,9 @@ fn renderFeishuConfigForm(layout: SessionLayout, window_height: f32) void {
         i18n.s().feishu_form_secret_set_hint
     else
         "";
-    renderSessionRow(layout, window_height, 2, i18n.s().feishu_form_app_secret, secret_display, st.focus == 2);
+    renderSessionRow(layout, window_height, feishu_config.APP_SECRET_ROW, i18n.s().feishu_form_app_secret, secret_display, st.focus == feishu_config.APP_SECRET_ROW);
 
-    // Row 3: Save
+    // Row 4: Save
     renderSessionRow(layout, window_height, feishu_config.SAVE_ROW, i18n.s().feishu_form_save, i18n.s().toast_feishu_restart, st.focus == feishu_config.SAVE_ROW);
 }
 

--- a/src/renderer/overlays/feishu_config.zig
+++ b/src/renderer/overlays/feishu_config.zig
@@ -3,9 +3,12 @@ const std = @import("std");
 pub const FEISHU_FIELD_COUNT: usize = 2; // text fields: app_id, app_secret (buffer count)
 pub const FEISHU_FIELD_MAX: usize = 256;
 
-// Form rows: 0 = enabled toggle, 1 = app_id, 2 = app_secret, 3 = Save.
-pub const FEISHU_ROW_COUNT: usize = 4;
+// Form rows: 0 = enabled, 1 = international (Lark), 2 = app_id, 3 = app_secret, 4 = Save.
+pub const FEISHU_ROW_COUNT: usize = 5;
 pub const ENABLED_ROW: usize = 0;
+pub const INTERNATIONAL_ROW: usize = 1;
+pub const APP_ID_ROW: usize = 2;
+pub const APP_SECRET_ROW: usize = 3;
 pub const SAVE_ROW: usize = FEISHU_ROW_COUNT - 1;
 
 pub const FeishuField = enum(usize) {
@@ -14,9 +17,10 @@ pub const FeishuField = enum(usize) {
 };
 
 /// 凭证表单的固定缓冲区状态(镜像 assistant_profiles.State 的最小子集)。
-/// focus: 0 = 启用开关行;1 = app_id;2 = app_secret;3 = Save 行。
+/// focus: 0 = 启用;1 = 国际版;2 = app_id;3 = app_secret;4 = Save 行。
 pub const State = struct {
     enabled: bool = false,
+    international: bool = false,
     bufs: [FEISHU_FIELD_COUNT][FEISHU_FIELD_MAX]u8 = undefined,
     lens: [FEISHU_FIELD_COUNT]usize = .{0} ** FEISHU_FIELD_COUNT,
     focus: usize = 0,
@@ -25,6 +29,7 @@ pub const State = struct {
         self.lens = .{0} ** FEISHU_FIELD_COUNT;
         self.focus = 0;
         self.enabled = false;
+        self.international = false;
     }
 
     pub fn value(self: *const State, field: FeishuField) []const u8 {
@@ -56,17 +61,27 @@ pub const State = struct {
         self.lens[i] = n;
     }
 
-    /// 焦点所在行对应的文本字段(仅 row 1/2),启用行/Save 行返回 null。
+    /// 焦点所在行对应的文本字段(仅 app_id/app_secret 行),开关行/Save 行返回 null。
     pub fn focusedField(self: *const State) ?FeishuField {
         return switch (self.focus) {
-            1 => .app_id,
-            2 => .app_secret,
+            APP_ID_ROW => .app_id,
+            APP_SECRET_ROW => .app_secret,
             else => null,
         };
     }
 
     pub fn toggleEnabled(self: *State) void {
         self.enabled = !self.enabled;
+    }
+
+    /// Flips the bool for whichever toggle row is focused (enabled / international).
+    /// No-op on the text-field rows and the Save row.
+    pub fn toggleFocusedBool(self: *State) void {
+        switch (self.focus) {
+            ENABLED_ROW => self.enabled = !self.enabled,
+            INTERNATIONAL_ROW => self.international = !self.international,
+            else => {},
+        }
     }
 
     pub fn focusNextRow(self: *State) void {
@@ -119,11 +134,12 @@ test "setValue replaces and truncates" {
     try std.testing.expectEqual(FEISHU_FIELD_MAX, s.value(.app_secret).len);
 }
 
-test "focus navigation clamps over enabled, fields, and Save row" {
+test "focus navigation clamps over enabled, international, fields, and Save row" {
     var s = State{};
     try std.testing.expectEqual(@as(usize, 0), s.focus);
     s.focusPrevRow(); // clamp at enabled row
     try std.testing.expectEqual(ENABLED_ROW, s.focus);
+    s.focusNextRow(); // international
     s.focusNextRow(); // app_id
     s.focusNextRow(); // app_secret
     s.focusNextRow(); // Save row
@@ -136,12 +152,30 @@ test "focusedField maps only text rows to fields" {
     var s = State{};
     s.focus = ENABLED_ROW;
     try std.testing.expect(s.focusedField() == null);
-    s.focus = 1;
+    s.focus = INTERNATIONAL_ROW;
+    try std.testing.expect(s.focusedField() == null);
+    s.focus = APP_ID_ROW;
     try std.testing.expect(s.focusedField() == .app_id);
-    s.focus = 2;
+    s.focus = APP_SECRET_ROW;
     try std.testing.expect(s.focusedField() == .app_secret);
     s.focus = SAVE_ROW;
     try std.testing.expect(s.focusedField() == null);
+}
+
+test "toggleFocusedBool flips enabled or international by focused row, no-op elsewhere" {
+    var s = State{};
+    s.focus = ENABLED_ROW;
+    s.toggleFocusedBool();
+    try std.testing.expect(s.enabled and !s.international);
+    s.focus = INTERNATIONAL_ROW;
+    s.toggleFocusedBool();
+    try std.testing.expect(s.enabled and s.international);
+    // Field / Save rows must not flip either bool.
+    s.focus = APP_ID_ROW;
+    s.toggleFocusedBool();
+    s.focus = SAVE_ROW;
+    s.toggleFocusedBool();
+    try std.testing.expect(s.enabled and s.international);
 }
 
 test "toggleEnabled flips the enabled flag" {
@@ -153,13 +187,15 @@ test "toggleEnabled flips the enabled flag" {
     try std.testing.expect(!s.enabled);
 }
 
-test "reset clears lengths, focus, and enabled" {
+test "reset clears lengths, focus, enabled, and international" {
     var s = State{};
     s.append(.app_id, "x");
     s.focus = SAVE_ROW;
     s.enabled = true;
+    s.international = true;
     s.reset();
     try std.testing.expectEqual(@as(usize, 0), s.value(.app_id).len);
     try std.testing.expectEqual(@as(usize, 0), s.focus);
     try std.testing.expect(!s.enabled);
+    try std.testing.expect(!s.international);
 }


### PR DESCRIPTION
两个相关的飞书 channel 增强。

## 1. 国际版 (Lark) 区域支持
- 新增 `feishu-international` 配置项:开启走 `open.larksuite.com`,默认走国内 `open.feishu.cn`。
- 区域是进程级单例(`feishu/types.apiBase()`),`rest.zig`/`media.zig` 读取它,**网络函数签名全不变**,controller/longconn 调用点零改动。
- 命令面板「飞书:配置」表单新增「国际版 (Lark)」开关行,保存后重启生效。
- ⚠️ 两边账号互不通用,国际版 app 须在 open.larksuite.com 创建;wss 长连接地址由 API 返回,换域名后自动指向对应区域。

## 2. 群聊 @ 机器人支持
- 此前 `binding.shouldHandle` 一行无条件丢弃群消息(M2 p2p-only),这是"开了群聊权限却没反应"的根因。
- 现在:**群聊仅在 @ 机器人时响应**(私聊不变),避免刷屏。
- 解析 `event.message.mentions`,剥除 text 里的 `@_user_1` 占位符(AI 拿到干净文本)。
- `start()` 时经 `getBotOpenId` 获取机器人自身 open_id 做 @ 判断;失败安全降级(群聊不响应,私聊照常)。
- ⚠️ 群里需 @ 机器人才触发;若仍无反应,检查飞书后台:机器人已入群 + 事件订阅含 `im.message.receive_v1`。

## 测试
新增 ~16 条单元测试(config 解析、apiBase、表单 5 行模型、mentions 解析/剥离、群聊 @ 判断、controller 群 @ 路径)。

本地验证:`zig fmt --check` ✅ · `zig build test` ✅ · `zig build macos-app -Dtarget=aarch64-macos` ✅ · `zig build test-full -Dtarget=aarch64-macos` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
