### PR TITLE
[codex] Space copilot status dot from close button

### DIFF
--- a/src/assistant/conversation/layout.zig
+++ b/src/assistant/conversation/layout.zig
@@ -104,11 +104,23 @@ pub fn stopButtonRect(
     stop_h: f32,
     header_h: f32,
 ) Rect {
+    return headerButtonRect(x, w, titlebar_offset, line_pad_x, stop_w, stop_h, header_h);
+}
+
+pub fn headerButtonRect(
+    x: f32,
+    w: f32,
+    titlebar_offset: f32,
+    right_pad: f32,
+    button_w: f32,
+    button_h: f32,
+    header_h: f32,
+) Rect {
     return .{
-        .x = x + w - line_pad_x - stop_w,
-        .top_px = titlebar_offset + @round((header_h - stop_h) / 2),
-        .w = stop_w,
-        .h = stop_h,
+        .x = x + w - right_pad - button_w,
+        .top_px = titlebar_offset + @round((header_h - button_h) / 2),
+        .w = button_w,
+        .h = button_h,
     };
 }
 
@@ -304,6 +316,14 @@ test "stopButtonRect centers in header_h" {
     try std.testing.expectApproxEqAbs(@as(f32, 878), r.x, 0.001); // 1000-18-104
     try std.testing.expectApproxEqAbs(@as(f32, 18), r.top_px, 0.001); // 5+round((54-28)/2)
     try std.testing.expectApproxEqAbs(@as(f32, 104), r.w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.h, 0.001);
+}
+
+test "headerButtonRect can reserve trailing controls" {
+    const r = headerButtonRect(600, 128, 5, 18 + 34, 28, 28, 54);
+    try std.testing.expectApproxEqAbs(@as(f32, 648), r.x, 0.001); // 600+128-52-28
+    try std.testing.expectApproxEqAbs(@as(f32, 18), r.top_px, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 28), r.w, 0.001);
     try std.testing.expectApproxEqAbs(@as(f32, 28), r.h, 0.001);
 }
 

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -45,6 +45,7 @@ const STOP_BUTTON_H: f32 = 28;
 // stops an in-flight request when the dot is busy/yellow.
 const STATUS_DOT_D: f32 = 9;
 const STATUS_DOT_HIT: f32 = 28;
+const COMPACT_STATUS_TRAILING_RESERVE: f32 = 36;
 const MODE_SLOT_W: f32 = 76;
 const INPUT_SCROLLBAR_GUTTER: f32 = 10;
 const INPUT_SCROLLBAR_W: f32 = 4;
@@ -1260,7 +1261,7 @@ fn permissionChipX(x: f32, w: f32) f32 {
 // dot is yellow and clicking this square stops it (mirrors the old stop button;
 // Esc still works). Reuses the generic header-button geometry.
 fn statusDotRect(x: f32, w: f32, titlebar_offset: f32) HeaderButtonRect {
-    return ai_chat_layout.stopButtonRect(x, w, titlebar_offset, LINE_PAD_X, STATUS_DOT_HIT, STATUS_DOT_HIT, HEADER_H);
+    return ai_chat_layout.headerButtonRect(x, w, titlebar_offset, LINE_PAD_X + COMPACT_STATUS_TRAILING_RESERVE, STATUS_DOT_HIT, STATUS_DOT_HIT, HEADER_H);
 }
 
 // Filled disc approximated by stacked 1px scanlines (no circle primitive exists;


### PR DESCRIPTION
## Summary

- keep the compact Copilot status dot clear of the sidebar close icon
- add reusable header-button geometry that supports reserving trailing controls
- cover the new geometry with a focused layout unit test

## Root cause

The compact Copilot sidebar status dot reused the right-aligned stop-button geometry, so it was positioned without accounting for the close button rendered separately by `AppWindow.renderAiCopilotCloseButton`.

## Validation

- `zig test src/assistant/conversation/layout.zig`
- `zig build test`
- `zig build test-full`
