### PR TITLE
[codex] add continue_later agent tool

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -230,6 +230,10 @@ Local slash commands (handled in the panel, without calling the model):
   time. `/watch` lists this session's watch tasks, `/watch all` lists all watch
   tasks from Copilot, and `/watch stop <id>` or `/watch stop all` cancels
   tasks.
+- The Agent can also call `continue_later` when a terminal, SSH, Codex, Claude
+  Code, or REPL task is still running. It schedules a one-shot continuation
+  through the same `/watch` store, then resumes this session later and checks
+  progress with `terminal_snapshot` before acting.
 - `/remember <fact>` saves a long-term memory in the project tier when a
   working directory is set, otherwise in the global tier. `/记住` is the Chinese
   alias.

--- a/docs/superpowers/plans/2026-07-03-agent-continue-later-tool.md
+++ b/docs/superpowers/plans/2026-07-03-agent-continue-later-tool.md
@@ -1,0 +1,835 @@
+# Agent `continue_later` Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-party Agent tool, `continue_later`, so the model can schedule itself to resume a long-running terminal task through the existing `/watch` scheduler.
+
+**Architecture:** Reuse `assistant/loop/store.zig` as the only scheduler and persistence owner. Pass explicit session identity through the existing `ChatRequest` -> `ToolContext` seam so `agent_tools/schedule.zig` remains a leaf module and never imports `Session` or `AppWindow`. Advertise the tool through the existing first-party catalog and shared protocol schema.
+
+**Tech Stack:** Zig 0.15.2, existing `assistant/loop/*` schedule engine, first-party tool catalog, `ToolContext` seam, source guards, `zig build test`, `zig build test-full`.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-agent-continue-later-tool-design.md`
+
+---
+
+## Global Constraints
+
+- Do not import `AppWindow.zig` or `assistant/conversation/session.zig` from `src/agent_tools/**`; source guards enforce this.
+- Do not add a new scheduler file, timer thread, or persistence file. Reuse `src/assistant/loop/store.zig` and its `loop_tasks.json`.
+- Keep the new tool disableable through the existing first-party disabled-tool path.
+- Keep subagents from seeing `continue_later`; it is a main-agent tool only.
+- Run `zig fmt src build.zig` before each code commit.
+- Because this work adds `src/agent_tools/schedule.zig`, run the Windows checkout-safety checks from `docs/development.md` before finishing.
+- Ghostty comparison from the spec stands: Ghostty has no AI scheduler; do not modify terminal core, rendering, or platform host code for this feature.
+
+## File Structure
+
+- Modify `src/assistant/loop/store.zig` — add programmatic one-shot continuation registration on top of watch tasks.
+- Modify `src/assistant/conversation/types.zig` — add `ScheduleContext` and attach it to `ToolContext`.
+- Modify `src/assistant/conversation/session.zig` — capture owned scheduling identity on `ChatRequest` during request construction.
+- Modify `src/assistant/conversation/request.zig` — copy scheduling identity into `ToolContext`.
+- Create `src/agent_tools/schedule.zig` — parse `continue_later` args and register a continuation.
+- Modify `src/agent_tools/mod.zig` — dispatch `continue_later`.
+- Modify `src/tools/first_party.zig` — catalog the tool for Skill Center and disabled-tool state.
+- Modify `src/assistant/conversation/protocol.zig` — advertise schema and reserve the name.
+- Modify `src/platform/agent_prompt.zig` and `src/agent_tools/exec.zig` — teach the Agent to use the tool for still-running work.
+- Modify `docs/ai-agent.md` — document the behavior for users and `wispterm_docs`.
+- Modify `src/test_fast.zig` and `src/test_main.zig` — import the new leaf module so its tests run.
+
+---
+
+### Task 1: Add Scheduler Registration For One-Shot Continuations
+
+**Files:**
+- Modify: `src/assistant/loop/store.zig`
+
+**Interface:**
+- Add `pub fn registerContinuation(self: *Store, delay_ms: i64, prompt: []const u8, ctx: SessionCtx, now_ms: i64) error{OutOfMemory}!RegisterInfo`
+- It creates a `.watch` task with `daily=false`, `remaining=1`, and `next_fire_ms=now_ms + delay_ms`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add near the existing store tests:
+
+```zig
+test "registerContinuation schedules a one-shot watch task after delay" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = Store.init(a, path);
+    defer store.deinit();
+
+    const now_ms: i64 = 10_000;
+    const delay_ms: i64 = 30 * std.time.ms_per_min;
+    const info = try store.registerContinuation(
+        delay_ms,
+        "Continue the previous task. First inspect the terminal with terminal_snapshot.",
+        .{ .session_id = "session-continue", .model = "deepseek", .title = "Build" },
+        now_ms,
+    );
+
+    try std.testing.expectEqual(TaskKind.watch, info.kind);
+    try std.testing.expect(!info.daily);
+    try std.testing.expectEqual(now_ms + delay_ms, info.next_fire_ms);
+
+    const snap = try store.snapshotForSession(a, "session-continue", .watch);
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expect(!snap[0].daily);
+    try std.testing.expectEqual(@as(u32, 1), snap[0].remaining);
+    try std.testing.expectEqual(now_ms + delay_ms, snap[0].next_fire_ms);
+    try std.testing.expectEqualStrings("deepseek", snap[0].model);
+    try std.testing.expectEqualStrings("Build", snap[0].title);
+    try std.testing.expectEqualStrings(
+        "Continue the previous task. First inspect the terminal with terminal_snapshot.",
+        snap[0].prompt,
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+zig build test 2>&1 | rg -n "registerContinuation|one-shot watch"
+```
+
+Expected: compile failure mentioning `no field or member function named 'registerContinuation'`.
+
+- [ ] **Step 3: Implement the minimal helper**
+
+Add after `registerWatch`:
+
+```zig
+    pub fn registerContinuation(
+        self: *Store,
+        delay_ms: i64,
+        prompt: []const u8,
+        ctx: SessionCtx,
+        now_ms: i64,
+    ) error{OutOfMemory}!RegisterInfo {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const next_fire_ms = now_ms + delay_ms;
+        const id = try self.appendOwned(.{
+            .kind = .watch,
+            .session_id = ctx.session_id,
+            .model = ctx.model,
+            .title = ctx.title,
+            .prompt = prompt,
+            .daily = false,
+            .remaining = 1,
+            .next_fire_ms = next_fire_ms,
+            .created_ms = now_ms,
+        });
+        self.saveLocked();
+        return .{ .id = id, .kind = .watch, .daily = false, .next_fire_ms = next_fire_ms };
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: fast suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+zig fmt src/assistant/loop/store.zig
+git add src/assistant/loop/store.zig
+git commit -m "feat(agent): add scheduler helper for continuations"
+```
+
+---
+
+### Task 2: Carry Scheduling Identity Through `ChatRequest` And `ToolContext`
+
+**Files:**
+- Modify: `src/assistant/conversation/types.zig`
+- Modify: `src/assistant/conversation/session.zig`
+- Modify: `src/assistant/conversation/request.zig`
+
+**Interface:**
+- `ToolContext` gains `schedule_context: ?ScheduleContext`.
+- `ChatRequest` owns `schedule_session_id` and `schedule_title`; it reuses its owned `model`.
+
+- [ ] **Step 1: Write the failing request-seam test**
+
+Add to `src/assistant/conversation/request.zig` after `testSessionAndRequest`:
+
+```zig
+test "toolContextFromRequest exposes scheduling identity" {
+    const a = std.testing.allocator;
+    const env = try testSessionAndRequest(a);
+    defer env.session.deinit();
+    defer env.request.deinit();
+
+    env.request.schedule_session_id = try a.dupe(u8, "session-abc");
+    env.request.schedule_title = try a.dupe(u8, "Long Build");
+
+    const ctx = toolContextFromRequest(env.request);
+    const schedule = ctx.schedule_context orelse return error.MissingScheduleContext;
+    try std.testing.expectEqualStrings("session-abc", schedule.session_id);
+    try std.testing.expectEqualStrings("model", schedule.model);
+    try std.testing.expectEqualStrings("Long Build", schedule.title);
+}
+```
+
+- [ ] **Step 2: Write the failing session-construction test**
+
+Add to `src/assistant/conversation/session.zig` near the `buildRequestLocked` tests:
+
+```zig
+test "buildRequestLocked captures schedule identity for agent tools" {
+    const a = std.testing.allocator;
+    const session = try Session.init(a, "Long Build", "", "", "model-x", "", "", "", "", "true");
+    defer session.deinit();
+    session.copySessionId("session-build");
+
+    session.mutex.lock();
+    const request = try session.buildRequestLocked();
+    session.mutex.unlock();
+    defer request.deinit();
+    defer mcp_registry.reloadCacheFromServersForTest(a, &.{});
+
+    try std.testing.expectEqualStrings("session-build", request.schedule_session_id);
+    try std.testing.expectEqualStrings("Long Build", request.schedule_title);
+    try std.testing.expectEqualStrings("model-x", request.model);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | rg -n "schedule_context|schedule_session_id|ScheduleContext"
+```
+
+Expected: compile failures for missing fields/types.
+
+- [ ] **Step 4: Add the shared type and `ToolContext` field**
+
+In `src/assistant/conversation/types.zig`, add near `McpTool`:
+
+```zig
+pub const ScheduleContext = struct {
+    session_id: []const u8,
+    model: []const u8,
+    title: []const u8,
+};
+```
+
+Then add to `ToolContext`:
+
+```zig
+    schedule_context: ?ScheduleContext = null,
+```
+
+- [ ] **Step 5: Add owned fields to `ChatRequest`**
+
+In `src/assistant/conversation/session.zig`, add fields to `ChatRequest`:
+
+```zig
+    schedule_session_id: []u8 = &.{},
+    schedule_title: []u8 = &.{},
+```
+
+In `ChatRequest.deinit`, after freeing `disabled_first_party_tools`:
+
+```zig
+        if (self.schedule_session_id.len > 0) self.allocator.free(self.schedule_session_id);
+        if (self.schedule_title.len > 0) self.allocator.free(self.schedule_title);
+```
+
+- [ ] **Step 6: Populate the fields in `buildRequestLocked`**
+
+Before `req.* = .{`:
+
+```zig
+        const schedule_session_id = try self.allocator.dupe(u8, self.sessionId());
+        var schedule_session_id_owned = true;
+        errdefer if (schedule_session_id_owned) self.allocator.free(schedule_session_id);
+        const schedule_title = try self.allocator.dupe(u8, self.title());
+        var schedule_title_owned = true;
+        errdefer if (schedule_title_owned) self.allocator.free(schedule_title);
+```
+
+Inside `req.* = .{ ... }`:
+
+```zig
+            .schedule_session_id = schedule_session_id,
+            .schedule_title = schedule_title,
+```
+
+After ownership flags already set false:
+
+```zig
+        schedule_session_id_owned = false;
+        schedule_title_owned = false;
+```
+
+- [ ] **Step 7: Copy the identity into `ToolContext`**
+
+In `src/assistant/conversation/request.zig`, inside `toolContextFromRequest` return value:
+
+```zig
+        .schedule_context = if (request.schedule_session_id.len > 0) .{
+            .session_id = request.schedule_session_id,
+            .model = request.model,
+            .title = request.schedule_title,
+        } else null,
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: fast suite passes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+zig fmt src/assistant/conversation/types.zig src/assistant/conversation/session.zig src/assistant/conversation/request.zig
+git add src/assistant/conversation/types.zig src/assistant/conversation/session.zig src/assistant/conversation/request.zig
+git commit -m "feat(agent): pass schedule context to tool runtime"
+```
+
+---
+
+### Task 3: Implement `agent_tools/schedule.zig` And Dispatch `continue_later`
+
+**Files:**
+- Create: `src/agent_tools/schedule.zig`
+- Modify: `src/agent_tools/mod.zig`
+- Modify: `src/test_fast.zig`
+- Modify: `src/test_main.zig`
+
+**Interface:**
+- `pub fn run(ctx: *ToolContext, arguments: []const u8) ![]u8`
+- Uses active scheduler store and `ToolContext.schedule_context`.
+
+- [ ] **Step 1: Write the failing leaf-module tests**
+
+Create `src/agent_tools/schedule.zig` with imports and tests only:
+
+```zig
+//! Agent scheduling tools.
+const std = @import("std");
+const types = @import("../assistant/conversation/types.zig");
+const ai_loop_store = @import("../assistant/loop/store.zig");
+
+const ToolContext = types.ToolContext;
+
+var test_dummy_ctx: u8 = 0;
+
+fn approve(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return true;
+}
+
+fn cancelled(_: *anyopaque) bool {
+    return false;
+}
+
+fn testContext(schedule: ?types.ScheduleContext) ToolContext {
+    return .{
+        .allocator = std.testing.allocator,
+        .ctx = &test_dummy_ctx,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{},
+        .schedule_context = schedule,
+        .approve = approve,
+        .cancelled = cancelled,
+    };
+}
+
+test "continue_later rejects invalid delay before touching scheduler" {
+    var ctx = testContext(.{ .session_id = "s", .model = "m", .title = "t" });
+    const out = try run(&ctx, "{\"delay\":\"soon\"}");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("Bad delay. Use a positive interval like 30m, 2h, or 1d.", out);
+}
+
+test "continue_later requires schedule context" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const a = std.testing.allocator;
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = ai_loop_store.Store.init(a, path);
+    defer store.deinit();
+    ai_loop_store.setActive(&store);
+    defer ai_loop_store.clearActive();
+
+    var ctx = testContext(null);
+    const out = try run(&ctx, "{\"delay\":\"30m\"}");
+    defer a.free(out);
+    try std.testing.expectEqualStrings("Scheduler context is not available.", out);
+}
+
+test "continue_later registers a one-shot watch task" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const a = std.testing.allocator;
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = ai_loop_store.Store.init(a, path);
+    defer store.deinit();
+    ai_loop_store.setActive(&store);
+    defer ai_loop_store.clearActive();
+
+    var ctx = testContext(.{ .session_id = "session-tool", .model = "m", .title = "Tool Session" });
+    const out = try run(&ctx, "{\"delay\":\"30m\",\"message\":\"check progress\"}");
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Scheduled continuation #") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "in 30m") != null);
+
+    const snap = try store.snapshotForSession(a, "session-tool", .watch);
+    defer ai_loop_store.freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expectEqualStrings("check progress", snap[0].prompt);
+}
+```
+
+- [ ] **Step 2: Register the new module in test aggregators**
+
+Add `_ = @import("agent_tools/schedule.zig");` next to the other `agent_tools` imports in both:
+
+```zig
+// src/test_fast.zig
+_ = @import("agent_tools/schedule.zig");
+
+// src/test_main.zig
+_ = @import("agent_tools/schedule.zig");
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | rg -n "run\\(|continue_later|schedule.zig"
+```
+
+Expected: compile failure because `run` is undefined.
+
+- [ ] **Step 4: Implement the leaf module**
+
+Replace the top of `src/agent_tools/schedule.zig` with the implementation, keeping the tests:
+
+```zig
+//! Agent scheduling tools.
+const std = @import("std");
+const types = @import("../assistant/conversation/types.zig");
+const tool_args = @import("args.zig");
+const ai_loop_schedule = @import("../assistant/loop/schedule.zig");
+const ai_loop_store = @import("../assistant/loop/store.zig");
+
+const ToolContext = types.ToolContext;
+
+const DEFAULT_CONTINUATION_MESSAGE =
+    "Continue the previous task. First inspect the terminal with terminal_snapshot, then report progress.";
+
+pub fn run(ctx: *ToolContext, arguments: []const u8) ![]u8 {
+    const parsed = tool_args.parse(ctx.allocator, arguments) orelse
+        return ctx.allocator.dupe(u8, "Invalid tool arguments");
+    defer parsed.deinit();
+
+    const delay_text = tool_args.string(parsed.value, "delay") orelse
+        return ctx.allocator.dupe(u8, "Bad delay. Use a positive interval like 30m, 2h, or 1d.");
+    const delay_ms = ai_loop_schedule.parseIntervalMs(delay_text) catch
+        return ctx.allocator.dupe(u8, "Bad delay. Use a positive interval like 30m, 2h, or 1d.");
+
+    const store = ai_loop_store.active() orelse
+        return ctx.allocator.dupe(u8, "Scheduler is not available.");
+    const schedule = ctx.schedule_context orelse
+        return ctx.allocator.dupe(u8, "Scheduler context is not available.");
+    const message = tool_args.string(parsed.value, "message") orelse DEFAULT_CONTINUATION_MESSAGE;
+
+    const info = try store.registerContinuation(
+        delay_ms,
+        message,
+        .{ .session_id = schedule.session_id, .model = schedule.model, .title = schedule.title },
+        std.time.milliTimestamp(),
+    );
+    const display = ai_loop_schedule.formatInterval(delay_ms);
+    return std.fmt.allocPrint(ctx.allocator, "Scheduled continuation #{d} in {d}{c}.", .{
+        info.id,
+        display.value,
+        display.unit,
+    });
+}
+```
+
+Keep the test helpers below the implementation.
+
+- [ ] **Step 5: Dispatch from `agent_tools/mod.zig`**
+
+Add import:
+
+```zig
+const agent_schedule = @import("schedule.zig");
+```
+
+Add a dispatch branch after `ask_user` or before session/file tools:
+
+```zig
+    if (std.mem.eql(u8, call.name, "continue_later")) {
+        return agent_schedule.run(ctx, call.arguments);
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: fast suite passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+zig fmt src/agent_tools/schedule.zig src/agent_tools/mod.zig src/test_fast.zig src/test_main.zig
+git add src/agent_tools/schedule.zig src/agent_tools/mod.zig src/test_fast.zig src/test_main.zig
+git commit -m "feat(agent): add continue_later tool runtime"
+```
+
+---
+
+### Task 4: Advertise And Reserve The First-Party Tool
+
+**Files:**
+- Modify: `src/tools/first_party.zig`
+- Modify: `src/assistant/conversation/protocol.zig`
+
+- [ ] **Step 1: Add failing first-party catalog test**
+
+In `src/tools/first_party.zig`, extend `test "first_party_tools: active definitions include webread and the local command tool"`:
+
+```zig
+    try std.testing.expect(catalogContains(defs, "continue_later"));
+```
+
+- [ ] **Step 2: Add failing protocol schema tests**
+
+In `src/assistant/conversation/protocol.zig`, add near the other tool schema tests:
+
+```zig
+test "continue_later appears in the full tool schema" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+    try appendToolSchemas(a, &out, .{ .include_memory = false });
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"name\":\"continue_later\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"delay\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"message\"") != null);
+}
+```
+
+Also update the `denied` list in `test "subagent toolset restricts tool schemas to research tools"`:
+
+```zig
+        "continue_later",
+```
+
+And update `builtinToolNameReserved` coverage by adding to an existing reserved-name test if present, or add:
+
+```zig
+test "continue_later is a reserved builtin tool name" {
+    try std.testing.expect(builtinToolNameReserved("continue_later"));
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | rg -n "continue_later|reserved builtin"
+```
+
+Expected: failures because the catalog/schema/name reservation do not include the tool.
+
+- [ ] **Step 4: Add the first-party catalog entry**
+
+In `static_definitions`, add after `ask_user`:
+
+```zig
+    .{ .name = "continue_later", .label = "continue_later", .description = "Schedule this Agent session to continue a long-running task later.", .category = .agent },
+```
+
+- [ ] **Step 5: Reserve and emit the protocol schema**
+
+In `builtinToolNameReserved`, add:
+
+```zig
+        "continue_later",
+```
+
+In `forEachToolSpec`, add after `ask_user`:
+
+```zig
+    try Filtered.emitTool(ctx, opts, "continue_later", "Schedule this same Agent or Copilot session to continue later. Use when a terminal command, SSH command, Codex/Claude Code run, or REPL task is still running and immediate polling would waste tokens or risk duplicate side effects. At wake time WispTerm submits message back into this session; the message should inspect progress with terminal_snapshot before acting.", "{\"delay\":{\"type\":\"string\",\"description\":\"Required positive interval: integer plus s, m, h, or d, e.g. 30m, 2h, 1d.\"},\"message\":{\"type\":\"string\",\"description\":\"Optional follow-up prompt. Defaults to continuing the previous task and checking terminal_snapshot first.\"}}");
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: fast suite passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+zig fmt src/tools/first_party.zig src/assistant/conversation/protocol.zig
+git add src/tools/first_party.zig src/assistant/conversation/protocol.zig
+git commit -m "feat(agent): advertise continue_later tool"
+```
+
+---
+
+### Task 5: Teach The Agent When To Use `continue_later`
+
+**Files:**
+- Modify: `src/platform/agent_prompt.zig`
+- Modify: `src/agent_tools/exec.zig`
+- Modify: `docs/ai-agent.md`
+
+- [ ] **Step 1: Write failing prompt guidance test**
+
+In `src/platform/agent_prompt.zig`, add:
+
+```zig
+test "platform agent prompt teaches continue_later for long-running work" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "continue_later") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "terminal_snapshot") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "Do not re-run") != null);
+    }
+}
+```
+
+- [ ] **Step 2: Write failing exec-message test**
+
+In `src/agent_tools/exec.zig`, extend `test "agent exec timeout message says still running, do not re-issue"`:
+
+```zig
+    try std.testing.expect(std.mem.indexOf(u8, msg, "continue_later") != null);
+```
+
+Add a focused test for the busy-guard message:
+
+```zig
+test "agent exec busy guard message points at continue_later" {
+    const allocator = std.testing.allocator;
+    const msg = try allocStillRunningBusyGuard(allocator, "SSH");
+    defer allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "previous command is still running") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "continue_later") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "terminal_snapshot") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "code=<ctrl-c>") != null);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+zig build test 2>&1 | rg -n "continue_later|agent prompt|timeout message"
+```
+
+Expected: tests fail because prompt/messages do not mention `continue_later`.
+
+- [ ] **Step 4: Update the default Agent prompt**
+
+In `common_tools_after_wsl`, replace the slow-command line:
+
+```zig
+    \\- A slow session/exec command is usually still running; wait, then re-check with `terminal_snapshot`.
+```
+
+with:
+
+```zig
+    \\- A slow session/exec command is usually still running. Do not re-run it. If waiting is better than immediate polling, call `continue_later` with a delay such as 30m and a message that checks `terminal_snapshot` first.
+```
+
+- [ ] **Step 5: Update still-running tool messages**
+
+In `src/agent_tools/exec.zig`, add this helper near `allocStillRunningTimeout`:
+
+```zig
+fn allocStillRunningBusyGuard(allocator: std.mem.Allocator, label: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "A previous command is still running in this {s} terminal. Do not start another command. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt it first with terminal_repl_exec repl=plain code=<ctrl-c>.", .{label});
+}
+```
+
+Replace the busy guard result with:
+
+```zig
+            return allocStillRunningBusyGuard(ctx.allocator, kind.label());
+```
+
+Replace `allocStillRunningTimeout` body with:
+
+```zig
+fn allocStillRunningTimeout(allocator: std.mem.Allocator, label: []const u8, elapsed_s: i64, snapshot: ?[]const u8) ![]u8 {
+    if (snapshot) |text| {
+        return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.\nLatest snapshot:\n{s}", .{ label, elapsed_s, text });
+    }
+    return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.", .{ label, elapsed_s });
+}
+```
+
+- [ ] **Step 6: Update user docs**
+
+In `docs/ai-agent.md`, after the `/watch` bullet block, add:
+
+```markdown
+- The Agent can also call `continue_later` when a terminal, SSH, Codex, Claude
+  Code, or REPL task is still running. It schedules a one-shot continuation
+  through the same `/watch` store, then resumes this session later and checks
+  progress with `terminal_snapshot` before acting.
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: fast suite passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+zig fmt src/platform/agent_prompt.zig src/agent_tools/exec.zig
+git add src/platform/agent_prompt.zig src/agent_tools/exec.zig docs/ai-agent.md
+git commit -m "docs(agent): teach continue_later for long-running tasks"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No code changes unless verification finds a bug.
+
+- [ ] **Step 1: Run formatting**
+
+Run:
+
+```bash
+zig fmt src build.zig
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 2: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run full pre-merge tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: pass. If this is too slow for the current machine, run it anyway before final handoff unless the user explicitly agrees to defer it.
+
+- [ ] **Step 4: Run Windows checkout-safety checks**
+
+If running in PowerShell, use the exact commands from `docs/development.md#Windows Checkout Safety`. Minimum required output:
+
+```text
+windows_name_violations=0
+casefold_collisions=0
+```
+
+Also run:
+
+```powershell
+git ls-files -s | Select-String '^120000'
+```
+
+Expected: no output.
+
+If PowerShell is unavailable in the current environment, report that the checkout-safety PowerShell check was not run and list the added paths:
+
+```text
+src/agent_tools/schedule.zig
+docs/superpowers/plans/2026-07-03-agent-continue-later-tool.md
+```
+
+- [ ] **Step 5: Inspect source-guard-sensitive imports**
+
+Run:
+
+```bash
+rg -n "AppWindow.zig|assistant/conversation/session.zig" src/agent_tools
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+Expected: only intended implementation files are changed; unrelated `.claude/` remains untouched if still untracked.
+
+- [ ] **Step 7: Final commit if verification changed files**
+
+If Task 6 produced fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "fix(agent): finalize continue_later verification"
+```
+
+Expected: working tree has only unrelated user-owned files left.

--- a/docs/superpowers/specs/2026-07-03-agent-continue-later-tool-design.md
+++ b/docs/superpowers/specs/2026-07-03-agent-continue-later-tool-design.md
@@ -1,0 +1,175 @@
+# Agent `continue_later` Tool Design
+
+**Date:** 2026-07-03
+**Status:** Design approved, pending spec review
+**Component:** WispTerm AI Agent / Copilot scheduled prompts
+
+## Summary
+
+Add a first-party Agent tool, `continue_later`, that lets the model schedule
+itself to resume a long-running task later. When an SSH/session/REPL command is
+still running, the Agent should avoid re-running the command or repeatedly
+polling the terminal. Instead, it calls `continue_later` with a delay such as
+`30m` and a short follow-up prompt such as:
+
+```json
+{"delay":"30m","message":"Continue the previous task. First inspect the terminal with terminal_snapshot, then report progress."}
+```
+
+The tool reuses the existing `/watch` one-shot scheduler and session injector:
+at the scheduled time, WispTerm submits the follow-up prompt back into the same
+AI Chat or Copilot session as if the user typed it.
+
+## Goals
+
+- Let the Agent decide to pause and resume later when a task is still running.
+- Reuse the existing `/watch` scheduled-prompt store, persistence, and tick path.
+- Avoid duplicate command execution while long-running terminal work is still in
+  progress.
+- Keep the implementation inside the Agent/scheduler layer; do not touch the
+  terminal core, renderer, or input dispatch.
+- Keep the behavior testable with small unit tests around parsing,
+  registration, schema emission, and dispatch.
+
+## Non-goals
+
+- A new scheduler, worker thread, or background Agent loop.
+- Event-driven wakeups based on terminal output, file changes, or process exit.
+- A visible task-manager UI beyond the existing `/watch`/`/loop` listing paths.
+- Auto-resuming a closed chat tab by creating a new UI session.
+
+## Ghostty Comparison
+
+Ghostty has no equivalent AI Agent, tool-calling runtime, or scheduled prompt
+system. Its relevant design lesson is separation of terminal core from host/UI
+coordination: terminal emulation and rendering should not own application-level
+automation. WispTerm should keep `continue_later` above the platform-neutral
+terminal core, in the existing Agent tool and `/watch` scheduler layer.
+
+## User-Facing Behavior
+
+`continue_later` is advertised as a first-party Agent tool.
+
+Arguments:
+
+- `delay`: required interval string, same unit grammar as `/loop`:
+  `<positive integer><s|m|h|d>`, for example `30m`, `2h`, or `1d`.
+- `message`: optional follow-up prompt. If omitted or empty, WispTerm uses a
+  concise default prompt that tells the Agent to continue the previous task and
+  inspect the terminal before acting.
+
+Runtime result:
+
+- On success, the tool returns a confirmation with the scheduled task id and
+  delay, for example `Scheduled continuation #42 in 30m.`
+- On invalid delay, missing scheduler, or allocation failure, it returns a plain
+  tool result explaining the failure.
+
+At fire time:
+
+- If the bound session is open and idle, the scheduler submits `message` to that
+  session.
+- If the session is busy, the task remains due and retries on a later scheduler
+  tick. It does not create duplicate prompts.
+- If the session is closed, the task remains in the persistent `/watch` store
+  and can fire when the session is reopened, matching current `/watch` behavior.
+
+## Architecture
+
+### Scheduler Reuse
+
+Do not introduce a new persistence file or timer. Add a small programmatic
+registration helper to `src/assistant/loop/store.zig` that creates a one-shot
+watch task from an already-parsed delay:
+
+- compute `next_fire_ms = now_ms + delay_ms`;
+- set `kind = .watch`, `daily = false`, `remaining = 1`;
+- capture the current `SessionCtx` (`session_id`, `model`, `title`);
+- append and persist through the same store path used by `/watch`.
+
+This keeps restart behavior, busy retry, closed-session handling, and
+`loop_tasks.json` compatibility in one place.
+
+### Tool Catalog And Schema
+
+Add `continue_later` to:
+
+- `src/tools/first_party.zig` so Skill Center and disabled-tool state know about
+  the tool.
+- `src/assistant/conversation/protocol.zig` so Chat Completions, Responses, and
+  Anthropic requests all expose the same tool schema.
+- `builtinToolNameReserved` so imported dynamic tools cannot reuse the name.
+
+The tool belongs to the Agent category, not terminal or file.
+
+### Tool Dispatch
+
+Add an `agent_tools/schedule.zig` leaf module or a focused function in
+`agent_tools/mod.zig`. It should:
+
+1. Parse `delay` with the existing `ai_loop_schedule.parseIntervalMs`.
+2. Resolve `ai_loop_store.active()`.
+3. Build `SessionCtx` from an explicit scheduling context on `ToolContext`.
+4. Register the one-shot watch task.
+5. Return a short confirmation string.
+
+The dispatch must not import `AppWindow.zig`; the existing scheduler active
+store is the boundary.
+
+`ToolContext` does not currently carry session identity, and the leaf tool layer
+must not reach back into `Session`. Add a small `ScheduleContext` with borrowed
+`session_id`, `model`, and `title` fields to the request/session seam:
+
+- `Session.buildRequestLocked` fills owned/borrowed values on `ChatRequest`;
+- the request-to-tool adapter copies those fields into `ToolContext`;
+- `continue_later` returns `Scheduler context is not available.` if the context
+  is absent.
+
+### Prompt Guidance
+
+Update `src/platform/agent_prompt.zig` so the default Agent prompt says:
+
+- when a terminal command or REPL app is still running, do not re-run it;
+- schedule `continue_later` when a sensible waiting period is better than
+  immediate polling;
+- the follow-up should inspect progress with `terminal_snapshot` first.
+
+Also update `agent_tools/exec.zig` timeout/busy messages so they point at
+`continue_later` instead of only saying "re-check later".
+
+## Data Flow
+
+```text
+terminal_repl_exec reports "still running"
+  -> model calls continue_later(delay="30m", message="Continue ...")
+  -> tool registers one-shot watch task bound to this session
+  -> existing scheduler tick sees it due later
+  -> loopInjector calls session.submitScheduledPrompt(message)
+  -> Agent continues from the same conversation context
+```
+
+## Error Handling
+
+- Bad or missing `delay`: return `Bad delay. Use a positive interval like 30m,
+  2h, or 1d.`
+- Scheduler inactive: return `Scheduler is not available.`
+- Empty `message`: use the default continuation prompt rather than failing.
+- Disabled tool: existing first-party disabled-tool guard returns
+  `Tool is disabled: continue_later`.
+
+## Testing
+
+Add focused tests:
+
+- `assistant/loop/store.zig`: programmatic one-shot watch registration stores
+  `daily=false`, `remaining=1`, and `next_fire_ms=now+delay`.
+- `assistant/conversation/protocol.zig`: full tool schemas include
+  `continue_later`, `delay`, and `message`; subagent schemas do not include it.
+- `tools/first_party.zig`: active definitions include `continue_later`.
+- `agent_tools/mod.zig` or the new schedule leaf module: invalid delay returns a
+  clear tool result; successful registration returns the scheduled id.
+- `platform/agent_prompt.zig`: prompt guidance mentions `continue_later` and
+  still-running terminal work.
+
+Run `zig build test` during implementation and `zig build test-full` before
+finishing the change.

--- a/src/agent_tools/exec.zig
+++ b/src/agent_tools/exec.zig
@@ -924,7 +924,7 @@ fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []c
     if (host.surfaceSnapshot(host.ctx, ctx.allocator, surface.id, surface.ptr) catch null) |guard_snapshot| {
         defer ctx.allocator.free(guard_snapshot);
         if (agentCommandStillRunning(guard_snapshot)) {
-            return std.fmt.allocPrint(ctx.allocator, "A previous command is still running in this {s} terminal. Do not start another command. Wait and re-check with terminal_snapshot, or interrupt it first with terminal_repl_exec repl=plain code=<ctrl-c>.", .{kind.label()});
+            return allocStillRunningBusyGuard(ctx.allocator, kind.label());
         }
     }
 
@@ -960,11 +960,15 @@ fn unixSessionExecTool(ctx: *ToolContext, kind: UnixSessionKind, surface_id: []c
 /// it as "still running, do not re-issue" with recovery hints, so the model
 /// waits/re-checks instead of re-running the command (which duplicates side
 /// effects, e.g. a second git clone).
+fn allocStillRunningBusyGuard(allocator: std.mem.Allocator, label: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "A previous command is still running in this {s} terminal. Do not start another command. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt it first with terminal_repl_exec repl=plain code=<ctrl-c>.", .{label});
+}
+
 fn allocStillRunningTimeout(allocator: std.mem.Allocator, label: []const u8, elapsed_s: i64, snapshot: ?[]const u8) ![]u8 {
     if (snapshot) |text| {
-        return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Re-check later with terminal_snapshot, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.\nLatest snapshot:\n{s}", .{ label, elapsed_s, text });
+        return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.\nLatest snapshot:\n{s}", .{ label, elapsed_s, text });
     }
-    return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Re-check later with terminal_snapshot, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.", .{ label, elapsed_s });
+    return std.fmt.allocPrint(allocator, "The {s} command has not returned after {d}s; it is most likely still running. Do NOT re-issue it. Use continue_later to re-check with terminal_snapshot after a sensible delay, or interrupt with terminal_repl_exec repl=plain code=<ctrl-c>.", .{ label, elapsed_s });
 }
 
 fn waitForSentinelResult(
@@ -1439,8 +1443,27 @@ test "agent exec timeout message says still running, do not re-issue" {
     defer allocator.free(msg);
     try std.testing.expect(std.mem.indexOf(u8, msg, "still running") != null);
     try std.testing.expect(std.mem.indexOf(u8, msg, "Do NOT re-issue") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "continue_later") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "Use continue_later to re-check with terminal_snapshot after a sensible delay") != null);
     try std.testing.expect(std.mem.indexOf(u8, msg, "code=<ctrl-c>") != null);
     try std.testing.expect(std.mem.indexOf(u8, msg, "Cloning into 'x'...") != null);
+
+    const no_snapshot_msg = try allocStillRunningTimeout(allocator, "SSH", 60, null);
+    defer allocator.free(no_snapshot_msg);
+    try std.testing.expect(std.mem.indexOf(u8, no_snapshot_msg, "still running") != null);
+    try std.testing.expect(std.mem.indexOf(u8, no_snapshot_msg, "Do NOT re-issue") != null);
+    try std.testing.expect(std.mem.indexOf(u8, no_snapshot_msg, "Use continue_later to re-check with terminal_snapshot after a sensible delay") != null);
+    try std.testing.expect(std.mem.indexOf(u8, no_snapshot_msg, "code=<ctrl-c>") != null);
+}
+
+test "agent exec busy guard message points at continue_later" {
+    const allocator = std.testing.allocator;
+    const msg = try allocStillRunningBusyGuard(allocator, "SSH");
+    defer allocator.free(msg);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "previous command is still running") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "continue_later") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "terminal_snapshot") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg, "code=<ctrl-c>") != null);
 }
 
 test "agent exec sentinel ignores the echoed command line" {

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -25,6 +25,7 @@ const terminal_tools = @import("terminal.zig");
 const agent_sessions = @import("sessions.zig");
 const tool_access = @import("access.zig");
 const agent_files = @import("files.zig");
+const agent_schedule = @import("schedule.zig");
 const agent_exec = @import("exec.zig");
 const agent_dynamic = @import("dynamic.zig");
 const agent_mcp = @import("mcp.zig");
@@ -120,6 +121,9 @@ pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
         var opts_buf: [16]types.QuestionOption = undefined;
         const options = parseAskOptions(args.value, &opts_buf);
         return askUserTool(ctx, question, options);
+    }
+    if (std.mem.eql(u8, call.name, "continue_later")) {
+        return agent_schedule.run(ctx, call.arguments);
     }
     if (std.mem.eql(u8, call.name, "ssh_profile_save")) {
         const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");

--- a/src/agent_tools/schedule.zig
+++ b/src/agent_tools/schedule.zig
@@ -1,0 +1,124 @@
+//! Agent scheduling tools.
+const std = @import("std");
+const types = @import("../assistant/conversation/types.zig");
+const tool_args = @import("args.zig");
+const ai_loop_schedule = @import("../assistant/loop/schedule.zig");
+
+const ToolContext = types.ToolContext;
+
+const DEFAULT_CONTINUATION_MESSAGE =
+    "Continue the previous task. First inspect the terminal with terminal_snapshot, then report progress.";
+
+pub fn run(ctx: *ToolContext, arguments: []const u8) ![]u8 {
+    const parsed = tool_args.parse(ctx.allocator, arguments) orelse
+        return ctx.allocator.dupe(u8, "Invalid tool arguments");
+    defer parsed.deinit();
+
+    const delay_text = tool_args.string(parsed.value, "delay") orelse
+        return ctx.allocator.dupe(u8, "Bad delay. Use a positive interval like 30m, 2h, or 1d.");
+    const delay_ms = ai_loop_schedule.parseIntervalMs(delay_text) catch
+        return ctx.allocator.dupe(u8, "Bad delay. Use a positive interval like 30m, 2h, or 1d.");
+
+    const message = tool_args.string(parsed.value, "message") orelse DEFAULT_CONTINUATION_MESSAGE;
+
+    const id = ctx.scheduleContinuation(delay_ms, message) catch |err| switch (err) {
+        error.NoScheduler => return ctx.allocator.dupe(u8, "Scheduler is not available."),
+        error.NoScheduleContext => return ctx.allocator.dupe(u8, "Scheduler context is not available."),
+        else => return err,
+    };
+    const display = ai_loop_schedule.formatInterval(delay_ms);
+    return std.fmt.allocPrint(ctx.allocator, "Scheduled continuation #{d} in {d}{c}.", .{
+        id,
+        display.value,
+        display.unit,
+    });
+}
+
+var test_dummy_ctx: u8 = 0;
+
+const FakeScheduler = struct {
+    var calls: u32 = 0;
+    var last_delay_ms: i64 = 0;
+    var last_message_buf: [256]u8 = undefined;
+    var last_message_len: usize = 0;
+    var last_session_buf: [64]u8 = undefined;
+    var last_session_len: usize = 0;
+
+    fn reset() void {
+        calls = 0;
+        last_delay_ms = 0;
+        last_message_len = 0;
+        last_session_len = 0;
+    }
+
+    fn schedule(_: *anyopaque, schedule_context: types.ScheduleContext, delay_ms: i64, message: []const u8) anyerror!u32 {
+        calls += 1;
+        last_delay_ms = delay_ms;
+        last_message_len = @min(message.len, last_message_buf.len);
+        @memcpy(last_message_buf[0..last_message_len], message[0..last_message_len]);
+        last_session_len = @min(schedule_context.session_id.len, last_session_buf.len);
+        @memcpy(last_session_buf[0..last_session_len], schedule_context.session_id[0..last_session_len]);
+        return 42;
+    }
+};
+
+fn approve(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return true;
+}
+
+fn cancelled(_: *anyopaque) bool {
+    return false;
+}
+
+fn testContext(schedule: ?types.ScheduleContext, callback: ?types.ScheduleContinuationFn) ToolContext {
+    return .{
+        .allocator = std.testing.allocator,
+        .ctx = &test_dummy_ctx,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{},
+        .schedule_context = schedule,
+        .schedule_continuation = callback,
+        .approve = approve,
+        .cancelled = cancelled,
+    };
+}
+
+test "continue_later rejects invalid delay before touching scheduler" {
+    FakeScheduler.reset();
+    var ctx = testContext(.{ .session_id = "s", .model = "m", .title = "t" }, FakeScheduler.schedule);
+    const out = try run(&ctx, "{\"delay\":\"soon\"}");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("Bad delay. Use a positive interval like 30m, 2h, or 1d.", out);
+    try std.testing.expectEqual(@as(u32, 0), FakeScheduler.calls);
+}
+
+test "continue_later requires scheduler callback" {
+    FakeScheduler.reset();
+    var ctx = testContext(.{ .session_id = "session-tool", .model = "m", .title = "Tool Session" }, null);
+    const out = try run(&ctx, "{\"delay\":\"30m\"}");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("Scheduler is not available.", out);
+    try std.testing.expectEqual(@as(u32, 0), FakeScheduler.calls);
+}
+
+test "continue_later requires schedule context" {
+    FakeScheduler.reset();
+    var ctx = testContext(null, FakeScheduler.schedule);
+    const out = try run(&ctx, "{\"delay\":\"30m\"}");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("Scheduler context is not available.", out);
+    try std.testing.expectEqual(@as(u32, 0), FakeScheduler.calls);
+}
+
+test "continue_later schedules through callback" {
+    FakeScheduler.reset();
+    var ctx = testContext(.{ .session_id = "session-tool", .model = "m", .title = "Tool Session" }, FakeScheduler.schedule);
+    const out = try run(&ctx, "{\"delay\":\"30m\",\"message\":\"check progress\"}");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("Scheduled continuation #42 in 30m.", out);
+    try std.testing.expectEqual(@as(u32, 1), FakeScheduler.calls);
+    try std.testing.expectEqual(@as(i64, 30 * std.time.ms_per_min), FakeScheduler.last_delay_ms);
+    try std.testing.expectEqualStrings("check progress", FakeScheduler.last_message_buf[0..FakeScheduler.last_message_len]);
+    try std.testing.expectEqualStrings("session-tool", FakeScheduler.last_session_buf[0..FakeScheduler.last_session_len]);
+}

--- a/src/assistant/conversation/protocol.zig
+++ b/src/assistant/conversation/protocol.zig
@@ -705,6 +705,7 @@ pub fn builtinToolNameReserved(name: []const u8) bool {
         "terminal_repl_exec",
         "terminal_answer_prompt",
         "ask_user",
+        "continue_later",
         "read_file",
         "copy_file",
         "write_file",
@@ -754,18 +755,22 @@ fn mcpToolNameSeenBefore(tools: []const McpToolSpec, index: usize) bool {
 // the schema text is never duplicated across protocols.
 //
 // `Ctx` is the emitter's context type; `emit` receives `(ctx, name, description,
-// properties)` for every active tool, in order.
+// properties, required)` for every active tool, in order.
 fn forEachToolSpec(
     comptime Ctx: type,
     ctx: Ctx,
     opts: ToolSpecOpts,
-    comptime emit: fn (Ctx, []const u8, []const u8, []const u8) anyerror!void,
+    comptime emit: fn (Ctx, []const u8, []const u8, []const u8, []const []const u8) anyerror!void,
 ) !void {
     const Filtered = struct {
         fn emitTool(c: Ctx, o: ToolSpecOpts, name: []const u8, description: []const u8, properties: []const u8) anyerror!void {
+            try emitToolWithRequired(c, o, name, description, properties, &.{});
+        }
+
+        fn emitToolWithRequired(c: Ctx, o: ToolSpecOpts, name: []const u8, description: []const u8, properties: []const u8, required: []const []const u8) anyerror!void {
             if (o.toolset == .subagent and !subagentToolAllowed(name)) return;
             if (first_party_tools.isKnown(name) and first_party_tools.isDisabledName(o.disabled_first_party_tools, name)) return;
-            try emit(c, name, description, properties);
+            try emit(c, name, description, properties, required);
         }
     };
     try Filtered.emitTool(ctx, opts, "terminal_list", "List WispTerm terminal surfaces visible to the agent, including the current agent-selected write context. Before any terminal write, use terminal_select to choose the intended surface_id; use focused=true only as a default hint.", "{}");
@@ -782,6 +787,7 @@ fn forEachToolSpec(
     try Filtered.emitTool(ctx, opts, "terminal_repl_exec", "Send code or text to the selected already-open interactive REPL/app terminal without shell syntax. The surface_id must match the current terminal_select context. Use repl=r for R, repl=python for Python, repl=codex for Codex, repl=claude_code for Claude Code, or repl=plain for raw text input. For Codex and Claude Code, this waits until the app settles, requests approval/input, reports completion/failure, or reaches timeout_ms.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Selected surface id from terminal_select.\"},\"repl\":{\"type\":\"string\",\"description\":\"r, python, codex, claude_code, or plain\"},\"code\":{\"type\":\"string\",\"description\":\"Code or plain text to submit. To send a control key instead, set code to exactly one of <ctrl-c>, <ctrl-d>, <ctrl-u>, <esc>, <enter> — e.g. to interrupt a stuck command or leave a `>` continuation prompt.\"},\"timeout_ms\":{\"type\":\"integer\"}}");
     try Filtered.emitTool(ctx, opts, "terminal_answer_prompt", "Answer a Claude Code or Codex confirmation/approval prompt in a terminal surface. Reads the on-screen options and sends the correct keystroke. Prefer this over terminal_repl_exec to confirm or reject an agent approval menu. Only acts when a prompt is awaiting input; otherwise it reports the screen and sends nothing.", "{\"surface_id\":{\"type\":\"string\",\"description\":\"Optional surface id; defaults to the focused terminal.\"},\"answer\":{\"type\":\"string\",\"description\":\"approve (the plain Yes), approve_all (Yes + allow all / don't ask again), reject (No / cancel), enter, esc, or an explicit option digit 1-9.\"}}");
     try Filtered.emitTool(ctx, opts, "ask_user", "Ask the user a single multiple-choice question and block until they answer. Use when you reach a genuine decision you should not guess (which target, which of several matches, a risky direction). Provide 2 or more options; the user may also type a custom free-text answer. Returns the user's choice. The question is shown as a card in the chat and, when the request came from WeChat, pushed there too.", "{\"question\":{\"type\":\"string\",\"description\":\"The question to ask. One sentence.\"},\"options\":{\"type\":\"array\",\"description\":\"Two or more answer options.\",\"items\":{\"type\":\"object\",\"properties\":{\"label\":{\"type\":\"string\",\"description\":\"Short option label.\"},\"description\":{\"type\":\"string\",\"description\":\"Optional one-line explanation of the option.\"}},\"required\":[\"label\"]}}}");
+    try Filtered.emitToolWithRequired(ctx, opts, "continue_later", "Schedule this same Agent or Copilot session to continue later. Use when a terminal command, SSH command, Codex/Claude Code run, or REPL task is still running and immediate polling would waste tokens or risk duplicate side effects. At wake time WispTerm submits message back into this session; the message should inspect progress with terminal_snapshot before acting.", "{\"delay\":{\"type\":\"string\",\"description\":\"Required positive interval: integer plus s, m, h, or d, e.g. 30m, 2h, 1d.\"},\"message\":{\"type\":\"string\",\"description\":\"Optional follow-up prompt. Defaults to continuing the previous task and checking terminal_snapshot first.\"}}", &.{"delay"});
     try Filtered.emitTool(ctx, opts, "read_file", "Read a local, WSL, or SSH text file. Returns numbered lines. Set surface_id to an open terminal surface to read there; omitted surface_id follows the selected terminal context, or local when none is selected. Relative paths resolve against that surface cwd or the agent working directory.", "{\"path\":{\"type\":\"string\",\"description\":\"File path. Absolute, or relative to the selected surface cwd / working directory.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Optional terminal surface id (from terminal_list). Omit to use the selected terminal context, or local when none is selected.\"},\"offset\":{\"type\":\"integer\",\"description\":\"Optional 1-based first line to return.\"},\"limit\":{\"type\":\"integer\",\"description\":\"Optional maximum number of lines to return.\"}}");
     try Filtered.emitTool(ctx, opts, "copy_file", "Copy a binary/artifact file between local workspace, WSL, and SSH without pasting shell commands into a terminal. Pull mode: omit dest_surface_id and dest_path to copy source_path into local wispterm-files and return local_path, useful before send_attachment. Push mode: set dest_surface_id to an open WSL or SSH terminal to copy a local/Weixin/workspace file to that environment. Relative source paths resolve against source_surface_id cwd or the agent working directory; relative destination paths resolve against dest_surface_id cwd or the agent working directory.", "{\"source_path\":{\"type\":\"string\",\"description\":\"Path to the source file. Relative paths resolve against source_surface_id cwd, or the agent working directory when source_surface_id is omitted.\"},\"source_surface_id\":{\"type\":\"string\",\"description\":\"Optional source terminal id from terminal_list. SSH pulls via scp; WSL uses a host-accessible WSL path; omitted means local.\"},\"dest_surface_id\":{\"type\":\"string\",\"description\":\"Optional destination terminal id from terminal_list. Use an SSH or WSL surface to send a local file there. Omit to copy into local wispterm-files.\"},\"dest_path\":{\"type\":\"string\",\"description\":\"Optional destination file path. Relative paths resolve against destination surface cwd, or the agent working directory for local destinations. If omitted, uses dest_name or the source basename.\"},\"dest_name\":{\"type\":\"string\",\"description\":\"Optional safe destination filename. In pull mode it is placed inside wispterm-files. Must not contain path separators.\"}}");
     try Filtered.emitTool(ctx, opts, "write_file", "Create or overwrite a local, WSL, or SSH text file with exact content. Shows a diff and (unless permission is full) asks for approval. Set surface_id to an open terminal surface to write there; omitted surface_id follows the selected terminal context, or local when none is selected. Relative paths resolve against that surface cwd or the agent working directory.", "{\"path\":{\"type\":\"string\",\"description\":\"File path. Absolute, or relative to the selected surface cwd / working directory.\"},\"content\":{\"type\":\"string\",\"description\":\"Full file content to write.\"},\"surface_id\":{\"type\":\"string\",\"description\":\"Optional terminal surface id. Omit to use the selected terminal context, or local when none is selected.\"}}");
@@ -828,9 +834,10 @@ const ToolNameCollectorForTesting = struct {
     allocator: std.mem.Allocator,
     names: std.ArrayListUnmanaged([]const u8) = .empty,
 
-    fn emit(self: *ToolNameCollectorForTesting, name: []const u8, description: []const u8, properties: []const u8) !void {
+    fn emit(self: *ToolNameCollectorForTesting, name: []const u8, description: []const u8, properties: []const u8, required: []const []const u8) !void {
         _ = description;
         _ = properties;
+        _ = required;
         try self.names.append(self.allocator, name);
     }
 };
@@ -853,7 +860,7 @@ const ToolSchemaEmitter = struct {
     out: *std.ArrayListUnmanaged(u8),
     first: bool = true,
 
-    fn emit(self: *ToolSchemaEmitter, name: []const u8, description: []const u8, properties: []const u8) !void {
+    fn emit(self: *ToolSchemaEmitter, name: []const u8, description: []const u8, properties: []const u8, required: []const []const u8) !void {
         if (!self.first) try self.out.append(self.allocator, ',');
         self.first = false;
         try self.out.appendSlice(self.allocator, "{\"type\":\"function\",\"function\":{\"name\":");
@@ -862,6 +869,7 @@ const ToolSchemaEmitter = struct {
         try appendJsonString(self.allocator, self.out, description);
         try self.out.appendSlice(self.allocator, ",\"parameters\":{\"type\":\"object\",\"properties\":");
         try self.out.appendSlice(self.allocator, properties);
+        try appendSchemaRequired(self.allocator, self.out, required);
         try self.out.appendSlice(self.allocator, ",\"additionalProperties\":false}}}");
     }
 };
@@ -871,7 +879,7 @@ const ResponseToolSchemaEmitter = struct {
     out: *std.ArrayListUnmanaged(u8),
     first: bool = true,
 
-    fn emit(self: *ResponseToolSchemaEmitter, name: []const u8, description: []const u8, properties: []const u8) !void {
+    fn emit(self: *ResponseToolSchemaEmitter, name: []const u8, description: []const u8, properties: []const u8, required: []const []const u8) !void {
         if (!self.first) try self.out.append(self.allocator, ',');
         self.first = false;
         try self.out.appendSlice(self.allocator, "{\"type\":\"function\",\"name\":");
@@ -880,6 +888,7 @@ const ResponseToolSchemaEmitter = struct {
         try appendJsonString(self.allocator, self.out, description);
         try self.out.appendSlice(self.allocator, ",\"parameters\":{\"type\":\"object\",\"properties\":");
         try self.out.appendSlice(self.allocator, properties);
+        try appendSchemaRequired(self.allocator, self.out, required);
         try self.out.appendSlice(self.allocator, ",\"additionalProperties\":false}}");
     }
 };
@@ -889,7 +898,7 @@ const AnthropicToolEmitter = struct {
     out: *std.ArrayListUnmanaged(u8),
     first: bool = true,
 
-    fn emit(self: *AnthropicToolEmitter, name: []const u8, description: []const u8, properties: []const u8) !void {
+    fn emit(self: *AnthropicToolEmitter, name: []const u8, description: []const u8, properties: []const u8, required: []const []const u8) !void {
         if (!self.first) try self.out.append(self.allocator, ',');
         self.first = false;
         try self.out.appendSlice(self.allocator, "{\"name\":");
@@ -899,9 +908,20 @@ const AnthropicToolEmitter = struct {
         // input_schema reuses the SAME JSON Schema object the OpenAI `parameters` uses.
         try self.out.appendSlice(self.allocator, ",\"input_schema\":{\"type\":\"object\",\"properties\":");
         try self.out.appendSlice(self.allocator, properties);
+        try appendSchemaRequired(self.allocator, self.out, required);
         try self.out.appendSlice(self.allocator, ",\"additionalProperties\":false}}");
     }
 };
+
+fn appendSchemaRequired(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), required: []const []const u8) !void {
+    if (required.len == 0) return;
+    try out.appendSlice(allocator, ",\"required\":[");
+    for (required, 0..) |name, i| {
+        if (i > 0) try out.append(allocator, ',');
+        try appendJsonString(allocator, out, name);
+    }
+    try out.append(allocator, ']');
+}
 
 fn appendToolSchemas(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), opts: ToolSpecOpts) !void {
     try out.appendSlice(allocator, ",\"tools\":[");
@@ -1869,6 +1889,10 @@ test "MCP tool whose name collides with a builtin is not advertised" {
     try std.testing.expect(std.mem.indexOf(u8, json, "shadow attempt") == null);
 }
 
+test "continue_later is a reserved builtin tool name" {
+    try std.testing.expect(builtinToolNameReserved("continue_later"));
+}
+
 test "disabled first-party list does not hide dynamic binary tools" {
     const a = std.testing.allocator;
     const disabled = [_][]const u8{"agent_docx_review"};
@@ -2156,9 +2180,9 @@ test "subagentToolAllowed accepts exactly the research tools" {
     };
     for (allowed) |name| try std.testing.expect(subagentToolAllowed(name));
     const denied = [_][]const u8{
-        "subagent",       "memory_save",        "ssh_session_exec", "write_file",
-        "edit_file",      "tab_new",            "tab_close",        "terminal_select",
-        "terminal_focus", "terminal_repl_exec",
+        "subagent",        "continue_later", "memory_save",        "ssh_session_exec",
+        "write_file",      "edit_file",      "tab_new",            "tab_close",
+        "terminal_select", "terminal_focus", "terminal_repl_exec",
     };
     for (denied) |name| try std.testing.expect(!subagentToolAllowed(name));
 }
@@ -2177,6 +2201,7 @@ test "subagent toolset restricts tool schemas to research tools" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\"terminal_snapshot\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"wispterm_docs\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"subagent\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"continue_later\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"memory_save\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"ssh_session_exec\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"write_file\"") == null);
@@ -2203,6 +2228,18 @@ test "ask_user appears in the full tool schema with question and options" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\"options\"") != null);
 }
 
+test "continue_later appears in the full tool schema with delay and message" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+    try appendToolSchemas(a, &out, .{ .include_memory = false });
+    const json = out.items;
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"continue_later\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"delay\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"message\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"required\":[\"delay\"]") != null);
+}
+
 test "ask_user is absent from the subagent tool schema" {
     const a = std.testing.allocator;
     var out: std.ArrayListUnmanaged(u8) = .empty;
@@ -2219,6 +2256,7 @@ test "subagent toolset gating applies to all three protocol emitters" {
     try appendResponseToolSchemas(a, &responses_out, .{ .include_memory = true, .toolset = .subagent });
     try std.testing.expect(std.mem.indexOf(u8, responses_out.items, "\"websearch\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, responses_out.items, "\"name\":\"subagent\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, responses_out.items, "\"name\":\"continue_later\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, responses_out.items, "\"write_file\"") == null);
 
     var anthropic_out: std.ArrayListUnmanaged(u8) = .empty;
@@ -2226,5 +2264,6 @@ test "subagent toolset gating applies to all three protocol emitters" {
     try appendAnthropicTools(a, &anthropic_out, .{ .include_memory = true, .toolset = .subagent });
     try std.testing.expect(std.mem.indexOf(u8, anthropic_out.items, "\"websearch\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, anthropic_out.items, "\"name\":\"subagent\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, anthropic_out.items, "\"name\":\"continue_later\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, anthropic_out.items, "\"write_file\"") == null);
 }

--- a/src/assistant/conversation/request.zig
+++ b/src/assistant/conversation/request.zig
@@ -886,6 +886,11 @@ fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
         .settings = settings,
         .copilot = request.copilot,
         .reply_context = request.reply_context,
+        .schedule_context = if (request.schedule_session_id.len > 0) .{
+            .session_id = request.schedule_session_id,
+            .model = request.model,
+            .title = request.schedule_title,
+        } else null,
         .write_context_surface_id = request.write_context_surface_id,
         .write_context_surface_id_len = request.write_context_surface_id_len,
         .approve = toolApprove,
@@ -1242,6 +1247,22 @@ fn testSessionAndRequest(a: std.mem.Allocator) !struct { session: *Session, requ
         .started_ms = 0,
     };
     return .{ .session = session, .request = request };
+}
+
+test "toolContextFromRequest exposes scheduling identity" {
+    const a = std.testing.allocator;
+    const env = try testSessionAndRequest(a);
+    defer env.session.deinit();
+    defer env.request.deinit();
+
+    env.request.schedule_session_id = try a.dupe(u8, "session-abc");
+    env.request.schedule_title = try a.dupe(u8, "Long Build");
+
+    const ctx = toolContextFromRequest(env.request);
+    const schedule = ctx.schedule_context orelse return error.MissingScheduleContext;
+    try std.testing.expectEqualStrings("session-abc", schedule.session_id);
+    try std.testing.expectEqualStrings("model", schedule.model);
+    try std.testing.expectEqualStrings("Long Build", schedule.title);
 }
 
 test "subagent loop rejects disallowed tools, returns the final report, accumulates usage" {

--- a/src/assistant/conversation/request.zig
+++ b/src/assistant/conversation/request.zig
@@ -16,6 +16,7 @@ const web_search = @import("../../research/web_search.zig");
 const web_read = @import("../../research/web_read.zig");
 const pubmed = @import("../../research/pubmed.zig");
 const ai_chat_types = @import("types.zig");
+const ai_loop_store = @import("../loop/store.zig");
 const platform_agent_prompt = @import("../../platform/agent_prompt.zig");
 
 const title_log = std.log.scoped(.ai_title);
@@ -870,6 +871,22 @@ fn toolAsk(ctx: *anyopaque, question: []const u8, options: []const ai_chat_types
     return session.askUser(question, options);
 }
 
+fn toolScheduleContinuation(
+    _: *anyopaque,
+    schedule: ai_chat_types.ScheduleContext,
+    delay_ms: i64,
+    message: []const u8,
+) !u32 {
+    const store = ai_loop_store.active() orelse return error.NoScheduler;
+    const info = try store.registerContinuation(
+        delay_ms,
+        message,
+        .{ .session_id = schedule.session_id, .model = schedule.model, .title = schedule.title },
+        std.time.milliTimestamp(),
+    );
+    return info.id;
+}
+
 fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
     var settings = ai_chat.currentAgentSettings();
     settings.dynamic_tools = request.dynamic_tools;
@@ -891,6 +908,7 @@ fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
             .model = request.model,
             .title = request.schedule_title,
         } else null,
+        .schedule_continuation = toolScheduleContinuation,
         .write_context_surface_id = request.write_context_surface_id,
         .write_context_surface_id_len = request.write_context_surface_id_len,
         .approve = toolApprove,

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -179,6 +179,8 @@ pub const ChatRequest = struct {
     mcp_tool_specs: []const ai_chat_protocol.McpToolSpec = &.{},
     mcp_tools: []const ai_chat_types.McpTool = &.{},
     disabled_first_party_tools: []const []const u8 = &.{},
+    schedule_session_id: []u8 = &.{},
+    schedule_title: []u8 = &.{},
     copilot: bool = false,
     tool_host: ?ToolHost,
     tool_snapshot: ?ToolSnapshot,
@@ -206,6 +208,8 @@ pub const ChatRequest = struct {
         freeOwnedMcpToolSpecs(self.allocator, self.mcp_tool_specs);
         freeOwnedMcpTools(self.allocator, self.mcp_tools);
         freeOwnedStringList(self.allocator, self.disabled_first_party_tools);
+        if (self.schedule_session_id.len > 0) self.allocator.free(self.schedule_session_id);
+        if (self.schedule_title.len > 0) self.allocator.free(self.schedule_title);
         if (self.tool_snapshot) |snapshot| snapshot.deinit(self.allocator);
         if (self.reply_context) |*ctx| ctx.deinit(self.allocator);
         if (self.subagent_profile) |profile| profile.deinit(self.allocator);
@@ -4164,6 +4168,12 @@ pub const Session = struct {
         const disabled_first_party_tools = try cloneStringList(self.allocator, settings.disabled_first_party_tools);
         var disabled_first_party_tools_owned = true;
         errdefer if (disabled_first_party_tools_owned) freeOwnedStringList(self.allocator, disabled_first_party_tools);
+        const schedule_session_id = try self.allocator.dupe(u8, self.sessionId());
+        var schedule_session_id_owned = true;
+        errdefer if (schedule_session_id_owned) self.allocator.free(schedule_session_id);
+        const schedule_title = try self.allocator.dupe(u8, self.title());
+        var schedule_title_owned = true;
+        errdefer if (schedule_title_owned) self.allocator.free(schedule_title);
 
         req.* = .{
             .allocator = self.allocator,
@@ -4185,6 +4195,8 @@ pub const Session = struct {
             .mcp_tool_specs = mcp_tool_specs,
             .mcp_tools = mcp_tools,
             .disabled_first_party_tools = disabled_first_party_tools,
+            .schedule_session_id = schedule_session_id,
+            .schedule_title = schedule_title,
             .copilot = self.presentation().isSidebar(),
             .tool_host = tool_host,
             .tool_snapshot = tool_snapshot,
@@ -4204,6 +4216,8 @@ pub const Session = struct {
         mcp_tool_specs_owned = false;
         mcp_tools_owned = false;
         disabled_first_party_tools_owned = false;
+        schedule_session_id_owned = false;
+        schedule_title_owned = false;
         if (self.presentation().isSidebar() and self.bound_surface_id_len > 0) {
             // Inline the write-context seed directly on ChatRequest (the field
             // layout is identical to ToolContext; terminal tool helpers operate
@@ -8285,6 +8299,23 @@ test "ai chat session request owns dynamic tool specs snapshot" {
 
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"agent_docx_review\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"agent_xlsx_review\"") == null);
+}
+
+test "buildRequestLocked captures schedule identity for agent tools" {
+    const a = std.testing.allocator;
+    const session = try Session.init(a, "Long Build", "", "", "model-x", "", "", "", "", "true");
+    defer session.deinit();
+    session.copySessionId("session-build");
+
+    session.mutex.lock();
+    const request = try session.buildRequestLocked();
+    session.mutex.unlock();
+    defer request.deinit();
+    defer mcp_registry.reloadCacheFromServersForTest(a, &.{});
+
+    try std.testing.expectEqualStrings("session-build", request.schedule_session_id);
+    try std.testing.expectEqualStrings("Long Build", request.schedule_title);
+    try std.testing.expectEqualStrings("model-x", request.model);
 }
 
 test "ai chat session request owns dynamic binary runtime snapshot" {

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -52,6 +52,12 @@ pub const McpTool = struct {
     server_args: []const []const u8 = &.{},
 };
 
+pub const ScheduleContext = struct {
+    session_id: []const u8,
+    model: []const u8,
+    title: []const u8,
+};
+
 // AgentPermission lives in agent/config.zig (extracted so config.zig
 // stays out of the ai_chat dependency graph). Re-export the single source of truth.
 pub const AgentPermission = @import("../../agent/config.zig").AgentPermission;
@@ -346,6 +352,7 @@ pub const ToolContext = struct {
     settings: AgentSettings,
     copilot: bool = false,
     reply_context: ?OwnedReplyContext = null,
+    schedule_context: ?ScheduleContext = null,
     write_context_surface_id: [64]u8 = undefined,
     write_context_surface_id_len: usize = 0,
 

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -58,6 +58,13 @@ pub const ScheduleContext = struct {
     title: []const u8,
 };
 
+pub const ScheduleContinuationFn = *const fn (
+    ctx: *anyopaque,
+    schedule: ScheduleContext,
+    delay_ms: i64,
+    message: []const u8,
+) anyerror!u32;
+
 // AgentPermission lives in agent/config.zig (extracted so config.zig
 // stays out of the ai_chat dependency graph). Re-export the single source of truth.
 pub const AgentPermission = @import("../../agent/config.zig").AgentPermission;
@@ -353,6 +360,7 @@ pub const ToolContext = struct {
     copilot: bool = false,
     reply_context: ?OwnedReplyContext = null,
     schedule_context: ?ScheduleContext = null,
+    schedule_continuation: ?ScheduleContinuationFn = null,
     write_context_surface_id: [64]u8 = undefined,
     write_context_surface_id_len: usize = 0,
 
@@ -380,6 +388,11 @@ pub const ToolContext = struct {
     }
     pub fn askUser(self: *const ToolContext, question: []const u8, options: []const QuestionOption) AskResult {
         return self.ask(self.ctx, question, options);
+    }
+    pub fn scheduleContinuation(self: *const ToolContext, delay_ms: i64, message: []const u8) !u32 {
+        const schedule = self.schedule_context orelse return error.NoScheduleContext;
+        const callback = self.schedule_continuation orelse return error.NoScheduler;
+        return callback(self.ctx, schedule, delay_ms, message);
     }
     pub fn sshConnectionForSurface(self: *const ToolContext, surface_id: []const u8) ?SshConnection {
         const host = self.tool_host orelse return null;

--- a/src/assistant/loop/store.zig
+++ b/src/assistant/loop/store.zig
@@ -186,6 +186,31 @@ pub const Store = struct {
         return .{ .id = id, .kind = .watch, .daily = p.daily, .next_fire_ms = p.next_fire_ms };
     }
 
+    pub fn registerContinuation(
+        self: *Store,
+        delay_ms: i64,
+        prompt: []const u8,
+        ctx: SessionCtx,
+        now_ms: i64,
+    ) error{OutOfMemory}!RegisterInfo {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const next_fire_ms = now_ms + delay_ms;
+        const id = try self.appendOwned(.{
+            .kind = .watch,
+            .session_id = ctx.session_id,
+            .model = ctx.model,
+            .title = ctx.title,
+            .prompt = prompt,
+            .daily = false,
+            .remaining = 1,
+            .next_fire_ms = next_fire_ms,
+            .created_ms = now_ms,
+        });
+        self.saveLocked();
+        return .{ .id = id, .kind = .watch, .daily = false, .next_fire_ms = next_fire_ms };
+    }
+
     pub fn snapshotForSession(self: *Store, allocator: std.mem.Allocator, session_id: []const u8, kind: TaskKind) ![]TaskView {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -403,6 +428,45 @@ test "register loop, snapshot, stop, persist round-trip" {
     const snap3 = try store2.snapshotForSession(a, "session-7", .loop);
     defer freeSnapshot(a, snap3);
     try std.testing.expectEqual(@as(usize, 0), snap3.len);
+}
+
+test "registerContinuation schedules a one-shot watch task after delay" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir_path);
+    const path = try std.fs.path.join(a, &.{ dir_path, "loop_tasks.json" });
+    defer a.free(path);
+
+    var store = Store.init(a, path);
+    defer store.deinit();
+
+    const now_ms: i64 = 10_000;
+    const delay_ms: i64 = 30 * std.time.ms_per_min;
+    const info = try store.registerContinuation(
+        delay_ms,
+        "Continue the previous task. First inspect the terminal with terminal_snapshot.",
+        .{ .session_id = "session-continue", .model = "deepseek", .title = "Build" },
+        now_ms,
+    );
+
+    try std.testing.expectEqual(TaskKind.watch, info.kind);
+    try std.testing.expect(!info.daily);
+    try std.testing.expectEqual(now_ms + delay_ms, info.next_fire_ms);
+
+    const snap = try store.snapshotForSession(a, "session-continue", .watch);
+    defer freeSnapshot(a, snap);
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expect(!snap[0].daily);
+    try std.testing.expectEqual(@as(u32, 1), snap[0].remaining);
+    try std.testing.expectEqual(now_ms + delay_ms, snap[0].next_fire_ms);
+    try std.testing.expectEqualStrings("deepseek", snap[0].model);
+    try std.testing.expectEqualStrings("Build", snap[0].title);
+    try std.testing.expectEqualStrings(
+        "Continue the previous task. First inspect the terminal with terminal_snapshot.",
+        snap[0].prompt,
+    );
 }
 
 test "snapshotAll and stopById support global copilot task management" {

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -69,7 +69,7 @@ const common_tools_after_wsl =
     \\- In line REPLs (Python/R/Node), type raw code as a human would; bare expressions auto-display, so send `1+1`, not print wrappers.
     \\- surface_id accepts `focused`.
     \\- Do not paste shell commands into Codex or Claude Code; send user text.
-    \\- A slow session/exec command is usually still running; wait, then re-check with `terminal_snapshot`.
+    \\- A slow session/exec command is usually still running. Do not re-run it. If waiting is better than immediate polling, call `continue_later` with a delay such as 30m and a message that checks `terminal_snapshot` first.
     \\- For a stuck terminal (`>` prompt, unclosed quote, hung command, pager), send `terminal_repl_exec repl=plain code=<ctrl-c>` (or `<ctrl-u>`/`<esc>`/`<ctrl-d>`).
     \\- Read terminal snapshots from the bottom; if stale/truncated, re-read with `terminal_snapshot`.
     \\- Answer Claude Code/Codex approval menus with `terminal_answer_prompt`; never blind-press unseen prompts.
@@ -172,6 +172,15 @@ test "platform agent prompt teaches stuck-terminal interrupt recovery" {
         const p = defaultSystemPromptForOs(os);
         try std.testing.expect(std.mem.indexOf(u8, p, "code=<ctrl-c>") != null);
         try std.testing.expect(std.mem.indexOf(u8, p, "still running") != null);
+    }
+}
+
+test "platform agent prompt teaches continue_later for long-running work" {
+    for ([_]std.Target.Os.Tag{ .windows, .linux, .macos }) |os| {
+        const p = defaultSystemPromptForOs(os);
+        try std.testing.expect(std.mem.indexOf(u8, p, "continue_later") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "terminal_snapshot") != null);
+        try std.testing.expect(std.mem.indexOf(u8, p, "Do not re-run") != null);
     }
 }
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -260,6 +260,7 @@ test {
     _ = @import("agent_tools/knowledge.zig");
     _ = @import("agent_tools/memory.zig");
     _ = @import("agent_tools/output.zig");
+    _ = @import("agent_tools/schedule.zig");
     _ = @import("agent_tools/terminal.zig");
     _ = @import("agent_tools/sessions.zig");
     _ = @import("agent_tools/access.zig");

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -56,6 +56,7 @@ comptime {
         _ = @import("agent_tools/knowledge.zig");
         _ = @import("agent_tools/memory.zig");
         _ = @import("agent_tools/output.zig");
+        _ = @import("agent_tools/schedule.zig");
         _ = @import("agent_tools/terminal.zig");
         _ = @import("agent_tools/sessions.zig");
         _ = @import("agent_tools/access.zig");

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -37,6 +37,7 @@ const static_definitions = [_]Definition{
     .{ .name = "terminal_repl_exec", .label = "terminal_repl_exec", .description = "Send text to an already-open interactive REPL or agent app.", .category = .terminal },
     .{ .name = "terminal_answer_prompt", .label = "terminal_answer_prompt", .description = "Answer an approval prompt in an agent terminal surface.", .category = .terminal },
     .{ .name = "ask_user", .label = "ask_user", .description = "Ask the user a blocking multiple-choice question.", .category = .agent },
+    .{ .name = "continue_later", .label = "continue_later", .description = "Schedule this Agent session to continue a long-running task later.", .category = .agent },
     .{ .name = "read_file", .label = "read_file", .description = "Read a local or remote text file.", .category = .file },
     .{ .name = "copy_file", .label = "copy_file", .description = "Copy a file between local, WSL, and SSH contexts.", .category = .file },
     .{ .name = "write_file", .label = "write_file", .description = "Create or overwrite a local or remote text file.", .category = .file },
@@ -267,6 +268,7 @@ test "first_party_tools: active definitions include webread and the local comman
     const local_name = platform_process.localCommandToolName();
 
     try std.testing.expect(catalogContains(defs, "webread"));
+    try std.testing.expect(catalogContains(defs, "continue_later"));
     try std.testing.expect(catalogContains(defs, local_name));
     try std.testing.expectEqual(@as(?bool, true), catalogDisableable("webread"));
     try std.testing.expectEqual(@as(?bool, true), catalogDisableable(local_name));


### PR DESCRIPTION
## Summary
- Add a first-party `continue_later` tool that schedules the current Agent session to resume through the existing `/watch` store.
- Carry scheduling identity through `ChatRequest`/`ToolContext` and keep `agent_tools` behind a callback seam.
- Advertise the tool in catalog/protocol schemas, exclude it from subagents, and teach prompts/exec guidance to use it for long-running work.

## Test Plan
- `zig fmt src build.zig`
- `zig build test`
- `zig build test-full`
- Windows checkout-safety equivalent: `windows_name_violations=0`, `casefold_collisions=0`, no symlinks
- Final code review subagent: approved
