### PR TITLE
[codex] diagnose d3d11 present failures

### DIFF
--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -47,9 +47,10 @@ chrome, sidebar, file explorer, background image, Markdown/image previews,
 Copilot assistant sidebar, command palette, startup shortcuts overlay, Settings
 page, Skill Center, D3D11 present diagnostics, UI probe, and offscreen
 round-trip marker. This does not make D3D11 product-default-ready yet: Phase V
-hardening is not started, Phase VI default migration remains blocked until
-fallback coverage is proven, and Windows `auto` still must not default to D3D11
-on this branch.
+hardening has started with backend-owned present/device-loss diagnostics, but
+device recreation, automatic fallback policy, environment validation, and Phase
+VI default migration remain blocked until fallback coverage is proven. Windows
+`auto` still must not default to D3D11 on this branch.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -51,6 +51,7 @@ fn hexByte(comptime pair: *const [2]u8) u8 {
 
 // Interface IDs the presenter queries.
 pub const IID_IDXGIDevice = guid("54ec77fa-1377-44e6-8c32-88fd5f44c84c");
+pub const IID_IDXGIAdapter1 = guid("29038f61-3839-4626-91fd-086879011a05");
 pub const IID_IDXGIFactory1 = guid("770aae78-f26f-4dba-a829-253c83d1b387");
 pub const IID_IDXGIFactory2 = guid("50c83a1c-e072-4c48-87b0-3630fa36a6d0");
 pub const IID_IDXGIResource = guid("035f3ab4-482e-4e50-b41f-8a7f8bd8960b");
@@ -200,6 +201,21 @@ pub const D3D11_RASTERIZER_DESC = extern struct {
 
 pub const HRESULT = i32;
 
+pub fn hresult(comptime value: u32) HRESULT {
+    return @bitCast(@as(u32, value));
+}
+
+pub fn hresultBits(value: HRESULT) u32 {
+    return @bitCast(value);
+}
+
+pub const S_OK: HRESULT = 0;
+pub const DXGI_ERROR_INVALID_CALL: HRESULT = hresult(0x887A0001);
+pub const DXGI_ERROR_DEVICE_REMOVED: HRESULT = hresult(0x887A0005);
+pub const DXGI_ERROR_DEVICE_HUNG: HRESULT = hresult(0x887A0006);
+pub const DXGI_ERROR_DEVICE_RESET: HRESULT = hresult(0x887A0007);
+pub const DXGI_ERROR_DRIVER_INTERNAL_ERROR: HRESULT = hresult(0x887A0020);
+
 pub const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87;
 pub const DXGI_FORMAT_R32G32B32A32_FLOAT: u32 = 2;
 pub const DXGI_FORMAT_R32G32B32_FLOAT: u32 = 6;
@@ -228,6 +244,62 @@ pub const D3D11_BIND_SHADER_RESOURCE: u32 = 0x8;
 pub const D3D11_BIND_RENDER_TARGET: u32 = 0x20;
 pub const D3D11_CPU_ACCESS_WRITE: u32 = 0x10000;
 pub const D3D11_CPU_ACCESS_READ: u32 = 0x20000;
+
+pub const DxgiFailureKind = enum {
+    ok,
+    invalid_call,
+    device_removed,
+    device_hung,
+    device_reset,
+    driver_internal_error,
+    other,
+
+    pub fn name(self: DxgiFailureKind) []const u8 {
+        return switch (self) {
+            .ok => "ok",
+            .invalid_call => "invalid_call",
+            .device_removed => "device_removed",
+            .device_hung => "device_hung",
+            .device_reset => "device_reset",
+            .driver_internal_error => "driver_internal_error",
+            .other => "other",
+        };
+    }
+
+    pub fn requiresDeviceRecreate(self: DxgiFailureKind) bool {
+        return switch (self) {
+            .device_removed, .device_hung, .device_reset, .driver_internal_error => true,
+            else => false,
+        };
+    }
+};
+
+pub fn dxgiFailureKind(hr: HRESULT) DxgiFailureKind {
+    if (hr >= 0) return .ok;
+    return switch (hr) {
+        DXGI_ERROR_INVALID_CALL => .invalid_call,
+        DXGI_ERROR_DEVICE_REMOVED => .device_removed,
+        DXGI_ERROR_DEVICE_HUNG => .device_hung,
+        DXGI_ERROR_DEVICE_RESET => .device_reset,
+        DXGI_ERROR_DRIVER_INTERNAL_ERROR => .driver_internal_error,
+        else => .other,
+    };
+}
+
+pub fn dxgiFailureName(hr: HRESULT) []const u8 {
+    return dxgiFailureKind(hr).name();
+}
+
+pub fn dxgiFailureRequiresDeviceRecreate(hr: HRESULT) bool {
+    return dxgiFailureKind(hr).requiresDeviceRecreate();
+}
+
+pub fn dxgiSwapEffectName(value: u32) []const u8 {
+    return switch (value) {
+        DXGI_SWAP_EFFECT_FLIP_DISCARD => "flip_discard",
+        else => "unknown",
+    };
+}
 pub const D3D11_RESOURCE_MISC_SHARED: u32 = 0x2;
 pub const D3D11_MAP_READ: u32 = 1;
 pub const D3D11_MAP_WRITE_DISCARD: u32 = 4;
@@ -337,6 +409,7 @@ pub const slot = struct {
     pub const D3D11Device_CreateBlendState: usize = 20;
     pub const D3D11Device_CreateRasterizerState: usize = 22;
     pub const D3D11Device_CreateSamplerState: usize = 23;
+    pub const D3D11Device_GetDeviceRemovedReason: usize = 39;
 
     // ID3D11DeviceContext (IUnknown + ID3D11DeviceChild(4) → first own slot 7:
     // VSSetConstantBuffers(7) … Draw(13) Map(14) Unmap(15) … CopyResource(47))
@@ -614,6 +687,8 @@ test "well-known interface IIDs round-trip their documented strings" {
     // transposed hex pair in the declarations can't reach the COM boundary.
     try std.testing.expectEqual(@as(u32, 0x54ec77fa), IID_IDXGIDevice.data1);
     try std.testing.expectEqual(@as(u8, 0x4c), IID_IDXGIDevice.data4[7]);
+    try std.testing.expectEqual(@as(u32, 0x29038f61), IID_IDXGIAdapter1.data1);
+    try std.testing.expectEqual(@as(u8, 0x05), IID_IDXGIAdapter1.data4[7]);
     try std.testing.expectEqual(@as(u32, 0x50c83a1c), IID_IDXGIFactory2.data1);
     try std.testing.expectEqual(@as(u8, 0xd0), IID_IDXGIFactory2.data4[7]);
     try std.testing.expectEqual(@as(u32, 0x035f3ab4), IID_IDXGIResource.data1);
@@ -632,6 +707,20 @@ test "DXGI_SWAP_CHAIN_DESC1 matches the documented 48-byte layout" {
     try std.testing.expectEqual(@as(usize, 36), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "swap_effect"));
     try std.testing.expectEqual(@as(usize, 40), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "alpha_mode"));
     try std.testing.expectEqual(@as(usize, 44), @offsetOf(DXGI_SWAP_CHAIN_DESC1, "flags"));
+}
+
+test "DXGI HRESULT failure classification names device loss signals" {
+    try std.testing.expectEqual(@as(u32, 0x887A0005), hresultBits(DXGI_ERROR_DEVICE_REMOVED));
+    try std.testing.expectEqual(DxgiFailureKind.ok, dxgiFailureKind(S_OK));
+    try std.testing.expectEqual(DxgiFailureKind.invalid_call, dxgiFailureKind(DXGI_ERROR_INVALID_CALL));
+    try std.testing.expectEqual(DxgiFailureKind.device_removed, dxgiFailureKind(DXGI_ERROR_DEVICE_REMOVED));
+    try std.testing.expectEqual(DxgiFailureKind.device_hung, dxgiFailureKind(DXGI_ERROR_DEVICE_HUNG));
+    try std.testing.expectEqual(DxgiFailureKind.device_reset, dxgiFailureKind(DXGI_ERROR_DEVICE_RESET));
+    try std.testing.expectEqual(DxgiFailureKind.driver_internal_error, dxgiFailureKind(DXGI_ERROR_DRIVER_INTERNAL_ERROR));
+    try std.testing.expectEqualStrings("device_removed", dxgiFailureName(DXGI_ERROR_DEVICE_REMOVED));
+    try std.testing.expect(dxgiFailureRequiresDeviceRecreate(DXGI_ERROR_DEVICE_RESET));
+    try std.testing.expect(!dxgiFailureRequiresDeviceRecreate(DXGI_ERROR_INVALID_CALL));
+    try std.testing.expectEqualStrings("flip_discard", dxgiSwapEffectName(DXGI_SWAP_EFFECT_FLIP_DISCARD));
 }
 
 test "D3D11_TEXTURE2D_DESC matches the documented 44-byte layout" {

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -60,6 +60,10 @@ pub const InitError = error{
 };
 
 pub const PresentError = error{
+    DeviceHung,
+    DeviceRemoved,
+    DeviceReset,
+    DriverInternalError,
     PresentFailed,
 };
 
@@ -79,6 +83,7 @@ const State = struct {
     current_height: i32 = 0,
     vertex_shader: ?*anyopaque = null,
     pixel_shader: ?*anyopaque = null,
+    adapter: AdapterInfo = .{},
     width: i32,
     height: i32,
     feature_draws_this_frame: bool = false,
@@ -122,6 +127,20 @@ pub threadlocal var gl: GlTable = .{};
 
 const GlTable = @import("GlTable.zig").GlTable;
 
+const AdapterInfo = struct {
+    available: bool = false,
+    vendor_id: u32 = 0,
+    device_id: u32 = 0,
+    luid_low: u32 = 0,
+    luid_high: i32 = 0,
+    flags: u32 = 0,
+};
+
+const SwapchainCreateResult = struct {
+    swapchain: *anyopaque,
+    adapter: AdapterInfo,
+};
+
 pub fn init(_: anytype) !void {
     return error.D3D11RequiresWindow;
 }
@@ -157,13 +176,14 @@ pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
         core.comRelease(device.?);
     }
 
-    const swapchain = try createSwapchain(device.?, hwnd, width, height);
-    errdefer core.comRelease(swapchain);
+    const swapchain_result = try createSwapchain(device.?, hwnd, width, height);
+    errdefer core.comRelease(swapchain_result.swapchain);
 
     var next = State{
         .device = device.?,
         .context = context.?,
-        .swapchain = swapchain,
+        .swapchain = swapchain_result.swapchain,
+        .adapter = swapchain_result.adapter,
         .width = width,
         .height = height,
     };
@@ -173,11 +193,11 @@ pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
     try createPhase2Pipeline(&next);
 
     state = next;
-    render_diagnostics.log("gpu-backend=d3d11 present=dxgi swapchain={}x{}", .{ width, height });
+    logBackendInit(&state.?);
     std.debug.print("D3D11: native backend initialized {}x{}\n", .{ width, height });
 }
 
-fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) InitError!*anyopaque {
+fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) InitError!SwapchainCreateResult {
     const dxgi_device = core.comQueryInterface(device, &core.IID_IDXGIDevice) orelse
         return error.FactoryUnavailable;
     defer core.comRelease(dxgi_device);
@@ -186,6 +206,7 @@ fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) Init
     var adapter: ?*anyopaque = null;
     if (get_adapter(dxgi_device, &adapter) < 0 or adapter == null) return error.FactoryUnavailable;
     defer core.comRelease(adapter.?);
+    const adapter_info = queryAdapterInfo(adapter.?);
 
     const get_parent = core.comCall(adapter.?, core.slot.DXGIObject_GetParent, *const fn (*anyopaque, *const core.Guid, *?*anyopaque) callconv(.winapi) HRESULT);
     var factory: ?*anyopaque = null;
@@ -222,7 +243,48 @@ fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) Init
     const make_assoc = core.comCall(factory.?, core.slot.DXGIFactory_MakeWindowAssociation, *const fn (*anyopaque, HWND, u32) callconv(.winapi) HRESULT);
     _ = make_assoc(factory.?, hwnd, DXGI_MWA_NO_ALT_ENTER);
 
-    return swapchain.?;
+    return .{ .swapchain = swapchain.?, .adapter = adapter_info };
+}
+
+fn queryAdapterInfo(adapter: *anyopaque) AdapterInfo {
+    const adapter1 = core.comQueryInterface(adapter, &core.IID_IDXGIAdapter1) orelse return .{};
+    defer core.comRelease(adapter1);
+
+    const get_desc = core.comCall(adapter1, core.slot.DXGIAdapter1_GetDesc1, *const fn (*anyopaque, *core.DXGI_ADAPTER_DESC1) callconv(.winapi) HRESULT);
+    var desc: core.DXGI_ADAPTER_DESC1 = undefined;
+    if (get_desc(adapter1, &desc) < 0) return .{};
+
+    return .{
+        .available = true,
+        .vendor_id = desc.vendor_id,
+        .device_id = desc.device_id,
+        .luid_low = desc.adapter_luid.low_part,
+        .luid_high = desc.adapter_luid.high_part,
+        .flags = desc.flags,
+    };
+}
+
+fn logBackendInit(self: *const State) void {
+    if (self.adapter.available) {
+        render_diagnostics.log(
+            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter_vendor=0x{x} adapter_device=0x{x} adapter_luid={x}:{x} adapter_flags=0x{x} fallback_reason=none",
+            .{
+                self.width,
+                self.height,
+                core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD),
+                self.adapter.vendor_id,
+                self.adapter.device_id,
+                @as(u32, @bitCast(self.adapter.luid_high)),
+                self.adapter.luid_low,
+                self.adapter.flags,
+            },
+        );
+    } else {
+        render_diagnostics.log(
+            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter=unknown fallback_reason=none",
+            .{ self.width, self.height, core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD) },
+        );
+    }
 }
 
 fn createRenderTarget(self: *State, width: i32, height: i32) InitError!void {
@@ -394,8 +456,9 @@ pub fn resize(width: i32, height: i32) bool {
 
     self.releaseSized();
     const resize_buffers = core.comCall(self.swapchain, core.slot.DXGISwapChain_ResizeBuffers, *const fn (*anyopaque, u32, u32, u32, u32, u32) callconv(.winapi) HRESULT);
-    if (resize_buffers(self.swapchain, 0, @intCast(width), @intCast(height), 0, 0) < 0) {
-        render_diagnostics.log("gpu-backend=d3d11 resize failed at {}x{}", .{ width, height });
+    const hr = resize_buffers(self.swapchain, 0, @intCast(width), @intCast(height), 0, 0);
+    if (hr < 0) {
+        logDxgiFailure(self, "resize", hr);
         return false;
     }
     createRenderTarget(self, width, height) catch |err| {
@@ -441,7 +504,43 @@ pub fn present() PresentError!void {
     if (state == null) return;
     const self = &state.?;
     const present_fn = core.comCall(self.swapchain, core.slot.DXGISwapChain_Present, *const fn (*anyopaque, u32, u32) callconv(.winapi) HRESULT);
-    if (present_fn(self.swapchain, 1, 0) < 0) return error.PresentFailed;
+    const hr = present_fn(self.swapchain, 1, 0);
+    if (hr < 0) {
+        logDxgiFailure(self, "present", hr);
+        return presentErrorFromHRESULT(hr);
+    }
+}
+
+fn presentErrorFromHRESULT(hr: HRESULT) PresentError {
+    return switch (core.dxgiFailureKind(hr)) {
+        .device_removed => error.DeviceRemoved,
+        .device_hung => error.DeviceHung,
+        .device_reset => error.DeviceReset,
+        .driver_internal_error => error.DriverInternalError,
+        else => error.PresentFailed,
+    };
+}
+
+fn deviceRemovedReason(self: *const State) HRESULT {
+    const get_reason = core.comCall(self.device, core.slot.D3D11Device_GetDeviceRemovedReason, *const fn (*anyopaque) callconv(.winapi) HRESULT);
+    return get_reason(self.device);
+}
+
+fn logDxgiFailure(self: *const State, operation: []const u8, hr: HRESULT) void {
+    const kind = core.dxgiFailureKind(hr);
+    if (kind.requiresDeviceRecreate()) {
+        const reason = deviceRemovedReason(self);
+        render_diagnostics.log(
+            "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} device_removed_reason=0x{x:0>8} device_removed_kind={s} requires_device_recreate=true fallback_reason=device_lost",
+            .{ operation, core.hresultBits(hr), kind.name(), core.hresultBits(reason), core.dxgiFailureName(reason) },
+        );
+        return;
+    }
+
+    render_diagnostics.log(
+        "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} requires_device_recreate=false fallback_reason={s}",
+        .{ operation, core.hresultBits(hr), kind.name(), if (kind == .invalid_call) "invalid_call" else "present_failed" },
+    );
 }
 
 pub fn deinit() void {
@@ -454,4 +553,12 @@ test "D3D11 context module exposes the backend lifecycle surface" {
     try std.testing.expectEqual(@as(usize, 3), init_info.params.len);
     try std.testing.expect(@typeInfo(@TypeOf(resize)).@"fn".return_type.? == bool);
     try std.testing.expect(@typeInfo(@TypeOf(present)).@"fn".return_type.? == PresentError!void);
+}
+
+test "D3D11 present errors distinguish device-loss HRESULTs" {
+    try std.testing.expectEqual(error.DeviceRemoved, presentErrorFromHRESULT(core.DXGI_ERROR_DEVICE_REMOVED));
+    try std.testing.expectEqual(error.DeviceHung, presentErrorFromHRESULT(core.DXGI_ERROR_DEVICE_HUNG));
+    try std.testing.expectEqual(error.DeviceReset, presentErrorFromHRESULT(core.DXGI_ERROR_DEVICE_RESET));
+    try std.testing.expectEqual(error.DriverInternalError, presentErrorFromHRESULT(core.DXGI_ERROR_DRIVER_INTERNAL_ERROR));
+    try std.testing.expectEqual(error.PresentFailed, presentErrorFromHRESULT(core.DXGI_ERROR_INVALID_CALL));
 }


### PR DESCRIPTION
## Summary

- add fast-testable DXGI HRESULT classification for D3D11 present/device-loss failures
- record D3D11 init diagnostics with swap effect, adapter vendor/device/LUID, adapter flags, and fallback reason
- log D3D11 present/resize failures with raw HRESULT, classified kind, device-removed reason when relevant, and whether device recreation is required
- update the roadmap status from Phase V not-started to Phase V-A diagnostics started, while keeping fallback/default migration blocked

## Ghostty comparison

Ghostty does not have a D3D11/DXGI backend, but its renderer architecture keeps graphics API surface ownership inside the backend/generic renderer boundary. This PR follows that pattern: DXGI HRESULT/device-loss details stay in `platform/dxgi_core.zig` and `renderer/gpu/d3d11/Context.zig`, not in feature renderers or UI surfaces.

## Scope

This is a Phase V hardening signal slice only. It does not recreate the D3D11 device, does not implement automatic fallback, does not change Windows `auto`, and does not remove OpenGL fallback.

## Validation

- `zig build test`
- `zig build -Dgpu-backend=d3d11`
- `./debug/test-d3d11-normal-session.ps1` => `pass=true`
  - JSON: `zig-out/d3d11-normal-session-smoke/d3d11-normal-session-20260703-030941.json`
  - diagnostic init line includes `swap_effect=flip_discard`, `adapter_vendor=...`, `adapter_device=...`, `adapter_luid=...`, `fallback_reason=none`
- `git diff --check`
- `zig build check-sizes`
- `zig build test-full --summary all`
