### PR TITLE
[codex] assert d3d11 init diagnostics

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -793,6 +793,13 @@ try {
 
     $diagText = Wait-ForDiagnosticText $diagnosticPath "d3d11-ui-smoke probe .* ok=true" 12
     $hasD3D11Present = $diagText -match "gpu-backend=d3d11 present=dxgi"
+    $hasD3D11InitDetails = (
+        $diagText -match "gpu-backend=d3d11 present=dxgi .*swap_effect=flip_discard.*fallback_reason=none" -and
+        (
+            $diagText -match "adapter_vendor=0x[0-9a-fA-F]+.*adapter_device=0x[0-9a-fA-F]+.*adapter_luid=" -or
+            $diagText -match "adapter=unknown"
+        )
+    )
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $hasFailures = $diagText -match "present failed|shader compile failed|backbuffer probe failed|resize sync failed"
@@ -811,6 +818,7 @@ try {
         $settingsPageMetrics.Pass -and
         $skillCenterMetrics.Pass -and
         $hasD3D11Present -and
+        $hasD3D11InitDetails -and
         $hasUiProbe -and
         $hasOffscreen -and
         !$hasFailures
@@ -958,6 +966,7 @@ try {
         }
         diagnostics = [ordered]@{
             d3d11_present = [bool]$hasD3D11Present
+            d3d11_init_details = [bool]$hasD3D11InitDetails
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures

--- a/docs/development.md
+++ b/docs/development.md
@@ -174,9 +174,11 @@ Center, opens the Settings page from the titlebar gear, and opens the Skill
 Center from the Command Center. It captures
 screenshots, writes JSON metrics under
 `zig-out\d3d11-normal-session-smoke\`, and verifies that
-`render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, a successful
+`render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, D3D11 init
+details for swap effect / adapter / fallback reason, a successful
 `d3d11-ui-smoke` probe, and an offscreen round-trip marker. It is a Phase IV
-evidence tool only; it does not change the Windows default renderer.
+and Phase V diagnostics evidence tool only; it does not change the Windows
+default renderer.
 
 ## macOS UI Smoke Tests
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -68,9 +68,11 @@ Markdown and image preview panes from a temporary File Explorer fixture, opens
 the Copilot assistant sidebar with a temporary AI profile, opens the startup
 shortcuts overlay from the Command Center, opens the Settings page from the
 titlebar gear and the Skill Center from the Command Center, then verifies the
-render-diagnostics log for D3D11 present, UI probe, and offscreen round-trip
-markers. This is runtime evidence for the Phase IV exit criteria; it is not a
-Phase V hardening substitute and does not change the Windows default backend.
+render-diagnostics log for D3D11 present, init details (swap effect, adapter or
+unknown-adapter fallback, and fallback reason), UI probe, and offscreen
+round-trip markers. This is runtime evidence for the Phase IV exit criteria and
+the first Phase V diagnostics slice; it is not a device-recreation or automatic
+fallback substitute and does not change the Windows default backend.
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

- require the D3D11 normal-session smoke to assert the Phase V-A init diagnostics fields from #466
- record `d3d11_init_details` in the smoke JSON
- update development/roadmap docs to describe the swap-effect, adapter/unknown-adapter, and fallback-reason checks

## Scope

Smoke/docs only. This keeps D3D11 explicit/experimental, does not change Windows `auto`, and does not implement automatic fallback.

## Validation

- PowerShell AST parse for `debug/test-d3d11-normal-session.ps1`
- `./debug/test-d3d11-normal-session.ps1` => `pass=true`
  - JSON: `zig-out/d3d11-normal-session-smoke/d3d11-normal-session-20260703-032450.json`
  - `diagnostics.d3d11_init_details=true`
- `git diff --check`
- `zig build check-sizes`
- `zig build test`
