### PR TITLE
[codex] smoke d3d11 settings page layout

### DIFF
--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -39,6 +39,7 @@ const overlay_keys = @import("overlay_keys.zig");
 const overlay_state = @import("overlays/state.zig");
 const confirm_modals = @import("overlays/confirm_modals.zig");
 const settings_page = @import("overlays/settings_page.zig");
+const settings_page_layout = @import("overlays/settings_page_layout.zig");
 const toasts = @import("overlays/toasts.zig");
 const ssh_profiles = @import("overlays/ssh_profiles.zig");
 const ssh_profiles_layout = @import("overlays/ssh_profiles_layout.zig");
@@ -6128,21 +6129,7 @@ const SettingsAction = settings_page.Action;
 const SETTINGS_THEME_ROW = settings_page.SETTINGS_THEME_ROW;
 const SETTINGS_CONTROL_ROW_START = settings_page.SETTINGS_CONTROL_ROW_START;
 const SETTINGS_ROW_COUNT = settings_page.SETTINGS_ROW_COUNT;
-
-const SettingsLayout = struct {
-    box_x: f32,
-    box_top_px: f32,
-    box_w: f32,
-    box_h: f32,
-    header_h: f32,
-    footer_h: f32,
-    row_top_px: f32,
-    row_h: f32,
-    /// Number of rows that fit in the box for the current window height.
-    visible_rows: usize,
-    /// Index of the first rendered row (scroll offset).
-    scroll: usize,
-};
+const SettingsLayout = settings_page_layout.Layout;
 
 pub fn settingsPageVisible() bool {
     return settingsState().visible;
@@ -6178,8 +6165,7 @@ pub fn settingsPageContainsPoint(xpos: f64, ypos: f64, window_width: f32, window
     const layout = settingsLayout(window_width, window_height, top_offset);
     const x: f32 = @floatCast(xpos);
     const y: f32 = @floatCast(ypos);
-    return x >= layout.box_x and x <= layout.box_x + layout.box_w and
-        y >= layout.box_top_px and y <= layout.box_top_px + layout.box_h;
+    return layout.containsPoint(x, y);
 }
 
 pub fn settingsPageExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) bool {
@@ -6188,46 +6174,23 @@ pub fn settingsPageExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_hei
     return true;
 }
 
-/// Number of settings rows that fit within the box for the given window height,
-/// leaving room for the header and footer. Mirrors commandPaletteRowCapacity().
 fn settingsRowCapacity(content_height: f32, base_h: f32, row_h: f32) usize {
-    const usable_h = @max(row_h, content_height - 32.0 - base_h);
-    if (usable_h <= row_h) return 1;
-    const count_f = @floor(usable_h / row_h);
-    const count: usize = @intFromFloat(@max(1.0, count_f));
-    return @min(count, SETTINGS_ROW_COUNT);
+    return settings_page_layout.rowCapacity(content_height, base_h, row_h, SETTINGS_ROW_COUNT);
 }
 
-/// First row to render so the focused row stays visible (scroll offset).
-/// Mirrors commandPaletteFirstVisibleIndex().
 fn settingsFirstVisibleRow(visible_rows: usize) usize {
-    return settingsState().firstVisibleRow(visible_rows);
+    return settings_page_layout.firstVisibleRow(settingsState().focus, visible_rows, SETTINGS_ROW_COUNT);
 }
 
 fn settingsLayout(window_width: f32, window_height: f32, top_offset: f32) SettingsLayout {
-    const content_height = @max(1, window_height - top_offset);
-    const box_w = @round(@min(@max(420, window_width - 48), 760));
-    const row_h = overlayRowHeight(42);
-    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
-    const footer_h = @round(@max(52.0, overlayTextHeight() + 28.0));
-    const visible_rows = settingsRowCapacity(content_height, header_h + footer_h, row_h);
-    const scroll = settingsFirstVisibleRow(visible_rows);
-    const box_h = @round(clampOverlayBoxHeight(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h, content_height));
-    const box_x = @round(@max(16, (window_width - box_w) / 2));
-    const box_top_px = @round(top_offset + @max(16, (content_height - box_h) / 2));
-    const row_top_px = @round(box_top_px + header_h);
-    return .{
-        .box_x = box_x,
-        .box_top_px = box_top_px,
-        .box_w = box_w,
-        .box_h = box_h,
-        .header_h = header_h,
-        .footer_h = footer_h,
-        .row_top_px = row_top_px,
-        .row_h = row_h,
-        .visible_rows = visible_rows,
-        .scroll = scroll,
-    };
+    return settings_page_layout.compute(.{
+        .window_width = window_width,
+        .window_height = window_height,
+        .top_offset = top_offset,
+        .cell_height = font.g_titlebar_cell_height,
+        .focus = settingsState().focus,
+        .row_count = SETTINGS_ROW_COUNT,
+    });
 }
 
 fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) ?SettingsAction {
@@ -6235,25 +6198,18 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, 
     const x: f32 = @floatCast(xpos);
     const y: f32 = @floatCast(ypos);
 
-    const close_x = layout.box_x + layout.box_w - 62;
-    if (y >= layout.box_top_px + 18 and y < layout.box_top_px + 46 and x >= close_x and x < close_x + 44) {
+    if (layout.hitClose(x, y)) {
         return .close;
     }
 
-    if (x < layout.box_x + 18 or x > layout.box_x + layout.box_w - 18) return null;
-    if (y < layout.row_top_px) return null;
-    const visible_index: usize = @intFromFloat(@floor((y - layout.row_top_px) / layout.row_h));
-    if (visible_index >= layout.visible_rows) return null;
-    const row = visible_index + layout.scroll;
-    if (row >= SETTINGS_ROW_COUNT) return null;
+    const row = layout.rowAt(x, y) orelse return null;
     settingsState().focus = row;
 
     if (row == 0) {
-        const plus_x = layout.box_x + layout.box_w - 70;
-        const minus_x = plus_x - 42;
-        if (x >= minus_x and x < minus_x + 30) return .font_size_minus;
-        if (x >= plus_x and x < plus_x + 30) return .font_size_plus;
-        return null;
+        return switch (layout.fontControlAt(x) orelse return null) {
+            .minus => .font_size_minus,
+            .plus => .font_size_plus,
+        };
     }
 
     if (row == SETTINGS_THEME_ROW) {
@@ -6432,13 +6388,8 @@ fn languageSettingText(setting: i18n.LanguageSetting) []const u8 {
 }
 
 fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, title: []const u8, value: []const u8, hint: []const u8, clickable: bool, selected: bool) void {
-    // Skip rows scrolled out of view above or below the visible window.
-    if (row < layout.scroll) return;
-    const visible_index = row - layout.scroll;
-    if (visible_index >= layout.visible_rows) return;
-    const row_y = @round(@as(f32, @floatFromInt(visible_index)) * layout.row_h);
-    const y_top_px = layout.row_top_px + row_y;
-    const gl_y = @round(window_height - y_top_px - layout.row_h);
+    const visible = layout.visibleRow(window_height, row) orelse return;
+    const gl_y = visible.gl_y;
     const x = layout.box_x + 18;
     const w = layout.box_w - 36;
     const bg = AppWindow.g_theme.background;

--- a/src/renderer/overlays/settings_page_layout.zig
+++ b/src/renderer/overlays/settings_page_layout.zig
@@ -1,0 +1,265 @@
+//! Pure layout math for the settings page overlay.
+//!
+//! The settings page state owns focus/config mutation and overlays.zig owns
+//! drawing. This module only computes panel geometry, visible-row scroll, and
+//! hit-test bands from viewport/font inputs.
+
+const std = @import("std");
+
+pub const Input = struct {
+    window_width: f32,
+    window_height: f32,
+    top_offset: f32,
+    cell_height: f32,
+    focus: usize,
+    row_count: usize,
+};
+
+pub const Rect = struct {
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+
+    pub fn contains(self: Rect, x: f32, y: f32) bool {
+        return x >= self.x and x < self.x + self.w and
+            y >= self.top_px and y < self.top_px + self.h;
+    }
+};
+
+pub const FontControl = enum {
+    minus,
+    plus,
+};
+
+pub const VisibleRow = struct {
+    visible_index: usize,
+    top_px: f32,
+    gl_y: f32,
+};
+
+/// Computed geometry for the settings page, in top-down client pixels.
+pub const Layout = struct {
+    box_x: f32,
+    box_top_px: f32,
+    box_w: f32,
+    box_h: f32,
+    header_h: f32,
+    footer_h: f32,
+    row_top_px: f32,
+    row_h: f32,
+    /// Number of rows that fit in the box for the current window height.
+    visible_rows: usize,
+    /// Index of the first rendered row (scroll offset).
+    scroll: usize,
+    row_count: usize,
+
+    pub fn containsPoint(self: Layout, x: f32, y: f32) bool {
+        return x >= self.box_x and x <= self.box_x + self.box_w and
+            y >= self.box_top_px and y <= self.box_top_px + self.box_h;
+    }
+
+    pub fn closeRect(self: Layout) Rect {
+        return .{
+            .x = self.box_x + self.box_w - 62,
+            .top_px = self.box_top_px + 18,
+            .w = 44,
+            .h = 28,
+        };
+    }
+
+    pub fn hitClose(self: Layout, x: f32, y: f32) bool {
+        return self.closeRect().contains(x, y);
+    }
+
+    pub fn rowAt(self: Layout, x: f32, y: f32) ?usize {
+        if (x < self.box_x + 18 or x > self.box_x + self.box_w - 18) return null;
+        if (y < self.row_top_px) return null;
+        const visible_index: usize = @intFromFloat(@floor((y - self.row_top_px) / self.row_h));
+        if (visible_index >= self.visible_rows) return null;
+        const row = visible_index + self.scroll;
+        if (row >= self.row_count) return null;
+        return row;
+    }
+
+    pub fn visibleRow(self: Layout, window_height: f32, row: usize) ?VisibleRow {
+        if (row < self.scroll) return null;
+        const visible_index = row - self.scroll;
+        if (visible_index >= self.visible_rows) return null;
+
+        const row_y = @round(@as(f32, @floatFromInt(visible_index)) * self.row_h);
+        const top_px = self.row_top_px + row_y;
+        return .{
+            .visible_index = visible_index,
+            .top_px = top_px,
+            .gl_y = @round(window_height - top_px - self.row_h),
+        };
+    }
+
+    pub fn fontControlAt(self: Layout, x: f32) ?FontControl {
+        const plus_x = self.box_x + self.box_w - 70;
+        const minus_x = plus_x - 42;
+        if (x >= minus_x and x < minus_x + 30) return .minus;
+        if (x >= plus_x and x < plus_x + 30) return .plus;
+        return null;
+    }
+
+    pub fn focusVisible(self: Layout, focus: usize) bool {
+        return focus >= self.scroll and focus < self.scroll + self.visible_rows;
+    }
+};
+
+/// Text height for an overlay line, derived from the font cell height.
+/// Mirrors overlays.overlayTextHeight().
+fn textHeight(cell_height: f32) f32 {
+    return @max(1.0, cell_height);
+}
+
+/// Mirrors overlays.overlayLineHeight().
+fn lineHeight(cell_height: f32) f32 {
+    return @round(@max(24.0, textHeight(cell_height) + 8.0));
+}
+
+/// Mirrors overlays.overlayRowHeight().
+fn rowHeight(cell_height: f32, min_h: f32) f32 {
+    return @round(@max(min_h, textHeight(cell_height) + 14.0));
+}
+
+/// Mirrors overlays.clampOverlayBoxHeight().
+fn clampBoxHeight(box_h: f32, content_height: f32) f32 {
+    return @max(1.0, @min(box_h, content_height - 32.0));
+}
+
+pub fn headerHeight(cell_height: f32) f32 {
+    return @round(18.0 + lineHeight(cell_height) * 2.0 + 12.0);
+}
+
+pub fn footerHeight(cell_height: f32) f32 {
+    return @round(@max(52.0, textHeight(cell_height) + 28.0));
+}
+
+pub fn settingsRowHeight(cell_height: f32) f32 {
+    return rowHeight(cell_height, 42.0);
+}
+
+/// Number of settings rows that fit within the box for the given window height,
+/// leaving room for the header and footer. Mirrors commandPaletteRowCapacity().
+pub fn rowCapacity(content_height: f32, base_h: f32, row_h: f32, row_count: usize) usize {
+    if (row_count == 0) return 0;
+    const usable_h = @max(row_h, content_height - 32.0 - base_h);
+    if (usable_h <= row_h) return 1;
+    const count_f = @floor(usable_h / row_h);
+    const count: usize = @intFromFloat(@max(1.0, count_f));
+    return @min(count, row_count);
+}
+
+/// First row to render so the focused row stays visible (scroll offset).
+pub fn firstVisibleRow(focus_in: usize, visible_rows: usize, row_count: usize) usize {
+    if (visible_rows == 0 or row_count <= visible_rows) return 0;
+    const focus = @min(focus_in, row_count - 1);
+    if (focus < visible_rows) return 0;
+    return @min(focus - visible_rows + 1, row_count - visible_rows);
+}
+
+pub fn compute(input: Input) Layout {
+    const content_height = @max(1.0, input.window_height - input.top_offset);
+    const box_w = @round(@min(@max(420.0, input.window_width - 48.0), 760.0));
+    const row_h = settingsRowHeight(input.cell_height);
+    const header_h = headerHeight(input.cell_height);
+    const footer_h = footerHeight(input.cell_height);
+    const visible_rows = rowCapacity(content_height, header_h + footer_h, row_h, input.row_count);
+    const scroll = firstVisibleRow(input.focus, visible_rows, input.row_count);
+    const box_h = @round(clampBoxHeight(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h, content_height));
+    const box_x = @round(@max(16.0, (input.window_width - box_w) / 2.0));
+    const box_top_px = @round(input.top_offset + @max(16.0, (content_height - box_h) / 2.0));
+    const row_top_px = @round(box_top_px + header_h);
+
+    return .{
+        .box_x = box_x,
+        .box_top_px = box_top_px,
+        .box_w = box_w,
+        .box_h = box_h,
+        .header_h = header_h,
+        .footer_h = footer_h,
+        .row_top_px = row_top_px,
+        .row_h = row_h,
+        .visible_rows = visible_rows,
+        .scroll = scroll,
+        .row_count = input.row_count,
+    };
+}
+
+test "settings page layout fits every row in tall windows" {
+    const cell: f32 = 20;
+    const row_count: usize = 14;
+    const layout = compute(.{
+        .window_width = 1200,
+        .window_height = 2000,
+        .top_offset = 0,
+        .cell_height = cell,
+        .focus = row_count - 1,
+        .row_count = row_count,
+    });
+
+    try std.testing.expectEqual(row_count, layout.visible_rows);
+    try std.testing.expectEqual(@as(usize, 0), layout.scroll);
+}
+
+test "settings page layout scrolls to keep focused row visible" {
+    const cell: f32 = 20;
+    const row_count: usize = 14;
+    const layout = compute(.{
+        .window_width = 900,
+        .window_height = 522,
+        .top_offset = 0,
+        .cell_height = cell,
+        .focus = row_count - 1,
+        .row_count = row_count,
+    });
+
+    try std.testing.expect(layout.visible_rows >= 1);
+    try std.testing.expect(layout.visible_rows < row_count);
+    try std.testing.expectEqual(row_count - layout.visible_rows, layout.scroll);
+    try std.testing.expect(layout.focusVisible(row_count - 1));
+}
+
+test "settings page hit testing maps close row and font buttons" {
+    const layout = compute(.{
+        .window_width = 900,
+        .window_height = 700,
+        .top_offset = 40,
+        .cell_height = 20,
+        .focus = 0,
+        .row_count = 14,
+    });
+
+    const close = layout.closeRect();
+    try std.testing.expect(layout.hitClose(close.x + 2, close.top_px + 2));
+
+    const first_row_y = layout.row_top_px + 2;
+    try std.testing.expectEqual(@as(?usize, 0), layout.rowAt(layout.box_x + 24, first_row_y));
+
+    const plus_x = layout.box_x + layout.box_w - 68;
+    const minus_x = plus_x - 42;
+    try std.testing.expectEqual(FontControl.minus, layout.fontControlAt(minus_x).?);
+    try std.testing.expectEqual(FontControl.plus, layout.fontControlAt(plus_x).?);
+}
+
+test "settings page short-window box stays inside content area" {
+    const layout = compute(.{
+        .window_width = 800,
+        .window_height = 120,
+        .top_offset = 0,
+        .cell_height = 20,
+        .focus = 0,
+        .row_count = 14,
+    });
+
+    try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
+    try std.testing.expect(layout.row_h > 0);
+}
+
+test "first visible row handles degenerate row counts" {
+    try std.testing.expectEqual(@as(usize, 0), firstVisibleRow(10, 4, 0));
+    try std.testing.expectEqual(@as(usize, 0), rowCapacity(400, 100, 40, 0));
+}

--- a/src/source_guards/overlay_boundary_guard.zig
+++ b/src/source_guards/overlay_boundary_guard.zig
@@ -24,6 +24,7 @@ const pure_overlay_modules = [_]PureModule{
     .{ .name = "command_palette_input.zig", .source = @embedFile("../renderer/overlays/command_palette_input.zig") },
     .{ .name = "command_palette_state.zig", .source = @embedFile("../renderer/overlays/command_palette_state.zig") },
     .{ .name = "startup_shortcuts_layout.zig", .source = @embedFile("../renderer/overlays/startup_shortcuts_layout.zig") },
+    .{ .name = "settings_page_layout.zig", .source = @embedFile("../renderer/overlays/settings_page_layout.zig") },
     .{ .name = "assistant_profiles.zig", .source = @embedFile("../renderer/overlays/assistant_profiles.zig") },
     .{ .name = "profile_codec.zig", .source = @embedFile("../renderer/overlays/profile_codec.zig") },
     .{ .name = "ssh_profiles.zig", .source = @embedFile("../renderer/overlays/ssh_profiles.zig") },

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -158,6 +158,7 @@ test {
     _ = @import("renderer/overlays/command_palette_input.zig");
     _ = @import("renderer/overlays/command_palette_layout.zig");
     _ = @import("renderer/overlays/startup_shortcuts_layout.zig");
+    _ = @import("renderer/overlays/settings_page_layout.zig");
     _ = @import("renderer/overlays/settings_page.zig");
     _ = @import("renderer/overlays/toasts.zig");
     _ = @import("renderer/overlays/confirm_modals.zig");


### PR DESCRIPTION
## Summary

- Extract settings page panel geometry, scroll math, visible-row placement, and mouse hit-test bands into a pure `settings_page_layout` module.
- Keep settings state, config mutation, i18n strings, and drawing in `overlays.zig`, now consuming the pure layout result.
- Register the new pure module in the fast suite and overlay AppWindow-import guard so it stays backend-neutral.

## Why

Phase IV requires user-visible overlays to render through backend-neutral UI paths before D3D11 can approach UI parity. Ghostty's renderer layering keeps feature state above API-specific targets/frames/pipelines; this follows the same split by keeping the settings page renderer independent of D3D11/HLSL/COM details.

## Validation

- `zig test src\renderer\overlays\settings_page_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- Windows checkout path-safety: 1714 paths, 0 violations, 0 casefold collisions, 0 symlinks
- `zig build test-full --summary all` (60/60 steps succeeded; 12968 passed, 275 skipped)

## D3D11 Smoke Evidence

- Screenshot: `zig-out\d3d11-settings-page-smoke\20260702-193757\d3d11-settings-page.png`
- Diagnostics: `zig-out\d3d11-settings-page-smoke\20260702-193757\render-diagnostic.log`
- Key diagnostics:
  - `gpu-backend=d3d11 present=dxgi`
  - `renderer="Direct3D 11"`
  - `shading_language="HLSL"`

## Scope Guardrails

- Base branch: `windows-native-render`
- Does not merge to `main`
- Does not change the Windows default renderer
- Does not remove or weaken the OpenGL fallback