### PR TITLE
[codex] smoke d3d11 markdown preview layout

### DIFF
--- a/src/preview/markdown_layout.zig
+++ b/src/preview/markdown_layout.zig
@@ -1,0 +1,187 @@
+//! Backend-neutral geometry for the right-side markdown/text/image preview pane.
+//!
+//! The renderer consumes these rectangles in GL-style bottom-left coordinates
+//! while document layout still uses top-down pixel offsets. Keeping both in one
+//! pure model lets OpenGL, Metal, and D3D11 share the same panel geometry.
+
+const std = @import("std");
+
+pub const Rect = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const Input = struct {
+    panel_x: f32,
+    panel_top: f32,
+    panel_w: f32,
+    panel_h: f32,
+    window_height: f32,
+    header_h: f32,
+    footer_h: f32,
+    pad_x: f32,
+    pad_y: f32,
+};
+
+pub const StatusLine = struct {
+    rect: Rect,
+    text_y: f32,
+};
+
+pub const Panel = struct {
+    panel_x: f32,
+    panel_top: f32,
+    panel_w: f32,
+    panel_h: f32,
+    window_height: f32,
+    pane_gl_bottom: f32,
+    content_x: f32,
+    content_w: f32,
+    body_top: f32,
+    body_h: f32,
+    background: Rect,
+    header: Rect,
+    header_rule: Rect,
+    footer: Rect,
+    footer_rule: Rect,
+
+    pub fn contentRight(self: Panel) f32 {
+        return self.content_x + self.content_w;
+    }
+
+    pub fn headerTextY(self: Panel, text_h: f32) f32 {
+        return self.header.y + (self.header.h - text_h) / 2;
+    }
+
+    pub fn footerTextY(self: Panel, text_h: f32) f32 {
+        return self.footer.y + (self.footer.h - text_h) / 2;
+    }
+
+    pub fn bodyAvailable(self: Panel) bool {
+        return self.body_h > 0;
+    }
+
+    pub fn statusLine(self: Panel, row_h: f32, text_h: f32) StatusLine {
+        const y_top = self.body_top + @max(@as(f32, 0), (self.body_h - row_h) / 2);
+        const gl_y = self.window_height - y_top - row_h;
+        return .{
+            .rect = .{ .x = self.content_x, .y = gl_y, .w = self.content_w, .h = row_h },
+            .text_y = gl_y + (row_h - text_h) / 2,
+        };
+    }
+};
+
+pub fn compute(input: Input) ?Panel {
+    if (input.panel_w <= 0 or input.panel_h <= 0 or input.window_height <= 0) return null;
+
+    const pane_gl_bottom = input.window_height - input.panel_top - input.panel_h;
+    const body_top = input.panel_top + input.header_h + input.pad_y;
+    const body_bottom_margin = pane_gl_bottom + input.footer_h + input.pad_y;
+    const body_h = input.window_height - body_top - body_bottom_margin;
+
+    return .{
+        .panel_x = input.panel_x,
+        .panel_top = input.panel_top,
+        .panel_w = input.panel_w,
+        .panel_h = input.panel_h,
+        .window_height = input.window_height,
+        .pane_gl_bottom = pane_gl_bottom,
+        .content_x = input.panel_x + input.pad_x,
+        .content_w = input.panel_w - input.pad_x * 2,
+        .body_top = body_top,
+        .body_h = body_h,
+        .background = .{
+            .x = input.panel_x,
+            .y = pane_gl_bottom,
+            .w = input.panel_w,
+            .h = input.panel_h,
+        },
+        .header = .{
+            .x = input.panel_x,
+            .y = input.window_height - input.panel_top - input.header_h,
+            .w = input.panel_w,
+            .h = input.header_h,
+        },
+        .header_rule = .{
+            .x = input.panel_x,
+            .y = input.window_height - input.panel_top - input.header_h,
+            .w = input.panel_w,
+            .h = 1,
+        },
+        .footer = .{
+            .x = input.panel_x,
+            .y = pane_gl_bottom,
+            .w = input.panel_w,
+            .h = input.footer_h,
+        },
+        .footer_rule = .{
+            .x = input.panel_x,
+            .y = pane_gl_bottom + input.footer_h - 1,
+            .w = input.panel_w,
+            .h = 1,
+        },
+    };
+}
+
+test "markdown_layout: compute maps pane chrome into GL rectangles" {
+    const p = compute(.{
+        .panel_x = 100,
+        .panel_top = 50,
+        .panel_w = 320,
+        .panel_h = 500,
+        .window_height = 720,
+        .header_h = 36,
+        .footer_h = 44,
+        .pad_x = 16,
+        .pad_y = 18,
+    }).?;
+
+    try std.testing.expectApproxEqAbs(@as(f32, 170), p.pane_gl_bottom, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 170), p.background.y, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 634), p.header.y, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 170), p.footer.y, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 116), p.content_x, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 288), p.content_w, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 104), p.body_top, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 384), p.body_h, 0.001);
+}
+
+test "markdown_layout: text baselines stay centered in chrome bands" {
+    const p = compute(.{
+        .panel_x = 0,
+        .panel_top = 40,
+        .panel_w = 240,
+        .panel_h = 360,
+        .window_height = 500,
+        .header_h = 32,
+        .footer_h = 44,
+        .pad_x = 16,
+        .pad_y = 18,
+    }).?;
+
+    try std.testing.expectApproxEqAbs(p.header.y + 6, p.headerTextY(20), 0.001);
+    try std.testing.expectApproxEqAbs(p.footer.y + 12, p.footerTextY(20), 0.001);
+}
+
+test "markdown_layout: status line centers in the body viewport" {
+    const p = compute(.{
+        .panel_x = 10,
+        .panel_top = 30,
+        .panel_w = 260,
+        .panel_h = 420,
+        .window_height = 600,
+        .header_h = 36,
+        .footer_h = 44,
+        .pad_x = 20,
+        .pad_y = 16,
+    }).?;
+    const line = p.statusLine(24, 18);
+
+    try std.testing.expectApproxEqAbs(@as(f32, 30), line.rect.x, 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 220), line.rect.w, 0.001);
+    try std.testing.expect(line.rect.y > p.footer.y + p.footer.h);
+    try std.testing.expect(line.rect.y + line.rect.h < p.header.y);
+    try std.testing.expectApproxEqAbs(line.rect.y + 3, line.text_y, 0.001);
+}

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -8,6 +8,7 @@ const text_wrap = @import("../text_wrap.zig");
 const ui_perf = @import("../ui_perf.zig");
 const PreviewPane = @import("../preview/pane.zig");
 const preview_diagnostics = @import("../preview/diagnostics.zig");
+const markdown_layout = @import("../preview/markdown_layout.zig");
 const preview_image_layout = @import("../preview/image_layout.zig");
 const preview_close_button = @import("../input/preview_close_button.zig");
 const titlebar = AppWindow.titlebar;
@@ -57,11 +58,17 @@ pub fn renderInto(
     window_height: f32,
     close_hovered: bool,
 ) void {
-    if (panel_h <= 0) return;
-
-    // GL origin is bottom-left, so the pane's bottom edge in GL space is:
-    //   window_height - panel_top - panel_h
-    const pane_gl_bottom = window_height - panel_top - panel_h;
+    const layout = markdown_layout.compute(.{
+        .panel_x = panel_x,
+        .panel_top = panel_top,
+        .panel_w = panel_w,
+        .panel_h = panel_h,
+        .window_height = window_height,
+        .header_h = HEADER_HEIGHT,
+        .footer_h = FOOTER_HEIGHT,
+        .pad_x = PAD_X,
+        .pad_y = PAD_Y,
+    }) orelse return;
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
@@ -74,13 +81,12 @@ pub fn renderInto(
     const normal = blend(bg, fg, 0.88);
     const strong = blend(bg, fg, 0.96);
 
-    // Side background: fillQuad(x, gl_y, w, h) — gl_y = pane_gl_bottom
-    ui_pipeline.fillQuad(panel_x, pane_gl_bottom, panel_w, panel_h, panel_bg);
+    ui_pipeline.fillQuad(layout.background.x, layout.background.y, layout.background.w, layout.background.h, panel_bg);
 
-    renderHeader(pane, panel_x, panel_w, window_height, panel_top, card_bg, border, muted, normal, accent, close_hovered);
-    renderFooter(pane, panel_x, panel_w, pane_gl_bottom, card_bg, border, muted, normal, accent);
+    renderHeader(pane, layout, card_bg, border, muted, normal, accent, close_hovered);
+    renderFooter(pane, layout, card_bg, border, muted, normal, accent);
 
-    renderDocument(pane, panel_x, panel_w, window_height, panel_top, panel_h, pane_gl_bottom, normal, muted, strong, accent, code_bg, border);
+    renderDocument(pane, layout, normal, muted, strong, accent, code_bg, border);
 }
 
 pub fn deinit() void {
@@ -89,10 +95,7 @@ pub fn deinit() void {
 
 fn renderHeader(
     pane: *const PreviewPane,
-    panel_x: f32,
-    panel_w: f32,
-    window_height: f32,
-    panel_top: f32,
+    layout: markdown_layout.Panel,
     card_bg: [3]f32,
     border: [3]f32,
     muted: [3]f32,
@@ -104,16 +107,14 @@ fn renderHeader(
     // so its top-right corner is free for a close (×) button. The button lets
     // users dismiss the preview with the mouse without knowing the close-split
     // keybind; Ctrl+Shift+W still works too.
-    // header_y (GL): window_height - panel_top - HEADER_HEIGHT.
-    const header_y = window_height - panel_top - HEADER_HEIGHT;
-    ui_pipeline.fillQuad(panel_x, header_y, panel_w, HEADER_HEIGHT, card_bg);
-    ui_pipeline.fillQuad(panel_x, header_y, panel_w, 1, border);
+    ui_pipeline.fillQuad(layout.header.x, layout.header.y, layout.header.w, layout.header.h, card_bg);
+    ui_pipeline.fillQuad(layout.header_rule.x, layout.header_rule.y, layout.header_rule.w, layout.header_rule.h, border);
 
     // Close (×) button, top-right. Geometry comes from the shared pure module
     // (top-down px); flip to GL for drawing. Symmetric box, so the X centers the
     // same in either y-convention.
-    const b = preview_close_button.rect(panel_x, panel_top, panel_w);
-    const btn_gl_y = window_height - b.y - b.h;
+    const b = preview_close_button.rect(layout.panel_x, layout.panel_top, layout.panel_w);
+    const btn_gl_y = layout.window_height - b.y - b.h;
     if (close_hovered) {
         ui_pipeline.fillQuad(b.x, btn_gl_y, b.w, b.h, blend(card_bg, normal, 0.18));
     }
@@ -123,11 +124,11 @@ fn renderHeader(
     // Large text/log files are shown as a scrollable head; tell the user the rest
     // is clipped so they don't mistake the end of the window for the end of file.
     // The banner stops before the × button (b.x) so the two never overlap.
-    if (pane.content_truncated and panel_w > PAD_X * 2) {
+    if (pane.content_truncated and layout.panel_w > PAD_X * 2) {
         var buf: [96]u8 = undefined;
         const label = truncatedBannerText(&buf, pane.sourceText().len);
-        const text_y = header_y + (HEADER_HEIGHT - font.g_titlebar_cell_height) / 2;
-        const banner_x = panel_x + PAD_X;
+        const text_y = layout.headerTextY(font.g_titlebar_cell_height);
+        const banner_x = layout.content_x;
         const banner_max_w = @max(@as(f32, 0), b.x - 8 - banner_x);
         _ = titlebar.renderTextLimited(label, banner_x, text_y, accent, banner_max_w);
     }
@@ -149,19 +150,15 @@ fn truncatedBannerText(buf: []u8, head_bytes: usize) []const u8 {
 
 fn renderFooter(
     pane: *PreviewPane,
-    panel_x: f32,
-    panel_w: f32,
-    pane_gl_bottom: f32,
+    layout: markdown_layout.Panel,
     card_bg: [3]f32,
     border: [3]f32,
     muted: [3]f32,
     normal: [3]f32,
     accent: [3]f32,
 ) void {
-    // Footer sits at the pane's bottom edge in GL space.
-    // Dock check: pane_gl_bottom = window_height - titlebar_h - (window_height - titlebar_h) = 0 ✓
-    ui_pipeline.fillQuad(panel_x, pane_gl_bottom, panel_w, FOOTER_HEIGHT, card_bg);
-    ui_pipeline.fillQuad(panel_x, pane_gl_bottom + FOOTER_HEIGHT - 1, panel_w, 1, border);
+    ui_pipeline.fillQuad(layout.footer.x, layout.footer.y, layout.footer.w, layout.footer.h, card_bg);
+    ui_pipeline.fillQuad(layout.footer_rule.x, layout.footer_rule.y, layout.footer_rule.w, layout.footer_rule.h, border);
 
     const badge = switch (pane.kind) {
         .markdown => "MD",
@@ -171,16 +168,16 @@ fn renderFooter(
         .image => "IMG",
         .pdf => "PDF",
     };
-    const text_y = pane_gl_bottom + (FOOTER_HEIGHT - font.g_titlebar_cell_height) / 2;
-    var badge_end = titlebar.renderTextLimited(badge, panel_x + PAD_X, text_y, accent, 40);
+    const text_y = layout.footerTextY(font.g_titlebar_cell_height);
+    var badge_end = titlebar.renderTextLimited(badge, layout.content_x, text_y, accent, 40);
     if (pane.kind == .pdf and pane.pdf_page_count > 0) {
         var page_buf: [24]u8 = undefined;
         const label = pdf_preview.formatPageIndicator(&page_buf, pane.pdf_page, pane.pdf_page_count);
         badge_end = titlebar.renderTextLimited(label, badge_end + 8, text_y, muted, 64);
     }
-    const content_right = panel_x + panel_w - PAD_X;
+    const content_right = layout.contentRight();
     const title_x = badge_end + 10;
-    const title_max_w = @max(40, @min(panel_w * 0.34, content_right - title_x));
+    const title_max_w = @max(40, @min(layout.panel_w * 0.34, content_right - title_x));
     const title_end = titlebar.renderTextLimited(pane.title(), title_x, text_y, normal, title_max_w);
 
     var sep_x = title_end + 10;
@@ -192,12 +189,7 @@ fn renderFooter(
 
 fn renderDocument(
     pane: *PreviewPane,
-    panel_x: f32,
-    panel_w: f32,
-    window_height: f32,
-    panel_top: f32,
-    panel_h: f32,
-    pane_gl_bottom: f32,
+    layout: markdown_layout.Panel,
     normal: [3]f32,
     muted: [3]f32,
     strong: [3]f32,
@@ -205,30 +197,21 @@ fn renderDocument(
     code_bg: [3]f32,
     border: [3]f32,
 ) void {
-    // body_top (from window top): panel_top + HEADER_HEIGHT + PAD_Y
-    // Dock check: titlebar_h + HEADER_HEIGHT + PAD_Y ✓
-    const body_top = panel_top + HEADER_HEIGHT + PAD_Y;
-    // body_bottom margin (from window BOTTOM): pane_gl_bottom + FOOTER_HEIGHT + PAD_Y
-    // Dock check: 0 + FOOTER_HEIGHT + PAD_Y = FOOTER_HEIGHT + PAD_Y ✓
-    const body_bottom_margin = pane_gl_bottom + FOOTER_HEIGHT + PAD_Y;
-    // body_h = window_height - body_top - body_bottom_margin
-    // Dock check: window_height - (titlebar_h+HEADER_HEIGHT+PAD_Y) - (FOOTER_HEIGHT+PAD_Y) ✓
-    const body_h = window_height - body_top - body_bottom_margin;
-    if (body_h <= 0) return;
+    if (!layout.bodyAvailable()) return;
 
     if (pane.kind.isRaster()) {
-        renderImageDocument(pane, panel_x, panel_w, window_height, body_top, body_h, normal, muted, border);
+        renderImageDocument(pane, layout.panel_x, layout.panel_w, layout.window_height, layout.body_top, layout.body_h, normal, muted, border);
         return;
     }
     if (markdown_preview.delimiterForKind(pane.kind)) |delimiter| {
-        renderDelimitedDocument(pane, panel_x, panel_w, window_height, body_top, body_h, delimiter, normal, muted, strong, accent, code_bg, border);
+        renderDelimitedDocument(pane, layout.panel_x, layout.panel_w, layout.window_height, layout.body_top, layout.body_h, delimiter, normal, muted, strong, accent, code_bg, border);
         return;
     }
 
     const row_h = @max(22, font.g_titlebar_cell_height + LINE_GAP);
-    const body_origin = body_top - pane.scroll_offset;
+    const body_origin = layout.body_top - pane.scroll_offset;
     var y_from_top: f32 = body_origin;
-    const max_w = panel_w - PAD_X * 2;
+    const max_w = layout.content_w;
 
     var in_code = false;
     var rendered: usize = 0;
@@ -241,11 +224,11 @@ fn renderDocument(
         // full content height (needed to clamp scroll) without extra draw cost.
         const consumed = renderMarkdownLine(
             pane,
-            panel_x + PAD_X,
+            layout.content_x,
             max_w,
-            window_height,
-            body_top,
-            body_h,
+            layout.window_height,
+            layout.body_top,
+            layout.body_h,
             y_from_top,
             row_h,
             line,
@@ -262,8 +245,7 @@ fn renderDocument(
     }
     // Clamp scroll to the laid-out height so the pane can't scroll past its last
     // rendered line into blank space (large heads now stop cleanly at the end).
-    pane.max_scroll = @max(0, (y_from_top - body_origin) - body_h);
-    _ = panel_h;
+    pane.max_scroll = @max(0, (y_from_top - body_origin) - layout.body_h);
 }
 
 /// Number of non-blank lines — the count of rows the delimited renderer actually

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -247,6 +247,7 @@ test {
     _ = @import("preview/pdf.zig");
     _ = @import("preview/gallery.zig");
     _ = @import("preview/diagnostics.zig");
+    _ = @import("preview/markdown_layout.zig");
     _ = @import("preview/image_layout.zig");
     _ = @import("file_backend.zig");
     _ = @import("file_explorer.zig");


### PR DESCRIPTION
## Summary

- Add `preview/markdown_layout.zig` as a pure backend-neutral geometry model for the right-side preview pane.
- Route markdown preview panel background, header, footer, and document body viewport through the shared layout.
- Add fast unit tests for GL-space chrome rectangles, centered text baselines, and body status-line placement.

## Renderer Boundary

Ghostty has renderer backends behind a shared renderer boundary, but no WispTerm-specific markdown preview pane. This follows the same boundary shape: pane geometry is now backend-neutral and unit-tested, while actual draw calls and texture handling remain behind the existing renderer pipeline.

## Scope

- Does not change the Windows default renderer.
- Does not remove or alter the OpenGL fallback.
- Does not start Phase V hardening or Phase VI default migration.
- Targets `windows-native-render`, not `main`.

## Validation

- `zig test src\preview\markdown_layout.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- Windows checkout safety checks: reserved names, illegal characters, case-fold collisions, max path length, symlinks
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all`