### PR TITLE
feat(assistant): add isolated /btw conversation overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,9 @@ Structural debt is frozen mechanically by source-scanning ratchet tests (the sam
 | Guard | Freezes | Today's ceiling | Escape hatch |
 |---|---|---|---|
 | `file_size_guard` | lines in any `src/**/*.zig` | < **10,000** (also `zig build check-sizes`) | split by responsibility; never raise the limit |
-| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow **67**, input **52**, overlays **39**, assistant/conversation/session **20** | put new state in a state struct (`appwindow/state.zig`, …) |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow **66**, input **49**, overlays **33**, assistant/conversation/session **16** | put new state in a state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | **17** | import the real module directly, not via `AppWindow.X` |
-| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow **57**, input **81**, overlays **12**, assistant/conversation/session **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow **45**, input **81**, overlays **10**, assistant/conversation/session **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
 
 The 10,000-line guard is a **runaway tripwire, not a health metric**: `check-sizes` prevents uncontrolled growth, it does not certify architectural health. A file under it can still be tangled; treat any file over **5,000 lines** as a signal to review responsibility, dependency direction, state ownership, and test boundaries. The boundary ratchets — not the line count — are the primary enforcement mechanism.
 

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -447,9 +447,9 @@ gate — you must first remove one, or use the pattern the guard names.
 | Guard | Freezes | Today's ceiling | Escape hatch |
 |---|---|---|---|
 | `file_size_guard` | lines in any `src/**/*.zig` (whole tree, future files too) | < 10,000 | split by responsibility; never raise the limit |
-| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow 67, input 52, overlays 39, assistant/conversation/session 20 | new state → an explicit state struct (`appwindow/state.zig`, …) |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow 66, input 49, overlays 33, assistant/conversation/session 16 | new state → an explicit state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | 17 | import the real module directly, not via `AppWindow.X` |
-| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow 57, input 81, overlays 12, assistant/conversation/session 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow 45, input 81, overlays 10, assistant/conversation/session 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
 
 They run in `zig build test` and — since `test-full` is now a superset of `test`
 — in the pre-merge gate. The file-size backstop is also a standalone command,

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -197,6 +197,25 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
             }
         }
     }.cb);
+    // `/btw [question]` opens a transient side conversation cloned from the
+    // submitting session. The overlay owns that clone; the source stays intact.
+    ai_chat.setBtwOverlayTrigger(struct {
+        fn cb(source: *ai_chat.Session) void {
+            const app_allocator = g_allocator orelse return;
+            const prompt = source.takePendingBtwPrompt(app_allocator) catch {
+                overlays.showStatusToast("Could not open BTW conversation");
+                return;
+            };
+            defer app_allocator.free(prompt);
+            if (overlays.btwConversationSession() == source) {
+                source.appendLocalToolMessage("Already in the BTW conversation.");
+                applyUiEffect(.repaint);
+                return;
+            }
+            overlays.openBtwConversation(source, prompt);
+            applyUiEffect(.repaint);
+        }
+    }.cb);
     app.maybeStartStartupUpdateCheck();
 
     try ensureGlobalAgentHistoryStore(allocator);
@@ -3993,8 +4012,7 @@ fn clearUiStateOnTabChange() void {
     syncVisibleFileExplorerForActiveTab(false);
     syncActiveSurfaceCaches();
     requestImmediateLayoutResize();
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    applyUiEffect(.repaint);
 }
 
 /// Convert the active surface's CWD from a WSL guest path to a platform-native path.
@@ -5051,6 +5069,7 @@ fn renderResizeFrame(width: i32, height: i32) void {
     overlays.renderMcpServers(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     feishu_reg_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    overlays.renderBtwConversation(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderDebugOverlay(@floatFromInt(fb_width));
     overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));
@@ -6321,6 +6340,9 @@ fn clearVisibleSurfaceDirty() void {
 }
 
 fn aiStreamingActive() bool {
+    if (overlays.btwConversationSession()) |session| {
+        if (session.requestState().inflight) return true;
+    }
     if (activeAiChat()) |session| {
         if (session.request_inflight) return true;
     }
@@ -6563,6 +6585,17 @@ const ImeCaret = struct {
 };
 
 fn syncImeCaretPosition(win: *window_backend.Window, split_count: usize) void {
+    if (overlays.btwConversationSession()) |session| {
+        if (win.ime_composing) return;
+        const size = window_backend.clientSize(win);
+        const layout = overlays.btwConversationLayout(
+            @floatFromInt(size.width),
+            currentTitlebarHeight(),
+        );
+        syncAiChatImeCaret(win, session, layout.chat_x, layout.chat_w);
+        return;
+    }
+
     // The command palette is a modal overlay on top of every tab; anchor the IME
     // caret to its text filter, not the underlying terminal/AI-chat cursor.
     if (overlays.commandPaletteVisible()) {
@@ -7886,6 +7919,7 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderMcpServers(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         feishu_reg_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+        overlays.renderBtwConversation(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderDebugOverlay(@floatFromInt(fb_width));
         overlays.renderCloseShortcutConfirm(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderCopyToast(@floatFromInt(fb_width), @floatFromInt(fb_height));

--- a/src/assistant/conversation/composer.zig
+++ b/src/assistant/conversation/composer.zig
@@ -296,15 +296,15 @@ pub const slash_command_entries = [_]SlashCommandEntry{
         .action = .model_switch,
     },
     .{
-        .suggestion = .{ .command = "/btw", .description = "show current progress without adding context" },
+        .suggestion = .{ .command = "/btw", .description = "open an isolated side conversation" },
         .action = .btw,
     },
     .{
-        .suggestion = .{ .command = "/verbos", .description = "show detailed current progress" },
+        .suggestion = .{ .command = "/verbos", .description = "open an isolated side conversation" },
         .action = .btw,
     },
     .{
-        .suggestion = .{ .command = "/verbose", .description = "show detailed current progress" },
+        .suggestion = .{ .command = "/verbose", .description = "open an isolated side conversation" },
         .action = .btw,
     },
 };

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -79,6 +79,8 @@ pub fn parseVisionEnabled(value: []const u8) bool {
 const REMOTE_SNAPSHOT_MAX_BYTES: usize = 24 * 1024;
 const INPUT_PROMPT_MAX_BYTES: usize = 64 * 1024;
 const SYSTEM_PROMPT_MAX_BYTES: usize = 16 * 1024;
+const BTW_PROMPT_MAX_BYTES: usize = 8 * 1024;
+const BTW_CONTEXT_MAX_BYTES: usize = 12 * 1024;
 const WORKING_DIR_MAX_BYTES: usize = 1024;
 /// 两次 ESC 间隔不超过此毫秒数时判定为"双击"，用于打开回溯选择器。
 const DOUBLE_ESC_WINDOW_MS: i64 = 400;
@@ -413,6 +415,7 @@ const DeferredAction = union(enum) {
     resume_picker,
     copilot_conversation_picker,
     model_switch_picker,
+    btw_overlay,
     export_markdown: MarkdownExportMode,
     copy_transcript: MarkdownExportMode,
 };
@@ -431,16 +434,17 @@ const BuiltinResult = struct {
 fn fireDeferredAction(session: *Session, action: DeferredAction) void {
     switch (action) {
         .none => {},
-        .resume_picker => if (g_session_resume_trigger) |t| t(),
-        .copilot_conversation_picker => if (g_copilot_picker_trigger) |t| t(),
+        .resume_picker => if (g_ui_triggers.session_resume) |t| t(),
+        .copilot_conversation_picker => if (g_ui_triggers.copilot_picker) |t| t(),
         // Targets the session that submitted `/model` (copilot sidebar OR a tab),
         // not the active tab — they can differ.
-        .model_switch_picker => if (g_model_switch_trigger) |t| t(session),
+        .model_switch_picker => if (g_ui_triggers.model_switch) |t| t(session),
+        .btw_overlay => if (g_ui_triggers.btw_overlay) |t| t(session),
         // Targets the session that submitted `/export` (copilot sidebar OR a tab),
         // not the active tab — they can differ.
-        .export_markdown => |mode| if (g_transcript_sink_triggers.export_markdown) |t| t(session, mode),
+        .export_markdown => |mode| if (g_ui_triggers.export_markdown) |t| t(session, mode),
         // Targets the session that submitted `/copy` (copilot sidebar OR a tab).
-        .copy_transcript => |mode| if (g_transcript_sink_triggers.copy) |t| t(session, mode),
+        .copy_transcript => |mode| if (g_ui_triggers.copy) |t| t(session, mode),
     }
 }
 
@@ -450,16 +454,15 @@ var g_access_rules_storage: ?ai_agent_access.AccessRules = null;
 var g_access_rules: ?*const ai_agent_access.AccessRules = null;
 var g_default_working_dir_buf: [WORKING_DIR_MAX_BYTES]u8 = undefined;
 var g_default_working_dir_len: usize = 0;
-var g_session_resume_trigger: ?*const fn () void = null;
-var g_copilot_picker_trigger: ?*const fn () void = null;
-/// Sinks for the rendered conversation Markdown: `/export` writes a file,
-/// `/copy` writes the clipboard. One struct to respect the g_* global ceiling.
-const TranscriptSinkTriggers = struct {
+const UiTriggers = struct {
+    session_resume: ?*const fn () void = null,
+    copilot_picker: ?*const fn () void = null,
+    model_switch: ?*const fn (*Session) void = null,
+    btw_overlay: ?*const fn (*Session) void = null,
     export_markdown: ?*const fn (*Session, MarkdownExportMode) void = null,
     copy: ?*const fn (*Session, MarkdownExportMode) void = null,
 };
-var g_transcript_sink_triggers: TranscriptSinkTriggers = .{};
-var g_model_switch_trigger: ?*const fn (*Session) void = null;
+var g_ui_triggers: UiTriggers = .{};
 threadlocal var g_dynamic_tool_specs: []ai_chat_protocol.DynamicToolSpec = &.{};
 threadlocal var g_dynamic_tool_specs_owned: bool = false;
 threadlocal var g_dynamic_binary_tools: []ai_chat_types.DynamicBinaryTool = &.{};
@@ -506,33 +509,40 @@ fn resolveSubagentProfileForRequest(allocator: std.mem.Allocator, agent_enabled:
 /// Wire the callback that `/resume` fires to open the agent history picker.
 /// Fired AFTER the session mutex unlocks (the picker lives in the app layer).
 pub fn setSessionResumeTrigger(cb: ?*const fn () void) void {
-    g_session_resume_trigger = cb;
+    g_ui_triggers.session_resume = cb;
 }
 
 /// Wire the callback that `/resume` fires in a Copilot sidebar session to open
 /// the Copilot conversation picker. Fired AFTER the session mutex unlocks.
 pub fn setCopilotPickerTrigger(cb: ?*const fn () void) void {
-    g_copilot_picker_trigger = cb;
+    g_ui_triggers.copilot_picker = cb;
 }
 
 /// Wire the callback that `/model` fires (after unlock) to either switch by the
 /// pending name or open the profile picker. Lives in the app layer.
 pub fn setModelSwitchTrigger(cb: ?*const fn (*Session) void) void {
-    g_model_switch_trigger = cb;
+    g_ui_triggers.model_switch = cb;
+}
+
+/// Wire the callback that opens the temporary `/btw` conversation overlay.
+/// Fired after the source session mutex unlocks; the callback reads and clears
+/// the pending prompt with `takePendingBtwPrompt`.
+pub fn setBtwOverlayTrigger(cb: ?*const fn (*Session) void) void {
+    g_ui_triggers.btw_overlay = cb;
 }
 
 /// Wire the callback that `/export [full|clean]` fires to write the conversation
 /// Markdown. Fired AFTER the session mutex unlocks, because the export reads the
 /// session under the SAME mutex (`allocMarkdownExport`) and would otherwise deadlock.
 pub fn setMarkdownExportTrigger(cb: ?*const fn (*Session, MarkdownExportMode) void) void {
-    g_transcript_sink_triggers.export_markdown = cb;
+    g_ui_triggers.export_markdown = cb;
 }
 
 /// Wire the callback that `/copy [full|clean]` fires to put the conversation
 /// Markdown on the clipboard. Fired AFTER the session mutex unlocks, because
 /// the copy reads the session under the SAME mutex (`allocMarkdownExport`).
 pub fn setTranscriptCopyTrigger(cb: ?*const fn (*Session, MarkdownExportMode) void) void {
-    g_transcript_sink_triggers.copy = cb;
+    g_ui_triggers.copy = cb;
 }
 threadlocal var g_tool_host: ?ToolHost = null;
 
@@ -977,12 +987,6 @@ fn parseBtwArg(input: []const u8) ?[]const u8 {
     return std.mem.trim(u8, prompt[tok_end..], " \t\r\n");
 }
 
-fn firstProgressLine(s: []const u8) []const u8 {
-    const trimmed = std.mem.trim(u8, s, " \t\r\n");
-    const end = std.mem.indexOfScalar(u8, trimmed, '\n') orelse trimmed.len;
-    return std.mem.trim(u8, trimmed[0..end], " \t\r\n");
-}
-
 const LoopTaskListScope = enum { session, all };
 
 fn taskOwnerLabel(v: ai_loop_store.TaskView) []const u8 {
@@ -1130,6 +1134,8 @@ pub const Session = struct {
     summary_thread: ?std.Thread = null,
     pending_model_switch_name_buf: [128]u8 = undefined,
     pending_model_switch_name_len: usize = 0,
+    pending_btw_prompt_buf: [BTW_PROMPT_MAX_BYTES]u8 = undefined,
+    pending_btw_prompt_len: usize = 0,
 
     pub const RequestState = struct {
         inflight: bool,
@@ -1476,6 +1482,81 @@ pub const Session = struct {
         const out = self.pending_model_switch_name_buf[0..self.pending_model_switch_name_len];
         self.pending_model_switch_name_len = 0;
         return out;
+    }
+
+    /// Return an owned copy of the prompt supplied after `/btw`, then clear the
+    /// pending slot. Copying under the lock keeps concurrent chatops input from
+    /// overwriting the prompt before the overlay consumes it.
+    pub fn takePendingBtwPrompt(self: *Session, allocator: std.mem.Allocator) ![]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const out = try allocator.dupe(u8, self.pending_btw_prompt_buf[0..self.pending_btw_prompt_len]);
+        self.pending_btw_prompt_len = 0;
+        return out;
+    }
+
+    /// Create the isolated chat session displayed by the `/btw` overlay. It
+    /// shares model credentials/configuration, but receives only a bounded
+    /// snapshot of this conversation and has tools disabled, so its turns can
+    /// never mutate or enter the source session's context.
+    pub fn createBtwSession(
+        self: *Session,
+        allocator: std.mem.Allocator,
+        initial_prompt: []const u8,
+    ) !*Session {
+        var child: *Session = undefined;
+        {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+
+            const turns = try allocator.alloc(ai_model_switch.TurnMessage, self.messages.items.len);
+            defer allocator.free(turns);
+            for (self.messages.items, 0..) |message, i| {
+                turns[i] = .{ .role = message.role, .content = message.content };
+            }
+            const snapshot = try ai_model_switch.buildSummaryUserContent(allocator, turns);
+            defer allocator.free(snapshot);
+            const snapshot_len = ai_model_switch.utf8SafeLen(snapshot, @min(snapshot.len, BTW_CONTEXT_MAX_BYTES));
+            const side_system_prompt = try std.fmt.allocPrint(
+                allocator,
+                "You are handling a temporary BTW side conversation while another assistant session continues independently. " ++
+                    "Answer concise questions using the source-session snapshot below. Do not claim that this side conversation changes, stops, or continues the source task. " ++
+                    "Do not execute tools. Reply in the user's language.\n\nSource status: {s}\n\nSource-session snapshot:\n{s}",
+                .{ self.status(), snapshot[0..snapshot_len] },
+            );
+            defer allocator.free(side_system_prompt);
+
+            child = try Session.initWithVision(
+                allocator,
+                "BTW",
+                self.baseUrl(),
+                self.apiKey(),
+                self.model(),
+                self.apiProtocolName(),
+                side_system_prompt,
+                self.thinkingConfigValue(),
+                self.reasoningEffort(),
+                self.streamConfigValue(),
+                "false",
+                self.visionConfigValue(),
+            );
+            errdefer child.deinit();
+            child.setMaxTokens(self.maxTokens());
+            child.copyTitle("BTW");
+            child.title_is_custom = true;
+            if (self.working_dir_len > 0) {
+                @memcpy(child.working_dir_buf[0..self.working_dir_len], self.working_dir_buf[0..self.working_dir_len]);
+                child.working_dir_len = self.working_dir_len;
+            }
+            if (self.acp_command.len > 0) child.acp_command = try allocator.dupe(u8, self.acp_command);
+        }
+
+        const prompt = std.mem.trim(u8, initial_prompt, " \t\r\n");
+        if (prompt.len > 0) {
+            child.appendInputText(prompt);
+            child.submit();
+        }
+        return child;
     }
 
     pub fn thinkingConfigValue(self: *const Session) []const u8 {
@@ -2563,22 +2644,9 @@ pub const Session = struct {
         self.scroll_px = 1_000_000;
     }
 
-    fn allocCurrentProgressLocked(self: *Session) ![]u8 {
-        var i = self.messages.items.len;
-        while (i > 0) : (i -= 1) {
-            const msg = self.messages.items[i - 1];
-            if (msg.role != .tool) continue;
-            const content = firstProgressLine(msg.content);
-            if (std.mem.startsWith(u8, content, "subagent:")) return self.allocator.dupe(u8, content);
-        }
-        const s = std.mem.trim(u8, self.status(), " \t\r\n");
-        if (s.len != 0 and !std.mem.eql(u8, s, "Ready")) return std.fmt.allocPrint(self.allocator, "Status: {s}", .{s});
-        return self.allocator.dupe(u8, "No active progress.");
-    }
-
     fn runBtwCommandLocked(self: *Session) ?BuiltinResult {
-        _ = parseBtwArg(self.input()) orelse return null;
-        return self.runBuiltinCommandLocked(.btw, "");
+        const arg = parseBtwArg(self.input()) orelse return null;
+        return self.runBuiltinCommandLocked(.btw, arg);
     }
 
     /// Thread-safe wrapper used by the tool layer (worker thread) to post a
@@ -3069,17 +3137,9 @@ pub const Session = struct {
                 result.suppress_output = true;
             },
             .btw => {
-                const text = self.allocCurrentProgressLocked() catch {
-                    self.setStatusLocked("Out of memory");
-                    result.suppress_output = true;
-                    return result;
-                };
-                defer self.allocator.free(text);
-                self.appendLocalToolMessageLocked(text) catch {
-                    self.setStatusLocked("Out of memory");
-                    result.suppress_output = true;
-                    return result;
-                };
+                self.pending_btw_prompt_len = @min(arg.len, self.pending_btw_prompt_buf.len);
+                @memcpy(self.pending_btw_prompt_buf[0..self.pending_btw_prompt_len], arg[0..self.pending_btw_prompt_len]);
+                result.deferred = .btw_overlay;
                 self.clearSubmittedInputLocked();
                 if (!self.request_inflight) self.setStatusLocked("Ready");
                 result.suppress_output = true;
@@ -5979,7 +6039,7 @@ test "ai chat enter submits slash commands instead of completing suggestions" {
     session.messages.deinit(allocator);
 }
 
-test "/btw emits local progress without adding user context" {
+test "/btw opens an isolated overlay without adding user context" {
     const allocator = std.testing.allocator;
     var session = Session{ .allocator = allocator };
     defer {
@@ -5996,6 +6056,24 @@ test "/btw emits local progress without adding user context" {
     session.request_thread = try std.Thread.spawn(.{}, Noop.run, .{});
     session.request_inflight = true;
 
+    const Hook = struct {
+        var seen: ?*Session = null;
+        var prompt_buf: [64]u8 = undefined;
+        var prompt_len: usize = 0;
+
+        fn cb(source: *Session) void {
+            seen = source;
+            const prompt = source.takePendingBtwPrompt(std.testing.allocator) catch return;
+            defer std.testing.allocator.free(prompt);
+            prompt_len = @min(prompt.len, prompt_buf.len);
+            @memcpy(prompt_buf[0..prompt_len], prompt[0..prompt_len]);
+        }
+    };
+    Hook.seen = null;
+    Hook.prompt_len = 0;
+    setBtwOverlayTrigger(Hook.cb);
+    defer setBtwOverlayTrigger(null);
+
     try session.messages.append(allocator, .{
         .role = .tool,
         .content = try allocator.dupe(u8, "subagent: running web_search"),
@@ -6005,10 +6083,9 @@ test "/btw emits local progress without adding user context" {
     session.submit();
 
     try std.testing.expectEqualStrings("", session.input());
-    try std.testing.expectEqual(@as(usize, 2), session.messages.items.len);
-    try std.testing.expectEqual(Role.tool, session.messages.items[1].role);
-    try std.testing.expectEqualStrings("subagent: running web_search", session.messages.items[1].content);
-    try std.testing.expect(!session.messages.items[1].persist_to_history);
+    try std.testing.expectEqual(@as(?*Session, &session), Hook.seen);
+    try std.testing.expectEqualStrings("当前进展", Hook.prompt_buf[0..Hook.prompt_len]);
+    try std.testing.expectEqual(@as(usize, 1), session.messages.items.len);
 
     session.mutex.lock();
     defer session.mutex.unlock();
@@ -6018,6 +6095,46 @@ test "/btw emits local progress without adding user context" {
         allocator.free(reqs);
     }
     try std.testing.expectEqual(@as(usize, 0), reqs.len);
+}
+
+test "btw child session receives a bounded snapshot and disables tools" {
+    const allocator = std.testing.allocator;
+    const source = try Session.init(
+        allocator,
+        "Source",
+        "https://example.invalid",
+        "test-key",
+        "test-model",
+        "source system prompt",
+        "disabled",
+        "low",
+        "false",
+        "true",
+    );
+    defer source.deinit();
+    source.mutex.lock();
+    try source.messages.append(allocator, .{
+        .role = .user,
+        .content = try allocator.dupe(u8, "original goal"),
+    });
+    try source.messages.append(allocator, .{
+        .role = .assistant,
+        .content = try allocator.dupe(u8, "working on it"),
+    });
+    source.setStatusLocked("Running");
+    source.mutex.unlock();
+
+    const child = try source.createBtwSession(allocator, "");
+    defer child.deinit();
+
+    try std.testing.expectEqualStrings("BTW", child.title());
+    try std.testing.expectEqualStrings("test-model", child.model());
+    try std.testing.expect(!child.agent_enabled);
+    try std.testing.expectEqual(@as(usize, 0), child.messages.items.len);
+    try std.testing.expect(std.mem.indexOf(u8, child.systemPrompt(), "Source status: Running") != null);
+    try std.testing.expect(std.mem.indexOf(u8, child.systemPrompt(), "User: original goal") != null);
+    try std.testing.expect(std.mem.indexOf(u8, child.systemPrompt(), "Assistant: working on it") != null);
+    try std.testing.expectEqual(@as(usize, 2), source.messages.items.len);
 }
 
 test "/rewind via submit opens picker without adding transcript noise" {

--- a/src/input.zig
+++ b/src/input.zig
@@ -173,6 +173,54 @@ test "input: command palette shortcut toggles command center" {
     try std.testing.expect(!overlays.commandPaletteVisible());
 }
 
+test "input: btw overlay owns text input and Escape closes it" {
+    try skipUnlessInputRendererShard();
+    const allocator = std.testing.allocator;
+    const previous_allocator = AppWindow.g_allocator;
+    defer AppWindow.g_allocator = previous_allocator;
+    AppWindow.g_allocator = allocator;
+
+    const source = try AppWindow.ai_chat.Session.init(
+        allocator,
+        "Source",
+        "https://example.invalid",
+        "",
+        "test-model",
+        "system",
+        "disabled",
+        "low",
+        "false",
+        "false",
+    );
+    defer source.deinit();
+    defer overlays.closeBtwConversation();
+
+    overlays.openBtwConversation(source, "");
+    try std.testing.expect(overlays.btwConversationVisible());
+    const child = overlays.btwConversationSession().?;
+
+    handleChar(.{ .codepoint = 'h' });
+    try std.testing.expectEqualStrings("h", child.input());
+
+    handleKey(.{
+        .key_code = platform_input.key_enter,
+        .ctrl = false,
+        .shift = false,
+        .alt = false,
+        .super = false,
+    });
+    try std.testing.expect(std.mem.startsWith(u8, child.status(), "Missing API key"));
+
+    handleKey(.{
+        .key_code = platform_input.key_escape,
+        .ctrl = false,
+        .shift = false,
+        .alt = false,
+        .super = false,
+    });
+    try std.testing.expect(!overlays.btwConversationVisible());
+}
+
 test "input: browser toolbar has a refresh action entrypoint" {
     try skipUnlessInputRendererShard();
     const info = @typeInfo(@TypeOf(refreshBrowserPanel)).@"fn";
@@ -1861,7 +1909,11 @@ fn weixinQrPanelConsumesChar() bool {
 pub threadlocal var g_selecting: bool = false; // True while mouse button is held
 pub threadlocal var g_click_x: f64 = 0; // X position of initial click (for threshold calculation)
 pub threadlocal var g_click_y: f64 = 0; // Y position of initial click
-var g_selection_changed_for_copy: bool = false;
+const RuntimeState = struct {
+    selection_changed_for_copy: bool = false,
+    left_click_tracker: click_tracker.ClickTracker = .{},
+};
+threadlocal var g_runtime_state: RuntimeState = .{};
 
 // Terminal mouse reporting drag state. When a press is delivered to the PTY
 // (the focused program enabled mouse tracking and Shift wasn't held), the
@@ -1872,7 +1924,6 @@ var g_selection_changed_for_copy: bool = false;
 // input/mouse_dispatch.zig as a pure, std-only helper; input.zig owns the one
 // instance and supplies the I/O (report target, PTY write, focus).
 threadlocal var g_mouse_report: mouse_dispatch.TerminalMouseReportState(*Surface) = .{};
-threadlocal var g_left_click_tracker: click_tracker.ClickTracker = .{};
 const MULTI_CLICK_INTERVAL_MS: i64 = 500;
 const MAX_SELECTION_COLS: usize = 4096;
 
@@ -2719,6 +2770,13 @@ fn handleChar(ev: platform_input.CharEvent) void {
 
 fn dispatchChar(ev: platform_input.CharEvent) ui_effect.UiEffect {
     overlays.startupShortcutsDismiss();
+    if (overlays.btwConversationVisible()) {
+        if (!ev.ctrl and !ev.alt) {
+            AppWindow.resetCursorBlink();
+            return overlays.btwConversationHandleChar(ev.codepoint);
+        }
+        return .consumed_only;
+    }
     if (overlays.sessionLauncherVisible()) {
         if (!ev.ctrl and !ev.alt) {
             overlays.sessionLauncherInsertChar(ev.codepoint);
@@ -3138,6 +3196,35 @@ fn dispatchKey(ev: platform_input.KeyEvent) ui_effect.UiEffect {
     const action = configuredAction(ev);
     const is_close_shortcut = actionIs(action, .close_panel_or_tab);
     if (!is_close_shortcut and !isModifierKey(ev.key_code)) close_confirm_state.clear();
+    if (overlays.btwConversationVisible()) {
+        const session = overlays.btwConversationSession() orelse return .consumed_only;
+        if (actionIs(action, .paste)) {
+            pasteFromClipboardIntoAiChat(session);
+            return input_effects.repaint();
+        }
+        if (actionIs(action, .paste_image)) {
+            pasteImageIntoAiChat(session);
+            return input_effects.repaint();
+        }
+        const mod = ev.ctrl or ev.super;
+        if (mod and !ev.alt and ev.key_code == 0x41) {
+            session.selectAll();
+            return input_effects.repaint();
+        }
+        if (mod and !ev.alt and ev.key_code == 0x43) {
+            copyAiChatToClipboard(session);
+            return .consumed_only;
+        }
+        if (mod and !ev.alt and ev.key_code == 0x58) {
+            copyAiChatCutToClipboard(session);
+            return input_effects.repaint();
+        }
+        if (isAiChatKey(ev)) {
+            AppWindow.resetCursorBlink();
+            return overlays.btwConversationHandleKey(key_event, btwInputWrapCols());
+        }
+        return .consumed_only;
+    }
     if (overlays.sessionLauncherVisible()) {
         if (actionIs(action, .paste)) {
             return if (pasteClipboardIntoSessionLauncher()) .repaint else .none;
@@ -3803,6 +3890,16 @@ fn aiChatInputWrapCols() usize {
     const ww: f32 = @floatFromInt(size.width);
     const panel_w = @max(1.0, ww - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidth());
     return AppWindow.assistant_conversation_renderer.inputWrapColumns(panel_w);
+}
+
+fn btwInputWrapCols() usize {
+    const win = AppWindow.g_window orelse return std.math.maxInt(usize);
+    const size = clientSize(win);
+    const layout = overlays.btwConversationLayout(
+        @floatFromInt(size.width),
+        @floatCast(titlebarHeight()),
+    );
+    return AppWindow.assistant_conversation_renderer.inputWrapColumns(layout.chat_w);
 }
 
 /// Wrap columns for the AI copilot sidebar's composer. Mirrors
@@ -4536,18 +4633,18 @@ const TerminalTokenGrid = struct {
 };
 
 fn markSelectionChanged() void {
-    g_selection_changed_for_copy = true;
+    g_runtime_state.selection_changed_for_copy = true;
     requestInputRepaint();
 }
 
 fn nextLeftClickCount(xpos: f64, ypos: f64) u8 {
     const now = std.time.milliTimestamp();
     const max_distance: f64 = @floatCast(@max(font.cell_width, font.cell_height));
-    return g_left_click_tracker.register(xpos, ypos, now, max_distance, MULTI_CLICK_INTERVAL_MS);
+    return g_runtime_state.left_click_tracker.register(xpos, ypos, now, max_distance, MULTI_CLICK_INTERVAL_MS);
 }
 
 fn resetLeftClickCount() void {
-    g_left_click_tracker.reset();
+    g_runtime_state.left_click_tracker.reset();
 }
 
 fn readViewportRowLocked(surface: *Surface, row: usize, buf: *[MAX_SELECTION_COLS]u21) []const u21 {
@@ -5380,6 +5477,7 @@ fn openInEditorAtRightClick(ev: platform_input.MouseButtonEvent) bool {
 
 fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
     if (ev.action == .press) close_confirm_state.clear();
+    if (overlays.btwConversationVisible()) return;
     if (overlays.whatsNewVisible()) {
         if (ev.button == .left and ev.action == .press) {
             const win = AppWindow.g_window orelse return;
@@ -5646,7 +5744,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         const titlebar_h: f64 = titlebarHeight();
 
         if (ev.action == .press) {
-            g_selection_changed_for_copy = false;
+            g_runtime_state.selection_changed_for_copy = false;
 
             // Commit rename on any click
             if (tab.g_tab_rename_active) tab.commitTabRename();
@@ -6236,10 +6334,10 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                 }
                 return;
             }
-            if (AppWindow.g_copy_on_select and g_selection_changed_for_copy and activeTerminalSelectionExists()) {
+            if (AppWindow.g_copy_on_select and g_runtime_state.selection_changed_for_copy and activeTerminalSelectionExists()) {
                 copySelectionToClipboard();
             }
-            g_selection_changed_for_copy = false;
+            g_runtime_state.selection_changed_for_copy = false;
             g_selecting = false;
         }
     }
@@ -6404,6 +6502,10 @@ fn updateAiTranscriptSelectionDrag(chat: *AppWindow.ai_chat.Session, xpos: f64, 
 fn handleMouseMove(ev: platform_input.MouseMoveEvent) void {
     const xpos: f64 = @floatFromInt(ev.x);
     const ypos: f64 = @floatFromInt(ev.y);
+    if (overlays.btwConversationVisible()) {
+        platform_cursor.set(.arrow);
+        return;
+    }
     if (g_sidebar_resize_dragging) {
         applySidebarWidthFromMouse(xpos);
         platform_cursor.set(.size_we);
@@ -6898,6 +7000,10 @@ fn reportMouseMotion(surface: *Surface, button: mouse_report.Button, ev: platfor
 
 fn handleMouseWheel(ev: platform_input.MouseWheelEvent) void {
     overlays.startupShortcutsDismiss();
+    if (overlays.btwConversationVisible()) {
+        applyInputEffect(overlays.btwConversationHandleScroll(@floatFromInt(ev.delta)));
+        return;
+    }
     if (overlays.whatsNewVisible()) {
         overlays.whatsNewHandleScroll(@floatFromInt(ev.delta));
         requestInputRebuild();

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -58,6 +58,7 @@ const feishu_reg_panel = @import("../feishu/registration_panel.zig");
 const session_launcher = @import("overlays/session_launcher.zig");
 const command_palette_state = @import("overlays/command_palette_state.zig");
 const command_palette_layout = @import("overlays/command_palette_layout.zig");
+const btw_conversation = @import("overlays/btw_conversation.zig");
 const close_confirm = @import("../close_confirm.zig");
 const close_confirm_state = @import("../ui/close_shortcut_confirm.zig");
 const weixin_qr_panel = @import("../weixin/qr_panel.zig");
@@ -129,6 +130,7 @@ fn overlayState() *overlay_state.OverlayState {
 /// accidental use safely reallocates fresh state instead of dangling.
 pub fn releaseThreadState() void {
     if (g_overlay_state) |s| {
+        s.deinit(AppWindow.g_allocator orelse std.heap.page_allocator);
         std.heap.page_allocator.destroy(s);
         g_overlay_state = null;
     }
@@ -178,6 +180,14 @@ fn launcherState() *session_launcher.State {
     return &overlayState().session;
 }
 
+fn btwState() *btw_conversation.State {
+    return &overlayState().btw;
+}
+
+fn whatsNewState() *overlay_state.WhatsNewState {
+    return &overlayState().whats_new;
+}
+
 fn commandPaletteState() *command_palette_state.State {
     return &overlayState().command_palette;
 }
@@ -224,8 +234,6 @@ const update_prompt_model = @import("overlays/update_prompt_model.zig");
 const UpdatePromptAction = update_prompt_model.UpdatePromptAction;
 const md = @import("../markdown_text.zig");
 const whats_new_model = @import("overlays/whats_new_model.zig");
-threadlocal var g_whats_new_visible: bool = false;
-threadlocal var g_whats_new_scroll: i64 = 0;
 threadlocal var g_integration_prompt_visible: bool = false;
 threadlocal var g_integration_prompt_scroll: i64 = 0;
 threadlocal var g_update_prompt_rect: ?DebugLineRect = null;
@@ -2179,6 +2187,91 @@ pub fn renderBrowserUrlBar(window_width: f32, window_height: f32, top_offset: f3
     }
 
     ui_pipeline.fillQuadAlpha(panel_x, bar_y, panel_w, 1, mixColor(bg, fg, 0.18), 0.55);
+}
+
+pub fn btwConversationVisible() bool {
+    return btwState().visible();
+}
+
+pub fn btwConversationSession() ?*ai_chat.Session {
+    const opaque_ptr = btwState().session orelse return null;
+    return @ptrCast(@alignCast(opaque_ptr));
+}
+
+pub fn openBtwConversation(source: *ai_chat.Session, initial_prompt: []const u8) void {
+    const allocator = AppWindow.g_allocator orelse return;
+    const session = source.createBtwSession(allocator, initial_prompt) catch {
+        showStatusToast("Could not open BTW conversation");
+        return;
+    };
+    btwState().set(session, struct {
+        fn deinit(opaque_ptr: *anyopaque) void {
+            const owned: *ai_chat.Session = @ptrCast(@alignCast(opaque_ptr));
+            owned.deinit();
+        }
+    }.deinit);
+}
+
+pub fn closeBtwConversation() void {
+    btwState().close();
+}
+
+pub fn btwConversationLayout(window_width: f32, top_offset: f32) btw_conversation.Layout {
+    return btw_conversation.layout(window_width, top_offset);
+}
+
+pub fn btwConversationHandleChar(codepoint: u21) AppWindow.UiEffect {
+    const session = btwConversationSession() orelse return .none;
+    session.handleChar(codepoint);
+    return .repaint;
+}
+
+pub fn btwConversationHandleKey(ev: input_key.KeyEvent, wrap_cols: usize) AppWindow.UiEffect {
+    const session = btwConversationSession() orelse return .none;
+    if (ev.key == .escape and !session.requestState().inflight) {
+        closeBtwConversation();
+        return .repaint;
+    }
+    session.handleKeyWithWrapCols(ev, wrap_cols);
+    return .repaint;
+}
+
+pub fn btwConversationHandleScroll(delta_y: f64) AppWindow.UiEffect {
+    const session = btwConversationSession() orelse return .none;
+    const delta: f32 = -@as(f32, @floatCast(delta_y)) * 72.0 / 120.0;
+    session.scrollBy(delta);
+    return .repaint;
+}
+
+pub fn renderBtwConversation(window_width: f32, window_height: f32, top_offset: f32) void {
+    const session = btwConversationSession() orelse return;
+    const layout = btw_conversation.layout(window_width, top_offset);
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const banner_y = @round(window_height - layout.banner_top_px - layout.banner_h);
+
+    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.54);
+    ui_pipeline.fillQuadAlpha(layout.chat_x - 1, 0, layout.chat_w + 2, window_height - layout.banner_top_px + 1, mixColor(bg, accent, 0.32), 0.72);
+    ui_pipeline.fillQuad(layout.chat_x, banner_y, layout.chat_w, layout.banner_h, mixColor(bg, fg, 0.065));
+    renderTitlebarTextStrong("BTW · Temporary conversation", layout.chat_x + 18, rowTextY(banner_y, layout.banner_h), mixColor(fg, accent, 0.16));
+    const hint = "Isolated from the original context · Esc stops, then closes";
+    const hint_w = measureTitlebarText(hint);
+    if (hint_w + 420 < layout.chat_w) {
+        renderTitlebarText(hint, layout.chat_x + layout.chat_w - hint_w - 18, rowTextY(banner_y, layout.banner_h), mixColor(bg, fg, 0.56));
+    } else {
+        const compact_hint = "Esc";
+        renderTitlebarText(compact_hint, layout.chat_x + layout.chat_w - measureTitlebarText(compact_hint) - 18, rowTextY(banner_y, layout.banner_h), mixColor(bg, fg, 0.56));
+    }
+    AppWindow.assistant_conversation_renderer.render(
+        session,
+        window_width,
+        window_height,
+        layout.chat_top_px,
+        layout.chat_x,
+        layout.chat_w,
+        false,
+    );
 }
 
 /// Render the command center overlay.
@@ -7809,7 +7902,7 @@ test "overlays: SSH list filter backspace restores matching rows" {
 test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     const saved_palette = commandPaletteState().visible;
     const saved_settings_visible = settingsState().visible;
-    const saved_whats_new = g_whats_new_visible;
+    const saved_whats_new = whatsNewState().visible;
     const saved_integration_prompt = g_integration_prompt_visible;
     const saved_confirms = overlayState().confirms;
     const saved_session = g_session_launcher_visible;
@@ -7821,7 +7914,7 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     defer {
         commandPaletteState().visible = saved_palette;
         settingsState().visible = saved_settings_visible;
-        g_whats_new_visible = saved_whats_new;
+        whatsNewState().visible = saved_whats_new;
         g_integration_prompt_visible = saved_integration_prompt;
         overlayState().confirms = saved_confirms;
         g_session_launcher_visible = saved_session;
@@ -7835,7 +7928,7 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     // Clear every blocking flag → nothing should report blocking.
     commandPaletteState().visible = false;
     settingsState().visible = false;
-    g_whats_new_visible = false;
+    whatsNewState().visible = false;
     g_integration_prompt_visible = false;
     overlayState().confirms = .{};
     g_session_launcher_visible = false;
@@ -7855,9 +7948,9 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     try std.testing.expect(anyBlockingOverlayVisible());
     settingsState().visible = false;
 
-    g_whats_new_visible = true;
+    whatsNewState().visible = true;
     try std.testing.expect(anyBlockingOverlayVisible());
-    g_whats_new_visible = false;
+    whatsNewState().visible = false;
 
     g_integration_prompt_visible = true;
     try std.testing.expect(anyBlockingOverlayVisible());
@@ -8383,16 +8476,16 @@ fn whatsNewNotes() []const u8 {
 }
 
 pub fn showWhatsNew() void {
-    g_whats_new_scroll = 0;
-    g_whats_new_visible = true;
+    whatsNewState().scroll = 0;
+    whatsNewState().visible = true;
 }
 
 pub fn hideWhatsNew() void {
-    g_whats_new_visible = false;
+    whatsNewState().visible = false;
 }
 
 pub fn whatsNewVisible() bool {
-    return g_whats_new_visible;
+    return whatsNewState().visible;
 }
 
 /// True when a full-window GPU overlay is up that the native browser/Jupyter
@@ -8402,7 +8495,8 @@ pub fn whatsNewVisible() bool {
 /// webview while this holds so the command center, settings, confirm dialogs,
 /// etc. stay visible.
 pub fn anyBlockingOverlayVisible() bool {
-    return commandPaletteVisible() or
+    return btwConversationVisible() or
+        commandPaletteVisible() or
         settingsPageVisible() or
         sessionLauncherVisible() or
         whatsNewVisible() or
@@ -8444,22 +8538,22 @@ pub fn anyOverlayActive(now: i64) bool {
 }
 
 pub fn whatsNewHandleKey(ev: input_key.KeyEvent) void {
-    if (!g_whats_new_visible) return;
+    if (!whatsNewState().visible) return;
     switch (ev.key) {
         .escape, .enter => hideWhatsNew(),
-        .page_up => g_whats_new_scroll -= 10,
-        .page_down => g_whats_new_scroll += 10,
-        .arrow_up => g_whats_new_scroll -= 1,
-        .arrow_down => g_whats_new_scroll += 1,
-        .home => g_whats_new_scroll = 0,
-        .end => g_whats_new_scroll = std.math.maxInt(i32),
+        .page_up => whatsNewState().scroll -= 10,
+        .page_down => whatsNewState().scroll += 10,
+        .arrow_up => whatsNewState().scroll -= 1,
+        .arrow_down => whatsNewState().scroll += 1,
+        .home => whatsNewState().scroll = 0,
+        .end => whatsNewState().scroll = std.math.maxInt(i32),
         else => {},
     }
 }
 
 pub fn whatsNewHandleScroll(delta_y: f64) void {
-    if (!g_whats_new_visible) return;
-    g_whats_new_scroll += if (delta_y > 0) @as(i64, -3) else 3;
+    if (!whatsNewState().visible) return;
+    whatsNewState().scroll += if (delta_y > 0) @as(i64, -3) else 3;
 }
 
 fn openWhatsNewRelease() void {
@@ -8472,7 +8566,7 @@ fn openWhatsNewRelease() void {
 /// Returns true if the click was consumed by the modal (always true while open,
 /// so clicks never fall through to the terminal underneath).
 pub fn whatsNewExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_height: f32) bool {
-    if (!g_whats_new_visible) return false;
+    if (!whatsNewState().visible) return false;
     const layout = whatsNewLayout(window_width, window_height);
     const px: f32 = @floatCast(xpos);
     const py: f32 = @floatCast(ypos);
@@ -8644,7 +8738,7 @@ fn renderWhatsNewBody(
 }
 
 pub fn renderWhatsNew(window_width: f32, window_height: f32) void {
-    const fade = autoFade(.whats_new, g_whats_new_visible) orelse return;
+    const fade = autoFade(.whats_new, whatsNewState().visible) orelse return;
     ui_pipeline.g_ui_fade = fade;
     defer ui_pipeline.g_ui_fade = 1.0;
 
@@ -8711,8 +8805,8 @@ pub fn renderWhatsNew(window_width: f32, window_height: f32) void {
         const highlights = whats_new_model.highlightClauses(&highlights_buf, summary);
 
         const total = whatsNewHighlightsRows(highlights, wrap_cols) + whats_new_model.totalRows(body_notes, wrap_cols);
-        const scroll = whats_new_model.clampScroll(g_whats_new_scroll, total, layout.visible_rows);
-        g_whats_new_scroll = @intCast(scroll);
+        const scroll = whats_new_model.clampScroll(whatsNewState().scroll, total, layout.visible_rows);
+        whatsNewState().scroll = @intCast(scroll);
 
         var rows_state: WhatsNewRows = .{ .scroll = scroll };
         if (renderWhatsNewHighlights(layout, window_height, highlights, wrap_cols, line_h, &rows_state, heading, accent, body)) {

--- a/src/renderer/overlays/btw_conversation.zig
+++ b/src/renderer/overlays/btw_conversation.zig
@@ -1,0 +1,57 @@
+//! State and layout for the temporary `/btw` conversation overlay.
+//! Rendering stays in the overlay facade; the conversation itself is a normal
+//! assistant Session so input, streaming, and Markdown behavior stay shared.
+
+const std = @import("std");
+
+pub const Layout = struct {
+    chat_x: f32,
+    chat_w: f32,
+    banner_top_px: f32,
+    banner_h: f32,
+    chat_top_px: f32,
+};
+
+pub const State = struct {
+    session: ?*anyopaque = null,
+    deinit_session: ?*const fn (*anyopaque) void = null,
+
+    pub fn visible(self: *const State) bool {
+        return self.session != null;
+    }
+
+    pub fn set(self: *State, session: *anyopaque, deinit_session: *const fn (*anyopaque) void) void {
+        self.close();
+        self.session = session;
+        self.deinit_session = deinit_session;
+    }
+
+    pub fn close(self: *State) void {
+        if (self.session) |session| if (self.deinit_session) |deinit_session| deinit_session(session);
+        self.session = null;
+        self.deinit_session = null;
+    }
+};
+
+pub fn layout(window_width: f32, top_offset: f32) Layout {
+    const margin = @round(@min(80.0, @max(16.0, window_width * 0.08)));
+    const banner_h: f32 = 44;
+    return .{
+        .chat_x = margin,
+        .chat_w = @max(1.0, window_width - margin * 2),
+        .banner_top_px = top_offset + 16,
+        .banner_h = banner_h,
+        .chat_top_px = top_offset + 16 + banner_h,
+    };
+}
+
+test "btw overlay layout keeps a usable chat width" {
+    const narrow = layout(240, 36);
+    try std.testing.expectEqual(@as(f32, 19), narrow.chat_x);
+    try std.testing.expectEqual(@as(f32, 202), narrow.chat_w);
+
+    const wide = layout(1600, 36);
+    try std.testing.expectEqual(@as(f32, 80), wide.chat_x);
+    try std.testing.expectEqual(@as(f32, 1440), wide.chat_w);
+    try std.testing.expectEqual(narrow.banner_top_px + narrow.banner_h, narrow.chat_top_px);
+}

--- a/src/renderer/overlays/state.zig
+++ b/src/renderer/overlays/state.zig
@@ -9,6 +9,7 @@ const feishu_config = @import("feishu_config.zig");
 const quick_ai_config = @import("quick_ai_config.zig");
 const session_launcher = @import("session_launcher.zig");
 const command_palette_state = @import("command_palette_state.zig");
+const btw_conversation = @import("btw_conversation.zig");
 const command_registry = @import("../../command/registry.zig");
 
 /// User command snippets loaded from `<config-dir>/snippets/*.md`, re-read each
@@ -34,6 +35,11 @@ pub const QuickAiFormState = struct {
     visible: bool = false,
 };
 
+pub const WhatsNewState = struct {
+    visible: bool = false,
+    scroll: i64 = 0,
+};
+
 pub const OverlayState = struct {
     settings: settings_page.State = .{},
     toasts: toasts.State = .{},
@@ -45,9 +51,12 @@ pub const OverlayState = struct {
     quick_ai: QuickAiFormState = .{},
     session: session_launcher.State = .{},
     command_palette: command_palette_state.State = .{},
+    btw: btw_conversation.State = .{},
+    whats_new: WhatsNewState = .{},
     snippets: SnippetState = .{},
 
     pub fn deinit(self: *OverlayState, allocator: std.mem.Allocator) void {
+        self.btw.close();
         self.settings.deinit(allocator);
         command_registry.freeCommandList(allocator, self.snippets.items);
         self.snippets = .{};

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -23,15 +23,13 @@ const Frozen = struct {
 };
 
 const monoliths = [_]Frozen{
-    // Ceilings re-tightened to the current actual after the adoption passes.
-    // input.zig dropped 73->50 via action/query API adoption;
-    // overlays.zig dropped 47->39 by moving command-palette fields into
-    // OverlayState. AppWindow (67) and assistant/conversation/session.zig (20)
-    // are at their actual.
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
-    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 50 },
-    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 39 },
-    .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 20 },
+    // Ceilings re-tightened to the current actual after the `/btw` overlay
+    // adoption: input runtime fields and conversation UI triggers are grouped,
+    // while overlay-owned state now includes What's New and BTW.
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 66 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 49 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 33 },
+    .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 16 },
 };
 
 fn globalCount(source: []const u8) usize {

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,11 +19,11 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Ratchet ceilings for watched files (AppWindow 54, input 81, overlays 10,
+// Ratchet ceilings for watched files (AppWindow 45, input 81, overlays 10,
 // assistant/conversation/session.zig 0). Lower a ceiling only when direct
 // writes are removed.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 54 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 45 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 10 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -194,6 +194,7 @@ test {
     _ = @import("renderer/overlays/profile_codec.zig");
     _ = @import("renderer/overlays/command_palette_input.zig");
     _ = @import("renderer/overlays/command_palette_layout.zig");
+    _ = @import("renderer/overlays/btw_conversation.zig");
     _ = @import("renderer/overlays/startup_shortcuts_layout.zig");
     _ = @import("renderer/overlays/settings_page_layout.zig");
     _ = @import("renderer/overlays/settings_page.zig");


### PR DESCRIPTION
## Summary

- open `/btw [question]` in a modal, transient assistant conversation
- seed the child conversation from a bounded source-session snapshot without mutating source context or history, with tools disabled
- wire keyboard, paste, IME, scrolling, streaming repaint, and overlay lifecycle through the UI-effect boundary
- lower the touched global-state and side-effect source-guard ratchets

## Testing

- `zig build --cache-dir /tmp/phantty-zig-cache --global-cache-dir /tmp/phantty-zig-global -j1`
- `zig build test --cache-dir /tmp/phantty-zig-cache --global-cache-dir /tmp/phantty-zig-global -j1`
- `zig build check-sizes --cache-dir /tmp/phantty-zig-cache --global-cache-dir /tmp/phantty-zig-global -j1`
- Windows UI smoke test: launched the built app and visually confirmed the `/btw` overlay
- `zig build test-full -j1`: new `/btw` assistant/input tests pass; the remaining failures are existing WSL UNC `memory_digest` missing-file cases