### PR TITLE
[codex] collect d3d11 environment smoke evidence

### DIFF
--- a/debug/test-d3d11-environment-smoke.ps1
+++ b/debug/test-d3d11-environment-smoke.ps1
@@ -1,0 +1,261 @@
+param(
+    [string]$Shell = "cmd",
+    [string]$ExePath = "",
+    [string]$OutDir = "",
+    [ValidateSet("d3d11", "opengl")]
+    [string]$Backend = "d3d11",
+    [int]$WindowX = 90,
+    [int]$WindowY = 90,
+    [int]$WindowWidth = 1240,
+    [int]$WindowHeight = 780,
+    [switch]$KeepOpen
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+if ($OutDir.Length -eq 0) {
+    $OutDir = Join-Path $repoRoot "zig-out\d3d11-env-smoke\$timestamp"
+}
+
+function Get-FirstLine([string]$Text, [string]$Pattern) {
+    $match = [regex]::Match($Text, $Pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    if ($match.Success) {
+        return $match.Value
+    }
+    return ""
+}
+
+function Get-Field([string]$Line, [string]$Pattern) {
+    $match = [regex]::Match($Line, $Pattern)
+    if ($match.Success) {
+        return $match.Groups[1].Value
+    }
+    return $null
+}
+
+function Convert-HexField([object]$Value) {
+    if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) {
+        return $null
+    }
+    return [Convert]::ToUInt64([string]$Value, 16)
+}
+
+function Convert-UIntField([object]$Value) {
+    if ($null -eq $Value -or [string]::IsNullOrWhiteSpace([string]$Value)) {
+        return $null
+    }
+    return [UInt64]$Value
+}
+
+function Convert-BoolField([object]$Value) {
+    if ($null -eq $Value) {
+        return $null
+    }
+    return ([string]$Value) -eq "true"
+}
+
+function Read-D3D11Environment([string]$DiagnosticText) {
+    $line = Get-FirstLine $DiagnosticText '^.*gpu-backend=d3d11 environment.*$'
+    if ($line.Length -eq 0) {
+        return [ordered]@{
+            available = $false
+        }
+    }
+
+    return [ordered]@{
+        available = $true
+        adapter_description = Get-Field $line 'adapter_description="([^"]*)"'
+        vendor_id_hex = Get-Field $line 'vendor_id=0x([0-9a-fA-F]+)'
+        vendor_id = Convert-HexField (Get-Field $line 'vendor_id=0x([0-9a-fA-F]+)')
+        device_id_hex = Get-Field $line 'device_id=0x([0-9a-fA-F]+)'
+        device_id = Convert-HexField (Get-Field $line 'device_id=0x([0-9a-fA-F]+)')
+        subsys_id_hex = Get-Field $line 'subsys_id=0x([0-9a-fA-F]+)'
+        subsys_id = Convert-HexField (Get-Field $line 'subsys_id=0x([0-9a-fA-F]+)')
+        revision = Convert-UIntField (Get-Field $line 'revision=([0-9]+)')
+        dedicated_video_memory = Convert-UIntField (Get-Field $line 'dedicated_video_memory=([0-9]+)')
+        dedicated_system_memory = Convert-UIntField (Get-Field $line 'dedicated_system_memory=([0-9]+)')
+        shared_system_memory = Convert-UIntField (Get-Field $line 'shared_system_memory=([0-9]+)')
+        adapter_luid = Get-Field $line 'adapter_luid=([0-9a-fA-F]+:[0-9a-fA-F]+)'
+        adapter_flags_hex = Get-Field $line 'adapter_flags=0x([0-9a-fA-F]+)'
+        adapter_flags = Convert-HexField (Get-Field $line 'adapter_flags=0x([0-9a-fA-F]+)')
+        output_count = Convert-UIntField (Get-Field $line 'output_count=([0-9]+)')
+        feature_level = Get-Field $line 'feature_level=([0-9_]+|unknown)'
+        swap_effect = Get-Field $line 'swap_effect=([A-Za-z0-9_]+)'
+        raw = $line
+    }
+}
+
+function Read-WindowsEnvironment([string]$DiagnosticText) {
+    $line = Get-FirstLine $DiagnosticText '^.*windows-environment.*$'
+    if ($line.Length -eq 0) {
+        return [ordered]@{
+            available = $false
+        }
+    }
+
+    $primaryDpi = Get-Field $line 'primary_dpi=([0-9]+x[0-9]+)'
+    $primaryDpiX = $null
+    $primaryDpiY = $null
+    if ($null -ne $primaryDpi -and $primaryDpi -match '^([0-9]+)x([0-9]+)$') {
+        $primaryDpiX = [UInt64]$Matches[1]
+        $primaryDpiY = [UInt64]$Matches[2]
+    }
+
+    return [ordered]@{
+        available = $true
+        remote_session = Convert-BoolField (Get-Field $line 'remote_session=(true|false)')
+        session_id = Convert-UIntField (Get-Field $line 'session_id=([0-9]+)')
+        monitor_count = Convert-UIntField (Get-Field $line 'monitor_count=([0-9]+)')
+        mixed_dpi = Convert-BoolField (Get-Field $line 'mixed_dpi=(true|false)')
+        primary_dpi = $primaryDpi
+        primary_dpi_x = $primaryDpiX
+        primary_dpi_y = $primaryDpiY
+        system_dpi = Convert-UIntField (Get-Field $line 'system_dpi=([0-9]+)')
+        raw = $line
+    }
+}
+
+function Read-MonitorTopology([string]$DiagnosticText) {
+    $items = @()
+    $matches = [regex]::Matches($DiagnosticText, '^.*monitor-enum.*$', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    foreach ($match in $matches) {
+        $line = $match.Value
+        $items += [ordered]@{
+            monitor_rect = Get-Field $line 'rcMonitor=\(([^)]*)\)'
+            work_rect = Get-Field $line 'rcWork=\(([^)]*)\)'
+            dpi = Get-Field $line 'dpi=([0-9]+x[0-9]+)'
+            primary = Convert-BoolField (Get-Field $line 'primary=(true|false)')
+            raw = $line
+        }
+    }
+    return @($items)
+}
+
+function Copy-SmokeScreenshots([object]$NormalResult, [string]$ScreenshotsDir) {
+    New-Item -ItemType Directory -Force -Path $ScreenshotsDir | Out-Null
+    $copied = [ordered]@{}
+    if ($null -eq $NormalResult.screenshots) {
+        return $copied
+    }
+
+    foreach ($property in $NormalResult.screenshots.PSObject.Properties) {
+        $source = [string]$property.Value
+        if ($source.Length -gt 0 -and (Test-Path -LiteralPath $source)) {
+            $dest = Join-Path $ScreenshotsDir (Split-Path -Leaf $source)
+            Copy-Item -LiteralPath $source -Destination $dest -Force
+            $copied[$property.Name] = $dest
+        } else {
+            $copied[$property.Name] = $source
+        }
+    }
+    return $copied
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$normalOutDir = Join-Path $OutDir "normal-session"
+$screenshotsDir = Join-Path $OutDir "screenshots"
+$normalScript = Join-Path $scriptDir "test-d3d11-normal-session.ps1"
+
+$normalArgs = @(
+    "-NoProfile",
+    "-ExecutionPolicy", "Bypass",
+    "-File", $normalScript,
+    "-Shell", $Shell,
+    "-OutDir", $normalOutDir,
+    "-Backend", $Backend,
+    "-WindowX", $WindowX,
+    "-WindowY", $WindowY,
+    "-WindowWidth", $WindowWidth,
+    "-WindowHeight", $WindowHeight
+)
+if ($ExePath.Length -gt 0) {
+    $normalArgs += @("-ExePath", $ExePath)
+}
+if ($KeepOpen) {
+    $normalArgs += "-KeepOpen"
+}
+
+& powershell @normalArgs
+$normalSessionExitCode = $LASTEXITCODE
+
+$normalJsonPath = Get-ChildItem -LiteralPath $normalOutDir -Filter "*-normal-session-*.json" |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+if ($null -eq $normalJsonPath -or !(Test-Path -LiteralPath $normalJsonPath)) {
+    throw "normal-session result JSON not found under $normalOutDir"
+}
+
+$normalResult = Get-Content -LiteralPath $normalJsonPath -Raw | ConvertFrom-Json
+$diagnosticPath = [string]$normalResult.diagnostic_log
+$diagnosticText = if (Test-Path -LiteralPath $diagnosticPath) {
+    Get-Content -LiteralPath $diagnosticPath -Raw
+} else {
+    ""
+}
+
+$copiedScreenshots = Copy-SmokeScreenshots $normalResult $screenshotsDir
+$gitBranch = (& git -C $repoRoot branch --show-current).Trim()
+$gitCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
+
+$environment = [ordered]@{
+    schema = "wispterm-d3d11-environment-smoke/v1"
+    generated_at = (Get-Date).ToString("o")
+    backend = $Backend
+    pass = [bool]$normalResult.pass
+    repo = [ordered]@{
+        branch = $gitBranch
+        commit = $gitCommit
+    }
+    artifacts = [ordered]@{
+        root = $OutDir
+        environment_json = (Join-Path $OutDir "environment.json")
+        normal_session_json = $normalJsonPath
+        diagnostic_log = $diagnosticPath
+        screenshots = $copiedScreenshots
+    }
+    smoke = [ordered]@{
+        normal_session_exit_code = $normalSessionExitCode
+        visible_session = [bool]$normalResult.pass
+        window = $normalResult.window
+        d3d11_present = [bool]$normalResult.diagnostics.d3d11_present
+        d3d11_environment = [bool]$normalResult.diagnostics.d3d11_environment
+        windows_environment = [bool]$normalResult.diagnostics.windows_environment
+        d3d11_policy_healthy = [bool]$normalResult.diagnostics.d3d11_policy_healthy
+        d3d11_resize_events = $normalResult.diagnostics.d3d11_resize_events
+        failure_lines = [bool]$normalResult.diagnostics.failure_lines
+    }
+    environment = [ordered]@{
+        d3d11 = Read-D3D11Environment $diagnosticText
+        windows = Read-WindowsEnvironment $diagnosticText
+        monitors = Read-MonitorTopology $diagnosticText
+    }
+    policy = [ordered]@{
+        automatic_fallback = $false
+        environment_blocking = $false
+        default_unchanged = $true
+        note = "collector only; no environment classification or fallback decision is applied"
+    }
+}
+
+$environmentJsonPath = Join-Path $OutDir "environment.json"
+$environment | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $environmentJsonPath -Encoding UTF8
+
+$summary = [ordered]@{
+    pass = [bool]$normalResult.pass
+    backend = $Backend
+    environment_json = $environmentJsonPath
+    normal_session_json = $normalJsonPath
+    diagnostic_log = $diagnosticPath
+    screenshots = $screenshotsDir
+    normal_session_exit_code = $normalSessionExitCode
+    d3d11_environment = [bool]$normalResult.diagnostics.d3d11_environment
+    windows_environment = [bool]$normalResult.diagnostics.windows_environment
+}
+$summary | ConvertTo-Json -Depth 5
+
+if ($normalSessionExitCode -ne 0 -or ![bool]$normalResult.pass) {
+    throw "normal-session smoke failed; environment evidence was written to $environmentJsonPath"
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -226,6 +226,20 @@ recovery request in the healthy path. It is a Phase IV and Phase V
 diagnostics/policy/recovery-coordination evidence tool only; it does not change
 the Windows default renderer.
 
+Use `debug\test-d3d11-environment-smoke.ps1` after a D3D11 build to wrap the
+normal-session smoke into a matrix evidence package:
+
+```powershell
+zig build -Dgpu-backend=d3d11
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1
+```
+
+The collector writes `zig-out\d3d11-env-smoke\<timestamp>\environment.json`, a
+`normal-session\` result directory, copied screenshots under `screenshots\`, and
+the original render diagnostics path. It records adapter/session/monitor facts
+and smoke health only; it does not classify or block environments and it does
+not change fallback policy.
+
 To exercise the controlled Phase V device-recreate path, run the same smoke
 with `-RecreateSmoke` after building the D3D11 executable:
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -93,7 +93,12 @@ adapter flags, output count, feature level, and swap effect, while the Win32
 host logs remote-session state, process session id, monitor count, mixed-DPI
 state, primary DPI, and system DPI. The normal-session smoke verifies both
 lines so later RDP/VM/hybrid-GPU/multi-monitor matrix runs have a stable JSON
-and log surface.
+and log surface. A dedicated environment smoke collector now wraps the
+normal-session smoke and emits a timestamped evidence package with
+`environment.json`, the raw normal-session JSON, copied screenshots, adapter
+facts, Win32 session facts, monitor topology, and explicit policy fields stating
+that no environment classification, blocking, default change, or automatic
+fallback was applied.
 
 The Phase IV normal-session evidence gate is the checked-in Windows GUI smoke:
 
@@ -146,6 +151,19 @@ The D3D11 normal-session smoke also gates the environment-diagnostics surface:
 `d3d11_environment` and `windows_environment` must be true in the emitted JSON.
 This still only reports and verifies environment facts; it does not classify or
 block any environment yet.
+
+Add the environment collector when recording Phase V matrix evidence:
+
+```powershell
+zig build -Dgpu-backend=d3d11
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1
+```
+
+The default output root is `zig-out\d3d11-env-smoke\<timestamp>\`. Each run
+contains `environment.json`, `normal-session\`, and `screenshots\`. Use the same
+collector in RDP, VM, hybrid-GPU, weak-integrated-GPU, single-monitor,
+multi-monitor, and mixed-DPI environments; skipped or unavailable environments
+must be recorded as missing evidence rather than treated as passing.
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

- Add `debug/test-d3d11-environment-smoke.ps1`, a Phase V collector that wraps the existing D3D11 normal-session smoke and emits a timestamped evidence package under `zig-out\d3d11-env-smoke\<timestamp>\`.
- Write `environment.json` with adapter facts, Win32 session/display facts, monitor topology, normal-session health, artifact paths, and explicit policy fields showing no environment blocking or automatic fallback was applied.
- Copy normal-session screenshots into a stable `screenshots\` directory while retaining the raw normal-session JSON and diagnostics log.
- Document the collector in `docs/development.md` and the D3D11 roadmap as matrix evidence tooling for RDP/VM/hybrid-GPU/multi-monitor runs.

## Ghostty Comparison

Ghostty's renderer backend selector remains a thin boundary (`opengl`, `metal`, `webgl`) and does not carry Windows D3D11 environment matrix collection. This keeps WispTerm's collector outside renderer feature code: it reads the backend/Win32 diagnostics already emitted by the Windows-specific seams and packages them as test evidence.

## Validation

- PowerShell parse check for `debug/test-d3d11-environment-smoke.ps1`
- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1`
- Verified generated `environment.json` includes D3D11 adapter data, Win32 environment data, monitor topology, copied screenshots, and policy fields (`automatic_fallback=false`, `environment_blocking=false`, `default_unchanged=true`).
- Windows checkout path-safety check including the new file
- `git diff --check`
- `zig build check-sizes`
- `zig build test`
- `zig build test-full --summary all`

Note: the first `test-full` attempt hit a transient Windows `NTSTATUS=0xc0000056` in unrelated `skill.center` temporary directory access; the immediate rerun passed with `60/60 steps succeeded`.

## Scope Boundaries

- Does not change Windows `auto`; OpenGL remains the default/fallback path.
- Does not classify or block environments.
- Does not enable automatic fallback or runtime D3D11-to-OpenGL switching.
- Base branch is `windows-native-render`, not `main`.