### PR TITLE
Free locked wispterm.exe before Windows install

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -632,7 +632,16 @@ pub fn build(b: *std.Build) void {
             exe.subsystem = if (optimize == .Debug or debug_console) .Console else .Windows;
         }
 
-        b.installArtifact(exe);
+        const install_exe = b.addInstallArtifact(exe, .{});
+        if (target.result.os.tag == .windows) {
+            // Windows locks a running .exe, so overwriting zig-out\bin\wispterm.exe
+            // while WispTerm is open fails the install with AccessDenied. Free the
+            // destination first (delete, or rename it aside — Windows allows renaming
+            // a running exe) so a rebuild-while-running succeeds. Mirrors the macOS
+            // bundle's clean-existing pre-step below.
+            install_exe.step.dependOn(&FreeLockedInstallTarget.create(b, "wispterm.exe").step);
+        }
+        b.getInstallStep().dependOn(&install_exe.step);
 
         if (target.result.os.tag == .windows) {
             const askpass_mod = b.createModule(.{
@@ -1386,6 +1395,58 @@ fn createBenchModule(
     }
     return bench_mod;
 }
+
+/// Install pre-step that frees a locked destination in zig-out/bin before the
+/// artifact is copied. On Windows a running .exe cannot be overwritten (the OS
+/// holds a lock), so `zig build` fails with AccessDenied whenever WispTerm is
+/// open. Deleting the running exe also fails — but Windows *does* allow renaming
+/// it aside, which frees the path so the fresh binary can be written. Leftover
+/// `<name>.old-N` files delete cleanly on the next build once the old process
+/// has exited. Best-effort everywhere else (a missing/unlocked file is fine).
+const FreeLockedInstallTarget = struct {
+    step: std.Build.Step,
+    name: []const u8,
+
+    fn create(b: *std.Build, name: []const u8) *FreeLockedInstallTarget {
+        const self = b.allocator.create(FreeLockedInstallTarget) catch @panic("OOM");
+        self.* = .{
+            .step = std.Build.Step.init(.{
+                .id = .custom,
+                .name = b.fmt("free locked {s}", .{name}),
+                .owner = b,
+                .makeFn = make,
+            }),
+            .name = name,
+        };
+        return self;
+    }
+
+    fn make(step: *std.Build.Step, options: std.Build.Step.MakeOptions) anyerror!void {
+        _ = options;
+        const self: *FreeLockedInstallTarget = @fieldParentPtr("step", step);
+        const b = step.owner;
+        var dir = std.fs.cwd().openDir(b.getInstallPath(.bin, ""), .{ .iterate = true }) catch return;
+        defer dir.close();
+
+        // Sweep leftover renamed-aside binaries from earlier rebuilds.
+        var it = dir.iterate();
+        while (it.next() catch null) |entry| {
+            if (std.mem.indexOf(u8, entry.name, ".old-") != null) dir.deleteFile(entry.name) catch {};
+        }
+
+        dir.deleteFile(self.name) catch |err| switch (err) {
+            error.FileNotFound => {}, // nothing installed yet
+            else => {
+                // Almost certainly a running exe (AccessDenied); rename it aside.
+                var n: usize = 0;
+                while (n < 1000) : (n += 1) {
+                    if (dir.rename(self.name, b.fmt("{s}.old-{d}", .{ self.name, n }))) |_| return else |_| {}
+                }
+                return error.CouldNotFreeInstallTarget;
+            },
+        };
+    }
+};
 
 fn addMacosAppBundle(
     b: *std.Build,


### PR DESCRIPTION
## What

Rebuilding while WispTerm is open failed the `install wispterm` build step on Windows:

```
error: unable to update file from '.zig-cache\...\wispterm.exe' to
'...\zig-out\bin\wispterm.exe': AccessDenied
Build Summary: 24/26 steps succeeded; 1 failed
```

The compile itself succeeds (24/26) — only the final copy into `zig-out\bin` fails, because Windows locks a running `.exe` and won't let the fresh binary overwrite it.

## Why / root cause

Windows holds an exclusive lock on the image of any running process, so `zig build`'s install copy hits `AccessDenied` whenever the app is open. Every rebuild-while-running loop hits this.

## Fix

Add a Windows-only install pre-step, `FreeLockedInstallTarget`, that frees the destination in `zig-out\bin` before the artifact is copied:

- Delete the existing `wispterm.exe`; if it's a running exe (delete fails), **rename it aside** to `wispterm.exe.old-N` — Windows permits renaming a running binary, which frees the path so the new one can be written.
- Leftover `.old-N` files are swept on the next build once the old process has exited.
- Best-effort and no-op when the target is absent/unlocked or on non-Windows hosts.

This mirrors the existing macOS bundle "clean-existing" pre-step at `addMacosAppBundle`.

## Reviewer notes

- Scoped to the main `wispterm.exe` only. `wispterm-ssh-askpass.exe` is a short-lived helper that's ~never locked during a build, so it's intentionally left out (easy to add later if it ever bites).
- `b.getInstallStep().dependOn(&install_exe.step)` is the exact expansion of the previous `b.installArtifact(exe)` — no behavior change beyond the added pre-step dependency.
- Verified on macOS: `zig build --help` configures cleanly with the default (Windows) target, and `zig fmt --check build.zig` passes. The rename-aside path only triggers under a real Windows lock, so it wasn't exercisable here — worth a quick confirm by rebuilding with the app open on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)