### PR TITLE
[codex] smoke d3d11 command palette layout

### DIFF
--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1980,7 +1980,8 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     }
 
     const layout = commandPaletteLayout(window_width, window_height, top_offset);
-    const box_y = @round(window_height - layout.box_top_px - layout.box_h);
+    const text_h = overlayTextHeight();
+    const chrome = command_palette_layout.panelChrome(layout, window_width, window_height);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -1995,9 +1996,9 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     const selected_bg = mixColor(bg, accent, 0.50);
     const selected_border = mixColor(accent, fg, 0.16);
 
-    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.22);
-    renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 9, border_color, 0.42);
-    renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 8, panel_color, 0.98);
+    ui_pipeline.fillQuadAlpha(chrome.scrim.x, chrome.scrim.y, chrome.scrim.w, chrome.scrim.h, .{ 0.0, 0.0, 0.0 }, 0.22);
+    renderRoundedQuadAlpha(chrome.border.x, chrome.border.y, chrome.border.w, chrome.border.h, 9, border_color, 0.42);
+    renderRoundedQuadAlpha(chrome.panel.x, chrome.panel.y, chrome.panel.w, chrome.panel.h, 8, panel_color, 0.98);
 
     const pad_x: f32 = 24;
     const title_y = textYFromTop(window_height, layout.box_top_px + 16);
@@ -2011,26 +2012,24 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
         renderTitlebarText(chip, chip_x, title_y, mixColor(fg, accent, 0.20));
     }
 
-    const filter_x = @round(layout.box_x + pad_x);
-    const filter_box_y = @round(window_height - (layout.box_top_px + layout.header_h + layout.filter_h));
-    const filter_w = layout.box_w - pad_x * 2;
-    renderRoundedQuadAlpha(filter_x - 1, filter_box_y - 1, filter_w + 2, layout.filter_h + 2, 6, field_border, 0.42);
-    renderRoundedQuadAlpha(filter_x, filter_box_y, filter_w, layout.filter_h, 5, field_color, 0.92);
+    const filter_chrome = command_palette_layout.fieldChrome(layout, window_height, pad_x, text_h);
+    renderRoundedQuadAlpha(filter_chrome.border.x, filter_chrome.border.y, filter_chrome.border.w, filter_chrome.border.h, 6, field_border, 0.42);
+    renderRoundedQuadAlpha(filter_chrome.field.x, filter_chrome.field.y, filter_chrome.field.w, filter_chrome.field.h, 5, field_color, 0.92);
 
-    const filter_text_y = rowTextY(filter_box_y, layout.filter_h);
+    const filter_text_y = filter_chrome.text_y;
     if (commandPaletteIsHistoryMode()) {
         const filter = commandPaletteFilter();
         if (filter.len > 0) {
-            renderTitlebarTextLimited(filter, filter_x + 12, filter_text_y, fg, filter_w - 24);
+            renderTitlebarTextLimited(filter, filter_chrome.field.x + 12, filter_text_y, fg, filter_chrome.field.w - 24);
         } else {
-            renderTitlebarTextLimited(i18n.s().cmd_palette_history_search_placeholder, filter_x + 12, filter_text_y, dim, filter_w - 24);
+            renderTitlebarTextLimited(i18n.s().cmd_palette_history_search_placeholder, filter_chrome.field.x + 12, filter_text_y, dim, filter_chrome.field.w - 24);
         }
     } else {
         const filter = commandPaletteFilter();
         if (filter.len > 0) {
-            renderTitlebarTextLimited(filter, filter_x + 12, filter_text_y, fg, filter_w - 24);
+            renderTitlebarTextLimited(filter, filter_chrome.field.x + 12, filter_text_y, fg, filter_chrome.field.w - 24);
         } else {
-            renderTitlebarTextLimited(i18n.s().cmd_palette_filter_placeholder, filter_x + 12, filter_text_y, dim, filter_w - 24);
+            renderTitlebarTextLimited(i18n.s().cmd_palette_filter_placeholder, filter_chrome.field.x + 12, filter_text_y, dim, filter_chrome.field.w - 24);
         }
     }
 
@@ -2038,7 +2037,7 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
         const selectable = if (history_view) |v| v.rowCount() else 0;
         if (history_view == null or selectable == 0) {
             const empty_text = i18n.s().cmd_palette_no_sessions;
-            const empty_y = @round(window_height - layout.row_top_px - layout.row_h + (layout.row_h - overlayTextHeight()) / 2);
+            const empty_y = command_palette_layout.emptyTextY(layout, window_height, text_h);
             renderTitlebarText(empty_text, layout.box_x + (layout.box_w - measureTitlebarText(empty_text)) / 2, empty_y, muted);
         } else {
             const view = history_view.?;
@@ -2050,9 +2049,8 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
             while (display_row < layout.rendered_rows) : (display_row += 1) {
                 const item_idx = first_item + display_row;
                 if (item_idx >= view.items.len) break;
-                const row_top = @round(layout.row_top_px + @as(f32, @floatFromInt(display_row)) * layout.row_h);
-                const row_y = @round(window_height - row_top - layout.row_h);
-                const text_y = rowTextY(row_y, layout.row_h);
+                const slot = command_palette_layout.rowSlot(layout, window_height, display_row, text_h);
+                const text_y = slot.text_y;
                 switch (view.items[item_idx]) {
                     .header => |b| {
                         const label = historyBucketLabel(b);
@@ -2062,8 +2060,8 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
                         const row = g_command_palette_history_rows[view.filtered[ord]];
                         const selected = ord == selected_ord;
                         if (selected) {
-                            renderRoundedQuadAlpha(layout.box_x + 12, row_y + 4, layout.box_w - 24, layout.row_h - 8, 5, selected_border, 0.38);
-                            renderRoundedQuadAlpha(layout.box_x + 13, row_y + 5, layout.box_w - 26, layout.row_h - 10, 4, selected_bg, 0.78);
+                            renderRoundedQuadAlpha(slot.selected_border.x, slot.selected_border.y, slot.selected_border.w, slot.selected_border.h, 5, selected_border, 0.38);
+                            renderRoundedQuadAlpha(slot.selected_fill.x, slot.selected_fill.y, slot.selected_fill.w, slot.selected_fill.h, 4, selected_bg, 0.78);
                         }
                         const row_title_color = if (selected) fg else mixColor(bg, fg, 0.86);
                         const meta_color = if (selected) mixColor(fg, accent, 0.08) else mixColor(bg, fg, 0.54);
@@ -2091,7 +2089,7 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
         rebuildPaletteScratch();
         if (g_palette_scratch_len == 0) {
             const empty_text = "No matching results";
-            const empty_y = @round(window_height - layout.row_top_px - layout.row_h + (layout.row_h - overlayTextHeight()) / 2);
+            const empty_y = command_palette_layout.emptyTextY(layout, window_height, text_h);
             renderTitlebarText(empty_text, layout.box_x + (layout.box_w - measureTitlebarText(empty_text)) / 2, empty_y, muted);
         } else {
             const first_row = commandPaletteFirstVisibleIndex(layout.rendered_rows);
@@ -2102,17 +2100,16 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
                 const item = g_palette_scratch[item_idx];
                 const selected = item_idx == commandPaletteState().selected;
 
-                const row_top = @round(layout.row_top_px + @as(f32, @floatFromInt(display_row)) * layout.row_h);
-                const row_y = @round(window_height - row_top - layout.row_h);
+                const slot = command_palette_layout.rowSlot(layout, window_height, display_row, text_h);
                 if (selected) {
-                    renderRoundedQuadAlpha(layout.box_x + 12, row_y + 4, layout.box_w - 24, layout.row_h - 8, 5, selected_border, 0.38);
-                    renderRoundedQuadAlpha(layout.box_x + 13, row_y + 5, layout.box_w - 26, layout.row_h - 10, 4, selected_bg, 0.78);
+                    renderRoundedQuadAlpha(slot.selected_border.x, slot.selected_border.y, slot.selected_border.w, slot.selected_border.h, 5, selected_border, 0.38);
+                    renderRoundedQuadAlpha(slot.selected_fill.x, slot.selected_fill.y, slot.selected_fill.w, slot.selected_fill.h, 4, selected_bg, 0.78);
                 }
 
                 const row_title_color = if (selected) fg else mixColor(bg, fg, 0.86);
                 const shortcut_color = if (selected) mixColor(fg, accent, 0.08) else mixColor(bg, fg, 0.54);
 
-                const text_y = rowTextY(row_y, layout.row_h);
+                const text_y = slot.text_y;
                 const title_x = @round(layout.box_x + pad_x + 2);
 
                 switch (item) {
@@ -2198,15 +2195,6 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
     // and the mouse wheel.
     const total_results = commandPaletteResultCount();
     if (total_results > layout.rendered_rows and layout.rendered_rows > 0) {
-        const total_f: f32 = @floatFromInt(total_results);
-        const vis_f: f32 = @floatFromInt(layout.rendered_rows);
-        const track_h = layout.row_h * vis_f;
-        const track_top_px = layout.row_top_px;
-        const sb_w: f32 = 3;
-        const sb_x = layout.box_x + layout.box_w - sb_w - 7;
-        const track_gl_y = @round(window_height - track_top_px - track_h);
-        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
-
         // History mode windows over display items (rows + group headers), so the
         // thumb must track the same item-index window the list render uses, not the
         // raw-ordinal window commandPaletteFirstVisibleIndex assumes.
@@ -2216,16 +2204,14 @@ pub fn renderCommandPalette(window_width: f32, window_height: f32, top_offset: f
             const selected_ord = if (selectable == 0) 0 else @min(commandPaletteState().history_selected, selectable - 1);
             break :blk historyWindowStart(v.items.len, layout.rendered_rows, historySelectedItemIndex(v, selected_ord));
         } else commandPaletteFirstVisibleIndex(layout.rendered_rows);
-        const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
-        const max_scroll_f: f32 = @floatFromInt(total_results - layout.rendered_rows);
-        const scroll_f: f32 = @floatFromInt(first_row);
-        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
-        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
-        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
+        if (command_palette_layout.scrollbar(layout, window_height, total_results, first_row)) |sb| {
+            ui_pipeline.fillQuadAlpha(sb.track.x, sb.track.y, sb.track.w, sb.track.h, mixColor(bg, fg, 0.25), 0.30);
+            ui_pipeline.fillQuadAlpha(sb.thumb.x, sb.thumb.y, sb.thumb.w, sb.thumb.h, accent, 0.55);
+        }
     }
 
     const footer = if (commandPaletteIsHistoryMode()) i18n.s().cmd_palette_footer_history else i18n.s().cmd_palette_footer;
-    renderTitlebarTextLimited(footer, layout.box_x + pad_x, rowTextY(box_y, layout.footer_h), muted, layout.box_w - pad_x * 2);
+    renderTitlebarTextLimited(footer, layout.box_x + pad_x, command_palette_layout.footerTextY(layout, window_height, text_h), muted, layout.box_w - pad_x * 2);
 }
 
 // ============================================================================

--- a/src/renderer/overlays/command_palette_layout.zig
+++ b/src/renderer/overlays/command_palette_layout.zig
@@ -28,6 +28,37 @@ pub const Layout = struct {
     rendered_rows: usize,
 };
 
+pub const DrawRect = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const PanelChrome = struct {
+    scrim: DrawRect,
+    border: DrawRect,
+    panel: DrawRect,
+};
+
+pub const FieldChrome = struct {
+    border: DrawRect,
+    field: DrawRect,
+    text_y: f32,
+};
+
+pub const RowSlot = struct {
+    row: DrawRect,
+    selected_border: DrawRect,
+    selected_fill: DrawRect,
+    text_y: f32,
+};
+
+pub const Scrollbar = struct {
+    track: DrawRect,
+    thumb: DrawRect,
+};
+
 /// Text height for an overlay line, derived from the font cell height.
 /// Mirrors overlays.overlayTextHeight().
 fn textHeight(cell_height: f32) f32 {
@@ -115,6 +146,76 @@ pub fn firstVisibleIndex(rendered_rows: usize, count: usize, selected_in: usize)
     return @min(selected - rendered_rows + 1, count - rendered_rows);
 }
 
+pub fn rectY(window_height: f32, top_px: f32, h: f32) f32 {
+    return @round(window_height - top_px - h);
+}
+
+pub fn textY(row_y: f32, row_h: f32, text_h: f32) f32 {
+    return @round(row_y + (row_h - text_h) / 2.0);
+}
+
+pub fn panelChrome(layout: Layout, window_width: f32, window_height: f32) PanelChrome {
+    const y = rectY(window_height, layout.box_top_px, layout.box_h);
+    return .{
+        .scrim = .{ .x = 0, .y = 0, .w = window_width, .h = window_height },
+        .border = .{ .x = layout.box_x - 1, .y = y - 1, .w = layout.box_w + 2, .h = layout.box_h + 2 },
+        .panel = .{ .x = layout.box_x, .y = y, .w = layout.box_w, .h = layout.box_h },
+    };
+}
+
+pub fn fieldChrome(layout: Layout, window_height: f32, pad_x: f32, text_h: f32) FieldChrome {
+    const x = @round(layout.box_x + pad_x);
+    const w = layout.box_w - pad_x * 2;
+    const y = rectY(window_height, layout.box_top_px + layout.header_h, layout.filter_h);
+    return .{
+        .border = .{ .x = x - 1, .y = y - 1, .w = w + 2, .h = layout.filter_h + 2 },
+        .field = .{ .x = x, .y = y, .w = w, .h = layout.filter_h },
+        .text_y = textY(y, layout.filter_h, text_h),
+    };
+}
+
+pub fn rowSlot(layout: Layout, window_height: f32, display_row: usize, text_h: f32) RowSlot {
+    const row_top = @round(layout.row_top_px + @as(f32, @floatFromInt(display_row)) * layout.row_h);
+    const y = rectY(window_height, row_top, layout.row_h);
+    return .{
+        .row = .{ .x = layout.box_x, .y = y, .w = layout.box_w, .h = layout.row_h },
+        .selected_border = .{ .x = layout.box_x + 12, .y = y + 4, .w = layout.box_w - 24, .h = layout.row_h - 8 },
+        .selected_fill = .{ .x = layout.box_x + 13, .y = y + 5, .w = layout.box_w - 26, .h = layout.row_h - 10 },
+        .text_y = textY(y, layout.row_h, text_h),
+    };
+}
+
+pub fn emptyTextY(layout: Layout, window_height: f32, text_h: f32) f32 {
+    const first = rowSlot(layout, window_height, 0, text_h);
+    return first.text_y;
+}
+
+pub fn scrollbar(layout: Layout, window_height: f32, total_results: usize, first_row: usize) ?Scrollbar {
+    if (total_results <= layout.rendered_rows or layout.rendered_rows == 0) return null;
+
+    const total_f: f32 = @floatFromInt(total_results);
+    const vis_f: f32 = @floatFromInt(layout.rendered_rows);
+    const track_h = layout.row_h * vis_f;
+    const sb_w: f32 = 3;
+    const sb_x = layout.box_x + layout.box_w - sb_w - 7;
+    const track_y = rectY(window_height, layout.row_top_px, track_h);
+    const thumb_h = @max(24.0, @round(track_h * vis_f / total_f));
+    const max_scroll_f: f32 = @floatFromInt(total_results - layout.rendered_rows);
+    const scroll_f: f32 = @floatFromInt(@min(first_row, total_results - layout.rendered_rows));
+    const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
+    const thumb_y = rectY(window_height, layout.row_top_px + thumb_offset, thumb_h);
+
+    return .{
+        .track = .{ .x = sb_x, .y = track_y, .w = sb_w, .h = track_h },
+        .thumb = .{ .x = sb_x, .y = thumb_y, .w = sb_w, .h = thumb_h },
+    };
+}
+
+pub fn footerTextY(layout: Layout, window_height: f32, text_h: f32) f32 {
+    const panel_y = rectY(window_height, layout.box_top_px, layout.box_h);
+    return textY(panel_y, layout.footer_h, text_h);
+}
+
 test "row capacity is capped at MAX_VISIBLE_ROWS" {
     // A very tall window with a small base/row height would otherwise fit more
     // than the cap; the result must clamp to MAX_VISIBLE_ROWS.
@@ -183,4 +284,49 @@ test "first visible index keeps selection in view" {
     try std.testing.expectEqual(@as(usize, 15), firstVisibleIndex(5, 20, 99));
     // rendered_rows == 0: degenerate, no scroll.
     try std.testing.expectEqual(@as(usize, 0), firstVisibleIndex(0, 20, 5));
+}
+
+test "panel chrome converts command palette box to draw rectangles" {
+    const l = compute(1200, 800, 40, 20, 8);
+    const chrome = panelChrome(l, 1200, 800);
+    const y = rectY(800, l.box_top_px, l.box_h);
+
+    try std.testing.expectEqual(DrawRect{ .x = 0, .y = 0, .w = 1200, .h = 800 }, chrome.scrim);
+    try std.testing.expectEqual(DrawRect{ .x = l.box_x - 1, .y = y - 1, .w = l.box_w + 2, .h = l.box_h + 2 }, chrome.border);
+    try std.testing.expectEqual(DrawRect{ .x = l.box_x, .y = y, .w = l.box_w, .h = l.box_h }, chrome.panel);
+}
+
+test "field chrome reserves horizontal padding and centers text" {
+    const l = compute(1200, 800, 40, 20, 8);
+    const field = fieldChrome(l, 800, 24, 20);
+    const expected_y = rectY(800, l.box_top_px + l.header_h, l.filter_h);
+
+    try std.testing.expectEqual(@as(f32, l.box_x + 24), field.field.x);
+    try std.testing.expectEqual(expected_y, field.field.y);
+    try std.testing.expectEqual(@as(f32, l.box_w - 48), field.field.w);
+    try std.testing.expectEqual(textY(expected_y, l.filter_h, 20), field.text_y);
+}
+
+test "row slots map display rows to selected affordance rects" {
+    const l = compute(1200, 800, 40, 20, 8);
+    const row0 = rowSlot(l, 800, 0, 20);
+    const row2 = rowSlot(l, 800, 2, 20);
+
+    try std.testing.expectEqual(l.box_x, row0.row.x);
+    try std.testing.expectEqual(l.box_w, row0.row.w);
+    try std.testing.expectEqual(l.row_h, row0.row.h);
+    try std.testing.expectEqual(row0.row.y - l.row_h * 2, row2.row.y);
+    try std.testing.expectEqual(DrawRect{ .x = l.box_x + 12, .y = row0.row.y + 4, .w = l.box_w - 24, .h = l.row_h - 8 }, row0.selected_border);
+    try std.testing.expectEqual(DrawRect{ .x = l.box_x + 13, .y = row0.row.y + 5, .w = l.box_w - 26, .h = l.row_h - 10 }, row0.selected_fill);
+}
+
+test "scrollbar geometry tracks visible row window" {
+    const l = compute(1200, 800, 40, 20, 100);
+    const sb = scrollbar(l, 800, 100, 10).?;
+
+    try std.testing.expectEqual(@as(f32, l.box_x + l.box_w - 10), sb.track.x);
+    try std.testing.expectEqual(@as(f32, 3), sb.track.w);
+    try std.testing.expectEqual(l.row_h * @as(f32, @floatFromInt(l.rendered_rows)), sb.track.h);
+    try std.testing.expect(sb.thumb.h >= 24);
+    try std.testing.expect(sb.thumb.y < sb.track.y + sb.track.h);
 }


### PR DESCRIPTION
## Summary
- add backend-neutral command palette draw geometry for panel chrome, filter field, rows, scrollbar, and footer text placement
- route `renderCommandPalette` through the shared layout helpers before emitting overlay/UI pipeline draw calls
- add focused layout tests for panel conversion, field placement, selected row affordances, and scrollbar geometry

## Scope
- targets `windows-native-render`
- does not change the Windows default renderer
- does not remove the OpenGL fallback
- does not start Phase V hardening or Phase VI default migration

## Ghostty comparison
Ghostty does not have WispTerm's command palette, but its renderer tree keeps backend-specific implementations in OpenGL/Metal/WebGL modules while shared renderer concepts live outside individual backends. This follows that boundary: command palette UI geometry remains backend-neutral, and backend details stay behind `ui_pipeline` and renderer backend APIs.

## Validation
- `zig test src\renderer\overlays\command_palette_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all` (first run hit unrelated Windows `skill.local_fs` temp rename AccessDenied; immediate rerun passed 60/60 steps)