### PR TITLE
Fix memory digest local root resolution

### DIFF
--- a/src/memory_digest/run.zig
+++ b/src/memory_digest/run.zig
@@ -116,10 +116,10 @@ pub const OwnedLocalRoots = struct {
 /// Assembles the three real local session roots (Claude/.claude/projects,
 /// Codex/.codex/sessions, WispTerm's own agent-history/sessions), matching
 /// scan_main.zig's dev-CLI wiring exactly so both entry points scan the same
-/// on-disk sources. Shared here so the M2 scheduler doesn't drift from the
-/// CLI's root assembly.
+/// on-disk sources. Shared here so the scheduler doesn't drift from the CLI's
+/// root assembly.
 pub fn defaultLocalRoots(gpa: std.mem.Allocator) !OwnedLocalRoots {
-    const home = try std.process.getEnvVarOwned(gpa, "HOME");
+    const home = try dirs.homeDir(gpa);
     defer gpa.free(home);
 
     const claude_dir = try std.fs.path.join(gpa, &.{ home, ".claude", "projects" });


### PR DESCRIPTION
## Summary
- Fix `Run Memory Digest Now` failing before scan when the app process has no `HOME` environment variable.
- Reuse `platform/dirs.homeDir()` so Windows resolves local Claude/Codex roots via `%USERPROFILE%` while Unix keeps `$HOME` behavior.
- Keep missing actual history directories as non-fatal; the collector already skips absent roots.

## Notes
- Ghostty has no equivalent AI memory digest feature; this follows WispTerm's existing scheduler/root resolver path.

## Tests
- `zig test src/platform/dirs.zig`
- `zig build test`
- `git diff --check`
- `zig test src/memory_digest/run.zig` is not a valid single-file test for this module under Zig 0.15 because its existing relative imports leave the module path.
- `zig build test-full` still fails in this WSL/Windows test environment on existing `memory_digest.store` and `memory_digest.cursors` missing/corrupt file readback tests under `\\wsl.localhost` paths; no new failure type was introduced.
