### PR TITLE
[codex] prepare d3d11 recreate resources

### DIFF
--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -54,7 +54,13 @@ recovery request and records whether the requested action is device recreation
 or fallback-candidate handling, but actual device recreation, automatic fallback
 policy, environment validation, and Phase VI default migration remain blocked
 until fallback coverage is proven. Windows `auto` still must not default to
-D3D11 on this branch.
+D3D11 on this branch. This hardening slice adds the first controlled
+device-recreate preparation path: when the backend latches a recreate-class
+failure, the host releases D3D11-owned pipelines, auxiliary render targets,
+background/post-process resources, font atlas GPU textures, and backend
+backbuffer/RTV/phase2 shader resources, then logs that preparation. Actual
+device/swapchain recreation and automatic fallback are still intentionally
+separate Phase V work.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -1605,7 +1605,32 @@ fn presentBackendFrame(win: *window_backend.Window) void {
     }
 }
 
-fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator) void {
+fn prepareD3D11DeviceRecreateResources() void {
+    if (comptime gpu.active == .d3d11) {
+        cell_pipeline.deinit();
+        ui_pipeline.deinit();
+        d3d11_offscreen_smoke.deinit();
+        d3d11_ui_smoke.deinit();
+        background_image.deinit();
+        post_process.deinit();
+        const atlas_release = font.releaseAtlasGpuTexturesForDeviceRecreate();
+        const context_release = gpu.Context.prepareForDeviceRecreate();
+        render_diagnostics.log(
+            "gpu-backend=d3d11 resource recreate prepared context_initialized={} context_released_any={} released_atlas_any={} released_atlas_glyph={} released_atlas_color={} released_atlas_icon={} released_atlas_titlebar={} released_feature_pipelines=true released_auxiliary_targets=true automatic_fallback=false default_unchanged=true",
+            .{
+                context_release.initialized,
+                context_release.anyReleased(),
+                atlas_release.anyReleased(),
+                atlas_release.glyph,
+                atlas_release.color,
+                atlas_release.icon,
+                atlas_release.titlebar,
+            },
+        );
+    }
+}
+
+fn handleD3D11RecoveryRequest() void {
     if (comptime gpu.active == .d3d11) {
         const request = gpu.Context.takeRecoveryRequest() orelse return;
         const status = request.status;
@@ -1622,7 +1647,7 @@ fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator) void {
         );
 
         if (status.requires_device_recreate) {
-            font.clearGlyphCache(allocator);
+            prepareD3D11DeviceRecreateResources();
         }
         applyUiEffect(UiEffect.repaint);
         markAllRenderersDirty();
@@ -7183,7 +7208,7 @@ fn runMainLoop(self: *AppWindow) !void {
         gpu.state.endFrame();
         agent_requests.capturePendingUiScreenshots(agentRequestHost());
         presentBackendFrame(win);
-        handleD3D11RecoveryRequest(allocator);
+        handleD3D11RecoveryRequest();
         if (windowState().takePresentBringupSettlement()) {
             platform_window_state.settleD3dBringup(allocator);
         }

--- a/src/font/manager.zig
+++ b/src/font/manager.zig
@@ -1651,6 +1651,39 @@ pub fn clearGlyphCache(allocator: std.mem.Allocator) void {
     }
 }
 
+pub const AtlasGpuTextureRelease = struct {
+    glyph: bool = false,
+    color: bool = false,
+    icon: bool = false,
+    titlebar: bool = false,
+
+    pub fn anyReleased(self: AtlasGpuTextureRelease) bool {
+        return self.glyph or self.color or self.icon or self.titlebar;
+    }
+};
+
+fn releaseAtlasGpuTexture(atlas: anytype, texture: *gpu.Texture, modified: *usize) bool {
+    const released = texture.isValid();
+    if (released) {
+        texture.destroy();
+        texture.* = gpu.Texture.invalid();
+    }
+    if (atlas != null) modified.* = 0;
+    return released;
+}
+
+/// Release only GPU atlas textures while keeping CPU atlas/cache state intact.
+/// Used before a D3D11 device recreate so the next context can re-upload the
+/// existing CPU atlas data instead of forcing a full glyph re-rasterization.
+pub fn releaseAtlasGpuTexturesForDeviceRecreate() AtlasGpuTextureRelease {
+    return .{
+        .glyph = releaseAtlasGpuTexture(g_atlas, &g_atlas_texture, &g_atlas_modified),
+        .color = releaseAtlasGpuTexture(g_color_atlas, &g_color_atlas_texture, &g_color_atlas_modified),
+        .icon = releaseAtlasGpuTexture(g_icon_atlas, &g_icon_atlas_texture, &g_icon_atlas_modified),
+        .titlebar = releaseAtlasGpuTexture(g_titlebar_atlas, &g_titlebar_atlas_texture, &g_titlebar_atlas_modified),
+    };
+}
+
 /// Clear fallback font faces.
 pub fn clearFallbackFaces(allocator: std.mem.Allocator) void {
     var it = g_fallback_faces.iterator();

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -73,6 +73,19 @@ pub const ShaderError = error{
     ShaderCompileFailed,
 };
 
+pub const DeviceRecreatePreparation = struct {
+    initialized: bool = false,
+    released_backbuffer: bool = false,
+    released_render_target: bool = false,
+    released_phase2_pipeline: bool = false,
+
+    pub fn anyReleased(self: DeviceRecreatePreparation) bool {
+        return self.released_backbuffer or
+            self.released_render_target or
+            self.released_phase2_pipeline;
+    }
+};
+
 const State = struct {
     device: *anyopaque,
     context: *anyopaque,
@@ -557,6 +570,29 @@ pub fn needsDeviceRecreate() bool {
     return presentPolicyStatus().state == .needs_recreate;
 }
 
+pub fn prepareForDeviceRecreate() DeviceRecreatePreparation {
+    if (state == null) return .{};
+    const self = &state.?;
+    const result = DeviceRecreatePreparation{
+        .initialized = true,
+        .released_backbuffer = self.backbuffer != null,
+        .released_render_target = self.rtv != null,
+        .released_phase2_pipeline = self.vertex_shader != null or self.pixel_shader != null,
+    };
+    self.releaseSized();
+    self.releaseShaders();
+    render_diagnostics.log(
+        "gpu-backend=d3d11 device recreate preparation context_initialized=true released_backbuffer={} released_render_target={} released_phase2_pipeline={} released_any={}",
+        .{
+            result.released_backbuffer,
+            result.released_render_target,
+            result.released_phase2_pipeline,
+            result.anyReleased(),
+        },
+    );
+    return result;
+}
+
 fn logDxgiFailure(self: *const State, operation: []const u8, hr: HRESULT, status: present_policy.Status) void {
     const kind = core.dxgiFailureKind(hr);
     if (kind.requiresDeviceRecreate()) {
@@ -592,4 +628,10 @@ test "D3D11 present errors distinguish device-loss HRESULTs" {
     try std.testing.expectEqual(error.DeviceReset, presentErrorFromHRESULT(core.DXGI_ERROR_DEVICE_RESET));
     try std.testing.expectEqual(error.DriverInternalError, presentErrorFromHRESULT(core.DXGI_ERROR_DRIVER_INTERNAL_ERROR));
     try std.testing.expectEqual(error.PresentFailed, presentErrorFromHRESULT(core.DXGI_ERROR_INVALID_CALL));
+}
+
+test "D3D11 context device recreate preparation is a no-op when uninitialized" {
+    const preparation = prepareForDeviceRecreate();
+    try std.testing.expect(!preparation.initialized);
+    try std.testing.expect(!preparation.anyReleased());
 }

--- a/src/renderer/post_process.zig
+++ b/src/renderer/post_process.zig
@@ -232,4 +232,7 @@ pub fn deinit() void {
     g_post_pipeline.deinit();
     g_post_vbo_buf.deinit();
     g_post_fb.deinit();
+    g_post_enabled = false;
+    g_frame_count = 0;
+    g_start_time = 0;
 }


### PR DESCRIPTION
## Summary
- add a D3D11 backend-owned preparation hook that releases backbuffer/RTV/phase2 shader resources after a recreate-class recovery request
- release feature-level D3D11 resources from AppWindow recovery coordination: cell/UI pipelines, smoke framebuffers, background/post-process resources, and font atlas GPU textures
- document that this is device-recreate preparation only; automatic device/swapchain recreation, fallback policy, and Windows default migration remain separate Phase V/VI work

## Validation
- zig build test
- zig build -Dgpu-backend=d3d11
- powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1
- git diff --check
- zig build check-sizes
- zig build test-full --summary all
- zig build test -Dgpu-backend=d3d11
