### PR TITLE
feat(palette): make the full result list scrollable past the 14-row window

### DIFF
--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1159,12 +1159,12 @@ test "command palette surfaces user snippets and filters them by name/descriptio
     sshState().profiles_loaded = true;
     assistantProfiles().profiles_loaded = true;
 
-    // Empty filter shows only the curated built-in commands; snippets surface
-    // by typing, like SSH/AI/theme rows.
+    // Empty filter lists the user's snippets after the built-in commands
+    // (the list scrolls past the render window; themes stay search-only).
     setCommandPaletteFilterForTest("");
     rebuildPaletteScratch();
-    try std.testing.expect(!paletteContainsSnippetForTest(0));
-    try std.testing.expect(!paletteContainsSnippetForTest(1));
+    try std.testing.expect(paletteContainsSnippetForTest(0));
+    try std.testing.expect(paletteContainsSnippetForTest(1));
 
     // Name match.
     setCommandPaletteFilterForTest("deploy");

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -267,7 +267,6 @@ const TransferCancelConfirmLayout = struct {
 // ============================================================================
 
 const COMMAND_PALETTE_FILTER_MAX = command_palette_state.FILTER_MAX;
-const COMMAND_PALETTE_MAX_VISIBLE_ROWS = command_palette_layout.MAX_VISIBLE_ROWS;
 
 const THEME_OVERRIDE_KEYS = [_][]const u8{
     "background",
@@ -333,7 +332,11 @@ fn sendSnippet(idx: usize) void {
 
 const CommandPaletteMode = command_center_state.CommandPaletteMode;
 
-threadlocal var g_palette_scratch: [COMMAND_PALETTE_MAX_VISIBLE_ROWS]PaletteItem = undefined;
+/// Result-list capacity, decoupled from the 14-row render window: the list
+/// scrolls (selection-follow + wheel) through everything the rebuild collects.
+/// Sized for all commands + user snippets/profiles + a broad theme search.
+const PALETTE_SCRATCH_CAP: usize = 512;
+threadlocal var g_palette_scratch: [PALETTE_SCRATCH_CAP]PaletteItem = undefined;
 threadlocal var g_palette_scratch_len: usize = 0;
 threadlocal var g_command_palette_history_rows: []agent_history.Row = &.{};
 threadlocal var g_command_palette_history_rows_owned: bool = false;
@@ -1256,13 +1259,30 @@ fn rebuildPaletteScratch() void {
     loadSnippets();
 
     if (filter.len == 0) {
-        // Empty filter shows the curated top-N built-in commands only. Snippets
-        // (like SSH/AI/theme rows) surface once the user types a filter — the
-        // 14-row cap means anything appended here would just be truncated.
+        // Empty filter: every command plus the user's own entries (snippets,
+        // SSH profiles, AI profiles), scrollable past the render window.
+        // Themes stay search-only — 453 embedded entries would drown the list.
         for (COMMAND_ENTRIES, 0..) |entry, idx| {
             if (!commandEntryMatches(entry)) continue;
-            if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+            if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
             g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
+            g_palette_scratch_len += 1;
+        }
+        for (snippetsState().items, 0..) |_, idx| {
+            if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
+            g_palette_scratch[g_palette_scratch_len] = .{ .snippet = idx };
+            g_palette_scratch_len += 1;
+        }
+        loadSshProfiles();
+        for (0..sshState().profile_count) |profile_idx| {
+            if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
+            g_palette_scratch[g_palette_scratch_len] = .{ .ssh_profile = profile_idx };
+            g_palette_scratch_len += 1;
+        }
+        loadAiProfiles();
+        for (0..assistantProfiles().profile_count) |ai_idx| {
+            if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
+            g_palette_scratch[g_palette_scratch_len] = .{ .ai_profile = ai_idx };
             g_palette_scratch_len += 1;
         }
         return;
@@ -1270,12 +1290,12 @@ fn rebuildPaletteScratch() void {
 
     for (COMMAND_ENTRIES, 0..) |entry, idx| {
         if (!commandEntryTitleMatches(entry, filter)) continue;
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
         g_palette_scratch_len += 1;
     }
     for (snippetsState().items, 0..) |snippet, idx| {
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         if (!containsIgnoreCase(snippet.name, filter) and !containsIgnoreCase(snippet.description, filter)) continue;
         g_palette_scratch[g_palette_scratch_len] = .{ .snippet = idx };
         g_palette_scratch_len += 1;
@@ -1283,19 +1303,19 @@ fn rebuildPaletteScratch() void {
     for (COMMAND_ENTRIES, 0..) |entry, idx| {
         if (commandEntryTitleMatches(entry, filter)) continue;
         if (!commandEntrySecondaryMatches(entry, filter)) continue;
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         g_palette_scratch[g_palette_scratch_len] = .{ .command = idx };
         g_palette_scratch_len += 1;
     }
     loadSshProfiles();
     for (0..sshState().profile_count) |profile_idx| {
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         const profile = &sshState().profiles[profile_idx];
         const name = profileField(profile, .name);
         if (command_palette_model.sshProfileNameMatchesFilter(name, filter)) {
             g_palette_scratch[g_palette_scratch_len] = .{ .ssh_profile = profile_idx };
             g_palette_scratch_len += 1;
-            if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+            if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         }
         if (command_palette_model.tmuxProfileMatchesFilter(name, filter)) {
             g_palette_scratch[g_palette_scratch_len] = .{ .tmux_profile = profile_idx };
@@ -1304,14 +1324,14 @@ fn rebuildPaletteScratch() void {
     }
     loadAiProfiles();
     for (0..assistantProfiles().profile_count) |ai_idx| {
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         const profile = &assistantProfiles().profiles[ai_idx];
         if (!command_palette_model.aiProfileLabelMatchesFilter(aiProfileField(profile, .name), filter)) continue;
         g_palette_scratch[g_palette_scratch_len] = .{ .ai_profile = ai_idx };
         g_palette_scratch_len += 1;
     }
     for (&themes_embed.entries, 0..) |th, ti| {
-        if (g_palette_scratch_len >= COMMAND_PALETTE_MAX_VISIBLE_ROWS) break;
+        if (g_palette_scratch_len >= PALETTE_SCRATCH_CAP) break;
         if (!containsIgnoreCase(th.name, filter)) continue;
         g_palette_scratch[g_palette_scratch_len] = .{ .theme = ti };
         g_palette_scratch_len += 1;


### PR DESCRIPTION
## Summary

Fixes the command center only ever showing its "first page": the result scratch buffer was sized to the render window (`MAX_VISIBLE_ROWS = 14`), so entries beyond 14 never existed — 32 of the 46 commands (Settings, Open Config, Check for Updates, font size, exports, ...) were unreachable without typing a filter, and arrow-down just wrapped within the first 14.

- **`PALETTE_SCRATCH_CAP` (512)** decouples result-list capacity from the 14-row render window. Selection-follow scrolling, the wheel handler, hit-testing, and the scrollbar all already operate on windows over larger counts, so no other logic changed.
- **Empty filter now lists every command** plus the user's own entries (snippets, SSH profiles, AI profiles) in registry order, instead of a curated top-14.
- **Themes stay search-only** (unchanged): the 453 embedded themes would drown the list; they still appear when typing a filter.

Command indices in the empty-filter list are unchanged (registry order, no truncation before index 14), so the macOS e2e `_select_palette_command` fixed-index navigation is unaffected.

## Test plan

- `zig build test` (fast suite) ✅
- Manual on macOS: arrow-down scrolls past row 14 through all 46 commands (user-verified), scrollbar appears, theme search still works with a filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)