### PR TITLE
[codex] smoke d3d11 fallback marker path

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -9,6 +9,7 @@ param(
     [int]$WindowHeight = 780,
     [switch]$RecreateSmoke,
     [switch]$RapidResizeSmoke,
+    [switch]$FallbackMarkerSmoke,
     [switch]$KeepOpen
 )
 
@@ -697,6 +698,8 @@ $appDataDir = Join-Path $OutDir "appdata"
 $diagnosticPath = Join-Path $appDataDir "wispterm\render-diagnostic.log"
 
 New-Item -ItemType Directory -Force -Path $appDataDir | Out-Null
+$statePath = Join-Path $appDataDir "wispterm\state"
+Remove-Item -LiteralPath $statePath -ErrorAction SilentlyContinue
 New-SmokeBackgroundImage $backgroundImagePath
 $previewFixtures = New-SmokePreviewFixtures $previewFixtureDir
 $aiProfilePath = New-SmokeAiProfile $appDataDir
@@ -718,6 +721,7 @@ $oldRenderDiagnostics = $env:WISPTERM_RENDER_DIAGNOSTICS
 $oldUiSmoke = $env:WISPTERM_D3D11_UI_SMOKE
 $oldOffscreenSmoke = $env:WISPTERM_D3D11_OFFSCREEN_SMOKE
 $oldRecreateSmoke = $env:WISPTERM_D3D11_RECREATE_SMOKE
+$oldFallbackMarkerSmoke = $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE
 
 $env:APPDATA = $appDataDir
 $env:WISPTERM_RENDER_DIAGNOSTICS = "1"
@@ -727,6 +731,11 @@ if ($RecreateSmoke) {
     $env:WISPTERM_D3D11_RECREATE_SMOKE = "1"
 } else {
     Remove-Item Env:WISPTERM_D3D11_RECREATE_SMOKE -ErrorAction SilentlyContinue
+}
+if ($FallbackMarkerSmoke) {
+    $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = "1"
+} else {
+    Remove-Item Env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE -ErrorAction SilentlyContinue
 }
 
 $proc = $null
@@ -862,6 +871,7 @@ try {
     $hasD3D11RecreateSmokeRequest = $diagText -match "d3d11-recreate-smoke requested device recreate"
     $hasD3D11RecreateSucceeded = $diagText -match "gpu-backend=d3d11 recovery recreate attempt attempted=true succeeded=true"
     $hasD3D11ResourceRestore = $diagText -match "gpu-backend=d3d11 resource recreate restored"
+    $hasD3D11FallbackMarkerSmoke = $diagText -match "d3d11-fallback-marker-smoke .*readback_ok=true.*readback_matches=true.*explicit_d3d11_ignored=true.*current_auto_default_unchanged=true.*future_auto_opengl_marker=true.*automatic_fallback=false.*default_unchanged=true"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $d3d11ResizeEventCount = [regex]::Matches($diagText, "gpu-backend=d3d11 resized swapchain to").Count
@@ -871,6 +881,13 @@ try {
         ($hasD3D11RecoveryRequested -and $hasD3D11RecreateSmokeRequest -and $hasD3D11RecreateSucceeded -and $hasD3D11ResourceRestore)
     } else {
         (!$hasD3D11RecoveryRequested -and !$hasD3D11RecreateSmokeRequest -and !$hasD3D11RecreateSucceeded)
+    }
+    $stateText = if (Test-Path -LiteralPath $statePath) { Get-Content -LiteralPath $statePath -Raw } else { "" }
+    $hasD3D11FallbackMarkerState = $stateText -match "d3d11-fallback = d3d11:v1;kind=fallback_candidate;.*reason=environment_blocked"
+    $fallbackMarkerExpectation = if ($FallbackMarkerSmoke) {
+        ($hasD3D11FallbackMarkerSmoke -and $hasD3D11FallbackMarkerState)
+    } else {
+        (!$hasD3D11FallbackMarkerSmoke)
     }
 
     $pass = [bool](
@@ -891,6 +908,7 @@ try {
         $hasD3D11InitDetails -and
         $hasD3D11PolicyHealthy -and
         $recreateExpectation -and
+        $fallbackMarkerExpectation -and
         $rapidResizeDiagnostic -and
         $hasUiProbe -and
         $hasOffscreen -and
@@ -1059,6 +1077,8 @@ try {
             d3d11_recreate_smoke_requested = [bool]$hasD3D11RecreateSmokeRequest
             d3d11_recreate_succeeded = [bool]$hasD3D11RecreateSucceeded
             d3d11_resource_restore = [bool]$hasD3D11ResourceRestore
+            d3d11_fallback_marker_smoke = [bool]$hasD3D11FallbackMarkerSmoke
+            d3d11_fallback_marker_state = [bool]$hasD3D11FallbackMarkerState
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures
@@ -1088,4 +1108,5 @@ try {
     $env:WISPTERM_D3D11_UI_SMOKE = $oldUiSmoke
     $env:WISPTERM_D3D11_OFFSCREEN_SMOKE = $oldOffscreenSmoke
     $env:WISPTERM_D3D11_RECREATE_SMOKE = $oldRecreateSmoke
+    $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = $oldFallbackMarkerSmoke
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -214,6 +214,20 @@ scoped by app version and adapter identity, and currently feeds only tests and
 future-auto dry-run decisions. Explicit `d3d11` must ignore a matching marker
 except for diagnostics; current Windows `auto` still resolves to OpenGL.
 
+To exercise the marker path without changing selection, run:
+
+```powershell
+zig build -Dgpu-backend=d3d11
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FallbackMarkerSmoke
+```
+
+This sets `WISPTERM_D3D11_FALLBACK_MARKER_SMOKE=1`, writes a synthetic
+version+adapter-scoped `d3d11-fallback` marker into the smoke profile's isolated
+state file, verifies explicit `d3d11` still wins with a warning-class decision,
+verifies current Windows `auto` remains OpenGL, and verifies a future-auto
+dry-run would select OpenGL from the marker. It does not enable live failure
+writes or automatic fallback.
+
 ## macOS UI Smoke Tests
 
 macOS UI debugging is native-target first. Unless a task explicitly asks for

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -108,6 +108,10 @@ The fallback marker policy is intentionally policy-only at this stage. It
 defines marker format, persistence, stale-version/adapter handling, explicit
 backend behavior, and the future-auto dry-run decision surface, but it does not
 write markers from live failures and does not change renderer selection.
+Add `-FallbackMarkerSmoke` to the normal-session smoke to write a synthetic
+marker in the isolated smoke profile and verify marker persistence plus the
+explicit/current-auto/future-auto decision surface without triggering automatic
+fallback.
 
 ## Ghostty Comparison
 

--- a/src/renderer/d3d11_fallback_marker_smoke.zig
+++ b/src/renderer/d3d11_fallback_marker_smoke.zig
@@ -1,0 +1,163 @@
+//! Opt-in D3D11 fallback marker smoke.
+//!
+//! Enable with `WISPTERM_D3D11_FALLBACK_MARKER_SMOKE=1`. This writes a
+//! synthetic next-launch fallback marker into the isolated state file used by
+//! the smoke harness, then verifies the current/future selector decisions. It
+//! does not change the current Windows `auto` default and does not trigger
+//! automatic fallback.
+
+const std = @import("std");
+const build_options = @import("build_options");
+
+const gpu = @import("gpu/gpu.zig");
+const Backend = @import("gpu/backend.zig").Backend;
+const fallback_marker = @import("gpu/d3d11/fallback_marker.zig");
+const platform_window_state = @import("../platform/window_state.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
+
+const ENV_NAME = "WISPTERM_D3D11_FALLBACK_MARKER_SMOKE";
+
+threadlocal var checked_env = false;
+threadlocal var enabled_cache = false;
+threadlocal var fired = false;
+
+const SmokeDecision = struct {
+    readback_ok: bool,
+    explicit_d3d11_ignored: bool,
+    current_auto_default_unchanged: bool,
+    future_auto_opengl_marker: bool,
+};
+
+fn parseEnabledValue(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.mem.eql(u8, trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+fn enabled() bool {
+    if (comptime gpu.active != .d3d11) return false;
+    if (checked_env) return enabled_cache;
+    checked_env = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, ENV_NAME) catch {
+        enabled_cache = false;
+        return enabled_cache;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    enabled_cache = parseEnabledValue(value);
+    return enabled_cache;
+}
+
+fn evaluateDecisions(marker_text: []const u8, version: []const u8, adapter_id: []const u8) SmokeDecision {
+    const explicit_d3d11 = fallback_marker.decide(
+        .windows,
+        "d3d11",
+        marker_text,
+        version,
+        adapter_id,
+        .future_windows_auto,
+    );
+    const current_auto = fallback_marker.decide(
+        .windows,
+        "auto",
+        marker_text,
+        version,
+        adapter_id,
+        .current_default,
+    );
+    const future_auto = fallback_marker.decide(
+        .windows,
+        "auto",
+        marker_text,
+        version,
+        adapter_id,
+        .future_windows_auto,
+    );
+
+    return .{
+        .readback_ok = fallback_marker.parse(marker_text) != null,
+        .explicit_d3d11_ignored = explicit_d3d11.backend == .d3d11 and
+            explicit_d3d11.effect == .explicit_d3d11_ignores_marker and
+            explicit_d3d11.warning,
+        .current_auto_default_unchanged = current_auto.backend == Backend.opengl and
+            current_auto.effect == .current_auto_default_unchanged,
+        .future_auto_opengl_marker = future_auto.backend == Backend.opengl and
+            future_auto.effect == .future_auto_opengl_marker,
+    };
+}
+
+pub fn maybeRun() void {
+    if (comptime gpu.active != .d3d11) return;
+    if (!enabled() or fired) return;
+    fired = true;
+
+    var adapter_buf: [64]u8 = undefined;
+    const adapter_id = gpu.Context.adapterFallbackIdentity(&adapter_buf) orelse "unknown-adapter";
+
+    var marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const marker = fallback_marker.format(
+        &marker_buf,
+        .fallback_candidate,
+        build_options.app_version,
+        adapter_id,
+        .environment_blocked,
+    ) catch |err| {
+        render_diagnostics.log("d3d11-fallback-marker-smoke marker format failed: {s}", .{@errorName(err)});
+        return;
+    };
+
+    const allocator = std.heap.page_allocator;
+    platform_window_state.recordD3d11Fallback(allocator, marker);
+
+    var readback_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const readback = platform_window_state.d3d11Fallback(allocator, &readback_buf);
+    const decision = evaluateDecisions(readback, build_options.app_version, adapter_id);
+    const readback_matches = std.mem.eql(u8, marker, readback);
+
+    render_diagnostics.log(
+        "d3d11-fallback-marker-smoke marker={s} adapter={s} readback_ok={} readback_matches={} explicit_d3d11_ignored={} current_auto_default_unchanged={} future_auto_opengl_marker={} automatic_fallback=false default_unchanged=true",
+        .{
+            marker,
+            adapter_id,
+            decision.readback_ok,
+            readback_matches,
+            decision.explicit_d3d11_ignored,
+            decision.current_auto_default_unchanged,
+            decision.future_auto_opengl_marker,
+        },
+    );
+}
+
+test "D3D11 fallback marker smoke env parser accepts truthy values" {
+    try std.testing.expect(parseEnabledValue("1"));
+    try std.testing.expect(parseEnabledValue("true"));
+    try std.testing.expect(parseEnabledValue("YES"));
+    try std.testing.expect(parseEnabledValue("on"));
+}
+
+test "D3D11 fallback marker smoke env parser rejects falsey values" {
+    try std.testing.expect(!parseEnabledValue(""));
+    try std.testing.expect(!parseEnabledValue("0"));
+    try std.testing.expect(!parseEnabledValue("false"));
+    try std.testing.expect(!parseEnabledValue("off"));
+}
+
+test "D3D11 fallback marker smoke validates selector decisions" {
+    var marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const marker = try fallback_marker.format(
+        &marker_buf,
+        .fallback_candidate,
+        "1.20.0",
+        "adapter-a",
+        .environment_blocked,
+    );
+    const decision = evaluateDecisions(marker, "1.20.0", "adapter-a");
+
+    try std.testing.expect(decision.readback_ok);
+    try std.testing.expect(decision.explicit_d3d11_ignored);
+    try std.testing.expect(decision.current_auto_default_unchanged);
+    try std.testing.expect(decision.future_auto_opengl_marker);
+}

--- a/src/renderer/d3d11_recreate_smoke.zig
+++ b/src/renderer/d3d11_recreate_smoke.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 
+const fallback_marker_smoke = @import("d3d11_fallback_marker_smoke.zig");
 const gpu = @import("gpu/gpu.zig");
 const render_diagnostics = @import("../render_diagnostics.zig");
 
@@ -41,6 +42,7 @@ fn enabled() bool {
 
 pub fn maybeRequest() void {
     if (comptime gpu.active != .d3d11) return;
+    fallback_marker_smoke.maybeRun();
     if (!enabled() or fired) return;
     fired = true;
     if (gpu.Context.requestDeviceRecreateForSmoke()) {

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const windows = std.os.windows;
 const core = @import("../../../platform/dxgi_core.zig");
+const fallback_marker = @import("fallback_marker.zig");
 const present_policy = @import("present_policy.zig");
 const render_diagnostics = @import("../../../render_diagnostics.zig");
 const shaders = @import("shaders.zig");
@@ -607,6 +608,20 @@ fn deviceRemovedReason(self: *const State) HRESULT {
 
 pub fn presentPolicyStatus() present_policy.Status {
     return if (state) |*self| self.policy.status() else present_policy.Status.healthy();
+}
+
+pub fn adapterFallbackIdentity(buf: []u8) ?[]const u8 {
+    if (state) |*self| {
+        if (!self.adapter.available) return null;
+        return fallback_marker.adapterIdentity(
+            buf,
+            self.adapter.vendor_id,
+            self.adapter.device_id,
+            self.adapter.luid_low,
+            self.adapter.luid_high,
+        ) catch null;
+    }
+    return null;
 }
 
 pub fn takeRecoveryRequest() ?present_policy.RecoveryRequest {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -196,6 +196,7 @@ test {
     _ = @import("renderer/file_explorer_layout.zig");
     _ = @import("renderer/post_process_policy.zig");
     _ = @import("renderer/d3d11_recreate_smoke.zig");
+    _ = @import("renderer/d3d11_fallback_marker_smoke.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");
     _ = @import("renderer/gpu/types.zig");
     _ = @import("renderer/gpu/d3d11/fallback_marker.zig");


### PR DESCRIPTION
## Summary

Adds the Phase V opt-in smoke for the D3D11 fallback marker path.

- adds `WISPTERM_D3D11_FALLBACK_MARKER_SMOKE=1` and a `-FallbackMarkerSmoke` normal-session mode
- writes a synthetic version+adapter-scoped `d3d11-fallback` marker into the smoke profile's isolated state file
- verifies marker readback, explicit `d3d11` marker-ignore behavior, current Windows `auto` staying OpenGL, and future-auto dry-run selecting OpenGL from the marker
- documents the new smoke command in the D3D11 development notes and roadmap

## Boundaries

- Does not change the current Windows `auto` default.
- Does not enable automatic fallback.
- Does not write markers from live D3D11 failures.
- Does not implement same-process D3D11-to-OpenGL switching.
- Keeps explicit D3D11 and explicit OpenGL behavior unchanged.

## Ghostty Comparison

Ghostty keeps a thin compile-time backend selector (`opengl`, `metal`, `webgl`), defaults Darwin to Metal, and defaults other native targets to OpenGL. Ghostty has no D3D11 backend or Windows fallback marker model. This PR keeps WispTerm aligned with that backend boundary by proving marker persistence and future selection decisions through an opt-in smoke, not by adding runtime backend swapping.

## Validation

- `zig build test`
- `zig build test -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `zig build`
- `zig build check-sizes`
- `zig build test-full --summary all`
- `git diff --check`
- `git diff --cached --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FallbackMarkerSmoke`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
- Windows checkout safety path scan
- `git ls-files -s | Select-String '^120000'`