### PR TITLE
fix(ssh): stop helper connections from tripping brute-force risk control (#422) + auth-method toggle

### DIFF
--- a/src/html/server.zig
+++ b/src/html/server.zig
@@ -478,7 +478,7 @@ fn spawnSshCommand(
     appendSshOption(&argv_buf, &argc, "ServerAliveInterval=60");
     appendSshOption(&argv_buf, &argc, "ServerAliveCountMax=3");
     if (conn.usesPasswordAuth()) {
-        appendSshOption(&argv_buf, &argc, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        appendSshOption(&argv_buf, &argc, "PreferredAuthentications=password,keyboard-interactive");
         appendSshOption(&argv_buf, &argc, "NumberOfPasswordPrompts=1");
     } else {
         appendSshOption(&argv_buf, &argc, "BatchMode=yes");

--- a/src/platform/remote_file.zig
+++ b/src/platform/remote_file.zig
@@ -129,7 +129,7 @@ pub fn sshExecCaptureFull(allocator: std.mem.Allocator, conn: anytype, command: 
     if (conn.usesPasswordAuth()) {
         argv_buf[argc] = "-o";
         argc += 1;
-        argv_buf[argc] = "PreferredAuthentications=publickey,password,keyboard-interactive";
+        argv_buf[argc] = "PreferredAuthentications=password,keyboard-interactive";
         argc += 1;
         argv_buf[argc] = "-o";
         argc += 1;

--- a/src/port_forward/manager.zig
+++ b/src/port_forward/manager.zig
@@ -673,7 +673,7 @@ fn buildSshArgv(allocator: std.mem.Allocator, rule: *const rule_mod.Rule, conn: 
         try appendSshOption(allocator, &argv, "Ciphers=+aes128-cbc,3des-cbc");
     }
     if (conn.usesPasswordAuth()) {
-        try appendSshOption(allocator, &argv, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        try appendSshOption(allocator, &argv, "PreferredAuthentications=password,keyboard-interactive");
         try appendSshOption(allocator, &argv, "NumberOfPasswordPrompts=1");
     } else {
         try appendSshOption(allocator, &argv, "BatchMode=yes");
@@ -1083,7 +1083,7 @@ test "port_forward_manager: password auth argv uses askpass compatible options a
     defer arena.deinit();
 
     const password_argv = try buildSshArgvForTest(arena.allocator(), &rule, &password_conn);
-    try std.testing.expect(argvContainsForTest(password_argv, "PreferredAuthentications=publickey,password,keyboard-interactive"));
+    try std.testing.expect(argvContainsForTest(password_argv, "PreferredAuthentications=password,keyboard-interactive"));
     try std.testing.expect(argvContainsForTest(password_argv, "NumberOfPasswordPrompts=1"));
     try std.testing.expect(!argvContainsForTest(password_argv, "BatchMode=yes"));
     try expectArgvLacksForTest(password_argv, "secret");
@@ -1091,7 +1091,7 @@ test "port_forward_manager: password auth argv uses askpass compatible options a
     var key_conn = sshConnectionForTest("alice", "key.test", "", "", "", false, false);
     const key_argv = try buildSshArgvForTest(arena.allocator(), &rule, &key_conn);
     try std.testing.expect(argvContainsForTest(key_argv, "BatchMode=yes"));
-    try std.testing.expect(!argvContainsForTest(key_argv, "PreferredAuthentications=publickey,password,keyboard-interactive"));
+    try std.testing.expect(!argvContainsForTest(key_argv, "PreferredAuthentications=password,keyboard-interactive"));
 }
 
 test "port_forward_manager: running child exit becomes error on tick" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2521,6 +2521,7 @@ pub fn sessionLauncherInsertChar(codepoint: u21) void {
         if (codepoint > 0x7f) return;
         if (sshState().focus >= SSH_FIELD_COUNT) return;
         const field = sshState().focus;
+        if (field == @intFromEnum(SshField.auth_method)) return; // ←/→ toggle, not free text
         if (sshState().lens[field] >= SSH_FIELD_MAX) return;
         sshState().bufs[field][sshState().lens[field]] = @intCast(codepoint);
         sshState().lens[field] += 1;
@@ -2555,6 +2556,7 @@ pub fn sessionLauncherPasteText(text: []const u8) bool {
     }
     if (g_ssh_form_visible) {
         if (sshState().focus >= SSH_FIELD_COUNT) return false;
+        if (sshState().focus == @intFromEnum(SshField.auth_method)) return true; // toggle field, ignore paste
         appendSshFormText(sshState().focus, text);
         return true;
     }
@@ -2718,8 +2720,15 @@ fn sessionLauncherHandleKeyImpl(ev: input_key.KeyEvent) void {
     switch (ev.key) {
         .tab, .arrow_down => sshState().focusNextRow(),
         .arrow_up => sshState().focusPrevRow(),
+        .arrow_right => {
+            if (sshState().focus == @intFromEnum(SshField.auth_method)) cycleSshFormAuthMethod(true);
+        },
+        .arrow_left => {
+            if (sshState().focus == @intFromEnum(SshField.auth_method)) cycleSshFormAuthMethod(false);
+        },
         .backspace => {
-            if (sshState().focus < SSH_FIELD_COUNT and sshState().lens[sshState().focus] > 0) sshState().lens[sshState().focus] -= 1;
+            // auth_method is a ←/→ toggle, not a text field — never backspace it.
+            if (sshState().focus < SSH_FIELD_COUNT and sshState().focus != @intFromEnum(SshField.auth_method) and sshState().lens[sshState().focus] > 0) sshState().lens[sshState().focus] -= 1;
         },
         .enter => runSshFormFocusAction(),
         else => {},
@@ -3110,6 +3119,27 @@ fn sshFormAuthMethod() ?ssh_connection.SshAuthMethod {
     const raw = sshField(.auth_method);
     if (std.mem.trim(u8, raw, " \t\r\n").len == 0) return defaultSshAuthMethodForPassword(sshField(.password));
     return parseSshAuthMethod(raw);
+}
+
+/// Cycle the auth-method form field to the next/previous valid method. The field
+/// is constrained to password/key/credentials, so users toggle with ←/→ instead
+/// of typing an arbitrary string.
+fn cycleSshFormAuthMethod(forward: bool) void {
+    const idx = @intFromEnum(SshField.auth_method);
+    const current: ssh_connection.SshAuthMethod = sshFormAuthMethod() orelse .credentials;
+    const next = current.cycle(forward).fieldValue();
+    const len = @min(next.len, SSH_FIELD_MAX);
+    @memcpy(sshState().bufs[idx][0..len], next[0..len]);
+    sshState().lens[idx] = len;
+}
+
+/// Auth-method row display: current method name plus the ←/→ toggle affordance.
+fn sshAuthMethodDisplay() []const u8 {
+    const S = struct {
+        threadlocal var buf: [48]u8 = undefined;
+    };
+    const m: ssh_connection.SshAuthMethod = sshFormAuthMethod() orelse .credentials;
+    return std.fmt.bufPrint(&S.buf, "{s}   <-/->", .{m.fieldValue()}) catch m.fieldValue();
 }
 
 fn sshProfileAuthMethod(profile: *const SshProfile) ?ssh_connection.SshAuthMethod {
@@ -4968,7 +4998,7 @@ fn sessionDesiredBoxWidth() f32 {
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_password, sshField(.password)));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_port, sshField(.port)));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_jump_host, sshField(.proxy_jump)));
-        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_auth_method, sshField(.auth_method)));
+        desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_auth_method, sshAuthMethodDisplay()));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_ssh_identity_file, sshField(.identity_file)));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save_connect, platform_pty_command.sshLauncherDetail()));
         desired = @max(desired, sessionTwoColumnWidth(i18n.s().sl_save, i18n.s().sl_v_profile));
@@ -5657,7 +5687,7 @@ pub fn renderSessionLauncher(window_width: f32, window_height: f32, top_offset: 
     renderSessionField(layout, window_height, @intFromEnum(SshField.password), i18n.s().sl_ssh_password, sshField(.password), true);
     renderSessionField(layout, window_height, @intFromEnum(SshField.port), i18n.s().sl_ssh_port, sshField(.port), false);
     renderSessionField(layout, window_height, @intFromEnum(SshField.proxy_jump), i18n.s().sl_ssh_jump_host, sshField(.proxy_jump), false);
-    renderSessionField(layout, window_height, @intFromEnum(SshField.auth_method), i18n.s().sl_ssh_auth_method, sshField(.auth_method), false);
+    renderSessionField(layout, window_height, @intFromEnum(SshField.auth_method), i18n.s().sl_ssh_auth_method, sshAuthMethodDisplay(), false);
     renderSessionField(layout, window_height, @intFromEnum(SshField.identity_file), i18n.s().sl_ssh_identity_file, sshField(.identity_file), false);
     renderSessionRow(layout, window_height, SSH_FIELD_COUNT, i18n.s().sl_save_connect, platform_pty_command.sshLauncherDetail(), sshState().focus == SSH_FIELD_COUNT);
     renderSessionRow(layout, window_height, SSH_FIELD_COUNT + 1, i18n.s().sl_save, i18n.s().sl_v_profile, sshState().focus == SSH_FIELD_COUNT + 1);

--- a/src/ssh/connection.zig
+++ b/src/ssh/connection.zig
@@ -26,6 +26,24 @@ pub const SshAuthMethod = enum {
             .credentials => "credentials",
         };
     }
+
+    /// Cycle to the next/previous auth method (wraps). Used by the SSH profile
+    /// form so the auth-method field is a ←/→ toggle over valid values instead
+    /// of a free-text field.
+    pub fn cycle(self: SshAuthMethod, forward: bool) SshAuthMethod {
+        if (forward) {
+            return switch (self) {
+                .password => .key,
+                .key => .credentials,
+                .credentials => .password,
+            };
+        }
+        return switch (self) {
+            .password => .credentials,
+            .key => .password,
+            .credentials => .key,
+        };
+    }
 };
 
 pub const SshConnection = struct {
@@ -146,4 +164,14 @@ test "fromParts supports explicit key auth" {
     try std.testing.expectEqual(SshAuthMethod.key, c.auth_method);
     try std.testing.expectEqualStrings("C:/Users/alice/.ssh/id_ed25519", c.identityFile());
     try std.testing.expect(!c.password_auth);
+}
+
+test "SshAuthMethod.cycle wraps forward and backward over all three methods" {
+    try std.testing.expectEqual(SshAuthMethod.key, SshAuthMethod.password.cycle(true));
+    try std.testing.expectEqual(SshAuthMethod.credentials, SshAuthMethod.key.cycle(true));
+    try std.testing.expectEqual(SshAuthMethod.password, SshAuthMethod.credentials.cycle(true));
+
+    try std.testing.expectEqual(SshAuthMethod.credentials, SshAuthMethod.password.cycle(false));
+    try std.testing.expectEqual(SshAuthMethod.password, SshAuthMethod.key.cycle(false));
+    try std.testing.expectEqual(SshAuthMethod.key, SshAuthMethod.credentials.cycle(false));
 }

--- a/src/ssh/scp.zig
+++ b/src/ssh/scp.zig
@@ -1123,7 +1123,7 @@ fn appendSshOptions(
     if (conn.usesPasswordAuth()) {
         argv_buf[argc] = "-o";
         argc += 1;
-        argv_buf[argc] = "PreferredAuthentications=publickey,password,keyboard-interactive";
+        argv_buf[argc] = "PreferredAuthentications=password,keyboard-interactive";
         argc += 1;
         argv_buf[argc] = "-o";
         argc += 1;

--- a/src/ssh/tunnel.zig
+++ b/src/ssh/tunnel.zig
@@ -285,7 +285,7 @@ fn spawnSshTunnel(allocator: std.mem.Allocator, conn: *const ssh_connection.SshC
     appendSshOption(&argv_buf, &argc, "ServerAliveInterval=60");
     appendSshOption(&argv_buf, &argc, "ServerAliveCountMax=3");
     if (conn.usesPasswordAuth()) {
-        appendSshOption(&argv_buf, &argc, "PreferredAuthentications=publickey,password,keyboard-interactive");
+        appendSshOption(&argv_buf, &argc, "PreferredAuthentications=password,keyboard-interactive");
         appendSshOption(&argv_buf, &argc, "NumberOfPasswordPrompts=1");
     } else {
         appendSshOption(&argv_buf, &argc, "BatchMode=yes");


### PR DESCRIPTION
Fixes #422 — 连接 xiyouyun 触发 SSH 登录爆破风控。

## 根因

主交互 SSH tab 对密码 profile 已经强制只走密码(`PreferredAuthentications=password,keyboard-interactive` + `PubkeyAuthentication=no`)。但**所有辅助连接**——文件浏览器远程列目录、SCP/预览、SSH 隧道、HTML 隧道、端口转发——用的是 `PreferredAuthentications=publickey,password,keyboard-interactive`,**公钥优先**。

密码 profile 不带 `-i`、也没有 `IdentitiesOnly=yes`,OpenSSH 会把本机 ssh-agent 里的每一把 key + 默认身份文件逐个发给服务器认证,失败后才回落到密码。每一次都是服务器日志里一条 `Failed publickey`;再叠加打开一个远程 tab 常常同时拉起多条 helper 连接,几秒内同一 IP 就刷出十几条失败认证,正好命中云厂商爆破风控。不同厂商阈值不同 → xiyouyun 被封、guotosky 没事。

## 改动

**1. 对齐 helper 认证策略(修根因)**

5 处 helper 的密码分支去掉 `publickey`,改为 `password,keyboard-interactive`,与主 tab 一致——密码 profile 直接走密码(恰好 1 次认证),agent 里的 key 一把都不发。密钥 profile 不变(`BatchMode=yes` + `-i`)。

| helper | 文件 |
|---|---|
| 文件浏览器远程列目录 | `src/platform/remote_file.zig` |
| SCP / 预览 | `src/ssh/scp.zig` |
| SSH 隧道 | `src/ssh/tunnel.zig` |
| HTML 预览隧道 | `src/html/server.zig` |
| 端口转发 | `src/port_forward/manager.zig` |

**2. 认证方式字段改成 ←/→ 开关(顺手)**

SSH profile 表单的"认证方式"行原本是手写文本,打错会静默回落到默认探测。现在约束为合法枚举(password / key / credentials),用 ←/→ 切换(和 AI 表单的 Protocol/Vision 行一致):
- `SshAuthMethod.cycle()` 前后循环三种方式;
- auth_method 拒绝键入/粘贴/退格,只有 ←/→ 能改;
- 行渲染 `<method>   <-/->` 显示可切换提示。

## 测试

- `SshAuthMethod.cycle` 前后循环单测(connection.zig)
- `zig build test` 快速套件 EXIT=0
- `zig build test-macos-ui` 编译 + UI 冒烟 EXIT=0

## 审阅者须知

- 只改了密码分支;`PreferredAuthentications` 里不列 `publickey` 即可让 OpenSSH 完全不尝试公钥(与主 tab 额外的 `PubkeyAuthentication=no` 冗余保险功能等价)。零新增 argv 条目,scp 的定长 buffer/索引断言不受影响。
- 未做真实 xiyouyun 复现;根因经代码核查确认。建议合入后按 issue 里的验证法(只开一个普通 SSH tab、关掉文件浏览器/端口转发/预览)对照服务器日志确认失败认证条数下降。

🤖 Generated with [Claude Code](https://claude.com/claude-code)