### PR TITLE
[codex] smoke d3d11 background image layout

### DIFF
--- a/src/renderer/background_image.zig
+++ b/src/renderer/background_image.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const Config = @import("../config.zig");
 const AppWindow = @import("../AppWindow.zig");
 const gpu = AppWindow.gpu;
+const layout = @import("background_image_layout.zig");
 const ui_pipeline = @import("ui_pipeline.zig");
 
 const c = @cImport({
@@ -44,7 +45,7 @@ fn freeLoadedPath() void {
     g_loaded_path = null;
 }
 
-/// Load an image from `path` and upload it as a GL texture. Replaces any
+/// Load an image from `path` and upload it as a GPU texture. Replaces any
 /// previously loaded image. Call with `null` (or empty) to disable. Safe to
 /// call repeatedly for hot-reload — duplicate loads of the same path are a
 /// no-op.
@@ -116,71 +117,6 @@ pub fn deinit() void {
     freeLoadedPath();
 }
 
-/// Compute UVs for a fullscreen quad given the chosen mode.
-/// For fill/fit/center we keep the quad covering the whole framebuffer and
-/// adjust UVs so the image aspect is preserved. For tile we set UVs > 1 and
-/// rely on the repeat sampler mode.
-const Uv = struct { u_min: f32, v_min: f32, u_max: f32, v_max: f32 };
-
-fn computeUv(fb_w: f32, fb_h: f32, mode: Mode) Uv {
-    if (g_width <= 0 or g_height <= 0) return .{ .u_min = 0, .v_min = 0, .u_max = 1, .v_max = 1 };
-    const iw: f32 = @floatFromInt(g_width);
-    const ih: f32 = @floatFromInt(g_height);
-
-    switch (mode) {
-        .fill => {
-            // Cover: the image is scaled so the smaller axis fills the
-            // framebuffer; the larger axis is cropped via UVs (< 1 range).
-            const win_aspect = fb_w / fb_h;
-            const img_aspect = iw / ih;
-            if (img_aspect > win_aspect) {
-                // image is wider than the window — crop sides
-                const visible = win_aspect / img_aspect;
-                const offset = (1.0 - visible) * 0.5;
-                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
-            } else {
-                // image is taller — crop top/bottom
-                const visible = img_aspect / win_aspect;
-                const offset = (1.0 - visible) * 0.5;
-                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
-            }
-        },
-        .fit => {
-            // Letterbox: scale so the larger axis fills, the smaller is
-            // padded with extra UV space (sampled outside [0,1]). With
-            // CLAMP_TO_EDGE the padding shows the edge pixels — usually fine
-            // for landscape wallpapers but acceptable as a v1.
-            const win_aspect = fb_w / fb_h;
-            const img_aspect = iw / ih;
-            if (img_aspect > win_aspect) {
-                const extra = img_aspect / win_aspect;
-                const offset = (1.0 - extra) * 0.5;
-                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
-            } else {
-                const extra = win_aspect / img_aspect;
-                const offset = (1.0 - extra) * 0.5;
-                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
-            }
-        },
-        .center => {
-            // 1:1 pixel scale, centered. UV range is window/image so a
-            // center crop or surround happens naturally. Outside [0,1] the
-            // CLAMP_TO_EDGE wrap shows the edge row — close enough.
-            const u_range = fb_w / iw;
-            const v_range = fb_h / ih;
-            const u_off = (1.0 - u_range) * 0.5;
-            const v_off = (1.0 - v_range) * 0.5;
-            return .{ .u_min = u_off, .v_min = v_off, .u_max = u_off + u_range, .v_max = v_off + v_range };
-        },
-        .tile => {
-            // Repeat the image at native size. UVs equal window / image.
-            const u_range = fb_w / iw;
-            const v_range = fb_h / ih;
-            return .{ .u_min = 0, .v_min = 0, .u_max = u_range, .v_max = v_range };
-        },
-    }
-}
-
 /// Draw the loaded image filling the current viewport. The caller must have
 /// already set the viewport and projection. No-op when no image is loaded.
 /// Note: `viewport_height` is the height in pixels of the current viewport
@@ -189,22 +125,13 @@ pub fn drawFullscreen(viewport_width: f32, viewport_height: f32) void {
     if (!g_enabled or !g_texture.isValid()) return;
     if (ui_pipeline.emoji.program == 0) return;
 
-    const uv = computeUv(viewport_width, viewport_height, g_mode);
-
-    // Two triangles covering the whole viewport in pixel coords.
-    // drawTextureQuad's setProjection maps [0..w] x [0..h] to NDC.
-    const x_lo: f32 = 0;
-    const y_lo: f32 = 0;
-    const x_hi: f32 = viewport_width;
-    const y_hi: f32 = viewport_height;
-    const vertices = [6][4]f32{
-        .{ x_lo, y_hi, uv.u_min, uv.v_min }, // top-left
-        .{ x_lo, y_lo, uv.u_min, uv.v_max }, // bottom-left
-        .{ x_hi, y_lo, uv.u_max, uv.v_max }, // bottom-right
-        .{ x_lo, y_hi, uv.u_min, uv.v_min },
-        .{ x_hi, y_lo, uv.u_max, uv.v_max },
-        .{ x_hi, y_hi, uv.u_max, uv.v_min }, // top-right
+    const image_size = layout.Size{
+        .width = @floatFromInt(g_width),
+        .height = @floatFromInt(g_height),
     };
+    const viewport_size = layout.Size{ .width = viewport_width, .height = viewport_height };
+    const uv = layout.uvForMode(image_size, viewport_size, g_mode);
+    const vertices = layout.fullscreenVertices(viewport_size, uv);
 
     // The image is opaque RGBA; we want to write it directly without blending
     // against whatever ClearColor wrote. Disable blending for this single draw.

--- a/src/renderer/background_image_layout.zig
+++ b/src/renderer/background_image_layout.zig
@@ -1,0 +1,177 @@
+//! Pure background-image UV and fullscreen-quad layout math.
+//!
+//! The renderer owns image loading, GPU texture lifetime, and tint passes. This
+//! module only computes backend-neutral vertices so D3D11/OpenGL/Metal can share
+//! the same feature geometry through `ui_pipeline.drawTextureQuad`.
+
+const std = @import("std");
+
+pub const Size = struct {
+    width: f32,
+    height: f32,
+
+    fn valid(self: Size) bool {
+        return self.width > 0 and self.height > 0;
+    }
+};
+
+pub const Uv = struct {
+    u_min: f32,
+    v_min: f32,
+    u_max: f32,
+    v_max: f32,
+};
+
+pub const Vertex = [4]f32;
+pub const Vertices = [6]Vertex;
+
+pub const default_uv = Uv{ .u_min = 0, .v_min = 0, .u_max = 1, .v_max = 1 };
+
+/// Compute UVs for a fullscreen quad given the chosen background image mode.
+///
+/// `mode` is intentionally `anytype` so the pure helper can stay independent of
+/// the full config module while still accepting `Config.BackgroundImageMode`.
+pub fn uvForMode(image: Size, viewport: Size, mode: anytype) Uv {
+    if (!image.valid() or !viewport.valid()) return default_uv;
+
+    const win_aspect = viewport.width / viewport.height;
+    const img_aspect = image.width / image.height;
+
+    switch (mode) {
+        .fill => {
+            if (img_aspect > win_aspect) {
+                const visible = win_aspect / img_aspect;
+                const offset = (1.0 - visible) * 0.5;
+                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
+            } else {
+                const visible = img_aspect / win_aspect;
+                const offset = (1.0 - visible) * 0.5;
+                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
+            }
+        },
+        .fit => {
+            if (img_aspect > win_aspect) {
+                const extra = img_aspect / win_aspect;
+                const offset = (1.0 - extra) * 0.5;
+                return .{ .u_min = 0, .v_min = offset, .u_max = 1, .v_max = 1.0 - offset };
+            } else {
+                const extra = win_aspect / img_aspect;
+                const offset = (1.0 - extra) * 0.5;
+                return .{ .u_min = offset, .v_min = 0, .u_max = 1.0 - offset, .v_max = 1 };
+            }
+        },
+        .center => {
+            const u_range = viewport.width / image.width;
+            const v_range = viewport.height / image.height;
+            const u_off = (1.0 - u_range) * 0.5;
+            const v_off = (1.0 - v_range) * 0.5;
+            return .{ .u_min = u_off, .v_min = v_off, .u_max = u_off + u_range, .v_max = v_off + v_range };
+        },
+        .tile => {
+            return .{
+                .u_min = 0,
+                .v_min = 0,
+                .u_max = viewport.width / image.width,
+                .v_max = viewport.height / image.height,
+            };
+        },
+    }
+}
+
+/// Build the two triangles used by `ui_pipeline.drawTextureQuad`.
+pub fn fullscreenVertices(viewport: Size, uv: Uv) Vertices {
+    const x_lo: f32 = 0;
+    const y_lo: f32 = 0;
+    const x_hi = viewport.width;
+    const y_hi = viewport.height;
+
+    return .{
+        .{ x_lo, y_hi, uv.u_min, uv.v_min },
+        .{ x_lo, y_lo, uv.u_min, uv.v_max },
+        .{ x_hi, y_lo, uv.u_max, uv.v_max },
+        .{ x_lo, y_hi, uv.u_min, uv.v_min },
+        .{ x_hi, y_lo, uv.u_max, uv.v_max },
+        .{ x_hi, y_hi, uv.u_max, uv.v_min },
+    };
+}
+
+const TestMode = enum { fill, fit, center, tile };
+
+fn expectApprox(actual: f32, expected: f32) !void {
+    try std.testing.expectApproxEqAbs(expected, actual, 0.0001);
+}
+
+fn expectUv(actual: Uv, expected: Uv) !void {
+    try expectApprox(actual.u_min, expected.u_min);
+    try expectApprox(actual.v_min, expected.v_min);
+    try expectApprox(actual.u_max, expected.u_max);
+    try expectApprox(actual.v_max, expected.v_max);
+}
+
+test "background image fill crops the wider image axis" {
+    try expectUv(
+        uvForMode(.{ .width = 1600, .height = 900 }, .{ .width = 900, .height = 900 }, TestMode.fill),
+        .{ .u_min = 0.21875, .v_min = 0, .u_max = 0.78125, .v_max = 1 },
+    );
+}
+
+test "background image fill crops the taller image axis" {
+    try expectUv(
+        uvForMode(.{ .width = 900, .height = 1600 }, .{ .width = 1600, .height = 900 }, TestMode.fill),
+        .{ .u_min = 0, .v_min = 0.341796875, .u_max = 1, .v_max = 0.658203125 },
+    );
+}
+
+test "background image fit expands UVs on the padded axis" {
+    try expectUv(
+        uvForMode(.{ .width = 1600, .height = 900 }, .{ .width = 800, .height = 600 }, TestMode.fit),
+        .{ .u_min = 0, .v_min = -0.16666669, .u_max = 1, .v_max = 1.1666667 },
+    );
+    try expectUv(
+        uvForMode(.{ .width = 900, .height = 1600 }, .{ .width = 800, .height = 600 }, TestMode.fit),
+        .{ .u_min = -0.6851852, .v_min = 0, .u_max = 1.6851852, .v_max = 1 },
+    );
+}
+
+test "background image center uses viewport to image pixel ratio" {
+    try expectUv(
+        uvForMode(.{ .width = 400, .height = 200 }, .{ .width = 200, .height = 100 }, TestMode.center),
+        .{ .u_min = 0.25, .v_min = 0.25, .u_max = 0.75, .v_max = 0.75 },
+    );
+    try expectUv(
+        uvForMode(.{ .width = 100, .height = 50 }, .{ .width = 200, .height = 100 }, TestMode.center),
+        .{ .u_min = -0.5, .v_min = -0.5, .u_max = 1.5, .v_max = 1.5 },
+    );
+}
+
+test "background image tile repeats by viewport to image ratio" {
+    try expectUv(
+        uvForMode(.{ .width = 100, .height = 50 }, .{ .width = 350, .height = 125 }, TestMode.tile),
+        .{ .u_min = 0, .v_min = 0, .u_max = 3.5, .v_max = 2.5 },
+    );
+}
+
+test "background image invalid dimensions use default UVs" {
+    try expectUv(
+        uvForMode(.{ .width = 0, .height = 50 }, .{ .width = 350, .height = 125 }, TestMode.fill),
+        default_uv,
+    );
+    try expectUv(
+        uvForMode(.{ .width = 100, .height = 50 }, .{ .width = 0, .height = 125 }, TestMode.tile),
+        default_uv,
+    );
+}
+
+test "background image fullscreen vertices match ui texture quad ordering" {
+    const vertices = fullscreenVertices(
+        .{ .width = 320, .height = 200 },
+        .{ .u_min = 0.1, .v_min = 0.2, .u_max = 0.9, .v_max = 0.8 },
+    );
+
+    try std.testing.expectEqual(Vertex{ 0, 200, 0.1, 0.2 }, vertices[0]);
+    try std.testing.expectEqual(Vertex{ 0, 0, 0.1, 0.8 }, vertices[1]);
+    try std.testing.expectEqual(Vertex{ 320, 0, 0.9, 0.8 }, vertices[2]);
+    try std.testing.expectEqual(Vertex{ 0, 200, 0.1, 0.2 }, vertices[3]);
+    try std.testing.expectEqual(Vertex{ 320, 0, 0.9, 0.8 }, vertices[4]);
+    try std.testing.expectEqual(Vertex{ 320, 200, 0.9, 0.2 }, vertices[5]);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -190,6 +190,7 @@ test {
     _ = @import("renderer/overlays/update_prompt_model.zig");
     _ = @import("renderer/overlays/whats_new_model.zig");
     _ = @import("renderer/ui_batch.zig");
+    _ = @import("renderer/background_image_layout.zig");
     _ = @import("renderer/qr_panel_layout.zig");
     _ = @import("renderer/file_explorer_layout.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");


### PR DESCRIPTION
## Summary

- Extract background image UV and fullscreen-quad generation into a pure `renderer/background_image_layout.zig` helper.
- Route `background_image.zig` through the helper while keeping image loading, GPU texture lifetime, opacity tinting, and `ui_pipeline.drawTextureQuad` unchanged.
- Add fast-suite coverage for fill/fit/center/tile UVs, invalid dimensions, and vertex ordering.

## Ghostty comparison

Ghostty's generic renderer keeps background image state in the renderer, but sends drawing through its backend abstraction hierarchy (`GraphicsAPI -> Target -> Frame -> RenderPass -> Pipeline -> Texture`). This PR follows that boundary shape for WispTerm: the feature renderer only computes backend-neutral geometry and calls the existing `ui_pipeline`/`gpu.Texture` surface. No D3D11/HLSL/COM details enter `background_image.zig`.

## Scope boundaries

- Targets `windows-native-render` only.
- Does not change the Windows default renderer; D3D11 remains build-time opt-in.
- Does not remove or alter the OpenGL fallback.
- Does not start Phase V hardening or Phase VI default migration.

## Validation

- `zig fmt src\renderer\background_image_layout.zig src\renderer\background_image.zig src\test_fast.zig`
- `zig test src\renderer\background_image_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `zig build test-full --summary all` -> `60/60 steps succeeded; 13023/13298 tests passed; 275 skipped`
- Windows checkout path safety including the new file: `windows_name_violations=0`, `casefold_collisions=0`, `max_path_length=90`, no symlink entries
- D3D11 background-image smoke with isolated profile and generated PNG:
  - screenshot: `zig-out\d3d11-background-image-smoke\20260702-204517\d3d11-background-image.png`
  - diagnostics: `gpu-backend=d3d11 present=dxgi`, `renderer="Direct3D 11"`, `shading_language="HLSL"`
  - stderr confirms generated background image loaded at `480x300`
  - screenshot colorful coverage ratio: `0.8348`