### PR TITLE
fix(mcp): trim whitespace from MCP server names

### DIFF
--- a/src/agent_tools/mcp_config.zig
+++ b/src/agent_tools/mcp_config.zig
@@ -149,7 +149,9 @@ pub fn run(ctx: *ToolContext, arguments_json: []const u8) ![]u8 {
     if (std.mem.eql(u8, action, "list")) return listText(ctx.allocator);
 
     if (std.mem.eql(u8, action, "add")) {
-        const name = tool_args.string(value, "name") orelse return ctx.allocator.dupe(u8, "add requires a \"name\".");
+        const name_raw = tool_args.string(value, "name") orelse return ctx.allocator.dupe(u8, "add requires a \"name\".");
+        const name = std.mem.trim(u8, name_raw, " \t");
+        if (name.len == 0) return ctx.allocator.dupe(u8, "add requires a non-empty \"name\".");
         const command = tool_args.string(value, "command") orelse return ctx.allocator.dupe(u8, "add requires a \"command\".");
         const enabled = tool_args.boolean(value, "enabled") orelse true;
         const argv = try parseArgsOwned(ctx.allocator, value);
@@ -271,6 +273,41 @@ test "listText reports empty config" {
     const dir_path = try setupTempConfig(a, &tmp);
     defer a.free(dir_path);
     defer dirs.setTestConfigDirOverride(null);
+
+    const listing = try listText(a);
+    defer a.free(listing);
+    try std.testing.expect(std.mem.indexOf(u8, listing, "No MCP servers") != null);
+}
+
+fn allowApprove(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return true;
+}
+fn notCancelled(_: *anyopaque) bool {
+    return false;
+}
+
+test "run rejects a whitespace-only name on add and writes no server" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try setupTempConfig(a, &tmp);
+    defer a.free(dir_path);
+    defer dirs.setTestConfigDirOverride(null);
+
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = allowApprove,
+        .cancelled = notCancelled,
+    };
+
+    const out = try run(&ctx, "{\"action\":\"add\",\"name\":\"   \",\"command\":\"x\"}");
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "non-empty") != null);
 
     const listing = try listText(a);
     defer a.free(listing);

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -2636,7 +2636,7 @@ fn mcpStartProbeFromForm() AppWindow.UiEffect {
     st.form_error = null;
     st.probe.status = .running;
     st.probe.target_index = st.editing_index;
-    const name = st.formField(.name);
+    const name = std.mem.trim(u8, st.formField(.name), " \t");
     mcp_probe.start(allocator, command, args_buf[0..args_len], if (name.len > 0) name else null, mcpProbeDone, @ptrCast(st));
     return .repaint;
 }

--- a/src/renderer/overlays/mcp_servers.zig
+++ b/src/renderer/overlays/mcp_servers.zig
@@ -298,7 +298,7 @@ pub const State = struct {
     /// Adding past `MCP_SERVER_MAX` returns `error.Full` instead of
     /// overflowing `servers`.
     pub fn commitForm(self: *State) FormError!void {
-        const name = self.formField(.name);
+        const name = std.mem.trim(u8, self.formField(.name), " \t");
         if (name.len == 0) return error.EmptyName;
         const command = self.formField(.command);
         if (command.len == 0) return error.EmptyCommand;
@@ -557,6 +557,19 @@ test "form rejects empty name, empty command, and duplicate name" {
     s.setFormField(.name, "a");
     s.setFormField(.command, "y");
     try std.testing.expectError(error.DuplicateName, s.commitForm());
+}
+
+test "commitForm rejects a whitespace-only name and trims a padded one" {
+    var s: State = .{};
+    s.beginAdd();
+    s.setFormField(.name, "   ");
+    s.setFormField(.command, "x");
+    try std.testing.expectError(error.EmptyName, s.commitForm());
+    try std.testing.expectEqual(@as(usize, 0), s.count);
+
+    s.setFormField(.name, "  gh  ");
+    try s.commitForm();
+    try std.testing.expectEqualStrings("gh", s.serverName(0));
 }
 
 test "toggle and remove the selected server" {


### PR DESCRIPTION
## Why

deferred-tool-catalog(#480/#482)终审留下的一条既有小缺陷:MCP server 名字输入不做空白 trim,纯空格名(如 `"   "`)能通过 `len==0` 校验,写出一个空白名字的配置/目录条目。面板表单与 Copilot `mcp_config` 工具共有此问题。

## What changed

三个输入入口统一 `std.mem.trim(u8, name, " \t")`,trim 后为空按空名拒绝;存盘/探测用 trim 后的值:

- `src/renderer/overlays/mcp_servers.zig` `commitForm` —— 复用既有 `error.EmptyName` 拒绝路径,padded 名字落盘前 trim。
- `src/agent_tools/mcp_config.zig` `run`(action=add)—— 空白名返回 `add requires a non-empty "name".`;remove/enable/disable 走精确匹配,不动。
- `src/renderer/overlays.zig` `mcpStartProbeFromForm` —— 传给 probe 的 `catalog_name` 用 trim 后的名字,空则传 null。

## Verification

- 新增 2 个测试:`commitForm` 拒绝纯空格名 + trim padded 名字;`mcp_config.run` 拒绝纯空格 add 且不写盘。
- `zig build test` 全绿(mcp_servers 测试已在 test_fast 聚合);`zig fmt` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)