### PR TITLE
[codex] smoke d3d11 assistant conversation layout

### DIFF
--- a/src/assistant/conversation/layout.zig
+++ b/src/assistant/conversation/layout.zig
@@ -18,6 +18,39 @@ pub const Rect = struct {
     h: f32,
 };
 
+/// Renderer draw-space rect with bottom-left-origin `y` (the coordinate system
+/// accepted by ui_pipeline fill/clip calls).
+pub const DrawRect = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const PanelFrame = struct {
+    x: f32,
+    w: f32,
+    top_px: f32,
+    h: f32,
+    panel: DrawRect,
+    header: DrawRect,
+    header_rule: DrawRect,
+};
+
+pub const InputBand = struct {
+    panel: DrawRect,
+    top_rule: DrawRect,
+};
+
+pub const TranscriptViewport = struct {
+    clip: DrawRect,
+    transcript_top_px: f32,
+    transcript_bottom_y: f32,
+    viewport_bottom_top_px: f32,
+    content_x: f32,
+    content_w: f32,
+};
+
 /// Horizontal placement of a message bubble: `x` is its left edge (which is
 /// right-shifted for the right-aligned user bubble) and `w` its width.
 pub const BubbleGeometry = struct {
@@ -27,6 +60,59 @@ pub const BubbleGeometry = struct {
 
 pub fn pointInRect(px: f32, py: f32, rect: Rect) bool {
     return px >= rect.x and px <= rect.x + rect.w and py >= rect.top_px and py <= rect.top_px + rect.h;
+}
+
+pub fn panelFrame(
+    window_height: f32,
+    titlebar_offset: f32,
+    chat_x: f32,
+    chat_w: f32,
+    header_h: f32,
+) ?PanelFrame {
+    const x = @round(chat_x);
+    const w = @round(@max(1.0, chat_w));
+    const top = @round(titlebar_offset);
+    const h = @round(@max(1.0, window_height - top));
+    if (w <= 1 or h <= 1) return null;
+
+    const header_y = window_height - top - header_h;
+    return .{
+        .x = x,
+        .w = w,
+        .top_px = top,
+        .h = h,
+        .panel = .{ .x = x, .y = 0, .w = w, .h = h },
+        .header = .{ .x = x, .y = header_y, .w = w, .h = header_h },
+        .header_rule = .{ .x = x, .y = header_y, .w = w, .h = 1 },
+    };
+}
+
+pub fn inputBand(frame: PanelFrame, input_h: f32) InputBand {
+    return .{
+        .panel = .{ .x = frame.x, .y = 0, .w = frame.w, .h = input_h },
+        .top_rule = .{ .x = frame.x, .y = input_h - 1, .w = frame.w, .h = 1 },
+    };
+}
+
+pub fn transcriptViewport(
+    frame: PanelFrame,
+    window_height: f32,
+    input_h: f32,
+    card_footer_h: f32,
+    line_pad_x: f32,
+    gap: f32,
+) TranscriptViewport {
+    const transcript_top = frame.top_px + frame.header.h + gap;
+    const transcript_bottom = input_h + card_footer_h + gap;
+    const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
+    return .{
+        .clip = .{ .x = frame.x, .y = transcript_bottom, .w = frame.w, .h = transcript_h },
+        .transcript_top_px = transcript_top,
+        .transcript_bottom_y = transcript_bottom,
+        .viewport_bottom_top_px = window_height - transcript_bottom,
+        .content_x = frame.x + line_pad_x,
+        .content_w = frame.w - line_pad_x * 2,
+    };
 }
 
 pub fn bubbleGeometry(is_user: bool, x: f32, w: f32) BubbleGeometry {
@@ -263,6 +349,45 @@ test "pointInRect inside, edges, outside" {
     try std.testing.expect(pointInRect(20, 20, r)); // bottom-right edge inclusive
     try std.testing.expect(!pointInRect(21, 10, r));
     try std.testing.expect(!pointInRect(10, 21, r));
+}
+
+test "panelFrame converts assistant panel chrome to draw rectangles" {
+    const frame = panelFrame(700, 40, 100.4, 400.2, 54).?;
+
+    try std.testing.expectEqual(@as(f32, 100), frame.x);
+    try std.testing.expectEqual(@as(f32, 400), frame.w);
+    try std.testing.expectEqual(@as(f32, 40), frame.top_px);
+    try std.testing.expectEqual(@as(f32, 660), frame.h);
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 0, .w = 400, .h = 660 }, frame.panel);
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 606, .w = 400, .h = 54 }, frame.header);
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 606, .w = 400, .h = 1 }, frame.header_rule);
+}
+
+test "inputBand anchors the composer at the bottom of the assistant panel" {
+    const frame = panelFrame(700, 40, 100, 400, 54).?;
+    const band = inputBand(frame, 120);
+
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 0, .w = 400, .h = 120 }, band.panel);
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 119, .w = 400, .h = 1 }, band.top_rule);
+}
+
+test "transcriptViewport reserves header, composer, footer cards, and side padding" {
+    const frame = panelFrame(700, 40, 100, 400, 54).?;
+    const viewport = transcriptViewport(frame, 700, 120, 80, 18, 18);
+
+    try std.testing.expectEqual(@as(f32, 112), viewport.transcript_top_px);
+    try std.testing.expectEqual(@as(f32, 218), viewport.transcript_bottom_y);
+    try std.testing.expectEqual(@as(f32, 482), viewport.viewport_bottom_top_px);
+    try std.testing.expectEqual(DrawRect{ .x = 100, .y = 218, .w = 400, .h = 370 }, viewport.clip);
+    try std.testing.expectEqual(@as(f32, 118), viewport.content_x);
+    try std.testing.expectEqual(@as(f32, 364), viewport.content_w);
+}
+
+test "transcriptViewport keeps a positive clip height on cramped windows" {
+    const frame = panelFrame(180, 40, 0, 240, 54).?;
+    const viewport = transcriptViewport(frame, 180, 100, 80, 18, 18);
+
+    try std.testing.expectEqual(@as(f32, 1), viewport.clip.h);
 }
 
 test "bubbleGeometry user vs assistant" {

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -188,20 +188,19 @@ pub fn render(
     const panel = mixColor(bg, fg, 0.045);
     const line = mixColor(bg, fg, 0.18);
 
-    const x = @round(chat_x);
-    const w = @round(@max(1.0, chat_w));
-    const top = @round(titlebar_offset);
-    const h = @round(@max(1.0, window_height - top));
-    if (w <= 1 or h <= 1) return;
+    const frame = ai_chat_layout.panelFrame(window_height, titlebar_offset, chat_x, chat_w, HEADER_H) orelse return;
+    const x = frame.x;
+    const w = frame.w;
+    const top = frame.top_px;
 
-    ui_pipeline.fillQuad(x, 0, w, h, bg);
+    ui_pipeline.fillQuad(frame.panel.x, frame.panel.y, frame.panel.w, frame.panel.h, bg);
 
     session.mutex.lock();
     defer session.mutex.unlock();
 
-    const header_y = window_height - top - HEADER_H;
-    ui_pipeline.fillQuadAlpha(x, header_y, w, HEADER_H, panel, 0.95);
-    ui_pipeline.fillQuadAlpha(x, header_y, w, 1, line, 0.8);
+    const header_y = frame.header.y;
+    ui_pipeline.fillQuadAlpha(frame.header.x, frame.header.y, frame.header.w, frame.header.h, panel, 0.95);
+    ui_pipeline.fillQuadAlpha(frame.header_rule.x, frame.header_rule.y, frame.header_rule.w, frame.header_rule.h, line, 0.8);
     const permission = ai_chat.agentPermission();
     const chip_x = permissionChipX(x, w);
     const mode_text = if (session.agent_enabled) "Agent" else "Chat";
@@ -269,9 +268,9 @@ pub fn render(
     const input_text = session.input();
     const layout = inputLayout(x, w, input_text);
     const input_h = layout.input_h;
-    const input_y: f32 = 0;
-    ui_pipeline.fillQuadAlpha(x, input_y, w, input_h, panel, 0.98);
-    ui_pipeline.fillQuadAlpha(x, input_y + input_h - 1, w, 1, line, 0.72);
+    const input_band = ai_chat_layout.inputBand(frame, input_h);
+    ui_pipeline.fillQuadAlpha(input_band.panel.x, input_band.panel.y, input_band.panel.w, input_band.panel.h, panel, 0.98);
+    ui_pipeline.fillQuadAlpha(input_band.top_rule.x, input_band.top_rule.y, input_band.top_rule.w, input_band.top_rule.h, line, 0.72);
 
     const field_bg = mixColor(bg, fg, 0.075);
     ui_pipeline.fillQuadAlpha(layout.field_x, layout.field_y, layout.field_w, layout.field_h, field_bg, 0.95);
@@ -354,12 +353,12 @@ pub fn render(
     const question_h: f32 = if (question) |view| questionCardHeight(view) + APPROVAL_GAP else 0;
     const card_footer_h = approval_h + question_h;
 
-    const transcript_top = top + HEADER_H + 18;
-    const transcript_bottom = input_h + card_footer_h + 18;
-    const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
-    const content_w = w - LINE_PAD_X * 2;
-    const content_x = x + LINE_PAD_X;
-    const viewport_bottom_top_px = window_height - transcript_bottom;
+    const transcript_viewport = ai_chat_layout.transcriptViewport(frame, window_height, input_h, card_footer_h, LINE_PAD_X, 18);
+    const transcript_top = transcript_viewport.transcript_top_px;
+    const transcript_h = transcript_viewport.clip.h;
+    const content_w = transcript_viewport.content_w;
+    const content_x = transcript_viewport.content_x;
+    const viewport_bottom_top_px = transcript_viewport.viewport_bottom_top_px;
 
     var content_h: f32 = 0;
     for (session.messages.items) |msg| {
@@ -375,7 +374,12 @@ pub fn render(
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
 
-    ui_pipeline.beginClip(.{ .x = x, .y = transcript_bottom, .w = w, .h = transcript_h });
+    ui_pipeline.beginClip(.{
+        .x = transcript_viewport.clip.x,
+        .y = transcript_viewport.clip.y,
+        .w = transcript_viewport.clip.w,
+        .h = transcript_viewport.clip.h,
+    });
 
     const gravity_offset = @max(0.0, transcript_h - content_h);
     const palette = markdownPalette(bg, fg, accent);
@@ -830,18 +834,16 @@ fn transcriptLayoutLocked(
     chat_w: f32,
 ) ?TranscriptLayout {
     _ = window_width;
-    const x = @round(chat_x);
-    const w = @round(@max(1.0, chat_w));
-    if (w <= 1) return null;
+    const frame = ai_chat_layout.panelFrame(window_height, titlebar_offset, chat_x, chat_w, HEADER_H) orelse return null;
+    const x = frame.x;
+    const w = frame.w;
 
     const approval = session.approvalView();
     const approval_h: f32 = if (approval) |view| approvalCardHeight(view) + APPROVAL_GAP else 0;
     const question_h: f32 = if (approval == null) (if (session.questionView()) |view| questionCardHeight(view) + APPROVAL_GAP else 0) else 0;
     const input_h = inputLayout(x, w, session.input()).input_h;
-    const transcript_top = titlebar_offset + HEADER_H + 18;
-    const transcript_bottom = input_h + approval_h + question_h + 18;
-    const transcript_h = @max(1.0, window_height - transcript_top - transcript_bottom);
-    const content_w = w - LINE_PAD_X * 2;
+    const transcript_viewport = ai_chat_layout.transcriptViewport(frame, window_height, input_h, approval_h + question_h, LINE_PAD_X, 18);
+    const content_w = transcript_viewport.content_w;
 
     var content_h: f32 = 0;
     for (session.messages.items) |msg| {
@@ -858,8 +860,8 @@ fn transcriptLayoutLocked(
     return .{
         .x = x,
         .w = w,
-        .transcript_top = transcript_top,
-        .transcript_h = transcript_h,
+        .transcript_top = transcript_viewport.transcript_top_px,
+        .transcript_h = transcript_viewport.clip.h,
         .content_h = content_h,
     };
 }


### PR DESCRIPTION
## Summary
- add pure assistant conversation panel geometry helpers for the panel frame, composer input band, and transcript viewport
- route the assistant conversation renderer and transcript scrollbar layout through the shared backend-neutral geometry
- add focused fast tests for panel/header draw rects, input band anchoring, transcript clipping, footer reservation, and cramped-window clamping

## Scope
- targets `windows-native-render`
- does not change the Windows default renderer
- does not remove the OpenGL fallback
- does not start Phase V hardening or Phase VI default migration

## Ghostty comparison
Ghostty does not have WispTerm's Assistant conversation panel, but its renderer tree keeps backend-specific code in renderer backend modules such as OpenGL/Metal/WebGL while shared renderer concepts live outside individual backends. This follows that boundary: Assistant UI geometry is backend-neutral data, and D3D11/OpenGL/Metal details remain behind `ui_pipeline` and backend APIs.

## Validation
- `zig test src\assistant\conversation\layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all`