### PR TITLE
feat(ai-chat): copy buttons for markdown tables and code blocks

### DIFF
--- a/src/assistant/conversation/layout.zig
+++ b/src/assistant/conversation/layout.zig
@@ -73,6 +73,24 @@ pub fn detailCopyButtonRect(
     };
 }
 
+/// Copy button anchored to the top-right corner of a markdown sub-block (a code
+/// fence or a table) of width `block_w`, sitting inside the block. Lets the user
+/// copy just that block's source instead of the whole message bubble.
+pub fn copyButtonRectForBlock(
+    x: f32,
+    top_px: f32,
+    block_w: f32,
+    button_size: f32,
+    button_pad: f32,
+) Rect {
+    return .{
+        .x = x + block_w - button_pad - button_size,
+        .top_px = top_px + button_pad,
+        .w = button_size,
+        .h = button_size,
+    };
+}
+
 pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip_gap: f32, chip_w: f32) f32 {
     return x + w - line_pad_x - status_slot_w - chip_gap - chip_w;
 }
@@ -264,6 +282,14 @@ test "detailCopyButtonRect centers in header_h" {
     const r = detailCopyButtonRect(10, 20, 300, 40, 14, 24);
     try std.testing.expectApproxEqAbs(@as(f32, 272), r.x, 0.001); // 10+300-14-24
     try std.testing.expectApproxEqAbs(@as(f32, 28), r.top_px, 0.001); // 20+round((40-24)/2)
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
+}
+
+test "copyButtonRectForBlock anchors to block top-right" {
+    const r = copyButtonRectForBlock(100, 50, 300, 24, 4);
+    try std.testing.expectApproxEqAbs(@as(f32, 372), r.x, 0.001); // 100+300-4-24
+    try std.testing.expectApproxEqAbs(@as(f32, 54), r.top_px, 0.001); // 50+4
     try std.testing.expectApproxEqAbs(@as(f32, 24), r.w, 0.001);
     try std.testing.expectApproxEqAbs(@as(f32, 24), r.h, 0.001);
 }

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -2006,6 +2006,20 @@ pub const Session = struct {
         return allocator.dupe(u8, self.messages.items[message_index].content);
     }
 
+    /// Copy a byte sub-range of a message's raw content — a single code block or
+    /// table the renderer located for its per-block copy button. Bounds are
+    /// clamped so a range stale from a streaming edit can never read OOB.
+    pub fn allocMessageSpanText(self: *Session, allocator: std.mem.Allocator, message_index: usize, start: usize, end: usize) ![]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (message_index >= self.messages.items.len) return allocator.dupe(u8, "");
+        const content = self.messages.items[message_index].content;
+        const s = @min(start, content.len);
+        const e = @min(end, content.len);
+        if (e <= s) return allocator.dupe(u8, "");
+        return allocator.dupe(u8, content[s..e]);
+    }
+
     pub fn toggleToolMessageCollapsed(self: *Session, message_index: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();

--- a/src/input.zig
+++ b/src/input.zig
@@ -80,6 +80,7 @@ const handleConfiguredRightClick = clipboard.handleConfiguredRightClick;
 const copyAiChatToClipboard = clipboard.copyAiChatToClipboard;
 const copyAiChatCutToClipboard = clipboard.copyAiChatCutToClipboard;
 const copyAiChatMessageToClipboard = clipboard.copyAiChatMessageToClipboard;
+const copyAiChatSpanToClipboard = clipboard.copyAiChatSpanToClipboard;
 pub const handleFileDrop = clipboard.handleFileDrop;
 pub const copySelectionToClipboard = clipboard.copySelectionToClipboard;
 pub const pasteFromClipboard = clipboard.pasteFromClipboard;
@@ -5611,6 +5612,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                         )) |target| {
                             switch (target) {
                                 .copy_message => |message_index| copyAiChatMessageToClipboard(chat, message_index),
+                                .copy_span => |s| copyAiChatSpanToClipboard(chat, s.message_index, s.start, s.end),
                                 .toggle_tool => |message_index| {
                                     chat.toggleToolMessageCollapsed(message_index);
                                     requestInputRepaint();
@@ -5744,6 +5746,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 )) |target| {
                     switch (target) {
                         .copy_message => |message_index| copyAiChatMessageToClipboard(chat, message_index),
+                        .copy_span => |s| copyAiChatSpanToClipboard(chat, s.message_index, s.start, s.end),
                         .toggle_tool => |message_index| {
                             chat.toggleToolMessageCollapsed(message_index);
                             requestInputRepaint();

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -421,6 +421,21 @@ pub fn copyAiChatMessageToClipboard(chat: *AppWindow.ai_chat.Session, message_in
     }
 }
 
+/// Copy a single code block or table (a byte sub-range of a message) located by
+/// the renderer's per-block copy button.
+pub fn copyAiChatSpanToClipboard(chat: *AppWindow.ai_chat.Session, message_index: usize, start: usize, end: usize) void {
+    const allocator = AppWindow.g_allocator orelse return;
+    const text = chat.allocMessageSpanText(allocator, message_index, start, end) catch return;
+    defer allocator.free(text);
+    if (text.len == 0) return;
+    if (copyTextToClipboard(text)) {
+        overlays.showCopyToast(text.len);
+        AppWindow.g_force_rebuild = true;
+        AppWindow.g_cells_valid = false;
+        std.debug.print("Copied {} AI chat block bytes to clipboard\n", .{text.len});
+    }
+}
+
 pub fn copySelectionToClipboard() void {
     const surface = selectionSurfaceForClipboard() orelse return;
     const allocator = AppWindow.g_allocator orelse return;

--- a/src/markdown_text.zig
+++ b/src/markdown_text.zig
@@ -370,7 +370,44 @@ pub fn allocDisplayText(allocator: std.mem.Allocator, content: []const u8) ![]u8
     return out.toOwnedSlice(allocator);
 }
 
+pub const Range = struct { start: usize, end: usize };
+
+/// Byte range of a fenced code block's *content* — the lines between the
+/// opening fence at `fence_start` and the matching closing fence, excluding
+/// both fence lines. An unterminated fence (still streaming) runs to EOF.
+/// Powers the renderer's per-code-block copy button (copies just the code).
+pub fn codeBlockContentRange(text: []const u8, fence_start: usize) Range {
+    const opening = nextSourceLine(text, fence_start);
+    const start = opening.next;
+    var cursor = start;
+    while (cursor < text.len) {
+        const info = nextSourceLine(text, cursor);
+        if (isFence(std.mem.trimLeft(u8, info.line, " \t"))) return .{ .start = start, .end = cursor };
+        cursor = info.next;
+    }
+    return .{ .start = start, .end = text.len };
+}
+
 const testing = std.testing;
+
+test "codeBlockContentRange extracts code between fences" {
+    const text = "```rust\nfn main() {}\n```\n";
+    const r = codeBlockContentRange(text, 0);
+    try testing.expectEqualStrings("fn main() {}\n", text[r.start..r.end]);
+}
+
+test "codeBlockContentRange unterminated fence runs to end" {
+    const text = "```\nline1\nline2";
+    const r = codeBlockContentRange(text, 0);
+    try testing.expectEqualStrings("line1\nline2", text[r.start..r.end]);
+}
+
+test "codeBlockContentRange skips language label and finds nested closing" {
+    const text = "prefix\n```py\na\nb\nc\n```\nafter";
+    const fence = std.mem.indexOf(u8, text, "```").?;
+    const r = codeBlockContentRange(text, fence);
+    try testing.expectEqualStrings("a\nb\nc\n", text[r.start..r.end]);
+}
 
 test "allocDisplayText strips inline emphasis and code spans" {
     const out = try allocDisplayText(testing.allocator, "**生成的完整 `Markdown`**");

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -57,6 +57,10 @@ const USAGE_FOOTER_PAD_TOP: f32 = 4;
 const APPROVAL_GAP: f32 = 12;
 const COPY_BUTTON_SIZE: f32 = 24;
 const COPY_BUTTON_PAD: f32 = 8;
+// Per-block (code fence / table) copy buttons hug the block's top-right corner
+// tighter than the bubble button, since a fence line is shorter than the bubble
+// header.
+const BLOCK_COPY_BUTTON_PAD: f32 = 4;
 const DETAIL_PAD_X: f32 = 14;
 const DETAIL_PAD_Y: f32 = 10;
 const DETAIL_ARROW_W: f32 = 12;
@@ -80,10 +84,19 @@ const MISSING_API_KEY_ACTION_TEXT = "Missing API key. Click to configure";
 
 pub const HitTarget = union(enum) {
     copy_message: usize,
+    /// Click on a code block / table's own copy button: copy just that block's
+    /// source (a byte range of the message), not the whole message.
+    copy_span: CopySpan,
     toggle_tool: usize,
     toggle_reasoning: usize,
     /// Click on the Nth (zero-based) visible option of a pending ask_user card.
     question_option: usize,
+};
+
+pub const CopySpan = struct {
+    message_index: usize,
+    start: usize,
+    end: usize,
 };
 
 /// Visible option rows in the question card before it scrolls. Beyond this, the
@@ -497,6 +510,15 @@ pub fn interactionHitTest(
         } else if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
             const rect = copyButtonRect(msg.role, content_x, cursor_top, content_w);
             if (pointInRect(px, py, rect)) return .{ .copy_message = message_index };
+            if (msg.role == .assistant) {
+                const bubble = bubbleGeometry(msg.role, content_x, content_w);
+                const body_x = bubble.x + BUBBLE_PAD_X;
+                const body_top = cursor_top + BUBBLE_PAD_Y + lineHeight();
+                const body_w = @max(1.0, bubble.w - BUBBLE_PAD_X * 2);
+                var hctx = BlockHitCtx{ .px = px, .py = py, .message_index = message_index };
+                forEachCopyBlock(msg.content, body_x, body_top, body_w, &hctx, checkBlockHit);
+                if (hctx.hit) |h| return h;
+            }
         }
         cursor_top += block_h;
 
@@ -1828,7 +1850,90 @@ fn renderMarkdownContent(
         display_cursor += prepared.text.len + 1;
     }
 
+    forEachCopyBlock(text, x, top_px, max_w, window_height, drawCopyBlockButton);
     return current_top - top_px;
+}
+
+const CopyBlock = struct {
+    button: Rect,
+    start: usize,
+    end: usize,
+};
+
+/// Walk an assistant message's markdown body and `emit` a copy-button rect plus
+/// the source byte range for every code block and table. The renderer calls it
+/// to draw the buttons and `interactionHitTest` calls it to detect clicks, so a
+/// button the user sees and the region a click maps to come from one geometry
+/// source. Vertical advance MUST stay in lockstep with markdownContentHeight /
+/// renderMarkdownContent, or the buttons drift off their blocks.
+fn forEachCopyBlock(
+    text: []const u8,
+    x: f32,
+    top_px: f32,
+    max_w: f32,
+    ctx: anytype,
+    comptime emit: anytype,
+) void {
+    if (std.mem.trim(u8, text, " \t\r\n").len == 0) return;
+    const palette = markdownPalette(AppWindow.g_theme.background, AppWindow.g_theme.foreground, AppWindow.g_theme.cursor_color);
+    var cursor: usize = 0;
+    var current_top = top_px;
+    var in_code = false;
+
+    while (cursor < text.len) {
+        if (!in_code and isMarkdownTableStart(text, cursor)) {
+            const start = cursor;
+            const end = tableBlockEnd(text, cursor);
+            var widths: [TABLE_MAX_COLS]f32 = .{0} ** TABLE_MAX_COLS;
+            const col_count = measureTableColumns(text, start, end, max_w, &widths);
+            const table_w = if (col_count == 0) max_w else tableUsedWidth(widths[0..col_count]);
+            emit(ctx, CopyBlock{ .button = blockCopyButtonRect(x, current_top, table_w), .start = start, .end = end });
+            current_top += tableBlockHeight(text, start, end);
+            cursor = end;
+            continue;
+        }
+
+        const info = nextSourceLine(text, cursor);
+        var clean_buf: [1024]u8 = undefined;
+        const prepared = prepareMarkdownLine(&clean_buf, info.line, in_code, palette);
+        switch (prepared.kind) {
+            .fence => {
+                if (!in_code) {
+                    const range = md.codeBlockContentRange(text, cursor);
+                    if (range.end > range.start) {
+                        emit(ctx, CopyBlock{ .button = blockCopyButtonRect(x, current_top, max_w), .start = range.start, .end = range.end });
+                    }
+                }
+                current_top += prepared.line_h;
+                in_code = !in_code;
+            },
+            .blank, .rule => current_top += prepared.line_h,
+            .text => current_top += plainContentHeight(prepared.text, @max(1.0, max_w - prepared.indent), prepared.line_h),
+        }
+        cursor = info.next;
+    }
+}
+
+fn blockCopyButtonRect(x: f32, top_px: f32, block_w: f32) Rect {
+    return ai_chat_layout.copyButtonRectForBlock(x, top_px, block_w, COPY_BUTTON_SIZE, BLOCK_COPY_BUTTON_PAD);
+}
+
+fn drawCopyBlockButton(window_height: f32, block: CopyBlock) void {
+    renderCopyButton(block.button, window_height, false);
+}
+
+const BlockHitCtx = struct {
+    px: f32,
+    py: f32,
+    message_index: usize,
+    hit: ?HitTarget = null,
+};
+
+fn checkBlockHit(ctx: *BlockHitCtx, block: CopyBlock) void {
+    if (ctx.hit != null) return;
+    if (pointInRect(ctx.px, ctx.py, block.button)) {
+        ctx.hit = .{ .copy_span = .{ .message_index = ctx.message_index, .start = block.start, .end = block.end } };
+    }
 }
 
 fn byteOffsetForMarkdownPoint(


### PR DESCRIPTION
## 这是什么

AI 聊天里**每个表格和代码块**的右上角现在都有一个「复制」按钮，点击复制该块内容。

起因：渲染后的表格带边框/对齐，鼠标拖选复制出来是错位的乱码，用户无法方便地复制表格；代码块虽可拖选但也希望有快捷按钮。

## 改了什么

- **表格按钮** → 复制原始 markdown 源（`| 系列 | 开发商 | ... |`）
- **代码块按钮** → 只复制 fence 之间的纯代码（不含 ` ``` ` 行）
- 渲染与点击命中**共用同一次几何遍历** `forEachCopyBlock`，保证「画出来的按钮」和「可点的区域」永远一致，纵向推进与 `markdownContentHeight` / `renderMarkdownContent` 同步
- 复用现有复制按钮的绘制（`renderCopyButton`）与剪贴板链路；新增 `HitTarget.copy_span`，在两个鼠标处理 switch 里分发，落到带越界夹紧的 `Session.allocMessageSpanText`

## 文件

| 文件 | 改动 |
|---|---|
| `markdown_text.zig` | `codeBlockContentRange`（+3 单测） |
| `assistant/conversation/layout.zig` | `copyButtonRectForBlock`（+1 单测） |
| `assistant/conversation/session.zig` | `allocMessageSpanText`（夹紧防越界） |
| `input/clipboard.zig` | `copyAiChatSpanToClipboard` |
| `renderer/assistant/conversation.zig` | `HitTarget.copy_span` + `forEachCopyBlock` + 渲染/命中接线 |
| `input.zig` | 两个鼠标 switch 分发 `.copy_span` |

## 验证

- `zig build test`（快测）通过
- `zig build test-full -Dtarget=aarch64-macos` 全量编译 + ~2300 原生测试通过（EXIT=0）
- `zig build macos-app -Dtarget=aarch64-macos` 成功出包

## Reviewer 注意

- **表格复制格式**取的是 markdown 源——粘进 Excel/飞书表格会是一行不分列；若更想要 TSV 分列，改 `allocMessageSpanText` 即可。
- 按钮位于块右上角内侧、半透明，会轻微盖住最后一列表头末尾；如嫌碍事可把表格按钮移到表格外侧右上。
- 运行时的**实际显示位置/点击手感尚未做可视化回归**，单测只覆盖纯逻辑与矩形几何。

🤖 Generated with [Claude Code](https://claude.com/claude-code)