### PR TITLE
feat(assistant): collapse tool-call runs into one activity row; add /copy

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -175,6 +175,12 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
             exportAiChatMarkdown(session, mode);
         }
     }.cb);
+    // `/copy [full|clean]` puts the same Markdown on the clipboard instead.
+    ai_chat.setTranscriptCopyTrigger(struct {
+        fn cb(session: *ai_chat.Session, mode: ai_chat.MarkdownExportMode) void {
+            copyAiChatMarkdown(session, mode);
+        }
+    }.cb);
     // `/model [name]` switches the active session's profile (and summarizes the
     // prior context with the new model). Empty pending name => open the picker.
     ai_chat.setModelSwitchTrigger(struct {
@@ -3256,6 +3262,24 @@ fn exportAiChatMarkdown(session: *ai_chat.Session, mode: ai_chat.MarkdownExportM
         overlays.showStatusToast("Exported Markdown");
     }
     std.debug.print("Exported AI chat Markdown to {s}\n", .{path});
+}
+
+fn copyAiChatMarkdown(session: *ai_chat.Session, mode: ai_chat.MarkdownExportMode) void {
+    const allocator = g_allocator orelse return;
+
+    const markdown = session.allocMarkdownExport(allocator, mode) catch |err| {
+        log.warn("failed to render AI chat Markdown for copy: {}", .{err});
+        overlays.showStatusToast("Copy failed");
+        return;
+    };
+    defer allocator.free(markdown);
+
+    if (input.copyTextToClipboard(markdown)) {
+        overlays.showCopyToast(markdown.len);
+        g_force_rebuild = true;
+    } else {
+        overlays.showStatusToast("Copy failed");
+    }
 }
 
 pub fn currentTitlebarHeight() f32 {

--- a/src/assistant/conversation/composer.zig
+++ b/src/assistant/conversation/composer.zig
@@ -177,6 +177,7 @@ pub const SlashCommand = enum {
     permission,
     cwd,
     export_markdown,
+    copy_transcript,
     distill,
     loop,
     watch,
@@ -257,6 +258,10 @@ pub const slash_command_entries = [_]SlashCommandEntry{
     .{
         .suggestion = .{ .command = "/export", .description = "export conversation as Markdown" },
         .action = .export_markdown,
+    },
+    .{
+        .suggestion = .{ .command = "/copy", .description = "copy conversation to clipboard (add full for tool detail)" },
+        .action = .copy_transcript,
     },
     .{
         .suggestion = .{ .command = "/distill", .description = "distill this conversation into a reusable skill" },

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -106,6 +106,17 @@ pub const Message = struct {
     is_context_summary: bool = false,
     reasoning_collapsed: bool = true,
     reasoning_auto_expand: bool = false,
+    /// Collapsed state of the activity group this message starts. Only read on
+    /// the first message of a run of groupable tool messages (see
+    /// `groupableTool`); the whole run renders as one header row while true.
+    tool_group_collapsed: bool = true,
+
+    /// True when this message can merge into an activity group with adjacent
+    /// tool messages: a real tool card that is not a context summary and not
+    /// live (auto-expanded messages render individually while a request runs).
+    pub fn groupableTool(self: Message) bool {
+        return self.role == .tool and !self.is_context_summary and !self.content_auto_expand;
+    }
 
     pub fn deinit(self: Message, allocator: std.mem.Allocator) void {
         allocator.free(self.content);
@@ -120,6 +131,14 @@ pub const Message = struct {
         }
     }
 };
+
+/// First index of the run of groupable tool messages containing `index`.
+/// The renderer and the group toggle both anchor group state here.
+pub fn toolRunStart(msgs: []const Message, index: usize) usize {
+    var start = index;
+    while (start > 0 and msgs[start - 1].groupableTool()) start -= 1;
+    return start;
+}
 
 pub const MarkdownExportMode = enum {
     full,
@@ -370,6 +389,7 @@ const DeferredAction = union(enum) {
     copilot_conversation_picker,
     model_switch_picker,
     export_markdown: MarkdownExportMode,
+    copy_transcript: MarkdownExportMode,
 };
 
 /// Result of running a built-in command under the lock: the (optional) history
@@ -393,7 +413,9 @@ fn fireDeferredAction(session: *Session, action: DeferredAction) void {
         .model_switch_picker => if (g_model_switch_trigger) |t| t(session),
         // Targets the session that submitted `/export` (copilot sidebar OR a tab),
         // not the active tab — they can differ.
-        .export_markdown => |mode| if (g_markdown_export_trigger) |t| t(session, mode),
+        .export_markdown => |mode| if (g_transcript_sink_triggers.export_markdown) |t| t(session, mode),
+        // Targets the session that submitted `/copy` (copilot sidebar OR a tab).
+        .copy_transcript => |mode| if (g_transcript_sink_triggers.copy) |t| t(session, mode),
     }
 }
 
@@ -406,7 +428,13 @@ var g_default_working_dir_len: usize = 0;
 var g_session_id_counter = std.atomic.Value(u64).init(1);
 var g_session_resume_trigger: ?*const fn () void = null;
 var g_copilot_picker_trigger: ?*const fn () void = null;
-var g_markdown_export_trigger: ?*const fn (*Session, MarkdownExportMode) void = null;
+/// Sinks for the rendered conversation Markdown: `/export` writes a file,
+/// `/copy` writes the clipboard. One struct to respect the g_* global ceiling.
+const TranscriptSinkTriggers = struct {
+    export_markdown: ?*const fn (*Session, MarkdownExportMode) void = null,
+    copy: ?*const fn (*Session, MarkdownExportMode) void = null,
+};
+var g_transcript_sink_triggers: TranscriptSinkTriggers = .{};
 var g_model_switch_trigger: ?*const fn (*Session) void = null;
 threadlocal var g_dynamic_tool_specs: []ai_chat_protocol.DynamicToolSpec = &.{};
 threadlocal var g_dynamic_tool_specs_owned: bool = false;
@@ -473,7 +501,14 @@ pub fn setModelSwitchTrigger(cb: ?*const fn (*Session) void) void {
 /// Markdown. Fired AFTER the session mutex unlocks, because the export reads the
 /// session under the SAME mutex (`allocMarkdownExport`) and would otherwise deadlock.
 pub fn setMarkdownExportTrigger(cb: ?*const fn (*Session, MarkdownExportMode) void) void {
-    g_markdown_export_trigger = cb;
+    g_transcript_sink_triggers.export_markdown = cb;
+}
+
+/// Wire the callback that `/copy [full|clean]` fires to put the conversation
+/// Markdown on the clipboard. Fired AFTER the session mutex unlocks, because
+/// the copy reads the session under the SAME mutex (`allocMarkdownExport`).
+pub fn setTranscriptCopyTrigger(cb: ?*const fn (*Session, MarkdownExportMode) void) void {
+    g_transcript_sink_triggers.copy = cb;
 }
 threadlocal var g_tool_host: ?ToolHost = null;
 
@@ -857,6 +892,9 @@ fn slashCommandOutput(allocator: std.mem.Allocator, command: SlashCommand) ![]u8
         // .model_switch suppresses output and defers to the picker / by-name path;
         // this path is never reached, but the arm is required for exhaustiveness.
         .model_switch => allocator.dupe(u8, ""),
+        // .copy_transcript suppresses output (the copied Markdown must not
+        // include its own progress message); this path is never reached.
+        .copy_transcript => allocator.dupe(u8, ""),
     };
 }
 
@@ -2107,6 +2145,18 @@ pub const Session = struct {
         return allocator.dupe(u8, content[s..e]);
     }
 
+    /// Toggle the collapsed state of the activity group containing
+    /// `message_index`. The state lives on the run's first message; membership
+    /// is derived per frame, so appended messages join the group automatically.
+    pub fn toggleToolGroupCollapsed(self: *Session, message_index: usize) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const msgs = self.messages.items;
+        if (message_index >= msgs.len or !msgs[message_index].groupableTool()) return;
+        const start = toolRunStart(msgs, message_index);
+        self.messages.items[start].tool_group_collapsed = !msgs[start].tool_group_collapsed;
+    }
+
     pub fn toggleToolMessageCollapsed(self: *Session, message_index: usize) void {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -2847,6 +2897,16 @@ pub const Session = struct {
                 .resume_picker,
             .export_markdown => result.deferred = .{
                 .export_markdown = if (std.mem.eql(u8, std.mem.trim(u8, arg, " \t\r\n"), "full")) .full else .clean,
+            },
+            .copy_transcript => {
+                // Suppress the transcript message: it would be appended before
+                // the deferred copy fires and pollute the copied Markdown.
+                result.deferred = .{
+                    .copy_transcript = if (std.mem.eql(u8, std.mem.trim(u8, arg, " \t\r\n"), "full")) .full else .clean,
+                };
+                self.clearSubmittedInputLocked();
+                if (!self.request_inflight) self.setStatusLocked("Ready");
+                result.suppress_output = true;
             },
             .loop => self.runLoopCommandLocked(.loop, arg, &result),
             .watch => self.runLoopCommandLocked(.watch, arg, &result),
@@ -5531,9 +5591,9 @@ test "ai chat slash command suggestions show and filter from input" {
     try std.testing.expectEqual(slash_command_entries.len, session.slashCommandSuggestionCount());
     try std.testing.expectEqualStrings("/skills", session.slashCommandSuggestionAt(0).?.command);
 
-    // "/c" filters to /commands, /clear, /cwd.
+    // "/c" filters to /commands, /clear, /cwd, /copy.
     session.appendInputText("c");
-    try std.testing.expectEqual(@as(usize, 3), session.slashCommandSuggestionCount());
+    try std.testing.expectEqual(@as(usize, 4), session.slashCommandSuggestionCount());
     try std.testing.expectEqualStrings("/commands", session.slashCommandSuggestionAt(0).?.command);
 }
 
@@ -5712,6 +5772,61 @@ var test_export_session: ?*Session = null;
 fn testExportHook(session: *Session, mode: MarkdownExportMode) void {
     test_export_session = session;
     test_export_mode = mode;
+}
+
+test "/copy via submit fires the transcript copy trigger with parsed mode" {
+    const a = std.testing.allocator;
+    setTranscriptCopyTrigger(testExportHook);
+    defer setTranscriptCopyTrigger(null);
+    var session = try Session.init(a, "chat", "https://api.example.com", "key", "m1", "sys", "false", "", "false", "false");
+    defer session.deinit();
+    test_export_mode = null;
+    test_export_session = null;
+    session.appendInputText("/copy full");
+    session.submit();
+    try std.testing.expectEqual(session, test_export_session.?);
+    try std.testing.expectEqual(MarkdownExportMode.full, test_export_mode.?);
+    // Suppressed output: /copy must not append a transcript message, or the
+    // copied Markdown would include it.
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
+
+    test_export_mode = null;
+    test_export_session = null;
+    session.appendInputText("/copy");
+    session.submit();
+    try std.testing.expectEqual(MarkdownExportMode.clean, test_export_mode.?);
+}
+
+test "toolGroupCollapsed: toggle from any member flips the run's first message" {
+    const a = std.testing.allocator;
+    var session = try Session.init(a, "chat", "https://api.example.com", "key", "m1", "sys", "false", "", "false", "false");
+    defer session.deinit();
+    try session.messages.append(a, .{ .role = .user, .content = try a.dupe(u8, "hi") });
+    try session.messages.append(a, .{ .role = .tool, .content = try a.dupe(u8, "running exec one"), .content_collapsed = true });
+    try session.messages.append(a, .{ .role = .tool, .content = try a.dupe(u8, "running exec two"), .content_collapsed = true });
+    try session.messages.append(a, .{ .role = .tool, .content = try a.dupe(u8, "running exec three"), .content_collapsed = true });
+
+    // Default: the run is collapsed into a group anchored at index 1.
+    try std.testing.expect(session.messages.items[1].tool_group_collapsed);
+    try std.testing.expectEqual(@as(usize, 1), toolRunStart(session.messages.items, 3));
+
+    // Toggling via a non-first member expands the group at its start.
+    session.toggleToolGroupCollapsed(3);
+    try std.testing.expect(!session.messages.items[1].tool_group_collapsed);
+    session.toggleToolGroupCollapsed(1);
+    try std.testing.expect(session.messages.items[1].tool_group_collapsed);
+
+    // Non-groupable targets are ignored: user bubbles and live (auto-expanded)
+    // tool cards never anchor or toggle a group.
+    session.toggleToolGroupCollapsed(0);
+    try std.testing.expect(session.messages.items[1].tool_group_collapsed);
+    session.messages.items[2].content_auto_expand = true;
+    session.toggleToolGroupCollapsed(2);
+    try std.testing.expect(session.messages.items[1].tool_group_collapsed);
+    try std.testing.expect(session.messages.items[2].tool_group_collapsed);
+
+    // A live card splits the run: index 3 now anchors its own (length-1) run.
+    try std.testing.expectEqual(@as(usize, 3), toolRunStart(session.messages.items, 3));
 }
 
 test "/export via submit fires the export trigger with submitting session and parsed mode" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -5732,6 +5732,10 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                                     chat.toggleToolMessageCollapsed(message_index);
                                     requestInputRepaint();
                                 },
+                                .toggle_tool_group => |message_index| {
+                                    chat.toggleToolGroupCollapsed(message_index);
+                                    requestInputRepaint();
+                                },
                                 .toggle_reasoning => |message_index| {
                                     chat.toggleReasoningCollapsed(message_index);
                                     requestInputRepaint();
@@ -5864,6 +5868,10 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                         .copy_span => |s| copyAiChatSpanToClipboard(chat, s.message_index, s.start, s.end),
                         .toggle_tool => |message_index| {
                             chat.toggleToolMessageCollapsed(message_index);
+                            requestInputRepaint();
+                        },
+                        .toggle_tool_group => |message_index| {
+                            chat.toggleToolGroupCollapsed(message_index);
                             requestInputRepaint();
                         },
                         .toggle_reasoning => |message_index| {

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -66,6 +66,8 @@ const DETAIL_PAD_X: f32 = 14;
 const DETAIL_PAD_Y: f32 = 10;
 const DETAIL_ARROW_W: f32 = 12;
 const DETAIL_RULE_W: f32 = 3;
+/// Gap between an expanded activity group's header row and its first card.
+const GROUP_HEADER_GAP: f32 = 6;
 const TABLE_CELL_PAD_X: f32 = 10;
 const TABLE_MIN_COL_W: f32 = 56;
 const SUGGESTION_ROW_H: f32 = 28;
@@ -89,6 +91,9 @@ pub const HitTarget = union(enum) {
     /// source (a byte range of the message), not the whole message.
     copy_span: CopySpan,
     toggle_tool: usize,
+    /// Click on an activity group's header row: toggle the whole run of tool
+    /// cards between one summary row and individual cards.
+    toggle_tool_group: usize,
     toggle_reasoning: usize,
     /// Click on the Nth (zero-based) visible option of a pending ask_user card.
     question_option: usize,
@@ -360,17 +365,7 @@ pub fn render(
     const content_x = transcript_viewport.content_x;
     const viewport_bottom_top_px = transcript_viewport.viewport_bottom_top_px;
 
-    var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
-        content_h += messageBlockHeight(msg, content_w);
-        if (msg.reasoning) |reasoning| {
-            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
-        }
-        if (msg.usage_footer) |footer| {
-            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
-        }
-        content_h += BUBBLE_GAP;
-    }
+    const content_h = transcriptContentHeight(session.messages.items, content_w);
     const max_scroll = @max(0.0, content_h - transcript_h);
     session.scroll_px = @min(session.scroll_px, max_scroll);
 
@@ -387,10 +382,19 @@ pub fn render(
     var cursor_top = transcript_top + gravity_offset - session.scroll_px;
 
     for (session.messages.items, 0..) |msg, message_index| {
-        const block_h = messageBlockHeight(msg, content_w);
+        const block_h = messageBlockHeight(session.messages.items, message_index, content_w);
         if (rendersAsCard(msg)) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
-                renderToolCard(msg, content_x, cursor_top, content_w, block_h, window_height, transcript_selected);
+                switch (toolGroupPosition(session.messages.items, message_index)) {
+                    .hidden => {},
+                    .header => renderToolGroupHeader(session.messages.items, message_index, content_x, cursor_top, content_w, window_height, transcript_selected),
+                    .expanded_first => {
+                        renderToolGroupHeader(session.messages.items, message_index, content_x, cursor_top, content_w, window_height, transcript_selected);
+                        const card_top = cursor_top + detailHeaderHeight() + GROUP_HEADER_GAP;
+                        renderToolCard(msg, content_x, card_top, content_w, toolCardHeight(msg, content_w), window_height, transcript_selected);
+                    },
+                    .none, .expanded_member => renderToolCard(msg, content_x, cursor_top, content_w, block_h, window_height, transcript_selected),
+                }
             }
         } else if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
             const selection_range = if (session.transcript_selection) |selection|
@@ -421,7 +425,7 @@ pub fn render(
             }
         }
 
-        cursor_top += BUBBLE_GAP;
+        cursor_top += blockGapAfter(session.messages.items, message_index);
     }
 
     ui_pipeline.endClip();
@@ -487,30 +491,38 @@ pub fn interactionHitTest(
         }
     }
 
-    var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
-        content_h += messageBlockHeight(msg, content_w);
-        if (msg.reasoning) |reasoning| {
-            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
-        }
-        if (msg.usage_footer) |footer| {
-            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
-        }
-        content_h += BUBBLE_GAP;
-    }
+    const content_h = transcriptContentHeight(session.messages.items, content_w);
 
     const scroll_px = @min(session.scroll_px, @max(0.0, content_h - transcript_h));
     const gravity_offset = @max(0.0, transcript_h - content_h);
     var cursor_top = transcript_top + gravity_offset - scroll_px;
 
     for (session.messages.items, 0..) |msg, message_index| {
-        const block_h = messageBlockHeight(msg, content_w);
+        const block_h = messageBlockHeight(session.messages.items, message_index, content_w);
         if (rendersAsCard(msg)) {
             if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
-                const copy_rect = detailCopyButtonRect(content_x, cursor_top, content_w);
-                if (pointInRect(px, py, copy_rect)) return .{ .copy_message = message_index };
-                const header_rect = detailHeaderRect(content_x, cursor_top, content_w);
-                if (pointInRect(px, py, header_rect)) return .{ .toggle_tool = message_index };
+                switch (toolGroupPosition(session.messages.items, message_index)) {
+                    .hidden => {},
+                    .header => {
+                        const header_rect = detailHeaderRect(content_x, cursor_top, content_w);
+                        if (pointInRect(px, py, header_rect)) return .{ .toggle_tool_group = message_index };
+                    },
+                    .expanded_first => {
+                        const group_rect = detailHeaderRect(content_x, cursor_top, content_w);
+                        if (pointInRect(px, py, group_rect)) return .{ .toggle_tool_group = message_index };
+                        const card_top = cursor_top + detailHeaderHeight() + GROUP_HEADER_GAP;
+                        const copy_rect = detailCopyButtonRect(content_x, card_top, content_w);
+                        if (pointInRect(px, py, copy_rect)) return .{ .copy_message = message_index };
+                        const header_rect = detailHeaderRect(content_x, card_top, content_w);
+                        if (pointInRect(px, py, header_rect)) return .{ .toggle_tool = message_index };
+                    },
+                    .none, .expanded_member => {
+                        const copy_rect = detailCopyButtonRect(content_x, cursor_top, content_w);
+                        if (pointInRect(px, py, copy_rect)) return .{ .copy_message = message_index };
+                        const header_rect = detailHeaderRect(content_x, cursor_top, content_w);
+                        if (pointInRect(px, py, header_rect)) return .{ .toggle_tool = message_index };
+                    },
+                }
             }
         } else if (sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
             const rect = copyButtonRect(msg.role, content_x, cursor_top, content_w);
@@ -540,7 +552,7 @@ pub fn interactionHitTest(
         if (msg.usage_footer) |footer| {
             if (footer.len > 0) cursor_top += usageFooterHeight(footer, content_w);
         }
-        cursor_top += BUBBLE_GAP;
+        cursor_top += blockGapAfter(session.messages.items, message_index);
     }
 
     return null;
@@ -575,17 +587,7 @@ pub fn transcriptTextHitTest(
     const content_w = w - LINE_PAD_X * 2;
     const content_x = x + LINE_PAD_X;
 
-    var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
-        content_h += messageBlockHeight(msg, content_w);
-        if (msg.reasoning) |reasoning| {
-            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
-        }
-        if (msg.usage_footer) |footer| {
-            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
-        }
-        content_h += BUBBLE_GAP;
-    }
+    const content_h = transcriptContentHeight(session.messages.items, content_w);
 
     const scroll_px = @min(session.scroll_px, @max(0.0, content_h - transcript_h));
     const gravity_offset = @max(0.0, transcript_h - content_h);
@@ -594,7 +596,7 @@ pub fn transcriptTextHitTest(
     var cursor_top = transcript_top + gravity_offset - scroll_px;
 
     for (session.messages.items, 0..) |msg, message_index| {
-        const block_h = messageBlockHeight(msg, content_w);
+        const block_h = messageBlockHeight(session.messages.items, message_index, content_w);
         if (msg.role == .assistant and sectionVisible(cursor_top, block_h, transcript_top, viewport_bottom_top_px)) {
             const bubble = bubbleGeometry(msg.role, content_x, content_w);
             const body_x = bubble.x + BUBBLE_PAD_X;
@@ -617,7 +619,7 @@ pub fn transcriptTextHitTest(
         if (msg.usage_footer) |footer| {
             if (footer.len > 0) cursor_top += usageFooterHeight(footer, content_w);
         }
-        cursor_top += BUBBLE_GAP;
+        cursor_top += blockGapAfter(session.messages.items, message_index);
     }
 
     return null;
@@ -845,17 +847,7 @@ fn transcriptLayoutLocked(
     const transcript_viewport = ai_chat_layout.transcriptViewport(frame, window_height, input_h, approval_h + question_h, LINE_PAD_X, 18);
     const content_w = transcript_viewport.content_w;
 
-    var content_h: f32 = 0;
-    for (session.messages.items) |msg| {
-        content_h += messageBlockHeight(msg, content_w);
-        if (msg.reasoning) |reasoning| {
-            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
-        }
-        if (msg.usage_footer) |footer| {
-            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
-        }
-        content_h += BUBBLE_GAP;
-    }
+    const content_h = transcriptContentHeight(session.messages.items, content_w);
 
     return .{
         .x = x,
@@ -918,9 +910,65 @@ fn rendersAsCard(msg: ai_chat.Message) bool {
     return msg.role == .tool or msg.is_context_summary;
 }
 
-fn messageBlockHeight(msg: ai_chat.Message, max_w: f32) f32 {
-    if (rendersAsCard(msg)) return toolCardHeight(msg, max_w);
+/// Where a card message sits relative to its activity group: runs of two or
+/// more adjacent groupable tool messages render as one collapsible group so a
+/// long agent run costs one header row instead of one per step (issue #507).
+const GroupPosition = enum {
+    /// Not grouped: a bubble, a context summary, a live (auto-expanded) card,
+    /// or a lone tool card.
+    none,
+    /// First message of a collapsed run: renders the single group header row.
+    header,
+    /// Non-first message of a collapsed run: renders nothing.
+    hidden,
+    /// First message of an expanded run: group header row plus its own card.
+    expanded_first,
+    /// Non-first message of an expanded run: its own card, as ungrouped.
+    expanded_member,
+};
+
+fn toolGroupPosition(msgs: []const ai_chat.Message, index: usize) GroupPosition {
+    if (!msgs[index].groupableTool()) return .none;
+    const start = ai_chat.toolRunStart(msgs, index);
+    const in_run = index > start or (index + 1 < msgs.len and msgs[index + 1].groupableTool());
+    if (!in_run) return .none;
+    const collapsed = msgs[start].tool_group_collapsed;
+    if (index == start) return if (collapsed) .header else .expanded_first;
+    return if (collapsed) .hidden else .expanded_member;
+}
+
+fn messageBlockHeight(msgs: []const ai_chat.Message, index: usize, max_w: f32) f32 {
+    const msg = msgs[index];
+    if (rendersAsCard(msg)) {
+        return switch (toolGroupPosition(msgs, index)) {
+            .header => detailHeaderHeight(),
+            .hidden => 0,
+            .expanded_first => detailHeaderHeight() + GROUP_HEADER_GAP + toolCardHeight(msg, max_w),
+            .none, .expanded_member => toolCardHeight(msg, max_w),
+        };
+    }
     return bubbleHeight(msg.role, msg.content, max_w);
+}
+
+/// Gap below a message block. Hidden group members contribute no gap, so a
+/// collapsed group costs exactly one header row plus one BUBBLE_GAP.
+fn blockGapAfter(msgs: []const ai_chat.Message, index: usize) f32 {
+    return if (toolGroupPosition(msgs, index) == .hidden) 0 else BUBBLE_GAP;
+}
+
+fn transcriptContentHeight(msgs: []const ai_chat.Message, content_w: f32) f32 {
+    var content_h: f32 = 0;
+    for (msgs, 0..) |msg, i| {
+        content_h += messageBlockHeight(msgs, i, content_w);
+        if (msg.reasoning) |reasoning| {
+            if (reasoning.len > 0) content_h += reasoningCardHeight(msg, content_w);
+        }
+        if (msg.usage_footer) |footer| {
+            if (footer.len > 0) content_h += usageFooterHeight(footer, content_w);
+        }
+        content_h += blockGapAfter(msgs, i);
+    }
+    return content_h;
 }
 
 fn bubbleHeight(role: ai_chat.Role, text: []const u8, max_w: f32) f32 {
@@ -1034,6 +1082,43 @@ fn renderMessageBubble(
     } else {
         renderWrappedSelection(text, 0, body_x, body_top, body_w, lineHeight(), selection_range, window_height, window_height);
         _ = renderWrappedText(text, body_x, body_top, body_w, lineHeight(), fg, window_height, window_height);
+    }
+}
+
+/// One-row summary header for an activity group (a run of tool cards):
+/// "> N steps  <latest step preview>" when collapsed, "v N steps" expanded.
+fn renderToolGroupHeader(msgs: []const ai_chat.Message, start: usize, x: f32, top_px: f32, w: f32, window_height: f32, selected: bool) void {
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const h = detailHeaderHeight();
+    const y = window_height - top_px - h;
+    const header_bg = if (selected) mixColor(bg, accent, 0.28) else mixColor(bg, fg, 0.08);
+
+    var end = start;
+    while (end < msgs.len and msgs[end].groupableTool()) end += 1;
+    const collapsed = msgs[start].tool_group_collapsed;
+
+    ui_pipeline.fillQuadAlpha(x, y, w, h, header_bg, 0.98);
+    ui_pipeline.fillQuadAlpha(x, y, DETAIL_RULE_W, h, accent, if (selected) 0.78 else 0.52);
+
+    const arrow_x = x + DETAIL_PAD_X;
+    const text_y = y + @round((h - font.g_titlebar_cell_height) / 2);
+    _ = titlebar.renderTextLimited(if (collapsed) ">" else "v", arrow_x, text_y, mixColor(fg, accent, 0.16), DETAIL_ARROW_W);
+
+    var title_buf: [32]u8 = undefined;
+    const title = std.fmt.bufPrint(&title_buf, "{d} steps", .{end - start}) catch "steps";
+    var text_x = arrow_x + DETAIL_ARROW_W + 6;
+    const text_limit = x + w - DETAIL_PAD_X;
+    text_x = titlebar.renderTextLimited(title, text_x, text_y, mixColor(fg, accent, 0.18), @max(24.0, text_limit - text_x)) + 10;
+    if (collapsed and text_x + 12 < text_limit) {
+        const meta = toolSectionMeta(msgs[end - 1].content);
+        if (meta.name.len > 0 and text_x + 10 < text_limit) {
+            text_x = titlebar.renderTextLimited(meta.name, text_x, text_y, mixColor(fg, accent, 0.32), @max(24.0, text_limit - text_x)) + 10;
+        }
+        if (meta.preview.len > 0 and text_x + 12 < text_limit) {
+            _ = titlebar.renderTextLimited(meta.preview, text_x, text_y, mixColor(bg, fg, 0.58), @max(24.0, text_limit - text_x));
+        }
     }
 }
 


### PR DESCRIPTION
## What

Fixes #507 (会话界面工具卡片占屏、报告无法整段复制).

**Activity grouping.** Consecutive settled tool messages between two regular messages now render as one collapsible activity group. Collapsed (the default, and re-applied automatically when a request finishes) the whole run costs a single header row — `> 12 steps <latest step preview>` — instead of one row per tool call. Clicking the header expands the individual step cards; each card still toggles its full output as before. Live auto-expanded cards are excluded from grouping, so the current step stays visible while a request streams.

**`/copy [full|clean]`.** Puts the whole conversation on the clipboard as Markdown, reusing the `/export` renderer (`clean` = user input + answers, `full` = everything incl. tool detail). Single-message drag selection stays unchanged; this covers the "无法整段复制" half of the issue.

## How

- Group state lives on the run's first message (`Message.tool_group_collapsed`); membership (`groupableTool()`) is derived per frame, so steps appended during a run join the group automatically and the whole run folds to one row when `collapseAutoExpandedDetailsLocked` fires at request end.
- The renderer's four transcript geometry loops (render, interaction hit test, text hit test, scrollbar layout) previously duplicated the same height walk; they now share `transcriptContentHeight` / `messageBlockHeight` / `blockGapAfter`, so the grouping geometry is defined once and hit testing cannot drift from rendering.
- `/copy` follows the `/export` deferred-trigger pattern (fires after the session mutex unlocks) and suppresses its own transcript message so the copied Markdown is not polluted. Both sinks fold into one `g_transcript_sink_triggers` struct to respect the frozen `g_*` global ceiling in `session.zig`.

## Tests

- New: group toggle anchors/flips the run's first message from any member and ignores non-groupable targets; `/copy` fires the trigger with the parsed mode and appends no transcript message.
- Updated: `/c` slash-suggestion count (now also matches `/copy`).
- `zig build test -Dtarget=aarch64-macos` and `zig build test-full -Dtarget=aarch64-macos` pass; Windows default build and `macos-app` build pass. (`tool_import: runArgvProbe…` flakes on clean main too — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)