### PR TITLE
fix: keep Side Copilot bound to its terminal tab

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -3972,8 +3972,7 @@ fn syncActiveSurfaceCaches() void {
 pub fn handleActiveSurfaceChangeWithinTab() void {
     syncVisibleFileExplorerForActiveTab(false);
     syncActiveSurfaceCaches();
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    applyUiEffect(.{ .needs_rebuild = true, .cells_invalid = true });
 }
 
 fn clearUiStateOnTabChange() void {
@@ -7339,7 +7338,11 @@ fn runMainLoop(self: *AppWindow) !void {
                 .initial_cwd_present = initial_cwd != null,
                 .first_plain_window = restore_once,
             })) {
-                .restored_session => {},
+                // Restoring tabs bypasses the normal tab-switch integration
+                // path. Seed the active surface context now so a restored SSH
+                // tab's Copilot binds to SSH instead of falling back to the
+                // host-local command tool.
+                .restored_session => syncActiveSurfaceCaches(),
                 .single_terminal => {
                     if (!spawnTabWithCwd(allocator, initial_cwd)) {
                         std.debug.print("Failed to spawn initial tab\n", .{});

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -45,6 +45,16 @@ const platform_dirs = @import("../platform/dirs.zig");
 
 pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
+    const remote_sidebar_local_command = blk: {
+        if (!ctx.copilot or !first_party_tools.isHostLocalCommand(call.name)) break :blk false;
+        const selected = ctx.writeContextSurfaceId() orelse break :blk false;
+        const snapshot = ctx.tool_snapshot orelse break :blk false;
+        const surface = terminal_tools.findSurface(snapshot, selected) orelse break :blk false;
+        break :blk surface.is_ssh or surface.is_wsl;
+    };
+    if (ctx.copilot and (first_party_tools.isSidebarRestricted(call.name) or remote_sidebar_local_command)) {
+        return std.fmt.allocPrint(ctx.allocator, "Tool is unavailable in Side Copilot because it is restricted to the bound tab: {s}", .{call.name});
+    }
     if (first_party_tools.isKnown(call.name) and first_party_tools.isDisabledName(ctx.settings.disabled_first_party_tools, call.name)) {
         return std.fmt.allocPrint(ctx.allocator, "Tool is disabled: {s}", .{call.name});
     }
@@ -635,6 +645,84 @@ test "executeToolCall rejects disabled first-party webread before validating arg
     defer std.testing.allocator.free(out);
 
     try std.testing.expectEqualStrings("Tool is disabled: webread", out);
+}
+
+test "executeToolCall hard-denies tab lifecycle tools in Side Copilot" {
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = std.testing.allocator,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{},
+        .copilot = true,
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+
+    inline for (.{ "tab_new", "tab_close", "ssh_profile_connect" }) |name| {
+        const out = try executeToolCall(&ctx, .{
+            .id = @constCast("c1"),
+            .name = @constCast(name),
+            .arguments = @constCast("{}"),
+        });
+        defer std.testing.allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") != null);
+    }
+}
+
+test "executeToolCall allows host-local exec for local Side Copilot" {
+    var dummy: u8 = 0;
+    var ctx = ToolContext{
+        .allocator = std.testing.allocator,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = null,
+        .settings = .{},
+        .copilot = true,
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast(platform_process.localCommandToolName()),
+        .arguments = @constCast("{}"),
+    });
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") == null);
+}
+
+test "executeToolCall denies host-local exec for remote Side Copilot" {
+    var dummy: u8 = 0;
+    var surfaces = [_]ToolSurface{.{
+        .id = @constCast("remote-1"),
+        .title = @constCast("ssh"),
+        .cwd = @constCast("/home/user"),
+        .snapshot = @constCast("$ "),
+        .tab_index = 0,
+        .focused = true,
+        .is_ssh = true,
+        .is_wsl = false,
+        .ptr = @ptrCast(&dummy),
+    }};
+    var ctx = ToolContext{
+        .allocator = std.testing.allocator,
+        .ctx = &dummy,
+        .tool_host = null,
+        .tool_snapshot = .{ .surfaces = surfaces[0..], .active_tab = 0 },
+        .settings = .{},
+        .copilot = true,
+        .approve = fakeApprove,
+        .cancelled = fakeCancelled,
+    };
+    terminal_tools.setWriteContext(&ctx, "remote-1");
+    const out = try executeToolCall(&ctx, .{
+        .id = @constCast("c1"),
+        .name = @constCast(platform_process.localCommandToolName()),
+        .arguments = @constCast("{}"),
+    });
+    defer std.testing.allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") != null);
 }
 
 test "executeToolCall does not treat disabled dynamic names as first-party tools" {

--- a/src/agent_tools/sessions.zig
+++ b/src/agent_tools/sessions.zig
@@ -129,7 +129,7 @@ pub fn tabNew(ctx: *ToolContext, kind: []const u8, command: ?[]const u8) ![]u8 {
 
     const out = try std.fmt.allocPrint(
         ctx.allocator,
-        "created tab kind={s} surface_id={s} tab={d} focused={} surface_kind={s} title=\"{s}\" cwd=\"{s}\"",
+        "created tab kind={s} surface_id={s} tab={d} focused={} surface_kind={s} title=\"{s}\" cwd=\"{s}\". Close this temporary tab with tab_close when the task finishes.",
         .{
             if (trimmed_kind.len > 0) trimmed_kind else "default",
             surface.id,

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -563,6 +563,40 @@ fn cloneStringList(allocator: std.mem.Allocator, list: []const []const u8) ![]co
     return out;
 }
 
+fn cloneDisabledFirstPartyTools(allocator: std.mem.Allocator, list: []const []const u8, copilot: bool, remote_bound: bool) ![]const []const u8 {
+    if (!copilot) return cloneStringList(allocator, list);
+
+    const restrictions = [_][]const u8{
+        "ssh_profile_connect",
+        "tab_new",
+        "tab_close",
+        platform_process.localCommandToolName(),
+    };
+    var restricted_count: usize = 0;
+    for (restrictions, 0..) |name, index| {
+        if (index == restrictions.len - 1 and !remote_bound) continue;
+        if (!first_party_tools.isDisabledName(list, name)) restricted_count += 1;
+    }
+
+    const out = try allocator.alloc([]const u8, list.len + restricted_count);
+    var written: usize = 0;
+    errdefer {
+        for (out[0..written]) |item| allocator.free(item);
+        allocator.free(out);
+    }
+    for (list) |item| {
+        out[written] = try allocator.dupe(u8, item);
+        written += 1;
+    }
+    for (restrictions, 0..) |name, index| {
+        if (index == restrictions.len - 1 and !remote_bound) continue;
+        if (first_party_tools.isDisabledName(list, name)) continue;
+        out[written] = try allocator.dupe(u8, name);
+        written += 1;
+    }
+    return out;
+}
+
 fn freeDynamicToolSpecsSlice(allocator: std.mem.Allocator, specs: []ai_chat_protocol.DynamicToolSpec) void {
     freeOwnedDynamicToolSpecs(allocator, specs);
 }
@@ -4343,7 +4377,13 @@ pub const Session = struct {
         const mcp_tools = try cloneMcpTools(self.allocator, mcp_registry.cachedTools());
         var mcp_tools_owned = true;
         errdefer if (mcp_tools_owned) freeOwnedMcpTools(self.allocator, mcp_tools);
-        const disabled_first_party_tools = try cloneStringList(self.allocator, settings.disabled_first_party_tools);
+        const remote_bound = blk: {
+            if (!self.copilot or self.bound_surface_id_len == 0) break :blk false;
+            const snapshot = tool_snapshot orelse break :blk false;
+            const surface = agent_terminal.findSurface(snapshot, self.boundSurfaceId()) orelse break :blk false;
+            break :blk surface.is_ssh or surface.is_wsl;
+        };
+        const disabled_first_party_tools = try cloneDisabledFirstPartyTools(self.allocator, settings.disabled_first_party_tools, self.copilot, remote_bound);
         var disabled_first_party_tools_owned = true;
         errdefer if (disabled_first_party_tools_owned) freeOwnedStringList(self.allocator, disabled_first_party_tools);
         const schedule_session_id = try self.allocator.dupe(u8, self.sessionId());
@@ -8833,6 +8873,15 @@ test "copilot request appends bound-terminal snapshot to latest user message" {
     // Snapshot block is appended: cwd + recent output line.
     try std.testing.expect(std.mem.indexOf(u8, user_content, "cwd: /home/tester/work") != null);
     try std.testing.expect(std.mem.indexOf(u8, user_content, "UNIQUE_OUTPUT_LINE") != null);
+
+    const json = try ai_chat_request.buildRequestJson(allocator, request);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_new\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_close\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"ssh_profile_connect\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"terminal_select\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"ssh_session_exec\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, platform_process.localCommandToolName()) != null);
 }
 
 test "ai chat request json replays durable tool messages and skips progress tools" {

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -74,7 +74,7 @@ const common_tools_after_wsl =
     \\- For a stuck terminal (`>` prompt, unclosed quote, hung command, pager), send `terminal_repl_exec repl=plain code=<ctrl-c>` (or `<ctrl-u>`/`<esc>`/`<ctrl-d>`).
     \\- Read terminal snapshots from the bottom; if stale/truncated, re-read with `terminal_snapshot`.
     \\- Answer Claude Code/Codex approval menus with `terminal_answer_prompt`; never blind-press unseen prompts.
-    \\- Use `tab_new` only when no suitable terminal exists; it is reserved for this Agent.
+    \\- Use `tab_new` only when no suitable terminal exists; it is reserved for this Agent. Close temporary tabs with `tab_close` as soon as their task finishes. Side Copilot cannot create or close tabs and stays within its bound tab and splits.
     \\- For WispTerm questions, call `wispterm_docs`.
     \\- For biomedical literature, decompose into English keywords (AND/OR), then call `pubmed`.
     \\- Delegate heavy research/reading (full web pages, PDFs, multi-query searches) to `subagent` with one complete task description; only its final report enters this conversation.

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,11 +19,11 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Ratchet ceilings for watched files (AppWindow 56, input 81, overlays 12,
+// Ratchet ceilings for watched files (AppWindow 54, input 81, overlays 12,
 // assistant/conversation/session.zig 0). Lower a ceiling only when direct
 // writes are removed.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 56 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 54 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 12 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },

--- a/src/test_main_guards.zig
+++ b/src/test_main_guards.zig
@@ -31,6 +31,9 @@ test "app source guards" {
     if (std.mem.indexOf(u8, app_window_source, "W" ++ "M_") != null) {
         return guardFailed("AppWindow.zig comments and logic must describe platform-neutral event handling, not Win32 messages");
     }
+    if (std.mem.indexOf(u8, app_window_source, ".restored_session => syncActiveSurfaceCaches(),") == null) {
+        return guardFailed("restored startup tabs must seed the active Agent/Copilot surface context");
+    }
     if (std.mem.indexOf(u8, app_window_source, "[260]u16") != null or
         std.mem.indexOf(u8, app_window_source, "[256]u16") != null or
         std.mem.indexOf(u8, app_window_source, "[*:0]const u16") != null or

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -130,10 +130,33 @@ pub fn isKnown(name: []const u8) bool {
     return catalogDisableable(name) != null;
 }
 
+/// Sidebar Copilot is scoped to the tab and split surfaces it was opened on.
+/// These tools change the tab set; regular Agent/Copilot-tab sessions keep the
+/// full catalog. Host-local exec is restricted separately only for remote tabs.
+pub fn isSidebarRestricted(name: []const u8) bool {
+    return std.mem.eql(u8, name, "ssh_profile_connect") or
+        std.mem.eql(u8, name, "tab_new") or
+        std.mem.eql(u8, name, "tab_close");
+}
+
+pub fn isHostLocalCommand(name: []const u8) bool {
+    return std.mem.eql(u8, name, platform_process.localCommandToolName());
+}
+
 fn catalogDisableable(name: []const u8) ?bool {
     if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
     if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
     return definitionDisableable(&static_definitions, name);
+}
+
+test "first_party_tools: sidebar restrictions keep terminal work in the bound tab" {
+    try std.testing.expect(isHostLocalCommand(platform_process.localCommandToolName()));
+    try std.testing.expect(!isSidebarRestricted(platform_process.localCommandToolName()));
+    try std.testing.expect(isSidebarRestricted("ssh_profile_connect"));
+    try std.testing.expect(isSidebarRestricted("tab_new"));
+    try std.testing.expect(isSidebarRestricted("tab_close"));
+    try std.testing.expect(!isSidebarRestricted("terminal_select"));
+    try std.testing.expect(!isSidebarRestricted("ssh_session_exec"));
 }
 
 fn definitionDisableable(definitions: []const Definition, name: []const u8) ?bool {


### PR DESCRIPTION
## Summary
- seed Agent/Copilot surface context after startup tab restoration so restored SSH tabs do not fall back to host-local execution
- restrict Side Copilot from creating, closing, or connecting other tabs while retaining panel operations inside its bound tab
- keep host-local PowerShell/shell available for local Side Copilot, but hide and hard-deny it when Side Copilot is bound to SSH or WSL
- keep regular Agent/Copilot tab creation available and remind it to close temporary tabs after use
- ratchet AppWindow direct dirty writes from 56 to 54

Addresses #542.

## Verification
- zig build test: passed
- zig build test-full: modified code compiled and relevant tests passed; the suite remains blocked by existing Windows/WSL UNC temp-path failures in memory_digest.store and memory_digest.cursors