### PR TITLE
fix(ssh): keep NAT state alive and tolerate lossy links in interactive SSH

### DIFF
--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -249,7 +249,12 @@ const ssh_remote_env_prefix = "export TERM_PROGRAM=ghostty; ";
 
 fn buildSshCommandLine(buf: []u8, options: SshCommandOptions, export_term_program: bool) ?[]const u8 {
     var pos: usize = 0;
-    if (!appendAscii(buf, &pos, "ssh -tt ")) return null;
+    // ServerAlive*: 30s probes keep NAT/firewall state alive (kernel TCP
+    // keepalive defaults to 2h, far past middlebox idle timeouts); CountMax=20
+    // gives a 10-minute tolerance window so lossy links are ridden out by TCP
+    // retransmission instead of OpenSSH hard-killing the session after 3
+    // missed probes. Keep in sync with pty_command_windows.zig.
+    if (!appendAscii(buf, &pos, "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 ")) return null;
     if (options.proxy_jump.len > 0) {
         if (!appendAscii(buf, &pos, "-o ProxyJump=")) return null;
         if (!appendAscii(buf, &pos, options.proxy_jump)) return null;
@@ -299,13 +304,13 @@ test "unsupported backend builds SSH interactive command lines with ProxyJump" {
 
     // No jump host keeps the existing bare invocation shape.
     try std.testing.expectEqualStrings(
-        "ssh -tt user@example.test",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test",
         sshInteractiveCommand(&buf, .{ .user = "user", .host = "example.test" }).?,
     );
 
     // ProxyJump is inserted before the destination, after any port flag.
     try std.testing.expectEqualStrings(
-        "ssh -tt -o ProxyJump=admin@jump.test user@example.test",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o ProxyJump=admin@jump.test user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -314,7 +319,7 @@ test "unsupported backend builds SSH interactive command lines with ProxyJump" {
     );
 
     try std.testing.expectEqualStrings(
-        "ssh -tt -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -331,7 +336,7 @@ test "unsupported backend exports TERM_PROGRAM into the SSH remote command (#302
     // a Kitty-capable TERM_PROGRAM (ssh doesn't forward the local one). The
     // original command stays intact inside the same single-quoted argument.
     try std.testing.expectEqualStrings(
-        "ssh -tt user@example.test 'export TERM_PROGRAM=ghostty; cd '\\''/srv/p'\\'' && claude'",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test 'export TERM_PROGRAM=ghostty; cd '\\''/srv/p'\\'' && claude'",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -341,7 +346,7 @@ test "unsupported backend exports TERM_PROGRAM into the SSH remote command (#302
 
     // No remote command (plain interactive login shell) is left untouched.
     try std.testing.expectEqualStrings(
-        "ssh -tt user@example.test",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test",
         sshInteractiveCommand(&buf, .{ .user = "user", .host = "example.test" }).?,
     );
 }

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -430,9 +430,11 @@ fn effectiveSshAuthMethod(options: SshCommandOptions) ssh_connection.SshAuthMeth
 }
 
 fn appendSshOptionString(buf: []u8, pos: *usize, options: SshCommandOptions, mode: SshInvocationMode) bool {
-    // ServerAlive* prevents long-idle interactive sessions from hanging behind
-    // NAT/firewall drops while preserving the existing OpenSSH invocation shape.
-    if (!appendAscii(buf, pos, "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 ")) return false;
+    // ServerAlive*: 30s probes keep NAT/firewall state alive; CountMax=20 gives
+    // a 10-minute tolerance window so lossy links (e.g. cross-border routes) are
+    // ridden out by TCP retransmission instead of OpenSSH hard-killing the
+    // session after 3 missed probes. Keep both platforms' builders in sync.
+    if (!appendAscii(buf, pos, "-o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 ")) return false;
     const auth_method = effectiveSshAuthMethod(options);
     switch (auth_method) {
         .password => {
@@ -743,7 +745,7 @@ test "windows pty command builds SSH interactive command lines" {
     var buf: [1024]u8 = undefined;
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -p 2222 user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -p 2222 user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -754,7 +756,7 @@ test "windows pty command builds SSH interactive command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o HostkeyAlgorithms=+ssh-rsa,ssh-dss -o PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss -o KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 -o Ciphers=+aes128-cbc,3des-cbc user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o HostkeyAlgorithms=+ssh-rsa,ssh-dss -o PubkeyAcceptedAlgorithms=+ssh-rsa,ssh-dss -o KexAlgorithms=+diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 -o Ciphers=+aes128-cbc,3des-cbc user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -766,7 +768,7 @@ test "windows pty command builds SSH interactive command lines" {
 
     // ProxyJump is inserted after the auth/legacy flags, before any port flag.
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o ProxyJump=admin@jump.test:2200 -p 2222 user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -776,7 +778,7 @@ test "windows pty command builds SSH interactive command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -788,7 +790,7 @@ test "windows pty command builds SSH interactive command lines" {
     // An interactive remote command gains the TERM_PROGRAM export so remote
     // Claude Code/Codex enable the Kitty keyboard protocol (#302).
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 user@example.test \"export TERM_PROGRAM=ghostty; cd /srv && claude\"",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test \"export TERM_PROGRAM=ghostty; cd /srv && claude\"",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -801,7 +803,7 @@ test "windows pty command builds direct SSH control command lines" {
     var buf: [1024]u8 = undefined;
 
     try std.testing.expectEqualStrings(
-        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o BatchMode=yes -p 2222 user@example.test \"tmux -CC new -A -s wispterm-test\"",
+        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o BatchMode=yes -p 2222 user@example.test \"tmux -CC new -A -s wispterm-test\"",
         sshControlCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -811,7 +813,7 @@ test "windows pty command builds direct SSH control command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o NumberOfPasswordPrompts=1 user@example.test \"tmux -CC new -A -s wispterm-test\"",
+        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o PreferredAuthentications=password,keyboard-interactive -o PubkeyAuthentication=no -o NumberOfPasswordPrompts=1 user@example.test \"tmux -CC new -A -s wispterm-test\"",
         sshControlCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -821,7 +823,7 @@ test "windows pty command builds direct SSH control command lines" {
     );
 
     try std.testing.expectEqualStrings(
-        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=60 -o ServerAliveCountMax=3 -o BatchMode=yes -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test \"tmux -CC new -A -s wispterm-test\"",
+        "ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -o BatchMode=yes -i \"C:/Users/user/.ssh/id_ed25519\" user@example.test \"tmux -CC new -A -s wispterm-test\"",
         sshControlCommand(&buf, .{
             .user = "user",
             .host = "example.test",


### PR DESCRIPTION
## What

Adjust the OpenSSH keepalive options baked into interactive and tmux-control SSH command lines on both platforms:

- **macOS/POSIX** (`pty_command_unsupported.zig`): was a bare `ssh -tt` with **no** ServerAlive options → now `-o ServerAliveInterval=30 -o ServerAliveCountMax=20`.
- **Windows** (`pty_command_windows.zig`): was `ServerAliveInterval=60 CountMax=3` → now `30 × 20`.

## Why

Users report SSH sessions to internet servers dropping easily. The two platforms failed for opposite reasons:

- **macOS**: with no application-level keepalive, the only liveness traffic is kernel TCP keepalive, which defaults to **2 hours** — far past typical NAT/stateful-firewall idle timeouts (minutes). Idle sessions silently died when the middlebox dropped its state entry.
- **Windows**: `60 × 3` means OpenSSH **hard-kills** the session after 180 s without a probe response ("Timeout, server not responding"). On lossy routes (cross-border links, Wi-Fi roaming), 3-minute blackouts are common and TCP retransmission would have recovered — the aggressive setting converted recoverable stalls into disconnects.

The diagnosis was confirmed by comparing against tssh, which survives the same networks: Go's runtime enables **15 s TCP keepalive** on dialed connections (keeps NAT state alive), and tssh never hard-kills on missed heartbeats by default (`ServerAliveInterval=0`, and its liveness timer resets on any server data).

`30 × 20` gets both properties from OpenSSH: a 30 s probe holds NAT/firewall state, and the kill threshold widens to 10 minutes so transient degradation is ridden out. Truly dead connections still surface the existing reconnect prompt, just later.

## Notes for reviewers

- Both builders feed interactive sessions, session restore, and tmux `-CC` control mode; the 14 exact-string test expectations in the two files are updated to match.
- The restore-path `parseArgv` in `pty_posix.zig` is a generic tokenizer, so the extra `-o` argv entries are passed straight to exec; call-site buffers (4096–8192 B) have ample headroom for the ~53 extra bytes.
- Command-line `-o` still overrides a user's `~/.ssh/config` values — pre-existing trade-off on Windows, now consistent on macOS.
- Port-forward / tunnel / scp helpers keep their own (intentionally fast-failing) ServerAlive settings; untouched.
- Verified: `zig build test` (2028 tests) and `zig fmt --check build.zig src` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)