### PR TITLE
fix(feishu): longconn keepalive pings every 1s — PingInterval is seconds, not ms

### DIFF
--- a/src/feishu/rest.zig
+++ b/src/feishu/rest.zig
@@ -33,6 +33,27 @@ pub fn buildTextContent(alloc: std.mem.Allocator, text: []const u8) ![]u8 {
     return std.json.Stringify.valueAlloc(alloc, .{ .text = text }, .{});
 }
 
+/// Normalises the server-sent `ClientConfig.PingInterval` to a ping period in
+/// seconds. The value is already in SECONDS — see the official Go SDK
+/// `larksuite/oapi-sdk-go` `ws/client.go`:
+/// `c.pingInterval = time.Duration(conf.PingInterval) * time.Second`.
+/// When the server omits it (0 or negative) fall back to 120s, matching the
+/// SDK default (`2 * time.Minute`).
+///
+/// Previously this divided by 1000 as if PingInterval were milliseconds, so a
+/// real value like 120 truncated to 0 and the ping thread floored it to 1s — a
+/// ping storm every second.
+pub fn pingIntervalSeconds(raw: i64) i64 {
+    return if (raw > 0) raw else 120;
+}
+
+test "pingIntervalSeconds: value is seconds, default 120 on non-positive" {
+    try std.testing.expectEqual(@as(i64, 120), pingIntervalSeconds(120));
+    try std.testing.expectEqual(@as(i64, 8), pingIntervalSeconds(8));
+    try std.testing.expectEqual(@as(i64, 120), pingIntervalSeconds(0));
+    try std.testing.expectEqual(@as(i64, 120), pingIntervalSeconds(-1));
+}
+
 // ---------------------------------------------------------------------------
 // tenant_access_token
 // ---------------------------------------------------------------------------
@@ -190,13 +211,10 @@ pub fn discoverWsEndpoint(alloc: std.mem.Allocator, creds: types.Credentials) !W
     const safe_url = stripQuery(parsed.data.URL);
     log.info("discoverWsEndpoint: ok url_host_path={s}", .{safe_url});
 
-    const ping_ms = parsed.data.ClientConfig.PingInterval;
-    // PingInterval in the protocol notes is in milliseconds.
-    const ping_s = @divTrunc(ping_ms, 1000);
-
     return .{
         .url = try alloc.dupe(u8, parsed.data.URL),
-        .ping_interval_s = ping_s,
+        // PingInterval is in SECONDS (Go SDK ws/client.go); default 120s when absent.
+        .ping_interval_s = pingIntervalSeconds(parsed.data.ClientConfig.PingInterval),
     };
 }
 


### PR DESCRIPTION
## 问题

飞书长连接 debug 日志里每 **1 秒**发一次心跳 ping:

```
debug(feishu_longconn): ping: sent
debug(feishu_longconn): longconn: control frame type=pong
```

应该是服务端下发的间隔(默认 **120 秒**),1s 是 ping 风暴。

## 根因

`discoverWsEndpoint`([src/feishu/rest.zig](src/feishu/rest.zig))把 `/callback/ws/endpoint` 返回的 `ClientConfig.PingInterval` **当成毫秒**除了 1000:

```zig
const ping_ms = parsed.data.ClientConfig.PingInterval;
// PingInterval in the protocol notes is in milliseconds.   ← 注释错误
const ping_s = @divTrunc(ping_ms, 1000);                    ← 错误换算
```

但 `PingInterval` 单位是**秒**。权威参照——官方 Go SDK `larksuite/oapi-sdk-go` `ws/client.go`:

```go
func (c *Client) configure(conf *ClientConfig) {
    ...
    c.pingInterval = time.Duration(conf.PingInterval) * time.Second   // ← 秒
}
// 默认 pingInterval: 2 * time.Minute(120s)
```

服务端发 `PingInterval = 120`(秒)→ `@divTrunc(120, 1000) = 0` → `ping_interval_s = 0` → ping 线程 `@max(0, 1) = 1` → **每 1 秒 ping**。

> 症状即铁证:1s ping ⟺ `ping_interval_s = 0` ⟺ `PingInterval < 1000` ⟺ 它本来就是秒。若真是毫秒(120000),除 1000 会得 120s,就不会每秒了。

## 修复

直接当秒用,服务端给 0/缺省时回退 120s(对齐 SDK 默认),抽成纯函数 + 单测:

```zig
pub fn pingIntervalSeconds(raw: i64) i64 {
    return if (raw > 0) raw else 120;
}
```

## 验证

- 新增 `pingIntervalSeconds` 纯函数单测(秒透传 + 非正回退 120),`zig build test` PASS。
- `zig fmt --check build.zig src` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)