### PR TITLE
fix(remote): 远程 Web 控制台快照下发 VT 模式状态，修复全屏 TUI 无法回看历史

### DIFF
--- a/src/appwindow/remote_sync.zig
+++ b/src/appwindow/remote_sync.zig
@@ -121,7 +121,7 @@ fn appendLayoutJson(host: Host, allocator: std.mem.Allocator, out: *std.ArrayLis
             try out.appendSlice(allocator, ",\"cursorY\":");
             try out.print(allocator, "{d}", .{cursor_y});
             try out.appendSlice(allocator, ",\"snapshot\":\"");
-            const snapshot = surface_snapshots.buildRemoteSurfaceSnapshot(allocator, entry.surface, remote_snapshot.default_max_history_rows) catch null;
+            const snapshot = surface_snapshots.buildRemoteSurfaceSnapshotWithModes(allocator, entry.surface, remote_snapshot.default_max_history_rows) catch null;
             defer if (snapshot) |text| allocator.free(text);
             if (snapshot) |text| try remote.appendJsonString(out, allocator, text);
             try out.append(allocator, '"');

--- a/src/appwindow/surface_snapshots.zig
+++ b/src/appwindow/surface_snapshots.zig
@@ -49,6 +49,19 @@ pub fn buildRemoteSurfaceSnapshot(allocator: std.mem.Allocator, surface: *Surfac
     );
 }
 
+/// Web-console snapshot: plain text plus the host VT's mode state so the
+/// remote xterm mirrors desktop input behavior (issue #502). Text-only
+/// consumers keep using buildRemoteSurfaceSnapshot.
+pub fn buildRemoteSurfaceSnapshotWithModes(allocator: std.mem.Allocator, surface: *Surface, max_history_rows: usize) ![]u8 {
+    surface.render_state.mutex.lock();
+    defer surface.render_state.mutex.unlock();
+    return remote_snapshot.allocTerminalSnapshotWithModes(
+        allocator,
+        &surface.terminal,
+        max_history_rows,
+    );
+}
+
 pub fn activeSurfaceSnapshot(allocator: std.mem.Allocator) ?[]u8 {
     const surface = tab.activeSurface() orelse return null;
     // Jupyter-URL detection / web-remote mirror want the full scrollback, not the

--- a/src/remote_snapshot.zig
+++ b/src/remote_snapshot.zig
@@ -15,6 +15,64 @@ const RowSpace = enum {
     screen,
 };
 
+/// Web-console variant of `allocTerminalSnapshot`: wraps the plain-text dump
+/// with the escape sequences that mirror the host VT's input-affecting mode
+/// state (alternate screen, mouse tracking, bracketed paste, ...). Without
+/// them a remote xterm never learns that a full-screen TUI (issue #502:
+/// Claude Code) enabled mouse tracking before the client connected, so its
+/// wheel scrolls an empty local scrollback instead of reaching the app the
+/// way the desktop does. Plain-text consumers (agent tools, ctl, Jupyter
+/// detection) must keep using `allocTerminalSnapshot`.
+pub fn allocTerminalSnapshotWithModes(
+    allocator: std.mem.Allocator,
+    terminal: *const ghostty_vt.Terminal,
+    max_history_rows: usize,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    // Must precede the content so it lands in the same screen as on the host.
+    if (terminal.screens.active_key == .alternate)
+        try out.appendSlice(allocator, "\x1b[?1049h");
+
+    const text = try allocTerminalSnapshot(allocator, terminal, max_history_rows);
+    defer allocator.free(text);
+    try out.appendSlice(allocator, text);
+
+    try appendInputModes(allocator, &out, terminal);
+    return out.toOwnedSlice(allocator);
+}
+
+/// Emit only deviations from xterm defaults so a mode-less shell snapshot
+/// stays escape-free.
+fn appendInputModes(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    terminal: *const ghostty_vt.Terminal,
+) !void {
+    const modes = &terminal.modes;
+    if (modes.get(.cursor_keys)) try out.appendSlice(allocator, "\x1b[?1h");
+    if (!modes.get(.cursor_visible)) try out.appendSlice(allocator, "\x1b[?25l");
+    if (modes.get(.focus_event)) try out.appendSlice(allocator, "\x1b[?1004h");
+    if (modes.get(.bracketed_paste)) try out.appendSlice(allocator, "\x1b[?2004h");
+    // No ?1007 (alternate scroll): xterm.js doesn't implement it — on the alt
+    // buffer it always converts wheel to arrow keys, which is what we want.
+    switch (terminal.flags.mouse_event) {
+        .none => return,
+        .x10 => try out.appendSlice(allocator, "\x1b[?9h"),
+        .normal => try out.appendSlice(allocator, "\x1b[?1000h"),
+        .button => try out.appendSlice(allocator, "\x1b[?1002h"),
+        .any => try out.appendSlice(allocator, "\x1b[?1003h"),
+    }
+    switch (terminal.flags.mouse_format) {
+        .x10 => {},
+        .utf8 => try out.appendSlice(allocator, "\x1b[?1005h"),
+        .sgr => try out.appendSlice(allocator, "\x1b[?1006h"),
+        .urxvt => try out.appendSlice(allocator, "\x1b[?1015h"),
+        .sgr_pixels => try out.appendSlice(allocator, "\x1b[?1016h"),
+    }
+}
+
 pub fn allocTerminalSnapshot(
     allocator: std.mem.Allocator,
     terminal: *const ghostty_vt.Terminal,
@@ -173,6 +231,50 @@ test "agent snapshot caps history to the most recent rows but keeps the active s
 
     try std.testing.expect(std.mem.indexOf(u8, snapshot, "row1\r\n") == null);
     try std.testing.expect(std.mem.indexOf(u8, snapshot, "row13") != null);
+}
+
+test "web snapshot mirrors alt-screen and mouse-tracking modes (issue #502)" {
+    var terminal = try ghostty_vt.Terminal.init(std.testing.allocator, .{
+        .cols = 20,
+        .rows = 4,
+        .max_scrollback = 1024,
+    });
+    defer terminal.deinit(std.testing.allocator);
+
+    var stream = terminal.vtStream();
+    defer stream.deinit();
+    // The modes Claude Code sets at startup, captured from a live PTY.
+    stream.nextSlice("\x1b[?1049h\x1b[?1003h\x1b[?1006h\x1b[?1004h\x1b[?2004hTUI FRAME");
+
+    const snapshot = try allocTerminalSnapshotWithModes(std.testing.allocator, &terminal, 1024);
+    defer std.testing.allocator.free(snapshot);
+
+    // Alt-screen switch must precede the content so it lands in the alt buffer.
+    try std.testing.expect(std.mem.startsWith(u8, snapshot, "\x1b[?1049h"));
+    const content_at = std.mem.indexOf(u8, snapshot, "TUI FRAME").?;
+    for ([_][]const u8{ "\x1b[?1003h", "\x1b[?1006h", "\x1b[?1004h", "\x1b[?2004h" }) |mode| {
+        try std.testing.expect(std.mem.indexOfPos(u8, snapshot, content_at, mode) != null);
+    }
+}
+
+test "web snapshot of a plain shell stays escape-free and keeps scrollback" {
+    var terminal = try ghostty_vt.Terminal.init(std.testing.allocator, .{
+        .cols = 16,
+        .rows = 3,
+        .max_scrollback = 1024,
+    });
+    defer terminal.deinit(std.testing.allocator);
+
+    var stream = terminal.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("line1\r\nline2\r\nline3\r\nline4\r\nline5");
+
+    const snapshot = try allocTerminalSnapshotWithModes(std.testing.allocator, &terminal, 1024);
+    defer std.testing.allocator.free(snapshot);
+
+    try std.testing.expect(std.mem.indexOfScalar(u8, snapshot, 0x1b) == null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "line1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, snapshot, "line5") != null);
 }
 
 test "soft-wrapped line is joined into one logical line (no \\r\\n mid-wrap)" {


### PR DESCRIPTION
Fixes #502

## 根因

Issue 中抓包看到的三个现象（快照行数恰好等于 rows、输出流 LF=0 / CUP 数百次、必须回桌面端滚动才能"激活"）都指向同一个根因，但不是"scrollback 未下发"——**主屏 scrollback 其实早已随快照下发（最多 10000 行，`remote_snapshot.zig` 里有既有测试覆盖）**。真正的问题是：

1. **Claude Code 这类全屏 TUI 运行在 alternate screen 上**（本地 PTY 实测其启动序列含 `\x1b[?1049h`，且开启 `?1000h/?1002h/?1003h/?1006h` 完整鼠标追踪）。Alt screen 没有 scrollback，`total_rows == rows`，所以快照恰好等于可见屏行数——历史在应用内部，不在 VT scrollback 里。
2. **桌面端能回看**是因为主机 VT 知道鼠标追踪已开启：滚轮被编码成 SGR 鼠标报告发给 Claude Code，由它自己重绘旧内容。
3. **Web 端快照只有纯文本，从不携带模式状态**。浏览器 xterm.js 连接时 `?1049h`/`?1003h` 早已发生，它永远不知道主机处于 alt screen + 鼠标追踪状态，于是滚轮只滚本地（空的）scrollback——完全滚不动。刷新后同理。"回桌面滚动才激活"正是桌面滚轮触发 TUI 重绘、重绘字节流恰好镜像到了 Web。

## 修复

Web 控制台路径的快照包一层主机 VT 模式状态（只发与 xterm 默认值的偏差）：

- 内容前置 `?1049h`（alt screen 激活时），让内容落进正确的 buffer；
- 内容后追加 DECCKM、光标可见性、`?1004`（focus）、`?2004`（bracketed paste）、鼠标追踪级别（`?9/?1000/?1002/?1003`）与编码（`?1005/?1006/?1015/?1016`）。

xterm.js 回放快照时解释这些序列后：滚轮变成鼠标报告发回主机（无鼠标追踪的 alt-screen 应用则由 xterm.js 内建行为转方向键），TUI 自己重绘历史，Web 端获得与桌面一致的回看体验；刷新/重连后立即可用。普通 shell（主屏）的 10k 行 scrollback 快照行为不变，纯文本消费方（agent 工具、ctl、Jupyter 检测）继续用无转义快照。

不发 `?1007`：xterm.js 未实现该模式，其 alt buffer 上滚轮转方向键是无条件内建行为。

## 验证

- 新增 2 个测试：alt screen + 鼠标追踪模式镜像（用 Claude Code 实际启动序列驱动）；普通 shell 快照保持无转义且含 scrollback。
- `zig build test-full -Dtarget=aarch64-macos`：13926/14057 通过，唯一失败为已知 flaky 的 `tools.import` runArgvProbe 测试（与本改动无关，改动前同样失败）。
- `zig fmt --check build.zig src` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)