### PR TITLE
Scope memory digest status to Memory Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Export selected AI History transcript as Markdown | **M** in AI History | **M** in AI History |
 | Attach selected AI History transcript to Copilot | **A** in AI History | **A** in AI History |
 | Refresh local AI History scan | **R** in local AI History | **R** in local AI History |
+| Run Memory Digest now | **D** in Memory Center | **D** in Memory Center |
 | Edit AI Chat input cursor | Left/Right/Home/End/Delete/Backspace | Left/Right/Home/End/Delete/Backspace |
 | Stop in-flight AI Chat or Agent request | **Esc** in AI Chat while working | **Esc** in AI Chat while working |
 | Copy selection (right-click) | Right-click a selection | Right-click a selection |

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -90,7 +90,6 @@ pub const ui_pipeline = @import("renderer/ui_pipeline.zig");
 pub const titlebar = @import("renderer/titlebar.zig");
 pub const input = @import("input.zig");
 pub const overlays = @import("renderer/overlays.zig");
-const overlay_toasts = @import("renderer/overlays/toasts.zig");
 const post_process = @import("renderer/post_process.zig");
 const d3d11_offscreen_smoke = @import("renderer/d3d11_offscreen_smoke.zig");
 const d3d11_ui_smoke = @import("renderer/d3d11_ui_smoke.zig");
@@ -1511,10 +1510,6 @@ fn windowState() *appwindow_state.WindowState {
 
 fn remoteState() *appwindow_state.RemoteState {
     return &g_appwindow_state.remote;
-}
-
-fn notificationState() *appwindow_state.NotificationState {
-    return &g_appwindow_state.notifications;
 }
 
 // Global theme (set at startup via config)
@@ -4312,6 +4307,24 @@ pub fn spawnMemoryCenterTab() bool {
     return true;
 }
 
+/// Opens a dedicated Memory Center tab so digest progress stays scoped to it.
+pub fn runMemoryDigestNow() bool {
+    const allocator = g_allocator orelse return false;
+    if (!spawnMemoryCenterTab()) return false;
+    memory_digest_scheduler.runNow(allocator);
+    syncMemoryDigestStatus();
+    return true;
+}
+
+/// Runs a digest from the focused Memory Center without creating another tab.
+pub fn runMemoryDigestFromCenter() bool {
+    const allocator = g_allocator orelse return false;
+    if (activeMemoryCenter() == null) return false;
+    memory_digest_scheduler.runNow(allocator);
+    syncMemoryDigestStatus();
+    return true;
+}
+
 /// Open a new Skill Center tab and scan the local library.
 pub fn spawnSkillCenterTab() bool {
     const allocator = g_allocator orelse return false;
@@ -5043,7 +5056,6 @@ fn renderResizeFrame(width: i32, height: i32) void {
     overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderTransferToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
-    overlays.renderMemoryDigestToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderTransferCancelConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderUpdatePrompt(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -5197,52 +5209,11 @@ fn syncTransferToastFromFileExplorer() void {
     markUiDirty();
 }
 
-fn syncMemoryDigestToast() void {
+fn syncMemoryDigestStatus() void {
     const progress = memory_digest_scheduler.progressSnapshot();
-    if (!progress.visible) return;
-    if (!notificationState().acceptMemoryDigestProgress(progress.seq)) return;
-
-    var buf: [160]u8 = undefined;
-    const msg = switch (progress.stage) {
-        .queued => "Memory digest queued",
-        .scanning => "Memory digest: scanning chat logs",
-        .summarizing => if (progress.detail().len != 0)
-            std.fmt.bufPrint(
-                &buf,
-                "Memory digest: summarizing {s} ({d}/{d} done, {d} failed)",
-                .{ progress.detail(), progress.sessions_done, progress.sessions_total, progress.sessions_failed },
-            ) catch "Memory digest: summarizing sessions"
-        else
-            std.fmt.bufPrint(
-                &buf,
-                "Memory digest: summarizing {d}/{d} ({d} failed)",
-                .{ progress.sessions_done, progress.sessions_total, progress.sessions_failed },
-            ) catch "Memory digest: summarizing sessions",
-        .finalizing => "Memory digest: writing digest files",
-        .success => std.fmt.bufPrint(
-            &buf,
-            "Memory digest complete: {d} sessions, {d} days, {d} tokens",
-            .{ progress.sessions_done, progress.days_written, progress.total_tokens },
-        ) catch "Memory digest complete",
-        .failed => if (progress.detail().len != 0)
-            std.fmt.bufPrint(&buf, "Memory digest failed: {s}", .{progress.detail()}) catch "Memory digest failed"
-        else
-            "Memory digest failed",
-        .skipped => if (progress.detail().len != 0)
-            std.fmt.bufPrint(&buf, "Memory digest skipped: {s}", .{progress.detail()}) catch "Memory digest skipped"
-        else
-            "Memory digest skipped",
-        .idle => return,
-    };
-
-    const status: overlay_toasts.MemoryDigestStatus = switch (progress.stage) {
-        .queued, .scanning, .summarizing, .finalizing => .in_progress,
-        .success => .success,
-        .failed => .failed,
-        .skipped => .skipped,
-        .idle => return,
-    };
-    overlays.showMemoryDigestToast(status, msg);
+    if (activeMemoryCenter()) |session| {
+        if (session.syncDigestProgress(progress)) markUiDirty();
+    }
 }
 
 /// Apply freshly loaded configuration to this window/font/theme state.
@@ -7417,7 +7388,7 @@ fn runMainLoop(self: *AppWindow) !void {
         // Check for config file changes
         if (config_watcher) |*w| checkConfigReload(allocator, w);
         memory_digest_scheduler.tick(allocator);
-        syncMemoryDigestToast();
+        syncMemoryDigestStatus();
         tmux_controller.tickAll(allocator, term_cols, term_rows);
         overlays.tickSessionLauncher();
         overlays.tickQuickAiVerify();
@@ -7886,7 +7857,6 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderTransferToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
-        overlays.renderMemoryDigestToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderTransferCancelConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderUpdatePrompt(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderWindowCloseConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));

--- a/src/appwindow/state.zig
+++ b/src/appwindow/state.zig
@@ -1,17 +1,14 @@
 const std = @import("std");
 const window_state = @import("window_state.zig");
 const remote_state = @import("remote_state.zig");
-const notification_state = @import("notification_state.zig");
 
 pub const WindowState = window_state.State;
 pub const RemoteState = remote_state.State;
 pub const RemoteAiInputSink = remote_state.AiInputSink;
-pub const NotificationState = notification_state.State;
 
 pub const State = struct {
     window: WindowState = .{},
     remote: RemoteState = .{},
-    notifications: NotificationState = .{},
 };
 
 test "appwindow state aggregates window and remote state" {
@@ -19,8 +16,6 @@ test "appwindow state aggregates window and remote state" {
 
     state.window.queueResize(120, 32, 100);
     _ = state.remote.recordAiSink(1, 0x5678);
-    try std.testing.expect(state.notifications.acceptMemoryDigestProgress(1));
-
     try std.testing.expect(state.window.pending_resize.pending);
     try std.testing.expectEqual(@as(usize, 0x5678), state.remote.aiSink(1).?.native_handle_bits);
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -3405,6 +3405,10 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
                 _ = AppWindow.memoryCenterReload();
                 return .none;
             },
+            0x44 => if (plain and !ev.shift) {
+                _ = AppWindow.runMemoryDigestFromCenter();
+                return .none;
+            },
             else => {},
         }
         return .none;

--- a/src/memory_center/session.zig
+++ b/src/memory_center/session.zig
@@ -1,7 +1,15 @@
 const std = @import("std");
+const memory_digest_scheduler = @import("../memory_digest/scheduler.zig");
 const memory_viewer = @import("../memory_viewer.zig");
 
 pub const Source = memory_viewer.Source;
+
+pub const DigestStatus = enum { in_progress, success, failed, skipped };
+
+pub const DigestNotification = struct {
+    status: DigestStatus,
+    message: []const u8,
+};
 
 pub const Session = struct {
     source: Source = .remembered,
@@ -10,6 +18,10 @@ pub const Session = struct {
     snapshot: ?memory_viewer.Snapshot = null,
     status_buf: [96]u8 = undefined,
     status_len: usize = 0,
+    last_digest_progress_seq: u64 = 0,
+    digest_status: DigestStatus = .in_progress,
+    digest_status_buf: [160]u8 = undefined,
+    digest_status_len: usize = 0,
 
     pub fn init(allocator: std.mem.Allocator) Session {
         var self = Session{};
@@ -20,6 +32,7 @@ pub const Session = struct {
     pub fn deinit(self: *Session) void {
         self.clearSnapshot();
         self.status_len = 0;
+        self.digest_status_len = 0;
         self.selected = 0;
         self.detail_scroll = 0;
     }
@@ -39,6 +52,48 @@ pub const Session = struct {
 
     pub fn status(self: *const Session) []const u8 {
         return self.status_buf[0..self.status_len];
+    }
+
+    /// Copies a newly published scheduler update into this tab's own UI state.
+    pub fn syncDigestProgress(self: *Session, progress: memory_digest_scheduler.ProgressSnapshot) bool {
+        if (!progress.visible or progress.seq == 0 or progress.seq == self.last_digest_progress_seq) return false;
+        self.last_digest_progress_seq = progress.seq;
+
+        var buf: [160]u8 = undefined;
+        const message = switch (progress.stage) {
+            .queued => "Memory digest queued",
+            .scanning => "Memory digest: scanning chat logs",
+            .summarizing => if (progress.detail().len != 0)
+                std.fmt.bufPrint(&buf, "Memory digest: summarizing {s} ({d}/{d} done, {d} failed)", .{ progress.detail(), progress.sessions_done, progress.sessions_total, progress.sessions_failed }) catch "Memory digest: summarizing sessions"
+            else
+                std.fmt.bufPrint(&buf, "Memory digest: summarizing {d}/{d} ({d} failed)", .{ progress.sessions_done, progress.sessions_total, progress.sessions_failed }) catch "Memory digest: summarizing sessions",
+            .finalizing => "Memory digest: writing digest files",
+            .success => std.fmt.bufPrint(&buf, "Memory digest complete: {d} sessions, {d} days, {d} tokens", .{ progress.sessions_done, progress.days_written, progress.total_tokens }) catch "Memory digest complete",
+            .failed => if (progress.detail().len != 0)
+                std.fmt.bufPrint(&buf, "Memory digest failed: {s}", .{progress.detail()}) catch "Memory digest failed"
+            else
+                "Memory digest failed",
+            .skipped => if (progress.detail().len != 0)
+                std.fmt.bufPrint(&buf, "Memory digest skipped: {s}", .{progress.detail()}) catch "Memory digest skipped"
+            else
+                "Memory digest skipped",
+            .idle => return false,
+        };
+        self.digest_status = switch (progress.stage) {
+            .queued, .scanning, .summarizing, .finalizing => .in_progress,
+            .success => .success,
+            .failed => .failed,
+            .skipped => .skipped,
+            .idle => unreachable,
+        };
+        self.digest_status_len = @min(self.digest_status_buf.len, message.len);
+        @memcpy(self.digest_status_buf[0..self.digest_status_len], message[0..self.digest_status_len]);
+        return true;
+    }
+
+    pub fn digestNotification(self: *const Session) ?DigestNotification {
+        if (self.digest_status_len == 0) return null;
+        return .{ .status = self.digest_status, .message = self.digest_status_buf[0..self.digest_status_len] };
     }
 
     pub fn count(self: *const Session) usize {
@@ -133,4 +188,22 @@ test "memory center session switches source and clamps selection" {
     try std.testing.expectEqual(@as(usize, 8), state.detail_scroll);
     state.scrollDetailBy(-3);
     try std.testing.expectEqual(@as(usize, 5), state.detail_scroll);
+}
+
+test "memory center session keeps digest progress in the tab" {
+    var state = Session{};
+    const progress = memory_digest_scheduler.ProgressSnapshot{
+        .seq = 9,
+        .visible = true,
+        .stage = .success,
+        .sessions_done = 3,
+        .days_written = 1,
+        .total_tokens = 42,
+    };
+
+    try std.testing.expect(state.syncDigestProgress(progress));
+    try std.testing.expect(!state.syncDigestProgress(progress));
+    const notification = state.digestNotification().?;
+    try std.testing.expectEqual(DigestStatus.success, notification.status);
+    try std.testing.expect(std.mem.indexOf(u8, notification.message, "3 sessions") != null);
 }

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -136,6 +136,7 @@ pub fn render(
     renderSources(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line, selected_bg);
     renderList(draw, session, layout, window_height, top, fg, muted, accent, selected_bg, line);
     renderDetail(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line);
+    renderDigestNotification(draw, session, layout, window_height, top);
 }
 
 fn renderSources(
@@ -179,8 +180,27 @@ fn renderSources(
     }
 
     _ = draw.renderTextLimited("Tab / Left / Right switches source", layout.left_x + PAD_X, 12 + draw.cell_h + 6, muted, layout.left_w - PAD_X * 2);
-    _ = draw.renderTextLimited("Up / Down selects - PgUp / PgDn scrolls", layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited("D runs digest - Up / Down selects", layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
     _ = content_h;
+}
+
+fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Session, layout: Layout, window_height: f32, top: f32) void {
+    const notification = session.digestNotification() orelse return;
+    const accent: [3]f32 = switch (notification.status) {
+        .in_progress => .{ 0.56, 0.82, 1.0 },
+        .success => .{ 0.24, 1.0, 0.44 },
+        .failed => .{ 1.0, 0.30, 0.28 },
+        .skipped => .{ 1.0, 0.72, 0.28 },
+    };
+    const pad: f32 = 12;
+    const h = draw.cell_h + pad;
+    const w = @min(layout.detail_w - pad * 2, 460);
+    if (w <= 0) return;
+    const x = layout.detail_x + layout.detail_w - w - pad;
+    const y_top = @max(top + 4, window_height - h - pad);
+    draw.fillQuadAlpha(x, yFromTop(window_height, y_top, h), w, h, mixColor(draw.bg, accent, 0.16), 0.96);
+    draw.fillQuad(x, yFromTop(window_height, y_top, h), 3, h, accent);
+    _ = draw.renderTextLimited(notification.message, x + pad, yTextFromTop(draw, window_height, y_top + 6), accent, w - pad * 2);
 }
 
 fn renderList(

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -29,7 +29,6 @@ const ctl_ui_state = @import("../ctl/ui_state.zig");
 const command_palette_history_view = @import("../command/palette_history_view.zig");
 const command_palette_model = @import("../command/palette_model.zig");
 const command_registry = @import("../command/registry.zig");
-const memory_digest_scheduler = @import("../memory_digest/scheduler.zig");
 const agent_history = @import("../agent/history.zig");
 const platform_dirs = @import("../platform/dirs.zig");
 const platform_open_url = @import("../platform/open_url.zig");
@@ -782,7 +781,7 @@ fn executeCommand(action: CommandAction) void {
             }
         },
         .run_memory_digest_now => {
-            if (AppWindow.g_allocator) |gpa| memory_digest_scheduler.runNow(gpa);
+            _ = AppWindow.runMemoryDigestNow();
         },
     }
 }
@@ -6912,11 +6911,6 @@ pub fn showTransferToast(
     if (status != .in_progress) transferCancelConfirmClose();
 }
 
-pub fn showMemoryDigestToast(status: toasts.MemoryDigestStatus, message: []const u8) void {
-    toastState().memory_digest.show(status, message, std.time.milliTimestamp(), toasts.MEMORY_DIGEST_TOAST_DURATION_MS);
-    AppWindow.applyUiEffect(.repaint);
-}
-
 test "overlays: command center Settings command opens settings page" {
     commandPaletteOpen();
     defer settingsPageClose();
@@ -6955,21 +6949,10 @@ test "overlays: transfer toast state is owned by OverlayState" {
     try std.testing.expect(overlayState().toasts.transfer.clickable);
 }
 
-test "overlays: memory digest toast state is owned by OverlayState" {
-    const saved = overlayState().toasts.memory_digest;
-    defer overlayState().toasts.memory_digest = saved;
-
-    showMemoryDigestToast(.in_progress, "Digest running");
-
-    try std.testing.expect(overlayState().toasts.memory_digest.sticky);
-    try std.testing.expectEqualStrings("Digest running", overlayState().toasts.memory_digest.text().?);
-}
-
 test "overlays: sticky transfer toast does not keep render gate active forever" {
     const saved_copy = overlayState().toasts.copy;
     const saved_transfer = overlayState().toasts.transfer;
     const saved_update = overlayState().toasts.update;
-    const saved_memory_digest = overlayState().toasts.memory_digest;
     const saved_close_shortcut = close_confirm_state.deadline();
     const saved_remote_key_copied = g_remote_key_copied_until_ms;
     const saved_resize = resize.g_split_resize_overlay_until;
@@ -6978,7 +6961,6 @@ test "overlays: sticky transfer toast does not keep render gate active forever" 
         overlayState().toasts.copy = saved_copy;
         overlayState().toasts.transfer = saved_transfer;
         overlayState().toasts.update = saved_update;
-        overlayState().toasts.memory_digest = saved_memory_digest;
         close_confirm_state.setDeadline(saved_close_shortcut);
         g_remote_key_copied_until_ms = saved_remote_key_copied;
         resize.g_split_resize_overlay_until = saved_resize;
@@ -8115,34 +8097,6 @@ pub fn renderTransferToast(window_width: f32, window_height: f32) void {
     renderTitlebarTextStrongLimited(text, text_x, y, accent, layout.w - pad_h * 2);
 }
 
-pub fn renderMemoryDigestToast(window_width: f32, window_height: f32) void {
-    _ = window_height;
-    const now = std.time.milliTimestamp();
-    const toast = &toastState().memory_digest;
-    if (!toast.active(now)) return;
-    const text = toast.text() orelse return;
-
-    const pad_h: f32 = 14;
-    const pad_v: f32 = 6;
-    const line_h = font.g_titlebar_cell_height + pad_v * 2;
-    const text_width = measureTitlebarText(text);
-    const max_w = @max(220.0, window_width - 32.0);
-    const bg_w = @min(text_width + pad_h * 2, max_w);
-    const bg_x = @round(@max(12.0, window_width - bg_w - 16.0));
-    const bg_y: f32 = if (toastState().transfer.active(now)) 96 else 60;
-
-    const accent: [3]f32 = switch (toast.status) {
-        .in_progress => .{ 0.56, 0.82, 1.0 },
-        .success => .{ 0.24, 1.0, 0.44 },
-        .failed => .{ 1.0, 0.30, 0.28 },
-        .skipped => .{ 1.0, 0.72, 0.28 },
-    };
-    const bg = mixColor(AppWindow.g_theme.background, accent, 0.16);
-    ui_pipeline.fillQuadAlpha(bg_x, bg_y, bg_w, line_h, bg, 0.96);
-    ui_pipeline.fillQuadAlpha(bg_x, bg_y, 3, line_h, accent, 0.88);
-    renderTitlebarTextStrongLimited(text, bg_x + pad_h, bg_y + pad_v, accent, bg_w - pad_h * 2);
-}
-
 fn whatsNewNotes() []const u8 {
     return app_metadata.release_notes;
 }
@@ -8187,7 +8141,6 @@ pub fn anyOverlayActive(now: i64) bool {
     if (toast_state.copy.active(now)) return true;
     if (toast_state.transfer.text() != null and now < toast_state.transfer.until_ms) return true;
     if (toast_state.update.active(now)) return true;
-    if (toast_state.memory_digest.active(now)) return true;
     if (close_confirm_state.isActive(now)) return true;
     if (now < g_remote_key_copied_until_ms) return true;
     if (now < resize.g_split_resize_overlay_until) return true;

--- a/src/renderer/overlays/state.zig
+++ b/src/renderer/overlays/state.zig
@@ -62,7 +62,6 @@ test "overlay state aggregates migrated overlay groups" {
 
     state.settings.open();
     state.toasts.copy.show("Copied", 10, 100);
-    state.toasts.memory_digest.show(.in_progress, "Digest running", 10, 100);
     state.confirms.openRestoreDefaults();
     state.ssh.setFormField(.name, "web");
     state.assistant_profiles.setFormField(.name, "claude");
@@ -73,7 +72,6 @@ test "overlay state aggregates migrated overlay groups" {
 
     try std.testing.expect(state.settings.visible);
     try std.testing.expectEqualStrings("Copied", state.toasts.copy.text().?);
-    try std.testing.expectEqualStrings("Digest running", state.toasts.memory_digest.text().?);
     try std.testing.expect(state.confirms.restore_defaults_visible);
     try std.testing.expectEqualStrings("web", state.ssh.formField(.name));
     try std.testing.expectEqualStrings("claude", state.assistant_profiles.formField(.name));

--- a/src/renderer/overlays/toasts.zig
+++ b/src/renderer/overlays/toasts.zig
@@ -7,9 +7,6 @@ pub const COPY_TOAST_DURATION_MS: i64 = 1500;
 pub const TRANSFER_TOAST_DURATION_MS: i64 = 2500;
 pub const UPDATE_PROMPT_DURATION_MS: i64 = 10000;
 pub const UPDATE_STATUS_DURATION_MS: i64 = 2500;
-pub const MEMORY_DIGEST_TOAST_DURATION_MS: i64 = 4000;
-
-pub const MemoryDigestStatus = enum { in_progress, success, failed, skipped };
 
 pub const TextToast = struct {
     until_ms: i64 = 0,
@@ -104,35 +101,10 @@ pub const UpdatePrompt = struct {
     }
 };
 
-pub const MemoryDigestToast = struct {
-    until_ms: i64 = 0,
-    sticky: bool = false,
-    status: MemoryDigestStatus = .in_progress,
-    buf: [160]u8 = undefined,
-    len: usize = 0,
-
-    pub fn show(self: *MemoryDigestToast, status: MemoryDigestStatus, message: []const u8, now_ms: i64, duration_ms: i64) void {
-        self.len = copyTruncated(&self.buf, message);
-        self.status = status;
-        self.sticky = status == .in_progress;
-        self.until_ms = now_ms + duration_ms;
-    }
-
-    pub fn active(self: MemoryDigestToast, now_ms: i64) bool {
-        return self.len > 0 and (self.sticky or now_ms < self.until_ms);
-    }
-
-    pub fn text(self: *const MemoryDigestToast) ?[]const u8 {
-        if (self.len == 0) return null;
-        return self.buf[0..self.len];
-    }
-};
-
 pub const State = struct {
     copy: TextToast = .{},
     transfer: TransferToast = .{},
     update: UpdatePrompt = .{},
-    memory_digest: MemoryDigestToast = .{},
     close_shortcut_confirm_until_ms: i64 = 0,
 };
 
@@ -255,17 +227,4 @@ test "text toast truncates stored text to fixed buffer" {
 
     try std.testing.expectEqual(@as(usize, 64), toast.text().?.len);
     try std.testing.expectEqualStrings(long_message[0..64], toast.text().?);
-}
-
-test "memory digest toast stays sticky only while in progress" {
-    var toast: MemoryDigestToast = .{};
-
-    toast.show(.in_progress, "Digest running", 1000, MEMORY_DIGEST_TOAST_DURATION_MS);
-    try std.testing.expect(toast.active(1000 + MEMORY_DIGEST_TOAST_DURATION_MS + 1));
-    try std.testing.expect(toast.sticky);
-
-    toast.show(.success, "Digest complete", 2000, MEMORY_DIGEST_TOAST_DURATION_MS);
-    try std.testing.expect(!toast.sticky);
-    try std.testing.expect(toast.active(2000 + MEMORY_DIGEST_TOAST_DURATION_MS - 1));
-    try std.testing.expect(!toast.active(2000 + MEMORY_DIGEST_TOAST_DURATION_MS + 1));
 }


### PR DESCRIPTION
## Summary

- Add the `D` shortcut in Memory Center to run a digest immediately.
- Make the command-center action open a dedicated Memory Center tab before starting the digest.
- Move digest progress, success, and failure notifications out of the global overlay and into that tab.

## Why

Digest status previously appeared as a global toast even when the action was initiated from memory management. Keeping the notification in the owning Memory Center session preserves context and avoids unrelated tabs receiving it.

## Validation

- `zig fmt` and `git diff --check` passed.
- `zig build test` and `zig build test-full` could not complete in this environment after a Zig cache/WSL failure (`manifest_create Unexpected`; WSL vsock test-launch failure), rather than a test assertion failure.
