### PR TITLE
[codex] report d3d11 environment diagnostics

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -961,6 +961,8 @@ try {
             $diagText -match "adapter=unknown"
         )
     )
+    $hasD3D11Environment = $diagText -match "gpu-backend=d3d11 environment .*vendor_id=0x[0-9a-fA-F]+.*device_id=0x[0-9a-fA-F]+.*subsys_id=0x[0-9a-fA-F]+.*revision=[0-9]+.*dedicated_video_memory=[0-9]+.*dedicated_system_memory=[0-9]+.*shared_system_memory=[0-9]+.*adapter_flags=0x[0-9a-fA-F]+.*output_count=[0-9]+.*feature_level=([0-9_]+|unknown).*swap_effect=flip_discard"
+    $hasWindowsEnvironment = $diagText -match "windows-environment remote_session=(true|false) session_id=[0-9]+ monitor_count=[0-9]+ mixed_dpi=(true|false) primary_dpi=[0-9]+x[0-9]+ system_dpi=[0-9]+"
     $hasD3D11PolicyHealthy = $diagText -match "gpu-backend=d3d11 present=dxgi .*policy_state=healthy.*fallback_candidate=false"
     $hasD3D11RecoveryRequested = $diagText -match "gpu-backend=d3d11 recovery requested"
     $hasD3D11RecreateSmokeRequest = $diagText -match "d3d11-recreate-smoke requested device recreate"
@@ -985,9 +987,9 @@ try {
         (!$hasD3D11FallbackMarkerSmoke -and !$hasD3D11FallbackMarkerState)
     }
     $backendExpectation = if ($isD3D11Backend) {
-        ($hasD3D11Present -and $hasD3D11InitDetails -and $hasD3D11PolicyHealthy)
+        ($hasD3D11Present -and $hasD3D11InitDetails -and $hasD3D11Environment -and $hasWindowsEnvironment -and $hasD3D11PolicyHealthy)
     } else {
-        ($hasOpenGLBackend -and $hasOpenGLHostPresent -and !$hasD3D11Present -and !$hasD3D11InitDetails -and !$hasD3D11PolicyHealthy)
+        ($hasOpenGLBackend -and $hasOpenGLHostPresent -and $hasWindowsEnvironment -and !$hasD3D11Present -and !$hasD3D11InitDetails -and !$hasD3D11Environment -and !$hasD3D11PolicyHealthy)
     }
     $probeExpectation = if ($isD3D11Backend) {
         ($hasUiProbe -and $hasOffscreen)
@@ -1175,6 +1177,8 @@ try {
             opengl_host_present = [bool]$hasOpenGLHostPresent
             d3d11_present = [bool]$hasD3D11Present
             d3d11_init_details = [bool]$hasD3D11InitDetails
+            d3d11_environment = [bool]$hasD3D11Environment
+            windows_environment = [bool]$hasWindowsEnvironment
             d3d11_policy_healthy = [bool]$hasD3D11PolicyHealthy
             d3d11_resize_events = $d3d11ResizeEventCount
             d3d11_rapid_resize_diagnostics = [bool]$rapidResizeDiagnostic

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,6 +176,10 @@ screenshots, writes JSON metrics under
 `zig-out\d3d11-normal-session-smoke\`, and verifies that
 `render-diagnostic.log` contains `gpu-backend=d3d11 present=dxgi`, D3D11 init
 details for swap effect / adapter / fallback reason / healthy policy state, a
+D3D11 environment line for adapter description, vendor/device/subsystem,
+revision, memory sizes, output count, feature level, and swap effect, a Win32
+environment line for remote session, session id, monitor count, mixed-DPI state,
+primary DPI, and system DPI, a
 successful `d3d11-ui-smoke` probe, an offscreen round-trip marker, and no D3D11
 recovery request in the healthy path. It is a Phase IV and Phase V
 diagnostics/policy/recovery-coordination evidence tool only; it does not change

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -87,6 +87,13 @@ explorer, previews, assistant panel, command palette, startup shortcuts,
 Settings, Skill Center, and background image rendering while verifying
 `gpu-backend=opengl` diagnostics and the absence of D3D11 recovery/probe/marker
 activity.
+D3D11 environment diagnostics are now collected on startup: the backend logs
+adapter description, vendor/device/subsystem/revision, dedicated/shared memory,
+adapter flags, output count, feature level, and swap effect, while the Win32
+host logs remote-session state, process session id, monitor count, mixed-DPI
+state, primary DPI, and system DPI. The normal-session smoke verifies both
+lines so later RDP/VM/hybrid-GPU/multi-monitor matrix runs have a stable JSON
+and log surface.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
@@ -134,6 +141,11 @@ Add `-Backend opengl` after a default `zig build` to run the OpenGL fallback
 normal-session smoke. This is the Phase V proof that the compatibility renderer
 still supports the same core user-visible workflow on the native-render
 integration branch.
+
+The D3D11 normal-session smoke also gates the environment-diagnostics surface:
+`d3d11_environment` and `windows_environment` must be true in the emitted JSON.
+This still only reports and verifies environment facts; it does not classify or
+block any environment yet.
 
 ## Ghostty Comparison
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -536,6 +536,7 @@ const WAIT_TIMEOUT: DWORD = 0x00000102;
 const INFINITE: DWORD = 0xFFFFFFFF;
 
 extern "kernel32" fn GetCurrentProcessId() callconv(.winapi) DWORD;
+extern "kernel32" fn ProcessIdToSessionId(dwProcessId: DWORD, pSessionId: *DWORD) callconv(.winapi) BOOL;
 extern "kernel32" fn SetHandleInformation(hObject: windows.HANDLE, dwMask: DWORD, dwFlags: DWORD) callconv(.winapi) BOOL;
 
 extern "kernel32" fn CreatePipe(
@@ -723,6 +724,7 @@ extern "user32" fn GetSystemMetrics(nIndex: INT) callconv(.winapi) INT;
 const SM_CXSIZEFRAME: INT = 32;
 const SM_CYSIZEFRAME: INT = 33;
 const SM_CXPADDEDBORDER: INT = 92;
+const SM_REMOTESESSION: INT = 0x1000;
 
 // IsZoomed (maximized check)
 extern "user32" fn IsZoomed(hWnd: HWND) callconv(.winapi) BOOL;
@@ -1389,15 +1391,43 @@ fn currentSystemDpi() u32 {
     return if (dpi == 0) 96 else dpi;
 }
 
+const MonitorTopologySummary = struct {
+    count: u32 = 0,
+    primary_dpi_x: UINT = 0,
+    primary_dpi_y: UINT = 0,
+    first_dpi_x: UINT = 0,
+    first_dpi_y: UINT = 0,
+    mixed_dpi: bool = false,
+
+    fn note(self: *MonitorTopologySummary, primary: bool, dx: UINT, dy: UINT) void {
+        if (self.count == 0) {
+            self.first_dpi_x = dx;
+            self.first_dpi_y = dy;
+        } else if (dx != self.first_dpi_x or dy != self.first_dpi_y) {
+            self.mixed_dpi = true;
+        }
+        if (primary) {
+            self.primary_dpi_x = dx;
+            self.primary_dpi_y = dy;
+        }
+        self.count += 1;
+    }
+};
+
 /// EnumDisplayMonitors callback: log every monitor's bounds + effective DPI.
 /// Used to record the full multi-monitor topology when diagnostics start, so
 /// the high-vs-low DPI pair behind drag-between-monitors glitches is visible.
-fn logMonitorEnumProc(hmon: HMONITOR, _: ?HDC, _: *RECT, _: LPARAM) callconv(.winapi) BOOL {
+fn logMonitorEnumProc(hmon: HMONITOR, _: ?HDC, _: *RECT, data: LPARAM) callconv(.winapi) BOOL {
     var mi = MONITORINFO{};
     if (GetMonitorInfoW(hmon, &mi) == 0) return 1;
     var dx: UINT = 0;
     var dy: UINT = 0;
     _ = GetDpiForMonitor(hmon, MDT_EFFECTIVE_DPI, &dx, &dy);
+    const primary = (mi.dwFlags & 1) != 0; // MONITORINFOF_PRIMARY
+    if (data != 0) {
+        const summary: *MonitorTopologySummary = @ptrFromInt(@as(usize, @intCast(data)));
+        summary.note(primary, dx, dy);
+    }
     render_diagnostics.log(
         "monitor-enum rcMonitor=({},{} {}x{}) rcWork=({},{} {}x{}) dpi={}x{} primary={}",
         .{
@@ -1406,7 +1436,7 @@ fn logMonitorEnumProc(hmon: HMONITOR, _: ?HDC, _: *RECT, _: LPARAM) callconv(.wi
             mi.rcWork.left,                         mi.rcWork.top,
             mi.rcWork.right - mi.rcWork.left,       mi.rcWork.bottom - mi.rcWork.top,
             dx,                                     dy,
-            (mi.dwFlags & 1) != 0, // MONITORINFOF_PRIMARY
+            primary,
         },
     );
     return 1;
@@ -1416,7 +1446,22 @@ fn logMonitorEnumProc(hmon: HMONITOR, _: ?HDC, _: *RECT, _: LPARAM) callconv(.wi
 /// diagnostics are enabled.
 pub fn logDisplayTopology() void {
     if (!render_diagnostics.enabled()) return;
-    _ = EnumDisplayMonitors(null, null, &logMonitorEnumProc, 0);
+    var summary = MonitorTopologySummary{};
+    _ = EnumDisplayMonitors(null, null, &logMonitorEnumProc, @intCast(@intFromPtr(&summary)));
+    var session_id: DWORD = 0;
+    const have_session_id = ProcessIdToSessionId(GetCurrentProcessId(), &session_id) != 0;
+    render_diagnostics.log(
+        "windows-environment remote_session={} session_id={} monitor_count={} mixed_dpi={} primary_dpi={}x{} system_dpi={}",
+        .{
+            GetSystemMetrics(SM_REMOTESESSION) != 0,
+            if (have_session_id) session_id else 0,
+            summary.count,
+            summary.mixed_dpi,
+            summary.primary_dpi_x,
+            summary.primary_dpi_y,
+            currentSystemDpi(),
+        },
+    );
 }
 
 /// Log the monitor the given window currently sits on, tagged with `tag`

--- a/src/platform/dxgi_core.zig
+++ b/src/platform/dxgi_core.zig
@@ -211,6 +211,7 @@ pub fn hresultBits(value: HRESULT) u32 {
 
 pub const S_OK: HRESULT = 0;
 pub const DXGI_ERROR_INVALID_CALL: HRESULT = hresult(0x887A0001);
+pub const DXGI_ERROR_NOT_FOUND: HRESULT = hresult(0x887A0002);
 pub const DXGI_ERROR_DEVICE_REMOVED: HRESULT = hresult(0x887A0005);
 pub const DXGI_ERROR_DEVICE_HUNG: HRESULT = hresult(0x887A0006);
 pub const DXGI_ERROR_DEVICE_RESET: HRESULT = hresult(0x887A0007);
@@ -234,6 +235,13 @@ pub const D3D_DRIVER_TYPE_UNKNOWN: u32 = 0;
 pub const D3D_DRIVER_TYPE_HARDWARE: u32 = 1;
 pub const D3D11_SDK_VERSION: u32 = 7;
 pub const D3D11_CREATE_DEVICE_BGRA_SUPPORT: u32 = 0x20;
+pub const D3D_FEATURE_LEVEL_9_1: u32 = 0x9100;
+pub const D3D_FEATURE_LEVEL_9_2: u32 = 0x9200;
+pub const D3D_FEATURE_LEVEL_9_3: u32 = 0x9300;
+pub const D3D_FEATURE_LEVEL_10_0: u32 = 0xa000;
+pub const D3D_FEATURE_LEVEL_10_1: u32 = 0xa100;
+pub const D3D_FEATURE_LEVEL_11_0: u32 = 0xb000;
+pub const D3D_FEATURE_LEVEL_11_1: u32 = 0xb100;
 pub const D3D11_USAGE_DEFAULT: u32 = 0;
 pub const D3D11_USAGE_STAGING: u32 = 3;
 pub const D3D11_USAGE_DYNAMIC: u32 = 2;
@@ -297,6 +305,19 @@ pub fn dxgiFailureRequiresDeviceRecreate(hr: HRESULT) bool {
 pub fn dxgiSwapEffectName(value: u32) []const u8 {
     return switch (value) {
         DXGI_SWAP_EFFECT_FLIP_DISCARD => "flip_discard",
+        else => "unknown",
+    };
+}
+
+pub fn d3dFeatureLevelName(value: u32) []const u8 {
+    return switch (value) {
+        D3D_FEATURE_LEVEL_9_1 => "9_1",
+        D3D_FEATURE_LEVEL_9_2 => "9_2",
+        D3D_FEATURE_LEVEL_9_3 => "9_3",
+        D3D_FEATURE_LEVEL_10_0 => "10_0",
+        D3D_FEATURE_LEVEL_10_1 => "10_1",
+        D3D_FEATURE_LEVEL_11_0 => "11_0",
+        D3D_FEATURE_LEVEL_11_1 => "11_1",
         else => "unknown",
     };
 }
@@ -461,6 +482,7 @@ pub const slot = struct {
 
     // IDXGIAdapter1 (IDXGIObject + EnumOutputs(7) GetDesc(8)
     // CheckInterfaceSupport(9) → GetDesc1(10))
+    pub const DXGIAdapter1_EnumOutputs: usize = 7;
     pub const DXGIAdapter1_GetDesc1: usize = 10;
 
     // IDXGIDeviceSubObject: GetDevice(7)
@@ -723,6 +745,10 @@ test "DXGI HRESULT failure classification names device loss signals" {
     try std.testing.expect(dxgiFailureRequiresDeviceRecreate(DXGI_ERROR_DEVICE_RESET));
     try std.testing.expect(!dxgiFailureRequiresDeviceRecreate(DXGI_ERROR_INVALID_CALL));
     try std.testing.expectEqualStrings("flip_discard", dxgiSwapEffectName(DXGI_SWAP_EFFECT_FLIP_DISCARD));
+    try std.testing.expectEqual(@as(u32, 0x887A0002), hresultBits(DXGI_ERROR_NOT_FOUND));
+    try std.testing.expectEqualStrings("11_0", d3dFeatureLevelName(D3D_FEATURE_LEVEL_11_0));
+    try std.testing.expectEqualStrings("11_1", d3dFeatureLevelName(D3D_FEATURE_LEVEL_11_1));
+    try std.testing.expectEqualStrings("unknown", d3dFeatureLevelName(0));
 }
 
 test "D3D11_TEXTURE2D_DESC matches the documented 44-byte layout" {

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -130,6 +130,7 @@ const State = struct {
     vertex_shader: ?*anyopaque = null,
     pixel_shader: ?*anyopaque = null,
     adapter: AdapterInfo = .{},
+    feature_level: u32 = 0,
     policy: present_policy.Policy,
     width: i32,
     height: i32,
@@ -195,11 +196,26 @@ const GlTable = @import("GlTable.zig").GlTable;
 
 const AdapterInfo = struct {
     available: bool = false,
+    description: [128]u16 = [_]u16{0} ** 128,
     vendor_id: u32 = 0,
     device_id: u32 = 0,
+    sub_sys_id: u32 = 0,
+    revision: u32 = 0,
+    dedicated_video_memory: usize = 0,
+    dedicated_system_memory: usize = 0,
+    shared_system_memory: usize = 0,
     luid_low: u32 = 0,
     luid_high: i32 = 0,
     flags: u32 = 0,
+    output_count: u32 = 0,
+
+    fn descriptionUtf8(self: *const AdapterInfo, buf: []u8) []const u8 {
+        if (!self.available or buf.len == 0) return "";
+        const end = std.mem.indexOfScalar(u16, &self.description, 0) orelse self.description.len;
+        if (end == 0) return "";
+        const written = std.unicode.utf16LeToUtf8(buf, self.description[0..end]) catch return "unavailable";
+        return buf[0..written];
+    }
 };
 
 const SwapchainCreateResult = struct {
@@ -236,6 +252,7 @@ fn createStateForWindow(hwnd: HWND, width: i32, height: i32) InitError!State {
 
     var device: ?*anyopaque = null;
     var context: ?*anyopaque = null;
+    var feature_level: u32 = 0;
     if (create_device(
         null,
         core.D3D_DRIVER_TYPE_HARDWARE,
@@ -245,7 +262,7 @@ fn createStateForWindow(hwnd: HWND, width: i32, height: i32) InitError!State {
         0,
         core.D3D11_SDK_VERSION,
         &device,
-        null,
+        &feature_level,
         &context,
     ) < 0 or device == null or context == null) return error.DeviceCreateFailed;
     errdefer {
@@ -262,6 +279,7 @@ fn createStateForWindow(hwnd: HWND, width: i32, height: i32) InitError!State {
         .context = context.?,
         .swapchain = swapchain_result.swapchain,
         .adapter = swapchain_result.adapter,
+        .feature_level = feature_level,
         .policy = present_policy.Policy.init(width, height),
         .width = width,
         .height = height,
@@ -339,16 +357,38 @@ fn queryAdapterInfo(adapter: *anyopaque) AdapterInfo {
 
     return .{
         .available = true,
+        .description = desc.description,
         .vendor_id = desc.vendor_id,
         .device_id = desc.device_id,
+        .sub_sys_id = desc.sub_sys_id,
+        .revision = desc.revision,
+        .dedicated_video_memory = desc.dedicated_video_memory,
+        .dedicated_system_memory = desc.dedicated_system_memory,
+        .shared_system_memory = desc.shared_system_memory,
         .luid_low = desc.adapter_luid.low_part,
         .luid_high = desc.adapter_luid.high_part,
         .flags = desc.flags,
+        .output_count = countAdapterOutputs(adapter1),
     };
+}
+
+fn countAdapterOutputs(adapter1: *anyopaque) u32 {
+    const enum_outputs = core.comCall(adapter1, core.slot.DXGIAdapter1_EnumOutputs, *const fn (*anyopaque, u32, *?*anyopaque) callconv(.winapi) HRESULT);
+    var count: u32 = 0;
+    while (count < 32) : (count += 1) {
+        var output: ?*anyopaque = null;
+        const hr = enum_outputs(adapter1, count, &output);
+        if (hr == core.DXGI_ERROR_NOT_FOUND) return count;
+        if (hr < 0 or output == null) return count;
+        core.comRelease(output.?);
+    }
+    return count;
 }
 
 fn logBackendInit(self: *const State) void {
     if (self.adapter.available) {
+        var desc_buf: [256]u8 = undefined;
+        const adapter_description = self.adapter.descriptionUtf8(&desc_buf);
         render_diagnostics.log(
             "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter_vendor=0x{x} adapter_device=0x{x} adapter_luid={x}:{x} adapter_flags=0x{x} fallback_reason=none policy_state={s} fallback_candidate=false",
             .{
@@ -363,10 +403,33 @@ fn logBackendInit(self: *const State) void {
                 self.policy.status().stateName(),
             },
         );
+        render_diagnostics.log(
+            "gpu-backend=d3d11 environment adapter_description=\"{s}\" vendor_id=0x{x} device_id=0x{x} subsys_id=0x{x} revision={} dedicated_video_memory={} dedicated_system_memory={} shared_system_memory={} adapter_luid={x}:{x} adapter_flags=0x{x} output_count={} feature_level={s} swap_effect={s}",
+            .{
+                adapter_description,
+                self.adapter.vendor_id,
+                self.adapter.device_id,
+                self.adapter.sub_sys_id,
+                self.adapter.revision,
+                self.adapter.dedicated_video_memory,
+                self.adapter.dedicated_system_memory,
+                self.adapter.shared_system_memory,
+                @as(u32, @bitCast(self.adapter.luid_high)),
+                self.adapter.luid_low,
+                self.adapter.flags,
+                self.adapter.output_count,
+                core.d3dFeatureLevelName(self.feature_level),
+                core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD),
+            },
+        );
     } else {
         render_diagnostics.log(
             "gpu-backend=d3d11 present=dxgi swapchain={}x{} swap_effect={s} adapter=unknown fallback_reason=none policy_state={s} fallback_candidate=false",
             .{ self.width, self.height, core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD), self.policy.status().stateName() },
+        );
+        render_diagnostics.log(
+            "gpu-backend=d3d11 environment adapter_description=\"unknown\" output_count=0 feature_level={s} swap_effect={s}",
+            .{ core.d3dFeatureLevelName(self.feature_level), core.dxgiSwapEffectName(core.DXGI_SWAP_EFFECT_FLIP_DISCARD) },
         );
     }
 }
@@ -813,4 +876,13 @@ test "D3D11 context recreate result reports fallback reason names" {
     try std.testing.expect(result.fallback_candidate);
     try std.testing.expectEqualStrings("recreate_failed", result.fallbackReasonName());
     try std.testing.expectEqual(fallback_marker.Reason.recreate_failed, result.fallbackMarkerReason());
+}
+
+test "D3D11 adapter info converts UTF-16 descriptions for diagnostics" {
+    var info = AdapterInfo{ .available = true };
+    const text = std.unicode.utf8ToUtf16LeStringLiteral("Test Adapter");
+    @memcpy(info.description[0..text.len], text);
+
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("Test Adapter", info.descriptionUtf8(&buf));
 }


### PR DESCRIPTION
## Summary

- Report richer D3D11 adapter environment diagnostics: adapter description, vendor/device/subsystem/revision, memory buckets, output count, feature level, LUID, flags, and swap effect.
- Report Win32 session/display environment diagnostics: remote-session state, process session id, monitor count, mixed-DPI state, primary DPI, and system DPI.
- Extend the Windows normal-session smoke so D3D11 requires both D3D11 and Win32 environment lines, while OpenGL fallback still requires the Win32 environment line and no D3D11 diagnostics.
- Update Phase V documentation to mark this as an environment-diagnostics surface only, not environment classification or blocking.

## Ghostty Comparison

Ghostty keeps renderer selection behind a thin backend boundary (`src/renderer/backend.zig`): WebGL for wasm, Metal for Darwin, and OpenGL for other native targets. It does not carry a D3D11 fallback/policy surface. This keeps WispTerm's D3D11 environment reporting local to the Windows/DXGI backend and Win32 host seam, without changing backend selection or the Windows `auto` default.

## Validation

- `zig build test -Dgpu-backend=d3d11`
- `zig build`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl`
- `zig build check-sizes`
- `git diff --check`
- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1`
- `zig build test-full --summary all`

Note: the first `test-full` attempt hit a transient Windows `AccessDenied` in unrelated `skill.local_fs` directory overwrite/rename; the immediate rerun passed with `60/60 steps succeeded`.

## Scope Boundaries

- Does not change Windows `auto`; OpenGL remains the default/fallback path.
- Does not add environment blocking, classification, or runtime D3D11-to-OpenGL switching.
- Base branch is `windows-native-render`, not `main`.