### PR TITLE
fix(ui): polish settings and prevent panel text overlap

### DIFF
--- a/src/i18n.zig
+++ b/src/i18n.zig
@@ -331,7 +331,7 @@ const en = Strings{
     .settings_value_open = "open",
     .settings_value_none = "(none)",
     .settings_lang_auto = "Auto",
-    .settings_workbench_footer = "Changes save automatically   Esc: close settings",
+    .settings_workbench_footer = "Changes save automatically   Up/Down: navigate   Left/Right: adjust",
 
     .memory_center_title = "Memory Center",
     .memory_center_source = "SOURCE",
@@ -599,7 +599,7 @@ const zh_CN = Strings{
     .settings_value_open = "打开",
     .settings_value_none = "（无）",
     .settings_lang_auto = "自动",
-    .settings_workbench_footer = "配置自动保存   Esc：关闭设置",
+    .settings_workbench_footer = "配置自动保存   ↑↓：浏览   ←→：调整",
 
     .memory_center_title = "记忆中心",
     .memory_center_source = "来源",

--- a/src/renderer/memory_center_renderer.zig
+++ b/src/renderer/memory_center_renderer.zig
@@ -89,10 +89,11 @@ pub fn hitTest(
     const layout = computeLayout(@round(x), @round(@max(1.0, width)));
     const top = @round(titlebar_offset);
     const src_top = sourceRowsTop(top, cell_h);
+    const source_row_h = sourceRowHeight(cell_h);
     const sources = [_]memory_center.Source{ .remembered, .digest };
     for (sources, 0..) |source, i| {
-        const row_top = src_top + @as(f32, @floatFromInt(i)) * SOURCE_ROW_H;
-        if (rectContains(mx, my, layout.left_x, row_top, layout.left_w, SOURCE_ROW_H)) return .{ .source = source };
+        const row_top = src_top + @as(f32, @floatFromInt(i)) * source_row_h;
+        if (rectContains(mx, my, layout.left_x, row_top, layout.left_w, source_row_h)) return .{ .source = source };
     }
 
     // While a digest run reports progress the list renders a status line, not
@@ -181,21 +182,22 @@ fn renderSources(
     _ = draw.renderTextLimited(i18n.s().memory_center_title, layout.left_x + PAD_X, yTextFromTop(draw, window_height, top + 11), fg, layout.left_w - PAD_X * 2);
 
     const src_top = sourceRowsTop(top, draw.cell_h);
+    const source_row_h = sourceRowHeight(draw.cell_h);
     _ = draw.renderTextLimited(i18n.s().memory_center_source, layout.left_x + PAD_X, yTextFromTop(draw, window_height, src_top - draw.cell_h - 8), muted, layout.left_w - PAD_X * 2);
     const sources = [_]memory_center.Source{ .remembered, .digest };
     for (sources, 0..) |source, i| {
-        const row_top = src_top + @as(f32, @floatFromInt(i)) * SOURCE_ROW_H;
+        const row_top = src_top + @as(f32, @floatFromInt(i)) * source_row_h;
         const active = session.source == source;
         if (active) {
-            draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, row_top, SOURCE_ROW_H), layout.left_w, SOURCE_ROW_H, selected_bg, 0.92);
-            draw.fillQuad(layout.left_x, yFromTop(window_height, row_top, SOURCE_ROW_H), 4, SOURCE_ROW_H, accent);
+            draw.fillQuadAlpha(layout.left_x, yFromTop(window_height, row_top, source_row_h), layout.left_w, source_row_h, selected_bg, 0.92);
+            draw.fillQuad(layout.left_x, yFromTop(window_height, row_top, source_row_h), 4, source_row_h, accent);
         }
         var count_buf: [16]u8 = undefined;
         const count_text = std.fmt.bufPrint(&count_buf, "{d}", .{if (session.snapshot) |snap| snap.count(source) else 0}) catch "";
         const count_w = countColumnWidth(count_text, draw.glyphAdvance);
         const count_x = layout.left_x + layout.left_w - PAD_X - count_w;
         const label_x = layout.left_x + PAD_X + 6;
-        const text_y = yTextFromTop(draw, window_height, row_top + 9);
+        const text_y = yTextFromTop(draw, window_height, row_top + (source_row_h - draw.cell_h) / 2);
         const label_color = if (active) fg else muted;
         _ = draw.renderTextLimited(sourceLabel(source), label_x, text_y, label_color, @max(0, count_x - label_x - SMALL_GAP));
         _ = draw.renderTextLimited(count_text, count_x, text_y, muted, count_w);
@@ -465,6 +467,10 @@ fn sourceRowsTop(top: f32, cell_h: f32) f32 {
     return top + headerHeight(cell_h) + cell_h + 28;
 }
 
+fn sourceRowHeight(cell_h: f32) f32 {
+    return @max(SOURCE_ROW_H, cell_h + 14);
+}
+
 fn rowHeight(cell_h: f32) f32 {
     return @max(ROW_H, cell_h * 2 + 22);
 }
@@ -525,4 +531,15 @@ test "memory center renderer exposes the empty-state digest action" {
 test "memory center renderer wraps body text" {
     try std.testing.expectEqual(@as(usize, 2), wrappedLineCount("alpha beta", 48, testAdvance));
     try std.testing.expectEqual(@as(usize, 2), wrappedLineCount("alpha\nbeta", 200, testAdvance));
+}
+
+test "memory center source rows grow with large UI text" {
+    const cell_heights = [_]f32{ 16, 24, 32, 40 };
+    for (cell_heights) |cell_h| {
+        const row_h = sourceRowHeight(cell_h);
+        const text_top = (row_h - cell_h) / 2;
+        try std.testing.expect(row_h >= cell_h + 14);
+        try std.testing.expect(text_top >= 0);
+        try std.testing.expect(text_top + cell_h <= row_h);
+    }
 }

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -6893,6 +6893,23 @@ fn settingsCategoryLabel(category: settings_page.Category) []const u8 {
     };
 }
 
+fn settingsCategoryDescription(category: settings_page.Category) []const u8 {
+    return switch (i18n.lang()) {
+        .en => switch (category) {
+            .general => "Startup, language, and configuration",
+            .appearance => "Typography, theme, and cursor behavior",
+            .ai => "Profiles and assistant integrations",
+            .system => "Desktop integration and startup behavior",
+        },
+        .zh_CN => switch (category) {
+            .general => "启动、语言与配置管理",
+            .appearance => "字体、主题与光标行为",
+            .ai => "配置文件与智能助手集成",
+            .system => "桌面集成与启动方式",
+        },
+    };
+}
+
 fn settingsRowDescription(row: usize) []const u8 {
     const zh = i18n.lang() == .zh_CN;
     if (shell_integration.supported) {
@@ -6963,7 +6980,6 @@ fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, row
     var title_max_w = w - 40;
 
     if (selected) {
-        ui_pipeline.fillQuadAlpha(x + 2, gl_y + 2, w - 4, layout.row_h - 4, mixColor(bg, accent, 0.16), 0.64);
         ui_pipeline.fillQuadAlpha(x + 2, gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
     }
     if (value.len > 0) {
@@ -6984,23 +7000,27 @@ fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, row
             .choice, .action => 26,
             .adjuster, .toggle => 12,
         };
-        const value_w = @min(max_value_w, @max(min_value_w, measureTitlebarText(value) + 24 + trailing_w));
+        const value_w = if (kind == .toggle)
+            46.0
+        else
+            @min(max_value_w, @max(min_value_w, measureTitlebarText(value) + 24 + trailing_w));
         const value_x = @round(right_edge - value_w);
-        const control_h = @round(@max(32.0, font.g_titlebar_cell_height + 10.0));
+        const control_h = if (kind == .toggle) 24.0 else @round(@max(32.0, font.g_titlebar_cell_height + 10.0));
         const pill_y = gl_y + @round((layout.row_h - control_h) / 2);
         const is_on = std.mem.eql(u8, value, i18n.s().settings_value_on);
-        const control_bg = if (kind == .toggle and is_on) mixColor(bg, accent, 0.20) else mixColor(bg, fg, 0.09);
-        renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, 9, control_bg, 0.92);
+        if (kind == .toggle) {
+            const track_color = if (is_on) mixColor(bg, accent, 0.40) else mixColor(bg, fg, 0.18);
+            renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, control_h / 2, track_color, 0.96);
+        }
         const value_color = if (selected) accent else mixColor(bg, fg, 0.82);
         if (kind == .toggle) {
-            const knob_d: f32 = @max(16.0, control_h - 12.0);
-            const knob_x = if (is_on) value_x + value_w - knob_d - 7 else value_x + 7;
+            const knob_d: f32 = control_h - 6;
+            const knob_x = if (is_on) value_x + value_w - knob_d - 3 else value_x + 3;
             renderRoundedQuadAlpha(knob_x, pill_y + (control_h - knob_d) / 2, knob_d, knob_d, knob_d / 2, if (is_on) accent else mixColor(bg, fg, 0.42), 0.96);
-            _ = renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), value_color, value_w - knob_d - 24);
         } else {
-            _ = renderTitlebarTextLimited(value, value_x + 12, rowTextY(pill_y, control_h), value_color, value_w - 20 - trailing_w);
+            _ = renderTitlebarTextLimited(value, value_x, rowTextY(pill_y, control_h), value_color, value_w - trailing_w);
             if (kind == .choice or kind == .action) {
-                renderTitlebarText(">", value_x + value_w - 18, rowTextY(pill_y, control_h), mixColor(bg, fg, 0.60));
+                renderTitlebarText(">", value_x + value_w - 12, rowTextY(pill_y, control_h), mixColor(bg, fg, 0.60));
             }
         }
         title_max_w = @max(1.0, value_x - title_x - 18);
@@ -7046,7 +7066,6 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
         const item_y = @round(window_height - item_top - layout.nav_item_h);
         const selected = category == state.category;
         if (selected) {
-            renderRoundedQuadAlpha(layout.page_x + 12, item_y + 3, layout.nav_w - 24, layout.nav_item_h - 6, 9, mixColor(bg, accent, 0.15), 0.82);
             ui_pipeline.fillQuadAlpha(layout.page_x + 14, item_y + 10, 3, layout.nav_item_h - 20, accent, 0.84);
         }
         renderTitlebarTextLimited(settingsCategoryLabel(category), layout.page_x + 28, rowTextY(item_y, layout.nav_item_h), if (selected) mixColor(fg, accent, 0.16) else mixColor(bg, fg, 0.76), layout.nav_w - 48);
@@ -7055,7 +7074,8 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
     const page_title_y = textYFromTop(window_height, layout.page_top_px + 28);
     const subtitle_y = textYFromTop(window_height, layout.page_top_px + 28 + overlayLineHeight());
     renderTitlebarText(settingsCategoryLabel(state.category), layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
-    renderTitlebarTextLimited(i18n.s().settings_subtitle, layout.content_x, subtitle_y, muted_color, layout.content_w);
+    renderTitlebarTextLimited(settingsCategoryDescription(state.category), layout.content_x, subtitle_y, muted_color, layout.content_w);
+    ui_pipeline.fillQuadAlpha(layout.content_x, @round(window_height - layout.row_top_px), layout.content_w, 1, border_color, 0.52);
 
     loadAiProfiles();
     const ai_default_value = if (assistantProfiles().profile_count > 0)

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -7028,7 +7028,6 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
     const bg = AppWindow.g_theme.background;
     const fg = AppWindow.g_theme.foreground;
     const accent = AppWindow.g_theme.cursor_color;
-    const panel_color = mixColor(bg, fg, 0.042);
     const border_color = mixColor(bg, fg, 0.16);
     const muted_color = mixColor(bg, fg, 0.58);
 
@@ -7057,11 +7056,6 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
     const subtitle_y = textYFromTop(window_height, layout.page_top_px + 28 + overlayLineHeight());
     renderTitlebarText(settingsCategoryLabel(state.category), layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
     renderTitlebarTextLimited(i18n.s().settings_subtitle, layout.content_x, subtitle_y, muted_color, layout.content_w);
-
-    const card_h = layout.row_h * @as(f32, @floatFromInt(layout.visible_rows));
-    const card_y = @round(window_height - layout.row_top_px - card_h);
-    renderRoundedQuadAlpha(layout.content_x - 1, card_y - 1, layout.content_w + 2, card_h + 2, 11, border_color, 0.66);
-    renderRoundedQuadAlpha(layout.content_x, card_y, layout.content_w, card_h, 10, panel_color, 0.96);
 
     loadAiProfiles();
     const ai_default_value = if (assistantProfiles().profile_count > 0)

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -7055,8 +7055,8 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
     ui_pipeline.fillQuadAlpha(layout.page_x, page_y, layout.nav_w, layout.page_h, mixColor(bg, fg, 0.025), 0.96);
     ui_pipeline.fillQuadAlpha(layout.page_x + layout.nav_w - 1, page_y, 1, layout.page_h, border_color, 0.72);
 
-    const nav_title_y = textYFromTop(window_height, layout.page_top_px + 24);
-    const nav_label_y = textYFromTop(window_height, layout.page_top_px + 68);
+    const nav_title_y = textYFromTop(window_height, layout.nav_title_top_px);
+    const nav_label_y = textYFromTop(window_height, layout.nav_label_top_px);
     renderTitlebarText(i18n.s().settings_title, layout.page_x + 24, nav_title_y, mixColor(fg, accent, 0.10));
     renderTitlebarText(if (i18n.lang() == .zh_CN) "偏好设置" else "PREFERENCES", layout.page_x + 24, nav_label_y, muted_color);
 

--- a/src/renderer/overlays/settings_page_layout.zig
+++ b/src/renderer/overlays/settings_page_layout.zig
@@ -44,6 +44,8 @@ pub const Layout = struct {
     page_w: f32,
     page_h: f32,
     nav_w: f32,
+    nav_title_top_px: f32,
+    nav_label_top_px: f32,
     nav_item_top_px: f32,
     nav_item_h: f32,
     category_count: usize,
@@ -139,6 +141,10 @@ pub fn compute(input: Input) Layout {
     // read as a workbench and leaves deliberate expansion space on the right.
     const content_w = @max(1.0, @min(1060.0, main_w - side_pad * 2));
     const content_x = @round(input.content_x + nav_w + side_pad);
+    const nav_title_top_px = input.top_offset + 24;
+    const nav_label_top_px = nav_title_top_px + textHeight(input.cell_height) + 10;
+    const nav_item_top_px = nav_label_top_px + textHeight(input.cell_height) + 12;
+    const nav_item_h = @round(@max(42.0, textHeight(input.cell_height) + 14.0));
     const row_h = settingsRowHeight(input.cell_height);
     const header_h = @round(@max(104.0, textHeight(input.cell_height) * 2.0 + 56.0));
     const bottom_pad: f32 = 24;
@@ -156,8 +162,10 @@ pub fn compute(input: Input) Layout {
         .page_w = page_w,
         .page_h = page_h,
         .nav_w = nav_w,
-        .nav_item_top_px = input.top_offset + 98,
-        .nav_item_h = 42,
+        .nav_title_top_px = nav_title_top_px,
+        .nav_label_top_px = nav_label_top_px,
+        .nav_item_top_px = nav_item_top_px,
+        .nav_item_h = nav_item_h,
         .category_count = input.category_count,
         .content_x = content_x,
         .content_w = content_w,
@@ -221,4 +229,23 @@ test "settings tab hit testing maps content rows and font buttons" {
     try std.testing.expectEqual(@as(?usize, 0), layout.rowAt(layout.content_x + 8, layout.row_top_px + 2));
     const plus_x = layout.content_x + layout.content_w - 46;
     try std.testing.expectEqual(FontControl.plus, layout.fontControlAt(plus_x).?);
+}
+
+test "settings category rail grows with large UI text" {
+    const cell_height: f32 = 40;
+    const layout = compute(.{
+        .window_height = 1200,
+        .top_offset = 58,
+        .content_x = 220,
+        .content_width = 1710,
+        .cell_height = cell_height,
+        .focus_index = 0,
+        .row_count = 5,
+        .category_count = 3,
+    });
+
+    try std.testing.expect(layout.nav_label_top_px >= layout.nav_title_top_px + cell_height);
+    try std.testing.expect(layout.nav_item_top_px >= layout.nav_label_top_px + cell_height);
+    try std.testing.expect(layout.nav_item_h >= cell_height + 14);
+    try std.testing.expectEqual(@as(?usize, 0), layout.categoryAt(layout.page_x + 20, layout.nav_item_top_px + 2));
 }

--- a/src/renderer/overlays/settings_page_layout.zig
+++ b/src/renderer/overlays/settings_page_layout.zig
@@ -1,7 +1,8 @@
 //! Pure layout math for the full-page Settings tab.
 //!
-//! The page uses the same two-column structure as Codex settings: a compact
-//! category rail on the left and a centered settings card on the right.
+//! The page uses a full workbench structure: a compact category rail on the
+//! left and an aligned settings list in the content region. The list is not a
+//! floating card; Settings is a persistent tab rather than a nested dialog.
 
 const std = @import("std");
 const ui_patterns = @import("../ui_patterns.zig");
@@ -133,8 +134,11 @@ pub fn compute(input: Input) Layout {
     const nav_w = @round(@min(250.0, @max(min_nav_w, page_w * 0.23)));
     const main_w = @max(1.0, page_w - nav_w);
     const side_pad: f32 = if (main_w < 560) 20 else 44;
-    const content_w = @max(1.0, @min(900.0, main_w - side_pad * 2));
-    const content_x = @round(input.content_x + nav_w + @max(side_pad, (main_w - content_w) / 2));
+    // Keep the settings readable on ultra-wide displays without centering a
+    // card inside the page. Anchoring this column to the rail makes the page
+    // read as a workbench and leaves deliberate expansion space on the right.
+    const content_w = @max(1.0, @min(1060.0, main_w - side_pad * 2));
+    const content_x = @round(input.content_x + nav_w + side_pad);
     const row_h = settingsRowHeight(input.cell_height);
     const header_h = @round(@max(104.0, textHeight(input.cell_height) * 2.0 + 56.0));
     const bottom_pad: f32 = 24;
@@ -165,7 +169,7 @@ pub fn compute(input: Input) Layout {
     };
 }
 
-test "settings tab layout reserves a category rail and centered content" {
+test "settings tab layout reserves a category rail and aligned content" {
     const layout = compute(.{
         .window_height = 900,
         .top_offset = 40,
@@ -178,8 +182,8 @@ test "settings tab layout reserves a category rail and centered content" {
     });
 
     try std.testing.expect(layout.nav_w >= 190);
-    try std.testing.expect(layout.content_x >= layout.page_x + layout.nav_w);
-    try std.testing.expect(layout.content_w <= 900);
+    try std.testing.expectEqual(layout.page_x + layout.nav_w + 44, layout.content_x);
+    try std.testing.expect(layout.content_w <= 1060);
     try std.testing.expectEqual(@as(?usize, 1), layout.categoryAt(layout.page_x + 20, layout.nav_item_top_px + layout.nav_item_h + 2));
 }
 


### PR DESCRIPTION
## Summary
- Render Settings as a persistent tab workbench with an aligned category rail, content list, and full-width footer instead of nested overlay-style cards.
- Refine the Settings presentation with category-specific descriptions, accent-line selection, inline values, and compact switch controls.
- Make the Settings category rail and Memory Center source rows scale from the actual UI font height so large text cannot overlap.
- Keep hit testing aligned with the dynamically sized Memory Center source rows.

## Root cause
The Settings rail placed its title, section label, and first category at fixed pixel offsets, while Memory Center used a fixed 38px source-row height. Both assumptions fail when the configured UI font is larger.

## User impact
Settings and Memory Center remain readable and clickable at large font sizes, while retaining the workbench visual hierarchy introduced in #565.

## Validation
- `zig build test`
- `zig build test-full`
- `zig build check-sizes`
- `zig build macos-app -Dtarget=aarch64-macos`

Rendering and layout only; no keyboard bindings changed.