### PR TITLE
[codex] define d3d11 fallback marker policy

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -206,6 +206,14 @@ the session remains nonblank with D3D11 resize diagnostics and no present/resize
 failure lines. It is Phase V hardening evidence only; it does not change the
 Windows default backend or fallback policy.
 
+D3D11 fallback is a next-launch policy while the renderer backend remains a
+comptime selection. Do not implement same-process D3D11-to-OpenGL switching
+without first changing the backend architecture. The `d3d11-fallback` state-file
+marker is separate from the older OpenGL+DXGI present `d3d-bringup` fuse,
+scoped by app version and adapter identity, and currently feeds only tests and
+future-auto dry-run decisions. Explicit `d3d11` must ignore a matching marker
+except for diagnostics; current Windows `auto` still resolves to OpenGL.
+
 ## macOS UI Smoke Tests
 
 macOS UI debugging is native-target first. Unless a task explicitly asks for

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -70,7 +70,12 @@ intentionally separate work. The normal-session smoke has an opt-in
 successful recreate/restore diagnostics without changing the healthy path. It
 also has an opt-in `-RapidResizeSmoke` mode that drives a burst of real Win32
 resizes, restores the baseline window size, and verifies the session remains
-nonblank with D3D11 resize diagnostics and no resize/present failure lines.
+nonblank with D3D11 resize diagnostics and no resize/present failure lines. The
+native D3D11 fallback topology is now defined as next-launch/future-auto policy,
+not in-process renderer switching: explicit `d3d11` continues to honor the
+user's build/runtime choice and only reports a warning when a matching marker is
+present, while a future Windows `auto` default can use a version+adapter-scoped
+`d3d11-fallback` marker to choose OpenGL without changing the current default.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
@@ -98,6 +103,11 @@ not change the Windows default backend.
 
 Add `-RapidResizeSmoke` to the same command to include Phase V rapid-resize
 stress evidence in the normal-session run.
+
+The fallback marker policy is intentionally policy-only at this stage. It
+defines marker format, persistence, stale-version/adapter handling, explicit
+backend behavior, and the future-auto dry-run decision surface, but it does not
+write markers from live failures and does not change renderer selection.
 
 ## Ghostty Comparison
 

--- a/src/platform/window_state.zig
+++ b/src/platform/window_state.zig
@@ -50,7 +50,7 @@ fn loadPersisted(allocator: std.mem.Allocator) codec.PersistedState {
 fn savePersisted(allocator: std.mem.Allocator, state: codec.PersistedState) void {
     const path = stateFilePath(allocator) orelse return;
     defer allocator.free(path);
-    var buf: [384]u8 = undefined;
+    var buf: [768]u8 = undefined;
     const content = codec.format(&buf, state) catch return;
     // Create the config directory first: on a first-ever launch it does not
     // exist yet (Config.ensureConfigExists only runs later, in the window
@@ -203,6 +203,22 @@ pub fn blockD3dBringup(allocator: std.mem.Allocator, version: []const u8) void {
     recordD3dBringup(allocator, marker);
 }
 
+/// The stored native D3D11 renderer fallback marker (empty when none). Separate
+/// from the OpenGL+DXGI presenter bring-up fuse above.
+pub fn d3d11Fallback(allocator: std.mem.Allocator, buf: []u8) []const u8 {
+    const m = loadPersisted(allocator).d3d11Fallback();
+    const n = @min(m.len, buf.len);
+    @memcpy(buf[0..n], m[0..n]);
+    return buf[0..n];
+}
+
+/// Persist a native D3D11 renderer fallback marker. Later Phase V slices will
+/// decide when to write it; this helper only provides the state-file plumbing.
+pub fn recordD3d11Fallback(allocator: std.mem.Allocator, marker: []const u8) void {
+    const current = loadPersisted(allocator);
+    savePersisted(allocator, codec.withD3d11Fallback(current, marker));
+}
+
 test "savePersisted creates the config directory on a fresh profile" {
     const allocator = std.testing.allocator;
 
@@ -226,4 +242,32 @@ test "savePersisted creates the config directory on a fresh profile" {
 
     var buf: [codec.bringup_max_len]u8 = undefined;
     try std.testing.expectEqualStrings("probing:9.9.9", d3dBringup(allocator, &buf));
+}
+
+test "d3d11 fallback marker persists independently from d3d bringup" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base);
+    const config_dir = try std.fs.path.join(allocator, &.{ base, "d3d11-fallback", "wispterm" });
+    defer allocator.free(config_dir);
+
+    platform_dirs.setTestConfigDirForCurrentThread(config_dir);
+    defer platform_dirs.clearTestConfigDirForCurrentThread();
+
+    recordD3dBringup(allocator, "probing:9.9.9");
+    const marker = "d3d11:v1;kind=blocked;version=9.9.9;adapter=v10ded2684l1234abcd00000000;reason=device_lost";
+    recordD3d11Fallback(allocator, marker);
+
+    var bringup_buf: [codec.bringup_max_len]u8 = undefined;
+    var fallback_buf: [codec.d3d11_fallback_max_len]u8 = undefined;
+    try std.testing.expectEqualStrings("probing:9.9.9", d3dBringup(allocator, &bringup_buf));
+    try std.testing.expectEqualStrings(marker, d3d11Fallback(allocator, &fallback_buf));
+
+    recordD3d11Fallback(allocator, "");
+    try std.testing.expectEqualStrings("", d3d11Fallback(allocator, &fallback_buf));
+    try std.testing.expectEqualStrings("probing:9.9.9", d3dBringup(allocator, &bringup_buf));
 }

--- a/src/platform/window_state_codec.zig
+++ b/src/platform/window_state_codec.zig
@@ -18,6 +18,11 @@ pub const version_max_len: usize = 24;
 /// ("probing:<version>" / "blocked:<version>", see dxgi_core's crash fuse).
 pub const bringup_max_len: usize = 32;
 
+/// Max stored length of the native D3D11 renderer fallback marker.
+/// Format is defined in renderer/gpu/d3d11/fallback_marker.zig; duplicated here
+/// to keep this platform codec independent from renderer modules.
+pub const d3d11_fallback_max_len: usize = 160;
+
 pub const PersistedState = struct {
     x: ?i32 = null,
     y: ?i32 = null,
@@ -46,6 +51,10 @@ pub const PersistedState = struct {
     // app version (see dxgi_core.bringupFuseDecision).
     d3d_bringup_buf: [bringup_max_len]u8 = undefined,
     d3d_bringup_len: usize = 0,
+    // Native D3D11 renderer next-launch fallback marker. Separate from
+    // d3d-bringup, which belongs to the older OpenGL+DXGI presenter fuse.
+    d3d11_fallback_buf: [d3d11_fallback_max_len]u8 = undefined,
+    d3d11_fallback_len: usize = 0,
 
     pub fn lastSeenVersion(self: *const PersistedState) []const u8 {
         return self.last_seen_version_buf[0..self.last_seen_version_len];
@@ -53,6 +62,10 @@ pub const PersistedState = struct {
 
     pub fn d3dBringup(self: *const PersistedState) []const u8 {
         return self.d3d_bringup_buf[0..self.d3d_bringup_len];
+    }
+
+    pub fn d3d11Fallback(self: *const PersistedState) []const u8 {
+        return self.d3d11_fallback_buf[0..self.d3d11_fallback_len];
     }
 };
 
@@ -102,6 +115,10 @@ pub fn parse(data: []const u8) PersistedState {
             const n = @min(val.len, bringup_max_len);
             @memcpy(state.d3d_bringup_buf[0..n], val[0..n]);
             state.d3d_bringup_len = n;
+        } else if (std.mem.eql(u8, key, "d3d11-fallback")) {
+            const n = @min(val.len, d3d11_fallback_max_len);
+            @memcpy(state.d3d11_fallback_buf[0..n], val[0..n]);
+            state.d3d11_fallback_len = n;
         }
     }
     return state;
@@ -127,6 +144,9 @@ pub fn format(buf: []u8, state: PersistedState) ![]const u8 {
     if (state.d3d_bringup_len > 0) {
         len += (try std.fmt.bufPrint(buf[len..], "d3d-bringup = {s}\n", .{state.d3dBringup()})).len;
     }
+    if (state.d3d11_fallback_len > 0) {
+        len += (try std.fmt.bufPrint(buf[len..], "d3d11-fallback = {s}\n", .{state.d3d11Fallback()})).len;
+    }
     return buf[0..len];
 }
 
@@ -137,6 +157,16 @@ pub fn withD3dBringup(state: PersistedState, marker: []const u8) PersistedState 
     const n = @min(marker.len, bringup_max_len);
     @memcpy(next.d3d_bringup_buf[0..n], marker[0..n]);
     next.d3d_bringup_len = n;
+    return next;
+}
+
+/// Copy of `state` with the native D3D11 renderer fallback marker replaced
+/// (truncated to d3d11_fallback_max_len; empty clears it).
+pub fn withD3d11Fallback(state: PersistedState, marker: []const u8) PersistedState {
+    var next = state;
+    const n = @min(marker.len, d3d11_fallback_max_len);
+    @memcpy(next.d3d11_fallback_buf[0..n], marker[0..n]);
+    next.d3d11_fallback_len = n;
     return next;
 }
 
@@ -310,7 +340,7 @@ test "over-length last-seen-version is truncated, never overflows" {
 }
 
 test "d3d-bringup marker round-trips, clears, and is omitted when empty" {
-    var buf: [384]u8 = undefined;
+    var buf: [640]u8 = undefined;
     // empty → omitted
     const empty_text = try format(&buf, .{});
     try std.testing.expect(std.mem.indexOf(u8, empty_text, "d3d-bringup") == null);
@@ -330,6 +360,33 @@ test "old state file without d3d-bringup leaves the marker empty" {
     try std.testing.expectEqual(@as(usize, 0), s.d3d_bringup_len);
 }
 
+test "d3d11 fallback marker round-trips, clears, and is omitted when empty" {
+    var buf: [640]u8 = undefined;
+    const empty_text = try format(&buf, .{});
+    try std.testing.expect(std.mem.indexOf(u8, empty_text, "d3d11-fallback") == null);
+
+    const marker = "d3d11:v1;kind=blocked;version=1.20.0;adapter=v10ded2684l1234abcd00000000;reason=device_lost";
+    const set = withD3d11Fallback(.{ .x = 4, .ai_setup_prompted = true }, marker);
+    const text = try format(&buf, set);
+    const reparsed = parse(text);
+    try std.testing.expectEqualStrings(marker, reparsed.d3d11Fallback());
+    try std.testing.expectEqual(@as(?i32, 4), reparsed.x);
+
+    const cleared_text = try format(&buf, withD3d11Fallback(reparsed, ""));
+    try std.testing.expect(std.mem.indexOf(u8, cleared_text, "d3d11-fallback") == null);
+}
+
+test "old state file without d3d11 fallback marker leaves it empty" {
+    const s = parse("window-x = 10\nai-setup-prompted = 1\n");
+    try std.testing.expectEqual(@as(usize, 0), s.d3d11_fallback_len);
+}
+
+test "over-length d3d11 fallback marker is truncated, never overflows" {
+    const long = "d3d11:v1;kind=blocked;version=1.20.0;adapter=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;reason=device_lost";
+    const s = withD3d11Fallback(.{}, long);
+    try std.testing.expectEqual(d3d11_fallback_max_len, s.d3d11_fallback_len);
+}
+
 test "a full state file fits the save buffer with the bring-up marker" {
     // savePersisted formats into a fixed buffer; every key at worst-case
     // width must fit or the marker write would be silently dropped.
@@ -347,7 +404,8 @@ test "a full state file fits the save buffer with the bring-up marker" {
     };
     full = withLastSeenVersion(full, "1.2.3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     full = withD3dBringup(full, "probing:1.2.3-aaaaaaaaaaaaaaaaaaaaaaaa");
-    var buf: [384]u8 = undefined;
+    full = withD3d11Fallback(full, "d3d11:v1;kind=fallback_candidate;version=1.2.3-aaaaaaaaaaaaaaaa;adapter=v10ded2684l1234abcd00000000;reason=render_target_failed");
+    var buf: [640]u8 = undefined;
     _ = try format(&buf, full);
 }
 

--- a/src/renderer/gpu/d3d11/api.zig
+++ b/src/renderer/gpu/d3d11/api.zig
@@ -13,6 +13,7 @@ pub const Pipeline = @import("Pipeline.zig");
 pub const Framebuffer = @import("Framebuffer.zig");
 pub const readback = @import("readback.zig");
 pub const shaders = @import("shaders.zig");
+pub const fallback_marker = @import("fallback_marker.zig");
 pub const present_policy = @import("present_policy.zig");
 pub const render_state = @import("render_state.zig");
 pub const vertex = @import("vertex.zig");

--- a/src/renderer/gpu/d3d11/fallback_marker.zig
+++ b/src/renderer/gpu/d3d11/fallback_marker.zig
@@ -1,0 +1,292 @@
+//! D3D11 next-launch fallback marker policy.
+//!
+//! WispTerm resolves the active renderer backend at comptime, Ghostty-style, so
+//! D3D11 cannot safely switch to OpenGL in-process. This module defines the
+//! state-file marker and dry-run selection rules used by later Phase V/VI work;
+//! it does not change the current Windows `auto` default or trigger fallback.
+
+const std = @import("std");
+const Backend = @import("../backend.zig").Backend;
+
+pub const marker_max_len: usize = 160;
+pub const schema = "d3d11:v1";
+
+pub const Kind = enum {
+    blocked,
+    fallback_candidate,
+
+    pub fn name(self: Kind) []const u8 {
+        return switch (self) {
+            .blocked => "blocked",
+            .fallback_candidate => "fallback_candidate",
+        };
+    }
+
+    pub fn parse(value: []const u8) ?Kind {
+        inline for (@typeInfo(Kind).@"enum".fields) |field| {
+            if (std.mem.eql(u8, value, field.name)) return @enumFromInt(field.value);
+        }
+        return null;
+    }
+};
+
+pub const Reason = enum {
+    device_lost,
+    recreate_failed,
+    init_failed,
+    invalid_call,
+    render_target_failed,
+    present_failed,
+    resize_failed,
+    environment_blocked,
+    unknown,
+
+    pub fn name(self: Reason) []const u8 {
+        return switch (self) {
+            .device_lost => "device_lost",
+            .recreate_failed => "recreate_failed",
+            .init_failed => "init_failed",
+            .invalid_call => "invalid_call",
+            .render_target_failed => "render_target_failed",
+            .present_failed => "present_failed",
+            .resize_failed => "resize_failed",
+            .environment_blocked => "environment_blocked",
+            .unknown => "unknown",
+        };
+    }
+
+    pub fn parse(value: []const u8) ?Reason {
+        inline for (@typeInfo(Reason).@"enum".fields) |field| {
+            if (std.mem.eql(u8, value, field.name)) return @enumFromInt(field.value);
+        }
+        return null;
+    }
+};
+
+pub const Marker = struct {
+    kind: Kind,
+    version: []const u8,
+    adapter_id: []const u8,
+    reason: Reason,
+
+    pub fn appliesTo(self: Marker, version: []const u8, adapter_id: []const u8) bool {
+        return std.mem.eql(u8, self.version, version) and
+            std.mem.eql(u8, self.adapter_id, adapter_id);
+    }
+};
+
+pub const Phase = enum {
+    current_default,
+    future_windows_auto,
+};
+
+pub const MarkerEffect = enum {
+    none,
+    stale_marker,
+    explicit_opengl,
+    explicit_d3d11_ignores_marker,
+    current_auto_default_unchanged,
+    future_auto_d3d11,
+    future_auto_opengl_marker,
+};
+
+pub const SelectionDecision = struct {
+    backend: Backend,
+    effect: MarkerEffect = .none,
+    marker_reason: ?Reason = null,
+    warning: bool = false,
+};
+
+pub fn adapterIdentity(
+    buf: []u8,
+    vendor_id: u32,
+    device_id: u32,
+    luid_low: u32,
+    luid_high: i32,
+) ![]const u8 {
+    const luid_high_bits: u32 = @bitCast(luid_high);
+    return std.fmt.bufPrint(
+        buf,
+        "v{x:0>4}d{x:0>4}l{x:0>8}{x:0>8}",
+        .{ vendor_id, device_id, luid_low, luid_high_bits },
+    );
+}
+
+pub fn format(
+    buf: []u8,
+    kind: Kind,
+    version: []const u8,
+    adapter_id: []const u8,
+    reason: Reason,
+) ![]const u8 {
+    if (!fieldSafe(version) or !fieldSafe(adapter_id)) return error.InvalidMarkerField;
+    return std.fmt.bufPrint(
+        buf,
+        schema ++ ";kind={s};version={s};adapter={s};reason={s}",
+        .{ kind.name(), version, adapter_id, reason.name() },
+    );
+}
+
+pub fn parse(marker: []const u8) ?Marker {
+    const prefix = schema ++ ";";
+    if (!std.mem.startsWith(u8, marker, prefix)) return null;
+
+    var kind: ?Kind = null;
+    var version: ?[]const u8 = null;
+    var adapter_id: ?[]const u8 = null;
+    var reason: ?Reason = null;
+
+    var it = std.mem.splitScalar(u8, marker[prefix.len..], ';');
+    while (it.next()) |part| {
+        const eq = std.mem.indexOfScalar(u8, part, '=') orelse continue;
+        const key = part[0..eq];
+        const value = part[eq + 1 ..];
+        if (std.mem.eql(u8, key, "kind")) {
+            kind = Kind.parse(value);
+        } else if (std.mem.eql(u8, key, "version")) {
+            version = value;
+        } else if (std.mem.eql(u8, key, "adapter")) {
+            adapter_id = value;
+        } else if (std.mem.eql(u8, key, "reason")) {
+            reason = Reason.parse(value);
+        }
+    }
+
+    return .{
+        .kind = kind orelse return null,
+        .version = version orelse return null,
+        .adapter_id = adapter_id orelse return null,
+        .reason = reason orelse return null,
+    };
+}
+
+pub fn decide(
+    os_tag: std.Target.Os.Tag,
+    build_option: []const u8,
+    marker_text: []const u8,
+    version: []const u8,
+    adapter_id: []const u8,
+    phase: Phase,
+) SelectionDecision {
+    const marker = parse(marker_text);
+    const marker_applies = if (marker) |m| m.appliesTo(version, adapter_id) else false;
+    const stale_marker = marker != null and !marker_applies;
+
+    if (std.mem.eql(u8, build_option, "d3d11")) {
+        return .{
+            .backend = .d3d11,
+            .effect = if (marker_applies) .explicit_d3d11_ignores_marker else if (stale_marker) .stale_marker else .none,
+            .marker_reason = if (marker_applies) marker.?.reason else null,
+            .warning = marker_applies,
+        };
+    }
+
+    if (std.mem.eql(u8, build_option, "opengl")) {
+        return .{
+            .backend = .opengl,
+            .effect = .explicit_opengl,
+            .marker_reason = if (marker_applies) marker.?.reason else null,
+        };
+    }
+
+    if (!std.mem.eql(u8, build_option, "auto")) {
+        return .{ .backend = Backend.resolve(os_tag, build_option) };
+    }
+
+    if (phase == .future_windows_auto and os_tag == .windows) {
+        if (marker_applies) {
+            return .{
+                .backend = .opengl,
+                .effect = .future_auto_opengl_marker,
+                .marker_reason = marker.?.reason,
+            };
+        }
+        return .{
+            .backend = .d3d11,
+            .effect = if (stale_marker) .stale_marker else .future_auto_d3d11,
+        };
+    }
+
+    return .{
+        .backend = Backend.default(os_tag),
+        .effect = if (stale_marker) .stale_marker else .current_auto_default_unchanged,
+    };
+}
+
+fn fieldSafe(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |c| switch (c) {
+        ';', '\r', '\n' => return false,
+        else => {},
+    };
+    return true;
+}
+
+test "D3D11 fallback marker formats and parses version adapter reason" {
+    var adapter_buf: [48]u8 = undefined;
+    const adapter = try adapterIdentity(&adapter_buf, 0x10de, 0x2684, 0x1234abcd, -1);
+    var marker_buf: [marker_max_len]u8 = undefined;
+    const text = try format(&marker_buf, .blocked, "1.20.0", adapter, .device_lost);
+    const parsed = parse(text) orelse return error.MissingMarker;
+
+    try std.testing.expectEqual(Kind.blocked, parsed.kind);
+    try std.testing.expectEqual(Reason.device_lost, parsed.reason);
+    try std.testing.expectEqualStrings("1.20.0", parsed.version);
+    try std.testing.expectEqualStrings(adapter, parsed.adapter_id);
+    try std.testing.expect(parsed.appliesTo("1.20.0", adapter));
+}
+
+test "D3D11 fallback marker rejects unsafe fields and unknown schema" {
+    var buf: [marker_max_len]u8 = undefined;
+    try std.testing.expectError(error.InvalidMarkerField, format(&buf, .blocked, "1.0\nbad", "adapter", .unknown));
+    try std.testing.expect(parse("blocked:1.20.0") == null);
+    try std.testing.expect(parse(schema ++ ";kind=blocked;version=1;adapter=a;reason=nope") == null);
+}
+
+test "D3D11 fallback marker ignores stale version and adapter" {
+    var buf: [marker_max_len]u8 = undefined;
+    const text = try format(&buf, .blocked, "1.20.0", "adapter-a", .recreate_failed);
+
+    try std.testing.expect(!(parse(text) orelse return error.MissingMarker).appliesTo("1.21.0", "adapter-a"));
+    try std.testing.expect(!(parse(text) orelse return error.MissingMarker).appliesTo("1.20.0", "adapter-b"));
+}
+
+test "D3D11 fallback policy keeps current Windows auto default unchanged" {
+    var buf: [marker_max_len]u8 = undefined;
+    const text = try format(&buf, .blocked, "1.20.0", "adapter-a", .device_lost);
+    const decision = decide(.windows, "auto", text, "1.20.0", "adapter-a", .current_default);
+
+    try std.testing.expectEqual(Backend.opengl, decision.backend);
+    try std.testing.expectEqual(MarkerEffect.current_auto_default_unchanged, decision.effect);
+    try std.testing.expect(!decision.warning);
+}
+
+test "D3D11 fallback policy explicit d3d11 ignores marker with warning" {
+    var buf: [marker_max_len]u8 = undefined;
+    const text = try format(&buf, .blocked, "1.20.0", "adapter-a", .device_lost);
+    const decision = decide(.windows, "d3d11", text, "1.20.0", "adapter-a", .future_windows_auto);
+
+    try std.testing.expectEqual(Backend.d3d11, decision.backend);
+    try std.testing.expectEqual(MarkerEffect.explicit_d3d11_ignores_marker, decision.effect);
+    try std.testing.expectEqual(Reason.device_lost, decision.marker_reason.?);
+    try std.testing.expect(decision.warning);
+}
+
+test "D3D11 fallback policy future auto consumes matching marker" {
+    var buf: [marker_max_len]u8 = undefined;
+    const text = try format(&buf, .fallback_candidate, "1.20.0", "adapter-a", .render_target_failed);
+    const decision = decide(.windows, "auto", text, "1.20.0", "adapter-a", .future_windows_auto);
+
+    try std.testing.expectEqual(Backend.opengl, decision.backend);
+    try std.testing.expectEqual(MarkerEffect.future_auto_opengl_marker, decision.effect);
+    try std.testing.expectEqual(Reason.render_target_failed, decision.marker_reason.?);
+}
+
+test "D3D11 fallback policy future auto selects d3d11 without matching marker" {
+    var buf: [marker_max_len]u8 = undefined;
+    const text = try format(&buf, .blocked, "1.20.0", "adapter-a", .device_lost);
+    const decision = decide(.windows, "auto", text, "1.21.0", "adapter-a", .future_windows_auto);
+
+    try std.testing.expectEqual(Backend.d3d11, decision.backend);
+    try std.testing.expectEqual(MarkerEffect.stale_marker, decision.effect);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -198,6 +198,7 @@ test {
     _ = @import("renderer/d3d11_recreate_smoke.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");
+    _ = @import("renderer/gpu/d3d11/fallback_marker.zig");
     _ = @import("renderer/gpu/d3d11/present_policy.zig");
     _ = @import("close_confirm.zig");
     _ = @import("command/palette_model.zig");


### PR DESCRIPTION
## Summary

Defines the native D3D11 next-launch fallback marker policy without enabling fallback behavior yet.

- adds a pure `fallback_marker` module for marker format, parsing, adapter identity, and dry-run selection decisions
- persists a separate `d3d11-fallback` state-file field independent from the older OpenGL+DXGI `d3d-bringup` fuse
- documents the Phase V topology: next-launch/future-auto fallback policy, not same-process D3D11-to-OpenGL switching

## Boundaries

- Does not change the current Windows `auto` default; it still resolves to OpenGL.
- Does not write fallback markers from live D3D11 failures.
- Does not trigger automatic fallback.
- Does not implement same-process backend switching.
- Preserves explicit D3D11 as an opt-in/experimental path and explicit OpenGL fallback.

## Ghostty Comparison

Ghostty keeps renderer backend selection thin and compile-time oriented (`opengl`, `metal`, `webgl`), with Darwin defaulting to Metal and other native targets defaulting to OpenGL. Ghostty has no D3D11 backend or Windows fallback marker model. This PR keeps WispTerm aligned with that compile-time backend boundary and models D3D11 fallback as a future launch/auto-selection policy instead of an in-process renderer swap.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `zig build check-sizes`
- `zig build test-full --summary all`
- `zig build test -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RapidResizeSmoke`
- Windows checkout safety path scan
- `git ls-files -s | Select-String '^120000'`