### PR TITLE
feat(ui): establish resilient presentation patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,20 @@ Windows is the **primary and default development target** (`x86_64-windows-gnu`)
 
 WispTerm is split into a platform-agnostic **core** (terminal state, IO, rendering) and a per-platform **host** (window, event loop, input) that drives the core through a narrow surface API. The host interface is `src/platform/window_backend.zig`; OS facilities go through capability facades in `src/platform/`. The named contract — what the host implements, what services it supplies, and the invariants that keep the seam intact — is documented in [docs/architecture.md](docs/architecture.md). Read it before touching the platform boundary or starting a port.
 
+### UI presentation styles
+
+WispTerm has exactly three application UI styles. Choose one before adding a screen; do not create a fourth ad-hoc overlay shape. The shared geometry contract is `src/renderer/ui_patterns.zig`. It is intentionally pure and is included in the fast test suite.
+
+| Style | Use for | Required structure | Examples |
+|---|---|---|---|
+| **Command palette** | Find-and-run actions with no persistent form state | Search field, filtered and scrollable action list, visible selection, shortcut/meta column, Escape closes. Keep it transient; do not put multi-step configuration here. | Command Center, Copilot History picker |
+| **Form dialog** | Small configuration, profile editing, confirmation, and launch choices | Centered constrained dialog, title plus one-line instruction, aligned rows/fields, explicit primary and cancel/close actions. Must fit inside viewport gutters at every size. | New Session, AI/SSH/MCP forms |
+| **Workbench page** | Persistent tab-owned tools with browsing, status, or multi-column content | Header, content region, and a full-width footer/status band. Empty states explain why the page is empty and name the next action. Keyboard hints and non-blocking status belong in the footer/status band, never squeezed into a content column. | Settings, Memory Center, Skill Center, Port Forwarding, Agent History |
+
+This follows Ghostty's separation of its command palette dialog from its persistent window/tab shell: Ghostty's palette has a search entry and a scrollable rich list with shortcut metadata, while tabs live in a stable window container. WispTerm uses its GPU renderer rather than GTK, but should preserve that same separation of transient command execution, form input, and persistent workspace state.
+
+When changing a UI page, verify: full labels are visible or deliberately ellipsized with a way to reveal them; the localized UI language is consistent (proper names/model IDs may remain literal); state is placed next to its owner; and the page requests a repaint through `UiEffect` after input changes.
+
 ## Cohesion and coupling
 
 These are the **primary** architectural criteria. File length is a symptom, not the rule.

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -2944,6 +2944,7 @@ pub fn memoryCenterHandleMousePress(xpos: f64, ypos: f64) bool {
     switch (hit) {
         .source => |source| session.setSource(source),
         .row => |idx| session.selectIndex(idx),
+        .run_digest => _ = runMemoryDigestFromCenter(),
         .detail => {},
         .none => return false,
     }
@@ -2970,7 +2971,7 @@ pub fn memoryCenterHandleMouseWheel(xpos: i32, ypos: i32, delta: i32) bool {
     const direction: isize = if (delta > 0) -1 else 1;
     switch (hit) {
         .detail => session.scrollDetailBy(direction * 3),
-        .source, .row, .none => session.moveSelection(direction),
+        .source, .row, .run_digest, .none => session.moveSelection(direction),
     }
     markUiDirty();
     return true;

--- a/src/assistant/sidebar/panel.zig
+++ b/src/assistant/sidebar/panel.zig
@@ -10,7 +10,9 @@
 const std = @import("std");
 
 pub const DEFAULT_WIDTH: f32 = 480;
-pub const MIN_WIDTH: f32 = 320;
+// 320px left the model, Agent mode, permission chip, and status dot fighting
+// for one header row. Keep enough width for their labels to remain legible.
+pub const MIN_WIDTH: f32 = 380;
 pub const MAX_WIDTH: f32 = 1200;
 pub const MIN_CONTENT_WIDTH: f32 = 320;
 pub const RESIZE_HIT_WIDTH: f32 = 12;

--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -52,6 +52,19 @@ pub const Strings = struct {
     settings_value_open: []const u8,
     settings_value_none: []const u8,
     settings_lang_auto: []const u8,
+    settings_workbench_footer: []const u8,
+
+    // —— 记忆中心工作台 ——
+    memory_center_title: []const u8,
+    memory_center_source: []const u8,
+    memory_center_detail: []const u8,
+    memory_source_remembered: []const u8,
+    memory_source_digest: []const u8,
+    memory_empty_title: []const u8,
+    memory_empty_action: []const u8,
+    memory_detail_empty: []const u8,
+    memory_detail_select: []const u8,
+    memory_footer: []const u8,
 
     // —— 会话启动器 & AI 智能体对话框 ——
     sl_new_session: []const u8,
@@ -318,6 +331,18 @@ const en = Strings{
     .settings_value_open = "open",
     .settings_value_none = "(none)",
     .settings_lang_auto = "Auto",
+    .settings_workbench_footer = "Changes save automatically   Esc: close settings",
+
+    .memory_center_title = "Memory Center",
+    .memory_center_source = "SOURCE",
+    .memory_center_detail = "Memory Detail",
+    .memory_source_remembered = "AI Remembered",
+    .memory_source_digest = "Memory Digest",
+    .memory_empty_title = "No memories yet",
+    .memory_empty_action = "Run Memory Digest",
+    .memory_detail_empty = "No memory selected.",
+    .memory_detail_select = "Select a memory row to inspect it.",
+    .memory_footer = "Tab / Left / Right: source   Up / Down: select   D: run digest",
 
     .sl_new_session = "New Session",
     .sl_ai_agent = "Copilot",
@@ -574,6 +599,18 @@ const zh_CN = Strings{
     .settings_value_open = "打开",
     .settings_value_none = "（无）",
     .settings_lang_auto = "自动",
+    .settings_workbench_footer = "配置自动保存   Esc：关闭设置",
+
+    .memory_center_title = "记忆中心",
+    .memory_center_source = "来源",
+    .memory_center_detail = "记忆详情",
+    .memory_source_remembered = "AI 记忆",
+    .memory_source_digest = "记忆摘要",
+    .memory_empty_title = "暂无记忆",
+    .memory_empty_action = "运行记忆摘要",
+    .memory_detail_empty = "尚未选中记忆。",
+    .memory_detail_select = "选择一条记忆以查看详情。",
+    .memory_footer = "Tab / 左 / 右：切换来源   上 / 下：选择   D：运行摘要",
 
     .sl_new_session = "新建会话",
     .sl_ai_agent = "副驾",

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -46,7 +46,7 @@ const STOP_BUTTON_H: f32 = 28;
 const STATUS_DOT_D: f32 = 9;
 const STATUS_DOT_HIT: f32 = 28;
 const COMPACT_STATUS_TRAILING_RESERVE: f32 = 36;
-const MODE_SLOT_W: f32 = 76;
+const MODE_SLOT_W: f32 = 84;
 const INPUT_SCROLLBAR_GUTTER: f32 = 10;
 const INPUT_SCROLLBAR_W: f32 = 4;
 const INPUT_SCROLLBAR_PAD: f32 = 7;
@@ -207,9 +207,18 @@ pub fn render(
     ui_pipeline.fillQuadAlpha(frame.header.x, frame.header.y, frame.header.w, frame.header.h, panel, 0.95);
     ui_pipeline.fillQuadAlpha(frame.header_rule.x, frame.header_rule.y, frame.header_rule.w, frame.header_rule.h, line, 0.8);
     const permission = ai_chat.agentPermission();
-    const chip_x = permissionChipX(x, w);
+    // A compact Copilot only renders a status dot, but the generic permission
+    // layout used to reserve a full status-text slot here. That left barely a
+    // handful of pixels for both the model and the Agent label. Anchor the
+    // chip beside the dot in compact mode and give the model the reclaimed
+    // header width.
+    const chip_x = if (compact)
+        x + w - LINE_PAD_X - COMPACT_STATUS_TRAILING_RESERVE - 12 - PERMISSION_CHIP_W
+    else
+        permissionChipX(x, w);
     const mode_text = if (session.agent_enabled) "Agent" else "Chat";
-    const mode_x = @max(x + LINE_PAD_X, chip_x - MODE_SLOT_W - 8);
+    const mode_slot_w = @max(MODE_SLOT_W, titlebarTextWidth(mode_text) + 20);
+    const mode_x = @max(x + LINE_PAD_X, chip_x - mode_slot_w - 8);
 
     // Model label fills the space left of the mode slot; it is hidden when the
     // panel (e.g. the narrow copilot sidebar) is too tight to show it without
@@ -219,7 +228,7 @@ pub fn render(
     if (model_limit > 24) {
         _ = titlebar.renderTextLimited(session.model(), model_x, header_y + 10, mixColor(fg, accent, 0.12), model_limit);
     }
-    _ = titlebar.renderTextLimited(mode_text, mode_x, header_y + 10, mixColor(fg, accent, 0.18), MODE_SLOT_W);
+    _ = titlebar.renderTextLimited(mode_text, mode_x, header_y + 10, mixColor(fg, accent, 0.18), mode_slot_w);
 
     const perm_text = permissionDisplayName(permission);
     const perm_color = switch (permission) {

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const memory_center = @import("../memory_center/session.zig");
 const panel_draw = @import("panel_draw.zig");
+const ui_patterns = @import("ui_patterns.zig");
 
 const HEADER_H: f32 = 54;
 const ROW_H: f32 = 54;
@@ -32,18 +33,20 @@ pub fn computeLayout(x: f32, width: f32) Layout {
         return .{ .left_x = x, .left_w = 0, .list_x = x, .list_w = 0, .detail_x = x, .detail_w = 0 };
     }
 
-    const min_left_w: f32 = 260;
+    // A workbench source column must fit a full source label plus its count.
+    // The old 320px cap clipped "AI Remembered" at the default Retina scale.
+    const min_left_w: f32 = 300;
     const min_list_w: f32 = 300;
     const min_detail_w: f32 = 180;
     const min_total = min_left_w + min_list_w + min_detail_w;
     const left_w = if (available < min_total)
         available * (min_left_w / min_total)
     else
-        @min(@max(available * 0.20, min_left_w), 320);
+        @min(@max(available * 0.22, min_left_w), 400);
     const list_w = if (available < min_total)
         available * (min_list_w / min_total)
     else
-        @min(@max(available * 0.34, min_list_w), 460);
+        @min(@max(available * 0.33, min_list_w), 460);
     return .{
         .left_x = x,
         .left_w = left_w,
@@ -56,7 +59,8 @@ pub fn computeLayout(x: f32, width: f32) Layout {
 
 pub fn listVisibleCapacity(window_height: f32, titlebar_offset: f32, cell_h: f32) usize {
     const top = @round(titlebar_offset);
-    const content_h = @round(@max(1.0, window_height - top));
+    const footer_h = ui_patterns.workbenchFooterHeight(cell_h);
+    const content_h = @round(@max(1.0, window_height - top - footer_h));
     const visible_h = @max(0, content_h - headerHeight(cell_h));
     return @intFromFloat(@max(0, @floor(visible_h / rowHeight(cell_h))));
 }
@@ -126,6 +130,8 @@ pub fn render(
     const selected_bg = mixColor(bg, accent, 0.18);
 
     const layout = computeLayout(content_x, content_w);
+    const footer_h = ui_patterns.workbenchFooterHeight(draw.cell_h);
+    const content_bottom = ui_patterns.workbenchFooterTop(window_height, top, footer_h);
     draw.fillQuad(content_x, 0, content_w, content_h, bg);
     draw.fillQuadAlpha(layout.left_x, 0, layout.left_w, content_h, panel, 0.96);
     draw.fillQuadAlpha(layout.list_x, 0, layout.list_w, content_h, panel_soft, 0.98);
@@ -133,10 +139,11 @@ pub fn render(
     draw.fillQuad(layout.list_x, 0, 1, content_h, line);
     draw.fillQuad(layout.detail_x, 0, 1, content_h, line);
 
-    renderSources(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line, selected_bg);
+    renderSources(draw, session, layout, window_height, top, fg, muted, accent, panel_strong, line, selected_bg);
     renderList(draw, session, layout, window_height, top, fg, muted, accent, selected_bg, line);
-    renderDetail(draw, session, layout, window_height, top, content_h, fg, muted, accent, panel_strong, line);
-    renderDigestNotification(draw, session, layout, window_height, top);
+    renderDetail(draw, session, layout, window_height, content_bottom, top, fg, muted, accent, panel_strong, line);
+    renderDigestNotification(draw, session, layout, window_height, content_bottom, top);
+    renderWorkbenchFooter(draw, content_x, content_w, window_height, content_bottom, footer_h, muted, line);
 }
 
 fn renderSources(
@@ -145,7 +152,6 @@ fn renderSources(
     layout: Layout,
     window_height: f32,
     top: f32,
-    content_h: f32,
     fg: [3]f32,
     muted: [3]f32,
     accent: [3]f32,
@@ -178,13 +184,15 @@ fn renderSources(
         _ = draw.renderTextLimited(source.label(), label_x, text_y, label_color, @max(0, count_x - label_x - SMALL_GAP));
         _ = draw.renderTextLimited(count_text, count_x, text_y, muted, count_w);
     }
-
-    _ = draw.renderTextLimited("Tab / Left / Right switches source", layout.left_x + PAD_X, 12 + draw.cell_h + 6, muted, layout.left_w - PAD_X * 2);
-    _ = draw.renderTextLimited("D runs digest - Up / Down selects", layout.left_x + PAD_X, 12, muted, layout.left_w - PAD_X * 2);
-    _ = content_h;
 }
 
-fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Session, layout: Layout, window_height: f32, top: f32) void {
+fn renderWorkbenchFooter(draw: DrawContext, content_x: f32, content_w: f32, window_height: f32, footer_top: f32, footer_h: f32, muted: [3]f32, line: [3]f32) void {
+    draw.fillQuadAlpha(content_x, yFromTop(window_height, footer_top, footer_h), content_w, footer_h, mixColor(draw.bg, draw.fg, 0.035), 0.98);
+    draw.fillQuad(content_x, yFromTop(window_height, footer_top, 1), content_w, 1, line);
+    _ = draw.renderTextLimited("Tab / Left / Right: source   Up / Down: select   D: run digest", content_x + PAD_X, yTextFromTop(draw, window_height, footer_top + (footer_h - draw.cell_h) / 2), muted, content_w - PAD_X * 2);
+}
+
+fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Session, layout: Layout, window_height: f32, content_bottom: f32, top: f32) void {
     const notification = session.digestNotification() orelse return;
     const accent: [3]f32 = switch (notification.status) {
         .in_progress => .{ 0.56, 0.82, 1.0 },
@@ -197,7 +205,7 @@ fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Ses
     const w = @min(layout.detail_w - pad * 2, 460);
     if (w <= 0) return;
     const x = layout.detail_x + layout.detail_w - w - pad;
-    const y_top = @max(top + 4, window_height - h - pad);
+    const y_top = @max(top + 4, content_bottom - h - pad);
     draw.fillQuadAlpha(x, yFromTop(window_height, y_top, h), w, h, mixColor(draw.bg, accent, 0.16), 0.96);
     draw.fillQuad(x, yFromTop(window_height, y_top, h), 3, h, accent);
     _ = draw.renderTextLimited(notification.message, x + pad, yTextFromTop(draw, window_height, y_top + 6), accent, w - pad * 2);
@@ -231,7 +239,8 @@ fn renderList(
     }
 
     if (count == 0) {
-        _ = draw.renderTextLimited("No memory in this source.", layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), muted, layout.list_w - PAD_X * 2);
+        _ = draw.renderTextLimited("No memories yet", layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), fg, layout.list_w - PAD_X * 2);
+        _ = draw.renderTextLimited("Press D to collect.", layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + draw.cell_h + 38), muted, layout.list_w - PAD_X * 2);
         return;
     }
 
@@ -277,8 +286,8 @@ fn renderDetail(
     session: *memory_center.Session,
     layout: Layout,
     window_height: f32,
+    content_bottom: f32,
     top: f32,
-    content_h: f32,
     fg: [3]f32,
     muted: [3]f32,
     accent: [3]f32,
@@ -291,8 +300,11 @@ fn renderDetail(
     _ = draw.renderTextLimited("Memory Detail", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.detail_w - PAD_X * 2);
 
     const row = session.selectedRow() orelse {
-        _ = draw.renderTextLimited("Select a memory row", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), muted, layout.detail_w - PAD_X * 2);
-        _ = content_h;
+        const empty_detail = if (session.count() == 0)
+            "No memory selected."
+        else
+            "Select a memory row to inspect it.";
+        _ = draw.renderTextLimited(empty_detail, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), muted, layout.detail_w - PAD_X * 2);
         return;
     };
 
@@ -315,12 +327,12 @@ fn renderDetail(
     const line_h = draw.cell_h + 4;
     const wrap_w = @max(1.0, layout.detail_w - PAD_X * 2);
     const total = wrappedLineCount(row.body, wrap_w, draw.glyphAdvance);
-    const visible: usize = @intFromFloat(@max(0, @floor((window_height - y) / line_h)));
+    const visible: usize = @intFromFloat(@max(0, @floor((content_bottom - y) / line_h)));
     session.detail_scroll = clampScroll(session.detail_scroll, total, visible);
-    renderBody(draw, row.body, layout, window_height, y, fg, muted, session.detail_scroll);
+    renderBody(draw, row.body, layout, window_height, content_bottom, y, fg, muted, session.detail_scroll);
 }
 
-fn renderBody(draw: DrawContext, body: []const u8, layout: Layout, window_height: f32, top: f32, fg: [3]f32, muted: [3]f32, scroll_lines: usize) void {
+fn renderBody(draw: DrawContext, body: []const u8, layout: Layout, window_height: f32, content_bottom: f32, top: f32, fg: [3]f32, muted: [3]f32, scroll_lines: usize) void {
     if (body.len == 0) {
         _ = draw.renderTextLimited("(empty)", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top), muted, layout.detail_w - PAD_X * 2);
         return;
@@ -333,7 +345,7 @@ fn renderBody(draw: DrawContext, body: []const u8, layout: Layout, window_height
     var drew_any = false;
     while (it.next()) |line| {
         if (line_index >= scroll_lines) {
-            if (top_px + line_h > window_height) return;
+            if (top_px + line_h > content_bottom) return;
             _ = draw.renderTextLimited(std.mem.trim(u8, line, "\r"), layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top_px), fg, wrap_w);
             top_px += line_h;
             drew_any = true;

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const i18n = @import("../i18n.zig");
 const memory_center = @import("../memory_center/session.zig");
 const panel_draw = @import("panel_draw.zig");
 const ui_patterns = @import("ui_patterns.zig");
@@ -24,7 +25,15 @@ pub const Hit = union(enum) {
     none,
     source: memory_center.Source,
     row: usize,
+    run_digest,
     detail,
+};
+
+const EmptyActionRect = struct {
+    x: f32,
+    top: f32,
+    w: f32,
+    h: f32,
 };
 
 pub fn computeLayout(x: f32, width: f32) Layout {
@@ -84,6 +93,13 @@ pub fn hitTest(
     for (sources, 0..) |source, i| {
         const row_top = src_top + @as(f32, @floatFromInt(i)) * SOURCE_ROW_H;
         if (rectContains(mx, my, layout.left_x, row_top, layout.left_w, SOURCE_ROW_H)) return .{ .source = source };
+    }
+
+    // While a digest run reports progress the list renders a status line, not
+    // the empty-state action. Keep hit testing aligned with that visible UI.
+    if (session.count() == 0 and session.status().len == 0) {
+        const action = emptyActionRect(layout, top, cell_h);
+        if (rectContains(mx, my, action.x, action.top, action.w, action.h)) return .run_digest;
     }
 
     const row_h = rowHeight(cell_h);
@@ -162,10 +178,10 @@ fn renderSources(
     const header_h = headerHeight(draw.cell_h);
     draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, top, header_h), layout.left_w, header_h, panel_strong, 0.9);
     draw.fillQuad(layout.left_x, yFromTop(window_height, top + header_h, 1), layout.left_w, 1, line);
-    _ = draw.renderTextLimited("Memory Center", layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited(i18n.s().memory_center_title, layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
 
     const src_top = sourceRowsTop(top, draw.cell_h);
-    _ = draw.renderTextLimited("SOURCE", layout.left_x + PAD_X, yTextFromTop(draw, window_height, src_top - draw.cell_h - 8), muted, layout.left_w - PAD_X * 2);
+    _ = draw.renderTextLimited(i18n.s().memory_center_source, layout.left_x + PAD_X, yTextFromTop(draw, window_height, src_top - draw.cell_h - 8), muted, layout.left_w - PAD_X * 2);
     const sources = [_]memory_center.Source{ .remembered, .digest };
     for (sources, 0..) |source, i| {
         const row_top = src_top + @as(f32, @floatFromInt(i)) * SOURCE_ROW_H;
@@ -181,7 +197,7 @@ fn renderSources(
         const label_x = layout.left_x + PAD_X + 6;
         const text_y = yTextFromTop(draw, window_height, row_top + 9);
         const label_color = if (active) fg else muted;
-        _ = draw.renderTextLimited(source.label(), label_x, text_y, label_color, @max(0, count_x - label_x - SMALL_GAP));
+        _ = draw.renderTextLimited(sourceLabel(source), label_x, text_y, label_color, @max(0, count_x - label_x - SMALL_GAP));
         _ = draw.renderTextLimited(count_text, count_x, text_y, muted, count_w);
     }
 }
@@ -189,7 +205,7 @@ fn renderSources(
 fn renderWorkbenchFooter(draw: DrawContext, content_x: f32, content_w: f32, window_height: f32, footer_top: f32, footer_h: f32, muted: [3]f32, line: [3]f32) void {
     draw.fillQuadAlpha(content_x, yFromTop(window_height, footer_top, footer_h), content_w, footer_h, mixColor(draw.bg, draw.fg, 0.035), 0.98);
     draw.fillQuad(content_x, yFromTop(window_height, footer_top, 1), content_w, 1, line);
-    _ = draw.renderTextLimited("Tab / Left / Right: source   Up / Down: select   D: run digest", content_x + PAD_X, yTextFromTop(draw, window_height, footer_top + (footer_h - draw.cell_h) / 2), muted, content_w - PAD_X * 2);
+    _ = draw.renderTextLimited(i18n.s().memory_footer, content_x + PAD_X, yTextFromTop(draw, window_height, footer_top + (footer_h - draw.cell_h) / 2), muted, content_w - PAD_X * 2);
 }
 
 fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Session, layout: Layout, window_height: f32, content_bottom: f32, top: f32) void {
@@ -229,7 +245,7 @@ fn renderList(
 
     const count = session.count();
     var header_buf: [96]u8 = undefined;
-    const header = std.fmt.bufPrint(&header_buf, "{s} ({d})", .{ session.source.label(), count }) catch session.source.label();
+    const header = std.fmt.bufPrint(&header_buf, "{s} ({d})", .{ sourceLabel(session.source), count }) catch sourceLabel(session.source);
     _ = draw.renderTextLimited(header, layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.list_w - PAD_X * 2);
 
     const status = session.status();
@@ -239,8 +255,8 @@ fn renderList(
     }
 
     if (count == 0) {
-        _ = draw.renderTextLimited("No memories yet", layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), fg, layout.list_w - PAD_X * 2);
-        _ = draw.renderTextLimited("Press D to collect.", layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + draw.cell_h + 38), muted, layout.list_w - PAD_X * 2);
+        _ = draw.renderTextLimited(i18n.s().memory_empty_title, layout.list_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), fg, layout.list_w - PAD_X * 2);
+        renderEmptyAction(draw, layout, window_height, top, accent);
         return;
     }
 
@@ -281,6 +297,30 @@ fn renderList(
     }
 }
 
+fn emptyActionRect(layout: Layout, top: f32, cell_h: f32) EmptyActionRect {
+    const header_h = headerHeight(cell_h);
+    return .{
+        .x = layout.list_x + PAD_X,
+        .top = top + header_h + cell_h + 56,
+        .w = @max(1.0, @min(240.0, layout.list_w - PAD_X * 2)),
+        .h = @max(34.0, cell_h + 12),
+    };
+}
+
+fn renderEmptyAction(draw: DrawContext, layout: Layout, window_height: f32, top: f32, accent: [3]f32) void {
+    const rect = emptyActionRect(layout, top, draw.cell_h);
+    const y = yFromTop(window_height, rect.top, rect.h);
+    draw.fillQuadAlpha(rect.x, y, rect.w, rect.h, mixColor(draw.bg, accent, 0.22), 0.98);
+    _ = draw.renderTextLimited(i18n.s().memory_empty_action, rect.x + 12, y + (rect.h - draw.cell_h) / 2, accent, rect.w - 24);
+}
+
+fn sourceLabel(source: memory_center.Source) []const u8 {
+    return switch (source) {
+        .remembered => i18n.s().memory_source_remembered,
+        .digest => i18n.s().memory_source_digest,
+    };
+}
+
 fn renderDetail(
     draw: DrawContext,
     session: *memory_center.Session,
@@ -297,13 +337,13 @@ fn renderDetail(
     const header_h = headerHeight(draw.cell_h);
     draw.fillQuadAlpha(layout.detail_x, yFromTop(window_height, top, header_h), layout.detail_w, header_h, panel_strong, 0.82);
     draw.fillQuad(layout.detail_x, yFromTop(window_height, top + header_h, 1), layout.detail_w, 1, line);
-    _ = draw.renderTextLimited("Memory Detail", layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.detail_w - PAD_X * 2);
+    _ = draw.renderTextLimited(i18n.s().memory_center_detail, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.detail_w - PAD_X * 2);
 
     const row = session.selectedRow() orelse {
         const empty_detail = if (session.count() == 0)
-            "No memory selected."
+            i18n.s().memory_detail_empty
         else
-            "Select a memory row to inspect it.";
+            i18n.s().memory_detail_select;
         _ = draw.renderTextLimited(empty_detail, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, top + header_h + 24), muted, layout.detail_w - PAD_X * 2);
         return;
     };
@@ -312,7 +352,7 @@ fn renderDetail(
     _ = draw.renderTextLimited(row.title, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), fg, layout.detail_w - PAD_X * 2);
     y += draw.cell_h + 8;
     var meta_buf: [192]u8 = undefined;
-    const meta = std.fmt.bufPrint(&meta_buf, "{s} / {s}", .{ row.source.label(), row.scope }) catch row.scope;
+    const meta = std.fmt.bufPrint(&meta_buf, "{s} / {s}", .{ sourceLabel(row.source), row.scope }) catch row.scope;
     _ = draw.renderTextLimited(meta, layout.detail_x + PAD_X, yTextFromTop(draw, window_height, y), accent, layout.detail_w - PAD_X * 2);
     y += draw.cell_h + 8;
     if (row.detail.len > 0) {
@@ -457,6 +497,17 @@ test "memory center renderer computes stable three-column layout" {
     try std.testing.expect(layout.list_w >= 300);
     try std.testing.expect(layout.detail_w > 0);
     try std.testing.expectEqual(@as(f32, layout.left_x + layout.left_w), layout.list_x);
+}
+
+test "memory center renderer exposes the empty-state digest action" {
+    const session = memory_center.Session{};
+    const layout = computeLayout(0, 1200);
+    const rect = emptyActionRect(layout, 40, 20);
+    const hit = hitTest(&session, 800, 40, 0, 1200, 20, rect.x + 4, rect.top + 4);
+    switch (hit) {
+        .run_digest => {},
+        else => return error.ExpectedDigestAction,
+    }
 }
 
 test "memory center renderer wraps body text" {

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -217,14 +217,26 @@ fn renderDigestNotification(draw: DrawContext, session: *const memory_center.Ses
         .skipped => .{ 1.0, 0.72, 0.28 },
     };
     const pad: f32 = 12;
-    const h = draw.cell_h + pad;
-    const w = @min(layout.detail_w - pad * 2, 460);
+    // Digest status belongs to the workbench, not only the narrow detail
+    // column. Borrow the list + detail span so progress and result messages
+    // keep their full wording instead of disappearing at the right edge.
+    const left = layout.list_x + pad;
+    const available_w = layout.detail_x + layout.detail_w - left - pad;
+    const w = @min(640.0, available_w);
     if (w <= 0) return;
+    const text_w = w - pad * 2;
+    const rows = @max(@as(usize, 1), wrappedLineCount(notification.message, text_w, draw.glyphAdvance));
+    const line_h = draw.cell_h + 3;
+    const h = @as(f32, @floatFromInt(rows)) * line_h + pad * 2;
     const x = layout.detail_x + layout.detail_w - w - pad;
     const y_top = @max(top + 4, content_bottom - h - pad);
     draw.fillQuadAlpha(x, yFromTop(window_height, y_top, h), w, h, mixColor(draw.bg, accent, 0.16), 0.96);
     draw.fillQuad(x, yFromTop(window_height, y_top, h), 3, h, accent);
-    _ = draw.renderTextLimited(notification.message, x + pad, yTextFromTop(draw, window_height, y_top + 6), accent, w - pad * 2);
+    var it = LineWrap{ .text = notification.message, .max_w = text_w, .advance = draw.glyphAdvance };
+    var row: usize = 0;
+    while (it.next()) |line| : (row += 1) {
+        _ = draw.renderTextLimited(line, x + pad, yTextFromTop(draw, window_height, y_top + pad + @as(f32, @floatFromInt(row)) * line_h), accent, text_w);
+    }
 }
 
 fn renderList(

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -6917,7 +6917,37 @@ fn settingsRowDescription(row: usize) []const u8 {
     };
 }
 
-fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row_index: usize, title: []const u8, value: []const u8, selected: bool) void {
+const SettingsControlKind = enum {
+    adjuster,
+    toggle,
+    choice,
+    action,
+};
+
+fn settingsControlKind(row: usize) SettingsControlKind {
+    if (shell_integration.supported and (row == SETTINGS_CONTROL_ROW_START + 9 or row == SETTINGS_CONTROL_ROW_START + 10)) return .toggle;
+    return switch (row) {
+        0 => .adjuster,
+        SETTINGS_THEME_ROW,
+        SETTINGS_CONTROL_ROW_START + 0,
+        SETTINGS_CONTROL_ROW_START + 3,
+        SETTINGS_CONTROL_ROW_START + 4,
+        SETTINGS_CONTROL_ROW_START + 6,
+        => .choice,
+        SETTINGS_CONTROL_ROW_START + 1,
+        SETTINGS_CONTROL_ROW_START + 2,
+        SETTINGS_CONTROL_ROW_START + 5,
+        SETTINGS_CONTROL_ROW_START + 7,
+        SETTINGS_CONTROL_ROW_START + 8,
+        => .toggle,
+        settings_page.SETTINGS_RAW_CONFIG_ROW,
+        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW,
+        => .action,
+        else => .action,
+    };
+}
+
+fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, row_index: usize, title: []const u8, value: []const u8, selected: bool) void {
     const visible = layout.visibleRow(window_height, row_index) orelse return;
     const gl_y = visible.gl_y;
     const x = layout.content_x;
@@ -6937,12 +6967,42 @@ fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row_index: usiz
         ui_pipeline.fillQuadAlpha(x + 2, gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
     }
     if (value.len > 0) {
-        const value_w = @min(210.0, measureTitlebarText(value) + 24);
+        const kind = settingsControlKind(row);
+        const max_value_w: f32 = switch (kind) {
+            .toggle => 96,
+            .adjuster => 152,
+            .choice => 360,
+            .action => 180,
+        };
+        const min_value_w: f32 = switch (kind) {
+            .toggle => 76,
+            .adjuster => 118,
+            .choice => 132,
+            .action => 96,
+        };
+        const trailing_w: f32 = switch (kind) {
+            .choice, .action => 26,
+            .adjuster, .toggle => 12,
+        };
+        const value_w = @min(max_value_w, @max(min_value_w, measureTitlebarText(value) + 24 + trailing_w));
         const value_x = @round(right_edge - value_w);
         const control_h = @round(@max(32.0, font.g_titlebar_cell_height + 10.0));
         const pill_y = gl_y + @round((layout.row_h - control_h) / 2);
-        renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, 9, mixColor(bg, fg, 0.09), 0.92);
-        renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), if (selected) accent else mixColor(bg, fg, 0.82), value_w - 24);
+        const is_on = std.mem.eql(u8, value, i18n.s().settings_value_on);
+        const control_bg = if (kind == .toggle and is_on) mixColor(bg, accent, 0.20) else mixColor(bg, fg, 0.09);
+        renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, 9, control_bg, 0.92);
+        const value_color = if (selected) accent else mixColor(bg, fg, 0.82);
+        if (kind == .toggle) {
+            const knob_d: f32 = @max(16.0, control_h - 12.0);
+            const knob_x = if (is_on) value_x + value_w - knob_d - 7 else value_x + 7;
+            renderRoundedQuadAlpha(knob_x, pill_y + (control_h - knob_d) / 2, knob_d, knob_d, knob_d / 2, if (is_on) accent else mixColor(bg, fg, 0.42), 0.96);
+            _ = renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), value_color, value_w - knob_d - 24);
+        } else {
+            _ = renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), value_color, value_w - 20 - trailing_w);
+            if (kind == .choice or kind == .action) {
+                renderTitlebarText(">", value_x + value_w - 18, rowTextY(pill_y, control_h), mixColor(bg, fg, 0.60));
+            }
+        }
         title_max_w = @max(1.0, value_x - title_x - 18);
     }
 
@@ -7058,7 +7118,7 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
             settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => "Enter",
             else => "",
         };
-        renderSettingsRow(layout, window_height, row_index, title, value, focus == row);
+        renderSettingsRow(layout, window_height, row, row_index, title, value, focus == row);
     }
 
     // Scrollbar indicator when not all rows fit (short windows). The list is
@@ -7080,6 +7140,13 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
         const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
         ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
     }
+
+    const footer_h = ui_patterns.workbenchFooterHeight(font.g_titlebar_cell_height);
+    const footer_top = ui_patterns.workbenchFooterTop(window_height, layout.page_top_px, footer_h);
+    const footer_y = @round(window_height - footer_top - footer_h);
+    ui_pipeline.fillQuadAlpha(layout.page_x, footer_y, layout.page_w, footer_h, mixColor(bg, fg, 0.030), 0.98);
+    ui_pipeline.fillQuadAlpha(layout.page_x, footer_y + footer_h - 1, layout.page_w, 1, border_color, 0.68);
+    renderTitlebarTextLimited(i18n.s().settings_workbench_footer, layout.content_x, rowTextY(footer_y, footer_h), muted_color, layout.content_w);
 }
 
 /// Mouse-wheel handling for the settings page. The list scrolls by moving the

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1596,6 +1596,7 @@ fn paletteDpiScale() f32 {
 }
 
 const platform_display = @import("../platform/display.zig");
+const ui_patterns = @import("ui_patterns.zig");
 
 pub const ImeCaretPx = struct { x: f32, y: f32, h: f32 };
 
@@ -5761,8 +5762,7 @@ fn sessionFirstVisibleRow(selection: usize, visible_rows: usize, row_count: usiz
 fn sessionLayout(window_width: f32, window_height: f32, top_offset: f32) SessionLayout {
     const content_height = @max(1, window_height - top_offset);
     const min_box_w: f32 = if (g_ssh_form_visible or g_ssh_list_visible or g_ai_form_visible or g_ai_list_visible) 460 else 360;
-    const max_box_w = @max(260.0, @min(760.0, window_width - 48.0));
-    const box_w: f32 = @round(@min(@max(min_box_w, sessionDesiredBoxWidth()), max_box_w));
+    const box_w = ui_patterns.modalWidth(window_width, min_box_w, sessionDesiredBoxWidth(), 760, 24);
     const row_h = overlayRowHeight(38);
     const header_h = @round(18 + overlayLineHeight() * 2 + 12);
     const filter_h = if (g_ssh_list_visible) overlayControlHeight(42) else 0;

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -8413,12 +8413,52 @@ pub fn renderRestoreDefaultsConfirm(window_width: f32, window_height: f32) void 
     renderTitlebarTextStrong(cancel_label, layout.cancel_x + (layout.cancel_w - measureTitlebarText(cancel_label)) / 2, rowTextY(cancel_y, layout.cancel_h), body);
 }
 
-fn integrationPromptLineCount(text: []const u8) usize {
-    if (text.len == 0) return 0;
-    var lines: usize = 1;
-    for (text) |ch| {
-        if (ch == '\n') lines += 1;
+/// Display-line iterator for the integration prompt. The prompt is prose and
+/// code-like snippets, so wrap at a preceding space when possible and fall
+/// back to codepoint boundaries for URLs or long identifiers.
+const IntegrationPromptWrap = struct {
+    text: []const u8,
+    max_w: f32,
+    pos: usize = 0,
+
+    fn next(self: *IntegrationPromptWrap) ?[]const u8 {
+        if (self.pos >= self.text.len or self.max_w <= 0) return null;
+        const start = self.pos;
+        var i = start;
+        var width: f32 = 0;
+        var last_space: ?usize = null;
+        while (i < self.text.len) {
+            const seq_len = std.unicode.utf8ByteSequenceLength(self.text[i]) catch 1;
+            const end = @min(i + seq_len, self.text.len);
+            const cp = std.unicode.utf8Decode(self.text[i..end]) catch 0xFFFD;
+            if (cp == '\n') {
+                self.pos = end;
+                return self.text[start..i];
+            }
+            const advance = titlebar.titlebarGlyphAdvance(cp);
+            if (width + advance > self.max_w and i > start) {
+                if (last_space) |space| {
+                    if (space > start) {
+                        self.pos = space + 1;
+                        return self.text[start..space];
+                    }
+                }
+                self.pos = i;
+                return self.text[start..i];
+            }
+            if (cp == ' ') last_space = i;
+            width += advance;
+            i = end;
+        }
+        self.pos = self.text.len;
+        return self.text[start..];
     }
+};
+
+fn integrationPromptLineCount(text: []const u8, max_w: f32) usize {
+    var it = IntegrationPromptWrap{ .text = text, .max_w = max_w };
+    var lines: usize = 0;
+    while (it.next()) |_| lines += 1;
     return lines;
 }
 
@@ -8473,7 +8513,15 @@ pub fn renderIntegrationPrompt(window_width: f32, window_height: f32) void {
     const text_right = layout.panel_x + layout.panel_w - pad;
     renderTitlebarTextStrongLimited("Install Integration", text_x, title_y, fg, text_right - text_x);
     const subtitle_y = title_y - overlayTextHeight() - 14;
-    renderTitlebarTextLimited("Copy this prompt into Codex, Claude Code, or another agent.", text_x, subtitle_y, body, text_right - text_x);
+    const subtitle = "Copy this prompt into Codex, Claude Code, or another agent.";
+    const subtitle_w = text_right - text_x;
+    const subtitle_line_h = @round(@max(overlayTextHeight(), 20.0));
+    var subtitle_it = IntegrationPromptWrap{ .text = subtitle, .max_w = subtitle_w };
+    var subtitle_rows: usize = 0;
+    while (subtitle_it.next()) |line| : (subtitle_rows += 1) {
+        if (subtitle_rows >= 2) break;
+        renderTitlebarTextLimited(line, text_x, subtitle_y - subtitle_line_h * @as(f32, @floatFromInt(subtitle_rows)), body, subtitle_w);
+    }
 
     const footer_y = copy_y + layout.close_h + 20;
     ui_pipeline.fillQuadAlpha(layout.panel_x + 5, footer_y, layout.panel_w - 5, 1, quiet_border, 0.46);
@@ -8481,7 +8529,7 @@ pub fn renderIntegrationPrompt(window_width: f32, window_height: f32) void {
     const prompt_x = layout.panel_x + pad;
     const prompt_y = footer_y + 18;
     const prompt_w = layout.panel_w - pad * 2;
-    const prompt_top = subtitle_y - 22;
+    const prompt_top = subtitle_y - subtitle_line_h * @as(f32, @floatFromInt(@max(@as(usize, 1), subtitle_rows))) - 12;
     const prompt_h = @max(72.0, prompt_top - prompt_y);
     renderRoundedQuadAlpha(prompt_x - 1, prompt_y - 1, prompt_w + 2, prompt_h + 2, 8, quiet_border, 0.55);
     renderRoundedQuadAlpha(prompt_x, prompt_y, prompt_w, prompt_h, 7, prompt_box, 0.96);
@@ -8490,18 +8538,19 @@ pub fn renderIntegrationPrompt(window_width: f32, window_height: f32) void {
     const line_h = @round(@max(22.0, overlayTextHeight() + 6.0));
     const available_h = @max(line_h, prompt_h - 18.0);
     const visible_rows: usize = @intFromFloat(@max(1.0, @floor(available_h / line_h)));
-    const total_lines = integrationPromptLineCount(prompt);
+    const text_w = prompt_w - 24;
+    const total_lines = integrationPromptLineCount(prompt, text_w);
     const scroll = integrationPromptClampedScroll(total_lines, visible_rows);
     g_integration_prompt_scroll = @intCast(scroll);
 
     var drawn: usize = 0;
     var line_index: usize = 0;
-    var it = std.mem.splitScalar(u8, prompt, '\n');
+    var it = IntegrationPromptWrap{ .text = prompt, .max_w = text_w };
     while (it.next()) |line| {
         if (line_index >= scroll and drawn < visible_rows) {
             const row_y = prompt_y + prompt_h - 9.0 - line_h * @as(f32, @floatFromInt(drawn + 1));
             if (row_y < prompt_y + 6.0) break;
-            renderTitlebarTextLimited(line, prompt_x + 12, rowTextY(row_y, line_h), body, prompt_w - 24);
+            renderTitlebarTextLimited(line, prompt_x + 12, rowTextY(row_y, line_h), body, text_w);
             drawn += 1;
         }
         line_index += 1;
@@ -8809,7 +8858,15 @@ fn whatsNewButtonMetrics() whats_new_model.ButtonMetrics {
 }
 
 fn whatsNewLayout(window_width: f32, window_height: f32) whats_new_model.Layout {
-    return whats_new_model.computeLayoutWithButtons(window_width, window_height, whatsNewLineHeight(), whatsNewButtonMetrics());
+    const notes = whatsNewNotes();
+    var summary_buf: [512]u8 = undefined;
+    const summary = whats_new_model.summaryText(&summary_buf, notes);
+    const panel_w = @round(@min(@max(@as(f32, 320), window_width - 80), @as(f32, 860)));
+    const content_w = @max(1.0, panel_w - 68.0);
+    const advance = @max(@as(f32, 1), titlebar.titlebarGlyphAdvance('M'));
+    const summary_cols: usize = @max(whats_new_model.MIN_WRAP_COLS, @as(usize, @intFromFloat(@floor(content_w / advance))));
+    const summary_rows = whats_new_model.lineRows(summary.len, summary_cols);
+    return whats_new_model.computeLayoutWithHeaderRows(window_width, window_height, whatsNewLineHeight(), whatsNewButtonMetrics(), summary_rows);
 }
 
 fn topRectY(window_height: f32, rect: whats_new_model.Rect) f32 {
@@ -8873,6 +8930,23 @@ fn renderWhatsNewWrappedLine(
     return true;
 }
 
+fn whatsNewBodyRows(notes: []const u8, wrap_cols: usize, indented_wrap_cols: usize) usize {
+    var total: usize = 0;
+    var in_code = false;
+    var it = std.mem.splitScalar(u8, notes, '\n');
+    while (it.next()) |raw| {
+        var cbuf: [1024]u8 = undefined;
+        const cleaned = md.cleanedLine(&cbuf, raw, in_code);
+        if (cleaned.style == .fence) in_code = !in_code;
+        const cols = switch (cleaned.style) {
+            .list, .quote, .code => indented_wrap_cols,
+            else => wrap_cols,
+        };
+        total += whats_new_model.lineRows(cleaned.text.len, cols);
+    }
+    return total;
+}
+
 fn whatsNewHighlightsRows(highlights: whats_new_model.Highlights, wrap_cols: usize) usize {
     if (highlights.len == 0) return 0;
     var total: usize = whats_new_model.lineRows("Highlights".len, wrap_cols);
@@ -8888,6 +8962,7 @@ fn renderWhatsNewHighlights(
     window_height: f32,
     highlights: whats_new_model.Highlights,
     wrap_cols: usize,
+    indented_wrap_cols: usize,
     line_h: f32,
     rows_state: *WhatsNewRows,
     heading_color: [3]f32,
@@ -8901,7 +8976,7 @@ fn renderWhatsNewHighlights(
     while (i < highlights.len) : (i += 1) {
         var line_buf: [512]u8 = undefined;
         const line = std.fmt.bufPrint(&line_buf, "* {s}", .{highlights.items[i]}) catch highlights.items[i];
-        if (!renderWhatsNewWrappedLine(layout, window_height, line, layout.content.x + 16, mixColor(body, accent, 0.08), false, wrap_cols, line_h, rows_state)) return false;
+        if (!renderWhatsNewWrappedLine(layout, window_height, line, layout.content.x + 16, mixColor(body, accent, 0.08), false, indented_wrap_cols, line_h, rows_state)) return false;
     }
     return renderWhatsNewWrappedLine(layout, window_height, "", layout.content.x, body, false, wrap_cols, line_h, rows_state);
 }
@@ -8911,6 +8986,7 @@ fn renderWhatsNewBody(
     window_height: f32,
     notes: []const u8,
     wrap_cols: usize,
+    indented_wrap_cols: usize,
     line_h: f32,
     rows_state: *WhatsNewRows,
     heading_color: [3]f32,
@@ -8938,7 +9014,11 @@ fn renderWhatsNewBody(
             else => body,
         };
         const strong = cleaned.style == .heading;
-        if (!renderWhatsNewWrappedLine(layout, window_height, cleaned.text, x, color, strong, wrap_cols, line_h, rows_state)) return;
+        const line_cols = switch (cleaned.style) {
+            .list, .quote, .code => indented_wrap_cols,
+            else => wrap_cols,
+        };
+        if (!renderWhatsNewWrappedLine(layout, window_height, cleaned.text, x, color, strong, line_cols, line_h, rows_state)) return;
     }
 }
 
@@ -8992,7 +9072,16 @@ pub fn renderWhatsNew(window_width: f32, window_height: f32) void {
         const summary = whats_new_model.summaryText(&summary_buf, notes);
         if (summary.len > 0) {
             const subtitle_top = title_top + overlayTextHeight() + 12;
-            renderTitlebarTextLimited(summary, layout.content.x, textYFromTop(window_height, subtitle_top), body, header_right - layout.content.x);
+            const summary_w = header_right - layout.content.x;
+            const summary_adv = @max(@as(f32, 1), titlebar.titlebarGlyphAdvance('M'));
+            const summary_cols: usize = @max(whats_new_model.MIN_WRAP_COLS, @as(usize, @intFromFloat(@floor(summary_w / summary_adv))));
+            const rows = whats_new_model.lineRows(summary.len, summary_cols);
+            var row: usize = 0;
+            while (row < rows) : (row += 1) {
+                const start = row * summary_cols;
+                const end = @min(summary.len, start + summary_cols);
+                renderTitlebarTextLimited(summary[start..end], layout.content.x, textYFromTop(window_height, subtitle_top + @as(f32, @floatFromInt(row)) * line_h), body, summary_w);
+            }
         }
     }
 
@@ -9002,6 +9091,8 @@ pub fn renderWhatsNew(window_width: f32, window_height: f32) void {
         const adv = @max(@as(f32, 1), titlebar.titlebarGlyphAdvance('M'));
         var wrap_cols: usize = @intFromFloat(layout.content.w / adv);
         if (wrap_cols < whats_new_model.MIN_WRAP_COLS) wrap_cols = whats_new_model.MIN_WRAP_COLS;
+        var indented_wrap_cols: usize = @intFromFloat(@max(1.0, (layout.content.w - 16.0) / adv));
+        if (indented_wrap_cols < whats_new_model.MIN_WRAP_COLS) indented_wrap_cols = whats_new_model.MIN_WRAP_COLS;
 
         const body_notes = whats_new_model.bodyNotes(notes);
         var summary_buf: [512]u8 = undefined;
@@ -9009,13 +9100,13 @@ pub fn renderWhatsNew(window_width: f32, window_height: f32) void {
         var highlights_buf: [512]u8 = undefined;
         const highlights = whats_new_model.highlightClauses(&highlights_buf, summary);
 
-        const total = whatsNewHighlightsRows(highlights, wrap_cols) + whats_new_model.totalRows(body_notes, wrap_cols);
+        const total = whatsNewHighlightsRows(highlights, indented_wrap_cols) + whatsNewBodyRows(body_notes, wrap_cols, indented_wrap_cols);
         const scroll = whats_new_model.clampScroll(whatsNewState().scroll, total, layout.visible_rows);
         whatsNewState().scroll = @intCast(scroll);
 
         var rows_state: WhatsNewRows = .{ .scroll = scroll };
-        if (renderWhatsNewHighlights(layout, window_height, highlights, wrap_cols, line_h, &rows_state, heading, accent, body)) {
-            renderWhatsNewBody(layout, window_height, body_notes, wrap_cols, line_h, &rows_state, heading, body, muted);
+        if (renderWhatsNewHighlights(layout, window_height, highlights, wrap_cols, indented_wrap_cols, line_h, &rows_state, heading, accent, body)) {
+            renderWhatsNewBody(layout, window_height, body_notes, wrap_cols, indented_wrap_cols, line_h, &rows_state, heading, body, muted);
         }
     }
 

--- a/src/renderer/overlays/command_palette_layout.zig
+++ b/src/renderer/overlays/command_palette_layout.zig
@@ -9,6 +9,7 @@
 //! passes them in, then uses the returned numbers exactly as before.
 
 const std = @import("std");
+const ui_patterns = @import("../ui_patterns.zig");
 
 /// Hard cap on rows the palette ever renders at once. Must match the scratch
 /// buffer size in overlays.zig.
@@ -112,7 +113,13 @@ pub fn compute(
     // Ghostty: maxWidth 500 logical points, anchored a small gap below the
     // top of the content area rather than vertically centered. All layout
     // math is in physical pixels, so the point-based widths scale by DPI.
-    const box_w = @round(@min(@max(420 * scale, window_width - 64 * scale), 500 * scale));
+    const box_w = ui_patterns.modalWidth(
+        window_width,
+        420 * scale,
+        500 * scale,
+        500 * scale,
+        32 * scale,
+    );
     const row_h = rowHeight(cell_height, 36);
     const filter_h = controlHeight(cell_height, 48);
     const top_gap = @max(16.0, content_height * 0.05);
@@ -228,11 +235,11 @@ test "row capacity is at least one row even when cramped" {
     try std.testing.expectEqual(@as(usize, 1), rowCapacity(80, 200, row_h));
 }
 
-test "layout box width clamps between 420 and 500" {
+test "layout box width clamps to the viewport gutters and palette maximum" {
     const cell: f32 = 20;
-    // Narrow window (width-64 < 420) -> min width 420.
+    // Narrow windows stay inside their 32px gutters rather than overflowing.
     const narrow = compute(460, 800, 0, cell, 5, 1.0);
-    try std.testing.expectEqual(@as(f32, 420), narrow.box_w);
+    try std.testing.expectEqual(@as(f32, 460 - 64), narrow.box_w);
     // Wide window -> capped at 500.
     const wide = compute(2000, 800, 0, cell, 5, 1.0);
     try std.testing.expectEqual(@as(f32, 500), wide.box_w);

--- a/src/renderer/overlays/settings_page_layout.zig
+++ b/src/renderer/overlays/settings_page_layout.zig
@@ -4,6 +4,7 @@
 //! category rail on the left and a centered settings card on the right.
 
 const std = @import("std");
+const ui_patterns = @import("../ui_patterns.zig");
 
 pub const Input = struct {
     window_height: f32,
@@ -137,7 +138,12 @@ pub fn compute(input: Input) Layout {
     const row_h = settingsRowHeight(input.cell_height);
     const header_h = @round(@max(104.0, textHeight(input.cell_height) * 2.0 + 56.0));
     const bottom_pad: f32 = 24;
-    const visible_rows = rowCapacity(page_h, header_h + bottom_pad, row_h, input.row_count);
+    // The footer is a persistent part of the Settings workbench, rather than
+    // an overlay on the last row. Reserve its band here so short windows
+    // scroll content above it instead of hiding the final control.
+    const footer_h = ui_patterns.workbenchFooterHeight(input.cell_height);
+    const content_h = @max(1.0, page_h - footer_h);
+    const visible_rows = rowCapacity(content_h, header_h + bottom_pad, row_h, input.row_count);
     const scroll = firstVisibleRow(input.focus_index, visible_rows, input.row_count);
 
     return .{
@@ -192,6 +198,8 @@ test "settings tab layout keeps focused rows visible in short windows" {
     try std.testing.expect(layout.visible_rows >= 1);
     try std.testing.expect(layout.visible_rows < layout.row_count);
     try std.testing.expect(layout.focusVisible(4));
+    const last = layout.visibleRow(330, layout.scroll + layout.visible_rows - 1).?;
+    try std.testing.expect(last.top_px + layout.row_h <= 330 - ui_patterns.workbenchFooterHeight(20));
 }
 
 test "settings tab hit testing maps content rows and font buttons" {

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -258,8 +258,8 @@ pub fn renderStartupShortcutsOverlay(window_width: f32, window_height: f32, top_
         var keys_buf: [256]u8 = undefined;
         const keys = startupShortcutKeys(entry, &keys_buf);
         const item = layout.entry(idx) orelse continue;
-        renderTitlebarTextLimited(keys, item.keys_x, item.y, keys_color, item.keys_width);
-        renderTitlebarTextLimited(localizedAction(entry), item.action_x, item.y, action_color, item.action_width);
+        renderTitlebarTextLimited(keys, item.keys_x, item.keys_y, keys_color, item.keys_width);
+        renderTitlebarTextLimited(localizedAction(entry), item.action_x, item.action_y, action_color, item.action_width);
     }
 
     renderTitlebarTextLimited(hint, layout.hint_x, layout.hint_y, hint_color, layout.hint_max_width);

--- a/src/renderer/overlays/startup_shortcuts_layout.zig
+++ b/src/renderer/overlays/startup_shortcuts_layout.zig
@@ -42,6 +42,7 @@ pub const Layout = struct {
     keys_width: f32,
     action_width: f32,
     line_height: f32,
+    entry_h: f32,
     entry_count: usize,
 
     pub fn entry(self: Layout, idx: usize) ?Entry {
@@ -54,8 +55,9 @@ pub const Layout = struct {
         const col_x = @round(self.box_x + self.pad_x + @as(f32, @floatFromInt(col)) * (self.column_width + self.column_gap));
         return .{
             .keys_x = col_x,
-            .action_x = @round(col_x + self.keys_width + self.pair_gap),
-            .y = @round(self.first_entry_y - @as(f32, @floatFromInt(row)) * self.line_height),
+            .action_x = col_x,
+            .keys_y = @round(self.first_entry_y - @as(f32, @floatFromInt(row)) * self.entry_h),
+            .action_y = @round(self.first_entry_y - self.line_height - @as(f32, @floatFromInt(row)) * self.entry_h),
             .keys_width = self.keys_width,
             .action_width = self.action_width,
         };
@@ -65,7 +67,8 @@ pub const Layout = struct {
 pub const Entry = struct {
     keys_x: f32,
     action_x: f32,
-    y: f32,
+    keys_y: f32,
+    action_y: f32,
     keys_width: f32,
     action_width: f32,
 };
@@ -73,21 +76,24 @@ pub const Entry = struct {
 pub fn compute(input: Input) Layout {
     const pad_x: f32 = 24;
     const pad_y: f32 = 18;
-    const pair_gap_base: f32 = 48;
     const column_gap: f32 = 38;
     const heading_gap: f32 = 16;
     const hint_gap: f32 = 12;
     const content_height = @max(1.0, input.window_height - input.top_offset);
     const available_height = @max(input.line_height, content_height - 24.0);
     const fixed_height = pad_y * 2 + input.text_height + heading_gap + hint_gap + input.text_height;
-    const available_entry_height = @max(input.line_height, available_height - fixed_height);
-    const rows_fit: usize = @max(1, @as(usize, @intFromFloat(@floor(available_entry_height / input.line_height))));
+    // A shortcut and its description occupy separate rows. This removes the
+    // brittle two-column key/action split that cut both halves at normal
+    // desktop widths (notably Option+Left and "Close panel / tab…").
+    const entry_h = input.line_height * 2.0;
+    const available_entry_height = @max(entry_h, available_height - fixed_height);
+    const rows_fit: usize = @max(1, @as(usize, @intFromFloat(@floor(available_entry_height / entry_h))));
 
     var columns: usize = (input.entry_count + rows_fit - 1) / rows_fit;
     columns = @min(@max(columns, 1), MAX_COLUMNS);
     const rows_per_column = (input.entry_count + columns - 1) / columns;
-    const entries_height = input.line_height * @as(f32, @floatFromInt(rows_per_column));
-    const pair_width = input.max_keys_width + pair_gap_base + input.max_action_width;
+    const entries_height = entry_h * @as(f32, @floatFromInt(rows_per_column));
+    const pair_width = @max(input.max_keys_width, input.max_action_width);
     const desired_box_width = @round(@max(
         input.heading_width + pad_x * 2,
         @max(input.hint_width + pad_x * 2, pair_width * @as(f32, @floatFromInt(columns)) + column_gap * @as(f32, @floatFromInt(columns - 1)) + pad_x * 2),
@@ -102,9 +108,9 @@ pub fn compute(input: Input) Layout {
     const inner_w = @max(1.0, box_width - pad_x * 2);
     const total_column_gap = column_gap * @as(f32, @floatFromInt(columns - 1));
     const column_width = @max(1.0, (inner_w - total_column_gap) / @as(f32, @floatFromInt(columns)));
-    const pair_gap = @min(pair_gap_base, @max(18.0, column_width * 0.08));
-    const keys_width = @min(input.max_keys_width, column_width * 0.48);
-    const action_width = @max(1.0, column_width - keys_width - pair_gap);
+    const pair_gap: f32 = 0;
+    const keys_width = column_width;
+    const action_width = column_width;
     const hint_max_width = box_width - pad_x * 2;
 
     return .{
@@ -128,6 +134,7 @@ pub fn compute(input: Input) Layout {
         .keys_width = keys_width,
         .action_width = action_width,
         .line_height = input.line_height,
+        .entry_h = entry_h,
         .entry_count = input.entry_count,
     };
 }
@@ -189,9 +196,13 @@ test "entry placement advances down rows then across columns" {
     const next_column = layout.entry(layout.rows_per_column).?;
 
     try std.testing.expectEqual(first.keys_x, second.keys_x);
-    try std.testing.expectEqual(first.y - layout.line_height, second.y);
+    try std.testing.expectEqual(first.keys_y - layout.entry_h, second.keys_y);
+    try std.testing.expectEqual(first.keys_y - layout.line_height, first.action_y);
+    try std.testing.expectEqual(first.keys_x, first.action_x);
+    try std.testing.expectEqual(layout.column_width, first.keys_width);
+    try std.testing.expectEqual(layout.column_width, first.action_width);
     try std.testing.expect(next_column.keys_x > first.keys_x);
-    try std.testing.expectEqual(first.y, next_column.y);
+    try std.testing.expectEqual(first.keys_y, next_column.keys_y);
     try std.testing.expectEqual(@as(?Entry, null), layout.entry(24));
 }
 

--- a/src/renderer/overlays/whats_new_model.zig
+++ b/src/renderer/overlays/whats_new_model.zig
@@ -216,13 +216,21 @@ pub fn computeLayout(window_w: f32, window_h: f32, row_h: f32) Layout {
 /// Centered modal layout with caller-supplied button widths. The renderer uses
 /// measured label widths here so centered text cannot escape the panel.
 pub fn computeLayoutWithButtons(window_w: f32, window_h: f32, row_h: f32, buttons: ButtonMetrics) Layout {
+    return computeLayoutWithHeaderRows(window_w, window_h, row_h, buttons, 1);
+}
+
+/// Variant for release notes whose summary needs more than one display row.
+/// Keeping the full summary in the header avoids treating it as a clipped
+/// decoration; the scrollable body receives only the remaining release notes.
+pub fn computeLayoutWithHeaderRows(window_w: f32, window_h: f32, row_h: f32, buttons: ButtonMetrics, summary_rows: usize) Layout {
     const panel_w = @round(@min(@max(@as(f32, 320), window_w - 80), @as(f32, 860)));
     const panel_h = @round(@min(@max(@as(f32, 360), window_h - 80), @as(f32, 620)));
     const panel_x = @round((window_w - panel_w) / 2);
     const panel_y = @round((window_h - panel_h) / 2);
 
     const pad: f32 = 34;
-    const header_h = @round(@max(@as(f32, 86), row_h * 2 + 34));
+    const summary_row_count: f32 = @floatFromInt(@max(@as(usize, 1), summary_rows));
+    const header_h = @round(@max(@as(f32, 86), row_h * (summary_row_count + 1) + 34));
     const footer_h = @round(@max(@as(f32, 58), row_h + 30));
     const content_top = panel_y + header_h + 18;
     const footer_y = panel_y + panel_h - footer_h;
@@ -340,6 +348,13 @@ test "computeLayout exposes header content footer bands and top close button" {
         layout.title_close_btn.x + layout.title_close_btn.w / 2,
         layout.title_close_btn.y + layout.title_close_btn.h / 2,
     ));
+}
+
+test "computeLayoutWithHeaderRows reserves every summary row above content" {
+    const layout = computeLayoutWithHeaderRows(1200, 800, 24, .{}, 4);
+    try std.testing.expect(layout.header.h >= 24 * 5 + 34);
+    try std.testing.expect(layout.content.y >= layout.header.y + layout.header.h + 18);
+    try std.testing.expect(layout.visible_rows >= 1);
 }
 
 test "computeLayout places GitHub action on the left side of the footer" {

--- a/src/renderer/port_forwarding_renderer.zig
+++ b/src/renderer/port_forwarding_renderer.zig
@@ -4,7 +4,7 @@ const form_mod = @import("../port_forward/forwarding.zig");
 
 const HEADER_H: f32 = 54;
 const ROW_H: f32 = 52;
-const LEGEND_H: f32 = 36;
+const LEGEND_H: f32 = 72;
 const PAD_X: f32 = 16;
 const COL_GAP: f32 = 10;
 const DIRECTION_W: f32 = 78;
@@ -216,7 +216,28 @@ fn rowHeight(cell_h: f32) f32 {
 }
 
 fn legendHeight(cell_h: f32) f32 {
-    return @max(LEGEND_H, cell_h + 18);
+    return @max(LEGEND_H, cell_h * 3 + 16);
+}
+
+const RowColumns = struct {
+    direction_w: f32,
+    auto_w: f32,
+    status_w: f32,
+
+    fn total(self: RowColumns) f32 {
+        return self.direction_w + self.auto_w + self.status_w + COL_GAP * 2;
+    }
+};
+
+fn rowColumns(draw: DrawContext) RowColumns {
+    const a = @max(1.0, draw.glyphAdvance('M'));
+    return .{
+        // These labels are semantic state, so fixed pixel slots are unsafe
+        // once the terminal UI font grows. Size from the longest label.
+        .direction_w = @max(DIRECTION_W, a * 8), // Reverse
+        .auto_w = @max(AUTO_W, a * 7), // Manual
+        .status_w = @max(STATUS_W, a * 8), // Stopped
+    };
 }
 
 fn yFromTop(window_height: f32, top_px: f32, h: f32) f32 {
@@ -319,7 +340,8 @@ fn renderRow(
     }
     draw.fillQuadAlpha(content_x, row_y, content_w, 1, line, 0.45);
 
-    const right_w = DIRECTION_W + AUTO_W + STATUS_W + COL_GAP * 2;
+    const columns = rowColumns(draw);
+    const right_w = columns.total();
     const show_columns = content_w >= PAD_X * 2 + right_w + 120;
     const right_x = content_x + content_w - PAD_X - right_w;
     const text_x = content_x + PAD_X;
@@ -332,11 +354,11 @@ fn renderRow(
 
     if (show_columns) {
         var x = right_x;
-        _ = draw.renderTextLimited(directionLabel(row.rule.direction), x, primary_y, muted, DIRECTION_W);
-        x += DIRECTION_W + COL_GAP;
-        _ = draw.renderTextLimited(autoLabel(row.auto_start), x, primary_y, muted, AUTO_W);
-        x += AUTO_W + COL_GAP;
-        _ = draw.renderTextLimited(statusLabel(row.status), x, primary_y, statusColor(row.status, fg, muted, accent), STATUS_W);
+        _ = draw.renderTextLimited(directionLabel(row.rule.direction), x, primary_y, muted, columns.direction_w);
+        x += columns.direction_w + COL_GAP;
+        _ = draw.renderTextLimited(autoLabel(row.auto_start), x, primary_y, muted, columns.auto_w);
+        x += columns.auto_w + COL_GAP;
+        _ = draw.renderTextLimited(statusLabel(row.status), x, primary_y, statusColor(row.status, fg, muted, accent), columns.status_w);
     }
 
     var listen_buf: [96]u8 = undefined;
@@ -452,9 +474,55 @@ fn renderLegend(draw: DrawContext, legend: []const u8, content_x: f32, content_w
     const text_x = content_x + PAD_X;
     const content_right = content_x + content_w - PAD_X;
     draw.fillQuad(content_x, legend_h, content_w, 1, line);
-    const text_y = (legend_h - draw.cell_h) / 2;
-    _ = draw.renderTextLimited(legend, text_x, text_y, muted, clampedTextWidth(text_x, content_right, content_w - PAD_X * 2));
+    const text_w = clampedTextWidth(text_x, content_right, content_w - PAD_X * 2);
+    var it = TextWrap{ .text = legend, .max_w = text_w, .advance = draw.glyphAdvance };
+    var line_index: usize = 0;
+    while (it.next()) |display_line| : (line_index += 1) {
+        if (line_index >= 3) break;
+        const text_y = legend_h - draw.cell_h - 6 - @as(f32, @floatFromInt(line_index)) * (draw.cell_h + 2);
+        _ = draw.renderTextLimited(display_line, text_x, text_y, muted, text_w);
+    }
 }
+
+const TextWrap = struct {
+    text: []const u8,
+    max_w: f32,
+    advance: *const fn (u32) f32,
+    pos: usize = 0,
+
+    fn next(self: *TextWrap) ?[]const u8 {
+        if (self.pos >= self.text.len or self.max_w <= 0) return null;
+        const start = self.pos;
+        var i = start;
+        var width: f32 = 0;
+        var last_space: ?usize = null;
+        while (i < self.text.len) {
+            const seq_len = std.unicode.utf8ByteSequenceLength(self.text[i]) catch 1;
+            const end = @min(i + seq_len, self.text.len);
+            const cp = std.unicode.utf8Decode(self.text[i..end]) catch 0xFFFD;
+            if (cp == '\n') {
+                self.pos = end;
+                return self.text[start..i];
+            }
+            const w = self.advance(cp);
+            if (width + w > self.max_w and i > start) {
+                if (last_space) |space| {
+                    if (space > start) {
+                        self.pos = space + 1;
+                        return self.text[start..space];
+                    }
+                }
+                self.pos = i;
+                return self.text[start..i];
+            }
+            if (cp == ' ') last_space = i;
+            width += w;
+            i = end;
+        }
+        self.pos = self.text.len;
+        return self.text[start..];
+    }
+};
 
 test "port_forwarding_renderer: status labels" {
     try std.testing.expectEqualStrings("Stopped", statusLabel(StatusKind.stopped));

--- a/src/renderer/skill_center_renderer.zig
+++ b/src/renderer/skill_center_renderer.zig
@@ -11,7 +11,9 @@ pub const DrawContext = panel_draw.DrawContext;
 const HEADER_H: f32 = 54;
 const ROW_H: f32 = 30;
 const PAD_X: f32 = 16;
-const LEGEND_H: f32 = 36;
+// Action legends are instructional content, not a disposable one-line status.
+// Three rows keep the full key map readable at large fonts and narrow panels.
+const LEGEND_H: f32 = 72;
 
 pub const ListItem = struct {
     label: []const u8,
@@ -76,7 +78,7 @@ fn rowHeight(cell_h: f32) f32 {
     return @max(ROW_H, cell_h + 12);
 }
 fn legendHeight(cell_h: f32) f32 {
-    return @max(LEGEND_H, cell_h + 18);
+    return @max(LEGEND_H, cell_h * 3 + 16);
 }
 
 const DrawRect = struct {
@@ -582,7 +584,15 @@ fn renderTextPreview(
 fn renderLegend(draw: DrawContext, legend: []const u8, layout: PanelLayout, muted: [3]f32, line: [3]f32) void {
     const footer = layout.footer(draw.cell_h);
     draw.fillQuad(footer.rule.x, footer.rule.y, footer.rule.w, footer.rule.h, line);
-    _ = draw.renderTextLimited(legend, layout.content_x + PAD_X, footer.text_y, muted, layout.content_w - PAD_X * 2);
+    const text_w = layout.content_w - PAD_X * 2;
+    const cols = wrapCols(text_w, draw.glyphAdvance('M'));
+    var it = WrapIter{ .content = legend, .cols = cols };
+    var line_index: usize = 0;
+    while (it.next()) |display_line| : (line_index += 1) {
+        if (line_index >= 3) break;
+        const y = (layout.legend_h - draw.cell_h - 6) - @as(f32, @floatFromInt(line_index)) * (draw.cell_h + 2);
+        _ = draw.renderTextLimited(display_line, layout.content_x + PAD_X, y, muted, text_w);
+    }
 }
 
 // --- Tests ---

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -182,21 +182,34 @@ fn fallbackCodepoint(byte: u8) u32 {
 }
 
 fn renderFallbackBytesLimited(text: []const u8, x: f32, y: f32, color: [3]f32, max_w: f32) f32 {
+    var total_w: f32 = 0;
+    for (text) |byte| total_w += titlebarGlyphAdvance(fallbackCodepoint(byte));
+    if (total_w <= max_w) {
+        var full_x = x;
+        for (text) |byte| {
+            const cp = fallbackCodepoint(byte);
+            renderTitlebarChar(cp, full_x, y, color);
+            full_x += titlebarGlyphAdvance(cp);
+        }
+        return full_x;
+    }
+
     var cursor_x = x;
+    const ellipsis: u32 = 0x2026;
+    const ellipsis_w = titlebarGlyphAdvance(ellipsis);
     for (text) |byte| {
         const cp = fallbackCodepoint(byte);
         const adv = titlebarGlyphAdvance(cp);
-        if (cursor_x + adv > x + max_w) {
-            const ellipsis: u32 = 0x2026;
-            const ellipsis_w = titlebarGlyphAdvance(ellipsis);
-            if (cursor_x + ellipsis_w <= x + max_w) {
-                renderTitlebarChar(ellipsis, cursor_x, y, color);
-                cursor_x += ellipsis_w;
-            }
-            break;
-        }
+        // Reserve the ellipsis before drawing the final visible glyph. The
+        // old post-overflow check often had no pixels left for it, leaving a
+        // hard-cut label in narrow sidebars and compact panel headers.
+        if (cursor_x + adv + ellipsis_w > x + max_w) break;
         renderTitlebarChar(cp, cursor_x, y, color);
         cursor_x += adv;
+    }
+    if (cursor_x + ellipsis_w <= x + max_w) {
+        renderTitlebarChar(ellipsis, cursor_x, y, color);
+        cursor_x += ellipsis_w;
     }
     return cursor_x;
 }
@@ -229,22 +242,33 @@ fn collectTextCodepoints(text: []const u8, codepoints: []u32, text_width: *f32) 
 pub fn renderTextLimited(text: []const u8, x: f32, y: f32, color: [3]f32, max_w: f32) f32 {
     if (max_w <= 0) return x;
 
+    var total_w: f32 = 0;
+    var measure_view = std.unicode.Utf8View.init(text) catch return renderFallbackBytesLimited(text, x, y, color, max_w);
+    var measure_it = measure_view.iterator();
+    while (measure_it.nextCodepoint()) |cp| total_w += titlebarGlyphAdvance(cp);
+
     var cursor_x = x;
-    var view = std.unicode.Utf8View.init(text) catch return renderFallbackBytesLimited(text, x, y, color, max_w);
+    var view = std.unicode.Utf8View.init(text) catch unreachable;
     var it = view.iterator();
+    if (total_w <= max_w) {
+        while (it.nextCodepoint()) |cp| {
+            renderTitlebarChar(cp, cursor_x, y, color);
+            cursor_x += titlebarGlyphAdvance(cp);
+        }
+        return cursor_x;
+    }
+
+    const ellipsis: u32 = 0x2026;
+    const ellipsis_w = titlebarGlyphAdvance(ellipsis);
     while (it.nextCodepoint()) |cp| {
         const adv = titlebarGlyphAdvance(cp);
-        if (cursor_x + adv > x + max_w) {
-            const ellipsis: u32 = 0x2026;
-            const ellipsis_w = titlebarGlyphAdvance(ellipsis);
-            if (cursor_x + ellipsis_w <= x + max_w) {
-                renderTitlebarChar(ellipsis, cursor_x, y, color);
-                cursor_x += ellipsis_w;
-            }
-            break;
-        }
+        if (cursor_x + adv + ellipsis_w > x + max_w) break;
         renderTitlebarChar(cp, cursor_x, y, color);
         cursor_x += adv;
+    }
+    if (cursor_x + ellipsis_w <= x + max_w) {
+        renderTitlebarChar(ellipsis, cursor_x, y, color);
+        cursor_x += ellipsis_w;
     }
     return cursor_x;
 }

--- a/src/renderer/ui_patterns.zig
+++ b/src/renderer/ui_patterns.zig
@@ -1,0 +1,53 @@
+//! Shared geometry contracts for WispTerm's three UI presentation styles.
+//!
+//! Command palettes are transient search-and-act dialogs. Form dialogs collect
+//! or confirm a small amount of configuration. Workbenches are persistent tab
+//! pages with a header, content area, and an always-readable footer. Keep this
+//! module free of renderer/AppWindow imports so the geometry stays testable.
+
+const std = @import("std");
+
+pub const Style = enum {
+    command_palette,
+    form_dialog,
+    workbench,
+};
+
+/// Calculates a centered modal width without allowing narrow windows to paint
+/// beyond their side gutters. `preferred_width` is clamped by the style's min
+/// and max, then by the viewport that remains after the gutters.
+pub fn modalWidth(
+    window_width: f32,
+    min_width: f32,
+    preferred_width: f32,
+    max_width: f32,
+    side_gutter: f32,
+) f32 {
+    const available = @max(1.0, window_width - side_gutter * 2.0);
+    const capped_max = @min(max_width, available);
+    return @round(@min(capped_max, @max(min_width, preferred_width)));
+}
+
+/// A workbench footer is its own persistent information band. It keeps
+/// keyboard hints and non-blocking status out of feature columns.
+pub fn workbenchFooterHeight(cell_height: f32) f32 {
+    return @round(@max(44.0, cell_height + 24.0));
+}
+
+/// Top-down y coordinate where a workbench footer begins.
+pub fn workbenchFooterTop(window_height: f32, top_offset: f32, footer_height: f32) f32 {
+    return @max(top_offset, window_height - footer_height);
+}
+
+test "modal width honors gutters before the style minimum" {
+    // A narrow viewport must not overflow merely to satisfy a modal minimum.
+    try std.testing.expectEqual(@as(f32, 396), modalWidth(460, 420, 500, 500, 32));
+    try std.testing.expectEqual(@as(f32, 500), modalWidth(1600, 420, 500, 500, 32));
+}
+
+test "workbench footer stays below the content top" {
+    const h = workbenchFooterHeight(20);
+    try std.testing.expectEqual(@as(f32, 44), h);
+    try std.testing.expectEqual(@as(f32, 756), workbenchFooterTop(800, 40, h));
+    try std.testing.expectEqual(@as(f32, 80), workbenchFooterTop(80, 80, h));
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -195,6 +195,7 @@ test {
     _ = @import("renderer/overlays/command_palette_input.zig");
     _ = @import("renderer/overlays/command_palette_layout.zig");
     _ = @import("renderer/overlays/btw_conversation.zig");
+    _ = @import("renderer/ui_patterns.zig");
     _ = @import("renderer/overlays/startup_shortcuts_layout.zig");
     _ = @import("renderer/overlays/settings_page_layout.zig");
     _ = @import("renderer/overlays/settings_page.zig");


### PR DESCRIPTION
## Summary
- Establish command palette, form dialog, and workbench presentation patterns and document them in AGENTS.md.
- Make Settings and Memory Center full workbenches with clearer controls, empty-state action, localized static copy, and persistent footers.
- Remove text clipping across Memory Center, Keyboard Shortcuts, Install Integration, What’s New, Tab Sidebar, Skill Center, Port Forwarding, and the Copilot sidebar.

## Root cause
Several views used fixed pixel columns or one-line text rendering without reserving an ellipsis. Wrapped content also sometimes used the parent width after indentation.

## Validation
- `zig build test`
- `zig build test-full`
- `zig build check-sizes`
- `zig build macos-app -Dtarget=aarch64-macos`