### PR TITLE
[codex] record d3d11 environment matrix evidence

### DIFF
--- a/debug/test-d3d11-environment-smoke.ps1
+++ b/debug/test-d3d11-environment-smoke.ps1
@@ -4,6 +4,9 @@ param(
     [string]$OutDir = "",
     [ValidateSet("d3d11", "opengl")]
     [string]$Backend = "d3d11",
+    [ValidateSet("unspecified", "local-physical", "rdp", "virtual-machine", "hybrid-gpu", "weak-integrated-gpu", "single-monitor", "multi-monitor-same-dpi", "multi-monitor-mixed-dpi")]
+    [string]$MatrixClass = "unspecified",
+    [switch]$RequireMatrixClass,
     [int]$WindowX = 90,
     [int]$WindowY = 90,
     [int]$WindowWidth = 1240,
@@ -134,6 +137,88 @@ function Read-MonitorTopology([string]$DiagnosticText) {
     return @($items)
 }
 
+function Test-TextMatchesAny([string]$Text, [string[]]$Patterns) {
+    if ($null -eq $Text) {
+        return $false
+    }
+    foreach ($pattern in $Patterns) {
+        if ($Text -match $pattern) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Read-MatrixDetection([object]$D3D11Environment, [object]$WindowsEnvironment, [object[]]$Monitors) {
+    $adapterDescription = if ($null -ne $D3D11Environment.adapter_description) {
+        [string]$D3D11Environment.adapter_description
+    } else {
+        ""
+    }
+    $adapterText = $adapterDescription.ToLowerInvariant()
+    $adapterFlags = $D3D11Environment.adapter_flags
+    $softwareAdapter = ($null -ne $adapterFlags) -and (([UInt64]$adapterFlags -band [UInt64]2) -ne 0)
+    $virtualMachineCandidate = $softwareAdapter -or (Test-TextMatchesAny $adapterText @(
+        "microsoft basic render",
+        "microsoft remote",
+        "vmware",
+        "virtualbox",
+        "parallels",
+        "hyper-v",
+        "virtual",
+        "virtio",
+        "qxl"
+    ))
+    $integratedGpuCandidate = Test-TextMatchesAny $adapterText @(
+        "intel",
+        "uhd graphics",
+        "iris",
+        "radeon\(tm\) graphics",
+        "radeon graphics",
+        "vega",
+        "integrated"
+    )
+    $dedicatedVideoMemory = $D3D11Environment.dedicated_video_memory
+    $weakIntegratedGpuCandidate = $integratedGpuCandidate -and
+        ($null -ne $dedicatedVideoMemory) -and
+        ([UInt64]$dedicatedVideoMemory -le [UInt64]1073741824)
+    $monitorCount = $WindowsEnvironment.monitor_count
+    $mixedDpi = $WindowsEnvironment.mixed_dpi
+
+    return [ordered]@{
+        remote_session = $WindowsEnvironment.remote_session
+        session_id = $WindowsEnvironment.session_id
+        monitor_count = $monitorCount
+        mixed_dpi = $mixedDpi
+        single_monitor = ($null -ne $monitorCount) -and ([UInt64]$monitorCount -eq [UInt64]1)
+        multi_monitor_same_dpi = ($null -ne $monitorCount) -and ([UInt64]$monitorCount -gt [UInt64]1) -and ($mixedDpi -eq $false)
+        multi_monitor_mixed_dpi = ($null -ne $monitorCount) -and ([UInt64]$monitorCount -gt [UInt64]1) -and ($mixedDpi -eq $true)
+        adapter_description = $adapterDescription
+        software_adapter_candidate = $softwareAdapter
+        virtual_machine_candidate = $virtualMachineCandidate
+        integrated_gpu_candidate = $integratedGpuCandidate
+        weak_integrated_gpu_candidate = $weakIntegratedGpuCandidate
+        hybrid_gpu_candidate = $null
+        hybrid_gpu_note = "operator-declared evidence; a single DXGI adapter diagnostic cannot prove hybrid topology"
+        monitor_topology_count = @($Monitors).Count
+    }
+}
+
+function Test-MatrixClassMatch([string]$Class, [object]$Detection) {
+    switch ($Class) {
+        "unspecified" { return $null }
+        "local-physical" { return (($Detection.remote_session -eq $false) -and ($Detection.virtual_machine_candidate -ne $true)) }
+        "rdp" { return ($Detection.remote_session -eq $true) }
+        "virtual-machine" { return ($Detection.virtual_machine_candidate -eq $true) }
+        "hybrid-gpu" { return $null }
+        "weak-integrated-gpu" { return ($Detection.weak_integrated_gpu_candidate -eq $true) }
+        "single-monitor" { return ($Detection.single_monitor -eq $true) }
+        "multi-monitor-same-dpi" { return ($Detection.multi_monitor_same_dpi -eq $true) }
+        "multi-monitor-mixed-dpi" { return ($Detection.multi_monitor_mixed_dpi -eq $true) }
+    }
+    return $null
+}
+
 function Copy-SmokeScreenshots([object]$NormalResult, [string]$ScreenshotsDir) {
     New-Item -ItemType Directory -Force -Path $ScreenshotsDir | Out-Null
     $copied = [ordered]@{}
@@ -196,6 +281,12 @@ $diagnosticText = if (Test-Path -LiteralPath $diagnosticPath) {
     ""
 }
 
+$d3d11Environment = Read-D3D11Environment $diagnosticText
+$windowsEnvironment = Read-WindowsEnvironment $diagnosticText
+$monitorTopology = Read-MonitorTopology $diagnosticText
+$matrixDetection = Read-MatrixDetection $d3d11Environment $windowsEnvironment $monitorTopology
+$matrixClassMatch = Test-MatrixClassMatch $MatrixClass $matrixDetection
+
 $copiedScreenshots = Copy-SmokeScreenshots $normalResult $screenshotsDir
 $gitBranch = (& git -C $repoRoot branch --show-current).Trim()
 $gitCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
@@ -228,15 +319,24 @@ $environment = [ordered]@{
         failure_lines = [bool]$normalResult.diagnostics.failure_lines
     }
     environment = [ordered]@{
-        d3d11 = Read-D3D11Environment $diagnosticText
-        windows = Read-WindowsEnvironment $diagnosticText
-        monitors = Read-MonitorTopology $diagnosticText
+        d3d11 = $d3d11Environment
+        windows = $windowsEnvironment
+        monitors = $monitorTopology
+    }
+    matrix = [ordered]@{
+        requested_class = $MatrixClass
+        class_match = $matrixClassMatch
+        require_class_match = [bool]$RequireMatrixClass
+        detection = $matrixDetection
+        missing_evidence = $false
+        note = "record-only matrix evidence; no environment blocking or fallback decision is applied"
     }
     policy = [ordered]@{
         automatic_fallback = $false
         environment_blocking = $false
+        environment_classification = "record-only"
         default_unchanged = $true
-        note = "collector only; no environment classification or fallback decision is applied"
+        note = "collector only; no environment blocking or fallback decision is applied"
     }
 }
 
@@ -251,10 +351,16 @@ $summary = [ordered]@{
     diagnostic_log = $diagnosticPath
     screenshots = $screenshotsDir
     normal_session_exit_code = $normalSessionExitCode
+    matrix_class = $MatrixClass
+    matrix_class_match = $matrixClassMatch
     d3d11_environment = [bool]$normalResult.diagnostics.d3d11_environment
     windows_environment = [bool]$normalResult.diagnostics.windows_environment
 }
 $summary | ConvertTo-Json -Depth 5
+
+if ($RequireMatrixClass -and $MatrixClass -ne "unspecified" -and $matrixClassMatch -ne $true) {
+    throw "matrix class '$MatrixClass' did not match detected facts; environment evidence was written to $environmentJsonPath"
+}
 
 if ($normalSessionExitCode -ne 0 -or ![bool]$normalResult.pass) {
     throw "normal-session smoke failed; environment evidence was written to $environmentJsonPath"

--- a/docs/development.md
+++ b/docs/development.md
@@ -253,8 +253,14 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 The collector writes `zig-out\d3d11-env-smoke\<timestamp>\environment.json`, a
 `normal-session\` result directory, copied screenshots under `screenshots\`, and
 the original render diagnostics path. It records adapter/session/monitor facts
-and smoke health only; it does not classify or block environments and it does
-not change fallback policy.
+and smoke health, plus a record-only `matrix` section when `-MatrixClass` is
+provided. Use classes such as `local-physical`, `rdp`, `virtual-machine`,
+`hybrid-gpu`, `weak-integrated-gpu`, `single-monitor`,
+`multi-monitor-same-dpi`, and `multi-monitor-mixed-dpi`; add
+`-RequireMatrixClass` only when the class can be proven from collected facts.
+The collector does not block environments and does not change fallback policy.
+The durable ledger format is documented in
+[windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 
 To exercise the controlled Phase V device-recreate path, run the same smoke
 with `-RecreateSmoke` after building the D3D11 executable:

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -43,14 +43,16 @@ unavailable environment is missing evidence, not a passing result.
 | Window state | `-WindowStateSmoke` proves maximize, restore, minimize, and restore-from-minimize. |
 | Fullscreen startup | `-FullscreenStartupSmoke` proves config startup fullscreen, Alt+Enter exit, and restored baseline size. |
 | Long-run soak | `-SoakMinutes 20` records periodic nonblank screenshots, process liveness, resize diagnostics, and no failure lines. |
-| Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, normal-session JSON, screenshots, adapter facts, Win32 session facts, and policy fields. |
+| Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
 | Test gates | `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI pass. |
 
 ## Environment Matrix
 
 The matrix evidence should cover at least these classes before default
-migration. Use the environment collector for each run and keep the generated
-artifact directory with the PR or issue that records the result.
+migration. Use the environment collector for each run, pass the matching
+`-MatrixClass`, and keep the generated artifact directory with the PR or issue
+that records the result. The ledger format lives in
+[windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 
 | Environment class | Evidence expectation |
 |---|---|
@@ -109,7 +111,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -WindowStateSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FullscreenStartupSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -SoakMinutes 20
-powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass local-physical
 
 zig build
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -1,0 +1,90 @@
+# Windows Native D3D11 Environment Matrix
+
+This is the Phase V evidence ledger for Windows native D3D11 environment
+coverage. It records evidence requirements and the JSON fields emitted by
+`debug/test-d3d11-environment-smoke.ps1`; it is not a default migration plan.
+Windows `auto` remains OpenGL until the separate Phase VI gate is satisfied.
+
+## Boundary
+
+- The collector records facts only. It does not block environments, write
+  fallback markers, or change renderer selection.
+- A skipped or unavailable environment is missing evidence, not a pass.
+- Keep generated artifacts outside the repository unless a PR or issue asks for
+  a small redacted sample. The durable record should point to the artifact
+  directory or uploaded artifact.
+- `-RequireMatrixClass` is optional and should be used only when the class can
+  be proven from collected facts.
+
+## Ghostty Comparison
+
+Ghostty's renderer backend selector remains a thin `Backend` enum with OpenGL,
+Metal, and WebGL defaults. It has no D3D11 backend, DXGI device-loss policy, or
+Windows environment matrix to mirror. WispTerm keeps the Ghostty-style thin
+backend boundary while treating RDP, VM, hybrid-GPU, weak-iGPU, monitor, and DPI
+evidence as Windows-specific Phase V hardening.
+
+## Matrix Classes
+
+Use `-MatrixClass` to label the environment being recorded:
+
+| Matrix class | Match source | Evidence expectation |
+|---|---|---|
+| `local-physical` | Remote session is false and no VM adapter candidate is detected. | Baseline physical Windows evidence. |
+| `rdp` | Win32 remote-session diagnostic is true. | No black window, recovery loop, or unexpected fallback activity. |
+| `virtual-machine` | Adapter description/flags suggest a virtual or software adapter. | Adapter/session facts are recorded; failures are classified in the issue/PR. |
+| `hybrid-gpu` | Operator-declared; single-adapter diagnostics cannot prove topology. | Adapter identity is stable enough for fallback-marker scoping. |
+| `weak-integrated-gpu` | Integrated adapter candidate with <= 1 GiB dedicated video memory. | Feature level and memory facts are recorded; unhealthy modes are classified. |
+| `single-monitor` | Monitor count is 1. | Baseline smoke evidence. |
+| `multi-monitor-same-dpi` | Monitor count > 1 and mixed DPI is false. | Resize/window evidence remains nonblank after monitor moves when available. |
+| `multi-monitor-mixed-dpi` | Monitor count > 1 and mixed DPI is true. | DPI facts are recorded; failures are classified and documented. |
+
+`hybrid-gpu` deliberately reports `class_match = null` because a single DXGI
+adapter line cannot prove the machine has both integrated and discrete GPUs.
+
+## Collector Commands
+
+```powershell
+zig build -Dgpu-backend=d3d11
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass local-physical
+```
+
+For automatically provable classes, add `-RequireMatrixClass` when you want the
+collector to fail if the requested class does not match the detected facts:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass rdp -RequireMatrixClass
+```
+
+## JSON Contract
+
+Each `environment.json` contains:
+
+| Field | Meaning |
+|---|---|
+| `matrix.requested_class` | The operator-supplied `-MatrixClass`. |
+| `matrix.class_match` | `true`, `false`, or `null` when the class cannot be proven automatically. |
+| `matrix.require_class_match` | Whether mismatch was configured to fail the run. |
+| `matrix.detection.remote_session` | Win32 remote-session fact. |
+| `matrix.detection.monitor_count` / `mixed_dpi` | Monitor topology facts used for monitor classes. |
+| `matrix.detection.virtual_machine_candidate` | Heuristic adapter/software-adapter classification. |
+| `matrix.detection.integrated_gpu_candidate` | Heuristic integrated-GPU adapter classification. |
+| `matrix.detection.weak_integrated_gpu_candidate` | Integrated adapter with low dedicated video memory. |
+| `policy.environment_classification` | Always `record-only` during Phase V. |
+| `policy.environment_blocking` | Always `false` during Phase V. |
+
+## Ledger
+
+| Environment class | Status | Evidence |
+|---|---|---|
+| Local physical Windows machine | Missing | Collect with `-MatrixClass local-physical`. |
+| RDP session | Missing | Collect with `-MatrixClass rdp -RequireMatrixClass`. |
+| Virtual machine | Missing | Collect with `-MatrixClass virtual-machine`; attach adapter facts. |
+| Hybrid GPU laptop | Missing | Collect with `-MatrixClass hybrid-gpu`; record operator-observed topology. |
+| Weak integrated GPU | Missing | Collect with `-MatrixClass weak-integrated-gpu`; attach memory/feature-level facts. |
+| Single monitor | Missing | Collect with `-MatrixClass single-monitor -RequireMatrixClass`. |
+| Multi-monitor same DPI | Missing | Collect with `-MatrixClass multi-monitor-same-dpi -RequireMatrixClass`. |
+| Multi-monitor mixed DPI | Missing | Collect with `-MatrixClass multi-monitor-mixed-dpi -RequireMatrixClass`. |
+
+Phase VI must not start until this ledger is backed by current artifacts or the
+remaining gaps are explicitly accepted in `KNOWN_ISSUES.md`.

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -202,10 +202,13 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 ```
 
 The default output root is `zig-out\d3d11-env-smoke\<timestamp>\`. Each run
-contains `environment.json`, `normal-session\`, and `screenshots\`. Use the same
-collector in RDP, VM, hybrid-GPU, weak-integrated-GPU, single-monitor,
-multi-monitor, and mixed-DPI environments; skipped or unavailable environments
-must be recorded as missing evidence rather than treated as passing.
+contains `environment.json`, `normal-session\`, and `screenshots\`. Pass
+`-MatrixClass <class>` to label evidence for RDP, VM, hybrid-GPU,
+weak-integrated-GPU, single-monitor, multi-monitor same-DPI, and mixed-DPI
+environments; use `-RequireMatrixClass` only when the requested class can be
+proved from collected facts. Skipped or unavailable environments must be
+recorded as missing evidence rather than treated as passing. The ledger format
+lives in [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

- Add record-only `-MatrixClass` / `-RequireMatrixClass` support to `debug/test-d3d11-environment-smoke.ps1`.
- Write `matrix` detection fields into `environment.json` for RDP, VM, integrated/weak-iGPU, monitor count, mixed-DPI, and operator-declared hybrid-GPU evidence.
- Add `docs/windows-native-d3d11-environment-matrix.md` and link it from the Phase V roadmap, default gate, and development docs.

## Ghostty comparison

Ghostty keeps renderer backend selection as a thin `Backend` selector for `opengl`, `metal`, and `webgl`; it has no D3D11 backend, DXGI recovery policy, or Windows environment matrix to copy. This keeps WispTerm's Ghostty-aligned backend boundary while recording Windows-specific Phase V evidence as a WispTerm hardening layer.

## Validation

- `powershell -NoProfile -Command '$script = Get-Content -LiteralPath "debug\\test-d3d11-environment-smoke.ps1" -Raw; [scriptblock]::Create($script) | Out-Null; "syntax-ok"'`
- `zig build -Dgpu-backend=d3d11`
- `zig build test`
- `git diff --check -- debug\\test-d3d11-environment-smoke.ps1 docs\\development.md docs\\windows-native-d3d11-default-gate.md docs\\windows-native-d3d11-roadmap.md docs\\windows-native-d3d11-environment-matrix.md`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\debug\\test-d3d11-environment-smoke.ps1 -MatrixClass local-physical`
  - emitted `matrix_class=local-physical`
  - emitted `matrix_class_match=true`
  - recorded `monitor_count=2`, `mixed_dpi=true`, adapter `NVIDIA GeForce RTX 4090`
  - kept `environment_blocking=false`, `environment_classification=record-only`, `automatic_fallback=false`, `default_unchanged=true`
- `zig build check-sizes`
- `zig build`
- `zig build test-full --summary all`
  - 60/60 steps succeeded; 13486/13772 tests passed; 286 skipped
- `git diff --cached --check`
- Windows checkout safety: reserved names 0, illegal chars 0, casefold collisions 0, symlinks 0

## Boundaries

- No Windows `auto` default change.
- No environment blocking.
- No fallback-marker writes.
- No same-process D3D11-to-OpenGL fallback.
