### PR TITLE
fix(ssh): dedup OpenSSH import by Host alias, not shared IP

### DIFF
--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -3496,7 +3496,10 @@ fn mergeOpenSshCandidate(candidate: openssh_config_import.Candidate, stats: *Ope
         return;
     }
 
-    const found_idx = findLoadedSshProfileIndex(name) orelse findLoadedSshProfileIndex(host);
+    // Dedup by Host alias only: same server on multiple ports (e.g. port
+    // forwards / containers) are distinct OpenSSH Host blocks, so merging by
+    // shared HostName/IP would collapse them into one. ponytail: name-only.
+    const found_idx = findLoadedSshProfileIndex(name);
     var created_new = false;
     const idx = found_idx orelse blk: {
         if (sshState().profile_count >= SSH_PROFILE_MAX) {
@@ -7421,6 +7424,34 @@ test "overlays: OpenSSH import keeps more than sixteen SSH profiles" {
     try std.testing.expectEqual(@as(usize, 27), sshState().profile_count);
     try std.testing.expectEqual(@as(usize, 27), stats.created);
     try std.testing.expect(!stats.capped);
+}
+
+test "overlays: OpenSSH import keeps same-host different-port aliases separate" {
+    const saved_count = sshState().profile_count;
+    var saved_profiles: [SSH_PROFILE_MAX]SshProfile = undefined;
+    if (saved_count > 0) @memcpy(saved_profiles[0..saved_count], sshState().profiles[0..saved_count]);
+    defer {
+        sshState().profile_count = saved_count;
+        if (saved_count > 0) @memcpy(sshState().profiles[0..saved_count], saved_profiles[0..saved_count]);
+    }
+
+    sshState().profile_count = 0;
+    var stats = OpenSshImportStats{};
+    const ports = [_][]const u8{ "7524", "7525", "7422" };
+    const names = [_][]const u8{ "90_mengzijun", "91_mengzijun", "98_mengzijun" };
+    for (ports, names) |port, name| {
+        var candidate = openssh_config_import.Candidate{};
+        opensshCandidateSetForTest(&candidate, .name, name);
+        opensshCandidateSetForTest(&candidate, .host, "172.16.190.96");
+        opensshCandidateSetForTest(&candidate, .user, "mengzijun");
+        opensshCandidateSetForTest(&candidate, .port, port);
+        mergeOpenSshCandidate(candidate, &stats);
+    }
+
+    // Shared HostName must NOT collapse the three Host blocks into one.
+    try std.testing.expectEqual(@as(usize, 3), sshState().profile_count);
+    try std.testing.expectEqual(@as(usize, 3), stats.created);
+    try std.testing.expectEqual(@as(usize, 0), stats.updated);
 }
 
 test "overlays: SSH delete picker supports multi-select batch delete" {


### PR DESCRIPTION
## 问题

用户导入 OpenSSH config 时只识别到部分 Host。config 里同一台机器多个端口(端口转发/多容器)是多个独立的 `Host` block,共用同一个 `HostName`,

## 根因

`mergeOpenSshCandidate` 去重时先按名字找,找不到再**按 IP 回退**:

```zig
const found_idx = findLoadedSshProfileIndex(name) orelse findLoadedSshProfileIndex(host);
```

四个共享 `172.16.190.96` 的 Host 因 IP 相同被判为重复,后者覆盖前者,最终只剩最后一条。

## 修复

去掉 IP 回退,只按 `Host` 别名去重——符合 OpenSSH 语义(每个 Host block 独立)。连接时按名字或 IP 查找的路径不受影响(输 IP 仍可连)。

加回归测试:同 IP、不同 Host 名/端口的三条应各建一条,不合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)