### PR TITLE
[codex] smoke d3d11 recreate failure escalation

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -8,6 +8,7 @@ param(
     [int]$WindowWidth = 1240,
     [int]$WindowHeight = 780,
     [switch]$RecreateSmoke,
+    [switch]$RecreateFailureSmoke,
     [switch]$RapidResizeSmoke,
     [switch]$FallbackMarkerSmoke,
     [switch]$KeepOpen
@@ -721,16 +722,22 @@ $oldRenderDiagnostics = $env:WISPTERM_RENDER_DIAGNOSTICS
 $oldUiSmoke = $env:WISPTERM_D3D11_UI_SMOKE
 $oldOffscreenSmoke = $env:WISPTERM_D3D11_OFFSCREEN_SMOKE
 $oldRecreateSmoke = $env:WISPTERM_D3D11_RECREATE_SMOKE
+$oldRecreateFailureSmoke = $env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE
 $oldFallbackMarkerSmoke = $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE
 
 $env:APPDATA = $appDataDir
 $env:WISPTERM_RENDER_DIAGNOSTICS = "1"
 $env:WISPTERM_D3D11_UI_SMOKE = "1"
 $env:WISPTERM_D3D11_OFFSCREEN_SMOKE = "1"
-if ($RecreateSmoke) {
+if ($RecreateSmoke -and !$RecreateFailureSmoke) {
     $env:WISPTERM_D3D11_RECREATE_SMOKE = "1"
 } else {
     Remove-Item Env:WISPTERM_D3D11_RECREATE_SMOKE -ErrorAction SilentlyContinue
+}
+if ($RecreateFailureSmoke) {
+    $env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE = "1"
+} else {
+    Remove-Item Env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE -ErrorAction SilentlyContinue
 }
 if ($FallbackMarkerSmoke) {
     $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = "1"
@@ -765,6 +772,70 @@ try {
     Start-Sleep -Milliseconds 900
     Send-Escape
     Start-Sleep -Milliseconds 900
+
+    if ($RecreateFailureSmoke) {
+        $diagText = Wait-ForDiagnosticText $diagnosticPath "gpu-backend=d3d11 recovery recreate failed escalated .*fallback_candidate_reason=recreate_failed" 12
+        Start-Sleep -Milliseconds 900
+        $diagText = if (Test-Path -LiteralPath $diagnosticPath) { Get-Content -LiteralPath $diagnosticPath -Raw } else { "" }
+        $stateText = if (Test-Path -LiteralPath $statePath) { Get-Content -LiteralPath $statePath -Raw } else { "" }
+        $proc.Refresh()
+
+        $recoveryRequestCount = [regex]::Matches($diagText, "gpu-backend=d3d11 recovery requested action=recreate_device").Count
+        $recreateAttemptCount = [regex]::Matches($diagText, "gpu-backend=d3d11 recovery recreate attempt attempted=true").Count
+        $forcedFailureCount = [regex]::Matches($diagText, "gpu-backend=d3d11 device recreate forced failure for smoke").Count
+        $failureSmokeRequestCount = [regex]::Matches($diagText, "d3d11-recreate-failure-smoke requested failed device recreate").Count
+        $escalatedCount = [regex]::Matches($diagText, "gpu-backend=d3d11 recovery recreate failed escalated .*fallback_candidate_reason=recreate_failed").Count
+        $markerRecordedCount = [regex]::Matches($diagText, "gpu-backend=d3d11 fallback marker recorded .*reason=recreate_failed").Count
+        $resourceRestoreCount = [regex]::Matches($diagText, "gpu-backend=d3d11 resource recreate restored").Count
+        $recreateSuccessCount = [regex]::Matches($diagText, "gpu-backend=d3d11 recovery recreate attempt attempted=true succeeded=true").Count
+        $hasD3D11FallbackMarkerState = $stateText -match "d3d11-fallback = d3d11:v1;kind=fallback_candidate;.*reason=recreate_failed"
+
+        $pass = [bool](
+            !$proc.HasExited -and
+            $recoveryRequestCount -eq 1 -and
+            $recreateAttemptCount -eq 1 -and
+            $forcedFailureCount -eq 1 -and
+            $failureSmokeRequestCount -eq 1 -and
+            $escalatedCount -eq 1 -and
+            $markerRecordedCount -eq 1 -and
+            $resourceRestoreCount -eq 0 -and
+            $recreateSuccessCount -eq 0 -and
+            $hasD3D11FallbackMarkerState
+        )
+
+        $result = [ordered]@{
+            pass = $pass
+            mode = "recreate_failure"
+            shell = $Shell
+            exe = $ExePath
+            config = $configPath
+            diagnostic_log = $diagnosticPath
+            state_path = $statePath
+            diagnostics = [ordered]@{
+                process_alive = [bool](!$proc.HasExited)
+                recovery_request_count = $recoveryRequestCount
+                recreate_attempt_count = $recreateAttemptCount
+                forced_failure_count = $forcedFailureCount
+                failure_smoke_request_count = $failureSmokeRequestCount
+                escalated_count = $escalatedCount
+                marker_recorded_count = $markerRecordedCount
+                resource_restore_count = $resourceRestoreCount
+                recreate_success_count = $recreateSuccessCount
+                d3d11_fallback_marker_state = [bool]$hasD3D11FallbackMarkerState
+                automatic_fallback = $false
+                default_unchanged = $true
+            }
+        }
+
+        $json = $result | ConvertTo-Json -Depth 5
+        $json | Set-Content -LiteralPath $metricsPath -Encoding UTF8
+        $json
+
+        if (!$pass) {
+            throw "D3D11 recreate-failure smoke failed. Inspect metrics=$metricsPath and diagnostic_log=$diagnosticPath"
+        }
+        return
+    }
 
     Send-AltDigit 0x31
     Start-Sleep -Milliseconds 450
@@ -1108,5 +1179,6 @@ try {
     $env:WISPTERM_D3D11_UI_SMOKE = $oldUiSmoke
     $env:WISPTERM_D3D11_OFFSCREEN_SMOKE = $oldOffscreenSmoke
     $env:WISPTERM_D3D11_RECREATE_SMOKE = $oldRecreateSmoke
+    $env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE = $oldRecreateFailureSmoke
     $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = $oldFallbackMarkerSmoke
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -194,6 +194,20 @@ recreate request, a successful single-shot device/swapchain recreate attempt,
 and restored feature resources. It still leaves automatic fallback and the
 Windows default backend unchanged.
 
+To exercise the failed-recreate escalation path, run:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateFailureSmoke
+```
+
+This sets `WISPTERM_D3D11_RECREATE_FAILURE_SMOKE=1`, asks the backend to latch
+one recreate-class recovery request, injects a synthetic failed recreate, and
+verifies that diagnostics escalate it to a `recreate_failed` fallback candidate
+exactly once. The smoke also verifies a version+adapter-scoped
+`d3d11-fallback` marker is written to the isolated smoke profile state file,
+that feature resources are not reported as restored after the forced failure,
+and that automatic fallback plus the Windows default backend remain unchanged.
+
 To add rapid resize stress evidence to the same D3D11 session smoke, use:
 
 ```powershell

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -76,6 +76,11 @@ not in-process renderer switching: explicit `d3d11` continues to honor the
 user's build/runtime choice and only reports a warning when a matching marker is
 present, while a future Windows `auto` default can use a version+adapter-scoped
 `d3d11-fallback` marker to choose OpenGL without changing the current default.
+The failed-recreate escalation path now has an opt-in `-RecreateFailureSmoke`
+mode: it injects one synthetic recreate failure, verifies the policy transitions
+to a `recreate_failed` fallback candidate exactly once, persists a
+version+adapter-scoped `d3d11-fallback` marker in the isolated smoke profile,
+and still reports `automatic_fallback=false` / `default_unchanged=true`.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
@@ -106,12 +111,18 @@ stress evidence in the normal-session run.
 
 The fallback marker policy is intentionally policy-only at this stage. It
 defines marker format, persistence, stale-version/adapter handling, explicit
-backend behavior, and the future-auto dry-run decision surface, but it does not
-write markers from live failures and does not change renderer selection.
+backend behavior, and the future-auto dry-run decision surface, but marker
+writes are still evidence for next launch/future-auto only and do not change
+renderer selection.
 Add `-FallbackMarkerSmoke` to the normal-session smoke to write a synthetic
 marker in the isolated smoke profile and verify marker persistence plus the
 explicit/current-auto/future-auto decision surface without triggering automatic
 fallback.
+
+Add `-RecreateFailureSmoke` to the same smoke to exercise the failed-recreate
+escalation path. This mode is intentionally a diagnostics/state-file proof: it
+does not attempt same-process OpenGL fallback, does not change Windows `auto`,
+and treats the persisted marker as next-launch/future-auto evidence only.
 
 ## Ghostty Comparison
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -91,6 +91,7 @@ const post_process = @import("renderer/post_process.zig");
 const d3d11_offscreen_smoke = @import("renderer/d3d11_offscreen_smoke.zig");
 const d3d11_ui_smoke = @import("renderer/d3d11_ui_smoke.zig");
 const d3d11_recreate_smoke = @import("renderer/d3d11_recreate_smoke.zig");
+const d3d11_fallback_marker = @import("renderer/gpu/d3d11/fallback_marker.zig");
 pub const gpu = @import("renderer/gpu/gpu.zig");
 pub const split_layout = @import("appwindow/split_layout.zig");
 const render_gate = @import("appwindow/render_gate.zig");
@@ -1652,10 +1653,41 @@ fn restoreD3D11DeviceRecreateResources(allocator: std.mem.Allocator) void {
     }
 }
 
+fn recordD3D11FallbackCandidate(
+    allocator: std.mem.Allocator,
+    adapter_id: []const u8,
+    reason: d3d11_fallback_marker.Reason,
+) bool {
+    if (comptime gpu.active != .d3d11) return false;
+    var marker_buf: [d3d11_fallback_marker.marker_max_len]u8 = undefined;
+    const marker = d3d11_fallback_marker.format(
+        &marker_buf,
+        .fallback_candidate,
+        build_options.app_version,
+        adapter_id,
+        reason,
+    ) catch |err| {
+        render_diagnostics.log(
+            "gpu-backend=d3d11 fallback marker record failed error={s} adapter={s} reason={s} automatic_fallback=false default_unchanged=true",
+            .{ @errorName(err), adapter_id, reason.name() },
+        );
+        return false;
+    };
+
+    platform_window_state.recordD3d11Fallback(allocator, marker);
+    render_diagnostics.log(
+        "gpu-backend=d3d11 fallback marker recorded marker={s} adapter={s} reason={s} automatic_fallback=false default_unchanged=true",
+        .{ marker, adapter_id, reason.name() },
+    );
+    return true;
+}
+
 fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator, fb_width: c_int, fb_height: c_int) void {
     if (comptime gpu.active == .d3d11) {
         const request = gpu.Context.takeRecoveryRequest() orelse return;
         const status = request.status;
+        var adapter_buf: [64]u8 = undefined;
+        const adapter_id = gpu.Context.adapterFallbackIdentity(&adapter_buf) orelse "unknown-adapter";
         render_diagnostics.log(
             "gpu-backend=d3d11 recovery requested action={s} policy_state={s} operation={s} fallback_candidate_reason={s} dxgi_kind={s} requires_device_recreate={} automatic_fallback=false default_unchanged=true",
             .{
@@ -1677,6 +1709,16 @@ fn handleD3D11RecoveryRequest(allocator: std.mem.Allocator, fb_width: c_int, fb_
             );
             if (recreate.succeeded) {
                 restoreD3D11DeviceRecreateResources(allocator);
+            } else if (recreate.fallback_candidate) {
+                const marker_written = recordD3D11FallbackCandidate(
+                    allocator,
+                    adapter_id,
+                    recreate.fallbackMarkerReason(),
+                );
+                render_diagnostics.log(
+                    "gpu-backend=d3d11 recovery recreate failed escalated policy_state=fallback_candidate fallback_candidate={} fallback_candidate_reason={s} marker_written={} automatic_fallback=false default_unchanged=true",
+                    .{ recreate.fallback_candidate, recreate.fallbackReasonName(), marker_written },
+                );
             }
         }
         applyUiEffect(UiEffect.repaint);

--- a/src/renderer/d3d11_recreate_smoke.zig
+++ b/src/renderer/d3d11_recreate_smoke.zig
@@ -12,9 +12,12 @@ const gpu = @import("gpu/gpu.zig");
 const render_diagnostics = @import("../render_diagnostics.zig");
 
 const ENV_NAME = "WISPTERM_D3D11_RECREATE_SMOKE";
+const FAILURE_ENV_NAME = "WISPTERM_D3D11_RECREATE_FAILURE_SMOKE";
 
 threadlocal var checked_env = false;
 threadlocal var enabled_cache = false;
+threadlocal var checked_failure_env = false;
+threadlocal var failure_enabled_cache = false;
 threadlocal var fired = false;
 
 fn parseEnabledValue(value: []const u8) bool {
@@ -40,12 +43,33 @@ fn enabled() bool {
     return enabled_cache;
 }
 
+fn failureEnabled() bool {
+    if (comptime gpu.active != .d3d11) return false;
+    if (checked_failure_env) return failure_enabled_cache;
+    checked_failure_env = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, FAILURE_ENV_NAME) catch {
+        failure_enabled_cache = false;
+        return failure_enabled_cache;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    failure_enabled_cache = parseEnabledValue(value);
+    return failure_enabled_cache;
+}
+
 pub fn maybeRequest() void {
     if (comptime gpu.active != .d3d11) return;
     fallback_marker_smoke.maybeRun();
-    if (!enabled() or fired) return;
+    if (!(enabled() or failureEnabled()) or fired) return;
     fired = true;
-    if (gpu.Context.requestDeviceRecreateForSmoke()) {
+    if (failureEnabled()) {
+        if (gpu.Context.requestFailedDeviceRecreateForSmoke()) {
+            render_diagnostics.log("d3d11-recreate-failure-smoke requested failed device recreate", .{});
+        } else {
+            render_diagnostics.log("d3d11-recreate-failure-smoke request skipped backend_unavailable=true", .{});
+        }
+    } else if (gpu.Context.requestDeviceRecreateForSmoke()) {
         render_diagnostics.log("d3d11-recreate-smoke requested device recreate", .{});
     } else {
         render_diagnostics.log("d3d11-recreate-smoke request skipped backend_unavailable=true", .{});

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -90,12 +90,30 @@ pub const DeviceRecreatePreparation = struct {
 pub const DeviceRecreateResult = struct {
     attempted: bool = false,
     succeeded: bool = false,
+    fallback_candidate: bool = false,
+    fallback_reason: present_policy.FallbackReason = .none,
     width: i32 = 0,
     height: i32 = 0,
     error_name: []const u8 = "none",
 
     pub fn failed(self: DeviceRecreateResult) bool {
         return self.attempted and !self.succeeded;
+    }
+
+    pub fn fallbackReasonName(self: DeviceRecreateResult) []const u8 {
+        return self.fallback_reason.name();
+    }
+
+    pub fn fallbackMarkerReason(self: DeviceRecreateResult) fallback_marker.Reason {
+        return switch (self.fallback_reason) {
+            .none => .unknown,
+            .device_lost => .device_lost,
+            .invalid_call => .invalid_call,
+            .present_failed => .present_failed,
+            .resize_failed => .resize_failed,
+            .recreate_failed => .recreate_failed,
+            .render_target_failed => .render_target_failed,
+        };
     }
 };
 
@@ -170,6 +188,7 @@ const State = struct {
 };
 
 pub threadlocal var state: ?State = null;
+threadlocal var force_recreate_failure_for_smoke = false;
 pub threadlocal var gl: GlTable = .{};
 
 const GlTable = @import("GlTable.zig").GlTable;
@@ -668,17 +687,34 @@ pub fn recreateDevice(width: i32, height: i32) DeviceRecreateResult {
         .height = target_height,
     };
 
+    if (force_recreate_failure_for_smoke) {
+        force_recreate_failure_for_smoke = false;
+        const status = self.policy.noteRecreateFailed();
+        render_diagnostics.log(
+            "gpu-backend=d3d11 device recreate forced failure for smoke error=smoke_forced_recreate_failed swapchain={}x{} policy_state={s} fallback_candidate={} fallback_candidate_reason={s} automatic_fallback=false default_unchanged=true",
+            .{ target_width, target_height, status.stateName(), status.fallbackCandidate(), status.reasonName() },
+        );
+        var failed_result = result_base;
+        failed_result.error_name = "smoke_forced_recreate_failed";
+        failed_result.fallback_candidate = status.fallbackCandidate();
+        failed_result.fallback_reason = status.reason;
+        return failed_result;
+    }
+
     var old = state.?;
     state = null;
     old.deinit();
 
     const next = createStateForWindow(hwnd, target_width, target_height) catch |err| {
+        const failed_status = old.policy.noteRecreateFailed();
         render_diagnostics.log(
-            "gpu-backend=d3d11 device recreate failed error={s} swapchain={}x{} automatic_fallback=false default_unchanged=true",
-            .{ @errorName(err), target_width, target_height },
+            "gpu-backend=d3d11 device recreate failed error={s} swapchain={}x{} policy_state={s} fallback_candidate={} fallback_candidate_reason={s} automatic_fallback=false default_unchanged=true",
+            .{ @errorName(err), target_width, target_height, failed_status.stateName(), failed_status.fallbackCandidate(), failed_status.reasonName() },
         );
         var failed_result = result_base;
         failed_result.error_name = @errorName(err);
+        failed_result.fallback_candidate = failed_status.fallbackCandidate();
+        failed_result.fallback_reason = failed_status.reason;
         return failed_result;
     };
 
@@ -698,6 +734,17 @@ pub fn requestDeviceRecreateForSmoke() bool {
     const status = state.?.policy.noteBackendFailure(.present, .device_lost, true);
     render_diagnostics.log(
         "gpu-backend=d3d11 recreate smoke latched policy_state={s} fallback_candidate_reason={s} requires_device_recreate={}",
+        .{ status.stateName(), status.reasonName(), status.requires_device_recreate },
+    );
+    return status.requires_device_recreate;
+}
+
+pub fn requestFailedDeviceRecreateForSmoke() bool {
+    if (state == null) return false;
+    force_recreate_failure_for_smoke = true;
+    const status = state.?.policy.noteBackendFailure(.present, .device_lost, true);
+    render_diagnostics.log(
+        "gpu-backend=d3d11 recreate failure smoke latched policy_state={s} fallback_candidate_reason={s} requires_device_recreate={}",
         .{ status.stateName(), status.reasonName(), status.requires_device_recreate },
     );
     return status.requires_device_recreate;
@@ -752,4 +799,18 @@ test "D3D11 context device recreate reports no attempt when uninitialized" {
     try std.testing.expect(!result.succeeded);
     try std.testing.expect(!result.failed());
     try std.testing.expectEqualStrings("not_initialized", result.error_name);
+}
+
+test "D3D11 context recreate result reports fallback reason names" {
+    const result = DeviceRecreateResult{
+        .attempted = true,
+        .fallback_candidate = true,
+        .fallback_reason = .recreate_failed,
+        .error_name = "smoke_forced_recreate_failed",
+    };
+
+    try std.testing.expect(result.failed());
+    try std.testing.expect(result.fallback_candidate);
+    try std.testing.expectEqualStrings("recreate_failed", result.fallbackReasonName());
+    try std.testing.expectEqual(fallback_marker.Reason.recreate_failed, result.fallbackMarkerReason());
 }

--- a/src/renderer/gpu/d3d11/present_policy.zig
+++ b/src/renderer/gpu/d3d11/present_policy.zig
@@ -63,6 +63,7 @@ pub const FallbackReason = enum {
     invalid_call,
     present_failed,
     resize_failed,
+    recreate_failed,
     render_target_failed,
 
     pub fn name(self: FallbackReason) []const u8 {
@@ -72,6 +73,7 @@ pub const FallbackReason = enum {
             .invalid_call => "invalid_call",
             .present_failed => "present_failed",
             .resize_failed => "resize_failed",
+            .recreate_failed => "recreate_failed",
             .render_target_failed => "render_target_failed",
         };
     }
@@ -167,6 +169,18 @@ pub const Policy = struct {
         requires_recreate: bool,
     ) Status {
         return self.latchFailure(operation, reason, .other, requires_recreate);
+    }
+
+    pub fn noteRecreateFailed(self: *Policy) Status {
+        self.status_value = .{
+            .state = .fallback_candidate,
+            .operation = self.status_value.operation orelse .present,
+            .reason = .recreate_failed,
+            .dxgi_kind = self.status_value.dxgi_kind,
+            .requires_device_recreate = false,
+        };
+        self.recovery_pending = false;
+        return self.status_value;
     }
 
     fn latchFailure(
@@ -298,4 +312,19 @@ test "D3D11 present policy records render-target creation failures" {
     try std.testing.expectEqualStrings("fallback_candidate", status.stateName());
     try std.testing.expectEqualStrings("render_target_failed", status.reasonName());
     try std.testing.expectEqualStrings("resize_target", status.operationName());
+}
+
+test "D3D11 present policy escalates failed recreate to fallback candidate once" {
+    var policy = Policy.init(800, 600);
+    _ = policy.noteDxgiFailure(.present, core.DXGI_ERROR_DEVICE_REMOVED);
+    _ = policy.takeRecoveryRequest() orelse return error.MissingRecoveryRequest;
+
+    const status = policy.noteRecreateFailed();
+
+    try std.testing.expectEqual(State.fallback_candidate, status.state);
+    try std.testing.expectEqual(FallbackReason.recreate_failed, status.reason);
+    try std.testing.expect(!status.requires_device_recreate);
+    try std.testing.expect(status.fallbackCandidate());
+    try std.testing.expectEqual(Action.fallback_candidate, policy.frameAction(800, 600));
+    try std.testing.expect(policy.takeRecoveryRequest() == null);
 }


### PR DESCRIPTION
## Summary
- Add an opt-in `-RecreateFailureSmoke` / `WISPTERM_D3D11_RECREATE_FAILURE_SMOKE=1` path for the D3D11 normal-session smoke.
- Escalate a failed D3D11 recreate attempt to a `recreate_failed` fallback candidate exactly once, and persist a version+adapter-scoped `d3d11-fallback` marker.
- Keep the current renderer boundary intact: no same-process D3D11-to-OpenGL switch, no automatic fallback, and no Windows `auto` default change.
- Document the new Phase V failure-escalation evidence in the D3D11 roadmap and development smoke instructions.

## Ghostty comparison
Ghostty still uses a thin renderer backend selector (`opengl`, `metal`, `webgl`): Darwin selects Metal and other native targets select OpenGL. It has no D3D11 runtime fallback equivalent, so this keeps WispTerm aligned with that backend-boundary shape by treating D3D11 failure recovery as backend-local state plus next-launch/future-auto marker evidence rather than an in-process renderer swap.

## Validation
- `zig fmt src\renderer\gpu\d3d11\present_policy.zig src\renderer\gpu\d3d11\Context.zig src\renderer\d3d11_recreate_smoke.zig src\AppWindow.zig src\test_fast.zig`
- `zig build test`
- `zig build test -Dgpu-backend=d3d11`
- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateFailureSmoke`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateSmoke`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FallbackMarkerSmoke`
- `zig build`
- `zig build check-sizes`
- `git diff --check`
- `git diff --cached --check`
- `zig build test-full --summary all`