### PR TITLE
[codex] update d3d11 phase4 status

### DIFF
--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -29,24 +29,29 @@ real native renderer path, not merely OpenGL frames presented through DXGI. The
 branch has backend/present/shader diagnostics for `gpu-backend=d3d11`, a D3D11
 swapchain, HLSL shader plumbing, terminal grid rendering, D3D11 off-screen
 framebuffers, off-screen render-target round-trip smoke coverage, backend-neutral
-UI pipeline smoke coverage, and a growing set of Phase IV layout/policy slices.
+UI pipeline smoke coverage, and the Phase IV UI/auxiliary parity evidence set.
 
-The explicit Phase IV slices currently covered by fast-suite layout/policy tests
-and source guards are: titlebar/tabs/sidebar/caption-button layout, startup
-overlay, file explorer, settings page, background image layout, image preview
-layout, QR panel layout, assistant conversation panel layout, command palette
-layout, skill center layout, markdown preview layout, and backend-specific
+The explicit Phase IV slices covered by fast-suite layout/policy tests and
+source guards are: titlebar/tabs/sidebar/caption-button layout, startup overlay,
+file explorer, settings page, background image layout, image preview layout, QR
+panel layout, assistant conversation panel layout, command palette layout, skill
+center layout, markdown preview layout, and backend-specific
 post-process/custom shader policy. Supplemental user-visible panels such as the
 port-forwarding renderer are also guarded as backend-neutral when they already
 fit the same shared draw-context shape.
 
-This does not make D3D11 product-default-ready yet. Phase IV exit criteria still
-need stronger normal-session evidence that the D3D11 backend can run day-to-day
-without major missing UI, Phase V hardening is not started, and Phase VI default
-migration must remain blocked until feature parity and fallback coverage are
-proven. Windows `auto` still must not default to D3D11 on this branch.
+Phase IV UI parity evidence is complete on this branch: the guarded layout/policy
+slices cover the explicit user-visible renderer surfaces, and the checked-in
+normal-session smoke now proves a real D3D11 WispTerm session with the tab
+chrome, sidebar, file explorer, background image, Markdown/image previews,
+Copilot assistant sidebar, command palette, startup shortcuts overlay, Settings
+page, Skill Center, D3D11 present diagnostics, UI probe, and offscreen
+round-trip marker. This does not make D3D11 product-default-ready yet: Phase V
+hardening is not started, Phase VI default migration remains blocked until
+fallback coverage is proven, and Windows `auto` still must not default to D3D11
+on this branch.
 
-The next Phase IV evidence step is the checked-in Windows GUI smoke:
+The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
 ```powershell
 zig build -Dgpu-backend=d3d11


### PR DESCRIPTION
## Summary

- update the D3D11 roadmap status now that the Phase IV normal-session evidence chain through #464 has landed
- mark Phase IV UI/auxiliary parity evidence complete on `windows-native-render`
- keep the Phase V and Phase VI boundaries explicit: no product-default migration, no Windows `auto` default change, and no OpenGL fallback removal

## Validation

- `git diff --check`
- `zig build test`

## Scope

Docs/status only. This does not change renderer behavior or the Windows default backend.
