### PR TITLE
[codex] smoke d3d11 sidebar tabs layout

### DIFF
--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -1077,19 +1077,26 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
     ui_pipeline.fillQuad(0, 0, sidebar_w, side_h, sidebar_bg);
     ui_pipeline.fillQuad(sidebar_w - 1, 0, if (resize_hovered) 2 else 1, side_h, edge_color);
 
-    const header_top_px = titlebar_h;
     const header_h = sidebarHeaderHeight();
     const row_h_full = sidebarRowHeight();
-    const header_y = window_height - header_top_px - header_h;
     const plus_btn_w: f32 = 42;
-    const plus_x = sidebar_w - plus_btn_w - 6;
-    const plus_hovered = mouseInRect(plus_x, header_top_px, plus_btn_w, header_h);
+    const header = titlebar_layout.sidebarHeaderLayout(
+        window_height,
+        titlebar_h,
+        sidebar_w,
+        header_h,
+        14,
+        plus_btn_w,
+        6,
+        font.g_titlebar_cell_height,
+    );
+    const plus_hovered = mouseInRect(header.plus_x, header.top_px, header.plus_w, header.plus_h);
     if (plus_hovered) {
-        ui_pipeline.fillQuad(plus_x, header_y + 4, plus_btn_w, header_h - 8, hover_bg);
+        ui_pipeline.fillQuad(header.plus_x, header.plus_y + 4, header.plus_w, header.plus_h - 8, hover_bg);
     }
-    _ = renderTextLimited("Tabs", 14, header_y + (header_h - font.g_titlebar_cell_height) / 2, header_text, sidebar_w - plus_btn_w - 26);
-    renderPlusIcon(plus_x, header_y, plus_btn_w, header_h, text_active);
-    ui_pipeline.fillQuad(0, header_y, sidebar_w, 1, border_color);
+    _ = renderTextLimited("Tabs", header.title_x, header.title_y, header_text, header.title_max_w);
+    renderPlusIcon(header.plus_x, header.plus_y, header.plus_w, header.plus_h, text_active);
+    ui_pipeline.fillQuad(0, header.rule_y, sidebar_w, 1, border_color);
 
     const now_ms = std.time.milliTimestamp();
     const dt: f32 = if (tab.g_last_frame_time_ms > 0)
@@ -1098,7 +1105,6 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
         0.016;
     tab.g_last_frame_time_ms = now_ms;
 
-    const list_top_px = titlebar_h + header_h + 6;
     for (0..tab.MAX_TABS) |tab_idx| {
         tab.g_tab_text_x_start[tab_idx] = 0;
         tab.g_tab_text_x_end[tab_idx] = 0;
@@ -1108,33 +1114,24 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
 
     const number_x: f32 = 14;
     const number_w = sidebarTabNumberWidth();
-    const title_x = number_x + number_w + 8;
 
     for (0..tab.g_tab_count) |tab_idx| {
-        const row_top_px = list_top_px + @as(f32, @floatFromInt(tab_idx)) * row_h_full;
-        if (row_top_px >= window_height) break;
-        const row_h = @min(row_h_full, window_height - row_top_px);
-        const row_y = window_height - row_top_px - row_h;
+        const base_row = titlebar_layout.sidebarTabRowLayout(
+            window_height,
+            titlebar_h,
+            header_h,
+            row_h_full,
+            sidebar_w,
+            tab_idx,
+            number_x,
+            number_w,
+            tab.TAB_CLOSE_BTN_W,
+            font.g_titlebar_cell_height,
+            false,
+            0,
+            false,
+        ) orelse break;
         const is_active = tab_idx == active_tab_state.g_active_tab;
-
-        const row_hovered = mouseInRect(0, row_top_px, sidebar_w, row_h);
-
-        if (is_active) {
-            ui_pipeline.fillQuad(0, row_y, sidebar_w, row_h, active_bg);
-            ui_pipeline.fillQuad(0, row_y + 6, 3, row_h - 12, AppWindow.g_theme.cursor_color);
-        } else if (row_hovered) {
-            ui_pipeline.fillQuad(0, row_y, sidebar_w, row_h, hover_bg);
-        }
-
-        if (tab.g_tab_count > 1) {
-            if (row_hovered) {
-                tab.g_tab_close_opacity[tab_idx] = @min(1.0, tab.g_tab_close_opacity[tab_idx] + tab.TAB_CLOSE_FADE_SPEED * dt);
-            } else {
-                tab.g_tab_close_opacity[tab_idx] = @max(0.0, tab.g_tab_close_opacity[tab_idx] - tab.TAB_CLOSE_FADE_SPEED * dt);
-            }
-        } else {
-            tab.g_tab_close_opacity[tab_idx] = 0;
-        }
 
         if (tab.g_tabs[tab_idx]) |tb| {
             if (tb.focusedSurface()) |surface| {
@@ -1149,21 +1146,6 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
             }
         }
 
-        var prefix_buf: [8]u8 = undefined;
-        const prefix = std.fmt.bufPrint(&prefix_buf, "{d}", .{tab_idx + 1}) catch "";
-        const text_y = row_y + (row_h - font.g_titlebar_cell_height) / 2;
-        _ = renderTextLimited(prefix, number_x, text_y, if (is_active) text_active else muted, number_w);
-
-        const title = if (tab.g_tab_rename_active and tab_idx == tab.g_tab_rename_idx)
-            tab.g_tab_rename_buf[0..tab.g_tab_rename_len]
-        else if (tab.g_tabs[tab_idx]) |t|
-            t.getTitle()
-        else
-            "New Tab";
-
-        const close_opacity = tab.g_tab_close_opacity[tab_idx];
-        const close_btn_x = sidebar_w - tab.TAB_CLOSE_BTN_W - 4;
-        var right_content_x = close_btn_x - titlebar_layout.SIDEBAR_STATUS_CLOSE_GAP;
         // Use aggregate of all panes' visible states so the sidebar badge
         // reflects the most attention-worthy agent across all split panes,
         // not just the focused one.
@@ -1201,40 +1183,79 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
             break :blk agent_detector.Detection{};
         } else agent_detector.Detection{};
         const show_agent_badge = detection.visible();
-        var agent_badge_x: f32 = 0;
         var agent_badge_w: f32 = 0;
         if (show_agent_badge) {
             const badge_text_w = titlebarTextWidth(detection.badge());
             agent_badge_w = @max(@as(f32, 18), badge_text_w + 10);
-            const badge_layout = titlebar_layout.sidebarStatusBadgeLayout(close_btn_x, agent_badge_w);
-            agent_badge_x = badge_layout.x;
-            right_content_x = badge_layout.next_right_content_x;
         }
 
         const bell_opacity: f32 = if (tab.g_tabs[tab_idx]) |t| (if (t.focusedSurface()) |s| s.bell_opacity else 0) else 0;
         const show_bell = bell_opacity > 0.01;
-        const bell_x = right_content_x - 20;
-        if (show_bell) right_content_x = bell_x - 4;
+        const row = titlebar_layout.sidebarTabRowLayout(
+            window_height,
+            titlebar_h,
+            header_h,
+            row_h_full,
+            sidebar_w,
+            tab_idx,
+            number_x,
+            number_w,
+            tab.TAB_CLOSE_BTN_W,
+            font.g_titlebar_cell_height,
+            show_agent_badge,
+            agent_badge_w,
+            show_bell,
+        ) orelse base_row;
 
-        const title_max_w = right_content_x - title_x - 8;
+        const row_hovered = mouseInRect(0, row.row_top_px, sidebar_w, row.row_h);
+
+        if (is_active) {
+            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, active_bg);
+            ui_pipeline.fillQuad(row.active_marker_x, row.active_marker_y, row.active_marker_w, row.active_marker_h, AppWindow.g_theme.cursor_color);
+        } else if (row_hovered) {
+            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, hover_bg);
+        }
+
+        if (tab.g_tab_count > 1) {
+            if (row_hovered) {
+                tab.g_tab_close_opacity[tab_idx] = @min(1.0, tab.g_tab_close_opacity[tab_idx] + tab.TAB_CLOSE_FADE_SPEED * dt);
+            } else {
+                tab.g_tab_close_opacity[tab_idx] = @max(0.0, tab.g_tab_close_opacity[tab_idx] - tab.TAB_CLOSE_FADE_SPEED * dt);
+            }
+        } else {
+            tab.g_tab_close_opacity[tab_idx] = 0;
+        }
+
+        var prefix_buf: [8]u8 = undefined;
+        const prefix = std.fmt.bufPrint(&prefix_buf, "{d}", .{tab_idx + 1}) catch "";
+        _ = renderTextLimited(prefix, row.number_x, row.text_y, if (is_active) text_active else muted, row.number_w);
+
+        const title = if (tab.g_tab_rename_active and tab_idx == tab.g_tab_rename_idx)
+            tab.g_tab_rename_buf[0..tab.g_tab_rename_len]
+        else if (tab.g_tabs[tab_idx]) |t|
+            t.getTitle()
+        else
+            "New Tab";
+
+        const close_opacity = tab.g_tab_close_opacity[tab_idx];
         const title_color = if (is_active) text_active else text_inactive;
-        const text_end = renderTextLimited(title, title_x, text_y, title_color, title_max_w);
+        const text_end = renderTextLimited(title, row.title_x, row.text_y, title_color, row.title_max_w);
 
         if (tab.g_tab_rename_active and tab_idx == tab.g_tab_rename_idx and AppWindow.g_cursor_blink_visible) {
-            ui_pipeline.fillQuad(@min(text_end + 1, title_x + title_max_w), text_y, 1, font.g_titlebar_cell_height, text_active);
+            ui_pipeline.fillQuad(@min(text_end + 1, row.title_x + row.title_max_w), row.text_y, 1, font.g_titlebar_cell_height, text_active);
         }
 
         if (show_bell) {
-            renderBellEmoji(bell_x, text_y, bell_opacity);
+            renderBellEmoji(row.bell_x, row.text_y, bell_opacity);
         }
         if (show_agent_badge) {
-            _ = renderAgentBadge(detection, agent_badge_x, text_y, is_active);
+            _ = renderAgentBadge(detection, row.badge_x, row.text_y, is_active);
         }
 
         if (close_opacity > 0.01 and tab.g_tab_count > 1) {
             const close_hovered = row_hovered and blk: {
                 const mx = mouseX() orelse break :blk false;
-                break :blk mx >= close_btn_x and mx < close_btn_x + tab.TAB_CLOSE_BTN_W;
+                break :blk mx >= row.close_x and mx < row.close_x + tab.TAB_CLOSE_BTN_W;
             };
             const raw_color = if (close_hovered) text_active else muted;
             const close_color = [3]f32{
@@ -1243,15 +1264,15 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
                 raw_color[2] * close_opacity + sidebar_bg[2] * (1 - close_opacity),
             };
             if (close_hovered) {
-                ui_pipeline.fillQuad(close_btn_x + 6, row_y + 10, 20, 20, blend(bg, fg, 0.14));
+                ui_pipeline.fillQuad(row.close_hover_x, row.close_hover_y, row.close_hover_w, row.close_hover_h, blend(bg, fg, 0.14));
             }
-            renderCloseIcon(close_btn_x, row_y, tab.TAB_CLOSE_BTN_W, row_h, close_color);
+            renderCloseIcon(row.close_x, row.row_y, tab.TAB_CLOSE_BTN_W, row.row_h, close_color);
         }
 
-        tab.g_tab_text_x_start[tab_idx] = title_x;
+        tab.g_tab_text_x_start[tab_idx] = row.title_x;
         tab.g_tab_text_x_end[tab_idx] = text_end;
-        tab.g_tab_text_y_start[tab_idx] = row_top_px;
-        tab.g_tab_text_y_end[tab_idx] = row_top_px + row_h;
+        tab.g_tab_text_y_start[tab_idx] = row.row_top_px;
+        tab.g_tab_text_y_end[tab_idx] = row.row_top_px + row.row_h;
     }
 }
 

--- a/src/renderer/titlebar_layout.zig
+++ b/src/renderer/titlebar_layout.zig
@@ -31,6 +31,17 @@ pub fn clampSidebarWidth(width: f32, min_width: f32, max_for_window: f32) f32 {
 
 pub const SIDEBAR_STATUS_CLOSE_GAP: f32 = 10;
 pub const SIDEBAR_STATUS_LEADING_GAP: f32 = 6;
+pub const SIDEBAR_TAB_LIST_TOP_GAP: f32 = 6;
+pub const SIDEBAR_TAB_TITLE_GAP: f32 = 8;
+pub const SIDEBAR_TAB_RIGHT_GAP: f32 = 8;
+pub const SIDEBAR_TAB_BELL_W: f32 = 20;
+pub const SIDEBAR_TAB_BELL_GAP: f32 = 4;
+pub const SIDEBAR_TAB_CLOSE_MARGIN: f32 = 4;
+pub const SIDEBAR_TAB_CLOSE_HOVER_INSET_X: f32 = 6;
+pub const SIDEBAR_TAB_CLOSE_HOVER_TOP_PAD: f32 = 10;
+pub const SIDEBAR_TAB_CLOSE_HOVER_SIZE: f32 = 20;
+pub const SIDEBAR_ACTIVE_MARKER_W: f32 = 3;
+pub const SIDEBAR_ACTIVE_MARKER_VPAD: f32 = 6;
 
 pub const SidebarStatusBadgeLayout = struct {
     x: f32,
@@ -42,6 +53,140 @@ pub fn sidebarStatusBadgeLayout(close_btn_x: f32, badge_w: f32) SidebarStatusBad
     return .{
         .x = x,
         .next_right_content_x = x - SIDEBAR_STATUS_LEADING_GAP,
+    };
+}
+
+pub const SidebarHeaderLayout = struct {
+    top_px: f32,
+    y: f32,
+    h: f32,
+    title_x: f32,
+    title_y: f32,
+    title_max_w: f32,
+    plus_x: f32,
+    plus_y: f32,
+    plus_w: f32,
+    plus_h: f32,
+    rule_y: f32,
+};
+
+pub fn sidebarHeaderLayout(
+    window_height: f32,
+    titlebar_h: f32,
+    sidebar_w: f32,
+    header_h: f32,
+    title_x: f32,
+    plus_w: f32,
+    plus_margin: f32,
+    titlebar_cell_h: f32,
+) SidebarHeaderLayout {
+    const y = window_height - titlebar_h - header_h;
+    const plus_x = sidebar_w - plus_w - plus_margin;
+    return .{
+        .top_px = titlebar_h,
+        .y = y,
+        .h = header_h,
+        .title_x = title_x,
+        .title_y = y + (header_h - titlebar_cell_h) / 2,
+        .title_max_w = @max(0.0, sidebar_w - plus_w - title_x - 12.0),
+        .plus_x = plus_x,
+        .plus_y = y,
+        .plus_w = plus_w,
+        .plus_h = header_h,
+        .rule_y = y,
+    };
+}
+
+pub const SidebarTabRowLayout = struct {
+    row_top_px: f32,
+    row_y: f32,
+    row_h: f32,
+    number_x: f32,
+    number_w: f32,
+    title_x: f32,
+    title_max_w: f32,
+    text_y: f32,
+    close_x: f32,
+    right_content_x: f32,
+    badge_x: f32,
+    badge_w: f32,
+    bell_x: f32,
+    bell_w: f32,
+    active_marker_x: f32,
+    active_marker_y: f32,
+    active_marker_w: f32,
+    active_marker_h: f32,
+    close_hover_x: f32,
+    close_hover_y: f32,
+    close_hover_w: f32,
+    close_hover_h: f32,
+};
+
+pub fn sidebarTabRowLayout(
+    window_height: f32,
+    titlebar_h: f32,
+    header_h: f32,
+    row_h_full: f32,
+    sidebar_w: f32,
+    tab_idx: usize,
+    number_x: f32,
+    number_w: f32,
+    close_btn_w: f32,
+    titlebar_cell_h: f32,
+    show_agent_badge: bool,
+    agent_badge_w: f32,
+    show_bell: bool,
+) ?SidebarTabRowLayout {
+    const list_top_px = titlebar_h + header_h + SIDEBAR_TAB_LIST_TOP_GAP;
+    const row_top_px = list_top_px + @as(f32, @floatFromInt(tab_idx)) * row_h_full;
+    if (row_top_px >= window_height) return null;
+
+    const row_h = @min(row_h_full, window_height - row_top_px);
+    if (row_h <= 0) return null;
+
+    const row_y = window_height - row_top_px - row_h;
+    const close_x = sidebar_w - close_btn_w - SIDEBAR_TAB_CLOSE_MARGIN;
+    var right_content_x = close_x - SIDEBAR_STATUS_CLOSE_GAP;
+    var badge_x: f32 = 0;
+    const badge_w = if (show_agent_badge) @max(0.0, agent_badge_w) else 0.0;
+    if (show_agent_badge) {
+        const badge = sidebarStatusBadgeLayout(close_x, badge_w);
+        badge_x = badge.x;
+        right_content_x = badge.next_right_content_x;
+    }
+
+    var bell_x: f32 = 0;
+    const bell_w = if (show_bell) SIDEBAR_TAB_BELL_W else 0.0;
+    if (show_bell) {
+        bell_x = right_content_x - SIDEBAR_TAB_BELL_W;
+        right_content_x = bell_x - SIDEBAR_TAB_BELL_GAP;
+    }
+
+    const title_x = number_x + number_w + SIDEBAR_TAB_TITLE_GAP;
+    const marker_h = @max(0.0, row_h - SIDEBAR_ACTIVE_MARKER_VPAD * 2.0);
+    return .{
+        .row_top_px = row_top_px,
+        .row_y = row_y,
+        .row_h = row_h,
+        .number_x = number_x,
+        .number_w = number_w,
+        .title_x = title_x,
+        .title_max_w = @max(0.0, right_content_x - title_x - SIDEBAR_TAB_RIGHT_GAP),
+        .text_y = row_y + (row_h - titlebar_cell_h) / 2.0,
+        .close_x = close_x,
+        .right_content_x = right_content_x,
+        .badge_x = badge_x,
+        .badge_w = badge_w,
+        .bell_x = bell_x,
+        .bell_w = bell_w,
+        .active_marker_x = 0,
+        .active_marker_y = row_y + SIDEBAR_ACTIVE_MARKER_VPAD,
+        .active_marker_w = SIDEBAR_ACTIVE_MARKER_W,
+        .active_marker_h = marker_h,
+        .close_hover_x = close_x + SIDEBAR_TAB_CLOSE_HOVER_INSET_X,
+        .close_hover_y = row_y + SIDEBAR_TAB_CLOSE_HOVER_TOP_PAD,
+        .close_hover_w = SIDEBAR_TAB_CLOSE_HOVER_SIZE,
+        .close_hover_h = SIDEBAR_TAB_CLOSE_HOVER_SIZE,
     };
 }
 
@@ -134,6 +279,65 @@ test "sidebar status badge leaves readable gap before close button" {
 
     try std.testing.expectEqual(@as(f32, 10), close_btn_x - (layout.x + badge_w));
     try std.testing.expectEqual(@as(f32, close_btn_x - 10 - badge_w - 6), layout.next_right_content_x);
+}
+
+test "sidebarHeaderLayout computes header title and plus button geometry" {
+    const l = sidebarHeaderLayout(820, 57, 220, 46, 14, 42, 6, 23);
+
+    try std.testing.expectEqual(@as(f32, 57), l.top_px);
+    try std.testing.expectEqual(@as(f32, 717), l.y);
+    try std.testing.expectEqual(@as(f32, 46), l.h);
+    try std.testing.expectEqual(@as(f32, 14), l.title_x);
+    try std.testing.expectEqual(@as(f32, 728.5), l.title_y);
+    try std.testing.expectEqual(@as(f32, 172), l.plus_x);
+    try std.testing.expectEqual(@as(f32, 717), l.plus_y);
+    try std.testing.expectEqual(@as(f32, 152), l.title_max_w);
+    try std.testing.expectEqual(@as(f32, 717), l.rule_y);
+}
+
+test "sidebarTabRowLayout computes tab text and affordance slots" {
+    const l = sidebarTabRowLayout(820, 57, 46, 45, 220, 1, 14, 28, 36, 23, true, 34, true).?;
+
+    try std.testing.expectEqual(@as(f32, 154), l.row_top_px);
+    try std.testing.expectEqual(@as(f32, 621), l.row_y);
+    try std.testing.expectEqual(@as(f32, 45), l.row_h);
+    try std.testing.expectEqual(@as(f32, 14), l.number_x);
+    try std.testing.expectEqual(@as(f32, 28), l.number_w);
+    try std.testing.expectEqual(@as(f32, 50), l.title_x);
+    try std.testing.expectEqual(@as(f32, 180), l.close_x);
+    try std.testing.expectEqual(@as(f32, 136), l.badge_x);
+    try std.testing.expectEqual(@as(f32, 110), l.bell_x);
+    try std.testing.expectEqual(@as(f32, 106), l.right_content_x);
+    try std.testing.expectEqual(@as(f32, 48), l.title_max_w);
+    try std.testing.expectEqual(@as(f32, 632), l.text_y);
+    try std.testing.expectEqual(@as(f32, 627), l.active_marker_y);
+    try std.testing.expectEqual(@as(f32, 33), l.active_marker_h);
+    try std.testing.expectEqual(@as(f32, 186), l.close_hover_x);
+    try std.testing.expectEqual(@as(f32, 631), l.close_hover_y);
+}
+
+test "sidebarTabRowLayout clips bottom row and reports offscreen rows" {
+    const clipped = sidebarTabRowLayout(160, 30, 40, 32, 200, 2, 14, 24, 36, 18, false, 0, false).?;
+
+    try std.testing.expectEqual(@as(f32, 140), clipped.row_top_px);
+    try std.testing.expectEqual(@as(f32, 20), clipped.row_h);
+    try std.testing.expectEqual(@as(f32, 0), clipped.row_y);
+    try std.testing.expectEqual(@as(f32, 8), clipped.active_marker_h);
+
+    try std.testing.expectEqual(
+        @as(?SidebarTabRowLayout, null),
+        sidebarTabRowLayout(160, 30, 40, 32, 200, 3, 14, 24, 36, 18, false, 0, false),
+    );
+}
+
+test "sidebarTabRowLayout clamps title width in narrow sidebars" {
+    const l = sidebarTabRowLayout(400, 40, 46, 42, 96, 0, 14, 30, 36, 20, true, 32, true).?;
+
+    try std.testing.expectEqual(@as(f32, 52), l.title_x);
+    try std.testing.expectEqual(@as(f32, 56), l.close_x);
+    try std.testing.expectEqual(@as(f32, 14), l.badge_x);
+    try std.testing.expectEqual(@as(f32, -12), l.bell_x);
+    try std.testing.expectEqual(@as(f32, 0), l.title_max_w);
 }
 
 test "fallbackCodepoint maps printable ASCII, else '?'" {


### PR DESCRIPTION
## Scope

Phase IV Goal 3B: smoke the sidebar tab rows for text/icons/states on the backend-neutral UI path.

This PR:
- adds pure sidebar header and tab-row layout helpers in `src/renderer/titlebar_layout.zig`
- moves sidebar tab row geometry for numbers, title text bounds, active marker, agent badge slot, bell slot, close affordance, and clipped rows out of `titlebar.zig`
- keeps rendering through existing backend-neutral `ui_pipeline` calls and existing titlebar glyph/emoji/icon helpers

Out of scope:
- no command palette, settings, startup overlay, file explorer, QR, assistant panel, previews, background image, or post-process work
- no D3D11/HLSL/COM details in feature renderer files
- no Windows default migration
- no OpenGL fallback removal

## D3D11 evidence

Fresh screenshot set after rebuilding with `zig build -Dgpu-backend=d3d11`:

- `zig-out\d3d11-sidebar-tabs-smoke\20260702-171042\d3d11-sidebar-tabs-window.png`
- `zig-out\d3d11-sidebar-tabs-smoke\20260702-171042\d3d11-sidebar-tabs-crop.png`
- `zig-out\d3d11-sidebar-tabs-smoke\20260702-171042\d3d11-sidebar-tabs-diagnostics.txt`
- `zig-out\d3d11-sidebar-tabs-smoke\20260702-171042\panes.json`

The crop shows 3 sidebar tab rows, active/inactive treatment, and a hovered close affordance. `panes.json` reports 3 tabs.

Key diagnostic lines:

```text
gpu-backend=d3d11 present=dxgi swapchain=1200x900
gpu vendor="D3D11" renderer="Direct3D 11" version="experimental" shading_language="HLSL"
frame-geometry client=1280x820 fb=1280x820 dpi=144 font_dpi=144 cell=20.00x45.00 titlebar=57.0 panels_l=220.0 panels_r=0.0 term=51x16 max=false full=false min=false
```

## Ghostty reference

Checked Ghostty's renderer layering in `src/renderer/generic.zig`: feature renderers stay API-agnostic while backend-specific details live under the graphics API / target / frame / render pass / pipeline hierarchy. This PR follows that shape by extracting pure sidebar tab geometry and leaving D3D11-specific work inside the backend/UI pipeline layer.

## Validation

- `zig fmt src\renderer\titlebar_layout.zig src\renderer\titlebar.zig`
- `zig test src\renderer\titlebar_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- visible D3D11 sidebar tabs smoke screenshot: `20260702-171042`
- `zig build test-full --summary all`
- `zig build`
- `git diff --check`
