### PR TITLE
[codex] smoke d3d11 preview image layout

### DIFF
--- a/src/preview/image_layout.zig
+++ b/src/preview/image_layout.zig
@@ -1,0 +1,214 @@
+//! Pure layout math for raster preview panes.
+//!
+//! Image/PDF preview rendering owns decode/upload in the renderer and zoom/pan
+//! state in `PreviewPane`; this module only converts image size + viewport size
+//! into backend-neutral draw rectangles, scissor boxes, and texture vertices.
+
+const std = @import("std");
+
+pub const Size = struct {
+    width: f32,
+    height: f32,
+
+    fn valid(self: Size) bool {
+        return self.width > 0 and self.height > 0;
+    }
+};
+
+pub const Point = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+};
+
+pub const Rect = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const Scissor = struct {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+};
+
+pub const Vertex = [4]f32;
+pub const Vertices = [6]Vertex;
+
+pub const Input = struct {
+    content_x: f32,
+    content_width: f32,
+    body_top: f32,
+    body_height: f32,
+    window_height: f32,
+    image: Size,
+    zoom: f32,
+    pan: Point = .{},
+};
+
+pub const Layout = struct {
+    scale: f32,
+    draw: Rect,
+    border: Rect,
+    scissor: Scissor,
+    vertices: Vertices,
+    clamped_pan: Point,
+};
+
+pub fn drawSize(image: Size, view: Size, zoom: f32) ?Size {
+    if (!image.valid() or !view.valid() or zoom <= 0) return null;
+    const scale = @min(view.width / image.width, view.height / image.height) * zoom;
+    if (scale <= 0) return null;
+    return .{ .width = image.width * scale, .height = image.height * scale };
+}
+
+pub fn clampPan(view: Size, draw: Size, pan: Point) Point {
+    if (!view.valid() or !draw.valid()) return .{};
+    const max_x = if (draw.width > view.width) (draw.width - view.width) / 2 else 0;
+    const max_y = if (draw.height > view.height) (draw.height - view.height) / 2 else 0;
+    return .{
+        .x = @max(-max_x, @min(max_x, pan.x)),
+        .y = @max(-max_y, @min(max_y, pan.y)),
+    };
+}
+
+pub fn compute(input: Input) ?Layout {
+    if (input.window_height <= 0) return null;
+
+    const view = Size{ .width = input.content_width, .height = input.body_height };
+    const draw = drawSize(input.image, view, input.zoom) orelse return null;
+    const scale = draw.width / input.image.width;
+    const pan = clampPan(view, draw, input.pan);
+
+    const draw_x = input.content_x + (view.width - draw.width) / 2 + pan.x;
+    const draw_top = input.body_top + (view.height - draw.height) / 2 + pan.y;
+    const draw_y = input.window_height - draw_top - draw.height;
+    const rect = Rect{ .x = draw_x, .y = draw_y, .w = draw.width, .h = draw.height };
+
+    const scissor = scissorFor(input.content_x, input.body_top, view, input.window_height) orelse return null;
+    return .{
+        .scale = scale,
+        .draw = rect,
+        .border = .{ .x = rect.x - 1, .y = rect.y - 1, .w = rect.w + 2, .h = rect.h + 2 },
+        .scissor = scissor,
+        .vertices = textureVertices(rect),
+        .clamped_pan = pan,
+    };
+}
+
+pub fn scissorFor(content_x: f32, body_top: f32, view: Size, window_height: f32) ?Scissor {
+    if (!view.valid() or window_height <= 0) return null;
+    const x: i32 = @intFromFloat(@max(0, @floor(content_x)));
+    const y: i32 = @intFromFloat(@max(0, @floor(window_height - body_top - view.height)));
+    const w: i32 = @intFromFloat(@max(0, @ceil(view.width)));
+    const h: i32 = @intFromFloat(@max(0, @ceil(view.height)));
+    if (w <= 0 or h <= 0) return null;
+    return .{ .x = x, .y = y, .w = w, .h = h };
+}
+
+pub fn textureVertices(rect: Rect) Vertices {
+    return .{
+        .{ rect.x, rect.y + rect.h, 0, 0 },
+        .{ rect.x, rect.y, 0, 1 },
+        .{ rect.x + rect.w, rect.y, 1, 1 },
+        .{ rect.x, rect.y + rect.h, 0, 0 },
+        .{ rect.x + rect.w, rect.y, 1, 1 },
+        .{ rect.x + rect.w, rect.y + rect.h, 1, 0 },
+    };
+}
+
+fn expectApprox(actual: f32, expected: f32) !void {
+    try std.testing.expectApproxEqAbs(expected, actual, 0.0001);
+}
+
+fn expectPoint(actual: Point, expected: Point) !void {
+    try expectApprox(actual.x, expected.x);
+    try expectApprox(actual.y, expected.y);
+}
+
+fn expectRect(actual: Rect, expected: Rect) !void {
+    try expectApprox(actual.x, expected.x);
+    try expectApprox(actual.y, expected.y);
+    try expectApprox(actual.w, expected.w);
+    try expectApprox(actual.h, expected.h);
+}
+
+test "preview image drawSize fits inside the body and honors zoom" {
+    const fitted = drawSize(.{ .width = 400, .height = 200 }, .{ .width = 800, .height = 600 }, 1).?;
+    try expectApprox(fitted.width, 800);
+    try expectApprox(fitted.height, 400);
+
+    const zoomed = drawSize(.{ .width = 400, .height = 200 }, .{ .width = 800, .height = 600 }, 1.5).?;
+    try expectApprox(zoomed.width, 1200);
+    try expectApprox(zoomed.height, 600);
+}
+
+test "preview image clampPan permits panning only when draw exceeds view" {
+    try expectPoint(
+        clampPan(.{ .width = 300, .height = 200 }, .{ .width = 200, .height = 100 }, .{ .x = 80, .y = -80 }),
+        .{},
+    );
+    try expectPoint(
+        clampPan(.{ .width = 300, .height = 200 }, .{ .width = 700, .height = 500 }, .{ .x = 400, .y = -600 }),
+        .{ .x = 200, .y = -150 },
+    );
+}
+
+test "preview image compute centers fitted images in GL coordinates" {
+    const layout = compute(.{
+        .content_x = 100,
+        .content_width = 800,
+        .body_top = 50,
+        .body_height = 600,
+        .window_height = 800,
+        .image = .{ .width = 400, .height = 200 },
+        .zoom = 1,
+    }).?;
+
+    try expectApprox(layout.scale, 2);
+    try expectRect(layout.draw, .{ .x = 100, .y = 250, .w = 800, .h = 400 });
+    try expectRect(layout.border, .{ .x = 99, .y = 249, .w = 802, .h = 402 });
+    try std.testing.expectEqual(Scissor{ .x = 100, .y = 150, .w = 800, .h = 600 }, layout.scissor);
+}
+
+test "preview image compute clamps pan before positioning a zoomed image" {
+    const layout = compute(.{
+        .content_x = 10,
+        .content_width = 200,
+        .body_top = 20,
+        .body_height = 100,
+        .window_height = 300,
+        .image = .{ .width = 400, .height = 300 },
+        .zoom = 3,
+        .pan = .{ .x = 200, .y = -150 },
+    }).?;
+
+    try expectApprox(layout.scale, 1);
+    try expectPoint(layout.clamped_pan, .{ .x = 100, .y = -100 });
+    try expectRect(layout.draw, .{ .x = 10, .y = 180, .w = 400, .h = 300 });
+}
+
+test "preview image textureVertices match ui texture quad ordering" {
+    const vertices = textureVertices(.{ .x = 10, .y = 20, .w = 30, .h = 40 });
+    try std.testing.expectEqual(Vertex{ 10, 60, 0, 0 }, vertices[0]);
+    try std.testing.expectEqual(Vertex{ 10, 20, 0, 1 }, vertices[1]);
+    try std.testing.expectEqual(Vertex{ 40, 20, 1, 1 }, vertices[2]);
+    try std.testing.expectEqual(Vertex{ 10, 60, 0, 0 }, vertices[3]);
+    try std.testing.expectEqual(Vertex{ 40, 20, 1, 1 }, vertices[4]);
+    try std.testing.expectEqual(Vertex{ 40, 60, 1, 0 }, vertices[5]);
+}
+
+test "preview image invalid sizes do not produce layout" {
+    try std.testing.expect(drawSize(.{ .width = 0, .height = 20 }, .{ .width = 100, .height = 100 }, 1) == null);
+    try std.testing.expect(compute(.{
+        .content_x = 0,
+        .content_width = 100,
+        .body_top = 0,
+        .body_height = 100,
+        .window_height = 200,
+        .image = .{ .width = 10, .height = 10 },
+        .zoom = 0,
+    }) == null);
+}

--- a/src/preview/pane.zig
+++ b/src/preview/pane.zig
@@ -7,6 +7,7 @@ const Allocator = std.mem.Allocator;
 const markdown_preview = @import("markdown.zig");
 const preview_source = @import("../input/preview_source.zig");
 const preview_diagnostics = @import("diagnostics.zig");
+const image_layout = @import("image_layout.zig");
 const pdf_preview = @import("pdf.zig");
 const pdf_render = @import("../platform/pdf_render.zig");
 const gpu = @import("../renderer/gpu/gpu.zig");
@@ -220,10 +221,13 @@ pub fn panImageBy(self: *PreviewPane, dx: f32, dy: f32) bool {
 }
 
 pub fn clampImagePan(self: *PreviewPane, view_w: f32, view_h: f32, draw_w: f32, draw_h: f32) void {
-    const max_x = if (draw_w > view_w) (draw_w - view_w) / 2 else 0;
-    const max_y = if (draw_h > view_h) (draw_h - view_h) / 2 else 0;
-    self.image_pan_x = @max(-max_x, @min(max_x, self.image_pan_x));
-    self.image_pan_y = @max(-max_y, @min(max_y, self.image_pan_y));
+    const pan = image_layout.clampPan(
+        .{ .width = view_w, .height = view_h },
+        .{ .width = draw_w, .height = draw_h },
+        .{ .x = self.image_pan_x, .y = self.image_pan_y },
+    );
+    self.image_pan_x = pan.x;
+    self.image_pan_y = pan.y;
 }
 
 pub fn beginAsyncLoad(self: *PreviewPane, kind: markdown_preview.Kind, t: []const u8, p: []const u8, source_kind: PreviewSourceKind) bool {

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -8,6 +8,7 @@ const text_wrap = @import("../text_wrap.zig");
 const ui_perf = @import("../ui_perf.zig");
 const PreviewPane = @import("../preview/pane.zig");
 const preview_diagnostics = @import("../preview/diagnostics.zig");
+const preview_image_layout = @import("../preview/image_layout.zig");
 const preview_close_button = @import("../input/preview_close_button.zig");
 const titlebar = AppWindow.titlebar;
 const font = AppWindow.font;
@@ -698,31 +699,30 @@ fn renderImageDocument(
         return;
     }
 
-    const image_w: f32 = @floatFromInt(pane.image_width);
-    const image_h: f32 = @floatFromInt(pane.image_height);
-    if (image_w <= 0 or image_h <= 0) return;
+    const image_size = preview_image_layout.Size{
+        .width = @floatFromInt(pane.image_width),
+        .height = @floatFromInt(pane.image_height),
+    };
+    const view_size = preview_image_layout.Size{ .width = content_w, .height = body_h };
+    const draw_size = preview_image_layout.drawSize(image_size, view_size, pane.imageZoom()) orelse return;
+    pane.clampImagePan(content_w, body_h, draw_size.width, draw_size.height);
 
-    const scale = @min(content_w / image_w, body_h / image_h) * pane.imageZoom();
-    if (scale <= 0) return;
-
-    const draw_w = image_w * scale;
-    const draw_h = image_h * scale;
-    pane.clampImagePan(content_w, body_h, draw_w, draw_h);
-    const draw_x = content_x + (content_w - draw_w) / 2 + pane.imagePanX();
-    const draw_top = body_top + (body_h - draw_h) / 2 + pane.imagePanY();
-    const draw_y = window_height - draw_top - draw_h;
-
-    const clip_x: i32 = @intFromFloat(@max(0, @floor(content_x)));
-    const clip_y: i32 = @intFromFloat(@max(0, @floor(window_height - body_top - body_h)));
-    const clip_w: i32 = @intFromFloat(@max(0, @ceil(content_w)));
-    const clip_h: i32 = @intFromFloat(@max(0, @ceil(body_h)));
-    if (clip_w <= 0 or clip_h <= 0) return;
+    const layout = preview_image_layout.compute(.{
+        .content_x = content_x,
+        .content_width = content_w,
+        .body_top = body_top,
+        .body_height = body_h,
+        .window_height = window_height,
+        .image = image_size,
+        .zoom = pane.imageZoom(),
+        .pan = .{ .x = pane.imagePanX(), .y = pane.imagePanY() },
+    }) orelse return;
 
     // Clip the image to the body area, restoring any outer scissor afterward.
     const saved_scissor = gpu.state.scissorState();
-    gpu.state.setScissor(.{ .x = clip_x, .y = clip_y, .w = clip_w, .h = clip_h });
-    ui_pipeline.fillQuad(draw_x - 1, draw_y - 1, draw_w + 2, draw_h + 2, border);
-    drawImageTexture(pane, draw_x, draw_y, draw_w, draw_h, window_height);
+    gpu.state.setScissor(.{ .x = layout.scissor.x, .y = layout.scissor.y, .w = layout.scissor.w, .h = layout.scissor.h });
+    ui_pipeline.fillQuad(layout.border.x, layout.border.y, layout.border.w, layout.border.h, border);
+    drawImageTexture(pane, layout.vertices);
     gpu.state.restoreScissor(saved_scissor);
 }
 
@@ -805,18 +805,8 @@ fn ensureImageTexture(pane: *PreviewPane) bool {
     return true;
 }
 
-fn drawImageTexture(pane: *PreviewPane, x: f32, y: f32, w: f32, h: f32, window_height: f32) void {
-    _ = window_height;
+fn drawImageTexture(pane: *PreviewPane, vertices: preview_image_layout.Vertices) void {
     if (!pane.image_texture.isValid() or ui_pipeline.emoji.program == 0) return;
-
-    const vertices = [6][4]f32{
-        .{ x, y + h, 0, 0 },
-        .{ x, y, 0, 1 },
-        .{ x + w, y, 1, 1 },
-        .{ x, y + h, 0, 0 },
-        .{ x + w, y, 1, 1 },
-        .{ x + w, y + h, 1, 0 },
-    };
 
     ui_pipeline.drawTextureQuad(vertices, pane.image_texture, 1.0);
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -247,6 +247,7 @@ test {
     _ = @import("preview/pdf.zig");
     _ = @import("preview/gallery.zig");
     _ = @import("preview/diagnostics.zig");
+    _ = @import("preview/image_layout.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");
     _ = @import("i18n.zig");


### PR DESCRIPTION
## Summary

- add `src/preview/image_layout.zig` as pure backend-neutral raster preview layout math for fit/zoom, pan clamping, scissors, borders, and texture vertices
- route `PreviewPane.clampImagePan` through the shared helper so UI state and renderer placement use the same clamp rules
- refactor markdown/image preview rendering to feed precomputed texture vertices into the backend-neutral `ui_pipeline.drawTextureQuad` path

## Scope

This is a Phase IV parity slice for `windows-native-render`.

- Targets `windows-native-render`, not `main`
- Does not change the Windows default renderer
- Does not remove the OpenGL fallback
- Does not start Phase V hardening or Phase VI default migration

## Ghostty comparison

Ghostty keeps renderer feature data backend-neutral and routes backend-specific texture, target, pass, and pipeline details through the renderer API boundary (`src/renderer/generic.zig`, `src/renderer/image.zig`). This follows the same shape: preview code computes placement/vertices as plain data, while decode/upload and backend-specific texture handling remain inside WispTerm's renderer/GPU layer.

## Validation

- `zig fmt src\preview\image_layout.zig src\preview\pane.zig src\renderer\markdown_preview_renderer.zig src\test_fast.zig`
- `zig test src\preview\image_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all` (60/60 steps, 13053 passed, 275 skipped)
- Windows checkout path safety check including untracked files: 1717 files, 0 name violations, 0 casefold collisions, no symlinks
