### PR TITLE
[codex] attempt d3d11 device recreate

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -7,6 +7,7 @@ param(
     [int]$WindowY = 90,
     [int]$WindowWidth = 1240,
     [int]$WindowHeight = 780,
+    [switch]$RecreateSmoke,
     [switch]$KeepOpen
 )
 
@@ -681,11 +682,17 @@ $oldAppData = $env:APPDATA
 $oldRenderDiagnostics = $env:WISPTERM_RENDER_DIAGNOSTICS
 $oldUiSmoke = $env:WISPTERM_D3D11_UI_SMOKE
 $oldOffscreenSmoke = $env:WISPTERM_D3D11_OFFSCREEN_SMOKE
+$oldRecreateSmoke = $env:WISPTERM_D3D11_RECREATE_SMOKE
 
 $env:APPDATA = $appDataDir
 $env:WISPTERM_RENDER_DIAGNOSTICS = "1"
 $env:WISPTERM_D3D11_UI_SMOKE = "1"
 $env:WISPTERM_D3D11_OFFSCREEN_SMOKE = "1"
+if ($RecreateSmoke) {
+    $env:WISPTERM_D3D11_RECREATE_SMOKE = "1"
+} else {
+    Remove-Item Env:WISPTERM_D3D11_RECREATE_SMOKE -ErrorAction SilentlyContinue
+}
 
 $proc = $null
 try {
@@ -802,9 +809,17 @@ try {
     )
     $hasD3D11PolicyHealthy = $diagText -match "gpu-backend=d3d11 present=dxgi .*policy_state=healthy.*fallback_candidate=false"
     $hasD3D11RecoveryRequested = $diagText -match "gpu-backend=d3d11 recovery requested"
+    $hasD3D11RecreateSmokeRequest = $diagText -match "d3d11-recreate-smoke requested device recreate"
+    $hasD3D11RecreateSucceeded = $diagText -match "gpu-backend=d3d11 recovery recreate attempt attempted=true succeeded=true"
+    $hasD3D11ResourceRestore = $diagText -match "gpu-backend=d3d11 resource recreate restored"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $hasFailures = $diagText -match "present failed|shader compile failed|backbuffer probe failed|resize sync failed"
+    $recreateExpectation = if ($RecreateSmoke) {
+        ($hasD3D11RecoveryRequested -and $hasD3D11RecreateSmokeRequest -and $hasD3D11RecreateSucceeded -and $hasD3D11ResourceRestore)
+    } else {
+        (!$hasD3D11RecoveryRequested -and !$hasD3D11RecreateSmokeRequest -and !$hasD3D11RecreateSucceeded)
+    }
 
     $pass = [bool](
         $initialMetrics.Pass -and
@@ -822,7 +837,7 @@ try {
         $hasD3D11Present -and
         $hasD3D11InitDetails -and
         $hasD3D11PolicyHealthy -and
-        !$hasD3D11RecoveryRequested -and
+        $recreateExpectation -and
         $hasUiProbe -and
         $hasOffscreen -and
         !$hasFailures
@@ -973,6 +988,9 @@ try {
             d3d11_init_details = [bool]$hasD3D11InitDetails
             d3d11_policy_healthy = [bool]$hasD3D11PolicyHealthy
             d3d11_recovery_requested = [bool]$hasD3D11RecoveryRequested
+            d3d11_recreate_smoke_requested = [bool]$hasD3D11RecreateSmokeRequest
+            d3d11_recreate_succeeded = [bool]$hasD3D11RecreateSucceeded
+            d3d11_resource_restore = [bool]$hasD3D11ResourceRestore
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures
@@ -1001,4 +1019,5 @@ try {
     $env:WISPTERM_RENDER_DIAGNOSTICS = $oldRenderDiagnostics
     $env:WISPTERM_D3D11_UI_SMOKE = $oldUiSmoke
     $env:WISPTERM_D3D11_OFFSCREEN_SMOKE = $oldOffscreenSmoke
+    $env:WISPTERM_D3D11_RECREATE_SMOKE = $oldRecreateSmoke
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -181,6 +181,19 @@ recovery request in the healthy path. It is a Phase IV and Phase V
 diagnostics/policy/recovery-coordination evidence tool only; it does not change
 the Windows default renderer.
 
+To exercise the controlled Phase V device-recreate path, run the same smoke
+with `-RecreateSmoke` after building the D3D11 executable:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateSmoke
+```
+
+This sets `WISPTERM_D3D11_RECREATE_SMOKE=1`, asks the backend to latch one
+recreate-class recovery request, and verifies that diagnostics record the
+recreate request, a successful single-shot device/swapchain recreate attempt,
+and restored feature resources. It still leaves automatic fallback and the
+Windows default backend unchanged.
+
 ## macOS UI Smoke Tests
 
 macOS UI debugging is native-target first. Unless a task explicitly asks for

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -59,8 +59,15 @@ device-recreate preparation path: when the backend latches a recreate-class
 failure, the host releases D3D11-owned pipelines, auxiliary render targets,
 background/post-process resources, font atlas GPU textures, and backend
 backbuffer/RTV/phase2 shader resources, then logs that preparation. Actual
-device/swapchain recreation and automatic fallback are still intentionally
-separate Phase V work.
+device/swapchain recreation has now started as a controlled single-shot attempt:
+after recreate-class failure preparation, the backend can rebuild its D3D11
+device, immediate context, swapchain, backbuffer, and minimal shader resources
+for the same HWND/current framebuffer size, then the host restores the
+backend-neutral feature pipelines and reloadable auxiliary resources. Automatic
+fallback, environment validation, and Phase VI default migration are still
+intentionally separate work. The normal-session smoke has an opt-in
+`-RecreateSmoke` mode that latches one recreate-class request and verifies the
+successful recreate/restore diagnostics without changing the healthy path.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -90,6 +90,7 @@ pub const overlays = @import("renderer/overlays.zig");
 const post_process = @import("renderer/post_process.zig");
 const d3d11_offscreen_smoke = @import("renderer/d3d11_offscreen_smoke.zig");
 const d3d11_ui_smoke = @import("renderer/d3d11_ui_smoke.zig");
+const d3d11_recreate_smoke = @import("renderer/d3d11_recreate_smoke.zig");
 pub const gpu = @import("renderer/gpu/gpu.zig");
 pub const split_layout = @import("appwindow/split_layout.zig");
 const render_gate = @import("appwindow/render_gate.zig");
@@ -1630,7 +1631,28 @@ fn prepareD3D11DeviceRecreateResources() void {
     }
 }
 
-fn handleD3D11RecoveryRequest() void {
+fn restoreD3D11DeviceRecreateResources(allocator: std.mem.Allocator) void {
+    if (comptime gpu.active == .d3d11) {
+        ui_pipeline.init();
+        cell_pipeline.init();
+        post_process.init(allocator, g_shader_path);
+        if (g_app) |app| {
+            app.mutex.lock();
+            const image_path: ?[]u8 = if (app.background_image) |p| (allocator.dupe(u8, p) catch null) else null;
+            app.mutex.unlock();
+            if (image_path) |p| {
+                defer allocator.free(p);
+                background_image.load(allocator, p);
+            }
+        }
+        render_diagnostics.log(
+            "gpu-backend=d3d11 resource recreate restored feature_pipelines=true background_reloaded={} post_process_rechecked=true automatic_fallback=false default_unchanged=true",
+            .{background_image.g_enabled},
+        );
+    }
+}
+
+fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator, fb_width: c_int, fb_height: c_int) void {
     if (comptime gpu.active == .d3d11) {
         const request = gpu.Context.takeRecoveryRequest() orelse return;
         const status = request.status;
@@ -1648,6 +1670,14 @@ fn handleD3D11RecoveryRequest() void {
 
         if (status.requires_device_recreate) {
             prepareD3D11DeviceRecreateResources();
+            const recreate = gpu.Context.recreateDevice(fb_width, fb_height);
+            render_diagnostics.log(
+                "gpu-backend=d3d11 recovery recreate attempt attempted={} succeeded={} error={s} swapchain={}x{} automatic_fallback=false default_unchanged=true",
+                .{ recreate.attempted, recreate.succeeded, recreate.error_name, recreate.width, recreate.height },
+            );
+            if (recreate.succeeded) {
+                restoreD3D11DeviceRecreateResources(allocator);
+            }
         }
         applyUiEffect(UiEffect.repaint);
         markAllRenderersDirty();
@@ -7203,12 +7233,13 @@ fn runMainLoop(self: *AppWindow) !void {
 
         d3d11_offscreen_smoke.render(fb_width, fb_height);
         d3d11_ui_smoke.render(fb_width, fb_height);
+        d3d11_recreate_smoke.maybeRequest();
         logSwapDiagnosticsIfChanged(win, fb_width, fb_height);
         forceOpaqueBackbufferForPresent();
         gpu.state.endFrame();
         agent_requests.capturePendingUiScreenshots(agentRequestHost());
         presentBackendFrame(win);
-        handleD3D11RecoveryRequest();
+        handleD3D11RecoveryRequest(allocator, fb_width, fb_height);
         if (windowState().takePresentBringupSettlement()) {
             platform_window_state.settleD3dBringup(allocator);
         }

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -435,6 +435,8 @@ pub const slot = struct {
     pub const D3D11DeviceContext_CopyResource: usize = 47;
     pub const D3D11DeviceContext_UpdateSubresource: usize = 48;
     pub const D3D11DeviceContext_ClearRenderTargetView: usize = 50;
+    pub const D3D11DeviceContext_ClearState: usize = 110;
+    pub const D3D11DeviceContext_Flush: usize = 111;
 
     // ID3DBlob (IUnknown + GetBufferPointer/GetBufferSize).
     pub const Blob_GetBufferPointer: usize = 3;

--- a/src/renderer/d3d11_recreate_smoke.zig
+++ b/src/renderer/d3d11_recreate_smoke.zig
@@ -1,0 +1,65 @@
+//! Opt-in D3D11 device-recreate recovery smoke.
+//!
+//! Enable with `WISPTERM_D3D11_RECREATE_SMOKE=1`. The normal render loop asks
+//! the D3D11 backend to latch a recreate-class recovery request exactly once;
+//! AppWindow then exercises the same recovery path used after device-loss
+//! diagnostics.
+
+const std = @import("std");
+
+const gpu = @import("gpu/gpu.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
+
+const ENV_NAME = "WISPTERM_D3D11_RECREATE_SMOKE";
+
+threadlocal var checked_env = false;
+threadlocal var enabled_cache = false;
+threadlocal var fired = false;
+
+fn parseEnabledValue(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.mem.eql(u8, trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+fn enabled() bool {
+    if (comptime gpu.active != .d3d11) return false;
+    if (checked_env) return enabled_cache;
+    checked_env = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, ENV_NAME) catch {
+        enabled_cache = false;
+        return enabled_cache;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    enabled_cache = parseEnabledValue(value);
+    return enabled_cache;
+}
+
+pub fn maybeRequest() void {
+    if (comptime gpu.active != .d3d11) return;
+    if (!enabled() or fired) return;
+    fired = true;
+    if (gpu.Context.requestDeviceRecreateForSmoke()) {
+        render_diagnostics.log("d3d11-recreate-smoke requested device recreate", .{});
+    } else {
+        render_diagnostics.log("d3d11-recreate-smoke request skipped backend_unavailable=true", .{});
+    }
+}
+
+test "D3D11 recreate smoke env parser accepts truthy values" {
+    try std.testing.expect(parseEnabledValue("1"));
+    try std.testing.expect(parseEnabledValue("true"));
+    try std.testing.expect(parseEnabledValue("YES"));
+    try std.testing.expect(parseEnabledValue("on"));
+}
+
+test "D3D11 recreate smoke env parser rejects falsey values" {
+    try std.testing.expect(!parseEnabledValue(""));
+    try std.testing.expect(!parseEnabledValue("0"));
+    try std.testing.expect(!parseEnabledValue("false"));
+    try std.testing.expect(!parseEnabledValue("off"));
+}

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -86,7 +86,20 @@ pub const DeviceRecreatePreparation = struct {
     }
 };
 
+pub const DeviceRecreateResult = struct {
+    attempted: bool = false,
+    succeeded: bool = false,
+    width: i32 = 0,
+    height: i32 = 0,
+    error_name: []const u8 = "none",
+
+    pub fn failed(self: DeviceRecreateResult) bool {
+        return self.attempted and !self.succeeded;
+    }
+};
+
 const State = struct {
+    hwnd: HWND,
     device: *anyopaque,
     context: *anyopaque,
     swapchain: *anyopaque,
@@ -103,14 +116,32 @@ const State = struct {
     height: i32,
     feature_draws_this_frame: bool = false,
 
+    fn clearAndFlushContext(self: *State) void {
+        const clear_state = core.comCall(self.context, core.slot.D3D11DeviceContext_ClearState, *const fn (*anyopaque) callconv(.winapi) void);
+        clear_state(self.context);
+        const flush = core.comCall(self.context, core.slot.D3D11DeviceContext_Flush, *const fn (*anyopaque) callconv(.winapi) void);
+        flush(self.context);
+        self.current_rtv = null;
+        self.current_width = 0;
+        self.current_height = 0;
+    }
+
+    fn unbindRenderTargets(self: *State) void {
+        const om_set = core.comCall(self.context, core.slot.D3D11DeviceContext_OMSetRenderTargets, *const fn (*anyopaque, u32, [*]const ?*anyopaque, ?*anyopaque) callconv(.winapi) void);
+        var rtvs = [_]?*anyopaque{null};
+        om_set(self.context, 1, &rtvs, null);
+        self.current_rtv = null;
+        self.current_width = 0;
+        self.current_height = 0;
+    }
+
     fn releaseSized(self: *State) void {
+        self.unbindRenderTargets();
+        self.clearAndFlushContext();
         if (self.rtv) |rtv| {
             core.comRelease(rtv);
             self.rtv = null;
         }
-        self.current_rtv = null;
-        self.current_width = 0;
-        self.current_height = 0;
         if (self.backbuffer) |backbuffer| {
             core.comRelease(backbuffer);
             self.backbuffer = null;
@@ -131,8 +162,8 @@ const State = struct {
     fn deinit(self: *State) void {
         self.releaseSized();
         self.releaseShaders();
-        core.comRelease(self.swapchain);
         core.comRelease(self.context);
+        core.comRelease(self.swapchain);
         core.comRelease(self.device);
     }
 };
@@ -165,6 +196,17 @@ pub fn initWithLayer(_: ?*anyopaque) !void {
 }
 
 pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
+    if (state) |*self| {
+        self.deinit();
+        state = null;
+    }
+
+    state = try createStateForWindow(hwnd, width, height);
+    logBackendInit(&state.?);
+    std.debug.print("D3D11: native backend initialized {}x{}\n", .{ width, height });
+}
+
+fn createStateForWindow(hwnd: HWND, width: i32, height: i32) InitError!State {
     if (width <= 0 or height <= 0) return error.SwapchainCreateFailed;
 
     const d3d11 = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("d3d11.dll")) orelse
@@ -195,6 +237,7 @@ pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
     errdefer core.comRelease(swapchain_result.swapchain);
 
     var next = State{
+        .hwnd = hwnd,
         .device = device.?,
         .context = context.?,
         .swapchain = swapchain_result.swapchain,
@@ -208,9 +251,7 @@ pub fn initForWindow(hwnd: HWND, width: i32, height: i32) InitError!void {
     try createRenderTarget(&next, width, height);
     try createPhase2Pipeline(&next);
 
-    state = next;
-    logBackendInit(&state.?);
-    std.debug.print("D3D11: native backend initialized {}x{}\n", .{ width, height });
+    return next;
 }
 
 fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) InitError!SwapchainCreateResult {
@@ -253,8 +294,14 @@ fn createSwapchain(device: *anyopaque, hwnd: HWND, width: i32, height: i32) Init
         *?*anyopaque,
     ) callconv(.winapi) HRESULT);
     var swapchain: ?*anyopaque = null;
-    if (create_for_hwnd(factory.?, device, hwnd, &desc, null, null, &swapchain) < 0 or swapchain == null)
+    const hr = create_for_hwnd(factory.?, device, hwnd, &desc, null, null, &swapchain);
+    if (hr < 0 or swapchain == null) {
+        render_diagnostics.log(
+            "gpu-backend=d3d11 create swapchain failed hr=0x{x:0>8} kind={s} swapchain={}x{}",
+            .{ core.hresultBits(hr), core.dxgiFailureKind(hr).name(), width, height },
+        );
         return error.SwapchainCreateFailed;
+    }
 
     const make_assoc = core.comCall(factory.?, core.slot.DXGIFactory_MakeWindowAssociation, *const fn (*anyopaque, HWND, u32) callconv(.winapi) HRESULT);
     _ = make_assoc(factory.?, hwnd, DXGI_MWA_NO_ALT_ENTER);
@@ -593,6 +640,54 @@ pub fn prepareForDeviceRecreate() DeviceRecreatePreparation {
     return result;
 }
 
+pub fn recreateDevice(width: i32, height: i32) DeviceRecreateResult {
+    if (state == null) return .{ .error_name = "not_initialized" };
+
+    const self = &state.?;
+    const hwnd = self.hwnd;
+    const target_width = if (width > 0) width else self.width;
+    const target_height = if (height > 0) height else self.height;
+    const result_base = DeviceRecreateResult{
+        .attempted = true,
+        .width = target_width,
+        .height = target_height,
+    };
+
+    var old = state.?;
+    state = null;
+    old.deinit();
+
+    const next = createStateForWindow(hwnd, target_width, target_height) catch |err| {
+        render_diagnostics.log(
+            "gpu-backend=d3d11 device recreate failed error={s} swapchain={}x{} automatic_fallback=false default_unchanged=true",
+            .{ @errorName(err), target_width, target_height },
+        );
+        var failed_result = result_base;
+        failed_result.error_name = @errorName(err);
+        return failed_result;
+    };
+
+    state = next;
+    logBackendInit(&state.?);
+    render_diagnostics.log(
+        "gpu-backend=d3d11 device recreate succeeded swapchain={}x{} policy_state={s} automatic_fallback=false default_unchanged=true",
+        .{ target_width, target_height, state.?.policy.status().stateName() },
+    );
+    var success_result = result_base;
+    success_result.succeeded = true;
+    return success_result;
+}
+
+pub fn requestDeviceRecreateForSmoke() bool {
+    if (state == null) return false;
+    const status = state.?.policy.noteBackendFailure(.present, .device_lost, true);
+    render_diagnostics.log(
+        "gpu-backend=d3d11 recreate smoke latched policy_state={s} fallback_candidate_reason={s} requires_device_recreate={}",
+        .{ status.stateName(), status.reasonName(), status.requires_device_recreate },
+    );
+    return status.requires_device_recreate;
+}
+
 fn logDxgiFailure(self: *const State, operation: []const u8, hr: HRESULT, status: present_policy.Status) void {
     const kind = core.dxgiFailureKind(hr);
     if (kind.requiresDeviceRecreate()) {
@@ -634,4 +729,12 @@ test "D3D11 context device recreate preparation is a no-op when uninitialized" {
     const preparation = prepareForDeviceRecreate();
     try std.testing.expect(!preparation.initialized);
     try std.testing.expect(!preparation.anyReleased());
+}
+
+test "D3D11 context device recreate reports no attempt when uninitialized" {
+    const result = recreateDevice(800, 600);
+    try std.testing.expect(!result.attempted);
+    try std.testing.expect(!result.succeeded);
+    try std.testing.expect(!result.failed());
+    try std.testing.expectEqualStrings("not_initialized", result.error_name);
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -195,6 +195,7 @@ test {
     _ = @import("renderer/qr_panel_layout.zig");
     _ = @import("renderer/file_explorer_layout.zig");
     _ = @import("renderer/post_process_policy.zig");
+    _ = @import("renderer/d3d11_recreate_smoke.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");
     _ = @import("renderer/gpu/d3d11/present_policy.zig");


### PR DESCRIPTION
## Summary

- add a controlled single-shot D3D11 device/swapchain recreate attempt after a recreate-class recovery request
- clear and flush the D3D11 immediate context before releasing old sized resources so the same HWND can create a fresh swapchain
- add opt-in `WISPTERM_D3D11_RECREATE_SMOKE=1` / `-RecreateSmoke` coverage to prove recreate and resource restore diagnostics

## Scope

This keeps D3D11 explicit/experimental. It does not change the Windows `auto` default, does not remove the OpenGL fallback, and does not add automatic fallback policy.

## Root Cause

The first recreate smoke hit `CreateSwapChainForHwnd` failure `0x80070005` after releasing the old swapchain. The old immediate context could still retain references to old render targets/backbuffer resources. The recreate path now calls `ClearState` and `Flush` before releasing sized resources.

## Validation

- `zig build test`
- `zig build test -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateSmoke`
- `git diff --check`
- `git diff --cached --check`
- `zig build check-sizes`
- `zig build test-full --summary all`
- Windows checkout safety path scan
- `git ls-files -s | Select-String '^120000'`
