### PR TITLE
[codex] smoke d3d11 qr panel layout

### DIFF
--- a/src/renderer/feishu_qr_renderer.zig
+++ b/src/renderer/feishu_qr_renderer.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
 const panel = @import("../feishu/registration_panel.zig");
+const qr_layout = @import("qr_panel_layout.zig");
 const ui_pipeline = @import("ui_pipeline.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
@@ -30,11 +31,11 @@ fn textWidth(text: []const u8) f32 {
 }
 
 fn textYFromTop(window_height: f32, top_px: f32) f32 {
-    return @round(window_height - top_px - font.g_titlebar_cell_height);
+    return qr_layout.textYFromTop(window_height, top_px, font.g_titlebar_cell_height);
 }
 
 fn rectY(window_height: f32, rect: panel.Rect) f32 {
-    return @round(window_height - rect.top_px - rect.h);
+    return qr_layout.rectY(window_height, rect);
 }
 
 pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
@@ -43,8 +44,7 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
     const r = panel.refresh(allocator);
     if (r.redraw) {
-        AppWindow.g_force_rebuild = true; // ponytail: direct write mirrors weixin_qr_renderer.zig exactly
-        AppWindow.g_cells_valid = false;
+        AppWindow.applyUiEffect(.repaint);
     }
     if (r.succeeded) {
         AppWindow.overlays.applyFeishuRegistrationSuccess(); // 回填表单 + 关面板 + toast
@@ -110,21 +110,13 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
 }
 
 fn renderQrMatrix(matrix: panel.QrMatrixView, rect: panel.Rect, window_height: f32) void {
-    const quiet_modules: usize = 4;
-    const total_modules = matrix.size + quiet_modules * 2;
-    const module_px = @max(1.0, @floor(rect.w / @as(f32, @floatFromInt(total_modules))));
-    const draw_size = module_px * @as(f32, @floatFromInt(total_modules));
-    const start_x = @round(rect.x + (rect.w - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
-    const start_top = @round(rect.top_px + (rect.h - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
-
+    const layout = qr_layout.qrModules(rect, matrix.size);
     const black = .{ 0.03, 0.04, 0.05 };
     for (0..matrix.size) |y| {
-        const y_top = start_top + module_px * @as(f32, @floatFromInt(y));
-        const gl_y = @round(window_height - y_top - module_px);
         for (0..matrix.size) |x| {
             if (!matrix.isBlack(x, y)) continue;
-            const gl_x = start_x + module_px * @as(f32, @floatFromInt(x));
-            ui_pipeline.fillQuadAlpha(gl_x, gl_y, module_px, module_px, black, 1.0);
+            const module = layout.moduleRect(window_height, x, y);
+            ui_pipeline.fillQuadAlpha(module.x, module.y, module.size, module.size, black, 1.0);
         }
     }
 }
@@ -144,8 +136,8 @@ fn renderButton(rect: panel.Rect, window_height: f32, label: []const u8, base: [
     AppWindow.overlays.renderRoundedQuadAlpha(rect.x - 1, y - 1, rect.w + 2, rect.h + 2, 6, border, if (primary) 0.74 else 0.42);
     AppWindow.overlays.renderRoundedQuadAlpha(rect.x, y, rect.w, rect.h, 5, bg, if (primary) 0.92 else 0.58);
     const label_w = textWidth(label);
-    const text_y = @round(y + (rect.h - font.g_titlebar_cell_height) / 2.0);
-    _ = titlebar.renderTextLimited(label, rect.x + @max(8.0, (rect.w - label_w) / 2.0), text_y, text_color, rect.w - 16);
+    const label_layout = qr_layout.buttonLabel(rect, window_height, font.g_titlebar_cell_height, label_w);
+    _ = titlebar.renderTextLimited(label, label_layout.x, label_layout.y, text_color, label_layout.max_w);
 }
 
 pub fn deinit() void {}

--- a/src/renderer/qr_panel_layout.zig
+++ b/src/renderer/qr_panel_layout.zig
@@ -1,0 +1,114 @@
+//! Pure renderer-side geometry helpers shared by QR panels.
+//!
+//! The WeChat and Feishu QR panels own their UI state and panel layout. This
+//! module handles only the renderer math both panels need after that: converting
+//! top-down rectangles to bottom-up draw coordinates, centering QR modules with
+//! quiet-zone padding, and placing button labels.
+
+const std = @import("std");
+
+pub const Rect = struct {
+    x: f32,
+    top_px: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const ModuleRect = struct {
+    x: f32,
+    y: f32,
+    size: f32,
+};
+
+pub const QrModules = struct {
+    quiet_modules: usize,
+    total_modules: usize,
+    module_px: f32,
+    draw_size: f32,
+    start_x: f32,
+    start_top_px: f32,
+
+    pub fn moduleRect(self: QrModules, window_height: f32, x: usize, y: usize) ModuleRect {
+        const top_px = self.start_top_px + self.module_px * @as(f32, @floatFromInt(y));
+        return .{
+            .x = self.start_x + self.module_px * @as(f32, @floatFromInt(x)),
+            .y = @round(window_height - top_px - self.module_px),
+            .size = self.module_px,
+        };
+    }
+};
+
+pub const ButtonLabel = struct {
+    x: f32,
+    y: f32,
+    max_w: f32,
+};
+
+pub fn rectY(window_height: f32, rect: anytype) f32 {
+    return @round(window_height - rect.top_px - rect.h);
+}
+
+pub fn textYFromTop(window_height: f32, top_px: f32, cell_h: f32) f32 {
+    return @round(window_height - top_px - cell_h);
+}
+
+pub fn qrModules(rect: anytype, matrix_size: usize) QrModules {
+    const quiet_modules: usize = 4;
+    const total_modules = matrix_size + quiet_modules * 2;
+    const module_px = @max(1.0, @floor(rect.w / @as(f32, @floatFromInt(total_modules))));
+    const draw_size = module_px * @as(f32, @floatFromInt(total_modules));
+    return .{
+        .quiet_modules = quiet_modules,
+        .total_modules = total_modules,
+        .module_px = module_px,
+        .draw_size = draw_size,
+        .start_x = @round(rect.x + (rect.w - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules))),
+        .start_top_px = @round(rect.top_px + (rect.h - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules))),
+    };
+}
+
+pub fn buttonLabel(rect: anytype, window_height: f32, cell_h: f32, label_w: f32) ButtonLabel {
+    const y = rectY(window_height, rect);
+    return .{
+        .x = rect.x + @max(8.0, (rect.w - label_w) / 2.0),
+        .y = @round(y + (rect.h - cell_h) / 2.0),
+        .max_w = @max(1.0, rect.w - 16.0),
+    };
+}
+
+test "rectY converts top-down panel rects to bottom-up draw coordinates" {
+    const rect = Rect{ .x = 10, .top_px = 100, .w = 80, .h = 40 };
+    try std.testing.expectEqual(@as(f32, 460), rectY(600, rect));
+}
+
+test "qr modules are centered with a four-module quiet zone" {
+    const rect = Rect{ .x = 100, .top_px = 120, .w = 292, .h = 292 };
+    const layout = qrModules(rect, 21);
+
+    try std.testing.expectEqual(@as(usize, 4), layout.quiet_modules);
+    try std.testing.expectEqual(@as(usize, 29), layout.total_modules);
+    try std.testing.expectEqual(@as(f32, 10), layout.module_px);
+    try std.testing.expectEqual(@as(f32, 290), layout.draw_size);
+    try std.testing.expectEqual(@as(f32, 141), layout.start_x);
+    try std.testing.expectEqual(@as(f32, 161), layout.start_top_px);
+
+    const first = layout.moduleRect(600, 0, 0);
+    try std.testing.expectEqual(@as(f32, 141), first.x);
+    try std.testing.expectEqual(@as(f32, 429), first.y);
+    try std.testing.expectEqual(@as(f32, 10), first.size);
+}
+
+test "small QR rect still keeps at least one pixel per module" {
+    const rect = Rect{ .x = 0, .top_px = 0, .w = 20, .h = 20 };
+    const layout = qrModules(rect, 177);
+    try std.testing.expectEqual(@as(f32, 1), layout.module_px);
+    try std.testing.expect(layout.draw_size > rect.w);
+}
+
+test "button label centers text and reserves horizontal padding" {
+    const rect = Rect{ .x = 50, .top_px = 400, .w = 118, .h = 38 };
+    const label = buttonLabel(rect, 600, 20, 48);
+    try std.testing.expectEqual(@as(f32, 85), label.x);
+    try std.testing.expectEqual(@as(f32, 171), label.y);
+    try std.testing.expectEqual(@as(f32, 102), label.max_w);
+}

--- a/src/renderer/weixin_qr_renderer.zig
+++ b/src/renderer/weixin_qr_renderer.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const AppWindow = @import("../AppWindow.zig");
 const qr_panel = @import("../weixin/qr_panel.zig");
+const qr_layout = @import("qr_panel_layout.zig");
 const ui_pipeline = @import("ui_pipeline.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
@@ -29,11 +30,11 @@ fn textWidth(text: []const u8) f32 {
 }
 
 fn textYFromTop(window_height: f32, top_px: f32) f32 {
-    return @round(window_height - top_px - font.g_titlebar_cell_height);
+    return qr_layout.textYFromTop(window_height, top_px, font.g_titlebar_cell_height);
 }
 
 fn rectY(window_height: f32, rect: qr_panel.Rect) f32 {
-    return @round(window_height - rect.top_px - rect.h);
+    return qr_layout.rectY(window_height, rect);
 }
 
 pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
@@ -41,8 +42,7 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
 
     const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
     if (qr_panel.refresh(allocator)) {
-        AppWindow.g_force_rebuild = true;
-        AppWindow.g_cells_valid = false;
+        AppWindow.applyUiEffect(.repaint);
     }
     if (!qr_panel.visible()) return;
 
@@ -106,21 +106,13 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
 }
 
 fn renderQrMatrix(matrix: qr_panel.QrMatrixView, rect: qr_panel.Rect, window_height: f32) void {
-    const quiet_modules: usize = 4;
-    const total_modules = matrix.size + quiet_modules * 2;
-    const module_px = @max(1.0, @floor(rect.w / @as(f32, @floatFromInt(total_modules))));
-    const draw_size = module_px * @as(f32, @floatFromInt(total_modules));
-    const start_x = @round(rect.x + (rect.w - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
-    const start_top = @round(rect.top_px + (rect.h - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules)));
-
+    const layout = qr_layout.qrModules(rect, matrix.size);
     const black = .{ 0.03, 0.04, 0.05 };
     for (0..matrix.size) |y| {
-        const y_top = start_top + module_px * @as(f32, @floatFromInt(y));
-        const gl_y = @round(window_height - y_top - module_px);
         for (0..matrix.size) |x| {
             if (!matrix.isBlack(x, y)) continue;
-            const gl_x = start_x + module_px * @as(f32, @floatFromInt(x));
-            ui_pipeline.fillQuadAlpha(gl_x, gl_y, module_px, module_px, black, 1.0);
+            const module = layout.moduleRect(window_height, x, y);
+            ui_pipeline.fillQuadAlpha(module.x, module.y, module.size, module.size, black, 1.0);
         }
     }
 }
@@ -151,8 +143,8 @@ fn renderButton(rect: qr_panel.Rect, window_height: f32, label: []const u8, base
     AppWindow.overlays.renderRoundedQuadAlpha(rect.x, y, rect.w, rect.h, 5, bg, if (primary) 0.92 else 0.58);
 
     const label_w = textWidth(label);
-    const text_y = @round(y + (rect.h - font.g_titlebar_cell_height) / 2.0);
-    _ = titlebar.renderTextLimited(label, rect.x + @max(8.0, (rect.w - label_w) / 2.0), text_y, text_color, rect.w - 16);
+    const label_layout = qr_layout.buttonLabel(rect, window_height, font.g_titlebar_cell_height, label_w);
+    _ = titlebar.renderTextLimited(label, label_layout.x, label_layout.y, text_color, label_layout.max_w);
 }
 
 pub fn deinit() void {}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -190,6 +190,7 @@ test {
     _ = @import("renderer/overlays/update_prompt_model.zig");
     _ = @import("renderer/overlays/whats_new_model.zig");
     _ = @import("renderer/ui_batch.zig");
+    _ = @import("renderer/qr_panel_layout.zig");
     _ = @import("renderer/file_explorer_layout.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");


### PR DESCRIPTION
## Summary

This Phase IV slice moves the renderer-side QR panel geometry shared by the WeChat and Feishu QR panels into a small pure helper, then wires both panel renderers through that helper.

- add `src/renderer/qr_panel_layout.zig` for top-down to draw-space conversion, quiet-zone QR module placement, and button-label placement
- update WeChat and Feishu QR renderers to reuse the helper while staying on the existing backend-neutral `ui_pipeline`
- route QR refresh repaint requests through `AppWindow.applyUiEffect(.repaint)` instead of direct dirty-global writes
- register the pure helper in the fast suite

## Scope

Target branch: `windows-native-render`.

This does not change the Windows default renderer, does not merge anything to `main`, and does not remove or alter the OpenGL fallback. It stays in Phase IV UI/auxiliary renderer parity and does not start Phase V hardening or Phase VI default migration.

## Ghostty reference

Ghostty's `src/renderer/generic.zig` documents the renderer hierarchy as `GraphicsAPI -> Target -> Frame -> RenderPass -> Pipeline`. This change follows that shape by keeping D3D11/HLSL concerns inside WispTerm's backend/pipeline layer and keeping QR panel renderers feature-level: they own UI content and delegate only backend-neutral geometry/draw calls.

## Validation

- `zig fmt src\renderer\qr_panel_layout.zig src\renderer\weixin_qr_renderer.zig src\renderer\feishu_qr_renderer.zig src\test_fast.zig`
- `zig test src\renderer\qr_panel_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `zig build test-full --summary all`
  - `60/60 steps succeeded; 12988/13263 tests passed; 275 skipped`
- Windows checkout path safety, including the new untracked file before staging:
  - `windows_name_violations=0`
  - `casefold_collisions=0`
  - `max_path_length=90`
  - `git ls-files -s | Select-String '^120000'` produced no symlink entries

## D3D11 smoke evidence

Built with `zig build -Dgpu-backend=d3d11` and launched with isolated config/appdata plus `WISPTERM_RENDER_DIAGNOSTICS=1`.

Diagnostics from `zig-out\d3d11-qr-panels-smoke\20260702-201330\appdata\wispterm\render-diagnostic.log` include:

```text
[+117ms] gpu-backend=d3d11 present=dxgi swapchain=1200x900
[+178ms] gpu vendor="D3D11" renderer="Direct3D 11" version="experimental" shading_language="HLSL" clear_alpha=1.0 dwm_frame_extend_top=-1
```

The same run opened the WeChat QR panel through Command Center; stderr includes:

```text
info(weixin): QR login started
info(weixin): login: thread start
```

A local screenshot was captured at `zig-out\d3d11-qr-panels-smoke\20260702-201330\d3d11-wechat-qr-panel.png`. The screenshot is not embedded here because it contains a live one-time login QR code.
