### PR TITLE
feat: add wispterm-bench CPU-side benchmark CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance_report.yml
+++ b/.github/ISSUE_TEMPLATE/performance_report.yml
@@ -1,0 +1,70 @@
+name: 📊 Performance Report
+description: Share a WispTerm benchmark run so we can compare performance across hardware/backends
+title: "[Perf] "
+labels: ["performance"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a performance report! Run the benchmark (see
+        `docs/development.md` → Performance Benchmarking) and paste the Markdown
+        report the CLI prints. One report per machine/backend combo keeps the
+        data easier to compare.
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Renderer backend
+      description: Which GPU backend were you measuring (or `n/a` for the CPU-only CLI)?
+      options:
+        - opengl
+        - metal
+        - d3d11
+        - n/a (CPU CLI)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: WispTerm version
+      description: Output of `wispterm --version`, or the commit/release you built from.
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware (CPU / GPU / RAM)
+      description: e.g. "Intel i5-1235U, Iris Xe, 16GB" — helps group reports by tier.
+    validations:
+      required: true
+
+  - type: textarea
+    id: report
+    attributes:
+      label: Benchmark report
+      description: Paste the Markdown report the CLI printed to stdout (the `## WispTerm performance report` block).
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: build
+    attributes:
+      label: Build / run command
+      description: The exact `zig build` / `wispterm-bench` invocation and any relevant config.
+      render: shell
+    validations:
+      required: false

--- a/build.zig
+++ b/build.zig
@@ -418,6 +418,14 @@ test "standalone filetool build contract is declared" {
     try expectSourceContains(source, "b.step(\"wispterm-filetool\"");
 }
 
+test "standalone benchmark CLI build contract is declared" {
+    const source = @embedFile("build.zig");
+    try expectSourceContains(source, ".name = \"wispterm-bench\"");
+    try expectSourceContains(source, "src/wispterm_bench.zig");
+    try expectSourceContains(source, "b.step(\"bench\"");
+    try expectSourceContains(source, "-Demit-bench");
+}
+
 test "shared compile checks default to platforms without desktop backends" {
     try std.testing.expect(!defaultEmitSharedCompileChecks(PlatformFeatures.forOs(.windows)));
     try std.testing.expect(!defaultEmitSharedCompileChecks(PlatformFeatures.forOs(.linux)));
@@ -586,6 +594,14 @@ pub fn build(b: *std.Build) void {
         "emit-shared-compile-checks",
         "Compile shared modules without running them on targets that do not have desktop host backends yet.",
     ) orelse defaultEmitSharedCompileChecks(platform);
+    // Standalone CPU-side benchmark CLI (Ghostty-aligned `wispterm-bench`). Off
+    // by default: it links ghostty-vt and is meant for branch-to-branch
+    // performance comparisons, not for app packaging or the pre-merge gate.
+    const emit_bench = b.option(
+        bool,
+        "emit-bench",
+        "Build the standalone wispterm-bench CPU benchmark CLI (links ghostty-vt).",
+    ) orelse false;
     const app_version = packageVersion(b);
 
     if (emit_desktop_exe) {
@@ -667,6 +683,39 @@ pub fn build(b: *std.Build) void {
     if (platform.supports_gui_subsystem) filetool_exe.subsystem = .Console;
     const filetool_step = b.step("wispterm-filetool", "Build the standalone remote-side file edit helper");
     filetool_step.dependOn(&b.addInstallArtifact(filetool_exe, .{}).step);
+
+    // Standalone CPU benchmark CLI. Mirrors Ghostty's `zig build -Demit-bench`:
+    // a separate artifact that links ghostty-vt for the TerminalStream case.
+    // Built only on explicit request (`-Demit-bench` or `zig build bench`).
+    const bench_step = b.step("bench", "Build the standalone wispterm-bench CPU benchmark CLI (separate artifact; not bundled with the app)");
+    if (emit_bench) {
+        const bench_mod = createBenchModule(b, target, optimize);
+        const bench_exe = b.addExecutable(.{
+            .name = "wispterm-bench",
+            .root_module = bench_mod,
+        });
+        if (platform.supports_gui_subsystem) bench_exe.subsystem = .Console;
+        const install_bench = b.addInstallArtifact(bench_exe, .{});
+        bench_step.dependOn(&install_bench.step);
+        // Include in the default install too, so `zig build -Demit-bench`
+        // actually produces the binary (the named `bench` step alone is not
+        // run by a bare `zig build`).
+        b.getInstallStep().dependOn(&install_bench.step);
+    } else {
+        bench_step.dependOn(&b.addFail("bench requires -Demit-bench").step);
+    }
+
+    // `test-bench`: runs the bench modules' own tests (TerminalStream + cli),
+    // which link ghostty-vt and so cannot live in the lean fast suite. Kept
+    // separate from test-full so it does not slow the pre-merge gate; run it
+    // explicitly when touching the benchmark code.
+    const bench_test_mod = createBenchModule(b, target, optimize);
+    const bench_tests = b.addTest(.{
+        .name = "wispterm-bench-test",
+        .root_module = bench_test_mod,
+    });
+    const test_bench_step = b.step("test-bench", "Run the wispterm-bench module tests (links ghostty-vt)");
+    test_bench_step.dependOn(&b.addRunArtifact(bench_tests).step);
 
     b.installDirectory(.{
         .source_dir = b.path("plugins"),
@@ -1280,6 +1329,40 @@ fn createAppModuleWithRootAndTestShard(
         app_mod.linkSystemLibrary("objc", .{});
     }
     return app_mod;
+}
+
+fn createBenchModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) *std.Build.Module {
+    const bench_mod = b.createModule(.{
+        .root_source_file = b.path("src/wispterm_bench.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    // env.zig reads app_version + gpu_backend from build_options. The bench
+    // CLI links no GPU backend, so gpu_backend is reported as "n/a".
+    const bench_options = b.addOptions();
+    bench_options.addOption([]const u8, "app_version", packageVersion(b));
+    bench_options.addOption([]const u8, "gpu_backend", "n/a");
+    bench_mod.addOptions("build_options", bench_options);
+    // The TerminalStream case drives ghostty-vt; wire the same dep + stb the
+    // app uses so the VT parser is the exact shipped code path.
+    if (b.lazyDependency("ghostty", .{
+        .target = target,
+        .optimize = optimize,
+        .simd = false,
+    })) |dep| {
+        bench_mod.addImport("ghostty-vt", dep.module("ghostty-vt"));
+        bench_mod.addIncludePath(dep.path("src/stb"));
+        bench_mod.addCSourceFile(.{
+            .file = dep.path("src/stb/stb.c"),
+            .flags = &.{},
+        });
+    }
+    return bench_mod;
 }
 
 fn addMacosAppBundle(

--- a/docs/development.md
+++ b/docs/development.md
@@ -125,6 +125,47 @@ preview is visible, the table preview labels should move with the regression.
 For that scenario, add `-ManualSetupSeconds 15`, open the CSV/TSV preview during
 the pause, then let the script run the resize sequence.
 
+## Performance Benchmarking
+
+`wispterm-bench` is the CPU-side benchmark CLI (Ghostty-aligned: mirrors
+`ghostty-bench`'s `--duration` case-runner shape). It links ghostty-vt and
+drives a synthetic VT byte stream through the same parser the shipped app uses,
+so the number is directly comparable across branches and machines. Build and
+run it with:
+
+```powershell
+zig build -Demit-bench -Doptimize=ReleaseFast
+.\zig-out\bin\wispterm-bench.exe --list
+.\zig-out\bin\wispterm-bench.exe --case terminal-stream --duration 1000
+```
+
+Always pass `-Doptimize=ReleaseFast` for benchmarks — a debug build is not
+representative of real performance. Use `--duration <ms>` to set the per-case
+window (default 1000ms) and `--case <name>` to run a single case.
+
+The CLI writes a machine-readable `benchmark-report-<timestamp>.json` and a
+paste-ready `benchmark-report-<timestamp>.md` into the WispTerm config dir
+(`%APPDATA%\wispterm\` on Windows, `~/Library/Application Support/wispterm/` on
+macOS), and prints the Markdown to stdout. Paste that Markdown block into a
+**Performance Report** issue (or a Discussion) so we can compare results across
+hardware and renderer backends. The JSON is for tooling/regression tracking.
+
+The bench module's own tests (which link ghostty-vt and so cannot run in the
+lean fast suite) have their own step:
+
+```powershell
+zig build test-bench
+```
+
+An in-app GPU-side benchmark (`wispterm --benchmark`, measuring per-frame render
+latency and FPS through the real renderer) is planned; the report schema in
+`src/benchmark/report.zig` already reserves the GPU-adapter / window / DPI /
+grid fields that mode will fill, so CLI and in-app reports stay comparable.
+
+When publishing a desktop release, run `wispterm-bench --case terminal-stream
+--duration 1000` on the release machine and attach the Markdown report to the
+release notes as a regression baseline for that version.
+
 ## Windows UI Automation
 
 When debugging UI behavior, automate WispTerm as a real visible Windows app from

--- a/src/benchmark/Benchmark.zig
+++ b/src/benchmark/Benchmark.zig
@@ -1,0 +1,143 @@
+//! A single benchmark case. Mirrors Ghostty's `src/benchmark/Benchmark.zig`:
+//! a vtable-driven run abstraction with `RunMode{ once, duration }` and
+//! `RunResult{ iterations, duration }`. Setup/teardown are excluded from the
+//! measured window, matching Ghostty so branch-to-branch comparisons stay
+//! meaningful (see Ghostty's `src/benchmark/AGENTS.md`).
+//!
+//! Deliberately zero project dependencies (std only) so this compiles in the
+//! fast suite and the bench CLI alike.
+
+const Benchmark = @This();
+
+const std = @import("std");
+
+ptr: *anyopaque,
+vtable: VTable,
+
+/// Wrap a pointer + vtable. Usually called by benchmark implementations,
+/// not benchmark users.
+pub fn init(pointer: anytype, vtable: VTable) Benchmark {
+    const Ptr = @TypeOf(pointer);
+    assert(@typeInfo(Ptr) == .pointer); // Must be a pointer
+    assert(@typeInfo(Ptr).pointer.size == .one); // Must be a single-item pointer
+    assert(@typeInfo(@typeInfo(Ptr).pointer.child) == .@"struct"); // Must point to a struct
+    return .{ .ptr = pointer, .vtable = vtable };
+}
+
+/// Run the benchmark. Setup/teardown run outside the timed window.
+pub fn run(self: Benchmark, mode: RunMode) Error!RunResult {
+    if (self.vtable.setupFn) |func| try func(self.ptr);
+    defer if (self.vtable.teardownFn) |func| func(self.ptr);
+
+    var result: RunResult = .{};
+    const start = std.time.Instant.now() catch return error.BenchmarkFailed;
+    while (true) {
+        try self.vtable.stepFn(self.ptr);
+        result.iterations += 1;
+
+        const now = std.time.Instant.now() catch return error.BenchmarkFailed;
+        const exit = switch (mode) {
+            .once => true,
+            .duration => |ns| now.since(start) >= ns,
+        };
+        if (exit) {
+            result.duration = now.since(start);
+            return result;
+        }
+    }
+    unreachable;
+}
+
+/// How a benchmark is driven. `once` runs a single step (setup+teardown still
+/// excluded); `duration` runs steps until `ns` nanoseconds have elapsed.
+pub const RunMode = union(enum) {
+    once,
+    duration: u64,
+};
+
+pub const RunResult = struct {
+    iterations: u32 = 0,
+    /// Nanoseconds. For `duration` runs this is close to the requested window.
+    duration: u64 = 0,
+
+    /// Throughput in iterations/sec over the measured window.
+    pub fn iterationsPerSecond(self: RunResult) f64 {
+        if (self.duration == 0) return 0;
+        return @as(f64, @floatFromInt(self.iterations)) * std.time.ns_per_s /
+            @as(f64, @floatFromInt(self.duration));
+    }
+};
+
+pub const Error = error{BenchmarkFailed};
+
+pub const VTable = struct {
+    /// A single step of the work under test. Called repeatedly under `duration`.
+    stepFn: *const fn (ptr: *anyopaque) Error!void,
+    setupFn: ?*const fn (ptr: *anyopaque) Error!void = null,
+    teardownFn: ?*const fn (ptr: *anyopaque) void = null,
+};
+
+fn assert(condition: bool) void {
+    if (!condition) unreachable;
+}
+
+test "Benchmark: once mode runs setup+step once, excludes setup from duration" {
+    // Ghostty's equivalent test skips on Windows/FreeBSD because a single
+    // trivial step can complete within one timer tick (duration == 0). We keep
+    // the structural assertions (which are timer-independent) and skip only the
+    // positivity check on those hosts; the duration-mode test below covers
+    // timing on every host.
+    const Simple = struct {
+        setup_i: usize = 0,
+        step_i: usize = 0,
+
+        fn setup(ptr: *anyopaque) Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.setup_i += 1;
+        }
+        fn step(ptr: *anyopaque) Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.step_i += 1;
+        }
+        fn benchmark(self: *@This()) Benchmark {
+            return .init(self, .{ .stepFn = step, .setupFn = setup });
+        }
+    };
+
+    var s: Simple = .{};
+    const b = s.benchmark();
+    const result = try b.run(.once);
+    try std.testing.expectEqual(@as(usize, 1), s.setup_i);
+    try std.testing.expectEqual(@as(usize, 1), s.step_i);
+    try std.testing.expectEqual(@as(u32, 1), result.iterations);
+    if (@import("builtin").os.tag != .windows and @import("builtin").os.tag != .freebsd) {
+        try std.testing.expect(result.duration > 0);
+    }
+}
+
+test "Benchmark: duration mode accumulates iterations until window elapses" {
+    const Counter = struct {
+        step_i: usize = 0,
+        fn step(ptr: *anyopaque) Error!void {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.step_i += 1;
+        }
+        fn benchmark(self: *@This()) Benchmark {
+            return .init(self, .{ .stepFn = step });
+        }
+    };
+
+    var c: Counter = .{};
+    const b = c.benchmark();
+    // 5ms window — enough for many iterations of an increment, short enough
+    // for a unit test.
+    const result = try b.run(.{ .duration = 5 * std.time.ns_per_ms });
+    try std.testing.expectEqual(@as(u32, @intCast(c.step_i)), result.iterations);
+    try std.testing.expect(result.duration >= 5 * std.time.ns_per_ms);
+    try std.testing.expect(result.iterationsPerSecond() > 0);
+}
+
+test "RunResult.iterationsPerSecond is zero for zero duration" {
+    const r: RunResult = .{ .iterations = 100, .duration = 0 };
+    try std.testing.expectEqual(@as(f64, 0), r.iterationsPerSecond());
+}

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -1,0 +1,147 @@
+//! TerminalStream benchmark case: feed a synthetic VT byte stream through
+//! ghostty-vt's `Stream.nextSlice` and measure parser+screen throughput in
+//! MB/s. This is the WispTerm counterpart to Ghostty's
+//! `src/benchmark/TerminalStream.zig` — same idea (synthetic bytes through the
+//! VT state machine), adapted to our `ghostty_vt` import name.
+//!
+//! Setup pre-generates a deterministic payload (printable lines + CRLF, with a
+//! sprinkling of SGR/CSI so the parser's escape path is exercised); each step
+//! runs one full payload through `nextSlice`. Setup/teardown are excluded from
+//! the timed window by `Benchmark.run`.
+
+const std = @import("std");
+const ghostty_vt = @import("ghostty-vt");
+const Benchmark = @import("Benchmark.zig");
+
+const Handler = @typeInfo(@TypeOf(ghostty_vt.Terminal.vtHandler)).@"fn".return_type.?;
+const Stream = ghostty_vt.Stream(Handler);
+
+pub const Spec = struct {
+    cols: usize = 120,
+    rows: usize = 40,
+    /// Bytes of synthetic VT generated in setup and fed per step.
+    payload_bytes: usize = 64 * 1024,
+};
+
+pub const TerminalStream = @This();
+
+allocator: std.mem.Allocator,
+terminal: ghostty_vt.Terminal,
+handler: Handler,
+stream: Stream,
+payload: []u8,
+spec: Spec,
+
+/// Heap-allocate the case so `&self.terminal` is stable for the handler.
+pub fn create(allocator: std.mem.Allocator, spec: Spec) !*TerminalStream {
+    const self = try allocator.create(TerminalStream);
+    errdefer allocator.destroy(self);
+
+    self.* = .{
+        .allocator = allocator,
+        .terminal = undefined,
+        .handler = undefined,
+        .stream = undefined,
+        .payload = &.{},
+        .spec = spec,
+    };
+    self.terminal = try ghostty_vt.Terminal.init(allocator, .{
+        .cols = @intCast(spec.cols),
+        .rows = @intCast(spec.rows),
+    });
+    errdefer self.terminal.deinit(allocator);
+
+    self.handler = self.terminal.vtHandler();
+    self.stream = Stream.initAlloc(self.terminal.screens.active.alloc, self.handler);
+    return self;
+}
+
+pub fn destroy(self: *TerminalStream) void {
+    self.stream.deinit();
+    self.handler.deinit();
+    self.terminal.deinit(self.allocator);
+    if (self.payload.len > 0) self.allocator.free(self.payload);
+    self.allocator.destroy(self);
+}
+
+pub fn benchmark(self: *TerminalStream) Benchmark {
+    return .init(self, .{
+        .stepFn = step,
+        .setupFn = setup,
+        .teardownFn = teardown,
+    });
+}
+
+/// Bytes processed per step — used by the CLI to convert iterations → MB/s.
+pub fn bytesPerStep(self: *const TerminalStream) usize {
+    return self.spec.payload_bytes;
+}
+
+fn setup(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *TerminalStream = @ptrCast(@alignCast(ptr));
+    self.payload = generatePayload(self.allocator, self.spec) catch return error.BenchmarkFailed;
+}
+
+fn teardown(ptr: *anyopaque) void {
+    const self: *TerminalStream = @ptrCast(@alignCast(ptr));
+    if (self.payload.len > 0) {
+        self.allocator.free(self.payload);
+        self.payload = &.{};
+    }
+}
+
+fn step(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *TerminalStream = @ptrCast(@alignCast(ptr));
+    // nextSlice returns void on this ghostty snapshot (see AGENTS.md): no try.
+    self.stream.nextSlice(self.payload);
+}
+
+/// Build a deterministic payload: mostly printable lines of width `cols` + CRLF,
+/// with one SGR sequence per line so the escape-sequence parser path is hit.
+fn generatePayload(allocator: std.mem.Allocator, spec: Spec) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    var written: usize = 0;
+    var color: u8 = 0;
+    while (written < spec.payload_bytes) {
+        // CSI SGR color set
+        const sgr = try std.fmt.allocPrint(allocator, "\x1b[3{d}m", .{color});
+        defer allocator.free(sgr);
+        try buf.appendSlice(allocator, sgr);
+        color = (color + 1) % 8;
+
+        const line_len = @min(spec.cols, spec.payload_bytes - written);
+        var i: usize = 0;
+        while (i < line_len) : (i += 1) {
+            // Cycle printable ASCII 0x21..0x7e.
+            const ch: u8 = 0x21 + @as(u8, @intCast((written + i) % 94));
+            try buf.append(allocator, ch);
+        }
+        try buf.appendSlice(allocator, "\r\n");
+        written += line_len + 2;
+    }
+
+    return try buf.toOwnedSlice(allocator);
+}
+
+test "TerminalStream: generatePayload produces requested order of bytes" {
+    const allocator = std.testing.allocator;
+    const spec: Spec = .{ .cols = 10, .rows = 4, .payload_bytes = 256 };
+    const payload = try generatePayload(allocator, spec);
+    defer allocator.free(payload);
+    // Roughly payload_bytes (± a line); never wildly over.
+    try std.testing.expect(payload.len >= 128 and payload.len <= 512);
+    // Contains a CRLF and an SGR escape.
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\x1b[3") != null);
+}
+
+test "TerminalStream: create/destroy round-trips without leaking" {
+    const allocator = std.testing.allocator;
+    const self = try TerminalStream.create(allocator, .{ .cols = 20, .rows = 4, .payload_bytes = 512 });
+    // Run setup so the payload is allocated, then teardown+destroy frees it.
+    const bench = self.benchmark();
+    _ = try bench.run(.once);
+    self.destroy();
+}

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -1,0 +1,185 @@
+//! wispterm-bench CLI runner. Builds the case set, applies `options.zig`
+//! selection, runs each case through `Benchmark.run`, prints a human summary,
+//! and writes a shareable JSON + Markdown report to the WispTerm config dir.
+//! The bench binary links ghostty-vt for the TerminalStream case; this module
+//! stays free of GUI/app dependencies.
+
+const std = @import("std");
+const Benchmark = @import("Benchmark.zig");
+const options_mod = @import("options.zig");
+const TerminalStream = @import("TerminalStream.zig");
+const report = @import("report.zig");
+const env = @import("env.zig");
+const platform_dirs = @import("../platform/dirs.zig");
+
+pub const CaseName = struct {
+    name: []const u8,
+    description: []const u8,
+};
+
+pub const all_cases = [_]CaseName{
+    .{ .name = "terminal-stream", .description = "Synthetic VT byte stream through ghostty-vt (MB/s)" },
+};
+
+pub fn run(allocator: std.mem.Allocator, raw_args: []const []const u8) !void {
+    var opts = try options_mod.parse(allocator, raw_args);
+    defer opts.deinit();
+
+    if (opts.help) {
+        try stdoutAll(options_mod.USAGE);
+        return;
+    }
+    if (opts.list) {
+        try listCases(std.fs.File.stdout().deprecatedWriter());
+        return;
+    }
+
+    const duration_ms: u64 = if (opts.duration_ms == 0) 1000 else opts.duration_ms;
+    const mode: Benchmark.RunMode = .{ .duration = duration_ms * std.time.ns_per_ms };
+
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    try stdout.print(
+        "wispterm-bench: duration={d}ms optimize={s}\n",
+        .{ duration_ms, @tagName(@import("builtin").mode) },
+    );
+
+    var results: std.ArrayList(report.ScenarioResult) = .empty;
+    defer {
+        for (results.items) |r| allocator.free(r.name);
+        results.deinit(allocator);
+    }
+
+    var any_ran = false;
+    for (all_cases) |case| {
+        if (opts.only) |only| {
+            if (!std.mem.eql(u8, only, case.name)) continue;
+        }
+        if (try runCase(allocator, case, mode, stdout)) |sr| {
+            try results.append(allocator, sr);
+        }
+        any_ran = true;
+    }
+
+    if (!any_ran) {
+        try stdout.print("no benchmark case matched '{?s}'\n", .{opts.only});
+        try listCases(stdout);
+        return;
+    }
+    try stdout.writeAll("\n");
+
+    try writeReport(allocator, results.items, stdout);
+}
+
+fn runCase(
+    allocator: std.mem.Allocator,
+    case: CaseName,
+    mode: Benchmark.RunMode,
+    w: anytype,
+) !?report.ScenarioResult {
+    if (std.mem.eql(u8, case.name, "terminal-stream")) {
+        const ts = try TerminalStream.create(allocator, .{});
+        defer ts.destroy();
+        const bench = ts.benchmark();
+        const result = try bench.run(mode);
+        const mb_per_s: f64 = blk: {
+            const bytes = @as(f64, @floatFromInt(@as(u64, result.iterations) * ts.bytesPerStep()));
+            const secs = @as(f64, @floatFromInt(result.duration)) / @as(f64, @floatFromInt(std.time.ns_per_s));
+            if (secs == 0) break :blk 0;
+            break :blk bytes / (1024.0 * 1024.0) / secs;
+        };
+        try w.print(
+            "  {s:<18} iters={d:>10}  {d:>8.2} MB/s   ({s})\n",
+            .{ case.name, result.iterations, mb_per_s, case.description },
+        );
+        const duration_ms: u64 = @intCast(@divTrunc(result.duration, std.time.ns_per_ms));
+        return .{
+            .name = try allocator.dupe(u8, case.name),
+            .unit = .throughput,
+            .value = mb_per_s,
+            .samples = result.iterations,
+            .duration_ms = duration_ms,
+        };
+    }
+    try w.print("  {s:<18} (not implemented)\n", .{case.name});
+    return null;
+}
+
+fn writeReport(
+    allocator: std.mem.Allocator,
+    results: []const report.ScenarioResult,
+    w: anytype,
+) !void {
+    const e = env.collect();
+    const rep: report.Report = .{
+        .app_version = e.app_version,
+        .os = e.os,
+        .cpu_arch = e.cpu_arch,
+        .logical_cores = e.logical_cores,
+        .runner = "cli",
+        .backend = e.backend,
+        .scenarios = results,
+        .timestamp_ms = std.time.milliTimestamp(),
+    };
+
+    const json = try report.formatJson(allocator, rep);
+    defer allocator.free(json);
+    const md = try report.formatMarkdown(allocator, rep);
+    defer allocator.free(md);
+
+    if (writeReportFiles(allocator, json, md)) |paths| {
+        try w.print("report written:\n  {s}\n  {s}\n\n", .{ paths.json_path, paths.md_path });
+        allocator.free(paths.json_path);
+        allocator.free(paths.md_path);
+    } else |_| {
+        try w.writeAll("report: could not write files to config dir; printing markdown only.\n\n");
+    }
+    // Always print the markdown so it can be pasted straight into a GitHub
+    // issue/discussion even when file writing failed.
+    try w.writeAll(md);
+}
+
+const ReportPaths = struct {
+    json_path: []u8,
+    md_path: []u8,
+};
+
+fn writeReportFiles(allocator: std.mem.Allocator, json: []const u8, md: []const u8) !ReportPaths {
+    const dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(dir);
+    std.fs.cwd().makePath(dir) catch {};
+
+    const ts = std.time.milliTimestamp();
+    const json_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.json", .{ts});
+    defer allocator.free(json_name);
+    const md_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.md", .{ts});
+    defer allocator.free(md_name);
+
+    const json_path = try std.fs.path.join(allocator, &.{ dir, json_name });
+    errdefer allocator.free(json_path);
+    const md_path = try std.fs.path.join(allocator, &.{ dir, md_name });
+    errdefer allocator.free(md_path);
+
+    try std.fs.cwd().writeFile(.{ .sub_path = json_path, .data = json });
+    try std.fs.cwd().writeFile(.{ .sub_path = md_path, .data = md });
+    return .{ .json_path = json_path, .md_path = md_path };
+}
+
+fn listCases(w: anytype) !void {
+    try w.writeAll("Available benchmark cases:\n");
+    for (all_cases) |case| {
+        try w.print("  {s:<18} {s}\n", .{ case.name, case.description });
+    }
+}
+
+fn stdoutAll(s: []const u8) !void {
+    try std.fs.File.stdout().deprecatedWriter().writeAll(s);
+}
+
+test "cli: all_cases lists terminal-stream" {
+    try std.testing.expect(all_cases.len >= 1);
+    var found = false;
+    for (all_cases) |c| {
+        if (std.mem.eql(u8, c.name, "terminal-stream")) found = true;
+    }
+    try std.testing.expect(found);
+}

--- a/src/benchmark/env.zig
+++ b/src/benchmark/env.zig
@@ -1,0 +1,33 @@
+//! Benchmark environment collection: the cross-platform scalars shared by
+//! every report (app version, OS, CPU arch, logical cores, renderer backend).
+//! GPU-adapter / window / DPI fields are filled by the in-app runner (future
+//! M2) directly into `report.Report`; this module only gathers what the
+//! `wispterm-bench` CLI can know without a window.
+//!
+//! Depends on `build_options` (app_version, gpu_backend), so it is compiled
+//! into the bench binary and the in-app benchmark, not the fast suite.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+
+pub const Env = struct {
+    app_version: []const u8,
+    os: []const u8,
+    cpu_arch: []const u8,
+    logical_cores: u32,
+    /// Renderer backend the report is about ("opengl" | "metal" | "d3d11"), or
+    /// "n/a" for the CPU-only CLI which links no GPU backend.
+    backend: []const u8,
+};
+
+pub fn collect() Env {
+    const cores = std.Thread.getCpuCount() catch 1;
+    return .{
+        .app_version = build_options.app_version,
+        .os = @tagName(builtin.os.tag),
+        .cpu_arch = @tagName(builtin.cpu.arch),
+        .logical_cores = @intCast(cores),
+        .backend = build_options.gpu_backend,
+    };
+}

--- a/src/benchmark/options.zig
+++ b/src/benchmark/options.zig
@@ -1,0 +1,135 @@
+//! wispterm-bench CLI options. Pure parse logic so it is unit-tested in the
+//! fast suite without spawning the bench binary (which links ghostty-vt).
+
+const std = @import("std");
+
+pub const Options = struct {
+    /// Per-case run mode. `duration_ms` drives a fixed-window run; 0 means the
+    /// default (a single `once` step), which is useful for smoke-checking.
+    duration_ms: u64 = 0,
+    /// If non-empty, only cases whose names match are run. Empty = run all.
+    only: ?[]const u8 = null,
+    list: bool = false,
+    help: bool = false,
+    /// Allocator the parsed `only` string is duped into, so the caller owns it.
+    allocator: std.mem.Allocator,
+    _only_owned: ?[]u8 = null,
+
+    pub fn deinit(self: *Options) void {
+        if (self._only_owned) |o| self.allocator.free(o);
+    }
+};
+
+pub const ParseError = error{
+    MissingValue,
+    InvalidDuration,
+    OutOfMemory,
+};
+
+pub fn parse(allocator: std.mem.Allocator, args: []const []const u8) ParseError!Options {
+    var opts: Options = .{ .allocator = allocator };
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (eql(arg, "--help") or eql(arg, "-h")) {
+            opts.help = true;
+        } else if (eql(arg, "--list")) {
+            opts.list = true;
+        } else if (eql(arg, "--duration")) {
+            i += 1;
+            if (i >= args.len) return error.MissingValue;
+            opts.duration_ms = parseDuration(args[i]) catch return error.InvalidDuration;
+        } else if (eql(arg, "--case")) {
+            i += 1;
+            if (i >= args.len) return error.MissingValue;
+            if (opts._only_owned) |o| allocator.free(o);
+            opts._only_owned = try allocator.dupe(u8, args[i]);
+            opts.only = opts._only_owned;
+        } else if (std.mem.startsWith(u8, arg, "--duration=")) {
+            opts.duration_ms = parseDuration(arg["--duration=".len..]) catch return error.InvalidDuration;
+        } else if (std.mem.startsWith(u8, arg, "--case=")) {
+            if (opts._only_owned) |o| allocator.free(o);
+            opts._only_owned = try allocator.dupe(u8, arg["--case=".len..]);
+            opts.only = opts._only_owned;
+        } else {
+            // Unknown args are ignored so the CLI stays forgiving; listing the
+            // known set is `--help`'s job.
+        }
+    }
+    return opts;
+}
+
+fn parseDuration(text: []const u8) !u64 {
+    return std.fmt.parseInt(u64, text, 10) catch return error.InvalidDuration;
+}
+
+fn eql(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, a, b);
+}
+
+pub const USAGE =
+    \\wispterm-bench — WispTerm CPU-side benchmark CLI (Ghostty-aligned)
+    \\
+    \\Usage:
+    \\  wispterm-bench [options]
+    \\
+    \\Options:
+    \\  --list              List available benchmark cases and exit
+    \\  --case <name>       Run only the named case (default: run all)
+    \\  --duration <ms>     Per-case run window in milliseconds (default: 1000)
+    \\  --help, -h          Show this help
+    \\
+    \\Build with:
+    \\  zig build -Demit-bench -Doptimize=ReleaseFast
+    \\
+    \\Compare branches with hyperfine; keep inputs/flags identical across runs.
+    \\
+;
+
+test "parse: defaults" {
+    var opts = try parse(std.testing.allocator, &.{});
+    defer opts.deinit();
+    try std.testing.expectEqual(@as(u64, 0), opts.duration_ms);
+    try std.testing.expect(opts.only == null);
+    try std.testing.expect(!opts.list);
+    try std.testing.expect(!opts.help);
+}
+
+test "parse: --list and --help flags" {
+    var opts = try parse(std.testing.allocator, &.{ "--list", "--help" });
+    defer opts.deinit();
+    try std.testing.expect(opts.list);
+    try std.testing.expect(opts.help);
+}
+
+test "parse: --duration accepts integer milliseconds" {
+    var opts = try parse(std.testing.allocator, &.{ "--duration", "250" });
+    defer opts.deinit();
+    try std.testing.expectEqual(@as(u64, 250), opts.duration_ms);
+}
+
+test "parse: --duration=eq form" {
+    var opts = try parse(std.testing.allocator, &.{"--duration=500"});
+    defer opts.deinit();
+    try std.testing.expectEqual(@as(u64, 500), opts.duration_ms);
+}
+
+test "parse: --case dups name into owned storage" {
+    var opts = try parse(std.testing.allocator, &.{ "--case", "terminal-stream" });
+    defer opts.deinit();
+    try std.testing.expectEqualStrings("terminal-stream", opts.only.?);
+}
+
+test "parse: missing --duration value returns MissingValue" {
+    try std.testing.expectError(error.MissingValue, parse(std.testing.allocator, &.{"--duration"}));
+}
+
+test "parse: non-numeric duration returns InvalidDuration" {
+    try std.testing.expectError(error.InvalidDuration, parse(std.testing.allocator, &.{ "--duration", "abc" }));
+}
+
+test "parse: unknown args are ignored, not fatal" {
+    var opts = try parse(std.testing.allocator, &.{ "--bogus", "--duration", "10" });
+    defer opts.deinit();
+    try std.testing.expectEqual(@as(u64, 10), opts.duration_ms);
+}

--- a/src/benchmark/report.zig
+++ b/src/benchmark/report.zig
@@ -1,0 +1,279 @@
+//! Performance benchmark report schema + JSON/Markdown formatters.
+//!
+//! Pure formatter module: takes a `Report` value the caller assembles (env
+//! fields + per-scenario results) and renders a machine-readable JSON blob and
+//! a paste-ready GitHub Markdown table. No build_options or platform deps, so
+//! it unit-tests in the fast suite. The in-app GPU benchmark (future M2) and
+//! the `wispterm-bench` CLI both feed the same `Report` shape, so reports from
+//! different machines and backends stay comparable.
+//!
+//! Field philosophy: optional in-app/GPU fields (`gpu_adapter`, `window`,
+//! `dpi`, `grid`) are `?`-typed so a CLI run leaves them null and the formatter
+//! omits them, while a future in-app run fills them. The shared scalar fields
+//! (version, os, backend, cpu) are always present.
+
+const std = @import("std");
+
+pub const ScenarioUnit = enum {
+    /// Per-second throughput (MB/s, iterations/s). `value` is the rate.
+    throughput,
+    /// Latency / frame time in nanoseconds. `p50`/`p95`/`max` apply.
+    latency_ns,
+
+    pub fn name(self: ScenarioUnit) []const u8 {
+        return switch (self) {
+            .throughput => "throughput",
+            .latency_ns => "latency_ns",
+        };
+    }
+};
+
+pub const ScenarioResult = struct {
+    name: []const u8,
+    unit: ScenarioUnit,
+    /// For throughput: the rate (MB/s etc.). For latency: mean frame ns.
+    value: f64,
+    /// Latency-only percentiles in ns; ignored for throughput.
+    p50_ns: i64 = 0,
+    p95_ns: i64 = 0,
+    max_ns: i64 = 0,
+    /// Wall-clock frames/iterations observed.
+    samples: usize = 0,
+    /// Run window in ms.
+    duration_ms: u64 = 0,
+};
+
+pub const WindowInfo = struct {
+    width_px: u32,
+    height_px: u32,
+    grid_cols: u32,
+    grid_rows: u32,
+    dpi: u32,
+};
+
+pub const GpuInfo = struct {
+    /// "opengl" | "metal" | "d3d11" — the active renderer backend.
+    backend: []const u8,
+    /// Adapter/device description (DXGI description or Metal device name).
+    adapter: []const u8,
+    /// DXGI vendor id (Windows); 0 when not applicable.
+    vendor_id: u32 = 0,
+    device_id: u32 = 0,
+};
+
+pub const Report = struct {
+    app_version: []const u8,
+    os: []const u8,
+    cpu_arch: []const u8,
+    logical_cores: u32,
+    /// "cli" for wispterm-bench, "in-app" for the future --benchmark mode.
+    runner: []const u8,
+    /// Always present (CLI derives it from build options; in-app from gpu.zig).
+    backend: []const u8,
+    gpu: ?GpuInfo = null,
+    window: ?WindowInfo = null,
+    scenarios: []const ScenarioResult = &.{},
+    /// ISO-8601-ish timestamp the caller stamps (keeps this module pure/clockless).
+    timestamp_ms: i64 = 0,
+};
+
+/// Render the report as a single-line JSON object (deterministic field order).
+pub fn formatJson(allocator: std.mem.Allocator, r: Report) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    var w = buf.writer(allocator);
+    try w.writeAll("{");
+    try writeJsonField(&w, "app_version", r.app_version);
+    try w.writeAll(",");
+    try writeJsonField(&w, "os", r.os);
+    try w.writeAll(",");
+    try writeJsonField(&w, "cpu_arch", r.cpu_arch);
+    try w.print(",\"logical_cores\":{d}", .{r.logical_cores});
+    try w.writeAll(",");
+    try writeJsonField(&w, "runner", r.runner);
+    try w.writeAll(",");
+    try writeJsonField(&w, "backend", r.backend);
+    try w.print(",\"timestamp_ms\":{d}", .{r.timestamp_ms});
+
+    if (r.gpu) |g| {
+        try w.writeAll(",\"gpu\":{");
+        try writeJsonField(&w, "backend", g.backend);
+        try w.writeAll(",");
+        try writeJsonField(&w, "adapter", g.adapter);
+        try w.print(",\"vendor_id\":{d},\"device_id\":{d}}}", .{ g.vendor_id, g.device_id });
+    }
+    if (r.window) |win| {
+        try w.print(",\"window\":{{\"width_px\":{d},\"height_px\":{d},\"grid_cols\":{d},\"grid_rows\":{d},\"dpi\":{d}}}", .{
+            win.width_px, win.height_px, win.grid_cols, win.grid_rows, win.dpi,
+        });
+    }
+
+    try w.writeAll(",\"scenarios\":[");
+    for (r.scenarios, 0..) |s, i| {
+        if (i > 0) try w.writeAll(",");
+        try w.writeAll("{");
+        try writeJsonField(&w, "name", s.name);
+        try w.writeAll(",");
+        try writeJsonField(&w, "unit", s.unit.name());
+        try w.print(",\"value\":{d}", .{s.value});
+        if (s.unit == .latency_ns) {
+            try w.print(",\"p50_ns\":{d},\"p95_ns\":{d},\"max_ns\":{d}", .{ s.p50_ns, s.p95_ns, s.max_ns });
+        }
+        try w.print(",\"samples\":{d},\"duration_ms\":{d}}}", .{ s.samples, s.duration_ms });
+    }
+    try w.writeAll("]}");
+
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Render a paste-ready GitHub Markdown summary (key=value table + scenario
+/// table). Designed to be readable in an issue/comment.
+pub fn formatMarkdown(allocator: std.mem.Allocator, r: Report) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    var w = buf.writer(allocator);
+    try w.print("## WispTerm performance report\n\n", .{});
+    try w.print("- **version:** {s}\n", .{r.app_version});
+    try w.print("- **os:** {s}\n", .{r.os});
+    try w.print("- **cpu:** {s} ({d} cores)\n", .{ r.cpu_arch, r.logical_cores });
+    try w.print("- **backend:** {s}\n", .{r.backend});
+    try w.print("- **runner:** {s}\n", .{r.runner});
+    if (r.gpu) |g| {
+        try w.print("- **gpu:** {s} — {s}", .{ g.backend, g.adapter });
+        if (g.vendor_id != 0) try w.print(" (vendor={d}, device={d})", .{ g.vendor_id, g.device_id });
+        try w.writeAll("\n");
+    }
+    if (r.window) |win| {
+        try w.print("- **window:** {d}x{d} @ {d} DPI, grid {d}x{d}\n", .{
+            win.width_px, win.height_px, win.dpi, win.grid_cols, win.grid_rows,
+        });
+    }
+    try w.writeAll("\n| scenario | unit | value | p50 | p95 | max | samples | duration_ms |\n");
+    try w.writeAll("|---|---|---|---|---|---|---|---|\n");
+    for (r.scenarios) |s| {
+        const p50 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p50_ns}) else try allocator.dupe(u8, "—");
+        defer allocator.free(p50);
+        const p95 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p95_ns}) else try allocator.dupe(u8, "—");
+        defer allocator.free(p95);
+        const mx = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.max_ns}) else try allocator.dupe(u8, "—");
+        defer allocator.free(mx);
+        try w.print("| {s} | {s} | {d:.2} | {s} | {s} | {s} | {d} | {d} |\n", .{
+            s.name, s.unit.name(), s.value, p50, p95, mx, s.samples, s.duration_ms,
+        });
+    }
+
+    return buf.toOwnedSlice(allocator);
+}
+
+fn writeJsonField(w: anytype, key: []const u8, value: []const u8) !void {
+    try w.print("\"{s}\":", .{key});
+    try writeJsonString(w, value);
+}
+
+fn writeJsonString(w: anytype, s: []const u8) !void {
+    try w.writeAll("\"");
+    for (s) |c| {
+        switch (c) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            0...8, 11, 12, 14...31 => try w.print("\\u{x:0>4}", .{c}),
+            else => try w.writeByte(c),
+        }
+    }
+    try w.writeAll("\"");
+}
+
+test "report: JSON includes shared scalars and omits null gpu/window" {
+    const allocator = std.testing.allocator;
+    const scenarios = [_]ScenarioResult{
+        .{ .name = "terminal-stream", .unit = .throughput, .value = 56.2, .samples = 900, .duration_ms = 1000 },
+    };
+    const r: Report = .{
+        .app_version = "1.31.0",
+        .os = "windows",
+        .cpu_arch = "x86_64",
+        .logical_cores = 8,
+        .runner = "cli",
+        .backend = "opengl",
+        .scenarios = &scenarios,
+        .timestamp_ms = 1234,
+    };
+    const json = try formatJson(allocator, r);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.31.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"logical_cores\":8") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"backend\":\"opengl\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"runner\":\"cli\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"value\":56.2") != null);
+    // No gpu/window keys when null.
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"gpu\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"window\"") == null);
+}
+
+test "report: JSON includes gpu/window when filled and latency percentiles" {
+    const allocator = std.testing.allocator;
+    const scenarios = [_]ScenarioResult{
+        .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
+    };
+    const r: Report = .{
+        .app_version = "1.31.0",
+        .os = "macos",
+        .cpu_arch = "aarch64",
+        .logical_cores = 10,
+        .runner = "in-app",
+        .backend = "metal",
+        .gpu = .{ .backend = "metal", .adapter = "Apple M2", .vendor_id = 0, .device_id = 0 },
+        .window = .{ .width_px = 1280, .height_px = 800, .grid_cols = 120, .grid_rows = 40, .dpi = 144 },
+        .scenarios = &scenarios,
+    };
+    const json = try formatJson(allocator, r);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"gpu\":{\"backend\":\"metal\",\"adapter\":\"Apple M2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"window\":{\"width_px\":1280") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"p50_ns\":900000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"unit\":\"latency_ns\"") != null);
+}
+
+test "report: Markdown renders header, env, and scenario table" {
+    const allocator = std.testing.allocator;
+    const scenarios = [_]ScenarioResult{
+        .{ .name = "terminal-stream", .unit = .throughput, .value = 56.2, .samples = 900, .duration_ms = 1000 },
+        .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
+    };
+    const r: Report = .{
+        .app_version = "1.31.0",
+        .os = "windows",
+        .cpu_arch = "x86_64",
+        .logical_cores = 8,
+        .runner = "cli",
+        .backend = "d3d11",
+        .scenarios = &scenarios,
+    };
+    const md = try formatMarkdown(allocator, r);
+    defer allocator.free(md);
+    try std.testing.expect(std.mem.indexOf(u8, md, "## WispTerm performance report") != null);
+    try std.testing.expect(std.mem.indexOf(u8, md, "**backend:** d3d11") != null);
+    try std.testing.expect(std.mem.indexOf(u8, md, "terminal-stream") != null);
+    try std.testing.expect(std.mem.indexOf(u8, md, "scroll_flood") != null);
+    try std.testing.expect(std.mem.indexOf(u8, md, "900000 ns") != null);
+}
+
+test "report: JSON escapes quotes/backslashes in string fields" {
+    const allocator = std.testing.allocator;
+    const r: Report = .{
+        .app_version = "1.0",
+        .os = "win\"dows\\x",
+        .cpu_arch = "x86_64",
+        .logical_cores = 1,
+        .runner = "cli",
+        .backend = "opengl",
+    };
+    const json = try formatJson(allocator, r);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"os\":\"win\\\"dows\\\\x\"") != null);
+}

--- a/src/benchmark/stats.zig
+++ b/src/benchmark/stats.zig
@@ -1,0 +1,116 @@
+//! Benchmark statistics: nearest-rank percentiles over a caller-owned sample
+//! slice, plus a throughput helper. Complements `src/appwindow/frame_latency.zig`
+//! (which keeps a rolling ring buffer for live frame-latency probes): bench
+//! cases instead collect a fixed sample set per run and summarize it once, so
+//! this module takes the samples by reference rather than owning them.
+//!
+//! Zero project dependencies (std only) so it runs in the fast suite.
+
+const std = @import("std");
+
+pub const Summary = struct {
+    count: usize,
+    /// All latency/time fields are caller-defined units (typically ns). The
+    /// module is unit-agnostic; callers label the units in their reports.
+    p50: i64,
+    p95: i64,
+    max: i64,
+    min: i64,
+    mean: i64,
+};
+
+/// Compute a summary over `samples` (caller-owned). The slice is copied into a
+/// stack-backed temp via `sort_buf` so the caller's input order is preserved.
+/// `sort_buf` must be at least `samples.len` long.
+pub fn summaryWithBuf(samples: []const i64, sort_buf: []i64) Summary {
+    if (samples.len == 0) return .{ .count = 0, .p50 = 0, .p95 = 0, .max = 0, .min = 0, .mean = 0 };
+    @memcpy(sort_buf[0..samples.len], samples);
+    std.mem.sort(i64, sort_buf[0..samples.len], {}, std.sort.asc(i64));
+
+    var sum: i64 = 0;
+    var maxv: i64 = sort_buf[0];
+    var minv: i64 = sort_buf[0];
+    for (samples) |s| {
+        sum += s;
+        if (s > maxv) maxv = s;
+        if (s < minv) minv = s;
+    }
+    const mean = @divTrunc(sum, @as(i64, @intCast(samples.len)));
+    return .{
+        .count = samples.len,
+        .p50 = percentileSorted(sort_buf[0..samples.len], 50),
+        .p95 = percentileSorted(sort_buf[0..samples.len], 95),
+        .max = maxv,
+        .min = minv,
+        .mean = mean,
+    };
+}
+
+/// Convenience for small fixed-size sample sets. For large sets use
+/// `summaryWithBuf` with a caller-provided buffer to avoid the fixed cap.
+pub fn summaryFixed(samples: []const i64) Summary {
+    var buf: [4096]i64 = undefined;
+    if (samples.len > buf.len) {
+        // Fall back to summarizing only the first buf.len samples; callers
+        // with larger sets should use summaryWithBuf.
+        return summaryWithBuf(samples[0..buf.len], &buf);
+    }
+    return summaryWithBuf(samples, &buf);
+}
+
+/// Nearest-rank percentile of an ascending-sorted slice, p ∈ [1,100].
+/// rank = ceil(p*n/100), clamped to [1,n]. Matches `frame_latency.percentile`.
+pub fn percentileSorted(sorted: []const i64, p: u8) i64 {
+    if (sorted.len == 0) return 0;
+    const n = sorted.len;
+    const num = @as(usize, p) * n;
+    var rank = num / 100;
+    if (num % 100 != 0) rank += 1; // ceil
+    if (rank == 0) rank = 1;
+    if (rank > n) rank = n;
+    return sorted[rank - 1];
+}
+
+test "stats: empty sample set yields zero summary" {
+    const s = summaryFixed(&.{});
+    try std.testing.expectEqual(@as(usize, 0), s.count);
+    try std.testing.expectEqual(@as(i64, 0), s.max);
+}
+
+test "stats: nearest-rank p50/p95 over 1..10" {
+    var samples: [10]i64 = undefined;
+    for (0..10) |i| samples[i] = @intCast(i + 1);
+    const s = summaryFixed(&samples);
+    try std.testing.expectEqual(@as(usize, 10), s.count);
+    // sorted 1..10: p50 rank=ceil(5)=5 → 5; p95 rank=ceil(9.5)=10 → 10
+    try std.testing.expectEqual(@as(i64, 5), s.p50);
+    try std.testing.expectEqual(@as(i64, 10), s.p95);
+    try std.testing.expectEqual(@as(i64, 10), s.max);
+    try std.testing.expectEqual(@as(i64, 1), s.min);
+    try std.testing.expectEqual(@as(i64, 5), s.mean); // (1+..+10)/10 = 5.5 → 5
+}
+
+test "stats: preserves caller input order (summaryWithBuf copies)" {
+    var samples = [_]i64{ 30, 10, 20 };
+    const before = samples;
+    _ = summaryFixed(&samples);
+    try std.testing.expectEqualSlices(i64, &before, &samples);
+}
+
+test "stats: percentileSorted boundary ranks" {
+    const data = [_]i64{ 10, 20, 30, 40 };
+    try std.testing.expectEqual(@as(i64, 10), percentileSorted(&data, 1));
+    try std.testing.expectEqual(@as(i64, 20), percentileSorted(&data, 50));
+    try std.testing.expectEqual(@as(i64, 40), percentileSorted(&data, 100));
+}
+
+test "stats: single sample" {
+    const samples = [_]i64{42};
+    const s = summaryFixed(&samples);
+    try std.testing.expectEqual(@as(usize, 1), s.count);
+    try std.testing.expectEqual(@as(i64, 42), s.p50);
+    try std.testing.expectEqual(@as(i64, 42), s.p95);
+    try std.testing.expectEqual(@as(i64, 42), s.max);
+    try std.testing.expectEqual(@as(i64, 42), s.min);
+    try std.testing.expectEqual(@as(i64, 42), s.mean);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -311,6 +311,14 @@ test {
     _ = @import("notification.zig");
     _ = @import("clipboard_osc52.zig");
     _ = @import("renderer/gpu/backend.zig");
+    // Performance benchmark core (pure modules). cli.zig is excluded here
+    // because it pulls in TerminalStream → ghostty-vt, which the lean fast
+    // suite does not link; the cli module's tests run via the wispterm-bench
+    // binary and test-full.
+    _ = @import("benchmark/Benchmark.zig");
+    _ = @import("benchmark/stats.zig");
+    _ = @import("benchmark/options.zig");
+    _ = @import("benchmark/report.zig");
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");
     _ = @import("assistant/conversation/layout.zig");

--- a/src/wispterm_bench.zig
+++ b/src/wispterm_bench.zig
@@ -1,0 +1,19 @@
+//! wispterm-bench — standalone CPU-side benchmark CLI.
+//!
+//! Build with `zig build -Demit-bench -Doptimize=ReleaseFast` (mirrors Ghostty's
+//! `zig build -Demit-bench`). Deliberately a separate artifact, not part of the
+//! default install or app packaging: it links ghostty-vt for the TerminalStream
+//! case and is intended for branch-to-branch performance comparisons.
+const std = @import("std");
+const cli = @import("benchmark/cli.zig");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    try cli.run(allocator, args[1..]);
+}


### PR DESCRIPTION
## Summary

- Adds `wispterm-bench`, a standalone Ghostty-aligned CPU-side benchmark CLI (`zig build -Demit-bench -Doptimize=ReleaseFast`) that links `ghostty-vt` and drives a synthetic VT byte stream through the same parser the shipped app uses, producing comparable throughput numbers (MB/s) across branches and machines.
- New `src/benchmark/` feature domain: `Benchmark.zig` vtable runner (mirrors Ghostty's `RunMode`/`RunResult`), `stats.zig` nearest-rank percentiles, `TerminalStream.zig` VT-stream case, `options.zig` CLI parsing, `report.zig` JSON/Markdown report schema (reserves GPU/window/DPI fields for a future in-app GPU mode), and `env.zig` cross-platform environment collection.
- `build.zig` wires `-Demit-bench` + `bench`/`test-bench` steps (off by default; `test-bench` is separate from `test-full` so it does not slow the pre-merge gate) and a build-contract test, via a shared `createBenchModule` helper that attaches `ghostty-vt` + `stb`.
- Community sharing: a `performance_report` GitHub issue template and a `docs/development.md` "Performance Benchmarking" section (build/run/share instructions + release-baseline note). The CLI writes a JSON + paste-ready Markdown report to the config dir and prints the Markdown to stdout.

## Why

WispTerm lacked a quantifiable performance metric for cross-platform/cross-hardware comparison. This gives release-time local baselines and lets users share results via GitHub issues so we can see how WispTerm performs across different machines and renderer backends — directly relevant to the ongoing native D3D11 work, where an OpenGL-vs-D3D11 same-machine A/B will inform the default-backend switch.

## Test plan

- [x] `zig build test` (fast suite) — pure benchmark modules (`Benchmark.zig`, `stats.zig`, `options.zig`, `report.zig`) added to `test_fast.zig`; passes (exit 0).
- [x] `zig build test-bench` — `ghostty-vt`-linked modules (`TerminalStream.zig`, `cli.zig`) compile and pass (exit 0).
- [x] Build contract test for `wispterm-bench` declared in `build.zig`.
- [x] No guarded integration/session files (`AppWindow.zig`, `input.zig`, `overlays.zig`, `assistant/conversation/session`) touched.
- [ ] Reviewer: run `zig build -Demit-bench -Doptimize=ReleaseFast` and `.\zig-out\bin\wispterm-bench.exe --case terminal-stream --duration 1000` to confirm the CLI produces a Markdown report on your machine.
