### PR TITLE
feat(palette): add "Star Me" command that opens the GitHub repo

### DIFF
--- a/src/command/center_state.zig
+++ b/src/command/center_state.zig
@@ -52,6 +52,7 @@ pub const CommandAction = enum {
     open_port_forwarding,
     split_preview,
     run_memory_digest_now,
+    star_repo,
 };
 
 pub const CommandEntry = struct {
@@ -110,6 +111,7 @@ pub const command_entries = [_]CommandEntry{
     .{ .title = "Port Forwarding", .detail = "Manage SSH port forwarding rules", .shortcut = "", .action = .open_port_forwarding },
     .{ .title = "Split Preview", .detail = "Open a preview panel on the right", .shortcut = "", .action = .split_preview },
     .{ .title = "Run Memory Digest Now", .detail = "Scan AI chat logs and generate today's digest", .shortcut = "", .action = .run_memory_digest_now },
+    .{ .title = "Star Me", .detail = "Open the WispTerm GitHub repo to give it a star", .shortcut = "", .action = .star_repo },
 };
 
 test "command center exposes generic integration prompt action only" {

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -937,6 +937,7 @@ pub fn commandTitle(action: CommandAction) ?[]const u8 {
         .open_port_forwarding => "端口转发",
         .split_preview => "分屏预览",
         .run_memory_digest_now => "立即运行记忆摘要",
+        .star_repo => "给项目点个 Star（赞一个）",
     };
 }
 
@@ -994,6 +995,7 @@ pub fn commandDetail(action: CommandAction) ?[]const u8 {
         .open_port_forwarding => "管理 SSH 端口转发规则",
         .split_preview => "在右侧打开预览面板",
         .run_memory_digest_now => "扫描 AI 对话记录并生成今日摘要",
+        .star_repo => "打开 WispTerm 的 GitHub 仓库,给它点个 Star",
     };
 }
 

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -936,7 +936,13 @@ fn executeCommand(action: CommandAction) void {
         .run_memory_digest_now => {
             _ = AppWindow.runMemoryDigestNow();
         },
+        .star_repo => openRepoStar(),
     }
+}
+
+pub fn openRepoStar() void {
+    const allocator = AppWindow.g_allocator orelse return;
+    _ = platform_open_url.open(allocator, .{ .url = update_check.repo_url });
 }
 
 fn activeWeixinController() ?*weixin_qr_panel.Controller {

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -4,6 +4,7 @@ const release_package = @import("release_package.zig");
 
 pub const latest_release_api_url = "https://api.github.com/repos/xuzhougeng/wispterm/releases/latest";
 pub const latest_release_page_url = "https://github.com/xuzhougeng/wispterm/releases/latest";
+pub const repo_url = "https://github.com/xuzhougeng/wispterm";
 pub const asset_name_buffer_len = 128;
 pub const asset_download_url_buffer_len = 512;
 


### PR DESCRIPTION
## Summary

Adds a **Star Me / 给项目点个 Star（赞一个）** command to the command center, appended as the last entry so it appears at the bottom of the empty-filter list. Selecting it opens `https://github.com/xuzhougeng/wispterm` in the default browser so the user can star the repo.

- **update_check.zig**: new `repo_url` constant next to `latest_release_page_url`.
- **center_state.zig**: `star_repo` action + `"Star Me"` entry appended to the end of `command_entries`.
- **overlays.zig**: `executeCommand` dispatches to `openRepoStar()`, which reuses the existing `platform_open_url.open` path (same mechanism as *Open Latest Release*).
- **i18n.zig**: zh_CN title `给项目点个 Star（赞一个）` and matching detail (both `commandTitle`/`commandDetail` are exhaustive switches, so the compiler enforces the new case).

## Test plan

- `zig build test` (fast) ✅
- `zig build test-full -Dtarget=aarch64-macos` ✅ (only the known-flaky `tool_import runArgvProbe` timing test failed — fails on main too, unrelated)
- Manual on macOS: filtered "star" → "Star Me" appears; pressing Enter activated the default browser (opening the repo URL). Verified in the English locale; the zh_CN title is compiler-guaranteed via the exhaustive switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)