### PR TITLE
[codex] write d3d11 environment matrix summary

### DIFF
--- a/debug/test-d3d11-environment-smoke.ps1
+++ b/debug/test-d3d11-environment-smoke.ps1
@@ -219,6 +219,99 @@ function Test-MatrixClassMatch([string]$Class, [object]$Detection) {
     return $null
 }
 
+function Format-SummaryValue([object]$Value) {
+    if ($null -eq $Value) {
+        return "unknown"
+    }
+    if ($Value -is [bool]) {
+        if ($Value) {
+            return "true"
+        }
+        return "false"
+    }
+    return ([string]$Value).Replace("|", "\|").Replace("`r", " ").Replace("`n", " ")
+}
+
+function Add-SummaryRow([object]$Lines, [string]$Name, [object]$Value) {
+    $Lines.Add("| $Name | $(Format-SummaryValue $Value) |") | Out-Null
+}
+
+function Write-MatrixSummary([string]$Path, [object]$Environment) {
+    $repo = $Environment["repo"]
+    $artifacts = $Environment["artifacts"]
+    $smoke = $Environment["smoke"]
+    $envFacts = $Environment["environment"]
+    $d3d11 = $envFacts["d3d11"]
+    $windows = $envFacts["windows"]
+    $matrix = $Environment["matrix"]
+    $detection = $matrix["detection"]
+    $policy = $Environment["policy"]
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("# WispTerm D3D11 Environment Matrix Summary") | Out-Null
+    $lines.Add("") | Out-Null
+    $lines.Add("This summary is generated from environment.json for PR/issue review. It is record-only Phase V evidence and does not imply a Windows default renderer change.") | Out-Null
+    $lines.Add("") | Out-Null
+    $lines.Add("## Run") | Out-Null
+    $lines.Add("") | Out-Null
+    $lines.Add("| Field | Value |") | Out-Null
+    $lines.Add("|---|---|") | Out-Null
+    Add-SummaryRow $lines "Generated at" $Environment["generated_at"]
+    Add-SummaryRow $lines "Branch" $repo["branch"]
+    Add-SummaryRow $lines "Commit" $repo["commit"]
+    Add-SummaryRow $lines "Backend" $Environment["backend"]
+    Add-SummaryRow $lines "Pass" $Environment["pass"]
+    Add-SummaryRow $lines "Normal-session exit code" $smoke["normal_session_exit_code"]
+    Add-SummaryRow $lines "Environment JSON" $artifacts["environment_json"]
+    Add-SummaryRow $lines "Normal-session JSON" $artifacts["normal_session_json"]
+    Add-SummaryRow $lines "Diagnostic log" $artifacts["diagnostic_log"]
+
+    $lines.Add("") | Out-Null
+    $lines.Add("## Matrix") | Out-Null
+    $lines.Add("") | Out-Null
+    $lines.Add("| Field | Value |") | Out-Null
+    $lines.Add("|---|---|") | Out-Null
+    Add-SummaryRow $lines "Requested class" $matrix["requested_class"]
+    Add-SummaryRow $lines "Class match" $matrix["class_match"]
+    Add-SummaryRow $lines "Require class match" $matrix["require_class_match"]
+    Add-SummaryRow $lines "Remote session" $detection["remote_session"]
+    Add-SummaryRow $lines "Session id" $detection["session_id"]
+    Add-SummaryRow $lines "Monitor count" $detection["monitor_count"]
+    Add-SummaryRow $lines "Mixed DPI" $detection["mixed_dpi"]
+    Add-SummaryRow $lines "Single monitor" $detection["single_monitor"]
+    Add-SummaryRow $lines "Multi-monitor same DPI" $detection["multi_monitor_same_dpi"]
+    Add-SummaryRow $lines "Multi-monitor mixed DPI" $detection["multi_monitor_mixed_dpi"]
+    Add-SummaryRow $lines "Virtual-machine candidate" $detection["virtual_machine_candidate"]
+    Add-SummaryRow $lines "Integrated-GPU candidate" $detection["integrated_gpu_candidate"]
+    Add-SummaryRow $lines "Weak integrated-GPU candidate" $detection["weak_integrated_gpu_candidate"]
+    Add-SummaryRow $lines "Hybrid-GPU candidate" $detection["hybrid_gpu_candidate"]
+
+    $lines.Add("") | Out-Null
+    $lines.Add("## Adapter And Policy") | Out-Null
+    $lines.Add("") | Out-Null
+    $lines.Add("| Field | Value |") | Out-Null
+    $lines.Add("|---|---|") | Out-Null
+    Add-SummaryRow $lines "Adapter" $d3d11["adapter_description"]
+    Add-SummaryRow $lines "Vendor id" $d3d11["vendor_id_hex"]
+    Add-SummaryRow $lines "Device id" $d3d11["device_id_hex"]
+    Add-SummaryRow $lines "Feature level" $d3d11["feature_level"]
+    Add-SummaryRow $lines "Dedicated video memory" $d3d11["dedicated_video_memory"]
+    Add-SummaryRow $lines "Output count" $d3d11["output_count"]
+    Add-SummaryRow $lines "Primary DPI" $windows["primary_dpi"]
+    Add-SummaryRow $lines "System DPI" $windows["system_dpi"]
+    Add-SummaryRow $lines "D3D11 environment line present" $smoke["d3d11_environment"]
+    Add-SummaryRow $lines "Windows environment line present" $smoke["windows_environment"]
+    Add-SummaryRow $lines "Failure lines" $smoke["failure_lines"]
+    Add-SummaryRow $lines "Automatic fallback" $policy["automatic_fallback"]
+    Add-SummaryRow $lines "Environment blocking" $policy["environment_blocking"]
+    Add-SummaryRow $lines "Environment classification" $policy["environment_classification"]
+    Add-SummaryRow $lines "Default unchanged" $policy["default_unchanged"]
+
+    $lines.Add("") | Out-Null
+    $lines.Add("Screenshots are copied under the package screenshots directory recorded in environment.json.") | Out-Null
+    Set-Content -LiteralPath $Path -Value $lines -Encoding UTF8
+}
+
 function Copy-SmokeScreenshots([object]$NormalResult, [string]$ScreenshotsDir) {
     New-Item -ItemType Directory -Force -Path $ScreenshotsDir | Out-Null
     $copied = [ordered]@{}
@@ -290,6 +383,8 @@ $matrixClassMatch = Test-MatrixClassMatch $MatrixClass $matrixDetection
 $copiedScreenshots = Copy-SmokeScreenshots $normalResult $screenshotsDir
 $gitBranch = (& git -C $repoRoot branch --show-current).Trim()
 $gitCommit = (& git -C $repoRoot rev-parse HEAD).Trim()
+$environmentJsonPath = Join-Path $OutDir "environment.json"
+$matrixSummaryPath = Join-Path $OutDir "matrix-summary.md"
 
 $environment = [ordered]@{
     schema = "wispterm-d3d11-environment-smoke/v1"
@@ -302,7 +397,8 @@ $environment = [ordered]@{
     }
     artifacts = [ordered]@{
         root = $OutDir
-        environment_json = (Join-Path $OutDir "environment.json")
+        environment_json = $environmentJsonPath
+        matrix_summary = $matrixSummaryPath
         normal_session_json = $normalJsonPath
         diagnostic_log = $diagnosticPath
         screenshots = $copiedScreenshots
@@ -340,13 +436,14 @@ $environment = [ordered]@{
     }
 }
 
-$environmentJsonPath = Join-Path $OutDir "environment.json"
+Write-MatrixSummary $matrixSummaryPath $environment
 $environment | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $environmentJsonPath -Encoding UTF8
 
 $summary = [ordered]@{
     pass = [bool]$normalResult.pass
     backend = $Backend
     environment_json = $environmentJsonPath
+    matrix_summary = $matrixSummaryPath
     normal_session_json = $normalJsonPath
     diagnostic_log = $diagnosticPath
     screenshots = $screenshotsDir

--- a/docs/development.md
+++ b/docs/development.md
@@ -251,15 +251,15 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 ```
 
 The collector writes `zig-out\d3d11-env-smoke\<timestamp>\environment.json`, a
-`normal-session\` result directory, copied screenshots under `screenshots\`, and
-the original render diagnostics path. It records adapter/session/monitor facts
-and smoke health, plus a record-only `matrix` section when `-MatrixClass` is
-provided. Use classes such as `local-physical`, `rdp`, `virtual-machine`,
-`hybrid-gpu`, `weak-integrated-gpu`, `single-monitor`,
-`multi-monitor-same-dpi`, and `multi-monitor-mixed-dpi`; add
-`-RequireMatrixClass` only when the class can be proven from collected facts.
-The collector does not block environments and does not change fallback policy.
-The durable ledger format is documented in
+redacted `matrix-summary.md` review artifact, a `normal-session\` result
+directory, copied screenshots under `screenshots\`, and the original render
+diagnostics path. It records adapter/session/monitor facts and smoke health,
+plus a record-only `matrix` section when `-MatrixClass` is provided. Use classes
+such as `local-physical`, `rdp`, `virtual-machine`, `hybrid-gpu`,
+`weak-integrated-gpu`, `single-monitor`, `multi-monitor-same-dpi`, and
+`multi-monitor-mixed-dpi`; add `-RequireMatrixClass` only when the class can be
+proven from collected facts. The collector does not block environments and does
+not change fallback policy. The durable ledger format is documented in
 [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 
 To exercise the controlled Phase V device-recreate path, run the same smoke

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -43,7 +43,7 @@ unavailable environment is missing evidence, not a passing result.
 | Window state | `-WindowStateSmoke` proves maximize, restore, minimize, and restore-from-minimize. |
 | Fullscreen startup | `-FullscreenStartupSmoke` proves config startup fullscreen, Alt+Enter exit, and restored baseline size. |
 | Long-run soak | `-SoakMinutes 20` records periodic nonblank screenshots, process liveness, resize diagnostics, and no failure lines. |
-| Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
+| Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, `matrix-summary.md`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
 | Test gates | `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI pass. |
 
 ## Environment Matrix

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -12,7 +12,8 @@ Windows `auto` remains OpenGL until the separate Phase VI gate is satisfied.
 - A skipped or unavailable environment is missing evidence, not a pass.
 - Keep generated artifacts outside the repository unless a PR or issue asks for
   a small redacted sample. The durable record should point to the artifact
-  directory or uploaded artifact.
+  directory or uploaded artifact, and should include the generated
+  `matrix-summary.md` when possible.
 - `-RequireMatrixClass` is optional and should be used only when the class can
   be proven from collected facts.
 
@@ -58,7 +59,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 
 ## JSON Contract
 
-Each `environment.json` contains:
+Each collector run writes both `environment.json` and a redacted
+`matrix-summary.md` review artifact. `environment.json` contains:
 
 | Field | Meaning |
 |---|---|
@@ -72,6 +74,11 @@ Each `environment.json` contains:
 | `matrix.detection.weak_integrated_gpu_candidate` | Integrated adapter with low dedicated video memory. |
 | `policy.environment_classification` | Always `record-only` during Phase V. |
 | `policy.environment_blocking` | Always `false` during Phase V. |
+
+`matrix-summary.md` is derived from the same JSON and is intended for PR or
+issue comments. It includes branch/commit, requested matrix class, class-match
+state, adapter facts, monitor/DPI facts, smoke health, and record-only policy
+fields, without copying raw diagnostic log lines.
 
 ## Ledger
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -202,8 +202,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 ```
 
 The default output root is `zig-out\d3d11-env-smoke\<timestamp>\`. Each run
-contains `environment.json`, `normal-session\`, and `screenshots\`. Pass
-`-MatrixClass <class>` to label evidence for RDP, VM, hybrid-GPU,
+contains `environment.json`, `matrix-summary.md`, `normal-session\`, and
+`screenshots\`. Pass `-MatrixClass <class>` to label evidence for RDP, VM, hybrid-GPU,
 weak-integrated-GPU, single-monitor, multi-monitor same-DPI, and mixed-DPI
 environments; use `-RequireMatrixClass` only when the requested class can be
 proved from collected facts. Skipped or unavailable environments must be


### PR DESCRIPTION
## Summary

- Emit a redacted `matrix-summary.md` beside each D3D11 environment collector `environment.json`.
- Record the summary path in `environment.json.artifacts.matrix_summary` and stdout JSON.
- Update Phase V docs/gate wording so matrix evidence packages include the summary artifact for PR/issue review.

## Ghostty comparison

Ghostty's `src/renderer/backend.zig` is still a thin `Backend` selector over `opengl`, `metal`, and `webgl`; it has no D3D11 backend or Windows environment evidence layer. This keeps WispTerm's Ghostty-aligned backend boundary intact and adds only WispTerm-specific Phase V evidence packaging.

## Validation

- PowerShell parse check for `debug/test-d3d11-environment-smoke.ps1`
- `zig build -Dgpu-backend=d3d11`
- `git diff --check -- debug\\test-d3d11-environment-smoke.ps1 docs\\development.md docs\\windows-native-d3d11-default-gate.md docs\\windows-native-d3d11-environment-matrix.md docs\\windows-native-d3d11-roadmap.md`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\\debug\\test-d3d11-environment-smoke.ps1 -MatrixClass multi-monitor-mixed-dpi -RequireMatrixClass`
  - first pre-commit run passed and wrote `matrix-summary.md`
  - one post-commit run failed because a default `zig build` had overwritten `zig-out/bin/wispterm.exe` with OpenGL; diagnostics showed `opengl_backend=true`, `d3d11_present=false`
  - after rebuilding with `zig build -Dgpu-backend=d3d11`, post-commit rerun passed
  - successful post-commit summary recorded commit `a1d31b72df9f14a14b587f8e8240836a2f78f394`, `matrix_class=multi-monitor-mixed-dpi`, `matrix_class_match=true`, monitor count 2, mixed DPI true, adapter NVIDIA GeForce RTX 4090, `environment_blocking=false`, `automatic_fallback=false`, `default_unchanged=true`
- `zig build test`
- `zig build check-sizes`
- `zig build`
- `zig build test-full --summary all`
  - 60/60 steps succeeded; 13486/13772 tests passed; 286 skipped

## Boundaries

- No Windows `auto` default change.
- No environment blocking/classification beyond record-only evidence.
- No fallback-marker writes.
- No same-process D3D11-to-OpenGL fallback.
