### PR TITLE
fix: move the big shared threadlocal state out of the TLS template

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -6475,16 +6475,20 @@ fn runMainLoop(self: *AppWindow) !void {
             try gpu.Context.initForWindow(window_backend.nativeHandle(&backend_window), fb.width, fb.height);
         },
     }
-    // Free the D3D11 handle registries (heap-allocated per window thread) when
-    // this window unwinds. Declared before the pipeline/texture-owning defers
-    // below so it runs after all of them (defers are LIFO); their deinits still
-    // see a live registry to release COM objects through.
-    defer if (comptime gpu.active == .d3d11) {
-        gpu.Pipeline.releaseRegistry();
-        gpu.Texture.releaseRegistry();
-        gpu.Buffer.releaseRegistry();
-        gpu.vertex.releaseRegistry();
-    };
+    // Free the per-window-thread heap-backed TLS state (overlay state and, on
+    // D3D11, the handle registries) when this window unwinds. Declared before
+    // the pipeline/texture-owning defers below so it runs after all of them
+    // (defers are LIFO); their deinits still see live storage to release
+    // resources through.
+    defer {
+        overlays.releaseThreadState();
+        if (comptime gpu.active == .d3d11) {
+            gpu.Pipeline.releaseRegistry();
+            gpu.Texture.releaseRegistry();
+            gpu.Buffer.releaseRegistry();
+            gpu.vertex.releaseRegistry();
+        }
+    }
 
     // Initialize FreeType
     const ft_lib = freetype.Library.init() catch |err| {

--- a/src/file_explorer.zig
+++ b/src/file_explorer.zig
@@ -117,9 +117,31 @@ pub threadlocal var g_history_selected: ?usize = null;
 pub threadlocal var g_root_path: [260]u8 = undefined;
 pub threadlocal var g_root_path_len: usize = 0;
 
-// Flat list of currently visible entries (rebuilt on expand/collapse/rescan)
-pub threadlocal var g_entries: [MAX_ENTRIES]FlatEntry = undefined;
+// Flat list of currently visible entries (rebuilt on expand/collapse/rescan).
+// Heap-allocated on first use: as a direct `threadlocal` array this was
+// ~1.6 MB in the TLS template, which Windows commits privately for EVERY
+// thread — see renderer/gpu/d3d11/vertex.zig for the same pattern. Contents
+// start undefined, matching the old `= undefined` initializer.
+threadlocal var g_entries_storage: ?*[MAX_ENTRIES]FlatEntry = null;
 pub threadlocal var g_entry_count: usize = 0;
+
+pub fn entries() *[MAX_ENTRIES]FlatEntry {
+    if (g_entries_storage == null) {
+        g_entries_storage = std.heap.page_allocator.create([MAX_ENTRIES]FlatEntry) catch
+            @panic("out of memory allocating file explorer entries");
+    }
+    return g_entries_storage.?;
+}
+
+/// Free this thread's entries storage (window-thread teardown). A later
+/// accidental use safely reallocates fresh storage instead of dangling.
+fn releaseEntriesStorage() void {
+    if (g_entries_storage) |e| {
+        std.heap.page_allocator.destroy(e);
+        g_entries_storage = null;
+    }
+    g_entry_count = 0;
+}
 
 const AsyncListKind = enum { rescan, expand };
 
@@ -290,13 +312,13 @@ pub fn selectEntry(idx: usize) ?EntryView {
 }
 
 pub fn toggleDirectoryAt(idx: usize) bool {
-    if (idx >= g_entry_count or !g_entries[idx].is_dir) return false;
+    if (idx >= g_entry_count or !entries()[idx].is_dir) return false;
     toggleExpand(idx);
     return true;
 }
 
 fn entryViewAssumeValid(idx: usize) EntryView {
-    const entry = &g_entries[idx];
+    const entry = &entries()[idx];
     return .{
         .index = idx,
         .name = entry.name_buf[0..entry.name_len],
@@ -656,7 +678,7 @@ pub fn tickAsync() bool {
         setTransferStatus(.failed, if (job.resolve_root) "SSH pwd failed" else "SSH list failed");
         if (job.kind == .expand) {
             if (findEntryByPath(job.path_buf[0..job.path_len])) |idx| {
-                g_entries[idx].expanded = false;
+                entries()[idx].expanded = false;
             }
         }
         return true;
@@ -679,7 +701,7 @@ pub fn tickAsync() bool {
         .expand => {
             const path = job.path_buf[0..job.path_len];
             const idx = findEntryByPath(path) orelse return true;
-            if (!g_entries[idx].expanded) return true;
+            if (!entries()[idx].expanded) return true;
             _ = insertBackendChildren(idx + 1, job.entries[0..job.count], job.depth, path, '/');
         },
     }
@@ -756,7 +778,7 @@ pub fn refresh() void {
     g_refresh_keep_path_len = 0;
     if (g_selected) |sel| {
         if (sel < g_entry_count) {
-            const p = g_entries[sel].path_buf[0..g_entries[sel].path_len];
+            const p = entries()[sel].path_buf[0..entries()[sel].path_len];
             const n: u16 = @intCast(@min(p.len, g_refresh_keep_path.len));
             @memcpy(g_refresh_keep_path[0..n], p[0..n]);
             g_refresh_keep_path_len = n;
@@ -807,19 +829,19 @@ fn loadBackendEntries(
     const perf = ui_perf.begin("file_explorer.load_backend_entries");
     defer perf.end();
 
-    const capacity = g_entries.len - g_entry_count;
+    const capacity = entries().len - g_entry_count;
     if (capacity == 0) return .ok;
 
     const allocator = std.heap.page_allocator;
-    const entries = allocator.alloc(file_backend.Entry, capacity) catch return .open_failed;
-    defer allocator.free(entries);
+    const backend_entries = allocator.alloc(file_backend.Entry, capacity) catch return .open_failed;
+    defer allocator.free(backend_entries);
 
-    const result = file_backend.list(allocator, backend, path, entries);
+    const result = file_backend.list(allocator, backend, path, backend_entries);
     if (result.status != .ok) return result.status;
 
-    for (entries[0..result.count]) |*entry| {
-        if (g_entry_count >= g_entries.len) break;
-        if (copyBackendEntry(&g_entries[g_entry_count], entry, depth, parent_path, sep)) {
+    for (backend_entries[0..result.count]) |*entry| {
+        if (g_entry_count >= entries().len) break;
+        if (copyBackendEntry(&entries()[g_entry_count], entry, depth, parent_path, sep)) {
             g_entry_count += 1;
         }
     }
@@ -872,9 +894,9 @@ fn pathEndsWithSeparator(path: []const u8, sep: u8) bool {
 
 pub fn toggleExpand(idx: usize) void {
     if (idx >= g_entry_count) return;
-    if (!g_entries[idx].is_dir) return;
+    if (!entries()[idx].is_dir) return;
 
-    if (g_entries[idx].expanded) {
+    if (entries()[idx].expanded) {
         collapse(idx);
     } else {
         if (g_mode == .remote and g_has_ssh_conn) {
@@ -888,7 +910,7 @@ pub fn toggleExpand(idx: usize) void {
 }
 
 fn expandRemote(idx: usize) void {
-    const entry = &g_entries[idx];
+    const entry = &entries()[idx];
     entry.expanded = true;
     const path = entry.path_buf[0..entry.path_len];
     if (startAsyncList(.expand, path, entry.depth + 1, false) == .blocked) {
@@ -898,13 +920,13 @@ fn expandRemote(idx: usize) void {
 }
 
 fn expandWithBackend(idx: usize, backend: file_backend.Backend, sep: u8) void {
-    const entry = &g_entries[idx];
+    const entry = &entries()[idx];
     entry.expanded = true;
 
     const path = entry.path_buf[0..entry.path_len];
     const child_depth = entry.depth + 1;
     const insert_pos = idx + 1;
-    const max_new = g_entries.len - g_entry_count;
+    const max_new = entries().len - g_entry_count;
     if (max_new == 0) return;
 
     const allocator = std.heap.page_allocator;
@@ -940,10 +962,10 @@ fn insertBackendChildren(
     sep: u8,
 ) usize {
     if (backend_entries.len == 0) return 0;
-    if (g_entry_count >= g_entries.len) return 0;
+    if (g_entry_count >= entries().len) return 0;
 
     const allocator = std.heap.page_allocator;
-    const max_new = g_entries.len - g_entry_count;
+    const max_new = entries().len - g_entry_count;
     const flat_children = allocator.alloc(FlatEntry, @min(backend_entries.len, max_new)) catch {
         return 0;
     };
@@ -962,19 +984,19 @@ fn insertBackendChildren(
     if (insert_pos < g_entry_count) {
         std.mem.copyBackwards(
             FlatEntry,
-            g_entries[insert_pos + filled .. g_entry_count + filled],
-            g_entries[insert_pos..g_entry_count],
+            entries()[insert_pos + filled .. g_entry_count + filled],
+            entries()[insert_pos..g_entry_count],
         );
     }
 
-    @memcpy(g_entries[insert_pos .. insert_pos + filled], flat_children[0..filled]);
+    @memcpy(entries()[insert_pos .. insert_pos + filled], flat_children[0..filled]);
     g_entry_count += filled;
     return filled;
 }
 
 fn findEntryByPath(path: []const u8) ?usize {
     for (0..g_entry_count) |idx| {
-        const entry_path = g_entries[idx].path_buf[0..g_entries[idx].path_len];
+        const entry_path = entries()[idx].path_buf[0..entries()[idx].path_len];
         if (std.mem.eql(u8, entry_path, path)) return idx;
     }
     return null;
@@ -986,9 +1008,9 @@ fn startAsyncList(kind: AsyncListKind, path: []const u8, depth: u16, resolve_roo
     if (g_async_job != null) return queueAsyncList(kind, path, depth, resolve_root);
 
     const allocator = std.heap.page_allocator;
-    const entries = allocator.alloc(file_backend.Entry, MAX_ENTRIES) catch return .blocked;
+    const backend_entries = allocator.alloc(file_backend.Entry, MAX_ENTRIES) catch return .blocked;
     const job = allocator.create(AsyncListJob) catch {
-        allocator.free(entries);
+        allocator.free(backend_entries);
         return .blocked;
     };
 
@@ -999,12 +1021,12 @@ fn startAsyncList(kind: AsyncListKind, path: []const u8, depth: u16, resolve_roo
         .path_len = path.len,
         .depth = depth,
         .resolve_root = resolve_root,
-        .entries = entries,
+        .entries = backend_entries,
     };
     @memcpy(job.path_buf[0..path.len], path);
 
     const thread = std.Thread.spawn(.{}, asyncListThread, .{job}) catch {
-        allocator.free(entries);
+        allocator.free(backend_entries);
         allocator.destroy(job);
         return .blocked;
     };
@@ -1390,6 +1412,7 @@ pub fn deinit() void {
     g_pending_async_list = null;
     g_loading = false;
     clearHistoryRows();
+    releaseEntriesStorage();
 }
 
 fn setLoading(msg: []const u8) void {
@@ -1407,13 +1430,13 @@ fn expandWsl(idx: usize) void {
 }
 
 fn collapse(idx: usize) void {
-    var entry = &g_entries[idx];
+    var entry = &entries()[idx];
     entry.expanded = false;
 
     // Remove all entries after idx with depth > entry.depth
     const base_depth = entry.depth;
     var end = idx + 1;
-    while (end < g_entry_count and g_entries[end].depth > base_depth) {
+    while (end < g_entry_count and entries()[end].depth > base_depth) {
         end += 1;
     }
 
@@ -1424,7 +1447,7 @@ fn collapse(idx: usize) void {
     const remaining = g_entry_count - end;
     var k: usize = 0;
     while (k < remaining) : (k += 1) {
-        g_entries[idx + 1 + k] = g_entries[end + k];
+        entries()[idx + 1 + k] = entries()[end + k];
     }
     g_entry_count -= remove_count;
 
@@ -1474,7 +1497,7 @@ pub fn startRename() void {
     const sel = g_selected orelse return;
     if (sel >= g_entry_count) return;
     g_op_mode = .rename;
-    const entry = &g_entries[sel];
+    const entry = &entries()[sel];
     @memcpy(g_input_buf[0..entry.name_len], entry.name_buf[0..entry.name_len]);
     g_input_len = entry.name_len;
 }
@@ -1516,7 +1539,7 @@ fn commitRename() void {
     if (sel >= g_entry_count) return;
     if (g_input_len == 0) return;
 
-    const entry = &g_entries[sel];
+    const entry = &entries()[sel];
     const old_path = entry.path_buf[0..entry.path_len];
     const new_name = g_input_buf[0..g_input_len];
 
@@ -1567,7 +1590,7 @@ fn commitDelete() void {
     const sel = g_selected orelse return;
     if (sel >= g_entry_count) return;
 
-    const entry = &g_entries[sel];
+    const entry = &entries()[sel];
     const path = entry.path_buf[0..entry.path_len];
 
     const cwd = std.fs.cwd();
@@ -1583,7 +1606,7 @@ fn commitDelete() void {
 fn getSelectedParentPath() []const u8 {
     if (g_selected) |sel| {
         if (sel < g_entry_count) {
-            const entry = &g_entries[sel];
+            const entry = &entries()[sel];
             if (entry.is_dir and entry.expanded) {
                 return entry.path_buf[0..entry.path_len];
             }
@@ -1643,7 +1666,7 @@ pub fn handleAction(act: Action) void {
             // (toggleExpand also guards is_dir, so the inner check just avoids
             // the call, preserving the original conditional shape).
             if (g_selected) |sel| {
-                if (sel < g_entry_count and g_entries[sel].is_dir) {
+                if (sel < g_entry_count and entries()[sel].is_dir) {
                     toggleExpand(sel);
                 }
             }
@@ -1739,7 +1762,7 @@ pub fn downloadSelected(local_dir: []const u8) void {
     const sel = g_selected orelse return;
     if (sel >= g_entry_count) return;
 
-    const entry = &g_entries[sel];
+    const entry = &entries()[sel];
 
     const name = entry.name_buf[0..entry.name_len];
     if (!isSafeDownloadEntryName(name)) {
@@ -2109,13 +2132,13 @@ test "file_explorer: download refuses remote entry names that can escape the des
     g_ssh_conn = .{};
     g_selected = 0;
     g_entry_count = 1;
-    g_entries[0] = .{};
+    entries()[0] = .{};
     const evil_name = "..\\..\\evil";
-    @memcpy(g_entries[0].name_buf[0..evil_name.len], evil_name);
-    g_entries[0].name_len = evil_name.len;
+    @memcpy(entries()[0].name_buf[0..evil_name.len], evil_name);
+    entries()[0].name_len = evil_name.len;
     const evil_path = "/srv/..\\..\\evil";
-    @memcpy(g_entries[0].path_buf[0..evil_path.len], evil_path);
-    g_entries[0].path_len = evil_path.len;
+    @memcpy(entries()[0].path_buf[0..evil_path.len], evil_path);
+    entries()[0].path_len = evil_path.len;
 
     downloadSelected("/tmp/wispterm-test-downloads");
 
@@ -2383,23 +2406,23 @@ test "file_explorer: handleAction toggle collapses an expanded directory and no-
     g_panel_mode = .files;
     g_mode = .local;
     g_entry_count = 3;
-    g_entries[0] = .{ .is_dir = true, .expanded = true, .depth = 0 };
+    entries()[0] = .{ .is_dir = true, .expanded = true, .depth = 0 };
     // One synthetic child of entry 0, so collapse has something to remove.
-    g_entries[1] = .{ .is_dir = false, .expanded = false, .depth = 1 };
-    g_entries[2] = .{ .is_dir = false, .expanded = false, .depth = 0 };
+    entries()[1] = .{ .is_dir = false, .expanded = false, .depth = 1 };
+    entries()[2] = .{ .is_dir = false, .expanded = false, .depth = 0 };
 
     // Selected directory (expanded): Enter toggles it to collapsed and drops
     // the child row.
     g_selected = 0;
     handleAction(.toggle_selected_expand);
-    try std.testing.expect(!g_entries[0].expanded);
+    try std.testing.expect(!entries()[0].expanded);
     try std.testing.expectEqual(@as(usize, 2), g_entry_count);
 
     // Selected file: Enter is a no-op (entry untouched).
-    g_entries[1] = .{ .is_dir = false, .expanded = false, .depth = 0 };
+    entries()[1] = .{ .is_dir = false, .expanded = false, .depth = 0 };
     g_selected = 1;
     handleAction(.toggle_selected_expand);
-    try std.testing.expect(!g_entries[1].expanded);
+    try std.testing.expect(!entries()[1].expanded);
     try std.testing.expectEqual(@as(usize, 2), g_entry_count);
 
     // No selection: Enter is a no-op (no crash).
@@ -2587,8 +2610,8 @@ test "file_explorer: unchanged terminal target preserves file state" {
 }
 
 fn setFlatEntryPathForTest(idx: usize, path: []const u8) void {
-    @memcpy(g_entries[idx].path_buf[0..path.len], path);
-    g_entries[idx].path_len = @intCast(path.len);
+    @memcpy(entries()[idx].path_buf[0..path.len], path);
+    entries()[idx].path_len = @intCast(path.len);
 }
 
 test "file_explorer: refresh restore re-selects entry by path" {

--- a/src/renderer/file_explorer_renderer.zig
+++ b/src/renderer/file_explorer_renderer.zig
@@ -228,7 +228,7 @@ fn renderFiles(
             .visible => |row| row,
         };
 
-        const entry = &file_explorer.g_entries[i];
+        const entry = &file_explorer.entries()[i];
         const indent = @as(f32, @floatFromInt(entry.depth)) * file_explorer.INDENT_WIDTH;
 
         // Hover detection

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -108,54 +108,77 @@ pub const copilotEdgeHandleSetTarget = copilot_edge_handle.setProximityTarget;
 pub const copilotEdgeHandleSetHovered = copilot_edge_handle.setHovered;
 pub const copilotEdgeHandleStartShimmer = copilot_edge_handle.startShimmer;
 
-threadlocal var g_overlay_state: overlay_state.OverlayState = .{};
+// Heap-allocated on first use: as a direct `threadlocal` struct this was the
+// single largest entry in the TLS template (~2.3 MB), which Windows commits
+// privately for EVERY thread — see renderer/gpu/d3d11/vertex.zig for the
+// same pattern. Only window/render threads ever touch overlay state.
+threadlocal var g_overlay_state: ?*overlay_state.OverlayState = null;
+
+fn overlayState() *overlay_state.OverlayState {
+    if (g_overlay_state == null) {
+        const s = std.heap.page_allocator.create(overlay_state.OverlayState) catch
+            @panic("out of memory allocating overlay state");
+        s.* = .{};
+        g_overlay_state = s;
+    }
+    return g_overlay_state.?;
+}
+
+/// Free this thread's overlay state storage (window-thread teardown). A later
+/// accidental use safely reallocates fresh state instead of dangling.
+pub fn releaseThreadState() void {
+    if (g_overlay_state) |s| {
+        std.heap.page_allocator.destroy(s);
+        g_overlay_state = null;
+    }
+}
 
 fn settingsState() *settings_page.State {
-    return &g_overlay_state.settings;
+    return &overlayState().settings;
 }
 
 fn toastState() *toasts.State {
-    return &g_overlay_state.toasts;
+    return &overlayState().toasts;
 }
 
 fn confirmState() *confirm_modals.State {
-    return &g_overlay_state.confirms;
+    return &overlayState().confirms;
 }
 
 fn sshState() *ssh_profiles.State {
-    return &g_overlay_state.ssh;
+    return &overlayState().ssh;
 }
 
 fn mcpState() *mcp_servers.State {
-    return &g_overlay_state.mcp;
+    return &overlayState().mcp;
 }
 
 fn assistantProfiles() *assistant_profiles.State {
-    return &g_overlay_state.assistant_profiles;
+    return &overlayState().assistant_profiles;
 }
 
 fn feishuForm() *overlay_state.FeishuFormState {
-    return &g_overlay_state.feishu;
+    return &overlayState().feishu;
 }
 
 fn feishuConfig() *feishu_config.State {
-    return &g_overlay_state.feishu.config;
+    return &overlayState().feishu.config;
 }
 
 fn quickAiForm() *overlay_state.QuickAiFormState {
-    return &g_overlay_state.quick_ai;
+    return &overlayState().quick_ai;
 }
 
 fn quickAi() *quick_ai_config.State {
-    return &g_overlay_state.quick_ai.config;
+    return &overlayState().quick_ai.config;
 }
 
 fn launcherState() *session_launcher.State {
-    return &g_overlay_state.session;
+    return &overlayState().session;
 }
 
 fn commandPaletteState() *command_palette_state.State {
-    return &g_overlay_state.command_palette;
+    return &overlayState().command_palette;
 }
 
 fn switchModelTarget() ?*AppWindow.ai_chat.Session {
@@ -270,10 +293,10 @@ const PaletteItem = union(enum) {
 
 // User-defined snippets: `<config-dir>/snippets/*.md`, parsed by command_registry
 // (frontmatter name=title, description=detail, body=text sent to the active PTY).
-// State lives in g_overlay_state.snippets; reloaded each time the palette opens
+// State lives in overlayState().snippets; reloaded each time the palette opens
 // (see commandPaletteOpenWithMode).
 fn snippetsState() *overlay_state.SnippetState {
-    return &g_overlay_state.snippets;
+    return &overlayState().snippets;
 }
 
 fn loadSnippets() void {
@@ -2312,14 +2335,14 @@ threadlocal var g_ai_history_source_visible: bool = false;
 // Feishu credential form rides on the session-launcher overlay plumbing
 // (render/input/hit-test are all gated by sessionLauncherVisible()); openFeishuConfigForm
 // sets g_session_launcher_visible so those gates fire, then feishuForm().visible
-// short-circuits the launcher branches. State lives in g_overlay_state.feishu (not a new
+// short-circuits the launcher branches. State lives in overlayState().feishu (not a new
 // top-level global — see global_state_guard; not in command_center_state — Task 2 scope).
 // Launcher transient state (AI history source selection + switch-model target)
-// now lives in `g_overlay_state.session` (session_launcher.State), reached
+// now lives in `overlayState().session` (session_launcher.State), reached
 // through `launcherState()` / `switchModelTarget()` / `setSwitchModelTarget()`.
-// SSH list/form state now lives in `g_overlay_state.ssh` (ssh_profiles.State),
+// SSH list/form state now lives in `overlayState().ssh` (ssh_profiles.State),
 // reached through `sshState()`.
-// AI list/form state now lives in `g_overlay_state.assistant_profiles` (assistant_profiles.State),
+// AI list/form state now lives in `overlayState().assistant_profiles` (assistant_profiles.State),
 // reached through `assistantProfiles()`.
 
 pub const RemoteAgentOpenResult = enum {
@@ -6897,49 +6920,49 @@ test "overlays: settings page state is owned by OverlayState" {
     settingsPageOpen();
     defer settingsPageClose();
 
-    try std.testing.expect(g_overlay_state.settings.visible);
+    try std.testing.expect(overlayState().settings.visible);
     try std.testing.expect(settingsPageVisible());
 }
 
 test "overlays: status toast state is owned by OverlayState" {
-    const saved = g_overlay_state.toasts.copy;
-    defer g_overlay_state.toasts.copy = saved;
+    const saved = overlayState().toasts.copy;
+    defer overlayState().toasts.copy = saved;
 
     showStatusToast("hello");
 
-    try std.testing.expectEqualStrings("hello", g_overlay_state.toasts.copy.text().?);
+    try std.testing.expectEqualStrings("hello", overlayState().toasts.copy.text().?);
 }
 
 test "overlays: transfer toast state is owned by OverlayState" {
-    const saved = g_overlay_state.toasts.transfer;
-    defer g_overlay_state.toasts.transfer = saved;
+    const saved = overlayState().toasts.transfer;
+    defer overlayState().toasts.transfer = saved;
 
     showTransferToast(.download, .in_progress, "file.txt");
 
-    try std.testing.expect(g_overlay_state.toasts.transfer.sticky);
-    try std.testing.expect(g_overlay_state.toasts.transfer.clickable);
+    try std.testing.expect(overlayState().toasts.transfer.sticky);
+    try std.testing.expect(overlayState().toasts.transfer.clickable);
 }
 
 test "overlays: sticky transfer toast does not keep render gate active forever" {
-    const saved_copy = g_overlay_state.toasts.copy;
-    const saved_transfer = g_overlay_state.toasts.transfer;
-    const saved_update = g_overlay_state.toasts.update;
+    const saved_copy = overlayState().toasts.copy;
+    const saved_transfer = overlayState().toasts.transfer;
+    const saved_update = overlayState().toasts.update;
     const saved_close_shortcut = close_confirm_state.deadline();
     const saved_remote_key_copied = g_remote_key_copied_until_ms;
     const saved_resize = resize.g_split_resize_overlay_until;
     const saved_debug_fps = g_debug_fps;
     defer {
-        g_overlay_state.toasts.copy = saved_copy;
-        g_overlay_state.toasts.transfer = saved_transfer;
-        g_overlay_state.toasts.update = saved_update;
+        overlayState().toasts.copy = saved_copy;
+        overlayState().toasts.transfer = saved_transfer;
+        overlayState().toasts.update = saved_update;
         close_confirm_state.setDeadline(saved_close_shortcut);
         g_remote_key_copied_until_ms = saved_remote_key_copied;
         resize.g_split_resize_overlay_until = saved_resize;
         g_debug_fps = saved_debug_fps;
     }
 
-    g_overlay_state.toasts.copy = .{};
-    g_overlay_state.toasts.update = .{};
+    overlayState().toasts.copy = .{};
+    overlayState().toasts.update = .{};
     close_confirm_state.clear();
     g_remote_key_copied_until_ms = 0;
     resize.g_split_resize_overlay_until = 0;
@@ -6947,8 +6970,8 @@ test "overlays: sticky transfer toast does not keep render gate active forever" 
 
     showTransferToast(.download, .in_progress, "file.txt");
 
-    const after_deadline = g_overlay_state.toasts.transfer.until_ms + 1;
-    try std.testing.expect(g_overlay_state.toasts.transfer.active(after_deadline));
+    const after_deadline = overlayState().toasts.transfer.until_ms + 1;
+    try std.testing.expect(overlayState().toasts.transfer.active(after_deadline));
     try std.testing.expect(!anyOverlayActive(after_deadline));
 }
 
@@ -7230,8 +7253,8 @@ test "overlays: short-window overlay boxes stay within the window" {
 }
 
 test "overlays: active download toast can be clicked for interruption" {
-    const saved = g_overlay_state.toasts.transfer;
-    defer g_overlay_state.toasts.transfer = saved;
+    const saved = overlayState().toasts.transfer;
+    defer overlayState().toasts.transfer = saved;
 
     showTransferToast(.download, .in_progress, "file.txt - 1.5 MB/s");
     try std.testing.expect(transferToastHitTestForTest(780, 534, 800, 600));
@@ -7271,13 +7294,13 @@ test "overlays: restore defaults confirm state is owned by OverlayState" {
     restoreDefaultsConfirmOpen();
     defer restoreDefaultsConfirmClose();
 
-    try std.testing.expect(g_overlay_state.confirms.restore_defaults_visible);
+    try std.testing.expect(overlayState().confirms.restore_defaults_visible);
     try std.testing.expect(restoreDefaultsConfirmVisible());
 }
 
 test "overlays: stored prompt URL does not affect latest release command URL" {
-    const saved = g_overlay_state.toasts.update;
-    defer g_overlay_state.toasts.update = saved;
+    const saved = overlayState().toasts.update;
+    defer overlayState().toasts.update = saved;
 
     showSshCwdFallbackPrompt();
 
@@ -7509,7 +7532,7 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     const saved_settings_visible = settingsState().visible;
     const saved_whats_new = g_whats_new_visible;
     const saved_integration_prompt = g_integration_prompt_visible;
-    const saved_confirms = g_overlay_state.confirms;
+    const saved_confirms = overlayState().confirms;
     const saved_session = g_session_launcher_visible;
     const saved_ssh_list = g_ssh_list_visible;
     const saved_ssh_form = g_ssh_form_visible;
@@ -7521,7 +7544,7 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
         settingsState().visible = saved_settings_visible;
         g_whats_new_visible = saved_whats_new;
         g_integration_prompt_visible = saved_integration_prompt;
-        g_overlay_state.confirms = saved_confirms;
+        overlayState().confirms = saved_confirms;
         g_session_launcher_visible = saved_session;
         g_ssh_list_visible = saved_ssh_list;
         g_ssh_form_visible = saved_ssh_form;
@@ -7535,7 +7558,7 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     settingsState().visible = false;
     g_whats_new_visible = false;
     g_integration_prompt_visible = false;
-    g_overlay_state.confirms = .{};
+    overlayState().confirms = .{};
     g_session_launcher_visible = false;
     g_ssh_list_visible = false;
     g_ssh_form_visible = false;
@@ -7593,20 +7616,20 @@ test "overlays: integration prompt opens scrolls and closes" {
 
 test "overlays: successful integration prompt copy closes modal and shows toast" {
     const saved_visible = g_integration_prompt_visible;
-    const saved_toast = g_overlay_state.toasts.copy;
+    const saved_toast = overlayState().toasts.copy;
     defer {
         g_integration_prompt_visible = saved_visible;
-        g_overlay_state.toasts.copy = saved_toast;
+        overlayState().toasts.copy = saved_toast;
     }
 
     g_integration_prompt_visible = true;
-    g_overlay_state.toasts.copy = .{};
+    overlayState().toasts.copy = .{};
 
     integrationPromptCopySucceeded();
 
     try std.testing.expect(!integrationPromptVisible());
-    try std.testing.expectEqualStrings("Integration prompt copied", g_overlay_state.toasts.copy.text().?);
-    try std.testing.expect(g_overlay_state.toasts.copy.until_ms > 0);
+    try std.testing.expectEqualStrings("Integration prompt copied", overlayState().toasts.copy.text().?);
+    try std.testing.expect(overlayState().toasts.copy.until_ms > 0);
 }
 
 fn showVersionToast() void {

--- a/src/renderer/ui_pipeline.zig
+++ b/src/renderer/ui_pipeline.zig
@@ -39,7 +39,20 @@ const batching_supported = gpu.active == .opengl;
 threadlocal var batch: Pipeline = .{ .program = 0, .vao = 0 };
 threadlocal var batch_instances: Buffer = .{ .handle = 0, .target = 0 };
 threadlocal var batch_quad: Buffer = .{ .handle = 0, .target = 0 };
-threadlocal var batcher: ui_batch.Batcher = .{};
+// GL-only UI glyph batcher, heap-allocated on first use (~180 KB — kept out
+// of the TLS template, which Windows commits privately for every thread; on
+// non-GL backends it never allocates at all).
+threadlocal var g_batcher: ?*ui_batch.Batcher = null;
+
+fn batcher() *ui_batch.Batcher {
+    if (g_batcher == null) {
+        const b = std.heap.page_allocator.create(ui_batch.Batcher) catch
+            @panic("out of memory allocating UI batcher");
+        b.* = .{};
+        g_batcher = b;
+    }
+    return g_batcher.?;
+}
 /// Shadow of the text pipeline's projection (set in setProjection); the batch
 /// draw applies it at flush time. Flushes happen before any projection change,
 /// so pending instances always use the projection they were issued under.
@@ -67,11 +80,11 @@ const GlSink = struct {
 /// Submit any pending batched UI draws. Registered into the gpu hooks; also
 /// called directly by frame tails that present without an endFrame (resize).
 pub fn flushBatch() void {
-    batcher.flush(GlSink{});
+    batcher().flush(GlSink{});
 }
 
 fn pipelineUseHook(program: gpu.ProgramHandle) void {
-    if (ui_batch.shouldFlushOnPipelineUse(batcher.pending(), program, batch.program)) flushBatch();
+    if (ui_batch.shouldFlushOnPipelineUse(batcher().pending(), program, batch.program)) flushBatch();
 }
 
 fn drawCallTick() void {
@@ -163,7 +176,10 @@ pub fn deinit() void {
     if (comptime batching_supported) {
         gpu.state.pre_change_hook = null;
         Pipeline.pre_use_hook = null;
-        batcher.count = 0;
+        if (g_batcher) |b| {
+            std.heap.page_allocator.destroy(b);
+            g_batcher = null;
+        }
         batch.deinit();
         batch_instances.deinit();
         batch_quad.deinit();
@@ -242,7 +258,7 @@ pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) 
     const b = color[2] * alpha + bg[2] * (1 - alpha);
     if (comptime batching_supported) {
         if (batch.program != 0) {
-            batcher.push(solid.handle, .{
+            batcher().push(solid.handle, .{
                 .x = x,
                 .y = y,
                 .w = w,
@@ -272,7 +288,7 @@ pub fn fillQuadAlpha(x: f32, y: f32, w: f32, h: f32, color: [3]f32, alpha: f32) 
 pub fn drawGlyph(rect: Rect, uv: Uv, tex: Texture, color: [3]f32) void {
     if (comptime batching_supported) {
         if (batch.program != 0) {
-            batcher.push(tex.handle, .{
+            batcher().push(tex.handle, .{
                 .x = rect.x,
                 .y = rect.y,
                 .w = rect.w,


### PR DESCRIPTION
## Summary
Follow-up to #510, fixing the remaining shared TLS base that both backends pay for. ELF symbol analysis of the Linux build ranked the offenders precisely: `renderer.overlays.g_overlay_state` (~2.3 MB), `file_explorer.g_entries` (~1.6 MB), and the GL-only `ui_pipeline.batcher` (~180 KB) — 95% of the ~4 MB template that Windows commits privately for **every** thread (~90 threads in a busy session).

Each moves to the pattern proven in #510 — threadlocal pointer, heap-allocated on first use, freed at window-thread teardown:
- **overlay state**: already accessed only through accessor fns inside overlays.zig; they now route through a lazy `overlayState()`. New `releaseThreadState()` runs in the window-unwind defer (after all pipeline-owning defers, LIFO).
- **file explorer entries**: `pub g_entries` array becomes a `pub fn entries()` accessor (one external caller in file_explorer_renderer.zig). Contents remain undefined-on-alloc, exactly matching the old `= undefined` initializer; freed in the existing `file_explorer.deinit()` (also resets `g_entry_count`). Two locals shadowing the new name were renamed `backend_entries`.
- **UI batcher**: internal lazy accessor; freed in the existing `ui_pipeline.deinit()`. Non-GL backends (`batching_supported == false`) now never allocate it at all — previously they carried the 180 KB as pure TLS waste.

Accessors `@panic` on OOM (they must return a valid pointer and a failed multi-MB alloc at UI init is fatal anyway); a use-after-release safely reallocates fresh state instead of dangling.

## Risk notes (checked)
- Threadlocal semantics are unchanged — any hypothetical cross-thread access was equally broken before (each thread saw its own TLS copy); the file-explorer async list thread fills its own heap slice (`job.entries`), never the flattened array.
- Pointers returned by the overlay accessors now point into a heap block that lives until window teardown — same effective lifetime as the old TLS storage.
- Reads before first write were already reading `undefined`/default state; behavior identical.

## Measured
| build | TLS template before | after |
|---|---:|---:|
| Windows d3d11 `.tls` | 3.87 MB/thread | **0.20 MB/thread** |
| Windows opengl `.tls` | 4.05 MB/thread | **0.20 MB/thread** |
| Linux ELF `.tdata` | 5.63 MB | 0.25 MB |

Expected field effect: clean-baseline Private drops by roughly (thread count × ~3.8 MB) on BOTH backends.

## Verification
- `zig build -Dgpu-backend=d3d11`, `zig build` (opengl), `zig build -Dtarget=x86_64-linux-gnu` all compile.
- `zig build test`, `zig build test-full`, `zig build test-full -Dgpu-backend=d3d11` all exit 0.
- Field check pending: rerun the clean-baseline Private A/B on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qsXkYqtZhmhY6ptkEEYZC