### PR TITLE
fix: honor Skill Center tool list in Copilot; Ctrl+Shift+V text fallback (#567, #568)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,6 +65,33 @@ To confirm a background tool is responsible, select text with **Shift + arrow
 keys** (keyboard only, no mouse): if that does *not* trigger the interrupt, a
 pointing-device/selection utility is the cause.
 
+## How Do I Copy and Paste Inside tmux (or Other Mouse-Mode Programs)?
+
+When tmux runs with `set -g mouse on` (or a full-screen app enables mouse
+tracking), WispTerm forwards mouse presses and drags to the program, so a plain
+drag drives tmux's own copy mode instead of selecting text in WispTerm. That is
+by design — and every part of the normal copy/paste workflow still works:
+
+- **Select: hold Shift while dragging.** Shift bypasses the program's mouse
+  mode and makes a normal WispTerm selection, exactly like other terminals.
+  Shift-click extends the selection from the previous anchor.
+- **Copy: `Ctrl+Shift+C`** (macOS: `Cmd+C`) copies the current selection to the
+  system clipboard. `copy-on-select = true` in the config copies automatically
+  as soon as you finish selecting.
+- **Paste: `Ctrl+V`** (macOS: `Cmd+V`) pastes clipboard text into the terminal,
+  tmux included. `Ctrl+Shift+V` pastes an image from the clipboard and falls
+  back to a text paste when the clipboard holds no image.
+- **Right-click:** set `right-click-action = copy-or-paste` in the config to
+  make right-click copy the selection (or paste when nothing is selected).
+  Inside tmux with mouse mode on, a plain right-click is forwarded to tmux
+  (which shows tmux's own menu); hold **Shift and right-click** to use
+  WispTerm's configured action instead.
+- **Copy from tmux's own copy mode:** WispTerm applies OSC 52 clipboard writes,
+  so text yanked with tmux's internal copy mode can land on the system
+  clipboard — put `set -g set-clipboard on` in `.tmux.conf` on the remote host
+  (over SSH, the remote `TERM` must advertise clipboard support; tmux ≥ 3.2 with
+  `set -as terminal-features ',*:clipboard'` works with any `TERM`).
+
 ## Why Is WispTerm Laggy or Black on a Low-Spec PC (Weak Integrated GPU)?
 
 On Windows, WispTerm presents frames through a DXGI flip-model swapchain by

--- a/src/agent_tools/mod.zig
+++ b/src/agent_tools/mod.zig
@@ -44,16 +44,6 @@ const platform_dirs = @import("../platform/dirs.zig");
 
 pub fn executeToolCall(ctx: *ToolContext, call: ToolCall) ![]u8 {
     if (ctx.isCancelled()) return ctx.allocator.dupe(u8, "Canceled.");
-    const remote_sidebar_local_command = blk: {
-        if (!ctx.copilot or !first_party_tools.isHostLocalCommand(call.name)) break :blk false;
-        const selected = ctx.writeContextSurfaceId() orelse break :blk false;
-        const snapshot = ctx.tool_snapshot orelse break :blk false;
-        const surface = terminal_tools.findSurface(snapshot, selected) orelse break :blk false;
-        break :blk surface.is_ssh or surface.is_wsl;
-    };
-    if (ctx.copilot and (first_party_tools.isSidebarRestricted(call.name) or remote_sidebar_local_command)) {
-        return std.fmt.allocPrint(ctx.allocator, "Tool is unavailable in Side Copilot because it is restricted to the bound tab: {s}", .{call.name});
-    }
     if (first_party_tools.isKnown(call.name) and first_party_tools.isDisabledName(ctx.settings.disabled_first_party_tools, call.name)) {
         return std.fmt.allocPrint(ctx.allocator, "Tool is disabled: {s}", .{call.name});
     }
@@ -635,82 +625,39 @@ test "executeToolCall rejects disabled first-party webread before validating arg
     try std.testing.expectEqualStrings("Tool is disabled: webread", out);
 }
 
-test "executeToolCall hard-denies tab lifecycle tools in Side Copilot" {
+test "executeToolCall respects the Skill Center disabled list in Side Copilot" {
+    // Issue #567: Side Copilot has no blanket tool deny — only the user's
+    // Skill Center disabled list removes first-party tools.
+    const disabled = [_][]const u8{"tab_new"};
     var dummy: u8 = 0;
     var ctx = ToolContext{
         .allocator = std.testing.allocator,
         .ctx = &dummy,
         .tool_host = null,
         .tool_snapshot = null,
-        .settings = .{},
+        .settings = .{
+            .disabled_first_party_tools = disabled[0..],
+        },
         .copilot = true,
         .approve = fakeApprove,
         .cancelled = fakeCancelled,
     };
 
-    inline for (.{ "tab_new", "tab_close", "ssh_profile_connect" }) |name| {
-        const out = try executeToolCall(&ctx, .{
-            .id = @constCast("c1"),
-            .name = @constCast(name),
-            .arguments = @constCast("{}"),
-        });
-        defer std.testing.allocator.free(out);
-        try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") != null);
-    }
-}
-
-test "executeToolCall allows host-local exec for local Side Copilot" {
-    var dummy: u8 = 0;
-    var ctx = ToolContext{
-        .allocator = std.testing.allocator,
-        .ctx = &dummy,
-        .tool_host = null,
-        .tool_snapshot = null,
-        .settings = .{},
-        .copilot = true,
-        .approve = fakeApprove,
-        .cancelled = fakeCancelled,
-    };
-    const out = try executeToolCall(&ctx, .{
+    const denied = try executeToolCall(&ctx, .{
         .id = @constCast("c1"),
+        .name = @constCast("tab_new"),
+        .arguments = @constCast("{}"),
+    });
+    defer std.testing.allocator.free(denied);
+    try std.testing.expectEqualStrings("Tool is disabled: tab_new", denied);
+
+    const allowed = try executeToolCall(&ctx, .{
+        .id = @constCast("c2"),
         .name = @constCast(platform_process.localCommandToolName()),
         .arguments = @constCast("{}"),
     });
-    defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") == null);
-}
-
-test "executeToolCall denies host-local exec for remote Side Copilot" {
-    var dummy: u8 = 0;
-    var surfaces = [_]ToolSurface{.{
-        .id = @constCast("remote-1"),
-        .title = @constCast("ssh"),
-        .cwd = @constCast("/home/user"),
-        .snapshot = @constCast("$ "),
-        .tab_index = 0,
-        .focused = true,
-        .is_ssh = true,
-        .is_wsl = false,
-        .ptr = @ptrCast(&dummy),
-    }};
-    var ctx = ToolContext{
-        .allocator = std.testing.allocator,
-        .ctx = &dummy,
-        .tool_host = null,
-        .tool_snapshot = .{ .surfaces = surfaces[0..], .active_tab = 0 },
-        .settings = .{},
-        .copilot = true,
-        .approve = fakeApprove,
-        .cancelled = fakeCancelled,
-    };
-    terminal_tools.setWriteContext(&ctx, "remote-1");
-    const out = try executeToolCall(&ctx, .{
-        .id = @constCast("c1"),
-        .name = @constCast(platform_process.localCommandToolName()),
-        .arguments = @constCast("{}"),
-    });
-    defer std.testing.allocator.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "restricted to the bound tab") != null);
+    defer std.testing.allocator.free(allowed);
+    try std.testing.expect(std.mem.indexOf(u8, allowed, "Tool is disabled") == null);
 }
 
 test "executeToolCall does not treat disabled dynamic names as first-party tools" {

--- a/src/appwindow/tab.zig
+++ b/src/appwindow/tab.zig
@@ -659,6 +659,10 @@ pub fn spawnAiChatSession(allocator: std.mem.Allocator, session: *ai_chat.Sessio
     if (g_tab_count >= MAX_TABS) return false;
 
     const t = allocator.create(TabState) catch return false;
+    // A session hosted in its own tab is never a Side Copilot, even when the
+    // history record it was restored from was sidebar-born (issue #567) —
+    // presentation reflects where the session lives now.
+    session.setPresentation(.chat_tab);
     installAiChatHistoryHook(session);
     t.kind = .ai_chat;
     t.tree = .empty;

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -578,40 +578,6 @@ fn cloneStringList(allocator: std.mem.Allocator, list: []const []const u8) ![]co
     return out;
 }
 
-fn cloneDisabledFirstPartyTools(allocator: std.mem.Allocator, list: []const []const u8, copilot: bool, remote_bound: bool) ![]const []const u8 {
-    if (!copilot) return cloneStringList(allocator, list);
-
-    const restrictions = [_][]const u8{
-        "ssh_profile_connect",
-        "tab_new",
-        "tab_close",
-        platform_process.localCommandToolName(),
-    };
-    var restricted_count: usize = 0;
-    for (restrictions, 0..) |name, index| {
-        if (index == restrictions.len - 1 and !remote_bound) continue;
-        if (!first_party_tools.isDisabledName(list, name)) restricted_count += 1;
-    }
-
-    const out = try allocator.alloc([]const u8, list.len + restricted_count);
-    var written: usize = 0;
-    errdefer {
-        for (out[0..written]) |item| allocator.free(item);
-        allocator.free(out);
-    }
-    for (list) |item| {
-        out[written] = try allocator.dupe(u8, item);
-        written += 1;
-    }
-    for (restrictions, 0..) |name, index| {
-        if (index == restrictions.len - 1 and !remote_bound) continue;
-        if (first_party_tools.isDisabledName(list, name)) continue;
-        out[written] = try allocator.dupe(u8, name);
-        written += 1;
-    }
-    return out;
-}
-
 fn freeDynamicToolSpecsSlice(allocator: std.mem.Allocator, specs: []ai_chat_protocol.DynamicToolSpec) void {
     freeOwnedDynamicToolSpecs(allocator, specs);
 }
@@ -4488,13 +4454,7 @@ pub const Session = struct {
         const mcp_tools = try cloneMcpTools(self.allocator, mcp_registry.cachedTools());
         var mcp_tools_owned = true;
         errdefer if (mcp_tools_owned) freeOwnedMcpTools(self.allocator, mcp_tools);
-        const remote_bound = blk: {
-            if (!self.copilot or self.bound_surface_id_len == 0) break :blk false;
-            const snapshot = tool_snapshot orelse break :blk false;
-            const surface = agent_terminal.findSurface(snapshot, self.boundSurfaceId()) orelse break :blk false;
-            break :blk surface.is_ssh or surface.is_wsl;
-        };
-        const disabled_first_party_tools = try cloneDisabledFirstPartyTools(self.allocator, settings.disabled_first_party_tools, self.copilot, remote_bound);
+        const disabled_first_party_tools = try cloneStringList(self.allocator, settings.disabled_first_party_tools);
         var disabled_first_party_tools_owned = true;
         errdefer if (disabled_first_party_tools_owned) freeOwnedStringList(self.allocator, disabled_first_party_tools);
         const schedule_session_id = try self.allocator.dupe(u8, self.sessionId());
@@ -9105,9 +9065,11 @@ test "copilot request appends bound-terminal snapshot to latest user message" {
 
     const json = try ai_chat_request.buildRequestJson(allocator, request);
     defer allocator.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_new\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_close\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"ssh_profile_connect\"") == null);
+    // Side Copilot keeps the full enabled tool catalog (issue #567): only the
+    // Skill Center disabled list removes first-party tools.
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_new\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"tab_close\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"ssh_profile_connect\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"terminal_select\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"name\":\"ssh_session_exec\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, platform_process.localCommandToolName()) != null);

--- a/src/input/clipboard.zig
+++ b/src/input/clipboard.zig
@@ -628,7 +628,12 @@ pub fn pasteImageIntoAiChat(chat: *AppWindow.ai_chat.Session) void {
     const allocator = AppWindow.g_allocator orelse return;
     const owner = clipboardOwner() orelse return;
 
-    const image_path = platform_clipboard.readImageAsPngTemp(allocator, owner) orelse return;
+    const image_path = platform_clipboard.readImageAsPngTemp(allocator, owner) orelse {
+        // No image on the clipboard — fall back to pasting clipboard text into
+        // the composer so Ctrl+Shift+V never silently does nothing (issue #568).
+        pasteFromClipboardIntoAiChat(chat);
+        return;
+    };
     defer allocator.free(image_path);
     // The temp PNG belongs to us once read; remove it either way.
     defer std.fs.deleteFileAbsolute(image_path) catch {};
@@ -672,7 +677,12 @@ pub fn pasteImageFromClipboard() void {
     const allocator = AppWindow.g_allocator orelse return;
     const owner = clipboardOwner() orelse return;
 
-    const image_path = platform_clipboard.readImageAsPngTemp(allocator, owner) orelse return;
+    const image_path = platform_clipboard.readImageAsPngTemp(allocator, owner) orelse {
+        // No image on the clipboard — fall back to a plain text paste so
+        // Ctrl+Shift+V behaves like paste in other terminals (issue #568).
+        pasteFromClipboard();
+        return;
+    };
     defer allocator.free(image_path);
 
     _ = pasteSavedClipboardImage(surface, allocator, image_path);

--- a/src/platform/agent_prompt.zig
+++ b/src/platform/agent_prompt.zig
@@ -74,7 +74,7 @@ const common_tools_after_wsl =
     \\- For a stuck terminal (`>` prompt, unclosed quote, hung command, pager), send `terminal_repl_exec repl=plain code=<ctrl-c>` (or `<ctrl-u>`/`<esc>`/`<ctrl-d>`).
     \\- Read terminal snapshots from the bottom; if stale/truncated, re-read with `terminal_snapshot`.
     \\- Answer Claude Code/Codex approval menus with `terminal_answer_prompt`; never blind-press unseen prompts.
-    \\- Use `tab_new` only when no suitable terminal exists; it is reserved for this Agent. Close temporary tabs with `tab_close` as soon as their task finishes. Side Copilot cannot create or close tabs and stays within its bound tab and splits.
+    \\- Use `tab_new` only when no suitable terminal exists; it is reserved for this Agent. Close temporary tabs with `tab_close` as soon as their task finishes. Side Copilot should prefer working in its bound tab and splits; create or close tabs only when the task genuinely needs it.
     \\- For WispTerm questions, call `wispterm_docs`.
     \\- For biomedical literature, decompose into English keywords (AND/OR), then call `pubmed`.
     \\- Delegate heavy research/reading (full web pages, PDFs, multi-query searches) to `subagent` with one complete task description; only its final report enters this conversation.

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -70,7 +70,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Shift-drag in AI", .action = "Copy answer selection", .action_zh = "复制回答选区" },
     .{ .keys = "Ctrl+A / Ctrl+C in AI", .keys_macos = "Cmd+A / Cmd+C in AI", .action = "Select / copy chat", .action_zh = "选择 / 复制对话" },
     .{ .keys = "Right-click selection", .action = "Copy selection", .action_zh = "复制选区" },
-    .{ .keys = "Ctrl+Shift+V", .kind = .action, .first = .paste_image, .action = "Paste image", .action_zh = "粘贴图片" },
+    .{ .keys = "Ctrl+Shift+V", .kind = .action, .first = .paste_image, .action = "Paste image (or text)", .action_zh = "粘贴图片（无图片时粘贴文本）" },
     .{ .keys = "Ctrl+,", .kind = .action, .first = .open_config, .action = "Open config", .action_zh = "打开配置" },
     .{ .keys = "Ctrl++ / Ctrl+-", .kind = .pair, .first = .font_size_increase, .second = .font_size_decrease, .action = "Font size", .action_zh = "字号" },
     .{ .keys = "Alt+Enter", .kind = .action, .first = .toggle_maximize, .action = "Maximize / restore", .action_zh = "最大化 / 还原" },

--- a/src/tools/first_party.zig
+++ b/src/tools/first_party.zig
@@ -129,33 +129,10 @@ pub fn isKnown(name: []const u8) bool {
     return catalogDisableable(name) != null;
 }
 
-/// Sidebar Copilot is scoped to the tab and split surfaces it was opened on.
-/// These tools change the tab set; regular Agent/Copilot-tab sessions keep the
-/// full catalog. Host-local exec is restricted separately only for remote tabs.
-pub fn isSidebarRestricted(name: []const u8) bool {
-    return std.mem.eql(u8, name, "ssh_profile_connect") or
-        std.mem.eql(u8, name, "tab_new") or
-        std.mem.eql(u8, name, "tab_close");
-}
-
-pub fn isHostLocalCommand(name: []const u8) bool {
-    return std.mem.eql(u8, name, platform_process.localCommandToolName());
-}
-
 fn catalogDisableable(name: []const u8) ?bool {
     if (std.mem.eql(u8, name, platform_process.localCommandToolName())) return true;
     if (platform_pty_command.wslSessionToolsEnabled() and std.mem.eql(u8, name, platform_pty_command.wslSessionToolName())) return true;
     return definitionDisableable(&static_definitions, name);
-}
-
-test "first_party_tools: sidebar restrictions keep terminal work in the bound tab" {
-    try std.testing.expect(isHostLocalCommand(platform_process.localCommandToolName()));
-    try std.testing.expect(!isSidebarRestricted(platform_process.localCommandToolName()));
-    try std.testing.expect(isSidebarRestricted("ssh_profile_connect"));
-    try std.testing.expect(isSidebarRestricted("tab_new"));
-    try std.testing.expect(isSidebarRestricted("tab_close"));
-    try std.testing.expect(!isSidebarRestricted("terminal_select"));
-    try std.testing.expect(!isSidebarRestricted("ssh_session_exec"));
 }
 
 fn definitionDisableable(definitions: []const Definition, name: []const u8) ?bool {


### PR DESCRIPTION
## Issue #567 — powershell_exec / tab_new missing from Copilot tool list

Two root causes:

1. **Side Copilot hard-deny** (added in e55f99b6): `tab_new`/`tab_close`/`ssh_profile_connect` were force-appended to the disabled list for every copilot request, and host-local exec (`powershell_exec`/`shell_exec`) was additionally denied when bound to an SSH/WSL tab — while the system prompt still described those tools, producing the prompt/tool-list mismatch reported in the issue and blocking legit local operations (extracting archives, running local tools).
2. **Presentation leak into standalone tabs**: a copilot conversation restored from history into its own tab kept `copilot=true` from the record, so the sidebar restrictions applied even in standalone Tab mode — contradicting the documented design ("regular Agent/Copilot-tab sessions keep the full catalog").

Fix:
- The Skill Center disabled list (`agent_tools.json`) is now the single source of truth for first-party tool availability — no blanket sidebar deny at either schema emission or dispatch.
- The system prompt keeps soft guidance: Side Copilot should prefer its bound tab and splits, creating/closing tabs only when the task needs it.
- `spawnAiChatSession` (the single funnel for hosting a session in a tab) re-presents the session as `.chat_tab`, so sidebar behavior never leaks into standalone tabs.
- Tests flipped/updated accordingly (`session.zig`, `agent_tools/mod.zig`, `first_party.zig`).

## Issue #568 — copy/paste in tmux

Investigation showed most of the workflow already exists (Shift+drag bypasses mouse reporting for local selection on all three backends, Ctrl+Shift+C copy, OSC 52 clipboard writes, `right-click-action`). Two real gaps:

- **`Ctrl+Shift+V` was bound to `paste_image` and silently did nothing when the clipboard held text** — the exact "paste does not work" symptom. It now falls back to a plain text paste (terminal and AI-chat composer paths), and the startup shortcut label says so.
- **No documentation** of the tmux copy/paste workflow. Added an FAQ section (embedded into `wispterm_docs`) covering Shift+drag selection, copy/paste shortcuts, `right-click-action` + Shift+right-click bypass, and `set -g set-clipboard on` / terminal-features for OSC 52 from tmux copy mode.

## Verification

- `zig fmt` clean (CI gate)
- `zig build test` (fast suite) — pass
- `zig build test-full -Dtarget=aarch64-macos` (~2300 native tests) — pass
- `zig build` (default Windows target) — compiles

Fixes #567
Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)