### PR TITLE
feat(tools): cli_agent — delegate self-contained tasks to external CLI agents (codex)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-cli-agent-tool.md
+++ b/docs/superpowers/plans/2026-07-10-cli-agent-tool.md
@@ -1,0 +1,902 @@
+# cli_agent 工具实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增第一方工具 `cli_agent`：把自包含任务委派给外部 CLI agent（首个后端 codex），流式进度进聊天卡片，返回最终答复。
+
+**Architecture:** 新叶子模块 `src/agent_tools/cli_agent.zig` 持有 Backend 数据表（key/exe/base_args/parseEvent）和共享 `run()`（审批→spawn→行流式→25ms 轮询→超时/取消→结果格式化）。`ToolContext` 增加 `progress` 钩子接到 `appendProgressMessage`。注册走现有四件套（protocol.zig schema+reserved、first_party.zig、mod.zig 分发）。
+
+**Tech Stack:** Zig（std.process.Child、std.Thread、std.json），无新依赖。
+
+Spec: `docs/superpowers/specs/2026-07-10-cli-agent-tool-design.md`
+
+## Global Constraints
+
+- 分支 `feat/cli-agent-tool`（已存在，spec 已提交）。
+- `agent_tools/**` 是叶子模块：**禁止** import `AppWindow.zig`（source guard 强制）；cli_agent.zig 只 import `../assistant/conversation/types.zig`、`../platform/process.zig`、`exec.zig`、`output.zig`。
+- 每次提交前必跑 `zig fmt build.zig src`（CI 有 fmt gate，本地 test 不含）。
+- 快测命令：`zig build test -Dtarget=aarch64-macos`（agent_tools/types 的测试在这里跑）。protocol.zig 的测试只在 `zig build test-full -Dtarget=aarch64-macos` 运行（约 2300 个用例，已知 flaky："skill center tool import" FileNotFound 与本改动无关）。
+- 用 `/bin/sh` 的测试须以 `if (builtin.os.tag == .windows) return error.SkipZigTest;` 开头（跟 mod.zig 现有 MCP dispatch 测试同模式）。
+- 工具名固定 `cli_agent`；codex 命令行固定为 `codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -- <task>`。
+- 超时常量：`DEFAULT_TIMEOUT_MS = 600_000`，`MAX_TIMEOUT_MS = 3_600_000`。
+
+---
+
+### Task 1: ToolContext 增加 progress 钩子并在 request.zig 接线
+
+**Files:**
+- Modify: `src/assistant/conversation/types.zig`（ToolContext，约 354-402 行）
+- Modify: `src/assistant/conversation/request.zig`（toolNote 附近约 865 行；toolContextFromRequest 约 915 行）
+
+**Interfaces:**
+- Produces: `ToolContext.progress: *const fn (ctx: *anyopaque, text: []const u8) void = noopProgress` 字段；`ToolContext.emitProgress(text: []const u8) void` 方法。Task 3 的 `run()` 调 `ctx.emitProgress(...)`，测试用自定义 hook 捕获。
+
+- [ ] **Step 1: types.zig 加默认 no-op 与字段**
+
+在 `fn noopNote` 旁（约 348 行）加：
+
+```zig
+fn noopProgress(_: *anyopaque, _: []const u8) void {}
+```
+
+在 ToolContext 的 `note` 字段之后加字段：
+
+```zig
+    /// Post an ephemeral progress line to the chat card while a tool runs
+    /// (persist_to_history=false; never enters LLM context). Defaults to a
+    /// no-op so test contexts need not wire it.
+    progress: *const fn (ctx: *anyopaque, text: []const u8) void = noopProgress,
+```
+
+在 `emitNote` 方法之后加方法：
+
+```zig
+    pub fn emitProgress(self: *const ToolContext, text: []const u8) void {
+        self.progress(self.ctx, text);
+    }
+```
+
+- [ ] **Step 2: request.zig 接线**
+
+在 `toolNote`（865 行）之后加：
+
+```zig
+fn toolProgress(ctx: *anyopaque, text: []const u8) void {
+    const session: *Session = @ptrCast(@alignCast(ctx));
+    ai_chat.appendProgressMessage(session, text) catch {};
+}
+```
+
+`toolContextFromRequest` 返回值里 `.note = toolNote,` 之后加一行：
+
+```zig
+        .progress = toolProgress,
+```
+
+- [ ] **Step 3: 验证编译与既有测试**
+
+Run: `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos`
+Expected: 全部通过（字段带默认值，既有 ToolContext 构造点不需要改）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/assistant/conversation/types.zig src/assistant/conversation/request.zig
+git commit -m "Add ToolContext progress hook wired to appendProgressMessage"
+```
+
+---
+
+### Task 2: cli_agent.zig 骨架 —— Backend 表、find、codex 事件解析器
+
+**Files:**
+- Create: `src/agent_tools/cli_agent.zig`
+- Modify: `src/test_fast.zig`（约 307-323 行 agent_tools 段）
+
+**Interfaces:**
+- Consumes: 无（纯数据+解析，本 task 不用 Task 1 的钩子）。
+- Produces（Task 3/4 依赖，签名精确）：
+  - `pub const Event = struct { progress: ?[]u8 = null, final: ?[]u8 = null };`（字段为 owned 内存）
+  - `pub const Backend = struct { key, display, exe: []const u8, base_args: []const []const u8, parseEvent: *const fn (std.mem.Allocator, []const u8) ?Event };`
+  - `pub const backends: [1]Backend`、`pub fn find(key: []const u8) ?*const Backend`
+  - `pub const available_keys: []const u8`（comptime 拼出 `"codex"`）
+  - `pub const DEFAULT_TIMEOUT_MS: u32 = 600_000;`、`pub const MAX_TIMEOUT_MS: u32 = 3_600_000;`
+  - 私有 `codexParseEvent`（经 backend.parseEvent 间接测试与调用）
+
+- [ ] **Step 1: 写失败测试（文件同时含最小声明骨架才能编译，Zig 测试与实现同文件；先写测试段）**
+
+创建 `src/agent_tools/cli_agent.zig`，先只写测试将引用的最小骨架 + 完整测试（TDD 红：先让 `codexParseEvent` 恒 return null、`find` 恒 return null，跑测试确认失败）：
+
+```zig
+//! Unified CLI agent delegation tool (`cli_agent`): hand one self-contained
+//! task to an external CLI agent (first backend: Codex), stream its progress
+//! into the chat card, and return its final report. Leaf module — depends on
+//! ai_chat_types, platform process helpers, and sibling exec/output adapters;
+//! never on session.zig or AppWindow.
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("../assistant/conversation/types.zig");
+
+const ToolContext = types.ToolContext;
+
+pub const DEFAULT_TIMEOUT_MS: u32 = 600_000;
+pub const MAX_TIMEOUT_MS: u32 = 3_600_000;
+
+/// One parsed stdout line from a backend. Set fields are owned by the
+/// caller-provided allocator; the caller frees them.
+pub const Event = struct {
+    progress: ?[]u8 = null,
+    final: ?[]u8 = null,
+};
+
+pub const Backend = struct {
+    key: []const u8, // value of the tool's `agent` argument
+    display: []const u8,
+    exe: []const u8, // executable name resolved via PATH
+    base_args: []const []const u8, // fixed args between exe and task
+    parseEvent: *const fn (allocator: std.mem.Allocator, line: []const u8) ?Event,
+};
+
+const codex_backend = Backend{
+    .key = "codex",
+    .display = "Codex",
+    .exe = "codex",
+    .base_args = &.{ "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "--" },
+    .parseEvent = codexParseEvent,
+};
+
+pub const backends = [_]Backend{codex_backend};
+
+/// Comma-joined backend keys for error messages and docs; stays correct as
+/// the table grows.
+pub const available_keys = blk: {
+    var s: []const u8 = "";
+    for (backends, 0..) |b, i| s = s ++ (if (i == 0) "" else ", ") ++ b.key;
+    break :blk s;
+};
+
+pub fn find(key: []const u8) ?*const Backend {
+    _ = key;
+    return null; // TDD: red
+}
+
+fn codexParseEvent(allocator: std.mem.Allocator, line: []const u8) ?Event {
+    _ = allocator;
+    _ = line;
+    return null; // TDD: red
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "find resolves codex and rejects unknown keys" {
+    const backend = find("codex") orelse return error.TestExpectedBackend;
+    try std.testing.expectEqualStrings("codex", backend.exe);
+    try std.testing.expect(find("oh-my-pi") == null);
+    try std.testing.expectEqualStrings("codex", available_keys);
+}
+
+test "codexParseEvent extracts progress from item.started command_execution" {
+    const a = std.testing.allocator;
+    const line = "{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"item_type\":\"command_execution\",\"command\":\"bash -lc 'ls'\",\"status\":\"in_progress\"}}";
+    const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
+    defer if (event.progress) |p| a.free(p);
+    defer if (event.final) |f| a.free(f);
+    try std.testing.expect(event.final == null);
+    try std.testing.expectEqualStrings("codex: $ bash -lc 'ls'", event.progress.?);
+}
+
+test "codexParseEvent extracts final from item.completed agent_message" {
+    const a = std.testing.allocator;
+    const line = "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_9\",\"item_type\":\"agent_message\",\"text\":\"All tests pass.\"}}";
+    const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
+    defer if (event.progress) |p| a.free(p);
+    defer if (event.final) |f| a.free(f);
+    try std.testing.expect(event.progress == null);
+    try std.testing.expectEqualStrings("All tests pass.", event.final.?);
+}
+
+test "codexParseEvent ignores unknown events, other item phases, and non-JSON lines" {
+    const a = std.testing.allocator;
+    try std.testing.expect(codexParseEvent(a, "[2026-07-10] plain human output") == null);
+    try std.testing.expect(codexParseEvent(a, "") == null);
+    try std.testing.expect(codexParseEvent(a, "{not json") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"thread.started\",\"thread_id\":\"t1\"}") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"reasoning\",\"text\":\"hmm\"}}") == null);
+    // command_execution progress only fires on item.started, not completed (no dupes)
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\",\"status\":\"completed\"}}") == null);
+    // agent_message only counts when completed
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.started\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"partial\"}}") == null);
+}
+```
+
+同时在 `src/test_fast.zig` 的 `_ = @import("agent_tools/args.zig");` 之后加一行：
+
+```zig
+    _ = @import("agent_tools/cli_agent.zig");
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `zig build test -Dtarget=aarch64-macos 2>&1 | grep -A2 "cli_agent\|codexParse\|find resolves"`
+Expected: FAIL（`TestExpectedBackend` / `TestExpectedEvent`）。
+
+- [ ] **Step 3: 写最小实现**
+
+替换两个 red 桩：
+
+```zig
+pub fn find(key: []const u8) ?*const Backend {
+    for (&backends) |*backend| {
+        if (std.mem.eql(u8, backend.key, key)) return backend;
+    }
+    return null;
+}
+
+fn objectString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const v = value.object.get(key) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+/// Parse one line of `codex exec --json` output. Tolerant by design: any
+/// line that is not JSON or not a recognized event returns null; when no
+/// agent_message is ever seen, run() falls back to the raw stdout tail, so
+/// codex JSON-format drift degrades gracefully instead of failing.
+fn codexParseEvent(allocator: std.mem.Allocator, line: []const u8) ?Event {
+    const trimmed = std.mem.trim(u8, line, " \t\r");
+    if (trimmed.len == 0 or trimmed[0] != '{') return null;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const event_type = objectString(parsed.value, "type") orelse return null;
+    const item = parsed.value.object.get("item") orelse return null;
+    const item_type = objectString(item, "item_type") orelse return null;
+    if (std.mem.eql(u8, event_type, "item.completed") and std.mem.eql(u8, item_type, "agent_message")) {
+        const text = objectString(item, "text") orelse return null;
+        const owned = allocator.dupe(u8, text) catch return null;
+        return .{ .final = owned };
+    }
+    if (std.mem.eql(u8, event_type, "item.started") and std.mem.eql(u8, item_type, "command_execution")) {
+        const command = objectString(item, "command") orelse return null;
+        const owned = std.fmt.allocPrint(allocator, "codex: $ {s}", .{command}) catch return null;
+        return .{ .progress = owned };
+    }
+    return null;
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos`
+Expected: PASS（含全部既有测试）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent_tools/cli_agent.zig src/test_fast.zig
+git commit -m "Add cli_agent backend table and codex JSONL event parser"
+```
+
+---
+
+### Task 3: cli_agent.run() —— spawn、行流式、轮询、结果格式化
+
+**Files:**
+- Modify: `src/agent_tools/cli_agent.zig`
+
+**Interfaces:**
+- Consumes: Task 1 的 `ctx.emitProgress(text)`；Task 2 的 `Backend`/`Event`；`agent_exec.CaptureOutput` + `agent_exec.captureOutputThread`（exec.zig 已 pub）；`platform_process.childExited(id, timeout_ms)`；`tool_output.deniedResult` / `tool_output.truncateOwned`。
+- Produces（Task 4 依赖）：`pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8`
+
+- [ ] **Step 1: 写失败测试**
+
+在 cli_agent.zig 测试段追加（fake hooks 跟 mod.zig 同模式）：
+
+```zig
+fn fakeApprove(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return true;
+}
+fn fakeDeny(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    const called: *bool = @ptrCast(@alignCast(ctx));
+    called.* = true;
+    return false;
+}
+fn fakeCancelled(_: *anyopaque) bool {
+    return false;
+}
+
+const ProgressCapture = struct {
+    count: usize = 0,
+    last: [256]u8 = undefined,
+    last_len: usize = 0,
+
+    fn hook(ctx: *anyopaque, text: []const u8) void {
+        const self: *ProgressCapture = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        const n = @min(text.len, self.last.len);
+        @memcpy(self.last[0..n], text[0..n]);
+        self.last_len = n;
+    }
+};
+
+test "run streams progress and returns the final agent message" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const script =
+        "printf '%s\\n' " ++
+        "'{\"type\":\"item.started\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"first\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"all done\"}}'";
+    const args = [_][]const u8{ "-c", script };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var progress = ProgressCapture{};
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &progress,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+        .progress = ProgressCapture.hook,
+    };
+    const out = try run(&ctx, &fake, "do the thing", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "agent=fake") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exit_code=0") != null);
+    // last agent_message wins
+    try std.testing.expect(std.mem.indexOf(u8, out, "all done") != null);
+    try std.testing.expectEqual(@as(usize, 1), progress.count);
+    try std.testing.expectEqualStrings("codex: $ ls", progress.last[0..progress.last_len]);
+}
+
+test "run falls back to the raw stdout tail when no final message parses" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "printf '%s\\n' 'plain line one' 'plain line two'" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No final message parsed") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "plain line two") != null);
+}
+
+test "run requires approval outside full permission and reports denial" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "true" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var approve_called = false;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &approve_called,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .auto },
+        .approve = fakeDeny,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "risky task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(approve_called);
+    try std.testing.expect(std.mem.indexOf(u8, out, "DENIED") != null);
+}
+
+test "run reports a missing executable clearly" {
+    const a = std.testing.allocator;
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "definitely-missing-cli-agent-binary",
+        .base_args = &.{},
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "not found or failed to start") != null);
+}
+
+test "run kills the child on timeout and marks the result" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "sleep 30" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 100);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "timed_out=true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exit_code=124") != null);
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `zig build test -Dtarget=aarch64-macos 2>&1 | tail -20`
+Expected: 编译错误 `run` 未定义（红）。
+
+- [ ] **Step 3: 实现 LineStream 与 run()**
+
+在 cli_agent.zig 顶部补 import：
+
+```zig
+const platform_process = @import("../platform/process.zig");
+const agent_exec = @import("exec.zig");
+const tool_output = @import("output.zig");
+```
+
+实现段（放在 find 之后、Tests 注释之前）：
+
+```zig
+// ---------------------------------------------------------------------------
+// Line-streaming child runner
+// ---------------------------------------------------------------------------
+
+/// Reader-thread line collector. The thread only does I/O and line splitting;
+/// parsed events and all session calls stay on the tool worker thread
+/// (markUiDirty is threadlocal — cross-thread UI calls are a known trap).
+const LineStream = struct {
+    allocator: std.mem.Allocator,
+    file: std.fs.File,
+    mutex: std.Thread.Mutex = .{},
+    lines: std.ArrayListUnmanaged([]u8) = .empty,
+    partial: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *LineStream) void {
+        for (self.lines.items) |line| self.allocator.free(line);
+        self.lines.deinit(self.allocator);
+        self.partial.deinit(self.allocator);
+    }
+
+    fn readThread(self: *LineStream) void {
+        var buf: [4096]u8 = undefined;
+        while (true) {
+            const n = self.file.read(&buf) catch break;
+            if (n == 0) break;
+            self.push(buf[0..n]);
+        }
+        self.flushPartial();
+    }
+
+    // ponytail: `partial` is unbounded for a single line with no newline;
+    // codex event lines are bounded in practice — cap it if a backend ever
+    // streams raw unbounded output.
+    fn push(self: *LineStream, chunk: []const u8) void {
+        var rest = chunk;
+        while (std.mem.indexOfScalar(u8, rest, '\n')) |nl| {
+            const line = std.mem.concat(self.allocator, u8, &.{ self.partial.items, rest[0..nl] }) catch return;
+            self.partial.clearRetainingCapacity();
+            self.appendLine(line);
+            rest = rest[nl + 1 ..];
+        }
+        self.partial.appendSlice(self.allocator, rest) catch {};
+    }
+
+    fn flushPartial(self: *LineStream) void {
+        if (self.partial.items.len == 0) return;
+        const line = self.allocator.dupe(u8, self.partial.items) catch return;
+        self.partial.clearRetainingCapacity();
+        self.appendLine(line);
+    }
+
+    fn appendLine(self: *LineStream, line: []u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.lines.append(self.allocator, line) catch self.allocator.free(line);
+    }
+
+    /// Move all pending lines to `out`; caller owns and frees each line.
+    fn drain(self: *LineStream, out: *std.ArrayListUnmanaged([]u8)) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        out.appendSlice(self.allocator, self.lines.items) catch return;
+        self.lines.clearRetainingCapacity();
+    }
+};
+
+/// Keep a bounded raw-stdout tail for the no-final-message fallback (the
+/// useful part of a stream is at the end).
+fn appendTail(allocator: std.mem.Allocator, tail: *std.ArrayListUnmanaged(u8), line: []const u8, limit: u32) void {
+    tail.appendSlice(allocator, line) catch return;
+    tail.append(allocator, '\n') catch return;
+    const max: usize = @max(@as(usize, limit), 1);
+    if (tail.items.len > 2 * max) {
+        // no overlap: only triggered when len > 2*max
+        std.mem.copyForwards(u8, tail.items[0..max], tail.items[tail.items.len - max ..]);
+        tail.shrinkRetainingCapacity(max);
+    }
+}
+
+fn drainAndParse(ctx: *ToolContext, backend: *const Backend, stream: *LineStream, final_message: *?[]u8, tail: *std.ArrayListUnmanaged(u8)) void {
+    const allocator = ctx.allocator;
+    var drained: std.ArrayListUnmanaged([]u8) = .empty;
+    defer drained.deinit(allocator);
+    stream.drain(&drained);
+    for (drained.items) |line| {
+        defer allocator.free(line);
+        appendTail(allocator, tail, line, ctx.settings.output_limit);
+        const event = backend.parseEvent(allocator, line) orelse continue;
+        if (event.progress) |p| {
+            defer allocator.free(p);
+            ctx.emitProgress(p);
+        }
+        if (event.final) |f| {
+            if (final_message.*) |old| allocator.free(old);
+            final_message.* = f;
+        }
+    }
+}
+
+pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8 {
+    const allocator = ctx.allocator;
+    if (ctx.isCancelled()) return allocator.dupe(u8, "Canceled.");
+    const trimmed_task = std.mem.trim(u8, task, " \t\r\n");
+    if (trimmed_task.len == 0) return allocator.dupe(u8, "Missing task");
+
+    // The backend runs with full access and cannot prompt mid-run, so both
+    // confirm AND auto permission modes gate the whole delegation up front.
+    if (ctx.settings.permission != .full) {
+        const reason = try std.fmt.allocPrint(allocator, "Delegate task to {s} with full access", .{backend.display});
+        defer allocator.free(reason);
+        if (!ctx.requestApproval("cli_agent", trimmed_task, reason)) {
+            return tool_output.deniedResult(allocator, trimmed_task, "cli_agent delegation not approved");
+        }
+    }
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, backend.exe);
+    try argv.appendSlice(allocator, backend.base_args);
+    try argv.append(allocator, trimmed_task);
+
+    var child = std.process.Child.init(argv.items, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.cwd = cwd orelse ctx.settings.working_dir;
+    child.create_no_window = true;
+    child.spawn() catch |err| {
+        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {}", .{ backend.display, backend.exe, err });
+    };
+
+    var stream = LineStream{ .allocator = allocator, .file = child.stdout.? };
+    defer stream.deinit();
+    var stderr_capture = agent_exec.CaptureOutput{
+        .allocator = allocator,
+        .file = child.stderr.?,
+        .max_bytes = ctx.settings.output_limit,
+    };
+    defer allocator.free(stderr_capture.data);
+
+    const stdout_thread = try std.Thread.spawn(.{}, LineStream.readThread, .{&stream});
+    const stderr_thread = try std.Thread.spawn(.{}, agent_exec.captureOutputThread, .{&stderr_capture});
+
+    var final_message: ?[]u8 = null;
+    defer if (final_message) |f| allocator.free(f);
+    var tail: std.ArrayListUnmanaged(u8) = .empty;
+    defer tail.deinit(allocator);
+
+    const wait_ms = @max(@min(timeout_ms, MAX_TIMEOUT_MS), 1);
+    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(wait_ms));
+    var timed_out = false;
+    var canceled = false;
+    while (true) {
+        drainAndParse(ctx, backend, &stream, &final_message, &tail);
+        switch (platform_process.childExited(child.id, 25)) {
+            .running => {},
+            .exited => |code| {
+                // Same trap as exec.runArgv: on POSIX childExited() already
+                // reaped the zombie; pre-set term so child.wait() skips its
+                // second waitpid (ECHILD aborts). Windows keeps the handle.
+                if (builtin.os.tag != .windows) child.term = .{ .Exited = @intCast(code) };
+                break;
+            },
+            .gone => {
+                if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
+                break;
+            },
+        }
+        if (ctx.isCancelled()) {
+            canceled = true;
+            _ = child.kill() catch {};
+            break;
+        }
+        if (std.time.milliTimestamp() >= deadline) {
+            timed_out = true;
+            _ = child.kill() catch {};
+            break;
+        }
+    }
+
+    stdout_thread.join();
+    stderr_thread.join();
+    // Lines that arrived between the last in-loop drain and thread exit.
+    drainAndParse(ctx, backend, &stream, &final_message, &tail);
+
+    const exit_code: i32 = if (timed_out or canceled) 124 else blk: {
+        const term = try child.wait();
+        break :blk switch (term) {
+            .Exited => |code| @intCast(code),
+            .Signal => |sig| -@as(i32, @intCast(sig)),
+            .Stopped => |sig| -@as(i32, @intCast(sig)),
+            .Unknown => |code| @intCast(code),
+        };
+    };
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    if (timed_out) try out.appendSlice(allocator, "timed_out=true\n");
+    if (canceled) try out.appendSlice(allocator, "canceled=true\n");
+    try out.print(allocator, "agent={s} exit_code={d}\n", .{ backend.key, exit_code });
+    if (final_message) |f| {
+        try out.appendSlice(allocator, f);
+    } else {
+        try out.appendSlice(allocator, "No final message parsed; raw output tail:\n");
+        try out.appendSlice(allocator, tail.items);
+    }
+    if (exit_code != 0 and stderr_capture.data.len > 0) {
+        try out.print(allocator, "\nstderr:\n{s}", .{stderr_capture.data});
+    }
+    return tool_output.truncateOwned(allocator, ctx.settings, try out.toOwnedSlice(allocator));
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos`
+Expected: PASS（timeout 测试约 100ms，整体不明显变慢）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent_tools/cli_agent.zig
+git commit -m "Implement cli_agent run(): spawn, line streaming, progress, timeout"
+```
+
+---
+
+### Task 4: mod.zig 分发
+
+**Files:**
+- Modify: `src/agent_tools/mod.zig`（import 段约 32 行；dispatch 链 `memory_search` 块之后、`agent_dynamic.find` 之前，约 296 行）
+
+**Interfaces:**
+- Consumes: Task 2/3 的 `find`、`run`、`DEFAULT_TIMEOUT_MS`、`available_keys`。
+- Produces: 工具名 `"cli_agent"` 经 `executeToolCall` 可达（Task 5 的 schema 对应此名）。
+
+- [ ] **Step 1: 写失败测试**
+
+mod.zig 测试段追加：
+
+```zig
+test "executeToolCall cli_agent validates agent and task arguments" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const missing_agent = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"task\":\"do something\"}"),
+    });
+    defer a.free(missing_agent);
+    try std.testing.expect(std.mem.indexOf(u8, missing_agent, "Missing agent") != null);
+
+    const unknown_agent = try executeToolCall(&ctx, .{
+        .id = @constCast("c2"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"agent\":\"oh-my-pi\",\"task\":\"x\"}"),
+    });
+    defer a.free(unknown_agent);
+    try std.testing.expect(std.mem.indexOf(u8, unknown_agent, "Unknown agent") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unknown_agent, "codex") != null);
+
+    const missing_task = try executeToolCall(&ctx, .{
+        .id = @constCast("c3"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"agent\":\"codex\"}"),
+    });
+    defer a.free(missing_task);
+    try std.testing.expect(std.mem.indexOf(u8, missing_task, "Missing task") != null);
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `zig build test -Dtarget=aarch64-macos 2>&1 | tail -10`
+Expected: FAIL —— 返回 "Unknown tool: cli_agent"，三个 expect 均不满足。
+
+- [ ] **Step 3: 实现分发**
+
+import 段（`agent_dynamic` 之前）加：
+
+```zig
+const agent_cli_agent = @import("cli_agent.zig");
+```
+
+`memory_search` 分支之后加：
+
+```zig
+    if (std.mem.eql(u8, call.name, "cli_agent")) {
+        const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const agent_key = tool_args.string(args.value, "agent") orelse return ctx.allocator.dupe(u8, "Missing agent");
+        const backend = agent_cli_agent.find(agent_key) orelse
+            return std.fmt.allocPrint(ctx.allocator, "Unknown agent \"{s}\". Available: {s}", .{ agent_key, agent_cli_agent.available_keys });
+        const task = tool_args.string(args.value, "task") orelse return ctx.allocator.dupe(u8, "Missing task");
+        const cwd = tool_args.string(args.value, "cwd");
+        const timeout_ms = tool_args.int(args.value, "timeout_ms") orelse agent_cli_agent.DEFAULT_TIMEOUT_MS;
+        return agent_cli_agent.run(ctx, backend, task, cwd, timeout_ms);
+    }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent_tools/mod.zig
+git commit -m "Dispatch cli_agent tool calls to the backend runner"
+```
+
+---
+
+### Task 5: 注册 —— protocol.zig schema + reserved、first_party.zig 目录
+
+**Files:**
+- Modify: `src/assistant/conversation/protocol.zig`（`forEachToolSpec` 内 subagent 的 emitTool 之后约 809 行；`builtinToolNameReserved` 约 725 行；测试段约 2215 行）
+- Modify: `src/tools/first_party.zig`（`static_definitions`，subagent 行之后约 57 行）
+
+**Interfaces:**
+- Consumes: Task 4 使 `"cli_agent"` 名字可分发。
+- Produces: 模型能看到 `cli_agent` schema（required: agent, task）；工具管理 UI 能禁用它；名字保留防动态工具撞名。
+
+- [ ] **Step 1: 写失败测试**
+
+protocol.zig 测试段（`"full toolset includes the subagent tool"` 附近）追加：
+
+```zig
+test "full toolset includes cli_agent and subagent toolset excludes it" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+    try appendToolSchemas(a, &out, .{ .include_memory = false });
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"cli_agent\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"agent\"") != null);
+
+    var sub: std.ArrayListUnmanaged(u8) = .empty;
+    defer sub.deinit(a);
+    try appendToolSchemas(a, &sub, .{ .include_memory = false, .toolset = .subagent });
+    try std.testing.expect(std.mem.indexOf(u8, sub.items, "\"cli_agent\"") == null);
+    try std.testing.expect(builtinToolNameReserved("cli_agent"));
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `zig build test-full -Dtarget=aarch64-macos 2>&1 | grep -B2 -A6 "cli_agent"`
+Expected: FAIL（schema 里没有 cli_agent）。
+
+- [ ] **Step 3: 实现注册**
+
+protocol.zig `forEachToolSpec` 里 subagent 的 emitTool（809 行）之后加：
+
+```zig
+    try Filtered.emitToolWithRequired(ctx, opts, "cli_agent", "Delegate one self-contained coding or analysis task to an external CLI agent that works autonomously in the working directory with its own shell and file tools and full access. Available agents: codex. It cannot see this conversation or ask questions: put every needed detail (goal, files, constraints, expected output format) into task. Command progress streams into this chat; the tool returns the agent's final report. Prefer this over driving an interactive codex terminal when the task is self-contained.", "{\"agent\":{\"type\":\"string\",\"description\":\"Which CLI agent to run. Available: codex.\"},\"task\":{\"type\":\"string\",\"description\":\"Complete self-contained task description with all needed context.\"},\"cwd\":{\"type\":\"string\",\"description\":\"Optional working directory; defaults to the agent working directory.\"},\"timeout_ms\":{\"type\":\"integer\",\"description\":\"Optional timeout in milliseconds; default 600000, max 3600000.\"}}", &.{ "agent", "task" });
+```
+
+`builtinToolNameReserved` 数组 `"subagent",` 之后加：
+
+```zig
+        "cli_agent",
+```
+
+first_party.zig `static_definitions` subagent 行之后加：
+
+```zig
+    .{ .name = "cli_agent", .label = "cli_agent", .description = "Delegate a self-contained task to an external CLI agent (codex).", .category = .agent },
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos && zig build test-full -Dtarget=aarch64-macos`
+Expected: 两个套件 PASS（test-full 约 2300 用例；已知 flaky "skill center tool import" FileNotFound 与本改动无关，重跑即过）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assistant/conversation/protocol.zig src/tools/first_party.zig
+git commit -m "Register cli_agent as a first-party tool (schema, reserved name, catalog)"
+```
+
+---
+
+### Task 6: 端到端验证
+
+**Files:**
+- 无代码改动（验证任务；发现问题回上面对应 task 修）。
+
+**Interfaces:**
+- Consumes: 全部前置 task。
+
+- [ ] **Step 1: 修复本机 codex 安装**
+
+Run: `npm i -g @openai/codex && codex exec --help | head -20`
+Expected: 用法输出含 `--json`、`--dangerously-bypass-approvals-and-sandbox`、`--skip-git-repo-check`。若 flag 名与 spec 不符，回 Task 2 修 `codex_backend.base_args` 与测试。
+
+- [ ] **Step 2: 构建并安装 macOS app**
+
+Run: `zig build macos-app -Dtarget=aarch64-macos`（按仓库惯例重建；注意 zig-out 与 /Applications 多副本坑，验证前确认跑的是新二进制）
+
+- [ ] **Step 3: 真机验证**
+
+启动 WispTerm，在 AI 面板发：「用 cli_agent 委派 codex 一个任务：在当前目录写一个 hello.txt，内容 hello from codex，然后报告结果」。
+Expected: 聊天卡片出现 "codex: $ ..." 进度行；结束后返回 codex 最终报告；hello.txt 存在。再验一次非 full 权限模式下会先弹审批。
+
+- [ ] **Step 4: 清理验证产物并收尾**
+
+删除 hello.txt。跑最后一遍 `zig fmt build.zig src && zig build test -Dtarget=aarch64-macos`，然后按用户指示推分支/开 PR（PR 引用 issue #533 与 spec/plan 文档）。

--- a/docs/superpowers/specs/2026-07-10-cli-agent-tool-design.md
+++ b/docs/superpowers/specs/2026-07-10-cli-agent-tool-design.md
@@ -1,0 +1,130 @@
+# cli_agent 工具：统一 CLI agent 委派框架
+
+Issue: https://github.com/xuzhougeng/wispterm/issues/533
+参考: wisp-science PR #138（codex-as-tool；本设计只取"委派"一半，不做 MCP bridge）
+
+## 目标
+
+让 WispTerm 内部 agent 把一个自包含的编码/分析任务委派给外部 CLI agent
+（首个后端 codex），运行期间在聊天卡片显示进度，结束后拿回最终答复。
+框架做成统一抽象，后续扩展 Oh-my-pi、reasonix 等后端时只加数据表行 +
+一个事件解析函数。
+
+已拍板的取舍：
+
+- 只做 codex 后端（claude 等后续加）
+- 沙箱完全放开（`--dangerously-bypass-approvals-and-sandbox`），由 WispTerm
+  自己的审批门兜底
+- 进度跟踪：流式解析 codex `--json` 事件推进度卡片
+- 不做 MCP bridge（codex 反向访问 WispTerm 能力），有真实需求再开 issue
+
+## 工具接口（发给模型的 schema）
+
+- 名称 `cli_agent`，required: `agent`, `task`
+- 参数：
+  - `agent`: string —— 后端 key，当前仅 `codex`（描述里枚举，后端增加时只改描述）
+  - `task`: string —— 完整自包含任务描述（CLI agent 看不到本对话）
+  - `cwd`: string, 可选 —— 默认 agent 工作目录
+  - `timeout_ms`: integer, 可选 —— 默认 600_000，钳制上限 3_600_000
+- 描述要点：委派自包含编码/分析任务；CLI agent 用自己的 shell/文件工具在
+  cwd 内自主工作、完全访问权限；返回最终报告；task 必须自带全部上下文。
+
+## 统一抽象（新文件 `src/agent_tools/cli_agent.zig`）
+
+```zig
+pub const Event = struct {
+    progress: ?[]u8 = null, // 推到进度卡片的一行（owned）
+    final: ?[]u8 = null,    // 候选最终答复，后到覆盖先到（owned）
+};
+
+pub const Backend = struct {
+    key: []const u8,                 // "codex"，agent 参数取值
+    display: []const u8,             // "Codex"
+    exe: []const u8,                 // PATH 上的可执行名
+    base_args: []const []const u8,   // exe 之后、task 之前的固定参数
+    parseEvent: *const fn (allocator, line: []const u8) ?Event,
+};
+
+pub const backends = [_]Backend{codex_backend};
+pub fn find(key: []const u8) ?*const Backend;
+pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8,
+           cwd: ?[]const u8, timeout_ms: u32) ![]u8;
+```
+
+`run()` 共享全部生命周期，后端零重复：
+
+1. **审批门**：权限非 `full`（即 confirm 和 auto 模式）强制
+   `ctx.requestApproval("cli_agent", task, reason)` —— 完全放开的沙箱必须有
+   这道门。拒绝→ denied 结果。
+2. **spawn**：argv = `{exe} ++ base_args ++ {task}`（task 位置参数，无 shell
+   介入无引号问题）；cwd = 参数或 `ctx.settings.working_dir`；
+   `create_no_window = true`；spawn 失败（含 FileNotFound）→ 明确返回
+   "codex CLI not found or failed to start: ..."。
+3. **stdout 流式**：读取线程按行收集进 mutex 队列（只做 I/O 和分行，不碰
+   session）；stderr 复用 `agent_exec.CaptureOutput` 线程。
+4. **轮询循环**（worker 线程，25ms tick，照 `runArgv` 现有模式含 waitpid
+   注释坑）：drain 行队列 → `backend.parseEvent` → `progress` 经 ToolContext
+   新增 `progress` 钩子推卡片，`final` 覆盖候选答复；检查取消与超时，触发
+   即 kill 子进程。所有 session 调用留在 worker 线程（markUiDirty
+   threadlocal，跨线程刷 UI 是已知坑）。
+5. **结果**：`agent=codex exit_code=N [timed_out=true]\n<final>`；无 final
+   （JSON 格式不识别/异常退出）回退 stdout 尾部（保尾不保头——答复在末尾），
+   exit≠0 时附 stderr 尾部；`tool_output.truncateOwned` 收口。
+
+## codex 后端
+
+```
+codex exec --json --dangerously-bypass-approvals-and-sandbox \
+  --skip-git-repo-check -- <task>
+```
+
+`--json` 一举两得：JSONL 事件流做进度，最后一条 `agent_message` 即干净的
+最终答复（免临时文件、免解析人类格式输出）。
+
+`parseEvent`（容错为先，解析失败一律返回 null）：
+
+- `item.completed` + `item_type=command_execution` → progress:
+  `"codex: $ <command>"`
+- `item.*` + `item_type=agent_message` → final: `<text>`
+- 其余事件（thread.started、reasoning 等）忽略
+- codex 版本间 JSON 格式有差异：解析不出 final 时靠 run() 的 stdout 尾部
+  回退，工具不至于空手而归
+
+## 注册点（新增第一方工具的固定四件套 + 钩子）
+
+| 文件 | 改动 |
+|---|---|
+| `assistant/conversation/protocol.zig` | `forEachToolSpec` 加 `emitToolWithRequired("cli_agent", ...)`；`builtinToolNameReserved` 加名字 |
+| `tools/first_party.zig` | `static_definitions` 加行，category=`.agent` |
+| `agent_tools/mod.zig` | 分发：解析 agent/task/cwd/timeout_ms → `cli_agent.run` |
+| `assistant/conversation/types.zig` | `ToolContext` 加 `progress: *const fn(...) void = noopProgress` + `emitProgress()` |
+| `assistant/conversation/request.zig` | `toolContextFromRequest` wire progress → `ai_chat.appendProgressMessage(session, text) catch {}` |
+
+不暴露给 subagent 工具集（`subagentToolAllowed` 默认 deny，无需改动）——
+防递归委派。
+
+## 明确不做
+
+- MCP bridge、claude/其他后端（框架留好扩展点）、PATH 预检测注册
+  （分发时报错同样有效）、`--json` 之外的进度来源、stdin 传 task
+  （位置参数够用；>30KB task 在 Windows 会失败，接受）。
+
+## 测试
+
+1. `parseEvent` 纯函数：喂 codex JSONL 样本行（command_execution、
+   agent_message、不认识的事件、非 JSON 行）断言 progress/final 提取。
+2. `run()` 集成：假后端 exe=`/bin/sh` 吐伪造 JSONL（Windows skip，同现有
+   MCP dispatch 测试模式），断言最终答复提取、progress 钩子被调（fake
+   钩子计数）、非 full 权限走审批、超时/取消 kill。
+3. `mod.zig` 分发：缺 agent/缺 task/未知 agent 的错误文案。
+4. `protocol.zig`：schema 含 `"cli_agent"`；subagent 工具集不含。
+
+约束：`agent_tools/**` 是叶子模块（source guard 禁 import AppWindow），
+cli_agent.zig 只依赖 types.zig / exec.zig / output.zig。
+
+## 验证
+
+`zig build test -Dtarget=aarch64-macos` 跑快测；端到端需要本机重装 codex
+（当前 npm shim 指向缺失的 vendor 二进制，`npm i -g @openai/codex`），
+然后在 AI 面板让 agent 调 `cli_agent` 委派一个小任务，观察进度卡片与
+最终答复。

--- a/src/agent_tools/cli_agent.zig
+++ b/src/agent_tools/cli_agent.zig
@@ -215,10 +215,11 @@ pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Pipe;
-    child.cwd = cwd orelse ctx.settings.working_dir;
+    const effective_cwd = cwd orelse ctx.settings.working_dir;
+    child.cwd = effective_cwd;
     child.create_no_window = true;
     child.spawn() catch |err| {
-        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {}", .{ backend.display, backend.exe, err });
+        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {} (cwd: {s})", .{ backend.display, backend.exe, err, effective_cwd orelse "." });
     };
     // posix_spawn() itself returns success even when the exec inside the
     // forked child fails (e.g. missing executable) — the real error only
@@ -234,7 +235,7 @@ pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[
         if (child.stdout) |*f| f.close();
         if (child.stderr) |*f| f.close();
         if (builtin.os.tag != .windows) _ = platform_process.childExited(child.id, 1000);
-        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {}", .{ backend.display, backend.exe, err });
+        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {} (cwd: {s})", .{ backend.display, backend.exe, err, effective_cwd orelse "." });
     };
 
     var stream = LineStream{ .allocator = allocator, .file = child.stdout.? };
@@ -276,6 +277,10 @@ pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[
         }
         if (ctx.isCancelled()) {
             canceled = true;
+            // ponytail: kill() is SIGTERM + blocking wait — a SIGTERM-ignoring
+            // child hangs here and grandchildren orphan; process-group +
+            // SIGKILL escalation if real codex runs hit it. Same ceiling as
+            // exec.runArgv, deliberate.
             _ = child.kill() catch {};
             break;
         }
@@ -310,7 +315,14 @@ pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[
         try out.appendSlice(allocator, f);
     } else {
         try out.appendSlice(allocator, "No final message parsed; raw output tail:\n");
-        try out.appendSlice(allocator, tail.items);
+        // appendTail lets `tail` grow to 2x output_limit before compressing;
+        // truncateOwned below keeps the FIRST output_limit bytes, which would
+        // cut off the very end of the stream the fallback exists to preserve.
+        // Budget the tail to half the limit so header+marker+tail survives
+        // keep-head truncation, leaving room for stderr too.
+        const tail_budget = @max(ctx.settings.output_limit / 2, 1);
+        const tail_slice = tail.items[tail.items.len -| tail_budget..];
+        try out.appendSlice(allocator, tail_slice);
     }
     if (exit_code != 0 and stderr_capture.data.len > 0) {
         try out.print(allocator, "\nstderr:\n{s}", .{stderr_capture.data});
@@ -460,6 +472,34 @@ test "run falls back to the raw stdout tail when no final message parses" {
     defer a.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "No final message parsed") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "plain line two") != null);
+}
+
+test "run fallback tail keeps the most recent output under a small output_limit" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const script = "for i in $(seq 1 40); do echo \"noise line $i padding padding padding\"; done; echo \"LAST_LINE_MARKER\"";
+    const args = [_][]const u8{ "-c", script };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full, .output_limit = 256 },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No final message parsed") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "LAST_LINE_MARKER") != null);
 }
 
 test "run requires approval outside full permission and reports denial" {

--- a/src/agent_tools/cli_agent.zig
+++ b/src/agent_tools/cli_agent.zig
@@ -6,6 +6,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const types = @import("../assistant/conversation/types.zig");
+const platform_process = @import("../platform/process.zig");
+const agent_exec = @import("exec.zig");
+const tool_output = @import("output.zig");
 
 const ToolContext = types.ToolContext;
 
@@ -85,6 +88,234 @@ fn codexParseEvent(allocator: std.mem.Allocator, line: []const u8) ?Event {
 }
 
 // ---------------------------------------------------------------------------
+// Line-streaming child runner
+// ---------------------------------------------------------------------------
+
+/// Reader-thread line collector. The thread only does I/O and line splitting;
+/// parsed events and all session calls stay on the tool worker thread
+/// (markUiDirty is threadlocal — cross-thread UI calls are a known trap).
+const LineStream = struct {
+    allocator: std.mem.Allocator,
+    file: std.fs.File,
+    mutex: std.Thread.Mutex = .{},
+    lines: std.ArrayListUnmanaged([]u8) = .empty,
+    partial: std.ArrayListUnmanaged(u8) = .empty,
+
+    fn deinit(self: *LineStream) void {
+        for (self.lines.items) |line| self.allocator.free(line);
+        self.lines.deinit(self.allocator);
+        self.partial.deinit(self.allocator);
+    }
+
+    fn readThread(self: *LineStream) void {
+        var buf: [4096]u8 = undefined;
+        while (true) {
+            const n = self.file.read(&buf) catch break;
+            if (n == 0) break;
+            self.push(buf[0..n]);
+        }
+        self.flushPartial();
+    }
+
+    // ponytail: `partial` is unbounded for a single line with no newline;
+    // codex event lines are bounded in practice — cap it if a backend ever
+    // streams raw unbounded output.
+    fn push(self: *LineStream, chunk: []const u8) void {
+        var rest = chunk;
+        while (std.mem.indexOfScalar(u8, rest, '\n')) |nl| {
+            const line = std.mem.concat(self.allocator, u8, &.{ self.partial.items, rest[0..nl] }) catch return;
+            self.partial.clearRetainingCapacity();
+            self.appendLine(line);
+            rest = rest[nl + 1 ..];
+        }
+        self.partial.appendSlice(self.allocator, rest) catch {};
+    }
+
+    fn flushPartial(self: *LineStream) void {
+        if (self.partial.items.len == 0) return;
+        const line = self.allocator.dupe(u8, self.partial.items) catch return;
+        self.partial.clearRetainingCapacity();
+        self.appendLine(line);
+    }
+
+    fn appendLine(self: *LineStream, line: []u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.lines.append(self.allocator, line) catch self.allocator.free(line);
+    }
+
+    /// Move all pending lines to `out`; caller owns and frees each line.
+    fn drain(self: *LineStream, out: *std.ArrayListUnmanaged([]u8)) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        out.appendSlice(self.allocator, self.lines.items) catch return;
+        self.lines.clearRetainingCapacity();
+    }
+};
+
+/// Keep a bounded raw-stdout tail for the no-final-message fallback (the
+/// useful part of a stream is at the end).
+fn appendTail(allocator: std.mem.Allocator, tail: *std.ArrayListUnmanaged(u8), line: []const u8, limit: u32) void {
+    tail.appendSlice(allocator, line) catch return;
+    tail.append(allocator, '\n') catch return;
+    const max: usize = @max(@as(usize, limit), 1);
+    if (tail.items.len > 2 * max) {
+        // no overlap: only triggered when len > 2*max
+        std.mem.copyForwards(u8, tail.items[0..max], tail.items[tail.items.len - max ..]);
+        tail.shrinkRetainingCapacity(max);
+    }
+}
+
+fn drainAndParse(ctx: *ToolContext, backend: *const Backend, stream: *LineStream, final_message: *?[]u8, tail: *std.ArrayListUnmanaged(u8)) void {
+    const allocator = ctx.allocator;
+    var drained: std.ArrayListUnmanaged([]u8) = .empty;
+    defer drained.deinit(allocator);
+    stream.drain(&drained);
+    for (drained.items) |line| {
+        defer allocator.free(line);
+        appendTail(allocator, tail, line, ctx.settings.output_limit);
+        const event = backend.parseEvent(allocator, line) orelse continue;
+        if (event.progress) |p| {
+            defer allocator.free(p);
+            ctx.emitProgress(p);
+        }
+        if (event.final) |f| {
+            if (final_message.*) |old| allocator.free(old);
+            final_message.* = f;
+        }
+    }
+}
+
+pub fn run(ctx: *ToolContext, backend: *const Backend, task: []const u8, cwd: ?[]const u8, timeout_ms: u32) ![]u8 {
+    const allocator = ctx.allocator;
+    if (ctx.isCancelled()) return allocator.dupe(u8, "Canceled.");
+    const trimmed_task = std.mem.trim(u8, task, " \t\r\n");
+    if (trimmed_task.len == 0) return allocator.dupe(u8, "Missing task");
+
+    // The backend runs with full access and cannot prompt mid-run, so both
+    // confirm AND auto permission modes gate the whole delegation up front.
+    if (ctx.settings.permission != .full) {
+        const reason = try std.fmt.allocPrint(allocator, "Delegate task to {s} with full access", .{backend.display});
+        defer allocator.free(reason);
+        if (!ctx.requestApproval("cli_agent", trimmed_task, reason)) {
+            return tool_output.deniedResult(allocator, trimmed_task, "cli_agent delegation not approved");
+        }
+    }
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer argv.deinit(allocator);
+    try argv.append(allocator, backend.exe);
+    try argv.appendSlice(allocator, backend.base_args);
+    try argv.append(allocator, trimmed_task);
+
+    var child = std.process.Child.init(argv.items, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.cwd = cwd orelse ctx.settings.working_dir;
+    child.create_no_window = true;
+    child.spawn() catch |err| {
+        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {}", .{ backend.display, backend.exe, err });
+    };
+    // posix_spawn() itself returns success even when the exec inside the
+    // forked child fails (e.g. missing executable) — the real error only
+    // surfaces via the err_pipe that waitForSpawn() drains. Must check this
+    // BEFORE the poll loop below preemptively sets child.term (to dodge the
+    // ECHILD-on-double-waitpid trap), because doing so would make wait()
+    // skip waitForSpawn()'s pipe read and silently swallow the spawn error.
+    child.waitForSpawn() catch |err| {
+        // wait()'s `try waitForSpawn()` re-throws before reaching
+        // cleanupStreams() or reaping the pid, so both the stdout/stderr
+        // pipe fds and the exited fork child (it _exit(1)s after reporting)
+        // would otherwise leak; clean up ourselves.
+        if (child.stdout) |*f| f.close();
+        if (child.stderr) |*f| f.close();
+        if (builtin.os.tag != .windows) _ = platform_process.childExited(child.id, 1000);
+        return std.fmt.allocPrint(allocator, "{s} CLI ({s}) not found or failed to start: {}", .{ backend.display, backend.exe, err });
+    };
+
+    var stream = LineStream{ .allocator = allocator, .file = child.stdout.? };
+    defer stream.deinit();
+    var stderr_capture = agent_exec.CaptureOutput{
+        .allocator = allocator,
+        .file = child.stderr.?,
+        .max_bytes = ctx.settings.output_limit,
+    };
+    defer allocator.free(stderr_capture.data);
+
+    const stdout_thread = try std.Thread.spawn(.{}, LineStream.readThread, .{&stream});
+    const stderr_thread = try std.Thread.spawn(.{}, agent_exec.captureOutputThread, .{&stderr_capture});
+
+    var final_message: ?[]u8 = null;
+    defer if (final_message) |f| allocator.free(f);
+    var tail: std.ArrayListUnmanaged(u8) = .empty;
+    defer tail.deinit(allocator);
+
+    const wait_ms = @max(@min(timeout_ms, MAX_TIMEOUT_MS), 1);
+    const deadline = std.time.milliTimestamp() + @as(i64, @intCast(wait_ms));
+    var timed_out = false;
+    var canceled = false;
+    while (true) {
+        drainAndParse(ctx, backend, &stream, &final_message, &tail);
+        switch (platform_process.childExited(child.id, 25)) {
+            .running => {},
+            .exited => |code| {
+                // Same trap as exec.runArgv: on POSIX childExited() already
+                // reaped the zombie; pre-set term so child.wait() skips its
+                // second waitpid (ECHILD aborts). Windows keeps the handle.
+                if (builtin.os.tag != .windows) child.term = .{ .Exited = @intCast(code) };
+                break;
+            },
+            .gone => {
+                if (builtin.os.tag != .windows) child.term = .{ .Unknown = 0 };
+                break;
+            },
+        }
+        if (ctx.isCancelled()) {
+            canceled = true;
+            _ = child.kill() catch {};
+            break;
+        }
+        if (std.time.milliTimestamp() >= deadline) {
+            timed_out = true;
+            _ = child.kill() catch {};
+            break;
+        }
+    }
+
+    stdout_thread.join();
+    stderr_thread.join();
+    // Lines that arrived between the last in-loop drain and thread exit.
+    drainAndParse(ctx, backend, &stream, &final_message, &tail);
+
+    const exit_code: i32 = if (timed_out or canceled) 124 else blk: {
+        const term = try child.wait();
+        break :blk switch (term) {
+            .Exited => |code| @intCast(code),
+            .Signal => |sig| -@as(i32, @intCast(sig)),
+            .Stopped => |sig| -@as(i32, @intCast(sig)),
+            .Unknown => |code| @intCast(code),
+        };
+    };
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    if (timed_out) try out.appendSlice(allocator, "timed_out=true\n");
+    if (canceled) try out.appendSlice(allocator, "canceled=true\n");
+    try out.print(allocator, "agent={s} exit_code={d}\n", .{ backend.key, exit_code });
+    if (final_message) |f| {
+        try out.appendSlice(allocator, f);
+    } else {
+        try out.appendSlice(allocator, "No final message parsed; raw output tail:\n");
+        try out.appendSlice(allocator, tail.items);
+    }
+    if (exit_code != 0 and stderr_capture.data.len > 0) {
+        try out.print(allocator, "\nstderr:\n{s}", .{stderr_capture.data});
+    }
+    return tool_output.truncateOwned(allocator, ctx.settings, try out.toOwnedSlice(allocator));
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -126,4 +357,172 @@ test "codexParseEvent ignores unknown events, other item phases, and non-JSON li
     try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\",\"status\":\"completed\"}}") == null);
     // agent_message only counts when completed
     try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.started\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"partial\"}}") == null);
+}
+
+fn fakeApprove(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    return true;
+}
+fn fakeDeny(ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
+    const called: *bool = @ptrCast(@alignCast(ctx));
+    called.* = true;
+    return false;
+}
+fn fakeCancelled(_: *anyopaque) bool {
+    return false;
+}
+
+const ProgressCapture = struct {
+    count: usize = 0,
+    last: [256]u8 = undefined,
+    last_len: usize = 0,
+
+    fn hook(ctx: *anyopaque, text: []const u8) void {
+        const self: *ProgressCapture = @ptrCast(@alignCast(ctx));
+        self.count += 1;
+        const n = @min(text.len, self.last.len);
+        @memcpy(self.last[0..n], text[0..n]);
+        self.last_len = n;
+    }
+};
+
+test "run streams progress and returns the final agent message" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const script =
+        "printf '%s\\n' " ++
+        "'{\"type\":\"item.started\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"first\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"all done\"}}'";
+    const args = [_][]const u8{ "-c", script };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var progress = ProgressCapture{};
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &progress,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+        .progress = ProgressCapture.hook,
+    };
+    const out = try run(&ctx, &fake, "do the thing", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "agent=fake") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exit_code=0") != null);
+    // last agent_message wins
+    try std.testing.expect(std.mem.indexOf(u8, out, "all done") != null);
+    try std.testing.expectEqual(@as(usize, 1), progress.count);
+    try std.testing.expectEqualStrings("codex: $ ls", progress.last[0..progress.last_len]);
+}
+
+test "run falls back to the raw stdout tail when no final message parses" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "printf '%s\\n' 'plain line one' 'plain line two'" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "No final message parsed") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "plain line two") != null);
+}
+
+test "run requires approval outside full permission and reports denial" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "true" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var approve_called = false;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &approve_called,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .auto },
+        .approve = fakeDeny,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "risky task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(approve_called);
+    try std.testing.expect(std.mem.indexOf(u8, out, "DENIED") != null);
+}
+
+test "run reports a missing executable clearly" {
+    const a = std.testing.allocator;
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "definitely-missing-cli-agent-binary",
+        .base_args = &.{},
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 30_000);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "not found or failed to start") != null);
+}
+
+test "run kills the child on timeout and marks the result" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest; // uses /bin/sh
+    const a = std.testing.allocator;
+    const args = [_][]const u8{ "-c", "sleep 30" };
+    const fake = Backend{
+        .key = "fake",
+        .display = "Fake",
+        .exe = "/bin/sh",
+        .base_args = args[0..],
+        .parseEvent = codexParseEvent,
+    };
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try run(&ctx, &fake, "task", null, 100);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "timed_out=true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "exit_code=124") != null);
 }

--- a/src/agent_tools/cli_agent.zig
+++ b/src/agent_tools/cli_agent.zig
@@ -73,7 +73,10 @@ fn codexParseEvent(allocator: std.mem.Allocator, line: []const u8) ?Event {
     if (parsed.value != .object) return null;
     const event_type = objectString(parsed.value, "type") orelse return null;
     const item = parsed.value.object.get("item") orelse return null;
-    const item_type = objectString(item, "item_type") orelse return null;
+    // Real codex CLI (0.144.1+) puts the item's type under "type" inside the
+    // item object; older experimental builds used "item_type". Try current
+    // first, fall back to the legacy spelling.
+    const item_type = objectString(item, "type") orelse objectString(item, "item_type") orelse return null;
     if (std.mem.eql(u8, event_type, "item.completed") and std.mem.eql(u8, item_type, "agent_message")) {
         const text = objectString(item, "text") orelse return null;
         const owned = allocator.dupe(u8, text) catch return null;
@@ -328,22 +331,32 @@ test "find resolves codex and rejects unknown keys" {
 
 test "codexParseEvent extracts progress from item.started command_execution" {
     const a = std.testing.allocator;
-    const line = "{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"item_type\":\"command_execution\",\"command\":\"bash -lc 'ls'\",\"status\":\"in_progress\"}}";
+    const line = "{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/zsh -lc 'ls'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}";
     const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
     defer if (event.progress) |p| a.free(p);
     defer if (event.final) |f| a.free(f);
     try std.testing.expect(event.final == null);
-    try std.testing.expectEqualStrings("codex: $ bash -lc 'ls'", event.progress.?);
+    try std.testing.expectEqualStrings("codex: $ /bin/zsh -lc 'ls'", event.progress.?);
 }
 
 test "codexParseEvent extracts final from item.completed agent_message" {
     const a = std.testing.allocator;
-    const line = "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_9\",\"item_type\":\"agent_message\",\"text\":\"All tests pass.\"}}";
+    const line = "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"All tests pass.\"}}";
     const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
     defer if (event.progress) |p| a.free(p);
     defer if (event.final) |f| a.free(f);
     try std.testing.expect(event.progress == null);
     try std.testing.expectEqualStrings("All tests pass.", event.final.?);
+}
+
+test "codexParseEvent falls back to legacy item_type field for older codex builds" {
+    const a = std.testing.allocator;
+    const line = "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_9\",\"item_type\":\"agent_message\",\"text\":\"legacy format still works\"}}";
+    const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
+    defer if (event.progress) |p| a.free(p);
+    defer if (event.final) |f| a.free(f);
+    try std.testing.expect(event.progress == null);
+    try std.testing.expectEqualStrings("legacy format still works", event.final.?);
 }
 
 test "codexParseEvent ignores unknown events, other item phases, and non-JSON lines" {
@@ -352,11 +365,11 @@ test "codexParseEvent ignores unknown events, other item phases, and non-JSON li
     try std.testing.expect(codexParseEvent(a, "") == null);
     try std.testing.expect(codexParseEvent(a, "{not json") == null);
     try std.testing.expect(codexParseEvent(a, "{\"type\":\"thread.started\",\"thread_id\":\"t1\"}") == null);
-    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"reasoning\",\"text\":\"hmm\"}}") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"type\":\"reasoning\",\"text\":\"hmm\"}}") == null);
     // command_execution progress only fires on item.started, not completed (no dupes)
-    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\",\"status\":\"completed\"}}") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"ls\",\"aggregated_output\":\"\",\"exit_code\":0,\"status\":\"completed\"}}") == null);
     // agent_message only counts when completed
-    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.started\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"partial\"}}") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.started\",\"item\":{\"type\":\"agent_message\",\"text\":\"partial\"}}") == null);
 }
 
 fn fakeApprove(_: *anyopaque, _: []const u8, _: []const u8, _: []const u8) bool {
@@ -390,9 +403,9 @@ test "run streams progress and returns the final agent message" {
     const a = std.testing.allocator;
     const script =
         "printf '%s\\n' " ++
-        "'{\"type\":\"item.started\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\"}}' " ++
-        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"first\"}}' " ++
-        "'{\"type\":\"item.completed\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"all done\"}}'";
+        "'{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"ls\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"first\"}}' " ++
+        "'{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"agent_message\",\"text\":\"all done\"}}'";
     const args = [_][]const u8{ "-c", script };
     const fake = Backend{
         .key = "fake",

--- a/src/agent_tools/cli_agent.zig
+++ b/src/agent_tools/cli_agent.zig
@@ -1,0 +1,129 @@
+//! Unified CLI agent delegation tool (`cli_agent`): hand one self-contained
+//! task to an external CLI agent (first backend: Codex), stream its progress
+//! into the chat card, and return its final report. Leaf module — depends on
+//! ai_chat_types, platform process helpers, and sibling exec/output adapters;
+//! never on session.zig or AppWindow.
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("../assistant/conversation/types.zig");
+
+const ToolContext = types.ToolContext;
+
+pub const DEFAULT_TIMEOUT_MS: u32 = 600_000;
+pub const MAX_TIMEOUT_MS: u32 = 3_600_000;
+
+/// One parsed stdout line from a backend. Set fields are owned by the
+/// caller-provided allocator; the caller frees them.
+pub const Event = struct {
+    progress: ?[]u8 = null,
+    final: ?[]u8 = null,
+};
+
+pub const Backend = struct {
+    key: []const u8, // value of the tool's `agent` argument
+    display: []const u8,
+    exe: []const u8, // executable name resolved via PATH
+    base_args: []const []const u8, // fixed args between exe and task
+    parseEvent: *const fn (allocator: std.mem.Allocator, line: []const u8) ?Event,
+};
+
+const codex_backend = Backend{
+    .key = "codex",
+    .display = "Codex",
+    .exe = "codex",
+    .base_args = &.{ "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check", "--" },
+    .parseEvent = codexParseEvent,
+};
+
+pub const backends = [_]Backend{codex_backend};
+
+/// Comma-joined backend keys for error messages and docs; stays correct as
+/// the table grows.
+pub const available_keys = blk: {
+    var s: []const u8 = "";
+    for (backends, 0..) |b, i| s = s ++ (if (i == 0) "" else ", ") ++ b.key;
+    break :blk s;
+};
+
+pub fn find(key: []const u8) ?*const Backend {
+    for (&backends) |*backend| {
+        if (std.mem.eql(u8, backend.key, key)) return backend;
+    }
+    return null;
+}
+
+fn objectString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const v = value.object.get(key) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+/// Parse one line of `codex exec --json` output. Tolerant by design: any
+/// line that is not JSON or not a recognized event returns null; when no
+/// agent_message is ever seen, run() falls back to the raw stdout tail, so
+/// codex JSON-format drift degrades gracefully instead of failing.
+fn codexParseEvent(allocator: std.mem.Allocator, line: []const u8) ?Event {
+    const trimmed = std.mem.trim(u8, line, " \t\r");
+    if (trimmed.len == 0 or trimmed[0] != '{') return null;
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const event_type = objectString(parsed.value, "type") orelse return null;
+    const item = parsed.value.object.get("item") orelse return null;
+    const item_type = objectString(item, "item_type") orelse return null;
+    if (std.mem.eql(u8, event_type, "item.completed") and std.mem.eql(u8, item_type, "agent_message")) {
+        const text = objectString(item, "text") orelse return null;
+        const owned = allocator.dupe(u8, text) catch return null;
+        return .{ .final = owned };
+    }
+    if (std.mem.eql(u8, event_type, "item.started") and std.mem.eql(u8, item_type, "command_execution")) {
+        const command = objectString(item, "command") orelse return null;
+        const owned = std.fmt.allocPrint(allocator, "codex: $ {s}", .{command}) catch return null;
+        return .{ .progress = owned };
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test "find resolves codex and rejects unknown keys" {
+    const backend = find("codex") orelse return error.TestExpectedBackend;
+    try std.testing.expectEqualStrings("codex", backend.exe);
+    try std.testing.expect(find("oh-my-pi") == null);
+    try std.testing.expectEqualStrings("codex", available_keys);
+}
+
+test "codexParseEvent extracts progress from item.started command_execution" {
+    const a = std.testing.allocator;
+    const line = "{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"item_type\":\"command_execution\",\"command\":\"bash -lc 'ls'\",\"status\":\"in_progress\"}}";
+    const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
+    defer if (event.progress) |p| a.free(p);
+    defer if (event.final) |f| a.free(f);
+    try std.testing.expect(event.final == null);
+    try std.testing.expectEqualStrings("codex: $ bash -lc 'ls'", event.progress.?);
+}
+
+test "codexParseEvent extracts final from item.completed agent_message" {
+    const a = std.testing.allocator;
+    const line = "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_9\",\"item_type\":\"agent_message\",\"text\":\"All tests pass.\"}}";
+    const event = codexParseEvent(a, line) orelse return error.TestExpectedEvent;
+    defer if (event.progress) |p| a.free(p);
+    defer if (event.final) |f| a.free(f);
+    try std.testing.expect(event.progress == null);
+    try std.testing.expectEqualStrings("All tests pass.", event.final.?);
+}
+
+test "codexParseEvent ignores unknown events, other item phases, and non-JSON lines" {
+    const a = std.testing.allocator;
+    try std.testing.expect(codexParseEvent(a, "[2026-07-10] plain human output") == null);
+    try std.testing.expect(codexParseEvent(a, "") == null);
+    try std.testing.expect(codexParseEvent(a, "{not json") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"thread.started\",\"thread_id\":\"t1\"}") == null);
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"reasoning\",\"text\":\"hmm\"}}") == null);
+    // command_execution progress only fires on item.started, not completed (no dupes)
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.completed\",\"item\":{\"item_type\":\"command_execution\",\"command\":\"ls\",\"status\":\"completed\"}}") == null);
+    // agent_message only counts when completed
+    try std.testing.expect(codexParseEvent(a, "{\"type\":\"item.started\",\"item\":{\"item_type\":\"agent_message\",\"text\":\"partial\"}}") == null);
+}

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -35,6 +35,7 @@ const agent_mcp_config = @import("mcp_config.zig");
 const agent_mcp_activate = @import("mcp_activate.zig");
 const agent_weixin = @import("weixin.zig");
 const agent_ui_screenshot = @import("ui_screenshot.zig");
+const agent_cli_agent = @import("cli_agent.zig");
 const platform_dirs = @import("../platform/dirs.zig");
 
 // ---------------------------------------------------------------------------
@@ -292,6 +293,17 @@ pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
         const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
         defer args.deinit();
         return agent_memory_search.search(ctx, args.value);
+    }
+    if (std.mem.eql(u8, call.name, "cli_agent")) {
+        const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
+        defer args.deinit();
+        const agent_key = tool_args.string(args.value, "agent") orelse return ctx.allocator.dupe(u8, "Missing agent");
+        const backend = agent_cli_agent.find(agent_key) orelse
+            return std.fmt.allocPrint(ctx.allocator, "Unknown agent \"{s}\". Available: {s}", .{ agent_key, agent_cli_agent.available_keys });
+        const task = tool_args.string(args.value, "task") orelse return ctx.allocator.dupe(u8, "Missing task");
+        const cwd = tool_args.string(args.value, "cwd");
+        const timeout_ms = tool_args.int(args.value, "timeout_ms") orelse agent_cli_agent.DEFAULT_TIMEOUT_MS;
+        return agent_cli_agent.run(ctx, backend, task, cwd, timeout_ms);
     }
     if (agent_dynamic.find(ctx.settings.dynamic_binary_tools, call.name)) |tool| {
         const args = tool_args.parse(ctx.allocator, call.arguments) orelse return ctx.allocator.dupe(u8, "Invalid tool arguments");
@@ -1269,4 +1281,42 @@ test "executeToolCall pubmed reports missing query" {
     });
     defer a.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "Missing query") != null);
+}
+
+test "executeToolCall cli_agent validates agent and task arguments" {
+    const a = std.testing.allocator;
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = a,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{ .permission = .full },
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const missing_agent = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"task\":\"do something\"}"),
+    });
+    defer a.free(missing_agent);
+    try std.testing.expect(std.mem.indexOf(u8, missing_agent, "Missing agent") != null);
+
+    const unknown_agent = try executeToolCall(&ctx, .{
+        .id = @constCast("c2"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"agent\":\"oh-my-pi\",\"task\":\"x\"}"),
+    });
+    defer a.free(unknown_agent);
+    try std.testing.expect(std.mem.indexOf(u8, unknown_agent, "Unknown agent") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unknown_agent, "codex") != null);
+
+    const missing_task = try executeToolCall(&ctx, .{
+        .id = @constCast("c3"),
+        .name = @constCast("cli_agent"),
+        .arguments = @constCast("{\"agent\":\"codex\"}"),
+    });
+    defer a.free(missing_task);
+    try std.testing.expect(std.mem.indexOf(u8, missing_task, "Missing task") != null);
 }

--- a/src/assistant/conversation/protocol.zig
+++ b/src/assistant/conversation/protocol.zig
@@ -2228,8 +2228,7 @@ test "full toolset includes cli_agent and subagent toolset excludes it" {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     defer out.deinit(a);
     try appendToolSchemas(a, &out, .{ .include_memory = false });
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"cli_agent\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"agent\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"name\":\"cli_agent\"") != null);
 
     var sub: std.ArrayListUnmanaged(u8) = .empty;
     defer sub.deinit(a);

--- a/src/assistant/conversation/protocol.zig
+++ b/src/assistant/conversation/protocol.zig
@@ -723,6 +723,7 @@ pub fn builtinToolNameReserved(name: []const u8) bool {
         "webread",
         "pubmed",
         "subagent",
+        "cli_agent",
         "send_attachment",
         "memory_save",
         "memory_recall",
@@ -807,6 +808,7 @@ fn forEachToolSpec(
     try Filtered.emitTool(ctx, opts, "webread", "Read a web page or local file into clean markdown via Jina Reader. Pass an http(s):// URL to fetch a page, or a local file path (PDF, Word, Excel, PowerPoint) to upload and convert it. Use when you need the full content of one source, not a search.", "{\"url\":{\"type\":\"string\",\"description\":\"An http(s):// URL, or a local file path to upload.\"}}");
     try Filtered.emitTool(ctx, opts, "pubmed", "Search PubMed (NCBI) for biomedical and life-sciences literature and return matching articles with title, authors, journal, year, PMID, DOI, and abstract. Before calling, decompose the user's academic question into English keywords joined with PubMed boolean operators (AND/OR), then pass that as `query`. Use for scholarly/medical literature questions, not general web search.", "{\"query\":{\"type\":\"string\",\"description\":\"PubMed query: English keywords joined with AND/OR, e.g. metformin AND type 2 diabetes AND cardiovascular events.\"},\"max_results\":{\"type\":\"integer\",\"description\":\"Optional max number of articles (default 10, max 20).\"}}");
     try Filtered.emitTool(ctx, opts, "subagent", "Delegate a self-contained research or reading task to a background subagent with its own separate context window. The subagent can use websearch, webread, pubmed, read_file, terminal_list, terminal_snapshot, and wispterm_docs, then returns one final report; its intermediate tool output never enters this conversation. Use it whenever a task would pull large content here (full web pages, PDFs, multi-query searches). It cannot see this conversation or ask questions: put every needed detail (URLs, paths, constraints) and the expected report format into task.", "{\"task\":{\"type\":\"string\",\"description\":\"Complete self-contained task description: what to investigate or read, all needed context (URLs, paths, constraints), and what the final report must contain.\"}}");
+    try Filtered.emitToolWithRequired(ctx, opts, "cli_agent", "Delegate one self-contained coding or analysis task to an external CLI agent that works autonomously in the working directory with its own shell and file tools and full access. Available agents: codex. It cannot see this conversation or ask questions: put every needed detail (goal, files, constraints, expected output format) into task. Command progress streams into this chat; the tool returns the agent's final report. Prefer this over driving an interactive codex terminal when the task is self-contained.", "{\"agent\":{\"type\":\"string\",\"description\":\"Which CLI agent to run. Available: codex.\"},\"task\":{\"type\":\"string\",\"description\":\"Complete self-contained task description with all needed context.\"},\"cwd\":{\"type\":\"string\",\"description\":\"Optional working directory; defaults to the agent working directory.\"},\"timeout_ms\":{\"type\":\"integer\",\"description\":\"Optional timeout in milliseconds; default 600000, max 3600000.\"}}", &.{ "agent", "task" });
     try Filtered.emitTool(ctx, opts, "send_attachment", "Send a local file back to the active chat conversation (WeChat or Feishu) that triggered this agent request. Use only when the current request came from a chat channel; ordinary local chat has no reply context. Audio and voice files are sent as ordinary file attachments.", "{\"kind\":{\"type\":\"string\",\"description\":\"Attachment kind: file, image, or voice. Voice is accepted as an alias for file.\"},\"path\":{\"type\":\"string\",\"description\":\"Readable local file path to send.\"},\"display_name\":{\"type\":\"string\",\"description\":\"Optional filename shown in the chat for file attachments; defaults to the path basename.\"}}");
     if (opts.include_memory) {
         try Filtered.emitTool(ctx, opts, "memory_save", "Save a durable long-term memory so future sessions remember it. Use for stable user preferences, project conventions, and key decisions — not transient task details. tier=global for facts about the user/preferences; tier=project for facts about the current project/working directory.", "{\"tier\":{\"type\":\"string\",\"description\":\"global or project.\"},\"name\":{\"type\":\"string\",\"description\":\"Short stable slug handle (kebab-case). Reusing an existing name updates that memory.\"},\"description\":{\"type\":\"string\",\"description\":\"One-line summary shown in the resident index.\"},\"type\":{\"type\":\"string\",\"description\":\"Optional: user, feedback, project, or reference. Defaults to user.\"},\"body\":{\"type\":\"string\",\"description\":\"The full memory text.\"}}");
@@ -2219,6 +2221,21 @@ test "full toolset includes the subagent tool" {
     try appendToolSchemas(a, &out, .{ .include_memory = false });
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\"name\":\"subagent\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out.items, "\"task\"") != null);
+}
+
+test "full toolset includes cli_agent and subagent toolset excludes it" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+    try appendToolSchemas(a, &out, .{ .include_memory = false });
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"cli_agent\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "\"agent\"") != null);
+
+    var sub: std.ArrayListUnmanaged(u8) = .empty;
+    defer sub.deinit(a);
+    try appendToolSchemas(a, &sub, .{ .include_memory = false, .toolset = .subagent });
+    try std.testing.expect(std.mem.indexOf(u8, sub.items, "\"cli_agent\"") == null);
+    try std.testing.expect(builtinToolNameReserved("cli_agent"));
 }
 
 test "ask_user appears in the full tool schema with question and options" {

--- a/src/assistant/conversation/request.zig
+++ b/src/assistant/conversation/request.zig
@@ -867,6 +867,11 @@ fn toolNote(ctx: *anyopaque, text: []const u8) void {
     session.appendLocalToolMessage(text);
 }
 
+fn toolProgress(ctx: *anyopaque, text: []const u8) void {
+    const session: *Session = @ptrCast(@alignCast(ctx));
+    ai_chat.appendProgressMessage(session, text) catch {};
+}
+
 fn toolAsk(ctx: *anyopaque, question: []const u8, options: []const ai_chat_types.QuestionOption) ai_chat_types.AskResult {
     const session: *Session = @ptrCast(@alignCast(ctx));
     return session.askUser(question, options);
@@ -915,6 +920,7 @@ fn toolContextFromRequest(request: *ChatRequest) ai_chat_types.ToolContext {
         .approve = toolApprove,
         .cancelled = toolCancelled,
         .note = toolNote,
+        .progress = toolProgress,
         .ask = toolAsk,
     };
 }

--- a/src/assistant/conversation/types.zig
+++ b/src/assistant/conversation/types.zig
@@ -346,6 +346,7 @@ pub const AskResult = union(enum) {
 };
 
 fn noopNote(_: *anyopaque, _: []const u8) void {}
+fn noopProgress(_: *anyopaque, _: []const u8) void {}
 fn noopAsk(_: *anyopaque, _: []const u8, _: []const QuestionOption) AskResult {
     return .cancelled;
 }
@@ -369,6 +370,10 @@ pub const ToolContext = struct {
     /// Post a transcript note (e.g. a diff) before an approval prompt. Defaults
     /// to a no-op so test contexts need not wire it.
     note: *const fn (ctx: *anyopaque, text: []const u8) void = noopNote,
+    /// Post an ephemeral progress line to the chat card while a tool runs
+    /// (persist_to_history=false; never enters LLM context). Defaults to a
+    /// no-op so test contexts need not wire it.
+    progress: *const fn (ctx: *anyopaque, text: []const u8) void = noopProgress,
     /// Present a blocking multiple-choice question to the user (ask_user tool).
     /// Defaults to immediate cancellation so test contexts need not wire it.
     ask: *const fn (ctx: *anyopaque, question: []const u8, options: []const QuestionOption) AskResult = noopAsk,
@@ -385,6 +390,9 @@ pub const ToolContext = struct {
     }
     pub fn emitNote(self: *const ToolContext, text: []const u8) void {
         self.note(self.ctx, text);
+    }
+    pub fn emitProgress(self: *const ToolContext, text: []const u8) void {
+        self.progress(self.ctx, text);
     }
     pub fn askUser(self: *const ToolContext, question: []const u8, options: []const QuestionOption) AskResult {
         return self.ask(self.ctx, question, options);

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -305,6 +305,7 @@ test {
     _ = @import("composer_detail_wrap.zig");
     _ = @import("assistant/conversation/presentation.zig");
     _ = @import("agent_tools/args.zig");
+    _ = @import("agent_tools/cli_agent.zig");
     _ = @import("agent_tools/mod.zig");
     _ = @import("agent_tools/mcp_config.zig");
     _ = @import("agent_tools/mcp_activate.zig");

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -55,6 +55,7 @@ const static_definitions = [_]Definition{
     .{ .name = "webread", .label = "webread", .description = "Read a web page or local document into markdown via Jina Reader.", .category = .web },
     .{ .name = "pubmed", .label = "pubmed", .description = "Search PubMed biomedical literature.", .category = .web },
     .{ .name = "subagent", .label = "subagent", .description = "Delegate a self-contained research task to a background subagent.", .category = .agent },
+    .{ .name = "cli_agent", .label = "cli_agent", .description = "Delegate a self-contained task to an external CLI agent (codex).", .category = .agent },
     .{ .name = "send_attachment", .label = "send_attachment", .description = "Send a local file back to the active chat conversation (WeChat or Feishu).", .category = .integration },
     .{ .name = "memory_save", .label = "memory_save", .description = "Save a durable long-term memory.", .category = .memory },
     .{ .name = "memory_recall", .label = "memory_recall", .description = "Read a durable long-term memory.", .category = .memory },


### PR DESCRIPTION
Closes #533

## What

New first-party tool **`cli_agent`**: WispTerm 内部 agent 可以把一个自包含的编码/分析任务委派给外部 CLI agent 无头执行，运行期间把命令执行进度流式推到聊天卡片，结束后返回最终报告。首个后端 **codex**（`codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -- <task>`）。

## Design

- **统一抽象**（`src/agent_tools/cli_agent.zig`）：`Backend` 数据表（key/exe/base_args/parseEvent）+ 共享 `run()`（审批门 → spawn → 行流式 → 25ms 轮询 → 超时/取消 → 结果格式化）。后续扩展 Oh-my-pi、reasonix 等后端 = 一行表 + 一个行解析函数。
- **进度跟踪**：codex `--json` JSONL 事件流；`item.started`/`command_execution` → 进度卡片（经 `ToolContext` 新增 `progress` 钩子 → `appendProgressMessage`，`persist_to_history=false` 不进 LLM 上下文）；最后一条 `agent_message` 即最终答复，解析失败回退 bounded stdout 尾部。读线程只做 I/O+分行，所有 session 调用留在 worker 线程。
- **安全**：codex 沙箱完全放开，因此权限非 `full`（confirm/auto 均）强制用户审批整个委派；不暴露给 subagent 研究工具集（schema 发射与分发两侧双重防递归）。
- **参数**：`{agent, task, cwd?, timeout_ms?}`，默认超时 600s、上限 3600s。

Spec/plan 文档随分支提交（`docs/superpowers/specs/2026-07-10-cli-agent-tool-design.md`、`docs/superpowers/plans/2026-07-10-cli-agent-tool.md`）。参考 wisp-science 的 codex-as-tool 方案（仅取委派一半；MCP bridge 明确不做，有需求另开 issue）。

## Verification

- `zig build test -Dtarget=aarch64-macos` 与 `zig build test-full -Dtarget=aarch64-macos` 全绿（新增 15 个测试：JSONL 解析、流式/超时/拒批/缺可执行/fallback 截断、分发校验、schema 注册/排除）。
- **实测 codex 0.144.1**：三个 flag 均存在；抓取真实 `--json` 事件流后发现计划假设的 `item_type` 字段实为 `type` → 已修复（现行格式优先 + legacy 回退，测试样本改用真实抓取行）。
- macOS 上 posix_spawn 对缺失可执行文件不在 `spawn()` 报错 → 显式 `waitForSpawn()` 检查 + fd 清理 + zombie 收割（对照 vendored std 0.15.2 源码核实）。
- 最终全分支审查发现 fallback 尾部会被保头截断吃掉 → 已修复（tail 预算 = output_limit/2 保尾）+ 回归测试。
- 已知天花板（`ponytail:` 注释在案）：SIGTERM kill 不处理进程组；LineStream 单行无上限。

🤖 Generated with [Claude Code](https://claude.com/claude-code)