### PR TITLE
[codex] smoke d3d11 qr panel layout

### DIFF
--- a/src/renderer/feishu_qr_renderer.zig
+++ b/src/renderer/feishu_qr_renderer.zig
@@ -56,8 +56,8 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     AppWindow.gpu.state.setBlendMode(.alpha);
 
     const l = panel.layout(window_width, window_height, top_offset);
-    const panel_y = rectY(window_height, l.panel);
-    const qr_y = rectY(window_height, l.qr);
+    const chrome = qr_layout.panelChrome(l.panel, window_width, window_height);
+    const frame = qr_layout.qrFrame(l.qr, window_height);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -70,9 +70,9 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     const muted = mix(bg, fg, 0.62);
     const danger = .{ 0.88, 0.28, 0.24 };
 
-    AppWindow.overlays.renderRoundedQuadAlpha(0, 0, window_width, window_height, 1, .{ 0.0, 0.0, 0.0 }, 0.28);
-    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x - 1, panel_y - 1, l.panel.w + 2, l.panel.h + 2, 10, panel_border, 0.50);
-    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x, panel_y, l.panel.w, l.panel.h, 9, panel_bg, 0.98);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.scrim.x, chrome.scrim.y, chrome.scrim.w, chrome.scrim.h, 1, .{ 0.0, 0.0, 0.0 }, 0.28);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.border.x, chrome.border.y, chrome.border.w, chrome.border.h, 10, panel_border, 0.50);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.panel.x, chrome.panel.y, chrome.panel.w, chrome.panel.h, 9, panel_bg, 0.98);
 
     const pad_x: f32 = 28;
     const title_y = textYFromTop(window_height, l.panel.top_px + 24);
@@ -90,8 +90,8 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     const detail_y = textYFromTop(window_height, l.panel.top_px + 94);
     _ = titlebar.renderTextLimited(panel.statusDetail(s), l.panel.x + pad_x, detail_y, muted, l.panel.w - pad_x * 2);
 
-    ui_pipeline.fillQuadAlpha(l.qr.x - 10, qr_y - 10, l.qr.w + 20, l.qr.h + 20, qr_border, 0.42);
-    ui_pipeline.fillQuadAlpha(l.qr.x - 8, qr_y - 8, l.qr.w + 16, l.qr.h + 16, qr_bg, 1.0);
+    ui_pipeline.fillQuadAlpha(frame.border.x, frame.border.y, frame.border.w, frame.border.h, qr_border, 0.42);
+    ui_pipeline.fillQuadAlpha(frame.fill.x, frame.fill.y, frame.fill.w, frame.fill.h, qr_bg, 1.0);
 
     if (panel.qrMatrix()) |matrix| {
         renderQrMatrix(matrix, l.qr, window_height);
@@ -122,11 +122,10 @@ fn renderQrMatrix(matrix: panel.QrMatrixView, rect: panel.Rect, window_height: f
 }
 
 fn renderQrFallback(l: panel.Layout, window_height: f32, normal: [3]f32) void {
-    const qr_y = rectY(window_height, l.qr);
     const message = if (panel.qrGenerationFailed()) "二维码生成失败" else "正在获取二维码…";
     const msg_w = textWidth(message);
-    const msg_y = qr_y + l.qr.h * 0.52;
-    _ = titlebar.renderTextLimited(message, l.qr.x + @max(8.0, (l.qr.w - msg_w) / 2.0), msg_y, normal, l.qr.w - 16);
+    const message_layout = qr_layout.fallbackMessage(l.qr, window_height, msg_w);
+    _ = titlebar.renderTextLimited(message, message_layout.x, message_layout.y, normal, message_layout.max_w);
 }
 
 fn renderButton(rect: panel.Rect, window_height: f32, label: []const u8, base: [3]f32, text_color: [3]f32, primary: bool) void {

--- a/src/renderer/qr_panel_layout.zig
+++ b/src/renderer/qr_panel_layout.zig
@@ -44,6 +44,24 @@ pub const ButtonLabel = struct {
     max_w: f32,
 };
 
+pub const DrawRect = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const PanelChrome = struct {
+    scrim: DrawRect,
+    border: DrawRect,
+    panel: DrawRect,
+};
+
+pub const QrFrame = struct {
+    border: DrawRect,
+    fill: DrawRect,
+};
+
 pub fn rectY(window_height: f32, rect: anytype) f32 {
     return @round(window_height - rect.top_px - rect.h);
 }
@@ -64,6 +82,41 @@ pub fn qrModules(rect: anytype, matrix_size: usize) QrModules {
         .draw_size = draw_size,
         .start_x = @round(rect.x + (rect.w - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules))),
         .start_top_px = @round(rect.top_px + (rect.h - draw_size) / 2.0 + module_px * @as(f32, @floatFromInt(quiet_modules))),
+    };
+}
+
+pub fn panelChrome(rect: anytype, window_width: f32, window_height: f32) PanelChrome {
+    const y = rectY(window_height, rect);
+    return .{
+        .scrim = .{ .x = 0, .y = 0, .w = window_width, .h = window_height },
+        .border = .{ .x = rect.x - 1, .y = y - 1, .w = rect.w + 2, .h = rect.h + 2 },
+        .panel = .{ .x = rect.x, .y = y, .w = rect.w, .h = rect.h },
+    };
+}
+
+pub fn qrFrame(rect: anytype, window_height: f32) QrFrame {
+    const y = rectY(window_height, rect);
+    return .{
+        .border = .{ .x = rect.x - 10, .y = y - 10, .w = rect.w + 20, .h = rect.h + 20 },
+        .fill = .{ .x = rect.x - 8, .y = y - 8, .w = rect.w + 16, .h = rect.h + 16 },
+    };
+}
+
+pub fn fallbackMessage(rect: anytype, window_height: f32, label_w: f32) ButtonLabel {
+    const y = rectY(window_height, rect) + rect.h * 0.52;
+    return .{
+        .x = rect.x + @max(8.0, (rect.w - label_w) / 2.0),
+        .y = y,
+        .max_w = @max(1.0, rect.w - 16.0),
+    };
+}
+
+pub fn fallbackDetail(rect: anytype, window_height: f32, cell_h: f32) ButtonLabel {
+    const message = fallbackMessage(rect, window_height, 0);
+    return .{
+        .x = rect.x + 12.0,
+        .y = message.y - cell_h - 10.0,
+        .max_w = @max(1.0, rect.w - 24.0),
     };
 }
 
@@ -103,6 +156,36 @@ test "small QR rect still keeps at least one pixel per module" {
     const layout = qrModules(rect, 177);
     try std.testing.expectEqual(@as(f32, 1), layout.module_px);
     try std.testing.expect(layout.draw_size > rect.w);
+}
+
+test "panel chrome converts shared QR panel surfaces to draw rectangles" {
+    const rect = Rect{ .x = 90, .top_px = 80, .w = 320, .h = 440 };
+    const chrome = panelChrome(rect, 900, 700);
+
+    try std.testing.expectEqual(DrawRect{ .x = 0, .y = 0, .w = 900, .h = 700 }, chrome.scrim);
+    try std.testing.expectEqual(DrawRect{ .x = 89, .y = 179, .w = 322, .h = 442 }, chrome.border);
+    try std.testing.expectEqual(DrawRect{ .x = 90, .y = 180, .w = 320, .h = 440 }, chrome.panel);
+}
+
+test "QR frame expands the matrix area consistently" {
+    const rect = Rect{ .x = 140, .top_px = 150, .w = 260, .h = 260 };
+    const frame = qrFrame(rect, 640);
+
+    try std.testing.expectEqual(DrawRect{ .x = 130, .y = 220, .w = 280, .h = 280 }, frame.border);
+    try std.testing.expectEqual(DrawRect{ .x = 132, .y = 222, .w = 276, .h = 276 }, frame.fill);
+}
+
+test "fallback labels share centered message and detail geometry" {
+    const rect = Rect{ .x = 120, .top_px = 200, .w = 240, .h = 250 };
+    const message = fallbackMessage(rect, 700, 96);
+    const detail = fallbackDetail(rect, 700, 22);
+
+    try std.testing.expectEqual(@as(f32, 192), message.x);
+    try std.testing.expectEqual(@as(f32, 380), message.y);
+    try std.testing.expectEqual(@as(f32, 224), message.max_w);
+    try std.testing.expectEqual(@as(f32, 132), detail.x);
+    try std.testing.expectEqual(@as(f32, 348), detail.y);
+    try std.testing.expectEqual(@as(f32, 216), detail.max_w);
 }
 
 test "button label centers text and reserves horizontal padding" {

--- a/src/renderer/weixin_qr_renderer.zig
+++ b/src/renderer/weixin_qr_renderer.zig
@@ -50,8 +50,8 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     AppWindow.gpu.state.setBlendMode(.alpha);
 
     const l = qr_panel.layout(window_width, window_height, top_offset);
-    const panel_y = rectY(window_height, l.panel);
-    const qr_y = rectY(window_height, l.qr);
+    const chrome = qr_layout.panelChrome(l.panel, window_width, window_height);
+    const frame = qr_layout.qrFrame(l.qr, window_height);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -64,9 +64,9 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     const muted = mix(bg, fg, 0.62);
     const danger = .{ 0.88, 0.28, 0.24 };
 
-    AppWindow.overlays.renderRoundedQuadAlpha(0, 0, window_width, window_height, 1, .{ 0.0, 0.0, 0.0 }, 0.28);
-    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x - 1, panel_y - 1, l.panel.w + 2, l.panel.h + 2, 10, panel_border, 0.50);
-    AppWindow.overlays.renderRoundedQuadAlpha(l.panel.x, panel_y, l.panel.w, l.panel.h, 9, panel_bg, 0.98);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.scrim.x, chrome.scrim.y, chrome.scrim.w, chrome.scrim.h, 1, .{ 0.0, 0.0, 0.0 }, 0.28);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.border.x, chrome.border.y, chrome.border.w, chrome.border.h, 10, panel_border, 0.50);
+    AppWindow.overlays.renderRoundedQuadAlpha(chrome.panel.x, chrome.panel.y, chrome.panel.w, chrome.panel.h, 9, panel_bg, 0.98);
 
     const pad_x: f32 = 28;
     const title_y = textYFromTop(window_height, l.panel.top_px + 24);
@@ -85,8 +85,8 @@ pub fn render(window_width: f32, window_height: f32, top_offset: f32) void {
     const detail_y = textYFromTop(window_height, l.panel.top_px + 94);
     _ = titlebar.renderTextLimited(qr_panel.statusDetail(qr_panel.status()), l.panel.x + pad_x, detail_y, muted, l.panel.w - pad_x * 2);
 
-    ui_pipeline.fillQuadAlpha(l.qr.x - 10, qr_y - 10, l.qr.w + 20, l.qr.h + 20, qr_border, 0.42);
-    ui_pipeline.fillQuadAlpha(l.qr.x - 8, qr_y - 8, l.qr.w + 16, l.qr.h + 16, qr_bg, 1.0);
+    ui_pipeline.fillQuadAlpha(frame.border.x, frame.border.y, frame.border.w, frame.border.h, qr_border, 0.42);
+    ui_pipeline.fillQuadAlpha(frame.fill.x, frame.fill.y, frame.fill.w, frame.fill.h, qr_bg, 1.0);
 
     if (qr_panel.qrMatrix()) |matrix| {
         renderQrMatrix(matrix, l.qr, window_height);
@@ -118,20 +118,19 @@ fn renderQrMatrix(matrix: qr_panel.QrMatrixView, rect: qr_panel.Rect, window_hei
 }
 
 fn renderQrFallback(l: qr_panel.Layout, window_height: f32, normal: [3]f32, muted: [3]f32) void {
-    const qr_y = rectY(window_height, l.qr);
     const message = if (qr_panel.qrGenerationFailed())
         "QR code could not be generated"
     else
         "Requesting QR code...";
 
     const msg_w = textWidth(message);
-    const msg_y = qr_y + l.qr.h * 0.52;
-    _ = titlebar.renderTextLimited(message, l.qr.x + @max(8.0, (l.qr.w - msg_w) / 2.0), msg_y, normal, l.qr.w - 16);
+    const message_layout = qr_layout.fallbackMessage(l.qr, window_height, msg_w);
+    _ = titlebar.renderTextLimited(message, message_layout.x, message_layout.y, normal, message_layout.max_w);
 
     const qr_text = qr_panel.qrString();
     if (qr_panel.qrGenerationFailed() and qr_text.len > 0) {
-        const text_y = msg_y - font.g_titlebar_cell_height - 10;
-        _ = titlebar.renderTextLimited(qr_text, l.qr.x + 12, text_y, muted, l.qr.w - 24);
+        const detail = qr_layout.fallbackDetail(l.qr, window_height, font.g_titlebar_cell_height);
+        _ = titlebar.renderTextLimited(qr_text, detail.x, detail.y, muted, detail.max_w);
     }
 }
 


### PR DESCRIPTION
## Summary
- extract QR panel chrome, QR frame, and fallback text geometry into `src/renderer/qr_panel_layout.zig`
- route WeChat and Feishu QR renderers through the backend-neutral layout helpers before emitting overlay/UI pipeline draw calls
- add focused layout tests for panel surfaces, QR frame expansion, and fallback labels

## Scope
- targets `windows-native-render`
- does not change the Windows default renderer
- does not remove the OpenGL fallback
- does not start Phase V hardening or Phase VI default migration

## Ghostty comparison
Ghostty does not have a WispTerm-specific QR panel or D3D11 renderer equivalent. This keeps the same style of boundary we are using for Ghostty-aligned renderer work: feature/UI code produces backend-neutral geometry, while backend-specific details stay behind renderer/pipeline APIs.

## Validation
- `git diff --cached --check`
- `zig test src\renderer\qr_panel_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `zig build test-full --summary all`