### PR TITLE
[codex] surface d3d11 recovery requests

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -801,6 +801,7 @@ try {
         )
     )
     $hasD3D11PolicyHealthy = $diagText -match "gpu-backend=d3d11 present=dxgi .*policy_state=healthy.*fallback_candidate=false"
+    $hasD3D11RecoveryRequested = $diagText -match "gpu-backend=d3d11 recovery requested"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $hasFailures = $diagText -match "present failed|shader compile failed|backbuffer probe failed|resize sync failed"
@@ -821,6 +822,7 @@ try {
         $hasD3D11Present -and
         $hasD3D11InitDetails -and
         $hasD3D11PolicyHealthy -and
+        !$hasD3D11RecoveryRequested -and
         $hasUiProbe -and
         $hasOffscreen -and
         !$hasFailures
@@ -970,6 +972,7 @@ try {
             d3d11_present = [bool]$hasD3D11Present
             d3d11_init_details = [bool]$hasD3D11InitDetails
             d3d11_policy_healthy = [bool]$hasD3D11PolicyHealthy
+            d3d11_recovery_requested = [bool]$hasD3D11RecoveryRequested
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,8 +176,9 @@ screenshots, writes JSON metrics under
 `zig-out\d3d11-normal-session-smoke\`, and verifies that
 `render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, D3D11 init
 details for swap effect / adapter / fallback reason / healthy policy state, a
-successful `d3d11-ui-smoke` probe, and an offscreen round-trip marker. It is a
-Phase IV and Phase V diagnostics/policy evidence tool only; it does not change
+successful `d3d11-ui-smoke` probe, an offscreen round-trip marker, and no D3D11
+recovery request in the healthy path. It is a Phase IV and Phase V
+diagnostics/policy/recovery-coordination evidence tool only; it does not change
 the Windows default renderer.
 
 ## macOS UI Smoke Tests

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -49,7 +49,9 @@ page, Skill Center, D3D11 present diagnostics, UI probe, and offscreen
 round-trip marker. This does not make D3D11 product-default-ready yet: Phase V
 hardening has started with backend-owned present/device-loss diagnostics and a
 pure D3D11 present policy that latches `needs_recreate` / `fallback_candidate`
-state from classified DXGI failures, but device recreation, automatic fallback
+state from classified DXGI failures. The host now consumes a single-shot D3D11
+recovery request and records whether the requested action is device recreation
+or fallback-candidate handling, but actual device recreation, automatic fallback
 policy, environment validation, and Phase VI default migration remain blocked
 until fallback coverage is proven. Windows `auto` still must not default to
 D3D11 on this branch.
@@ -72,10 +74,11 @@ shortcuts overlay from the Command Center, opens the Settings page from the
 titlebar gear and the Skill Center from the Command Center, then verifies the
 render-diagnostics log for D3D11 present, init details (swap effect, adapter or
 unknown-adapter fallback, fallback reason, and healthy D3D11 policy state), UI
-probe, and offscreen round-trip markers. This is runtime evidence for the Phase
-IV exit criteria and the first Phase V diagnostics/policy slice; it is not a
-device-recreation or automatic fallback substitute and does not change the
-Windows default backend.
+probe, offscreen round-trip markers, and the absence of a D3D11 recovery
+request in the healthy smoke path. This is runtime evidence for the Phase IV
+exit criteria and the first Phase V diagnostics/policy/recovery-coordination
+slice; it is not a device-recreation or automatic fallback substitute and does
+not change the Windows default backend.
 
 ## Ghostty Comparison
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1605,6 +1605,30 @@ fn presentBackendFrame(win: *window_backend.Window) void {
     }
 }
 
+fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator) void {
+    if (comptime gpu.active == .d3d11) {
+        const request = gpu.Context.takeRecoveryRequest() orelse return;
+        const status = request.status;
+        render_diagnostics.log(
+            "gpu-backend=d3d11 recovery requested action={s} policy_state={s} operation={s} fallback_candidate_reason={s} dxgi_kind={s} requires_device_recreate={} automatic_fallback=false default_unchanged=true",
+            .{
+                request.actionName(),
+                status.stateName(),
+                status.operationName(),
+                status.reasonName(),
+                status.dxgiKindName(),
+                status.requires_device_recreate,
+            },
+        );
+
+        if (status.requires_device_recreate) {
+            font.clearGlyphCache(allocator);
+        }
+        applyUiEffect(UiEffect.repaint);
+        markAllRenderersDirty();
+    }
+}
+
 threadlocal var g_diag_last_fb_w: c_int = -1;
 threadlocal var g_diag_last_fb_h: c_int = -1;
 threadlocal var g_diag_last_client_w: i32 = -1;
@@ -7159,6 +7183,7 @@ fn runMainLoop(self: *AppWindow) !void {
         gpu.state.endFrame();
         agent_requests.capturePendingUiScreenshots(agentRequestHost());
         presentBackendFrame(win);
+        handleD3D11RecoveryRequest(allocator);
         if (windowState().takePresentBringupSettlement()) {
             platform_window_state.settleD3dBringup(allocator);
         }

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -549,6 +549,10 @@ pub fn presentPolicyStatus() present_policy.Status {
     return if (state) |*self| self.policy.status() else present_policy.Status.healthy();
 }
 
+pub fn takeRecoveryRequest() ?present_policy.RecoveryRequest {
+    return if (state) |*self| self.policy.takeRecoveryRequest() else null;
+}
+
 pub fn needsDeviceRecreate() bool {
     return presentPolicyStatus().state == .needs_recreate;
 }

--- a/src/renderer/gpu/d3d11/present_policy.zig
+++ b/src/renderer/gpu/d3d11/present_policy.zig
@@ -45,6 +45,18 @@ pub const Action = enum {
     fallback_candidate,
 };
 
+pub const RecoveryAction = enum {
+    recreate_device,
+    flag_fallback_candidate,
+
+    pub fn name(self: RecoveryAction) []const u8 {
+        return switch (self) {
+            .recreate_device => "recreate_device",
+            .flag_fallback_candidate => "flag_fallback_candidate",
+        };
+    }
+};
+
 pub const FallbackReason = enum {
     none,
     device_lost,
@@ -97,10 +109,20 @@ pub const Status = struct {
     }
 };
 
+pub const RecoveryRequest = struct {
+    status: Status,
+    action: RecoveryAction,
+
+    pub fn actionName(self: RecoveryRequest) []const u8 {
+        return self.action.name();
+    }
+};
+
 pub const Policy = struct {
     width: i32,
     height: i32,
     status_value: Status = .{},
+    recovery_pending: bool = false,
 
     pub fn init(width: i32, height: i32) Policy {
         return .{ .width = width, .height = height };
@@ -168,9 +190,22 @@ pub const Policy = struct {
                 .dxgi_kind = kind,
                 .requires_device_recreate = requires_recreate,
             };
+            self.recovery_pending = true;
         }
 
         return self.status_value;
+    }
+
+    pub fn takeRecoveryRequest(self: *Policy) ?RecoveryRequest {
+        if (!self.recovery_pending or self.status_value.state == .healthy) return null;
+        self.recovery_pending = false;
+        return .{
+            .status = self.status_value,
+            .action = if (self.status_value.requires_device_recreate)
+                .recreate_device
+            else
+                .flag_fallback_candidate,
+        };
     }
 };
 
@@ -208,6 +243,12 @@ test "D3D11 present policy latches device loss as recreate state" {
     try std.testing.expect(status.fallbackCandidate());
     try std.testing.expectEqual(Action.wait_for_recreate, policy.frameAction(800, 600));
 
+    const request = policy.takeRecoveryRequest() orelse return error.MissingRecoveryRequest;
+    try std.testing.expectEqual(RecoveryAction.recreate_device, request.action);
+    try std.testing.expectEqual(State.needs_recreate, request.status.state);
+    try std.testing.expectEqualStrings("recreate_device", request.actionName());
+    try std.testing.expect(policy.takeRecoveryRequest() == null);
+
     policy.noteResizeSucceeded(1024, 768);
     try std.testing.expectEqual(Action.wait_for_recreate, policy.frameAction(1024, 768));
 }
@@ -222,17 +263,28 @@ test "D3D11 present policy records non-device-loss fallback candidates" {
     try std.testing.expect(!status.requires_device_recreate);
     try std.testing.expect(status.fallbackCandidate());
     try std.testing.expectEqual(Action.fallback_candidate, policy.frameAction(800, 600));
+
+    const request = policy.takeRecoveryRequest() orelse return error.MissingRecoveryRequest;
+    try std.testing.expectEqual(RecoveryAction.flag_fallback_candidate, request.action);
+    try std.testing.expectEqual(FallbackReason.invalid_call, request.status.reason);
+    try std.testing.expect(policy.takeRecoveryRequest() == null);
 }
 
 test "D3D11 present policy upgrades a fallback candidate to device recreate" {
     var policy = Policy.init(800, 600);
     _ = policy.noteDxgiFailure(.resize, core.DXGI_ERROR_INVALID_CALL);
+    _ = policy.takeRecoveryRequest() orelse return error.MissingRecoveryRequest;
+
     const status = policy.noteDxgiFailure(.present, core.DXGI_ERROR_DEVICE_RESET);
 
     try std.testing.expectEqual(State.needs_recreate, status.state);
     try std.testing.expectEqual(Operation.present, status.operation.?);
     try std.testing.expectEqual(FallbackReason.device_lost, status.reason);
     try std.testing.expectEqual(core.DxgiFailureKind.device_reset, status.dxgi_kind);
+
+    const request = policy.takeRecoveryRequest() orelse return error.MissingRecoveryRequest;
+    try std.testing.expectEqual(RecoveryAction.recreate_device, request.action);
+    try std.testing.expectEqual(core.DxgiFailureKind.device_reset, request.status.dxgi_kind);
 }
 
 test "D3D11 present policy records render-target creation failures" {


### PR DESCRIPTION
## Summary
- add a single-shot D3D11 recovery request on top of the present policy state
- let AppWindow consume the request, log the requested action/reason, clear glyph cache for device-recreate cases, and mark renderers dirty without changing defaults
- extend the normal-session smoke/docs to prove the healthy path has no D3D11 recovery request

## Notes
- This keeps D3D11 explicit/experimental and does not change Windows auto/default renderer selection.
- This does not implement automatic device recreation or OpenGL fallback yet; it creates the backend-to-host coordination point needed for that next Phase V slice.
- Ghostty comparison: Ghostty keeps backend API details inside backend implementations and generic renderer boundaries. This follows that shape by keeping DXGI classification/policy under the D3D11 backend and exposing only a host-level recovery request.

## Validation
- zig build test
- zig build -Dgpu-backend=d3d11
- powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1
- git diff --check
- zig build check-sizes
- zig build test-full --summary all (first run hit unrelated Windows STATUS_DELETE_PENDING in skill_center clearOverlay test; immediate rerun passed)
