### PR TITLE
[codex] Add AI History selected actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Move selected AI History session | Up / Down in AI History | Up / Down in AI History |
 | Resume selected AI History session | Enter in AI History | Enter in AI History |
 | Preview selected AI History transcript | Space in AI History | Space in AI History |
+| Download selected AI History raw file | **D** in AI History | **D** in AI History |
+| Export selected AI History transcript as Markdown | **M** in AI History | **M** in AI History |
+| Attach selected AI History transcript to Copilot | **A** in AI History | **A** in AI History |
 | Refresh local AI History scan | **R** in local AI History | **R** in local AI History |
 | Edit AI Chat input cursor | Left/Right/Home/End/Delete/Backspace | Left/Right/Home/End/Delete/Backspace |
 | Stop in-flight AI Chat or Agent request | **Esc** in AI Chat while working | **Esc** in AI Chat while working |

--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -85,6 +85,11 @@ Use `Resume` to open a real terminal tab on the same target. WispTerm first
 checks the original project directory recorded in the history file; if that
 directory is missing, resume stops instead of falling back to `$HOME`.
 
+The selected history row also supports local handoff actions: press `D` to
+download the provider's raw history file, `M` to export the parsed transcript as
+Markdown, or `A` to attach the transcript as a collapsed Copilot context card
+for a follow-up question.
+
 ## In-context Copilot Sidebar
 
 Press `Ctrl+Shift+A` (`Cmd+Shift+A` on macOS) on a terminal tab to toggle a

--- a/docs/superpowers/plans/2026-07-07-ai-history-actions.md
+++ b/docs/superpowers/plans/2026-07-07-ai-history-actions.md
@@ -1,0 +1,1400 @@
+# AI History Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add selected-session actions to AI History: download the raw provider file, export a Markdown transcript, and attach the transcript as Copilot context.
+
+**Architecture:** Keep pure export formatting in `terminal_agents/sessions/markdown.zig`, session ownership helpers in `terminal_agents/sessions/session.zig`, and UI/IO orchestration in `AppWindow.zig`. Reuse existing file dialogs, atomic writes, WSL/SSH remote read helpers, file explorer SCP downloads, Copilot session creation, and AI Chat history hooks. Ghostty has no equivalent AI-history surface, so terminal core and VT/rendering behavior remain untouched.
+
+**Tech Stack:** Zig, existing WispTerm AI History modules, existing AppWindow/Copilot integration, `zig build test`, `zig build test-full`.
+
+---
+
+## File Map
+
+- Create `src/terminal_agents/sessions/markdown.zig`: pure Markdown export, bounded Copilot context, raw download filename sanitization.
+- Modify `src/test_fast.zig`: import the new pure module into the fast suite.
+- Modify `src/test_main.zig`: import the new module into the full assistant shard.
+- Modify `src/terminal_agents/sessions/session.zig`: selected metadata clone, transcript clone, preview replacement helpers.
+- Modify `src/assistant/conversation/session.zig`: append a collapsed context card that persists to Copilot history.
+- Modify `src/appwindow/tab.zig`: spawn an AI Chat tab from an already-created `ai_chat.Session`.
+- Modify `src/renderer/terminal_agents/sessions.zig`: render and hit-test `Download Raw`, `Export Markdown`, and `Attach to Copilot` buttons.
+- Modify `src/AppWindow.zig`: implement selected AI History action entry points and raw/Markdown save flows.
+- Modify `src/input.zig`: route `D`, `M`, and `A` while AI History search is not focused.
+- Modify `src/source_guards/side_effect_guard.zig`: lower the AppWindow direct dirty-write ceiling after converting one legacy direct write to `markUiDirty()`.
+- Modify `README.md` and `docs/ai-agent.md`: document the new AI History actions and shortcuts.
+
+---
+
+### Task 1: Add Pure AI History Markdown Export Module
+
+**Files:**
+- Create: `src/terminal_agents/sessions/markdown.zig`
+- Modify: `src/test_fast.zig`
+- Modify: `src/test_main.zig`
+
+- [ ] **Step 1: Write the failing formatter tests**
+
+Create `src/terminal_agents/sessions/markdown.zig` with tests first:
+
+```zig
+const std = @import("std");
+const types = @import("types.zig");
+
+test "ai history markdown export includes metadata and role sections" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-1",
+        .title = "Fix renderer",
+        .project_dir = "/work/wispterm",
+        .source_path = "/home/me/.codex/sessions/sess-1.jsonl",
+        .resume_kind = .codex_resume,
+        .created_at_ms = 1000,
+        .last_active_at_ms = 2000,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .user, .content = "status?", .timestamp_ms = 1100 },
+        .{ .role = .assistant, .content = "ready", .timestamp_ms = 1200 },
+        .{ .role = .tool, .content = "tool output", .timestamp_ms = 1300 },
+    };
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "# AI History Export") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Provider: Codex") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Session: sess-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Project: /work/wispterm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## User") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "status?") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Assistant") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "ready") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Tool") != null);
+}
+
+test "ai history markdown export skips empty message bodies" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .claude,
+        .session_id = "sess-2",
+        .title = "Empty turn",
+        .source_path = "/home/me/.claude/projects/sess-2.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .system, .content = "" },
+        .{ .role = .assistant, .content = "answer" },
+    };
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## System") == null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Assistant") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "answer") != null);
+}
+```
+
+- [ ] **Step 2: Register the new module in test aggregators**
+
+In `src/test_fast.zig`, add this import near the other `terminal_agents/sessions/*` imports:
+
+```zig
+    _ = @import("terminal_agents/sessions/markdown.zig");
+```
+
+In `src/test_main.zig`, add this import in the `.assistant` shard near `terminal_agents/sessions/session.zig`:
+
+```zig
+        _ = @import("terminal_agents/sessions/markdown.zig");
+```
+
+- [ ] **Step 3: Run the failing tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because `allocMarkdownExport` is not defined.
+
+- [ ] **Step 4: Implement minimal Markdown export**
+
+Replace the top of `src/terminal_agents/sessions/markdown.zig` with this implementation, keeping the tests below it:
+
+```zig
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const ExportOptions = struct {};
+
+pub fn allocMarkdownExport(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    _: ExportOptions,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try appendHeader(allocator, &out, meta);
+
+    var wrote_message = false;
+    for (messages) |msg| {
+        const body = std.mem.trim(u8, msg.content, " \t\r\n");
+        if (body.len == 0) continue;
+        try appendMessage(allocator, &out, msg.role, body);
+        wrote_message = true;
+    }
+    if (!wrote_message) try out.appendSlice(allocator, "_No transcript messages._\n");
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn appendHeader(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), meta: types.SessionMeta) !void {
+    try out.appendSlice(allocator, "# AI History Export\n\n");
+    try out.writer(allocator).print("- Provider: {s}\n", .{meta.provider.label()});
+    try out.writer(allocator).print("- Session: {s}\n", .{meta.session_id});
+    if (meta.title.len > 0) try out.writer(allocator).print("- Title: {s}\n", .{meta.title});
+    if (meta.project_dir.len > 0) try out.writer(allocator).print("- Project: {s}\n", .{meta.project_dir});
+    try out.writer(allocator).print("- Source: {s}\n", .{meta.source_path});
+    if (meta.created_at_ms > 0) try out.writer(allocator).print("- Created: {d}\n", .{meta.created_at_ms});
+    if (meta.last_active_at_ms > 0) try out.writer(allocator).print("- Updated: {d}\n", .{meta.last_active_at_ms});
+    try out.appendSlice(allocator, "\n");
+}
+
+fn appendMessage(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    role: types.MessageRole,
+    body: []const u8,
+) !void {
+    try out.writer(allocator).print("## {s}\n\n", .{roleHeading(role)});
+    try out.appendSlice(allocator, body);
+    if (!std.mem.endsWith(u8, body, "\n")) try out.append(allocator, '\n');
+    try out.append(allocator, '\n');
+}
+
+fn roleHeading(role: types.MessageRole) []const u8 {
+    return switch (role) {
+        .user => "User",
+        .assistant => "Assistant",
+        .system => "System",
+        .tool => "Tool",
+    };
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS for the new Markdown export tests and existing fast tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/terminal_agents/sessions/markdown.zig src/test_fast.zig src/test_main.zig
+git commit -m "feat: add ai history markdown export formatter"
+```
+
+---
+
+### Task 2: Add Bounded Copilot Context and Raw Filename Helpers
+
+**Files:**
+- Modify: `src/terminal_agents/sessions/markdown.zig`
+
+- [ ] **Step 1: Write failing tests for context truncation and filename sanitization**
+
+Append these tests to `src/terminal_agents/sessions/markdown.zig`:
+
+```zig
+test "ai history copilot context truncates oversized transcripts from the front" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .reasonix,
+        .session_id = "sess-3",
+        .title = "Long chat",
+        .source_path = "/home/me/.reasonix/sessions/events.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .user, .content = "old prompt that should drop" },
+        .{ .role = .assistant, .content = "old answer that should drop" },
+        .{ .role = .user, .content = "recent prompt" },
+        .{ .role = .assistant, .content = "recent answer" },
+    };
+
+    var result = try allocCopilotContext(allocator, meta, &messages, 260);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.truncated);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "Transcript truncated") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "recent prompt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "recent answer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "old prompt that should drop") == null);
+}
+
+test "ai history raw download filename sanitizes provider session and basename" {
+    var buf: [160]u8 = undefined;
+    const meta = types.SessionMeta{
+        .provider = .claude,
+        .session_id = "session:bad/id",
+        .title = "Ignored",
+        .source_path = "/home/me/.claude/projects/original file.jsonl",
+        .resume_kind = .claude_resume,
+    };
+
+    const name = rawDownloadFilename(meta, &buf);
+    try std.testing.expectEqualStrings("claude-code-session-bad-id-original-file.jsonl", name);
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because `allocCopilotContext`, `ContextResult`, `deinit`, and `rawDownloadFilename` are not defined.
+
+- [ ] **Step 3: Implement context and filename helpers**
+
+Add this code above the tests in `src/terminal_agents/sessions/markdown.zig`:
+
+```zig
+pub const ContextResult = struct {
+    markdown: []u8,
+    truncated: bool,
+
+    pub fn deinit(self: *ContextResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.markdown);
+        self.truncated = false;
+    }
+};
+
+pub fn allocCopilotContext(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    max_bytes: usize,
+) !ContextResult {
+    const full = try allocMarkdownExport(allocator, meta, messages, .{});
+    if (full.len <= max_bytes) {
+        return .{ .markdown = full, .truncated = false };
+    }
+    allocator.free(full);
+
+    var start = messages.len;
+    while (start > 0) {
+        const candidate = try allocMarkdownExportWithNotice(allocator, meta, messages[start - 1 ..], true);
+        defer allocator.free(candidate);
+        if (candidate.len > max_bytes and start < messages.len) break;
+        start -= 1;
+        if (candidate.len <= max_bytes and start == 0) break;
+    }
+
+    const tail_start = @min(start + 1, messages.len);
+    const markdown = try allocMarkdownExportWithNotice(allocator, meta, messages[tail_start..], true);
+    return .{ .markdown = markdown, .truncated = true };
+}
+
+fn allocMarkdownExportWithNotice(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    truncated: bool,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try appendHeader(allocator, &out, meta);
+    if (truncated) try out.appendSlice(allocator, "_Transcript truncated; showing the most recent messages._\n\n");
+    var wrote_message = false;
+    for (messages) |msg| {
+        const body = std.mem.trim(u8, msg.content, " \t\r\n");
+        if (body.len == 0) continue;
+        try appendMessage(allocator, &out, msg.role, body);
+        wrote_message = true;
+    }
+    if (!wrote_message) try out.appendSlice(allocator, "_No transcript messages._\n");
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn rawDownloadFilename(meta: types.SessionMeta, out: []u8) []const u8 {
+    const provider = sanitizedProviderLabel(meta.provider);
+    const base = std.fs.path.basename(meta.source_path);
+    var tmp: [256]u8 = undefined;
+    const raw = std.fmt.bufPrint(&tmp, "{s}-{s}-{s}", .{ provider, meta.session_id, base }) catch provider;
+    return sanitizeFilename(raw, out);
+}
+
+fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
+    return switch (provider) {
+        .codex => "codex",
+        .claude => "claude-code",
+        .reasonix => "reasonix",
+    };
+}
+
+fn sanitizeFilename(raw: []const u8, out: []u8) []const u8 {
+    if (out.len == 0) return "";
+    var n: usize = 0;
+    var last_dash = false;
+    for (raw) |ch| {
+        if (n >= out.len) break;
+        const ok = std.ascii.isAlphanumeric(ch) or ch == '.' or ch == '_' or ch == '-';
+        const next = if (ok) std.ascii.toLower(ch) else '-';
+        if (next == '-' and last_dash) continue;
+        out[n] = next;
+        n += 1;
+        last_dash = next == '-';
+    }
+    while (n > 0 and out[n - 1] == '-') n -= 1;
+    return out[0..n];
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/terminal_agents/sessions/markdown.zig
+git commit -m "feat: bound ai history copilot context exports"
+```
+
+---
+
+### Task 3: Add AI History Session Ownership Helpers
+
+**Files:**
+- Modify: `src/terminal_agents/sessions/session.zig`
+
+- [ ] **Step 1: Write failing session helper tests**
+
+Append these tests near the existing `ai_history_session` tests in `src/terminal_agents/sessions/session.zig`:
+
+```zig
+test "ai_history_session: selectedMetadataClone owns selected row strings" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{.{
+        .provider = .codex,
+        .session_id = "s1",
+        .title = "Title",
+        .project_dir = "/work",
+        .source_path = "/tmp/s1.jsonl",
+        .resume_kind = .codex_resume,
+    }};
+    try session.replaceRows(&rows);
+
+    const cloned = session.selectedMetadataClone(allocator) orelse return error.MissingClone;
+    defer freeMetadata(allocator, cloned);
+
+    try session.replaceRows(&.{});
+    try std.testing.expectEqualStrings("s1", cloned.session_id);
+    try std.testing.expectEqualStrings("/tmp/s1.jsonl", cloned.source_path);
+}
+
+test "ai_history_session: replaceTranscriptFromMessages installs ready transcript" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const messages = try allocator.alloc(types.TranscriptMessage, 1);
+    messages[0] = .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "ready"),
+    };
+
+    session.replaceTranscriptFromMessages(.codex, messages);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(types.ProviderId.codex, session.transcript_provider.?);
+    try std.testing.expectEqualStrings("ready", session.transcript[0].content);
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because `selectedMetadataClone` and `replaceTranscriptFromMessages` are not defined.
+
+- [ ] **Step 3: Implement helpers**
+
+Inside `pub const Session = struct`, add these methods near `selectedVisible` and `clearTranscript`:
+
+```zig
+    pub fn selectedMetadataClone(self: *Session, allocator: std.mem.Allocator) ?types.SessionMeta {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const selected = self.selectedVisible() orelse return null;
+        return cloneMetadata(allocator, selected) catch null;
+    }
+
+    pub fn replaceTranscriptFromMessages(self: *Session, provider: types.ProviderId, messages: []types.TranscriptMessage) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.clearTranscript();
+        self.transcript = messages;
+        self.transcript_provider = provider;
+        self.transcript_state = .ready;
+        self.transcript_status = "Transcript ready";
+        self.transcript_scroll = 0;
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/terminal_agents/sessions/session.zig
+git commit -m "feat: add ai history selected transcript helpers"
+```
+
+---
+
+### Task 4: Add Collapsed Copilot Context Card API
+
+**Files:**
+- Modify: `src/assistant/conversation/session.zig`
+
+- [ ] **Step 1: Write the failing context-card test**
+
+Append this test near the other context-summary tests in `src/assistant/conversation/session.zig`:
+
+```zig
+test "ai chat appendContextCard stores collapsed persisted user context" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    defer session.deinit();
+
+    try session.appendContextCard("AI History: Codex sess-1", "## User\n\nstatus?", true);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
+    const msg = session.messages.items[0];
+    try std.testing.expectEqual(Role.user, msg.role);
+    try std.testing.expect(msg.is_context_summary);
+    try std.testing.expect(msg.content_collapsed);
+    try std.testing.expect(msg.persist_to_history);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "AI History: Codex sess-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "status?") != null);
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because `appendContextCard` is not defined.
+
+- [ ] **Step 3: Implement context-card append**
+
+Inside `pub const Session = struct`, near `appendInputText`, add:
+
+```zig
+    pub fn appendContextCard(self: *Session, title_text: []const u8, body: []const u8, collapsed: bool) !void {
+        const content = try std.fmt.allocPrint(self.allocator, "### {s}\n\n{s}", .{ title_text, body });
+        var history_change: ?PendingHistoryChange = null;
+        self.mutex.lock();
+        errdefer {
+            self.mutex.unlock();
+            self.allocator.free(content);
+        }
+        try self.messages.append(self.allocator, .{
+            .role = .user,
+            .content = content,
+            .is_context_summary = true,
+            .content_collapsed = collapsed,
+            .persist_to_history = true,
+        });
+        history_change = self.captureHistoryChangeLocked();
+        self.setStatusLocked("Ready");
+        self.mutex.unlock();
+        self.notifyHistoryChange(history_change);
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assistant/conversation/session.zig
+git commit -m "feat: add copilot context card append API"
+```
+
+---
+
+### Task 5: Allow AppWindow to Spawn an AI Chat Tab From an Existing Session
+
+**Files:**
+- Modify: `src/appwindow/tab.zig`
+
+- [ ] **Step 1: Write the failing tab helper test**
+
+Append this test near the existing AI Chat tab tests in `src/appwindow/tab.zig`:
+
+```zig
+test "tab: spawnAiChatSession creates active ai chat tab from owned session" {
+    const allocator = std.testing.allocator;
+    resetTestTabGlobals();
+    defer {
+        for (0..g_tab_count) |idx| {
+            if (g_tabs[idx]) |tab_state| {
+                tab_state.deinit(allocator);
+                allocator.destroy(tab_state);
+                g_tabs[idx] = null;
+            }
+        }
+        resetTestTabGlobals();
+    }
+
+    const session = try ai_chat.Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    try std.testing.expect(spawnAiChatSession(allocator, session));
+    try std.testing.expectEqual(@as(usize, 1), g_tab_count);
+    try std.testing.expect(activeAiChat() != null);
+    try std.testing.expectEqualStrings("Copilot", activeAiChat().?.title());
+}
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because `spawnAiChatSession` is not defined.
+
+- [ ] **Step 3: Implement `spawnAiChatSession` by extracting existing tab setup**
+
+In `src/appwindow/tab.zig`, add this helper near `spawnAiChatTab`:
+
+```zig
+pub fn spawnAiChatSession(allocator: std.mem.Allocator, session: *ai_chat.Session) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+    installAiChatHistoryHook(session);
+
+    const t = allocator.create(TabState) catch return false;
+    t.kind = .ai_chat;
+    t.tree = .empty;
+    t.focused = .root;
+    t.ai_chat_session = session;
+    t.ai_history_session = null;
+    t.skill_center_session = null;
+    t.port_forwarding_session = null;
+    t.copilot_session = null;
+    t.tmux_window_id = null;
+    t.tmux_owner = null;
+    t.tmux_name_len = 0;
+    t.copilot_visible = false;
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+    return true;
+}
+```
+
+Then replace the duplicated tab setup at the end of `spawnAiChatTab` with:
+
+```zig
+    if (!spawnAiChatSession(allocator, session)) {
+        session.deinit();
+        return false;
+    }
+    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
+    return true;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/appwindow/tab.zig
+git commit -m "feat: spawn ai chat tab from existing session"
+```
+
+---
+
+### Task 6: Add AI History Detail Action Buttons and Hit Tests
+
+**Files:**
+- Modify: `src/renderer/terminal_agents/sessions.zig`
+
+- [ ] **Step 1: Write failing renderer hit-test expectations**
+
+In `test "terminal agent sessions renderer: interaction hit test maps buttons and row offset"`, add these expectations after the existing `Hit.@"resume"` assertion:
+
+```zig
+    const action_top = detailActionTop(top, cell_h);
+    try std.testing.expectEqual(
+        Hit.download_raw,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.export_markdown,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + buttonHeight(cell_h) + ACTION_BUTTON_GAP + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.attach_copilot,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + (buttonHeight(cell_h) + ACTION_BUTTON_GAP) * 2 + 2),
+    );
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because the new hit variants and `detailActionTop` are missing.
+
+- [ ] **Step 3: Add hit variants, geometry, and hit-test routing**
+
+At the top of `src/renderer/terminal_agents/sessions.zig`, add constants near `RESUME_BUTTON_W`:
+
+```zig
+const ACTION_BUTTON_W: f32 = 148;
+const ACTION_BUTTON_GAP: f32 = 8;
+```
+
+Extend `pub const Hit`:
+
+```zig
+    download_raw,
+    export_markdown,
+    attach_copilot,
+```
+
+Add geometry helpers near `resumeButtonTop`:
+
+```zig
+fn detailActionTop(top: f32, cell_h: f32) f32 {
+    return resumeButtonTop(top, cell_h) + buttonHeight(cell_h) + 10;
+}
+
+fn detailActionHit(layout: Layout, top: f32, cell_h: f32, mx: f32, my: f32) Hit {
+    const left = layout.detail_x + PAD_X;
+    const h = buttonHeight(cell_h);
+    const w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
+    const y0 = detailActionTop(top, cell_h);
+    if (rectContains(mx, my, left, y0, w, h)) return .download_raw;
+    if (rectContains(mx, my, left, y0 + h + ACTION_BUTTON_GAP, w, h)) return .export_markdown;
+    if (rectContains(mx, my, left, y0 + (h + ACTION_BUTTON_GAP) * 2, w, h)) return .attach_copilot;
+    return .none;
+}
+```
+
+In `interactionHitTest`, after the resume-button hit-test block, add:
+
+```zig
+        const action_hit = detailActionHit(layout, top, cell_h, mx, my);
+        if (action_hit != .none) return action_hit;
+```
+
+- [ ] **Step 4: Render the buttons and move transcript content below them**
+
+In `renderDetail`, after rendering the Resume button, add:
+
+```zig
+    const action_top = detailActionTop(top, draw.cell_h);
+    const action_h = buttonHeight(draw.cell_h);
+    const action_w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
+    const action_x = layout.detail_x + PAD_X;
+    const action_labels = [_][]const u8{ "Download Raw", "Export Markdown", "Attach to Copilot" };
+    for (action_labels, 0..) |label, i| {
+        const row_top = action_top + @as(f32, @floatFromInt(i)) * (action_h + ACTION_BUTTON_GAP);
+        draw.fillQuadAlpha(action_x, yFromTop(window_height, row_top, action_h), action_w, action_h, panel_strong, 0.72);
+        _ = draw.renderTextLimited(label, action_x + 12, yTextFromTop(draw, window_height, row_top + BUTTON_PAD_Y), accent, action_w - 24);
+    }
+
+    y = action_top + (action_h + ACTION_BUTTON_GAP) * 3 + 12;
+```
+
+Leave the separator drawing immediately after that updated `y`.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/terminal_agents/sessions.zig
+git commit -m "feat: render ai history selected actions"
+```
+
+---
+
+### Task 7: Wire AppWindow AI History Actions
+
+**Files:**
+- Modify: `src/AppWindow.zig`
+- Modify: `src/source_guards/side_effect_guard.zig`
+
+- [ ] **Step 1: Add imports and helper signatures**
+
+In `src/AppWindow.zig`, add the export formatter import near the other AI History imports:
+
+```zig
+const ai_history_markdown = @import("terminal_agents/sessions/markdown.zig");
+```
+
+Add these function declarations by implementing them in Step 3:
+
+```zig
+pub fn aiHistoryDownloadSelectedRaw() bool
+pub fn aiHistoryExportSelectedMarkdown() bool
+pub fn aiHistoryAttachSelectedToCopilot() bool
+```
+
+- [ ] **Step 2: Write source-guard ratchet test expectation**
+
+In `src/source_guards/side_effect_guard.zig`, change the AppWindow ceiling from `57` to `56`:
+
+```zig
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 56 },
+```
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because AppWindow still has 57 direct dirty-global writes.
+
+- [ ] **Step 3: Lower the AppWindow side-effect ratchet**
+
+In `copyAiChatMarkdown` in `src/AppWindow.zig`, replace:
+
+```zig
+        g_force_rebuild = true;
+```
+
+with:
+
+```zig
+        markUiDirty();
+```
+
+- [ ] **Step 4: Implement selected metadata and transcript loaders**
+
+Add these helpers near `startAiHistoryTranscript`:
+
+```zig
+fn selectedAiHistoryMetaForAction(allocator: std.mem.Allocator, session: *ai_history_session.Session) ?ai_history_types.SessionMeta {
+    return session.selectedMetadataClone(allocator);
+}
+
+fn loadAiHistoryTranscriptForAction(
+    allocator: std.mem.Allocator,
+    session: *ai_history_session.Session,
+    meta: ai_history_types.SessionMeta,
+) ?[]ai_history_types.TranscriptMessage {
+    session.mutex.lock();
+    if (session.transcript_state == .ready and session.transcript_provider != null and session.transcript_provider.? == meta.provider) {
+        const cloned = cloneAiHistoryTranscriptMessages(allocator, session.transcript) catch null;
+        session.mutex.unlock();
+        return cloned;
+    }
+    session.mutex.unlock();
+
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse return null;
+    const messages: []ai_history_types.TranscriptMessage = switch (target) {
+        .local => ai_history_session.loadLocalTranscript(allocator, meta) catch return null,
+        .wsl => blk: {
+            var host_state = ai_history_session.WslScannerHost{};
+            const host = host_state.scannerHost();
+            break :blk host.loadTranscript(host.ctx, allocator, meta) catch return null;
+        },
+        .ssh => |conn| blk: {
+            var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+            const host = host_state.scannerHost();
+            break :blk host.loadTranscript(host.ctx, allocator, meta) catch return null;
+        },
+    };
+
+    const preview_copy = cloneAiHistoryTranscriptMessages(allocator, messages) catch null;
+    if (preview_copy) |copy| session.replaceTranscriptFromMessages(meta.provider, copy);
+    return messages;
+}
+
+fn cloneAiHistoryTranscriptMessages(
+    allocator: std.mem.Allocator,
+    messages: []const ai_history_types.TranscriptMessage,
+) ![]ai_history_types.TranscriptMessage {
+    const cloned = try allocator.alloc(ai_history_types.TranscriptMessage, messages.len);
+    var initialized: usize = 0;
+    errdefer {
+        while (initialized > 0) {
+            initialized -= 1;
+            allocator.free(cloned[initialized].content);
+        }
+        allocator.free(cloned);
+    }
+    for (messages) |msg| {
+        cloned[initialized] = msg;
+        cloned[initialized].content = try allocator.dupe(u8, msg.content);
+        initialized += 1;
+    }
+    return cloned;
+}
+```
+
+- [ ] **Step 5: Implement save path helpers**
+
+Add these helpers near `saveMarkdownDialogPath`:
+
+```zig
+fn chooseAiHistoryMarkdownExportPath(
+    allocator: std.mem.Allocator,
+    meta: ai_history_types.SessionMeta,
+) !?[]u8 {
+    const root = try aiChatExportRoot(allocator);
+    defer allocator.free(root);
+    std.fs.cwd().makePath(root) catch |err| {
+        log.warn("failed to create AI history export directory {s}: {}", .{ root, err });
+    };
+    var safe_buf: [180]u8 = undefined;
+    const raw = ai_history_markdown.rawDownloadFilename(meta, &safe_buf);
+    const filename = try std.fmt.allocPrint(allocator, "ai-history-{s}.md", .{std.fs.path.stem(raw)});
+    defer allocator.free(filename);
+    return saveMarkdownDialogPathWithTitle(allocator, "Save AI History Markdown", root, filename);
+}
+
+fn chooseAiHistoryRawDownloadPath(
+    allocator: std.mem.Allocator,
+    meta: ai_history_types.SessionMeta,
+) !?[]u8 {
+    const root = platform_dirs.downloadsDir(allocator) catch try aiChatExportRoot(allocator);
+    defer allocator.free(root);
+    var filename_buf: [180]u8 = undefined;
+    const filename = ai_history_markdown.rawDownloadFilename(meta, &filename_buf);
+    const filters = [_]platform_file_dialog.Filter{.{ .name = "All Files (*.*)", .pattern = "*.*" }};
+    const owner: platform_file_dialog.Owner = if (g_window) |w|
+        platform_file_dialog.windowOwner(window_backend.nativeHandleBits(w))
+    else
+        .{};
+    return platform_file_dialog.saveFile(allocator, .{
+        .owner = owner,
+        .title = "Save AI History Raw File",
+        .initial_dir = root,
+        .default_filename = filename,
+        .filters = &filters,
+    }) orelse {
+        overlays.showStatusToast("Raw download cancelled");
+        return null;
+    };
+}
+```
+
+Then split the existing Markdown save helper so Copilot keeps its current title
+and AI History gets its own title:
+
+```zig
+fn saveMarkdownDialogPath(
+    allocator: std.mem.Allocator,
+    initial_dir: []const u8,
+    default_filename: []const u8,
+) !?[]u8 {
+    return saveMarkdownDialogPathWithTitle(allocator, "Save Copilot Markdown", initial_dir, default_filename);
+}
+
+fn saveMarkdownDialogPathWithTitle(
+    allocator: std.mem.Allocator,
+    title_text: []const u8,
+    initial_dir: []const u8,
+    default_filename: []const u8,
+) !?[]u8 {
+    const filters = [_]platform_file_dialog.Filter{
+        .{ .name = "Markdown (*.md)", .pattern = "*.md" },
+        .{ .name = "All Files (*.*)", .pattern = "*.*" },
+    };
+    const owner: platform_file_dialog.Owner = if (g_window) |w|
+        platform_file_dialog.windowOwner(window_backend.nativeHandleBits(w))
+    else
+        .{};
+    const path = platform_file_dialog.saveFile(allocator, .{
+        .owner = owner,
+        .title = title_text,
+        .initial_dir = initial_dir,
+        .default_filename = default_filename,
+        .default_extension = "md",
+        .filters = &filters,
+    }) orelse {
+        overlays.showStatusToast("Markdown export cancelled");
+        return null;
+    };
+    return path;
+}
+```
+
+- [ ] **Step 6: Implement raw read/write helpers**
+
+Add:
+
+```zig
+fn readLocalAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return try file.readToEndAlloc(allocator, ai_history_session.MAX_METADATA_FILE_BYTES);
+    }
+    return try std.fs.cwd().readFileAlloc(allocator, path, ai_history_session.MAX_METADATA_FILE_BYTES);
+}
+
+fn readWslAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var command_buf: [2048]u8 = undefined;
+    const command = try ai_history_session.remoteCatCommand(path, command_buf[0..]);
+    return remote_file.wslExec(allocator, command) orelse error.RemoteExecFailed;
+}
+```
+
+- [ ] **Step 7: Implement the three public action entry points**
+
+Add:
+
+```zig
+pub fn aiHistoryDownloadSelectedRaw() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse {
+        overlays.showStatusToast("No AI History session selected");
+        markUiDirty();
+        return true;
+    };
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const path = chooseAiHistoryRawDownloadPath(allocator, meta) catch {
+        overlays.showStatusToast("Raw download failed");
+        markUiDirty();
+        return true;
+    } orelse {
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(path);
+
+    switch (session.source.target) {
+        .local => {
+            const bytes = readLocalAiHistoryRaw(allocator, meta.source_path) catch {
+                overlays.showStatusToast("Raw download failed");
+                markUiDirty();
+                return true;
+            };
+            defer allocator.free(bytes);
+            writeFilePath(path, bytes) catch {
+                overlays.showStatusToast("Raw download failed");
+                markUiDirty();
+                return true;
+            };
+            _ = input.copyTextToClipboard(path);
+            overlays.showStatusToast("Downloaded raw history; path copied");
+        },
+        .wsl => {
+            const bytes = readWslAiHistoryRaw(allocator, meta.source_path) catch {
+                overlays.showStatusToast("WSL raw download failed");
+                markUiDirty();
+                return true;
+            };
+            defer allocator.free(bytes);
+            writeFilePath(path, bytes) catch {
+                overlays.showStatusToast("Raw download failed");
+                markUiDirty();
+                return true;
+            };
+            _ = input.copyTextToClipboard(path);
+            overlays.showStatusToast("Downloaded raw history; path copied");
+        },
+        .ssh => |ssh_ref| {
+            const conn = overlays.aiHistorySshConnection(ssh_ref.profile_name) orelse {
+                overlays.showStatusToast("SSH profile unavailable");
+                markUiDirty();
+                return true;
+            };
+            var filename_buf: [180]u8 = undefined;
+            const filename = ai_history_markdown.rawDownloadFilename(meta, &filename_buf);
+            _ = file_explorer.downloadRemotePathToPath(meta.source_path, path, filename, &conn, false);
+        },
+    }
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryExportSelectedMarkdown() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse {
+        overlays.showStatusToast("No AI History session selected");
+        markUiDirty();
+        return true;
+    };
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const messages = loadAiHistoryTranscriptForAction(allocator, session, meta) orelse {
+        overlays.showStatusToast("Markdown export failed");
+        markUiDirty();
+        return true;
+    };
+    defer ai_history_session.freeTranscript(allocator, meta.provider, messages);
+
+    const markdown = ai_history_markdown.allocMarkdownExport(allocator, meta, messages, .{}) catch {
+        overlays.showStatusToast("Markdown export failed");
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(markdown);
+
+    const path = chooseAiHistoryMarkdownExportPath(allocator, meta) catch {
+        overlays.showStatusToast("Markdown export failed");
+        markUiDirty();
+        return true;
+    } orelse {
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(path);
+
+    writeFilePath(path, markdown) catch {
+        overlays.showStatusToast("Markdown export failed");
+        markUiDirty();
+        return true;
+    };
+    _ = input.copyTextToClipboard(path);
+    overlays.showStatusToast("Exported AI History Markdown; path copied");
+    markUiDirty();
+    return true;
+}
+
+pub fn aiHistoryAttachSelectedToCopilot() bool {
+    const session = activeAiHistory() orelse return false;
+    const allocator = g_allocator orelse return false;
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse {
+        overlays.showStatusToast("No AI History session selected");
+        markUiDirty();
+        return true;
+    };
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const messages = loadAiHistoryTranscriptForAction(allocator, session, meta) orelse {
+        overlays.showStatusToast("Attach failed");
+        markUiDirty();
+        return true;
+    };
+    defer ai_history_session.freeTranscript(allocator, meta.provider, messages);
+
+    var context = ai_history_markdown.allocCopilotContext(allocator, meta, messages, 48 * 1024) catch {
+        overlays.showStatusToast("Attach failed");
+        markUiDirty();
+        return true;
+    };
+    defer context.deinit(allocator);
+
+    const target = ensureAiHistoryCopilotTarget() orelse {
+        overlays.showStatusToast("Configure a Copilot profile first");
+        markUiDirty();
+        return true;
+    };
+    var title_buf: [160]u8 = undefined;
+    const title_text = std.fmt.bufPrint(&title_buf, "AI History: {s} {s}", .{ meta.provider.label(), meta.session_id }) catch "AI History";
+    target.appendContextCard(title_text, context.markdown, true) catch {
+        overlays.showStatusToast("Attach failed");
+        markUiDirty();
+        return true;
+    };
+    overlays.showStatusToast(if (context.truncated) "Attached truncated AI History context" else "Attached AI History context");
+    markUiDirty();
+    return true;
+}
+```
+
+- [ ] **Step 8: Implement Copilot target selection**
+
+Add:
+
+```zig
+fn ensureAiHistoryCopilotTarget() ?*ai_chat.Session {
+    if (activeAiChat()) |session| return session;
+    if (activeCopilotSessionForInput()) |session| return session;
+    const allocator = g_allocator orelse return null;
+    const session = makeCopilotSession() orelse return null;
+    if (!tab.spawnAiChatSession(allocator, session)) {
+        session.deinit();
+        return null;
+    }
+    clearUiStateOnTabChange();
+    return activeAiChat();
+}
+```
+
+- [ ] **Step 9: Route renderer hit variants**
+
+In `aiHistoryHandleMousePress`, add cases:
+
+```zig
+        .download_raw => {
+            _ = aiHistoryDownloadSelectedRaw();
+            return true;
+        },
+        .export_markdown => {
+            _ = aiHistoryExportSelectedMarkdown();
+            return true;
+        },
+        .attach_copilot => {
+            _ = aiHistoryAttachSelectedToCopilot();
+            return true;
+        },
+```
+
+- [ ] **Step 10: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS, including `side_effect_guard` with AppWindow ceiling `56`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/AppWindow.zig src/source_guards/side_effect_guard.zig
+git commit -m "feat: implement ai history selected actions"
+```
+
+---
+
+### Task 8: Add AI History Keyboard Shortcuts
+
+**Files:**
+- Modify: `src/input.zig`
+
+- [ ] **Step 1: Add source-scan expectations for the new action routing**
+
+In `src/test_fast.zig`, add this guard near the other input source-scan tests:
+
+```zig
+test "input routes AI History selected action shortcuts through AppWindow actions" {
+    const source = @embedFile("input.zig");
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryDownloadSelectedRaw") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryExportSelectedMarkdown") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryAttachSelectedToCopilot") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "!search_focused") != null);
+}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: FAIL because the action names are not present in `input.zig`.
+
+- [ ] **Step 3: Route `D`, `M`, and `A` when search is not focused**
+
+In the AI History key switch in `src/input.zig`, after the `0x52` (`R`) case, add:
+
+```zig
+            0x44 => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryDownloadSelectedRaw();
+                return .none;
+            },
+            0x4D => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryExportSelectedMarkdown();
+                return .none;
+            },
+            0x41 => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryAttachSelectedToCopilot();
+                return .none;
+            },
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/input.zig src/test_fast.zig
+git commit -m "feat: add ai history action shortcuts"
+```
+
+---
+
+### Task 9: Update User Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/ai-agent.md`
+
+- [ ] **Step 1: Update README shortcut table**
+
+In `README.md`, after the `Preview selected AI History transcript` row, add:
+
+```markdown
+| Download selected AI History raw file | **D** in AI History | **D** in AI History |
+| Export selected AI History transcript as Markdown | **M** in AI History | **M** in AI History |
+| Attach selected AI History transcript to Copilot | **A** in AI History | **A** in AI History |
+```
+
+- [ ] **Step 2: Update AI agent docs**
+
+In `docs/ai-agent.md`, after the paragraph that starts `Use Resume to open a real terminal tab`, add:
+
+```markdown
+The selected history row also supports local handoff actions: press `D` to
+download the provider's raw history file, `M` to export the parsed transcript as
+Markdown, or `A` to attach the transcript as a collapsed Copilot context card
+for a follow-up question.
+```
+
+- [ ] **Step 3: Run docs diff check**
+
+Run:
+
+```bash
+git diff --check -- README.md docs/ai-agent.md
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/ai-agent.md
+git commit -m "docs: document ai history selected actions"
+```
+
+---
+
+### Task 10: Final Verification
+
+**Files:**
+- No source edits unless verification finds a defect.
+
+- [ ] **Step 1: Run fast tests**
+
+Run:
+
+```bash
+zig build test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full tests**
+
+Run:
+
+```bash
+zig build test-full
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check Windows checkout safety only if files were added or renamed**
+
+This plan adds `src/terminal_agents/sessions/markdown.zig` and this plan file. Run the path-safety checks documented in `docs/development.md#windows-checkout-safety`.
+
+Expected: no reserved names, illegal characters, case-fold collisions, symlinks, or excessive path lengths.
+
+- [ ] **Step 4: Final source-guard sanity**
+
+Run:
+
+```bash
+zig build check-sizes
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional changes are present.

--- a/docs/superpowers/specs/2026-07-07-ai-history-actions-design.md
+++ b/docs/superpowers/specs/2026-07-07-ai-history-actions-design.md
@@ -1,0 +1,288 @@
+# AI History selected-session actions - design
+
+**Date:** 2026-07-07
+**Status:** Approved, pending implementation
+
+## Problem
+
+The AI History workbench can scan Local, WSL, and SSH targets, filter external
+Codex, Claude Code, and Reasonix sessions, preview the selected transcript with
+Space, and resume the selected session with Enter. It does not yet let the user
+take the selected history row out of the workbench for archiving, sharing, or
+continuing a question in WispTerm's own Copilot.
+
+## Goals
+
+- Download the selected provider's original history file as a local raw file.
+- Export the selected transcript as readable Markdown.
+- Attach the selected transcript to WispTerm Copilot as context for follow-up
+  questions.
+- Keep the feature inside the existing AI History and Copilot feature modules.
+- Preserve the event-driven UI rule: every action that mutates UI state marks
+  the UI dirty through the existing boundary.
+
+## Non-goals
+
+- Do not convert external Codex, Claude Code, or Reasonix histories into
+  WispTerm history records wholesale.
+- Do not add a new full-screen modal or row action menu for the first version.
+- Do not auto-submit a Copilot question after attaching context.
+- Do not change terminal emulation, VT parsing, rendering, or Ghostty-derived
+  terminal behavior.
+
+## Ghostty comparison
+
+Ghostty has no Copilot, external AI-history browser, Markdown transcript export,
+or equivalent session-history action surface. The Ghostty-aligned decision here
+is architectural rather than behavioral: keep this feature out of terminal core
+and platform rendering paths. The work stays in WispTerm's feature domains:
+`terminal_agents/sessions/*`, `renderer/terminal_agents/sessions.zig`, the
+existing AppWindow integration layer, and `assistant/conversation/*` for the
+Copilot context card.
+
+## Current code facts
+
+- AI History state and parsing live under `src/terminal_agents/sessions/`.
+- `SessionMeta.source_path` points at the original provider file.
+- Loaded transcripts use `types.TranscriptMessage`.
+- Local transcript loading already reads `meta.source_path` through
+  `loadLocalTranscript`.
+- WSL and SSH transcript loading already use `RemoteExecHost` and
+  `loadRemoteTranscript`, which `cat`s `meta.source_path` and parses it.
+- SSH downloads already have a reusable SCP path:
+  `file_explorer.downloadRemotePathToPath`.
+- Copilot and AI Chat sessions already support collapsed context-summary cards
+  (`Message.is_context_summary`) that are sent to the model as normal user
+  context.
+- Markdown export for WispTerm's own Copilot exists in
+  `assistant/conversation/session.zig`, but external AI History needs a small
+  formatter over `types.TranscriptMessage` instead of reusing WispTerm's own
+  `Message` type.
+
+## UX
+
+The selected row gains three actions in the detail pane below the existing
+session metadata and near the existing `Resume` action:
+
+- `Download Raw`
+- `Export Markdown`
+- `Attach to Copilot`
+
+Keyboard shortcuts fire only when AI History is active and the search box is not
+focused:
+
+- `D`: download raw provider file.
+- `M`: export Markdown.
+- `A`: attach transcript to Copilot.
+
+Search-focused printable input keeps its current behavior. Existing shortcuts
+remain unchanged: Enter resumes, Space previews, R rescans, arrows navigate.
+
+## Download raw
+
+`Download Raw` saves the selected provider's original history file. This is
+different from Markdown export: it preserves provider-native JSONL/JSON content
+for backup, migration, or debugging.
+
+Behavior:
+
+1. Clone the currently selected `SessionMeta` under the AI History session lock.
+2. Build a safe default filename from provider label, session id, and the source
+   path basename.
+3. Open a save dialog rooted at the user's Downloads folder.
+4. Save/copy the raw file:
+   - Local target: read `meta.source_path` and write to the selected local path.
+   - WSL target: read raw bytes with the existing WSL remote exec host using a
+     quoted `cat <source_path>` command, then write to the selected local path.
+     AI history files are provider text files, so this matches the existing WSL
+     transcript-loading path.
+   - SSH target: reuse `file_explorer.downloadRemotePathToPath` so Windows
+     OpenSSH behavior and SCP stderr handling stay consistent with existing SSH
+     downloads.
+5. Show a toast on success, cancellation, or failure. Local and WSL copies copy
+   the saved path to the clipboard on success, matching the existing Markdown
+   export behavior. SSH uses the existing asynchronous transfer notification.
+
+## Export Markdown
+
+Markdown export loads the selected transcript if it is not already loaded, then
+formats it as a standalone Markdown document.
+
+Format:
+
+```markdown
+# AI History Export
+
+- Provider: Codex
+- Session: abc123
+- Project: /path/to/project
+- Source: /path/to/provider/file.jsonl
+
+## User
+
+...
+
+## Assistant
+
+...
+
+## Tool
+
+...
+```
+
+Rules:
+
+- Include provider, session id, project directory, source path, and available
+  timestamps in the header.
+- Use the provider-neutral roles from `TranscriptMessage.role`.
+- Preserve message order.
+- Omit empty message bodies.
+- Keep the formatter pure and unit-testable.
+- Use the existing save-dialog and atomic-write pattern from WispTerm Copilot
+  Markdown export.
+
+## Attach to Copilot
+
+Attaching a transcript creates model-visible context inside WispTerm Copilot but
+does not submit a question.
+
+Behavior:
+
+1. Load the selected transcript if needed.
+2. Convert it to a bounded Markdown context block using the same formatter as
+   Markdown export.
+3. Attach it to a Copilot-capable session:
+   - If the active tab is an AI Chat tab, append the context there.
+   - If the active tab is a terminal tab with a visible Copilot sidebar, append
+     the context to that sidebar session.
+   - Otherwise create a new Copilot chat tab from the default AI profile and
+     append the context there.
+4. Append the context as a collapsed `is_context_summary` user message titled
+   with provider and session information.
+5. Focus the chat composer and show a toast such as
+   `Attached AI History context`.
+
+The context block is bounded before insertion. If the transcript exceeds the
+limit, keep the header plus the most recent messages and mark the card as
+truncated. This keeps requests under the existing composer/request budgets while
+preserving the useful tail of the conversation.
+
+## Architecture
+
+### `src/terminal_agents/sessions/markdown.zig`
+
+Add a focused formatter for external history transcripts:
+
+- `allocMarkdownExport(allocator, meta, messages, options) ![]u8`
+- `allocCopilotContext(allocator, meta, messages, max_bytes) !ContextResult`
+
+`ContextResult` returns the Markdown bytes plus a `truncated` flag. The module
+depends only on `types.zig` and standard library formatting.
+
+### `src/terminal_agents/sessions/session.zig`
+
+Add small helpers that do not know about AppWindow:
+
+- `selectedMetadataClone(allocator) ?types.SessionMeta`
+- `replaceTranscriptFromMessages(provider, messages)` for AppWindow action
+  helpers that synchronously load a transcript and want the preview pane to
+  reflect the same loaded data.
+
+Keep parsing and memory ownership in the existing provider-specific free paths.
+
+### `src/renderer/terminal_agents/sessions.zig`
+
+Extend the detail-pane hit model:
+
+- Add hit variants for raw download, Markdown export, and Copilot attachment.
+- Render the three actions as compact buttons near `Resume`.
+- Keep hit-test geometry shared with render geometry so the existing layout
+  pattern does not drift.
+
+### `src/AppWindow.zig`
+
+Add action entry points:
+
+- `aiHistoryDownloadSelectedRaw() bool`
+- `aiHistoryExportSelectedMarkdown() bool`
+- `aiHistoryAttachSelectedToCopilot() bool`
+
+These functions own UI integration: selected-row cloning, save dialogs, toasts,
+Copilot tab/session creation, and `markUiDirty()`.
+
+For SSH raw download, call the existing file explorer SCP helper. For Local and
+WSL, write the selected destination through the existing atomic file writer.
+
+### `src/assistant/conversation/session.zig`
+
+Add one narrow API for this feature:
+
+- `appendContextCard(title, body, collapsed) !void`
+
+It appends a `.user` message with `is_context_summary = true`,
+`content_collapsed = true`, and `persist_to_history = true`, then notifies the
+history hook.
+
+### `src/input.zig`
+
+When AI History is active and search is not focused:
+
+- `D` calls `AppWindow.aiHistoryDownloadSelectedRaw()`.
+- `M` calls `AppWindow.aiHistoryExportSelectedMarkdown()`.
+- `A` calls `AppWindow.aiHistoryAttachSelectedToCopilot()`.
+
+Return through the existing input repaint/effect path.
+
+### Docs
+
+Update:
+
+- `README.md` keyboard shortcut table.
+- `docs/ai-agent.md` Sessions section.
+
+## Error handling
+
+- No selected row: show a short unavailable toast.
+- Save dialog cancelled: show a cancellation toast and do nothing.
+- Local read/write failure: show raw download or Markdown export failure.
+- WSL remote read failure: show WSL read/download failure.
+- SSH profile unavailable: show SSH profile unavailable.
+- SSH SCP failure: rely on existing transfer status and stderr handling.
+- Missing default AI profile/API configuration for Copilot attachment: open the
+  existing AI config flow or show the existing missing-profile toast.
+- Transcript parse failure: show transcript load/export failure and leave any
+  existing preview state intact unless the user explicitly requested preview.
+
+## Testing
+
+Use TDD for implementation.
+
+Pure unit tests:
+
+- Markdown formatter includes metadata header and role sections.
+- Markdown formatter omits empty message bodies.
+- Copilot context formatter truncates oversized transcripts while keeping the
+  metadata header and recent messages.
+- Raw default filename sanitizes provider/session/path data.
+- Context-card append stores a collapsed `is_context_summary` user message and
+  persists it to history.
+
+Session/UI model tests:
+
+- Detail-pane hit-test returns the three new action variants.
+- Keyboard action routing ignores `D`/`M`/`A` while the AI History search field
+  is focused.
+- Keyboard action routing fires the AppWindow action when search is not focused.
+
+Integration checks:
+
+- `zig build test`
+- `zig build test-full` before finishing implementation.
+
+Manual checks:
+
+- Local AI History row: download raw, export Markdown, attach to Copilot.
+- WSL AI History row on Windows: download raw and export Markdown.
+- SSH AI History row with a configured profile: raw download uses SCP and keeps
+  useful stderr on failure.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3123,6 +3123,10 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
             markUiDirty();
             return true;
         },
+        .download_raw, .export_markdown, .attach_copilot => {
+            markUiDirty();
+            return true;
+        },
         .category => |cat| {
             session.setCategory(cat);
             session.ensureSelectionVisible(visible_rows);

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -50,6 +50,7 @@ pub const ai_chat = @import("assistant/conversation/session.zig");
 const ai_chat_types = @import("assistant/conversation/types.zig");
 const ai_history_cache = @import("terminal_agents/sessions/cache.zig");
 const ai_history_resume = @import("terminal_agents/sessions/resume.zig");
+const ai_history_markdown = @import("terminal_agents/sessions/markdown.zig");
 const ai_loop_store = @import("assistant/loop/store.zig");
 const ai_history_types = @import("terminal_agents/sessions/types.zig");
 const ai_history_session = @import("terminal_agents/sessions/session.zig");
@@ -3082,6 +3083,64 @@ fn startAiHistoryTranscript(allocator: std.mem.Allocator, session: *ai_history_s
     });
 }
 
+fn selectedAiHistoryMetaForAction(allocator: std.mem.Allocator, session: *ai_history_session.Session) ?ai_history_types.SessionMeta {
+    return session.selectedMetadataClone(allocator);
+}
+
+fn loadAiHistoryTranscriptForAction(
+    allocator: std.mem.Allocator,
+    session: *ai_history_session.Session,
+    meta: ai_history_types.SessionMeta,
+) ?[]ai_history_types.TranscriptMessage {
+    session.mutex.lock();
+    if (session.transcript_state == .ready and session.transcript_provider != null and session.transcript_provider.? == meta.provider) {
+        const cloned = cloneAiHistoryTranscriptMessages(allocator, session.transcript) catch null;
+        session.mutex.unlock();
+        return cloned;
+    }
+    session.mutex.unlock();
+
+    const target = aiHistoryTargetSnapshot(session.source.target) orelse return null;
+    const messages: []ai_history_types.TranscriptMessage = switch (target) {
+        .local => ai_history_session.loadLocalTranscript(allocator, meta) catch return null,
+        .wsl => blk: {
+            var host_state = ai_history_session.WslScannerHost{};
+            const host = host_state.scannerHost();
+            break :blk host.loadTranscript(host.ctx, allocator, meta) catch return null;
+        },
+        .ssh => |conn| blk: {
+            var host_state = ai_history_session.SshScannerHost{ .conn = conn };
+            const host = host_state.scannerHost();
+            break :blk host.loadTranscript(host.ctx, allocator, meta) catch return null;
+        },
+    };
+
+    const preview_copy = cloneAiHistoryTranscriptMessages(allocator, messages) catch null;
+    if (preview_copy) |copy| session.replaceTranscriptFromMessages(meta.provider, copy);
+    return messages;
+}
+
+fn cloneAiHistoryTranscriptMessages(
+    allocator: std.mem.Allocator,
+    messages: []const ai_history_types.TranscriptMessage,
+) ![]ai_history_types.TranscriptMessage {
+    const cloned = try allocator.alloc(ai_history_types.TranscriptMessage, messages.len);
+    var initialized: usize = 0;
+    errdefer {
+        while (initialized > 0) {
+            initialized -= 1;
+            allocator.free(cloned[initialized].content);
+        }
+        allocator.free(cloned);
+    }
+    for (messages) |msg| {
+        cloned[initialized] = msg;
+        cloned[initialized].content = try allocator.dupe(u8, msg.content);
+        initialized += 1;
+    }
+    return cloned;
+}
+
 pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
     const session = activeAiHistory() orelse return false;
     const win = g_window orelse return true;
@@ -3123,8 +3182,16 @@ pub fn aiHistoryHandleMousePress(xpos: f64, ypos: f64) bool {
             markUiDirty();
             return true;
         },
-        .download_raw, .export_markdown, .attach_copilot => {
-            markUiDirty();
+        .download_raw => {
+            _ = aiHistoryDownloadSelectedRaw();
+            return true;
+        },
+        .export_markdown => {
+            _ = aiHistoryExportSelectedMarkdown();
+            return true;
+        },
+        .attach_copilot => {
+            _ = aiHistoryAttachSelectedToCopilot();
             return true;
         },
         .category => |cat| {
@@ -3224,6 +3291,153 @@ fn localHomeForAiHistory(allocator: std.mem.Allocator) ![]u8 {
     return error.NoHomeDirectory;
 }
 
+fn showAiHistoryActionToast(message: []const u8) bool {
+    overlays.showStatusToast(message);
+    markUiDirty();
+    return true;
+}
+
+fn showNoAiHistorySelectionForAction() bool {
+    return showAiHistoryActionToast("No AI History session selected");
+}
+
+pub fn aiHistoryDownloadSelectedRaw() bool {
+    const allocator = g_allocator orelse return false;
+    const session = activeAiHistory() orelse return showNoAiHistorySelectionForAction();
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse return showNoAiHistorySelectionForAction();
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const path = chooseAiHistoryRawDownloadPath(allocator, meta) catch |err| {
+        log.warn("failed to choose AI history raw download path for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Raw download failed");
+    } orelse {
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(path);
+
+    var filename_buf: [180]u8 = undefined;
+    const filename = ai_history_markdown.rawDownloadFilename(meta, &filename_buf);
+
+    switch (session.source.target) {
+        .local => {
+            const bytes = readLocalAiHistoryRaw(allocator, meta.source_path) catch |err| {
+                log.warn("failed to read local AI history raw file {s}: {}", .{ meta.source_path, err });
+                return showAiHistoryActionToast("Raw download failed");
+            };
+            defer allocator.free(bytes);
+            return writeAiHistoryRawDownload(path, bytes);
+        },
+        .wsl => {
+            const bytes = readWslAiHistoryRaw(allocator, meta.source_path) catch |err| {
+                log.warn("failed to read WSL AI history raw file {s}: {}", .{ meta.source_path, err });
+                return showAiHistoryActionToast("Raw download failed");
+            };
+            defer allocator.free(bytes);
+            return writeAiHistoryRawDownload(path, bytes);
+        },
+        .ssh => |ssh| {
+            const conn = overlays.aiHistorySshConnection(ssh.profile_name) orelse {
+                return showAiHistoryActionToast("Raw download failed");
+            };
+            if (!file_explorer.downloadRemotePathToPath(meta.source_path, path, filename, &conn, false)) {
+                return showAiHistoryActionToast("Raw download failed");
+            }
+            markUiDirty();
+            return true;
+        },
+    }
+}
+
+fn writeAiHistoryRawDownload(path: []const u8, bytes: []const u8) bool {
+    writeFilePath(path, bytes) catch |err| {
+        log.warn("failed to write AI history raw download {s}: {}", .{ path, err });
+        return showAiHistoryActionToast("Raw download failed");
+    };
+    if (input.copyTextToClipboard(path)) {
+        return showAiHistoryActionToast("Downloaded raw file; path copied");
+    }
+    return showAiHistoryActionToast("Downloaded raw file");
+}
+
+pub fn aiHistoryExportSelectedMarkdown() bool {
+    const allocator = g_allocator orelse return false;
+    const session = activeAiHistory() orelse return showNoAiHistorySelectionForAction();
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse return showNoAiHistorySelectionForAction();
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const messages = loadAiHistoryTranscriptForAction(allocator, session, meta) orelse {
+        return showAiHistoryActionToast("Markdown export failed");
+    };
+    defer ai_history_session.freeTranscript(allocator, meta.provider, messages);
+
+    const markdown = ai_history_markdown.allocMarkdownExport(allocator, meta, messages, .{}) catch |err| {
+        log.warn("failed to render AI history Markdown export for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Markdown export failed");
+    };
+    defer allocator.free(markdown);
+
+    const path = chooseAiHistoryMarkdownExportPath(allocator, meta) catch |err| {
+        log.warn("failed to choose AI history Markdown export path for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Markdown export failed");
+    } orelse {
+        markUiDirty();
+        return true;
+    };
+    defer allocator.free(path);
+
+    writeFilePath(path, markdown) catch |err| {
+        log.warn("failed to write AI history Markdown export {s}: {}", .{ path, err });
+        return showAiHistoryActionToast("Markdown export failed");
+    };
+
+    if (input.copyTextToClipboard(path)) {
+        return showAiHistoryActionToast("Exported AI History Markdown; path copied");
+    }
+    return showAiHistoryActionToast("Exported AI History Markdown");
+}
+
+pub fn aiHistoryAttachSelectedToCopilot() bool {
+    const allocator = g_allocator orelse return false;
+    const session = activeAiHistory() orelse return showNoAiHistorySelectionForAction();
+    const meta = selectedAiHistoryMetaForAction(allocator, session) orelse return showNoAiHistorySelectionForAction();
+    defer ai_history_session.freeMetadata(allocator, meta);
+
+    const messages = loadAiHistoryTranscriptForAction(allocator, session, meta) orelse {
+        return showAiHistoryActionToast("Attach failed");
+    };
+    defer ai_history_session.freeTranscript(allocator, meta.provider, messages);
+
+    var context = ai_history_markdown.allocCopilotContext(allocator, meta, messages, 48 * 1024) catch |err| {
+        log.warn("failed to render AI history Copilot context for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Attach failed");
+    };
+    defer context.deinit(allocator);
+
+    const target = ensureAiHistoryCopilotTarget() orelse {
+        return showAiHistoryActionToast("Attach failed");
+    };
+    const title_text = std.fmt.allocPrint(
+        allocator,
+        "AI History: {s} {s}",
+        .{ meta.provider.label(), meta.session_id },
+    ) catch |err| {
+        log.warn("failed to build AI history Copilot context title for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Attach failed");
+    };
+    defer allocator.free(title_text);
+
+    target.appendContextCard(title_text, context.markdown, true) catch |err| {
+        log.warn("failed to attach AI history context to Copilot for {s}: {}", .{ meta.session_id, err });
+        return showAiHistoryActionToast("Attach failed");
+    };
+
+    if (context.truncated) {
+        return showAiHistoryActionToast("Attached AI History to Copilot; truncated");
+    }
+    return showAiHistoryActionToast("Attached AI History to Copilot");
+}
+
 fn activeMarkdownExportSession() ?*ai_chat.Session {
     if (activeAiChat()) |session| return session;
     return activeCopilotSessionForInput();
@@ -3280,7 +3494,7 @@ fn copyAiChatMarkdown(session: *ai_chat.Session, mode: ai_chat.MarkdownExportMod
 
     if (input.copyTextToClipboard(markdown)) {
         overlays.showCopyToast(markdown.len);
-        g_force_rebuild = true;
+        markUiDirty();
     } else {
         overlays.showStatusToast("Copy failed");
     }
@@ -3337,6 +3551,19 @@ fn makeCopilotSession() ?*ai_chat.Session {
 
 fn ensureActiveCopilotSession() ?*ai_chat.Session {
     return copilot_sidebar.ensureActiveSession(copilotSidebarHost());
+}
+
+fn ensureAiHistoryCopilotTarget() ?*ai_chat.Session {
+    if (activeAiChat()) |session| return session;
+    if (activeCopilotSessionForInput()) |session| return session;
+    const allocator = g_allocator orelse return null;
+    const session = makeCopilotSession() orelse return null;
+    if (!tab.spawnAiChatSession(allocator, session)) {
+        session.deinit();
+        return null;
+    }
+    clearUiStateOnTabChange();
+    return activeAiChat();
 }
 
 fn openCopilotApiConfig(session: ?*ai_chat.Session) void {
@@ -3484,8 +3711,58 @@ fn chooseAiChatMarkdownExportPath(
     return saveMarkdownDialogPath(allocator, root, filename);
 }
 
+fn chooseAiHistoryMarkdownExportPath(
+    allocator: std.mem.Allocator,
+    meta: ai_history_types.SessionMeta,
+) !?[]u8 {
+    const root = try aiChatExportRoot(allocator);
+    defer allocator.free(root);
+    std.fs.cwd().makePath(root) catch |err| {
+        log.warn("failed to create AI history export directory {s}: {}", .{ root, err });
+    };
+    var safe_buf: [180]u8 = undefined;
+    const raw = ai_history_markdown.rawDownloadFilename(meta, &safe_buf);
+    const filename = try std.fmt.allocPrint(allocator, "ai-history-{s}.md", .{std.fs.path.stem(raw)});
+    defer allocator.free(filename);
+    return saveMarkdownDialogPathWithTitle(allocator, "Save AI History Markdown", root, filename);
+}
+
+fn chooseAiHistoryRawDownloadPath(
+    allocator: std.mem.Allocator,
+    meta: ai_history_types.SessionMeta,
+) !?[]u8 {
+    const root = platform_dirs.downloadsDir(allocator) catch try aiChatExportRoot(allocator);
+    defer allocator.free(root);
+    var filename_buf: [180]u8 = undefined;
+    const filename = ai_history_markdown.rawDownloadFilename(meta, &filename_buf);
+    const filters = [_]platform_file_dialog.Filter{.{ .name = "All Files (*.*)", .pattern = "*.*" }};
+    const owner: platform_file_dialog.Owner = if (g_window) |w|
+        platform_file_dialog.windowOwner(window_backend.nativeHandleBits(w))
+    else
+        .{};
+    return platform_file_dialog.saveFile(allocator, .{
+        .owner = owner,
+        .title = "Save AI History Raw File",
+        .initial_dir = root,
+        .default_filename = filename,
+        .filters = &filters,
+    }) orelse {
+        overlays.showStatusToast("Raw download cancelled");
+        return null;
+    };
+}
+
 fn saveMarkdownDialogPath(
     allocator: std.mem.Allocator,
+    initial_dir: []const u8,
+    default_filename: []const u8,
+) !?[]u8 {
+    return saveMarkdownDialogPathWithTitle(allocator, "Save Copilot Markdown", initial_dir, default_filename);
+}
+
+fn saveMarkdownDialogPathWithTitle(
+    allocator: std.mem.Allocator,
+    title_text: []const u8,
     initial_dir: []const u8,
     default_filename: []const u8,
 ) !?[]u8 {
@@ -3499,7 +3776,7 @@ fn saveMarkdownDialogPath(
         .{};
     const path = platform_file_dialog.saveFile(allocator, .{
         .owner = owner,
-        .title = "Save Copilot Markdown",
+        .title = title_text,
         .initial_dir = initial_dir,
         .default_filename = default_filename,
         .default_extension = "md",
@@ -3513,6 +3790,21 @@ fn saveMarkdownDialogPath(
 
 fn writeFilePath(path: []const u8, bytes: []const u8) !void {
     try platform_atomic_file.writeFileReplaceSafe(path, bytes);
+}
+
+fn readLocalAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return try file.readToEndAlloc(allocator, ai_history_session.MAX_METADATA_FILE_BYTES);
+    }
+    return try std.fs.cwd().readFileAlloc(allocator, path, ai_history_session.MAX_METADATA_FILE_BYTES);
+}
+
+fn readWslAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    var command_buf: [2048]u8 = undefined;
+    const command = try ai_history_session.remoteCatCommand(path, command_buf[0..]);
+    return remote_file.wslExec(allocator, command) orelse error.RemoteExecFailed;
 }
 
 fn syncWindowTitlebarHeight(win: *window_backend.Window) f32 {

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3092,14 +3092,6 @@ fn loadAiHistoryTranscriptForAction(
     session: *ai_history_session.Session,
     meta: ai_history_types.SessionMeta,
 ) ?[]ai_history_types.TranscriptMessage {
-    session.mutex.lock();
-    if (session.transcript_state == .ready and session.transcript_provider != null and session.transcript_provider.? == meta.provider) {
-        const cloned = cloneAiHistoryTranscriptMessages(allocator, session.transcript) catch null;
-        session.mutex.unlock();
-        return cloned;
-    }
-    session.mutex.unlock();
-
     const target = aiHistoryTargetSnapshot(session.source.target) orelse return null;
     const messages: []ai_history_types.TranscriptMessage = switch (target) {
         .local => ai_history_session.loadLocalTranscript(allocator, meta) catch return null,
@@ -3331,14 +3323,14 @@ pub fn aiHistoryDownloadSelectedRaw() bool {
         .wsl => {
             const bytes = readWslAiHistoryRaw(allocator, meta.source_path) catch |err| {
                 log.warn("failed to read WSL AI history raw file {s}: {}", .{ meta.source_path, err });
-                return showAiHistoryActionToast("Raw download failed");
+                return showAiHistoryActionToast("WSL raw download failed");
             };
             defer allocator.free(bytes);
             return writeAiHistoryRawDownload(path, bytes);
         },
         .ssh => |ssh| {
             const conn = overlays.aiHistorySshConnection(ssh.profile_name) orelse {
-                return showAiHistoryActionToast("Raw download failed");
+                return showAiHistoryActionToast("SSH profile unavailable");
             };
             if (!file_explorer.downloadRemotePathToPath(meta.source_path, path, filename, &conn, false)) {
                 return showAiHistoryActionToast("Raw download failed");
@@ -3414,9 +3406,7 @@ pub fn aiHistoryAttachSelectedToCopilot() bool {
     };
     defer context.deinit(allocator);
 
-    const target = ensureAiHistoryCopilotTarget() orelse {
-        return showAiHistoryActionToast("Attach failed");
-    };
+    const target = ensureAiHistoryCopilotTarget() orelse return true;
     const title_text = std.fmt.allocPrint(
         allocator,
         "AI History: {s} {s}",
@@ -3429,7 +3419,12 @@ pub fn aiHistoryAttachSelectedToCopilot() bool {
 
     target.appendContextCard(title_text, context.markdown, true) catch |err| {
         log.warn("failed to attach AI history context to Copilot for {s}: {}", .{ meta.session_id, err });
-        return showAiHistoryActionToast("Attach failed");
+        const message = switch (err) {
+            error.SessionBusy => "Copilot is busy",
+            error.SessionClosing => "Copilot session is closing",
+            else => "Attach failed",
+        };
+        return showAiHistoryActionToast(message);
     };
 
     if (context.truncated) {
@@ -3556,10 +3551,18 @@ fn ensureActiveCopilotSession() ?*ai_chat.Session {
 fn ensureAiHistoryCopilotTarget() ?*ai_chat.Session {
     if (activeAiChat()) |session| return session;
     if (activeCopilotSessionForInput()) |session| return session;
-    const allocator = g_allocator orelse return null;
-    const session = makeCopilotSession() orelse return null;
+    const allocator = g_allocator orelse {
+        _ = showAiHistoryActionToast("Attach failed");
+        return null;
+    };
+    const session = makeCopilotSession() orelse {
+        overlays.openAiConfigForMissingCopilotApi();
+        _ = showAiHistoryActionToast("Configure a Copilot profile first");
+        return null;
+    };
     if (!tab.spawnAiChatSession(allocator, session)) {
         session.deinit();
+        _ = showAiHistoryActionToast("Attach failed");
         return null;
     }
     clearUiStateOnTabChange();

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3092,6 +3092,18 @@ fn loadAiHistoryTranscriptForAction(
     session: *ai_history_session.Session,
     meta: ai_history_types.SessionMeta,
 ) ?[]ai_history_types.TranscriptMessage {
+    session.mutex.lock();
+    if (session.transcript_state == .ready and
+        session.transcript_provider != null and
+        session.transcript_provider.? == meta.provider)
+    {
+        const preview_copy = cloneAiHistoryTranscriptMessages(allocator, session.transcript) catch null;
+        session.mutex.unlock();
+        if (preview_copy) |copy| return copy;
+    } else {
+        session.mutex.unlock();
+    }
+
     const target = aiHistoryTargetSnapshot(session.source.target) orelse return null;
     const messages: []ai_history_types.TranscriptMessage = switch (target) {
         .local => ai_history_session.loadLocalTranscript(allocator, meta) catch return null,

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -575,12 +575,20 @@ pub fn spawnAiChatTab(
         return false;
     };
     session.setMaxTokens(max_tokens);
-    installAiChatHistoryHook(session);
 
-    const t = allocator.create(TabState) catch {
+    if (!spawnAiChatSession(allocator, session)) {
         session.deinit();
         return false;
-    };
+    }
+    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
+    return true;
+}
+
+pub fn spawnAiChatSession(allocator: std.mem.Allocator, session: *ai_chat.Session) bool {
+    if (g_tab_count >= MAX_TABS) return false;
+    installAiChatHistoryHook(session);
+
+    const t = allocator.create(TabState) catch return false;
     t.kind = .ai_chat;
     t.tree = .empty;
     t.focused = .root;
@@ -600,8 +608,6 @@ pub fn spawnAiChatTab(
     g_tabs[g_tab_count] = t;
     active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
-
-    std.debug.print("New AI Chat tab spawned (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
 }
 
@@ -613,32 +619,11 @@ pub fn spawnAiChatTabFromHistoryRecord(allocator: std.mem.Allocator, record: age
         std.debug.print("Failed to restore AI Chat session from history\n", .{});
         return false;
     };
-    installAiChatHistoryHook(session);
 
-    const t = allocator.create(TabState) catch {
+    if (!spawnAiChatSession(allocator, session)) {
         session.deinit();
         return false;
-    };
-    t.kind = .ai_chat;
-    t.tree = .empty;
-    t.focused = .root;
-    t.ai_chat_session = session;
-    t.ai_history_session = null;
-    t.skill_center_session = null;
-    t.port_forwarding_session = null;
-    t.copilot_session = null;
-    // allocator.create returns undefined memory and struct-default values are
-    // NOT applied to field-by-field init, so these must be set explicitly or
-    // getTitle reads a garbage tmux_name_len (Phase 3c-2 fields).
-    t.tmux_window_id = null;
-    t.tmux_owner = null;
-    t.tmux_name_len = 0;
-    t.copilot_visible = false;
-
-    g_tabs[g_tab_count] = t;
-    active_tab_state.g_active_tab = g_tab_count;
-    g_tab_count += 1;
-
+    }
     std.debug.print("Restored AI Chat tab from history (count={}), active: {}\n", .{ g_tab_count, active_tab_state.g_active_tab });
     return true;
 }
@@ -2075,6 +2060,27 @@ test "tab: restoreTab skips an ai tab when no restore hook is installed" {
         .ai_session_id = "sess-xyz",
     };
     try std.testing.expect(!restoreTab(std.testing.allocator, &snap, 80, 24, .block, false));
+}
+
+test "tab: spawnAiChatSession creates active ai chat tab from owned session" {
+    const allocator = std.testing.allocator;
+    resetTestTabGlobals();
+    defer {
+        for (0..g_tab_count) |idx| {
+            if (g_tabs[idx]) |tab_state| {
+                tab_state.deinit(allocator);
+                allocator.destroy(tab_state);
+                g_tabs[idx] = null;
+            }
+        }
+        resetTestTabGlobals();
+    }
+
+    const session = try ai_chat.Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    try std.testing.expect(spawnAiChatSession(allocator, session));
+    try std.testing.expectEqual(@as(usize, 1), g_tab_count);
+    try std.testing.expect(activeAiChat() != null);
+    try std.testing.expectEqualStrings("Copilot", activeAiChat().?.title());
 }
 
 test "tab: restoreTab routes ai_history through the restore hook" {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -586,9 +586,9 @@ pub fn spawnAiChatTab(
 
 pub fn spawnAiChatSession(allocator: std.mem.Allocator, session: *ai_chat.Session) bool {
     if (g_tab_count >= MAX_TABS) return false;
-    installAiChatHistoryHook(session);
 
     const t = allocator.create(TabState) catch return false;
+    installAiChatHistoryHook(session);
     t.kind = .ai_chat;
     t.tree = .empty;
     t.focused = .root;
@@ -2081,6 +2081,24 @@ test "tab: spawnAiChatSession creates active ai chat tab from owned session" {
     try std.testing.expectEqual(@as(usize, 1), g_tab_count);
     try std.testing.expect(activeAiChat() != null);
     try std.testing.expectEqualStrings("Copilot", activeAiChat().?.title());
+}
+
+test "tab: spawnAiChatSession returns false without taking ownership when tabs are full" {
+    const allocator = std.testing.allocator;
+    resetTestTabGlobals();
+    defer resetTestTabGlobals();
+
+    const session = try ai_chat.Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+
+    g_tab_count = MAX_TABS;
+    active_tab_state.g_active_tab = 3;
+
+    try std.testing.expect(!spawnAiChatSession(allocator, session));
+    try std.testing.expectEqual(@as(usize, MAX_TABS), g_tab_count);
+    try std.testing.expectEqual(@as(usize, 3), active_tab_state.g_active_tab);
+    try std.testing.expect(session.history_on_change == null);
+
+    session.deinit();
 }
 
 test "tab: restoreTab routes ai_history through the restore hook" {

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -1721,6 +1721,8 @@ pub const Session = struct {
             self.mutex.unlock();
             self.allocator.free(content);
         }
+        if (self.closing.load(.acquire)) return error.SessionClosing;
+        if (self.request_inflight) return error.SessionBusy;
         try self.messages.append(self.allocator, .{
             .role = .user,
             .content = content,
@@ -9057,18 +9059,73 @@ test "ai chat appendContextCard stores collapsed persisted user context" {
     const session = try Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
     defer session.deinit();
 
+    var capture = TestHistoryHookCapture{};
+    defer capture.deinit();
+    g_test_history_hook_capture = &capture;
+    defer g_test_history_hook_capture = null;
+    session.setHistoryChangeHook(testHistoryHookCaptureCallback);
+
     try session.appendContextCard("AI History: Codex sess-1", "## User\n\nstatus?", true);
+
+    {
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
+        const msg = session.messages.items[0];
+        try std.testing.expectEqual(Role.user, msg.role);
+        try std.testing.expect(msg.is_context_summary);
+        try std.testing.expect(msg.content_collapsed);
+        try std.testing.expect(msg.persist_to_history);
+        try std.testing.expect(std.mem.indexOf(u8, msg.content, "AI History: Codex sess-1") != null);
+        try std.testing.expect(std.mem.indexOf(u8, msg.content, "status?") != null);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), capture.calls);
+    try std.testing.expect(capture.event != null);
+    try std.testing.expectEqual(@as(usize, 1), capture.event.?.record.messages.len);
+    const record_msg = capture.event.?.record.messages[0];
+    try std.testing.expectEqual(.user, record_msg.role);
+    try std.testing.expect(std.mem.indexOf(u8, record_msg.content, "AI History: Codex sess-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, record_msg.content, "status?") != null);
+}
+
+test "ai chat appendContextCard rejects busy session without changing state" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    defer session.deinit();
+
+    {
+        session.mutex.lock();
+        defer session.mutex.unlock();
+        try session.messages.append(allocator, .{
+            .role = .user,
+            .content = try allocator.dupe(u8, "existing"),
+        });
+        session.request_inflight = true;
+        session.setStatusLocked("Thinking...");
+    }
+
+    try std.testing.expectError(error.SessionBusy, session.appendContextCard("AI History: Codex sess-1", "## User\n\nstatus?", true));
 
     session.mutex.lock();
     defer session.mutex.unlock();
     try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
-    const msg = session.messages.items[0];
-    try std.testing.expectEqual(Role.user, msg.role);
-    try std.testing.expect(msg.is_context_summary);
-    try std.testing.expect(msg.content_collapsed);
-    try std.testing.expect(msg.persist_to_history);
-    try std.testing.expect(std.mem.indexOf(u8, msg.content, "AI History: Codex sess-1") != null);
-    try std.testing.expect(std.mem.indexOf(u8, msg.content, "status?") != null);
+    try std.testing.expectEqualStrings("existing", session.messages.items[0].content);
+    try std.testing.expectEqualStrings("Thinking...", session.status());
+}
+
+test "ai chat appendContextCard rejects closing session without appending" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    defer session.deinit();
+
+    session.closing.store(true, .release);
+
+    try std.testing.expectError(error.SessionClosing, session.appendContextCard("AI History: Codex sess-1", "## User\n\nstatus?", true));
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
 }
 
 test "applySummaryResult collapses pre-switch messages into one summary card" {

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -1713,6 +1713,27 @@ pub const Session = struct {
         self.ensureSkillSuggestionsForInputLocked();
     }
 
+    pub fn appendContextCard(self: *Session, title_text: []const u8, body: []const u8, collapsed: bool) !void {
+        const content = try std.fmt.allocPrint(self.allocator, "### {s}\n\n{s}", .{ title_text, body });
+        var history_change: ?PendingHistoryChange = null;
+        self.mutex.lock();
+        errdefer {
+            self.mutex.unlock();
+            self.allocator.free(content);
+        }
+        try self.messages.append(self.allocator, .{
+            .role = .user,
+            .content = content,
+            .is_context_summary = true,
+            .content_collapsed = collapsed,
+            .persist_to_history = true,
+        });
+        history_change = self.captureHistoryChangeLocked();
+        self.setStatusLocked("Ready");
+        self.mutex.unlock();
+        self.notifyHistoryChange(history_change);
+    }
+
     /// If the composer is selected (select-all) and non-empty, return a copy of
     /// the input text and clear the composer. Returns null otherwise (e.g. when
     /// only a read-only transcript selection is active).
@@ -9029,6 +9050,25 @@ test "is_context_summary messages are collapsible" {
     try std.testing.expect(session.messages.items[0].content_collapsed);
     session.toggleToolMessageCollapsed(0);
     try std.testing.expect(!session.messages.items[0].content_collapsed);
+}
+
+test "ai chat appendContextCard stores collapsed persisted user context" {
+    const allocator = std.testing.allocator;
+    const session = try Session.init(allocator, "Copilot", "https://example.test", "k", "model", "system", "disabled", "low", "false", "true");
+    defer session.deinit();
+
+    try session.appendContextCard("AI History: Codex sess-1", "## User\n\nstatus?", true);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
+    const msg = session.messages.items[0];
+    try std.testing.expectEqual(Role.user, msg.role);
+    try std.testing.expect(msg.is_context_summary);
+    try std.testing.expect(msg.content_collapsed);
+    try std.testing.expect(msg.persist_to_history);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "AI History: Codex sess-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, msg.content, "status?") != null);
 }
 
 test "applySummaryResult collapses pre-switch messages into one summary card" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -3337,6 +3337,18 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
                 _ = AppWindow.aiHistoryScanLocalNow();
                 return .none;
             },
+            0x44 => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryDownloadSelectedRaw();
+                return .none;
+            },
+            0x4D => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryExportSelectedMarkdown();
+                return .none;
+            },
+            0x41 => if (plain and !ev.shift and !search_focused) {
+                _ = AppWindow.aiHistoryAttachSelectedToCopilot();
+                return .none;
+            },
             else => {},
         }
         return .none;

--- a/src/input.zig
+++ b/src/input.zig
@@ -1949,8 +1949,12 @@ threadlocal var g_ai_transcript_selecting: bool = false;
 threadlocal var g_ai_transcript_select_chat: ?*AppWindow.ai_chat.Session = null;
 threadlocal var g_ai_transcript_select_auto_copy: bool = false;
 threadlocal var g_ai_transcript_select_panel: AiTranscriptPanel = .active_chat;
-threadlocal var g_port_forwarding_suppress_command_char: ?u21 = null;
-threadlocal var g_skill_center_suppress_command_char: ?u21 = null;
+const CommandCharSuppressors = struct {
+    port_forwarding: ?u21 = null,
+    skill_center: ?u21 = null,
+    ai_history: ?u21 = null,
+};
+threadlocal var command_char_suppressors: CommandCharSuppressors = .{};
 pub threadlocal var g_sidebar_resize_hover: bool = false; // Mouse is over the sidebar resize edge
 pub threadlocal var g_sidebar_resize_dragging: bool = false; // Currently dragging the sidebar edge
 pub threadlocal var g_explorer_resize_hover: bool = false; // Mouse is over the file explorer resize edge
@@ -2755,6 +2759,11 @@ fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
         tab.handleRenameChar(ev.codepoint);
         return .none;
     }
+    if (command_char_suppressors.ai_history) |codepoint| {
+        const suppress = !ev.ctrl and !ev.alt and !ev.super and ev.codepoint == codepoint;
+        command_char_suppressors.ai_history = null;
+        if (suppress) return .none;
+    }
     if (assistant_conversation.current(aiCopilotFocused())) |target| {
         if (!ev.ctrl and !ev.alt) {
             AppWindow.resetCursorBlink();
@@ -2774,9 +2783,9 @@ fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
         return .none;
     }
     if (AppWindow.activeSkillCenter() != null) {
-        if (g_skill_center_suppress_command_char) |codepoint| {
+        if (command_char_suppressors.skill_center) |codepoint| {
             const suppress = !ev.ctrl and !ev.alt and !ev.super and ev.codepoint == codepoint;
-            g_skill_center_suppress_command_char = null;
+            command_char_suppressors.skill_center = null;
             if (suppress) return .none;
         }
         if (!ev.ctrl and !ev.alt and !ev.super) {
@@ -2785,9 +2794,9 @@ fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
         return .none;
     }
     if (AppWindow.activePortForwarding() != null) {
-        if (g_port_forwarding_suppress_command_char) |codepoint| {
+        if (command_char_suppressors.port_forwarding) |codepoint| {
             const suppress = !ev.ctrl and !ev.alt and !ev.super and ev.codepoint == codepoint;
-            g_port_forwarding_suppress_command_char = null;
+            command_char_suppressors.port_forwarding = null;
             if (suppress) return .none;
         }
         if (!ev.ctrl and !ev.alt and !ev.super) {
@@ -3339,14 +3348,17 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
             },
             0x44 => if (plain and !ev.shift and !search_focused) {
                 _ = AppWindow.aiHistoryDownloadSelectedRaw();
+                command_char_suppressors.ai_history = 'd';
                 return .none;
             },
             0x4D => if (plain and !ev.shift and !search_focused) {
                 _ = AppWindow.aiHistoryExportSelectedMarkdown();
+                command_char_suppressors.ai_history = 'm';
                 return .none;
             },
             0x41 => if (plain and !ev.shift and !search_focused) {
                 _ = AppWindow.aiHistoryAttachSelectedToCopilot();
+                command_char_suppressors.ai_history = 'a';
                 return .none;
             },
             else => {},
@@ -3410,13 +3422,13 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
             },
             0x4E => if (plain and !ev.shift) {
                 if (!overlay_active and AppWindow.portForwardingOpenNew()) {
-                    g_port_forwarding_suppress_command_char = 'n';
+                    command_char_suppressors.port_forwarding = 'n';
                 }
                 return .none;
             },
             0x45 => if (plain and !ev.shift) {
                 if (!overlay_active and AppWindow.portForwardingOpenEdit()) {
-                    g_port_forwarding_suppress_command_char = 'e';
+                    command_char_suppressors.port_forwarding = 'e';
                 }
                 return .none;
             },
@@ -3546,7 +3558,7 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
                 // SDL text-input mode also fires a 'g' CHAR event after this
                 // key-down; suppress it so it doesn't land in the now-active
                 // URL field. (Only 'G' opens a text field, so only it suppresses.)
-                g_skill_center_suppress_command_char = 'g';
+                command_char_suppressors.skill_center = 'g';
                 return .none;
             },
             0x41 => if (plain and !ev.shift and picking) { // 'A' select-all

--- a/src/renderer/terminal_agents/sessions.zig
+++ b/src/renderer/terminal_agents/sessions.zig
@@ -234,7 +234,7 @@ pub fn interactionHitTest(
     }
 
     const visible_count = session.visibleCount();
-    if (visible_count > 0) {
+    if (session.selectedVisible() != null) {
         const resume_top = resumeButtonTop(top, cell_h);
         if (rectContains(mx, my, layout.detail_x + PAD_X, resume_top, RESUME_BUTTON_W, buttonHeight(cell_h))) {
             return .@"resume";
@@ -539,16 +539,21 @@ fn renderDetail(
 
     const action_top = detailActionTop(top, draw.cell_h);
     const action_h = buttonHeight(draw.cell_h);
-    const action_w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
-    const action_x = layout.detail_x + PAD_X;
-    const action_labels = [_][]const u8{ "Download Raw", "Export Markdown", "Attach to Copilot" };
-    for (action_labels, 0..) |label, i| {
-        const row_top = action_top + @as(f32, @floatFromInt(i)) * (action_h + ACTION_BUTTON_GAP);
-        draw.fillQuadAlpha(action_x, yFromTop(window_height, row_top, action_h), action_w, action_h, panel_strong, 0.72);
-        _ = draw.renderTextLimited(label, action_x + 12, yTextFromTop(draw, window_height, row_top + BUTTON_PAD_Y), accent, action_w - 24);
+    if (detailActionWidth(layout)) |action_w| {
+        const action_x = layout.detail_x + PAD_X;
+        const action_labels = [_][]const u8{ "Download Raw", "Export Markdown", "Attach to Copilot" };
+        for (action_labels, 0..) |label, i| {
+            const row_top = action_top + @as(f32, @floatFromInt(i)) * (action_h + ACTION_BUTTON_GAP);
+            draw.fillQuadAlpha(action_x, yFromTop(window_height, row_top, action_h), action_w, action_h, panel_strong, 0.72);
+            if (action_w > 24) {
+                _ = draw.renderTextLimited(label, action_x + 12, yTextFromTop(draw, window_height, row_top + BUTTON_PAD_Y), accent, action_w - 24);
+            }
+        }
+        y = action_top + (action_h + ACTION_BUTTON_GAP) * 3 + 12;
+    } else {
+        y = resume_top + buttonHeight(draw.cell_h) + 12;
     }
 
-    y = action_top + (action_h + ACTION_BUTTON_GAP) * 3 + 12;
     draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, y, 1), layout.detail_w - PAD_X * 2, 1, line, 0.78);
     y += 14;
 
@@ -813,10 +818,16 @@ fn detailActionTop(top: f32, cell_h: f32) f32 {
     return resumeButtonTop(top, cell_h) + buttonHeight(cell_h) + 10;
 }
 
+fn detailActionWidth(layout: Layout) ?f32 {
+    const inner = layout.detail_w - PAD_X * 2;
+    if (inner <= 0) return null;
+    return @min(ACTION_BUTTON_W, inner);
+}
+
 fn detailActionHit(layout: Layout, top: f32, cell_h: f32, mx: f32, my: f32) Hit {
     const left = layout.detail_x + PAD_X;
     const h = buttonHeight(cell_h);
-    const w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
+    const w = detailActionWidth(layout) orelse return .none;
     const y0 = detailActionTop(top, cell_h);
     if (rectContains(mx, my, left, y0, w, h)) return .download_raw;
     if (rectContains(mx, my, left, y0 + h + ACTION_BUTTON_GAP, w, h)) return .export_markdown;
@@ -912,9 +923,14 @@ test "terminal agent sessions renderer: zero width layout has no columns" {
 
 test "terminal agent sessions renderer: interaction hit test maps buttons and row offset" {
     const FakeSession = struct {
+        const Selected = struct {};
         date_offset: usize = 0,
         fn visibleCount(_: @This()) usize {
             return 8;
+        }
+
+        fn selectedVisible(_: @This()) ?Selected {
+            return .{};
         }
 
         fn listWindowStart(_: @This(), _: usize) usize {
@@ -960,6 +976,61 @@ test "terminal agent sessions renderer: interaction hit test maps buttons and ro
     try std.testing.expectEqual(
         Hit.search,
         interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.list_x + 8, top + 4),
+    );
+}
+
+test "terminal agent sessions renderer: detail button hits require selected visible session" {
+    const FakeSession = struct {
+        const Selected = struct {};
+        date_offset: usize = 0,
+        fn visibleCount(_: @This()) usize {
+            return 8;
+        }
+
+        fn selectedVisible(_: @This()) ?Selected {
+            return null;
+        }
+
+        fn listWindowStart(_: @This(), _: usize) usize {
+            return 0;
+        }
+
+        fn buildDateBuckets(_: @This(), buf: []types.DateBucket) []types.DateBucket {
+            return buf[0..0];
+        }
+    };
+
+    const session = FakeSession{};
+    const layout = computeLayout(0, 1000);
+    const cell_h: f32 = 16;
+    const top: f32 = 40;
+    const action_top = detailActionTop(top, cell_h);
+
+    try std.testing.expectEqual(
+        Hit.none,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, resumeButtonTop(top, cell_h) + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.none,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + 2),
+    );
+}
+
+test "terminal agent sessions renderer: detail action hit ignores non-positive inner width" {
+    const layout = Layout{
+        .left_x = 0,
+        .left_w = 0,
+        .list_x = 0,
+        .list_w = 0,
+        .detail_x = 100,
+        .detail_w = PAD_X * 2,
+    };
+    const cell_h: f32 = 16;
+    const top: f32 = 40;
+
+    try std.testing.expectEqual(
+        Hit.none,
+        detailActionHit(layout, top, cell_h, layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
     );
 }
 
@@ -1052,6 +1123,9 @@ test "terminal agent sessions renderer: interaction hit test maps category rows"
         fn visibleCount(_: @This()) usize {
             return 0;
         }
+        fn selectedVisible(_: @This()) ?void {
+            return null;
+        }
         fn listWindowStart(_: @This(), _: usize) usize {
             return 0;
         }
@@ -1102,6 +1176,9 @@ test "terminal agent sessions renderer: interaction hit test maps date rows" {
         date_offset: usize = 0,
         fn visibleCount(_: @This()) usize {
             return 0;
+        }
+        fn selectedVisible(_: @This()) ?void {
+            return null;
         }
         fn listWindowStart(_: @This(), _: usize) usize {
             return 0;

--- a/src/renderer/terminal_agents/sessions.zig
+++ b/src/renderer/terminal_agents/sessions.zig
@@ -820,7 +820,7 @@ fn detailActionTop(top: f32, cell_h: f32) f32 {
 
 fn detailActionWidth(layout: Layout) ?f32 {
     const inner = layout.detail_w - PAD_X * 2;
-    if (inner <= 0) return null;
+    if (inner <= 24) return null;
     return @min(ACTION_BUTTON_W, inner);
 }
 
@@ -1016,7 +1016,7 @@ test "terminal agent sessions renderer: detail button hits require selected visi
     );
 }
 
-test "terminal agent sessions renderer: detail action hit ignores non-positive inner width" {
+test "terminal agent sessions renderer: detail action hit ignores too-narrow inner width" {
     const layout = Layout{
         .left_x = 0,
         .left_w = 0,
@@ -1031,6 +1031,19 @@ test "terminal agent sessions renderer: detail action hit ignores non-positive i
     try std.testing.expectEqual(
         Hit.none,
         detailActionHit(layout, top, cell_h, layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
+    );
+
+    const tiny_layout = Layout{
+        .left_x = 0,
+        .left_w = 0,
+        .list_x = 0,
+        .list_w = 0,
+        .detail_x = 100,
+        .detail_w = PAD_X * 2 + 1,
+    };
+    try std.testing.expectEqual(
+        Hit.none,
+        detailActionHit(tiny_layout, top, cell_h, tiny_layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
     );
 }
 

--- a/src/renderer/terminal_agents/sessions.zig
+++ b/src/renderer/terminal_agents/sessions.zig
@@ -14,6 +14,7 @@ const BUTTON_PAD_Y: f32 = 4;
 const BUTTON_EXTRA_H: f32 = 10;
 const RESUME_BUTTON_W: f32 = 104;
 const ACTION_BUTTON_W: f32 = 148;
+const ACTION_BUTTON_MIN_W: f32 = 96;
 const ACTION_BUTTON_GAP: f32 = 8;
 /// Width of the "r Retry" affordance sharing the Status value line (right-aligned).
 const RETRY_LABEL_W: f32 = 70;
@@ -820,7 +821,7 @@ fn detailActionTop(top: f32, cell_h: f32) f32 {
 
 fn detailActionWidth(layout: Layout) ?f32 {
     const inner = layout.detail_w - PAD_X * 2;
-    if (inner <= 24) return null;
+    if (inner < ACTION_BUTTON_MIN_W) return null;
     return @min(ACTION_BUTTON_W, inner);
 }
 
@@ -1044,6 +1045,32 @@ test "terminal agent sessions renderer: detail action hit ignores too-narrow inn
     try std.testing.expectEqual(
         Hit.none,
         detailActionHit(tiny_layout, top, cell_h, tiny_layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
+    );
+
+    const one_px_label_layout = Layout{
+        .left_x = 0,
+        .left_w = 0,
+        .list_x = 0,
+        .list_w = 0,
+        .detail_x = 100,
+        .detail_w = PAD_X * 2 + 25,
+    };
+    try std.testing.expectEqual(
+        Hit.none,
+        detailActionHit(one_px_label_layout, top, cell_h, one_px_label_layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
+    );
+
+    const normal_layout = Layout{
+        .left_x = 0,
+        .left_w = 0,
+        .list_x = 0,
+        .list_w = 0,
+        .detail_x = 100,
+        .detail_w = PAD_X * 2 + ACTION_BUTTON_W,
+    };
+    try std.testing.expectEqual(
+        Hit.download_raw,
+        detailActionHit(normal_layout, top, cell_h, normal_layout.detail_x + PAD_X + 0.5, detailActionTop(top, cell_h) + 2),
     );
 }
 

--- a/src/renderer/terminal_agents/sessions.zig
+++ b/src/renderer/terminal_agents/sessions.zig
@@ -13,6 +13,8 @@ const SMALL_GAP: f32 = 6;
 const BUTTON_PAD_Y: f32 = 4;
 const BUTTON_EXTRA_H: f32 = 10;
 const RESUME_BUTTON_W: f32 = 104;
+const ACTION_BUTTON_W: f32 = 148;
+const ACTION_BUTTON_GAP: f32 = 8;
 /// Width of the "r Retry" affordance sharing the Status value line (right-aligned).
 const RETRY_LABEL_W: f32 = 70;
 const MAX_DATE_BUCKETS: usize = 256;
@@ -32,6 +34,9 @@ pub const Hit = union(enum) {
     none,
     refresh,
     @"resume",
+    download_raw,
+    export_markdown,
+    attach_copilot,
     search,
     category: types.CategoryFilter,
     date: ?types.DateKey,
@@ -234,6 +239,8 @@ pub fn interactionHitTest(
         if (rectContains(mx, my, layout.detail_x + PAD_X, resume_top, RESUME_BUTTON_W, buttonHeight(cell_h))) {
             return .@"resume";
         }
+        const action_hit = detailActionHit(layout, top, cell_h, mx, my);
+        if (action_hit != .none) return action_hit;
     }
 
     // The Search box spans the filter strip at the top of the list column; clicking
@@ -530,7 +537,18 @@ fn renderDetail(
     draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, resume_top, buttonHeight(draw.cell_h)), RESUME_BUTTON_W, buttonHeight(draw.cell_h), panel_strong, 0.72);
     _ = draw.renderTextLimited(if (can_resume) "Resume" else "Resume unavailable", layout.detail_x + PAD_X + 12, yTextFromTop(draw, window_height, y), if (can_resume) accent else muted, RESUME_BUTTON_W - 24);
 
-    y += draw.cell_h + 20;
+    const action_top = detailActionTop(top, draw.cell_h);
+    const action_h = buttonHeight(draw.cell_h);
+    const action_w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
+    const action_x = layout.detail_x + PAD_X;
+    const action_labels = [_][]const u8{ "Download Raw", "Export Markdown", "Attach to Copilot" };
+    for (action_labels, 0..) |label, i| {
+        const row_top = action_top + @as(f32, @floatFromInt(i)) * (action_h + ACTION_BUTTON_GAP);
+        draw.fillQuadAlpha(action_x, yFromTop(window_height, row_top, action_h), action_w, action_h, panel_strong, 0.72);
+        _ = draw.renderTextLimited(label, action_x + 12, yTextFromTop(draw, window_height, row_top + BUTTON_PAD_Y), accent, action_w - 24);
+    }
+
+    y = action_top + (action_h + ACTION_BUTTON_GAP) * 3 + 12;
     draw.fillQuadAlpha(layout.detail_x + PAD_X, yFromTop(window_height, y, 1), layout.detail_w - PAD_X * 2, 1, line, 0.78);
     y += 14;
 
@@ -791,6 +809,21 @@ fn resumeButtonTop(top: f32, cell_h: f32) f32 {
         (cell_h + 16) - BUTTON_PAD_Y;
 }
 
+fn detailActionTop(top: f32, cell_h: f32) f32 {
+    return resumeButtonTop(top, cell_h) + buttonHeight(cell_h) + 10;
+}
+
+fn detailActionHit(layout: Layout, top: f32, cell_h: f32, mx: f32, my: f32) Hit {
+    const left = layout.detail_x + PAD_X;
+    const h = buttonHeight(cell_h);
+    const w = @min(ACTION_BUTTON_W, @max(1.0, layout.detail_w - PAD_X * 2));
+    const y0 = detailActionTop(top, cell_h);
+    if (rectContains(mx, my, left, y0, w, h)) return .download_raw;
+    if (rectContains(mx, my, left, y0 + h + ACTION_BUTTON_GAP, w, h)) return .export_markdown;
+    if (rectContains(mx, my, left, y0 + (h + ACTION_BUTTON_GAP) * 2, w, h)) return .attach_copilot;
+    return .none;
+}
+
 /// How many DATE rows (including the pinned "All dates" row) fit between
 /// `date_rows_top` and the bottom of the left column, reserving the footer.
 pub fn dateVisibleCapacity(window_height: f32, date_rows_top: f32, cell_h: f32) usize {
@@ -906,6 +939,19 @@ test "terminal agent sessions renderer: interaction hit test maps buttons and ro
     try std.testing.expectEqual(
         Hit.@"resume",
         interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, resumeButtonTop(top, cell_h) + 2),
+    );
+    const action_top = detailActionTop(top, cell_h);
+    try std.testing.expectEqual(
+        Hit.download_raw,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.export_markdown,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + buttonHeight(cell_h) + ACTION_BUTTON_GAP + 2),
+    );
+    try std.testing.expectEqual(
+        Hit.attach_copilot,
+        interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.detail_x + PAD_X + 4, action_top + (buttonHeight(cell_h) + ACTION_BUTTON_GAP) * 2 + 2),
     );
     const row_hit = interactionHitTest(session, 1000, 700, top, 0, 1000, cell_h, layout.list_x + 8, top + FILTER_H + ROW_H + 2);
     try std.testing.expectEqual(@as(usize, 4), row_hit.row);

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -24,12 +24,12 @@ const Frozen = struct {
 
 const monoliths = [_]Frozen{
     // Ceilings re-tightened to the current actual after the adoption passes.
-    // input.zig dropped 73->55 via file-explorer action/query APIs;
+    // input.zig dropped 73->50 via action/query API adoption;
     // overlays.zig dropped 47->39 by moving command-palette fields into
     // OverlayState. AppWindow (67) and assistant/conversation/session.zig (20)
     // are at their actual.
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
-    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 52 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 50 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 39 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 20 },
 };

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,12 +19,11 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Verified against the post-round-1 tree: every direct-write ceiling here
-// already equals the current actual (AppWindow 57, input 81, overlays 12,
-// assistant/conversation/session.zig 0), so there is no slack to ratchet away
-// this round.
+// Ratchet ceilings for watched files (AppWindow 56, input 81, overlays 12,
+// assistant/conversation/session.zig 0). Lower a ceiling only when direct
+// writes are removed.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 57 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 56 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 12 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const ExportOptions = struct {};
+
+pub fn allocMarkdownExport(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    _: ExportOptions,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try appendHeader(allocator, &out, meta);
+
+    var wrote_message = false;
+    for (messages) |msg| {
+        const body = std.mem.trim(u8, msg.content, " \t\r\n");
+        if (body.len == 0) continue;
+        try appendMessage(allocator, &out, msg.role, body);
+        wrote_message = true;
+    }
+    if (!wrote_message) try out.appendSlice(allocator, "_No transcript messages._\n");
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn appendHeader(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), meta: types.SessionMeta) !void {
+    try out.appendSlice(allocator, "# AI History Export\n\n");
+    try out.writer(allocator).print("- Provider: {s}\n", .{meta.provider.label()});
+    try out.writer(allocator).print("- Session: {s}\n", .{meta.session_id});
+    if (meta.title.len > 0) try out.writer(allocator).print("- Title: {s}\n", .{meta.title});
+    if (meta.project_dir.len > 0) try out.writer(allocator).print("- Project: {s}\n", .{meta.project_dir});
+    try out.writer(allocator).print("- Source: {s}\n", .{meta.source_path});
+    if (meta.created_at_ms > 0) try out.writer(allocator).print("- Created: {d}\n", .{meta.created_at_ms});
+    if (meta.last_active_at_ms > 0) try out.writer(allocator).print("- Updated: {d}\n", .{meta.last_active_at_ms});
+    try out.appendSlice(allocator, "\n");
+}
+
+fn appendMessage(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    role: types.MessageRole,
+    body: []const u8,
+) !void {
+    try out.writer(allocator).print("## {s}\n\n", .{roleHeading(role)});
+    try out.appendSlice(allocator, body);
+    if (!std.mem.endsWith(u8, body, "\n")) try out.append(allocator, '\n');
+    try out.append(allocator, '\n');
+}
+
+fn roleHeading(role: types.MessageRole) []const u8 {
+    return switch (role) {
+        .user => "User",
+        .assistant => "Assistant",
+        .system => "System",
+        .tool => "Tool",
+    };
+}
+
+test "ai history markdown export includes metadata and role sections" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-1",
+        .title = "Fix renderer",
+        .project_dir = "/work/wispterm",
+        .source_path = "/home/me/.codex/sessions/sess-1.jsonl",
+        .resume_kind = .codex_resume,
+        .created_at_ms = 1000,
+        .last_active_at_ms = 2000,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .user, .content = "status?", .timestamp_ms = 1100 },
+        .{ .role = .assistant, .content = "ready", .timestamp_ms = 1200 },
+        .{ .role = .tool, .content = "tool output", .timestamp_ms = 1300 },
+    };
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "# AI History Export") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Provider: Codex") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Session: sess-1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Project: /work/wispterm") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## User") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "status?") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Assistant") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "ready") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Tool") != null);
+}
+
+test "ai history markdown export skips empty message bodies" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .claude,
+        .session_id = "sess-2",
+        .title = "Empty turn",
+        .source_path = "/home/me/.claude/projects/sess-2.jsonl",
+        .resume_kind = .claude_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .system, .content = "" },
+        .{ .role = .assistant, .content = "answer" },
+    };
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## System") == null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "## Assistant") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "answer") != null);
+}

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -55,7 +55,7 @@ pub fn allocCopilotContext(
         const fits = candidate.len <= max_bytes;
         allocator.free(candidate);
         if (!fits) break;
-        best_start = start;
+        if (messagesContainNonEmpty(messages[start..])) best_start = start;
     }
 
     if (best_start == messages.len) {
@@ -116,6 +116,13 @@ fn newestNonEmptyMessage(messages: []const types.TranscriptMessage) ?types.Trans
         if (std.mem.trim(u8, messages[i].content, " \t\r\n").len != 0) return messages[i];
     }
     return null;
+}
+
+fn messagesContainNonEmpty(messages: []const types.TranscriptMessage) bool {
+    for (messages) |msg| {
+        if (std.mem.trim(u8, msg.content, " \t\r\n").len != 0) return true;
+    }
+    return false;
 }
 
 fn allocBoundedTruncationFallback(allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
@@ -417,6 +424,30 @@ test "ai history copilot context keeps tail of oversized latest message" {
     try std.testing.expect(result.markdown.len <= 240);
     try std.testing.expect(std.mem.indexOf(u8, result.markdown, "LATEST_TAIL_MARKER") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.markdown, "older prompt") == null);
+}
+
+test "ai history copilot context ignores trailing empty messages for newest tail" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-empty-tail",
+        .title = "Tail with empties",
+        .source_path = "/home/me/.codex/sessions/empty-tail.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .assistant, .content = ("oversized body " ** 24) ++ "EMPTY_SUFFIX_TAIL_MARKER" },
+        .{ .role = .system, .content = " \t\n" },
+        .{ .role = .tool, .content = "" },
+    };
+
+    var result = try allocCopilotContext(allocator, meta, &messages, 260);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.truncated);
+    try std.testing.expect(result.markdown.len <= 260);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "EMPTY_SUFFIX_TAIL_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "_No transcript messages._") == null);
 }
 
 test "ai history raw download filename sanitizes provider session and basename" {

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -59,7 +59,19 @@ pub fn allocCopilotContext(
     }
 
     const markdown = try allocMarkdownExportWithNotice(allocator, meta, messages[best_start..], true);
+    if (markdown.len > max_bytes) {
+        allocator.free(markdown);
+        return .{ .markdown = try allocBoundedTruncationFallback(allocator, max_bytes), .truncated = true };
+    }
     return .{ .markdown = markdown, .truncated = true };
+}
+
+fn allocBoundedTruncationFallback(allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
+    const notice = "_Transcript truncated._\n";
+    const len = @min(max_bytes, notice.len);
+    const out = try allocator.alloc(u8, len);
+    @memcpy(out, notice[0..len]);
+    return out;
 }
 
 fn allocMarkdownExportWithNotice(
@@ -144,9 +156,15 @@ fn roleHeading(role: types.MessageRole) []const u8 {
 pub fn rawDownloadFilename(meta: types.SessionMeta, out: []u8) []const u8 {
     const provider = sanitizedProviderLabel(meta.provider);
     const base = std.fs.path.basename(meta.source_path);
-    var tmp: [256]u8 = undefined;
-    const raw = std.fmt.bufPrint(&tmp, "{s}-{s}-{s}", .{ provider, meta.session_id, base }) catch provider;
-    return sanitizeFilename(raw, out);
+    var n: usize = 0;
+    var last_dash = false;
+    appendSanitizedFilenamePart(provider, out, &n, &last_dash);
+    appendSanitizedFilenamePart("-", out, &n, &last_dash);
+    appendSanitizedFilenamePart(meta.session_id, out, &n, &last_dash);
+    appendSanitizedFilenamePart("-", out, &n, &last_dash);
+    appendSanitizedFilenamePart(base, out, &n, &last_dash);
+    while (n > 0 and out[n - 1] == '-') n -= 1;
+    return out[0..n];
 }
 
 fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
@@ -157,21 +175,16 @@ fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
     };
 }
 
-fn sanitizeFilename(raw: []const u8, out: []u8) []const u8 {
-    if (out.len == 0) return "";
-    var n: usize = 0;
-    var last_dash = false;
+fn appendSanitizedFilenamePart(raw: []const u8, out: []u8, n: *usize, last_dash: *bool) void {
     for (raw) |ch| {
-        if (n >= out.len) break;
+        if (n.* >= out.len) break;
         const ok = std.ascii.isAlphanumeric(ch) or ch == '.' or ch == '_' or ch == '-';
         const next = if (ok) std.ascii.toLower(ch) else '-';
-        if (next == '-' and last_dash) continue;
-        out[n] = next;
-        n += 1;
-        last_dash = next == '-';
+        if (next == '-' and last_dash.*) continue;
+        out[n.*] = next;
+        n.* += 1;
+        last_dash.* = next == '-';
     }
-    while (n > 0 and out[n - 1] == '-') n -= 1;
-    return out[0..n];
 }
 
 test "ai history markdown export includes metadata and role sections" {
@@ -294,6 +307,26 @@ test "ai history copilot context truncates oversized transcripts from the front"
     try std.testing.expect(std.mem.indexOf(u8, result.markdown, "old prompt that should drop") == null);
 }
 
+test "ai history copilot context stays bounded when metadata alone is too large" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .reasonix,
+        .session_id = "sess-" ++ ("x" ** 140),
+        .title = "Long " ++ ("y" ** 140),
+        .source_path = "/home/me/.reasonix/sessions/" ++ ("z" ** 140) ++ ".jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .assistant, .content = "recent answer" },
+    };
+
+    var result = try allocCopilotContext(allocator, meta, &messages, 32);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.truncated);
+    try std.testing.expect(result.markdown.len <= 32);
+}
+
 test "ai history raw download filename sanitizes provider session and basename" {
     var buf: [160]u8 = undefined;
     const meta = types.SessionMeta{
@@ -306,4 +339,20 @@ test "ai history raw download filename sanitizes provider session and basename" 
 
     const name = rawDownloadFilename(meta, &buf);
     try std.testing.expectEqualStrings("claude-code-session-bad-id-original-file.jsonl", name);
+}
+
+test "ai history raw download filename preserves long session and basename" {
+    var buf: [512]u8 = undefined;
+    const meta = types.SessionMeta{
+        .provider = .reasonix,
+        .session_id = "session:" ++ ("A" ** 220) ++ "/tail",
+        .title = "Ignored",
+        .source_path = "/home/me/.reasonix/sessions/original " ++ ("B" ** 80) ++ ".jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+
+    const name = rawDownloadFilename(meta, &buf);
+    try std.testing.expect(std.mem.startsWith(u8, name, "reasonix-session-"));
+    try std.testing.expect(std.mem.indexOf(u8, name, "tail-original") != null);
+    try std.testing.expect(std.mem.endsWith(u8, name, ".jsonl"));
 }

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -16,9 +16,8 @@ pub fn allocMarkdownExport(
 
     var wrote_message = false;
     for (messages) |msg| {
-        const body = std.mem.trim(u8, msg.content, " \t\r\n");
-        if (body.len == 0) continue;
-        try appendMessage(allocator, &out, msg.role, body);
+        if (std.mem.trim(u8, msg.content, " \t\r\n").len == 0) continue;
+        try appendMessage(allocator, &out, msg.role, msg.content);
         wrote_message = true;
     }
     if (!wrote_message) try out.appendSlice(allocator, "_No transcript messages._\n");
@@ -29,13 +28,36 @@ pub fn allocMarkdownExport(
 fn appendHeader(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), meta: types.SessionMeta) !void {
     try out.appendSlice(allocator, "# AI History Export\n\n");
     try out.writer(allocator).print("- Provider: {s}\n", .{meta.provider.label()});
-    try out.writer(allocator).print("- Session: {s}\n", .{meta.session_id});
-    if (meta.title.len > 0) try out.writer(allocator).print("- Title: {s}\n", .{meta.title});
-    if (meta.project_dir.len > 0) try out.writer(allocator).print("- Project: {s}\n", .{meta.project_dir});
-    try out.writer(allocator).print("- Source: {s}\n", .{meta.source_path});
+    try appendMetadataBullet(allocator, out, "Session", meta.session_id);
+    if (meta.title.len > 0) try appendMetadataBullet(allocator, out, "Title", meta.title);
+    if (meta.project_dir.len > 0) try appendMetadataBullet(allocator, out, "Project", meta.project_dir);
+    try appendMetadataBullet(allocator, out, "Source", meta.source_path);
     if (meta.created_at_ms > 0) try out.writer(allocator).print("- Created: {d}\n", .{meta.created_at_ms});
     if (meta.last_active_at_ms > 0) try out.writer(allocator).print("- Updated: {d}\n", .{meta.last_active_at_ms});
     try out.appendSlice(allocator, "\n");
+}
+
+fn appendMetadataBullet(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    label: []const u8,
+    value: []const u8,
+) !void {
+    try out.writer(allocator).print("- {s}: ", .{label});
+    var in_break = false;
+    for (value) |ch| {
+        switch (ch) {
+            '\r', '\n', '\t' => {
+                if (!in_break) try out.append(allocator, ' ');
+                in_break = true;
+            },
+            else => {
+                try out.append(allocator, ch);
+                in_break = false;
+            },
+        }
+    }
+    try out.append(allocator, '\n');
 }
 
 fn appendMessage(
@@ -111,4 +133,44 @@ test "ai history markdown export skips empty message bodies" {
     try std.testing.expect(std.mem.indexOf(u8, markdown, "## System") == null);
     try std.testing.expect(std.mem.indexOf(u8, markdown, "## Assistant") != null);
     try std.testing.expect(std.mem.indexOf(u8, markdown, "answer") != null);
+}
+
+test "ai history markdown export preserves non-empty message whitespace" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-3",
+        .title = "Whitespace",
+        .source_path = "/home/me/.codex/sessions/sess-3.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .assistant, .content = "  indented\n\tline  \n" },
+    };
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "  indented\n\tline  \n\n") != null);
+}
+
+test "ai history markdown export collapses metadata whitespace to one line" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-\n4",
+        .title = "Fix\n\tmetadata\rheading",
+        .project_dir = "/work/\nwispterm",
+        .source_path = "/home/me/.codex/sessions/\rsess-4.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const messages = [_]types.TranscriptMessage{};
+
+    const markdown = try allocMarkdownExport(allocator, meta, &messages, .{});
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Session: sess- 4\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Title: Fix metadata heading\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Project: /work/ wispterm\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "- Source: /home/me/.codex/sessions/ sess-4.jsonl\n") != null);
 }

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -58,12 +58,64 @@ pub fn allocCopilotContext(
         best_start = start;
     }
 
+    if (best_start == messages.len) {
+        if (try allocMarkdownExportWithNewestTail(allocator, meta, messages, max_bytes)) |markdown| {
+            return .{ .markdown = markdown, .truncated = true };
+        }
+        return .{ .markdown = try allocBoundedTruncationFallback(allocator, max_bytes), .truncated = true };
+    }
+
     const markdown = try allocMarkdownExportWithNotice(allocator, meta, messages[best_start..], true);
     if (markdown.len > max_bytes) {
         allocator.free(markdown);
         return .{ .markdown = try allocBoundedTruncationFallback(allocator, max_bytes), .truncated = true };
     }
     return .{ .markdown = markdown, .truncated = true };
+}
+
+fn allocMarkdownExportWithNewestTail(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    max_bytes: usize,
+) !?[]u8 {
+    const msg = newestNonEmptyMessage(messages) orelse return null;
+    const body = std.mem.trim(u8, msg.content, " \t\r\n");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try appendHeader(allocator, &out, meta);
+    try out.appendSlice(allocator, "_Transcript truncated; showing the most recent messages._\n\n");
+    try out.writer(allocator).print("## {s}\n\n", .{roleHeading(msg.role)});
+
+    if (out.items.len >= max_bytes) {
+        out.deinit(allocator);
+        return null;
+    }
+    const room = max_bytes - out.items.len;
+    if (room <= 2) {
+        out.deinit(allocator);
+        return null;
+    }
+
+    const tail_len = @min(body.len, room - 2);
+    if (tail_len == 0) {
+        out.deinit(allocator);
+        return null;
+    }
+    try out.appendSlice(allocator, body[body.len - tail_len ..]);
+    try out.appendSlice(allocator, "\n\n");
+    return try out.toOwnedSlice(allocator);
+}
+
+fn newestNonEmptyMessage(messages: []const types.TranscriptMessage) ?types.TranscriptMessage {
+    var i = messages.len;
+    while (i > 0) {
+        i -= 1;
+        if (std.mem.trim(u8, messages[i].content, " \t\r\n").len != 0) return messages[i];
+    }
+    return null;
 }
 
 fn allocBoundedTruncationFallback(allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
@@ -155,16 +207,27 @@ fn roleHeading(role: types.MessageRole) []const u8 {
 
 pub fn rawDownloadFilename(meta: types.SessionMeta, out: []u8) []const u8 {
     const provider = sanitizedProviderLabel(meta.provider);
-    const base = std.fs.path.basename(meta.source_path);
+    const base = portableBasename(meta.source_path);
     var n: usize = 0;
     var last_dash = false;
     appendSanitizedFilenamePart(provider, out, &n, &last_dash);
     appendSanitizedFilenamePart("-", out, &n, &last_dash);
-    appendSanitizedFilenamePart(meta.session_id, out, &n, &last_dash);
+    const remaining = out.len -| n;
+    const base_reserve = @min(remaining, base.len + @as(usize, 1));
+    const session_budget = remaining - base_reserve;
+    appendSanitizedFilenamePartBounded(meta.session_id, out, &n, &last_dash, session_budget);
     appendSanitizedFilenamePart("-", out, &n, &last_dash);
     appendSanitizedFilenamePart(base, out, &n, &last_dash);
     while (n > 0 and out[n - 1] == '-') n -= 1;
     return out[0..n];
+}
+
+fn portableBasename(path: []const u8) []const u8 {
+    var start: usize = 0;
+    for (path, 0..) |ch, i| {
+        if (ch == '/' or ch == '\\') start = i + 1;
+    }
+    return path[start..];
 }
 
 fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
@@ -176,13 +239,19 @@ fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
 }
 
 fn appendSanitizedFilenamePart(raw: []const u8, out: []u8, n: *usize, last_dash: *bool) void {
+    appendSanitizedFilenamePartBounded(raw, out, n, last_dash, std.math.maxInt(usize));
+}
+
+fn appendSanitizedFilenamePartBounded(raw: []const u8, out: []u8, n: *usize, last_dash: *bool, max_added: usize) void {
+    var added: usize = 0;
     for (raw) |ch| {
-        if (n.* >= out.len) break;
+        if (n.* >= out.len or added >= max_added) break;
         const ok = std.ascii.isAlphanumeric(ch) or ch == '.' or ch == '_' or ch == '-';
         const next = if (ok) std.ascii.toLower(ch) else '-';
         if (next == '-' and last_dash.*) continue;
         out[n.*] = next;
         n.* += 1;
+        added += 1;
         last_dash.* = next == '-';
     }
 }
@@ -327,6 +396,29 @@ test "ai history copilot context stays bounded when metadata alone is too large"
     try std.testing.expect(result.markdown.len <= 32);
 }
 
+test "ai history copilot context keeps tail of oversized latest message" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-tail",
+        .title = "Tail",
+        .source_path = "/home/me/.codex/sessions/tail.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .user, .content = "older prompt" },
+        .{ .role = .assistant, .content = ("oversized body " ** 24) ++ "LATEST_TAIL_MARKER" },
+    };
+
+    var result = try allocCopilotContext(allocator, meta, &messages, 240);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.truncated);
+    try std.testing.expect(result.markdown.len <= 240);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "LATEST_TAIL_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "older prompt") == null);
+}
+
 test "ai history raw download filename sanitizes provider session and basename" {
     var buf: [160]u8 = undefined;
     const meta = types.SessionMeta{
@@ -339,6 +431,20 @@ test "ai history raw download filename sanitizes provider session and basename" 
 
     const name = rawDownloadFilename(meta, &buf);
     try std.testing.expectEqualStrings("claude-code-session-bad-id-original-file.jsonl", name);
+}
+
+test "ai history raw download filename treats windows separators as basename" {
+    var buf: [160]u8 = undefined;
+    const meta = types.SessionMeta{
+        .provider = .claude,
+        .session_id = "session",
+        .title = "Ignored",
+        .source_path = "C:\\Users\\me\\.claude\\projects\\original file.jsonl",
+        .resume_kind = .claude_resume,
+    };
+
+    const name = rawDownloadFilename(meta, &buf);
+    try std.testing.expectEqualStrings("claude-code-session-original-file.jsonl", name);
 }
 
 test "ai history raw download filename preserves long session and basename" {
@@ -354,5 +460,21 @@ test "ai history raw download filename preserves long session and basename" {
     const name = rawDownloadFilename(meta, &buf);
     try std.testing.expect(std.mem.startsWith(u8, name, "reasonix-session-"));
     try std.testing.expect(std.mem.indexOf(u8, name, "tail-original") != null);
+    try std.testing.expect(std.mem.endsWith(u8, name, ".jsonl"));
+}
+
+test "ai history raw download filename reserves basename in integration buffer" {
+    var buf: [180]u8 = undefined;
+    const meta = types.SessionMeta{
+        .provider = .reasonix,
+        .session_id = "session-" ++ ("A" ** 220),
+        .title = "Ignored",
+        .source_path = "/home/me/.reasonix/sessions/original file.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+
+    const name = rawDownloadFilename(meta, &buf);
+    try std.testing.expect(std.mem.startsWith(u8, name, "reasonix-session-"));
+    try std.testing.expect(std.mem.indexOf(u8, name, "original-file") != null);
     try std.testing.expect(std.mem.endsWith(u8, name, ".jsonl"));
 }

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -104,9 +104,17 @@ fn allocMarkdownExportWithNewestTail(
         out.deinit(allocator);
         return null;
     }
-    try out.appendSlice(allocator, body[body.len - tail_len ..]);
+    try out.appendSlice(allocator, body[utf8SafeTailStart(body, tail_len)..]);
     try out.appendSlice(allocator, "\n\n");
     return try out.toOwnedSlice(allocator);
+}
+
+fn utf8SafeTailStart(s: []const u8, tail_len: usize) usize {
+    var start = s.len - @min(s.len, tail_len);
+    while (start < s.len and (s[start] & 0xC0) == 0x80) {
+        start += 1;
+    }
+    return start;
 }
 
 fn newestNonEmptyMessage(messages: []const types.TranscriptMessage) ?types.TranscriptMessage {
@@ -424,6 +432,32 @@ test "ai history copilot context keeps tail of oversized latest message" {
     try std.testing.expect(result.markdown.len <= 240);
     try std.testing.expect(std.mem.indexOf(u8, result.markdown, "LATEST_TAIL_MARKER") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.markdown, "older prompt") == null);
+}
+
+test "ai history copilot context newest tail stays on utf8 boundary" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .codex,
+        .session_id = "sess-utf8-tail",
+        .title = "Utf8 Tail",
+        .source_path = "/home/me/.codex/sessions/utf8-tail.jsonl",
+        .resume_kind = .codex_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .assistant, .content = ("汉" ** 20) ++ "TAIL" },
+    };
+
+    var prefix: std.ArrayListUnmanaged(u8) = .empty;
+    defer prefix.deinit(allocator);
+    try appendHeader(allocator, &prefix, meta);
+    try prefix.appendSlice(allocator, "_Transcript truncated; showing the most recent messages._\n\n");
+    try prefix.writer(allocator).print("## {s}\n\n", .{roleHeading(.assistant)});
+
+    const markdown = (try allocMarkdownExportWithNewestTail(allocator, meta, &messages, prefix.items.len + 7)).?;
+    defer allocator.free(markdown);
+
+    try std.testing.expect(std.unicode.utf8ValidateSlice(markdown));
+    try std.testing.expect(std.mem.indexOf(u8, markdown, "TAIL") != null);
 }
 
 test "ai history copilot context ignores trailing empty messages for newest tail" {

--- a/src/terminal_agents/sessions/markdown.zig
+++ b/src/terminal_agents/sessions/markdown.zig
@@ -3,6 +3,16 @@ const types = @import("types.zig");
 
 pub const ExportOptions = struct {};
 
+pub const ContextResult = struct {
+    markdown: []u8,
+    truncated: bool,
+
+    pub fn deinit(self: *ContextResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.markdown);
+        self.truncated = false;
+    }
+};
+
 pub fn allocMarkdownExport(
     allocator: std.mem.Allocator,
     meta: types.SessionMeta,
@@ -13,6 +23,56 @@ pub fn allocMarkdownExport(
     errdefer out.deinit(allocator);
 
     try appendHeader(allocator, &out, meta);
+
+    var wrote_message = false;
+    for (messages) |msg| {
+        if (std.mem.trim(u8, msg.content, " \t\r\n").len == 0) continue;
+        try appendMessage(allocator, &out, msg.role, msg.content);
+        wrote_message = true;
+    }
+    if (!wrote_message) try out.appendSlice(allocator, "_No transcript messages._\n");
+
+    return out.toOwnedSlice(allocator);
+}
+
+pub fn allocCopilotContext(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    max_bytes: usize,
+) !ContextResult {
+    const full = try allocMarkdownExport(allocator, meta, messages, .{});
+    if (full.len <= max_bytes) {
+        return .{ .markdown = full, .truncated = false };
+    }
+    allocator.free(full);
+
+    var best_start = messages.len;
+    var start = messages.len;
+    while (start > 0) {
+        start -= 1;
+        const candidate = try allocMarkdownExportWithNotice(allocator, meta, messages[start..], true);
+        const fits = candidate.len <= max_bytes;
+        allocator.free(candidate);
+        if (!fits) break;
+        best_start = start;
+    }
+
+    const markdown = try allocMarkdownExportWithNotice(allocator, meta, messages[best_start..], true);
+    return .{ .markdown = markdown, .truncated = true };
+}
+
+fn allocMarkdownExportWithNotice(
+    allocator: std.mem.Allocator,
+    meta: types.SessionMeta,
+    messages: []const types.TranscriptMessage,
+    truncated: bool,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try appendHeader(allocator, &out, meta);
+    if (truncated) try out.appendSlice(allocator, "_Transcript truncated; showing the most recent messages._\n\n");
 
     var wrote_message = false;
     for (messages) |msg| {
@@ -79,6 +139,39 @@ fn roleHeading(role: types.MessageRole) []const u8 {
         .system => "System",
         .tool => "Tool",
     };
+}
+
+pub fn rawDownloadFilename(meta: types.SessionMeta, out: []u8) []const u8 {
+    const provider = sanitizedProviderLabel(meta.provider);
+    const base = std.fs.path.basename(meta.source_path);
+    var tmp: [256]u8 = undefined;
+    const raw = std.fmt.bufPrint(&tmp, "{s}-{s}-{s}", .{ provider, meta.session_id, base }) catch provider;
+    return sanitizeFilename(raw, out);
+}
+
+fn sanitizedProviderLabel(provider: types.ProviderId) []const u8 {
+    return switch (provider) {
+        .codex => "codex",
+        .claude => "claude-code",
+        .reasonix => "reasonix",
+    };
+}
+
+fn sanitizeFilename(raw: []const u8, out: []u8) []const u8 {
+    if (out.len == 0) return "";
+    var n: usize = 0;
+    var last_dash = false;
+    for (raw) |ch| {
+        if (n >= out.len) break;
+        const ok = std.ascii.isAlphanumeric(ch) or ch == '.' or ch == '_' or ch == '-';
+        const next = if (ok) std.ascii.toLower(ch) else '-';
+        if (next == '-' and last_dash) continue;
+        out[n] = next;
+        n += 1;
+        last_dash = next == '-';
+    }
+    while (n > 0 and out[n - 1] == '-') n -= 1;
+    return out[0..n];
 }
 
 test "ai history markdown export includes metadata and role sections" {
@@ -173,4 +266,44 @@ test "ai history markdown export collapses metadata whitespace to one line" {
     try std.testing.expect(std.mem.indexOf(u8, markdown, "- Title: Fix metadata heading\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, markdown, "- Project: /work/ wispterm\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, markdown, "- Source: /home/me/.codex/sessions/ sess-4.jsonl\n") != null);
+}
+
+test "ai history copilot context truncates oversized transcripts from the front" {
+    const allocator = std.testing.allocator;
+    const meta = types.SessionMeta{
+        .provider = .reasonix,
+        .session_id = "sess-3",
+        .title = "Long chat",
+        .source_path = "/home/me/.reasonix/sessions/events.jsonl",
+        .resume_kind = .reasonix_resume,
+    };
+    const messages = [_]types.TranscriptMessage{
+        .{ .role = .user, .content = "old prompt that should drop" },
+        .{ .role = .assistant, .content = "old answer that should drop" },
+        .{ .role = .user, .content = "recent prompt" },
+        .{ .role = .assistant, .content = "recent answer" },
+    };
+
+    var result = try allocCopilotContext(allocator, meta, &messages, 260);
+    defer result.deinit(allocator);
+
+    try std.testing.expect(result.truncated);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "Transcript truncated") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "recent prompt") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "recent answer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.markdown, "old prompt that should drop") == null);
+}
+
+test "ai history raw download filename sanitizes provider session and basename" {
+    var buf: [160]u8 = undefined;
+    const meta = types.SessionMeta{
+        .provider = .claude,
+        .session_id = "session:bad/id",
+        .title = "Ignored",
+        .source_path = "/home/me/.claude/projects/original file.jsonl",
+        .resume_kind = .claude_resume,
+    };
+
+    const name = rawDownloadFilename(meta, &buf);
+    try std.testing.expectEqualStrings("claude-code-session-bad-id-original-file.jsonl", name);
 }

--- a/src/terminal_agents/sessions/session.zig
+++ b/src/terminal_agents/sessions/session.zig
@@ -616,6 +616,17 @@ pub const Session = struct {
         self.transcript_scroll = 0;
     }
 
+    pub fn replaceTranscriptFromMessages(self: *Session, provider: types.ProviderId, messages: []types.TranscriptMessage) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.clearTranscript();
+        self.transcript = messages;
+        self.transcript_provider = provider;
+        self.transcript_state = .ready;
+        self.transcript_status = "Transcript ready";
+        self.transcript_scroll = 0;
+    }
+
     /// Adjust the transcript preview scroll offset by `delta` visual lines,
     /// saturating at the top. The high end is clamped by the renderer against
     /// the wrapped content height. Callers must hold `mutex`.
@@ -683,6 +694,13 @@ pub const Session = struct {
             visible_index += 1;
         }
         return null;
+    }
+
+    pub fn selectedMetadataClone(self: *Session, allocator: std.mem.Allocator) ?types.SessionMeta {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const selected = self.selectedVisible() orelse return null;
+        return cloneMetadata(allocator, selected) catch null;
     }
 
     pub fn setCategory(self: *Session, category: types.CategoryFilter) void {
@@ -2103,6 +2121,49 @@ test "ai_history_session: metadata filter controls visible rows" {
     try std.testing.expectEqual(@as(usize, 1), session.visibleCount());
     const selected = session.selectedVisible() orelse return error.ExpectedSelectedSession;
     try std.testing.expectEqualStrings("b", selected.session_id);
+}
+
+test "ai_history_session: selectedMetadataClone owns selected row strings" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const rows = [_]types.SessionMeta{.{
+        .provider = .codex,
+        .session_id = "s1",
+        .title = "Title",
+        .project_dir = "/work",
+        .source_path = "/tmp/s1.jsonl",
+        .resume_kind = .codex_resume,
+    }};
+    try session.replaceRows(&rows);
+
+    const cloned = session.selectedMetadataClone(allocator) orelse return error.MissingClone;
+    defer freeMetadata(allocator, cloned);
+
+    try session.replaceRows(&.{});
+    try std.testing.expectEqualStrings("s1", cloned.session_id);
+    try std.testing.expectEqualStrings("/tmp/s1.jsonl", cloned.source_path);
+}
+
+test "ai_history_session: replaceTranscriptFromMessages installs ready transcript" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const messages = try allocator.alloc(types.TranscriptMessage, 1);
+    messages[0] = .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "ready"),
+    };
+
+    session.replaceTranscriptFromMessages(.codex, messages);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
+    try std.testing.expectEqual(types.ProviderId.codex, session.transcript_provider.?);
+    try std.testing.expectEqualStrings("ready", session.transcript[0].content);
 }
 
 test "ai_history_session: loading selected transcript stores and clears owned messages" {

--- a/src/terminal_agents/sessions/session.zig
+++ b/src/terminal_agents/sessions/session.zig
@@ -620,6 +620,7 @@ pub const Session = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         self.clearTranscript();
+        self.transcript_generation +%= 1;
         self.transcript = messages;
         self.transcript_provider = provider;
         self.transcript_state = .ready;
@@ -696,6 +697,7 @@ pub const Session = struct {
         return null;
     }
 
+    /// Self-locks; callers must not already hold `session.mutex`.
     pub fn selectedMetadataClone(self: *Session, allocator: std.mem.Allocator) ?types.SessionMeta {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -2151,6 +2153,13 @@ test "ai_history_session: replaceTranscriptFromMessages installs ready transcrip
     var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
     defer session.deinit();
 
+    const old_messages = try allocator.alloc(types.TranscriptMessage, 1);
+    old_messages[0] = .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "old"),
+    };
+    session.replaceTranscriptFromMessages(.codex, old_messages);
+
     const messages = try allocator.alloc(types.TranscriptMessage, 1);
     messages[0] = .{
         .role = .assistant,
@@ -2164,6 +2173,32 @@ test "ai_history_session: replaceTranscriptFromMessages installs ready transcrip
     try std.testing.expectEqual(TranscriptState.ready, session.transcript_state);
     try std.testing.expectEqual(types.ProviderId.codex, session.transcript_provider.?);
     try std.testing.expectEqualStrings("ready", session.transcript[0].content);
+}
+
+test "ai_history_session: replaceTranscriptFromMessages invalidates stale async publish" {
+    const allocator = std.testing.allocator;
+    var session = Session.init(allocator, .{ .id = "local", .name = "Local", .target = .local });
+    defer session.deinit();
+
+    const old_generation = session.transcript_generation;
+    const replacement = try allocator.alloc(types.TranscriptMessage, 1);
+    replacement[0] = .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "replacement"),
+    };
+    session.replaceTranscriptFromMessages(.codex, replacement);
+
+    const stale = try allocator.alloc(types.TranscriptMessage, 1);
+    stale[0] = .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "stale"),
+    };
+    session.publishTranscript(old_generation, .codex, stale);
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(old_generation +% 1, session.transcript_generation);
+    try std.testing.expectEqualStrings("replacement", session.transcript[0].content);
 }
 
 test "ai_history_session: loading selected transcript stores and clears owned messages" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -299,6 +299,7 @@ test {
     _ = @import("terminal_agents/sessions/provider_reasonix.zig");
     _ = @import("terminal_agents/sessions/source.zig");
     _ = @import("terminal_agents/sessions/cache.zig");
+    _ = @import("terminal_agents/sessions/markdown.zig");
     _ = @import("memory_digest/types.zig");
     _ = @import("memory_digest/provider_wispterm.zig");
     _ = @import("memory_digest/cursors.zig");

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -41,6 +41,27 @@ test "input routes AI History selected action shortcuts through AppWindow action
     try std.testing.expect(suppress_index < assistant_index);
 }
 
+test "AI History action transcript loader reuses ready preview before target snapshot" {
+    const source = @embedFile("AppWindow.zig");
+    const start = std.mem.indexOf(u8, source, "fn loadAiHistoryTranscriptForAction(") orelse return error.MissingLoader;
+    const rest = source[start..];
+    const end = std.mem.indexOf(u8, rest, "fn cloneAiHistoryTranscriptMessages(") orelse return error.MissingLoaderEnd;
+    const body = rest[0..end];
+
+    const target_snapshot = std.mem.indexOf(u8, body, "aiHistoryTargetSnapshot") orelse return error.MissingTargetSnapshot;
+    const lock = std.mem.indexOf(u8, body, "session.mutex.lock()") orelse return error.MissingPreviewLock;
+    const ready = std.mem.indexOf(u8, body, "session.transcript_state == .ready") orelse return error.MissingReadyPreviewBranch;
+    const provider = std.mem.indexOf(u8, body, "session.transcript_provider") orelse return error.MissingPreviewProviderCheck;
+    const clone = std.mem.indexOf(u8, body, "cloneAiHistoryTranscriptMessages(allocator, session.transcript)") orelse return error.MissingPreviewClone;
+    const unlock = std.mem.indexOf(u8, body, "session.mutex.unlock()") orelse return error.MissingPreviewUnlock;
+
+    try std.testing.expect(lock < ready);
+    try std.testing.expect(ready < provider);
+    try std.testing.expect(provider < clone);
+    try std.testing.expect(clone < unlock);
+    try std.testing.expect(unlock < target_snapshot);
+}
+
 test "assistant conversation input routing owns keyboard target lookup" {
     const routing_source = @embedFile("input/assistant_conversation.zig");
     try std.testing.expect(std.mem.indexOf(u8, routing_source, "activeAiChat()") != null);

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -31,6 +31,14 @@ test "input routes AI History selected action shortcuts through AppWindow action
     try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryExportSelectedMarkdown") != null);
     try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryAttachSelectedToCopilot") != null);
     try std.testing.expect(std.mem.indexOf(u8, source, "!search_focused") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "command_char_suppressors.ai_history") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "command_char_suppressors.ai_history = 'd'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "command_char_suppressors.ai_history = 'm'") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "command_char_suppressors.ai_history = 'a'") != null);
+    const dispatch_char = source[std.mem.indexOf(u8, source, "fn dispatchChar") orelse return error.MissingDispatchChar ..];
+    const suppress_index = std.mem.indexOf(u8, dispatch_char, "if (command_char_suppressors.ai_history)") orelse return error.MissingAiHistorySuppressor;
+    const assistant_index = std.mem.indexOf(u8, dispatch_char, "if (assistant_conversation.current(aiCopilotFocused()))") orelse return error.MissingAssistantCharRoute;
+    try std.testing.expect(suppress_index < assistant_index);
 }
 
 test "assistant conversation input routing owns keyboard target lookup" {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -25,6 +25,14 @@ test "input ssh download surfaces missing connection and helper probe failures" 
     try std.testing.expect(std.mem.indexOf(u8, input_source, "\"SSH helper unavailable\"") != null);
 }
 
+test "input routes AI History selected action shortcuts through AppWindow actions" {
+    const source = @embedFile("input.zig");
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryDownloadSelectedRaw") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryExportSelectedMarkdown") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "aiHistoryAttachSelectedToCopilot") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "!search_focused") != null);
+}
+
 test "assistant conversation input routing owns keyboard target lookup" {
     const routing_source = @embedFile("input/assistant_conversation.zig");
     try std.testing.expect(std.mem.indexOf(u8, routing_source, "activeAiChat()") != null);

--- a/src/test_main.zig
+++ b/src/test_main.zig
@@ -47,6 +47,7 @@ comptime {
         _ = @import("terminal_agents/sessions/cache.zig");
         _ = @import("terminal_agents/sessions/resume.zig");
         _ = @import("terminal_agents/sessions/session.zig");
+        _ = @import("terminal_agents/sessions/markdown.zig");
         _ = @import("renderer/terminal_agents/sessions.zig");
         _ = @import("terminal_agents/detector.zig");
         _ = @import("terminal_agents/prompt_answer.zig");


### PR DESCRIPTION
## Summary
- Add AI History selected-row actions for raw download, Markdown export, and attaching transcripts to Copilot context.
- Render and hit-test selected-session action buttons, plus D/M/A keyboard shortcuts with search-focus and char-event safeguards.
- Add Markdown/context formatting helpers, session ownership helpers, Copilot context card persistence, docs, and tightened source guards.

## User Impact
Users can hand off an AI History transcript without reopening or manually copying it: save the original provider file, export a readable Markdown transcript, or continue in Copilot with the transcript attached as collapsed context.

## Validation
- `zig build test`
- `zig build test-full`
- `zig build check-sizes`
- Windows checkout-safety equivalent scan: 0 Windows name violations, 0 casefold collisions, no tracked symlinks, max path length 90
- Final code review approved after fixes
