### PR TITLE
fix(reconnect): Windows SSH tabs exit on close so reconnect can fire

### DIFF
--- a/docs/superpowers/plans/2026-06-30-panel-reconnect.md
+++ b/docs/superpowers/plans/2026-06-30-panel-reconnect.md
@@ -1,0 +1,534 @@
+# Panel Reconnect / Re-run on Exit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user press Enter in a panel whose process has exited (SSH closed, shell `exit`) to re-run that panel's original command in place, keeping scrollback.
+
+**Architecture:** Store the panel's launch command+cwd on the `Surface` at init. On exit the panel already stays open and prints `[WispTerm] Process exited…`; we append `Press Enter to reconnect.` and intercept plain Enter in the key path to call a new `Surface.respawn()`. `respawn()` tears down the dead IO subsystem (both IO threads, mailbox, thread-state, pty, command) and brings up a fresh one transactionally — acquire the new resources into locals first, swap only on success — while retaining the `terminal` (scrollback) and `vt_stream`.
+
+**Tech Stack:** Zig, ghostty-vt, the repo's two-thread (reader+writer) per-surface IO model.
+
+## Global Constraints
+
+- **Cross-platform compile.** Default `zig build` targets Windows; ALL code and tests must compile for Windows too. `CommandLine`/`Cwd` are `[:0]const u8`/`?[*:0]const u8` on POSIX and `[:0]const u16`/`?[*:0]const u16` on Windows — never assume `u8`. Build cross-platform `CommandLine` values in tests via `platform_pty_command.allocCommandLineFromUtf8`, never a bare `"..."` literal.
+- **Run native tests on macOS.** `Surface` tests live in the app test binary; bare `zig build test-full` only compile-checks it. Use `zig build test-full -Dtarget=aarch64-macos` to actually RUN them. The `skill center tool import` test is known-flaky (FileNotFound) and unrelated.
+- **UI copy style.** Terminal status messages use the existing `\r\n[WispTerm] … \r\n` form; keep it.
+- **No double-free.** Tearing a resource down twice corrupts the heap (issue #65). `respawn()` must leave every field deinit-safe on every failure path.
+
+## File Structure
+
+- `src/Surface.zig` — add `respawn_command`/`respawn_cwd` fields + `setRespawnTarget`/`freeRespawnTarget` helpers; wire into `init`/`finishInit`/`deinit`; extract `formatIoStatusMessage` from `paintIoStatus` and add the reconnect hint; add `isExited` + `respawn` + `respawnFailed`.
+- `src/input.zig` — intercept plain Enter on an exited focused surface in `dispatchKey` and call `respawn()`.
+
+All work is in these two files. Tests are added inline in `src/Surface.zig` (alongside the existing `ioStateHarness`-style tests).
+
+---
+
+### Task 1: Store the panel's launch command + cwd on `Surface`
+
+**Files:**
+- Modify: `src/Surface.zig` (core-state fields ~245; `init` 466–469; `finishInit` ~489; `deinit` ~702–705; new helpers + test)
+
+**Interfaces:**
+- Produces:
+  - Fields `respawn_command: ?platform_pty_command.OwnedCommandLine = null`, `respawn_cwd: ?platform_pty_command.OwnedCwd = null`.
+  - `fn setRespawnTarget(self: *Surface, allocator: std.mem.Allocator, cmd: platform_pty_command.CommandLine, cwd: platform_pty_command.Cwd) void`
+  - `fn freeRespawnTarget(self: *Surface, allocator: std.mem.Allocator) void`
+- Consumes: `platform_pty_command` (already imported at `Surface.zig:26`): `OwnedCommandLine`, `OwnedCwd`, `CwdUnit`, `CommandLine`, `Cwd`, `freeCommandLine`, `freeCwd`, `allocCommandLineFromUtf8`, `commandLineFromOwned`, `commandLineDisplay`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the end of `src/Surface.zig` (after the last test, ~line 1851):
+
+```zig
+test "Surface respawn target stores command and frees it without leaking" {
+    var surface: Surface = undefined;
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
+
+    // Build a platform CommandLine from utf8 so this compiles on Windows too.
+    const owned = try platform_pty_command.allocCommandLineFromUtf8(
+        std.testing.allocator,
+        "ssh demo@host",
+    );
+    defer platform_pty_command.freeCommandLine(std.testing.allocator, owned);
+    const cmd = platform_pty_command.commandLineFromOwned(owned);
+
+    surface.setRespawnTarget(std.testing.allocator, cmd, null);
+    try std.testing.expect(surface.respawn_command != null);
+    try std.testing.expect(surface.respawn_cwd == null);
+
+    var disp: [64]u8 = undefined;
+    const got = platform_pty_command.commandLineDisplay(
+        platform_pty_command.commandLineFromOwned(surface.respawn_command.?),
+        &disp,
+    );
+    try std.testing.expectEqualStrings("ssh demo@host", got);
+
+    // testing.allocator fails the test if freeRespawnTarget leaks or
+    // double-frees.
+    surface.freeRespawnTarget(std.testing.allocator);
+    try std.testing.expect(surface.respawn_command == null);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "respawn target stores"`
+Expected: FAIL/compile error — `respawn_command`/`setRespawnTarget`/`freeRespawnTarget` don't exist yet.
+
+- [ ] **Step 3: Add the fields**
+
+In the core-state block of `src/Surface.zig`, right after the `remote_id: [16]u8,` field (~line 245):
+
+```zig
+remote_id: [16]u8,
+
+/// The command + cwd this surface was launched with, owned copies kept so the
+/// panel can be re-run in place after its process exits (Enter-to-reconnect).
+/// Null for virtual/tmux panes (no child) and if the dup ever fails.
+respawn_command: ?platform_pty_command.OwnedCommandLine = null,
+respawn_cwd: ?platform_pty_command.OwnedCwd = null,
+```
+
+- [ ] **Step 4: Add the helpers**
+
+Add after `captureInitialCwd` (~line 1175 in `src/Surface.zig`):
+
+```zig
+/// Store owned copies of the launch command/cwd for Enter-to-reconnect.
+/// `CommandLine`/`Cwd` are platform-native (`u8` POSIX / `u16` Windows); we
+/// dup with the element unit so this is cross-platform. Best-effort: on dup
+/// failure the field stays null and reconnect is simply unavailable.
+fn setRespawnTarget(
+    self: *Surface,
+    allocator: std.mem.Allocator,
+    cmd: platform_pty_command.CommandLine,
+    cwd: platform_pty_command.Cwd,
+) void {
+    const CmdUnit = std.meta.Child(platform_pty_command.CommandLine);
+    self.respawn_command = allocator.dupeZ(CmdUnit, cmd) catch null;
+    self.respawn_cwd = if (cwd) |c|
+        (allocator.dupeZ(platform_pty_command.CwdUnit, std.mem.span(c)) catch null)
+    else
+        null;
+}
+
+fn freeRespawnTarget(self: *Surface, allocator: std.mem.Allocator) void {
+    if (self.respawn_command) |c| platform_pty_command.freeCommandLine(allocator, c);
+    if (self.respawn_cwd) |c| platform_pty_command.freeCwd(allocator, c);
+    self.respawn_command = null;
+    self.respawn_cwd = null;
+}
+```
+
+- [ ] **Step 5: Initialize the fields in `finishInit` (so the virtual path is null)**
+
+In `finishInit`, next to the other null-defaults (after `surface.ssh_connection = null;`, ~line 489):
+
+```zig
+    surface.ssh_connection = null;
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
+```
+
+- [ ] **Step 6: Populate the fields in `init` (real-child path only)**
+
+Change the tail of `init` (line 469) from:
+
+```zig
+    return finishInit(surface, allocator, cols, rows, platform_pty_command.launchKindForCommand(shell_cmd), cwd);
+```
+
+to:
+
+```zig
+    const ready = try finishInit(surface, allocator, cols, rows, platform_pty_command.launchKindForCommand(shell_cmd), cwd);
+    ready.setRespawnTarget(allocator, shell_cmd, cwd);
+    return ready;
+```
+
+- [ ] **Step 7: Free the fields in `deinit`**
+
+In `deinit`, in the "safe to tear down" section, right after the clipboard-pending free (~line 705, before `self.wispterm_image_osc_buf.deinit(allocator);`):
+
+```zig
+    self.freeRespawnTarget(allocator);
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "respawn target stores"`
+Expected: PASS (no leak reported).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Surface.zig
+git commit -m "feat(surface): store launch command/cwd for reconnect"
+```
+
+---
+
+### Task 2: Append "Press Enter to reconnect." to the exit message
+
+**Files:**
+- Modify: `src/Surface.zig` (`paintIoStatus` 869–899; new `formatIoStatusMessage` + test)
+
+**Interfaces:**
+- Produces: `fn formatIoStatusMessage(buf: []u8, state: IoState, show_reconnect_hint: bool) ?[]const u8` — pure formatter returning the status string or null for non-terminal states.
+- Consumes: `respawn_command` field from Task 1 (gates the hint).
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the end of `src/Surface.zig`:
+
+```zig
+test "exit status message shows the reconnect hint only when asked" {
+    var buf: [256]u8 = undefined;
+    const state: IoState = .{ .exited = .{
+        .reason = .eof,
+        .status = .{ .exited = 0 },
+        .timestamp_ms = 0,
+    } };
+
+    const with_hint = formatIoStatusMessage(&buf, state, true).?;
+    try std.testing.expect(std.mem.indexOf(u8, with_hint, "Process exited with code 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_hint, "Press Enter to reconnect") != null);
+
+    var buf2: [256]u8 = undefined;
+    const no_hint = formatIoStatusMessage(&buf2, state, false).?;
+    try std.testing.expect(std.mem.indexOf(u8, no_hint, "Press Enter to reconnect") == null);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "reconnect hint only"`
+Expected: FAIL/compile error — `formatIoStatusMessage` doesn't exist.
+
+- [ ] **Step 3: Extract the formatter**
+
+Add immediately above `paintIoStatus` (~line 869) in `src/Surface.zig`:
+
+```zig
+/// Build the terminal status line printed when IO ends. Pure (no terminal
+/// access) so it is unit-testable. `show_reconnect_hint` appends the
+/// Enter-to-reconnect prompt to a normal exit message.
+fn formatIoStatusMessage(buf: []u8, state: IoState, show_reconnect_hint: bool) ?[]const u8 {
+    const hint = if (show_reconnect_hint) " Press Enter to reconnect." else "";
+    return switch (state) {
+        .failed => |failure| std.fmt.bufPrint(
+            buf,
+            "\r\n[WispTerm] Terminal IO failed during {s}: {s}\r\n",
+            .{ @tagName(failure.operation), @errorName(failure.error_code) },
+        ) catch null,
+        .exited => |info| exited: {
+            if (info.status) |status| switch (status) {
+                .exited => |code| break :exited std.fmt.bufPrint(
+                    buf,
+                    "\r\n[WispTerm] Process exited with code {d}.{s}\r\n",
+                    .{ code, hint },
+                ) catch null,
+                .unknown => {},
+            };
+            break :exited std.fmt.bufPrint(
+                buf,
+                "\r\n[WispTerm] Process exited.{s}\r\n",
+                .{hint},
+            ) catch null;
+        },
+        else => null,
+    };
+}
+```
+
+- [ ] **Step 4: Call the formatter from `paintIoStatus`**
+
+Replace the message-building block inside `paintIoStatus` (the `var buf` + `const message = switch (state) {…}` at lines 873–892) with:
+
+```zig
+    var buf: [256]u8 = undefined;
+    // Only a panel with a stored command can actually reconnect (virtual/tmux
+    // panes and dup failures leave respawn_command null), so gate the hint.
+    const message = formatIoStatusMessage(&buf, state, self.respawn_command != null) orelse return;
+```
+
+(Leave the `self.terminal.printString(message)` / `clearSynchronizedOutputLocked()` tail unchanged.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "reconnect hint only"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Surface.zig
+git commit -m "feat(surface): show reconnect hint on the exit message"
+```
+
+---
+
+### Task 3: `Surface.respawn()` — tear down the dead IO subsystem and bring up a fresh one
+
+**Files:**
+- Modify: `src/Surface.zig` (new `isExited`, `respawn`, `respawnFailed` after `paintIoStatus` ~line 900; new guard test)
+
+**Interfaces:**
+- Consumes: `respawn_command`/`respawn_cwd` (Task 1); `currentIoState`/`setIoRunning`/`failIo`/`clearSynchronizedOutputLocked`; `Pty.open`, `Command.start`, `termio.Mailbox.init`, `termio.Thread.init/threadMain`, `termio.ReadThread.threadMain`, `threading.surface_thread_spawn_config`, `self.terminal.resize`.
+- Produces:
+  - `pub fn isExited(self: *Surface) bool`
+  - `pub fn respawn(self: *Surface) void`
+
+- [ ] **Step 1: Write the failing test (guards only; the live fork path is E2E)**
+
+Add at the end of `src/Surface.zig`. `ioStateHarness` (defined ~line 1783) builds a Surface with `io_thread_state`/threads null, so the guard paths never touch real IO:
+
+```zig
+test "respawn is a no-op unless the surface has exited with a stored command" {
+    var surface: Surface = undefined;
+    try ioStateHarness(&surface);
+    defer ioStateHarnessDeinit(&surface);
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
+
+    // .running (harness default): guard returns immediately, state unchanged.
+    try std.testing.expect(!surface.isExited());
+    surface.respawn();
+    try std.testing.expect(surface.acceptsInput());
+
+    // .exited but no stored command: returns at the command guard, before any
+    // pty/thread work (which would crash on the null-threaded harness).
+    surface.markExited(.eof, .{ .exited = 0 });
+    try std.testing.expect(surface.isExited());
+    surface.respawn();
+    try std.testing.expect(surface.isExited());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "respawn is a no-op"`
+Expected: FAIL/compile error — `isExited`/`respawn` don't exist.
+
+- [ ] **Step 3: Add `isExited`**
+
+Add next to `acceptsInput` (~line 764) in `src/Surface.zig`:
+
+```zig
+pub fn isExited(self: *Surface) bool {
+    return switch (self.currentIoState()) {
+        .exited => true,
+        else => false,
+    };
+}
+```
+
+- [ ] **Step 4: Add `respawn` + `respawnFailed`**
+
+Add after `paintIoStatus` (~line 900) in `src/Surface.zig`:
+
+```zig
+/// Re-run this panel's original command in place after its process exited
+/// (Enter-to-reconnect). Keeps the terminal/scrollback; replaces the whole IO
+/// subsystem. Main-thread only (spawns threads, touches the mailbox). No-op
+/// unless the panel has cleanly exited and has a stored command.
+pub fn respawn(self: *Surface) void {
+    switch (self.currentIoState()) {
+        .exited => {},
+        else => return,
+    }
+    const owned_cmd = self.respawn_command orelse {
+        io_log.warn("respawn requested but no stored command", .{});
+        return;
+    };
+    const cmd = platform_pty_command.commandLineFromOwned(owned_cmd);
+    const cwd: platform_pty_command.Cwd =
+        if (self.respawn_cwd) |c| platform_pty_command.cwdFromOwned(c) else null;
+    const cols = self.size.grid.cols;
+    const rows = self.size.grid.rows;
+
+    // Both IO threads already returned (reader on EOF, writer on the stop
+    // notify markExited sent) but were never joined. Collect them before
+    // anything new starts.
+    if (self.io_thread_state) |state| state.stop.notify() catch {};
+    self.pty.cancelOutputRead();
+    if (self.io_writer_thread) |t| {
+        t.join();
+        self.io_writer_thread = null;
+    }
+    if (self.io_reader_thread) |t| {
+        t.join();
+        self.io_reader_thread = null;
+    }
+
+    // Acquire the new IO subsystem into locals FIRST. On any failure the OLD
+    // pty/command/mailbox/thread_state are still the surface's fields and stay
+    // deinit-safe — we just report failure and the old "exited" state holds.
+    var new_pty = Pty.open(.{ .ws_col = cols, .ws_row = rows }) catch |err|
+        return self.respawnFailed(err);
+    var new_command: Command = .{};
+    new_command.start(&new_pty, cmd, cwd) catch |err| {
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    var new_mailbox = termio.Mailbox.init() catch |err| {
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    const new_state = self.allocator.create(termio.Thread) catch |err| {
+        new_mailbox.deinit();
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    new_state.* = termio.Thread.init() catch |err| {
+        self.allocator.destroy(new_state);
+        new_mailbox.deinit();
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+
+    // Commit: tear down the OLD subsystem, swap in the new one.
+    if (self.io_thread_state) |state| {
+        state.deinit();
+        self.allocator.destroy(state);
+    }
+    self.mailbox.deinit();
+    self.command.deinit();
+    self.pty.deinit();
+    self.pty = new_pty;
+    self.command = new_command;
+    self.mailbox = new_mailbox;
+    self.io_thread_state = new_state;
+
+    // Sync the retained grid to the (possibly resized-while-exited) pane size
+    // and drop a separator into the existing scrollback.
+    {
+        self.render_state.mutex.lock();
+        defer self.render_state.mutex.unlock();
+        self.terminal.resize(self.allocator, cols, rows) catch {};
+        self.terminal.printString("\r\n[WispTerm] Reconnecting...\r\n") catch {};
+        self.clearSynchronizedOutputLocked();
+    }
+
+    // The reader loops on `!exited`; clear it and reset lifecycle BEFORE spawn.
+    self.exited.store(false, .release);
+    self.io_state_mutex.lock();
+    self.io_state = .starting;
+    self.io_state_mutex.unlock();
+
+    // ponytail: thread-spawn failure after the swap marks the surface failed
+    // with the NEW resources owned (still deinit-safe); we don't unwind the
+    // swap. Same residual exposure finishInit already has. Make spawn pre-swap
+    // only if this ever actually bites.
+    self.io_writer_thread = std.Thread.spawn(
+        threading.surface_thread_spawn_config,
+        termio.Thread.threadMain,
+        .{ new_state, self },
+    ) catch |err| {
+        self.failIo(.thread_spawn, err);
+        return;
+    };
+    self.io_reader_thread = std.Thread.spawn(
+        threading.surface_thread_spawn_config,
+        termio.ReadThread.threadMain,
+        .{self},
+    ) catch |err| {
+        self.failIo(.thread_spawn, err);
+        return;
+    };
+
+    self.setIoRunning();
+    self.dirty.store(true, .release);
+    window_backend.postWakeup();
+}
+
+/// Reconnect could not open a fresh PTY/command. The old (exited) resources are
+/// untouched and remain owned by the surface; surface a failure message.
+fn respawnFailed(self: *Surface, err: anyerror) void {
+    io_log.warn("respawn failed: {s}", .{@errorName(err)});
+    self.failIo(.thread_spawn, err);
+}
+```
+
+- [ ] **Step 5: Run the guard test to verify it passes**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -A3 "respawn is a no-op"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Surface.zig
+git commit -m "feat(surface): add in-place respawn for an exited panel"
+```
+
+---
+
+### Task 4: Intercept plain Enter on an exited panel and reconnect
+
+**Files:**
+- Modify: `src/input.zig` (`dispatchKey`, right after the focused-surface bind at line 3516)
+
+**Interfaces:**
+- Consumes: `Surface.isExited`, `Surface.respawn` (Task 3); `platform_input.key_enter` (`= 0x0D`); `input_effects.repaint()`; `AppWindow.activeSurface()`.
+
+- [ ] **Step 1: Add the interception**
+
+In `src/input.zig`, immediately after line 3516 (`const surface = AppWindow.activeSurface() orelse return .none;`) and before the `var wrote_to_pty = false;` comment block, insert:
+
+```zig
+    // A cleanly-exited panel (SSH closed, shell `exit`) stays open showing
+    // "Press Enter to reconnect". Plain Enter re-runs the panel's original
+    // command in place. Other keys fall through, so e.g. Shift+PageUp still
+    // scrolls the scrollback before reconnecting.
+    if (surface.isExited() and
+        ev.key_code == platform_input.key_enter and
+        !ev.ctrl and !ev.alt and !ev.super and !ev.shift)
+    {
+        surface.respawn();
+        return input_effects.repaint();
+    }
+```
+
+- [ ] **Step 2: Build the app test binary to verify it compiles (both default + macOS)**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | tail -5`
+Expected: builds; all new tests pass (ignore the known-flaky `skill center tool import`).
+Run: `zig build 2>&1 | tail -5`
+Expected: the default (Windows) target still compiles — confirms cross-platform.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/input.zig
+git commit -m "feat(input): reconnect an exited panel on Enter"
+```
+
+- [ ] **Step 4: Manual E2E (the live fork/rebuild path, not covered by unit tests)**
+
+```bash
+zig build macos-app
+```
+
+Then, in the launched app:
+1. Open a panel and run a short-lived remote-ish command, e.g. `ssh -o ConnectTimeout=2 localhost` then exit it, OR simply `sleep 1; exit` in the shell, OR `cat` then Ctrl-D.
+2. Confirm the panel stays open and the last line reads `… Press Enter to reconnect.`
+3. Press **Enter**. Expect a `[WispTerm] Reconnecting...` line, then the original command runs again in the SAME panel with prior scrollback retained above.
+4. Scroll up with **Shift+PageUp** while exited — confirm it still scrolls (not swallowed).
+5. Let it exit again and reconnect a second time — confirm the loop works.
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `docs/superpowers/specs/2026-06-30-panel-reconnect-design.md`):
+- ① store command+cwd → Task 1. ② respawn rebuilds IO (reader+writer+mailbox+thread_state, not just reader — corrected from the spec's simplification) → Task 3. ③ exit-message hint → Task 2. ④ Enter interception, other keys fall through → Task 4. Keep scrollback / no clear → Task 3 retains `terminal`, prints a separator only. Reconnect-failure retry loop → a failed child re-enters `.exited` and re-prompts (Task 3 + Task 2). YAGNI items (no auto-reconnect, no keybind, no env recapture) → not implemented, as specified.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `respawn_command: ?OwnedCommandLine` / `respawn_cwd: ?OwnedCwd` used identically in Task 1 (store/free), Task 2 (`!= null` gate), Task 3 (`commandLineFromOwned`/`cwdFromOwned`). `isExited`/`respawn`/`formatIoStatusMessage`/`setRespawnTarget`/`freeRespawnTarget` signatures match across definition and call sites. `formatIoStatusMessage`'s `.failed` arm intentionally omits the hint (a hard IO failure is not the Enter-reconnect path).

--- a/docs/superpowers/specs/2026-06-30-panel-reconnect-design.md
+++ b/docs/superpowers/specs/2026-06-30-panel-reconnect-design.md
@@ -1,0 +1,102 @@
+# 面板进程退出后原地重连 (Panel Reconnect / Re-run on Exit)
+
+- 日期: 2026-06-30
+- 状态: 设计已批准，待出实现计划
+
+## 背景与目标
+
+当面板里的进程退出（SSH 连接断开、用户误输 `exit`、远端 kill 等），面板会停在
+`[WispTerm] Process exited with code X.` 状态并保持打开，但**目前无法在同一个面板里重新运行**，
+用户只能关掉面板再手动新开一个、重新敲一遍 `ssh ...`。
+
+目标：在退出的面板里**按 Enter 即可原地重跑该面板最初启动的命令**（ssh / 本地 shell / 任意命令通用）。
+
+## 行为规格（用户视角）
+
+1. 进程退出后，退出提示行变为：
+   `[WispTerm] Process exited with code 0. Press Enter to reconnect.`
+2. 该面板获得焦点时按 **Enter** → 在**同一个面板**里重跑最初的命令：
+   - 保留滚动历史（不清屏），先打印一行 `[WispTerm] Reconnecting…` 作分隔，新进程输出接在后面。
+   - 用**当前**面板尺寸（面板可能在退出后被 resize 过）。
+   - 工作目录用最初启动时的 cwd。
+3. 退出状态下，Enter 以外的按键维持现状（不写入死 pty）；关闭面板仍走已有的 close-pane 快捷键。
+4. 重连失败（如 ssh 连不上）→ 新进程再次退出 → 回到退出提示 → 再按 Enter 重试。纯用户驱动，**无自动循环**。
+
+## 实现路线
+
+**原地重启（复用同一个 Surface）**，而非销毁重建。理由：贴合"同一个面板"语义、保留滚动历史、
+不需要对 split-tree / 焦点做手术。代价是 respawn 时要把进程相关字段逐个复位，通过抽取共享 helper 收敛风险。
+
+## 架构与实现
+
+涉及的核心结构（参考勘探，定位以函数/结构名为准，具体行号在计划阶段于本 worktree 重新定位）：
+
+- `src/Surface.zig` — `Surface`：每个面板的核心，持有 `pty`、`command`（子进程）、`terminal`（含滚动历史）、
+  退出状态（`io_state: IoState` union，`exited` 原子标志，`ExitInfo`）。构造入口 `Surface.init()`。
+  退出由 `markExited()` 置位，退出提示由打印 io 状态的函数（勘探中的 `paintIoStatus()`）输出。
+- `src/termio/ReadThread.zig` — PTY 读线程；读到 EOF（0 字节）后线程函数返回，并触发 `markExited`。
+- `src/input.zig` — 按键分发；key→PTY 字节在此处理。
+- `src/keybind.zig` / `src/input/command_dispatch.zig` — 动作/快捷键注册（**本期不新增动作**，见 YAGNI）。
+
+### ① Surface 存启动参数
+
+在 `Surface` 上新增两个 Surface 自有的字段：
+
+- `respawn_command`: 启动命令（POSIX 上是 `:0`-terminated 的 command line；存时 **dup 一份**，因为原 slice 由调用方持有/释放）。
+- `respawn_cwd: ?[]const u8`: 工作目录副本（同样 dup）。
+
+填充时机：`Surface.init()` 成功起进程后，dup 入参的 command/cwd 存上。
+释放时机：`Surface.deinit()` 里 free。
+
+**不存** env（在 fork 出的子进程 `childExec` 里统一设置，重跑走同一条 exec 路径）、**不存** grid 尺寸（重连用当前尺寸）。
+
+### ② 抽取 `startProcess()` helper
+
+把 `Surface.init()` 尾部"开 pty → `command.start()` 起进程 → 起 PTY 读线程"这一段抽成
+`Surface.startProcess()`，供 `init()` 与 `respawn()` 共用，避免两处复制起进程逻辑导致漂移。
+
+### ③ `Surface.respawn()`
+
+前置条件：仅当 `io_state == .exited` 时可调用（此时旧读线程已随 EOF 返回，无并发竞态；从主线程的按键路径调用）。步骤：
+
+1. 确保旧读线程已结束并 join/清理其 handle（EOF 后线程函数已返回；避免 thread handle 泄漏）。
+2. 关闭旧 pty master，复位 `command`（旧 pid 已在退出时 reap）。
+3. 复位退出状态：`io_state` → 运行态、`exited` 原子标志 → false、清 `ExitInfo`。
+4. 向 `terminal` 打印一行 `[WispTerm] Reconnecting…`（保留既有滚动历史，不清屏）。
+5. 调 `startProcess()`，用 `respawn_command` + `respawn_cwd` + **当前** grid 尺寸重开 pty、起进程、起新读线程。
+6. 失败处理：`startProcess()` 失败时按现有 init 失败路径处理（标记退出/打印错误），用户可再次按 Enter 重试。
+
+### ④ 退出提示追加
+
+修改打印退出状态的函数（`paintIoStatus()` 一类），在
+`[WispTerm] Process exited with code X.` 后追加 ` Press Enter to reconnect.`
+
+### ⑤ input.zig 拦 Enter
+
+在按键→PTY 路径里，写 PTY 之前判断：若当前焦点 surface 处于 `.exited`：
+- 是 **Enter** → 调 `surface.respawn()`，吞掉该键（不写 pty）。
+- 其它键 → 维持现状。
+
+## 明确不做（YAGNI）
+
+- 不做 `reconnect-on-exit` 自动重连配置。
+- 不新增快捷键入口（仅退出面板按 Enter）。以后若要加全局快捷键：在 `keybind.zig` 加 action、
+  `command_dispatch.zig` 加分发、路由到同一个 `respawn()`，约几行。
+- 不清屏、不加重试计数器、不重抓 env、不保留/重放 SSH 认证（SSH 会按正常流程重新认证）。
+
+## 涉及文件
+
+- `src/Surface.zig`：新增 `respawn_command`/`respawn_cwd` 字段；`init()` 填充、`deinit()` 释放；
+  抽取 `startProcess()`；新增 `respawn()`；退出提示追加文案。
+- `src/input.zig`：退出态下拦截 Enter → `respawn()`。
+- `src/termio/ReadThread.zig`：确认读线程在 EOF 后的清理/可被重启（respawn 起新线程与 init 同路）。
+
+## 测试
+
+退出→重连这条逻辑非平凡（PTY + 线程），留**一个可跑的检查**即可：
+
+在 app 测试二进制里加一个 Zig test（`zig build test-full -Dtarget=aarch64-macos` 运行）：
+用一个会立即退出的命令（如 `true` / 短命令）`init` 一个 headless Surface，等其进入 `.exited`，
+断言 `respawn_command` 已存；调 `respawn()`，断言 `io_state` 由 `.exited` → 运行态、
+子进程 pid 变化（确实重新 fork），再次退出后 `io_state` 回到 `.exited`。
+（headless Surface 构造参考 `Surface.initVirtual()` / 现有 Surface 测试。）

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3421,6 +3421,7 @@ fn installSessionRestoreHooks() void {
     // restore, re-attach each via the launcher's tmux connect path.
     tab.g_tmux_active_profiles_hook = tmux_controller.activeProfileNames;
     tab.g_tmux_restore_hook = overlays.connectProfileByNameTmux;
+    tab.g_ssh_restore_arm_hook = overlays.armSshPasswordFromProfileForSurface;
 }
 
 fn deinitGlobalAgentHistoryStore(allocator: std.mem.Allocator) void {
@@ -3951,7 +3952,7 @@ pub fn splitFocusedReturningSurface(direction: SplitTree.Split.Direction) ?*Surf
         if (conn.usesPasswordAuth()) {
             const pw = conn.password();
             if (pw.len > 0)
-                overlays.scheduleSshPasswordForSurface(surface, pw);
+                overlays.scheduleSshPasswordForSurface(surface);
         }
     }
     handleActiveSurfaceChangeWithinTab();

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1009,13 +1009,21 @@ pub fn respawn(self: *Surface) void {
     self.mailbox = new_mailbox;
     self.io_thread_state = new_state;
 
-    // Sync the retained grid to the (possibly resized-while-exited) pane size
-    // and drop a separator into the existing scrollback.
+    // Sync the retained grid to the (possibly resized-while-exited) pane size,
+    // clear the visible screen, then print a separator.
+    //
+    // The clear is load-bearing for SSH reconnect: the previous session's
+    // "password:" prompt would otherwise linger in the viewport, and the SSH
+    // password autofill (which scans the viewport for a prompt) would match that
+    // stale line and type the password in plaintext BEFORE the real prompt shows
+    // up. Erasing the screen makes the only on-screen prompt the reconnect's own.
+    // Scrollback above the viewport is preserved (ED 2 erases the screen only).
     {
         self.render_state.mutex.lock();
         defer self.render_state.mutex.unlock();
         self.terminal.resize(self.allocator, cols, rows) catch {};
-        self.terminal.printString("\r\n[WispTerm] Reconnecting...\r\n") catch {};
+        self.vt_stream.nextSlice("\x1b[2J\x1b[H");
+        self.terminal.printString("[WispTerm] Reconnecting...\r\n") catch {};
         self.clearSynchronizedOutputLocked();
     }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -877,30 +877,44 @@ fn requestWriterStop(self: *Surface) void {
     }
 }
 
+/// Build the terminal status line printed when IO ends. Pure (no terminal
+/// access) so it is unit-testable. `show_reconnect_hint` appends the
+/// Enter-to-reconnect prompt to a normal exit message.
+fn formatIoStatusMessage(buf: []u8, state: IoState, show_reconnect_hint: bool) ?[]const u8 {
+    const hint = if (show_reconnect_hint) " Press Enter to reconnect." else "";
+    return switch (state) {
+        .failed => |failure| std.fmt.bufPrint(
+            buf,
+            "\r\n[WispTerm] Terminal IO failed during {s}: {s}\r\n",
+            .{ @tagName(failure.operation), @errorName(failure.error_code) },
+        ) catch null,
+        .exited => |info| exited: {
+            if (info.status) |status| switch (status) {
+                .exited => |code| break :exited std.fmt.bufPrint(
+                    buf,
+                    "\r\n[WispTerm] Process exited with code {d}.{s}\r\n",
+                    .{ code, hint },
+                ) catch null,
+                .unknown => {},
+            };
+            break :exited std.fmt.bufPrint(
+                buf,
+                "\r\n[WispTerm] Process exited.{s}\r\n",
+                .{hint},
+            ) catch null;
+        },
+        else => null,
+    };
+}
+
 fn paintIoStatus(self: *Surface, state: IoState) void {
     self.render_state.mutex.lock();
     defer self.render_state.mutex.unlock();
 
     var buf: [256]u8 = undefined;
-    const message = switch (state) {
-        .failed => |failure| std.fmt.bufPrint(
-            &buf,
-            "\r\n[WispTerm] Terminal IO failed during {s}: {s}\r\n",
-            .{ @tagName(failure.operation), @errorName(failure.error_code) },
-        ) catch return,
-        .exited => |info| exited: {
-            if (info.status) |status| switch (status) {
-                .exited => |code| break :exited std.fmt.bufPrint(
-                    &buf,
-                    "\r\n[WispTerm] Process exited with code {d}.\r\n",
-                    .{code},
-                ) catch return,
-                .unknown => {},
-            };
-            break :exited std.fmt.bufPrint(&buf, "\r\n[WispTerm] Process exited.\r\n", .{}) catch return;
-        },
-        else => return,
-    };
+    // Only a panel with a stored command can actually reconnect (virtual/tmux
+    // panes and dup failures leave respawn_command null), so gate the hint.
+    const message = formatIoStatusMessage(&buf, state, self.respawn_command != null) orelse return;
 
     self.terminal.printString(message) catch |err| {
         io_log.warn("failed to paint io status err={s}", .{@errorName(err)});
@@ -1914,4 +1928,21 @@ test "Surface respawn target stores command and frees it without leaking" {
     // double-frees.
     surface.freeRespawnTarget(std.testing.allocator);
     try std.testing.expect(surface.respawn_command == null);
+}
+
+test "exit status message shows the reconnect hint only when asked" {
+    var buf: [256]u8 = undefined;
+    const state: IoState = .{ .exited = .{
+        .reason = .eof,
+        .status = .{ .exited = 0 },
+        .timestamp_ms = 0,
+    } };
+
+    const with_hint = formatIoStatusMessage(&buf, state, true).?;
+    try std.testing.expect(std.mem.indexOf(u8, with_hint, "Process exited with code 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, with_hint, "Press Enter to reconnect") != null);
+
+    var buf2: [256]u8 = undefined;
+    const no_hint = formatIoStatusMessage(&buf2, state, false).?;
+    try std.testing.expect(std.mem.indexOf(u8, no_hint, "Press Enter to reconnect") == null);
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -244,6 +244,12 @@ ssh_connection: ?SshConnection,
 remote_client: ?*remote.Client,
 remote_id: [16]u8,
 
+/// The command + cwd this surface was launched with, owned copies kept so the
+/// panel can be re-run in place after its process exits (Enter-to-reconnect).
+/// Null for virtual/tmux panes (no child) and if the dup ever fails.
+respawn_command: ?platform_pty_command.OwnedCommandLine = null,
+respawn_cwd: ?platform_pty_command.OwnedCwd = null,
+
 /// Size information for this surface (screen size, cell size, padding).
 /// Used by the renderer to position content correctly.
 size: renderer.size.Size = .{},
@@ -466,7 +472,9 @@ pub fn init(
     try surface.command.start(&surface.pty, shell_cmd, cwd);
     errdefer surface.command.deinit();
 
-    return finishInit(surface, allocator, cols, rows, platform_pty_command.launchKindForCommand(shell_cmd), cwd);
+    const ready = try finishInit(surface, allocator, cols, rows, platform_pty_command.launchKindForCommand(shell_cmd), cwd);
+    ready.setRespawnTarget(allocator, shell_cmd, cwd);
+    return ready;
 }
 
 /// Shared constructor tail for `init` (real PTY + child) and `initVirtual`
@@ -487,6 +495,8 @@ fn finishInit(
     surface.render_state = renderer.State.init(&surface.terminal);
     surface.launch_kind = launch_kind;
     surface.ssh_connection = null;
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
     surface.remote_client = null;
     remote.nextSurfaceId(&surface.remote_id);
     surface.vt_stream = surface.initVtStream();
@@ -703,6 +713,7 @@ pub fn deinit(self: *Surface, allocator: std.mem.Allocator) void {
         self.allocator.free(pending);
         self.clipboard_write_pending = null;
     }
+    self.freeRespawnTarget(allocator);
     self.wispterm_image_osc_buf.deinit(allocator);
     self.vt_stream.deinit();
     self.command.deinit();
@@ -1172,6 +1183,31 @@ fn captureInitialCwd(self: *Surface, cwd: platform_pty_command.Cwd) void {
 
     const path = std.process.getCwd(&self.initial_cwd_path) catch return;
     self.initial_cwd_path_len = path.len;
+}
+
+/// Store owned copies of the launch command/cwd for Enter-to-reconnect.
+/// `CommandLine`/`Cwd` are platform-native (`u8` POSIX / `u16` Windows); we
+/// dup with the element unit so this is cross-platform. Best-effort: on dup
+/// failure the field stays null and reconnect is simply unavailable.
+fn setRespawnTarget(
+    self: *Surface,
+    allocator: std.mem.Allocator,
+    cmd: platform_pty_command.CommandLine,
+    cwd: platform_pty_command.Cwd,
+) void {
+    const CmdUnit = std.meta.Child(platform_pty_command.CommandLine);
+    self.respawn_command = allocator.dupeZ(CmdUnit, cmd) catch null;
+    self.respawn_cwd = if (cwd) |c|
+        (allocator.dupeZ(platform_pty_command.CwdUnit, std.mem.span(c)) catch null)
+    else
+        null;
+}
+
+fn freeRespawnTarget(self: *Surface, allocator: std.mem.Allocator) void {
+    if (self.respawn_command) |c| platform_pty_command.freeCommandLine(allocator, c);
+    if (self.respawn_cwd) |c| platform_pty_command.freeCwd(allocator, c);
+    self.respawn_command = null;
+    self.respawn_cwd = null;
 }
 
 /// Reset OSC batch state — call before each PTY read batch.
@@ -1848,4 +1884,34 @@ test "Surface markExited preserves a normal exit as non-failure and blocks input
         },
         else => return error.ExpectedExitedState,
     }
+}
+
+test "Surface respawn target stores command and frees it without leaking" {
+    var surface: Surface = undefined;
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
+
+    // Build a platform CommandLine from utf8 so this compiles on Windows too.
+    const owned = try platform_pty_command.allocCommandLineFromUtf8(
+        std.testing.allocator,
+        "ssh demo@host",
+    );
+    defer platform_pty_command.freeCommandLine(std.testing.allocator, owned);
+    const cmd = platform_pty_command.commandLineFromOwned(owned);
+
+    surface.setRespawnTarget(std.testing.allocator, cmd, null);
+    try std.testing.expect(surface.respawn_command != null);
+    try std.testing.expect(surface.respawn_cwd == null);
+
+    var disp: [64]u8 = undefined;
+    const got = platform_pty_command.commandLineDisplay(
+        platform_pty_command.commandLineFromOwned(surface.respawn_command.?),
+        &disp,
+    );
+    try std.testing.expectEqualStrings("ssh demo@host", got);
+
+    // testing.allocator fails the test if freeRespawnTarget leaks or
+    // double-frees.
+    surface.freeRespawnTarget(std.testing.allocator);
+    try std.testing.expect(surface.respawn_command == null);
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -294,6 +294,15 @@ exited: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 io_state_mutex: std.Thread.Mutex = .{},
 io_state: IoState = .starting,
 
+/// SSH password autofill timing. When an SSH session (re)connects the saved
+/// password is typed once the remote password prompt appears. Per-surface (not
+/// a single global slot) so many sessions restoring at once each get filled.
+/// `deadline` == 0 means not armed; `due` is the earliest inject time (gives
+/// the prompt a moment to settle). The password itself is read from
+/// `ssh_connection` at inject time — not stored here.
+ssh_autofill_due_ms: i64 = 0,
+ssh_autofill_deadline_ms: i64 = 0,
+
 /// Set while the IO writer thread is resizing PTY and terminal state.
 /// The reader thread still drains PTY output during this window, but
 /// delays VT parsing until terminal.resize has caught up to the new grid.
@@ -496,6 +505,8 @@ fn finishInit(
     surface.render_state = renderer.State.init(&surface.terminal);
     surface.launch_kind = launch_kind;
     surface.ssh_connection = null;
+    surface.ssh_autofill_due_ms = 0;
+    surface.ssh_autofill_deadline_ms = 0;
     surface.respawn_command = null;
     surface.respawn_cwd = null;
     surface.remote_client = null;

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -779,6 +779,13 @@ pub fn acceptsInput(self: *Surface) bool {
     };
 }
 
+pub fn isExited(self: *Surface) bool {
+    return switch (self.currentIoState()) {
+        .exited => true,
+        else => false,
+    };
+}
+
 fn setIoRunning(self: *Surface) void {
     self.io_state_mutex.lock();
     defer self.io_state_mutex.unlock();
@@ -921,6 +928,130 @@ fn paintIoStatus(self: *Surface, state: IoState) void {
         return;
     };
     self.clearSynchronizedOutputLocked();
+}
+
+/// Re-run this panel's original command in place after its process exited
+/// (Enter-to-reconnect). Keeps the terminal/scrollback; replaces the whole IO
+/// subsystem. Main-thread only (spawns threads, touches the mailbox). No-op
+/// unless the panel has cleanly exited and has a stored command.
+pub fn respawn(self: *Surface) void {
+    switch (self.currentIoState()) {
+        .exited => {},
+        else => return,
+    }
+    const owned_cmd = self.respawn_command orelse {
+        io_log.warn("respawn requested but no stored command", .{});
+        return;
+    };
+    const cmd = platform_pty_command.commandLineFromOwned(owned_cmd);
+    const cwd: platform_pty_command.Cwd =
+        if (self.respawn_cwd) |c| platform_pty_command.cwdFromOwned(c) else null;
+    const cols = self.size.grid.cols;
+    const rows = self.size.grid.rows;
+
+    // Both IO threads already returned (reader on EOF, writer on the stop
+    // notify markExited sent) but were never joined. Collect them before
+    // anything new starts.
+    if (self.io_thread_state) |state| state.stop.notify() catch {};
+    self.pty.cancelOutputRead();
+    if (self.io_writer_thread) |t| {
+        t.join();
+        self.io_writer_thread = null;
+    }
+    if (self.io_reader_thread) |t| {
+        t.join();
+        self.io_reader_thread = null;
+    }
+
+    // Acquire the new IO subsystem into locals FIRST. On any failure the OLD
+    // pty/command/mailbox/thread_state are still the surface's fields and stay
+    // deinit-safe — we just report failure and the old "exited" state holds.
+    var new_pty = Pty.open(.{ .ws_col = cols, .ws_row = rows }) catch |err|
+        return self.respawnFailed(err);
+    var new_command: Command = .{};
+    new_command.start(&new_pty, cmd, cwd) catch |err| {
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    var new_mailbox = termio.Mailbox.init() catch |err| {
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    const new_state = self.allocator.create(termio.Thread) catch |err| {
+        new_mailbox.deinit();
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+    new_state.* = termio.Thread.init() catch |err| {
+        self.allocator.destroy(new_state);
+        new_mailbox.deinit();
+        new_command.deinit();
+        new_pty.deinit();
+        return self.respawnFailed(err);
+    };
+
+    // Commit: tear down the OLD subsystem, swap in the new one.
+    if (self.io_thread_state) |state| {
+        state.deinit();
+        self.allocator.destroy(state);
+    }
+    self.mailbox.deinit();
+    self.command.deinit();
+    self.pty.deinit();
+    self.pty = new_pty;
+    self.command = new_command;
+    self.mailbox = new_mailbox;
+    self.io_thread_state = new_state;
+
+    // Sync the retained grid to the (possibly resized-while-exited) pane size
+    // and drop a separator into the existing scrollback.
+    {
+        self.render_state.mutex.lock();
+        defer self.render_state.mutex.unlock();
+        self.terminal.resize(self.allocator, cols, rows) catch {};
+        self.terminal.printString("\r\n[WispTerm] Reconnecting...\r\n") catch {};
+        self.clearSynchronizedOutputLocked();
+    }
+
+    // The reader loops on `!exited`; clear it and reset lifecycle BEFORE spawn.
+    self.exited.store(false, .release);
+    self.io_state_mutex.lock();
+    self.io_state = .starting;
+    self.io_state_mutex.unlock();
+
+    // ponytail: thread-spawn failure after the swap marks the surface failed
+    // with the NEW resources owned (still deinit-safe); we don't unwind the
+    // swap. Same residual exposure finishInit already has. Make spawn pre-swap
+    // only if this ever actually bites.
+    self.io_writer_thread = std.Thread.spawn(
+        threading.surface_thread_spawn_config,
+        termio.Thread.threadMain,
+        .{ new_state, self },
+    ) catch |err| {
+        self.failIo(.thread_spawn, err);
+        return;
+    };
+    self.io_reader_thread = std.Thread.spawn(
+        threading.surface_thread_spawn_config,
+        termio.ReadThread.threadMain,
+        .{self},
+    ) catch |err| {
+        self.failIo(.thread_spawn, err);
+        return;
+    };
+
+    self.setIoRunning();
+    self.dirty.store(true, .release);
+    window_backend.postWakeup();
+}
+
+/// Reconnect could not open a fresh PTY/command. The old (exited) resources are
+/// untouched and remain owned by the surface; surface a failure message.
+fn respawnFailed(self: *Surface, err: anyerror) void {
+    io_log.warn("respawn failed: {s}", .{@errorName(err)});
+    self.failIo(.thread_spawn, err);
 }
 
 // ============================================================================
@@ -1928,6 +2059,26 @@ test "Surface respawn target stores command and frees it without leaking" {
     // double-frees.
     surface.freeRespawnTarget(std.testing.allocator);
     try std.testing.expect(surface.respawn_command == null);
+}
+
+test "respawn is a no-op unless the surface has exited with a stored command" {
+    var surface: Surface = undefined;
+    try ioStateHarness(&surface);
+    defer ioStateHarnessDeinit(&surface);
+    surface.respawn_command = null;
+    surface.respawn_cwd = null;
+
+    // .running (harness default): guard returns immediately, state unchanged.
+    try std.testing.expect(!surface.isExited());
+    surface.respawn();
+    try std.testing.expect(surface.acceptsInput());
+
+    // .exited but no stored command: returns at the command guard, before any
+    // pty/thread work (which would crash on the null-threaded harness).
+    surface.markExited(.eof, .{ .exited = 0 });
+    try std.testing.expect(surface.isExited());
+    surface.respawn();
+    try std.testing.expect(surface.isExited());
 }
 
 test "exit status message shows the reconnect hint only when asked" {

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -58,6 +58,7 @@ pub const Operation = enum {
     terminal_resize,
     thread_spawn,
     thread_shutdown,
+    respawn,
 };
 
 pub const IoFailure = struct {
@@ -933,10 +934,12 @@ fn paintIoStatus(self: *Surface, state: IoState) void {
 /// Re-run this panel's original command in place after its process exited
 /// (Enter-to-reconnect). Keeps the terminal/scrollback; replaces the whole IO
 /// subsystem. Main-thread only (spawns threads, touches the mailbox). No-op
-/// unless the panel has cleanly exited and has a stored command.
+/// unless the panel has exited or failed and has a stored command.
 pub fn respawn(self: *Surface) void {
     switch (self.currentIoState()) {
-        .exited => {},
+        // .failed too: a respawn that fails to acquire a PTY lands here, and
+        // the user must still be able to press Enter to retry.
+        .exited, .failed => {},
         else => return,
     }
     const owned_cmd = self.respawn_command orelse {
@@ -996,6 +999,7 @@ pub fn respawn(self: *Surface) void {
     if (self.io_thread_state) |state| {
         state.deinit();
         self.allocator.destroy(state);
+        self.io_thread_state = null;
     }
     self.mailbox.deinit();
     self.command.deinit();
@@ -1051,7 +1055,7 @@ pub fn respawn(self: *Surface) void {
 /// untouched and remain owned by the surface; surface a failure message.
 fn respawnFailed(self: *Surface, err: anyerror) void {
     io_log.warn("respawn failed: {s}", .{@errorName(err)});
-    self.failIo(.thread_spawn, err);
+    self.failIo(.respawn, err);
 }
 
 // ============================================================================

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -196,6 +196,9 @@ pub threadlocal var g_copilot_restore_hook: ?*const fn (session_id: []const u8) 
 // controller/overlay dependency (and the import cycle).
 pub threadlocal var g_tmux_active_profiles_hook: ?*const fn (std.mem.Allocator) []const []const u8 = null;
 pub threadlocal var g_tmux_restore_hook: ?*const fn (profile_name: []const u8) bool = null;
+/// Re-supply a restored SSH surface's password from its saved profile and arm
+/// autofill (the snapshot carries no password). Registered by AppWindow.
+pub threadlocal var g_ssh_restore_arm_hook: ?*const fn (*Surface) void = null;
 
 // Forced title from config (overrides all tab titles)
 pub threadlocal var g_forced_title: ?[]const u8 = null;
@@ -1667,11 +1670,12 @@ fn surfaceFromSnapImpl(
             defer platform_pty_command.freeCommandLine(gpa, command);
             const surface = try Surface.init(gpa, cols, rows, platform_pty_command.commandLineFromOwned(command), g_scrollback_limit, cursor_style, cursor_blink, null);
             surface.attachRemoteClient(g_remote_client);
-            // SSH password is never persisted (security invariant I1). On restore,
-            // the native SSH client prompts interactively if key auth fails;
-            // the in-app password-autofill flow (which requires password_auth=true)
-            // does not engage here.
+            // SSH password is never persisted (security invariant I1). Restore the
+            // endpoint without a password, then let the arm hook re-supply it from
+            // the saved profile (host/user/port match) and arm autofill — so a
+            // restored session logs in without re-typing, like a fresh connect.
             surface.setSshConnection(s.user, s.host, port_slice, "", s.proxy_jump, false, g_ssh_legacy_algorithms);
+            if (g_ssh_restore_arm_hook) |hook| hook(surface);
             return surface;
         },
     }

--- a/src/input.zig
+++ b/src/input.zig
@@ -3524,6 +3524,16 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
         !ev.ctrl and !ev.alt and !ev.super and !ev.shift)
     {
         surface.respawn();
+        // Initial connect arms SSH password auto-injection; respawn only re-runs
+        // the command, so re-arm it here or the reconnect stalls at the password
+        // prompt. The surface keeps its ssh_connection (with the saved password)
+        // across respawn. Key-auth profiles report usesPasswordAuth()=false and
+        // are skipped.
+        if (surface.ssh_connection) |*conn| {
+            if (conn.usesPasswordAuth()) {
+                overlays.scheduleSshPasswordForSurface(surface, conn.password());
+            }
+        }
         return input_effects.repaint();
     }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -3515,6 +3515,18 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
 
     const surface = AppWindow.activeSurface() orelse return .none;
 
+    // A cleanly-exited panel (SSH closed, shell `exit`) stays open showing
+    // "Press Enter to reconnect". Plain Enter re-runs the panel's original
+    // command in place. Other keys fall through, so e.g. Shift+PageUp still
+    // scrolls the scrollback before reconnecting.
+    if (surface.isExited() and
+        ev.key_code == platform_input.key_enter and
+        !ev.ctrl and !ev.alt and !ev.super and !ev.shift)
+    {
+        surface.respawn();
+        return input_effects.repaint();
+    }
+
     // Track whether this keypress actually sends data to the PTY.
     // Like Ghostty, we only scroll-to-bottom when input is actually generated,
     // not for modifier-only keys or key combos that don't produce PTY output.

--- a/src/input.zig
+++ b/src/input.zig
@@ -3531,7 +3531,7 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
         // are skipped.
         if (surface.ssh_connection) |*conn| {
             if (conn.usesPasswordAuth()) {
-                overlays.scheduleSshPasswordForSurface(surface, conn.password());
+                overlays.scheduleSshPasswordForSurface(surface);
             }
         }
         return input_effects.repaint();

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -371,7 +371,12 @@ pub fn scpExecutableName() []const u8 {
 
 pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 {
     var pos: usize = 0;
-    if (!appendAscii(buf, &pos, "cmd.exe /k ssh.exe -tt ")) return null;
+    // `/c` (run then terminate), not `/k` (keep open): when ssh exits the cmd
+    // host exits too, so the panel's process actually ends. That lets the
+    // exited-panel reconnect flow fire ("Press Enter to reconnect") instead of
+    // dropping the user into a lingering local cmd prompt. The cmd wrapper is
+    // kept (vs bare ssh.exe) so the remote-command quoting below is unchanged.
+    if (!appendAscii(buf, &pos, "cmd.exe /c ssh.exe -tt ")) return null;
     if (!appendSshOptionString(buf, &pos, options, .interactive)) return null;
     if (options.port.len > 0) {
         if (!appendAscii(buf, &pos, "-p ")) return null;
@@ -397,8 +402,9 @@ pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 
 pub fn sshControlCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 {
     var pos: usize = 0;
     // Hidden controller transport: launch ssh.exe directly so process exit
-    // means the transport is really gone. Interactive SSH tabs keep the cmd.exe
-    // wrapper above so the user sees a normal shell after ssh exits.
+    // means the transport is really gone. Interactive SSH tabs wrap in
+    // `cmd.exe /c` (above) — also exits on ssh close, but via cmd so the
+    // remote-command quoting matches the interactive path.
     if (!appendAscii(buf, &pos, "ssh.exe -tt ")) return null;
     if (!appendSshOptionString(buf, &pos, options, .control)) return null;
     if (options.port.len > 0) {
@@ -701,7 +707,7 @@ test "windows pty command maps native shell titles to friendly display labels" {
 test "windows pty command classifies launch context from native command lines" {
     const allocator = std.testing.allocator;
 
-    const ssh = try allocCommandLineFromUtf8(allocator, "cmd.exe /k ssh.exe -tt user@example.test");
+    const ssh = try allocCommandLineFromUtf8(allocator, "cmd.exe /c ssh.exe -tt user@example.test");
     defer freeCommandLine(allocator, ssh);
     try std.testing.expectEqual(LaunchKind.ssh, launchKindForCommand(commandLineFromOwned(ssh)));
 
@@ -737,7 +743,7 @@ test "windows pty command builds SSH interactive command lines" {
     var buf: [1024]u8 = undefined;
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /k ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -p 2222 user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -p 2222 user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -748,7 +754,7 @@ test "windows pty command builds SSH interactive command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /k ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o HostkeyAlgorithms=+ssh-rsa,ssh-dss -o PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss -o KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 -o Ciphers=+aes128-cbc,3des-cbc user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o HostkeyAlgorithms=+ssh-rsa,ssh-dss -o PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss -o KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 -o Ciphers=+aes128-cbc,3des-cbc user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -760,7 +766,7 @@ test "windows pty command builds SSH interactive command lines" {
 
     // ProxyJump is inserted after the auth/legacy flags, before any port flag.
     try std.testing.expectEqualStrings(
-        "cmd.exe /k ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -770,7 +776,7 @@ test "windows pty command builds SSH interactive command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /k ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -782,7 +788,7 @@ test "windows pty command builds SSH interactive command lines" {
     // An interactive remote command gains the TERM_PROGRAM export so remote
     // Claude Code/Codex enable the Kitty keyboard protocol (#302).
     try std.testing.expectEqualStrings(
-        "cmd.exe /k ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 user@example.test \"export TERM_PROGRAM=ghostty; cd /srv && claude\"",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 user@example.test \"export TERM_PROGRAM=ghostty; cd /srv && claude\"",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2331,12 +2331,6 @@ pub const ModelProfileSwitchResult = enum {
     failed,
 };
 
-threadlocal var g_pending_ssh_password: [SSH_FIELD_MAX + 1]u8 = undefined;
-threadlocal var g_pending_ssh_password_len: usize = 0;
-threadlocal var g_pending_ssh_password_due_ms: i64 = 0;
-threadlocal var g_pending_ssh_password_deadline_ms: i64 = 0;
-threadlocal var g_pending_ssh_surface: ?*Surface = null;
-
 const SSH_PASSWORD_PROMPT_MIN_WAIT_MS: i64 = 250;
 const SSH_PASSWORD_PROMPT_TIMEOUT_MS: i64 = 60_000;
 const SSH_PROMPT_SCAN_MAX_COLS: usize = 4096;
@@ -3618,7 +3612,7 @@ fn connectSshProfileReturningSurfaceWithCommand(idx: usize, remote_command: []co
             surface.setTitleOverride(server_name);
         }
         if (conn.usesPasswordAuth()) {
-            scheduleSshPasswordForSurface(surface, conn.password());
+            scheduleSshPasswordForSurface(surface);
         }
         return surface;
     }
@@ -3645,59 +3639,85 @@ fn isPortTokenSafe(value: []const u8) bool {
 /// Queue password entry for a new SSH surface.
 ///
 /// OpenSSH only consumes the password after it has printed the password prompt.
-/// A fixed startup delay races slow networks, so the main-loop tick waits until
-/// the prompt is visible in terminal state before injecting the stored password.
-pub fn scheduleSshPasswordForSurface(surface: *Surface, password: []const u8) void {
-    const len = @min(password.len, SSH_FIELD_MAX);
+/// Arm SSH password autofill for `surface`. Once the remote password prompt
+/// shows up (after a short settle delay), `tickSessionLauncher` types the
+/// password stored in the surface's `ssh_connection`. Per-surface (no single
+/// global slot), so many sessions (re)connecting at once each get filled.
+/// Callers only arm password-auth connections (key auth is left to native ssh).
+pub fn scheduleSshPasswordForSurface(surface: *Surface) void {
     const now = std.time.milliTimestamp();
-    @memcpy(g_pending_ssh_password[0..len], password[0..len]);
-    g_pending_ssh_password[len] = '\r';
-    g_pending_ssh_password_len = len + 1;
-    g_pending_ssh_password_due_ms = now + SSH_PASSWORD_PROMPT_MIN_WAIT_MS;
-    g_pending_ssh_password_deadline_ms = now + SSH_PASSWORD_PROMPT_TIMEOUT_MS;
-    g_pending_ssh_surface = surface;
+    surface.ssh_autofill_due_ms = now + SSH_PASSWORD_PROMPT_MIN_WAIT_MS;
+    surface.ssh_autofill_deadline_ms = now + SSH_PASSWORD_PROMPT_TIMEOUT_MS;
+}
+
+/// Re-supply an SSH password from the saved profile config and arm autofill.
+/// Used on session restore: the snapshot carries no password (security invariant
+/// I1 — never persisted to session.json), so the password is matched back from
+/// the profile by host/user/port and copied into the live `ssh_connection`.
+/// No-op if the surface is not SSH, no profile matches, or the match is key-auth.
+pub fn armSshPasswordFromProfileForSurface(surface: *Surface) void {
+    const conn = surface.ssh_connection orelse return;
+    loadSshProfiles();
+    var idx: usize = 0;
+    while (idx < sshState().profile_count) : (idx += 1) {
+        const profile = &sshState().profiles[idx];
+        if (!std.mem.eql(u8, profileField(profile, .ip), conn.host())) continue;
+        if (!std.mem.eql(u8, profileField(profile, .user), conn.user())) continue;
+        const p_port = profileField(profile, .port);
+        const c_port = conn.port();
+        const ports_match = std.mem.eql(u8, p_port, c_port) or
+            (p_port.len == 0 and std.mem.eql(u8, c_port, "22")) or
+            (c_port.len == 0 and std.mem.eql(u8, p_port, "22"));
+        if (!ports_match) continue;
+        if ((sshProfileAuthMethod(profile) orelse return) != .password) return;
+        const password = profileField(profile, .password);
+        if (password.len == 0) return;
+        // Copy the password into the live ssh_connection so this connect (and any
+        // later Enter-reconnect of the same pane) can autofill it.
+        surface.setSshConnection(conn.user(), conn.host(), conn.port(), password, conn.proxyJump(), true, AppWindow.g_ssh_legacy_algorithms);
+        scheduleSshPasswordForSurface(surface);
+        return;
+    }
 }
 
 pub fn tickSessionLauncher() void {
-    if (g_pending_ssh_password_len == 0) return;
     const now = std.time.milliTimestamp();
-    if (now < g_pending_ssh_password_due_ms) return;
-
-    const surface = g_pending_ssh_surface orelse {
-        clearPendingSshPassword();
-        return;
-    };
-    if (!surfaceIsOpen(surface)) {
-        clearPendingSshPassword();
-        return;
-    }
-    if (now > g_pending_ssh_password_deadline_ms) {
-        clearPendingSshPassword();
-        return;
-    }
-    if (!surfaceHasSshPasswordPrompt(surface)) return;
-
-    AppWindow.input.writeTextToSurfacePty(surface, g_pending_ssh_password[0..g_pending_ssh_password_len]);
-    clearPendingSshPassword();
-}
-
-fn clearPendingSshPassword() void {
-    g_pending_ssh_password_len = 0;
-    g_pending_ssh_password_due_ms = 0;
-    g_pending_ssh_password_deadline_ms = 0;
-    g_pending_ssh_surface = null;
-}
-
-fn surfaceIsOpen(surface: *const Surface) bool {
     for (0..tab.g_tab_count) |tab_index| {
         const tab_state = tab.g_tabs[tab_index] orelse continue;
         if (tab_state.kind != .terminal) continue;
         var it = tab_state.tree.surfaces();
         while (it.next()) |entry| {
-            if (@intFromPtr(entry.surface) == @intFromPtr(surface)) return true;
+            maybeInjectSshPassword(entry.surface, now);
         }
     }
-    return false;
+}
+
+/// Inject the armed SSH password into `surface` once its own password prompt is
+/// on screen. Each surface is independent, so concurrently-restoring sessions
+/// each fill their own prompt. `ssh_autofill_deadline_ms == 0` means not armed.
+fn maybeInjectSshPassword(surface: *Surface, now: i64) void {
+    if (surface.ssh_autofill_deadline_ms == 0) return;
+    if (now < surface.ssh_autofill_due_ms) return;
+    if (now > surface.ssh_autofill_deadline_ms) {
+        surface.ssh_autofill_deadline_ms = 0; // gave up waiting for the prompt
+        return;
+    }
+    if (surface.ssh_connection) |*conn| {
+        const pw = conn.password();
+        if (pw.len == 0) {
+            surface.ssh_autofill_deadline_ms = 0;
+            return;
+        }
+        if (!surfaceHasSshPasswordPrompt(surface)) return; // prompt not up yet
+        var buf: [129]u8 = undefined; // ssh_connection password_buf is [128]
+        const len = @min(pw.len, buf.len - 1);
+        @memcpy(buf[0..len], pw[0..len]);
+        buf[len] = '\r';
+        AppWindow.input.writeTextToSurfacePty(surface, buf[0 .. len + 1]);
+        surface.ssh_autofill_deadline_ms = 0; // injected once
+    } else {
+        surface.ssh_autofill_deadline_ms = 0;
+    }
 }
 
 fn surfaceHasSshPasswordPrompt(surface: *Surface) bool {

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -242,7 +242,7 @@ comptime {
     if (std.mem.indexOf(u8, pty_command_source, "if (std.ascii.eqlIgnoreCase(kind, \"powershell\")) return") != null or
         std.mem.indexOf(u8, pty_command_source, "if (!appendAscii(buf, &pos, \"wsl.exe\"))") != null or
         std.mem.indexOf(u8, pty_command_source, "return .{ \"wsl.exe\"") != null or
-        std.mem.indexOf(u8, pty_command_source, "std.fmt.bufPrint(buf, \"cmd.exe /k ssh.exe") != null)
+        std.mem.indexOf(u8, pty_command_source, "std.fmt.bufPrint(buf, \"cmd.exe /c ssh.exe") != null)
     {
         @compileError("platform/pty_command.zig must delegate concrete tab, WSL, and SSH command construction to backend implementations");
     }
@@ -251,7 +251,7 @@ comptime {
     {
         @compileError("platform/pty_command.zig must delegate concrete launch-kind command classification to backend implementations");
     }
-    if (std.mem.indexOf(u8, pty_command_source, "\"cmd.exe /k ssh.exe") != null or
+    if (std.mem.indexOf(u8, pty_command_source, "\"cmd.exe /c ssh.exe") != null or
         std.mem.indexOf(u8, pty_command_source, "\"wsl.exe ~") != null)
     {
         @compileError("platform/pty_command.zig facade tests must keep concrete Windows SSH/WSL command-line samples in backend implementations");


### PR DESCRIPTION
Follow-up to #428. That PR shipped in-panel reconnect + SSH password autofill, verified working on macOS — but on **Windows** the reconnect never fired.

## Root cause

Interactive SSH tabs on Windows were launched as `cmd.exe /k ssh.exe -tt …`. The `/k` flag keeps the cmd host open after `ssh` exits, so the **panel's process never ended** — it dropped to a local `C:\…>` prompt instead. The exited-panel reconnect flow only triggers when the panel process actually exits, so on Windows it could never engage. (On macOS the panel process *is* ssh, so it exits on close → reconnect works.)

Confirmed via `strings` + the Windows command builder (`sshInteractiveCommand`, `src/platform/pty_command_windows.zig`).

## Fix

`cmd.exe /k ssh.exe …` → `cmd.exe /c ssh.exe …`. `/c` runs ssh then terminates the cmd host, so the panel exits when ssh closes → `Press Enter to reconnect` shows, and Enter re-runs the stored command. The cmd wrapper is intentionally kept (vs bare `ssh.exe`) so the remote-command quoting is byte-for-byte unchanged — only the exit semantics change.

Updated the Windows backend command-sample tests and the facade guard strings to match.

## Verification

- ✅ Windows cross-compile (`zig build`)
- ✅ macOS `zig build test-full -Dtarget=aarch64-macos`
- ✅ `zig fmt`
- ⚠️ **Runtime behavior is Windows-only and not yet confirmed on a Windows host** — needs a Windows build + manual test (connect an SSH profile → `exit` → expect `Press Enter to reconnect` → Enter reconnects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)