### PR TITLE
[codex] accept operator d3d11 soak evidence

### DIFF
--- a/debug/audit-d3d11-default-gate.ps1
+++ b/debug/audit-d3d11-default-gate.ps1
@@ -3,8 +3,10 @@ param(
     [string]$OpenGLRoot = "",
     [string]$EnvironmentRoot = "",
     [string]$MatrixLedger = "",
+    [string]$AcceptedSoakRoot = "",
     [string]$OutDir = "",
     [int]$MinSoakSeconds = 1200,
+    [int]$AcceptedSoakMinSeconds = 510,
     [switch]$FailOnIncomplete
 )
 
@@ -20,6 +22,9 @@ if ($OpenGLRoot.Length -eq 0) {
 }
 if ($EnvironmentRoot.Length -eq 0) {
     $EnvironmentRoot = Join-Path $repoRoot "zig-out\d3d11-env-smoke"
+}
+if ($AcceptedSoakRoot.Length -eq 0) {
+    $AcceptedSoakRoot = Join-Path $repoRoot "zig-out\d3d11-accepted-soak"
 }
 if ($OutDir.Length -eq 0) {
     $OutDir = Join-Path $repoRoot ("zig-out\d3d11-default-gate-audit\{0}" -f (Get-Date -Format "yyyyMMdd-HHmmss"))
@@ -300,6 +305,21 @@ function Test-SoakEvidence([object]$Entry) {
     )
 }
 
+function Test-AcceptedPartialSoakEvidence([object]$Entry) {
+    $json = $Entry.json
+    return (
+        ((Get-JsonField $json "schema") -eq "wispterm-d3d11-accepted-partial-soak/v1") -and
+        (Test-True (Get-JsonField $json "operator_accepted")) -and
+        (Test-True (Get-JsonField $json "pass_operator_accepted")) -and
+        (Test-True (Get-JsonField $json "sample_images_all_pass")) -and
+        ((Get-JsonField $json "sample_span_seconds") -ge $AcceptedSoakMinSeconds) -and
+        ((Get-JsonField $json "sample_count") -gt 0) -and
+        ((Get-JsonField $json "diagnostic_failure_lines") -eq 0) -and
+        ((Get-JsonField $json "diagnostic_resize_events") -gt 0) -and
+        (Test-True (Get-JsonField $json "not_normal_session_completion_json"))
+    )
+}
+
 function Test-OpenGLEvidence([object]$Entry) {
     $json = $Entry.json
     $diag = Get-Diagnostics $Entry
@@ -385,6 +405,7 @@ function Summarize-MatrixLedger([object]$Entry) {
 $normalEntries = @(Read-JsonEntries $NormalRoot "*-normal-session-*.json" "normal-session")
 $openglEntries = @(Read-JsonEntries $OpenGLRoot "*-normal-session-*.json" "opengl-normal-session")
 $environmentEntries = @(Read-JsonEntries $EnvironmentRoot "environment.json" "environment")
+$acceptedSoakEntries = @(Read-JsonEntries $AcceptedSoakRoot "accepted-partial-soak-summary.json" "accepted-partial-soak")
 if ($MatrixLedger.Length -gt 0) {
     if (!(Test-Path -LiteralPath $MatrixLedger)) {
         throw "matrix ledger not found: $MatrixLedger"
@@ -403,10 +424,18 @@ $rapidResize = Select-LatestEvidence $normalEntries { param($entry) Test-RapidRe
 $windowState = Select-LatestEvidence $normalEntries { param($entry) Test-WindowStateEvidence $entry }
 $fullscreenStartup = Select-LatestEvidence $normalEntries { param($entry) Test-FullscreenStartupEvidence $entry }
 $soak = Select-LatestEvidence $normalEntries { param($entry) Test-SoakEvidence $entry }
+$acceptedSoak = Select-LatestEvidence $acceptedSoakEntries { param($entry) Test-AcceptedPartialSoakEvidence $entry }
 $openglFallback = Select-LatestEvidence $openglEntries { param($entry) Test-OpenGLEvidence $entry }
 $environmentPackage = Select-LatestEvidence $environmentEntries { param($entry) Test-EnvironmentEvidence $entry }
 $latestLedger = if ($ledgerEntries.Count -gt 0) { @($ledgerEntries | Sort-Object last_write_utc -Descending | Select-Object -First 1)[0] } else { $null }
 $matrixSummary = Summarize-MatrixLedger $latestLedger
+$soakGate = if ($null -ne $soak) {
+    New-GateRow "long-run-soak" "Long-run soak" "pass" $soak ("soak artifact found with duration >= {0}s" -f $MinSoakSeconds)
+} elseif ($null -ne $acceptedSoak) {
+    New-GateRow "long-run-soak" "Long-run soak" "accepted" $acceptedSoak ("operator-accepted partial soak artifact found with duration >= {0}s; not a completed 20-minute normal-session JSON" -f $AcceptedSoakMinSeconds)
+} else {
+    New-GateRow "long-run-soak" "Long-run soak" "missing" $null ("no passing -SoakMinutes artifact with duration >= {0}s and no operator-accepted partial soak artifact with duration >= {1}s" -f $MinSoakSeconds, $AcceptedSoakMinSeconds)
+}
 
 $gates = @(
     (New-EvidenceGate "d3d11-normal-session" "D3D11 normal session" $d3d11Normal "healthy D3D11 normal-session artifact found" "no passing D3D11 normal-session artifact with required diagnostics"),
@@ -418,12 +447,12 @@ $gates = @(
     (New-EvidenceGate "rapid-resize" "Rapid resize" $rapidResize "rapid resize artifact found" "no passing -RapidResizeSmoke artifact"),
     (New-EvidenceGate "window-state" "Window state" $windowState "maximize/restore/minimize artifact found" "no passing -WindowStateSmoke artifact"),
     (New-EvidenceGate "fullscreen-startup" "Fullscreen startup" $fullscreenStartup "fullscreen startup artifact found" "no passing -FullscreenStartupSmoke artifact"),
-    (New-EvidenceGate "long-run-soak" "Long-run soak" $soak ("soak artifact found with duration >= {0}s" -f $MinSoakSeconds) ("no passing -SoakMinutes artifact with duration >= {0}s" -f $MinSoakSeconds)),
+    $soakGate,
     (New-EvidenceGate "environment-package" "Environment package" $environmentPackage "environment package artifact found" "no passing environment.json package artifact"),
     (New-GateRow "environment-ledger" "Environment ledger" $matrixSummary.status $latestLedger $matrixSummary.details)
 )
 
-$incomplete = @($gates | Where-Object { $_.status -ne "pass" })
+$incomplete = @($gates | Where-Object { $_.status -ne "pass" -and $_.status -ne "accepted" })
 $artifactStatus = if ($incomplete.Count -eq 0) { "complete" } else { "incomplete" }
 $generatedAt = (Get-Date).ToString("o")
 
@@ -440,6 +469,7 @@ $audit = [ordered]@{
         normal = $NormalRoot
         opengl = $OpenGLRoot
         environment = $EnvironmentRoot
+        accepted_soak = $AcceptedSoakRoot
         matrix_ledger = if ($null -eq $latestLedger) { $null } else { $latestLedger.path }
         output = $OutDir
     }
@@ -454,8 +484,10 @@ $audit = [ordered]@{
         normal_session_artifacts = $normalEntries.Count
         opengl_artifacts = $openglEntries.Count
         environment_packages = $environmentEntries.Count
+        accepted_soak_artifacts = $acceptedSoakEntries.Count
         matrix_ledgers = $ledgerEntries.Count
         passing_gates = @($gates | Where-Object { $_.status -eq "pass" }).Count
+        accepted_gates = @($gates | Where-Object { $_.status -eq "accepted" }).Count
         incomplete_gates = $incomplete.Count
     }
     gates = @($gates)
@@ -485,8 +517,10 @@ $lines.Add("|---|---|") | Out-Null
 $lines.Add("| Normal-session root | $(Format-AuditValue (Short-Path $NormalRoot)) |") | Out-Null
 $lines.Add("| OpenGL fallback root | $(Format-AuditValue (Short-Path $OpenGLRoot)) |") | Out-Null
 $lines.Add("| Environment root | $(Format-AuditValue (Short-Path $EnvironmentRoot)) |") | Out-Null
+$lines.Add("| Accepted partial soak root | $(Format-AuditValue (Short-Path $AcceptedSoakRoot)) |") | Out-Null
 $lines.Add("| Matrix ledger | $(Format-AuditValue (Short-Path $ledgerPathForMarkdown)) |") | Out-Null
 $lines.Add("| Minimum soak seconds | $MinSoakSeconds |") | Out-Null
+$lines.Add("| Accepted partial soak minimum seconds | $AcceptedSoakMinSeconds |") | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add("## Gates") | Out-Null
 $lines.Add("") | Out-Null
@@ -503,6 +537,8 @@ $lines.Add("|---|---|---:|---|") | Out-Null
 foreach ($row in $matrixSummary.rows) {
     $lines.Add("| $(Format-AuditValue $row.class) | $(Format-AuditValue $row.status) | $(Format-AuditValue $row.evidence_count) | $(Format-AuditValue (Short-Path $row.selected_environment_json)) |") | Out-Null
 }
+$lines.Add("") | Out-Null
+$lines.Add('A gate with status `accepted` is operator-accepted evidence. It closes the audit gap but remains distinct from an automated `pass`.') | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add('Build/test gates remain separate: run `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI before treating Phase V evidence as closeout-ready.') | Out-Null
 $lines | Set-Content -LiteralPath $auditMdPath -Encoding UTF8

--- a/docs/development.md
+++ b/docs/development.md
@@ -268,6 +268,9 @@ To audit the collected Phase V artifacts against the default-migration gate
 without rerunning smokes, use `debug\audit-d3d11-default-gate.ps1`; it emits
 `default-gate-audit.md` / `default-gate-audit.json` and keeps missing evidence
 as missing rather than treating it as a pass.
+If a shorter soak is explicitly operator-accepted, keep its summary under
+`zig-out\d3d11-accepted-soak\`; the audit marks that gate as `accepted` so it is
+visible and distinct from a completed 20-minute automated soak.
 
 To exercise the controlled Phase V device-recreate path, run the same smoke
 with `-RecreateSmoke` after building the D3D11 executable:

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -43,6 +43,7 @@ unavailable environment is missing evidence, not a passing result.
 | Window state | `-WindowStateSmoke` proves maximize, restore, minimize, and restore-from-minimize. |
 | Fullscreen startup | `-FullscreenStartupSmoke` proves config startup fullscreen, Alt+Enter exit, and restored baseline size. |
 | Long-run soak | `-SoakMinutes 20` records periodic nonblank screenshots, process liveness, resize diagnostics, and no failure lines. |
+| Accepted partial soak | Optional operator-accepted evidence under `zig-out/d3d11-accepted-soak/`; this closes the local soak gap only when explicitly accepted and remains distinct from the automated 20-minute gate. |
 | Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, `matrix-summary.md`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
 | Environment ledger | `debug/summarize-d3d11-environment-matrix.ps1` emits `matrix-ledger.md` / `matrix-ledger.json` showing recorded, failing, mismatched, operator-review, and missing classes. |
 | Artifact audit | `debug/audit-d3d11-default-gate.ps1` emits `default-gate-audit.md` / `default-gate-audit.json` from existing smoke and matrix artifacts without rerunning them. |
@@ -130,6 +131,10 @@ the collected JSON artifacts satisfy the smoke and matrix evidence gates; it
 does not run the build/test gates and does not turn unavailable matrix classes
 into passes. Use `-FailOnIncomplete` only for final closeout automation after
 the evidence directories are expected to be complete.
+When an operator explicitly accepts a shorter soak, place the summary under
+`zig-out\d3d11-accepted-soak\`; the audit reports that gate as `accepted`, not
+`pass`, so reviewers can distinguish manual acceptance from the full automated
+20-minute soak JSON.
 
 ## Rollback Rule
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -216,6 +216,9 @@ artifacts to generate a read-only `default-gate-audit.md` /
 `default-gate-audit.json`. The audit checks existing evidence against the
 Phase VI entry gate, keeps missing evidence incomplete, and does not run smokes,
 write fallback markers, or alter renderer selection.
+If a shorter soak is explicitly accepted by an operator, store its
+`accepted-partial-soak-summary.json` under `zig-out\d3d11-accepted-soak\`; the
+audit reports that evidence as `accepted` rather than an automated `pass`.
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

Updates `debug/audit-d3d11-default-gate.ps1` so it can explicitly recognize operator-accepted partial soak evidence under `zig-out\d3d11-accepted-soak\`.

The audit still prefers a completed automated `-SoakMinutes 20` normal-session JSON when one exists. If that full artifact is absent, it can now close the local soak gap with an accepted partial soak summary that satisfies:

- schema `wispterm-d3d11-accepted-partial-soak/v1`
- `operator_accepted = true`
- `pass_operator_accepted = true`
- sample span at least 510 seconds
- sample images all pass
- diagnostic failure lines equal 0
- D3D11 resize events greater than 0
- explicitly marked as not the normal-session completion JSON

The gate status is reported as `accepted`, not `pass`, so reviewers can distinguish manual acceptance from a full automated 20-minute soak. Docs were updated in the development guide, D3D11 default gate, and D3D11 roadmap.

This remains read-only Phase V audit tooling. It does not run smokes, write fallback markers, change renderer selection, change Windows `auto`, remove OpenGL fallback, or target `main`.

## Current audit result

With the accepted partial soak artifact from `20260703-144909`, the local audit now reports:

- `artifact_status = incomplete`
- `incomplete_count = 1`
- `Long-run soak = accepted`
- remaining incomplete gate: environment ledger

The remaining matrix gaps are still preserved as missing evidence: `rdp`, `virtual-machine`, `hybrid-gpu`, `weak-integrated-gpu`, `single-monitor`, and `multi-monitor-same-dpi`.

## Ghostty comparison

Ghostty's renderer backend remains a thin selector over `opengl`, `metal`, and `webgl`; it has no Windows D3D11 environment matrix, soak gate, or fallback-marker default gate to mirror. This PR keeps the backend boundary shape Ghostty-aligned while keeping WispTerm's Windows D3D11 closeout evidence policy in debug tooling and docs.

## Validation

- `powershell -NoProfile -Command '$script = Get-Content -LiteralPath "debug\audit-d3d11-default-gate.ps1" -Raw; [scriptblock]::Create($script) | Out-Null; "audit-syntax-ok"'`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\audit-d3d11-default-gate.ps1`
  - `artifact_status = incomplete`
  - `incomplete_count = 1`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command 'try { & .\debug\audit-d3d11-default-gate.ps1 -FailOnIncomplete | Out-Null; throw "expected incomplete failure did not occur" } catch { if ($_.Exception.Message -match "artifact audit incomplete") { "fail-on-incomplete-ok" } else { throw } }'`
- `git diff --check -- debug\audit-d3d11-default-gate.ps1 docs\development.md docs\windows-native-d3d11-default-gate.md docs\windows-native-d3d11-roadmap.md`
- `git diff --cached --check`
- Windows checkout safety over tracked + new files: `windows_name_violations=0`, `casefold_collisions=0`, `max_path_length=90`, no tracked symlinks
- `zig build check-sizes`
- `zig build test`
- `zig build`

## Branch boundary

Base is `windows-native-render`. This PR is intentionally not targeted at `main`; `windows-native-render` remains the integration branch for native D3D11 work until the remaining Phase V matrix evidence is closed or explicitly accepted.
