### PR TITLE
[codex] accept d3d11 environment gaps

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,9 +34,28 @@ console release unless the release explicitly includes `remote/`.
   is satisfied.
 - D3D11 fallback is next-launch/future-auto policy only. The app does not switch
   from D3D11 to OpenGL inside the same running process.
-- RDP, virtual-machine, hybrid-GPU, weak-integrated-GPU, and multi-monitor
-  mixed-DPI evidence is still tracked as matrix evidence rather than a fully
-  closed release claim.
+- D3D11 Phase V environment matrix gaps are accepted known issues where the
+  current operators do not have matching machines or sessions available. These
+  accepted gaps are not passing test evidence, and should be replaced with
+  real `debug\test-d3d11-environment-smoke.ps1` artifacts when the environment
+  becomes available.
+
+### Accepted D3D11 Phase V Environment Matrix Gaps
+
+The following matrix classes are explicitly accepted as untested for the
+current Phase V closeout because matching hardware, monitor topology, VM, or
+RDP session coverage is not available:
+
+- `rdp`
+- `virtual-machine`
+- `hybrid-gpu`
+- `weak-integrated-gpu`
+- `single-monitor`
+- `multi-monitor-same-dpi`
+
+The current evidence set records `local-physical` and
+`multi-monitor-mixed-dpi`; the classes above remain accepted gaps rather than
+tested passes.
 
 ## macOS
 

--- a/debug/audit-d3d11-default-gate.ps1
+++ b/debug/audit-d3d11-default-gate.ps1
@@ -4,6 +4,7 @@ param(
     [string]$EnvironmentRoot = "",
     [string]$MatrixLedger = "",
     [string]$AcceptedSoakRoot = "",
+    [string]$KnownIssuesPath = "",
     [string]$OutDir = "",
     [int]$MinSoakSeconds = 1200,
     [int]$AcceptedSoakMinSeconds = 510,
@@ -25,6 +26,9 @@ if ($EnvironmentRoot.Length -eq 0) {
 }
 if ($AcceptedSoakRoot.Length -eq 0) {
     $AcceptedSoakRoot = Join-Path $repoRoot "zig-out\d3d11-accepted-soak"
+}
+if ($KnownIssuesPath.Length -eq 0) {
+    $KnownIssuesPath = Join-Path $repoRoot "KNOWN_ISSUES.md"
 }
 if ($OutDir.Length -eq 0) {
     $OutDir = Join-Path $repoRoot ("zig-out\d3d11-default-gate-audit\{0}" -f (Get-Date -Format "yyyyMMdd-HHmmss"))
@@ -118,6 +122,59 @@ function Read-JsonEntries([string]$Root, [string]$Filter, [string]$Kind) {
         }
     }
     return @($entries)
+}
+
+function Read-KnownIssuesAcceptedMatrixClasses([string]$Path) {
+    if (!(Test-Path -LiteralPath $Path)) {
+        return [pscustomobject][ordered]@{
+            path = $Path
+            available = $false
+            section_found = $false
+            accepted_classes = @()
+            details = "KNOWN_ISSUES.md not found"
+        }
+    }
+
+    $text = Get-Content -LiteralPath $Path -Raw
+    $lines = $text -split "`r?`n"
+    $inSection = $false
+    $sectionFound = $false
+    $accepted = @()
+    foreach ($line in $lines) {
+        if ($line -match '^###\s+Accepted D3D11 Phase V Environment Matrix Gaps\s*$') {
+            $inSection = $true
+            $sectionFound = $true
+            continue
+        }
+        if ($inSection -and $line -match '^##\s+') {
+            break
+        }
+        if (!$inSection) {
+            continue
+        }
+
+        $acceptedLine = [regex]::Match($line, '^\s*-\s+`([^`]+)`\s*$')
+        if ($acceptedLine.Success) {
+            $candidate = $acceptedLine.Groups[1].Value
+            if ($matrixClasses -contains $candidate -and !($accepted -contains $candidate)) {
+                $accepted += $candidate
+            }
+        }
+    }
+
+    $details = if ($sectionFound) {
+        "accepted matrix classes found: $($accepted -join ', ')"
+    } else {
+        "accepted matrix gap section not found"
+    }
+
+    return [pscustomobject][ordered]@{
+        path = $Path
+        available = $true
+        section_found = $sectionFound
+        accepted_classes = @($accepted)
+        details = $details
+    }
 }
 
 function Select-LatestEvidence([object[]]$Entries, [scriptblock]$Predicate) {
@@ -352,7 +409,7 @@ function Test-EnvironmentEvidence([object]$Entry) {
     )
 }
 
-function Summarize-MatrixLedger([object]$Entry) {
+function Summarize-MatrixLedger([object]$Entry, [object]$KnownIssuesAcceptance) {
     if ($null -eq $Entry) {
         return [pscustomobject][ordered]@{
             status = "missing"
@@ -366,21 +423,44 @@ function Summarize-MatrixLedger([object]$Entry) {
     foreach ($class in $matrixClasses) {
         $match = @($classes | Where-Object { (Get-JsonField $_ "class") -eq $class } | Select-Object -First 1)
         if ($match.Count -eq 0) {
-            $rows += [pscustomobject][ordered]@{ class = $class; status = "missing"; evidence_count = 0 }
-        } else {
-            $row = $match[0]
+            $acceptedByKnownIssues = $KnownIssuesAcceptance.accepted_classes -contains $class
             $rows += [pscustomobject][ordered]@{
                 class = $class
-                status = Get-JsonField $row "status"
+                status = if ($acceptedByKnownIssues) { "accepted" } else { "missing" }
+                original_status = "missing"
+                evidence_count = 0
+                selected_environment_json = $null
+                selected_generated_at = $null
+                accepted_by_known_issues = $acceptedByKnownIssues
+                accepted_evidence = if ($acceptedByKnownIssues) { $KnownIssuesAcceptance.path } else { $null }
+            }
+        } else {
+            $row = $match[0]
+            $status = Get-JsonField $row "status"
+            $acceptedByKnownIssues = ($status -ne "recorded") -and ($KnownIssuesAcceptance.accepted_classes -contains $class)
+            $rows += [pscustomobject][ordered]@{
+                class = $class
+                status = if ($acceptedByKnownIssues) { "accepted" } else { $status }
+                original_status = $status
                 evidence_count = Get-JsonField $row "evidence_count"
                 selected_environment_json = Get-JsonField $row "selected_environment_json"
                 selected_generated_at = Get-JsonField $row "selected_generated_at"
+                accepted_by_known_issues = $acceptedByKnownIssues
+                accepted_evidence = if ($acceptedByKnownIssues) { $KnownIssuesAcceptance.path } else { $null }
             }
         }
     }
 
-    $notRecorded = @($rows | Where-Object { $_.status -ne "recorded" })
-    if ($notRecorded.Count -eq 0) {
+    $notClosed = @($rows | Where-Object { $_.status -ne "recorded" -and $_.status -ne "accepted" })
+    $acceptedRows = @($rows | Where-Object { $_.status -eq "accepted" })
+    if ($notClosed.Count -eq 0) {
+        if ($acceptedRows.Count -gt 0) {
+            return [pscustomObject][ordered]@{
+                status = "accepted"
+                details = "matrix gaps accepted in KNOWN_ISSUES.md: $((@($acceptedRows | ForEach-Object { $_.class })) -join ', ')"
+                rows = @($rows)
+            }
+        }
         return [pscustomobject][ordered]@{
             status = "pass"
             details = "all matrix classes are recorded"
@@ -390,7 +470,7 @@ function Summarize-MatrixLedger([object]$Entry) {
 
     $parts = @()
     foreach ($status in @("missing", "failing", "mismatch", "operator-review", "recorded-unclassified")) {
-        $classesForStatus = @($notRecorded | Where-Object { $_.status -eq $status } | ForEach-Object { $_.class })
+        $classesForStatus = @($notClosed | Where-Object { $_.status -eq $status } | ForEach-Object { $_.class })
         if ($classesForStatus.Count -gt 0) {
             $parts += ("{0}: {1}" -f $status, ($classesForStatus -join ", "))
         }
@@ -428,7 +508,8 @@ $acceptedSoak = Select-LatestEvidence $acceptedSoakEntries { param($entry) Test-
 $openglFallback = Select-LatestEvidence $openglEntries { param($entry) Test-OpenGLEvidence $entry }
 $environmentPackage = Select-LatestEvidence $environmentEntries { param($entry) Test-EnvironmentEvidence $entry }
 $latestLedger = if ($ledgerEntries.Count -gt 0) { @($ledgerEntries | Sort-Object last_write_utc -Descending | Select-Object -First 1)[0] } else { $null }
-$matrixSummary = Summarize-MatrixLedger $latestLedger
+$knownIssuesAcceptance = Read-KnownIssuesAcceptedMatrixClasses $KnownIssuesPath
+$matrixSummary = Summarize-MatrixLedger $latestLedger $knownIssuesAcceptance
 $soakGate = if ($null -ne $soak) {
     New-GateRow "long-run-soak" "Long-run soak" "pass" $soak ("soak artifact found with duration >= {0}s" -f $MinSoakSeconds)
 } elseif ($null -ne $acceptedSoak) {
@@ -470,6 +551,7 @@ $audit = [ordered]@{
         opengl = $OpenGLRoot
         environment = $EnvironmentRoot
         accepted_soak = $AcceptedSoakRoot
+        known_issues = $KnownIssuesPath
         matrix_ledger = if ($null -eq $latestLedger) { $null } else { $latestLedger.path }
         output = $OutDir
     }
@@ -479,12 +561,14 @@ $audit = [ordered]@{
         does_not_infer_build_gates = $true
         does_not_change_default = $true
         automatic_fallback = $false
+        known_issues_acceptance = $true
     }
     counts = [ordered]@{
         normal_session_artifacts = $normalEntries.Count
         opengl_artifacts = $openglEntries.Count
         environment_packages = $environmentEntries.Count
         accepted_soak_artifacts = $acceptedSoakEntries.Count
+        known_issues_accepted_matrix_classes = @($knownIssuesAcceptance.accepted_classes).Count
         matrix_ledgers = $ledgerEntries.Count
         passing_gates = @($gates | Where-Object { $_.status -eq "pass" }).Count
         accepted_gates = @($gates | Where-Object { $_.status -eq "accepted" }).Count
@@ -495,6 +579,7 @@ $audit = [ordered]@{
         status = $matrixSummary.status
         details = $matrixSummary.details
         classes = @($matrixSummary.rows)
+        known_issues_acceptance = $knownIssuesAcceptance
     }
 }
 
@@ -518,6 +603,7 @@ $lines.Add("| Normal-session root | $(Format-AuditValue (Short-Path $NormalRoot)
 $lines.Add("| OpenGL fallback root | $(Format-AuditValue (Short-Path $OpenGLRoot)) |") | Out-Null
 $lines.Add("| Environment root | $(Format-AuditValue (Short-Path $EnvironmentRoot)) |") | Out-Null
 $lines.Add("| Accepted partial soak root | $(Format-AuditValue (Short-Path $AcceptedSoakRoot)) |") | Out-Null
+$lines.Add("| Known issues | $(Format-AuditValue (Short-Path $KnownIssuesPath)) |") | Out-Null
 $lines.Add("| Matrix ledger | $(Format-AuditValue (Short-Path $ledgerPathForMarkdown)) |") | Out-Null
 $lines.Add("| Minimum soak seconds | $MinSoakSeconds |") | Out-Null
 $lines.Add("| Accepted partial soak minimum seconds | $AcceptedSoakMinSeconds |") | Out-Null
@@ -532,10 +618,10 @@ foreach ($gate in $gates) {
 $lines.Add("") | Out-Null
 $lines.Add("## Environment Matrix") | Out-Null
 $lines.Add("") | Out-Null
-$lines.Add("| Class | Status | Evidence count | Selected evidence |") | Out-Null
-$lines.Add("|---|---|---:|---|") | Out-Null
+$lines.Add("| Class | Status | Ledger status | Evidence count | Selected evidence | Known issue |") | Out-Null
+$lines.Add("|---|---|---|---:|---|---|") | Out-Null
 foreach ($row in $matrixSummary.rows) {
-    $lines.Add("| $(Format-AuditValue $row.class) | $(Format-AuditValue $row.status) | $(Format-AuditValue $row.evidence_count) | $(Format-AuditValue (Short-Path $row.selected_environment_json)) |") | Out-Null
+    $lines.Add("| $(Format-AuditValue $row.class) | $(Format-AuditValue $row.status) | $(Format-AuditValue $row.original_status) | $(Format-AuditValue $row.evidence_count) | $(Format-AuditValue (Short-Path $row.selected_environment_json)) | $(Format-AuditValue (Short-Path $row.accepted_evidence)) |") | Out-Null
 }
 $lines.Add("") | Out-Null
 $lines.Add('A gate with status `accepted` is operator-accepted evidence. It closes the audit gap but remains distinct from an automated `pass`.') | Out-Null

--- a/docs/development.md
+++ b/docs/development.md
@@ -271,7 +271,11 @@ does not accept missing classes.
 To audit the collected Phase V artifacts against the default-migration gate
 without rerunning smokes, use `debug\audit-d3d11-default-gate.ps1`; it emits
 `default-gate-audit.md` / `default-gate-audit.json` and keeps missing evidence
-as missing rather than treating it as a pass.
+as missing rather than treating it as a pass. If unavailable environment
+classes are explicitly accepted under `KNOWN_ISSUES.md` heading
+`Accepted D3D11 Phase V Environment Matrix Gaps`, the audit marks those matrix
+rows and the environment-ledger gate as `accepted` while preserving the original
+ledger status.
 If a shorter soak is explicitly operator-accepted, keep its summary under
 `zig-out\d3d11-accepted-soak\`; the audit marks that gate as `accepted` so it is
 visible and distinct from a completed 20-minute automated soak.

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -46,7 +46,8 @@ unavailable environment is missing evidence, not a passing result.
 | Accepted partial soak | Optional operator-accepted evidence under `zig-out/d3d11-accepted-soak/`; this closes the local soak gap only when explicitly accepted and remains distinct from the automated 20-minute gate. |
 | Environment package | `debug/test-d3d11-environment-smoke.ps1` emits `environment.json`, `matrix-summary.md`, normal-session JSON, screenshots, adapter facts, Win32 session facts, record-only matrix fields, and policy fields. |
 | Environment ledger | `debug/summarize-d3d11-environment-matrix.ps1` emits `matrix-ledger.md` / `matrix-ledger.json` showing recorded, failing, mismatched, operator-review, and missing classes, plus `matrix-collection-plan.md` / `matrix-collection-plan.json` for the remaining collector commands. |
-| Artifact audit | `debug/audit-d3d11-default-gate.ps1` emits `default-gate-audit.md` / `default-gate-audit.json` from existing smoke and matrix artifacts without rerunning them. |
+| Accepted matrix gaps | Optional operator acceptance under `KNOWN_ISSUES.md` section `Accepted D3D11 Phase V Environment Matrix Gaps`; this closes unavailable environment gaps as `accepted`, not `pass`. |
+| Artifact audit | `debug/audit-d3d11-default-gate.ps1` emits `default-gate-audit.md` / `default-gate-audit.json` from existing smoke, matrix, accepted-soak, and known-issues artifacts without rerunning them. |
 | Test gates | `zig build check-sizes`, `zig build test`, `zig build test-full --summary all`, `zig build`, and PR CI pass. |
 
 ## Environment Matrix
@@ -127,14 +128,20 @@ zig build test-full --summary all
 ```
 
 The artifact audit is intentionally read-only. It reports `complete` only when
-the collected JSON artifacts satisfy the smoke and matrix evidence gates; it
+the collected JSON artifacts satisfy the smoke evidence gates and the matrix
+classes are either recorded or explicitly accepted in `KNOWN_ISSUES.md`; it
 does not run the build/test gates and does not turn unavailable matrix classes
 into passes. Use `-FailOnIncomplete` only for final closeout automation after
-the evidence directories are expected to be complete.
+the evidence directories and accepted-gap record are expected to be complete.
 When an operator explicitly accepts a shorter soak, place the summary under
 `zig-out\d3d11-accepted-soak\`; the audit reports that gate as `accepted`, not
 `pass`, so reviewers can distinguish manual acceptance from the full automated
 20-minute soak JSON.
+When an operator explicitly accepts unavailable environment classes, list each
+class as its own backticked bullet under the `KNOWN_ISSUES.md` heading
+`Accepted D3D11 Phase V Environment Matrix Gaps`; the audit reports the
+environment-ledger gate as `accepted` and keeps the original ledger status in
+the generated matrix table.
 
 ## Rollback Rule
 

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -128,4 +128,7 @@ cannot prove hybrid topology by itself.
 | Multi-monitor mixed DPI | Missing | Collect with `-MatrixClass multi-monitor-mixed-dpi -RequireMatrixClass`. |
 
 Phase VI must not start until this ledger is backed by current artifacts or the
-remaining gaps are explicitly accepted in `KNOWN_ISSUES.md`.
+remaining gaps are explicitly accepted in `KNOWN_ISSUES.md`. Accepted gaps must
+be listed as individual backticked bullets under the heading
+`Accepted D3D11 Phase V Environment Matrix Gaps`; the default-gate audit treats
+those classes as `accepted`, never as recorded/pass evidence.

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -221,6 +221,11 @@ write fallback markers, or alter renderer selection.
 If a shorter soak is explicitly accepted by an operator, store its
 `accepted-partial-soak-summary.json` under `zig-out\d3d11-accepted-soak\`; the
 audit reports that evidence as `accepted` rather than an automated `pass`.
+If unavailable environment classes are explicitly accepted by an operator, list
+them under `KNOWN_ISSUES.md` heading
+`Accepted D3D11 Phase V Environment Matrix Gaps`; the audit reports those
+matrix rows and the environment-ledger gate as `accepted`, not as recorded
+evidence.
 
 ## Ghostty Comparison
 


### PR DESCRIPTION
## Summary

Accepts the remaining unavailable D3D11 Phase V environment matrix classes as known issues, without converting them into passing evidence.

- Adds a dedicated `KNOWN_ISSUES.md` section for `Accepted D3D11 Phase V Environment Matrix Gaps`.
- Teaches `debug/audit-d3d11-default-gate.ps1` to read that section and mark matching non-recorded matrix rows as `accepted`.
- Keeps the original ledger status in the generated audit matrix table so reviewers can still see that those classes are missing, not tested.
- Updates the D3D11 docs to describe the known-issues acceptance path and the exact heading/bullet format.

## Why

The remaining matrix classes require hardware/session coverage that is not currently available: RDP, VM, hybrid GPU, weak integrated GPU, single monitor, and same-DPI multi-monitor. The user explicitly chose to track those Phase V scenarios as known issues for closeout rather than block on machines we do not have.

## Validation

- PowerShell parse check for `debug/audit-d3d11-default-gate.ps1`
- `debug/audit-d3d11-default-gate.ps1`
  - reports `artifact_status=complete`
  - reports `incomplete_count=0`
  - reports long-run soak as `accepted`
  - reports environment ledger as `accepted`
  - reports the six unavailable classes as `accepted` with original ledger status `missing`
- `debug/audit-d3d11-default-gate.ps1 -FailOnIncomplete`
- Negative control: audit with a temporary known-issues file without the accepted section still fails `-FailOnIncomplete`
- `debug/summarize-d3d11-environment-matrix.ps1`
- `git diff --check`
- `zig build check-sizes`
- `zig build test`
- `zig build`

## Boundary

This PR does not merge anything into `main`, does not change Windows `auto`, does not add runtime D3D11-to-OpenGL switching, and does not claim the unavailable environment classes have passing test evidence.
