### PR TITLE
[codex] summarize d3d11 environment matrix

### DIFF
--- a/debug/summarize-d3d11-environment-matrix.ps1
+++ b/debug/summarize-d3d11-environment-matrix.ps1
@@ -1,0 +1,276 @@
+param(
+    [string]$InputRoot = "",
+    [string]$OutDir = "",
+    [switch]$FailOnMissing
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+if ($InputRoot.Length -eq 0) {
+    $InputRoot = Join-Path $repoRoot "zig-out\d3d11-env-smoke"
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+if ($OutDir.Length -eq 0) {
+    $OutDir = Join-Path $InputRoot "matrix-ledger-$timestamp"
+}
+
+$matrixClasses = @(
+    "local-physical",
+    "rdp",
+    "virtual-machine",
+    "hybrid-gpu",
+    "weak-integrated-gpu",
+    "single-monitor",
+    "multi-monitor-same-dpi",
+    "multi-monitor-mixed-dpi"
+)
+
+function Get-JsonField([object]$Object, [string]$Name) {
+    if ($null -eq $Object) {
+        return $null
+    }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+    return $property.Value
+}
+
+function Format-LedgerValue([object]$Value) {
+    if ($null -eq $Value) {
+        return "unknown"
+    }
+    if ($Value -is [bool]) {
+        if ($Value) {
+            return "true"
+        }
+        return "false"
+    }
+    $text = [string]$Value
+    return $text.Replace("|", "\|").Replace("`r", " ").Replace("`n", " ")
+}
+
+function Short-Commit([object]$Commit) {
+    if ($null -eq $Commit) {
+        return "unknown"
+    }
+    $text = [string]$Commit
+    if ($text.Length -gt 8) {
+        return $text.Substring(0, 8)
+    }
+    return $text
+}
+
+function EvidenceStatus([object]$Entry) {
+    if ($Entry.pass -ne $true) {
+        return "failing"
+    }
+    if ($Entry.class_match -eq $true) {
+        return "recorded"
+    }
+    if ($Entry.class_match -eq $false) {
+        return "mismatch"
+    }
+    if ($Entry.class -eq "hybrid-gpu") {
+        return "operator-review"
+    }
+    return "recorded-unclassified"
+}
+
+function StatusRank([string]$Status) {
+    switch ($Status) {
+        "recorded" { return 0 }
+        "operator-review" { return 1 }
+        "recorded-unclassified" { return 2 }
+        "mismatch" { return 3 }
+        "failing" { return 4 }
+    }
+    return 5
+}
+
+function Add-MarkdownRow([object]$Lines, [object[]]$Values) {
+    $cells = @()
+    foreach ($value in $Values) {
+        $cells += (Format-LedgerValue $value)
+    }
+    $Lines.Add("| $($cells -join ' | ') |") | Out-Null
+}
+
+if (!(Test-Path -LiteralPath $InputRoot)) {
+    throw "input root not found: $InputRoot"
+}
+
+$jsonFiles = Get-ChildItem -LiteralPath $InputRoot -Recurse -Filter "environment.json" -File
+$entries = @()
+
+foreach ($file in $jsonFiles) {
+    $raw = Get-Content -LiteralPath $file.FullName -Raw
+    $json = $raw | ConvertFrom-Json
+    $matrix = Get-JsonField $json "matrix"
+    if ($null -eq $matrix) {
+        continue
+    }
+
+    $environment = Get-JsonField $json "environment"
+    $d3d11 = Get-JsonField $environment "d3d11"
+    $windows = Get-JsonField $environment "windows"
+    $detection = Get-JsonField $matrix "detection"
+    $policy = Get-JsonField $json "policy"
+    $repo = Get-JsonField $json "repo"
+    $artifacts = Get-JsonField $json "artifacts"
+
+    $class = [string](Get-JsonField $matrix "requested_class")
+    if ($class.Length -eq 0) {
+        $class = "unspecified"
+    }
+
+    $entry = [ordered]@{
+        class = $class
+        status = $null
+        pass = [bool](Get-JsonField $json "pass")
+        class_match = Get-JsonField $matrix "class_match"
+        require_class_match = [bool](Get-JsonField $matrix "require_class_match")
+        generated_at = Get-JsonField $json "generated_at"
+        branch = Get-JsonField $repo "branch"
+        commit = Get-JsonField $repo "commit"
+        root = Get-JsonField $artifacts "root"
+        environment_json = $file.FullName
+        matrix_summary = Get-JsonField $artifacts "matrix_summary"
+        normal_session_json = Get-JsonField $artifacts "normal_session_json"
+        diagnostic_log = Get-JsonField $artifacts "diagnostic_log"
+        adapter_description = Get-JsonField $d3d11 "adapter_description"
+        feature_level = Get-JsonField $d3d11 "feature_level"
+        dedicated_video_memory = Get-JsonField $d3d11 "dedicated_video_memory"
+        output_count = Get-JsonField $d3d11 "output_count"
+        remote_session = Get-JsonField $detection "remote_session"
+        monitor_count = Get-JsonField $detection "monitor_count"
+        mixed_dpi = Get-JsonField $detection "mixed_dpi"
+        virtual_machine_candidate = Get-JsonField $detection "virtual_machine_candidate"
+        integrated_gpu_candidate = Get-JsonField $detection "integrated_gpu_candidate"
+        weak_integrated_gpu_candidate = Get-JsonField $detection "weak_integrated_gpu_candidate"
+        environment_blocking = Get-JsonField $policy "environment_blocking"
+        automatic_fallback = Get-JsonField $policy "automatic_fallback"
+        default_unchanged = Get-JsonField $policy "default_unchanged"
+    }
+    $entry.status = EvidenceStatus $entry
+    $entries += [pscustomobject]$entry
+}
+
+$classRows = @()
+foreach ($class in $matrixClasses) {
+    $candidates = @($entries | Where-Object { $_.class -eq $class } | Sort-Object @{ Expression = { StatusRank $_.status }; Ascending = $true }, @{ Expression = { $_.generated_at }; Descending = $true })
+    $best = if ($candidates.Count -gt 0) { $candidates[0] } else { $null }
+    $status = if ($null -eq $best) { "missing" } else { $best.status }
+    $classRows += [pscustomobject][ordered]@{
+        class = $class
+        status = $status
+        evidence_count = $candidates.Count
+        selected_environment_json = if ($null -eq $best) { $null } else { $best.environment_json }
+        selected_matrix_summary = if ($null -eq $best) { $null } else { $best.matrix_summary }
+        selected_commit = if ($null -eq $best) { $null } else { $best.commit }
+        selected_generated_at = if ($null -eq $best) { $null } else { $best.generated_at }
+        selected_class_match = if ($null -eq $best) { $null } else { $best.class_match }
+        selected_pass = if ($null -eq $best) { $null } else { $best.pass }
+        selected_adapter = if ($null -eq $best) { $null } else { $best.adapter_description }
+        selected_monitor_count = if ($null -eq $best) { $null } else { $best.monitor_count }
+        selected_mixed_dpi = if ($null -eq $best) { $null } else { $best.mixed_dpi }
+    }
+}
+
+$missing = @($classRows | Where-Object { $_.status -eq "missing" })
+$generatedAt = (Get-Date).ToString("o")
+$ledger = [ordered]@{
+    schema = "wispterm-d3d11-environment-matrix-ledger/v1"
+    generated_at = $generatedAt
+    input_root = $InputRoot
+    evidence_count = $entries.Count
+    missing_count = $missing.Count
+    policy = [ordered]@{
+        record_only = $true
+        environment_blocking = $false
+        automatic_fallback = $false
+        default_unchanged = $true
+    }
+    classes = @($classRows)
+    evidence = @($entries)
+}
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$ledgerJsonPath = Join-Path $OutDir "matrix-ledger.json"
+$ledgerMdPath = Join-Path $OutDir "matrix-ledger.md"
+$ledger | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $ledgerJsonPath -Encoding UTF8
+
+$lines = [System.Collections.Generic.List[string]]::new()
+$lines.Add("# WispTerm D3D11 Environment Matrix Ledger") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("Generated at: $generatedAt") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("Input root: $InputRoot") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("This ledger aggregates record-only Phase V evidence packages. It does not imply environment blocking, fallback-marker writes, or a Windows default renderer change.") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("## Matrix Status") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("| Class | Status | Evidence | Commit | Generated | Class match | Pass | Adapter | Monitors | Mixed DPI | Summary |") | Out-Null
+$lines.Add("|---|---|---:|---|---|---|---|---|---:|---|---|") | Out-Null
+foreach ($row in $classRows) {
+    Add-MarkdownRow $lines @(
+        $row.class,
+        $row.status,
+        $row.evidence_count,
+        (Short-Commit $row.selected_commit),
+        $row.selected_generated_at,
+        $row.selected_class_match,
+        $row.selected_pass,
+        $row.selected_adapter,
+        $row.selected_monitor_count,
+        $row.selected_mixed_dpi,
+        $row.selected_matrix_summary
+    )
+}
+
+$lines.Add("") | Out-Null
+$lines.Add("## All Evidence Packages") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("| Class | Status | Pass | Class match | Generated | Commit | Adapter | Monitors | Mixed DPI | Environment JSON |") | Out-Null
+$lines.Add("|---|---|---|---|---|---|---|---:|---|---|") | Out-Null
+foreach ($entry in ($entries | Sort-Object generated_at)) {
+    Add-MarkdownRow $lines @(
+        $entry.class,
+        $entry.status,
+        $entry.pass,
+        $entry.class_match,
+        $entry.generated_at,
+        (Short-Commit $entry.commit),
+        $entry.adapter_description,
+        $entry.monitor_count,
+        $entry.mixed_dpi,
+        $entry.environment_json
+    )
+}
+
+if ($missing.Count -gt 0) {
+    $lines.Add("") | Out-Null
+    $lines.Add("## Missing Classes") | Out-Null
+    $lines.Add("") | Out-Null
+    foreach ($row in $missing) {
+        $lines.Add("- $($row.class)") | Out-Null
+    }
+}
+
+$lines | Set-Content -LiteralPath $ledgerMdPath -Encoding UTF8
+
+$summary = [ordered]@{
+    evidence_count = $entries.Count
+    missing_count = $missing.Count
+    ledger_json = $ledgerJsonPath
+    ledger_markdown = $ledgerMdPath
+}
+$summary | ConvertTo-Json -Depth 4
+
+if ($FailOnMissing -and $missing.Count -gt 0) {
+    throw "missing matrix evidence classes: $((@($missing | ForEach-Object { $_.class })) -join ', ')"
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -261,6 +261,9 @@ such as `local-physical`, `rdp`, `virtual-machine`, `hybrid-gpu`,
 proven from collected facts. The collector does not block environments and does
 not change fallback policy. The durable ledger format is documented in
 [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
+After collecting one or more environment packages, run
+`debug\summarize-d3d11-environment-matrix.ps1` to emit a consolidated
+`matrix-ledger.md` / `matrix-ledger.json` for PR or issue review.
 
 To exercise the controlled Phase V device-recreate path, run the same smoke
 with `-RecreateSmoke` after building the D3D11 executable:

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -44,6 +44,7 @@ unavailable environment is missing evidence, not a passing result.
 | Fullscreen startup | `-FullscreenStartupSmoke` proves config startup fullscreen, Alt+Enter exit, and restored baseline size. |
 | Long-run soak | `-SoakMinutes 20` records periodic nonblank screenshots, process liveness, resize diagnostics, and no failure lines. |
 | Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, `matrix-summary.md`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
+| Environment ledger | `debug/summarize-d3d11-environment-matrix.ps1` emits `matrix-ledger.md` / `matrix-ledger.json` showing recorded, failing, mismatched, operator-review, and missing classes. |
 | Test gates | `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI pass. |
 
 ## Environment Matrix
@@ -112,6 +113,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -FullscreenStartupSmoke
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -SoakMinutes 20
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass local-physical
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\summarize-d3d11-environment-matrix.ps1
 
 zig build
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -57,6 +57,18 @@ collector to fail if the requested class does not match the detected facts:
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass rdp -RequireMatrixClass
 ```
 
+After collecting one or more evidence packages, generate a review ledger:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\summarize-d3d11-environment-matrix.ps1
+```
+
+The summarizer scans `zig-out\d3d11-env-smoke\` by default and writes
+`matrix-ledger.json` plus `matrix-ledger.md` under a timestamped
+`matrix-ledger-*` directory. Use `-InputRoot <path>` to summarize uploaded or
+downloaded artifacts from another machine, and use `-FailOnMissing` only in a
+closeout audit where every matrix class is expected to be present.
+
 ## JSON Contract
 
 Each collector run writes both `environment.json` and a redacted
@@ -79,6 +91,18 @@ Each collector run writes both `environment.json` and a redacted
 issue comments. It includes branch/commit, requested matrix class, class-match
 state, adapter facts, monitor/DPI facts, smoke health, and record-only policy
 fields, without copying raw diagnostic log lines.
+
+`matrix-ledger.md` aggregates all available `environment.json` files and
+selects the best evidence per matrix class. Status values are:
+
+| Status | Meaning |
+|---|---|
+| `recorded` | Passing evidence with `class_match = true`. |
+| `operator-review` | Passing hybrid-GPU evidence that needs operator topology confirmation. |
+| `recorded-unclassified` | Passing evidence without an automatically provable class match. |
+| `mismatch` | Evidence exists but detected facts do not match the requested class. |
+| `failing` | Evidence package exists but the smoke failed. |
+| `missing` | No evidence package exists for the class. |
 
 ## Ledger
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -207,8 +207,10 @@ contains `environment.json`, `matrix-summary.md`, `normal-session\`, and
 weak-integrated-GPU, single-monitor, multi-monitor same-DPI, and mixed-DPI
 environments; use `-RequireMatrixClass` only when the requested class can be
 proved from collected facts. Skipped or unavailable environments must be
-recorded as missing evidence rather than treated as passing. The ledger format
-lives in [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
+recorded as missing evidence rather than treated as passing. Use
+`debug\summarize-d3d11-environment-matrix.ps1` to aggregate packages into a
+reviewable `matrix-ledger.md` / `matrix-ledger.json`. The ledger format lives
+in [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

Adds `debug/summarize-d3d11-environment-matrix.ps1`, a record-only Phase V helper that scans collected `environment.json` packages and emits a consolidated `matrix-ledger.json` plus `matrix-ledger.md` under `zig-out\d3d11-env-smoke\matrix-ledger-*`.

Updates the D3D11 environment matrix, default gate, roadmap, and development docs so operators can collect per-machine evidence packages and then summarize recorded, failing, mismatched, operator-review, and missing matrix classes for PR or issue review.

This does not launch the app, write fallback markers, change renderer selection, change the Windows `auto` default, remove OpenGL fallback, or merge `windows-native-render` toward `main`.

## Ghostty comparison

Ghostty's renderer backend boundary remains a thin selector over its supported renderer backends (`opengl`, `metal`, `webgl`). It does not have a Windows D3D11 environment evidence matrix or fallback/default gate to mirror. This PR keeps the Phase V hardening WispTerm-specific and confines it to debug tooling plus documentation.

## Validation

- `powershell -NoProfile -Command '$script = Get-Content -LiteralPath "debug\summarize-d3d11-environment-matrix.ps1" -Raw; [scriptblock]::Create($script) | Out-Null; "summary-syntax-ok"'`
- `powershell -NoProfile -Command '$script = Get-Content -LiteralPath "debug\test-d3d11-environment-smoke.ps1" -Raw; [scriptblock]::Create($script) | Out-Null; "collector-syntax-ok"'`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\summarize-d3d11-environment-matrix.ps1`
  - `evidence_count = 4`
  - `missing_count = 6`
  - generated `zig-out\d3d11-env-smoke\matrix-ledger-20260703-141153\matrix-ledger.md`
  - generated `zig-out\d3d11-env-smoke\matrix-ledger-20260703-141153\matrix-ledger.json`
- `git diff --check -- debug\summarize-d3d11-environment-matrix.ps1 docs\development.md docs\windows-native-d3d11-default-gate.md docs\windows-native-d3d11-environment-matrix.md docs\windows-native-d3d11-roadmap.md`
- `git diff --cached --check`
- Windows checkout safety: `windows_name_violations=0`, `casefold_collisions=0`, `max_path_length=90`, no tracked symlinks
- `zig build test`
- `zig build check-sizes`
- `zig build`
- `zig build test-full --summary all`
  - `Build Summary: 60/60 steps succeeded; 13486/13772 tests passed; 286 skipped`

## Branch boundary

Base is `windows-native-render`. This PR is intentionally not targeted at `main`; `windows-native-render` remains the integration branch for native D3D11 work until the Phase V closeout gates are finished.
