### PR TITLE
[codex] track d3d11 present policy state

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -794,12 +794,13 @@ try {
     $diagText = Wait-ForDiagnosticText $diagnosticPath "d3d11-ui-smoke probe .* ok=true" 12
     $hasD3D11Present = $diagText -match "gpu-backend=d3d11 present=dxgi"
     $hasD3D11InitDetails = (
-        $diagText -match "gpu-backend=d3d11 present=dxgi .*swap_effect=flip_discard.*fallback_reason=none" -and
+        $diagText -match "gpu-backend=d3d11 present=dxgi .*swap_effect=flip_discard.*fallback_reason=none.*policy_state=healthy.*fallback_candidate=false" -and
         (
             $diagText -match "adapter_vendor=0x[0-9a-fA-F]+.*adapter_device=0x[0-9a-fA-F]+.*adapter_luid=" -or
             $diagText -match "adapter=unknown"
         )
     )
+    $hasD3D11PolicyHealthy = $diagText -match "gpu-backend=d3d11 present=dxgi .*policy_state=healthy.*fallback_candidate=false"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $hasFailures = $diagText -match "present failed|shader compile failed|backbuffer probe failed|resize sync failed"
@@ -819,6 +820,7 @@ try {
         $skillCenterMetrics.Pass -and
         $hasD3D11Present -and
         $hasD3D11InitDetails -and
+        $hasD3D11PolicyHealthy -and
         $hasUiProbe -and
         $hasOffscreen -and
         !$hasFailures
@@ -967,6 +969,7 @@ try {
         diagnostics = [ordered]@{
             d3d11_present = [bool]$hasD3D11Present
             d3d11_init_details = [bool]$hasD3D11InitDetails
+            d3d11_policy_healthy = [bool]$hasD3D11PolicyHealthy
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,10 +175,10 @@ Center from the Command Center. It captures
 screenshots, writes JSON metrics under
 `zig-out\d3d11-normal-session-smoke\`, and verifies that
 `render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, D3D11 init
-details for swap effect / adapter / fallback reason, a successful
-`d3d11-ui-smoke` probe, and an offscreen round-trip marker. It is a Phase IV
-and Phase V diagnostics evidence tool only; it does not change the Windows
-default renderer.
+details for swap effect / adapter / fallback reason / healthy policy state, a
+successful `d3d11-ui-smoke` probe, and an offscreen round-trip marker. It is a
+Phase IV and Phase V diagnostics/policy evidence tool only; it does not change
+the Windows default renderer.
 
 ## macOS UI Smoke Tests
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -47,10 +47,12 @@ chrome, sidebar, file explorer, background image, Markdown/image previews,
 Copilot assistant sidebar, command palette, startup shortcuts overlay, Settings
 page, Skill Center, D3D11 present diagnostics, UI probe, and offscreen
 round-trip marker. This does not make D3D11 product-default-ready yet: Phase V
-hardening has started with backend-owned present/device-loss diagnostics, but
-device recreation, automatic fallback policy, environment validation, and Phase
-VI default migration remain blocked until fallback coverage is proven. Windows
-`auto` still must not default to D3D11 on this branch.
+hardening has started with backend-owned present/device-loss diagnostics and a
+pure D3D11 present policy that latches `needs_recreate` / `fallback_candidate`
+state from classified DXGI failures, but device recreation, automatic fallback
+policy, environment validation, and Phase VI default migration remain blocked
+until fallback coverage is proven. Windows `auto` still must not default to
+D3D11 on this branch.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
@@ -69,10 +71,11 @@ the Copilot assistant sidebar with a temporary AI profile, opens the startup
 shortcuts overlay from the Command Center, opens the Settings page from the
 titlebar gear and the Skill Center from the Command Center, then verifies the
 render-diagnostics log for D3D11 present, init details (swap effect, adapter or
-unknown-adapter fallback, and fallback reason), UI probe, and offscreen
-round-trip markers. This is runtime evidence for the Phase IV exit criteria and
-the first Phase V diagnostics slice; it is not a device-recreation or automatic
-fallback substitute and does not change the Windows default backend.
+unknown-adapter fallback, fallback reason, and healthy D3D11 policy state), UI
+probe, and offscreen round-trip markers. This is runtime evidence for the Phase
+IV exit criteria and the first Phase V diagnostics/policy slice; it is not a
+device-recreation or automatic fallback substitute and does not change the
+Windows default backend.
 
 ## Ghostty Comparison
 

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const windows = std.os.windows;
 const core = @import("../../../platform/dxgi_core.zig");
+const present_policy = @import("present_policy.zig");
 const render_diagnostics = @import("../../../render_diagnostics.zig");
 const shaders = @import("shaders.zig");
 
@@ -84,6 +85,7 @@ const State = struct {
     vertex_shader: ?*anyopaque = null,
     pixel_shader: ?*anyopaque = null,
     adapter: AdapterInfo = .{},
+    policy: present_policy.Policy,
     width: i32,
     height: i32,
     feature_draws_this_frame: bool = false,
@@ -184,6 +186,7 @@ pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
         .context = context.?,
         .swapchain = swapchain_result.swapchain,
         .adapter = swapchain_result.adapter,
+        .policy = present_policy.Policy.init(width, height),
         .width = width,
         .height = height,
     };
@@ -267,7 +270,7 @@ fn queryAdapterInfo(adapter: *anyopaque) AdapterInfo {
 fn logBackendInit(self: *const State) void {
     if (self.adapter.available) {
         render_diagnostics.log(
-            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter_vendor=0x{x} adapter_device=0x{x} adapter_luid={x}:{x} adapter_flags=0x{x} fallback_reason=none",
+            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter_vendor=0x{x} adapter_device=0x{x} adapter_luid={x}:{x} adapter_flags=0x{x} fallback_reason=none policy_state={s} fallback_candidate=false",
             .{
                 self.width,
                 self.height,
@@ -277,12 +280,13 @@ fn logBackendInit(self: *const State) void {
                 @as(u32, @bitCast(self.adapter.luid_high)),
                 self.adapter.luid_low,
                 self.adapter.flags,
+                self.policy.status().stateName(),
             },
         );
     } else {
         render_diagnostics.log(
-            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter=unknown fallback_reason=none",
-            .{ self.width, self.height, core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD) },
+            "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter=unknown fallback_reason=none policy_state={s} fallback_candidate=false",
+            .{ self.width, self.height, core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD), self.policy.status().stateName() },
         );
     }
 }
@@ -449,22 +453,32 @@ pub fn bindBackbufferRenderTarget() void {
 }
 
 pub fn resize(width: i32, height: i32) bool {
-    if (width <= 0 or height <= 0) return false;
     if (state == null) return false;
     const self = &state.?;
-    if (self.width == width and self.height == height) return true;
+    switch (self.policy.frameAction(width, height)) {
+        .skip => return false,
+        .present => return true,
+        .resize_then_present => {},
+        .wait_for_recreate, .fallback_candidate => return false,
+    }
 
     self.releaseSized();
     const resize_buffers = core.comCall(self.swapchain, core.slot.DXGISwapChain_ResizeBuffers, *const fn (*anyopaque, u32, u32, u32, u32, u32) callconv(.winapi) HRESULT);
     const hr = resize_buffers(self.swapchain, 0, @intCast(width), @intCast(height), 0, 0);
     if (hr < 0) {
-        logDxgiFailure(self, "resize", hr);
+        const status = self.policy.noteDxgiFailure(.resize, hr);
+        logDxgiFailure(self, "resize", hr, status);
         return false;
     }
     createRenderTarget(self, width, height) catch |err| {
-        render_diagnostics.log("gpu-backend=d3d11 resize target failed: {s}", .{@errorName(err)});
+        const status = self.policy.noteBackendFailure(.resize_target, .render_target_failed, false);
+        render_diagnostics.log(
+            "gpu-backend=d3d11 resize target failed: {s} policy_state={s} fallback_candidate={} fallback_candidate_reason={s} requires_device_recreate={}",
+            .{ @errorName(err), status.stateName(), status.fallbackCandidate(), status.reasonName(), status.requires_device_recreate },
+        );
         return false;
     };
+    self.policy.noteResizeSucceeded(width, height);
     render_diagnostics.log("gpu-backend=d3d11 resized swapchain to {}x{}", .{ width, height });
     return true;
 }
@@ -503,10 +517,15 @@ pub fn drawPhase2Quad() void {
 pub fn present() PresentError!void {
     if (state == null) return;
     const self = &state.?;
+    switch (self.policy.frameAction(self.width, self.height)) {
+        .present => {},
+        .skip, .resize_then_present, .wait_for_recreate, .fallback_candidate => return,
+    }
     const present_fn = core.comCall(self.swapchain, core.slot.DXGISwapChain_Present, *const fn (*anyopaque, u32, u32) callconv(.winapi) HRESULT);
     const hr = present_fn(self.swapchain, 1, 0);
     if (hr < 0) {
-        logDxgiFailure(self, "present", hr);
+        const status = self.policy.noteDxgiFailure(.present, hr);
+        logDxgiFailure(self, "present", hr, status);
         return presentErrorFromHRESULT(hr);
     }
 }
@@ -526,20 +545,28 @@ fn deviceRemovedReason(self: *const State) HRESULT {
     return get_reason(self.device);
 }
 
-fn logDxgiFailure(self: *const State, operation: []const u8, hr: HRESULT) void {
+pub fn presentPolicyStatus() present_policy.Status {
+    return if (state) |*self| self.policy.status() else present_policy.Status.healthy();
+}
+
+pub fn needsDeviceRecreate() bool {
+    return presentPolicyStatus().state == .needs_recreate;
+}
+
+fn logDxgiFailure(self: *const State, operation: []const u8, hr: HRESULT, status: present_policy.Status) void {
     const kind = core.dxgiFailureKind(hr);
     if (kind.requiresDeviceRecreate()) {
         const reason = deviceRemovedReason(self);
         render_diagnostics.log(
-            "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} device_removed_reason=0x{x:0>8} device_removed_kind={s} requires_device_recreate=true fallback_reason=device_lost",
-            .{ operation, core.hresultBits(hr), kind.name(), core.hresultBits(reason), core.dxgiFailureName(reason) },
+            "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} device_removed_reason=0x{x:0>8} device_removed_kind={s} policy_state={s} fallback_candidate={} fallback_candidate_reason={s} requires_device_recreate=true fallback_reason=device_lost",
+            .{ operation, core.hresultBits(hr), kind.name(), core.hresultBits(reason), core.dxgiFailureName(reason), status.stateName(), status.fallbackCandidate(), status.reasonName() },
         );
         return;
     }
 
     render_diagnostics.log(
-        "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} requires_device_recreate=false fallback_reason={s}",
-        .{ operation, core.hresultBits(hr), kind.name(), if (kind == .invalid_call) "invalid_call" else "present_failed" },
+        "gpu-backend=d3d11 {s} failed hr=0x{x:0>8} kind={s} policy_state={s} fallback_candidate={} fallback_candidate_reason={s} requires_device_recreate=false fallback_reason={s}",
+        .{ operation, core.hresultBits(hr), kind.name(), status.stateName(), status.fallbackCandidate(), status.reasonName(), status.reasonName() },
     );
 }
 

--- a/src/renderer/gpu/d3d11/api.zig
+++ b/src/renderer/gpu/d3d11/api.zig
@@ -13,5 +13,6 @@ pub const Pipeline = @import("Pipeline.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
 pub const readback = @import("readback.zig");
 pub const shaders = @import("shaders.zig");
+pub const present_policy = @import("present_policy.zig");
 pub const render_state = @import("render_state.zig");
 pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/d3d11/present_policy.zig
+++ b/src/renderer/gpu/d3d11/present_policy.zig
@@ -1,0 +1,249 @@
+//! Backend-owned D3D11 present health policy.
+//!
+//! The OpenGL+DXGI presenter has its own host-side `dxgi_core.PresentPolicy`
+//! because it can fall back to GDI on the next launch. The native D3D11 backend
+//! needs a separate state machine: a failed D3D device cannot be safely ignored,
+//! but automatic recreation/fallback is a later Phase V slice. For now this
+//! module latches the failure state and makes the next required action explicit.
+
+const std = @import("std");
+const core = @import("../../../platform/dxgi_core.zig");
+
+pub const Operation = enum {
+    present,
+    resize,
+    resize_target,
+
+    pub fn name(self: Operation) []const u8 {
+        return switch (self) {
+            .present => "present",
+            .resize => "resize",
+            .resize_target => "resize_target",
+        };
+    }
+};
+
+pub const State = enum {
+    healthy,
+    needs_recreate,
+    fallback_candidate,
+
+    pub fn name(self: State) []const u8 {
+        return switch (self) {
+            .healthy => "healthy",
+            .needs_recreate => "needs_recreate",
+            .fallback_candidate => "fallback_candidate",
+        };
+    }
+};
+
+pub const Action = enum {
+    skip,
+    present,
+    resize_then_present,
+    wait_for_recreate,
+    fallback_candidate,
+};
+
+pub const FallbackReason = enum {
+    none,
+    device_lost,
+    invalid_call,
+    present_failed,
+    resize_failed,
+    render_target_failed,
+
+    pub fn name(self: FallbackReason) []const u8 {
+        return switch (self) {
+            .none => "none",
+            .device_lost => "device_lost",
+            .invalid_call => "invalid_call",
+            .present_failed => "present_failed",
+            .resize_failed => "resize_failed",
+            .render_target_failed => "render_target_failed",
+        };
+    }
+};
+
+pub const Status = struct {
+    state: State = .healthy,
+    operation: ?Operation = null,
+    reason: FallbackReason = .none,
+    dxgi_kind: core.DxgiFailureKind = .ok,
+    requires_device_recreate: bool = false,
+
+    pub fn healthy() Status {
+        return .{};
+    }
+
+    pub fn stateName(self: Status) []const u8 {
+        return self.state.name();
+    }
+
+    pub fn reasonName(self: Status) []const u8 {
+        return self.reason.name();
+    }
+
+    pub fn dxgiKindName(self: Status) []const u8 {
+        return self.dxgi_kind.name();
+    }
+
+    pub fn operationName(self: Status) []const u8 {
+        return if (self.operation) |op| op.name() else "none";
+    }
+
+    pub fn fallbackCandidate(self: Status) bool {
+        return self.state != .healthy and self.reason != .none;
+    }
+};
+
+pub const Policy = struct {
+    width: i32,
+    height: i32,
+    status_value: Status = .{},
+
+    pub fn init(width: i32, height: i32) Policy {
+        return .{ .width = width, .height = height };
+    }
+
+    pub fn status(self: *const Policy) Status {
+        return self.status_value;
+    }
+
+    pub fn frameAction(self: *const Policy, width: i32, height: i32) Action {
+        return switch (self.status_value.state) {
+            .needs_recreate => .wait_for_recreate,
+            .fallback_candidate => .fallback_candidate,
+            .healthy => blk: {
+                if (width <= 0 or height <= 0) break :blk .skip;
+                if (width != self.width or height != self.height) break :blk .resize_then_present;
+                break :blk .present;
+            },
+        };
+    }
+
+    pub fn noteResizeSucceeded(self: *Policy, width: i32, height: i32) void {
+        self.width = width;
+        self.height = height;
+    }
+
+    pub fn noteDxgiFailure(self: *Policy, operation: Operation, hr: core.HRESULT) Status {
+        const kind = core.dxgiFailureKind(hr);
+        const requires_recreate = kind.requiresDeviceRecreate();
+        return self.latchFailure(
+            operation,
+            fallbackReason(operation, kind),
+            kind,
+            requires_recreate,
+        );
+    }
+
+    pub fn noteBackendFailure(
+        self: *Policy,
+        operation: Operation,
+        reason: FallbackReason,
+        requires_recreate: bool,
+    ) Status {
+        return self.latchFailure(operation, reason, .other, requires_recreate);
+    }
+
+    fn latchFailure(
+        self: *Policy,
+        operation: Operation,
+        reason: FallbackReason,
+        kind: core.DxgiFailureKind,
+        requires_recreate: bool,
+    ) Status {
+        const next_state: State = if (requires_recreate) .needs_recreate else .fallback_candidate;
+
+        // The first fallback candidate is useful evidence, but a later
+        // device-lost signal is more severe and must upgrade the state.
+        if (self.status_value.state == .healthy or
+            (next_state == .needs_recreate and self.status_value.state != .needs_recreate))
+        {
+            self.status_value = .{
+                .state = next_state,
+                .operation = operation,
+                .reason = reason,
+                .dxgi_kind = kind,
+                .requires_device_recreate = requires_recreate,
+            };
+        }
+
+        return self.status_value;
+    }
+};
+
+fn fallbackReason(operation: Operation, kind: core.DxgiFailureKind) FallbackReason {
+    if (kind.requiresDeviceRecreate()) return .device_lost;
+    if (kind == .invalid_call) return .invalid_call;
+    return switch (operation) {
+        .present => .present_failed,
+        .resize => .resize_failed,
+        .resize_target => .render_target_failed,
+    };
+}
+
+test "D3D11 present policy presents and resizes while healthy" {
+    var policy = Policy.init(800, 600);
+
+    try std.testing.expectEqual(Action.present, policy.frameAction(800, 600));
+    try std.testing.expectEqual(Action.resize_then_present, policy.frameAction(1024, 768));
+    try std.testing.expectEqual(Action.skip, policy.frameAction(0, 768));
+
+    policy.noteResizeSucceeded(1024, 768);
+    try std.testing.expectEqual(Action.present, policy.frameAction(1024, 768));
+    try std.testing.expectEqual(State.healthy, policy.status().state);
+}
+
+test "D3D11 present policy latches device loss as recreate state" {
+    var policy = Policy.init(800, 600);
+    const status = policy.noteDxgiFailure(.present, core.DXGI_ERROR_DEVICE_REMOVED);
+
+    try std.testing.expectEqual(State.needs_recreate, status.state);
+    try std.testing.expectEqual(Operation.present, status.operation.?);
+    try std.testing.expectEqual(FallbackReason.device_lost, status.reason);
+    try std.testing.expectEqual(core.DxgiFailureKind.device_removed, status.dxgi_kind);
+    try std.testing.expect(status.requires_device_recreate);
+    try std.testing.expect(status.fallbackCandidate());
+    try std.testing.expectEqual(Action.wait_for_recreate, policy.frameAction(800, 600));
+
+    policy.noteResizeSucceeded(1024, 768);
+    try std.testing.expectEqual(Action.wait_for_recreate, policy.frameAction(1024, 768));
+}
+
+test "D3D11 present policy records non-device-loss fallback candidates" {
+    var policy = Policy.init(800, 600);
+    const status = policy.noteDxgiFailure(.present, core.DXGI_ERROR_INVALID_CALL);
+
+    try std.testing.expectEqual(State.fallback_candidate, status.state);
+    try std.testing.expectEqual(FallbackReason.invalid_call, status.reason);
+    try std.testing.expectEqual(core.DxgiFailureKind.invalid_call, status.dxgi_kind);
+    try std.testing.expect(!status.requires_device_recreate);
+    try std.testing.expect(status.fallbackCandidate());
+    try std.testing.expectEqual(Action.fallback_candidate, policy.frameAction(800, 600));
+}
+
+test "D3D11 present policy upgrades a fallback candidate to device recreate" {
+    var policy = Policy.init(800, 600);
+    _ = policy.noteDxgiFailure(.resize, core.DXGI_ERROR_INVALID_CALL);
+    const status = policy.noteDxgiFailure(.present, core.DXGI_ERROR_DEVICE_RESET);
+
+    try std.testing.expectEqual(State.needs_recreate, status.state);
+    try std.testing.expectEqual(Operation.present, status.operation.?);
+    try std.testing.expectEqual(FallbackReason.device_lost, status.reason);
+    try std.testing.expectEqual(core.DxgiFailureKind.device_reset, status.dxgi_kind);
+}
+
+test "D3D11 present policy records render-target creation failures" {
+    var policy = Policy.init(800, 600);
+    const status = policy.noteBackendFailure(.resize_target, .render_target_failed, false);
+
+    try std.testing.expectEqual(State.fallback_candidate, status.state);
+    try std.testing.expectEqual(Operation.resize_target, status.operation.?);
+    try std.testing.expectEqual(FallbackReason.render_target_failed, status.reason);
+    try std.testing.expectEqual(Action.fallback_candidate, policy.frameAction(800, 600));
+    try std.testing.expectEqualStrings("fallback_candidate", status.stateName());
+    try std.testing.expectEqualStrings("render_target_failed", status.reasonName());
+    try std.testing.expectEqualStrings("resize_target", status.operationName());
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -197,6 +197,7 @@ test {
     _ = @import("renderer/post_process_policy.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");
+    _ = @import("renderer/gpu/d3d11/present_policy.zig");
     _ = @import("close_confirm.zig");
     _ = @import("command/palette_model.zig");
     _ = @import("command/center_state.zig");


### PR DESCRIPTION
## Summary
- add a pure D3D11 present policy that latches healthy, needs_recreate, and fallback_candidate state from classified DXGI failures
- wire the policy into the D3D11 Context present/resize path and enrich diagnostics with policy_state/fallback_candidate_reason
- extend the D3D11 normal-session smoke and docs to assert/report the healthy policy state

## Notes
- This keeps D3D11 explicit/experimental and does not change Windows auto/default renderer selection.
- This does not implement device recreation or automatic fallback yet; it only makes the backend-owned state observable and testable for the next Phase V slice.
- Ghostty comparison: Ghostty keeps backend selection thin and backend-specific implementation details under renderer backend directories; this follows the same boundary shape, while D3D11 remains WispTerm-specific because Ghostty has no D3D11/DXGI renderer backend.

## Validation
- zig build test
- zig build -Dgpu-backend=d3d11
- powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1
- git diff --check
- zig build check-sizes
- zig build test-full --summary all
