### PR TITLE
feat(notify): agent attention notifications + AI-session tab badges

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -31,6 +31,7 @@ const platform_global_hotkey = @import("platform/global_hotkey.zig");
 const platform_menu = @import("platform/menu.zig");
 const platform_notifications = @import("platform/notifications.zig");
 const notif_mod = @import("notification.zig");
+const agent_detector = @import("terminal_agents/detector.zig");
 const platform_pty_command = @import("platform/pty_command.zig");
 const copilot_hint_gate = @import("assistant/sidebar/hint_gate.zig");
 const platform_window_state = @import("platform/window_state.zig");
@@ -6845,12 +6846,7 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
             continue;
         }
 
-        // Lazy authorization request (macOS): first time we'd want a toast,
-        // ask once. This delivery falls back to badge until the user answers.
-        if (native_toast and !g_notif_auth_requested) {
-            platform_notifications.requestNotificationAuth();
-            g_notif_auth_requested = true;
-        }
+        ensureNotifAuthRequested(native_toast);
 
         const auth: notif_mod.AuthStatus = @enumFromInt(
             @intFromEnum(platform_notifications.notificationAuthStatus()),
@@ -6866,18 +6862,7 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
         switch (route) {
             .none => {},
             .toast => {
-                var title_z: [notif_mod.max_title + 1]u8 = undefined;
-                var body_z: [notif_mod.max_body + 1]u8 = undefined;
-                const t = item.title();
-                const b = item.body();
-                @memcpy(title_z[0..t.len], t);
-                title_z[t.len] = 0;
-                @memcpy(body_z[0..b.len], b);
-                body_z[b.len] = 0;
-                platform_notifications.showDesktopNotification(
-                    title_z[0..t.len :0],
-                    body_z[0..b.len :0],
-                );
+                showToastZ(item.title(), item.body());
                 surface.bell_indicator = true; // also badge the tab
                 surface.bell_indicator_time = now;
                 surface.last_notif_hash = h;
@@ -6904,6 +6889,121 @@ fn handleNotification(surface: *Surface, is_active_surface: bool) void {
             }
         }
     }
+}
+
+/// Lazy authorization request (macOS): first time we'd want a toast, ask once.
+/// Deliveries fall back to badge until the user answers.
+fn ensureNotifAuthRequested(native_toast: bool) void {
+    if (native_toast and !g_notif_auth_requested) {
+        platform_notifications.requestNotificationAuth();
+        g_notif_auth_requested = true;
+    }
+}
+
+/// Z-terminate title/body (truncating to the notification limits) and show a
+/// native toast. Caller has already routed via `notif_mod.decideRoute`.
+fn showToastZ(title: []const u8, body: []const u8) void {
+    var title_z: [notif_mod.max_title + 1]u8 = undefined;
+    var body_z: [notif_mod.max_body + 1]u8 = undefined;
+    const t = title[0..@min(title.len, notif_mod.max_title)];
+    const b = body[0..@min(body.len, notif_mod.max_body)];
+    @memcpy(title_z[0..t.len], t);
+    title_z[t.len] = 0;
+    @memcpy(body_z[0..b.len], b);
+    body_z[b.len] = 0;
+    platform_notifications.showDesktopNotification(
+        title_z[0..t.len :0],
+        body_z[0..b.len :0],
+    );
+}
+
+/// Per-frame OSC 7748 edge poll for one surface: a terminal agent that stops
+/// for approval/input notifies immediately; `done` goes through a quiet window
+/// (goal-loop agents bounce done→running between milestones). Notifications
+/// are pushed into the surface's own notif queue, so they inherit the whole
+/// existing pipeline — rate limit/dedup (vs. the hook's own OSC 777, typically
+/// in the same burst), focus suppression, and the desktop-notifications gate.
+fn pollAgentMarker(surface: *Surface) void {
+    const det = surface.agent_detection;
+    const cur: agent_detector.State = if (det.visible()) det.state else .none;
+    const now = std.time.milliTimestamp();
+    if (cur != surface.agent_notify_prev_state) {
+        switch (notif_mod.agentMarkerAction(surface.agent_notify_prev_state, cur)) {
+            .none => {},
+            .notify_attention => surface.notif_queue.push(
+                notif_mod.makeItem(det.app.displayName(), i18n.s().notif_agent_attention),
+            ),
+            .stage_done => surface.agent_done_staged_ms = now,
+        }
+        if (cur != .done) surface.agent_done_staged_ms = 0;
+        surface.agent_notify_prev_state = cur;
+    }
+    if (surface.agent_done_staged_ms != 0 and cur == .done and
+        now - surface.agent_done_staged_ms >= notif_mod.agent_done_quiet_ms)
+    {
+        const staged = surface.agent_done_staged_ms;
+        surface.agent_done_staged_ms = 0;
+        // The hook's own OSC 777 (richer, custom text) may have announced this
+        // completion already — it arrives in the same burst as the marker,
+        // but our synthetic fires past the rate-limit window. Let it win.
+        if (!notif_mod.doneAlreadyAnnounced(surface.last_notif_time, staged)) {
+            surface.notif_queue.push(
+                notif_mod.makeItem(det.app.displayName(), i18n.s().notif_agent_done),
+            );
+        }
+    }
+}
+
+/// Per-frame attention poll for one in-app AI session (AI-chat tab / copilot
+/// sidebar). Edge-triggered: entering waiting notifies "needs approval"; a
+/// turn ending notifies "finished" unless the user stopped it. `is_viewing`
+/// means the user is looking at this conversation right now (its tab is
+/// active; for copilot the sidebar is also open) — combined with window focus
+/// it suppresses the toast and the sticky done badge, Orca-style.
+fn pollSessionAttention(session: *ai_chat.Session, is_viewing: bool) void {
+    if (session.closing.load(.acquire)) return;
+
+    const viewing_now = window_focused and is_viewing;
+    if (viewing_now) session.attention_done = false;
+
+    const waiting = session.approvalView() != null or session.questionView() != null;
+    const cur: notif_mod.SessionPhase = if (waiting)
+        .waiting
+    else if (session.requestState().inflight)
+        .running
+    else
+        .idle;
+
+    const prev = session.ui_attention_phase;
+    if (cur == prev) return;
+    session.ui_attention_phase = cur;
+
+    const edge = notif_mod.sessionEdge(prev, cur, session.ui_stop_seen);
+    if (cur == .idle) session.ui_stop_seen = false;
+    switch (edge) {
+        .none => {},
+        .finished => {
+            if (!viewing_now) session.attention_done = true;
+            deliverSessionToast(session, i18n.s().notif_agent_done, is_viewing);
+        },
+        // The live waiting state itself badges the tab (tab.agentDetection),
+        // so only the toast needs delivering here.
+        .needs_attention => deliverSessionToast(session, i18n.s().notif_agent_attention, is_viewing),
+    }
+}
+
+fn deliverSessionToast(session: *ai_chat.Session, body: []const u8, is_viewing: bool) void {
+    if (!g_desktop_notifications) return;
+    const native_toast = platform_notifications.supports_desktop_notifications;
+    ensureNotifAuthRequested(native_toast);
+    const auth: notif_mod.AuthStatus = @enumFromInt(
+        @intFromEnum(platform_notifications.notificationAuthStatus()),
+    );
+    const route = notif_mod.decideRoute(true, native_toast, auth, window_focused, is_viewing);
+    if (route != .toast) return; // .badge is covered by attention_done / live state
+    const session_title = session.title();
+    const title = if (session_title.len > 0) session_title else i18n.s().sl_ai_agent;
+    showToastZ(title, body);
 }
 
 /// Internal main loop - called by AppWindow.run() after init() has set up globals.
@@ -7519,13 +7619,15 @@ fn runMainLoop(self: *AppWindow) !void {
         // output no longer triggers frames, so these must not depend on one.
         for (0..tab.g_tab_count) |ti| {
             if (tab.g_tabs[ti]) |tb| {
+                const tab_active = ti == active_tab_state.g_active_tab;
                 var it = tb.tree.surfaces();
                 while (it.next()) |entry| {
                     if (entry.surface.bell_pending.swap(false, .acquire)) {
-                        handleBell(entry.surface, win, ti == active_tab_state.g_active_tab);
+                        handleBell(entry.surface, win, tab_active);
                     }
+                    pollAgentMarker(entry.surface);
                     {
-                        const is_active_surface = (ti == active_tab_state.g_active_tab) and
+                        const is_active_surface = tab_active and
                             (if (tb.focusedSurface()) |fs| fs == entry.surface else false);
                         handleNotification(entry.surface, is_active_surface);
                     }
@@ -7534,6 +7636,10 @@ fn runMainLoop(self: *AppWindow) !void {
                         entry.surface.allocator.free(text);
                     }
                 }
+                // In-app AI sessions: turn-end / needs-approval attention edges.
+                if (tb.ai_chat_session) |s| pollSessionAttention(s, tab_active);
+                if (tb.copilot_session) |s|
+                    pollSessionAttention(s, tab_active and tb.copilot_visible);
             }
         }
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -414,6 +414,14 @@ initial_cwd_path_len: usize = 0,
 // markers; app identity may also be seeded from the foreground command.
 agent_detection: agent_detector.Detection = .{},
 
+/// Last agent state seen by the main loop's notification poll (edge detection;
+/// UI thread only — see AppWindow.pollAgentMarker).
+agent_notify_prev_state: agent_detector.State = .none,
+/// When a `done` edge was staged (ms since epoch); 0 = none. The notification
+/// only fires if the agent is still done `notification.agent_done_quiet_ms`
+/// later — goal-loop agents bounce done→running between milestones.
+agent_done_staged_ms: i64 = 0,
+
 // ============================================================================
 // VT stream
 // ============================================================================

--- a/src/agent_tools/exec.zig
+++ b/src/agent_tools/exec.zig
@@ -258,6 +258,8 @@ fn agentAppDisplayName(app: agent_detector.App) []const u8 {
         .none => "terminal app",
         .codex => "Codex",
         .claude_code => "Claude Code",
+        // In-app sessions never appear on a PTY surface; arm exists for exhaustiveness.
+        .assistant => "Copilot",
     };
 }
 
@@ -266,6 +268,7 @@ fn agentAppReplName(app: agent_detector.App) []const u8 {
         .none => "plain",
         .codex => "codex",
         .claude_code => "claude_code",
+        .assistant => "assistant",
     };
 }
 

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -25,9 +25,21 @@ const platform_pty_command = @import("../platform/pty_command.zig");
 const Pty = @import("../platform/pty.zig").Pty;
 const active_tab_state = @import("active_tab.zig");
 const i18n = @import("../i18n.zig");
+const agent_detector = @import("../terminal_agents/detector.zig");
 
 const CursorStyle = Config.CursorStyle;
 const Selection = Surface.Selection;
+
+/// Map an in-app AI session's live flags onto the terminal-agent badge
+/// vocabulary: pending approval/question beats an inflight turn; the sticky
+/// `attention_done` badge (set by AppWindow on an unseen turn end) shows last.
+fn sessionAgentState(session: *ai_chat.Session) agent_detector.State {
+    if (session.approvalView() != null or session.questionView() != null)
+        return .waiting_approval;
+    if (session.requestState().inflight) return .running;
+    if (session.attention_done) return .done;
+    return .none;
+}
 
 // ============================================================================
 // Constants
@@ -126,6 +138,43 @@ pub const TabState = struct {
         }
         const surface = self.focusedSurface() orelse return "wispterm";
         return surface.getTitle();
+    }
+
+    /// Aggregate agent state across this tab for the titlebar badge/dot:
+    /// terminal panes' OSC 7748 detections plus in-app AI sessions (AI-chat
+    /// tab session / copilot sidebar session). Returns a synthetic Detection
+    /// (visible() true) or a blank one when nothing is active.
+    pub fn agentDetection(self: *TabState) agent_detector.Detection {
+        var states_buf: [64]agent_detector.State = undefined;
+        var len: usize = 0;
+        // Source the badge's app from a pane that actually has a visible agent
+        // (NOT the focused surface — it may be a plain shell while a
+        // split-sibling runs the agent).
+        var app: agent_detector.App = .none;
+        var it = self.tree.surfaces();
+        while (it.next()) |entry| {
+            if (len >= states_buf.len) break;
+            const det = entry.surface.agent_detection;
+            if (det.visible()) {
+                states_buf[len] = det.state;
+                len += 1;
+                if (app == .none) app = det.app;
+            }
+        }
+        const sessions = [_]?*ai_chat.Session{ self.ai_chat_session, self.copilot_session };
+        for (sessions) |maybe| {
+            const session = maybe orelse continue;
+            const st = sessionAgentState(session);
+            if (st != .none and len < states_buf.len) {
+                states_buf[len] = st;
+                len += 1;
+                if (app == .none) app = .assistant;
+            }
+        }
+        if (len == 0) return .{};
+        const agg = agent_detector.aggregate(states_buf[0..len]);
+        if (agg == .none) return .{};
+        return .{ .app = app, .state = agg, .confidence = 100 };
     }
 
     pub fn deinit(self: *TabState, allocator: std.mem.Allocator) void {

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const ai_chat_input_text = @import("input_text.zig");
+const notification = @import("../../notification.zig");
 const input_key = @import("../../input/key.zig");
 const platform_agent_prompt = @import("../../platform/agent_prompt.zig");
 const platform_process = @import("../../platform/process.zig");
@@ -1078,6 +1079,13 @@ pub const Session = struct {
     history_on_change: ?HistoryChangeHook = null,
     request_inflight: bool = false,
     request_stopping: bool = false,
+    // —— UI 线程注意力跟踪（AppWindow.pollSessionAttention 每帧读写）——
+    // ui_attention_phase：上一帧观察到的相位，用于边沿检测。
+    // attention_done：「回合在你没看着时完成了」的粘性徽标，看到该 tab 即清除。
+    // ui_stop_seen：本回合内用户按过 Stop → 结束时静默（对应 Orca 的 interrupted）。
+    ui_attention_phase: notification.SessionPhase = .idle,
+    attention_done: bool = false,
+    ui_stop_seen: bool = false,
     request_thread: ?std.Thread = null,
     title_thread: ?std.Thread = null,
     pending_reply_context: ?OwnedReplyContext = null,
@@ -2056,6 +2064,7 @@ pub const Session = struct {
             return;
         }
         self.request_stopping = true;
+        self.ui_stop_seen = true;
         self.setStatusLocked("Stopping...");
     }
 

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -13,6 +13,9 @@ pub const Strings = struct {
     /// 预留给未来的语言选择 UI；当前仅用于演示 catalog 与测试，生产代码暂未读取。
     language_name: []const u8,
     toast_wechat_not_connected: []const u8,
+    // —— Agent 注意力通知（终端 OSC 7748 边沿 + in-app AI 会话回合边沿）——
+    notif_agent_done: []const u8,
+    notif_agent_attention: []const u8,
     toast_wechat_poller_started: []const u8,
     toast_wechat_poller_stopped: []const u8,
     toast_wechat_direct_disabled: []const u8,
@@ -278,6 +281,8 @@ pub const Strings = struct {
 const en = Strings{
     .language_name = "English",
     .toast_wechat_not_connected = "WeChat not connected",
+    .notif_agent_done = "Finished — your turn",
+    .notif_agent_attention = "Waiting for your approval",
     .toast_wechat_poller_started = "WeChat poller started",
     .toast_wechat_poller_stopped = "WeChat poller stopped",
     .toast_wechat_direct_disabled = "WeChat direct disabled",
@@ -532,6 +537,8 @@ const en = Strings{
 const zh_CN = Strings{
     .language_name = "中文",
     .toast_wechat_not_connected = "微信未连接",
+    .notif_agent_done = "任务完成，轮到你了",
+    .notif_agent_attention = "等待你的批准",
     .toast_wechat_poller_started = "微信轮询已启动",
     .toast_wechat_poller_stopped = "微信轮询已停止",
     .toast_wechat_direct_disabled = "微信直连已禁用",

--- a/src/notification.zig
+++ b/src/notification.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent_detector = @import("terminal_agents/detector.zig");
 
 /// Max bytes retained for a notification title / body. Longer input is truncated.
 pub const max_title: usize = 256;
@@ -137,6 +138,57 @@ pub fn decideRoute(
     return .badge;
 }
 
+// ---------------------------------------------------------------------------
+// Agent attention edges (in-app AI sessions + OSC 7748 terminal agents).
+// Pure classifiers; AppWindow's main loop polls once per frame and feeds edges
+// here, so notifications are edge-triggered — a pending approval never nags
+// twice, and re-entering a state re-notifies.
+// ---------------------------------------------------------------------------
+
+/// Attention phase of an in-app AI session (AI-chat tab / copilot sidebar),
+/// derived each frame from approvalView()/questionView() + request_inflight.
+pub const SessionPhase = enum { idle, running, waiting };
+
+pub const SessionEdge = enum { none, finished, needs_attention };
+
+/// Classify a phase change. `stopped` = the user pressed Stop during this turn
+/// (their own action — finishing silently, like Orca's `interrupted`).
+pub fn sessionEdge(prev: SessionPhase, cur: SessionPhase, stopped: bool) SessionEdge {
+    if (prev == cur) return .none;
+    if (cur == .waiting) return .needs_attention;
+    if (cur == .idle) return if (stopped) .none else .finished;
+    return .none;
+}
+
+/// Quiet window for a terminal agent's `done` marker: notify only if the agent
+/// is still done this long after the edge — goal-loop agents bounce
+/// done→running between milestones (calibrated to match Orca).
+pub const agent_done_quiet_ms: i64 = 1500;
+
+pub const AgentMarkerAction = enum { none, notify_attention, stage_done };
+
+/// A hook's own OSC 777 (richer, custom text) may announce the same completion
+/// the OSC 7748 marker signals — usually in the same burst, but the synthetic
+/// done fires `agent_done_quiet_ms` later, past the rate-limit window. Skip the
+/// synthetic when anything was delivered near/after the done edge.
+pub const done_announce_window_ms: i64 = 1000;
+
+pub fn doneAlreadyAnnounced(last_delivered_ms: i64, staged_ms: i64) bool {
+    if (last_delivered_ms == 0) return false;
+    return last_delivered_ms + done_announce_window_ms >= staged_ms;
+}
+
+/// Classify an OSC 7748 state edge. `stage_done` starts the quiet window; the
+/// caller cancels the stage whenever the state leaves `.done` before it fires.
+pub fn agentMarkerAction(prev: agent_detector.State, cur: agent_detector.State) AgentMarkerAction {
+    if (prev == cur) return .none;
+    return switch (cur) {
+        .waiting_approval, .needs_input => .notify_attention,
+        .done => .stage_done,
+        else => .none,
+    };
+}
+
 test "makeItem copies and truncates title/body" {
     const long_title = "T" ** 300;
     const item = makeItem(long_title, "hello");
@@ -210,4 +262,63 @@ test "makeItem without the marker keeps body intact and forward_wechat false" {
     const item = makeItem("t", "完成，轮到你了");
     try std.testing.expect(!item.forward_wechat);
     try std.testing.expectEqualStrings("完成，轮到你了", item.body());
+}
+
+test "sessionEdge: turn end notifies finished unless the user stopped it" {
+    // running → idle = turn finished
+    try std.testing.expectEqual(SessionEdge.finished, sessionEdge(.running, .idle, false));
+    // waiting → idle (approval answered elsewhere / turn aborted by agent) also finishes
+    try std.testing.expectEqual(SessionEdge.finished, sessionEdge(.waiting, .idle, false));
+    // user pressed Stop → silent
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.running, .idle, true));
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.waiting, .idle, true));
+}
+
+test "sessionEdge: entering waiting needs attention" {
+    try std.testing.expectEqual(SessionEdge.needs_attention, sessionEdge(.running, .waiting, false));
+    // approval popped before we ever observed running (fast first frame)
+    try std.testing.expectEqual(SessionEdge.needs_attention, sessionEdge(.idle, .waiting, false));
+    // a Stop in flight doesn't suppress a *new* attention request
+    try std.testing.expectEqual(SessionEdge.needs_attention, sessionEdge(.running, .waiting, true));
+}
+
+test "sessionEdge: no edge without a phase change; starting a turn is silent" {
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.idle, .idle, false));
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.running, .running, false));
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.waiting, .waiting, false));
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.idle, .running, false));
+    try std.testing.expectEqual(SessionEdge.none, sessionEdge(.waiting, .running, false));
+}
+
+test "agentMarkerAction: attention states notify immediately, done is staged" {
+    try std.testing.expectEqual(AgentMarkerAction.notify_attention, agentMarkerAction(.running, .waiting_approval));
+    try std.testing.expectEqual(AgentMarkerAction.notify_attention, agentMarkerAction(.running, .needs_input));
+    // done goes through the quiet window, not straight to a toast
+    try std.testing.expectEqual(AgentMarkerAction.stage_done, agentMarkerAction(.running, .done));
+    // even done → waiting (agent finished then asked) re-notifies attention
+    try std.testing.expectEqual(AgentMarkerAction.notify_attention, agentMarkerAction(.done, .waiting_approval));
+}
+
+test "agentMarkerAction: silent transitions" {
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.none, .running));
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.done, .running));
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.running, .running));
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.running, .halted));
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.running, .failed));
+    try std.testing.expectEqual(AgentMarkerAction.none, agentMarkerAction(.waiting_approval, .none));
+}
+
+test "agent done quiet window is Orca-calibrated (1.5s)" {
+    try std.testing.expectEqual(@as(i64, 1500), agent_done_quiet_ms);
+}
+
+test "doneAlreadyAnnounced: hook's own OSC 777 near the done edge wins" {
+    // OSC 777 delivered just before the marker (same hook run) → skip synthetic
+    try std.testing.expect(doneAlreadyAnnounced(9500, 10_000));
+    // delivered right after the edge (marker first, notify second) → skip
+    try std.testing.expect(doneAlreadyAnnounced(10_200, 10_000));
+    // an old unrelated notification does not count
+    try std.testing.expect(!doneAlreadyAnnounced(3000, 10_000));
+    // nothing ever delivered (0 sentinel) → fire
+    try std.testing.expect(!doneAlreadyAnnounced(0, 10_000));
 }

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -976,33 +976,18 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         }
 
         // Per-tab aggregate agent-state dot — bottom-center of the tab strip.
-        // Collects all panes' visible agent states, aggregates them, draws a
-        // small filled dot if any pane has a visible agent. The dot sits on the
+        // Aggregates terminal panes' agent states plus in-app AI sessions and
+        // draws a small filled dot if anything is active. The dot sits on the
         // bottom border so it's unobtrusive (2px tall, 6px wide pill shape).
-        {
-            var states_buf: [64]agent_detector.State = undefined;
-            var states_len: usize = 0;
-            if (tab.g_tabs[tab_idx]) |tb| {
-                var it = tb.tree.surfaces();
-                while (it.next()) |entry| {
-                    if (states_len >= states_buf.len) break;
-                    const det = entry.surface.agent_detection;
-                    if (det.visible()) {
-                        states_buf[states_len] = det.state;
-                        states_len += 1;
-                    }
-                }
-            }
-            if (states_len > 0) {
-                const agg = agent_detector.aggregate(states_buf[0..states_len]);
-                if (agg != .none) {
-                    const dot_color = agentBadgeColor(agg);
-                    const dot_w: f32 = 6;
-                    const dot_h: f32 = 2;
-                    const dot_x = cursor_x + (tab_w - dot_w) / 2;
-                    const dot_y = tb_top; // bottom edge of titlebar in GL coords
-                    ui_pipeline.fillQuad(dot_x, dot_y, dot_w, dot_h, dot_color);
-                }
+        if (tab.g_tabs[tab_idx]) |tb| {
+            const det = tb.agentDetection();
+            if (det.visible()) {
+                const dot_color = agentBadgeColor(det.state);
+                const dot_w: f32 = 6;
+                const dot_h: f32 = 2;
+                const dot_x = cursor_x + (tab_w - dot_w) / 2;
+                const dot_y = tb_top; // bottom edge of titlebar in GL coords
+                ui_pipeline.fillQuad(dot_x, dot_y, dot_w, dot_h, dot_color);
             }
         }
 
@@ -1169,40 +1154,11 @@ pub fn renderSidebar(window_width: f32, window_height: f32, titlebar_h: f32) voi
             }
         }
 
-        // Use aggregate of all panes' visible states so the sidebar badge
-        // reflects the most attention-worthy agent across all split panes,
-        // not just the focused one.
+        // Use aggregate of all panes' visible states (plus in-app AI sessions)
+        // so the sidebar badge reflects the most attention-worthy agent across
+        // all split panes, not just the focused one.
         const detection = if (!tab.g_tab_rename_active) blk: {
-            if (tab.g_tabs[tab_idx]) |t| {
-                var states_buf: [64]agent_detector.State = undefined;
-                var states_len: usize = 0;
-                // Source the badge's app from a pane that actually has a visible
-                // agent (NOT the focused surface — it may be a plain shell while a
-                // split-sibling runs the agent). visible() requires app != .none,
-                // so this guarantees the synthetic Detection below is visible.
-                var agg_app: agent_detector.App = .none;
-                var it = t.tree.surfaces();
-                while (it.next()) |entry| {
-                    if (states_len >= states_buf.len) break;
-                    const det = entry.surface.agent_detection;
-                    if (det.visible()) {
-                        states_buf[states_len] = det.state;
-                        states_len += 1;
-                        if (agg_app == .none) agg_app = det.app;
-                    }
-                }
-                if (states_len > 0) {
-                    const agg_state = agent_detector.aggregate(states_buf[0..states_len]);
-                    if (agg_state != .none) {
-                        // Build a synthetic Detection so the existing badge renderer works.
-                        break :blk agent_detector.Detection{
-                            .state = agg_state,
-                            .app = agg_app,
-                            .confidence = 100,
-                        };
-                    }
-                }
-            }
+            if (tab.g_tabs[tab_idx]) |t| break :blk t.agentDetection();
             break :blk agent_detector.Detection{};
         } else agent_detector.Detection{};
         const show_agent_badge = detection.visible();

--- a/src/terminal_agents/detector.zig
+++ b/src/terminal_agents/detector.zig
@@ -4,12 +4,26 @@ pub const App = enum {
     none,
     codex,
     claude_code,
+    /// In-app AI session (AI-chat tab / copilot sidebar), not a PTY agent.
+    /// Lets tab badges reuse Detection for those sessions.
+    assistant,
 
     pub fn label(self: App) []const u8 {
         return switch (self) {
             .none => "none",
             .codex => "codex",
             .claude_code => "claude_code",
+            .assistant => "assistant",
+        };
+    }
+
+    /// Human-facing name for notification titles.
+    pub fn displayName(self: App) []const u8 {
+        return switch (self) {
+            .none => "Agent",
+            .codex => "Codex",
+            .claude_code => "Claude Code",
+            .assistant => "Copilot",
         };
     }
 };
@@ -220,6 +234,7 @@ pub fn appFromLabel(s: []const u8) ?App {
     if (std.mem.eql(u8, s, "none")) return .none;
     if (std.mem.eql(u8, s, "codex")) return .codex;
     if (std.mem.eql(u8, s, "claude_code")) return .claude_code;
+    if (std.mem.eql(u8, s, "assistant")) return .assistant;
     return null;
 }
 
@@ -297,6 +312,15 @@ test "appFromCommand maps known agents" {
     try std.testing.expectEqual(App.claude_code, appFromCommand("claude"));
     try std.testing.expectEqual(App.codex, appFromCommand("/usr/bin/codex"));
     try std.testing.expectEqual(App.none, appFromCommand("bash"));
+}
+
+test "assistant App round-trips its label and has a display name" {
+    try std.testing.expectEqualStrings("assistant", App.assistant.label());
+    try std.testing.expectEqual(App.assistant, appFromLabel("assistant").?);
+    try std.testing.expectEqualStrings("Copilot", App.assistant.displayName());
+    try std.testing.expectEqualStrings("Claude Code", App.claude_code.displayName());
+    try std.testing.expectEqualStrings("Codex", App.codex.displayName());
+    try std.testing.expectEqualStrings("Agent", App.none.displayName());
 }
 
 test "aggregate prefers the most attention-worthy state" {


### PR DESCRIPTION
## What

Borrowing the attention/notification pipeline patterns from [stablyai/orca](https://github.com/stablyai/orca) (edge-triggered notifications, hooks/markers as the single source of truth):

1. **In-app AI sessions (AI-chat tab / copilot sidebar) now notify.** The main loop's existing bell/notif drain section polls each session's phase (`idle`/`running`/`waiting`, derived from `approvalView()`/`questionView()`/`request_inflight`) once per frame. Entering `waiting` raises a "needs your approval" toast; a turn ending raises a "finished — your turn" toast. Both go through the existing `decideRoute` gates (focus suppression, macOS auth, `desktop-notifications` master switch). A turn the user stopped finishes **silently** (Orca's `interrupted` semantics, latched in `stopRequest`), and an unseen completion leaves a sticky `done` badge that clears when the tab is viewed.
2. **AI session state shows on tab badges.** New `TabState.agentDetection()` aggregates terminal panes' OSC 7748 detections *plus* AI session states (`App.assistant`), feeding the existing tab-strip dot and sidebar badge renderers. The two duplicated aggregation blocks in `titlebar.zig` collapse into this helper.
3. **Terminal agents (OSC 7748) auto-notify on done/ask edges** — hooks no longer need to emit their own OSC 777 for this. Synthetic notifications are pushed into the surface's own `notif_queue`, inheriting the whole existing pipeline (rate limit, dedup, focus suppression, WeChat-forward gating). Two Orca-calibrated knobs:
   - `done` waits out a **1.5s quiet window** — goal-loop agents bounce done→running between milestones;
   - if the hook's own richer OSC 777 already announced the completion, the synthetic yields (`doneAlreadyAnnounced`; without this you get a double toast because the quiet-window delay clears the 1s rate limit).

## Why

Research of orca's multi-agent management (per-pane hook-driven state + attention-first UX) showed WispTerm already had the right foundation (OSC 7748 authoritative markers), but ACP/AI-chat sessions had **no completion notification, no tab badge, no cross-tab visibility** — the panel header dot was the only indicator.

## Notes for review

- Pure classifiers (`sessionEdge`, `agentMarkerAction`, `doneAlreadyAnnounced`) live in `notification.zig` with unit tests (TDD; fast suite).
- Edge-triggered by design: a pending approval never nags twice; re-entering a state re-notifies.
- Polling relies on the render gate's existing ≤500ms hidden-cap tick; no new wakeup mechanism.
- `App` enum gained `.assistant`; the two exhaustive switches in `agent_tools/exec.zig` got arms (unreachable on PTY surfaces).
- Verified: `zig build test` and full `zig build test-full -Dtarget=aarch64-macos` green (~15.3k tests; one known-flaky benchmark timing test passed on rerun). No live GUI e2e — manual check: `printf '\e]7748;wispterm-agent;state=done;app=claude_code\e\\'` in a terminal pane, unfocus, expect a toast after 1.5s and a `done` tab badge.
- The branch includes a merge of current `main` (#562/#563 touched the same files; no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)