### PR TITLE
Backfill quota counts only LLM attempts; capture remote find failure

### DIFF
--- a/src/memory_digest/remote.zig
+++ b/src/memory_digest/remote.zig
@@ -87,7 +87,9 @@ pub fn collectRemote(
 
 fn appendProviderDetail(arena: std.mem.Allocator, parts: *std.ArrayListUnmanaged(u8), provider_name: []const u8, r: ProviderResult) !void {
     if (parts.items.len > 0) try parts.appendSlice(arena, "; ");
-    if (r.no_stamps) {
+    if (r.find_failed and r.files_seen == 0) {
+        try parts.writer(arena).print("{s}: find failed (BSD?)", .{provider_name});
+    } else if (r.no_stamps) {
         try parts.writer(arena).print("{s}: no-stamps(BSD?)", .{provider_name});
     } else {
         try parts.writer(arena).print("{s}: {d} files", .{ provider_name, r.files_seen });
@@ -107,6 +109,11 @@ const ProviderResult = struct {
     /// True once a BSD-style (tab-less) find line was seen for this
     /// provider. Non-fatal: that line is skipped and collection continues.
     no_stamps: bool = false,
+    /// True once a FINDFAIL marker was seen: find itself exited nonzero
+    /// (BSD find rejecting -printf, most likely). Only surfaced in detail
+    /// when files_seen is also 0 — a partial traversal error alongside
+    /// real results keeps the "{N} files" text.
+    find_failed: bool = false,
 };
 
 fn collectProvider(
@@ -120,7 +127,8 @@ fn collectProvider(
     provider: types.DigestProvider,
     root: []const u8,
 ) !ProviderResult {
-    var cmd_buf: [2048]u8 = undefined;
+    // 4096: the dir-existence guard makes the quoted root appear twice.
+    var cmd_buf: [4096]u8 = undefined;
     const find_cmd = try findCommandNoSizeFilter(root, &cmd_buf);
     const find_out = try host.exec(host.ctx, gpa, find_cmd);
     defer gpa.free(find_out);
@@ -130,6 +138,13 @@ fn collectProvider(
     while (lines.next()) |raw_line| {
         const line = std.mem.trim(u8, raw_line, " \t\r");
         if (line.len == 0) continue;
+        if (std.mem.startsWith(u8, line, "FINDFAIL:")) {
+            if (!result.find_failed) {
+                std.log.warn("memory_digest: remote find for {s} exited nonzero ({s}; BSD find without -printf?) - recorded in detail", .{ @tagName(provider), line });
+                result.find_failed = true;
+            }
+            continue;
+        }
         var cand = parseFindLine(line, provider) catch {
             // BSD find (no tabs): unsupported shape, but must not abort the
             // other providers/sources (spec §13) — record and skip the line.
@@ -175,10 +190,17 @@ fn collectProvider(
 /// than have `find` drop them silently. Only used for claude/codex roots
 /// (this module's RemoteRootsSpec has no reasonix support), so no reasonix
 /// name filter is needed here.
+///
+/// `| sort | head` would swallow find's own exit code (BSD find rejects
+/// `-printf` outright), making "find failed" indistinguishable from "0
+/// files" — so a nonzero find exits leaves a FINDFAIL:<code> marker line in
+/// the pipe (a failed find printed nothing, so the marker is the sole line
+/// and survives `head`). A missing root dir stays plain empty output ("0
+/// files" is honest there), guarded by the leading `[ ! -d ... ]`.
 fn findCommandNoSizeFilter(root: []const u8, out: []u8) ![]const u8 {
     var quoted_buf: [1024]u8 = undefined;
     const quoted = remote_file.shellQuote(&quoted_buf, root) orelse return error.CommandTooLong;
-    return std.fmt.bufPrint(out, "find {s} -type f -name '*.jsonl' -printf '%T@\\t%s\\t%p\\n' 2>/dev/null | sort -rn | head -500", .{quoted}) catch error.CommandTooLong;
+    return std.fmt.bufPrint(out, "[ ! -d {s} ] || (find {s} -type f -name '*.jsonl' -printf '%T@\\t%s\\t%p\\n' 2>/dev/null || echo FINDFAIL:$?) | sort -rn | head -500", .{ quoted, quoted }) catch error.CommandTooLong;
 }
 
 const FindCandidate = struct {
@@ -246,7 +268,7 @@ const FakeHost = struct {
             if (self.fail_home) return error.ExecFailed;
             return gpa.dupe(u8, self.home);
         }
-        if (std.mem.startsWith(u8, command, "find ")) {
+        if (std.mem.indexOf(u8, command, "find ") != null) {
             // Tests can serve Claude and Codex roots independently; empty
             // output is a valid "nothing found".
             if (std.mem.indexOf(u8, command, "/.claude/projects") != null) {
@@ -407,6 +429,31 @@ test "memory_digest_remote: BSD find output (no tabs) is recorded in detail, not
     try std.testing.expectEqual(@as(u32, 0), r.count);
     try std.testing.expectEqual(@as(usize, 0), out.items.len);
     try std.testing.expect(std.mem.indexOf(u8, r.detail, "no-stamps") != null);
+}
+
+test "memory_digest_remote: find exit marker becomes 'find failed', not '0 files'" {
+    const allocator = std.testing.allocator;
+    // claude: BSD find rejected -printf → marker is the sole output line.
+    // codex: one valid line plus a trailing traversal-error marker (GNU find
+    // exits 1 on e.g. an unreadable subdir) → real results win the detail.
+    var host: FakeHost = .{
+        .find_output = "FINDFAIL:1\n",
+        .codex_find_output = "1780300861.0\t180\t/home/me/.codex/sessions/2026/05/codex-abc.jsonl\nFINDFAIL:1\n",
+    };
+    defer host.cat_files.deinit(allocator);
+    try host.cat_files.put(allocator, "/home/me/.codex/sessions/2026/05/codex-abc.jsonl", CODEX_JSONL);
+
+    var cur = cursors_mod.Set.init(allocator);
+    defer cur.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    var out: std.ArrayListUnmanaged(types.CollectedSession) = .empty;
+    const r = try collectRemote(allocator, arena_state.allocator(), &out, "ssh:box", host.execHost(), &cur, 0, .{});
+    try std.testing.expect(std.mem.indexOf(u8, r.detail, "claude: find failed (BSD?)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.detail, "codex: 1 files") != null);
+    // The marker must not be mistaken for a BSD no-stamps path line.
+    try std.testing.expect(std.mem.indexOf(u8, r.detail, "no-stamps") == null);
+    try std.testing.expectEqual(@as(u32, 1), r.count);
 }
 
 test "memory_digest_remote: home exec failure errors" {

--- a/src/memory_digest/run.zig
+++ b/src/memory_digest/run.zig
@@ -20,8 +20,17 @@ const types = @import("types.zig");
 pub const DEFAULT_INPUT_BUDGET_CHARS = digest.DEFAULT_INPUT_BUDGET_CHARS;
 
 /// Max historical empty-summary sessions summarized per run (spec §3).
+/// Counts only actual LLM summarize attempts: dead gaps (source file gone,
+/// load failed) and tombstoned gaps are skipped without consuming a slot.
 /// ponytail: fixed cap, make it a config key only if real backlogs demand.
 const BACKFILL_LIMIT: usize = 8;
+
+/// findGaps candidate scan cap. Since dead/tombstoned gaps don't consume
+/// BACKFILL_LIMIT, scan extra candidates or a run full of dead gaps would
+/// starve the real ones behind them.
+/// ponytail: fixed 8x over-scan; if dead gaps ever pile past this, switch
+/// findGaps to an iterator.
+const BACKFILL_SCAN_LIMIT: usize = BACKFILL_LIMIT * 8;
 
 /// One WSL/SSH remote source to collect from alongside local roots (spec §6,
 /// M3). `source_id` becomes CollectedSession.source_id and thus flows into
@@ -544,11 +553,13 @@ fn runOnceWithLlm(
     // Backfill (spec 2026-07-09 §3): summarize historical daily entries that
     // still have an empty summary (collected before M2, or map previously
     // failed). Never advances cursors; merges via the same summarized lists.
-    const gaps = backfill_mod.findGaps(gpa, arena, opts.memory_root, BACKFILL_LIMIT) catch |err| blk: {
+    const gaps = backfill_mod.findGaps(gpa, arena, opts.memory_root, BACKFILL_SCAN_LIMIT) catch |err| blk: {
         std.log.warn("memory_digest: backfill scan failed: {s}", .{@errorName(err)});
         break :blk &.{};
     };
+    var backfill_llm_attempts: usize = 0;
     for (gaps) |gap| {
+        if (backfill_llm_attempts >= BACKFILL_LIMIT) break;
         // Same-run duplicate guard: the map loop above may have just
         // summarized this exact session for this same date (M1 left an
         // empty-summary daily row and new messages arrived this run) —
@@ -570,11 +581,18 @@ fn runOnceWithLlm(
         // 本轮增量刚处理过（或历史已归纳但 daily 写失败的窗口）→ 直接复用。
         // An empty stored summary (digest returns "" for an all-meta
         // transcript) is NOT reusable: treat it as a miss so the gap is
-        // retried through the map path instead of being pinned empty
-        // forever while consuming a BACKFILL_LIMIT slot every run.
+        // retried once through the map path. A second consecutive empty
+        // result tombstones the record (no_retry) — an all-meta session
+        // summarizes to "" deterministically, so retrying forever would
+        // burn an LLM call every run.
         var reused: ?*store.SummaryRecord = summaries.find(key);
+        var prior_empty = false;
         if (reused) |rec| {
-            if (rec.summary.len == 0) reused = null;
+            if (rec.summary.len == 0) {
+                if (rec.no_retry) continue;
+                prior_empty = true;
+                reused = null;
+            }
         }
         var sess: ?types.CollectedSession = null;
         if (reused == null) {
@@ -603,6 +621,7 @@ fn runOnceWithLlm(
             artifacts = rec.artifacts;
         } else {
             const s = sess.?;
+            backfill_llm_attempts += 1;
             const result = digest.summarizeSession(arena, gpa, completer, s, null, .{
                 .max_chars_per_message = opts.max_chars_per_message,
                 .input_budget_chars = opts.input_budget_chars,
@@ -623,6 +642,7 @@ fn runOnceWithLlm(
                 .topics = result.topics,
                 .outcome = result.outcome,
                 .artifacts = result.artifacts,
+                .no_retry = prior_empty and result.summary.len == 0,
             });
             sessions_summarized += 1;
         }
@@ -1663,7 +1683,7 @@ const FakeRemoteHost = struct {
             if (self.fail_home) return error.ExecFailed;
             return gpa.dupe(u8, "/root");
         }
-        if (std.mem.startsWith(u8, command, "find ")) {
+        if (std.mem.indexOf(u8, command, "find ") != null) {
             if (std.mem.indexOf(u8, command, "/.claude/projects") != null) return gpa.dupe(u8, self.find_output);
             return gpa.dupe(u8, "");
         }
@@ -2131,4 +2151,106 @@ test "run: backfill retries a gap whose stored summary is empty instead of reusi
     const daily = try tmp.dir.readFileAlloc(allocator, "memory/daily/2026-06-30.json", 1 << 20);
     defer allocator.free(daily);
     try std.testing.expect(std.mem.indexOf(u8, daily, "\"summary\": \"修复了失败的测试\"") != null);
+}
+
+// An older daily full of dead gaps: sessions whose source files no longer
+// exist anywhere under the roots (locateSessionFile misses), so backfill can
+// never summarize them. There are BACKFILL_LIMIT+1 of them, sorted before
+// the real gap's 2026-06-30 daily.
+const DEAD_GAPS_DAILY_JSON =
+    \\{"schema_version":1,"date":"2026-06-29","generated_at":1,"sessions":[
+    \\{"provider":"codex","source_id":"local","session_id":"dead-1","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-2","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-3","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-4","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-5","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-6","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-7","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-8","project":"p","title":"t","message_count_new":1},
+    \\{"provider":"codex","source_id":"local","session_id":"dead-9","project":"p","title":"t","message_count_new":1}]}
+;
+
+test "run: backfill dead gaps (source file gone) don't consume the LLM quota" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    try writeBackfillFixtures(tmp);
+    // 9 dead gaps (> BACKFILL_LIMIT=8) on an EARLIER date than the real gap:
+    // if the quota were consumed at findGaps time, they alone would fill it
+    // and starve codex-gap-1 forever.
+    try tmp.dir.writeFile(.{ .sub_path = "memory/daily/2026-06-29.json", .data = DEAD_GAPS_DAILY_JSON });
+
+    const codex_root = try std.fs.path.join(allocator, &.{ root, "codex" });
+    defer allocator.free(codex_root);
+    const memory_root = try std.fs.path.join(allocator, &.{ root, "memory" });
+    defer allocator.free(memory_root);
+    try stampBackfillCursor(allocator, tmp, memory_root);
+
+    var stub = RoutingStub{ .map_response = MAP_JSON, .reduce_response = REDUCE_JSON };
+    _ = try runOnce(allocator, .{
+        .roots = .{ .codex_sessions_dir = codex_root },
+        .memory_root = memory_root,
+        .now_ms = 1783500000000,
+        .tz_offset_seconds = 8 * 3600,
+        .backfill_days = 0,
+        .completer = stub.completer(),
+        .model_label = "test-model",
+    });
+
+    // The real gap behind the 9 dead ones still got its LLM slot.
+    try std.testing.expect(stub.map_calls >= 1);
+    const daily = try tmp.dir.readFileAlloc(allocator, "memory/daily/2026-06-30.json", 1 << 20);
+    defer allocator.free(daily);
+    try std.testing.expect(std.mem.indexOf(u8, daily, "\"summary\": \"修复了失败的测试\"") != null);
+}
+
+const EMPTY_MAP_JSON =
+    \\{"summary":"","topics":[],"outcome":"unknown","artifacts":[]}
+;
+
+test "run: backfill tombstones a gap after two consecutive empty summaries" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+    try writeBackfillFixtures(tmp);
+
+    const codex_root = try std.fs.path.join(allocator, &.{ root, "codex" });
+    defer allocator.free(codex_root);
+    const memory_root = try std.fs.path.join(allocator, &.{ root, "memory" });
+    defer allocator.free(memory_root);
+    try stampBackfillCursor(allocator, tmp, memory_root);
+
+    // The LLM deterministically returns an empty summary for this session
+    // (the all-meta transcript case digest maps to "").
+    var stub = RoutingStub{ .map_response = EMPTY_MAP_JSON, .reduce_response = REDUCE_JSON };
+    const opts: Options = .{
+        .roots = .{ .codex_sessions_dir = codex_root },
+        .memory_root = memory_root,
+        .now_ms = 1783500000000,
+        .tz_offset_seconds = 8 * 3600,
+        .backfill_days = 0,
+        .completer = stub.completer(),
+        .model_label = "test-model",
+    };
+
+    // Run 1: fresh attempt, stores an empty record (retryable).
+    _ = try runOnce(allocator, opts);
+    try std.testing.expectEqual(@as(usize, 1), stub.map_calls);
+
+    // Run 2: stored summary is empty → one retry through the map path;
+    // empty again → the record is tombstoned.
+    _ = try runOnce(allocator, opts);
+    try std.testing.expectEqual(@as(usize, 2), stub.map_calls);
+    const summaries = try tmp.dir.readFileAlloc(allocator, "memory/state/session_summaries.json", 1 << 20);
+    defer allocator.free(summaries);
+    try std.testing.expect(std.mem.indexOf(u8, summaries, "\"no_retry\": true") != null);
+
+    // Run 3: the gap is still on disk (daily summary stayed empty) but the
+    // tombstone skips it — no further LLM calls, ever.
+    _ = try runOnce(allocator, opts);
+    try std.testing.expectEqual(@as(usize, 2), stub.map_calls);
 }

--- a/src/memory_digest/store.zig
+++ b/src/memory_digest/store.zig
@@ -342,6 +342,12 @@ pub const SummaryRecord = struct {
     topics: []const []const u8 = &.{},
     outcome: []const u8 = "unknown",
     artifacts: []const Artifact = &.{},
+    /// Backfill tombstone: the gap produced an empty summary twice in a row
+    /// (all-meta transcript summarizes to "" deterministically), so later
+    /// backfill runs skip it instead of burning an LLM call every run. The
+    /// normal map path resets this when new messages arrive (its put() uses
+    /// the default false).
+    no_retry: bool = false,
 };
 
 /// Per-session LLM summaries, keyed by "provider:session_id" (spec §8).
@@ -383,6 +389,7 @@ pub const SummaryStore = struct {
             .topics = topics,
             .outcome = try alloc.dupe(u8, rec.outcome),
             .artifacts = artifacts,
+            .no_retry = rec.no_retry,
         };
         if (self.find(rec.key)) |existing| {
             existing.* = duped;


### PR DESCRIPTION
Follow-ups from the #536 final review (chip task_cfe6b45c): the backfill quota algorithm and the BSD `find` exit-code gap.

## 1. Backfill quota only counts actual LLM attempts

Previously `BACKFILL_LIMIT=8` was consumed at `findGaps` time, so dead gaps (source file deleted) and all-meta sessions (LLM deterministically returns an empty summary) occupied slots every run and could starve real gaps behind them.

- `findGaps` is unchanged; `run.zig` now passes an 8x over-scan cap (`BACKFILL_SCAN_LIMIT=64`) and counts the quota only when a summarize attempt is actually made. `locateSessionFile`/`loadFullSessionByPath` failures skip without a slot.
- New `SummaryRecord.no_retry` tombstone: an empty stored summary is still retried once (B5 semantics), but a **second consecutive** empty result tombstones the record — later runs skip it with no LLM call and no quota. The normal map path resets the flag when new messages arrive (its `put()` uses the default `false`). Old store JSON parses fine (field defaults to `false`).

## 2. Remote `find` failure is no longer read as "0 files"

On real BSD `find`, `-printf` errors out, but `2>/dev/null | sort | head` swallowed the exit code — empty output was indistinguishable from "genuinely no sessions".

The command is now `[ ! -d root ] || (find ... 2>/dev/null || echo FINDFAIL:$?) | sort -rn | head -500`:

- find itself failing leaves the `FINDFAIL:<code>` marker as the sole line (a failed find printed nothing, so it survives `head`); detail reads `"claude: find failed (BSD?)"`.
- The leading dir-existence guard keeps the B6-accepted semantics: a missing remote root (e.g. no `~/.codex`) still reports `"0 files"`, not a false failure.
- A partial traversal error alongside real results (GNU find exits 1 on unreadable subdirs) keeps the `"N files"` text.

Verified all three branches against real BSD find (`/usr/bin/find` on macOS).

## Tests

Three new tests: dead gaps don't starve the LLM quota (9 dead gaps ahead of a real one), tombstone after two consecutive empty summaries (third run makes no LLM call), and `FINDFAIL` marker → `find failed (BSD?)` without being mistaken for a no-stamps line. Also updated the two ExecHost stubs that matched commands via `startsWith("find ")`.

`zig build test` (fast suite) exit 0; `zig fmt --check build.zig src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)