### PR TITLE
[codex] gate post process shaders by backend

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -61,8 +61,8 @@ console release unless the release explicitly includes `remote/`.
 
 ## Cross-Platform
 
-- Custom post-processing shaders are OpenGL/GLSL-oriented. Metal needs a
-  GLSL-to-MSL translation layer before macOS can support the same custom shader
-  path.
+- Custom post-processing shaders are OpenGL/GLSL-oriented. D3D11 and Metal
+  explicitly ignore custom shader paths and render without post-processing until
+  they have native shader support or a translation layer.
 - Some renderer coordination still uses documented OpenGL-shaped compatibility
   plumbing. It is guarded and shrinking, but not fully backend-neutral yet.

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -17,6 +17,8 @@ const ui_pipeline = @import("ui_pipeline.zig");
 const cell_renderer = AppWindow.cell_renderer;
 const background_image = AppWindow.background_image;
 const Renderer = @import("Renderer.zig");
+const policy = @import("post_process_policy.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
 
 // Post-processing state (gpu-primitive-backed)
 threadlocal var g_post_fb: gpu.Framebuffer = .{};
@@ -201,6 +203,21 @@ pub fn renderFrameWithPostFromCells(rend: *const Renderer, width: c_int, height:
 /// Initialize post-processing from a shader path. Returns true if enabled.
 pub fn init(allocator: std.mem.Allocator, shader_path: ?[]const u8) void {
     const sp = shader_path orelse return;
+    switch (policy.decide(gpu.active)) {
+        .load => {},
+        .disabled => |reason| {
+            const msg = reason.message();
+            std.debug.print(
+                "Custom post-processing shader disabled for gpu-backend={s}: {s}. Ignoring shader path: {s}\n",
+                .{ @tagName(gpu.active), msg, sp },
+            );
+            render_diagnostics.log(
+                "post-process custom shader disabled gpu-backend={s} reason=\"{s}\" path=\"{s}\"",
+                .{ @tagName(gpu.active), msg, sp },
+            );
+            return;
+        },
+    }
     if (initPostShader(allocator, sp)) {
         g_post_enabled = true;
         g_start_time = std.time.milliTimestamp();

--- a/src/renderer/post_process_policy.zig
+++ b/src/renderer/post_process_policy.zig
@@ -1,0 +1,53 @@
+//! Backend policy for Ghostty/Shadertoy-style custom post-processing shaders.
+//!
+//! The current custom shader path is GLSL/OpenGL-oriented. Until non-OpenGL
+//! backends grow real translation or native shader loading, they should fail
+//! closed with a clear fallback message instead of trying to compile GLSL as a
+//! backend-native shader language.
+
+const std = @import("std");
+const Backend = @import("gpu/backend.zig").Backend;
+
+pub const DisableReason = enum {
+    d3d11_experimental,
+    metal_translation_missing,
+
+    pub fn message(self: DisableReason) []const u8 {
+        return switch (self) {
+            .d3d11_experimental => "D3D11 custom post-processing shaders are disabled while the backend is experimental; the frame renders without the custom shader",
+            .metal_translation_missing => "Metal custom post-processing shaders need GLSL-to-MSL translation; the frame renders without the custom shader",
+        };
+    }
+};
+
+pub const Decision = union(enum) {
+    load,
+    disabled: DisableReason,
+};
+
+pub fn decide(backend: Backend) Decision {
+    return switch (backend) {
+        .opengl => .load,
+        .d3d11 => .{ .disabled = .d3d11_experimental },
+        .metal => .{ .disabled = .metal_translation_missing },
+    };
+}
+
+test "post_process_policy: OpenGL loads custom shaders" {
+    try std.testing.expect(decide(.opengl) == .load);
+}
+
+test "post_process_policy: D3D11 disables custom shaders with explicit fallback" {
+    const decision = decide(.d3d11);
+    try std.testing.expect(decision == .disabled);
+    try std.testing.expectEqual(DisableReason.d3d11_experimental, decision.disabled);
+    try std.testing.expect(std.mem.indexOf(u8, decision.disabled.message(), "disabled") != null);
+    try std.testing.expect(std.mem.indexOf(u8, decision.disabled.message(), "without the custom shader") != null);
+}
+
+test "post_process_policy: Metal disables custom shaders until translation exists" {
+    const decision = decide(.metal);
+    try std.testing.expect(decision == .disabled);
+    try std.testing.expectEqual(DisableReason.metal_translation_missing, decision.disabled);
+    try std.testing.expect(std.mem.indexOf(u8, decision.disabled.message(), "GLSL-to-MSL") != null);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -193,6 +193,7 @@ test {
     _ = @import("renderer/background_image_layout.zig");
     _ = @import("renderer/qr_panel_layout.zig");
     _ = @import("renderer/file_explorer_layout.zig");
+    _ = @import("renderer/post_process_policy.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");
     _ = @import("close_confirm.zig");


### PR DESCRIPTION
## Summary

- Add a pure `post_process_policy` helper for backend-specific custom shader decisions.
- Keep OpenGL on the existing Ghostty/Shadertoy GLSL path, while D3D11 and Metal now explicitly ignore custom shader paths and render without post-processing.
- Log a clear fallback message through stderr and render diagnostics when a non-OpenGL backend ignores a shader path.
- Update `KNOWN_ISSUES.md` to document the D3D11/Metal custom shader fallback policy.

## Renderer Boundary

Ghostty-compatible custom shaders are currently GLSL/OpenGL-oriented. Ghostty does not provide a D3D11 custom shader path to mirror, so this keeps the D3D11 backend experimental and explicit: no GLSL-as-HLSL compile attempts, no Windows default renderer change, and no fallback removal.

## Scope

- Does not implement HLSL custom shader translation.
- Does not change the Windows default renderer.
- Does not remove or alter the OpenGL fallback.
- Does not start Phase V hardening or Phase VI default migration.
- Targets `windows-native-render`, not `main`.

## Validation

- `zig test src\renderer\post_process_policy.zig`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- Windows checkout safety checks: reserved names, illegal characters, case-fold collisions, max path length, symlinks
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all`