### PR TITLE
perf(windows): shrink per-surface IO thread stack commit; honest page-pool accounting

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -4874,6 +4874,7 @@ const MemoryDebugTotals = struct {
     visible_surfaces: usize = 0,
     surfaces: usize = 0,
     terminal_page_bytes: usize = 0,
+    terminal_page_committed_bytes: usize = 0,
     terminal_page_limit_bytes: usize = 0,
     terminal_min_page_bytes: usize = 0,
     renderer_cpu_capacity_bytes: usize = 0,
@@ -4887,6 +4888,7 @@ const SurfaceMemoryDebug = struct {
     rows: usize = 0,
     screen_count: usize = 0,
     terminal_page_bytes: usize = 0,
+    terminal_page_committed_bytes: usize = 0,
     terminal_page_limit_bytes: usize = 0,
     terminal_min_page_bytes: usize = 0,
     renderer_cpu_capacity_bytes: usize = 0,
@@ -4916,6 +4918,15 @@ fn collectSurfaceMemoryDebug(surface: *Surface) SurfaceMemoryDebug {
         const screen = entry.value.*;
         stats.screen_count += 1;
         stats.terminal_page_bytes += screen.pages.page_size;
+        // page_size excludes the pool's preheated-but-unused pages (committed
+        // via VirtualAlloc at init), while the pool arena's capacity includes
+        // the in-use pooled pages — so take the max instead of summing.
+        // ponytail: undercounts a screen holding both pool surplus and
+        // oversized non-pool pages; fine for a debug metric.
+        stats.terminal_page_committed_bytes += @max(
+            screen.pages.page_size,
+            screen.pages.pool.pages.arena.queryCapacity(),
+        );
         stats.terminal_page_limit_bytes += screen.pages.explicit_max_size;
         stats.terminal_min_page_bytes += screen.pages.min_max_size;
     }
@@ -4960,6 +4971,7 @@ fn maybePrintMemoryDebug(now: i64) void {
             totals.surfaces += 1;
             if (visible) totals.visible_surfaces += 1;
             totals.terminal_page_bytes += stats.terminal_page_bytes;
+            totals.terminal_page_committed_bytes += stats.terminal_page_committed_bytes;
             totals.terminal_page_limit_bytes += stats.terminal_page_limit_bytes;
             totals.terminal_min_page_bytes += stats.terminal_min_page_bytes;
             totals.renderer_cpu_capacity_bytes += stats.renderer_cpu_capacity_bytes;
@@ -5008,7 +5020,7 @@ fn maybePrintMemoryDebug(now: i64) void {
         font_stats.icon_atlas_gpu_bytes +
         font_stats.titlebar_atlas_gpu_bytes;
     const tracked_cpu_bytes =
-        totals.terminal_page_bytes +
+        totals.terminal_page_committed_bytes +
         totals.renderer_cpu_capacity_bytes +
         font_cpu_bytes +
         totals.kitty_pending_cpu_bytes;
@@ -5039,7 +5051,7 @@ fn maybePrintMemoryDebug(now: i64) void {
     if (memory_debug.queryProcess()) |process| {
         const untracked_private = process.private_usage -| tracked_cpu_bytes;
         std.debug.print(
-            "[memory] process private={d:.1}MiB ws={d:.1}MiB commit={d:.1}MiB peak_ws={d:.1}MiB tabs={} ai_tabs={} surfaces={} visible_surfaces={} terminal_pages={d:.1}/{d:.1}MiB min={d:.1}MiB renderer_cap={d:.1}MiB font_atlas(cpu/gpu)={d:.1}/{d:.1}MiB kitty_bytes(cpu/gpu)={d:.1}/{d:.1}MiB fbo={d:.1}MiB tracked_cpu={d:.1}MiB untracked_private~={d:.1}MiB faults={}\n",
+            "[memory] process private={d:.1}MiB ws={d:.1}MiB commit={d:.1}MiB peak_ws={d:.1}MiB tabs={} ai_tabs={} surfaces={} visible_surfaces={} terminal_pages={d:.1}/{d:.1}MiB committed={d:.1}MiB min={d:.1}MiB renderer_cap={d:.1}MiB font_atlas(cpu/gpu)={d:.1}/{d:.1}MiB kitty_bytes(cpu/gpu)={d:.1}/{d:.1}MiB fbo={d:.1}MiB tracked_cpu={d:.1}MiB untracked_private~={d:.1}MiB faults={}\n",
             .{
                 memory_debug.mib(process.private_usage),
                 memory_debug.mib(process.working_set),
@@ -5051,6 +5063,7 @@ fn maybePrintMemoryDebug(now: i64) void {
                 totals.visible_surfaces,
                 memory_debug.mib(totals.terminal_page_bytes),
                 memory_debug.mib(totals.terminal_page_limit_bytes),
+                memory_debug.mib(totals.terminal_page_committed_bytes),
                 memory_debug.mib(totals.terminal_min_page_bytes),
                 memory_debug.mib(totals.renderer_cpu_capacity_bytes),
                 memory_debug.mib(font_cpu_bytes),

--- a/src/platform/threading.zig
+++ b/src/platform/threading.zig
@@ -6,23 +6,37 @@ const builtin = @import("builtin");
 /// Conservative stack size for per-surface helper threads.
 ///
 /// These helper threads run small event/read loops and do not need a large
-/// native runtime stack. On Linux (glibc), the program's static TLS block is
-/// carved out of each thread's stack region, so the stack must exceed the
-/// static TLS size (several MiB here, dominated by the threadlocal GL function
-/// table) plus PTHREAD_STACK_MIN and the guard page — otherwise pthread_create
-/// returns EINVAL. Other targets account for static TLS separately from the
-/// thread stack, so the smaller 1 MiB stack suffices there.
-pub const surface_thread_stack_size: usize = if (builtin.os.tag == .linux)
-    8 * 1024 * 1024
-else
-    1024 * 1024;
+/// native runtime stack.
+///
+/// - Linux (glibc): the program's static TLS block is carved out of each
+///   thread's stack region, so the stack must exceed the static TLS size
+///   (several MiB here, dominated by the threadlocal GL function table) plus
+///   PTHREAD_STACK_MIN and the guard page — otherwise pthread_create returns
+///   EINVAL.
+/// - Windows: std.Thread hands stack_size to CreateThread with
+///   dwCreationFlags=0, so it is the *initial commit*, not the reserve — the
+///   stack still grows on demand up to the PE-header reserve, making a small
+///   value overflow-safe. 1 MiB here showed up as ~2 MiB of committed private
+///   memory per surface (2 threads); 256 KiB covers the reader's 64 KiB
+///   on-stack buffer plus VT-parse frames without early guard-page faults.
+/// - Elsewhere (macOS): stack_size is the actual mapping ceiling but pages
+///   commit lazily, so shrinking buys no RSS; keep 1 MiB of headroom.
+pub const surface_thread_stack_size: usize = switch (builtin.os.tag) {
+    .linux => 8 * 1024 * 1024,
+    .windows => 256 * 1024,
+    else => 1024 * 1024,
+};
 
 pub const surface_thread_spawn_config: std.Thread.SpawnConfig = .{
     .stack_size = surface_thread_stack_size,
 };
 
 test "platform threading exposes a bounded surface helper stack" {
-    const expected: usize = if (builtin.os.tag == .linux) 8 * 1024 * 1024 else 1024 * 1024;
+    const expected: usize = switch (builtin.os.tag) {
+        .linux => 8 * 1024 * 1024,
+        .windows => 256 * 1024,
+        else => 1024 * 1024,
+    };
     try std.testing.expectEqual(expected, surface_thread_stack_size);
     try std.testing.expectEqual(surface_thread_stack_size, surface_thread_spawn_config.stack_size);
 }

--- a/src/platform/threading.zig
+++ b/src/platform/threading.zig
@@ -13,14 +13,13 @@ const builtin = @import("builtin");
 ///   (several MiB here, dominated by the threadlocal GL function table) plus
 ///   PTHREAD_STACK_MIN and the guard page — otherwise pthread_create returns
 ///   EINVAL.
-/// - Windows: std.Thread hands stack_size to CreateThread with
-///   dwCreationFlags=0, so it is the *initial commit*, not the reserve — the
-///   stack still grows on demand up to the PE-header reserve, making a small
-///   value overflow-safe. 1 MiB here showed up as ~2 MiB of committed private
-///   memory per surface (2 threads); 256 KiB covers the reader's 64 KiB
-///   on-stack buffer plus VT-parse frames without early guard-page faults.
-/// - Elsewhere (macOS): stack_size is the actual mapping ceiling but pages
-///   commit lazily, so shrinking buys no RSS; keep 1 MiB of headroom.
+/// - Reserve-growing native thread runtimes: stack_size controls the initial
+///   committed stack, while the stack can still grow to the executable's
+///   reserve. Keep the commit small for the two per-surface IO helpers; 256 KiB
+///   covers the reader's 64 KiB on-stack buffer plus VT-parse frames without
+///   early guard-page faults.
+/// - Lazily committed mapped-stack runtimes: stack_size is the mapping ceiling,
+///   so shrinking buys no RSS; keep 1 MiB of headroom.
 pub const surface_thread_stack_size: usize = switch (builtin.os.tag) {
     .linux => 8 * 1024 * 1024,
     .windows => 256 * 1024,


### PR DESCRIPTION
## Summary

Measured on Windows/D3D11: every new terminal surface adds ~6.0 MiB of private memory, of which only ~0.9 MiB was visible to the `--debug-memory` tracked counter. Investigation pinned the untracked ~5 MiB to (1) two 1 MiB IO thread stacks committed up front, (2) the PageList pool preheat surplus invisible to `page_size`, (3) per-thread `.tls` templates, (4) allocator rounding. This PR addresses the first two:

- **Windows IO thread stacks: 1 MiB → 256 KiB initial commit (~ -1.5 MiB/surface).** Zig's `std.Thread` passes `stack_size` to `CreateThread` with `dwCreationFlags=0`, i.e. it is the *initial commit*, not the reserve (verified in `std/Thread.zig`, Zig 0.15.2). The stack still grows on demand up to the PE-header reserve, so maximum stack depth is unchanged — this is a pure commit reduction with no overflow risk. 256 KiB comfortably covers the reader's 64 KiB on-stack buffer plus VT-parse frames without early guard-page faults. Linux keeps 8 MiB (static-TLS-in-stack constraint documented in `platform/threading.zig`); macOS/other keep 1 MiB (POSIX stacks commit lazily, shrinking buys nothing).

- **Memory-debug accounting: count committed page-pool capacity (~ +1.1 MiB/surface moved from "untracked" to tracked).** ghostty's `PageList.init` preheats `page_preheat=4` std pages via VirtualAlloc, but `page_size` deliberately excludes pool surplus — so ~3 committed-but-idle pages per surface were inflating `untracked_private~` and reading as a mystery. Tracked now uses `max(page_size, pool arena queryCapacity())` per screen and the process line prints it as `committed=`.

Not included: shrinking the preheat itself (`page_preheat = 4` is a hard constant inside the pinned ghostty dependency, `src/terminal/PageList.zig:34` — needs an upstream patch or a fork, not worth it for ~1.1 MiB) and the residual `.tls` template (~0.2 MiB/thread, tracked separately in #511).

Expected effect on the new-tab memory test: private delta per surface drops from ~6.0 MiB to ~4-4.5 MiB, and `untracked_private~` shrinks by a further ~1.1 MiB/surface reclassified as tracked.

## Test plan

- [x] `zig build` (native)
- [x] `zig build test` — 0 failures
- [x] `zig build -Dtarget=x86_64-windows-gnu` cross-compile
- [ ] Windows: re-run the d3d11-new-tab-memory sampling script and compare per-surface private delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xLmN3TpGw67Amq5W6nEsA