### PR TITLE
[codex] smoke d3d11 titlebar layout

### DIFF
--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -427,6 +427,17 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     if (AppWindow.g_window != null) {
+        const layout = titlebar_layout.topBarLayout(
+            window_width,
+            window_height,
+            titlebar_h,
+            titlebarLeftReserved(),
+            TITLEBAR_TOGGLE_W,
+            TITLEBAR_CONFIG_W,
+            TITLEBAR_HELP_W,
+            TITLEBAR_COPILOT_W,
+            window_backend.caption_button_visual_style.width,
+        );
         const top_bg = blend(bg, fg, 0.04);
         const hover_bg = blend(bg, fg, 0.11);
         const border_color_simple = blend(bg, .{ 0.0, 0.0, 0.0 }, 0.20);
@@ -436,71 +447,68 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         // Ghostty's apprt action/tab-view split. The top bar now only hosts the
         // sidebar toggle and native caption buttons; tab navigation is rendered by
         // renderSidebar below.
-        ui_pipeline.fillQuad(0, tb_top, window_width, titlebar_h, top_bg);
-        ui_pipeline.fillQuad(0, tb_top, window_width, 1, border_color_simple);
+        ui_pipeline.fillQuad(0, layout.top_y, window_width, titlebar_h, top_bg);
+        ui_pipeline.fillQuad(0, layout.top_y, window_width, 1, border_color_simple);
 
-        const toggle_x = titlebarLeftReserved();
+        const toggle_x = layout.toggle_x;
         const toggle_hovered = mouseInTitlebarRange(titlebar_h, toggle_x, toggle_x + TITLEBAR_TOGGLE_W);
         if (toggle_hovered) {
-            ui_pipeline.fillQuad(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, hover_bg);
+            ui_pipeline.fillQuad(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, hover_bg);
         }
         if (font.icon_face != null) {
             if (font.loadIconGlyph(0xE700)) |ch| {
-                renderIconGlyph(ch, toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color, 1.0);
+                renderIconGlyph(ch, toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color, 1.0);
             } else {
-                renderFallbackMenuIcon(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
+                renderFallbackMenuIcon(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
             }
         } else {
-            renderFallbackMenuIcon(toggle_x, tb_top, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
+            renderFallbackMenuIcon(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
         }
 
-        const top_caption_btn_w = window_backend.caption_button_visual_style.width;
-        const top_caption_area_w: f32 = top_caption_btn_w * 3;
         const top_btn_h: f32 = titlebar_h;
         const top_hovered: window_backend.CaptionButton = if (AppWindow.g_window) |w| window_backend.hoveredCaptionButton(w) else .none;
 
-        const top_caption_start = window_width - top_caption_area_w;
-        const config_x = top_caption_start - TITLEBAR_CONFIG_W;
+        const config_x = layout.config_x;
         if (TITLEBAR_CONFIG_W > 0) {
             const config_hovered = mouseInTitlebarRange(titlebar_h, config_x, config_x + TITLEBAR_CONFIG_W);
             if (config_hovered) {
-                ui_pipeline.fillQuad(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, hover_bg);
+                ui_pipeline.fillQuad(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, hover_bg);
             }
             if (font.icon_face != null) {
                 if (font.loadIconGlyph(0xE713)) |ch| {
-                    renderIconGlyph(ch, config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color, 1.0);
+                    renderIconGlyph(ch, config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color, 1.0);
                 } else {
-                    renderFallbackGearIcon(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
+                    renderFallbackGearIcon(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
                 }
             } else {
-                renderFallbackGearIcon(config_x, tb_top, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
+                renderFallbackGearIcon(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
             }
         }
 
-        const help_x = config_x - TITLEBAR_HELP_W;
+        const help_x = layout.help_x;
         if (TITLEBAR_HELP_W > 0) {
             const help_hovered = mouseInTitlebarRange(titlebar_h, help_x, help_x + TITLEBAR_HELP_W);
             if (help_hovered) {
-                ui_pipeline.fillQuad(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, hover_bg);
+                ui_pipeline.fillQuad(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, hover_bg);
             }
             if (font.icon_face != null) {
                 if (font.loadIconGlyph(0xEDA7)) |ch| {
-                    renderIconGlyph(ch, help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color, 1.0);
+                    renderIconGlyph(ch, help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color, 1.0);
                 } else {
-                    renderFallbackHelpIcon(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color);
+                    renderFallbackHelpIcon(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color);
                 }
             } else {
-                renderFallbackHelpIcon(help_x, tb_top, TITLEBAR_HELP_W, titlebar_h, icon_color);
+                renderFallbackHelpIcon(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color);
             }
         }
 
-        const copilot_x = help_x - TITLEBAR_COPILOT_W;
+        const copilot_x = layout.copilot_x;
         if (TITLEBAR_COPILOT_W > 0) {
             const copilot_open = AppWindow.aiCopilotVisible();
             const copilot_usable = AppWindow.isActiveTabTerminal();
             const copilot_hovered = mouseInTitlebarRange(titlebar_h, copilot_x, copilot_x + TITLEBAR_COPILOT_W);
             if (copilot_hovered and copilot_usable) {
-                ui_pipeline.fillQuad(copilot_x, tb_top, TITLEBAR_COPILOT_W, titlebar_h, hover_bg);
+                ui_pipeline.fillQuad(copilot_x, layout.top_y, TITLEBAR_COPILOT_W, titlebar_h, hover_bg);
             }
             const copilot_tint = if (!copilot_usable)
                 blend(bg, fg, 0.30) // dimmed: no terminal target
@@ -508,19 +516,18 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
                 blend(bg, AppWindow.g_theme.cursor_color, 0.85) // active
             else
                 icon_color;
-            renderFallbackCopilotIcon(copilot_x, tb_top, TITLEBAR_COPILOT_W, titlebar_h, copilot_tint);
+            renderFallbackCopilotIcon(copilot_x, layout.top_y, TITLEBAR_COPILOT_W, titlebar_h, copilot_tint);
         }
 
         if (tab.activeTab()) |active_tab| {
             const title = active_tab.getTitle();
-            const text_y = tb_top + (titlebar_h - font.g_titlebar_cell_height) / 2;
-            const text_x = titlebarLeftReserved() + TITLEBAR_TOGGLE_W + 10;
-            _ = renderTextLimited(title, text_x, text_y, blend(bg, fg, 0.90), copilot_x - text_x - 12);
+            const text_y = layout.top_y + (titlebar_h - font.g_titlebar_cell_height) / 2;
+            _ = renderTextLimited(title, layout.title_text_x, text_y, blend(bg, fg, 0.90), layout.title_text_max_w);
         }
 
-        renderCaptionButton(top_caption_start, tb_top, top_caption_btn_w, top_btn_h, .minimize, top_hovered == .minimize);
-        renderCaptionButton(top_caption_start + top_caption_btn_w, tb_top, top_caption_btn_w, top_btn_h, .maximize, top_hovered == .maximize);
-        renderCaptionButton(top_caption_start + top_caption_btn_w * 2, tb_top, top_caption_btn_w, top_btn_h, .close, top_hovered == .close);
+        renderCaptionButton(layout.caption_start_x, layout.top_y, layout.caption_button_w, top_btn_h, .minimize, top_hovered == .minimize);
+        renderCaptionButton(layout.caption_start_x + layout.caption_button_w, layout.top_y, layout.caption_button_w, top_btn_h, .maximize, top_hovered == .maximize);
+        renderCaptionButton(layout.caption_start_x + layout.caption_button_w * 2, layout.top_y, layout.caption_button_w, top_btn_h, .close, top_hovered == .close);
 
         {
             const is_focused = if (AppWindow.g_window) |w| window_backend.isFocused(w) else false;

--- a/src/renderer/titlebar_layout.zig
+++ b/src/renderer/titlebar_layout.zig
@@ -50,6 +50,53 @@ pub fn fallbackCodepoint(byte: u8) u32 {
     return if (byte >= 0x20 and byte <= 0x7e) byte else '?';
 }
 
+pub const TopBarLayout = struct {
+    top_y: f32,
+    toggle_x: f32,
+    caption_button_w: f32,
+    caption_start_x: f32,
+    config_x: f32,
+    help_x: f32,
+    copilot_x: f32,
+    title_text_x: f32,
+    title_text_max_w: f32,
+};
+
+/// Window-top chrome geometry for the app-drawn titlebar.
+///
+/// The renderer consumes this in framebuffer coordinates, with Y=0 at the
+/// bottom. Width arguments may be zero on platforms where those controls are
+/// hosted outside WispTerm's titlebar.
+pub fn topBarLayout(
+    window_width: f32,
+    window_height: f32,
+    titlebar_h: f32,
+    left_reserved: f32,
+    toggle_w: f32,
+    config_w: f32,
+    help_w: f32,
+    copilot_w: f32,
+    caption_button_w: f32,
+) TopBarLayout {
+    const caption_area_w = caption_button_w * 3.0;
+    const caption_start_x = window_width - caption_area_w;
+    const config_x = caption_start_x - config_w;
+    const help_x = config_x - help_w;
+    const copilot_x = help_x - copilot_w;
+    const title_text_x = left_reserved + toggle_w + 10.0;
+    return .{
+        .top_y = window_height - titlebar_h,
+        .toggle_x = left_reserved,
+        .caption_button_w = caption_button_w,
+        .caption_start_x = caption_start_x,
+        .config_x = config_x,
+        .help_x = help_x,
+        .copilot_x = copilot_x,
+        .title_text_x = title_text_x,
+        .title_text_max_w = @max(0.0, copilot_x - title_text_x - 12.0),
+    };
+}
+
 test "pointInRect inside / edges / outside" {
     try std.testing.expect(pointInRect(5, 5, 0, 0, 10, 10));
     try std.testing.expect(pointInRect(0, 0, 0, 0, 10, 10)); // top-left inclusive
@@ -97,4 +144,31 @@ test "fallbackCodepoint maps printable ASCII, else '?'" {
     try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x7f)); // just above
     try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0x07));
     try std.testing.expectEqual(@as(u32, '?'), fallbackCodepoint(0xC3));
+}
+
+test "topBarLayout computes titlebar chrome rectangles" {
+    const l = topBarLayout(1200, 800, 34, 0, 46, 46, 46, 46, 46);
+
+    try std.testing.expectEqual(@as(f32, 766), l.top_y);
+    try std.testing.expectEqual(@as(f32, 0), l.toggle_x);
+    try std.testing.expectEqual(@as(f32, 46), l.caption_button_w);
+    try std.testing.expectEqual(@as(f32, 1062), l.caption_start_x);
+    try std.testing.expectEqual(@as(f32, 1016), l.config_x);
+    try std.testing.expectEqual(@as(f32, 970), l.help_x);
+    try std.testing.expectEqual(@as(f32, 924), l.copilot_x);
+    try std.testing.expectEqual(@as(f32, 56), l.title_text_x);
+    try std.testing.expectEqual(@as(f32, 856), l.title_text_max_w);
+}
+
+test "topBarLayout collapses optional titlebar controls cleanly" {
+    const l = topBarLayout(360, 240, 40, 160, 46, 0, 0, 0, 46);
+
+    try std.testing.expectEqual(@as(f32, 200), l.top_y);
+    try std.testing.expectEqual(@as(f32, 160), l.toggle_x);
+    try std.testing.expectEqual(@as(f32, 222), l.caption_start_x);
+    try std.testing.expectEqual(@as(f32, 222), l.config_x);
+    try std.testing.expectEqual(@as(f32, 222), l.help_x);
+    try std.testing.expectEqual(@as(f32, 222), l.copilot_x);
+    try std.testing.expectEqual(@as(f32, 216), l.title_text_x);
+    try std.testing.expectEqual(@as(f32, 0), l.title_text_max_w);
 }


### PR DESCRIPTION
## Scope

Phase IV Goal 3A: smoke the D3D11 titlebar background/layout path without broadening into tabs, icon state migration, or caption-button behavior changes.

This PR:
- adds a pure `TopBarLayout` / `topBarLayout(...)` helper in `src/renderer/titlebar_layout.zig`
- updates `src/renderer/titlebar.zig` to consume that geometry for the top titlebar strip, sidebar toggle, right-side controls, caption buttons, and title text bounds
- keeps feature rendering backend-neutral through the existing `ui_pipeline` calls

Out of scope:
- no tabs text/icon/state migration
- no caption-button glyph/hover/pressed rewrite beyond preserving current behavior
- no D3D11, HLSL, or COM details in feature renderer files

## D3D11 evidence

Fresh screenshot set after rebuilding with `zig build -Dgpu-backend=d3d11`:

- `zig-out\d3d11-titlebar-smoke\20260702-163134\d3d11-titlebar-window.png`
- `zig-out\d3d11-titlebar-smoke\20260702-163134\d3d11-titlebar-top-strip.png`
- `zig-out\d3d11-titlebar-smoke\20260702-163134\d3d11-titlebar-diagnostics.txt`

Key diagnostic lines:

```text
gpu-backend=d3d11 present=dxgi swapchain=1200x900
gpu vendor="D3D11" renderer="Direct3D 11" version="experimental" shading_language="HLSL"
frame-geometry client=1280x820 fb=1280x820 dpi=144 font_dpi=144 cell=20.00x45.00 titlebar=57.0 panels_l=220.0 panels_r=480.0 term=27x16 max=false full=false min=false
```

## Ghostty reference

Checked Ghostty's renderer layering in `src/renderer/generic.zig`: backend concepts stay under the graphics API / target / frame / render pass / pipeline hierarchy while UI feature code remains API-agnostic. This PR follows that shape by extracting pure titlebar geometry and keeping drawing on WispTerm's backend-neutral `ui_pipeline` surface.

## Validation

- `zig fmt src\renderer\titlebar_layout.zig src\renderer\titlebar.zig`
- `zig build test`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build check-sizes`
- `zig build -Dgpu-backend=d3d11`
- visible D3D11 titlebar smoke screenshot: `20260702-163134`
- `zig build test-full --summary all`
- `zig build`
- `git diff --check`
