### PR TITLE
fix(d3d11): cut per-thread TLS cost, cache shader compiler, drop GL leftovers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1267,8 +1267,10 @@ fn createAppModuleWithRootAndTestShard(
     }
 
     // OpenGL backend (Windows + Linux): the glad loader needs its include path
-    // and C source compiled in. macOS uses Metal and skips this.
-    if (target.result.os.tag == .windows or target.result.os.tag == .linux) {
+    // and C source compiled in. macOS uses Metal and skips this; the native
+    // D3D11 flavor never touches GL, so it skips glad and opengl32 entirely.
+    const links_opengl = !std.mem.eql(u8, gpu_backend, "d3d11");
+    if (links_opengl and (target.result.os.tag == .windows or target.result.os.tag == .linux)) {
         app_mod.addIncludePath(b.path("vendor/glad/include"));
         app_mod.addCSourceFile(.{
             .file = b.path("vendor/glad/src/gl.c"),
@@ -1279,8 +1281,10 @@ fn createAppModuleWithRootAndTestShard(
     // Windows links the system OpenGL (opengl32); Linux gets its GL context and
     // function loader from SDL3 (linked via systemLibrariesFor above), so it
     // needs no separate GL system library.
-    if (platform.opengl_system_library) |library| {
-        app_mod.linkSystemLibrary(library, .{});
+    if (links_opengl) {
+        if (platform.opengl_system_library) |library| {
+            app_mod.linkSystemLibrary(library, .{});
+        }
     }
 
     if (target.result.os.tag == .linux) {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -6475,6 +6475,16 @@ fn runMainLoop(self: *AppWindow) !void {
             try gpu.Context.initForWindow(window_backend.nativeHandle(&backend_window), fb.width, fb.height);
         },
     }
+    // Free the D3D11 handle registries (heap-allocated per window thread) when
+    // this window unwinds. Declared before the pipeline/texture-owning defers
+    // below so it runs after all of them (defers are LIFO); their deinits still
+    // see a live registry to release COM objects through.
+    defer if (comptime gpu.active == .d3d11) {
+        gpu.Pipeline.releaseRegistry();
+        gpu.Texture.releaseRegistry();
+        gpu.Buffer.releaseRegistry();
+        gpu.vertex.releaseRegistry();
+    };
 
     // Initialize FreeType
     const ft_lib = freetype.Library.init() catch |err| {

--- a/src/renderer/gpu/d3d11/Buffer.zig
+++ b/src/renderer/gpu/d3d11/Buffer.zig
@@ -29,18 +29,42 @@ const Entry = struct {
     }
 };
 
-threadlocal var next_handle: c.GLuint = 1;
-threadlocal var live: [max_buffers]bool = @splat(false);
-threadlocal var table: [max_buffers]Entry = @splat(.{});
+const Registry = struct {
+    next_handle: c.GLuint = 1,
+    live: [max_buffers]bool = @splat(false),
+    table: [max_buffers]Entry = @splat(.{}),
+};
+
+// Heap-allocated on first use so the table stays out of the TLS template
+// (Windows commits the full template per thread; see vertex.zig).
+threadlocal var registry: ?*Registry = null;
+
+fn ensureRegistry() ?*Registry {
+    if (registry == null) {
+        const r = std.heap.page_allocator.create(Registry) catch return null;
+        r.* = .{};
+        registry = r;
+    }
+    return registry;
+}
+
+/// Free this thread's registry storage (window-thread teardown).
+pub fn releaseRegistry() void {
+    if (registry) |r| {
+        std.heap.page_allocator.destroy(r);
+        registry = null;
+    }
+}
 
 fn allocHandle() c.GLuint {
+    const r = ensureRegistry() orelse return 0;
     for (0..max_buffers - 1) |_| {
-        const h = next_handle;
-        next_handle +%= 1;
-        if (next_handle == 0 or next_handle >= max_buffers) next_handle = 1;
-        if (!live[h]) {
-            live[h] = true;
-            table[h] = .{};
+        const h = r.next_handle;
+        r.next_handle +%= 1;
+        if (r.next_handle == 0 or r.next_handle >= max_buffers) r.next_handle = 1;
+        if (!r.live[h]) {
+            r.live[h] = true;
+            r.table[h] = .{};
             return h;
         }
     }
@@ -48,8 +72,9 @@ fn allocHandle() c.GLuint {
 }
 
 fn entry(handle: c.GLuint) ?*Entry {
-    if (handle == 0 or handle >= max_buffers or !live[handle]) return null;
-    return &table[handle];
+    const r = registry orelse return null;
+    if (handle == 0 or handle >= max_buffers or !r.live[handle]) return null;
+    return &r.table[handle];
 }
 
 fn initTarget(target: c.GLenum) Buffer {
@@ -187,7 +212,7 @@ pub fn nativeHandle(handle: c.GLuint) ?*anyopaque {
 pub fn deinit(self: *Buffer) void {
     if (entry(self.handle)) |e| {
         e.release();
-        live[self.handle] = false;
+        registry.?.live[self.handle] = false;
     }
     self.* = .{ .handle = 0, .target = self.target };
 }

--- a/src/renderer/gpu/d3d11/Context.zig
+++ b/src/renderer/gpu/d3d11/Context.zig
@@ -530,11 +530,21 @@ fn createPhase2Pipeline(self: *State) InitError!void {
     self.pixel_shader = ps;
 }
 
+/// D3DCompile entry point, loaded once per thread. The compiler module stays
+/// resident on purpose: pipelines are recompiled on device recreate, and the
+/// DLL image is file-backed/shared — the waste was re-LoadLibraryW'ing it for
+/// every one of the ~18 startup compiles (refcount grew, never released).
+threadlocal var g_d3dcompile: ?D3DCompileFn = null;
+
 pub fn compileShaderBlob(source: []const u8, entrypoint: [*:0]const u8, target: [*:0]const u8) ShaderError!*anyopaque {
-    const compiler = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("d3dcompiler_47.dll")) orelse
-        return error.ShaderCompilerUnavailable;
-    const compile: D3DCompileFn = @ptrCast(GetProcAddress(compiler, "D3DCompile") orelse
-        return error.ShaderCompilerUnavailable);
+    const compile = g_d3dcompile orelse blk: {
+        const compiler = LoadLibraryW(std.unicode.utf8ToUtf16LeStringLiteral("d3dcompiler_47.dll")) orelse
+            return error.ShaderCompilerUnavailable;
+        const f: D3DCompileFn = @ptrCast(GetProcAddress(compiler, "D3DCompile") orelse
+            return error.ShaderCompilerUnavailable);
+        g_d3dcompile = f;
+        break :blk f;
+    };
 
     var code: ?*anyopaque = null;
     var errors: ?*anyopaque = null;

--- a/src/renderer/gpu/d3d11/Pipeline.zig
+++ b/src/renderer/gpu/d3d11/Pipeline.zig
@@ -50,18 +50,42 @@ const Entry = struct {
     }
 };
 
-threadlocal var next_program: types.ProgramHandle = 1;
-threadlocal var live: [max_programs]bool = @splat(false);
-threadlocal var table: [max_programs]Entry = @splat(.{});
+const Registry = struct {
+    next_program: types.ProgramHandle = 1,
+    live: [max_programs]bool = @splat(false),
+    table: [max_programs]Entry = @splat(.{}),
+};
+
+// Heap-allocated on first use so the table stays out of the TLS template
+// (Windows commits the full template per thread; see vertex.zig).
+threadlocal var registry: ?*Registry = null;
+
+fn ensureRegistry() ?*Registry {
+    if (registry == null) {
+        const r = std.heap.page_allocator.create(Registry) catch return null;
+        r.* = .{};
+        registry = r;
+    }
+    return registry;
+}
+
+/// Free this thread's registry storage (window-thread teardown).
+pub fn releaseRegistry() void {
+    if (registry) |r| {
+        std.heap.page_allocator.destroy(r);
+        registry = null;
+    }
+}
 
 fn allocProgram() types.ProgramHandle {
+    const r = ensureRegistry() orelse return 0;
     for (0..max_programs - 1) |_| {
-        const h = next_program;
-        next_program +%= 1;
-        if (next_program == 0 or next_program >= max_programs) next_program = 1;
-        if (!live[h]) {
-            live[h] = true;
-            table[h] = .{};
+        const h = r.next_program;
+        r.next_program +%= 1;
+        if (r.next_program == 0 or r.next_program >= max_programs) r.next_program = 1;
+        if (!r.live[h]) {
+            r.live[h] = true;
+            r.table[h] = .{};
             return h;
         }
     }
@@ -69,24 +93,9 @@ fn allocProgram() types.ProgramHandle {
 }
 
 fn entry(handle: types.ProgramHandle) ?*Entry {
-    if (handle == 0 or handle >= max_programs or !live[handle]) return null;
-    return &table[handle];
-}
-
-pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
-    const target: [*:0]const u8 = switch (shader_type) {
-        c.GL_VERTEX_SHADER => "vs_4_0",
-        c.GL_FRAGMENT_SHADER => "ps_4_0",
-        else => return null,
-    };
-    const entrypoint: [*:0]const u8 = switch (shader_type) {
-        c.GL_VERTEX_SHADER => "vs_main",
-        c.GL_FRAGMENT_SHADER => "ps_main",
-        else => return null,
-    };
-    const blob = Context.compileShaderBlob(std.mem.span(source), entrypoint, target) catch return null;
-    core.comRelease(blob);
-    return 1;
+    const r = registry orelse return null;
+    if (handle == 0 or handle >= max_programs or !r.live[handle]) return null;
+    return &r.table[handle];
 }
 
 pub fn init(vs_src: [*c]const u8, fs_src: [*c]const u8, vao: types.VertexArrayHandle) Pipeline {
@@ -112,25 +121,25 @@ pub fn init(vs_src: [*c]const u8, fs_src: [*c]const u8, vao: types.VertexArrayHa
     if (create_vs(device, Context.blobPointer(vs_blob), Context.blobSize(vs_blob), null, &e.vertex_shader) < 0 or e.vertex_shader == null) {
         std.debug.print("D3D11 vertex shader creation failed\n", .{});
         e.release();
-        live[handle] = false;
+        registry.?.live[handle] = false;
         return .{ .program = 0, .vao = vao };
     }
     if (create_ps(device, Context.blobPointer(ps_blob), Context.blobSize(ps_blob), null, &e.pixel_shader) < 0 or e.pixel_shader == null) {
         std.debug.print("D3D11 pixel shader creation failed\n", .{});
         e.release();
-        live[handle] = false;
+        registry.?.live[handle] = false;
         return .{ .program = 0, .vao = vao };
     }
     if (!createInputLayout(device, e, vao, vs_blob)) {
         std.debug.print("D3D11 input layout creation failed\n", .{});
         e.release();
-        live[handle] = false;
+        registry.?.live[handle] = false;
         return .{ .program = 0, .vao = vao };
     }
     if (!createConstantBuffer(device, e)) {
         std.debug.print("D3D11 constant buffer creation failed\n", .{});
         e.release();
-        live[handle] = false;
+        registry.?.live[handle] = false;
         return .{ .program = 0, .vao = vao };
     }
     e.vao = vao;
@@ -386,7 +395,7 @@ pub fn drawPhase2Quad() void {
 pub fn deinit(self: *Pipeline) void {
     if (entry(self.program)) |e| {
         e.release();
-        live[self.program] = false;
+        registry.?.live[self.program] = false;
     }
     if (self.vao != 0) vertex.deleteVertexArray(self.vao);
     self.* = .{ .program = 0, .vao = 0 };

--- a/src/renderer/gpu/d3d11/Texture.zig
+++ b/src/renderer/gpu/d3d11/Texture.zig
@@ -41,18 +41,42 @@ const Entry = struct {
     }
 };
 
-threadlocal var next_handle: c.GLuint = 1;
-threadlocal var live: [max_textures]bool = @splat(false);
-threadlocal var table: [max_textures]Entry = @splat(.{});
+const Registry = struct {
+    next_handle: c.GLuint = 1,
+    live: [max_textures]bool = @splat(false),
+    table: [max_textures]Entry = @splat(.{}),
+};
+
+// Heap-allocated on first use so the table stays out of the TLS template
+// (Windows commits the full template per thread; see vertex.zig).
+threadlocal var registry: ?*Registry = null;
+
+fn ensureRegistry() ?*Registry {
+    if (registry == null) {
+        const r = std.heap.page_allocator.create(Registry) catch return null;
+        r.* = .{};
+        registry = r;
+    }
+    return registry;
+}
+
+/// Free this thread's registry storage (window-thread teardown).
+pub fn releaseRegistry() void {
+    if (registry) |r| {
+        std.heap.page_allocator.destroy(r);
+        registry = null;
+    }
+}
 
 fn allocHandle() c.GLuint {
+    const r = ensureRegistry() orelse return 0;
     for (0..max_textures - 1) |_| {
-        const h = next_handle;
-        next_handle +%= 1;
-        if (next_handle == 0 or next_handle >= max_textures) next_handle = 1;
-        if (!live[h]) {
-            live[h] = true;
-            table[h] = .{};
+        const h = r.next_handle;
+        r.next_handle +%= 1;
+        if (r.next_handle == 0 or r.next_handle >= max_textures) r.next_handle = 1;
+        if (!r.live[h]) {
+            r.live[h] = true;
+            r.table[h] = .{};
             return h;
         }
     }
@@ -60,8 +84,9 @@ fn allocHandle() c.GLuint {
 }
 
 fn entry(handle: c.GLuint) ?*Entry {
-    if (handle == 0 or handle >= max_textures or !live[handle]) return null;
-    return &table[handle];
+    const r = registry orelse return null;
+    if (handle == 0 or handle >= max_textures or !r.live[handle]) return null;
+    return &r.table[handle];
 }
 
 pub fn invalid() Texture {
@@ -365,7 +390,7 @@ pub fn unbindShaderResourceSlots(first_slot: u32, count: u32) void {
 pub fn destroy(self: *Texture) void {
     if (entry(self.handle)) |e| {
         e.release();
-        live[self.handle] = false;
+        registry.?.live[self.handle] = false;
     }
     self.handle = 0;
 }

--- a/src/renderer/gpu/d3d11/gl_init.zig
+++ b/src/renderer/gpu/d3d11/gl_init.zig
@@ -1,7 +1,6 @@
 //! Transitional gl_init mirror for the D3D11 backend.
 
 const c = @import("c.zig");
-const Pipeline = @import("Pipeline.zig");
 
 pub const BackendHooks = struct {
     fillQuad: *const fn (x: f32, y: f32, w: f32, h: f32, color: [3]f32) void,
@@ -25,10 +24,6 @@ pub threadlocal var shader_program: c.GLuint = 1;
 pub threadlocal var simple_color_shader: c.GLuint = 1;
 pub threadlocal var g_draw_call_count: u32 = 0;
 pub threadlocal var g_bg_opacity: f32 = 1.0;
-
-pub fn compileShader(shader_type: c.GLenum, source: [*c]const u8) ?c.GLuint {
-    return Pipeline.compileShader(shader_type, source);
-}
 
 pub fn initShaders() bool {
     return true;

--- a/src/renderer/gpu/d3d11/vertex.zig
+++ b/src/renderer/gpu/d3d11/vertex.zig
@@ -4,6 +4,7 @@
 //! records the backend-neutral VAO description and `Pipeline.init` turns it
 //! into a native `ID3D11InputLayout`.
 
+const std = @import("std");
 const Buffer = @import("Buffer.zig");
 const c = @import("c.zig");
 const types = @import("../types.zig");
@@ -51,17 +52,42 @@ pub const Layout = struct {
     attr_count: u8 = 0,
 };
 
-threadlocal var next_handle: VaoHandle = 1;
-threadlocal var live: [max_layouts]bool = @splat(false);
-threadlocal var layout_table: [max_layouts]Layout = @splat(.{});
+const Registry = struct {
+    next_handle: VaoHandle = 1,
+    live: [max_layouts]bool = @splat(false),
+    layout_table: [max_layouts]Layout = @splat(.{}),
+};
+
+// Heap-allocated on first use. As plain `threadlocal` arrays this table lived
+// in the module's TLS template, which Windows commits per thread — every
+// thread in the process paid ~2.3 MB for a table only render threads touch.
+threadlocal var registry: ?*Registry = null;
+
+fn ensureRegistry() ?*Registry {
+    if (registry == null) {
+        const r = std.heap.page_allocator.create(Registry) catch return null;
+        r.* = .{};
+        registry = r;
+    }
+    return registry;
+}
+
+/// Free this thread's registry storage (window-thread teardown).
+pub fn releaseRegistry() void {
+    if (registry) |r| {
+        std.heap.page_allocator.destroy(r);
+        registry = null;
+    }
+}
 
 pub fn buildVertexArray(layouts: []const BufferLayout) VaoHandle {
+    const r = ensureRegistry() orelse return 0;
     for (0..max_layouts - 1) |_| {
-        const handle = next_handle;
-        next_handle +%= 1;
-        if (next_handle == 0 or next_handle >= max_layouts) next_handle = 1;
-        if (!live[handle]) {
-            live[handle] = true;
+        const handle = r.next_handle;
+        r.next_handle +%= 1;
+        if (r.next_handle == 0 or r.next_handle >= max_layouts) r.next_handle = 1;
+        if (!r.live[handle]) {
+            r.live[handle] = true;
             var stored: Layout = .{};
             const buffer_count = @min(layouts.len, max_buffers_per_layout);
             var attr_index: usize = 0;
@@ -83,7 +109,7 @@ pub fn buildVertexArray(layouts: []const BufferLayout) VaoHandle {
             }
             stored.buffer_count = @intCast(buffer_count);
             stored.attr_count = @intCast(attr_index);
-            layout_table[handle] = stored;
+            r.layout_table[handle] = stored;
             return handle;
         }
     }
@@ -91,15 +117,17 @@ pub fn buildVertexArray(layouts: []const BufferLayout) VaoHandle {
 }
 
 pub fn deleteVertexArray(vao: VaoHandle) void {
+    const r = registry orelse return;
     if (vao > 0 and vao < max_layouts) {
-        live[vao] = false;
-        layout_table[vao] = .{};
+        r.live[vao] = false;
+        r.layout_table[vao] = .{};
     }
 }
 
 pub fn layout(vao: VaoHandle) ?*const Layout {
-    if (vao == 0 or vao >= max_layouts or !live[vao]) return null;
-    return &layout_table[vao];
+    const r = registry orelse return null;
+    if (vao == 0 or vao >= max_layouts or !r.live[vao]) return null;
+    return &r.layout_table[vao];
 }
 
 pub fn bufferHandle(vao: VaoHandle, index: usize) c.GLuint {


### PR DESCRIPTION
## Summary
Follow-up to #509, fixing the remaining memory-waste findings from the D3D11 backend audit (A/B/C/D):

- **A — TLS registries (the big one).** The Buffer/Texture/Pipeline/vertex handle registries were fixed-size `threadlocal` arrays (~3.5 MB combined). Windows commits a private copy of the whole TLS template for **every** thread, so all ~90 threads of a busy session paid for tables only render threads touch. Registries are now threadlocal *pointers*, heap-allocated on first use and freed via `releaseRegistry()` when the window thread unwinds (registered before the pipeline-owning defers, so their deinits still release COM objects through a live registry). Measured on the exe: **.tls template 7.34 MB → 3.87 MB per thread (−3.47 MB/thread, −47%)** — now at parity with the opengl flavor (4.05 MB). Expected field effect: clean-baseline Private drop of roughly (thread count × 3.3 MB), and the remaining d3d11-vs-opengl private gap should mostly close.
- **B — d3dcompiler churn.** `compileShaderBlob` re-`LoadLibraryW`'d `d3dcompiler_47.dll` for every one of the ~18 startup compiles (refcount grew, never released). The `D3DCompile` pointer is now loaded once per thread; module intentionally stays resident (device-recreate recompiles pipelines).
- **C — dead compile shim.** `Pipeline.compileShader` ran a full `D3DCompile` only to release the blob and return `1`; its only caller was the transitional `gl_init.compileShader`. Both deleted (d3d11 backend only; metal shim untouched).
- **D — GL leftovers in the build.** The d3d11 flavor no longer compiles `vendor/glad/src/gl.c` nor links `opengl32` (its import was already dead-stripped since #509). The opengl flavor (`auto` default) is unchanged on Windows and Linux.

Handle semantics, capacities, and lookup behavior are unchanged; registry read paths return null before first allocation.

## Verification
- `zig build -Dgpu-backend=d3d11` and `zig build` (opengl) both compile.
- `zig build test`, `zig build test-full`, and `zig build test-full -Dgpu-backend=d3d11` all exit 0.
- objdump: d3d11 exe `.tls` 7,691,624 → 4,062,584 bytes; still no `OPENGL32.dll` import.
- Field check pending (Windows/NVIDIA): rerun the clean-baseline Private A/B; the drop should scale with thread count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qsXkYqtZhmhY6ptkEEYZC