### PR TITLE
[codex] fix ai history large transcript actions

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3813,15 +3813,15 @@ fn readLocalAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     if (std.fs.path.isAbsolute(path)) {
         const file = try std.fs.openFileAbsolute(path, .{});
         defer file.close();
-        return try file.readToEndAlloc(allocator, ai_history_session.MAX_METADATA_FILE_BYTES);
+        return try file.readToEndAlloc(allocator, ai_history_session.MAX_TRANSCRIPT_FILE_BYTES);
     }
-    return try std.fs.cwd().readFileAlloc(allocator, path, ai_history_session.MAX_METADATA_FILE_BYTES);
+    return try std.fs.cwd().readFileAlloc(allocator, path, ai_history_session.MAX_TRANSCRIPT_FILE_BYTES);
 }
 
 fn readWslAiHistoryRaw(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     var command_buf: [2048]u8 = undefined;
     const command = try ai_history_session.remoteCatCommand(path, command_buf[0..]);
-    return remote_file.wslExec(allocator, command) orelse error.RemoteExecFailed;
+    return remote_file.wslExecCapped(allocator, command, ai_history_session.MAX_TRANSCRIPT_FILE_BYTES) orelse error.RemoteExecFailed;
 }
 
 fn syncWindowTitlebarHeight(win: *window_backend.Window) f32 {

--- a/src/platform/remote_file.zig
+++ b/src/platform/remote_file.zig
@@ -60,9 +60,13 @@ pub fn wslHomeCommand() []const u8 {
 
 /// Run a command inside the default WSL distro and capture stdout.
 pub fn wslExec(allocator: std.mem.Allocator, command: []const u8) ?[]u8 {
+    return wslExecCapped(allocator, command, DEFAULT_CAPTURE_MAX_BYTES);
+}
+
+pub fn wslExecCapped(allocator: std.mem.Allocator, command: []const u8, max_stdout_bytes: usize) ?[]u8 {
     const argv = pty_command.wslExecArgv(command);
     var result = process_runner.runCapture(allocator, &argv, .{
-        .max_stdout_bytes = DEFAULT_CAPTURE_MAX_BYTES,
+        .max_stdout_bytes = max_stdout_bytes,
         .max_stderr_bytes = SSH_STDERR_MAX_BYTES,
     }) catch return null;
     if (!exitedOk(result.termination)) {
@@ -90,6 +94,10 @@ pub const SshCapture = struct {
 /// so callers can surface the real ssh error. Reads both pipes concurrently to
 /// avoid a full-stderr-pipe deadlock.
 pub fn sshExecCaptureFull(allocator: std.mem.Allocator, conn: anytype, command: []const u8) !SshCapture {
+    return sshExecCaptureFullCapped(allocator, conn, command, 2 * 1024 * 1024);
+}
+
+pub fn sshExecCaptureFullCapped(allocator: std.mem.Allocator, conn: anytype, command: []const u8, max_stdout_bytes: usize) !SshCapture {
     var askpass_path: ?[]const u8 = null;
     defer if (askpass_path) |p| allocator.free(p);
     var env_map: ?std.process.EnvMap = null;
@@ -186,7 +194,7 @@ pub fn sshExecCaptureFull(allocator: std.mem.Allocator, conn: anytype, command: 
 
     const result = try process_runner.runCapture(allocator, argv_buf[0..argc], .{
         .env_map = if (env_map) |*map| map else null,
-        .max_stdout_bytes = 2 * 1024 * 1024,
+        .max_stdout_bytes = max_stdout_bytes,
         .max_stderr_bytes = SSH_STDERR_MAX_BYTES,
     });
     return .{
@@ -197,7 +205,11 @@ pub fn sshExecCaptureFull(allocator: std.mem.Allocator, conn: anytype, command: 
 }
 
 pub fn sshExecCapture(allocator: std.mem.Allocator, conn: anytype, command: []const u8) ![]u8 {
-    var cap = try sshExecCaptureFull(allocator, conn, command);
+    return sshExecCaptureCapped(allocator, conn, command, 2 * 1024 * 1024);
+}
+
+pub fn sshExecCaptureCapped(allocator: std.mem.Allocator, conn: anytype, command: []const u8, max_stdout_bytes: usize) ![]u8 {
+    var cap = try sshExecCaptureFullCapped(allocator, conn, command, max_stdout_bytes);
     if (!cap.exited_ok) {
         logSshFailure(cap.stderr);
         cap.deinit(allocator);

--- a/src/terminal_agents/sessions/session.zig
+++ b/src/terminal_agents/sessions/session.zig
@@ -13,6 +13,7 @@ const i18n = @import("../../i18n.zig");
 pub const LoadState = enum { idle, scanning, ready, failed };
 pub const TranscriptState = enum { idle, loading, ready, failed };
 pub const MAX_METADATA_FILE_BYTES = 2 * 1024 * 1024;
+pub const MAX_TRANSCRIPT_FILE_BYTES = 64 * 1024 * 1024;
 const MAX_REMOTE_METADATA_PREFIX_BYTES: usize = MAX_METADATA_FILE_BYTES - 4096;
 pub const MAX_SCAN_METADATA_FILES: usize = 256;
 pub const MAX_SCAN_METADATA_BYTES: u64 = 48 * 1024 * 1024;
@@ -127,9 +128,12 @@ pub const WslScannerHost = struct {
         return try scanRemoteFilesystemSink(allocator, source, host, self.cache, sink);
     }
 
-    fn loadTranscript(ctx: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
-        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
-        return try loadRemoteTranscript(allocator, host, meta);
+    fn loadTranscript(_: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
+        var command_buf: [2048]u8 = undefined;
+        const command = try remoteCatCommand(meta.source_path, command_buf[0..]);
+        const bytes = remote_file.wslExecCapped(allocator, command, MAX_TRANSCRIPT_FILE_BYTES) orelse return error.RemoteExecFailed;
+        defer allocator.free(bytes);
+        return try parseTranscriptBytes(allocator, meta.provider, bytes);
     }
 };
 
@@ -157,8 +161,12 @@ pub const SshScannerHost = struct {
     }
 
     fn loadTranscript(ctx: *anyopaque, allocator: std.mem.Allocator, meta: types.SessionMeta) ![]types.TranscriptMessage {
-        const host = RemoteExecHost{ .ctx = ctx, .exec = exec };
-        return try loadRemoteTranscript(allocator, host, meta);
+        const self: *SshScannerHost = @ptrCast(@alignCast(ctx));
+        var command_buf: [2048]u8 = undefined;
+        const command = try remoteCatCommand(meta.source_path, command_buf[0..]);
+        const bytes = try remote_file.sshExecCaptureCapped(allocator, self.conn, command, MAX_TRANSCRIPT_FILE_BYTES);
+        defer allocator.free(bytes);
+        return try parseTranscriptBytes(allocator, meta.provider, bytes);
     }
 };
 
@@ -1065,11 +1073,15 @@ pub fn loadLocalTranscript(allocator: std.mem.Allocator, meta: types.SessionMeta
     const bytes = if (std.fs.path.isAbsolute(meta.source_path)) blk: {
         const file = try std.fs.openFileAbsolute(meta.source_path, .{});
         defer file.close();
-        break :blk try file.readToEndAlloc(allocator, MAX_METADATA_FILE_BYTES);
-    } else try std.fs.cwd().readFileAlloc(allocator, meta.source_path, MAX_METADATA_FILE_BYTES);
+        break :blk try file.readToEndAlloc(allocator, MAX_TRANSCRIPT_FILE_BYTES);
+    } else try std.fs.cwd().readFileAlloc(allocator, meta.source_path, MAX_TRANSCRIPT_FILE_BYTES);
     defer allocator.free(bytes);
 
-    return switch (meta.provider) {
+    return try parseTranscriptBytes(allocator, meta.provider, bytes);
+}
+
+fn parseTranscriptBytes(allocator: std.mem.Allocator, provider: types.ProviderId, bytes: []const u8) ![]types.TranscriptMessage {
+    return switch (provider) {
         .codex => try codex_provider.parseTranscript(allocator, bytes),
         .claude => try claude_provider.parseTranscript(allocator, bytes),
         .reasonix => try reasonix_provider.parseTranscript(allocator, bytes),
@@ -1244,11 +1256,7 @@ pub fn loadRemoteTranscript(allocator: std.mem.Allocator, host: RemoteExecHost, 
     const bytes = try host.exec(host.ctx, allocator, command);
     defer allocator.free(bytes);
 
-    return switch (meta.provider) {
-        .codex => try codex_provider.parseTranscript(allocator, bytes),
-        .claude => try claude_provider.parseTranscript(allocator, bytes),
-        .reasonix => try reasonix_provider.parseTranscript(allocator, bytes),
-    };
+    return try parseTranscriptBytes(allocator, meta.provider, bytes);
 }
 
 pub fn freeScanResult(allocator: std.mem.Allocator, result: ScanResult) void {
@@ -2375,6 +2383,48 @@ test "ai_history_session: remote transcript loads from fake host" {
     try std.testing.expectEqual(@as(usize, 1), messages.len);
     try std.testing.expectEqual(types.MessageRole.user, messages[0].role);
     try std.testing.expectEqualStrings("Fix remote renderer", messages[0].content);
+}
+
+test "ai_history_session: local transcript reads past metadata prefix limit" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".codex/sessions");
+    const first =
+        \\{"type":"session_meta","timestamp":"2026-07-08T10:00:00Z","payload":{"id":"codex-big","cwd":"/tmp/project"}}
+        \\{"type":"response_item","timestamp":"2026-07-08T10:01:00Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Prompt before cap"}]}}
+        \\
+    ;
+    const tail =
+        \\{"type":"response_item","timestamp":"2026-07-08T10:02:00Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Reply after cap"}]}}
+        \\
+    ;
+    const file_len = MAX_METADATA_FILE_BYTES + tail.len + 16;
+    const bytes = try allocator.alloc(u8, file_len);
+    defer allocator.free(bytes);
+    @memcpy(bytes[0..first.len], first);
+    @memset(bytes[first.len .. MAX_METADATA_FILE_BYTES + 16], ' ');
+    @memcpy(bytes[MAX_METADATA_FILE_BYTES + 16 ..][0..tail.len], tail);
+    try tmp.dir.writeFile(.{ .sub_path = ".codex/sessions/big-transcript.jsonl", .data = bytes });
+
+    var home_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const home = try tmp.dir.realpath(".", &home_buf);
+    const path = try std.fs.path.join(allocator, &.{ home, ".codex/sessions/big-transcript.jsonl" });
+    defer allocator.free(path);
+
+    const messages = try loadLocalTranscript(allocator, .{
+        .provider = .codex,
+        .session_id = "codex-big",
+        .title = "Big",
+        .source_path = path,
+        .resume_kind = .codex_resume,
+    });
+    defer freeTranscript(allocator, .codex, messages);
+
+    try std.testing.expectEqual(@as(usize, 2), messages.len);
+    try std.testing.expectEqualStrings("Prompt before cap", messages[0].content);
+    try std.testing.expectEqualStrings("Reply after cap", messages[1].content);
 }
 
 test "ai_history_session: replace rows preserves existing state on allocation failure" {


### PR DESCRIPTION
## Summary
- raise AI history transcript reads to a separate 64MiB cap while keeping scan metadata at 2MiB
- add capped WSL/SSH capture helpers and use them for preview/export/attach transcript loads
- use the transcript cap for local/WSL raw AI history reads too

## Root Cause
Large session rows could be discovered after the scan fix, but action paths still read full transcript JSONL through the metadata-size limit or the default SSH stdout cap. On SSH, `cat` output beyond the cap caused the child process to fail, surfacing as generic SSH command failures.

## Validation
- `zig build test`
- `zig build test-full` fails on existing `memory_digest.cursors` / `memory_digest.store` missing-or-corrupt-file tests in Windows-target app shards (`wispterm-app-test-app`, `platform`, `input_renderer`, `integrations`); no AI history failures observed.