### PR TITLE
[codex] d3d11 offscreen framebuffer foundation

### DIFF
--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -74,6 +74,9 @@ const State = struct {
     swapchain: *anyopaque,
     backbuffer: ?*anyopaque = null,
     rtv: ?*anyopaque = null,
+    current_rtv: ?*anyopaque = null,
+    current_width: i32 = 0,
+    current_height: i32 = 0,
     vertex_shader: ?*anyopaque = null,
     pixel_shader: ?*anyopaque = null,
     width: i32,
@@ -85,6 +88,9 @@ const State = struct {
             core.comRelease(rtv);
             self.rtv = null;
         }
+        self.current_rtv = null;
+        self.current_width = 0;
+        self.current_height = 0;
         if (self.backbuffer) |backbuffer| {
             core.comRelease(backbuffer);
             self.backbuffer = null;
@@ -239,20 +245,32 @@ fn createRenderTarget(self: *State, width: i32, height: i32) InitError!void {
 }
 
 fn bindRenderTargetAndViewport(self: *State) void {
+    bindRenderTargetViewForState(self, self.rtv, self.width, self.height);
+}
+
+fn bindRenderTargetViewForState(self: *State, rtv: ?*anyopaque, width: i32, height: i32) void {
+    if (rtv == null) return;
     const om_set = core.comCall(self.context, core.slot.D3D11DeviceContext_OMSetRenderTargets, *const fn (*anyopaque, u32, [*]const ?*anyopaque, ?*anyopaque) callconv(.winapi) void);
-    var rtvs = [_]?*anyopaque{self.rtv.?};
+    var rtvs = [_]?*anyopaque{rtv};
     om_set(self.context, 1, &rtvs, null);
+    self.current_rtv = rtv;
+    self.current_width = width;
+    self.current_height = height;
 
     const viewport = core.D3D11_VIEWPORT{
         .top_left_x = 0,
         .top_left_y = 0,
-        .width = @floatFromInt(@max(self.width, 1)),
-        .height = @floatFromInt(@max(self.height, 1)),
+        .width = @floatFromInt(@max(width, 1)),
+        .height = @floatFromInt(@max(height, 1)),
         .min_depth = 0,
         .max_depth = 1,
     };
     const rs_viewports = core.comCall(self.context, core.slot.D3D11DeviceContext_RSSetViewports, *const fn (*anyopaque, u32, *const core.D3D11_VIEWPORT) callconv(.winapi) void);
     rs_viewports(self.context, 1, &viewport);
+}
+
+pub fn bindRenderTargetView(rtv: ?*anyopaque, width: i32, height: i32) void {
+    if (state) |*self| bindRenderTargetViewForState(self, rtv, width, height);
 }
 
 fn createPhase2Pipeline(self: *State) InitError!void {
@@ -345,8 +363,15 @@ pub fn swapchainSize() ?struct { width: i32, height: i32 } {
     return if (state) |*self| .{ .width = self.width, .height = self.height } else null;
 }
 
+pub fn currentRenderTargetSize() ?struct { width: i32, height: i32 } {
+    return if (state) |*self| .{ .width = self.current_width, .height = self.current_height } else null;
+}
+
 pub fn beginFrame() void {
-    if (state) |*self| self.feature_draws_this_frame = false;
+    if (state) |*self| {
+        self.feature_draws_this_frame = false;
+        bindRenderTargetAndViewport(self);
+    }
 }
 
 pub fn noteFeatureDraw() void {
@@ -384,10 +409,14 @@ pub fn resize(width: i32, height: i32) bool {
 pub fn clear(r: f32, g: f32, b: f32, a: f32) void {
     if (state == null) return;
     const self = &state.?;
-    bindRenderTargetAndViewport(self);
+    const rtv = self.current_rtv orelse self.rtv orelse return;
+    if (self.rtv) |backbuffer_rtv| {
+        if (rtv == backbuffer_rtv) bindRenderTargetAndViewport(self);
+    }
+    const bound_rtv = self.current_rtv orelse rtv;
     const color = [_]f32{ r, g, b, a };
     const clear_rtv = core.comCall(self.context, core.slot.D3D11DeviceContext_ClearRenderTargetView, *const fn (*anyopaque, *anyopaque, *const [4]f32) callconv(.winapi) void);
-    clear_rtv(self.context, self.rtv.?, &color);
+    clear_rtv(self.context, bound_rtv, &color);
 }
 
 pub fn drawPhase2Quad() void {

--- a/src/renderer/gpu/d3d11/Framebuffer.zig
+++ b/src/renderer/gpu/d3d11/Framebuffer.zig
@@ -1,10 +1,14 @@
-//! D3D11 framebuffer compatibility wrapper.
+//! D3D11 off-screen framebuffer.
 //!
-//! The Phase III terminal-grid path renders directly to the swapchain
-//! backbuffer. Offscreen D3D11 framebuffer ownership can be made real when the
-//! auxiliary UI/preview renderers need it.
+//! Mirrors the OpenGL/Metal public surface while owning a real Direct3D render
+//! target: an `ID3D11Texture2D` with both RTV and SRV views. The RTV is bound
+//! for drawing; the texture handle is returned for later sampling/compositing.
 
+const std = @import("std");
+
+const Context = @import("Context.zig");
 const c = @import("c.zig");
+const core = @import("../../../platform/dxgi_core.zig");
 const Texture = @import("Texture.zig");
 const render_state = @import("render_state.zig");
 const Framebuffer = @This();
@@ -13,8 +17,9 @@ handle: c.GLuint = 0,
 color: c.GLuint = 0,
 width: c_int = 0,
 height: c_int = 0,
+rtv: ?*anyopaque = null,
 
-threadlocal var next_handle: c.GLuint = 1000;
+threadlocal var next_handle: c.GLuint = 1;
 
 fn allocHandle() c.GLuint {
     const h = next_handle;
@@ -24,13 +29,42 @@ fn allocHandle() c.GLuint {
 }
 
 pub fn initColor(width: c_int, height: c_int) ?Framebuffer {
-    const color = Texture.create();
-    if (!color.isValid()) return null;
-    return .{ .handle = allocHandle(), .color = color.handle, .width = width, .height = height };
+    if (width <= 0 or height <= 0) return null;
+
+    var color = Texture.createRenderTarget(width, height, .rgba8, .linear_clamp) orelse return null;
+
+    const device = Context.deviceHandle() orelse {
+        color.destroy();
+        return null;
+    };
+    const native_texture = Texture.nativeTexture(color.handle) orelse {
+        color.destroy();
+        return null;
+    };
+    const create_rtv = core.comCall(device, core.slot.D3D11Device_CreateRenderTargetView, *const fn (
+        *anyopaque,
+        *anyopaque,
+        ?*const anyopaque,
+        *?*anyopaque,
+    ) callconv(.winapi) core.HRESULT);
+    var rtv: ?*anyopaque = null;
+    if (create_rtv(device, native_texture, null, &rtv) < 0 or rtv == null) {
+        std.debug.print("D3D11 framebuffer RTV creation failed ({}x{})\n", .{ width, height });
+        color.destroy();
+        return null;
+    }
+
+    return .{
+        .handle = allocHandle(),
+        .color = color.handle,
+        .width = width,
+        .height = height,
+        .rtv = rtv,
+    };
 }
 
 pub fn isValid(self: Framebuffer) bool {
-    return self.handle != 0 and self.color != 0;
+    return self.handle != 0 and self.color != 0 and self.rtv != null and Texture.fromHandle(self.color).isValid();
 }
 
 pub fn colorTexture(self: Framebuffer) Texture {
@@ -38,11 +72,27 @@ pub fn colorTexture(self: Framebuffer) Texture {
 }
 
 pub fn bind(self: Framebuffer) void {
+    if (!self.isValid()) return;
+    if (render_state.pre_change_hook) |hook| hook();
+    Texture.unbindShaderResourceSlots(0, 16);
+    Context.bindRenderTargetView(self.rtv, self.width, self.height);
+    render_state.setRenderTargetSize(self.width, self.height);
     render_state.setViewport(0, 0, self.width, self.height);
 }
 
-pub fn unbind() void {}
+pub fn unbind() void {
+    if (render_state.pre_change_hook) |hook| hook();
+    Context.bindBackbufferRenderTarget();
+    if (Context.currentRenderTargetSize()) |size| {
+        render_state.setRenderTargetSize(size.width, size.height);
+    }
+}
 
 pub fn deinit(self: *Framebuffer) void {
+    if (self.rtv) |rtv| core.comRelease(rtv);
+    if (self.color != 0) {
+        var color = Texture.fromHandle(self.color);
+        color.destroy();
+    }
     self.* = .{};
 }

--- a/src/renderer/gpu/d3d11/Texture.zig
+++ b/src/renderer/gpu/d3d11/Texture.zig
@@ -148,7 +148,15 @@ fn samplerDesc(mode: types.SamplerMode) core.D3D11_SAMPLER_DESC {
 }
 
 fn createSampler(e: *Entry, mode: types.SamplerMode) bool {
-    const device = Context.deviceHandle() orelse return false;
+    const sampler = createSamplerNative(mode) orelse return false;
+    if (e.sampler) |old| core.comRelease(old);
+    e.sampler = sampler;
+    e.sampler_mode = mode;
+    return true;
+}
+
+fn createSamplerNative(mode: types.SamplerMode) ?*anyopaque {
+    const device = Context.deviceHandle() orelse return null;
     const create_sampler = core.comCall(device, core.slot.D3D11Device_CreateSamplerState, *const fn (
         *anyopaque,
         *const core.D3D11_SAMPLER_DESC,
@@ -156,11 +164,8 @@ fn createSampler(e: *Entry, mode: types.SamplerMode) bool {
     ) callconv(.winapi) core.HRESULT);
     const desc = samplerDesc(mode);
     var sampler: ?*anyopaque = null;
-    if (create_sampler(device, &desc, &sampler) < 0 or sampler == null) return false;
-    if (e.sampler) |old| core.comRelease(old);
-    e.sampler = sampler;
-    e.sampler_mode = mode;
-    return true;
+    if (create_sampler(device, &desc, &sampler) < 0 or sampler == null) return null;
+    return sampler;
 }
 
 pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopaque, o: Upload) void {
@@ -224,6 +229,77 @@ pub fn upload2D(self: Texture, width: c_int, height: c_int, data: ?*const anyopa
     }
 }
 
+pub fn createRenderTarget(width: c_int, height: c_int, format: types.TextureFormat, sampler: types.SamplerMode) ?Texture {
+    if (width <= 0 or height <= 0) return null;
+    var texture = create();
+    if (texture.handle == 0) return null;
+    if (!texture.allocateRenderTarget(width, height, format, sampler)) {
+        texture.destroy();
+        return null;
+    }
+    return texture;
+}
+
+fn allocateRenderTarget(self: Texture, width: c_int, height: c_int, format: types.TextureFormat, sampler: types.SamplerMode) bool {
+    const e = entry(self.handle) orelse return false;
+    const device = Context.deviceHandle() orelse return false;
+    const w: u32 = @intCast(width);
+    const h: u32 = @intCast(height);
+    const desc = core.D3D11_TEXTURE2D_DESC{
+        .width = w,
+        .height = h,
+        .mip_levels = 1,
+        .array_size = 1,
+        .format = dxgiFormat(format),
+        .sample_desc = .{ .count = 1, .quality = 0 },
+        .usage = core.D3D11_USAGE_DEFAULT,
+        .bind_flags = core.D3D11_BIND_SHADER_RESOURCE | core.D3D11_BIND_RENDER_TARGET,
+        .cpu_access_flags = 0,
+        .misc_flags = 0,
+    };
+    const create_texture = core.comCall(device, core.slot.D3D11Device_CreateTexture2D, *const fn (
+        *anyopaque,
+        *const core.D3D11_TEXTURE2D_DESC,
+        ?*const core.D3D11_SUBRESOURCE_DATA,
+        *?*anyopaque,
+    ) callconv(.winapi) core.HRESULT);
+    var native_texture: ?*anyopaque = null;
+    if (create_texture(device, &desc, null, &native_texture) < 0 or native_texture == null) {
+        std.debug.print("D3D11 render-target texture creation failed ({}x{})\n", .{ width, height });
+        return false;
+    }
+
+    const create_srv = core.comCall(device, core.slot.D3D11Device_CreateShaderResourceView, *const fn (
+        *anyopaque,
+        *anyopaque,
+        ?*const anyopaque,
+        *?*anyopaque,
+    ) callconv(.winapi) core.HRESULT);
+    var srv: ?*anyopaque = null;
+    if (create_srv(device, native_texture.?, null, &srv) < 0 or srv == null) {
+        std.debug.print("D3D11 render-target SRV creation failed ({}x{})\n", .{ width, height });
+        core.comRelease(native_texture.?);
+        return false;
+    }
+
+    const native_sampler = createSamplerNative(sampler) orelse {
+        std.debug.print("D3D11 render-target sampler creation failed\n", .{});
+        core.comRelease(srv.?);
+        core.comRelease(native_texture.?);
+        return false;
+    };
+
+    e.releaseNative();
+    e.texture = native_texture;
+    e.srv = srv;
+    e.sampler = native_sampler;
+    e.width = width;
+    e.height = height;
+    e.format = format;
+    e.sampler_mode = sampler;
+    return true;
+}
+
 pub fn setSamplerMode(self: Texture, sampler: types.SamplerMode) void {
     const e = entry(self.handle) orelse return;
     if (!createSampler(e, sampler)) {
@@ -270,6 +346,20 @@ pub fn nativeTexture(handle: c.GLuint) ?*anyopaque {
 
 pub fn nativeSrv(handle: c.GLuint) ?*anyopaque {
     return if (entry(handle)) |e| e.srv else null;
+}
+
+pub fn unbindShaderResourceSlots(first_slot: u32, count: u32) void {
+    if (count == 0) return;
+    const context = Context.contextHandle() orelse return;
+    var null_srvs: [16]?*anyopaque = @splat(null);
+    const capped = @min(count, null_srvs.len);
+    const ps_set_srv = core.comCall(context, core.slot.D3D11DeviceContext_PSSetShaderResources, *const fn (
+        *anyopaque,
+        u32,
+        u32,
+        [*]const ?*anyopaque,
+    ) callconv(.winapi) void);
+    ps_set_srv(context, first_slot, @intCast(capped), &null_srvs);
 }
 
 pub fn destroy(self: *Texture) void {

--- a/src/renderer/gpu/d3d11/render_state.zig
+++ b/src/renderer/gpu/d3d11/render_state.zig
@@ -20,6 +20,7 @@ pub threadlocal var pre_change_hook: ?*const fn () void = null;
 threadlocal var blend_enabled = false;
 threadlocal var blend_mode: BlendMode = .alpha;
 threadlocal var viewport: Viewport = .{ .x = 0, .y = 0, .w = 0, .h = 0 };
+threadlocal var render_target_size: Size = .{ .w = 0, .h = 0 };
 threadlocal var scissor: ScissorState = .{
     .enabled = false,
     .box = .{ .x = 0, .y = 0, .w = 0, .h = 0 },
@@ -35,6 +36,9 @@ inline fn notifyPreChange() void {
 
 pub fn beginFrame() void {
     Context.beginFrame();
+    if (Context.currentRenderTargetSize()) |size| {
+        render_target_size = .{ .w = size.width, .h = size.height };
+    }
 }
 
 pub fn endFrame() void {
@@ -79,6 +83,10 @@ pub fn setViewport(x: i32, y: i32, w: i32, h: i32) void {
 
 pub fn viewportSize() Size {
     return .{ .w = viewport.w, .h = viewport.h };
+}
+
+pub fn setRenderTargetSize(width: i32, height: i32) void {
+    render_target_size = .{ .w = width, .h = height };
 }
 
 pub fn driverInfo() DriverInfo {
@@ -136,8 +144,17 @@ pub fn restoreScissor(s: ScissorState) void {
     applyScissor();
 }
 
+fn activeRenderTargetSize() Size {
+    if (Context.currentRenderTargetSize()) |size| {
+        if (size.width > 0 and size.height > 0) return .{ .w = size.width, .h = size.height };
+    }
+    if (render_target_size.w > 0 and render_target_size.h > 0) return render_target_size;
+    if (Context.swapchainSize()) |size| return .{ .w = size.width, .h = size.height };
+    return .{ .w = @max(viewport.w, 1), .h = @max(viewport.h, 1) };
+}
+
 fn framebufferHeight() i32 {
-    return if (Context.swapchainSize()) |size| size.height else viewport.h;
+    return activeRenderTargetSize().h;
 }
 
 fn topLeftY(y: i32, h: i32) i32 {
@@ -164,14 +181,12 @@ fn applyScissor() void {
     applyRasterizerState();
     const rs_scissor = core.comCall(context, core.slot.D3D11DeviceContext_RSSetScissorRects, *const fn (*anyopaque, u32, ?*const core.D3D11_RECT) callconv(.winapi) void);
     if (!scissor.enabled or scissor.box.w <= 0 or scissor.box.h <= 0) {
-        const maybe_size = Context.swapchainSize();
-        const width = if (maybe_size) |s| s.width else @max(viewport.w, 1);
-        const height = if (maybe_size) |s| s.height else @max(viewport.h, 1);
+        const size = activeRenderTargetSize();
         const rect = core.D3D11_RECT{
             .left = 0,
             .top = 0,
-            .right = @max(width, 1),
-            .bottom = @max(height, 1),
+            .right = @max(size.w, 1),
+            .bottom = @max(size.h, 1),
         };
         rs_scissor(context, 1, &rect);
         return;


### PR DESCRIPTION
## Summary

Phase IV-A foundation for D3D11 auxiliary render targets.

- Replace the D3D11 framebuffer compatibility wrapper with a real offscreen render target: texture + RTV + SRV-backed color handle.
- Add render-target texture allocation and SRV/sampler ownership in the D3D11 texture registry.
- Track active D3D11 render target size so viewport/scissor math works for both swapchain backbuffer and offscreen targets.
- Preserve the existing swapchain backbuffer path; D3D11 remains explicit opt-in and Windows default behavior is unchanged.

## Notes

This follows Ghostty's renderer target model at the boundary level: an offscreen target owns native GPU renderable storage and can later be sampled/composited, while the terminal grid path can still render directly to the swapchain backbuffer.

During smoke testing, an early version produced a blank D3D11 frame because the new render-target tracking stopped rebinding the swapchain RTV for normal clears. The final version keeps offscreen clears directed at the current FBO but restores backbuffer OM binding for normal swapchain frames.

## Validation

- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build test`
- `zig build check-sizes`
- `git diff --check`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `zig build test-full --summary all` — 60/60 steps succeeded, 12837 passed, 275 skipped
- D3D11 visible control-spawn smoke with isolated config and active terminal tab:
  - clean `main`: Varied=28643 / Samples=120000
  - this branch after fix: Varied=28648 / Samples=120000
  - screenshot artifact: `zig-out/d3d11-framebuffer-smoke/20260702-131904/d3d11-terminal-control-spawn.png`
