### PR TITLE
feat: in-app GPU render benchmark (wispterm --benchmark)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -157,10 +157,26 @@ lean fast suite) have their own step:
 zig build test-bench
 ```
 
-An in-app GPU-side benchmark (`wispterm --benchmark`, measuring per-frame render
-latency and FPS through the real renderer) is planned; the report schema in
-`src/benchmark/report.zig` already reserves the GPU-adapter / window / DPI /
-grid fields that mode will fill, so CLI and in-app reports stay comparable.
+An in-app GPU-side benchmark (`wispterm --benchmark`) measures per-frame render
+latency through the real renderer. It spawns a no-shell virtual surface, drives a
+synthetic VT stream from the UI thread with vsync off, and records the
+rebuild+draw+present pipeline time per frame as `latency_ns` (p50/p95/max), then
+writes the same JSON + Markdown report shape as the CLI. The renderer backend is
+fixed at build time (`-Dgpu-backend`), so a D3D11-vs-OpenGL comparison is two
+builds of the same machine:
+
+```powershell
+zig build -Dgpu-backend=opengl -Doptimize=ReleaseFast
+.\zig-out\bin\wispterm.exe --benchmark
+zig build -Dgpu-backend=d3d11  -Doptimize=ReleaseFast
+.\zig-out\bin\wispterm.exe --benchmark
+```
+
+Each run writes `benchmark-report-<timestamp>.{json,md}` to the config dir and
+prints the Markdown to stdout; diff the two reports' `scroll-flood` /
+`unicode-heavy` rows to see the per-backend render delta. The report carries the
+GPU adapter name + PCI ids, window/DPI/grid size, and `runner: in-app` so it is
+distinguishable from a CLI report.
 
 When publishing a desktop release, run `wispterm-bench --case terminal-stream
 --duration 1000` on the release machine and attach the Markdown report to the

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -108,6 +108,8 @@ const appwindow_ui_screenshot = @import("appwindow/ui_screenshot.zig");
 const png_writer = @import("appwindow/png_writer.zig");
 const ui_effect = @import("appwindow/ui_effect.zig");
 pub const UiEffect = ui_effect.UiEffect;
+const bench_driver = @import("benchmark/driver.zig");
+const bench_report = @import("benchmark/report.zig");
 pub const background_image = @import("renderer/background_image.zig");
 pub const file_explorer = @import("file_explorer.zig");
 const file_explorer_renderer = @import("renderer/file_explorer_renderer.zig");
@@ -344,6 +346,10 @@ pub fn deinit(self: *AppWindow) void {
     // cleanup below: destroy closes every pane's virtual controller (EOF'ing the
     // Surfaces) without freeing the Surfaces, which the tab teardown then owns.
     tmux_controller.shutdownAll(self.allocator);
+
+    // In-app GPU benchmark: free the driver's run state (samples, payloads, and
+    // the benchmark surface's virtual PTY controller). No-op when not running.
+    bench_driver.deinit();
 
     // Clean up all tabs
     for (0..tab.g_tab_count) |ti| {
@@ -2204,6 +2210,34 @@ pub fn activeTab() ?*TabState {
 
 pub fn activeSurface() ?*Surface {
     return tab.activeSurface();
+}
+
+/// Gather GPU adapter + window/grid info and write the in-app benchmark report.
+/// Called once from the main loop when `bench_driver.finished()` turns true.
+fn finishBenchReport(win: *window_backend.Window) void {
+    var adapter_buf: [256]u8 = undefined;
+    const gpu_info: ?bench_report.GpuInfo = if (gpu.adapterReport(&adapter_buf)) |a|
+        .{
+            .backend = @tagName(gpu.active),
+            .adapter = a.name,
+            .vendor_id = a.vendor_id,
+            .device_id = a.device_id,
+        }
+    else
+        null;
+
+    const fb = window_backend.framebufferSize(win);
+    const window_info: ?bench_report.WindowInfo = .{
+        .width_px = @intCast(fb.width),
+        .height_px = @intCast(fb.height),
+        .grid_cols = @intCast(term_cols),
+        .grid_rows = @intCast(term_rows),
+        .dpi = window_backend.effectiveDpi(win),
+    };
+
+    bench_driver.finishAndWriteReport(@tagName(gpu.active), gpu_info, window_info) catch |err| {
+        std.debug.print("wispterm-benchmark: failed to write report: {}\n", .{err});
+    };
 }
 
 fn surfaceOnAltScreen(s: *const Surface) bool {
@@ -6712,42 +6746,62 @@ fn runMainLoop(self: *AppWindow) !void {
             null;
         g_initial_cwd_len = 0; // Clear after use
 
-        // Try to restore the previous session, but only:
-        //   - once per process (first window only),
-        //   - if config.restore-tabs-on-startup is true,
-        //   - if no CWD override was provided (CLI/spawn).
-        // TODO: also detect --command CLI override once a structured CLI
-        // arg parser exists (today CLI args are merged into Config keys
-        // and there is no positional/--command flag).
-        const restore_once = !g_session_restore_attempted.swap(true, .seq_cst);
-        const restore_enabled = if (g_app) |app| app.restore_tabs_on_startup else false;
-        const should_try_restore = restore_once and restore_enabled and initial_cwd == null;
-        const restored = should_try_restore and tab.restoreSessionFromFile(
-            allocator,
-            term_cols,
-            term_rows,
-            g_cursor_style,
-            g_cursor_blink,
-        );
+        if (bench_driver.isEnabled()) {
+            // In-app GPU benchmark: spawn a no-shell virtual surface and hand
+            // it (plus the virtual PTY controller) to the driver. Disable vsync
+            // on both present paths so the loop spins at the GPU's max rate.
+            // Session restore and the normal shell-tab plan are skipped — the
+            // benchmark owns the single virtual surface for its whole run.
+            const spawn = tab.spawnBenchmarkTab(allocator, term_cols, term_rows, g_cursor_style, g_cursor_blink) orelse {
+                std.debug.print("Failed to spawn benchmark surface\n", .{});
+                return error.SpawnFailed;
+            };
+            bench_driver.start(allocator, spawn.surface, term_cols, spawn.controller) catch {
+                std.debug.print("Failed to start benchmark driver\n", .{});
+                return error.SpawnFailed;
+            };
+            window_backend.setPresentInterval(0);
+            // Native D3D11 Present uses its own interval (OpenGL goes through
+            // window_backend above). Comptime-gated so non-D3D11 builds skip it.
+            if (gpu.active == .d3d11) gpu.Context.setPresentInterval(0);
+        } else {
+            // Try to restore the previous session, but only:
+            //   - once per process (first window only),
+            //   - if config.restore-tabs-on-startup is true,
+            //   - if no CWD override was provided (CLI/spawn).
+            // TODO: also detect --command CLI override once a structured CLI
+            // arg parser exists (today CLI args are merged into Config keys
+            // and there is no positional/--command flag).
+            const restore_once = !g_session_restore_attempted.swap(true, .seq_cst);
+            const restore_enabled = if (g_app) |app| app.restore_tabs_on_startup else false;
+            const should_try_restore = restore_once and restore_enabled and initial_cwd == null;
+            const restored = should_try_restore and tab.restoreSessionFromFile(
+                allocator,
+                term_cols,
+                term_rows,
+                g_cursor_style,
+                g_cursor_blink,
+            );
 
-        switch (startup_tabs.initialTabPlan(.{
-            .restored_session = restored,
-            .initial_cwd_present = initial_cwd != null,
-            .first_plain_window = restore_once,
-        })) {
-            .restored_session => {},
-            .single_terminal => {
-                if (!spawnTabWithCwd(allocator, initial_cwd)) {
-                    std.debug.print("Failed to spawn initial tab\n", .{});
-                    return error.SpawnFailed;
-                }
-            },
-            .agent_and_local_shell => {
-                if (!spawnDefaultAgentAndLocalShellTabs(allocator)) {
-                    std.debug.print("Failed to spawn default Agent and local shell tabs\n", .{});
-                    return error.SpawnFailed;
-                }
-            },
+            switch (startup_tabs.initialTabPlan(.{
+                .restored_session = restored,
+                .initial_cwd_present = initial_cwd != null,
+                .first_plain_window = restore_once,
+            })) {
+                .restored_session => {},
+                .single_terminal => {
+                    if (!spawnTabWithCwd(allocator, initial_cwd)) {
+                        std.debug.print("Failed to spawn initial tab\n", .{});
+                        return error.SpawnFailed;
+                    }
+                },
+                .agent_and_local_shell => {
+                    if (!spawnDefaultAgentAndLocalShellTabs(allocator)) {
+                        std.debug.print("Failed to spawn default Agent and local shell tabs\n", .{});
+                        return error.SpawnFailed;
+                    }
+                },
+            }
         }
 
         // Dev/automation hook: WISPTERM_AUTOCONNECT names an SSH profile to
@@ -6982,6 +7036,11 @@ fn runMainLoop(self: *AppWindow) !void {
             continue;
         }
         if (blink.due) g_gate_last_blink_render = gate_now;
+
+        // In-app GPU benchmark: capture the render-branch start timestamp. The
+        // matching frameEnd (after present + dirty-clear) records the sample and
+        // feeds the next VT chunk; see driver.zig for the measurement model.
+        if (bench_driver.isEnabled()) bench_driver.frameBegin();
 
         // A pending ui_screenshot is captured from this frame's framebuffer right
         // after endFrame. The Metal backend can't read a presented+released
@@ -7295,6 +7354,19 @@ fn runMainLoop(self: *AppWindow) !void {
         clearVisibleSurfaceDirty();
         g_force_rebuild = false;
         g_cells_valid = true;
+        if (bench_driver.isEnabled()) {
+            // Records this frame's pipeline sample, feeds the next VT chunk for
+            // the upcoming frame, and advances the scenario schedule. On the
+            // final frame of the last scenario, write the report and exit.
+            bench_driver.frameEnd() catch |err| {
+                std.debug.print("wispterm-benchmark: driver error: {}, aborting\n", .{err});
+                g_should_close = true;
+            };
+            if (bench_driver.finished()) {
+                finishBenchReport(win);
+                g_should_close = true;
+            }
+        }
         if (window_backend.takePresentFallbackEvent(win)) {
             // The DXGI present path was just latched off mid-session. While
             // it was broken the GPU may have dropped glyph-atlas uploads

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -692,6 +692,13 @@ pub fn setFlipPresentEnabled(enabled: bool) void {
     g_flip_present_enabled = enabled;
 }
 
+/// Override the Present sync interval (0 = vsync off, 1 = on). Used by the
+/// in-app GPU benchmark to spin the main loop at max frame rate. Safe to call
+/// after window creation; the next `presentFrame`/`SwapBuffers` honors it.
+pub fn setPresentInterval(interval: c_int) void {
+    setSwapInterval(interval);
+}
+
 fn setSwapInterval(interval: c_int) void {
     g_present_interval = interval;
     if (!g_swap_interval_loaded) {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -21,6 +21,7 @@ const port_forwarding = @import("../port_forward/forwarding.zig");
 const ai_history_time = @import("../terminal_agents/sessions/time.zig");
 const agent_history = @import("../agent/history.zig");
 const platform_pty_command = @import("../platform/pty_command.zig");
+const Pty = @import("../platform/pty.zig").Pty;
 const active_tab_state = @import("active_tab.zig");
 const i18n = @import("../i18n.zig");
 
@@ -465,6 +466,78 @@ pub fn spawnTabWithCommandAndCwd(allocator: std.mem.Allocator, cols: u16, rows: 
 
     std.debug.print("New tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
+}
+
+/// Result of `spawnBenchmarkTab`: the active surface (borrowed — the tab's
+/// SplitTree owns it) and the virtual PTY controller the caller must keep open
+/// for the run and deinit when done.
+pub const BenchmarkSpawn = struct {
+    surface: *Surface,
+    controller: Pty.VirtualController,
+};
+
+/// Spawn a no-shell virtual surface as a new tab, for the in-app GPU benchmark.
+/// Mirrors `spawnTabWithCommandAndCwd` but uses `Pty.openVirtual` +
+/// `Surface.initVirtual` (no child process): the benchmark driver direct-feeds
+/// the terminal from the UI thread, so there is no shell. The returned
+/// `controller` is the write half of the virtual PTY and is owned by the caller.
+pub fn spawnBenchmarkTab(
+    allocator: std.mem.Allocator,
+    cols: u16,
+    rows: u16,
+    cursor_style: CursorStyle,
+    cursor_blink: bool,
+) ?BenchmarkSpawn {
+    if (g_tab_count >= MAX_TABS) return null;
+
+    var pair = Pty.openVirtual(.{ .ws_col = cols, .ws_row = rows }) catch return null;
+    // On `initVirtual` failure its errdefer deinits the adopted pty; we still
+    // own and must close the controller side (see tmux_bridge.make).
+    const surface = Surface.initVirtual(
+        allocator,
+        cols,
+        rows,
+        pair.pty,
+        g_scrollback_limit,
+        cursor_style,
+        cursor_blink,
+    ) catch {
+        pair.controller.deinit();
+        return null;
+    };
+    surface.attachRemoteClient(g_remote_client);
+
+    const tree = SplitTree.init(allocator, surface) catch {
+        surface.deinit(allocator);
+        pair.controller.deinit();
+        return null;
+    };
+    surface.unref(allocator); // tree owns the ref now
+
+    const t = allocator.create(TabState) catch {
+        var tree_mut = tree;
+        tree_mut.deinit();
+        pair.controller.deinit();
+        return null;
+    };
+    t.kind = .terminal;
+    t.tree = tree;
+    t.focused = .root;
+    t.ai_chat_session = null;
+    t.ai_history_session = null;
+    t.skill_center_session = null;
+    t.port_forwarding_session = null;
+    t.copilot_session = null;
+    t.tmux_window_id = null;
+    t.tmux_owner = null;
+    t.tmux_name_len = 0;
+    t.copilot_visible = false;
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+
+    return .{ .surface = surface, .controller = pair.controller };
 }
 
 pub fn spawnAiChatTab(

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -98,31 +98,10 @@ fn step(ptr: *anyopaque) Benchmark.Error!void {
 
 /// Build a deterministic payload: mostly printable lines of width `cols` + CRLF,
 /// with one SGR sequence per line so the escape-sequence parser path is hit.
+/// Delegates to the shared `payload.zig` generator so the CPU CLI and the
+/// in-app GPU benchmark feed identical scroll-flood content.
 fn generatePayload(allocator: std.mem.Allocator, spec: Spec) ![]u8 {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-
-    var written: usize = 0;
-    var color: u8 = 0;
-    while (written < spec.payload_bytes) {
-        // CSI SGR color set
-        const sgr = try std.fmt.allocPrint(allocator, "\x1b[3{d}m", .{color});
-        defer allocator.free(sgr);
-        try buf.appendSlice(allocator, sgr);
-        color = (color + 1) % 8;
-
-        const line_len = @min(spec.cols, spec.payload_bytes - written);
-        var i: usize = 0;
-        while (i < line_len) : (i += 1) {
-            // Cycle printable ASCII 0x21..0x7e.
-            const ch: u8 = 0x21 + @as(u8, @intCast((written + i) % 94));
-            try buf.append(allocator, ch);
-        }
-        try buf.appendSlice(allocator, "\r\n");
-        written += line_len + 2;
-    }
-
-    return try buf.toOwnedSlice(allocator);
+    return @import("payload.zig").generateScrollFlood(allocator, spec.cols, spec.payload_bytes);
 }
 
 test "TerminalStream: generatePayload produces requested order of bytes" {

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -10,7 +10,7 @@ const options_mod = @import("options.zig");
 const TerminalStream = @import("TerminalStream.zig");
 const report = @import("report.zig");
 const env = @import("env.zig");
-const platform_dirs = @import("../platform/dirs.zig");
+const report_io = @import("report_io.zig");
 
 pub const CaseName = struct {
     name: []const u8,
@@ -67,7 +67,7 @@ pub fn run(allocator: std.mem.Allocator, raw_args: []const []const u8) !void {
     }
     try stdout.writeAll("\n");
 
-    try writeReport(allocator, results.items, stdout);
+    try writeReport(allocator, results.items);
 }
 
 fn runCase(
@@ -107,7 +107,6 @@ fn runCase(
 fn writeReport(
     allocator: std.mem.Allocator,
     results: []const report.ScenarioResult,
-    w: anytype,
 ) !void {
     const e = env.collect();
     const rep: report.Report = .{
@@ -126,42 +125,9 @@ fn writeReport(
     const md = try report.formatMarkdown(allocator, rep);
     defer allocator.free(md);
 
-    if (writeReportFiles(allocator, json, md)) |paths| {
-        try w.print("report written:\n  {s}\n  {s}\n\n", .{ paths.json_path, paths.md_path });
-        allocator.free(paths.json_path);
-        allocator.free(paths.md_path);
-    } else |_| {
-        try w.writeAll("report: could not write files to config dir; printing markdown only.\n\n");
-    }
-    // Always print the markdown so it can be pasted straight into a GitHub
-    // issue/discussion even when file writing failed.
-    try w.writeAll(md);
-}
-
-const ReportPaths = struct {
-    json_path: []u8,
-    md_path: []u8,
-};
-
-fn writeReportFiles(allocator: std.mem.Allocator, json: []const u8, md: []const u8) !ReportPaths {
-    const dir = try platform_dirs.configDir(allocator);
-    defer allocator.free(dir);
-    std.fs.cwd().makePath(dir) catch {};
-
-    const ts = std.time.milliTimestamp();
-    const json_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.json", .{ts});
-    defer allocator.free(json_name);
-    const md_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.md", .{ts});
-    defer allocator.free(md_name);
-
-    const json_path = try std.fs.path.join(allocator, &.{ dir, json_name });
-    errdefer allocator.free(json_path);
-    const md_path = try std.fs.path.join(allocator, &.{ dir, md_name });
-    errdefer allocator.free(md_path);
-
-    try std.fs.cwd().writeFile(.{ .sub_path = json_path, .data = json });
-    try std.fs.cwd().writeFile(.{ .sub_path = md_path, .data = md });
-    return .{ .json_path = json_path, .md_path = md_path };
+    // The CLI prints its own summary to `w` (stdout); file I/O is shared with
+    // the in-app driver via report_io. Emit files + markdown to stdout.
+    try report_io.emitReport(allocator, json, md);
 }
 
 fn listCases(w: anytype) !void {

--- a/src/benchmark/driver.zig
+++ b/src/benchmark/driver.zig
@@ -1,0 +1,231 @@
+//! In-app GPU render benchmark driver (`wispterm --benchmark`).
+//!
+//! Owns all benchmark run state in this module — AppWindow only queries
+//! `isEnabled()` and calls `start` / `frameBegin` / `frameEnd` / `finished` /
+//! `finishAndWriteReport` at the main-loop hooks. No `g_*` state is added to
+//! AppWindow/input/overlays (the integration-layer ratchets stay put).
+//!
+//! Measurement model: vsync off, the main loop spins on a dirty surface, and
+//! each frame's CPU pipeline time (render-gate entry → present return) is
+//! recorded as a latency sample. The UI thread direct-feeds a synthetic VT
+//! payload to the active surface every frame (no PTY/shell), so the feed cost
+//! lands outside the measured window and the two renderer backends are
+//! compared on pure rebuild+draw+present work.
+
+const std = @import("std");
+const Surface = @import("../Surface.zig");
+const Pty = @import("../platform/pty.zig").Pty;
+const scenarios = @import("scenarios.zig");
+const stats = @import("stats.zig");
+const report = @import("report.zig");
+const env = @import("env.zig");
+const report_io = @import("report_io.zig");
+
+/// Set by `main.zig` when `--benchmark` is present on the command line.
+pub var enabled: bool = false;
+
+pub fn isEnabled() bool {
+    return enabled;
+}
+
+const State = struct {
+    allocator: std.mem.Allocator,
+    surface: *Surface,
+    schedule: scenarios.Schedule,
+    /// Frame pipeline samples (ns) for the scenario currently being measured.
+    current_samples: std.ArrayList(i64) = .empty,
+    /// Completed scenario results, in run order.
+    results: std.ArrayList(report.ScenarioResult) = .empty,
+    /// One generated payload per scenario (indexed by `schedule.idx`).
+    payloads: [][]u8,
+    /// The virtual PTY controller half of the benchmark surface. Held for the
+    /// whole run so the surface's read thread never sees EOF; the driver
+    /// direct-feeds the terminal, so this is lifecycle-only.
+    controller: Pty.VirtualController,
+    /// Nano-timestamp captured at the render-gate entry of the current frame.
+    frame_start_ns: i64 = 0,
+    report_written: bool = false,
+
+    fn deinit(self: *State) void {
+        for (self.results.items) |r| self.allocator.free(r.name);
+        self.results.deinit(self.allocator);
+        self.current_samples.deinit(self.allocator);
+        for (self.payloads) |p| self.allocator.free(p);
+        self.allocator.free(self.payloads);
+        self.controller.deinit();
+    }
+};
+
+var g_state: ?State = null;
+
+/// Begin a benchmark run against `surface` (a virtual, no-shell surface).
+/// `controller` is the write half of the surface's virtual PTY; the driver
+/// keeps it open for the run and direct-feeds the terminal itself. Feeds the
+/// first scenario's payload so the very first rendered frame has content.
+pub fn start(
+    allocator: std.mem.Allocator,
+    surface: *Surface,
+    cols: usize,
+    controller: Pty.VirtualController,
+) !void {
+    if (g_state != null) return;
+    const cfg: scenarios.ScenarioConfig = .{};
+    const payloads = try allocator.alloc([]u8, scenarios.all_scenarios.len);
+    errdefer allocator.free(payloads);
+    var generated: usize = 0;
+    errdefer {
+        for (payloads[0..generated]) |p| allocator.free(p);
+    }
+    for (scenarios.all_scenarios, 0..) |scen, i| {
+        payloads[i] = try scenarios.generateScenarioPayload(allocator, scen, cols, cfg.payload_bytes);
+        generated += 1;
+    }
+
+    g_state = .{
+        .allocator = allocator,
+        .surface = surface,
+        .schedule = scenarios.Schedule.init(cfg),
+        .payloads = payloads,
+        .controller = controller,
+    };
+    errdefer g_state = null;
+
+    // Prime the surface with the first scenario's payload; markOutputDirty so
+    // the render gate fires on the next iteration instead of idling.
+    try feedCurrent(&g_state.?);
+    _ = surface.markOutputDirty();
+}
+
+/// Capture the render-gate entry timestamp for the current frame.
+pub fn frameBegin() void {
+    if (g_state) |*s| {
+        s.frame_start_ns = @as(i64, @intCast(std.time.nanoTimestamp()));
+    }
+}
+
+/// Record the frame that just presented, then feed the next chunk so the
+/// upcoming frame has fresh content. Drives warmup → measure → scenario
+/// transitions via the schedule. Errors propagate (e.g. OOM appending a
+/// sample); the caller should abort the run on error.
+pub fn frameEnd() !void {
+    const s = &(g_state orelse return);
+    const now_ns: i64 = @as(i64, @intCast(std.time.nanoTimestamp()));
+    const frame_ns = now_ns - s.frame_start_ns;
+    const now_ms: i64 = @divTrunc(now_ns, std.time.ns_per_ms);
+
+    if (s.schedule.observeFrame(now_ms)) {
+        try s.current_samples.append(s.allocator, frame_ns);
+    }
+    if (s.schedule.shouldFinishScenario(now_ms)) {
+        try finishCurrentScenario(s);
+    }
+    if (!s.schedule.done) {
+        try feedCurrent(s);
+        _ = s.surface.markOutputDirty();
+    }
+}
+
+pub fn finished() bool {
+    const s = g_state orelse return false;
+    return s.schedule.done;
+}
+
+/// Assemble the full report (env + GPU/window info the caller supplies) and
+/// write JSON + Markdown to the config dir, printing the Markdown to stdout.
+/// `backend` is the resolved renderer backend (e.g. "opengl"/"d3d11") — the
+/// caller knows `gpu.active`, while `env.backend` is only the build option
+/// ("auto" for the app). Safe to call once; idempotent.
+pub fn finishAndWriteReport(
+    backend: []const u8,
+    gpu: ?report.GpuInfo,
+    window: ?report.WindowInfo,
+) !void {
+    const s = &(g_state orelse return);
+    if (s.report_written) return;
+    const e = env.collect();
+    const rep: report.Report = .{
+        .app_version = e.app_version,
+        .os = e.os,
+        .cpu_arch = e.cpu_arch,
+        .logical_cores = e.logical_cores,
+        .runner = "in-app",
+        .backend = backend,
+        .gpu = gpu,
+        .window = window,
+        .scenarios = s.results.items,
+        .timestamp_ms = std.time.milliTimestamp(),
+    };
+
+    const json = try report.formatJson(s.allocator, rep);
+    defer s.allocator.free(json);
+    const md = try report.formatMarkdown(s.allocator, rep);
+    defer s.allocator.free(md);
+
+    std.debug.print("wispterm-benchmark: {d} scenarios measured\n", .{s.results.items.len});
+    try report_io.emitReport(s.allocator, json, md);
+    s.report_written = true;
+}
+
+/// Tear down the run, freeing all driver-owned memory. Called by AppWindow on
+/// close after `finishAndWriteReport`.
+pub fn deinit() void {
+    if (g_state) |*s| {
+        s.deinit();
+        g_state = null;
+    }
+    enabled = false;
+}
+
+/// Compute the latency summary for the scenario that just elapsed, store it as
+/// a `ScenarioResult`, then advance the schedule and reset per-scenario samples.
+fn finishCurrentScenario(s: *State) !void {
+    const scen = s.schedule.currentScenario() orelse return;
+    const samples = s.current_samples.items;
+    const sort_buf = try s.allocator.alloc(i64, samples.len);
+    defer s.allocator.free(sort_buf);
+    const summary = stats.summaryWithBuf(samples, sort_buf);
+
+    const mean_ns: f64 = if (summary.count > 0)
+        @as(f64, @floatFromInt(summary.mean))
+    else
+        0;
+
+    try s.results.append(s.allocator, .{
+        .name = try s.allocator.dupe(u8, scen.name()),
+        .unit = .latency_ns,
+        .value = mean_ns,
+        .p50_ns = summary.p50,
+        .p95_ns = summary.p95,
+        .max_ns = summary.max,
+        .samples = summary.count,
+        .duration_ms = s.schedule.cfg.duration_ms,
+    });
+    s.current_samples.clearRetainingCapacity();
+    s.schedule.advance();
+}
+
+/// Feed the current scenario's pre-generated payload to the surface under the
+/// render-state mutex, matching the IO thread's locking discipline so the VT
+/// parser and screen state stay consistent.
+fn feedCurrent(s: *State) !void {
+    const idx = s.schedule.idx;
+    if (idx >= s.payloads.len) return;
+    const data = s.payloads[idx];
+    s.surface.render_state.mutex.lock();
+    defer s.surface.render_state.mutex.unlock();
+    s.surface.feedVtWithWispTermImageFallback(data);
+}
+
+test "driver: start/frameEnd/finishAndWriteReport round-trip with a stub surface is not linked here" {
+    // The driver links Surface + platform_dirs (app-side), so its integration
+    // tests live in test-full. This stub test only forces analysis of the
+    // module's public API surface so a signature drift is caught at compile.
+    _ = &start;
+    _ = &frameBegin;
+    _ = &frameEnd;
+    _ = &finished;
+    _ = &finishAndWriteReport;
+    _ = &deinit;
+    _ = isEnabled;
+    try std.testing.expect(!isEnabled());
+}

--- a/src/benchmark/payload.zig
+++ b/src/benchmark/payload.zig
@@ -1,0 +1,130 @@
+//! Synthetic VT payload generators for benchmarks (pure std, fast-suite tested).
+//!
+//! Kept free of ghostty-vt / Surface / build_options so both the CPU CLI
+//! (`TerminalStream.zig`) and the in-app GPU benchmark (`scenarios.zig`) share
+//! one canonical generator — reports from the two runners stay comparable and
+//! this module unit-tests in the lean fast suite.
+
+const std = @import("std");
+
+/// Scroll-flood payload: printable ASCII lines of width `cols` + CRLF, with one
+/// SGR color sequence per line so the escape-sequence parser path is exercised.
+/// This is the exact content the CPU `terminal-stream` case feeds, so an in-app
+/// scroll-flood number lines up with the CLI throughput number.
+pub fn generateScrollFlood(allocator: std.mem.Allocator, cols: usize, payload_bytes: usize) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    var written: usize = 0;
+    var color: u8 = 0;
+    while (written < payload_bytes) {
+        const sgr = try std.fmt.allocPrint(allocator, "\x1b[3{d}m", .{color});
+        defer allocator.free(sgr);
+        try buf.appendSlice(allocator, sgr);
+        color = (color + 1) % 8;
+
+        const line_len = @min(cols, payload_bytes - written);
+        var i: usize = 0;
+        while (i < line_len) : (i += 1) {
+            // Cycle printable ASCII 0x21..0x7e.
+            const ch: u8 = 0x21 + @as(u8, @intCast((written + i) % 94));
+            try buf.append(allocator, ch);
+        }
+        try buf.appendSlice(allocator, "\r\n");
+        written += line_len + 2;
+    }
+
+    return try buf.toOwnedSlice(allocator);
+}
+
+/// Unicode-heavy payload: CJK (双宽, 3 UTF-8 bytes) + emoji (4 bytes) + ASCII,
+/// one SGR color per line. Stresses the wide-cell layout path and the color
+/// glyph atlas, which scroll-flood (pure ASCII) never touches — the two
+/// scenarios isolate different render costs. `cols` is a display-column budget.
+pub fn generateUnicode(allocator: std.mem.Allocator, cols: usize, payload_bytes: usize) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+
+    const cjk = "中";
+    const ascii_run = "A1";
+    const emoji = "😀";
+
+    var written: usize = 0;
+    var color: u8 = 0;
+    while (written < payload_bytes) {
+        const sgr = try std.fmt.allocPrint(allocator, "\x1b[3{d}m", .{color});
+        defer allocator.free(sgr);
+        try buf.appendSlice(allocator, sgr);
+        color = (color + 1) % 8;
+
+        var col_budget: usize = cols;
+        // Every run is 2 display columns; stop when fewer than 2 remain so an
+        // odd `cols` (e.g. a 79-col terminal) doesn't underflow `col_budget`.
+        while (col_budget >= 2 and written < payload_bytes) {
+            const pick = (written + col_budget) % 4;
+            if (pick == 0) {
+                try buf.appendSlice(allocator, cjk);
+                col_budget -= 2;
+                written += 3;
+            } else if (pick == 1) {
+                try buf.appendSlice(allocator, emoji);
+                col_budget -= 2;
+                written += 4;
+            } else {
+                try buf.appendSlice(allocator, ascii_run);
+                col_budget -= 2;
+                written += 2;
+            }
+        }
+        try buf.appendSlice(allocator, "\r\n");
+        written += 2;
+    }
+
+    return try buf.toOwnedSlice(allocator);
+}
+
+test "payload: scroll-flood shape — CRLF + SGR, ~payload_bytes" {
+    const allocator = std.testing.allocator;
+    const payload = try generateScrollFlood(allocator, 10, 256);
+    defer allocator.free(payload);
+    try std.testing.expect(payload.len >= 128 and payload.len <= 512);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\x1b[3") != null);
+}
+
+test "payload: unicode-heavy contains CJK and emoji" {
+    const allocator = std.testing.allocator;
+    const payload = try generateUnicode(allocator, 40, 1024);
+    defer allocator.free(payload);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "中") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "😀") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\x1b[3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\r\n") != null);
+}
+
+test "payload: scroll-flood is deterministic for the same inputs" {
+    const allocator = std.testing.allocator;
+    const a = try generateScrollFlood(allocator, 20, 512);
+    defer allocator.free(a);
+    const b = try generateScrollFlood(allocator, 20, 512);
+    defer allocator.free(b);
+    try std.testing.expectEqualSlices(u8, a, b);
+}
+
+test "payload: unicode-heavy does not underflow on odd column budgets" {
+    const allocator = std.testing.allocator;
+    // An odd col budget (e.g. a 79-col terminal) must not underflow the
+    // 2-column-wide run loop; the line just ends one column short.
+    const data = try generateUnicode(allocator, 79, 1024);
+    defer allocator.free(data);
+    try std.testing.expect(data.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\r\n") != null);
+}
+
+test "payload: unicode-heavy handles a 1-column budget without underflow" {
+    const allocator = std.testing.allocator;
+    const data = try generateUnicode(allocator, 1, 256);
+    defer allocator.free(data);
+    // No 2-col run fits a 1-col line, so the payload is just CRLFs.
+    try std.testing.expect(data.len > 0);
+}

--- a/src/benchmark/report.zig
+++ b/src/benchmark/report.zig
@@ -141,7 +141,7 @@ pub fn formatMarkdown(allocator: std.mem.Allocator, r: Report) ![]u8 {
     try w.print("- **backend:** {s}\n", .{r.backend});
     try w.print("- **runner:** {s}\n", .{r.runner});
     if (r.gpu) |g| {
-        try w.print("- **gpu:** {s} — {s}", .{ g.backend, g.adapter });
+        try w.print("- **gpu:** {s} - {s}", .{ g.backend, g.adapter });
         if (g.vendor_id != 0) try w.print(" (vendor={d}, device={d})", .{ g.vendor_id, g.device_id });
         try w.writeAll("\n");
     }
@@ -150,17 +150,24 @@ pub fn formatMarkdown(allocator: std.mem.Allocator, r: Report) ![]u8 {
             win.width_px, win.height_px, win.dpi, win.grid_cols, win.grid_rows,
         });
     }
-    try w.writeAll("\n| scenario | unit | value | p50 | p95 | max | samples | duration_ms |\n");
-    try w.writeAll("|---|---|---|---|---|---|---|---|\n");
+    try w.writeAll("\n| scenario | unit | value | fps | p50 | p95 | max | samples | duration_ms |\n");
+    try w.writeAll("|---|---|---|---|---|---|---|---|---|\n");
     for (r.scenarios) |s| {
-        const p50 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p50_ns}) else try allocator.dupe(u8, "—");
+        const p50 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p50_ns}) else try allocator.dupe(u8, "-");
         defer allocator.free(p50);
-        const p95 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p95_ns}) else try allocator.dupe(u8, "—");
+        const p95 = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.p95_ns}) else try allocator.dupe(u8, "-");
         defer allocator.free(p95);
-        const mx = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.max_ns}) else try allocator.dupe(u8, "—");
+        const mx = if (s.unit == .latency_ns) try std.fmt.allocPrint(allocator, "{d} ns", .{s.max_ns}) else try allocator.dupe(u8, "-");
         defer allocator.free(mx);
-        try w.print("| {s} | {s} | {d:.2} | {s} | {s} | {s} | {d} | {d} |\n", .{
-            s.name, s.unit.name(), s.value, p50, p95, mx, s.samples, s.duration_ms,
+        // FPS is only meaningful for latency scenarios, where `value` is the
+        // mean frame ns; throughput scenarios already report a rate in `value`.
+        const fps = if (s.unit == .latency_ns and s.value > 0)
+            try std.fmt.allocPrint(allocator, "{d:.1}", .{1_000_000_000.0 / s.value})
+        else
+            try allocator.dupe(u8, "-");
+        defer allocator.free(fps);
+        try w.print("| {s} | {s} | {d:.2} | {s} | {s} | {s} | {s} | {d} | {d} |\n", .{
+            s.name, s.unit.name(), s.value, fps, p50, p95, mx, s.samples, s.duration_ms,
         });
     }
 

--- a/src/benchmark/report_io.zig
+++ b/src/benchmark/report_io.zig
@@ -1,0 +1,56 @@
+//! Shared benchmark report file I/O (app-side: links platform_dirs).
+//!
+//! Both the `wispterm-bench` CPU CLI (`cli.zig`) and the in-app GPU benchmark
+//! driver (`driver.zig`) write reports to the WispTerm config dir in the same
+//! shape, so a CLI run and an in-app run land side-by-side and stay comparable.
+//! Extracted here (not in pure `report.zig`) because it needs `platform_dirs`.
+
+const std = @import("std");
+const platform_dirs = @import("../platform/dirs.zig");
+
+pub const ReportPaths = struct {
+    json_path: []u8,
+    md_path: []u8,
+
+    pub fn deinit(self: ReportPaths, allocator: std.mem.Allocator) void {
+        allocator.free(self.json_path);
+        allocator.free(self.md_path);
+    }
+};
+
+/// Write `json` and `md` as `benchmark-report-<timestamp>.{json,md}` into the
+/// WispTerm config dir, creating it if missing. Caller owns the returned paths.
+pub fn writeReportFiles(allocator: std.mem.Allocator, json: []const u8, md: []const u8) !ReportPaths {
+    const dir = try platform_dirs.configDir(allocator);
+    defer allocator.free(dir);
+    std.fs.cwd().makePath(dir) catch {};
+
+    const ts = std.time.milliTimestamp();
+    const json_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.json", .{ts});
+    defer allocator.free(json_name);
+    const md_name = try std.fmt.allocPrint(allocator, "benchmark-report-{d}.md", .{ts});
+    defer allocator.free(md_name);
+
+    const json_path = try std.fs.path.join(allocator, &.{ dir, json_name });
+    errdefer allocator.free(json_path);
+    const md_path = try std.fs.path.join(allocator, &.{ dir, md_name });
+    errdefer allocator.free(md_path);
+
+    try std.fs.cwd().writeFile(.{ .sub_path = json_path, .data = json });
+    try std.fs.cwd().writeFile(.{ .sub_path = md_path, .data = md });
+    return .{ .json_path = json_path, .md_path = md_path };
+}
+
+/// Print a paste-ready Markdown report to stdout (always, even when file
+/// writing fails) plus the paths of the written files (when it succeeded).
+pub fn emitReport(allocator: std.mem.Allocator, json: []const u8, md: []const u8) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    if (writeReportFiles(allocator, json, md)) |paths| {
+        var owned = paths;
+        defer owned.deinit(allocator);
+        try stdout.print("report written:\n  {s}\n  {s}\n\n", .{ paths.json_path, paths.md_path });
+    } else |_| {
+        try stdout.writeAll("report: could not write files to config dir; printing markdown only.\n\n");
+    }
+    try stdout.writeAll(md);
+}

--- a/src/benchmark/scenarios.zig
+++ b/src/benchmark/scenarios.zig
@@ -1,0 +1,186 @@
+//! In-app benchmark scenarios + run scheduler (pure logic, fast-suite unit-tested).
+//!
+//! Each scenario is a synthetic VT payload fed to the active surface every frame
+//! while the renderer is measured. `scroll-flood` reuses the CPU CLI's exact
+//! payload (`TerminalStream.generatePayload`) so the two reports are comparable;
+//! `unicode-heavy` stresses the glyph atlas / wide-cell path with CJK + emoji.
+//!
+//! The `Schedule` is the per-run state machine: warmup frames (atlas/rasterizer
+//! settle) are discarded, then a fixed wall-clock window of samples is collected
+//! per scenario. Kept pure (no clock, no Surface) so it unit-tests without a
+//! window — the driver threads `std.time` and the surface feed through it.
+
+const std = @import("std");
+const payload = @import("payload.zig");
+
+pub const ScenarioId = enum {
+    scroll_flood,
+    unicode_heavy,
+
+    pub fn name(self: ScenarioId) []const u8 {
+        return switch (self) {
+            .scroll_flood => "scroll-flood",
+            .unicode_heavy => "unicode-heavy",
+        };
+    }
+};
+
+pub const all_scenarios = [_]ScenarioId{ .scroll_flood, .unicode_heavy };
+
+/// Per-scenario tuning. Durations are wall-clock milliseconds the caller feeds
+/// from `std.time.milliTimestamp`; warmup is a frame count.
+pub const ScenarioConfig = struct {
+    warmup_frames: u32 = 30,
+    duration_ms: u64 = 5000,
+    /// Bytes of VT generated per scenario (fed each frame).
+    payload_bytes: usize = 64 * 1024,
+};
+
+pub const Schedule = struct {
+    cfg: ScenarioConfig,
+    /// Index into `all_scenarios` of the current scenario.
+    idx: usize = 0,
+    /// Frames remaining in the current scenario's warmup.
+    warmup_left: u32,
+    /// Wall-clock ms the current scenario's measure window started, or null
+    /// while still in warmup.
+    measure_start_ms: ?i64 = null,
+    done: bool = false,
+
+    pub fn init(cfg: ScenarioConfig) Schedule {
+        return .{ .cfg = cfg, .warmup_left = cfg.warmup_frames };
+    }
+
+    pub fn currentScenario(self: Schedule) ?ScenarioId {
+        if (self.done) return null;
+        return all_scenarios[self.idx];
+    }
+
+    /// Observe one frame's wall clock. Advances warmup/measure state and returns
+    /// `true` when this frame falls inside the measure window (i.e. the caller
+    /// should record a latency sample for it). Sample storage is owned by the
+    /// driver, not the schedule — this stays a pure state machine.
+    pub fn observeFrame(self: *Schedule, now_ms: i64) bool {
+        if (self.done) return false;
+        if (self.measure_start_ms == null) {
+            if (self.warmup_left > 0) {
+                self.warmup_left -= 1;
+                if (self.warmup_left == 0) self.measure_start_ms = now_ms;
+                return false;
+            }
+            // warmup_frames == 0: open the measure window on this frame.
+            self.measure_start_ms = now_ms;
+        }
+        return true;
+    }
+
+    /// True when the current scenario's measure window has elapsed. The caller
+    /// captures the just-finished scenario's samples, then calls `advance()`.
+    pub fn shouldFinishScenario(self: Schedule, now_ms: i64) bool {
+        const start = self.measure_start_ms orelse return false;
+        return now_ms - start >= @as(i64, @intCast(self.cfg.duration_ms));
+    }
+
+    /// Move to the next scenario (or mark done).
+    pub fn advance(self: *Schedule) void {
+        self.idx += 1;
+        if (self.idx >= all_scenarios.len) {
+            self.done = true;
+        } else {
+            self.warmup_left = self.cfg.warmup_frames;
+            self.measure_start_ms = null;
+        }
+    }
+};
+
+/// Generate the payload for a scenario. Caller owns the returned bytes.
+/// `cols` sizes the printable line width (scroll-flood) or the cell budget
+/// (unicode-heavy); both keep the per-frame feed cost bounded and comparable.
+pub fn generateScenarioPayload(
+    allocator: std.mem.Allocator,
+    scenario: ScenarioId,
+    cols: usize,
+    payload_bytes: usize,
+) ![]u8 {
+    return switch (scenario) {
+        .scroll_flood => try payload.generateScrollFlood(allocator, cols, payload_bytes),
+        .unicode_heavy => try payload.generateUnicode(allocator, cols, payload_bytes),
+    };
+}
+
+test "scenarios: all_scenarios lists scroll-flood and unicode-heavy" {
+    try std.testing.expectEqual(@as(usize, 2), all_scenarios.len);
+    try std.testing.expectEqual(ScenarioId.scroll_flood, all_scenarios[0]);
+    try std.testing.expectEqual(ScenarioId.unicode_heavy, all_scenarios[1]);
+    try std.testing.expectEqualStrings("scroll-flood", ScenarioId.scroll_flood.name());
+    try std.testing.expectEqualStrings("unicode-heavy", ScenarioId.unicode_heavy.name());
+}
+
+test "scenarios: scroll-flood payload matches the shared generator shape" {
+    const allocator = std.testing.allocator;
+    const data = try generateScenarioPayload(allocator, .scroll_flood, 40, 512);
+    defer allocator.free(data);
+    try std.testing.expect(data.len >= 256 and data.len <= 1024);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\x1b[3") != null);
+}
+
+test "scenarios: unicode-heavy payload contains CJK and emoji" {
+    const allocator = std.testing.allocator;
+    const data = try generateScenarioPayload(allocator, .unicode_heavy, 40, 1024);
+    defer allocator.free(data);
+    try std.testing.expect(std.mem.indexOf(u8, data, "中") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "😀") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\x1b[3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, data, "\r\n") != null);
+}
+
+test "Schedule: warmup frames are discarded, then measure window opens" {
+    var sch = Schedule.init(.{ .warmup_frames = 3, .duration_ms = 1000, .payload_bytes = 64 });
+
+    try std.testing.expectEqual(@as(?ScenarioId, .scroll_flood), sch.currentScenario());
+    // 3 warmup frames discarded; the 3rd opens the measure window.
+    try std.testing.expect(sch.observeFrame(0) == false);
+    try std.testing.expect(sch.observeFrame(0) == false);
+    try std.testing.expect(sch.observeFrame(0) == false);
+    try std.testing.expect(sch.measure_start_ms != null);
+    // Next frame is the first measured one.
+    try std.testing.expect(sch.observeFrame(10) == true);
+    try std.testing.expect(!sch.shouldFinishScenario(20));
+    try std.testing.expectEqual(@as(?ScenarioId, .scroll_flood), sch.currentScenario());
+}
+
+test "Schedule: advances to next scenario and finishes" {
+    var sch = Schedule.init(.{ .warmup_frames = 0, .duration_ms = 100, .payload_bytes = 64 });
+
+    // warmup_frames=0 → measure opens immediately, first frame is measured.
+    try std.testing.expect(sch.observeFrame(0) == true);
+    try std.testing.expect(!sch.shouldFinishScenario(0));
+    // Cross the 100ms deadline → advance to unicode-heavy.
+    try std.testing.expect(sch.observeFrame(101) == true);
+    try std.testing.expect(sch.shouldFinishScenario(101));
+    sch.advance();
+    try std.testing.expectEqual(@as(?ScenarioId, .unicode_heavy), sch.currentScenario());
+    try std.testing.expect(!sch.done);
+
+    // Second scenario: open, then cross deadline → done.
+    try std.testing.expect(sch.observeFrame(101) == true);
+    try std.testing.expect(sch.observeFrame(300) == true);
+    try std.testing.expect(sch.shouldFinishScenario(300));
+    sch.advance();
+    try std.testing.expect(sch.done);
+    try std.testing.expectEqual(@as(?ScenarioId, null), sch.currentScenario());
+}
+
+test "Schedule: observeFrame after done is a no-op" {
+    var sch = Schedule.init(.{ .warmup_frames = 0, .duration_ms = 1, .payload_bytes = 8 });
+    // Drive both scenarios to completion (2 scenarios × 1ms window).
+    _ = sch.observeFrame(0); // scroll-flood opens
+    _ = sch.observeFrame(10); // crosses 1ms → finish
+    sch.advance();
+    _ = sch.observeFrame(10); // unicode-heavy opens
+    _ = sch.observeFrame(20); // crosses 1ms → finish
+    sch.advance();
+    try std.testing.expect(sch.done);
+    try std.testing.expect(sch.observeFrame(30) == false);
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -1290,7 +1290,8 @@ pub fn isSpecialCommand(flag: []const u8) bool {
         std.mem.eql(u8, flag, "h") or
         std.mem.eql(u8, flag, "version") or
         std.mem.eql(u8, flag, "v") or
-        std.mem.eql(u8, flag, "show-config-path");
+        std.mem.eql(u8, flag, "show-config-path") or
+        std.mem.eql(u8, flag, "benchmark");
 }
 
 /// Check if CLI args contain a specific command flag (e.g. --list-fonts).
@@ -1477,6 +1478,8 @@ pub fn writeHelp(writer: anytype) !void {
         \\  --list-fonts                 List all available system fonts
         \\  --list-themes                List all available themes
         \\  --test-font-discovery        Test font discovery for common fonts
+        \\  --benchmark                  Run the in-app GPU render benchmark, write a
+        \\                               report, and exit (build per-backend with -Dgpu-backend)
         \\  --help, -h                   Show this help message
         \\
         \\Config priority: --config/--config-path, portable wispterm.conf next to the app, then the platform config directory

--- a/src/main.zig
+++ b/src/main.zig
@@ -164,6 +164,13 @@ pub fn main() !void {
         return;
     }
 
+    // In-app GPU render benchmark: needs a real window + GPU context, so it
+    // runs through the normal App/AppWindow startup with a flag that makes
+    // AppWindow substitute a virtual benchmark surface and drive the loop.
+    if (Config.hasCommand(allocator, "benchmark")) {
+        @import("benchmark/driver.zig").enabled = true;
+    }
+
     if (build_options.debug_console) {
         diag_log.init();
         diag_log.installCrashHandlers();

--- a/src/platform/window_backend.zig
+++ b/src/platform/window_backend.zig
@@ -89,6 +89,12 @@ pub const setGlobalWindow = impl.setGlobalWindow;
 pub fn setFlipPresentEnabled(enabled: bool) void {
     if (comptime @hasDecl(impl, "setFlipPresentEnabled")) impl.setFlipPresentEnabled(enabled);
 }
+
+/// Override the Present vsync interval (0 = off, 1 = on). Used by the in-app
+/// GPU benchmark to disable vsync. No-op on backends without the seam.
+pub fn setPresentInterval(interval: i32) void {
+    if (comptime @hasDecl(impl, "setPresentInterval")) impl.setPresentInterval(interval);
+}
 /// Renderer surface seam (host → GPU backend). This is OpenGL-shaped: the host
 /// supplies a GL proc-address loader, which `gpu.Context.init` consumes. The
 /// seam is per-backend by design — a macOS/AppKit host pairs with the Metal

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -12,6 +12,7 @@ const fallback_marker = @import("fallback_marker.zig");
 const present_policy = @import("present_policy.zig");
 const render_diagnostics = @import("../../../render_diagnostics.zig");
 const shaders = @import("shaders.zig");
+const types = @import("../types.zig");
 
 const HWND = windows.HWND;
 const HMODULE = windows.HMODULE;
@@ -116,6 +117,31 @@ pub const DeviceRecreateResult = struct {
         };
     }
 };
+
+/// DXGI Present sync interval (0 = tear off, 1 = vsync). Defaults to vsync on;
+/// the in-app GPU benchmark sets it to 0 so the main loop spins at the GPU's
+/// max frame rate instead of being capped at the refresh rate.
+var present_interval: u32 = 1;
+
+/// Set the Present sync interval. Called by the benchmark startup to disable
+/// vsync; normal app sessions leave the default (1).
+pub fn setPresentInterval(interval: u32) void {
+    present_interval = interval;
+}
+
+/// Active adapter identity for the benchmark report. `buf` backs the UTF-8 name
+/// (the adapter description is stored UTF-16); the returned `name` borrows it,
+/// so `buf` must outlive the result. Returns null before the device is created.
+pub fn adapterReport(buf: []u8) ?types.AdapterReport {
+    const s = state orelse return null;
+    if (!s.adapter.available) return null;
+    const name = s.adapter.descriptionUtf8(buf);
+    return .{
+        .name = name,
+        .vendor_id = s.adapter.vendor_id,
+        .device_id = s.adapter.device_id,
+    };
+}
 
 const State = struct {
     hwnd: HWND,
@@ -665,7 +691,7 @@ pub fn present() PresentError!void {
         .skip, .resize_then_present, .wait_for_recreate, .fallback_candidate => return,
     }
     const present_fn = core.comCall(self.swapchain, core.slot.DXGISwapChain_Present, *const fn (*anyopaque, u32, u32) callconv(.winapi) HRESULT);
-    const hr = present_fn(self.swapchain, 1, 0);
+    const hr = present_fn(self.swapchain, present_interval, 0);
     if (hr < 0) {
         const status = self.policy.noteDxgiFailure(.present, hr);
         logDxgiFailure(self, "present", hr, status);

--- a/src/renderer/gpu/gpu.zig
+++ b/src/renderer/gpu/gpu.zig
@@ -19,6 +19,7 @@ pub const Viewport = types.Viewport;
 pub const Scissor = types.Scissor;
 pub const ClearColor = types.ClearColor;
 pub const DriverInfo = types.DriverInfo;
+pub const AdapterReport = types.AdapterReport;
 pub const BlendSnapshot = types.BlendSnapshot;
 pub const SwapDiagnostics = types.SwapDiagnostics;
 pub const active: Backend = Backend.resolve(builtin.os.tag, build_options.gpu_backend);
@@ -49,6 +50,17 @@ pub const shaders = impl.shaders; // backend GLSL sources (for cell pipelines)
 /// renderer files until they route through the primitives (A3); removed in A6.
 pub inline fn glTable() *impl.GlTable {
     return &Context.gl;
+}
+
+/// Active GPU adapter identity for the benchmark report. `buf` backs the D3D11
+/// description string (UTF-16→UTF-8); OpenGL returns a GL-owned pointer and
+/// ignores `buf`. Returns null before the device/context is initialized.
+pub fn adapterReport(buf: []u8) ?AdapterReport {
+    return switch (active) {
+        .d3d11 => Context.adapterReport(buf),
+        .opengl => state.adapterReport(),
+        .metal => null,
+    };
 }
 
 // Reserved Ghostty-shaped primitive slots (bodies land in A3/A4):

--- a/src/renderer/gpu/opengl/render_state.zig
+++ b/src/renderer/gpu/opengl/render_state.zig
@@ -94,6 +94,16 @@ pub fn driverInfo() DriverInfo {
     };
 }
 
+/// GPU adapter identity for the benchmark report. OpenGL has no portable PCI-id
+/// query, so vendor/device stay 0 and the name is the GL renderer string (GL-
+/// owned pointer, valid while the context is current). Returns null when the GL
+/// table isn't loaded yet.
+pub fn adapterReport() ?types.AdapterReport {
+    const renderer = glString(c.GL_RENDERER);
+    if (renderer.len == 0) return null;
+    return .{ .name = renderer, .vendor_id = 0, .device_id = 0 };
+}
+
 pub fn swapDiagnostics() ?SwapDiagnostics {
     const get_integerv = Context.gl.GetIntegerv orelse return null;
     const is_enabled = Context.gl.IsEnabled orelse return null;

--- a/src/renderer/gpu/types.zig
+++ b/src/renderer/gpu/types.zig
@@ -78,6 +78,15 @@ pub const DriverInfo = struct {
     shading_language: []const u8,
 };
 
+/// GPU adapter identity for benchmark reports: a human-readable name plus the
+/// PCI vendor/device ids when the backend exposes them (D3D11 via DXGI; OpenGL
+/// leaves the ids at 0 since GL has no portable PCI-id query).
+pub const AdapterReport = struct {
+    name: []const u8,
+    vendor_id: u32 = 0,
+    device_id: u32 = 0,
+};
+
 pub const BlendSnapshot = struct {
     enabled: bool,
     src_rgb: BlendFactor,

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -332,6 +332,8 @@ test {
     _ = @import("benchmark/stats.zig");
     _ = @import("benchmark/options.zig");
     _ = @import("benchmark/report.zig");
+    _ = @import("benchmark/payload.zig");
+    _ = @import("benchmark/scenarios.zig");
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");
     _ = @import("assistant/conversation/layout.zig");


### PR DESCRIPTION
## Summary

- Adds `wispterm --benchmark`, the in-app GPU-side benchmark that complements the M1 CPU CLI (`wispterm-bench`). It spawns a no-shell virtual surface (`Pty.openVirtual` + `Surface.initVirtual`), drives a synthetic VT stream from the UI thread with vsync off, and records per-frame rebuild+draw+present pipeline time as `latency_ns` (p50/p95/max + FPS).
- The renderer backend is comptime-fixed (`-Dgpu-backend`), so a D3D11-vs-OpenGL A/B is two ReleaseFast builds of the same machine. Each run writes the same JSON + Markdown report shape as the CLI, carrying the GPU adapter name + PCI ids, window/DPI/grid, and `runner: in-app`.
- New `src/benchmark/` modules: `payload.zig` (pure VT payload generators shared with the CLI), `scenarios.zig` (pure Schedule state machine, fast-suite tested), `driver.zig` (in-app run driver — owns all state in-module, no AppWindow `g_*`/side-effect writes), `report_io.zig` (shared report file writer).
- Wiring: `config/main` `--benchmark` flag; `tab.zig` `spawnBenchmarkTab`; `AppWindow` main-loop 3 hooks (`frameBegin`/`frameEnd`/`finished`) + `finishBenchReport` (GPU adapter + window/grid/DPI); vsync off via `window_backend.setPresentInterval` + D3D11 `Context.present_interval`; cross-backend `gpu.adapterReport` (D3D11 DXGI description + PCI ids, OpenGL `GL_RENDERER`); `report.zig` FPS column + ASCII dashes (fixes GBK-console garbling).

## Why

WispTerm had no quantifiable GPU render metric. This gives the D3D11-vs-OpenGL same-machine A/B evidence that Phase VI needs to switch the Windows default backend, and lets users share results via the existing Performance Report issue template.

## Test plan

- [x] `zig build test` (fast suite) — `payload.zig` + `scenarios.zig` pure modules added; passes (exit 0).
- [x] `zig build test-full` — app + driver + tab + gpu compile and pass (exit 0).
- [x] `zig build test-bench` — CLI `report_io` refactor + `report.zig` compile/pass (exit 0).
- [x] No guarded integration/session files touched; AppWindow adds no `g_*`/`side-effect` writes (source-guard ratchets unchanged).
- [x] End-to-end A/B validated on this machine (RTX 4090, ReleaseFast):

| backend | scenario | mean | fps | p95 | max | samples |
|---|---|---|---|---|---|---|
| opengl | scroll-flood | 18.5ms | 54.1 | 19.4ms | 25.9ms | 250 |
| d3d11 | scroll-flood | 18.3ms | 54.6 | 18.9ms | 20.0ms | 251 |
| opengl | unicode-heavy | 18.6ms | 53.8 | 19.2ms | 31.7ms | 251 |
| d3d11 | unicode-heavy | 18.4ms | 54.3 | 19.1ms | 20.6ms | 251 |

D3D11 report correctly carries the DXGI adapter (`NVIDIA GeForce RTX 4090, vendor=4318, device=9860`). Mean frame time matches between backends; D3D11 has tighter tails.

- [x] Reviewer: `zig build -Dgpu-backend=d3d11 -Doptimize=ReleaseFast && .\zig-out\bin\wispterm.exe --benchmark` (and the opengl equivalent) on your machine to confirm the A/B report.

Note: Debug D3D11 is unusably slow (D3D11 debug-layer overhead); A/B requires `-Doptimize=ReleaseFast` (documented in `docs/development.md`).
