### PR TITLE
Fix stack buffer overflow in WebView2 loader path building

### DIFF
--- a/src/platform/webview2_bridge.c
+++ b/src/platform/webview2_bridge.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
+#include <strsafe.h>
 
 typedef struct ICoreWebView2 ICoreWebView2;
 typedef struct ICoreWebView2Controller ICoreWebView2Controller;
@@ -402,13 +403,16 @@ static HMODULE try_load_from_nuget(void) {
     DWORD profile_len = GetEnvironmentVariableW(L"USERPROFILE", user_profile, MAX_PATH);
     if (profile_len == 0 || profile_len >= MAX_PATH) return NULL;
 
+    // wsprintfW ignores the destination size; a relocated (long) USERPROFILE
+    // would overflow these MAX_PATH stack buffers. StringCchPrintfW bounds the
+    // write and fails closed on truncation instead.
     WCHAR base[MAX_PATH];
-    if (wsprintfW(base, L"%s\\.nuget\\packages\\microsoft.web.webview2", user_profile) <= 0) {
+    if (FAILED(StringCchPrintfW(base, MAX_PATH, L"%s\\.nuget\\packages\\microsoft.web.webview2", user_profile))) {
         return NULL;
     }
 
     WCHAR pattern[MAX_PATH];
-    if (wsprintfW(pattern, L"%s\\*", base) <= 0) return NULL;
+    if (FAILED(StringCchPrintfW(pattern, MAX_PATH, L"%s\\*", base))) return NULL;
 
     WIN32_FIND_DATAW data;
     HANDLE find = FindFirstFileW(pattern, &data);
@@ -420,7 +424,7 @@ static HMODULE try_load_from_nuget(void) {
         if (wcscmp(data.cFileName, L".") == 0 || wcscmp(data.cFileName, L"..") == 0) continue;
 
         WCHAR candidate[MAX_PATH];
-        if (wsprintfW(candidate, L"%s\\%s\\build\\native\\x64\\WebView2Loader.dll", base, data.cFileName) <= 0) {
+        if (FAILED(StringCchPrintfW(candidate, MAX_PATH, L"%s\\%s\\build\\native\\x64\\WebView2Loader.dll", base, data.cFileName))) {
             continue;
         }
         result = LoadLibraryW(candidate);
@@ -465,9 +469,9 @@ static void build_user_data_folder(WCHAR *buf, size_t len) {
     if (n == 0 || n >= MAX_PATH) return;
 
     WCHAR root[MAX_PATH];
-    if (wsprintfW(root, L"%s\\wispterm", local_app_data) <= 0) return;
+    if (FAILED(StringCchPrintfW(root, MAX_PATH, L"%s\\wispterm", local_app_data))) return;
     CreateDirectoryW(root, NULL);
-    wsprintfW(buf, L"%s\\webview2", root);
+    if (FAILED(StringCchPrintfW(buf, len, L"%s\\webview2", root))) return;
     CreateDirectoryW(buf, NULL);
 }
 


### PR DESCRIPTION
## Summary
Following up on #535 (hand-written Win32 interop with insufficient bounds), this fixes a real stack buffer overflow in the same file: `src/platform/webview2_bridge.c`.

`wsprintfW` does **not** respect the destination buffer size — it writes as many characters as the formatted result needs (MS documents it as deprecated in favor of `StringCch*`). The two path-building helpers only validate that `USERPROFILE`/`LOCALAPPDATA` are shorter than `MAX_PATH`, but appending the fixed suffixes can push the result past the `MAX_PATH` stack buffers.

## Root Cause
- `try_load_from_nuget`: `base` = `USERPROFILE` + `\.nuget\packages\microsoft.web.webview2` (39 chars) → up to ~298 chars into `WCHAR base[MAX_PATH]` (260) → overflow. `pattern` and especially `candidate` (which also appends the nuget package directory name `cFileName`, up to 255 chars) overflow further.
- `build_user_data_folder`: `root` = `LOCALAPPDATA` + `\wispterm`, and `buf` = `root` + `\webview2`, both can exceed their `MAX_PATH` buffers.

Trigger condition is a relocated / long profile path — an edge case, but a genuine out-of-bounds stack write.

## Fix
Replace all five `wsprintfW` calls with the bounded `StringCchPrintfW`, which clamps to the buffer size and fails closed on truncation instead of writing out of bounds. The two previously-unchecked calls (`root`, `buf`) now also bail on failure.

## Validation
- Cross-compiled the patched bridge for Windows: `zig cc -target x86_64-windows-gnu -DUNICODE -D_UNICODE -c src/platform/webview2_bridge.c` — compiles clean; `StringCchPrintfW` (`<strsafe.h>`) resolves in zig's bundled mingw-w64 headers.
- Windows-only translation unit, so no end-to-end run on macOS; single-file cross-compile covers the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)