### PR TITLE
[codex] plan d3d11 environment collection

### DIFF
--- a/debug/summarize-d3d11-environment-matrix.ps1
+++ b/debug/summarize-d3d11-environment-matrix.ps1
@@ -91,6 +91,65 @@ function StatusRank([string]$Status) {
     return 5
 }
 
+function Get-CollectionSpec([string]$Class) {
+    $requireClassMatch = $true
+    $operatorAction = "Run the collector on a machine or session that actually matches this class."
+    $note = "Use -RequireMatrixClass so a mismatched run stays visible as non-passing evidence."
+
+    switch ($Class) {
+        "local-physical" {
+            $operatorAction = "Run on a non-remote physical Windows machine with a non-virtual D3D11 adapter."
+        }
+        "rdp" {
+            $operatorAction = "Run from inside an RDP session."
+        }
+        "virtual-machine" {
+            $operatorAction = "Run inside the target VM and keep the adapter facts if the heuristic does not match."
+            $note = "Use -RequireMatrixClass when the VM adapter is expected to be detectable; otherwise rerun without it and review the adapter facts."
+        }
+        "hybrid-gpu" {
+            $requireClassMatch = $false
+            $operatorAction = "Run on a hybrid-GPU laptop or workstation and add operator confirmation of the topology in the PR or issue."
+            $note = "Hybrid topology cannot be proven from the single DXGI adapter diagnostic, so the ledger reports operator-review until the evidence is explicitly accepted."
+        }
+        "weak-integrated-gpu" {
+            $operatorAction = "Run on an integrated GPU with <= 1 GiB dedicated video memory."
+        }
+        "single-monitor" {
+            $operatorAction = "Run with exactly one active monitor."
+        }
+        "multi-monitor-same-dpi" {
+            $operatorAction = "Run with more than one active monitor and matching DPI values."
+        }
+        "multi-monitor-mixed-dpi" {
+            $operatorAction = "Run with more than one active monitor and mixed DPI values."
+        }
+    }
+
+    $command = "powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environment-smoke.ps1 -MatrixClass $Class"
+    if ($requireClassMatch) {
+        $command += " -RequireMatrixClass"
+    }
+
+    return [pscustomobject][ordered]@{
+        require_class_match = $requireClassMatch
+        command = $command
+        operator_action = $operatorAction
+        note = $note
+    }
+}
+
+function Get-CollectionReason([string]$Status) {
+    switch ($Status) {
+        "missing" { return "No evidence package exists for this class." }
+        "operator-review" { return "Evidence exists but still needs explicit operator confirmation or acceptance." }
+        "recorded-unclassified" { return "Evidence passed, but class_match is null and does not prove the requested class." }
+        "mismatch" { return "Evidence exists, but detected facts contradict the requested class." }
+        "failing" { return "Evidence exists, but the smoke failed." }
+    }
+    return "Status is not recorded."
+}
+
 function Add-MarkdownRow([object]$Lines, [object[]]$Values) {
     $cells = @()
     foreach ($value in $Values) {
@@ -201,6 +260,8 @@ $ledger = [ordered]@{
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 $ledgerJsonPath = Join-Path $OutDir "matrix-ledger.json"
 $ledgerMdPath = Join-Path $OutDir "matrix-ledger.md"
+$collectionPlanJsonPath = Join-Path $OutDir "matrix-collection-plan.json"
+$collectionPlanMdPath = Join-Path $OutDir "matrix-collection-plan.md"
 $ledger | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $ledgerJsonPath -Encoding UTF8
 
 $lines = [System.Collections.Generic.List[string]]::new()
@@ -263,11 +324,85 @@ if ($missing.Count -gt 0) {
 
 $lines | Set-Content -LiteralPath $ledgerMdPath -Encoding UTF8
 
+$outstandingRows = @($classRows | Where-Object { $_.status -ne "recorded" })
+$collectionItems = @()
+foreach ($row in $outstandingRows) {
+    $spec = Get-CollectionSpec $row.class
+    $collectionItems += [pscustomobject][ordered]@{
+        class = $row.class
+        current_status = $row.status
+        reason = Get-CollectionReason $row.status
+        evidence_count = $row.evidence_count
+        selected_environment_json = $row.selected_environment_json
+        require_class_match = $spec.require_class_match
+        command = $spec.command
+        operator_action = $spec.operator_action
+        note = $spec.note
+    }
+}
+
+$collectionPlan = [ordered]@{
+    schema = "wispterm-d3d11-environment-collection-plan/v1"
+    generated_at = $generatedAt
+    input_root = $InputRoot
+    ledger_json = $ledgerJsonPath
+    ledger_markdown = $ledgerMdPath
+    outstanding_count = $collectionItems.Count
+    policy = [ordered]@{
+        record_only = $true
+        does_not_create_evidence = $true
+        does_not_accept_missing_classes = $true
+        default_unchanged = $true
+    }
+    items = @($collectionItems)
+}
+$collectionPlan | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $collectionPlanJsonPath -Encoding UTF8
+
+$planLines = [System.Collections.Generic.List[string]]::new()
+$planLines.Add("# WispTerm D3D11 Environment Collection Plan") | Out-Null
+$planLines.Add("") | Out-Null
+$planLines.Add("Generated at: $generatedAt") | Out-Null
+$planLines.Add("") | Out-Null
+$planLines.Add("Input root: $InputRoot") | Out-Null
+$planLines.Add("") | Out-Null
+$planLines.Add("This plan is derived from the current matrix ledger. It does not create evidence, accept missing classes, block environments, or change the Windows default renderer.") | Out-Null
+$planLines.Add("") | Out-Null
+$planLines.Add("Build the D3D11 executable before running any collector command:") | Out-Null
+$planLines.Add("") | Out-Null
+$planLines.Add('```powershell') | Out-Null
+$planLines.Add("zig build -Dgpu-backend=d3d11") | Out-Null
+$planLines.Add('```') | Out-Null
+$planLines.Add("") | Out-Null
+if ($collectionItems.Count -eq 0) {
+    $planLines.Add("All matrix classes are recorded in the current ledger.") | Out-Null
+} else {
+    $planLines.Add("## Outstanding Classes") | Out-Null
+    $planLines.Add("") | Out-Null
+    $planLines.Add("| Class | Current status | Reason | Evidence | Require match | Collector command | Operator action | Note |") | Out-Null
+    $planLines.Add("|---|---|---|---:|---|---|---|---|") | Out-Null
+    foreach ($item in $collectionItems) {
+        Add-MarkdownRow $planLines @(
+            $item.class,
+            $item.current_status,
+            $item.reason,
+            $item.evidence_count,
+            $item.require_class_match,
+            $item.command,
+            $item.operator_action,
+            $item.note
+        )
+    }
+}
+$planLines | Set-Content -LiteralPath $collectionPlanMdPath -Encoding UTF8
+
 $summary = [ordered]@{
     evidence_count = $entries.Count
     missing_count = $missing.Count
+    outstanding_count = $collectionItems.Count
     ledger_json = $ledgerJsonPath
     ledger_markdown = $ledgerMdPath
+    collection_plan_json = $collectionPlanJsonPath
+    collection_plan_markdown = $collectionPlanMdPath
 }
 $summary | ConvertTo-Json -Depth 4
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -263,7 +263,11 @@ not change fallback policy. The durable ledger format is documented in
 [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 After collecting one or more environment packages, run
 `debug\summarize-d3d11-environment-matrix.ps1` to emit a consolidated
-`matrix-ledger.md` / `matrix-ledger.json` for PR or issue review.
+`matrix-ledger.md` / `matrix-ledger.json` plus a
+`matrix-collection-plan.md` / `matrix-collection-plan.json` for PR or issue
+review. The collection plan lists remaining non-recorded classes and the exact
+collector command to run in each matching environment; it is not evidence and
+does not accept missing classes.
 To audit the collected Phase V artifacts against the default-migration gate
 without rerunning smokes, use `debug\audit-d3d11-default-gate.ps1`; it emits
 `default-gate-audit.md` / `default-gate-audit.json` and keeps missing evidence

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -45,7 +45,7 @@ unavailable environment is missing evidence, not a passing result.
 | Long-run soak | `-SoakMinutes 20` records periodic nonblank screenshots, process liveness, resize diagnostics, and no failure lines. |
 | Accepted partial soak | Optional operator-accepted evidence under `zig-out/d3d11-accepted-soak/`; this closes the local soak gap only when explicitly accepted and remains distinct from the automated 20-minute gate. |
 | Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, `matrix-summary.md`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
-| Environment ledger | `debug/summarize-d3d11-environment-matrix.ps1` emits `matrix-ledger.md` / `matrix-ledger.json` showing recorded, failing, mismatched, operator-review, and missing classes. |
+| Environment ledger | `debug/summarize-d3d11-environment-matrix.ps1` emits `matrix-ledger.md` / `matrix-ledger.json` showing recorded, failing, mismatched, operator-review, and missing classes, plus `matrix-collection-plan.md` / `matrix-collection-plan.json` for the remaining collector commands. |
 | Artifact audit | `debug/audit-d3d11-default-gate.ps1` emits `default-gate-audit.md` / `default-gate-audit.json` from existing smoke and matrix artifacts without rerunning them. |
 | Test gates | `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI pass. |
 

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -64,10 +64,14 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\summarize-d3d11-envi
 ```
 
 The summarizer scans `zig-out\d3d11-env-smoke\` by default and writes
-`matrix-ledger.json` plus `matrix-ledger.md` under a timestamped
-`matrix-ledger-*` directory. Use `-InputRoot <path>` to summarize uploaded or
-downloaded artifacts from another machine, and use `-FailOnMissing` only in a
-closeout audit where every matrix class is expected to be present.
+`matrix-ledger.json`, `matrix-ledger.md`, `matrix-collection-plan.json`, and
+`matrix-collection-plan.md` under a timestamped `matrix-ledger-*` directory.
+The collection plan turns any non-recorded ledger class into a concrete
+collector command plus operator note; it does not create evidence, accept
+missing classes, or change renderer policy. Use `-InputRoot <path>` to
+summarize uploaded or downloaded artifacts from another machine, and use
+`-FailOnMissing` only in a closeout audit where every matrix class is expected
+to be present.
 
 ## JSON Contract
 
@@ -103,6 +107,12 @@ selects the best evidence per matrix class. Status values are:
 | `mismatch` | Evidence exists but detected facts do not match the requested class. |
 | `failing` | Evidence package exists but the smoke failed. |
 | `missing` | No evidence package exists for the class. |
+
+`matrix-collection-plan.md` lists each class whose status is not `recorded`.
+For automatically provable classes it includes a command with
+`-RequireMatrixClass`; for `hybrid-gpu` it omits that switch and records the
+operator-confirmation requirement because the single DXGI adapter diagnostic
+cannot prove hybrid topology by itself.
 
 ## Ledger
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -209,8 +209,10 @@ environments; use `-RequireMatrixClass` only when the requested class can be
 proved from collected facts. Skipped or unavailable environments must be
 recorded as missing evidence rather than treated as passing. Use
 `debug\summarize-d3d11-environment-matrix.ps1` to aggregate packages into a
-reviewable `matrix-ledger.md` / `matrix-ledger.json`. The ledger format lives
-in [windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
+reviewable `matrix-ledger.md` / `matrix-ledger.json` and a
+`matrix-collection-plan.md` / `matrix-collection-plan.json` for the remaining
+non-recorded classes. The ledger format lives in
+[windows-native-d3d11-environment-matrix.md](windows-native-d3d11-environment-matrix.md).
 Use `debug\audit-d3d11-default-gate.ps1` after collecting the smoke and matrix
 artifacts to generate a read-only `default-gate-audit.md` /
 `default-gate-audit.json`. The audit checks existing evidence against the


### PR DESCRIPTION
## Summary

Adds a generated D3D11 environment collection plan alongside the existing matrix ledger.

- `debug/summarize-d3d11-environment-matrix.ps1` now writes `matrix-collection-plan.json` and `matrix-collection-plan.md`.
- The plan lists every non-recorded matrix class, the collector command to run in the matching environment, whether `-RequireMatrixClass` should be used, and the operator note for hybrid-GPU evidence.
- Docs now describe the collection plan as an action checklist only: it does not create evidence, accept missing classes, block environments, or change renderer selection.

## Why

After #496, the long-run soak gap is operator-accepted, but the Phase V default-gate audit still has one incomplete gate: the environment ledger. This makes the remaining RDP/VM/hybrid/weak-iGPU/single-monitor/same-DPI multi-monitor work mechanical and reviewable without weakening the audit boundary.

## Validation

- PowerShell parse check for `debug/summarize-d3d11-environment-matrix.ps1`
- `debug/summarize-d3d11-environment-matrix.ps1`
  - generated `outstanding_count=6`
  - generated `matrix-collection-plan.json`
  - generated `matrix-collection-plan.md`
- `debug/summarize-d3d11-environment-matrix.ps1 -FailOnMissing` fails as expected while matrix evidence is missing
- `debug/audit-d3d11-default-gate.ps1`
  - still reports `artifact_status=incomplete`, `incomplete_count=1`
- `debug/audit-d3d11-default-gate.ps1 -FailOnIncomplete` fails as expected
- `git diff --check`
- `zig build check-sizes`
- `zig build test`
- `zig build`

## Boundary

This PR does not merge anything into `main`, does not change Windows `auto`, does not add runtime D3D11-to-OpenGL switching, and does not convert missing environment evidence into a pass.
