### PR TITLE
Add progress toast for manual memory digest runs

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -89,6 +89,7 @@ pub const ui_pipeline = @import("renderer/ui_pipeline.zig");
 pub const titlebar = @import("renderer/titlebar.zig");
 pub const input = @import("input.zig");
 pub const overlays = @import("renderer/overlays.zig");
+const overlay_toasts = @import("renderer/overlays/toasts.zig");
 const post_process = @import("renderer/post_process.zig");
 const d3d11_offscreen_smoke = @import("renderer/d3d11_offscreen_smoke.zig");
 const d3d11_ui_smoke = @import("renderer/d3d11_ui_smoke.zig");
@@ -1508,6 +1509,10 @@ fn windowState() *appwindow_state.WindowState {
 
 fn remoteState() *appwindow_state.RemoteState {
     return &g_appwindow_state.remote;
+}
+
+fn notificationState() *appwindow_state.NotificationState {
+    return &g_appwindow_state.notifications;
 }
 
 // Global theme (set at startup via config)
@@ -4912,6 +4917,7 @@ fn renderResizeFrame(width: i32, height: i32) void {
     overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderTransferToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    overlays.renderMemoryDigestToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderTransferCancelConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderUpdatePrompt(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -5062,8 +5068,48 @@ fn syncTransferToastFromFileExplorer() void {
     const notification = file_explorer.latestTransferNotification() orelse return;
     if (!remoteState().acceptTransferNotification(notification.seq)) return;
     overlays.showTransferToast(notification.kind, notification.status, notification.message);
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    markUiDirty();
+}
+
+fn syncMemoryDigestToast() void {
+    const progress = memory_digest_scheduler.progressSnapshot();
+    if (!progress.visible) return;
+    if (!notificationState().acceptMemoryDigestProgress(progress.seq)) return;
+
+    var buf: [160]u8 = undefined;
+    const msg = switch (progress.stage) {
+        .queued => "Memory digest queued",
+        .scanning => "Memory digest: scanning chat logs",
+        .summarizing => std.fmt.bufPrint(
+            &buf,
+            "Memory digest: summarizing {d}/{d} ({d} failed)",
+            .{ progress.sessions_done, progress.sessions_total, progress.sessions_failed },
+        ) catch "Memory digest: summarizing sessions",
+        .finalizing => "Memory digest: writing digest files",
+        .success => std.fmt.bufPrint(
+            &buf,
+            "Memory digest complete: {d} sessions, {d} days, {d} tokens",
+            .{ progress.sessions_done, progress.days_written, progress.total_tokens },
+        ) catch "Memory digest complete",
+        .failed => if (progress.detail().len != 0)
+            std.fmt.bufPrint(&buf, "Memory digest failed: {s}", .{progress.detail()}) catch "Memory digest failed"
+        else
+            "Memory digest failed",
+        .skipped => if (progress.detail().len != 0)
+            std.fmt.bufPrint(&buf, "Memory digest skipped: {s}", .{progress.detail()}) catch "Memory digest skipped"
+        else
+            "Memory digest skipped",
+        .idle => return,
+    };
+
+    const status: overlay_toasts.MemoryDigestStatus = switch (progress.stage) {
+        .queued, .scanning, .summarizing, .finalizing => .in_progress,
+        .success => .success,
+        .failed => .failed,
+        .skipped => .skipped,
+        .idle => return,
+    };
+    overlays.showMemoryDigestToast(status, msg);
 }
 
 /// Apply freshly loaded configuration to this window/font/theme state.
@@ -7237,6 +7283,7 @@ fn runMainLoop(self: *AppWindow) !void {
         // Check for config file changes
         if (config_watcher) |*w| checkConfigReload(allocator, w);
         memory_digest_scheduler.tick(allocator);
+        syncMemoryDigestToast();
         tmux_controller.tickAll(allocator, term_cols, term_rows);
         overlays.tickSessionLauncher();
         overlays.tickQuickAiVerify();
@@ -7703,6 +7750,7 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderTransferToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
+        overlays.renderMemoryDigestToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderTransferCancelConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderUpdatePrompt(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));

--- a/src/appwindow/notification_state.zig
+++ b/src/appwindow/notification_state.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub const State = struct {
+    last_memory_digest_progress_seq: u64 = 0,
+
+    pub fn acceptMemoryDigestProgress(self: *State, seq: u64) bool {
+        if (seq == 0 or seq == self.last_memory_digest_progress_seq) return false;
+        self.last_memory_digest_progress_seq = seq;
+        return true;
+    }
+};
+
+test "notification state dedupes memory digest progress by sequence" {
+    var state = State{};
+
+    try std.testing.expect(!state.acceptMemoryDigestProgress(0));
+    try std.testing.expect(state.acceptMemoryDigestProgress(10));
+    try std.testing.expect(!state.acceptMemoryDigestProgress(10));
+    try std.testing.expect(state.acceptMemoryDigestProgress(11));
+}

--- a/src/appwindow/state.zig
+++ b/src/appwindow/state.zig
@@ -1,14 +1,17 @@
 const std = @import("std");
 const window_state = @import("window_state.zig");
 const remote_state = @import("remote_state.zig");
+const notification_state = @import("notification_state.zig");
 
 pub const WindowState = window_state.State;
 pub const RemoteState = remote_state.State;
 pub const RemoteAiInputSink = remote_state.AiInputSink;
+pub const NotificationState = notification_state.State;
 
 pub const State = struct {
     window: WindowState = .{},
     remote: RemoteState = .{},
+    notifications: NotificationState = .{},
 };
 
 test "appwindow state aggregates window and remote state" {
@@ -16,6 +19,7 @@ test "appwindow state aggregates window and remote state" {
 
     state.window.queueResize(120, 32, 100);
     _ = state.remote.recordAiSink(1, 0x5678);
+    try std.testing.expect(state.notifications.acceptMemoryDigestProgress(1));
 
     try std.testing.expect(state.window.pending_resize.pending);
     try std.testing.expectEqual(@as(usize, 0x5678), state.remote.aiSink(1).?.native_handle_bits);

--- a/src/memory_digest/run.zig
+++ b/src/memory_digest/run.zig
@@ -43,6 +43,26 @@ pub const Options = struct {
     /// WSL/SSH sources to collect from in addition to local roots (spec §6,
     /// M3). Empty by default — M1/M2 behavior is local-only.
     remote_sources: []const RemoteSource = &.{},
+    progress_sink: ?ProgressSink = null,
+};
+
+pub const Progress = union(enum) {
+    scanning,
+    summarizing: struct {
+        total: usize,
+        completed: usize,
+        failed: usize,
+    },
+    finalizing,
+};
+
+pub const ProgressSink = struct {
+    ctx: *anyopaque,
+    onProgressFn: *const fn (*anyopaque, Progress) void,
+
+    pub fn notify(self: ProgressSink, progress: Progress) void {
+        self.onProgressFn(self.ctx, progress);
+    }
 };
 
 pub const Summary = struct {
@@ -230,6 +250,8 @@ pub fn runOnce(gpa: std.mem.Allocator, opts: Options) !Summary {
     else
         @as(i128, opts.now_ms) * 1_000_000 - @as(i128, opts.backfill_days) * 86_400_000_000_000;
 
+    if (opts.progress_sink) |sink| sink.notify(.scanning);
+
     var collected_sessions: std.ArrayListUnmanaged(types.CollectedSession) = .empty;
     var collect_result = try collectAllSources(gpa, arena, opts, &collected_sessions, &cur, min_mtime_ns);
     defer collect_result.local.deinit();
@@ -248,6 +270,8 @@ pub fn runOnce(gpa: std.mem.Allocator, opts: Options) !Summary {
             return err;
         }
     }
+
+    if (opts.progress_sink) |sink| sink.notify(.finalizing);
 
     // M1: cursor advancement is unconditional here (equivalent to the old
     // emit()-time advancement) — a real artifact-write failure below still
@@ -366,6 +390,14 @@ fn runOnceWithLlm(
     var sessions_summarized: usize = 0;
     var sessions_failed: usize = 0;
 
+    if (opts.progress_sink) |sink| {
+        sink.notify(.{ .summarizing = .{
+            .total = collected.len,
+            .completed = 0,
+            .failed = 0,
+        } });
+    }
+
     for (collected) |s| {
         const key = try summaryKey(arena, s.source_id, s.provider, s.session_id);
         const old_summary = try findOldSummary(arena, &summaries, s.source_id, s.provider, s.session_id, key);
@@ -373,11 +405,25 @@ fn runOnceWithLlm(
         const result = digest.summarizeSession(arena, gpa, completer, s, old_summary, map_opts) catch |err| {
             std.log.warn("memory_digest: map failed for {s} ({s}): {s}", .{ @tagName(s.provider), s.session_id, @errorName(err) });
             sessions_failed += 1;
+            if (opts.progress_sink) |sink| {
+                sink.notify(.{ .summarizing = .{
+                    .total = collected.len,
+                    .completed = sessions_summarized,
+                    .failed = sessions_failed,
+                } });
+            }
             continue;
         };
 
         try advanceCursor(cur, s);
         sessions_summarized += 1;
+        if (opts.progress_sink) |sink| {
+            sink.notify(.{ .summarizing = .{
+                .total = collected.len,
+                .completed = sessions_summarized,
+                .failed = sessions_failed,
+            } });
+        }
 
         const date_key = ai_types.dateKeyFromMs(lastActivityMs(s, opts.now_ms), opts.tz_offset_seconds);
         var date_buf: [10]u8 = undefined;
@@ -413,6 +459,7 @@ fn runOnceWithLlm(
     // Map results are persisted before reduce runs at all (spec §13): a
     // reduce failure below must not lose already-summarized sessions.
     try summaries.saveToPath(gpa, summaries_path);
+    if (opts.progress_sink) |sink| sink.notify(.finalizing);
 
     // Bucket only the successfully-summarized sessions by day; a session
     // that failed map stays out of every daily/reduce artifact this run

--- a/src/memory_digest/scheduler.zig
+++ b/src/memory_digest/scheduler.zig
@@ -21,6 +21,7 @@ const window_backend = @import("../platform/window_backend.zig");
 const TICK_INTERVAL_MS: i64 = 60_000;
 const STARTUP_DELAY_MS: i64 = 5 * 60 * 1000;
 const MAX_LAST_RUN_BYTES = 64 * 1024;
+const UI_DETAIL_MAX = 96;
 
 // ponytail: dev-only override so real-machine verification doesn't require
 // waiting out the real 5-minute startup delay. Read once (cached) from
@@ -54,6 +55,36 @@ pub const LastRun = struct {
     date_key: u32 = 0,
 };
 
+pub const ProgressStage = enum {
+    idle,
+    queued,
+    scanning,
+    summarizing,
+    finalizing,
+    success,
+    failed,
+    skipped,
+};
+
+pub const ProgressSnapshot = struct {
+    seq: u64 = 0,
+    visible: bool = false,
+    stage: ProgressStage = .idle,
+    sessions_total: u32 = 0,
+    sessions_done: u32 = 0,
+    sessions_failed: u32 = 0,
+    days_written: u32 = 0,
+    total_tokens: u64 = 0,
+    prompt_tokens: u64 = 0,
+    completion_tokens: u64 = 0,
+    detail_len: usize = 0,
+    detail_buf: [UI_DETAIL_MAX]u8 = [_]u8{0} ** UI_DETAIL_MAX,
+
+    pub fn detail(self: *const ProgressSnapshot) []const u8 {
+        return self.detail_buf[0..self.detail_len];
+    }
+};
+
 // ---- module state ----
 
 var g_settings_arena: std.heap.ArenaAllocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -63,6 +94,9 @@ var g_in_flight: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var g_last_tick_check_ms: i64 = 0;
 var g_app_started_ms: ?i64 = null;
 var g_shutting_down: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var g_progress_mutex: std.Thread.Mutex = .{};
+var g_progress: ProgressSnapshot = .{};
+var g_progress_ctx: u8 = 0;
 
 /// Loads a copy of `s`, duping the borrowed strings into the module's own
 /// arena. Call on the main thread whenever config is loaded/hot-reloaded.
@@ -125,6 +159,7 @@ pub fn tick(gpa: std.mem.Allocator) void {
 pub fn runNow(gpa: std.mem.Allocator) void {
     if (g_in_flight.load(.acquire)) {
         std.log.info("memory_digest: runNow skipped, a run is already in progress", .{});
+        setProgress(.skipped, true, .{ .detail = "Memory digest already running" });
         return;
     }
 
@@ -138,6 +173,12 @@ pub fn runNow(gpa: std.mem.Allocator) void {
     spawnRun(gpa, now_ms, tz_offset_seconds, true);
 }
 
+pub fn progressSnapshot() ProgressSnapshot {
+    g_progress_mutex.lock();
+    defer g_progress_mutex.unlock();
+    return g_progress;
+}
+
 /// Shared spawn path for both the scheduled tick and the manual runNow
 /// trigger: sets in_flight, builds thread params from current settings, and
 /// spawns runThreadMain. Caller must already hold the in_flight/join guards.
@@ -145,6 +186,7 @@ pub fn runNow(gpa: std.mem.Allocator) void {
 /// run with no profile configured must not consume today's scheduled slot.
 fn spawnRun(gpa: std.mem.Allocator, now_ms: i64, tz_offset_seconds: i32, manual: bool) void {
     g_in_flight.store(true, .release);
+    if (manual) setProgress(.queued, true, .{ .detail = "Queued" });
     const params = ThreadParams{
         .profile_name = gpa.dupe(u8, g_settings.profile_name) catch {
             g_in_flight.store(false, .release);
@@ -269,6 +311,7 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
             // don't mark today done, or the real scheduled run would be
             // skipped later once a profile is configured.
             std.log.warn("memory_digest: runNow skipped, no AI profile configured", .{});
+            setProgress(.skipped, true, .{ .detail = "Configure memory-digest-profile first" });
         } else {
             // Still record today as "done" so tick doesn't retry every 60s
             // and spam this warning until a profile is added.
@@ -284,18 +327,21 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
 
     const cfg = llm.configFromProfile(arena, &profiles[idx]) catch |err| {
         std.log.warn("memory_digest: scheduler failed to build LLM config: {s}", .{@errorName(err)});
+        if (params.manual) setProgress(.failed, true, .{ .detail = "Failed to load AI profile" });
         return;
     };
     var client: llm.Client = .{ .config = cfg };
 
     const local_roots = run_mod.defaultLocalRoots(gpa) catch |err| {
         std.log.warn("memory_digest: scheduler failed to resolve local roots: {s}", .{@errorName(err)});
+        if (params.manual) setProgress(.failed, true, .{ .detail = "Failed to resolve local history roots" });
         return;
     };
     defer local_roots.deinit(gpa);
 
     const memory_root = dirs.memoryDir(gpa) catch |err| {
         std.log.warn("memory_digest: scheduler failed to resolve memory dir: {s}", .{@errorName(err)});
+        if (params.manual) setProgress(.failed, true, .{ .detail = "Failed to resolve memory output dir" });
         return;
     };
     defer gpa.free(memory_root);
@@ -313,6 +359,11 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
         remote_sources = std.mem.concat(arena, run_mod.RemoteSource, &.{ ssh_sources, wsl_sources }) catch &.{};
     }
 
+    const progress_sink: ?run_mod.ProgressSink = if (params.manual)
+        .{ .ctx = @ptrCast(&g_progress_ctx), .onProgressFn = onRunProgress }
+    else
+        null;
+
     const summary = run_mod.runOnce(gpa, .{
         .roots = local_roots.roots(),
         .memory_root = memory_root,
@@ -324,11 +375,13 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
         .model_label = cfg.model,
         .remote_sources = remote_sources,
         .llm_usage = &client.total_usage,
+        .progress_sink = progress_sink,
     }) catch |err| {
         // ponytail: no saveLastRun here — the 60s tick throttle naturally
         // retries later today. M3's runs.json will own richer retry/backoff
         // bookkeeping; until then "just try again next tick" is enough.
         std.log.warn("memory_digest: scheduler run failed: {s}", .{@errorName(err)});
+        if (params.manual) setProgress(.failed, true, .{ .detail = "Digest run failed" });
         return;
     };
 
@@ -344,7 +397,67 @@ fn runThreadMain(gpa: std.mem.Allocator, params: ThreadParams) void {
             client.total_usage.completion_tokens,
         },
     );
+    if (params.manual) {
+        setProgress(.success, true, .{
+            .sessions_total = @intCast(summary.sessions_collected),
+            .sessions_done = @intCast(summary.sessions_summarized),
+            .sessions_failed = @intCast(summary.sessions_failed),
+            .days_written = @intCast(summary.days_written),
+            .total_tokens = client.total_usage.total_tokens,
+            .prompt_tokens = client.total_usage.prompt_tokens,
+            .completion_tokens = client.total_usage.completion_tokens,
+            .detail = "Complete",
+        });
+    }
     markRanToday(gpa, params.now_ms, params.tz_offset_seconds);
+}
+
+const ProgressUpdate = struct {
+    detail: []const u8 = "",
+    sessions_total: u32 = 0,
+    sessions_done: u32 = 0,
+    sessions_failed: u32 = 0,
+    days_written: u32 = 0,
+    total_tokens: u64 = 0,
+    prompt_tokens: u64 = 0,
+    completion_tokens: u64 = 0,
+};
+
+fn setProgress(stage: ProgressStage, visible: bool, update: ProgressUpdate) void {
+    g_progress_mutex.lock();
+    defer g_progress_mutex.unlock();
+
+    g_progress.seq +%= 1;
+    g_progress.visible = visible;
+    g_progress.stage = stage;
+    g_progress.sessions_total = update.sessions_total;
+    g_progress.sessions_done = update.sessions_done;
+    g_progress.sessions_failed = update.sessions_failed;
+    g_progress.days_written = update.days_written;
+    g_progress.total_tokens = update.total_tokens;
+    g_progress.prompt_tokens = update.prompt_tokens;
+    g_progress.completion_tokens = update.completion_tokens;
+    g_progress.detail_len = copyTruncated(&g_progress.detail_buf, update.detail);
+}
+
+fn copyTruncated(dst: []u8, src: []const u8) usize {
+    const len = @min(dst.len, src.len);
+    if (len > 0) @memcpy(dst[0..len], src[0..len]);
+    return len;
+}
+
+fn onRunProgress(ctx: *anyopaque, progress: run_mod.Progress) void {
+    _ = ctx;
+    switch (progress) {
+        .scanning => setProgress(.scanning, true, .{ .detail = "Scanning chat logs" }),
+        .summarizing => |v| setProgress(.summarizing, true, .{
+            .detail = "Summarizing sessions",
+            .sessions_total = @intCast(v.total),
+            .sessions_done = @intCast(v.completed),
+            .sessions_failed = @intCast(v.failed),
+        }),
+        .finalizing => setProgress(.finalizing, true, .{ .detail = "Writing digest files" }),
+    }
 }
 
 fn markRanToday(gpa: std.mem.Allocator, now_ms: i64, tz_offset_seconds: i32) void {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -6909,6 +6909,11 @@ pub fn showTransferToast(
     if (status != .in_progress) transferCancelConfirmClose();
 }
 
+pub fn showMemoryDigestToast(status: toasts.MemoryDigestStatus, message: []const u8) void {
+    toastState().memory_digest.show(status, message, std.time.milliTimestamp(), toasts.MEMORY_DIGEST_TOAST_DURATION_MS);
+    AppWindow.applyUiEffect(.repaint);
+}
+
 test "overlays: command center Settings command opens settings page" {
     commandPaletteOpen();
     defer settingsPageClose();
@@ -6947,10 +6952,21 @@ test "overlays: transfer toast state is owned by OverlayState" {
     try std.testing.expect(overlayState().toasts.transfer.clickable);
 }
 
+test "overlays: memory digest toast state is owned by OverlayState" {
+    const saved = overlayState().toasts.memory_digest;
+    defer overlayState().toasts.memory_digest = saved;
+
+    showMemoryDigestToast(.in_progress, "Digest running");
+
+    try std.testing.expect(overlayState().toasts.memory_digest.sticky);
+    try std.testing.expectEqualStrings("Digest running", overlayState().toasts.memory_digest.text().?);
+}
+
 test "overlays: sticky transfer toast does not keep render gate active forever" {
     const saved_copy = overlayState().toasts.copy;
     const saved_transfer = overlayState().toasts.transfer;
     const saved_update = overlayState().toasts.update;
+    const saved_memory_digest = overlayState().toasts.memory_digest;
     const saved_close_shortcut = close_confirm_state.deadline();
     const saved_remote_key_copied = g_remote_key_copied_until_ms;
     const saved_resize = resize.g_split_resize_overlay_until;
@@ -6959,6 +6975,7 @@ test "overlays: sticky transfer toast does not keep render gate active forever" 
         overlayState().toasts.copy = saved_copy;
         overlayState().toasts.transfer = saved_transfer;
         overlayState().toasts.update = saved_update;
+        overlayState().toasts.memory_digest = saved_memory_digest;
         close_confirm_state.setDeadline(saved_close_shortcut);
         g_remote_key_copied_until_ms = saved_remote_key_copied;
         resize.g_split_resize_overlay_until = saved_resize;
@@ -8095,6 +8112,34 @@ pub fn renderTransferToast(window_width: f32, window_height: f32) void {
     renderTitlebarTextStrongLimited(text, text_x, y, accent, layout.w - pad_h * 2);
 }
 
+pub fn renderMemoryDigestToast(window_width: f32, window_height: f32) void {
+    _ = window_height;
+    const now = std.time.milliTimestamp();
+    const toast = &toastState().memory_digest;
+    if (!toast.active(now)) return;
+    const text = toast.text() orelse return;
+
+    const pad_h: f32 = 14;
+    const pad_v: f32 = 6;
+    const line_h = font.g_titlebar_cell_height + pad_v * 2;
+    const text_width = measureTitlebarText(text);
+    const max_w = @max(220.0, window_width - 32.0);
+    const bg_w = @min(text_width + pad_h * 2, max_w);
+    const bg_x = @round(@max(12.0, window_width - bg_w - 16.0));
+    const bg_y: f32 = if (toastState().transfer.active(now)) 96 else 60;
+
+    const accent: [3]f32 = switch (toast.status) {
+        .in_progress => .{ 0.56, 0.82, 1.0 },
+        .success => .{ 0.24, 1.0, 0.44 },
+        .failed => .{ 1.0, 0.30, 0.28 },
+        .skipped => .{ 1.0, 0.72, 0.28 },
+    };
+    const bg = mixColor(AppWindow.g_theme.background, accent, 0.16);
+    ui_pipeline.fillQuadAlpha(bg_x, bg_y, bg_w, line_h, bg, 0.96);
+    ui_pipeline.fillQuadAlpha(bg_x, bg_y, 3, line_h, accent, 0.88);
+    renderTitlebarTextStrongLimited(text, bg_x + pad_h, bg_y + pad_v, accent, bg_w - pad_h * 2);
+}
+
 fn whatsNewNotes() []const u8 {
     return app_metadata.release_notes;
 }
@@ -8139,6 +8184,7 @@ pub fn anyOverlayActive(now: i64) bool {
     if (toast_state.copy.active(now)) return true;
     if (toast_state.transfer.text() != null and now < toast_state.transfer.until_ms) return true;
     if (toast_state.update.active(now)) return true;
+    if (toast_state.memory_digest.active(now)) return true;
     if (close_confirm_state.isActive(now)) return true;
     if (now < g_remote_key_copied_until_ms) return true;
     if (now < resize.g_split_resize_overlay_until) return true;

--- a/src/renderer/overlays/state.zig
+++ b/src/renderer/overlays/state.zig
@@ -62,6 +62,7 @@ test "overlay state aggregates migrated overlay groups" {
 
     state.settings.open();
     state.toasts.copy.show("Copied", 10, 100);
+    state.toasts.memory_digest.show(.in_progress, "Digest running", 10, 100);
     state.confirms.openRestoreDefaults();
     state.ssh.setFormField(.name, "web");
     state.assistant_profiles.setFormField(.name, "claude");
@@ -72,6 +73,7 @@ test "overlay state aggregates migrated overlay groups" {
 
     try std.testing.expect(state.settings.visible);
     try std.testing.expectEqualStrings("Copied", state.toasts.copy.text().?);
+    try std.testing.expectEqualStrings("Digest running", state.toasts.memory_digest.text().?);
     try std.testing.expect(state.confirms.restore_defaults_visible);
     try std.testing.expectEqualStrings("web", state.ssh.formField(.name));
     try std.testing.expectEqualStrings("claude", state.assistant_profiles.formField(.name));

--- a/src/renderer/overlays/toasts.zig
+++ b/src/renderer/overlays/toasts.zig
@@ -7,6 +7,9 @@ pub const COPY_TOAST_DURATION_MS: i64 = 1500;
 pub const TRANSFER_TOAST_DURATION_MS: i64 = 2500;
 pub const UPDATE_PROMPT_DURATION_MS: i64 = 10000;
 pub const UPDATE_STATUS_DURATION_MS: i64 = 2500;
+pub const MEMORY_DIGEST_TOAST_DURATION_MS: i64 = 4000;
+
+pub const MemoryDigestStatus = enum { in_progress, success, failed, skipped };
 
 pub const TextToast = struct {
     until_ms: i64 = 0,
@@ -101,10 +104,35 @@ pub const UpdatePrompt = struct {
     }
 };
 
+pub const MemoryDigestToast = struct {
+    until_ms: i64 = 0,
+    sticky: bool = false,
+    status: MemoryDigestStatus = .in_progress,
+    buf: [160]u8 = undefined,
+    len: usize = 0,
+
+    pub fn show(self: *MemoryDigestToast, status: MemoryDigestStatus, message: []const u8, now_ms: i64, duration_ms: i64) void {
+        self.len = copyTruncated(&self.buf, message);
+        self.status = status;
+        self.sticky = status == .in_progress;
+        self.until_ms = now_ms + duration_ms;
+    }
+
+    pub fn active(self: MemoryDigestToast, now_ms: i64) bool {
+        return self.len > 0 and (self.sticky or now_ms < self.until_ms);
+    }
+
+    pub fn text(self: *const MemoryDigestToast) ?[]const u8 {
+        if (self.len == 0) return null;
+        return self.buf[0..self.len];
+    }
+};
+
 pub const State = struct {
     copy: TextToast = .{},
     transfer: TransferToast = .{},
     update: UpdatePrompt = .{},
+    memory_digest: MemoryDigestToast = .{},
     close_shortcut_confirm_until_ms: i64 = 0,
 };
 
@@ -227,4 +255,17 @@ test "text toast truncates stored text to fixed buffer" {
 
     try std.testing.expectEqual(@as(usize, 64), toast.text().?.len);
     try std.testing.expectEqualStrings(long_message[0..64], toast.text().?);
+}
+
+test "memory digest toast stays sticky only while in progress" {
+    var toast: MemoryDigestToast = .{};
+
+    toast.show(.in_progress, "Digest running", 1000, MEMORY_DIGEST_TOAST_DURATION_MS);
+    try std.testing.expect(toast.active(1000 + MEMORY_DIGEST_TOAST_DURATION_MS + 1));
+    try std.testing.expect(toast.sticky);
+
+    toast.show(.success, "Digest complete", 2000, MEMORY_DIGEST_TOAST_DURATION_MS);
+    try std.testing.expect(!toast.sticky);
+    try std.testing.expect(toast.active(2000 + MEMORY_DIGEST_TOAST_DURATION_MS - 1));
+    try std.testing.expect(!toast.active(2000 + MEMORY_DIGEST_TOAST_DURATION_MS + 1));
 }


### PR DESCRIPTION
## Summary

Add visible progress feedback for `Run Memory Digest Now`.

This introduces a dedicated memory-digest toast that updates through the manual run lifecycle: queued, scanning, summarizing, finalizing, then success, failed, or skipped. Progress is produced by the digest scheduler and run pipeline, then polled and rendered on the UI thread.

## Changes

- add scheduler-side progress snapshots for manual memory digest runs
- add run-pipeline progress callbacks for scanning, summarizing, and finalizing stages
- add a dedicated sticky memory-digest toast model and renderer
- dedupe progress updates on the AppWindow side before refreshing the toast
- reuse `markUiDirty()` for the existing transfer-toast sync path touched in the same area

## Validation

- `zig build test` ✅
- `zig build test-full` ⚠️ hits pre-existing Windows-path-related test failures in:
  - `src/memory_digest/cursors.zig`
  - `src/memory_digest/store.zig`

