### PR TITLE
[codex] smoke d3d11 startup shortcuts layout

### DIFF
--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -9,6 +9,7 @@ const ui_pipeline = @import("../ui_pipeline.zig");
 const keybind = @import("../../keybind.zig");
 const i18n = @import("../../i18n.zig");
 const primitives = @import("primitives.zig");
+const layout_math = @import("startup_shortcuts_layout.zig");
 const mixColor = primitives.mixColor;
 const renderRoundedQuadAlpha = primitives.renderRoundedQuadAlpha;
 
@@ -218,39 +219,28 @@ pub fn renderStartupShortcutsOverlay(window_width: f32, window_height: f32, top_
         max_action_width = @max(max_action_width, measureTitlebarText(localizedAction(entry)));
     }
 
-    const pad_x: f32 = 24;
-    const pad_y: f32 = 18;
-    const pair_gap_base: f32 = 48;
-    const column_gap: f32 = 38;
     const line_height = overlayLineHeight();
-    const heading_gap: f32 = 16;
-    const hint_gap: f32 = 12;
     const hint = i18n.s().shortcuts_hint;
     const heading = i18n.s().shortcuts_heading;
-    const content_height = @max(1.0, window_height - top_offset);
-    const available_height = @max(line_height, content_height - 24.0);
-    const fixed_height = pad_y * 2 + overlayTextHeight() + heading_gap + hint_gap + overlayTextHeight();
-    const available_entry_height = @max(line_height, available_height - fixed_height);
-    const rows_fit: usize = @max(1, @as(usize, @intFromFloat(@floor(available_entry_height / line_height))));
-    var columns: usize = (STARTUP_SHORTCUT_ENTRIES.len + rows_fit - 1) / rows_fit;
-    columns = @min(@max(columns, 1), 3);
-    const rows_per_column = (STARTUP_SHORTCUT_ENTRIES.len + columns - 1) / columns;
-    const entries_height = line_height * @as(f32, @floatFromInt(rows_per_column));
-    const pair_width = max_keys_width + pair_gap_base + max_action_width;
-    const desired_box_width = @round(@max(
-        measureTitlebarText(heading) + pad_x * 2,
-        @max(measureTitlebarText(hint) + pad_x * 2, pair_width * @as(f32, @floatFromInt(columns)) + column_gap * @as(f32, @floatFromInt(columns - 1)) + pad_x * 2),
-    ));
-    const box_width = @round(@min(desired_box_width, @max(260.0, window_width - 24.0)));
-    const box_height = @round(fixed_height + entries_height);
-
-    const box_x = @round(@max(12, (window_width - box_width) / 2));
-    const box_y = @round(@max(12, (content_height - box_height) / 2));
+    const heading_w = measureTitlebarText(heading);
+    const hint_w = measureTitlebarText(hint);
+    const layout = layout_math.compute(.{
+        .window_width = window_width,
+        .window_height = window_height,
+        .top_offset = top_offset,
+        .text_height = overlayTextHeight(),
+        .line_height = line_height,
+        .entry_count = STARTUP_SHORTCUT_ENTRIES.len,
+        .max_keys_width = max_keys_width,
+        .max_action_width = max_action_width,
+        .heading_width = heading_w,
+        .hint_width = hint_w,
+    });
 
     const panel_color = mixColor(AppWindow.g_theme.background, AppWindow.g_theme.foreground, 0.035);
     const border_color = mixColor(AppWindow.g_theme.background, AppWindow.g_theme.cursor_color, 0.24);
-    renderRoundedQuadAlpha(box_x - 1, box_y - 1, box_width + 2, box_height + 2, 11, border_color, alpha * 0.24);
-    renderRoundedQuadAlpha(box_x, box_y, box_width, box_height, 10, panel_color, alpha * 0.94);
+    renderRoundedQuadAlpha(layout.box_x - 1, layout.box_y - 1, layout.box_width + 2, layout.box_height + 2, 11, border_color, alpha * 0.24);
+    renderRoundedQuadAlpha(layout.box_x, layout.box_y, layout.box_width, layout.box_height, 10, panel_color, alpha * 0.94);
 
     const heading_base = mixColor(AppWindow.g_theme.foreground, AppWindow.g_theme.cursor_color, 0.18);
     const keys_base = mixColor(AppWindow.g_theme.foreground, AppWindow.g_theme.cursor_color, 0.08);
@@ -261,30 +251,16 @@ pub fn renderStartupShortcutsOverlay(window_width: f32, window_height: f32, top_
     const action_color = mixColor(AppWindow.g_theme.background, action_base, alpha);
     const hint_color = mixColor(AppWindow.g_theme.background, hint_base, alpha);
 
-    const heading_w = measureTitlebarText(heading);
-    const heading_y = @round(box_y + box_height - pad_y - overlayTextHeight());
-    renderTitlebarText(heading, box_x + (box_width - heading_w) / 2, heading_y, heading_color);
-    ui_pipeline.fillQuadAlpha(box_x + pad_x, heading_y - heading_gap / 2 - 1, box_width - pad_x * 2, 1, border_color, alpha * 0.36);
-
-    const inner_w = @max(1.0, box_width - pad_x * 2);
-    const total_column_gap = column_gap * @as(f32, @floatFromInt(columns - 1));
-    const column_w = @max(1.0, (inner_w - total_column_gap) / @as(f32, @floatFromInt(columns)));
-    const pair_gap = @min(pair_gap_base, @max(18.0, column_w * 0.08));
-    const keys_w = @min(max_keys_width, column_w * 0.48);
-    const action_w = @max(1.0, column_w - keys_w - pair_gap);
+    renderTitlebarText(heading, layout.box_x + (layout.box_width - heading_w) / 2, layout.heading_y, heading_color);
+    ui_pipeline.fillQuadAlpha(layout.box_x + layout.pad_x, layout.divider_y, layout.box_width - layout.pad_x * 2, 1, border_color, alpha * 0.36);
 
     for (STARTUP_SHORTCUT_ENTRIES, 0..) |entry, idx| {
         var keys_buf: [256]u8 = undefined;
         const keys = startupShortcutKeys(entry, &keys_buf);
-        const col = idx / rows_per_column;
-        const row = idx % rows_per_column;
-        const col_x = @round(box_x + pad_x + @as(f32, @floatFromInt(col)) * (column_w + column_gap));
-        const action_x = @round(col_x + keys_w + pair_gap);
-        const y = @round(heading_y - heading_gap - line_height - @as(f32, @floatFromInt(row)) * line_height);
-        renderTitlebarTextLimited(keys, col_x, y, keys_color, keys_w);
-        renderTitlebarTextLimited(localizedAction(entry), action_x, y, action_color, action_w);
+        const item = layout.entry(idx) orelse continue;
+        renderTitlebarTextLimited(keys, item.keys_x, item.y, keys_color, item.keys_width);
+        renderTitlebarTextLimited(localizedAction(entry), item.action_x, item.y, action_color, item.action_width);
     }
 
-    const hint_w = measureTitlebarText(hint);
-    renderTitlebarTextLimited(hint, box_x + (box_width - @min(hint_w, box_width - pad_x * 2)) / 2, box_y + pad_y, hint_color, box_width - pad_x * 2);
+    renderTitlebarTextLimited(hint, layout.hint_x, layout.hint_y, hint_color, layout.hint_max_width);
 }

--- a/src/renderer/overlays/startup_shortcuts_layout.zig
+++ b/src/renderer/overlays/startup_shortcuts_layout.zig
@@ -1,0 +1,217 @@
+//! Pure layout math for the startup keyboard shortcuts overlay.
+//!
+//! The renderer owns text measurement and drawing; this module only decides
+//! panel geometry, column count, and row placement from measured widths and
+//! viewport dimensions.
+
+const std = @import("std");
+
+pub const MAX_COLUMNS: usize = 3;
+
+pub const Input = struct {
+    window_width: f32,
+    window_height: f32,
+    top_offset: f32,
+    text_height: f32,
+    line_height: f32,
+    entry_count: usize,
+    max_keys_width: f32,
+    max_action_width: f32,
+    heading_width: f32,
+    hint_width: f32,
+};
+
+pub const Layout = struct {
+    box_x: f32,
+    box_y: f32,
+    box_width: f32,
+    box_height: f32,
+    pad_x: f32,
+    pad_y: f32,
+    heading_y: f32,
+    divider_y: f32,
+    first_entry_y: f32,
+    hint_x: f32,
+    hint_y: f32,
+    hint_max_width: f32,
+    columns: usize,
+    rows_per_column: usize,
+    column_width: f32,
+    column_gap: f32,
+    pair_gap: f32,
+    keys_width: f32,
+    action_width: f32,
+    line_height: f32,
+    entry_count: usize,
+
+    pub fn entry(self: Layout, idx: usize) ?Entry {
+        if (idx >= self.entry_count or self.rows_per_column == 0) return null;
+
+        const col = idx / self.rows_per_column;
+        const row = idx % self.rows_per_column;
+        if (col >= self.columns) return null;
+
+        const col_x = @round(self.box_x + self.pad_x + @as(f32, @floatFromInt(col)) * (self.column_width + self.column_gap));
+        return .{
+            .keys_x = col_x,
+            .action_x = @round(col_x + self.keys_width + self.pair_gap),
+            .y = @round(self.first_entry_y - @as(f32, @floatFromInt(row)) * self.line_height),
+            .keys_width = self.keys_width,
+            .action_width = self.action_width,
+        };
+    }
+};
+
+pub const Entry = struct {
+    keys_x: f32,
+    action_x: f32,
+    y: f32,
+    keys_width: f32,
+    action_width: f32,
+};
+
+pub fn compute(input: Input) Layout {
+    const pad_x: f32 = 24;
+    const pad_y: f32 = 18;
+    const pair_gap_base: f32 = 48;
+    const column_gap: f32 = 38;
+    const heading_gap: f32 = 16;
+    const hint_gap: f32 = 12;
+    const content_height = @max(1.0, input.window_height - input.top_offset);
+    const available_height = @max(input.line_height, content_height - 24.0);
+    const fixed_height = pad_y * 2 + input.text_height + heading_gap + hint_gap + input.text_height;
+    const available_entry_height = @max(input.line_height, available_height - fixed_height);
+    const rows_fit: usize = @max(1, @as(usize, @intFromFloat(@floor(available_entry_height / input.line_height))));
+
+    var columns: usize = (input.entry_count + rows_fit - 1) / rows_fit;
+    columns = @min(@max(columns, 1), MAX_COLUMNS);
+    const rows_per_column = (input.entry_count + columns - 1) / columns;
+    const entries_height = input.line_height * @as(f32, @floatFromInt(rows_per_column));
+    const pair_width = input.max_keys_width + pair_gap_base + input.max_action_width;
+    const desired_box_width = @round(@max(
+        input.heading_width + pad_x * 2,
+        @max(input.hint_width + pad_x * 2, pair_width * @as(f32, @floatFromInt(columns)) + column_gap * @as(f32, @floatFromInt(columns - 1)) + pad_x * 2),
+    ));
+    const box_width = @round(@min(desired_box_width, @max(260.0, input.window_width - 24.0)));
+    const box_height = @round(fixed_height + entries_height);
+
+    const box_x = @round(@max(12.0, (input.window_width - box_width) / 2.0));
+    const box_y = @round(@max(12.0, (content_height - box_height) / 2.0));
+    const heading_y = @round(box_y + box_height - pad_y - input.text_height);
+    const first_entry_y = @round(heading_y - heading_gap - input.line_height);
+    const inner_w = @max(1.0, box_width - pad_x * 2);
+    const total_column_gap = column_gap * @as(f32, @floatFromInt(columns - 1));
+    const column_width = @max(1.0, (inner_w - total_column_gap) / @as(f32, @floatFromInt(columns)));
+    const pair_gap = @min(pair_gap_base, @max(18.0, column_width * 0.08));
+    const keys_width = @min(input.max_keys_width, column_width * 0.48);
+    const action_width = @max(1.0, column_width - keys_width - pair_gap);
+    const hint_max_width = box_width - pad_x * 2;
+
+    return .{
+        .box_x = box_x,
+        .box_y = box_y,
+        .box_width = box_width,
+        .box_height = box_height,
+        .pad_x = pad_x,
+        .pad_y = pad_y,
+        .heading_y = heading_y,
+        .divider_y = heading_y - heading_gap / 2.0 - 1.0,
+        .first_entry_y = first_entry_y,
+        .hint_x = box_x + (box_width - @min(input.hint_width, hint_max_width)) / 2.0,
+        .hint_y = box_y + pad_y,
+        .hint_max_width = hint_max_width,
+        .columns = columns,
+        .rows_per_column = rows_per_column,
+        .column_width = column_width,
+        .column_gap = column_gap,
+        .pair_gap = pair_gap,
+        .keys_width = keys_width,
+        .action_width = action_width,
+        .line_height = input.line_height,
+        .entry_count = input.entry_count,
+    };
+}
+
+test "wide startup overlay uses three columns when height is constrained" {
+    const layout = compute(.{
+        .window_width = 1280,
+        .window_height = 430,
+        .top_offset = 40,
+        .text_height = 22,
+        .line_height = 30,
+        .entry_count = 24,
+        .max_keys_width = 190,
+        .max_action_width = 220,
+        .heading_width = 260,
+        .hint_width = 300,
+    });
+
+    try std.testing.expectEqual(@as(usize, 3), layout.columns);
+    try std.testing.expectEqual(@as(usize, 8), layout.rows_per_column);
+    try std.testing.expect(layout.box_width <= 1280 - 24);
+    try std.testing.expect(layout.box_x >= 12);
+}
+
+test "startup overlay falls back to one column when rows fit" {
+    const layout = compute(.{
+        .window_width = 900,
+        .window_height = 1600,
+        .top_offset = 40,
+        .text_height = 20,
+        .line_height = 28,
+        .entry_count = 10,
+        .max_keys_width = 150,
+        .max_action_width = 180,
+        .heading_width = 220,
+        .hint_width = 260,
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), layout.columns);
+    try std.testing.expectEqual(@as(usize, 10), layout.rows_per_column);
+}
+
+test "entry placement advances down rows then across columns" {
+    const layout = compute(.{
+        .window_width = 1280,
+        .window_height = 820,
+        .top_offset = 40,
+        .text_height = 22,
+        .line_height = 30,
+        .entry_count = 24,
+        .max_keys_width = 190,
+        .max_action_width = 220,
+        .heading_width = 260,
+        .hint_width = 300,
+    });
+
+    const first = layout.entry(0).?;
+    const second = layout.entry(1).?;
+    const next_column = layout.entry(layout.rows_per_column).?;
+
+    try std.testing.expectEqual(first.keys_x, second.keys_x);
+    try std.testing.expectEqual(first.y - layout.line_height, second.y);
+    try std.testing.expect(next_column.keys_x > first.keys_x);
+    try std.testing.expectEqual(first.y, next_column.y);
+    try std.testing.expectEqual(@as(?Entry, null), layout.entry(24));
+}
+
+test "narrow startup overlay clamps width and preserves positive text bands" {
+    const layout = compute(.{
+        .window_width = 280,
+        .window_height = 360,
+        .top_offset = 36,
+        .text_height = 18,
+        .line_height = 26,
+        .entry_count = 24,
+        .max_keys_width = 220,
+        .max_action_width = 240,
+        .heading_width = 320,
+        .hint_width = 260,
+    });
+
+    try std.testing.expectEqual(@as(f32, 260), layout.box_width);
+    try std.testing.expect(layout.column_width > 0);
+    try std.testing.expect(layout.keys_width > 0);
+    try std.testing.expect(layout.action_width > 0);
+    try std.testing.expect(layout.hint_max_width > 0);
+}

--- a/src/source_guards/overlay_boundary_guard.zig
+++ b/src/source_guards/overlay_boundary_guard.zig
@@ -23,6 +23,7 @@ const pure_overlay_modules = [_]PureModule{
     .{ .name = "command_palette_layout.zig", .source = @embedFile("../renderer/overlays/command_palette_layout.zig") },
     .{ .name = "command_palette_input.zig", .source = @embedFile("../renderer/overlays/command_palette_input.zig") },
     .{ .name = "command_palette_state.zig", .source = @embedFile("../renderer/overlays/command_palette_state.zig") },
+    .{ .name = "startup_shortcuts_layout.zig", .source = @embedFile("../renderer/overlays/startup_shortcuts_layout.zig") },
     .{ .name = "assistant_profiles.zig", .source = @embedFile("../renderer/overlays/assistant_profiles.zig") },
     .{ .name = "profile_codec.zig", .source = @embedFile("../renderer/overlays/profile_codec.zig") },
     .{ .name = "ssh_profiles.zig", .source = @embedFile("../renderer/overlays/ssh_profiles.zig") },

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -157,6 +157,7 @@ test {
     _ = @import("renderer/overlays/profile_codec.zig");
     _ = @import("renderer/overlays/command_palette_input.zig");
     _ = @import("renderer/overlays/command_palette_layout.zig");
+    _ = @import("renderer/overlays/startup_shortcuts_layout.zig");
     _ = @import("renderer/overlays/settings_page.zig");
     _ = @import("renderer/overlays/toasts.zig");
     _ = @import("renderer/overlays/confirm_modals.zig");


### PR DESCRIPTION
## Summary
- Extract startup shortcuts overlay geometry into a pure `startup_shortcuts_layout` module with unit coverage for column selection, row placement, and narrow-window bounds.
- Wire the visible startup shortcuts renderer to consume the computed layout while keeping text measurement, keybind lookup, i18n, and drawing in the existing renderer module.
- Register the new pure overlay module in the fast suite and the overlay boundary guard so it stays free of `AppWindow` imports.

## Scope
- Base branch: `windows-native-render`.
- Phase IV startup overlay slice only.
- No Windows default renderer change.
- No OpenGL fallback removal.
- No D3D11/HLSL/COM details added to feature renderer code.

## Ghostty reference
Ghostty's `src/renderer/generic.zig` keeps renderer work behind a graphics abstraction hierarchy (`GraphicsAPI -> Target -> Frame -> RenderPass -> Pipeline`). This slice follows the same direction: startup overlay feature code remains backend-neutral and feeds geometry into WispTerm's shared `ui_pipeline`.

## Validation
- `zig test src\renderer\overlays\startup_shortcuts_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `zig build test-full --summary all`

## D3D11 smoke evidence
- Screenshot: `zig-out\d3d11-startup-shortcuts-smoke\20260702-183642\d3d11-startup-shortcuts-overlay-xl.png`
- Diagnostics: `zig-out\d3d11-startup-shortcuts-smoke\20260702-183642\d3d11-startup-shortcuts-diagnostics.txt`
- Confirmed diagnostics: `gpu-backend=d3d11`, `renderer="Direct3D 11"`, `shading_language="HLSL"`
- Client size: `2200x1100`
