### PR TITLE
[codex] smoke d3d11 sidebar tab states

### DIFF
--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -1232,13 +1232,6 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
 
         const row_hovered = mouseInRect(0, row.row_top_px, sidebar_w, row.row_h);
 
-        if (is_active) {
-            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, active_bg);
-            ui_pipeline.fillQuad(row.active_marker_x, row.active_marker_y, row.active_marker_w, row.active_marker_h, AppWindow.g_theme.cursor_color);
-        } else if (row_hovered) {
-            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, hover_bg);
-        }
-
         if (tab.g_tab_count > 1) {
             if (row_hovered) {
                 tab.g_tab_close_opacity[tab_idx] = @min(1.0, tab.g_tab_close_opacity[tab_idx] + tab.TAB_CLOSE_FADE_SPEED * dt);
@@ -1249,9 +1242,31 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
             tab.g_tab_close_opacity[tab_idx] = 0;
         }
 
+        const visual = titlebar_layout.sidebarTabVisual(.{
+            .row = row,
+            .active = is_active,
+            .hovered = row_hovered,
+            .tab_count = tab.g_tab_count,
+            .close_opacity = tab.g_tab_close_opacity[tab_idx],
+            .mouse_x = mouseX(),
+            .close_btn_w = tab.TAB_CLOSE_BTN_W,
+        });
+
+        if (visual.draw_active_background) {
+            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, active_bg);
+            ui_pipeline.fillQuad(row.active_marker_x, row.active_marker_y, row.active_marker_w, row.active_marker_h, AppWindow.g_theme.cursor_color);
+        } else if (visual.draw_hover_background) {
+            ui_pipeline.fillQuad(0, row.row_y, sidebar_w, row.row_h, hover_bg);
+        }
+
         var prefix_buf: [8]u8 = undefined;
         const prefix = std.fmt.bufPrint(&prefix_buf, "{d}", .{tab_idx + 1}) catch "";
-        _ = renderTextLimited(prefix, row.number_x, row.text_y, if (is_active) text_active else muted, row.number_w);
+        const number_color = switch (visual.number_tone) {
+            .active => text_active,
+            .inactive => text_inactive,
+            .muted => muted,
+        };
+        _ = renderTextLimited(prefix, row.number_x, row.text_y, number_color, row.number_w);
 
         const title = if (tab.g_tab_rename_active and tab_idx == tab.g_tab_rename_idx)
             tab.g_tab_rename_buf[0..tab.g_tab_rename_len]
@@ -1260,8 +1275,12 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
         else
             "New Tab";
 
-        const close_opacity = tab.g_tab_close_opacity[tab_idx];
-        const title_color = if (is_active) text_active else text_inactive;
+        const close_opacity = visual.close_opacity;
+        const title_color = switch (visual.title_tone) {
+            .active => text_active,
+            .inactive => text_inactive,
+            .muted => muted,
+        };
         const text_end = renderTextLimited(title, row.title_x, row.text_y, title_color, row.title_max_w);
 
         if (tab.g_tab_rename_active and tab_idx == tab.g_tab_rename_idx and AppWindow.g_cursor_blink_visible) {
@@ -1275,18 +1294,14 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
             _ = renderAgentBadge(detection, row.badge_x, row.text_y, is_active);
         }
 
-        if (close_opacity > 0.01 and tab.g_tab_count > 1) {
-            const close_hovered = row_hovered and blk: {
-                const mx = mouseX() orelse break :blk false;
-                break :blk mx >= row.close_x and mx < row.close_x + tab.TAB_CLOSE_BTN_W;
-            };
-            const raw_color = if (close_hovered) text_active else muted;
+        if (visual.draw_close) {
+            const raw_color = if (visual.close_hovered) text_active else muted;
             const close_color = [3]f32{
                 raw_color[0] * close_opacity + sidebar_bg[0] * (1 - close_opacity),
                 raw_color[1] * close_opacity + sidebar_bg[1] * (1 - close_opacity),
                 raw_color[2] * close_opacity + sidebar_bg[2] * (1 - close_opacity),
             };
-            if (close_hovered) {
+            if (visual.draw_close_hover_background) {
                 ui_pipeline.fillQuad(row.close_hover_x, row.close_hover_y, row.close_hover_w, row.close_hover_h, blend(bg, fg, 0.14));
             }
             renderCloseIcon(row.close_x, row.row_y, tab.TAB_CLOSE_BTN_W, row.row_h, close_color);

--- a/src/renderer/titlebar_layout.zig
+++ b/src/renderer/titlebar_layout.zig
@@ -122,6 +122,59 @@ pub const SidebarTabRowLayout = struct {
     close_hover_h: f32,
 };
 
+pub const SidebarTabTone = enum {
+    active,
+    inactive,
+    muted,
+};
+
+pub const SidebarTabVisual = struct {
+    active: bool,
+    hovered: bool,
+    draw_active_background: bool,
+    draw_hover_background: bool,
+    draw_active_marker: bool,
+    number_tone: SidebarTabTone,
+    title_tone: SidebarTabTone,
+    close_opacity: f32,
+    draw_close: bool,
+    close_hovered: bool,
+    draw_close_hover_background: bool,
+};
+
+pub const SidebarTabVisualInput = struct {
+    row: SidebarTabRowLayout,
+    active: bool,
+    hovered: bool,
+    tab_count: usize,
+    close_opacity: f32,
+    mouse_x: ?f32 = null,
+    close_btn_w: f32,
+};
+
+pub fn sidebarTabVisual(input: SidebarTabVisualInput) SidebarTabVisual {
+    const close_opacity = @max(0.0, @min(1.0, input.close_opacity));
+    const can_close = input.tab_count > 1 and close_opacity > 0.01;
+    const close_hovered = can_close and input.hovered and blk: {
+        const mx = input.mouse_x orelse break :blk false;
+        break :blk mx >= input.row.close_x and mx < input.row.close_x + input.close_btn_w;
+    };
+
+    return .{
+        .active = input.active,
+        .hovered = input.hovered,
+        .draw_active_background = input.active,
+        .draw_hover_background = !input.active and input.hovered,
+        .draw_active_marker = input.active,
+        .number_tone = if (input.active) .active else .muted,
+        .title_tone = if (input.active) .active else .inactive,
+        .close_opacity = close_opacity,
+        .draw_close = can_close,
+        .close_hovered = close_hovered,
+        .draw_close_hover_background = close_hovered,
+    };
+}
+
 pub fn sidebarTabRowLayout(
     window_height: f32,
     titlebar_h: f32,
@@ -427,6 +480,78 @@ test "sidebarTabRowLayout clamps title width in narrow sidebars" {
     try std.testing.expectEqual(@as(f32, 14), l.badge_x);
     try std.testing.expectEqual(@as(f32, -12), l.bell_x);
     try std.testing.expectEqual(@as(f32, 0), l.title_max_w);
+}
+
+test "sidebarTabVisual maps active hover and text tones" {
+    const row = sidebarTabRowLayout(820, 57, 46, 45, 220, 0, 14, 28, 36, 23, false, 0, false).?;
+
+    const visual = sidebarTabVisual(.{
+        .row = row,
+        .active = true,
+        .hovered = true,
+        .tab_count = 3,
+        .close_opacity = 0.5,
+        .mouse_x = row.close_x + 4,
+        .close_btn_w = 36,
+    });
+
+    try std.testing.expect(visual.draw_active_background);
+    try std.testing.expect(!visual.draw_hover_background);
+    try std.testing.expect(visual.draw_active_marker);
+    try std.testing.expectEqual(SidebarTabTone.active, visual.number_tone);
+    try std.testing.expectEqual(SidebarTabTone.active, visual.title_tone);
+    try std.testing.expect(visual.draw_close);
+    try std.testing.expect(visual.close_hovered);
+}
+
+test "sidebarTabVisual suppresses close affordance for single tabs" {
+    const row = sidebarTabRowLayout(820, 57, 46, 45, 220, 0, 14, 28, 36, 23, false, 0, false).?;
+
+    const visual = sidebarTabVisual(.{
+        .row = row,
+        .active = false,
+        .hovered = true,
+        .tab_count = 1,
+        .close_opacity = 1.0,
+        .mouse_x = row.close_x + 4,
+        .close_btn_w = 36,
+    });
+
+    try std.testing.expect(!visual.draw_active_background);
+    try std.testing.expect(visual.draw_hover_background);
+    try std.testing.expectEqual(SidebarTabTone.muted, visual.number_tone);
+    try std.testing.expectEqual(SidebarTabTone.inactive, visual.title_tone);
+    try std.testing.expect(!visual.draw_close);
+    try std.testing.expect(!visual.close_hovered);
+}
+
+test "sidebarTabVisual clamps opacity and requires row hover for close hover" {
+    const row = sidebarTabRowLayout(820, 57, 46, 45, 220, 0, 14, 28, 36, 23, false, 0, false).?;
+
+    const outside = sidebarTabVisual(.{
+        .row = row,
+        .active = false,
+        .hovered = false,
+        .tab_count = 3,
+        .close_opacity = 2.0,
+        .mouse_x = row.close_x + 4,
+        .close_btn_w = 36,
+    });
+    try std.testing.expectEqual(@as(f32, 1.0), outside.close_opacity);
+    try std.testing.expect(outside.draw_close);
+    try std.testing.expect(!outside.close_hovered);
+
+    const faded = sidebarTabVisual(.{
+        .row = row,
+        .active = false,
+        .hovered = true,
+        .tab_count = 3,
+        .close_opacity = 0.01,
+        .mouse_x = row.close_x + 4,
+        .close_btn_w = 36,
+    });
+    try std.testing.expect(!faded.draw_close);
+    try std.testing.expect(!faded.close_hovered);
 }
 
 test "fallbackCodepoint maps printable ASCII, else '?'" {


### PR DESCRIPTION
## Summary

- add a pure `titlebar_layout.sidebarTabVisual` model for sidebar tab active/hover/text-tone/close affordance state
- route the visible sidebar tab renderer through that backend-neutral visual model before issuing `ui_pipeline` quad/glyph/icon draw calls
- extend fast titlebar layout coverage for active/inactive tones, close visibility, close hover, and opacity clamping

## Scope

This is a Phase IV tab/chrome parity slice for `windows-native-render`.

- Targets `windows-native-render`, not `main`
- Keeps tabs in the existing left sidebar path; does not revive the legacy top tab-bar fallback path
- Does not change the Windows default renderer
- Does not remove the OpenGL fallback
- Does not start Phase V hardening or Phase VI default migration

## Ghostty comparison

Ghostty keeps tab chrome in the apprt/platform UI layer (`src/apprt/gtk/class/tab.zig` and GTK templates), with tab title/tooltip/close-request state outside renderer backend implementations. WispTerm draws its own chrome, so this keeps the same boundary shape by moving sidebar tab visual state into pure layout/model data while D3D11/OpenGL remain backend executors behind `ui_pipeline`.

## Validation

- `zig fmt src\renderer\titlebar_layout.zig src\renderer\titlebar.zig`
- `zig test src\renderer\titlebar_layout.zig` (19/19 passed)
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all` (60/60 steps, 13068 passed, 275 skipped)

Note: an earlier `test-full` attempt hit a transient Windows `MoveFileExW AccessDenied` in unrelated `tools.import` temp-file rename; an immediate rerun passed fully.
