### PR TITLE
[codex] add d3d11 auto dry-run smoke

### DIFF
--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -16,6 +16,7 @@ param(
     [switch]$WindowStateSmoke,
     [switch]$FullscreenStartupSmoke,
     [switch]$FallbackMarkerSmoke,
+    [switch]$AutoDryRunSmoke,
     [switch]$KeepOpen
 )
 
@@ -46,11 +47,14 @@ if ($SoakMinutes -lt 0.0) {
     throw "-SoakMinutes must be zero or greater."
 }
 
-if ($Backend -eq "opengl" -and ($RecreateSmoke -or $RecreateFailureSmoke -or $FallbackMarkerSmoke -or $WindowStateSmoke -or $FullscreenStartupSmoke -or $SoakMinutes -gt 0.0)) {
-    throw "-RecreateSmoke, -RecreateFailureSmoke, -FallbackMarkerSmoke, -WindowStateSmoke, -FullscreenStartupSmoke, and -SoakMinutes require -Backend d3d11."
+if ($Backend -eq "opengl" -and ($RecreateSmoke -or $RecreateFailureSmoke -or $FallbackMarkerSmoke -or $AutoDryRunSmoke -or $WindowStateSmoke -or $FullscreenStartupSmoke -or $SoakMinutes -gt 0.0)) {
+    throw "-RecreateSmoke, -RecreateFailureSmoke, -FallbackMarkerSmoke, -AutoDryRunSmoke, -WindowStateSmoke, -FullscreenStartupSmoke, and -SoakMinutes require -Backend d3d11."
 }
-if ($FullscreenStartupSmoke -and ($RecreateSmoke -or $RecreateFailureSmoke -or $RapidResizeSmoke -or $WindowStateSmoke -or $FallbackMarkerSmoke)) {
+if ($FullscreenStartupSmoke -and ($RecreateSmoke -or $RecreateFailureSmoke -or $RapidResizeSmoke -or $WindowStateSmoke -or $FallbackMarkerSmoke -or $AutoDryRunSmoke)) {
     throw "-FullscreenStartupSmoke must run by itself."
+}
+if ($AutoDryRunSmoke -and $RecreateFailureSmoke) {
+    throw "-AutoDryRunSmoke cannot be combined with -RecreateFailureSmoke."
 }
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
@@ -983,6 +987,7 @@ $oldOffscreenSmoke = $env:WISPTERM_D3D11_OFFSCREEN_SMOKE
 $oldRecreateSmoke = $env:WISPTERM_D3D11_RECREATE_SMOKE
 $oldRecreateFailureSmoke = $env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE
 $oldFallbackMarkerSmoke = $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE
+$oldAutoDryRunSmoke = $env:WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE
 
 $env:APPDATA = $appDataDir
 $env:WISPTERM_RENDER_DIAGNOSTICS = "1"
@@ -1008,6 +1013,11 @@ if ($isD3D11Backend -and $FallbackMarkerSmoke) {
     $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = "1"
 } else {
     Remove-Item Env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE -ErrorAction SilentlyContinue
+}
+if ($isD3D11Backend -and $AutoDryRunSmoke) {
+    $env:WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE = "1"
+} else {
+    Remove-Item Env:WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE -ErrorAction SilentlyContinue
 }
 
 $proc = $null
@@ -1398,6 +1408,7 @@ try {
     $hasD3D11RecreateSucceeded = $diagText -match "gpu-backend=d3d11 recovery recreate attempt attempted=true succeeded=true"
     $hasD3D11ResourceRestore = $diagText -match "gpu-backend=d3d11 resource recreate restored"
     $hasD3D11FallbackMarkerSmoke = $diagText -match "d3d11-fallback-marker-smoke .*readback_ok=true.*readback_matches=true.*explicit_d3d11_ignored=true.*current_auto_default_unchanged=true.*future_auto_opengl_marker=true.*automatic_fallback=false.*default_unchanged=true"
+    $hasD3D11AutoDryRunSmoke = $diagText -match "d3d11-auto-dry-run-smoke .*current_auto_opengl=true.*future_auto_d3d11=true.*future_auto_marker_opengl=true.*explicit_d3d11_ignored_marker=true.*explicit_opengl=true.*stale_marker_ignored=true.*automatic_fallback=false.*default_unchanged=true"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $d3d11ResizeEventCount = [regex]::Matches($diagText, "gpu-backend=d3d11 resized swapchain to").Count
@@ -1416,6 +1427,11 @@ try {
         ($hasD3D11FallbackMarkerSmoke -and $hasD3D11FallbackMarkerState)
     } else {
         (!$hasD3D11FallbackMarkerSmoke -and !$hasD3D11FallbackMarkerState)
+    }
+    $autoDryRunExpectation = if ($isD3D11Backend -and $AutoDryRunSmoke) {
+        $hasD3D11AutoDryRunSmoke
+    } else {
+        !$hasD3D11AutoDryRunSmoke
     }
     $backendExpectation = if ($isD3D11Backend) {
         ($hasD3D11Present -and $hasD3D11InitDetails -and $hasD3D11Environment -and $hasWindowsEnvironment -and $hasD3D11PolicyHealthy)
@@ -1447,6 +1463,7 @@ try {
         $backendExpectation -and
         $recreateExpectation -and
         $fallbackMarkerExpectation -and
+        $autoDryRunExpectation -and
         $rapidResizeDiagnostic -and
         $windowStateDiagnostic -and
         $soakDiagnostic -and
@@ -1687,6 +1704,7 @@ try {
             d3d11_resource_restore = [bool]$hasD3D11ResourceRestore
             d3d11_fallback_marker_smoke = [bool]$hasD3D11FallbackMarkerSmoke
             d3d11_fallback_marker_state = [bool]$hasD3D11FallbackMarkerState
+            d3d11_auto_dry_run_smoke = [bool]$hasD3D11AutoDryRunSmoke
             ui_probe_ok = [bool]$hasUiProbe
             offscreen_round_trip = [bool]$hasOffscreen
             failure_lines = [bool]$hasFailures
@@ -1718,4 +1736,5 @@ try {
     $env:WISPTERM_D3D11_RECREATE_SMOKE = $oldRecreateSmoke
     $env:WISPTERM_D3D11_RECREATE_FAILURE_SMOKE = $oldRecreateFailureSmoke
     $env:WISPTERM_D3D11_FALLBACK_MARKER_SMOKE = $oldFallbackMarkerSmoke
+    $env:WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE = $oldAutoDryRunSmoke
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -347,6 +347,21 @@ verifies current Windows `auto` remains OpenGL, and verifies a future-auto
 dry-run would select OpenGL from the marker. It does not enable live failure
 writes or automatic fallback.
 
+To record the future-auto selector dry-run surface without writing a marker,
+run:
+
+```powershell
+zig build -Dgpu-backend=d3d11
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -AutoDryRunSmoke
+```
+
+This sets `WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE=1` and verifies diagnostics for
+current Windows `auto` staying OpenGL, future Windows `auto` selecting D3D11
+when eligible, future-auto selecting OpenGL from a matching marker, explicit
+`d3d11` ignoring a matching marker with warning semantics, explicit `opengl`
+remaining OpenGL, and stale markers being ignored. It does not change the
+Windows default backend, write a fallback marker, or trigger automatic fallback.
+
 To prove the Windows OpenGL fallback path still runs the same normal-session UI
 subset on the native-render branch, build the default backend and run:
 

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -37,6 +37,7 @@ unavailable environment is missing evidence, not a passing result.
 | Device recreate success | `-RecreateSmoke` records exactly one successful recreate/restore path. |
 | Device recreate failure | `-RecreateFailureSmoke` escalates exactly once to a fallback candidate and writes a marker. |
 | Fallback marker policy | `-FallbackMarkerSmoke` proves explicit D3D11 still wins, current auto stays OpenGL, and future-auto would select OpenGL from a matching marker. |
+| Future-auto dry-run | `-AutoDryRunSmoke` proves current auto, future eligible D3D11, matching-marker OpenGL, explicit D3D11, explicit OpenGL, and stale-marker selector outcomes. |
 | OpenGL fallback | `zig build` plus `-Backend opengl` proves the compatibility renderer still runs the normal-session UI subset. |
 | Rapid resize | `-RapidResizeSmoke` proves nonblank frames, resize diagnostics, and no resize/present failures. |
 | Window state | `-WindowStateSmoke` proves maximize, restore, minimize, and restore-from-minimize. |
@@ -103,6 +104,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RecreateFailureSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FallbackMarkerSmoke
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -AutoDryRunSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -RapidResizeSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -WindowStateSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FullscreenStartupSmoke

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -172,6 +172,13 @@ marker in the isolated smoke profile and verify marker persistence plus the
 explicit/current-auto/future-auto decision surface without triggering automatic
 fallback.
 
+Add `-AutoDryRunSmoke` to the normal-session smoke to verify the future-auto
+selector explanation surface without writing a marker. It must prove current
+Windows `auto` still selects OpenGL, future Windows `auto` would select D3D11
+when eligible, a matching marker would make future-auto select OpenGL, explicit
+`d3d11` ignores the marker with warning semantics, explicit `opengl` remains
+OpenGL, and stale markers are ignored.
+
 Add `-RecreateFailureSmoke` to the same smoke to exercise the failed-recreate
 escalation path. This mode is intentionally a diagnostics/state-file proof: it
 does not attempt same-process OpenGL fallback, does not change Windows `auto`,

--- a/src/renderer/d3d11_auto_dry_run_smoke.zig
+++ b/src/renderer/d3d11_auto_dry_run_smoke.zig
@@ -1,0 +1,164 @@
+//! Opt-in D3D11 future-auto selector dry-run smoke.
+//!
+//! Enable with `WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE=1`. This logs selector
+//! decisions for the current Windows auto default and the future Windows auto
+//! policy without changing the active backend or writing fallback markers.
+
+const std = @import("std");
+const build_options = @import("build_options");
+
+const gpu = @import("gpu/gpu.zig");
+const Backend = @import("gpu/backend.zig").Backend;
+const fallback_marker = @import("gpu/d3d11/fallback_marker.zig");
+const render_diagnostics = @import("../render_diagnostics.zig");
+
+const ENV_NAME = "WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE";
+
+threadlocal var checked_env = false;
+threadlocal var enabled_cache = false;
+threadlocal var fired = false;
+
+const SmokeDecision = struct {
+    current_auto_opengl: bool,
+    future_auto_d3d11: bool,
+    future_auto_marker_opengl: bool,
+    explicit_d3d11_ignored_marker: bool,
+    explicit_opengl: bool,
+    stale_marker_ignored: bool,
+};
+
+fn parseEnabledValue(value: []const u8) bool {
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.mem.eql(u8, trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+fn enabled() bool {
+    if (comptime gpu.active != .d3d11) return false;
+    if (checked_env) return enabled_cache;
+    checked_env = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, ENV_NAME) catch {
+        enabled_cache = false;
+        return enabled_cache;
+    };
+    defer std.heap.page_allocator.free(value);
+
+    enabled_cache = parseEnabledValue(value);
+    return enabled_cache;
+}
+
+fn evaluateDecisions(version: []const u8, adapter_id: []const u8, marker_text: []const u8, stale_marker_text: []const u8) SmokeDecision {
+    const current_auto = fallback_marker.decide(.windows, "auto", "", version, adapter_id, .current_default);
+    const future_auto = fallback_marker.decide(.windows, "auto", "", version, adapter_id, .future_windows_auto);
+    const future_auto_marker = fallback_marker.decide(.windows, "auto", marker_text, version, adapter_id, .future_windows_auto);
+    const explicit_d3d11 = fallback_marker.decide(.windows, "d3d11", marker_text, version, adapter_id, .future_windows_auto);
+    const explicit_opengl = fallback_marker.decide(.windows, "opengl", marker_text, version, adapter_id, .future_windows_auto);
+    const stale_marker = fallback_marker.decide(.windows, "auto", stale_marker_text, version, adapter_id, .future_windows_auto);
+
+    return .{
+        .current_auto_opengl = current_auto.backend == Backend.opengl and
+            current_auto.effect == .current_auto_default_unchanged,
+        .future_auto_d3d11 = future_auto.backend == Backend.d3d11 and
+            future_auto.effect == .future_auto_d3d11,
+        .future_auto_marker_opengl = future_auto_marker.backend == Backend.opengl and
+            future_auto_marker.effect == .future_auto_opengl_marker,
+        .explicit_d3d11_ignored_marker = explicit_d3d11.backend == Backend.d3d11 and
+            explicit_d3d11.effect == .explicit_d3d11_ignores_marker and
+            explicit_d3d11.warning,
+        .explicit_opengl = explicit_opengl.backend == Backend.opengl and
+            explicit_opengl.effect == .explicit_opengl,
+        .stale_marker_ignored = stale_marker.backend == Backend.d3d11 and
+            stale_marker.effect == .stale_marker,
+    };
+}
+
+pub fn maybeRun() void {
+    if (comptime gpu.active != .d3d11) return;
+    if (!enabled() or fired) return;
+    fired = true;
+
+    var adapter_buf: [64]u8 = undefined;
+    const adapter_id = gpu.Context.adapterFallbackIdentity(&adapter_buf) orelse "unknown-adapter";
+
+    var marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const marker = fallback_marker.format(
+        &marker_buf,
+        .fallback_candidate,
+        build_options.app_version,
+        adapter_id,
+        .environment_blocked,
+    ) catch |err| {
+        render_diagnostics.log("d3d11-auto-dry-run-smoke marker format failed: {s}", .{@errorName(err)});
+        return;
+    };
+
+    var stale_marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const stale_marker = fallback_marker.format(
+        &stale_marker_buf,
+        .fallback_candidate,
+        "0.0.0-stale",
+        adapter_id,
+        .environment_blocked,
+    ) catch |err| {
+        render_diagnostics.log("d3d11-auto-dry-run-smoke stale marker format failed: {s}", .{@errorName(err)});
+        return;
+    };
+
+    const decision = evaluateDecisions(build_options.app_version, adapter_id, marker, stale_marker);
+    render_diagnostics.log(
+        "d3d11-auto-dry-run-smoke adapter={s} current_auto_opengl={} future_auto_d3d11={} future_auto_marker_opengl={} explicit_d3d11_ignored_marker={} explicit_opengl={} stale_marker_ignored={} automatic_fallback=false default_unchanged=true",
+        .{
+            adapter_id,
+            decision.current_auto_opengl,
+            decision.future_auto_d3d11,
+            decision.future_auto_marker_opengl,
+            decision.explicit_d3d11_ignored_marker,
+            decision.explicit_opengl,
+            decision.stale_marker_ignored,
+        },
+    );
+}
+
+test "D3D11 auto dry-run smoke env parser accepts truthy values" {
+    try std.testing.expect(parseEnabledValue("1"));
+    try std.testing.expect(parseEnabledValue("true"));
+    try std.testing.expect(parseEnabledValue("YES"));
+    try std.testing.expect(parseEnabledValue("on"));
+}
+
+test "D3D11 auto dry-run smoke env parser rejects falsey values" {
+    try std.testing.expect(!parseEnabledValue(""));
+    try std.testing.expect(!parseEnabledValue("0"));
+    try std.testing.expect(!parseEnabledValue("false"));
+    try std.testing.expect(!parseEnabledValue("off"));
+}
+
+test "D3D11 auto dry-run smoke validates selector decisions" {
+    var marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const marker = try fallback_marker.format(
+        &marker_buf,
+        .fallback_candidate,
+        "1.20.0",
+        "adapter-a",
+        .environment_blocked,
+    );
+    var stale_marker_buf: [fallback_marker.marker_max_len]u8 = undefined;
+    const stale_marker = try fallback_marker.format(
+        &stale_marker_buf,
+        .fallback_candidate,
+        "1.19.0",
+        "adapter-a",
+        .environment_blocked,
+    );
+
+    const decision = evaluateDecisions("1.20.0", "adapter-a", marker, stale_marker);
+    try std.testing.expect(decision.current_auto_opengl);
+    try std.testing.expect(decision.future_auto_d3d11);
+    try std.testing.expect(decision.future_auto_marker_opengl);
+    try std.testing.expect(decision.explicit_d3d11_ignored_marker);
+    try std.testing.expect(decision.explicit_opengl);
+    try std.testing.expect(decision.stale_marker_ignored);
+}

--- a/src/renderer/d3d11_recreate_smoke.zig
+++ b/src/renderer/d3d11_recreate_smoke.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 
+const auto_dry_run_smoke = @import("d3d11_auto_dry_run_smoke.zig");
 const fallback_marker_smoke = @import("d3d11_fallback_marker_smoke.zig");
 const gpu = @import("gpu/gpu.zig");
 const render_diagnostics = @import("../render_diagnostics.zig");
@@ -60,6 +61,7 @@ fn failureEnabled() bool {
 
 pub fn maybeRequest() void {
     if (comptime gpu.active != .d3d11) return;
+    auto_dry_run_smoke.maybeRun();
     fallback_marker_smoke.maybeRun();
     if (!(enabled() or failureEnabled()) or fired) return;
     fired = true;

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -195,6 +195,7 @@ test {
     _ = @import("renderer/qr_panel_layout.zig");
     _ = @import("renderer/file_explorer_layout.zig");
     _ = @import("renderer/post_process_policy.zig");
+    _ = @import("renderer/d3d11_auto_dry_run_smoke.zig");
     _ = @import("renderer/d3d11_recreate_smoke.zig");
     _ = @import("renderer/d3d11_fallback_marker_smoke.zig");
     _ = @import("renderer/gpu/gl_backend_guard.zig");


### PR DESCRIPTION
## Summary
- add an opt-in `WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE=1` diagnostic smoke for future Windows auto-selection policy
- expose it through `debug/test-d3d11-normal-session.ps1 -AutoDryRunSmoke`
- verify current Windows `auto` remains OpenGL, future-auto selects D3D11 when eligible, matching markers select OpenGL, explicit D3D11 ignores markers with warning semantics, explicit OpenGL remains OpenGL, and stale markers are ignored
- document the command in the development guide, roadmap, and default migration gate

## Ghostty comparison
Ghostty keeps renderer backend selection as a thin enum/default selector over WebGL, Metal, and OpenGL, with no D3D11/DXGI fallback marker model. This preserves that backend-boundary shape while adding WispTerm-specific Windows dry-run evidence before any Phase VI default migration.

## Boundary
- targets `windows-native-render`, not `main`
- does not change the Windows `auto` default
- does not write fallback markers
- does not remove or weaken the OpenGL fallback path
- does not add runtime D3D11-to-OpenGL switching

## Validation
- PowerShell parse check for `debug/test-d3d11-normal-session.ps1`
- `zig build test`
- `zig build -Dgpu-backend=d3d11`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -AutoDryRunSmoke`
- `zig build check-sizes`
- `zig build`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl`
- `zig build test-full --summary all` (first run hit transient Windows `MoveFileExW ACCESS_DENIED` in `tools.import`; immediate rerun passed)
- Windows checkout safety: no reserved names, illegal characters, case-fold collisions, symlinks, or long path concern