### PR TITLE
feat: memory digest M5 — llm timeouts, token usage, session ref fidelity

### DIFF
--- a/docs/superpowers/plans/2026-07-08-memory-digest-m5.md
+++ b/docs/superpowers/plans/2026-07-08-memory-digest-m5.md
@@ -1,0 +1,50 @@
+# Memory Digest M5（硬化：LLM 超时 + token 用量 + refs 保真）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 终审遗留三项硬化：① llm.Client 真实请求超时（替换"关停 detach"作为唯一兜底）；② runs.json 记录 token 用量；③ reduce 的 session_refs 保真（prompt 强化 + 代码过滤）。附带修 final-review Minor#7（同 slug 混合本地/远程时 paths/aliases 双累积）。**不做**：BSD find（远程机全 Linux，显式报错保留）、网页可视化（用户自建，契约 spec §9）。
+
+**Tech Stack:** Zig 0.15.2。已侦察：std.http.Client 无原生超时；`pub fn request()`（Client.zig:1660）返回 `Request{connection: ?*Connection, ...}`（:765-774），Connection 的 `stream_reader` 字段链可达 `net.Stream`/fd（Zig 结构体字段全公开；file-private 的 `getStream()` 不可调但可直接走字段）；`SO.RCVTIMEO/SNDTIMEO` 在 std.c 有常量，`std.posix.setsockopt` + `timeval` 即可。
+
+## Global Constraints
+
+- 分支 `feat/memory-digest-m1`（PR #521 尚未合并，继续演进）；commit 前 `zig fmt build.zig src`；测试 `zig build test`（禁裸 zig build；Benchmark/tool_import flake 复跑确认）。
+- **实现/审查代理亲自动手，禁止 Agent 工具/嵌套委派；显式 stage，严禁 git add -A。**
+- 测试绝不真连网络。
+- conventional commits + `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`。
+
+---
+
+### Task 1: LLM 请求超时 + token 用量入 runs.json
+
+**Files:** Modify `src/memory_digest/llm.zig`、`src/memory_digest/run.zig`、`src/memory_digest/store.zig`、`src/memory_digest/scheduler.zig`、`src/memory_digest/scan_main.zig`
+
+**A. 超时（llm.zig）**：
+1. `Config` += `timeout_seconds: u32 = 120`。
+2. `Client.complete` 从 `client.fetch(...)` 改为 request 级 API：`client.request(.POST, uri, ...)` → 拿 `req.connection.?` 沿字段链取 socket fd → `std.posix.setsockopt(fd, SOL.SOCKET, SO.RCVTIMEO, timeval)` + SNDTIMEO（macOS/Linux 常量都在 std.c；Windows 用 DWORD 毫秒——本模块只跑桌面端，按 builtin.os 分支或仅 posix 平台设置、Windows 留 TODO 注释均可，写明选择）→ 发 body（`sendBodyComplete`）→ `receiveHead` → 读响应体（沿用 16KB 缓冲/Allocating writer 的等价物，redirect_buffer 按 API 要求给）。头部行为不变（anthropic x-api-key 分支照旧——request API 下 headers 通过 `Request.headers`/`extra_headers` 设置，读 std 源确认字段再写）。
+3. 超时错误（read 返回 WouldBlock/超时类 error）→ `return error.LlmTimeout`；日志一行含 model/耗时上限。
+4. **兜底**：若实现中发现字段链在 0.15.2 实际不可达（编译不过），停下来把证据写进报告并改用方案 B：保留 fetch + 在 scheduler 线程侧文档化 detach 兜底为唯一机制——不许静默放弃。
+5. 无单测（网络粘合，惯例）；`zig build memory-digest -Dtarget=aarch64-macos` 编译过 + 真机 `--profile DeepSeek` 冒烟一次（跑通即够，见 Task 2 步骤合并做）。
+
+**B. token 用量**：
+1. `llm.Client` += `total_usage: protocol.ApiUsage = .{}`；complete() 里 parse 出 `ApiResult.usage` 非空则 `self.total_usage.add(u)`（在 free 前取）。
+2. `store.RunRecord` += `prompt_tokens: u64 = 0, completion_tokens: u64 = 0, total_tokens: u64 = 0`（additive，schema 兼容）。
+3. `run.Options` += `llm_usage: ?*const protocol.ApiUsage = null`；recordRun 时读入 RunRecord。
+4. scheduler.runThreadMain 与 scan_main：构造 client 后传 `&client.total_usage`；CLI 摘要行打印 tokens。
+5. 测试：store 的 RunRecord 新字段往返；run 的 stub 路径 usage 缺省 0（既有测试不破即可）。
+
+- [ ] 实现；`zig build test` 绿；fmt；commit `feat(memory-digest): llm request timeouts and token usage in runs.json`（显式 stage 五文件）。
+
+---
+
+### Task 2: session_refs 保真 + paths/aliases 双累积 + 真机验证
+
+**Files:** Modify `src/memory_digest/digest.zig`、`src/memory_digest/run.zig`
+
+1. **prompt 强化**（digest.zig reduce prompt const）：明确 "session_refs 与 timeline 的 session_refs 只能填输入数组里 session_id 字段的原值，禁止用标题"。
+2. **代码过滤**：reduceDay 后处理（或 dupeReduceResult 内）：`projects[].session_refs` 与 `timelines[].entry.session_refs` 逐项 ∩ 当日输入 sessions 的 session_id 集合，非法项丢弃并 `log.debug` 计数；events[].refs **不过滤**（合法含 pr/commit/file 引用）。测试：stub 回包 refs 混入标题与合法 id → 结果仅剩合法 id；全非法 → 空数组不报错。
+3. **Minor#7 双累积**（run.zig phase2 ~456-479 附近）：对每个 reduce slug，遍历该 slug 的全部 summarized 会话——local 的调 `upsertProject`（path），remote 的调 `upsertProjectAlias`（前缀 alias），不再"取第一个命中"。同 slug 同日混合两侧时两者都落。测试：一 local 一 remote 同项目名 stub → project.json 里 paths 与 aliases 各有其一。
+4. **真机验证（M5 出口）**：`zig build memory-digest -Dtarget=aarch64-macos`；`./zig-out/bin/wispterm-memory-digest --profile DeepSeek`（可加 --remote）跑通：runs.json 最新记录带非零 token 计数；无超时环境下行为不变；（若方便）临时把 timeout_seconds 调成 1 验证 LlmTimeout 触发路径后改回——或用不可达 base_url 的临时 profile 验证，如实报告。
+5. `zig build test-full -Dtarget=aarch64-macos` 全绿。
+
+- [ ] 实现+验证；fmt；commit `feat(memory-digest): session ref fidelity and mixed-source project records`（显式 stage）。

--- a/src/memory_digest/digest.zig
+++ b/src/memory_digest/digest.zig
@@ -34,6 +34,8 @@ const PROMPT_REDUCE_SYSTEM =
     \\- 只输出合法 JSON，不要输出任何 JSON 之外的文字或代码块围栏。
     \\- JSON 结构必须是：{"projects":[{"slug":"…","summary":"…","session_refs":["…"]}],"highlights":["…"],"timeline":[{"slug":"…","summary":"…","events":[{"type":"progress|decision|problem|todo","text":"…","refs":["…"]}]}]}
     \\- timeline 必须是数组（每个元素对应一个项目），不要用以 slug 为键的对象。
+    \\- projects 与 timeline 的 session_refs 只能填输入数组里 session_id 字段的原值（原样照抄，不得改写、拼接或翻译），
+    \\  禁止填标题（title）或自造的编号/名称；不确定就留空数组。
 ;
 
 const PROMPT_HIGHLIGHTS_SYSTEM =
@@ -304,9 +306,12 @@ pub const ReduceResult = struct {
     timelines: []const ProjectTimeline,
 };
 
-/// project/title/summary/outcome only — the compact input fed to the reduce
-/// prompt via `std.json.Stringify.valueAlloc` (never hand-built).
+/// session_id/project/title/summary/outcome — the compact input fed to the
+/// reduce prompt via `std.json.Stringify.valueAlloc` (never hand-built).
+/// `session_id` is included specifically so the LLM has the real id to copy
+/// into `session_refs` instead of inventing one from the title.
 const SessionCompact = struct {
+    session_id: []const u8,
     project: []const u8,
     title: []const u8,
     summary: []const u8,
@@ -360,7 +365,7 @@ fn compactSessionsJson(gpa: std.mem.Allocator, sessions: []const store.DailySess
     var compact = try gpa.alloc(SessionCompact, sessions.len);
     defer gpa.free(compact);
     for (sessions, 0..) |s, i| {
-        compact[i] = .{ .project = s.project, .title = s.title, .summary = s.summary, .outcome = s.outcome };
+        compact[i] = .{ .session_id = s.session_id, .project = s.project, .title = s.title, .summary = s.summary, .outcome = s.outcome };
     }
     return std.json.Stringify.valueAlloc(gpa, compact, .{});
 }
@@ -375,16 +380,42 @@ fn sessionRefsForSlug(arena: std.mem.Allocator, sessions: []const store.DailySes
     return refs.toOwnedSlice(arena);
 }
 
+/// Keeps only the entries of `refs` that match an actual `session_id` in
+/// `sessions` (the day's real input set), dropping anything the LLM
+/// hallucinated (e.g. a title copied in place of an id). Unlike `events[].refs`
+/// (which legitimately hold pr/commit/file references and are never
+/// filtered), `session_refs` must only ever point at real session ids.
+/// Illegal entries are dropped silently save for a debug-level count.
+fn filterSessionRefs(arena: std.mem.Allocator, refs: []const []const u8, sessions: []const store.DailySession) ![]const []const u8 {
+    var kept: std.ArrayListUnmanaged([]const u8) = .empty;
+    var dropped: usize = 0;
+    for (refs) |r| {
+        const valid = for (sessions) |s| {
+            if (std.mem.eql(u8, s.session_id, r)) break true;
+        } else false;
+        if (valid) {
+            try kept.append(arena, try arena.dupe(u8, r));
+        } else {
+            dropped += 1;
+        }
+    }
+    if (dropped > 0) {
+        std.log.debug("memory_digest: dropped {d} non-session_id ref(s) from session_refs", .{dropped});
+    }
+    return kept.toOwnedSlice(arena);
+}
+
 /// Dupes a parsed reduce result into `arena`, backfilling `session_refs` from
-/// `sessions` wherever the LLM left them empty.
+/// `sessions` wherever the LLM left them empty, and filtering whatever the
+/// LLM did supply down to real session ids (spec: session_refs must be
+/// faithful to the input, never a hallucinated title or made-up id).
 fn dupeReduceResult(arena: std.mem.Allocator, parsed: JsonReduceResult, date: []const u8, sessions: []const store.DailySession) !ReduceResult {
     const projects = try arena.alloc(store.DailyProject, parsed.projects.len);
     for (parsed.projects, 0..) |p, i| {
         const slug = try arena.dupe(u8, p.slug);
         var refs = p.session_refs;
         if (refs.len == 0) refs = try sessionRefsForSlug(arena, sessions, slug);
-        const duped_refs = try arena.alloc([]const u8, refs.len);
-        for (refs, 0..) |r, j| duped_refs[j] = try arena.dupe(u8, r);
+        const duped_refs = try filterSessionRefs(arena, refs, sessions);
         projects[i] = .{ .slug = slug, .summary = try arena.dupe(u8, p.summary), .session_refs = duped_refs };
     }
 
@@ -888,4 +919,55 @@ test "memory_digest_digest: reduceDay backfills session_refs when the LLM omits 
     try std.testing.expectEqual(@as(usize, 1), result.timelines.len);
     try std.testing.expectEqual(@as(usize, 2), result.timelines[0].entry.session_refs.len);
     try std.testing.expectEqualStrings("s1", result.timelines[0].entry.session_refs[0]);
+}
+
+test "memory_digest_digest: reduceDay filters hallucinated session_refs down to real session ids" {
+    var stub = StubCompleter{ .responses = &.{
+        \\{"projects":[{"slug":"phantty","summary":"s","session_refs":["s1","做了 A 功能","s2"]}],
+        \\"highlights":[],"timeline":[]}
+    } };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const sessions = [_]store.DailySession{
+        testDailySession("phantty", "s1", "t1", "sum1", "completed"),
+        testDailySession("phantty", "s2", "t2", "sum2", "completed"),
+    };
+    const result = try reduceDay(arena.allocator(), std.testing.allocator, stub.completer(), "2026-07-07", &sessions);
+
+    try std.testing.expectEqual(@as(usize, 1), result.projects.len);
+    try std.testing.expectEqual(@as(usize, 2), result.projects[0].session_refs.len);
+    try std.testing.expectEqualStrings("s1", result.projects[0].session_refs[0]);
+    try std.testing.expectEqualStrings("s2", result.projects[0].session_refs[1]);
+}
+
+test "memory_digest_digest: reduceDay drops all-illegal session_refs to an empty array without error" {
+    var stub = StubCompleter{ .responses = &.{
+        \\{"projects":[{"slug":"phantty","summary":"s","session_refs":["标题一","不存在的id"]}],
+        \\"highlights":[],"timeline":[]}
+    } };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const sessions = [_]store.DailySession{testDailySession("phantty", "s1", "t1", "sum1", "completed")};
+    const result = try reduceDay(arena.allocator(), std.testing.allocator, stub.completer(), "2026-07-07", &sessions);
+
+    try std.testing.expectEqual(@as(usize, 1), result.projects.len);
+    try std.testing.expectEqual(@as(usize, 0), result.projects[0].session_refs.len);
+}
+
+test "memory_digest_digest: reduceDay leaves events[].refs untouched (pr/commit/file refs are not session ids)" {
+    var stub = StubCompleter{ .responses = &.{
+        \\{"projects":[{"slug":"phantty","summary":"s","session_refs":[]}],
+        \\"highlights":[],"timeline":[{"slug":"phantty","summary":"t","events":[{"type":"progress","text":"x","refs":["#123","abc1234"]}]}]}
+    } };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const sessions = [_]store.DailySession{testDailySession("phantty", "s1", "t1", "sum1", "completed")};
+    const result = try reduceDay(arena.allocator(), std.testing.allocator, stub.completer(), "2026-07-07", &sessions);
+
+    try std.testing.expectEqual(@as(usize, 2), result.timelines[0].entry.events[0].refs.len);
+    try std.testing.expectEqualStrings("#123", result.timelines[0].entry.events[0].refs[0]);
+    try std.testing.expectEqualStrings("abc1234", result.timelines[0].entry.events[0].refs[1]);
 }

--- a/src/memory_digest/llm.zig
+++ b/src/memory_digest/llm.zig
@@ -14,6 +14,15 @@
 //! field chain had not compiled, we'd revert to fetch() + document the
 //! scheduler-thread detach as the only starvation guard; it did compile, see
 //! below).
+//!
+//! Timeout coverage: SO_RCVTIMEO/SNDTIMEO (set in `setRequestTimeout`) only
+//! bound the send/receive-head/body-read phases below, i.e. everything after
+//! `client.request()` returns a live connection. The TCP connect and TLS
+//! handshake happen *inside* `client.request()`, before the socket options
+//! are applied, and std has no pre-connect timeout knob to reach for — a
+//! stalled connect/handshake is unprotected here. The only backstop for that
+//! window is the scheduler detaching/killing the whole worker thread on
+//! shutdown (see the scheduler); it is not a per-call timeout.
 const std = @import("std");
 const builtin = @import("builtin");
 const protocol = @import("../assistant/conversation/protocol.zig");
@@ -112,7 +121,7 @@ pub const Client = struct {
 
         req.transfer_encoding = .{ .content_length = body.len };
         req.sendBodyComplete(@constCast(body)) catch |err| {
-            if (isTimeoutError(err)) {
+            if (err == error.WriteFailed and isTimeoutError(connectionWriteError(req.connection))) {
                 std.log.warn("memory_digest: llm request timed out sending body (model={s}, limit={d}s)", .{ config.model, config.timeout_seconds });
                 return error.LlmTimeout;
             }
@@ -124,7 +133,12 @@ pub const Client = struct {
         // in that mode, but receiveHead still requires a slice.
         var redirect_buffer: [8 * 1024]u8 = undefined;
         var response = req.receiveHead(&redirect_buffer) catch |err| {
-            if (isTimeoutError(err)) {
+            const timed_out = switch (err) {
+                error.ReadFailed => isTimeoutError(connectionReadError(req.connection)),
+                error.WriteFailed => isTimeoutError(connectionWriteError(req.connection)),
+                else => false,
+            };
+            if (timed_out) {
                 std.log.warn("memory_digest: llm request timed out waiting for response head (model={s}, limit={d}s)", .{ config.model, config.timeout_seconds });
                 return error.LlmTimeout;
             }
@@ -134,16 +148,36 @@ pub const Client = struct {
         var resp_buf: std.Io.Writer.Allocating = .init(gpa);
         defer resp_buf.deinit();
 
+        // Mirrors fetch()'s readerDecompressing path (std/http/Client.zig
+        // fetch(), ~line 1822-1839): Request advertises gzip/deflate/zstd
+        // accept-encoding by default, so a gateway is free to compress the
+        // response. response.reader() alone hands back the raw compressed
+        // bytes; without decompression here a gzip response would land in
+        // resp_buf as binary garbage instead of JSON.
+        const decompress_buffer: []u8 = switch (response.head.content_encoding) {
+            .identity => &.{},
+            .zstd => try gpa.alloc(u8, std.compress.zstd.default_window_len),
+            .deflate, .gzip => try gpa.alloc(u8, std.compress.flate.max_window_len),
+            .compress => return error.LlmUnsupportedCompression,
+        };
+        defer if (decompress_buffer.len != 0) gpa.free(decompress_buffer);
+
         var transfer_buffer: [64]u8 = undefined;
-        const body_reader = response.reader(&transfer_buffer);
+        var decompress: std.http.Decompress = undefined;
+        const body_reader = response.readerDecompressing(&transfer_buffer, &decompress, decompress_buffer);
         _ = body_reader.streamRemaining(&resp_buf.writer) catch |err| switch (err) {
             error.ReadFailed => {
-                const body_err = response.bodyErr().?;
-                if (isTimeoutError(body_err)) {
+                const read_err = connectionReadError(req.connection);
+                if (isTimeoutError(read_err)) {
                     std.log.warn("memory_digest: llm request timed out reading body (model={s}, limit={d}s, elapsed_ms={d})", .{ config.model, config.timeout_seconds, timer.read() / std.time.ns_per_ms });
                     return error.LlmTimeout;
                 }
-                return body_err;
+                // Fall back to the body-level diagnostic (set on the chunked
+                // path — see isTimeoutError doc comment) when the connection
+                // itself recorded no error, rather than unwrapping a null.
+                if (read_err) |e| return e;
+                if (response.bodyErr()) |body_err| return body_err;
+                return error.LlmHttpError;
             },
             else => |e| return e,
         };
@@ -168,11 +202,48 @@ pub const Client = struct {
     }
 };
 
-/// True when `err` (or, for the body-read path, the more specific
-/// `http.Reader.BodyError`) is the WouldBlock surfaced by a SO_RCVTIMEO /
-/// SO_SNDTIMEO expiry on a blocking socket (see `setRequestTimeout`).
-fn isTimeoutError(err: anyerror) bool {
-    return err == error.WouldBlock;
+/// True when `err` is the WouldBlock surfaced by a SO_RCVTIMEO / SO_SNDTIMEO
+/// expiry on a blocking socket (see `setRequestTimeout`). `null` (no error
+/// recorded on the connection) is never a timeout.
+///
+/// `std.http.Client`'s public error sets (`Request.sendBodyComplete`'s
+/// `Writer.Error`, `Request.receiveHead`'s `ReceiveHeadError`,
+/// `http.Reader.BodyError` from `bodyErr()`) collapse the real POSIX error
+/// down to a generic `WriteFailed`/`ReadFailed` marker — none of those sets
+/// mention `WouldBlock` themselves. The specific error always lives on the
+/// `Connection` instead: `connectionReadError`/`connectionWriteError` below
+/// fetch it from there, and this function only classifies whatever they
+/// return.
+fn isTimeoutError(err: ?anyerror) bool {
+    // ponytail: `err == error.WouldBlock` directly on an `?anyerror` trips a
+    // Zig 0.15.2 peer-type-resolution quirk (the comparison's inferred type
+    // becomes an error union, not bool — reproduced standalone outside this
+    // file). Unwrapping first avoids it.
+    const e = err orelse return false;
+    return e == error.WouldBlock;
+}
+
+/// Fetches the specific error stashed on the connection after a read-side
+/// `error.ReadFailed` (`Connection.getReadError`, std/http/Client.zig:368 —
+/// covers both the plain-socket and TLS read paths). Returns null when the
+/// request has no connection (already released) or the connection recorded
+/// no error.
+fn connectionReadError(connection: ?*std.http.Client.Connection) ?anyerror {
+    const c = connection orelse return null;
+    return c.getReadError();
+}
+
+/// Fetches the specific error stashed on the connection after a write-side
+/// `error.WriteFailed`. Unlike the read side, `Connection` has no
+/// `getWriteError` accessor — every write path (`sendHead`, `sendBodyComplete`,
+/// TLS or plain) funnels through `Connection.flush`, which always ends by
+/// flushing `stream_writer.interface` (std/http/Client.zig:442-449), so the
+/// raw-socket `net.Stream.Writer.err` field (std/net.zig, public on every
+/// platform) is where the real error — including a SO_SNDTIMEO `WouldBlock`
+/// — actually lands.
+fn connectionWriteError(connection: ?*std.http.Client.Connection) ?anyerror {
+    const c = connection orelse return null;
+    return c.stream_writer.err;
 }
 
 /// Applies `timeout_seconds` as a receive+send timeout on the request's

--- a/src/memory_digest/llm.zig
+++ b/src/memory_digest/llm.zig
@@ -5,7 +5,17 @@
 //! `Client.complete` is network glue with no unit test here — its components
 //! (protocol.buildRequestJson/apiEndpoint/parseApiResponse) are tested in
 //! place; real-network verification happens in Task 7.
+//!
+//! M5 Task 1: `complete()` uses the request-level `std.http.Client` API
+//! (not `fetch()`) so a per-request read/write timeout can be applied to the
+//! underlying socket via SO_RCVTIMEO/SO_SNDTIMEO before the body is sent.
+//! `fetch()` has no timeout knob in 0.15.2 — a hung server would block the
+//! digest scheduler thread forever otherwise (spec A.4 fallback: if this
+//! field chain had not compiled, we'd revert to fetch() + document the
+//! scheduler-thread detach as the only starvation guard; it did compile, see
+//! below).
 const std = @import("std");
+const builtin = @import("builtin");
 const protocol = @import("../assistant/conversation/protocol.zig");
 const profile_codec = @import("../renderer/overlays/profile_codec.zig");
 
@@ -24,10 +34,16 @@ pub const Config = struct {
     model: []const u8,
     protocol: protocol.ApiProtocol,
     max_tokens: u32 = 4096,
+    /// Read/write timeout applied to the request socket (spec M5 Task 1).
+    timeout_seconds: u32 = 120,
 };
 
 pub const Client = struct {
     config: Config,
+    /// Running total of token usage across every `complete()` call made
+    /// through this client (spec M5 Task 1 B.1). Callers read this after a
+    /// run to persist it into store.RunRecord — never reset mid-run.
+    total_usage: protocol.ApiUsage = .{},
 
     pub fn completer(self: *Client) Completer {
         return .{ .ctx = self, .completeFn = completeShim };
@@ -69,36 +85,80 @@ pub const Client = struct {
         };
         defer client.deinit();
 
-        var resp_buf: std.Io.Writer.Allocating = .init(gpa);
-        defer resp_buf.deinit();
-
         const is_anthropic = config.protocol == .anthropic;
         const anthropic_headers = [_]std.http.Header{
             .{ .name = "x-api-key", .value = config.api_key },
             .{ .name = "anthropic-version", .value = "2023-06-01" },
         };
-        const result = try client.fetch(.{
-            .location = .{ .url = endpoint },
-            .method = .POST,
-            .payload = body,
+
+        const uri = try std.Uri.parse(endpoint);
+
+        var req = client.request(.POST, uri, .{
+            .redirect_behavior = .unhandled,
             .headers = .{
                 .content_type = .{ .override = "application/json" },
                 .authorization = if (is_anthropic) .omit else .{ .override = bearer },
             },
             .extra_headers = if (is_anthropic) &anthropic_headers else &.{},
-            .response_writer = &resp_buf.writer,
-        });
+        }) catch |err| {
+            std.log.warn("memory_digest: llm request connect failed (model={s}): {s}", .{ config.model, @errorName(err) });
+            return err;
+        };
+        defer req.deinit();
+
+        setRequestTimeout(&req, config.timeout_seconds);
+
+        var timer = try std.time.Timer.start();
+
+        req.transfer_encoding = .{ .content_length = body.len };
+        req.sendBodyComplete(@constCast(body)) catch |err| {
+            if (isTimeoutError(err)) {
+                std.log.warn("memory_digest: llm request timed out sending body (model={s}, limit={d}s)", .{ config.model, config.timeout_seconds });
+                return error.LlmTimeout;
+            }
+            return err;
+        };
+
+        // Reuses fetch()'s own redirect_buffer sizing (8KB) since
+        // redirect_behavior is `.unhandled` here and this buffer is unused
+        // in that mode, but receiveHead still requires a slice.
+        var redirect_buffer: [8 * 1024]u8 = undefined;
+        var response = req.receiveHead(&redirect_buffer) catch |err| {
+            if (isTimeoutError(err)) {
+                std.log.warn("memory_digest: llm request timed out waiting for response head (model={s}, limit={d}s)", .{ config.model, config.timeout_seconds });
+                return error.LlmTimeout;
+            }
+            return err;
+        };
+
+        var resp_buf: std.Io.Writer.Allocating = .init(gpa);
+        defer resp_buf.deinit();
+
+        var transfer_buffer: [64]u8 = undefined;
+        const body_reader = response.reader(&transfer_buffer);
+        _ = body_reader.streamRemaining(&resp_buf.writer) catch |err| switch (err) {
+            error.ReadFailed => {
+                const body_err = response.bodyErr().?;
+                if (isTimeoutError(body_err)) {
+                    std.log.warn("memory_digest: llm request timed out reading body (model={s}, limit={d}s, elapsed_ms={d})", .{ config.model, config.timeout_seconds, timer.read() / std.time.ns_per_ms });
+                    return error.LlmTimeout;
+                }
+                return body_err;
+            },
+            else => |e| return e,
+        };
 
         var resp_list = resp_buf.toArrayList();
         defer resp_list.deinit(gpa);
 
-        if (result.status != .ok) return error.LlmHttpError;
+        if (response.head.status != .ok) return error.LlmHttpError;
 
         var api_result = try protocol.parseApiResponse(gpa, resp_list.items, config.protocol);
         if (api_result.api_error) {
             api_result.deinit(gpa);
             return error.LlmApiError;
         }
+        if (api_result.usage) |usage| self.total_usage.add(usage);
         if (api_result.reasoning) |reasoning| gpa.free(reasoning);
         if (api_result.tool_calls) |calls| {
             for (calls) |call| call.deinit(gpa);
@@ -107,6 +167,46 @@ pub const Client = struct {
         return api_result.content;
     }
 };
+
+/// True when `err` (or, for the body-read path, the more specific
+/// `http.Reader.BodyError`) is the WouldBlock surfaced by a SO_RCVTIMEO /
+/// SO_SNDTIMEO expiry on a blocking socket (see `setRequestTimeout`).
+fn isTimeoutError(err: anyerror) bool {
+    return err == error.WouldBlock;
+}
+
+/// Applies `timeout_seconds` as a receive+send timeout on the request's
+/// underlying socket (macOS/Linux/BSD via SO_RCVTIMEO/SO_SNDTIMEO — both
+/// take a `timeval` on every posix target Zig supports desktop-side).
+///
+/// `std.http.Client` has no built-in request timeout in 0.15.2 (`fetch()`
+/// can block forever on a stalled server), so this reaches through
+/// `Request.connection.?.stream_reader.getStream().handle` to the raw fd and
+/// sets the option directly. Every field on this chain is public in 0.15.2
+/// (only some *functions* on Connection are file-private), so this compiles
+/// without touching anything std marks private.
+///
+/// Windows has no SO_RCVTIMEO/SNDTIMEO with a `timeval` layout (it wants a
+/// DWORD milliseconds) and this module only ships on desktop hosts running
+/// the memory-digest scheduler (macOS/Linux dev today); a Windows branch is
+/// intentionally deferred rather than guessed at blind.
+/// TODO(windows): setsockopt(SOL_SOCKET, SO_RCVTIMEO/SNDTIMEO, DWORD ms) via
+/// ws2_32 once this scheduler ships on Windows.
+fn setRequestTimeout(req: *std.http.Client.Request, timeout_seconds: u32) void {
+    if (builtin.os.tag == .windows) return; // ponytail: TODO above, no Windows caller yet.
+    if (timeout_seconds == 0) return;
+
+    const connection = req.connection orelse return;
+    const stream = connection.stream_reader.getStream();
+    const tv: std.posix.timeval = .{ .sec = @intCast(timeout_seconds), .usec = 0 };
+    const tv_bytes = std.mem.asBytes(&tv);
+    std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, tv_bytes) catch |err| {
+        std.log.warn("memory_digest: failed to set RCVTIMEO: {s}", .{@errorName(err)});
+    };
+    std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, tv_bytes) catch |err| {
+        std.log.warn("memory_digest: failed to set SNDTIMEO: {s}", .{@errorName(err)});
+    };
+}
 
 /// Picks the profile matching `name`, falling back to the first profile when
 /// `name` is empty or not found. Returns null when there are no profiles.

--- a/src/memory_digest/run.zig
+++ b/src/memory_digest/run.zig
@@ -11,6 +11,7 @@ const cursors_mod = @import("cursors.zig");
 const digest = @import("digest.zig");
 const dirs = @import("../platform/dirs.zig");
 const llm = @import("llm.zig");
+const protocol = @import("../assistant/conversation/protocol.zig");
 const remote = @import("remote.zig");
 const store = @import("store.zig");
 const types = @import("types.zig");
@@ -35,6 +36,10 @@ pub const Options = struct {
     completer: ?llm.Completer = null,
     model_label: []const u8 = "",
     max_chars_per_message: usize = 2000,
+    /// Points at the llm.Client's running total_usage (spec M5 Task 1 B.3),
+    /// read into the RunRecord written at the end of this run. null (stub
+    /// completers, M1 raw path, tests) records zero usage.
+    llm_usage: ?*const protocol.ApiUsage = null,
     /// WSL/SSH sources to collect from in addition to local roots (spec §6,
     /// M3). Empty by default — M1/M2 behavior is local-only.
     remote_sources: []const RemoteSource = &.{},
@@ -125,7 +130,9 @@ fn recordRun(
     sessions_summarized: usize,
     sessions_failed: usize,
     llm_calls: usize,
+    llm_usage: ?*const protocol.ApiUsage,
 ) void {
+    const usage = if (llm_usage) |u| u.* else protocol.ApiUsage{};
     const rec: store.RunRecord = .{
         .started_at = started_at,
         .finished_at = std.time.milliTimestamp(),
@@ -134,6 +141,9 @@ fn recordRun(
         .sessions_summarized = @intCast(sessions_summarized),
         .sessions_failed = @intCast(sessions_failed),
         .llm_calls = @intCast(llm_calls),
+        .prompt_tokens = usage.prompt_tokens,
+        .completion_tokens = usage.completion_tokens,
+        .total_tokens = usage.total_tokens,
     };
     store.appendRunRecord(gpa, memory_root, rec) catch |err| {
         std.log.warn("memory_digest: appendRunRecord failed: {s}", .{@errorName(err)});
@@ -229,12 +239,12 @@ pub fn runOnce(gpa: std.mem.Allocator, opts: Options) !Summary {
     if (opts.completer) |completer| {
         var counting: CountingCompleter = .{ .inner = completer };
         if (runOnceWithLlm(gpa, arena, opts, counting.completer(), collected_sessions.items, &cur, cursors_path)) |summary| {
-            recordRun(gpa, opts.memory_root, started_at, overall_status, sources, summary.sessions_summarized, summary.sessions_failed, counting.count);
+            recordRun(gpa, opts.memory_root, started_at, overall_status, sources, summary.sessions_summarized, summary.sessions_failed, counting.count, opts.llm_usage);
             var s = summary;
             s.llm_calls = counting.count;
             return s;
         } else |err| {
-            recordRun(gpa, opts.memory_root, started_at, "failed", sources, 0, 0, counting.count);
+            recordRun(gpa, opts.memory_root, started_at, "failed", sources, 0, 0, counting.count, opts.llm_usage);
             return err;
         }
     }
@@ -285,7 +295,7 @@ pub fn runOnce(gpa: std.mem.Allocator, opts: Options) !Summary {
     try writeIndexFromDisk(gpa, arena, opts.memory_root, opts.now_ms);
     try cur.saveToPath(gpa, cursors_path);
 
-    recordRun(gpa, opts.memory_root, started_at, overall_status, sources, 0, 0, 0);
+    recordRun(gpa, opts.memory_root, started_at, overall_status, sources, 0, 0, 0, opts.llm_usage);
     return .{
         .sessions_collected = collected_sessions.items.len,
         .days_written = day_keys.items.len,
@@ -982,6 +992,71 @@ test "memory_digest_run: llm path writes summaries, projects, highlights and tim
         if (r.llm_calls > 0) saw_llm_calls = true;
     }
     try std.testing.expect(saw_llm_calls);
+}
+
+test "memory_digest_run: llm_usage flows into runs.json, defaults to 0 when unset" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    try writeFixtures(tmp);
+
+    const claude_root = try std.fs.path.join(allocator, &.{ root, "claude" });
+    defer allocator.free(claude_root);
+    const memory_root = try std.fs.path.join(allocator, &.{ root, "memory" });
+    defer allocator.free(memory_root);
+
+    var stub = RoutingStub{ .map_response = MAP_JSON, .reduce_response = REDUCE_JSON };
+    const usage: protocol.ApiUsage = .{ .prompt_tokens = 100, .completion_tokens = 20, .total_tokens = 120 };
+    const opts: Options = .{
+        .roots = .{ .claude_projects_dir = claude_root },
+        .memory_root = memory_root,
+        .now_ms = 1783500000000,
+        .tz_offset_seconds = 8 * 3600,
+        .backfill_days = 0,
+        .completer = stub.completer(),
+        .model_label = "test-model",
+        .llm_usage = &usage,
+    };
+    _ = try runOnce(allocator, opts);
+
+    const RunsShape = struct {
+        runs: []const struct {
+            prompt_tokens: u64 = 0,
+            completion_tokens: u64 = 0,
+            total_tokens: u64 = 0,
+        } = &.{},
+    };
+
+    const runs = try tmp.dir.readFileAlloc(allocator, "memory/state/runs.json", 1 << 20);
+    defer allocator.free(runs);
+    const parsed = try std.json.parseFromSlice(RunsShape, allocator, runs, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    const rec = parsed.value.runs[parsed.value.runs.len - 1];
+    try std.testing.expectEqual(@as(u64, 100), rec.prompt_tokens);
+    try std.testing.expectEqual(@as(u64, 20), rec.completion_tokens);
+    try std.testing.expectEqual(@as(u64, 120), rec.total_tokens);
+
+    // Stub/no-usage path (llm_usage left null, as every other test in this
+    // file does): usage fields default to 0, existing behavior unchanged.
+    const memory_root2 = try std.fs.path.join(allocator, &.{ root, "memory2" });
+    defer allocator.free(memory_root2);
+    var stub2 = RoutingStub{ .map_response = MAP_JSON, .reduce_response = REDUCE_JSON };
+    _ = try runOnce(allocator, .{
+        .roots = .{ .claude_projects_dir = claude_root },
+        .memory_root = memory_root2,
+        .now_ms = 1783500000000,
+        .tz_offset_seconds = 8 * 3600,
+        .backfill_days = 0,
+        .completer = stub2.completer(),
+        .model_label = "test-model",
+    });
+    const runs2 = try tmp.dir.readFileAlloc(allocator, "memory2/state/runs.json", 1 << 20);
+    defer allocator.free(runs2);
+    const parsed2 = try std.json.parseFromSlice(RunsShape, allocator, runs2, .{ .ignore_unknown_fields = true });
+    defer parsed2.deinit();
+    try std.testing.expectEqual(@as(u64, 0), parsed2.value.runs[0].total_tokens);
 }
 
 test "memory_digest_run: map failure withholds cursor and daily entry, other sessions unaffected" {

--- a/src/memory_digest/run.zig
+++ b/src/memory_digest/run.zig
@@ -478,20 +478,27 @@ fn runOnceWithLlm(
                 continue;
             }
             try store.upsertTimelineEntry(gpa, opts.memory_root, tl.slug, tl.entry);
-            const idx = for (summarized.items, 0..) |sm, i| {
-                if (std.mem.eql(u8, sm.project, tl.slug)) break i;
-            } else null;
-            const project_path = if (idx) |i| summarized_paths.items[i] else "";
-            const source_id = if (idx) |i| summarized_source_ids.items[i] else "local";
-            if (std.mem.eql(u8, source_id, "local")) {
-                try store.upsertProject(gpa, opts.memory_root, tl.slug, project_path, dr.date);
-            } else {
-                // Remote sessions (spec M3 Task 3): the raw project_path is a
-                // remote-host path with no meaning on this machine, so it is
-                // recorded as an alias ("{source_id}:{project_path}") instead
-                // of a local `paths[]` entry.
-                const alias = try std.fmt.allocPrint(arena, "{s}:{s}", .{ source_id, project_path });
-                try store.upsertProjectAlias(gpa, opts.memory_root, tl.slug, alias, dr.date);
+
+            // Minor#7: walk every summarized session under this slug (not
+            // just the first match) so a day mixing local and remote
+            // sessions of the same project records both a local `paths[]`
+            // entry and a remote alias, instead of only whichever source
+            // happened to appear first. upsertProject/upsertProjectAlias
+            // already dedupe within their own list.
+            for (summarized.items, 0..) |sm, i| {
+                if (!std.mem.eql(u8, sm.project, tl.slug)) continue;
+                const project_path = summarized_paths.items[i];
+                const source_id = summarized_source_ids.items[i];
+                if (std.mem.eql(u8, source_id, "local")) {
+                    try store.upsertProject(gpa, opts.memory_root, tl.slug, project_path, dr.date);
+                } else {
+                    // Remote sessions (spec M3 Task 3): the raw project_path is a
+                    // remote-host path with no meaning on this machine, so it is
+                    // recorded as an alias ("{source_id}:{project_path}") instead
+                    // of a local `paths[]` entry.
+                    const alias = try std.fmt.allocPrint(arena, "{s}:{s}", .{ source_id, project_path });
+                    try store.upsertProjectAlias(gpa, opts.memory_root, tl.slug, alias, dr.date);
+                }
             }
         }
     }
@@ -1553,6 +1560,55 @@ test "memory_digest_run: remote session produces a project alias, not a path" {
     const parsed = try std.json.parseFromSlice(store.Project, allocator, project, .{ .ignore_unknown_fields = true });
     defer parsed.deinit();
     try std.testing.expectEqual(@as(usize, 0), parsed.value.paths.len);
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.aliases.len);
+    try std.testing.expectEqualStrings("ssh:box:/root/project", parsed.value.aliases[0]);
+}
+
+test "memory_digest_run: mixed local+remote sessions under the same slug accumulate both paths and aliases" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    try writeFixtures(tmp); // local: claude-abc under /home/me/project → slug "project"
+
+    const claude_root = try std.fs.path.join(allocator, &.{ root, "claude" });
+    defer allocator.free(claude_root);
+    const memory_root = try std.fs.path.join(allocator, &.{ root, "memory" });
+    defer allocator.free(memory_root);
+
+    // remote-abc under /root/project also slugs to "project" (types.projectSlug
+    // takes only the basename), so one reduce-day bucket covers both sources.
+    var good_host = FakeRemoteHost{
+        .find_output = "1780300860.0\t200\t/root/.claude/projects/proj/remote-abc.jsonl\n",
+        .cat_content = REMOTE_CLAUDE_JSONL,
+    };
+
+    var stub = RoutingStub{ .map_response = MAP_JSON, .reduce_response = REDUCE_JSON };
+    const opts: Options = .{
+        .roots = .{ .claude_projects_dir = claude_root },
+        .memory_root = memory_root,
+        .now_ms = 1783500000000,
+        .tz_offset_seconds = 8 * 3600,
+        .backfill_days = 0,
+        .completer = stub.completer(),
+        .model_label = "test-model",
+        .remote_sources = &.{
+            .{ .source_id = "ssh:box", .host = good_host.execHost() },
+        },
+    };
+    const summary = try runOnce(allocator, opts);
+    try std.testing.expectEqual(@as(usize, 2), summary.sessions_summarized); // local + ssh:box
+
+    const project = try tmp.dir.readFileAlloc(allocator, "memory/projects/project/project.json", 1 << 20);
+    defer allocator.free(project);
+    const parsed = try std.json.parseFromSlice(store.Project, allocator, project, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+
+    // Both sides must land: the local session's path and the remote session's
+    // alias — not just whichever source happened to be summarized first.
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.paths.len);
+    try std.testing.expectEqualStrings("/home/me/project", parsed.value.paths[0]);
     try std.testing.expectEqual(@as(usize, 1), parsed.value.aliases.len);
     try std.testing.expectEqualStrings("ssh:box:/root/project", parsed.value.aliases[0]);
 }

--- a/src/memory_digest/scan_main.zig
+++ b/src/memory_digest/scan_main.zig
@@ -6,6 +6,7 @@
 const std = @import("std");
 const dirs = @import("../platform/dirs.zig");
 const llm = @import("llm.zig");
+const protocol = @import("../assistant/conversation/protocol.zig");
 const profile_codec = @import("../renderer/overlays/profile_codec.zig");
 const profile_store = @import("../assistant/profile/store.zig");
 const run_mod = @import("run.zig");
@@ -81,6 +82,11 @@ pub fn main() !void {
         remote_sources = try std.mem.concat(arena_state.allocator(), run_mod.RemoteSource, &.{ ssh_sources, wsl_sources });
     }
 
+    // `client` is only initialized when a completer was picked above; its
+    // total_usage field would otherwise be undefined memory, so the usage
+    // pointer must stay null on the raw/no-profile path.
+    const llm_usage: ?*const protocol.ApiUsage = if (completer != null) &client.total_usage else null;
+
     const summary = try run_mod.runOnce(gpa, .{
         .roots = local_roots.roots(),
         .memory_root = memory_root,
@@ -91,9 +97,16 @@ pub fn main() !void {
         .completer = completer,
         .model_label = model_label,
         .remote_sources = remote_sources,
+        .llm_usage = llm_usage,
     });
     std.debug.print(
         "memory-digest: {d} sessions with new messages, {d} daily files written, {d} summarized, {d} failed, under {s}\n",
         .{ summary.sessions_collected, summary.days_written, summary.sessions_summarized, summary.sessions_failed, memory_root },
     );
+    if (completer != null) {
+        std.debug.print(
+            "memory-digest: {d} tokens ({d} prompt + {d} completion)\n",
+            .{ client.total_usage.total_tokens, client.total_usage.prompt_tokens, client.total_usage.completion_tokens },
+        );
+    }
 }

--- a/src/memory_digest/scheduler.zig
+++ b/src/memory_digest/scheduler.zig
@@ -323,6 +323,7 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
         .completer = client.completer(),
         .model_label = cfg.model,
         .remote_sources = remote_sources,
+        .llm_usage = &client.total_usage,
     }) catch |err| {
         // ponytail: no saveLastRun here — the 60s tick throttle naturally
         // retries later today. M3's runs.json will own richer retry/backoff
@@ -332,8 +333,16 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
     };
 
     std.log.info(
-        "memory_digest: scheduler run ok, {d} sessions, {d} days, {d} summarized, {d} failed",
-        .{ summary.sessions_collected, summary.days_written, summary.sessions_summarized, summary.sessions_failed },
+        "memory_digest: scheduler run ok, {d} sessions, {d} days, {d} summarized, {d} failed, {d} tokens ({d} prompt + {d} completion)",
+        .{
+            summary.sessions_collected,
+            summary.days_written,
+            summary.sessions_summarized,
+            summary.sessions_failed,
+            client.total_usage.total_tokens,
+            client.total_usage.prompt_tokens,
+            client.total_usage.completion_tokens,
+        },
     );
     markRanToday(gpa, params.now_ms, params.tz_offset_seconds);
 }

--- a/src/memory_digest/store.zig
+++ b/src/memory_digest/store.zig
@@ -249,6 +249,11 @@ pub const RunRecord = struct {
     sessions_summarized: u32 = 0,
     sessions_failed: u32 = 0,
     llm_calls: u32 = 0,
+    // M5 Task 1 B.2: cumulative LLM token usage for the run (additive,
+    // schema-compatible — old runs.json entries parse fine with these at 0).
+    prompt_tokens: u64 = 0,
+    completion_tokens: u64 = 0,
+    total_tokens: u64 = 0,
 };
 
 const MAX_RUNS_STORE_BYTES = 16 * 1024 * 1024;
@@ -650,6 +655,44 @@ test "memory_digest_store: appendRunRecord creates, appends, then truncates to 6
         try std.testing.expectEqual(@as(i64, 2), parsed.value.runs[0].started_at);
         try std.testing.expectEqual(@as(i64, 61), parsed.value.runs[parsed.value.runs.len - 1].started_at);
     }
+}
+
+test "memory_digest_store: appendRunRecord round-trips token usage fields" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    try appendRunRecord(allocator, root, .{
+        .started_at = 1,
+        .status = "ok",
+        .prompt_tokens = 123,
+        .completion_tokens = 45,
+        .total_tokens = 168,
+    });
+
+    const bytes = try tmp.dir.readFileAlloc(allocator, "state/runs.json", 1 << 20);
+    defer allocator.free(bytes);
+    const parsed = try std.json.parseFromSlice(struct {
+        runs: []const RunRecord = &.{},
+    }, allocator, bytes, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(usize, 1), parsed.value.runs.len);
+    try std.testing.expectEqual(@as(u64, 123), parsed.value.runs[0].prompt_tokens);
+    try std.testing.expectEqual(@as(u64, 45), parsed.value.runs[0].completion_tokens);
+    try std.testing.expectEqual(@as(u64, 168), parsed.value.runs[0].total_tokens);
+
+    // A record with no usage set (M1-era stub path) defaults to 0 — schema
+    // compatibility with pre-M5 runs.json entries missing these fields.
+    try appendRunRecord(allocator, root, .{ .started_at = 2, .status = "ok" });
+    const bytes2 = try tmp.dir.readFileAlloc(allocator, "state/runs.json", 1 << 20);
+    defer allocator.free(bytes2);
+    const parsed2 = try std.json.parseFromSlice(struct {
+        runs: []const RunRecord = &.{},
+    }, allocator, bytes2, .{ .ignore_unknown_fields = true });
+    defer parsed2.deinit();
+    try std.testing.expectEqual(@as(u64, 0), parsed2.value.runs[1].total_tokens);
 }
 
 test "memory_digest_store: appendRunRecord rebuilds from a corrupt runs.json" {


### PR DESCRIPTION
## 概要

Memory Digest 终审遗留的三项硬化（M5，计划 `docs/superpowers/plans/2026-07-08-memory-digest-m5.md`）：

1. **LLM 请求超时**：`llm.Client` 从 `fetch` 改 request 级 API，socket `SO_RCVTIMEO/SNDTIMEO`（默认 120s，`Config.timeout_seconds`）→ `error.LlmTimeout`。审查者搭 stall-server 实证抓出三处错误路径缺陷（Content-Length 超时 `bodyErr().?` panic、两处死代码检测点、解压缩丢失），修复后同法实证：body-stall 与 head-stall 均整齐超时返回、零 panic。connect/TLS 握手阶段无保护已在 doc comment 诚实标注（scheduler 关停 detach 兜底）。
2. **token 用量可观测**：`Client.total_usage` 累计 ApiUsage → `runs.json` 新增 prompt/completion/total_tokens 字段（additive 兼容）。真机首验：92,302 tokens（86,117 prompt + 6,185 completion）正确入账。
3. **session_refs 保真**：根因修复——喂 LLM 的紧凑 JSON 原本不含 `session_id`，引用指令不可满足；补字段 + prompt 强化 + 代码级 ∩ 过滤三重保险（真机 DeepSeek 输出零幻觉 refs）。附带修混合源项目记录：同 slug 的 local/remote 会话现在 paths 与 aliases 双累积。

**不做**（有意）：BSD find（远端全 Linux，显式报错+升级注释保留）、网页可视化（用户自建，契约 spec §9）。

## 验证

- `zig build test` + `test-full -Dtarget=aarch64-macos` 全绿；新增过滤/双累积/RunRecord 字段测试，零真连
- 真机：`--profile DeepSeek` 6 会话归纳 0 失败、token 入账；超时路径本地 stall-server 双场景实证

🤖 Generated with [Claude Code](https://claude.com/claude-code)