### PR TITLE
fix(skill-center): 列表溢出时可滚动/翻页 (#556)

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2032,7 +2032,6 @@ fn renderSkillCenterFrame(active_tab: *TabState, fb_width: c_int, fb_height: c_i
             .ctx = @ptrCast(m),
             .itemAt = scEntryItemAt,
             .sel_row = m.sel_row,
-            .scroll = m.scroll,
             .title = i18n.s().sl_skill_center,
             .legend = switch (m.overlay) {
                 .import_list => i18n.s().sc_legend_import,

--- a/src/input.zig
+++ b/src/input.zig
@@ -3563,6 +3563,15 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
                 if (AppWindow.skillCenterMove(1)) markSkillCenterInputDirty();
                 return .none;
             },
+            // ponytail: fixed page of 10 rows; wire real visible-capacity if it matters.
+            platform_input.key_page_up => {
+                if (AppWindow.skillCenterMove(-10)) markSkillCenterInputDirty();
+                return .none;
+            },
+            platform_input.key_page_down => {
+                if (AppWindow.skillCenterMove(10)) markSkillCenterInputDirty();
+                return .none;
+            },
             platform_input.key_enter => {
                 if (overlay_active) {
                     if (AppWindow.skillCenterOverlaySelect()) markSkillCenterInputDirty();
@@ -6966,6 +6975,13 @@ fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
     }
     if (AppWindow.activeMemoryCenter() != null) {
         _ = AppWindow.memoryCenterHandleMouseWheel(ev.xpos, ev.ypos, @intCast(ev.delta));
+        return;
+    }
+    // Skill Center list follows the selection, so the wheel moves the selection
+    // (same as the copilot/jupyter pickers) to scroll the overflowing list.
+    if (AppWindow.activeSkillCenter() != null) {
+        const units: isize = @intCast(mouseWheelUnits(ev.delta));
+        if (AppWindow.skillCenterMove(if (ev.delta > 0) -units else units)) requestInputRepaint();
         return;
     }
     if (AppWindow.activeAiChat()) |chat| {

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -258,6 +258,18 @@ fn renderList(
         _ = draw.renderTextLimited(row.title, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top_px + 8), if (selected) fg else mixColor(fg, accent, 0.05), layout.list_w - PAD_X * 2);
         _ = draw.renderTextLimited(row.detail, layout.list_x + PAD_X, yTextFromTop(draw, window_height, row_top_px + row_h - 9 - draw.cell_h), muted, layout.list_w - PAD_X * 2);
     }
+
+    // Scrollbar for the overflowing list (mirrors the Skill Center list).
+    if (count > max_rows and max_rows > 0) {
+        const track_h = row_h * @as(f32, @floatFromInt(max_rows));
+        const sb_w: f32 = 3;
+        const sb_x = layout.list_x + layout.list_w - sb_w - 4;
+        const thumb_h = @max(24.0, @round(track_h * @as(f32, @floatFromInt(max_rows)) / @as(f32, @floatFromInt(count))));
+        const max_scroll: f32 = @floatFromInt(count - max_rows);
+        const thumb_offset = if (max_scroll > 0) @round((track_h - thumb_h) * (@as(f32, @floatFromInt(start)) / max_scroll)) else 0;
+        draw.fillQuadAlpha(sb_x, yFromTop(window_height, row_top, track_h), sb_w, track_h, mixColor(muted, fg, 0.2), 0.30);
+        draw.fillQuadAlpha(sb_x, yFromTop(window_height, row_top + thumb_offset, thumb_h), sb_w, thumb_h, accent, 0.55);
+    }
 }
 
 fn renderDetail(

--- a/src/renderer/skill_center_renderer.zig
+++ b/src/renderer/skill_center_renderer.zig
@@ -63,7 +63,6 @@ pub const View = struct {
     ctx: *anyopaque,
     itemAt: *const fn (*anyopaque, usize) ListItem,
     sel_row: usize,
-    scroll: usize,
     title: []const u8, // localized "Skill Center"
     legend: []const u8, // localized action legend
     status: []const u8, // "Scanning…" etc, or ""
@@ -152,12 +151,12 @@ const PanelLayout = struct {
         return @intFromFloat(@max(0.0, @floor(usable / self.row_h)));
     }
 
-    fn mainListWindow(self: PanelLayout, total: usize, requested_scroll: usize) ListWindow {
+    fn mainListWindow(self: PanelLayout, total: usize, selected: usize) ListWindow {
         const cap = self.bodyVisibleRows();
         return .{
             .top_px = self.body_top,
             .visible_rows = cap,
-            .first_visible = clampScroll(requested_scroll, total, cap),
+            .first_visible = firstVisibleForSelection(selected, cap, total),
         };
     }
 
@@ -414,7 +413,7 @@ fn renderSkillList(
         _ = draw.renderTextLimited(view.status, layout.content_x + PAD_X, empty_y, muted, layout.content_w - PAD_X * 2);
         return;
     }
-    const list = layout.mainListWindow(view.skills_len, view.scroll);
+    const list = layout.mainListWindow(view.skills_len, view.sel_row);
     var rendered: usize = 0;
     var ri: usize = list.first_visible;
     while (ri < view.skills_len and rendered < list.visible_rows) : (ri += 1) {
@@ -429,6 +428,11 @@ fn renderSkillList(
         _ = draw.renderTextLimited(item.label, layout.content_x + PAD_X, slot.text_y, fg, @max(0, layout.content_w - PAD_X * 2 - meta_w));
         renderListMetadata(draw, item, layout.content_x, layout.content_w, slot.text_y, muted);
         rendered += 1;
+    }
+
+    if (listScrollbar(layout, window_height, list, view.skills_len)) |sb| {
+        draw.fillQuadAlpha(sb.track.x, sb.track.y, sb.track.w, sb.track.h, mixColor(muted, fg, 0.2), 0.30);
+        draw.fillQuadAlpha(sb.thumb.x, sb.thumb.y, sb.thumb.w, sb.thumb.h, accent, 0.55);
     }
 }
 
@@ -588,6 +592,18 @@ test "skill_center_renderer: firstVisibleForSelection keeps selection in view" {
     try std.testing.expectEqual(@as(usize, 0), firstVisibleForSelection(2, 4, 16));
     try std.testing.expectEqual(@as(usize, 12), firstVisibleForSelection(15, 4, 16));
     try std.testing.expectEqual(@as(usize, 5), firstVisibleForSelection(8, 4, 16));
+}
+
+test "skill_center_renderer: main list window follows the selection" {
+    const layout = panelLayout(420, 40, 16, 0, 300).?;
+    // Selection near the top: window starts at row 0.
+    try std.testing.expectEqual(@as(usize, 0), layout.mainListWindow(40, 2).first_visible);
+    // Selection past the fold: window scrolls so the selected row stays visible
+    // (regression: previously the window was pinned at 0 and rows below were unreachable).
+    const deep = layout.mainListWindow(40, 39);
+    try std.testing.expect(deep.visible_rows > 0);
+    try std.testing.expect(deep.first_visible > 0);
+    try std.testing.expect(39 < deep.first_visible + deep.visible_rows);
 }
 
 test "skill_center_renderer: clampScroll keeps scroll within range" {

--- a/src/skill/center.zig
+++ b/src/skill/center.zig
@@ -446,7 +446,6 @@ pub const PanelModel = struct {
     allocator: std.mem.Allocator,
     entries: ?[]LibraryEntry = null,
     sel_row: usize = 0,
-    scroll: usize = 0,
     overlay: Overlay = .none,
 
     pub fn init(allocator: std.mem.Allocator) PanelModel {


### PR DESCRIPTION
Fixes #556

## 问题

Skill Center 的技能列表用 `PanelModel.scroll` 决定可视窗口,但**没有任何代码写过这个字段**。列表一旦超出面板高度:

- ↑/↓ 只移动了(已滚出屏幕的)选中项,窗口始终钉在顶部 → 下方条目无法查看
- 鼠标滚轮、PageUp/PageDown 根本没接到该面板
- 没有滚动条

## 修复(根因)

- **渲染层**:主列表改为跟随选中项(复用 picker/import 浮层早已在用的 `firstVisibleForSelection`),并绘制滚动条。
- **输入层**:PageUp/PageDown 与鼠标滚轮改为移动选中项(滚轮行为与 copilot/jupyter picker 一致),溢出列表即可滚动。
- 删除从未被写入的死字段 `PanelModel.scroll`(以及它在 View 里的镜像)。

## 顺带:Memory Center 视觉对齐

Memory Center 的列表本来就跟随选中项(`listWindowStart`)、键盘/滚轮都正常,**没有该 bug**,只是缺一个可见的滚动条。本 PR 一并补上,保持两个中心面板观感一致。

## 验证

- `zig fmt --check` 通过
- `zig build test`(快速套件)通过
- `zig build test-full -Dtarget=aarch64-macos`:2811/2853 通过,唯一失败为既有 flaky 的 `tool_import: runArgvProbe` 测试(与本改动无关)
- 新增回归测试:`main list window follows the selection`(渲染层 13/13 通过)

🤖 Generated with [Claude Code](https://claude.com/claude-code)