### PR TITLE
[codex] cover d3d11 overlay pages

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -325,11 +325,45 @@ function Analyze-TabChrome([string]$Active1Path, [string]$Active2Path, [string]$
     }
 }
 
+function Analyze-PageSurface(
+    [string]$BeforePath,
+    [string]$AfterPath,
+    [int]$Left,
+    [int]$Top,
+    [int]$Width,
+    [int]$Height,
+    [int]$MinChanged,
+    [double]$MinChangedRatio,
+    [int]$MinBright
+) {
+    $region = Analyze-Region $AfterPath $Left $Top $Width $Height 2
+    $delta = Compare-ImageRegion $BeforePath $AfterPath $Left $Top $Width $Height 2
+    $pass = ($delta.Changed -gt $MinChanged -and $delta.ChangedRatio -gt $MinChangedRatio -and $region.Bright -gt $MinBright)
+
+    return @{
+        Pass = [bool]$pass
+        Changed = $delta.Changed
+        ChangedRatio = $delta.ChangedRatio
+        Bright = $region.Bright
+        Saturated = $region.Saturated
+        Luma = $region.Luma
+        Samples = $region.Samples
+    }
+}
+
 function Click-WindowCenter([IntPtr]$Hwnd) {
     $rect = Get-WindowRectValue $Hwnd
     $x = [int](($rect.Left + $rect.Right) / 2)
     $y = [int](($rect.Top + $rect.Bottom) / 2)
     [WispTermD3D11SmokeAutomation]::SetCursorPos($x, $y) | Out-Null
+    [WispTermD3D11SmokeAutomation]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 80
+    [WispTermD3D11SmokeAutomation]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+}
+
+function Click-WindowPoint([IntPtr]$Hwnd, [int]$X, [int]$Y) {
+    Move-MouseWindow $Hwnd $X $Y
+    Start-Sleep -Milliseconds 80
     [WispTermD3D11SmokeAutomation]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero)
     Start-Sleep -Milliseconds 80
     [WispTermD3D11SmokeAutomation]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
@@ -399,6 +433,8 @@ $tabsCloseHoverShot = Join-Path $OutDir "d3d11-tabs-close-hover-$timestamp.png"
 $sidebarShot = Join-Path $OutDir "d3d11-sidebar-$timestamp.png"
 $explorerShot = Join-Path $OutDir "d3d11-file-explorer-$timestamp.png"
 $paletteShot = Join-Path $OutDir "d3d11-command-palette-$timestamp.png"
+$settingsShot = Join-Path $OutDir "d3d11-settings-page-$timestamp.png"
+$skillCenterShot = Join-Path $OutDir "d3d11-skill-center-$timestamp.png"
 $metricsPath = Join-Path $OutDir "d3d11-normal-session-$timestamp.json"
 $appDataDir = Join-Path $OutDir "appdata"
 $diagnosticPath = Join-Path $appDataDir "wispterm\render-diagnostic.log"
@@ -479,6 +515,22 @@ try {
     Capture-Window $wisptermWindow $paletteShot | Out-Null
     $paletteDelta = Compare-Images $explorerShot $paletteShot
 
+    Send-Escape
+    Start-Sleep -Milliseconds 650
+    Click-WindowPoint $wisptermWindow 1078 24
+    Start-Sleep -Milliseconds 1100
+    Capture-Window $wisptermWindow $settingsShot | Out-Null
+    $settingsPageMetrics = Analyze-PageSurface $explorerShot $settingsShot 230 54 780 662 900 0.018 120
+
+    Send-Escape
+    Start-Sleep -Milliseconds 650
+    Send-CtrlShiftP
+    Start-Sleep -Milliseconds 850
+    Click-WindowPoint $wisptermWindow 620 496
+    Start-Sleep -Milliseconds 1600
+    Capture-Window $wisptermWindow $skillCenterShot | Out-Null
+    $skillCenterMetrics = Analyze-PageSurface $explorerShot $skillCenterShot 220 46 1010 725 1100 0.014 140
+
     $diagText = Wait-ForDiagnosticText $diagnosticPath "d3d11-ui-smoke probe .* ok=true" 12
     $hasD3D11Present = $diagText -match "gpu-backend=d3d11 present=dxgi"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
@@ -491,6 +543,8 @@ try {
         $sidebarDelta.Pass -and
         $explorerDelta.Pass -and
         $paletteDelta.Pass -and
+        $settingsPageMetrics.Pass -and
+        $skillCenterMetrics.Pass -and
         $hasD3D11Present -and
         $hasUiProbe -and
         $hasOffscreen -and
@@ -511,6 +565,8 @@ try {
             sidebar = $sidebarShot
             file_explorer = $explorerShot
             command_palette = $paletteShot
+            settings_page = $settingsShot
+            skill_center = $skillCenterShot
         }
         initial = [ordered]@{
             samples = $initialMetrics.Samples
@@ -560,6 +616,24 @@ try {
             samples = $paletteDelta.Samples
             changed_ratio = [Math]::Round($paletteDelta.ChangedRatio, 5)
             pass = [bool]$paletteDelta.Pass
+        }
+        settings_page = [ordered]@{
+            changed = $settingsPageMetrics.Changed
+            changed_ratio = [Math]::Round($settingsPageMetrics.ChangedRatio, 5)
+            bright = $settingsPageMetrics.Bright
+            saturated = $settingsPageMetrics.Saturated
+            luma = [Math]::Round($settingsPageMetrics.Luma, 3)
+            samples = $settingsPageMetrics.Samples
+            pass = [bool]$settingsPageMetrics.Pass
+        }
+        skill_center = [ordered]@{
+            changed = $skillCenterMetrics.Changed
+            changed_ratio = [Math]::Round($skillCenterMetrics.ChangedRatio, 5)
+            bright = $skillCenterMetrics.Bright
+            saturated = $skillCenterMetrics.Saturated
+            luma = [Math]::Round($skillCenterMetrics.Luma, 3)
+            samples = $skillCenterMetrics.Samples
+            pass = [bool]$skillCenterMetrics.Pass
         }
         diagnostics = [ordered]@{
             d3d11_present = [bool]$hasD3D11Present

--- a/docs/development.md
+++ b/docs/development.md
@@ -166,7 +166,9 @@ The script launches a real visible WispTerm window with an isolated `%APPDATA%`,
 enables render diagnostics plus the D3D11 UI/offscreen probes, switches between
 two visible tabs, checks tab text, the `+` icon, active/inactive row states, and
 the close-hover affordance, then toggles the tab sidebar, file explorer, and
-command palette. It captures screenshots, writes JSON metrics under
+command palette. It also opens the Settings page from the titlebar gear and the
+Skill Center from the Command Center, capturing both as additional user-visible
+Phase IV pages. It captures screenshots, writes JSON metrics under
 `zig-out\d3d11-normal-session-smoke\`, and verifies that
 `render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, a successful
 `d3d11-ui-smoke` probe, and an offscreen round-trip marker. It is a Phase IV

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -56,10 +56,11 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 It launches a real visible D3D11 WispTerm session, captures screenshots while
 switching active tabs, validating tab text, the `+` icon, active/inactive tab
 states, and the close-hover affordance, then toggling the tab sidebar, file
-explorer, and command palette. It also verifies the render-diagnostics log for
-D3D11 present, UI probe, and offscreen round-trip markers. This is runtime
-evidence for the Phase IV exit criteria; it is not a Phase V hardening
-substitute and does not change the Windows default backend.
+explorer, and command palette. It also opens the Settings page from the titlebar
+gear and the Skill Center from the Command Center, then verifies the
+render-diagnostics log for D3D11 present, UI probe, and offscreen round-trip
+markers. This is runtime evidence for the Phase IV exit criteria; it is not a
+Phase V hardening substitute and does not change the Windows default backend.
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

- Extends the Windows D3D11 normal-session smoke to cover two more Phase IV user-visible pages.
- Opens the Settings page from the titlebar gear and the Skill Center from the Command Center in the same visible D3D11 session.
- Captures screenshots and JSON metrics for both pages in `zig-out/d3d11-normal-session-smoke/`.
- Updates the D3D11 roadmap and development docs to describe the stronger runtime evidence.

## Scope

This remains Phase IV parity/evidence work. It does not change the Windows default renderer, remove OpenGL fallback, or start Phase V hardening.

Ghostty comparison: Ghostty keeps renderer backends behind a shared boundary (`opengl`, `metal`, `webgl`); WispTerm keeps that shape while adding Windows-specific D3D11 evidence for app-owned overlay/page renderers.

## Validation

- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
  - latest run: `pass=true`
  - `settings_page.pass=true`
  - `skill_center.pass=true`
  - screenshots visually confirmed: Settings page and Skill Center tab rendered, not just Command Center filters
- PowerShell AST parse for `debug/test-d3d11-normal-session.ps1`
- `git diff --check`
- `zig build test`
- `zig build check-sizes`
- `zig build test-shared -Dgpu-backend=d3d11`
- `zig build test-full --summary all`
