### PR TITLE
Move Settings into a dedicated Codex-style tab

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -80,6 +80,7 @@ const ssh_error = @import("ssh/error.zig");
 const i18n = @import("i18n.zig");
 pub const tab = @import("appwindow/tab.zig");
 const active_tab_state = @import("appwindow/active_tab.zig");
+const link_open = @import("link_open.zig");
 const tmux_controller = @import("appwindow/tmux_controller.zig");
 const memory_digest_scheduler = @import("memory_digest/scheduler.zig");
 const memory_center_session = @import("memory_center/session.zig");
@@ -229,7 +230,7 @@ pub fn init(allocator: std.mem.Allocator, app: *App) !AppWindow {
     g_copy_on_select = app.copy_on_select;
     g_copilot_hint = app.copilot_hint;
     g_right_click_action = app.right_click_action;
-    input.g_url_open_mode = app.url_open_mode;
+    link_open.current_mode = app.url_open_mode;
     g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     tab.g_ssh_legacy_algorithms = app.ssh_legacy_algorithms;
     g_weixin_notify_forward = app.weixin_notify_forward;
@@ -2146,6 +2147,20 @@ fn renderPortForwardingFrame(active_tab: *TabState, fb_width: c_int, fb_height: 
     );
 }
 
+fn renderSettingsFrame(fb_width: c_int, fb_height: c_int, titlebar_offset: f32, left_panels_w: f32, right_panels_w: f32) void {
+    gpu.state.setViewport(0, 0, @intCast(fb_width), @intCast(fb_height));
+    ui_pipeline.setProjection(@floatFromInt(fb_width), @floatFromInt(fb_height));
+    clearWithBackground(fb_width, fb_height);
+    titlebar.renderTitlebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    titlebar.renderSidebar(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
+    overlays.renderSettingsPage(
+        @floatFromInt(fb_height),
+        titlebar_offset,
+        left_panels_w,
+        @max(1, @as(f32, @floatFromInt(fb_width)) - left_panels_w - right_panels_w),
+    );
+}
+
 /// Renderer accessor: library entry metadata at index i (read under the session lock).
 fn scEntryItemAt(ctx: *anyopaque, i: usize) skill_center_renderer.ListItem {
     const m: *const skill_center.PanelModel = @ptrCast(@alignCast(ctx));
@@ -3993,8 +4008,7 @@ fn clearUiStateOnTabChange() void {
     syncVisibleFileExplorerForActiveTab(false);
     syncActiveSurfaceCaches();
     requestImmediateLayoutResize();
-    g_force_rebuild = true;
-    g_cells_valid = false;
+    applyUiEffect(.repaint);
 }
 
 /// Convert the active surface's CWD from a WSL guest path to a platform-native path.
@@ -4338,6 +4352,14 @@ pub fn spawnSkillCenterTab() bool {
 pub fn spawnPortForwardingTab() bool {
     const allocator = g_allocator orelse return false;
     if (!tab.spawnPortForwardingTab(allocator)) return false;
+    clearUiStateOnTabChange();
+    markUiDirty();
+    return true;
+}
+
+pub fn openSettingsTab() bool {
+    const allocator = g_allocator orelse return false;
+    if (!tab.openSettingsTab(allocator)) return false;
     clearUiStateOnTabChange();
     markUiDirty();
     return true;
@@ -4931,6 +4953,8 @@ fn renderResizeFrame(width: i32, height: i32) void {
                 renderSkillCenterFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (active_tab.kind == .port_forwarding) {
                 renderPortForwardingFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .settings) {
+                renderSettingsFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (split_layout.soleTerminalSurface()) |surface| {
                 // Single surface: simple render path
                 const rend = &surface.surface_renderer;
@@ -5046,7 +5070,6 @@ fn renderResizeFrame(width: i32, height: i32) void {
     overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderJupyterPicker(@floatFromInt(fb_width), @floatFromInt(fb_height));
     overlays.renderCopilotPicker(@floatFromInt(fb_width), @floatFromInt(fb_height));
-    overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderSessionLauncher(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     overlays.renderMcpServers(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
     weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
@@ -5266,7 +5289,7 @@ fn applyReloadedConfig(allocator: std.mem.Allocator, cfg: *const Config) void {
     g_copy_on_select = cfg.@"copy-on-select";
     g_copilot_hint = cfg.@"copilot-hint";
     g_right_click_action = cfg.@"right-click-action";
-    input.g_url_open_mode = cfg.@"url-open-mode";
+    link_open.current_mode = cfg.@"url-open-mode";
     g_ssh_legacy_algorithms = cfg.@"ssh-legacy-algorithms";
     g_desktop_notifications = cfg.@"desktop-notifications";
     g_confirm_close_running_program = cfg.@"confirm-close-running-program";
@@ -7639,7 +7662,7 @@ fn runMainLoop(self: *AppWindow) !void {
             control_api.syncPanes(allocator);
             control_api.syncUiState(allocator);
             syncImeCaretPosition(win, split_count);
-            if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and active_tab.kind != .memory_center and active_tab.kind != .skill_center and active_tab.kind != .port_forwarding and synchronizedOutputPendingForVisibleSplits(split_count)) {
+            if (active_tab.kind != .ai_chat and active_tab.kind != .ai_history and active_tab.kind != .memory_center and active_tab.kind != .skill_center and active_tab.kind != .port_forwarding and active_tab.kind != .settings and synchronizedOutputPendingForVisibleSplits(split_count)) {
                 // Block instead of spinning at ~1kHz: the IO thread posts a
                 // wakeup when the application ends synchronized output (or new
                 // output arrives), and the timeout bounds the watchdog check.
@@ -7659,6 +7682,8 @@ fn runMainLoop(self: *AppWindow) !void {
                 renderSkillCenterFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (active_tab.kind == .port_forwarding) {
                 renderPortForwardingFrame(active_tab, fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
+            } else if (active_tab.kind == .settings) {
+                renderSettingsFrame(fb_width, fb_height, titlebar_offset, left_panels_w, right_panels_w);
             } else if (post_process.g_post_enabled and activeSurface() != null) {
                 // Post-processing path: only render focused surface for now.
                 // (With no focused terminal — e.g. a preview pane focused — fall
@@ -7881,7 +7906,6 @@ fn runMainLoop(self: *AppWindow) !void {
         overlays.renderCommandPalette(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderJupyterPicker(@floatFromInt(fb_width), @floatFromInt(fb_height));
         overlays.renderCopilotPicker(@floatFromInt(fb_width), @floatFromInt(fb_height));
-        overlays.renderSettingsPage(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderSessionLauncher(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         overlays.renderMcpServers(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);
         weixin_qr_renderer.render(@floatFromInt(fb_width), @floatFromInt(fb_height), titlebar_offset);

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -83,6 +83,7 @@ pub const TabState = struct {
         memory_center,
         skill_center,
         port_forwarding,
+        settings,
     };
 
     /// Get the focused surface in this tab, or null if tree is empty
@@ -123,6 +124,9 @@ pub const TabState = struct {
         }
         if (self.kind == .port_forwarding) {
             return i18n.s().pf_title;
+        }
+        if (self.kind == .settings) {
+            return i18n.s().settings_title;
         }
         const surface = self.focusedSurface() orelse return "wispterm";
         return surface.getTitle();
@@ -170,6 +174,7 @@ pub const TabState = struct {
                     self.port_forwarding_session = null;
                 }
             },
+            .settings => {},
         }
     }
 };
@@ -770,6 +775,55 @@ pub fn spawnPortForwardingTab(allocator: std.mem.Allocator) bool {
     active_tab_state.g_active_tab = g_tab_count;
     g_tab_count += 1;
     return true;
+}
+
+/// Open the singleton Settings page as a normal tab. Repeated invocations
+/// switch to the existing page instead of creating duplicate Settings tabs.
+pub fn openSettingsTab(allocator: std.mem.Allocator) bool {
+    for (0..g_tab_count) |idx| {
+        const existing = g_tabs[idx] orelse continue;
+        if (existing.kind != .settings) continue;
+        switchTab(idx);
+        return true;
+    }
+    if (g_tab_count >= MAX_TABS) return false;
+
+    const t = allocator.create(TabState) catch return false;
+    t.* = .{ .kind = .settings, .tree = .empty };
+
+    g_tabs[g_tab_count] = t;
+    active_tab_state.g_active_tab = g_tab_count;
+    g_tab_count += 1;
+    return true;
+}
+
+test "settings tab is singleton and carries the localized title" {
+    const saved_tabs = g_tabs;
+    const saved_count = g_tab_count;
+    const saved_active = active_tab_state.g_active_tab;
+    defer {
+        g_tabs = saved_tabs;
+        g_tab_count = saved_count;
+        active_tab_state.g_active_tab = saved_active;
+    }
+
+    g_tabs = .{null} ** MAX_TABS;
+    g_tab_count = 0;
+    active_tab_state.g_active_tab = 0;
+
+    try std.testing.expect(openSettingsTab(std.testing.allocator));
+    const first = g_tabs[0].?;
+    defer {
+        first.deinit(std.testing.allocator);
+        std.testing.allocator.destroy(first);
+    }
+    try std.testing.expectEqual(@as(usize, 1), g_tab_count);
+    try std.testing.expectEqual(TabState.Kind.settings, first.kind);
+    try std.testing.expectEqualStrings(i18n.s().settings_title, first.getTitle());
+
+    try std.testing.expect(openSettingsTab(std.testing.allocator));
+    try std.testing.expectEqual(@as(usize, 1), g_tab_count);
+    try std.testing.expect(g_tabs[0].? == first);
 }
 
 /// Active tab's Skill Center session, or null if the active tab isn't one.
@@ -1420,6 +1474,7 @@ pub fn commitTabRename() void {
                     .memory_center => {},
                     .skill_center => {},
                     .port_forwarding => {},
+                    .settings => {},
                 }
             }
         }
@@ -1923,6 +1978,7 @@ fn applyRestoredTabMetadata(t: *TabState, snap: *const session_persist.TabSnap) 
         .memory_center => {},
         .skill_center => {},
         .port_forwarding => {},
+        .settings => {},
     }
 }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -476,10 +476,28 @@ test "input: command center child escape returns to command center" {
 test "input: settings page arrow navigation requests a repaint" {
     try skipUnlessInputRendererShard();
     const previous_keybinds = AppWindow.g_keybinds;
-    defer AppWindow.g_keybinds = previous_keybinds;
-    defer overlays.settingsPageClose();
+    const previous_allocator = AppWindow.g_allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    const previous_should_close = AppWindow.g_should_close;
+    var settings_tab = tab.TabState{ .kind = .settings, .tree = .empty };
+    defer {
+        overlays.settingsPageClose();
+        AppWindow.g_keybinds = previous_keybinds;
+        AppWindow.g_allocator = previous_allocator;
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        AppWindow.g_should_close = previous_should_close;
+    }
 
     AppWindow.g_keybinds = keybind.Set.defaults();
+    AppWindow.g_allocator = std.testing.allocator;
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tabs[0] = &settings_tab;
+    tab.g_tab_count = 1;
+    active_tab_state.g_active_tab = 0;
     overlays.settingsPageOpen();
     try std.testing.expect(overlays.settingsPageVisible());
 
@@ -494,10 +512,28 @@ test "input: settings page arrow navigation requests a repaint" {
 test "input: settings page dispatchKey returns repaint effect" {
     try skipUnlessInputRendererShard();
     const previous_keybinds = AppWindow.g_keybinds;
-    defer AppWindow.g_keybinds = previous_keybinds;
-    defer overlays.settingsPageClose();
+    const previous_allocator = AppWindow.g_allocator;
+    const previous_tabs = tab.g_tabs;
+    const previous_count = tab.g_tab_count;
+    const previous_active = active_tab_state.g_active_tab;
+    const previous_should_close = AppWindow.g_should_close;
+    var settings_tab = tab.TabState{ .kind = .settings, .tree = .empty };
+    defer {
+        overlays.settingsPageClose();
+        AppWindow.g_keybinds = previous_keybinds;
+        AppWindow.g_allocator = previous_allocator;
+        tab.g_tabs = previous_tabs;
+        tab.g_tab_count = previous_count;
+        active_tab_state.g_active_tab = previous_active;
+        AppWindow.g_should_close = previous_should_close;
+    }
 
     AppWindow.g_keybinds = keybind.Set.defaults();
+    AppWindow.g_allocator = std.testing.allocator;
+    tab.g_tabs = .{null} ** tab.MAX_TABS;
+    tab.g_tabs[0] = &settings_tab;
+    tab.g_tab_count = 1;
+    active_tab_state.g_active_tab = 0;
     overlays.settingsPageOpen();
 
     const effect = dispatchKey(arrow_down_event);
@@ -1963,7 +1999,6 @@ pub threadlocal var g_browser_resize_hover: bool = false; // Mouse is over the e
 pub threadlocal var g_browser_resize_dragging: bool = false; // Currently dragging the browser edge
 pub threadlocal var g_ai_copilot_resize_hover: bool = false; // Mouse is over the AI copilot left edge
 pub threadlocal var g_ai_copilot_resize_dragging: bool = false; // Currently dragging the AI copilot edge
-pub threadlocal var g_url_open_mode: link_open.Mode = .embedded;
 
 /// Whether the AI copilot sidebar currently owns keyboard/mouse focus. Set by
 /// AppWindow.toggleAiCopilot; full key/mouse routing lands in a later task.
@@ -2186,7 +2221,7 @@ pub fn toggleBrowserPanel() void {
     const allocator = AppWindow.g_allocator orelse return;
     const parent = AppWindow.currentNativeHandle();
     const surface = AppWindow.activeSurface();
-    if (g_url_open_mode == .system_browser and !browser_panel.isVisibleForActiveTab()) {
+    if (link_open.current_mode == .system_browser and !browser_panel.isVisibleForActiveTab()) {
         const target = browser_panel.externalUrlForSurface(allocator, browser_panel.DEFAULT_URL, surface) orelse return;
         defer allocator.free(target);
         _ = platform_open_url.open(allocator, .{ .url = target });
@@ -4896,11 +4931,11 @@ fn openUrl(surface: *Surface, url: []const u8) bool {
 
     const handle = AppWindow.currentNativeHandle();
     const embedded_available = browser_panel.embeddedBrowserAvailable();
-    const destination = link_open.destinationForUrlClick(embedded_available, g_url_open_mode);
+    const destination = link_open.destinationForUrlClick(embedded_available, link_open.current_mode);
     preview_diagnostics.debug("url", &.{
         .{ .key = "stage", .value = "open" },
         .{ .key = "launch", .value = @tagName(surface.launch_kind) },
-        .{ .key = "mode", .value = @tagName(g_url_open_mode) },
+        .{ .key = "mode", .value = @tagName(link_open.current_mode) },
         .{ .key = "embedded_available", .value = if (embedded_available) "true" else "false" },
         .{ .key = "destination", .value = @tagName(destination) },
         .{ .key = "target", .value = target },
@@ -5456,22 +5491,6 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
         }
         return;
     }
-    if (overlays.settingsPageVisible()) {
-        if (ev.button == .left and ev.action == .press) {
-            const win = AppWindow.g_window orelse return;
-            const fb = window_backend.framebufferSize(win);
-            const w_f: f32 = @floatFromInt(fb.width);
-            const h_f: f32 = @floatFromInt(fb.height);
-            const top_offset: f32 = @floatCast(titlebarHeight());
-            const xpos: f64 = @floatFromInt(ev.x);
-            const ypos: f64 = @floatFromInt(ev.y);
-            if (overlays.settingsPageExecuteAt(xpos, ypos, w_f, h_f, top_offset)) return;
-            if (!overlays.settingsPageContainsPoint(xpos, ypos, w_f, h_f, top_offset)) {
-                overlays.settingsPageClose();
-            }
-        }
-        return;
-    }
     if (overlays.commandPaletteVisible()) {
         if (ev.button == .left and ev.action == .press) {
             const win = AppWindow.g_window orelse return;
@@ -5722,6 +5741,23 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
 
             if (tab.g_sidebar_visible and xpos < @as(f64, @floatCast(titlebar.sidebarWidth()))) {
                 handleSidebarPress(xpos, ypos);
+                return;
+            }
+
+            if (overlays.settingsPageVisible()) {
+                const win = AppWindow.g_window orelse return;
+                const fb = window_backend.framebufferSize(win);
+                const content_x = AppWindow.leftPanelsWidth();
+                const content_width = @max(1, @as(f32, @floatFromInt(fb.width)) - content_x - AppWindow.rightPanelsWidthForWindow(fb.width));
+                _ = overlays.settingsPageExecuteAt(
+                    xpos,
+                    ypos,
+                    @floatFromInt(fb.height),
+                    @floatCast(titlebarHeight()),
+                    content_x,
+                    content_width,
+                );
+                requestInputRepaint();
                 return;
             }
 

--- a/src/link_open.zig
+++ b/src/link_open.zig
@@ -27,6 +27,10 @@ pub const Mode = enum {
     }
 };
 
+/// Live URL-opening preference shared by AppWindow config reload and input
+/// dispatch. Keeping it with the decision model avoids another input.zig global.
+pub threadlocal var current_mode: Mode = .embedded;
+
 pub fn destinationForUrlClick(embedded_browser_available: bool, mode: Mode) Destination {
     if (mode == .system_browser) return .system_browser;
     return if (embedded_browser_available) .embedded_browser else .system_browser;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -929,8 +929,7 @@ fn executeCommand(action: CommandAction) void {
                 if (AppWindow.tab.splitIntoPreview(gpa)) |pane| {
                     _ = AppWindow.tab.focusPreviewPane(pane);
                 }
-                AppWindow.g_force_rebuild = true;
-                AppWindow.g_cells_valid = false;
+                AppWindow.applyUiEffect(.repaint);
             }
         },
         .run_memory_digest_now => {
@@ -6503,14 +6502,15 @@ const SETTINGS_THEME_PRESETS = [_]ThemePreset{
 const SettingsAction = settings_page.Action;
 const SETTINGS_THEME_ROW = settings_page.SETTINGS_THEME_ROW;
 const SETTINGS_CONTROL_ROW_START = settings_page.SETTINGS_CONTROL_ROW_START;
-const SETTINGS_ROW_COUNT = settings_page.SETTINGS_ROW_COUNT;
 const SettingsLayout = settings_page_layout.Layout;
 
 pub fn settingsPageVisible() bool {
-    return settingsState().visible;
+    const active = AppWindow.activeTab() orelse return false;
+    return settingsState().visible and active.kind == .settings;
 }
 
 pub fn settingsPageOpen() void {
+    if (!AppWindow.openSettingsTab()) return;
     var state = commandCenterStateSnapshot();
     state.settingsPageOpen();
     commandCenterStateCommit(state);
@@ -6527,6 +6527,7 @@ fn settingsCfg(allocator: std.mem.Allocator) *Config {
 }
 
 pub fn settingsPageClose() void {
+    if (settingsPageVisible()) AppWindow.closeFocusedSplit();
     settingsState().close(AppWindow.g_allocator);
 }
 
@@ -6536,48 +6537,54 @@ pub fn settingsPageHandleKey(ev: input_key.KeyEvent) AppWindow.UiEffect {
     return .repaint;
 }
 
-pub fn settingsPageContainsPoint(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) bool {
-    const layout = settingsLayout(window_width, window_height, top_offset);
-    const x: f32 = @floatCast(xpos);
-    const y: f32 = @floatCast(ypos);
-    return layout.containsPoint(x, y);
-}
-
-pub fn settingsPageExecuteAt(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) bool {
-    const action = settingsHitTest(xpos, ypos, window_width, window_height, top_offset) orelse return false;
+pub fn settingsPageExecuteAt(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, content_x: f32, content_width: f32) bool {
+    const action = settingsHitTest(xpos, ypos, window_height, top_offset, content_x, content_width) orelse return false;
     executeSettingsAction(action);
     return true;
 }
 
 fn settingsRowCapacity(content_height: f32, base_h: f32, row_h: f32) usize {
-    return settings_page_layout.rowCapacity(content_height, base_h, row_h, SETTINGS_ROW_COUNT);
+    return settings_page_layout.rowCapacity(content_height, base_h, row_h, settings_page.categoryRows(settingsState().category).len);
 }
 
 fn settingsFirstVisibleRow(visible_rows: usize) usize {
-    return settings_page_layout.firstVisibleRow(settingsState().focus, visible_rows, SETTINGS_ROW_COUNT);
+    const state = settingsState();
+    return settings_page_layout.firstVisibleRow(state.focusIndex(), visible_rows, settings_page.categoryRows(state.category).len);
 }
 
-fn settingsLayout(window_width: f32, window_height: f32, top_offset: f32) SettingsLayout {
+fn settingsLayout(window_height: f32, top_offset: f32, content_x: f32, content_width: f32) SettingsLayout {
+    const state = settingsState();
+    const rows = settings_page.categoryRows(state.category);
     return settings_page_layout.compute(.{
-        .window_width = window_width,
         .window_height = window_height,
         .top_offset = top_offset,
+        .content_x = content_x,
+        .content_width = content_width,
         .cell_height = font.g_titlebar_cell_height,
-        .focus = settingsState().focus,
-        .row_count = SETTINGS_ROW_COUNT,
+        .focus_index = state.focusIndex(),
+        .row_count = rows.len,
+        .category_count = settings_page.categoryCount(),
     });
 }
 
-fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, top_offset: f32) ?SettingsAction {
-    const layout = settingsLayout(window_width, window_height, top_offset);
+fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, content_x: f32, content_width: f32) ?SettingsAction {
+    const layout = settingsLayout(window_height, top_offset, content_x, content_width);
     const x: f32 = @floatCast(xpos);
     const y: f32 = @floatCast(ypos);
 
-    if (layout.hitClose(x, y)) {
-        return .close;
+    if (layout.categoryAt(x, y)) |index| {
+        return switch (settings_page.categoryAt(index) orelse return null) {
+            .general => .select_general,
+            .appearance => .select_appearance,
+            .ai => .select_ai,
+            .system => .select_system,
+        };
     }
 
-    const row = layout.rowAt(x, y) orelse return null;
+    const row_index = layout.rowAt(x, y) orelse return null;
+    const rows = settings_page.categoryRows(settingsState().category);
+    if (row_index >= rows.len) return null;
+    const row = rows[row_index];
     settingsState().focus = row;
 
     if (row == 0) {
@@ -6608,15 +6615,21 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_width: f32, window_height: f32, 
         8 => .toggle_distill_suggest,
         9 + settings_page.SHELL_INTEGRATION_ROWS => .open_raw_config,
         10 + settings_page.SHELL_INTEGRATION_ROWS => .restore_defaults,
-        11 + settings_page.SHELL_INTEGRATION_ROWS => .close,
         else => null,
     };
 }
 
 fn executeSettingsAction(action: SettingsAction) void {
-    if (action == .close) {
-        settingsPageClose();
-        return;
+    switch (action) {
+        .select_general => settingsState().selectCategory(.general),
+        .select_appearance => settingsState().selectCategory(.appearance),
+        .select_ai => settingsState().selectCategory(.ai),
+        .select_system => settingsState().selectCategory(.system),
+        else => {},
+    }
+    switch (action) {
+        .select_general, .select_appearance, .select_ai, .select_system => return,
+        else => {},
     }
 
     const allocator = AppWindow.g_allocator orelse return;
@@ -6648,7 +6661,7 @@ fn executeSettingsAction(action: SettingsAction) void {
         .toggle_startup => shell_integration.setEnabled(allocator, .startup, !shell_integration.isEnabled(allocator, .startup)) catch {},
         .open_raw_config => Config.openConfigInEditor(allocator),
         .restore_defaults => restoreDefaultsConfirmOpen(),
-        .close => settingsPageClose(),
+        .select_general, .select_appearance, .select_ai, .select_system => unreachable,
     }
     settingsPageReloadCfg();
 
@@ -6657,7 +6670,8 @@ fn executeSettingsAction(action: SettingsAction) void {
     // cycle_theme already applies via cycleThemePreset; the excluded actions open
     // an editor/confirm dialog or close the page and write nothing to apply.
     switch (action) {
-        .cycle_theme, .cycle_theme_prev, .toggle_start_menu, .toggle_startup, .open_raw_config, .restore_defaults, .close => {},
+        .cycle_theme, .cycle_theme_prev, .toggle_start_menu, .toggle_startup, .open_raw_config, .restore_defaults => {},
+        .select_general, .select_appearance, .select_ai, .select_system => unreachable,
         else => AppWindow.reloadConfigImmediate(allocator),
     }
 }
@@ -6769,92 +6783,133 @@ fn languageSettingText(setting: i18n.LanguageSetting) []const u8 {
     };
 }
 
-fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, title: []const u8, value: []const u8, hint: []const u8, clickable: bool, selected: bool) void {
-    const visible = layout.visibleRow(window_height, row) orelse return;
+fn settingsCategoryLabel(category: settings_page.Category) []const u8 {
+    return switch (i18n.lang()) {
+        .en => switch (category) {
+            .general => "General",
+            .appearance => "Appearance",
+            .ai => "AI & Integrations",
+            .system => "System",
+        },
+        .zh_CN => switch (category) {
+            .general => "常规",
+            .appearance => "外观",
+            .ai => "AI 与集成",
+            .system => "系统",
+        },
+    };
+}
+
+fn settingsRowDescription(row: usize) []const u8 {
+    const zh = i18n.lang() == .zh_CN;
+    if (shell_integration.supported) {
+        if (row == SETTINGS_CONTROL_ROW_START + 9) return if (zh) "在 Windows 开始菜单中显示 WispTerm" else "Show WispTerm in the Windows Start menu";
+        if (row == SETTINGS_CONTROL_ROW_START + 10) return if (zh) "登录系统后自动启动 WispTerm" else "Launch WispTerm when you sign in";
+    }
+    return switch (row) {
+        0 => if (zh) "调整终端内容的显示字号" else "Adjust the terminal text size",
+        SETTINGS_THEME_ROW => if (zh) "选择终端和应用界面的配色主题" else "Choose the terminal and app color theme",
+        SETTINGS_CONTROL_ROW_START + 0 => if (zh) "选择终端光标的形状" else "Choose the terminal cursor shape",
+        SETTINGS_CONTROL_ROW_START + 1 => if (zh) "控制光标是否闪烁" else "Control whether the cursor blinks",
+        SETTINGS_CONTROL_ROW_START + 2 => if (zh) "鼠标移动时自动切换面板焦点" else "Move panel focus with the pointer",
+        SETTINGS_CONTROL_ROW_START + 3 => if (zh) "设置新标签页使用的默认 Shell" else "Set the default shell for new tabs",
+        SETTINGS_CONTROL_ROW_START + 4 => if (zh) "选择新建 AI 会话使用的配置" else "Choose the profile for new AI sessions",
+        SETTINGS_CONTROL_ROW_START + 5 => if (zh) "允许微信消息直接进入当前会话" else "Allow WeChat messages into the active session",
+        SETTINGS_CONTROL_ROW_START + 6 => if (zh) "选择 WispTerm 的界面语言" else "Choose the WispTerm interface language",
+        SETTINGS_CONTROL_ROW_START + 7 => if (zh) "启动时恢复上次打开的标签页" else "Restore previously open tabs at launch",
+        SETTINGS_CONTROL_ROW_START + 8 => if (zh) "在合适时建议将工作流沉淀为技能" else "Suggest reusable skills from completed work",
+        settings_page.SETTINGS_RAW_CONFIG_ROW => if (zh) "在编辑器中打开完整配置文件" else "Open the complete config file in your editor",
+        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => if (zh) "移除自定义设置并恢复默认值" else "Remove custom settings and restore defaults",
+        else => "",
+    };
+}
+
+fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row_index: usize, title: []const u8, value: []const u8, selected: bool) void {
+    const visible = layout.visibleRow(window_height, row_index) orelse return;
     const gl_y = visible.gl_y;
-    const x = layout.box_x + 18;
-    const w = layout.box_w - 36;
+    const x = layout.content_x;
+    const w = layout.content_w;
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
-    const active = std.mem.eql(u8, value, "active");
+    const muted = mixColor(bg, fg, 0.56);
+    const title_x = x + 20;
+    const right_edge = x + w - 18;
+    const title_y = textYFromTop(window_height, visible.top_px + 10);
+    const detail_y = textYFromTop(window_height, visible.top_px + 10 + overlayLineHeight());
+    var title_max_w = w - 40;
 
-    if (clickable) {
-        const row_color = if (selected) mixColor(bg, accent, 0.24) else if (active) mixColor(bg, accent, 0.18) else mixColor(bg, fg, 0.055);
-        ui_pipeline.fillQuadAlpha(x, gl_y + 3, w, layout.row_h - 6, row_color, if (selected) 0.72 else if (active) 0.44 else 0.82);
-        if (selected) ui_pipeline.fillQuadAlpha(x, gl_y + 3, 3, layout.row_h - 6, accent, 0.82);
+    if (selected) {
+        ui_pipeline.fillQuadAlpha(x + 2, gl_y + 2, w - 4, layout.row_h - 4, mixColor(bg, accent, 0.16), 0.64);
+        ui_pipeline.fillQuadAlpha(x + 2, gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
     }
-
-    const text_y = rowTextY(gl_y, layout.row_h);
-    const title_color = if (selected or active) mixColor(fg, accent, 0.18) else fg;
-    const title_x = x + 12;
-    const right_edge = layout.box_x + layout.box_w - 36;
-    var title_max_w = w - 24;
-    var value_x = right_edge;
-
     if (value.len > 0) {
-        const value_w = measureTitlebarText(value);
-        const value_max_w = @min(value_w, @max(0.0, right_edge - title_x - 150));
-        value_x = @round(right_edge - value_max_w);
-        title_max_w = @min(title_max_w, value_x - title_x - 18);
-        const value_color = if (selected or active) accent else mixColor(bg, fg, 0.78);
-        renderTitlebarTextLimited(value, value_x, text_y, value_color, value_max_w);
+        const value_w = @min(210.0, measureTitlebarText(value) + 24);
+        const value_x = @round(right_edge - value_w);
+        const control_h = @round(@max(32.0, font.g_titlebar_cell_height + 10.0));
+        const pill_y = gl_y + @round((layout.row_h - control_h) / 2);
+        renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, 9, mixColor(bg, fg, 0.09), 0.92);
+        renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), if (selected) accent else mixColor(bg, fg, 0.82), value_w - 24);
+        title_max_w = @max(1.0, value_x - title_x - 18);
     }
 
-    if (hint.len > 0) {
-        const preferred_hint_x = title_x + @max(160.0, measureTitlebarText(title) + 28.0);
-        const hint_x = @min(preferred_hint_x, value_x - 60);
-        const hint_max_w = value_x - hint_x - 18;
-        title_max_w = @min(title_max_w, hint_x - title_x - 18);
-        if (hint_max_w > font.g_titlebar_cell_width * 4) {
-            renderTitlebarTextLimited(hint, hint_x, text_y, mixColor(bg, fg, 0.55), hint_max_w);
-        }
+    if (visible.visible_index > 0) {
+        ui_pipeline.fillQuadAlpha(x + 18, gl_y + layout.row_h - 1, w - 36, 1, mixColor(bg, fg, 0.14), 0.62);
     }
 
-    renderTitlebarTextLimited(title, title_x, text_y, title_color, title_max_w);
+    renderTitlebarTextLimited(title, title_x, title_y, if (selected) mixColor(fg, accent, 0.16) else fg, title_max_w);
+    renderTitlebarTextLimited(settingsRowDescription(settings_page.categoryRows(settingsState().category)[row_index]), title_x, detail_y, muted, title_max_w);
 }
 
-pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32) void {
-    const fade = autoFade(.settings_page, settingsPageVisible()) orelse return;
-    ui_pipeline.g_ui_fade = fade;
-    defer ui_pipeline.g_ui_fade = 1.0;
+pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, content_width: f32) void {
+    if (!settingsPageVisible()) return;
     const allocator = AppWindow.g_allocator orelse return;
-    const focus = settingsState().focus;
+    const state = settingsState();
+    const focus = state.focus;
 
     const cfg = settingsCfg(allocator);
 
-    const layout = settingsLayout(window_width, window_height, top_offset);
-    const box_y = @round(window_height - layout.box_top_px - layout.box_h);
+    const layout = settingsLayout(window_height, top_offset, content_x, content_width);
+    const page_y = @round(window_height - layout.page_top_px - layout.page_h);
 
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
-    const panel_color = mixColor(bg, fg, 0.035);
-    const border_color = mixColor(bg, accent, 0.24);
+    const panel_color = mixColor(bg, fg, 0.042);
+    const border_color = mixColor(bg, fg, 0.16);
     const muted_color = mixColor(bg, fg, 0.58);
 
-    ui_pipeline.fillQuadAlpha(0, 0, window_width, window_height, .{ 0.0, 0.0, 0.0 }, 0.16);
-    renderRoundedQuadAlpha(layout.box_x - 1, box_y - 1, layout.box_w + 2, layout.box_h + 2, 11, border_color, 0.24);
-    renderRoundedQuadAlpha(layout.box_x, box_y, layout.box_w, layout.box_h, 10, panel_color, 0.96);
+    ui_pipeline.fillQuadAlpha(layout.page_x, page_y, layout.page_w, layout.page_h, mixColor(bg, fg, 0.012), 1.0);
+    ui_pipeline.fillQuadAlpha(layout.page_x, page_y, layout.nav_w, layout.page_h, mixColor(bg, fg, 0.025), 0.96);
+    ui_pipeline.fillQuadAlpha(layout.page_x + layout.nav_w - 1, page_y, 1, layout.page_h, border_color, 0.72);
 
-    const title_y = textYFromTop(window_height, layout.box_top_px + 18);
-    const subtitle_y = textYFromTop(window_height, layout.box_top_px + 18 + overlayLineHeight());
-    renderTitlebarText(i18n.s().settings_title, layout.box_x + 24, title_y, mixColor(fg, accent, 0.14));
-    renderTitlebarTextLimited(i18n.s().settings_subtitle, layout.box_x + 24, subtitle_y, muted_color, layout.box_w - 96);
-    renderTitlebarText("Esc", layout.box_x + layout.box_w - 52, title_y, mixColor(bg, fg, 0.72));
+    const nav_title_y = textYFromTop(window_height, layout.page_top_px + 24);
+    const nav_label_y = textYFromTop(window_height, layout.page_top_px + 68);
+    renderTitlebarText(i18n.s().settings_title, layout.page_x + 24, nav_title_y, mixColor(fg, accent, 0.10));
+    renderTitlebarText(if (i18n.lang() == .zh_CN) "偏好设置" else "PREFERENCES", layout.page_x + 24, nav_label_y, muted_color);
 
-    var font_buf: [24]u8 = undefined;
-    const font_value = std.fmt.bufPrint(&font_buf, "-  {d}  +", .{cfg.@"font-size"}) catch "";
-    renderSettingsRow(layout, window_height, 0, i18n.s().settings_font_size, font_value, "", true, focus == 0);
+    for (0..settings_page.categoryCount()) |idx| {
+        const category = settings_page.categoryAt(idx) orelse continue;
+        const item_top = layout.nav_item_top_px + layout.nav_item_h * @as(f32, @floatFromInt(idx));
+        const item_y = @round(window_height - item_top - layout.nav_item_h);
+        const selected = category == state.category;
+        if (selected) {
+            renderRoundedQuadAlpha(layout.page_x + 12, item_y + 3, layout.nav_w - 24, layout.nav_item_h - 6, 9, mixColor(bg, accent, 0.15), 0.82);
+            ui_pipeline.fillQuadAlpha(layout.page_x + 14, item_y + 10, 3, layout.nav_item_h - 20, accent, 0.84);
+        }
+        renderTitlebarTextLimited(settingsCategoryLabel(category), layout.page_x + 28, rowTextY(item_y, layout.nav_item_h), if (selected) mixColor(fg, accent, 0.16) else mixColor(bg, fg, 0.76), layout.nav_w - 48);
+    }
 
-    var theme_buf: [96]u8 = undefined;
-    const theme_value = std.fmt.bufPrint(&theme_buf, "< {s} >", .{currentThemePresetLabel(cfg)}) catch currentThemePresetLabel(cfg);
-    renderSettingsRow(layout, window_height, SETTINGS_THEME_ROW, i18n.s().settings_theme, theme_value, "", true, focus == SETTINGS_THEME_ROW);
+    const page_title_y = textYFromTop(window_height, layout.page_top_px + 28);
+    const subtitle_y = textYFromTop(window_height, layout.page_top_px + 28 + overlayLineHeight());
+    renderTitlebarText(settingsCategoryLabel(state.category), layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
+    renderTitlebarTextLimited(i18n.s().settings_subtitle, layout.content_x, subtitle_y, muted_color, layout.content_w);
 
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 0, i18n.s().settings_cursor_style, cursorStyleText(cfg.@"cursor-style"), "", true, focus == SETTINGS_CONTROL_ROW_START + 0);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 1, i18n.s().settings_cursor_blink, boolText(cfg.@"cursor-style-blink"), "", true, focus == SETTINGS_CONTROL_ROW_START + 1);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 2, i18n.s().settings_focus_follows_mouse, boolText(cfg.@"focus-follows-mouse"), "", true, focus == SETTINGS_CONTROL_ROW_START + 2);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 3, i18n.s().settings_shell, cfg.shell, "", true, focus == SETTINGS_CONTROL_ROW_START + 3);
+    const card_h = layout.row_h * @as(f32, @floatFromInt(layout.visible_rows));
+    const card_y = @round(window_height - layout.row_top_px - card_h);
+    renderRoundedQuadAlpha(layout.content_x - 1, card_y - 1, layout.content_w + 2, card_h + 2, 11, border_color, 0.66);
+    renderRoundedQuadAlpha(layout.content_x, card_y, layout.content_w, card_h, 10, panel_color, 0.96);
+
     loadAiProfiles();
     const ai_default_value = if (assistantProfiles().profile_count > 0)
         aiProfileField(&assistantProfiles().profiles[defaultAiProfileIndex()], .name)
@@ -6864,33 +6919,69 @@ pub fn renderSettingsPage(window_width: f32, window_height: f32, top_offset: f32
         aiProfileModeLabel(&assistantProfiles().profiles[defaultAiProfileIndex()])
     else
         i18n.s().settings_hint_add_profiles;
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 4, i18n.s().settings_default_ai, ai_default_value, ai_default_hint, true, focus == SETTINGS_CONTROL_ROW_START + 4);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 5, i18n.s().settings_weixin_direct, boolText(cfg.@"weixin-direct-enabled"), "", true, focus == SETTINGS_CONTROL_ROW_START + 5);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 6, i18n.s().settings_language, languageSettingText(cfg.language), i18n.s().settings_hint_restart, true, focus == SETTINGS_CONTROL_ROW_START + 6);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 7, i18n.s().settings_restore_tabs, boolText(cfg.@"restore-tabs-on-startup"), "", true, focus == SETTINGS_CONTROL_ROW_START + 7);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 8, i18n.s().settings_distill_suggest, boolText(cfg.@"ai-distill-suggest"), "", true, focus == SETTINGS_CONTROL_ROW_START + 8);
-    if (shell_integration.supported) {
-        renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 9, i18n.s().settings_start_menu, boolText(shell_integration.isEnabled(allocator, .start_menu)), "", true, focus == SETTINGS_CONTROL_ROW_START + 9);
-        renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 10, i18n.s().settings_startup, boolText(shell_integration.isEnabled(allocator, .startup)), "", true, focus == SETTINGS_CONTROL_ROW_START + 10);
+    _ = ai_default_hint;
+
+    const rows = settings_page.categoryRows(state.category);
+    for (rows, 0..) |row, row_index| {
+        var font_buf: [24]u8 = undefined;
+        var theme_buf: [96]u8 = undefined;
+        const title: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
+            i18n.s().settings_start_menu
+        else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
+            i18n.s().settings_startup
+        else switch (row) {
+            0 => i18n.s().settings_font_size,
+            SETTINGS_THEME_ROW => i18n.s().settings_theme,
+            SETTINGS_CONTROL_ROW_START + 0 => i18n.s().settings_cursor_style,
+            SETTINGS_CONTROL_ROW_START + 1 => i18n.s().settings_cursor_blink,
+            SETTINGS_CONTROL_ROW_START + 2 => i18n.s().settings_focus_follows_mouse,
+            SETTINGS_CONTROL_ROW_START + 3 => i18n.s().settings_shell,
+            SETTINGS_CONTROL_ROW_START + 4 => i18n.s().settings_default_ai,
+            SETTINGS_CONTROL_ROW_START + 5 => i18n.s().settings_weixin_direct,
+            SETTINGS_CONTROL_ROW_START + 6 => i18n.s().settings_language,
+            SETTINGS_CONTROL_ROW_START + 7 => i18n.s().settings_restore_tabs,
+            SETTINGS_CONTROL_ROW_START + 8 => i18n.s().settings_distill_suggest,
+            settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_raw_config,
+            settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => i18n.s().settings_restore_defaults,
+            else => "",
+        };
+        const value: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
+            boolText(shell_integration.isEnabled(allocator, .start_menu))
+        else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
+            boolText(shell_integration.isEnabled(allocator, .startup))
+        else switch (row) {
+            0 => std.fmt.bufPrint(&font_buf, "-  {d}  +", .{cfg.@"font-size"}) catch "",
+            SETTINGS_THEME_ROW => std.fmt.bufPrint(&theme_buf, "{s}", .{currentThemePresetLabel(cfg)}) catch currentThemePresetLabel(cfg),
+            SETTINGS_CONTROL_ROW_START + 0 => cursorStyleText(cfg.@"cursor-style"),
+            SETTINGS_CONTROL_ROW_START + 1 => boolText(cfg.@"cursor-style-blink"),
+            SETTINGS_CONTROL_ROW_START + 2 => boolText(cfg.@"focus-follows-mouse"),
+            SETTINGS_CONTROL_ROW_START + 3 => cfg.shell,
+            SETTINGS_CONTROL_ROW_START + 4 => ai_default_value,
+            SETTINGS_CONTROL_ROW_START + 5 => boolText(cfg.@"weixin-direct-enabled"),
+            SETTINGS_CONTROL_ROW_START + 6 => languageSettingText(cfg.language),
+            SETTINGS_CONTROL_ROW_START + 7 => boolText(cfg.@"restore-tabs-on-startup"),
+            SETTINGS_CONTROL_ROW_START + 8 => boolText(cfg.@"ai-distill-suggest"),
+            settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_value_open,
+            settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => "Enter",
+            else => "",
+        };
+        renderSettingsRow(layout, window_height, row_index, title, value, focus == row);
     }
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 9 + settings_page.SHELL_INTEGRATION_ROWS, i18n.s().settings_raw_config, i18n.s().settings_value_open, i18n.s().settings_hint_advanced_editor, true, focus == SETTINGS_CONTROL_ROW_START + 9 + settings_page.SHELL_INTEGRATION_ROWS);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 10 + settings_page.SHELL_INTEGRATION_ROWS, i18n.s().settings_restore_defaults, "Enter", "", true, focus == SETTINGS_CONTROL_ROW_START + 10 + settings_page.SHELL_INTEGRATION_ROWS);
-    renderSettingsRow(layout, window_height, SETTINGS_CONTROL_ROW_START + 11 + settings_page.SHELL_INTEGRATION_ROWS, i18n.s().settings_close, "Esc", "", true, focus == SETTINGS_CONTROL_ROW_START + 11 + settings_page.SHELL_INTEGRATION_ROWS);
 
     // Scrollbar indicator when not all rows fit (short windows). The list is
     // scrolled via keyboard/click focus-follow and the mouse wheel.
-    if (layout.visible_rows < SETTINGS_ROW_COUNT) {
-        const total: f32 = @floatFromInt(SETTINGS_ROW_COUNT);
+    if (layout.visible_rows < rows.len) {
+        const total: f32 = @floatFromInt(rows.len);
         const vis: f32 = @floatFromInt(layout.visible_rows);
         const track_h = layout.row_h * vis;
         const track_top_px = layout.row_top_px;
         const sb_w: f32 = 3;
-        const sb_x = layout.box_x + layout.box_w - sb_w - 7;
+        const sb_x = layout.content_x + layout.content_w - sb_w - 7;
         const track_gl_y = @round(window_height - track_top_px - track_h);
         ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
 
         const thumb_h = @max(24.0, @round(track_h * vis / total));
-        const max_scroll_f: f32 = @floatFromInt(SETTINGS_ROW_COUNT - layout.visible_rows);
+        const max_scroll_f: f32 = @floatFromInt(rows.len - layout.visible_rows);
         const scroll_f: f32 = @floatFromInt(layout.scroll);
         const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
         const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
@@ -7184,9 +7275,55 @@ pub fn showTransferToast(
     if (status != .in_progress) transferCancelConfirmClose();
 }
 
+const SettingsPageTestContext = struct {
+    tabs: [AppWindow.tab.MAX_TABS]?*AppWindow.tab.TabState,
+    tab_count: usize,
+    active_tab: usize,
+    allocator: ?std.mem.Allocator,
+    should_close: bool,
+
+    fn restore(self: SettingsPageTestContext) void {
+        settingsState().close(AppWindow.g_allocator);
+        AppWindow.tab.g_tabs = self.tabs;
+        AppWindow.tab.g_tab_count = self.tab_count;
+        if (self.tab_count > 0) AppWindow.tab.switchTab(self.active_tab);
+        AppWindow.g_allocator = self.allocator;
+        AppWindow.g_should_close = self.should_close;
+    }
+};
+
+fn beginSettingsPageTest(settings_tab: *AppWindow.tab.TabState) SettingsPageTestContext {
+    var active_tab: usize = 0;
+    if (AppWindow.activeTab()) |active| {
+        for (0..AppWindow.tab.g_tab_count) |idx| {
+            const candidate = AppWindow.tab.g_tabs[idx] orelse continue;
+            if (candidate != active) continue;
+            active_tab = idx;
+            break;
+        }
+    }
+    const saved = SettingsPageTestContext{
+        .tabs = AppWindow.tab.g_tabs,
+        .tab_count = AppWindow.tab.g_tab_count,
+        .active_tab = active_tab,
+        .allocator = AppWindow.g_allocator,
+        .should_close = AppWindow.g_should_close,
+    };
+    settingsState().close(AppWindow.g_allocator);
+    settings_tab.* = .{ .kind = .settings, .tree = .empty };
+    AppWindow.g_allocator = std.testing.allocator;
+    AppWindow.tab.g_tabs = .{null} ** AppWindow.tab.MAX_TABS;
+    AppWindow.tab.g_tabs[0] = settings_tab;
+    AppWindow.tab.g_tab_count = 1;
+    AppWindow.tab.switchTab(0);
+    return saved;
+}
+
 test "overlays: command center Settings command opens settings page" {
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
     commandPaletteOpen();
-    defer settingsPageClose();
     defer commandPaletteClose();
 
     executeCommand(.open_settings);
@@ -7196,8 +7333,10 @@ test "overlays: command center Settings command opens settings page" {
 }
 
 test "overlays: settings page state is owned by OverlayState" {
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
     settingsPageOpen();
-    defer settingsPageClose();
 
     try std.testing.expect(overlayState().settings.visible);
     try std.testing.expect(settingsPageVisible());
@@ -7254,12 +7393,10 @@ test "overlays: sticky transfer toast does not keep render gate active forever" 
     try std.testing.expect(!anyOverlayActive(after_deadline));
 }
 
-test "overlays: settings page escape closes without allocator" {
-    const previous_allocator = AppWindow.g_allocator;
-    defer settingsPageClose();
-    defer AppWindow.g_allocator = previous_allocator;
-
-    AppWindow.g_allocator = null;
+test "overlays: settings tab escape is consumed without closing the page" {
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
     settingsPageOpen();
 
     const effect = settingsPageHandleKey(.{ .key = .escape });
@@ -7267,7 +7404,7 @@ test "overlays: settings page escape closes without allocator" {
     try std.testing.expect(effect.consumed);
     try std.testing.expect(effect.needs_rebuild);
     try std.testing.expect(effect.cells_invalid);
-    try std.testing.expect(!settingsPageVisible());
+    try std.testing.expect(settingsPageVisible());
 }
 
 test "macOS UI smoke: command center opens settings and settings writes config" {
@@ -7296,13 +7433,12 @@ test "macOS UI smoke: command center opens settings and settings writes config" 
         );
     }
 
-    const previous_allocator = AppWindow.g_allocator;
-    defer AppWindow.g_allocator = previous_allocator;
-    AppWindow.g_allocator = allocator;
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
 
     commandPaletteOpen();
     defer commandPaletteClose();
-    defer settingsPageClose();
 
     for ("settings") |c| commandPaletteInsertChar(c);
     try std.testing.expect(commandPaletteVisible());
@@ -7311,7 +7447,7 @@ test "macOS UI smoke: command center opens settings and settings writes config" 
     try std.testing.expect(!commandPaletteVisible());
     try std.testing.expect(settingsPageVisible());
 
-    _ = settingsPageHandleKey(.{ .key = .arrow_up });
+    executeSettingsAction(.select_appearance);
     _ = settingsPageHandleKey(.{ .key = .arrow_right });
 
     const config_path = try std.fs.path.join(allocator, &.{ config_dir, "config" });
@@ -7347,12 +7483,11 @@ test "macOS UI smoke: settings toggles WeChat direct" {
         );
     }
 
-    const previous_allocator = AppWindow.g_allocator;
-    defer AppWindow.g_allocator = previous_allocator;
-    AppWindow.g_allocator = allocator;
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
 
     settingsPageOpen();
-    defer settingsPageClose();
 
     executeSettingsAction(.toggle_weixin_direct);
 
@@ -7365,33 +7500,36 @@ test "macOS UI smoke: settings toggles WeChat direct" {
 }
 
 test "overlays: settings page caps visible rows and scrolls to keep focus visible on short windows" {
-    const row_h = overlayRowHeight(42);
-    const header_h = @round(18 + overlayLineHeight() * 2 + 12);
-    const footer_h = @round(@max(52.0, overlayTextHeight() + 28.0));
-    const base_h = header_h + footer_h;
+    const row_h = settings_page_layout.settingsRowHeight(font.g_titlebar_cell_height);
+    const base_h: f32 = 128;
+    const rows = settings_page.categoryRows(.appearance);
 
     // A tall window fits every row, so no scrolling is needed.
-    try std.testing.expectEqual(SETTINGS_ROW_COUNT, settingsRowCapacity(2000, base_h, row_h));
+    settingsState().selectCategory(.appearance);
+    try std.testing.expectEqual(rows.len, settingsRowCapacity(2000, base_h, row_h));
 
-    // The reported short window (~522px tall) cannot fit all rows.
-    const short_rows = settingsRowCapacity(522, base_h, row_h);
+    // A compact window cannot fit the full category card.
+    const short_rows = settingsRowCapacity(300, base_h, row_h);
     try std.testing.expect(short_rows >= 1);
-    try std.testing.expect(short_rows < SETTINGS_ROW_COUNT);
+    try std.testing.expect(short_rows < rows.len);
 
+    const saved_category = settingsState().category;
     const saved_focus = settingsState().focus;
-    defer settingsState().focus = saved_focus;
+    defer {
+        settingsState().category = saved_category;
+        settingsState().focus = saved_focus;
+    }
 
     // Focus near the top keeps the list pinned to the top.
-    settingsState().focus = 0;
+    settingsState().focus = rows[0];
     try std.testing.expectEqual(@as(usize, 0), settingsFirstVisibleRow(short_rows));
 
-    // Focusing the last row (the close action that was clipped in the report)
-    // scrolls just far enough to reveal it as the bottom visible row.
-    settingsState().focus = SETTINGS_ROW_COUNT - 1;
+    // Focusing the last row scrolls just far enough to reveal it.
+    settingsState().focus = rows[rows.len - 1];
     const scroll = settingsFirstVisibleRow(short_rows);
-    try std.testing.expectEqual(SETTINGS_ROW_COUNT - short_rows, scroll);
-    try std.testing.expect(settingsState().focus >= scroll);
-    try std.testing.expect(settingsState().focus < scroll + short_rows);
+    try std.testing.expectEqual(rows.len - short_rows, scroll);
+    try std.testing.expect(settingsState().focusIndex() >= scroll);
+    try std.testing.expect(settingsState().focusIndex() < scroll + short_rows);
 }
 
 test "overlays: command center mouse wheel moves selection without wrapping" {
@@ -7514,8 +7652,8 @@ test "overlays: short-window overlay boxes stay within the window" {
     // A window far too short to hold the full box must still keep the panel
     // inside the content area (never paint past the bottom edge).
     {
-        const layout = settingsLayout(800, 120, 0);
-        try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
+        const layout = settingsLayout(120, 0, 0, 800);
+        try std.testing.expect(layout.page_top_px + layout.page_h <= 120);
     }
     {
         sessionLauncherOpen();
@@ -7851,8 +7989,9 @@ test "overlays: anyBlockingOverlayVisible reflects each modal overlay" {
     try std.testing.expect(anyBlockingOverlayVisible());
     commandPaletteState().visible = false;
 
+    // Settings is now a page-type tab, not a modal that blocks native panels.
     settingsState().visible = true;
-    try std.testing.expect(anyBlockingOverlayVisible());
+    try std.testing.expect(!anyBlockingOverlayVisible());
     settingsState().visible = false;
 
     g_whats_new_visible = true;
@@ -8399,11 +8538,10 @@ pub fn whatsNewVisible() bool {
 /// webview would otherwise occlude. The webview is an OS-level control
 /// composited ABOVE the GPU surface, so in full mode it covers the entire
 /// content area — including these modals. Callers (browser_panel.sync) hide the
-/// webview while this holds so the command center, settings, confirm dialogs,
-/// etc. stay visible.
+/// webview while this holds so command palettes and confirm dialogs stay
+/// visible. Settings is a page tab now, not a blocking overlay.
 pub fn anyBlockingOverlayVisible() bool {
     return commandPaletteVisible() or
-        settingsPageVisible() or
         sessionLauncherVisible() or
         whatsNewVisible() or
         integrationPromptVisible() or

--- a/src/renderer/overlays/settings_page.zig
+++ b/src/renderer/overlays/settings_page.zig
@@ -6,7 +6,62 @@ const shell_integration = @import("../../platform/shell_integration.zig");
 pub const SETTINGS_THEME_ROW: usize = 1;
 pub const SETTINGS_CONTROL_ROW_START: usize = 2;
 pub const SHELL_INTEGRATION_ROWS: usize = if (shell_integration.supported) 2 else 0;
-pub const SETTINGS_ROW_COUNT: usize = SETTINGS_CONTROL_ROW_START + 12 + SHELL_INTEGRATION_ROWS;
+pub const SETTINGS_RAW_CONFIG_ROW: usize = SETTINGS_CONTROL_ROW_START + 9 + SHELL_INTEGRATION_ROWS;
+pub const SETTINGS_RESTORE_DEFAULTS_ROW: usize = SETTINGS_CONTROL_ROW_START + 10 + SHELL_INTEGRATION_ROWS;
+
+pub const Category = enum {
+    general,
+    appearance,
+    ai,
+    system,
+};
+
+const GENERAL_ROWS = [_]usize{
+    SETTINGS_CONTROL_ROW_START + 3, // shell
+    SETTINGS_CONTROL_ROW_START + 6, // language
+    SETTINGS_CONTROL_ROW_START + 7, // restore tabs
+    SETTINGS_RAW_CONFIG_ROW,
+    SETTINGS_RESTORE_DEFAULTS_ROW,
+};
+const APPEARANCE_ROWS = [_]usize{
+    0, // font size
+    SETTINGS_THEME_ROW,
+    SETTINGS_CONTROL_ROW_START + 0, // cursor style
+    SETTINGS_CONTROL_ROW_START + 1, // cursor blink
+    SETTINGS_CONTROL_ROW_START + 2, // focus follows mouse
+};
+const AI_ROWS = [_]usize{
+    SETTINGS_CONTROL_ROW_START + 4, // default AI
+    SETTINGS_CONTROL_ROW_START + 5, // WeChat direct
+    SETTINGS_CONTROL_ROW_START + 8, // distill suggestions
+};
+const SYSTEM_ROWS = [_]usize{
+    SETTINGS_CONTROL_ROW_START + 9, // Start menu
+    SETTINGS_CONTROL_ROW_START + 10, // startup
+};
+
+pub fn categoryCount() usize {
+    return if (shell_integration.supported) 4 else 3;
+}
+
+pub fn categoryAt(index: usize) ?Category {
+    return switch (index) {
+        0 => .general,
+        1 => .appearance,
+        2 => .ai,
+        3 => if (shell_integration.supported) .system else null,
+        else => null,
+    };
+}
+
+pub fn categoryRows(category: Category) []const usize {
+    return switch (category) {
+        .general => GENERAL_ROWS[0..],
+        .appearance => APPEARANCE_ROWS[0..],
+        .ai => AI_ROWS[0..],
+        .system => if (shell_integration.supported) SYSTEM_ROWS[0..] else &.{},
+    };
+}
 
 pub const Action = enum {
     font_size_minus,
@@ -27,20 +82,47 @@ pub const Action = enum {
     toggle_startup,
     open_raw_config,
     restore_defaults,
-    close,
+    select_general,
+    select_appearance,
+    select_ai,
+    select_system,
 };
 
 pub const State = struct {
     visible: bool = false,
-    focus: usize = SETTINGS_THEME_ROW,
+    category: Category = .general,
+    focus: usize = GENERAL_ROWS[0],
     cfg_dirty: bool = true,
     cfg_loaded: bool = false,
     cfg_cache: Config = .{},
 
     pub fn open(self: *State) void {
         self.visible = true;
-        self.focus = SETTINGS_THEME_ROW;
+        self.selectCategory(.general);
         self.cfg_dirty = true;
+    }
+
+    pub fn selectCategory(self: *State, category: Category) void {
+        const rows = categoryRows(category);
+        if (rows.len == 0) return;
+        self.category = category;
+        self.focus = rows[0];
+    }
+
+    pub fn focusIndex(self: *const State) usize {
+        const rows = categoryRows(self.category);
+        for (rows, 0..) |row, idx| {
+            if (row == self.focus) return idx;
+        }
+        return 0;
+    }
+
+    fn moveFocus(self: *State, delta: isize) void {
+        const rows = categoryRows(self.category);
+        if (rows.len == 0) return;
+        const current: isize = @intCast(self.focusIndex());
+        const count: isize = @intCast(rows.len);
+        self.focus = rows[@intCast(@mod(current + delta, count))];
     }
 
     pub fn close(self: *State, allocator: ?std.mem.Allocator) void {
@@ -85,13 +167,13 @@ pub const State = struct {
 
     pub fn handleKey(self: *State, ev: input_key.KeyEvent) ?Action {
         switch (ev.key) {
-            .escape => return .close,
+            .escape => return null,
             .arrow_down, .tab => {
-                self.focus = (self.focus + 1) % SETTINGS_ROW_COUNT;
+                self.moveFocus(1);
                 return null;
             },
             .arrow_up => {
-                self.focus = if (self.focus == 0) SETTINGS_ROW_COUNT - 1 else self.focus - 1;
+                self.moveFocus(-1);
                 return null;
             },
             .arrow_left => return self.focusLeftAction(),
@@ -104,17 +186,18 @@ pub const State = struct {
     pub fn handleScroll(self: *State, delta_y: f64) void {
         if (!self.visible) return;
         if (delta_y > 0) {
-            if (self.focus > 0) self.focus -= 1;
+            self.moveFocus(-1);
         } else if (delta_y < 0) {
-            if (self.focus + 1 < SETTINGS_ROW_COUNT) self.focus += 1;
+            self.moveFocus(1);
         }
     }
 
     pub fn firstVisibleRow(self: *const State, visible_rows: usize) usize {
-        if (visible_rows == 0 or SETTINGS_ROW_COUNT <= visible_rows) return 0;
-        const focus = @min(self.focus, SETTINGS_ROW_COUNT - 1);
+        const row_count = categoryRows(self.category).len;
+        if (visible_rows == 0 or row_count <= visible_rows) return 0;
+        const focus = @min(self.focusIndex(), row_count - 1);
         if (focus < visible_rows) return 0;
-        return @min(focus - visible_rows + 1, SETTINGS_ROW_COUNT - visible_rows);
+        return @min(focus - visible_rows + 1, row_count - visible_rows);
     }
 
     pub fn focusPrimaryAction(self: *const State) ?Action {
@@ -136,7 +219,6 @@ pub const State = struct {
             SETTINGS_CONTROL_ROW_START + 8 => .toggle_distill_suggest,
             SETTINGS_CONTROL_ROW_START + 9 + SHELL_INTEGRATION_ROWS => .open_raw_config,
             SETTINGS_CONTROL_ROW_START + 10 + SHELL_INTEGRATION_ROWS => .restore_defaults,
-            SETTINGS_CONTROL_ROW_START + 11 + SHELL_INTEGRATION_ROWS => .close,
             else => null,
         };
     }
@@ -159,28 +241,29 @@ pub const State = struct {
     }
 };
 
-test "settings page state open resets focus and marks config dirty" {
+test "settings page state open resets to General and marks config dirty" {
     var state = State{ .visible = false, .focus = 4, .cfg_dirty = false };
 
     state.open();
 
     try std.testing.expect(state.visible);
-    try std.testing.expectEqual(SETTINGS_THEME_ROW, state.focus);
+    try std.testing.expectEqual(Category.general, state.category);
+    try std.testing.expectEqual(GENERAL_ROWS[0], state.focus);
     try std.testing.expect(state.cfg_dirty);
 }
 
-test "settings page key navigation wraps and returns side-effect actions" {
-    var state = State{ .visible = true, .focus = 0 };
+test "settings page key navigation wraps within the selected category" {
+    var state = State{ .visible = true, .category = .appearance, .focus = APPEARANCE_ROWS[0] };
 
     try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_up }));
-    try std.testing.expectEqual(SETTINGS_ROW_COUNT - 1, state.focus);
+    try std.testing.expectEqual(APPEARANCE_ROWS[APPEARANCE_ROWS.len - 1], state.focus);
 
     try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_down }));
-    try std.testing.expectEqual(@as(usize, 0), state.focus);
+    try std.testing.expectEqual(APPEARANCE_ROWS[0], state.focus);
 
     try std.testing.expectEqual(Action.font_size_plus, state.handleKey(.{ .key = .enter }).?);
     try std.testing.expectEqual(Action.font_size_minus, state.handleKey(.{ .key = .arrow_left }).?);
-    try std.testing.expectEqual(Action.close, state.handleKey(.{ .key = .escape }).?);
+    try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .escape }));
 }
 
 test "settings page exposes shell integration rows only on Windows" {
@@ -193,13 +276,15 @@ test "settings page exposes shell integration rows only on Windows" {
     }
 }
 
-test "settings page first visible row keeps focus in short view" {
-    var state = State{ .visible = true, .focus = SETTINGS_ROW_COUNT - 1 };
+test "settings page category selection scopes visible rows" {
+    var state = State{ .visible = true };
+    state.selectCategory(.ai);
+    state.focus = AI_ROWS[AI_ROWS.len - 1];
 
-    const scroll = state.firstVisibleRow(3);
+    const scroll = state.firstVisibleRow(2);
 
-    try std.testing.expect(scroll <= state.focus);
-    try std.testing.expect(state.focus < scroll + 3);
+    try std.testing.expectEqual(Category.ai, state.category);
+    try std.testing.expectEqual(@as(usize, 1), scroll);
 }
 
 test "settings page deinit frees loaded cache after reload invalidation" {

--- a/src/renderer/overlays/settings_page_layout.zig
+++ b/src/renderer/overlays/settings_page_layout.zig
@@ -1,18 +1,19 @@
-//! Pure layout math for the settings page overlay.
+//! Pure layout math for the full-page Settings tab.
 //!
-//! The settings page state owns focus/config mutation and overlays.zig owns
-//! drawing. This module only computes panel geometry, visible-row scroll, and
-//! hit-test bands from viewport/font inputs.
+//! The page uses the same two-column structure as Codex settings: a compact
+//! category rail on the left and a centered settings card on the right.
 
 const std = @import("std");
 
 pub const Input = struct {
-    window_width: f32,
     window_height: f32,
     top_offset: f32,
+    content_x: f32,
+    content_width: f32,
     cell_height: f32,
-    focus: usize,
+    focus_index: usize,
     row_count: usize,
+    category_count: usize,
 };
 
 pub const Rect = struct {
@@ -27,10 +28,7 @@ pub const Rect = struct {
     }
 };
 
-pub const FontControl = enum {
-    minus,
-    plus,
-};
+pub const FontControl = enum { minus, plus };
 
 pub const VisibleRow = struct {
     visible_index: usize,
@@ -38,55 +36,48 @@ pub const VisibleRow = struct {
     gl_y: f32,
 };
 
-/// Computed geometry for the settings page, in top-down client pixels.
 pub const Layout = struct {
-    box_x: f32,
-    box_top_px: f32,
-    box_w: f32,
-    box_h: f32,
-    header_h: f32,
-    footer_h: f32,
+    page_x: f32,
+    page_top_px: f32,
+    page_w: f32,
+    page_h: f32,
+    nav_w: f32,
+    nav_item_top_px: f32,
+    nav_item_h: f32,
+    category_count: usize,
+    content_x: f32,
+    content_w: f32,
     row_top_px: f32,
     row_h: f32,
-    /// Number of rows that fit in the box for the current window height.
     visible_rows: usize,
-    /// Index of the first rendered row (scroll offset).
     scroll: usize,
     row_count: usize,
 
-    pub fn containsPoint(self: Layout, x: f32, y: f32) bool {
-        return x >= self.box_x and x <= self.box_x + self.box_w and
-            y >= self.box_top_px and y <= self.box_top_px + self.box_h;
-    }
-
-    pub fn closeRect(self: Layout) Rect {
-        return .{
-            .x = self.box_x + self.box_w - 62,
-            .top_px = self.box_top_px + 18,
-            .w = 44,
-            .h = 28,
+    pub fn categoryAt(self: Layout, x: f32, y: f32) ?usize {
+        const rect = Rect{
+            .x = self.page_x + 14,
+            .top_px = self.nav_item_top_px,
+            .w = @max(1, self.nav_w - 28),
+            .h = self.nav_item_h * @as(f32, @floatFromInt(self.category_count)),
         };
-    }
-
-    pub fn hitClose(self: Layout, x: f32, y: f32) bool {
-        return self.closeRect().contains(x, y);
+        if (!rect.contains(x, y)) return null;
+        const idx: usize = @intFromFloat(@floor((y - rect.top_px) / self.nav_item_h));
+        return if (idx < self.category_count) idx else null;
     }
 
     pub fn rowAt(self: Layout, x: f32, y: f32) ?usize {
-        if (x < self.box_x + 18 or x > self.box_x + self.box_w - 18) return null;
+        if (x < self.content_x or x >= self.content_x + self.content_w) return null;
         if (y < self.row_top_px) return null;
         const visible_index: usize = @intFromFloat(@floor((y - self.row_top_px) / self.row_h));
         if (visible_index >= self.visible_rows) return null;
-        const row = visible_index + self.scroll;
-        if (row >= self.row_count) return null;
-        return row;
+        const row_index = visible_index + self.scroll;
+        return if (row_index < self.row_count) row_index else null;
     }
 
-    pub fn visibleRow(self: Layout, window_height: f32, row: usize) ?VisibleRow {
-        if (row < self.scroll) return null;
-        const visible_index = row - self.scroll;
+    pub fn visibleRow(self: Layout, window_height: f32, row_index: usize) ?VisibleRow {
+        if (row_index < self.scroll) return null;
+        const visible_index = row_index - self.scroll;
         if (visible_index >= self.visible_rows) return null;
-
         const row_y = @round(@as(f32, @floatFromInt(visible_index)) * self.row_h);
         const top_px = self.row_top_px + row_y;
         return .{
@@ -97,91 +88,70 @@ pub const Layout = struct {
     }
 
     pub fn fontControlAt(self: Layout, x: f32) ?FontControl {
-        const plus_x = self.box_x + self.box_w - 70;
+        const plus_x = self.content_x + self.content_w - 48;
         const minus_x = plus_x - 42;
         if (x >= minus_x and x < minus_x + 30) return .minus;
         if (x >= plus_x and x < plus_x + 30) return .plus;
         return null;
     }
 
-    pub fn focusVisible(self: Layout, focus: usize) bool {
-        return focus >= self.scroll and focus < self.scroll + self.visible_rows;
+    pub fn focusVisible(self: Layout, focus_index: usize) bool {
+        return focus_index >= self.scroll and focus_index < self.scroll + self.visible_rows;
     }
 };
 
-/// Text height for an overlay line, derived from the font cell height.
-/// Mirrors overlays.overlayTextHeight().
 fn textHeight(cell_height: f32) f32 {
     return @max(1.0, cell_height);
 }
 
-/// Mirrors overlays.overlayLineHeight().
-fn lineHeight(cell_height: f32) f32 {
-    return @round(@max(24.0, textHeight(cell_height) + 8.0));
-}
-
-/// Mirrors overlays.overlayRowHeight().
-fn rowHeight(cell_height: f32, min_h: f32) f32 {
-    return @round(@max(min_h, textHeight(cell_height) + 14.0));
-}
-
-/// Mirrors overlays.clampOverlayBoxHeight().
-fn clampBoxHeight(box_h: f32, content_height: f32) f32 {
-    return @max(1.0, @min(box_h, content_height - 32.0));
-}
-
-pub fn headerHeight(cell_height: f32) f32 {
-    return @round(18.0 + lineHeight(cell_height) * 2.0 + 12.0);
-}
-
-pub fn footerHeight(cell_height: f32) f32 {
-    return @round(@max(52.0, textHeight(cell_height) + 28.0));
-}
-
 pub fn settingsRowHeight(cell_height: f32) f32 {
-    return rowHeight(cell_height, 42.0);
+    // Two full text lines (title + description) plus breathing room. The UI
+    // font follows the configured terminal size, so a fixed 58px row overlaps
+    // badly at larger, perfectly valid font sizes.
+    return @round(@max(82.0, textHeight(cell_height) * 2.0 + 32.0));
 }
 
-/// Number of settings rows that fit within the box for the given window height,
-/// leaving room for the header and footer. Mirrors commandPaletteRowCapacity().
 pub fn rowCapacity(content_height: f32, base_h: f32, row_h: f32, row_count: usize) usize {
     if (row_count == 0) return 0;
-    const usable_h = @max(row_h, content_height - 32.0 - base_h);
-    if (usable_h <= row_h) return 1;
-    const count_f = @floor(usable_h / row_h);
-    const count: usize = @intFromFloat(@max(1.0, count_f));
+    const usable_h = @max(row_h, content_height - base_h);
+    const count: usize = @intFromFloat(@max(1.0, @floor(usable_h / row_h)));
     return @min(count, row_count);
 }
 
-/// First row to render so the focused row stays visible (scroll offset).
-pub fn firstVisibleRow(focus_in: usize, visible_rows: usize, row_count: usize) usize {
+pub fn firstVisibleRow(focus_index: usize, visible_rows: usize, row_count: usize) usize {
     if (visible_rows == 0 or row_count <= visible_rows) return 0;
-    const focus = @min(focus_in, row_count - 1);
+    const focus = @min(focus_index, row_count - 1);
     if (focus < visible_rows) return 0;
     return @min(focus - visible_rows + 1, row_count - visible_rows);
 }
 
 pub fn compute(input: Input) Layout {
-    const content_height = @max(1.0, input.window_height - input.top_offset);
-    const box_w = @round(@min(@max(420.0, input.window_width - 48.0), 760.0));
+    const page_w = @max(1.0, input.content_width);
+    const page_h = @max(1.0, input.window_height - input.top_offset);
+    const min_nav_w: f32 = if (page_w < 640) 148.0 else 190.0;
+    const nav_w = @round(@min(250.0, @max(min_nav_w, page_w * 0.23)));
+    const main_w = @max(1.0, page_w - nav_w);
+    const side_pad: f32 = if (main_w < 560) 20 else 44;
+    const content_w = @max(1.0, @min(900.0, main_w - side_pad * 2));
+    const content_x = @round(input.content_x + nav_w + @max(side_pad, (main_w - content_w) / 2));
     const row_h = settingsRowHeight(input.cell_height);
-    const header_h = headerHeight(input.cell_height);
-    const footer_h = footerHeight(input.cell_height);
-    const visible_rows = rowCapacity(content_height, header_h + footer_h, row_h, input.row_count);
-    const scroll = firstVisibleRow(input.focus, visible_rows, input.row_count);
-    const box_h = @round(clampBoxHeight(header_h + row_h * @as(f32, @floatFromInt(visible_rows)) + footer_h, content_height));
-    const box_x = @round(@max(16.0, (input.window_width - box_w) / 2.0));
-    const box_top_px = @round(input.top_offset + @max(16.0, (content_height - box_h) / 2.0));
-    const row_top_px = @round(box_top_px + header_h);
+    const header_h = @round(@max(104.0, textHeight(input.cell_height) * 2.0 + 56.0));
+    const bottom_pad: f32 = 24;
+    const visible_rows = rowCapacity(page_h, header_h + bottom_pad, row_h, input.row_count);
+    const scroll = firstVisibleRow(input.focus_index, visible_rows, input.row_count);
 
     return .{
-        .box_x = box_x,
-        .box_top_px = box_top_px,
-        .box_w = box_w,
-        .box_h = box_h,
-        .header_h = header_h,
-        .footer_h = footer_h,
-        .row_top_px = row_top_px,
+        .page_x = input.content_x,
+        .page_top_px = input.top_offset,
+        .page_w = page_w,
+        .page_h = page_h,
+        .nav_w = nav_w,
+        .nav_item_top_px = input.top_offset + 98,
+        .nav_item_h = 42,
+        .category_count = input.category_count,
+        .content_x = content_x,
+        .content_w = content_w,
+        .row_top_px = input.top_offset + header_h,
         .row_h = row_h,
         .visible_rows = visible_rows,
         .scroll = scroll,
@@ -189,77 +159,54 @@ pub fn compute(input: Input) Layout {
     };
 }
 
-test "settings page layout fits every row in tall windows" {
-    const cell: f32 = 20;
-    const row_count: usize = 14;
+test "settings tab layout reserves a category rail and centered content" {
     const layout = compute(.{
-        .window_width = 1200,
-        .window_height = 2000,
-        .top_offset = 0,
-        .cell_height = cell,
-        .focus = row_count - 1,
-        .row_count = row_count,
+        .window_height = 900,
+        .top_offset = 40,
+        .content_x = 220,
+        .content_width = 1180,
+        .cell_height = 20,
+        .focus_index = 0,
+        .row_count = 5,
+        .category_count = 4,
     });
 
-    try std.testing.expectEqual(row_count, layout.visible_rows);
-    try std.testing.expectEqual(@as(usize, 0), layout.scroll);
+    try std.testing.expect(layout.nav_w >= 190);
+    try std.testing.expect(layout.content_x >= layout.page_x + layout.nav_w);
+    try std.testing.expect(layout.content_w <= 900);
+    try std.testing.expectEqual(@as(?usize, 1), layout.categoryAt(layout.page_x + 20, layout.nav_item_top_px + layout.nav_item_h + 2));
 }
 
-test "settings page layout scrolls to keep focused row visible" {
-    const cell: f32 = 20;
-    const row_count: usize = 14;
+test "settings tab layout keeps focused rows visible in short windows" {
     const layout = compute(.{
-        .window_width = 900,
-        .window_height = 522,
-        .top_offset = 0,
-        .cell_height = cell,
-        .focus = row_count - 1,
-        .row_count = row_count,
+        .window_height = 330,
+        .top_offset = 40,
+        .content_x = 0,
+        .content_width = 800,
+        .cell_height = 20,
+        .focus_index = 4,
+        .row_count = 5,
+        .category_count = 3,
     });
 
     try std.testing.expect(layout.visible_rows >= 1);
-    try std.testing.expect(layout.visible_rows < row_count);
-    try std.testing.expectEqual(row_count - layout.visible_rows, layout.scroll);
-    try std.testing.expect(layout.focusVisible(row_count - 1));
+    try std.testing.expect(layout.visible_rows < layout.row_count);
+    try std.testing.expect(layout.focusVisible(4));
 }
 
-test "settings page hit testing maps close row and font buttons" {
+test "settings tab hit testing maps content rows and font buttons" {
     const layout = compute(.{
-        .window_width = 900,
         .window_height = 700,
         .top_offset = 40,
+        .content_x = 180,
+        .content_width = 900,
         .cell_height = 20,
-        .focus = 0,
-        .row_count = 14,
+        .focus_index = 0,
+        .row_count = 5,
+        .category_count = 3,
     });
 
-    const close = layout.closeRect();
-    try std.testing.expect(layout.hitClose(close.x + 2, close.top_px + 2));
-
-    const first_row_y = layout.row_top_px + 2;
-    try std.testing.expectEqual(@as(?usize, 0), layout.rowAt(layout.box_x + 24, first_row_y));
-
-    const plus_x = layout.box_x + layout.box_w - 68;
-    const minus_x = plus_x - 42;
-    try std.testing.expectEqual(FontControl.minus, layout.fontControlAt(minus_x).?);
+    try std.testing.expectEqual(@as(?usize, 0), layout.rowAt(layout.content_x + 8, layout.row_top_px + 2));
+    const plus_x = layout.content_x + layout.content_w - 46;
     try std.testing.expectEqual(FontControl.plus, layout.fontControlAt(plus_x).?);
-}
-
-test "settings page short-window box stays inside content area" {
-    const layout = compute(.{
-        .window_width = 800,
-        .window_height = 120,
-        .top_offset = 0,
-        .cell_height = 20,
-        .focus = 0,
-        .row_count = 14,
-    });
-
-    try std.testing.expect(layout.box_top_px + layout.box_h <= 120);
-    try std.testing.expect(layout.row_h > 0);
-}
-
-test "first visible row handles degenerate row counts" {
-    try std.testing.expectEqual(@as(usize, 0), firstVisibleRow(10, 4, 0));
-    try std.testing.expectEqual(@as(usize, 0), rowCapacity(400, 100, 40, 0));
 }

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -24,12 +24,12 @@ const Frozen = struct {
 
 const monoliths = [_]Frozen{
     // Ceilings re-tightened to the current actual after the adoption passes.
-    // input.zig dropped 73->50 via action/query API adoption;
+    // input.zig dropped 73->49 via action/query API adoption;
     // overlays.zig dropped 47->39 by moving command-palette fields into
     // OverlayState. AppWindow (67) and assistant/conversation/session.zig (20)
     // are at their actual.
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 67 },
-    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 50 },
+    .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 49 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 39 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 20 },
 };

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,13 +19,13 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Ratchet ceilings for watched files (AppWindow 54, input 81, overlays 10,
+// Ratchet ceilings for watched files (AppWindow 45, input 81, overlays 8,
 // assistant/conversation/session.zig 0). Lower a ceiling only when direct
 // writes are removed.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 54 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 45 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
-    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 10 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 8 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },
 };
 


### PR DESCRIPTION
## Summary

- add a singleton Settings tab and render settings as a normal full-page tab
- replace the modal layout with a categorized, two-column settings page while preserving existing config actions
- route settings input through the UI-effect boundary and tighten the matching source-guard ratchets

## Testing

- `zig build test`
- `zig build check-sizes`
- `zig build`
- Windows visible UI smoke: `debug/test-d3d11-normal-session.ps1 -Backend opengl` (`pass: true`)
- `zig build test-full` (Settings-related tests pass; the existing WSL-host/Windows-target `memory_digest.store` and `memory_digest.cursors` missing/corrupt-file path tests still fail)
- `git diff --check`
- Windows checkout path-safety checks
