### PR TITLE
[codex] guard d3d11 phase4 coverage

### DIFF
--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -22,6 +22,30 @@ OpenGL renderer and then copied into the DXGI swapchain. This roadmap changes
 that into a real `d3d11` backend that draws cells, glyphs, emoji, UI, images,
 and render targets directly with Direct3D 11.
 
+## Current Branch Status
+
+On the `windows-native-render` integration branch, the opt-in D3D11 backend is a
+real native renderer path, not merely OpenGL frames presented through DXGI. The
+branch has backend/present/shader diagnostics for `gpu-backend=d3d11`, a D3D11
+swapchain, HLSL shader plumbing, terminal grid rendering, D3D11 off-screen
+framebuffers, off-screen render-target round-trip smoke coverage, backend-neutral
+UI pipeline smoke coverage, and a growing set of Phase IV layout/policy slices.
+
+The explicit Phase IV slices currently covered by fast-suite layout/policy tests
+and source guards are: titlebar/tabs/sidebar/caption-button layout, startup
+overlay, file explorer, settings page, background image layout, image preview
+layout, QR panel layout, assistant conversation panel layout, command palette
+layout, skill center layout, markdown preview layout, and backend-specific
+post-process/custom shader policy. Supplemental user-visible panels such as the
+port-forwarding renderer are also guarded as backend-neutral when they already
+fit the same shared draw-context shape.
+
+This does not make D3D11 product-default-ready yet. Phase IV exit criteria still
+need stronger normal-session evidence that the D3D11 backend can run day-to-day
+without major missing UI, Phase V hardening is not started, and Phase VI default
+migration must remain blocked until feature parity and fallback coverage are
+proven. Windows `auto` still must not default to D3D11 on this branch.
+
 ## Ghostty Comparison
 
 Ghostty is still the architectural reference for the renderer boundary. Its

--- a/src/source_guards/d3d11_phase4_guard.zig
+++ b/src/source_guards/d3d11_phase4_guard.zig
@@ -1,0 +1,112 @@
+//! Phase IV D3D11 parity coverage guard.
+//!
+//! This does not prove full visual parity. It freezes the explicit Phase IV
+//! coverage slices that have already been extracted into pure layout/policy
+//! modules so future work cannot silently drop them from the fast suite or
+//! reintroduce backend-specific GPU vocabulary into those shared surfaces.
+
+const std = @import("std");
+const scan = @import("scan.zig");
+
+const GuardedSource = struct {
+    name: []const u8,
+    source: []const u8,
+};
+
+const RequiredImport = struct {
+    label: []const u8,
+    import_text: []const u8,
+};
+
+const explicit_phase4_sources = [_]GuardedSource{
+    .{ .name = "renderer/titlebar_layout.zig", .source = @embedFile("../renderer/titlebar_layout.zig") },
+    .{ .name = "renderer/overlays/startup_shortcuts_layout.zig", .source = @embedFile("../renderer/overlays/startup_shortcuts_layout.zig") },
+    .{ .name = "renderer/file_explorer_layout.zig", .source = @embedFile("../renderer/file_explorer_layout.zig") },
+    .{ .name = "renderer/overlays/settings_page_layout.zig", .source = @embedFile("../renderer/overlays/settings_page_layout.zig") },
+    .{ .name = "renderer/background_image_layout.zig", .source = @embedFile("../renderer/background_image_layout.zig") },
+    .{ .name = "preview/image_layout.zig", .source = @embedFile("../preview/image_layout.zig") },
+    .{ .name = "renderer/qr_panel_layout.zig", .source = @embedFile("../renderer/qr_panel_layout.zig") },
+    .{ .name = "assistant/conversation/layout.zig", .source = @embedFile("../assistant/conversation/layout.zig") },
+    .{ .name = "renderer/overlays/command_palette_layout.zig", .source = @embedFile("../renderer/overlays/command_palette_layout.zig") },
+    .{ .name = "renderer/skill_center_renderer.zig", .source = @embedFile("../renderer/skill_center_renderer.zig") },
+    .{ .name = "preview/markdown_layout.zig", .source = @embedFile("../preview/markdown_layout.zig") },
+    .{ .name = "renderer/post_process_policy.zig", .source = @embedFile("../renderer/post_process_policy.zig") },
+};
+
+const supplemental_user_visible_sources = [_]GuardedSource{
+    .{ .name = "renderer/port_forwarding_renderer.zig", .source = @embedFile("../renderer/port_forwarding_renderer.zig") },
+};
+
+const forbidden_backend_vocab = [_][]const u8{
+    "gpu.c",
+    "gl_init",
+    "GL_",
+    "ID3D11",
+    "HLSL",
+    "MTL",
+};
+
+const required_fast_imports = [_]RequiredImport{
+    .{ .label = "titlebar layout", .import_text = "@import(\"renderer/titlebar_layout.zig\")" },
+    .{ .label = "startup overlay layout", .import_text = "@import(\"renderer/overlays/startup_shortcuts_layout.zig\")" },
+    .{ .label = "file explorer layout", .import_text = "@import(\"renderer/file_explorer_layout.zig\")" },
+    .{ .label = "settings page layout", .import_text = "@import(\"renderer/overlays/settings_page_layout.zig\")" },
+    .{ .label = "background image layout", .import_text = "@import(\"renderer/background_image_layout.zig\")" },
+    .{ .label = "image preview layout", .import_text = "@import(\"preview/image_layout.zig\")" },
+    .{ .label = "QR panel layout", .import_text = "@import(\"renderer/qr_panel_layout.zig\")" },
+    .{ .label = "assistant conversation layout", .import_text = "@import(\"assistant/conversation/layout.zig\")" },
+    .{ .label = "command palette layout", .import_text = "@import(\"renderer/overlays/command_palette_layout.zig\")" },
+    .{ .label = "skill center renderer layout", .import_text = "@import(\"renderer/skill_center_renderer.zig\")" },
+    .{ .label = "markdown preview layout", .import_text = "@import(\"preview/markdown_layout.zig\")" },
+    .{ .label = "post-process backend policy", .import_text = "@import(\"renderer/post_process_policy.zig\")" },
+    .{ .label = "supplemental port forwarding renderer", .import_text = "@import(\"renderer/port_forwarding_renderer.zig\")" },
+};
+
+fn countForbidden(source: []const u8) usize {
+    var total: usize = 0;
+    for (forbidden_backend_vocab) |needle| {
+        total += scan.countOccurrences(source, needle);
+    }
+    return total;
+}
+
+fn expectBackendNeutral(sources: []const GuardedSource) !void {
+    var failed = false;
+    for (sources) |source_file| {
+        const count = countForbidden(source_file.source);
+        if (count == 0) continue;
+
+        std.debug.print(
+            "d3d11_phase4_guard: {s} contains {d} backend-specific token(s); keep Phase IV feature layout/policy shared and route GPU work through backend-owned code.\n",
+            .{ source_file.name, count },
+        );
+        failed = true;
+    }
+
+    try std.testing.expect(!failed);
+}
+
+test "D3D11 Phase IV explicit parity surfaces stay backend-neutral" {
+    try expectBackendNeutral(&explicit_phase4_sources);
+}
+
+test "D3D11 Phase IV supplemental user-visible surfaces stay backend-neutral" {
+    try expectBackendNeutral(&supplemental_user_visible_sources);
+}
+
+test "D3D11 Phase IV coverage remains in the fast suite" {
+    const fast_suite = @embedFile("../test_fast.zig");
+
+    var missing = false;
+    for (required_fast_imports) |required| {
+        if (std.mem.indexOf(u8, fast_suite, required.import_text) != null) continue;
+
+        std.debug.print(
+            "d3d11_phase4_guard: missing fast-suite import for {s}: {s}\n",
+            .{ required.label, required.import_text },
+        );
+        missing = true;
+    }
+
+    try std.testing.expect(!missing);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -184,6 +184,7 @@ test {
     _ = @import("source_guards/agent_tools_guard.zig");
     _ = @import("source_guards/assistant_agent_boundary_guard.zig");
     _ = @import("source_guards/layered_dependency_guard.zig");
+    _ = @import("source_guards/d3d11_phase4_guard.zig");
     _ = @import("source_guards/overlay_boundary_guard.zig");
     _ = @import("source_guards/input_feature_boundary_guard.zig");
     _ = @import("renderer/overlays/transfer_toast_model.zig");


### PR DESCRIPTION
## Summary

- add a fast-suite source guard that freezes the explicit Phase IV D3D11 layout/policy coverage slices
- keep those shared Phase IV surfaces free of backend-specific GPU vocabulary
- update the D3D11 roadmap with the current `windows-native-render` branch status and remaining exit criteria

## Ghostty reference

Ghostty's renderer boundary still uses `Backend{ opengl, metal, webgl }` with parallel backend implementations under `src/renderer/`. WispTerm keeps that backend-boundary shape while adding the WispTerm-specific D3D11 backend; feature layout and policy modules should stay backend-neutral instead of growing D3D11/HLSL/OpenGL details.

## Validation

- `zig build test`
- `zig build check-sizes`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build test-full --summary all` (`60/60` steps, `13171/13446` tests passed, `275` skipped)
- Windows checkout safety: `tracked_files=1720`, `windows_name_violations=0`, `casefold_collisions=0`, no symlinks