### PR TITLE
feat(settings): improve visual settings and shell defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Previous / next image/PDF in gallery (preview focused) | Left / Right | Left / Right |
 | Previous / next PDF page (PDF preview focused) | PageUp / PageDown | PageUp / PageDown |
 | Download SSH remote file | Ctrl+Shift-click path in SSH output | Cmd+Shift-click path in SSH output |
-| Close focused panel, tab, or window | **Ctrl+Shift+W** | **Cmd+Shift+W** |
+| Close focused panel, tab, or window | **Ctrl+Shift+W** | **Cmd+W** |
 | Maximize or restore window | **Alt+Enter** | **Opt+Enter** |
 | Increase / decrease font size | **Ctrl++** / **Ctrl+-** | **Cmd++** / **Cmd+-** |
 | Copy terminal selection or AI Chat selection/transcript | **Ctrl+Shift+C** | **Cmd+Shift+C** |
@@ -186,7 +186,7 @@ Use `keybind = clear` before custom bindings if you want to remove all defaults 
 | Next tab | **Ctrl+Tab** | **Ctrl+Tab** |
 | Previous tab | **Ctrl+Shift+Tab** | **Ctrl+Shift+Tab** |
 | Switch to tab 1–9 | **Alt+1**–**9** | **Opt+1**–**9** |
-| Open config file | **Ctrl+,** | **Cmd+,** |
+| Open visual settings | **Ctrl+,** | **Cmd+,** |
 
 ## AI Chat Markdown export
 

--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,13 @@ comptime {
 
 const linux_system_libraries = [_][]const u8{ "SDL3", "fontconfig" };
 
+fn fastTestsNeedLibc(os_tag: std.Target.Os.Tag) bool {
+    return switch (os_tag) {
+        .linux, .macos => true,
+        else => false,
+    };
+}
+
 const windows_system_libraries = [_][]const u8{
     "user32",
     "advapi32", // registry access for WSL availability detection
@@ -349,6 +356,12 @@ test "windows system libraries are gated by platform" {
 
     const macos = PlatformFeatures.forOs(.macos);
     try std.testing.expectEqual(@as(usize, 0), systemLibrariesFor(macos).len);
+}
+
+test "fast tests link libc on hosts whose platform adapters import C headers" {
+    try std.testing.expect(fastTestsNeedLibc(.linux));
+    try std.testing.expect(fastTestsNeedLibc(.macos));
+    try std.testing.expect(!fastTestsNeedLibc(.windows));
 }
 
 test "macOS platform advertises required app frameworks" {
@@ -793,10 +806,10 @@ pub fn build(b: *std.Build) void {
         .name = "wispterm-fast-test",
         .root_module = fast_test_mod,
     });
+    fast_test_mod.link_libc = fastTestsNeedLibc(b.graph.host.result.os.tag);
     switch (b.graph.host.result.os.tag) {
         .windows => fast_test_mod.linkSystemLibrary("winhttp", .{}),
         .macos => {
-            fast_test_mod.link_libc = true;
             fast_test_mod.addCSourceFile(.{
                 .file = b.path("src/platform/http_client_macos_bridge.m"),
                 .flags = &.{},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,9 @@ main config path is resolved in this order:
    - **macOS:** `~/Library/Application Support/wispterm/config`
    - **Linux:** `$XDG_CONFIG_HOME/wispterm/config` (fallback: `~/.config/wispterm/config`)
 
-Press the configured `open_config` shortcut (default `Ctrl+,`, `Cmd+,` on macOS) to open the
-config file in your default editor, or run `wispterm --show-config-path` to
-print the resolved path.
+Press `Ctrl+,` (`Cmd+,` on macOS) to open the visual Settings page. Advanced
+users can run **Open Config** from the command center to edit the raw file, or
+run `wispterm --show-config-path` to print the resolved path.
 
 CLI flags override config file values (last wins). `config-file = extra.conf`
 and `--config-file extra.conf` include additional config files; they do not
@@ -126,7 +126,7 @@ login password configured on the relay server.
 
 You do not have to edit the config file by hand. Open the command center
 (`Ctrl+Shift+P`, `Cmd+Shift+P` on macOS) and run **Settings** to open an in-app
-settings page that edits the most common options: font size, theme, cursor style
+settings page that edits the most common options: font family and size, theme, cursor style
 and blink, focus-follows-mouse, restore-tabs-on-startup, the default shell, the
 default AI profile, WeChat direct control, and the interface language. The page
 also has an **Open raw config** button for the advanced keys above, and changes
@@ -140,7 +140,10 @@ the settings page; it leaves Quake mode, your saved AI profiles, and custom
 
 ## Default Shell and Git Bash
 
-Set `shell` in your config file to choose what new local shell sessions launch.
+By default, WispTerm follows the current OS account's login shell (for example
+`/bin/bash` or `/bin/zsh`). Choose **System default** in Settings to keep this
+behavior, or choose a specific shell to override it for new local sessions.
+You can also set `shell` in the config file explicitly.
 Existing tabs keep their current process; save the config, wait for hot reload
 or restart WispTerm, then open a new session.
 

--- a/docs/file-explorer.md
+++ b/docs/file-explorer.md
@@ -68,7 +68,8 @@ The left File Explorer and right-side preview/browser panels can be resized by
 dragging their inner edges. Markdown, text, CSV, and TSV previews scroll with
 the mouse wheel; CSV and TSV cells show a larger hover popup when their content
 does not fit in the visible cell. Image and PDF previews zoom in and out with
-the mouse wheel and can be dragged to pan after zooming. `Ctrl+Shift+W` closes
+the mouse wheel and can be dragged to pan after zooming. `Ctrl+Shift+W` (`Cmd+W`
+on macOS) closes
 the focused pane — click a preview pane (or press `Ctrl+1-9`) to select it, then
 close it like any other split.
 

--- a/docs/tabs-panels.md
+++ b/docs/tabs-panels.md
@@ -23,7 +23,7 @@ terminals together.
 - **Reorder tabs:** open the tab sidebar with `Ctrl+Shift+B` (`toggle_sidebar`)
   and drag a tab up or down to a new position.
 - **Close a tab:** click the `×` button on the tab, middle-click the tab, or
-  press `Ctrl+Shift+W` (`close_panel_or_tab`). When the tab (or focused panel)
+  press `Ctrl+Shift+W` (`Cmd+W` on macOS; `close_panel_or_tab`). When the tab (or focused panel)
   is running a full-screen TUI such as `vim` or `htop`, WispTerm asks for
   confirmation first; turn that off with `confirm-close-running-program = false`.
 

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -4588,12 +4588,15 @@ fn syncFileExplorerToActiveTerminalSurface(force: bool) void {
 pub fn closeTab(idx: usize) void {
     const allocator = g_allocator orelse return;
     if (tab.g_tab_count <= 1 or idx >= tab.g_tab_count) return;
+    var closing_settings = false;
     if (tab.g_tabs[idx]) |closing| {
+        closing_settings = closing.kind == .settings;
         if (closing.tmux_window_id != null) tmux_controller.forgetClosedTab(closing);
     }
     tab.closeTab(idx, allocator);
     file_explorer.onTabClosed(idx);
     browser_panel.onTabClosed(idx);
+    if (closing_settings) overlays.settingsPageDidClose();
     clearUiStateOnTabChange();
 }
 
@@ -4604,6 +4607,11 @@ pub fn closeFocusedSplitWouldCloseWindow() bool {
 }
 
 pub fn switchTab(idx: usize) void {
+    const deactivating_settings = if (activeTab()) |active|
+        active.kind == .settings and idx != active_tab_state.g_active_tab
+    else
+        false;
+    if (deactivating_settings) overlays.settingsPageDidDeactivate();
     tab.switchTab(idx);
     clearUiStateOnTabChange();
 }
@@ -4669,6 +4677,7 @@ pub fn closeFocusedSplit() void {
     }
 
     const closing_tab_idx = active_tab_state.g_active_tab;
+    const closing_settings = if (tab.activeTab()) |active| active.kind == .settings else false;
     var closing_surface_id: ?[16]u8 = null;
     if (tab.activeSurface()) |surface| closing_surface_id = surface.remote_id;
     switch (tab.closeFocusedSplit(allocator)) {
@@ -4681,9 +4690,11 @@ pub fn closeFocusedSplit() void {
         .closed_tab => {
             file_explorer.onTabClosed(closing_tab_idx);
             browser_panel.onTabClosed(closing_tab_idx);
+            if (closing_settings) overlays.settingsPageDidClose();
             clearUiStateOnTabChange();
         },
         .close_window => {
+            if (closing_settings) overlays.settingsPageDidClose();
             split_layout.invalidateCachedRects();
             cell_renderer.g_current_render_surface = null;
             g_should_close = true;

--- a/src/config.zig
+++ b/src/config.zig
@@ -331,7 +331,9 @@ theme: ?[]const u8 = null,
 
 /// The shell to run in the terminal. Platform aliases are resolved by
 /// platform/pty_command.zig; any other value is treated as a raw command path.
-shell: []const u8 = platform_pty_command.default_shell_name,
+/// Empty means follow the current user's OS login shell. A non-empty value is
+/// an explicit override written by the Settings page or config file.
+shell: []const u8 = "",
 
 /// Working directory for the first local terminal surface (unset = inherit app cwd).
 @"working-directory": ?[]const u8 = null,
@@ -1762,8 +1764,9 @@ pub fn removeConfigKeys(allocator: std.mem.Allocator, keys: []const []const u8) 
 /// Config keys backing the settings page. "Restore default settings" removes
 /// these active lines so each reverts to its built-in default. Intentionally
 /// excludes `quake-mode` (not a settings-page row) and anything carrying user
-/// data such as AI profiles, custom keybinds, or `font-family`.
+/// data such as AI profiles or custom keybinds.
 pub const settings_reset_keys = [_][]const u8{
+    "font-family",
     "font-size",
     "theme",
     "cursor-style",
@@ -1780,7 +1783,7 @@ pub const settings_reset_keys = [_][]const u8{
 
 /// Revert every settings-page option to its built-in default by removing its
 /// active line from the main config file. Non-destructive: comments, custom
-/// keybinds, AI profiles, font-family, and window geometry are all preserved.
+/// keybinds, AI profiles, and window geometry are all preserved.
 pub fn resetSettingsToDefaults(allocator: std.mem.Allocator) !void {
     try removeConfigKeys(allocator, &settings_reset_keys);
 }
@@ -2058,7 +2061,7 @@ test "config: help text is writable to a caller-provided writer" {
 
 test "config: shell defaults and template come from platform pty command" {
     const cfg = Config{};
-    try std.testing.expectEqualStrings(platform_pty_command.defaultShellName(), cfg.shell);
+    try std.testing.expectEqualStrings("", cfg.shell);
     try std.testing.expect(std.mem.indexOf(u8, default_config_template, platform_pty_command.shellSettingComment()) != null);
     try std.testing.expect(std.mem.indexOf(u8, default_config_template, platform_pty_command.defaultShellAssignmentComment()) != null);
 }
@@ -2209,7 +2212,7 @@ test "config: settings reset strips settings-page keys but preserves everything 
     // Untouched: comments, unrelated keys, custom keybinds, and quake-mode
     // (intentionally excluded — it is not a settings-page row).
     try std.testing.expect(std.mem.indexOf(u8, stripped, "# WispTerm config") != null);
-    try std.testing.expect(std.mem.indexOf(u8, stripped, "font-family = JetBrains Mono") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stripped, "font-family = JetBrains Mono") == null);
     try std.testing.expect(std.mem.indexOf(u8, stripped, "keybind = ctrl+shift+p=toggle_command_palette") != null);
     try std.testing.expect(std.mem.indexOf(u8, stripped, "quake-mode = true") != null);
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -3117,6 +3117,7 @@ fn executeCommand(cmd: command_dispatch.Command) bool {
         .close_panel_or_tab => closePanelOrTab(),
         .toggle_maximize => toggleMaximize(),
         .font_size => |delta| adjustFontSize(delta),
+        .open_settings => overlays.settingsPageOpen(),
         // Late
         .copy => copySelectionToClipboard(),
         .paste => {

--- a/src/input/command_dispatch.zig
+++ b/src/input/command_dispatch.zig
@@ -29,6 +29,7 @@ pub const Command = union(enum) {
     close_panel_or_tab,
     toggle_maximize,
     font_size: i32,
+    open_settings,
     // Late commands.
     copy,
     paste,
@@ -61,6 +62,7 @@ pub fn resolve(action: keybind.Action, phase: Phase) ?Command {
             .toggle_maximize => .toggle_maximize,
             .font_size_increase => .{ .font_size = 1 },
             .font_size_decrease => .{ .font_size = -1 },
+            .open_settings => .open_settings,
             else => null,
         },
         .late => switch (action) {
@@ -140,6 +142,11 @@ test "late commands resolve only in the late phase" {
     try std.testing.expectEqual(Command.copy, resolve(.copy, .late).?);
     try std.testing.expectEqual(Command.open_config, resolve(.open_config, .late).?);
     try std.testing.expectEqual(@as(?Command, null), resolve(.copy, .early));
+}
+
+test "visual settings resolves before overlay routing" {
+    try std.testing.expectEqual(Command.open_settings, resolve(.open_settings, .early).?);
+    try std.testing.expectEqual(@as(?Command, null), resolve(.open_settings, .late));
 }
 
 test "focus actions map to focus_split targets" {

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -100,6 +100,7 @@ pub const Action = enum {
     focus_panel_7,
     focus_panel_8,
     focus_panel_9,
+    open_settings,
     open_config,
 
     pub fn parse(value: []const u8) ?Action {
@@ -154,6 +155,9 @@ pub const Set = struct {
             // Cmd+C has no such conflict, so the migrated Cmd+Shift+C is replaced
             // by the single conventional shortcut rather than kept alongside it.
             set.replaceTrigger(.copy, .{ .mods = .{ .win = true }, .key_code = 'C' });
+            // Closing uses the native macOS Cmd+W convention. Windows/Linux keep
+            // Ctrl+Shift+W so Ctrl+W remains available to shells and TUIs.
+            set.replaceTrigger(.close_panel_or_tab, .{ .mods = .{ .win = true }, .key_code = 'W' });
         }
         return set;
     }
@@ -461,7 +465,7 @@ pub const default_bindings = [_]Binding{
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '7' }, .action = .focus_panel_7 },
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '8' }, .action = .focus_panel_8 },
     .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = '9' }, .action = .focus_panel_9 },
-    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = Key.comma }, .action = .open_config },
+    .{ .trigger = .{ .mods = .{ .ctrl = true }, .key_code = Key.comma }, .action = .open_settings },
 };
 
 test "keybind parses ghostty-style global trigger and action" {
@@ -489,6 +493,16 @@ test "keybind defaults include global quake and command palette" {
         .mods = if (is_macos) .{ .win = true, .shift = true } else .{ .ctrl = true, .shift = true },
         .key_code = 'P',
     }).?);
+}
+
+test "keybind defaults open the visual settings page with ctrl comma" {
+    const set = Set.defaults();
+    const is_macos = builtin.target.os.tag == .macos;
+    const action = set.lookupApp(.{
+        .mods = if (is_macos) .{ .win = true } else .{ .ctrl = true },
+        .key_code = Key.comma,
+    });
+    try std.testing.expectEqual(Action.open_settings, action.?);
 }
 
 test "copy default: macOS binds Cmd+C only, other platforms keep Ctrl+Shift+C" {

--- a/src/platform/font_discovery_linux.zig
+++ b/src/platform/font_discovery_linux.zig
@@ -118,7 +118,48 @@ pub const FontDiscovery = struct {
 
     pub fn listFontFamilies(self: *FontDiscovery, allocator: std.mem.Allocator) ![][]const u8 {
         _ = self;
-        return allocator.alloc([]const u8, 0);
+        const pattern = fc.FcPatternCreate() orelse return error.FontconfigPatternCreateFailed;
+        defer fc.FcPatternDestroy(pattern);
+        const objects = fc.FcObjectSetCreate() orelse return error.FontconfigObjectSetFailed;
+        defer fc.FcObjectSetDestroy(objects);
+        if (fc.FcObjectSetAdd(objects, fc.FC_FAMILY) == 0) return error.FontconfigObjectSetFailed;
+
+        const font_set = fc.FcFontList(null, pattern, objects) orelse return error.FontconfigFontListFailed;
+        defer fc.FcFontSetDestroy(font_set);
+
+        var families: std.ArrayList([]const u8) = .empty;
+        errdefer {
+            for (families.items) |family| allocator.free(family);
+            families.deinit(allocator);
+        }
+        var seen = std.StringHashMap(void).init(allocator);
+        defer seen.deinit();
+
+        const fonts = font_set.*.fonts;
+        const font_count: usize = @intCast(font_set.*.nfont);
+        for (0..font_count) |font_index| {
+            const font_pattern = fonts[font_index];
+            if (font_pattern == null) continue;
+            var value_index: c_int = 0;
+            while (true) : (value_index += 1) {
+                var family_ptr: ?[*:0]fc.FcChar8 = null;
+                if (fc.FcPatternGetString(font_pattern, fc.FC_FAMILY, value_index, @ptrCast(&family_ptr)) != fc.FcResultMatch) break;
+                const family = std.mem.span(@as([*:0]const u8, @ptrCast(family_ptr orelse continue)));
+                if (family.len == 0 or seen.contains(family)) continue;
+
+                const owned = try allocator.dupe(u8, family);
+                errdefer allocator.free(owned);
+                try seen.put(owned, {});
+                try families.append(allocator, owned);
+            }
+        }
+
+        std.sort.heap([]const u8, families.items, {}, struct {
+            fn lessThan(_: void, left: []const u8, right: []const u8) bool {
+                return std.mem.order(u8, left, right) == .lt;
+            }
+        }.lessThan);
+        return families.toOwnedSlice(allocator);
     }
 
     pub fn findFontFilePath(

--- a/src/platform/menu_macos.zig
+++ b/src/platform/menu_macos.zig
@@ -96,7 +96,7 @@ fn buildDefaultMenu() void {
     wispterm_macos_menu_begin_submenu("WispTerm");
     wispterm_macos_menu_add_item("About WispTerm", @intFromEnum(SystemAction.about), "", 0);
     wispterm_macos_menu_add_separator();
-    wispterm_macos_menu_add_item("Settings…", id(.open_config), ",", ModCmd);
+    wispterm_macos_menu_add_item("Settings…", id(.open_settings), ",", ModCmd);
     wispterm_macos_menu_add_separator();
     wispterm_macos_menu_add_item("Hide WispTerm", @intFromEnum(SystemAction.hide), "h", ModCmd);
     wispterm_macos_menu_add_item("Hide Others", @intFromEnum(SystemAction.hide_others), "h", ModCmd | ModOpt);
@@ -112,7 +112,7 @@ fn buildDefaultMenu() void {
     wispterm_macos_menu_add_item("Split Right", id(.split_right), "+", AppMod | ModShift);
     wispterm_macos_menu_add_item("Split Down", id(.split_down), "-", AppMod | ModShift);
     wispterm_macos_menu_add_separator();
-    wispterm_macos_menu_add_item("Close Tab", id(.close_panel_or_tab), "w", AppMod | ModShift);
+    wispterm_macos_menu_add_item("Close Tab", id(.close_panel_or_tab), "w", AppMod);
     wispterm_macos_menu_end_submenu();
 
     // Edit.

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -72,7 +72,17 @@ pub fn cwdFromUtf8(cwd_buf: *CwdBuffer, cwd: []const u8) Cwd {
 }
 
 pub fn resolveShellCommandLine(out_buf: *CommandLineBuffer, cmd: []const u8) usize {
-    return impl.resolveShellCommandLine(out_buf, cmd);
+    var detected_buf: [512]u8 = undefined;
+    const effective = effectiveShellConfigValue(cmd, detectedDefaultShell(&detected_buf));
+    return impl.resolveShellCommandLine(out_buf, effective);
+}
+
+pub fn effectiveShellConfigValue(configured: []const u8, detected: []const u8) []const u8 {
+    return if (configured.len == 0) detected else configured;
+}
+
+pub fn detectedDefaultShell(out: []u8) []const u8 {
+    return impl.detectDefaultShell(out);
 }
 
 pub fn commandLineDisplay(command: CommandLine, out: []u8) []const u8 {
@@ -247,6 +257,21 @@ pub fn defaultShellName() []const u8 {
 
 pub const default_shell_name = defaultShellNameForOs(builtin.os.tag);
 
+const WINDOWS_CONFIG_SHELL_CHOICES = [_][]const u8{ "", "cmd", "powershell", "pwsh", "wsl" };
+const MACOS_CONFIG_SHELL_CHOICES = [_][]const u8{ "", "zsh", "bash", "fish", "sh" };
+const POSIX_CONFIG_SHELL_CHOICES = [_][]const u8{ "", "sh", "bash", "zsh", "fish" };
+
+pub fn configShellChoices() []const []const u8 {
+    return configShellChoicesForOs(builtin.os.tag);
+}
+
+pub fn configShellChoicesForOs(os_tag: std.Target.Os.Tag) []const []const u8 {
+    return switch (backendForOs(os_tag)) {
+        .windows => &WINDOWS_CONFIG_SHELL_CHOICES,
+        .unsupported => if (os_tag == .macos) &MACOS_CONFIG_SHELL_CHOICES else &POSIX_CONFIG_SHELL_CHOICES,
+    };
+}
+
 pub fn defaultShellNameForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
         .windows => "cmd",
@@ -269,7 +294,7 @@ pub const shell_setting_choices_hint = shellSettingChoicesHintForOs(builtin.os.t
 pub fn shellSettingChoicesHintForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
         .windows => "cmd / powershell / pwsh / wsl",
-        .unsupported => "sh / zsh / fish",
+        .unsupported => "sh / bash / zsh / fish",
     };
 }
 
@@ -282,7 +307,7 @@ pub const shell_setting_comment = shellSettingCommentForOs(builtin.os.tag);
 pub fn shellSettingCommentForOs(os_tag: std.Target.Os.Tag) []const u8 {
     return switch (backendForOs(os_tag)) {
         .windows => "# Shell (cmd, powershell, pwsh, wsl, or a custom path)",
-        .unsupported => "# Shell (sh, zsh, fish, or a custom path)",
+        .unsupported => "# Shell (sh, bash, zsh, fish, or a custom path)",
     };
 }
 
@@ -293,13 +318,8 @@ pub fn defaultShellAssignmentComment() []const u8 {
 pub const default_shell_assignment_comment = defaultShellAssignmentCommentForOs(builtin.os.tag);
 
 pub fn defaultShellAssignmentCommentForOs(os_tag: std.Target.Os.Tag) []const u8 {
-    return switch (backendForOs(os_tag)) {
-        .windows => "# shell = cmd",
-        .unsupported => switch (os_tag) {
-            .macos => "# shell = zsh",
-            else => "# shell = sh",
-        },
-    };
+    _ = os_tag;
+    return "# shell =  # empty follows your OS login shell";
 }
 
 pub fn nextConfigShell(shell: []const u8) []const u8 {
@@ -661,6 +681,27 @@ test "platform pty command exposes shell config defaults by target OS" {
     try std.testing.expectEqualStrings("zsh", configReloadTestInitialShellForOs(.linux));
     try std.testing.expectEqualStrings("pwsh", configReloadTestNextShellForOs(.windows));
     try std.testing.expectEqualStrings("fish", configReloadTestNextShellForOs(.linux));
+}
+
+test "settings shell picker offers bash and zsh on POSIX" {
+    const mac_choices = configShellChoicesForOs(.macos);
+    try std.testing.expect(stringChoicesContain(mac_choices, "bash"));
+    try std.testing.expect(stringChoicesContain(mac_choices, "zsh"));
+    const windows_choices = configShellChoicesForOs(.windows);
+    try std.testing.expect(stringChoicesContain(windows_choices, "powershell"));
+    try std.testing.expect(stringChoicesContain(windows_choices, "pwsh"));
+}
+
+fn stringChoicesContain(choices: []const []const u8, expected: []const u8) bool {
+    for (choices) |choice| {
+        if (std.mem.eql(u8, choice, expected)) return true;
+    }
+    return false;
+}
+
+test "empty shell config follows the detected login shell while explicit config wins" {
+    try std.testing.expectEqualStrings("/bin/bash", effectiveShellConfigValue("", "/bin/bash"));
+    try std.testing.expectEqualStrings("zsh", effectiveShellConfigValue("zsh", "/bin/bash"));
 }
 
 test "platform pty command delegates launch context classification to backend" {

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -3,6 +3,12 @@ const builtin = @import("builtin");
 const process_shared = @import("process_shared.zig");
 const ssh_connection = @import("../ssh/connection.zig");
 
+const c = if (builtin.os.tag != .windows) @cImport({
+    @cInclude("sys/types.h");
+    @cInclude("unistd.h");
+    @cInclude("pwd.h");
+}) else {};
+
 pub const CommandLineBuffer = [256]u8;
 pub const CwdBuffer = [260]u8;
 pub const CwdUnit = u8;
@@ -36,6 +42,28 @@ pub fn resolveShellCommandLine(out_buf: *CommandLineBuffer, cmd: []const u8) usi
     @memcpy(out_buf[0..len], cmd[0..len]);
     out_buf[len] = 0;
     return len;
+}
+
+pub fn detectDefaultShell(out: []u8) []const u8 {
+    if (builtin.os.tag != .windows) {
+        var passwd_buf: [4096]u8 = undefined;
+        var entry: c.struct_passwd = undefined;
+        var result: ?*c.struct_passwd = null;
+        if (c.getpwuid_r(c.getuid(), &entry, &passwd_buf, passwd_buf.len, &result) == 0 and result != null) {
+            if (entry.pw_shell) |shell_ptr| {
+                const shell = std.mem.sliceTo(shell_ptr, 0);
+                if (shell.len != 0) {
+                    const len = @min(out.len, shell.len);
+                    @memcpy(out[0..len], shell[0..len]);
+                    return out[0..len];
+                }
+            }
+        }
+    }
+    const fallback = guaranteedLocalShellCommand();
+    const len = @min(out.len, fallback.len);
+    @memcpy(out[0..len], fallback[0..len]);
+    return out[0..len];
 }
 
 pub fn allocCommandLineFromUtf8(allocator: std.mem.Allocator, command: []const u8) !OwnedCommandLine {

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -160,6 +160,13 @@ pub fn resolveShellCommandLine(out_buf: *CommandLineBuffer, cmd: []const u8) usi
     return len;
 }
 
+pub fn detectDefaultShell(out: []u8) []const u8 {
+    const value = "cmd";
+    const len = @min(out.len, value.len);
+    @memcpy(out[0..len], value[0..len]);
+    return out[0..len];
+}
+
 fn commandLineLowerAscii(command: CommandLine, out: *[512]u8) []const u8 {
     const len = @min(command.len, out.len);
     for (command[0..len], 0..) |unit, i| {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -41,6 +41,7 @@ const overlay_state = @import("overlays/state.zig");
 const confirm_modals = @import("overlays/confirm_modals.zig");
 const settings_page = @import("overlays/settings_page.zig");
 const settings_page_layout = @import("overlays/settings_page_layout.zig");
+const settings_page_renderer = @import("settings_page_renderer.zig");
 const toasts = @import("overlays/toasts.zig");
 const ssh_profiles = @import("overlays/ssh_profiles.zig");
 const ssh_profiles_layout = @import("overlays/ssh_profiles_layout.zig");
@@ -1070,8 +1071,7 @@ pub fn weixinQrPanelHandleAction(action: weixin_qr_panel.Action) void {
         .close => {
             if (weixin_qr_panel.controller()) |controller| controller.cancelLogin();
             weixin_qr_panel.close();
-            AppWindow.g_force_rebuild = true;
-            AppWindow.g_cells_valid = false;
+            AppWindow.applyUiEffect(.repaint);
         },
         .retry => {
             const allocator = AppWindow.g_allocator orelse std.heap.page_allocator;
@@ -1083,8 +1083,7 @@ pub fn weixinQrPanelHandleAction(action: weixin_qr_panel.Action) void {
                 showStatusToast(i18n.s().toast_wechat_login_failed);
                 return;
             };
-            AppWindow.g_force_rebuild = true;
-            AppWindow.g_cells_valid = false;
+            AppWindow.applyUiEffect(.repaint);
         },
         .unbind => unbindWeixinDirect(),
     }
@@ -1853,6 +1852,11 @@ fn measureTitlebarText(text: []const u8) f32 {
         text_width += titlebar.titlebarGlyphAdvance(cp);
     }
     return text_width;
+}
+
+fn renderSettingsTextLimited(text: []const u8, x: f32, y: f32, color: [3]f32, max_width: f32) f32 {
+    renderTitlebarTextLimited(text, x, y, color, max_width);
+    return @min(max_width, measureTitlebarText(text));
 }
 
 fn renderTitlebarText(text: []const u8, x_start: f32, y: f32, color: [3]f32) void {
@@ -5101,8 +5105,7 @@ fn applyProfileToSession(session: *AppWindow.ai_chat.Session, idx: usize) bool {
     if (!aiProfileInputsValid(protocol, base_url, model, command)) return false;
     ai_chat.applyProviderProfile(session, base_url, api_key, model, protocol, thinking, reasoning_effort, max_tokens, vision_val);
     session.setAcpCommand(command);
-    AppWindow.g_force_rebuild = true;
-    AppWindow.g_cells_valid = false;
+    AppWindow.applyUiEffect(.repaint);
     return true;
 }
 
@@ -5120,8 +5123,7 @@ pub fn openSwitchModelPicker(session: *AppWindow.ai_chat.Session) void {
     loadAiProfiles();
     if (assistantProfiles().profile_count == 0) {
         session.appendLocalToolMessage(i18n.s().ai_model_no_profiles);
-        AppWindow.g_force_rebuild = true;
-        AppWindow.g_cells_valid = false;
+        AppWindow.applyUiEffect(.repaint);
         return;
     }
     setSwitchModelTarget(session);
@@ -6627,6 +6629,18 @@ pub fn settingsPageClose() void {
     settingsState().close(AppWindow.g_allocator);
 }
 
+/// Release transient Settings resources when its tab is closed through the
+/// shared tab chrome instead of the Settings-specific close action.
+pub fn settingsPageDidClose() void {
+    settingsState().close(AppWindow.g_allocator);
+}
+
+/// A picker is scoped to the active Settings visit. Keep the tab itself open,
+/// but discard transient choices when the user switches away.
+pub fn settingsPageDidDeactivate() void {
+    settingsState().closePicker(AppWindow.g_allocator);
+}
+
 pub fn settingsPageHandleKey(ev: input_key.KeyEvent) AppWindow.UiEffect {
     if (!settingsPageVisible()) return .none;
     if (settingsState().handleKey(ev)) |action| executeSettingsAction(action);
@@ -6666,61 +6680,7 @@ fn settingsLayout(window_height: f32, top_offset: f32, content_x: f32, content_w
 
 fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, content_x: f32, content_width: f32) ?SettingsAction {
     const layout = settingsLayout(window_height, top_offset, content_x, content_width);
-    const x: f32 = @floatCast(xpos);
-    const y: f32 = @floatCast(ypos);
-
-    if (layout.categoryAt(x, y)) |index| {
-        settingsState().closePicker(AppWindow.g_allocator);
-        return switch (settings_page.categoryAt(index) orelse return null) {
-            .general => .select_general,
-            .appearance => .select_appearance,
-            .ai => .select_ai,
-            .system => .select_system,
-        };
-    }
-
-    const row_index = layout.rowAt(x, y) orelse return null;
-    if (settingsState().pickerOpen()) {
-        if (!settingsState().selectPickerIndex(row_index)) return null;
-        return .choose_picker_value;
-    }
-    const rows = settings_page.categoryRows(settingsState().category);
-    if (row_index >= rows.len) return null;
-    const row = rows[row_index];
-    settingsState().focus = row;
-
-    if (row == SETTINGS_FONT_SIZE_ROW) {
-        return switch (layout.fontControlAt(x) orelse return null) {
-            .minus => .font_size_minus,
-            .plus => .font_size_plus,
-        };
-    }
-
-    if (row == SETTINGS_THEME_ROW) {
-        return .cycle_theme;
-    }
-
-    if (row == SETTINGS_FONT_FAMILY_ROW) return .open_font_picker;
-
-    const control_row = row - SETTINGS_CONTROL_ROW_START;
-    if (shell_integration.supported) {
-        if (control_row == 9) return .toggle_start_menu;
-        if (control_row == 10) return .toggle_startup;
-    }
-    return switch (control_row) {
-        0 => .cycle_cursor_style,
-        1 => .toggle_cursor_blink,
-        2 => .toggle_focus_follows_mouse,
-        3 => .open_shell_picker,
-        4 => .cycle_default_ai_profile,
-        5 => .toggle_weixin_direct,
-        6 => .cycle_language,
-        7 => .toggle_restore_tabs,
-        8 => .toggle_distill_suggest,
-        9 + settings_page.SHELL_INTEGRATION_ROWS => .open_raw_config,
-        10 + settings_page.SHELL_INTEGRATION_ROWS => .restore_defaults,
-        else => null,
-    };
+    return settingsState().hitTest(layout, @floatCast(xpos), @floatCast(ypos));
 }
 
 fn executeSettingsAction(action: SettingsAction) void {
@@ -6769,7 +6729,7 @@ fn executeSettingsAction(action: SettingsAction) void {
         .toggle_focus_follows_mouse => Config.setConfigValue(allocator, "focus-follows-mouse", if (cfg.@"focus-follows-mouse") "false" else "true") catch {},
         .open_shell_picker => {
             settingsState().closePicker(allocator);
-            settingsState().openPicker(.shell, platform_pty_command.configShellChoices(), cfg.shell, false);
+            settingsState().openPicker(.shell, platform_pty_command.configShellChoices(), cfg.shell, false, null);
         },
         .choose_picker_value => chooseSettingsPickerValue(allocator),
         .close_picker => settingsState().closePicker(allocator),
@@ -6798,10 +6758,6 @@ fn executeSettingsAction(action: SettingsAction) void {
     }
 }
 
-fn fontFamilyLessThan(_: void, left: []const u8, right: []const u8) bool {
-    return std.mem.order(u8, left, right) == .lt;
-}
-
 fn openFontFamilyPicker(allocator: std.mem.Allocator, current: []const u8) void {
     settingsState().closePicker(allocator);
     const discovery = font.g_font_discovery orelse return;
@@ -6810,8 +6766,7 @@ fn openFontFamilyPicker(allocator: std.mem.Allocator, current: []const u8) void 
         allocator.free(choices);
         return;
     }
-    std.sort.heap([]const u8, choices, {}, fontFamilyLessThan);
-    settingsState().openPicker(.font_family, choices, current, true);
+    settingsState().openPicker(.font_family, choices, current, true, allocator);
 }
 
 fn chooseSettingsPickerValue(allocator: std.mem.Allocator) void {
@@ -6939,302 +6894,38 @@ fn shellSettingText(configured: []const u8, buf: []u8) []const u8 {
     return std.fmt.bufPrint(buf, "{s} ({s})", .{ prefix, detected }) catch prefix;
 }
 
-fn settingsCategoryLabel(category: settings_page.Category) []const u8 {
-    return switch (i18n.lang()) {
-        .en => switch (category) {
-            .general => "General",
-            .appearance => "Appearance",
-            .ai => "AI & Integrations",
-            .system => "System",
-        },
-        .zh_CN => switch (category) {
-            .general => "常规",
-            .appearance => "外观",
-            .ai => "AI 与集成",
-            .system => "系统",
-        },
-    };
-}
-
-fn settingsCategoryDescription(category: settings_page.Category) []const u8 {
-    return switch (i18n.lang()) {
-        .en => switch (category) {
-            .general => "Startup, language, and configuration",
-            .appearance => "Typography, theme, and cursor behavior",
-            .ai => "Profiles and assistant integrations",
-            .system => "Desktop integration and startup behavior",
-        },
-        .zh_CN => switch (category) {
-            .general => "启动、语言与配置管理",
-            .appearance => "字体、主题与光标行为",
-            .ai => "配置文件与智能助手集成",
-            .system => "桌面集成与启动方式",
-        },
-    };
-}
-
-fn settingsRowDescription(row: usize) []const u8 {
-    const zh = i18n.lang() == .zh_CN;
-    if (shell_integration.supported) {
-        if (row == SETTINGS_CONTROL_ROW_START + 9) return if (zh) "在 Windows 开始菜单中显示 WispTerm" else "Show WispTerm in the Windows Start menu";
-        if (row == SETTINGS_CONTROL_ROW_START + 10) return if (zh) "登录系统后自动启动 WispTerm" else "Launch WispTerm when you sign in";
-    }
-    return switch (row) {
-        SETTINGS_FONT_FAMILY_ROW => if (zh) "从系统已安装字体中选择终端字体" else "Choose from fonts installed on this system",
-        SETTINGS_FONT_SIZE_ROW => if (zh) "调整终端内容的显示字号" else "Adjust the terminal text size",
-        SETTINGS_THEME_ROW => if (zh) "选择终端和应用界面的配色主题" else "Choose the terminal and app color theme",
-        SETTINGS_CONTROL_ROW_START + 0 => if (zh) "选择终端光标的形状" else "Choose the terminal cursor shape",
-        SETTINGS_CONTROL_ROW_START + 1 => if (zh) "控制光标是否闪烁" else "Control whether the cursor blinks",
-        SETTINGS_CONTROL_ROW_START + 2 => if (zh) "鼠标移动时自动切换面板焦点" else "Move panel focus with the pointer",
-        SETTINGS_CONTROL_ROW_START + 3 => if (zh) "设置新标签页使用的默认 Shell" else "Set the default shell for new tabs",
-        SETTINGS_CONTROL_ROW_START + 4 => if (zh) "选择新建 AI 会话使用的配置" else "Choose the profile for new AI sessions",
-        SETTINGS_CONTROL_ROW_START + 5 => if (zh) "允许微信消息直接进入当前会话" else "Allow WeChat messages into the active session",
-        SETTINGS_CONTROL_ROW_START + 6 => if (zh) "选择 WispTerm 的界面语言" else "Choose the WispTerm interface language",
-        SETTINGS_CONTROL_ROW_START + 7 => if (zh) "启动时恢复上次打开的标签页" else "Restore previously open tabs at launch",
-        SETTINGS_CONTROL_ROW_START + 8 => if (zh) "在合适时建议将工作流沉淀为技能" else "Suggest reusable skills from completed work",
-        settings_page.SETTINGS_RAW_CONFIG_ROW => if (zh) "在编辑器中打开完整配置文件" else "Open the complete config file in your editor",
-        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => if (zh) "移除自定义设置并恢复默认值" else "Remove custom settings and restore defaults",
-        else => "",
-    };
-}
-
-const SettingsControlKind = enum {
-    adjuster,
-    toggle,
-    choice,
-    action,
-};
-
-fn settingsControlKind(row: usize) SettingsControlKind {
-    if (shell_integration.supported and (row == SETTINGS_CONTROL_ROW_START + 9 or row == SETTINGS_CONTROL_ROW_START + 10)) return .toggle;
-    return switch (row) {
-        SETTINGS_FONT_SIZE_ROW => .adjuster,
-        SETTINGS_FONT_FAMILY_ROW,
-        SETTINGS_THEME_ROW,
-        SETTINGS_CONTROL_ROW_START + 0,
-        SETTINGS_CONTROL_ROW_START + 3,
-        SETTINGS_CONTROL_ROW_START + 4,
-        SETTINGS_CONTROL_ROW_START + 6,
-        => .choice,
-        SETTINGS_CONTROL_ROW_START + 1,
-        SETTINGS_CONTROL_ROW_START + 2,
-        SETTINGS_CONTROL_ROW_START + 5,
-        SETTINGS_CONTROL_ROW_START + 7,
-        SETTINGS_CONTROL_ROW_START + 8,
-        => .toggle,
-        settings_page.SETTINGS_RAW_CONFIG_ROW,
-        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW,
-        => .action,
-        else => .action,
-    };
-}
-
-fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, row_index: usize, title: []const u8, value: []const u8, selected: bool) void {
-    const visible = layout.visibleRow(window_height, row_index) orelse return;
-    const gl_y = visible.gl_y;
-    const x = layout.content_x;
-    const w = layout.content_w;
-    const bg = AppWindow.g_theme.background;
-    const fg = AppWindow.g_theme.foreground;
-    const accent = AppWindow.g_theme.cursor_color;
-    const muted = mixColor(bg, fg, 0.56);
-    const title_x = x + 20;
-    const right_edge = x + w - 18;
-    const title_y = textYFromTop(window_height, visible.top_px + 10);
-    const detail_y = textYFromTop(window_height, visible.top_px + 10 + overlayLineHeight());
-    var title_max_w = w - 40;
-
-    if (selected) {
-        ui_pipeline.fillQuadAlpha(x + 2, gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
-    }
-    if (value.len > 0) {
-        const kind = settingsControlKind(row);
-        const max_value_w: f32 = switch (kind) {
-            .toggle => 96,
-            .adjuster => 152,
-            .choice => 360,
-            .action => 180,
-        };
-        const min_value_w: f32 = switch (kind) {
-            .toggle => 76,
-            .adjuster => 118,
-            .choice => 132,
-            .action => 96,
-        };
-        const trailing_w: f32 = switch (kind) {
-            .choice, .action => 26,
-            .adjuster, .toggle => 12,
-        };
-        const value_w = if (kind == .toggle)
-            46.0
-        else
-            @min(max_value_w, @max(min_value_w, measureTitlebarText(value) + 24 + trailing_w));
-        const value_x = @round(right_edge - value_w);
-        const control_h = if (kind == .toggle) 24.0 else @round(@max(32.0, font.g_titlebar_cell_height + 10.0));
-        const pill_y = gl_y + @round((layout.row_h - control_h) / 2);
-        const is_on = std.mem.eql(u8, value, i18n.s().settings_value_on);
-        if (kind == .toggle) {
-            const track_color = if (is_on) mixColor(bg, accent, 0.40) else mixColor(bg, fg, 0.18);
-            renderRoundedQuadAlpha(value_x, pill_y, value_w, control_h, control_h / 2, track_color, 0.96);
-        }
-        const value_color = if (selected) accent else mixColor(bg, fg, 0.82);
-        if (kind == .toggle) {
-            const knob_d: f32 = control_h - 6;
-            const knob_x = if (is_on) value_x + value_w - knob_d - 3 else value_x + 3;
-            renderRoundedQuadAlpha(knob_x, pill_y + (control_h - knob_d) / 2, knob_d, knob_d, knob_d / 2, if (is_on) accent else mixColor(bg, fg, 0.42), 0.96);
-        } else {
-            _ = renderTitlebarTextLimited(value, value_x, rowTextY(pill_y, control_h), value_color, value_w - trailing_w);
-            if (kind == .choice or kind == .action) {
-                renderTitlebarText(">", value_x + value_w - 12, rowTextY(pill_y, control_h), mixColor(bg, fg, 0.60));
-            }
-        }
-        title_max_w = @max(1.0, value_x - title_x - 18);
-    }
-
-    if (visible.visible_index > 0) {
-        ui_pipeline.fillQuadAlpha(x + 18, gl_y + layout.row_h - 1, w - 36, 1, mixColor(bg, fg, 0.14), 0.62);
-    }
-
-    renderTitlebarTextLimited(title, title_x, title_y, if (selected) mixColor(fg, accent, 0.16) else fg, title_max_w);
-    renderTitlebarTextLimited(settingsRowDescription(settings_page.categoryRows(settingsState().category)[row_index]), title_x, detail_y, muted, title_max_w);
-}
-
-fn renderSettingsPickerRow(layout: SettingsLayout, window_height: f32, row_index: usize, label: []const u8, selected: bool, current: bool) void {
-    const visible = layout.visibleRow(window_height, row_index) orelse return;
-    const bg = AppWindow.g_theme.background;
-    const fg = AppWindow.g_theme.foreground;
-    const accent = AppWindow.g_theme.cursor_color;
-    const x = layout.content_x;
-    const title_x = x + 20;
-    if (selected) {
-        ui_pipeline.fillQuadAlpha(x + 2, visible.gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
-        ui_pipeline.fillQuadAlpha(x + 8, visible.gl_y + 6, layout.content_w - 16, layout.row_h - 12, mixColor(bg, accent, 0.08), 0.72);
-    }
-    if (visible.visible_index > 0) {
-        ui_pipeline.fillQuadAlpha(x + 18, visible.gl_y + layout.row_h - 1, layout.content_w - 36, 1, mixColor(bg, fg, 0.14), 0.62);
-    }
-    const text_y = rowTextY(visible.gl_y, layout.row_h);
-    renderTitlebarTextLimited(label, title_x, text_y, if (selected) mixColor(fg, accent, 0.16) else fg, layout.content_w - 170);
-    if (current) {
-        const current_label = if (i18n.lang() == .zh_CN) "当前" else "Current";
-        renderTitlebarText(current_label, layout.content_x + layout.content_w - 100, text_y, accent);
-    }
-}
-
 pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, content_width: f32) void {
     if (!settingsPageVisible()) return;
     const allocator = AppWindow.g_allocator orelse return;
     const state = settingsState();
-    const focus = state.focus;
-    const picker_open = state.pickerOpen();
-
     const cfg = settingsCfg(allocator);
-
     const layout = settingsLayout(window_height, top_offset, content_x, content_width);
-    const page_y = @round(window_height - layout.page_top_px - layout.page_h);
 
-    const bg = AppWindow.g_theme.background;
-    const fg = AppWindow.g_theme.foreground;
-    const accent = AppWindow.g_theme.cursor_color;
-    const border_color = mixColor(bg, fg, 0.16);
-    const muted_color = mixColor(bg, fg, 0.58);
+    var rows_storage: [8]settings_page_renderer.Row = undefined;
+    var value_buffers: [8][640]u8 = undefined;
+    var row_count: usize = 0;
 
-    ui_pipeline.fillQuadAlpha(layout.page_x, page_y, layout.page_w, layout.page_h, mixColor(bg, fg, 0.012), 1.0);
-    ui_pipeline.fillQuadAlpha(layout.page_x, page_y, layout.nav_w, layout.page_h, mixColor(bg, fg, 0.025), 0.96);
-    ui_pipeline.fillQuadAlpha(layout.page_x + layout.nav_w - 1, page_y, 1, layout.page_h, border_color, 0.72);
-
-    const nav_title_y = textYFromTop(window_height, layout.nav_title_top_px);
-    const nav_label_y = textYFromTop(window_height, layout.nav_label_top_px);
-    renderTitlebarText(i18n.s().settings_title, layout.page_x + 24, nav_title_y, mixColor(fg, accent, 0.10));
-    renderTitlebarText(if (i18n.lang() == .zh_CN) "偏好设置" else "PREFERENCES", layout.page_x + 24, nav_label_y, muted_color);
-
-    for (0..settings_page.categoryCount()) |idx| {
-        const category = settings_page.categoryAt(idx) orelse continue;
-        const item_top = layout.nav_item_top_px + layout.nav_item_h * @as(f32, @floatFromInt(idx));
-        const item_y = @round(window_height - item_top - layout.nav_item_h);
-        const selected = category == state.category;
-        if (selected) {
-            ui_pipeline.fillQuadAlpha(layout.page_x + 14, item_y + 10, 3, layout.nav_item_h - 20, accent, 0.84);
-        }
-        renderTitlebarTextLimited(settingsCategoryLabel(category), layout.page_x + 28, rowTextY(item_y, layout.nav_item_h), if (selected) mixColor(fg, accent, 0.16) else mixColor(bg, fg, 0.76), layout.nav_w - 48);
-    }
-
-    const page_title_y = textYFromTop(window_height, layout.page_top_px + 28);
-    const subtitle_y = textYFromTop(window_height, layout.page_top_px + 28 + overlayLineHeight());
-    const page_title = if (state.pickerKind()) |kind| switch (kind) {
-        .font_family => if (i18n.lang() == .zh_CN) "选择字体" else "Choose font family",
-        .shell => if (i18n.lang() == .zh_CN) "选择默认 Shell" else "Choose default shell",
-    } else settingsCategoryLabel(state.category);
-    const page_subtitle = if (picker_open)
-        (if (i18n.lang() == .zh_CN) "用方向键选择，按 Enter 应用，按 Esc 返回" else "Use arrows to choose, Enter to apply, Esc to go back")
-    else
-        settingsCategoryDescription(state.category);
-    renderTitlebarText(page_title, layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
-    renderTitlebarTextLimited(page_subtitle, layout.content_x, subtitle_y, muted_color, layout.content_w);
-    ui_pipeline.fillQuadAlpha(layout.content_x, @round(window_height - layout.row_top_px), layout.content_w, 1, border_color, 0.52);
-
-    const rows = settings_page.categoryRows(state.category);
-    const item_count = if (picker_open) state.pickerCount() else rows.len;
-    if (picker_open) {
-        const current = switch (state.pickerKind().?) {
-            .font_family => cfg.@"font-family",
-            .shell => cfg.shell,
-        };
-        for (0..state.pickerCount()) |row_index| {
-            const value = state.pickerValueAt(row_index) orelse continue;
-            var shell_label_buf: [640]u8 = undefined;
-            const label = if (state.pickerKind().? == .shell) shellSettingText(value, &shell_label_buf) else value;
-            renderSettingsPickerRow(layout, window_height, row_index, label, state.picker.selected == row_index, std.ascii.eqlIgnoreCase(value, current));
-        }
-    } else {
+    if (!state.pickerOpen()) {
         loadAiProfiles();
         const ai_default_value = if (assistantProfiles().profile_count > 0)
             aiProfileField(&assistantProfiles().profiles[defaultAiProfileIndex()], .name)
         else
             i18n.s().settings_value_none;
-        const ai_default_hint = if (assistantProfiles().profile_count > 0)
-            aiProfileModeLabel(&assistantProfiles().profiles[defaultAiProfileIndex()])
-        else
-            i18n.s().settings_hint_add_profiles;
-        _ = ai_default_hint;
 
-        for (rows, 0..) |row, row_index| {
-            var font_buf: [24]u8 = undefined;
-            var shell_buf: [640]u8 = undefined;
-            var theme_buf: [96]u8 = undefined;
-            const title: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
-                i18n.s().settings_start_menu
-            else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
-                i18n.s().settings_startup
-            else switch (row) {
-                SETTINGS_FONT_FAMILY_ROW => if (i18n.lang() == .zh_CN) "字体" else "Font family",
-                SETTINGS_FONT_SIZE_ROW => i18n.s().settings_font_size,
-                SETTINGS_THEME_ROW => i18n.s().settings_theme,
-                SETTINGS_CONTROL_ROW_START + 0 => i18n.s().settings_cursor_style,
-                SETTINGS_CONTROL_ROW_START + 1 => i18n.s().settings_cursor_blink,
-                SETTINGS_CONTROL_ROW_START + 2 => i18n.s().settings_focus_follows_mouse,
-                SETTINGS_CONTROL_ROW_START + 3 => i18n.s().settings_shell,
-                SETTINGS_CONTROL_ROW_START + 4 => i18n.s().settings_default_ai,
-                SETTINGS_CONTROL_ROW_START + 5 => i18n.s().settings_weixin_direct,
-                SETTINGS_CONTROL_ROW_START + 6 => i18n.s().settings_language,
-                SETTINGS_CONTROL_ROW_START + 7 => i18n.s().settings_restore_tabs,
-                SETTINGS_CONTROL_ROW_START + 8 => i18n.s().settings_distill_suggest,
-                settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_raw_config,
-                settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => i18n.s().settings_restore_defaults,
-                else => "",
-            };
+        for (settings_page.categoryRows(state.category), 0..) |row, row_index| {
+            const buf = value_buffers[row_index][0..];
             const value: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
                 boolText(shell_integration.isEnabled(allocator, .start_menu))
             else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
                 boolText(shell_integration.isEnabled(allocator, .startup))
             else switch (row) {
                 SETTINGS_FONT_FAMILY_ROW => cfg.@"font-family",
-                SETTINGS_FONT_SIZE_ROW => std.fmt.bufPrint(&font_buf, "-  {d}  +", .{cfg.@"font-size"}) catch "",
-                SETTINGS_THEME_ROW => std.fmt.bufPrint(&theme_buf, "{s}", .{currentThemePresetLabel(cfg)}) catch currentThemePresetLabel(cfg),
+                SETTINGS_FONT_SIZE_ROW => std.fmt.bufPrint(buf, "-  {d}  +", .{cfg.@"font-size"}) catch "",
+                SETTINGS_THEME_ROW => currentThemePresetLabel(cfg),
                 SETTINGS_CONTROL_ROW_START + 0 => cursorStyleText(cfg.@"cursor-style"),
                 SETTINGS_CONTROL_ROW_START + 1 => boolText(cfg.@"cursor-style-blink"),
                 SETTINGS_CONTROL_ROW_START + 2 => boolText(cfg.@"focus-follows-mouse"),
-                SETTINGS_CONTROL_ROW_START + 3 => shellSettingText(cfg.shell, &shell_buf),
+                SETTINGS_CONTROL_ROW_START + 3 => shellSettingText(cfg.shell, buf),
                 SETTINGS_CONTROL_ROW_START + 4 => ai_default_value,
                 SETTINGS_CONTROL_ROW_START + 5 => boolText(cfg.@"weixin-direct-enabled"),
                 SETTINGS_CONTROL_ROW_START + 6 => languageSettingText(cfg.language),
@@ -7244,42 +6935,32 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
                 settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => "Enter",
                 else => "",
             };
-            renderSettingsRow(layout, window_height, row, row_index, title, value, focus == row);
+            rows_storage[row_count] = .{ .id = row, .value = value };
+            row_count += 1;
         }
     }
 
-    // Scrollbar indicator when not all rows fit (short windows). The list is
-    // scrolled via keyboard/click focus-follow and the mouse wheel.
-    if (layout.visible_rows < item_count) {
-        const total: f32 = @floatFromInt(item_count);
-        const vis: f32 = @floatFromInt(layout.visible_rows);
-        const track_h = layout.row_h * vis;
-        const track_top_px = layout.row_top_px;
-        const sb_w: f32 = 3;
-        const sb_x = layout.content_x + layout.content_w - sb_w - 7;
-        const track_gl_y = @round(window_height - track_top_px - track_h);
-        ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
-
-        const thumb_h = @max(24.0, @round(track_h * vis / total));
-        const max_scroll_f: f32 = @floatFromInt(item_count - layout.visible_rows);
-        const scroll_f: f32 = @floatFromInt(layout.scroll);
-        const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
-        const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
-        ui_pipeline.fillQuadAlpha(sb_x, thumb_gl_y, sb_w, thumb_h, accent, 0.55);
-    }
-
-    const footer_h = ui_patterns.workbenchFooterHeight(font.g_titlebar_cell_height);
-    const footer_top = ui_patterns.workbenchFooterTop(window_height, layout.page_top_px, footer_h);
-    const footer_y = @round(window_height - footer_top - footer_h);
-    ui_pipeline.fillQuadAlpha(layout.page_x, footer_y, layout.page_w, footer_h, mixColor(bg, fg, 0.030), 0.98);
-    ui_pipeline.fillQuadAlpha(layout.page_x, footer_y + footer_h - 1, layout.page_w, 1, border_color, 0.68);
-    const footer_text = if (picker_open)
-        (if (i18n.lang() == .zh_CN) "↑/↓ 选择  ·  Enter 应用  ·  Esc 返回" else "↑/↓ choose  ·  Enter apply  ·  Esc back")
-    else
-        i18n.s().settings_workbench_footer;
-    renderTitlebarTextLimited(footer_text, layout.content_x, rowTextY(footer_y, footer_h), muted_color, layout.content_w);
+    var default_shell_buf: [640]u8 = undefined;
+    const picker_current = if (state.pickerKind()) |kind| switch (kind) {
+        .font_family => cfg.@"font-family",
+        .shell => cfg.shell,
+    } else "";
+    settings_page_renderer.render(.{
+        .bg = AppWindow.g_theme.background,
+        .fg = AppWindow.g_theme.foreground,
+        .accent = AppWindow.g_theme.cursor_color,
+        .cell_h = font.g_titlebar_cell_height,
+        .fillQuadAlpha = ui_pipeline.fillQuadAlpha,
+        .roundedQuadAlpha = renderRoundedQuadAlpha,
+        .renderTextLimited = renderSettingsTextLimited,
+        .measureText = measureTitlebarText,
+    }, .{
+        .state = state,
+        .rows = rows_storage[0..row_count],
+        .picker_current = picker_current,
+        .default_shell_label = shellSettingText("", &default_shell_buf),
+    }, layout, window_height);
 }
-
 /// Mouse-wheel handling for the settings page. The list scrolls by moving the
 /// focused row (which the view follows), matching the keyboard navigation model.
 /// Positive delta scrolls toward the top, mirroring whatsNewHandleScroll().
@@ -7631,6 +7312,27 @@ test "overlays: settings page state is owned by OverlayState" {
 
     try std.testing.expect(overlayState().settings.visible);
     try std.testing.expect(settingsPageVisible());
+}
+
+test "overlays: settings tab lifecycle releases owned picker choices" {
+    var settings_tab: AppWindow.tab.TabState = undefined;
+    const ctx = beginSettingsPageTest(&settings_tab);
+    defer ctx.restore();
+    settingsPageOpen();
+
+    const first = try std.testing.allocator.alloc([]const u8, 1);
+    first[0] = try std.testing.allocator.dupe(u8, "Fira Code");
+    settingsState().openPicker(.font_family, first, "Fira Code", true, std.testing.allocator);
+    settingsPageDidDeactivate();
+    try std.testing.expect(!settingsState().pickerOpen());
+    try std.testing.expect(settingsState().visible);
+
+    const second = try std.testing.allocator.alloc([]const u8, 1);
+    second[0] = try std.testing.allocator.dupe(u8, "JetBrains Mono");
+    settingsState().openPicker(.font_family, second, "JetBrains Mono", true, std.testing.allocator);
+    settingsPageDidClose();
+    try std.testing.expect(!settingsState().pickerOpen());
+    try std.testing.expect(!settingsState().visible);
 }
 
 test "overlays: status toast state is owned by OverlayState" {

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -1310,6 +1310,7 @@ fn commandEntryKeybindAction(action: CommandAction) ?keybind.Action {
         .toggle_sidebar => .toggle_sidebar,
         .toggle_file_explorer => .toggle_file_explorer,
         .toggle_quake => .toggle_quake,
+        .open_settings => .open_settings,
         .open_config => .open_config,
         .font_size_decrease => .font_size_decrease,
         .font_size_increase => .font_size_increase,
@@ -6593,6 +6594,8 @@ const SETTINGS_THEME_PRESETS = [_]ThemePreset{
 };
 
 const SettingsAction = settings_page.Action;
+const SETTINGS_FONT_FAMILY_ROW = settings_page.SETTINGS_FONT_FAMILY_ROW;
+const SETTINGS_FONT_SIZE_ROW = settings_page.SETTINGS_FONT_SIZE_ROW;
 const SETTINGS_THEME_ROW = settings_page.SETTINGS_THEME_ROW;
 const SETTINGS_CONTROL_ROW_START = settings_page.SETTINGS_CONTROL_ROW_START;
 const SettingsLayout = settings_page_layout.Layout;
@@ -6648,14 +6651,15 @@ fn settingsFirstVisibleRow(visible_rows: usize) usize {
 fn settingsLayout(window_height: f32, top_offset: f32, content_x: f32, content_width: f32) SettingsLayout {
     const state = settingsState();
     const rows = settings_page.categoryRows(state.category);
+    const picker_open = state.pickerOpen();
     return settings_page_layout.compute(.{
         .window_height = window_height,
         .top_offset = top_offset,
         .content_x = content_x,
         .content_width = content_width,
         .cell_height = font.g_titlebar_cell_height,
-        .focus_index = state.focusIndex(),
-        .row_count = rows.len,
+        .focus_index = if (picker_open) state.picker.selected else state.focusIndex(),
+        .row_count = if (picker_open) state.pickerCount() else rows.len,
         .category_count = settings_page.categoryCount(),
     });
 }
@@ -6666,6 +6670,7 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, co
     const y: f32 = @floatCast(ypos);
 
     if (layout.categoryAt(x, y)) |index| {
+        settingsState().closePicker(AppWindow.g_allocator);
         return switch (settings_page.categoryAt(index) orelse return null) {
             .general => .select_general,
             .appearance => .select_appearance,
@@ -6675,12 +6680,16 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, co
     }
 
     const row_index = layout.rowAt(x, y) orelse return null;
+    if (settingsState().pickerOpen()) {
+        if (!settingsState().selectPickerIndex(row_index)) return null;
+        return .choose_picker_value;
+    }
     const rows = settings_page.categoryRows(settingsState().category);
     if (row_index >= rows.len) return null;
     const row = rows[row_index];
     settingsState().focus = row;
 
-    if (row == 0) {
+    if (row == SETTINGS_FONT_SIZE_ROW) {
         return switch (layout.fontControlAt(x) orelse return null) {
             .minus => .font_size_minus,
             .plus => .font_size_plus,
@@ -6691,6 +6700,8 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, co
         return .cycle_theme;
     }
 
+    if (row == SETTINGS_FONT_FAMILY_ROW) return .open_font_picker;
+
     const control_row = row - SETTINGS_CONTROL_ROW_START;
     if (shell_integration.supported) {
         if (control_row == 9) return .toggle_start_menu;
@@ -6700,7 +6711,7 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, co
         0 => .cycle_cursor_style,
         1 => .toggle_cursor_blink,
         2 => .toggle_focus_follows_mouse,
-        3 => .cycle_shell,
+        3 => .open_shell_picker,
         4 => .cycle_default_ai_profile,
         5 => .toggle_weixin_direct,
         6 => .cycle_language,
@@ -6714,10 +6725,22 @@ fn settingsHitTest(xpos: f64, ypos: f64, window_height: f32, top_offset: f32, co
 
 fn executeSettingsAction(action: SettingsAction) void {
     switch (action) {
-        .select_general => settingsState().selectCategory(.general),
-        .select_appearance => settingsState().selectCategory(.appearance),
-        .select_ai => settingsState().selectCategory(.ai),
-        .select_system => settingsState().selectCategory(.system),
+        .select_general => {
+            settingsState().closePicker(AppWindow.g_allocator);
+            settingsState().selectCategory(.general);
+        },
+        .select_appearance => {
+            settingsState().closePicker(AppWindow.g_allocator);
+            settingsState().selectCategory(.appearance);
+        },
+        .select_ai => {
+            settingsState().closePicker(AppWindow.g_allocator);
+            settingsState().selectCategory(.ai);
+        },
+        .select_system => {
+            settingsState().closePicker(AppWindow.g_allocator);
+            settingsState().selectCategory(.system);
+        },
         else => {},
     }
     switch (action) {
@@ -6730,6 +6753,7 @@ fn executeSettingsAction(action: SettingsAction) void {
     defer cfg.deinit(allocator);
 
     switch (action) {
+        .open_font_picker => openFontFamilyPicker(allocator, cfg.@"font-family"),
         .font_size_minus => {
             const next = if (cfg.@"font-size" > 6) cfg.@"font-size" - 1 else cfg.@"font-size";
             writeConfigInt("font-size", next);
@@ -6743,7 +6767,12 @@ fn executeSettingsAction(action: SettingsAction) void {
         .cycle_cursor_style => Config.setConfigValue(allocator, "cursor-style", nextCursorStyle(cfg.@"cursor-style")) catch {},
         .toggle_cursor_blink => Config.setConfigValue(allocator, "cursor-style-blink", if (cfg.@"cursor-style-blink") "false" else "true") catch {},
         .toggle_focus_follows_mouse => Config.setConfigValue(allocator, "focus-follows-mouse", if (cfg.@"focus-follows-mouse") "false" else "true") catch {},
-        .cycle_shell => Config.setConfigValue(allocator, "shell", platform_pty_command.nextConfigShell(cfg.shell)) catch {},
+        .open_shell_picker => {
+            settingsState().closePicker(allocator);
+            settingsState().openPicker(.shell, platform_pty_command.configShellChoices(), cfg.shell, false);
+        },
+        .choose_picker_value => chooseSettingsPickerValue(allocator),
+        .close_picker => settingsState().closePicker(allocator),
         .cycle_default_ai_profile => cycleDefaultAiProfile(1),
         .cycle_default_ai_profile_prev => cycleDefaultAiProfile(-1),
         .toggle_weixin_direct => Config.setConfigValue(allocator, "weixin-direct-enabled", if (cfg.@"weixin-direct-enabled") "false" else "true") catch {},
@@ -6763,10 +6792,36 @@ fn executeSettingsAction(action: SettingsAction) void {
     // cycle_theme already applies via cycleThemePreset; the excluded actions open
     // an editor/confirm dialog or close the page and write nothing to apply.
     switch (action) {
-        .cycle_theme, .cycle_theme_prev, .toggle_start_menu, .toggle_startup, .open_raw_config, .restore_defaults => {},
+        .open_font_picker, .open_shell_picker, .close_picker, .cycle_theme, .cycle_theme_prev, .toggle_start_menu, .toggle_startup, .open_raw_config, .restore_defaults => {},
         .select_general, .select_appearance, .select_ai, .select_system => unreachable,
         else => AppWindow.reloadConfigImmediate(allocator),
     }
+}
+
+fn fontFamilyLessThan(_: void, left: []const u8, right: []const u8) bool {
+    return std.mem.order(u8, left, right) == .lt;
+}
+
+fn openFontFamilyPicker(allocator: std.mem.Allocator, current: []const u8) void {
+    settingsState().closePicker(allocator);
+    const discovery = font.g_font_discovery orelse return;
+    const choices = discovery.listFontFamilies(allocator) catch return;
+    if (choices.len == 0) {
+        allocator.free(choices);
+        return;
+    }
+    std.sort.heap([]const u8, choices, {}, fontFamilyLessThan);
+    settingsState().openPicker(.font_family, choices, current, true);
+}
+
+fn chooseSettingsPickerValue(allocator: std.mem.Allocator) void {
+    const kind = settingsState().pickerKind() orelse return;
+    const value = settingsState().pickerValue() orelse return;
+    switch (kind) {
+        .font_family => Config.setConfigValue(allocator, "font-family", value) catch return,
+        .shell => Config.setConfigValue(allocator, "shell", value) catch return,
+    }
+    settingsState().closePicker(allocator);
 }
 
 fn writeConfigInt(key: []const u8, value: u32) void {
@@ -6876,6 +6931,14 @@ fn languageSettingText(setting: i18n.LanguageSetting) []const u8 {
     };
 }
 
+fn shellSettingText(configured: []const u8, buf: []u8) []const u8 {
+    if (configured.len != 0) return configured;
+    var detected_buf: [512]u8 = undefined;
+    const detected = platform_pty_command.detectedDefaultShell(&detected_buf);
+    const prefix = if (i18n.lang() == .zh_CN) "系统默认" else "System default";
+    return std.fmt.bufPrint(buf, "{s} ({s})", .{ prefix, detected }) catch prefix;
+}
+
 fn settingsCategoryLabel(category: settings_page.Category) []const u8 {
     return switch (i18n.lang()) {
         .en => switch (category) {
@@ -6917,7 +6980,8 @@ fn settingsRowDescription(row: usize) []const u8 {
         if (row == SETTINGS_CONTROL_ROW_START + 10) return if (zh) "登录系统后自动启动 WispTerm" else "Launch WispTerm when you sign in";
     }
     return switch (row) {
-        0 => if (zh) "调整终端内容的显示字号" else "Adjust the terminal text size",
+        SETTINGS_FONT_FAMILY_ROW => if (zh) "从系统已安装字体中选择终端字体" else "Choose from fonts installed on this system",
+        SETTINGS_FONT_SIZE_ROW => if (zh) "调整终端内容的显示字号" else "Adjust the terminal text size",
         SETTINGS_THEME_ROW => if (zh) "选择终端和应用界面的配色主题" else "Choose the terminal and app color theme",
         SETTINGS_CONTROL_ROW_START + 0 => if (zh) "选择终端光标的形状" else "Choose the terminal cursor shape",
         SETTINGS_CONTROL_ROW_START + 1 => if (zh) "控制光标是否闪烁" else "Control whether the cursor blinks",
@@ -6944,7 +7008,8 @@ const SettingsControlKind = enum {
 fn settingsControlKind(row: usize) SettingsControlKind {
     if (shell_integration.supported and (row == SETTINGS_CONTROL_ROW_START + 9 or row == SETTINGS_CONTROL_ROW_START + 10)) return .toggle;
     return switch (row) {
-        0 => .adjuster,
+        SETTINGS_FONT_SIZE_ROW => .adjuster,
+        SETTINGS_FONT_FAMILY_ROW,
         SETTINGS_THEME_ROW,
         SETTINGS_CONTROL_ROW_START + 0,
         SETTINGS_CONTROL_ROW_START + 3,
@@ -7034,11 +7099,34 @@ fn renderSettingsRow(layout: SettingsLayout, window_height: f32, row: usize, row
     renderTitlebarTextLimited(settingsRowDescription(settings_page.categoryRows(settingsState().category)[row_index]), title_x, detail_y, muted, title_max_w);
 }
 
+fn renderSettingsPickerRow(layout: SettingsLayout, window_height: f32, row_index: usize, label: []const u8, selected: bool, current: bool) void {
+    const visible = layout.visibleRow(window_height, row_index) orelse return;
+    const bg = AppWindow.g_theme.background;
+    const fg = AppWindow.g_theme.foreground;
+    const accent = AppWindow.g_theme.cursor_color;
+    const x = layout.content_x;
+    const title_x = x + 20;
+    if (selected) {
+        ui_pipeline.fillQuadAlpha(x + 2, visible.gl_y + 8, 3, layout.row_h - 16, accent, 0.82);
+        ui_pipeline.fillQuadAlpha(x + 8, visible.gl_y + 6, layout.content_w - 16, layout.row_h - 12, mixColor(bg, accent, 0.08), 0.72);
+    }
+    if (visible.visible_index > 0) {
+        ui_pipeline.fillQuadAlpha(x + 18, visible.gl_y + layout.row_h - 1, layout.content_w - 36, 1, mixColor(bg, fg, 0.14), 0.62);
+    }
+    const text_y = rowTextY(visible.gl_y, layout.row_h);
+    renderTitlebarTextLimited(label, title_x, text_y, if (selected) mixColor(fg, accent, 0.16) else fg, layout.content_w - 170);
+    if (current) {
+        const current_label = if (i18n.lang() == .zh_CN) "当前" else "Current";
+        renderTitlebarText(current_label, layout.content_x + layout.content_w - 100, text_y, accent);
+    }
+}
+
 pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, content_width: f32) void {
     if (!settingsPageVisible()) return;
     const allocator = AppWindow.g_allocator orelse return;
     const state = settingsState();
     const focus = state.focus;
+    const picker_open = state.pickerOpen();
 
     const cfg = settingsCfg(allocator);
 
@@ -7073,72 +7161,97 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
 
     const page_title_y = textYFromTop(window_height, layout.page_top_px + 28);
     const subtitle_y = textYFromTop(window_height, layout.page_top_px + 28 + overlayLineHeight());
-    renderTitlebarText(settingsCategoryLabel(state.category), layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
-    renderTitlebarTextLimited(settingsCategoryDescription(state.category), layout.content_x, subtitle_y, muted_color, layout.content_w);
+    const page_title = if (state.pickerKind()) |kind| switch (kind) {
+        .font_family => if (i18n.lang() == .zh_CN) "选择字体" else "Choose font family",
+        .shell => if (i18n.lang() == .zh_CN) "选择默认 Shell" else "Choose default shell",
+    } else settingsCategoryLabel(state.category);
+    const page_subtitle = if (picker_open)
+        (if (i18n.lang() == .zh_CN) "用方向键选择，按 Enter 应用，按 Esc 返回" else "Use arrows to choose, Enter to apply, Esc to go back")
+    else
+        settingsCategoryDescription(state.category);
+    renderTitlebarText(page_title, layout.content_x, page_title_y, mixColor(fg, accent, 0.10));
+    renderTitlebarTextLimited(page_subtitle, layout.content_x, subtitle_y, muted_color, layout.content_w);
     ui_pipeline.fillQuadAlpha(layout.content_x, @round(window_height - layout.row_top_px), layout.content_w, 1, border_color, 0.52);
 
-    loadAiProfiles();
-    const ai_default_value = if (assistantProfiles().profile_count > 0)
-        aiProfileField(&assistantProfiles().profiles[defaultAiProfileIndex()], .name)
-    else
-        i18n.s().settings_value_none;
-    const ai_default_hint = if (assistantProfiles().profile_count > 0)
-        aiProfileModeLabel(&assistantProfiles().profiles[defaultAiProfileIndex()])
-    else
-        i18n.s().settings_hint_add_profiles;
-    _ = ai_default_hint;
-
     const rows = settings_page.categoryRows(state.category);
-    for (rows, 0..) |row, row_index| {
-        var font_buf: [24]u8 = undefined;
-        var theme_buf: [96]u8 = undefined;
-        const title: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
-            i18n.s().settings_start_menu
-        else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
-            i18n.s().settings_startup
-        else switch (row) {
-            0 => i18n.s().settings_font_size,
-            SETTINGS_THEME_ROW => i18n.s().settings_theme,
-            SETTINGS_CONTROL_ROW_START + 0 => i18n.s().settings_cursor_style,
-            SETTINGS_CONTROL_ROW_START + 1 => i18n.s().settings_cursor_blink,
-            SETTINGS_CONTROL_ROW_START + 2 => i18n.s().settings_focus_follows_mouse,
-            SETTINGS_CONTROL_ROW_START + 3 => i18n.s().settings_shell,
-            SETTINGS_CONTROL_ROW_START + 4 => i18n.s().settings_default_ai,
-            SETTINGS_CONTROL_ROW_START + 5 => i18n.s().settings_weixin_direct,
-            SETTINGS_CONTROL_ROW_START + 6 => i18n.s().settings_language,
-            SETTINGS_CONTROL_ROW_START + 7 => i18n.s().settings_restore_tabs,
-            SETTINGS_CONTROL_ROW_START + 8 => i18n.s().settings_distill_suggest,
-            settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_raw_config,
-            settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => i18n.s().settings_restore_defaults,
-            else => "",
+    const item_count = if (picker_open) state.pickerCount() else rows.len;
+    if (picker_open) {
+        const current = switch (state.pickerKind().?) {
+            .font_family => cfg.@"font-family",
+            .shell => cfg.shell,
         };
-        const value: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
-            boolText(shell_integration.isEnabled(allocator, .start_menu))
-        else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
-            boolText(shell_integration.isEnabled(allocator, .startup))
-        else switch (row) {
-            0 => std.fmt.bufPrint(&font_buf, "-  {d}  +", .{cfg.@"font-size"}) catch "",
-            SETTINGS_THEME_ROW => std.fmt.bufPrint(&theme_buf, "{s}", .{currentThemePresetLabel(cfg)}) catch currentThemePresetLabel(cfg),
-            SETTINGS_CONTROL_ROW_START + 0 => cursorStyleText(cfg.@"cursor-style"),
-            SETTINGS_CONTROL_ROW_START + 1 => boolText(cfg.@"cursor-style-blink"),
-            SETTINGS_CONTROL_ROW_START + 2 => boolText(cfg.@"focus-follows-mouse"),
-            SETTINGS_CONTROL_ROW_START + 3 => cfg.shell,
-            SETTINGS_CONTROL_ROW_START + 4 => ai_default_value,
-            SETTINGS_CONTROL_ROW_START + 5 => boolText(cfg.@"weixin-direct-enabled"),
-            SETTINGS_CONTROL_ROW_START + 6 => languageSettingText(cfg.language),
-            SETTINGS_CONTROL_ROW_START + 7 => boolText(cfg.@"restore-tabs-on-startup"),
-            SETTINGS_CONTROL_ROW_START + 8 => boolText(cfg.@"ai-distill-suggest"),
-            settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_value_open,
-            settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => "Enter",
-            else => "",
-        };
-        renderSettingsRow(layout, window_height, row, row_index, title, value, focus == row);
+        for (0..state.pickerCount()) |row_index| {
+            const value = state.pickerValueAt(row_index) orelse continue;
+            var shell_label_buf: [640]u8 = undefined;
+            const label = if (state.pickerKind().? == .shell) shellSettingText(value, &shell_label_buf) else value;
+            renderSettingsPickerRow(layout, window_height, row_index, label, state.picker.selected == row_index, std.ascii.eqlIgnoreCase(value, current));
+        }
+    } else {
+        loadAiProfiles();
+        const ai_default_value = if (assistantProfiles().profile_count > 0)
+            aiProfileField(&assistantProfiles().profiles[defaultAiProfileIndex()], .name)
+        else
+            i18n.s().settings_value_none;
+        const ai_default_hint = if (assistantProfiles().profile_count > 0)
+            aiProfileModeLabel(&assistantProfiles().profiles[defaultAiProfileIndex()])
+        else
+            i18n.s().settings_hint_add_profiles;
+        _ = ai_default_hint;
+
+        for (rows, 0..) |row, row_index| {
+            var font_buf: [24]u8 = undefined;
+            var shell_buf: [640]u8 = undefined;
+            var theme_buf: [96]u8 = undefined;
+            const title: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
+                i18n.s().settings_start_menu
+            else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
+                i18n.s().settings_startup
+            else switch (row) {
+                SETTINGS_FONT_FAMILY_ROW => if (i18n.lang() == .zh_CN) "字体" else "Font family",
+                SETTINGS_FONT_SIZE_ROW => i18n.s().settings_font_size,
+                SETTINGS_THEME_ROW => i18n.s().settings_theme,
+                SETTINGS_CONTROL_ROW_START + 0 => i18n.s().settings_cursor_style,
+                SETTINGS_CONTROL_ROW_START + 1 => i18n.s().settings_cursor_blink,
+                SETTINGS_CONTROL_ROW_START + 2 => i18n.s().settings_focus_follows_mouse,
+                SETTINGS_CONTROL_ROW_START + 3 => i18n.s().settings_shell,
+                SETTINGS_CONTROL_ROW_START + 4 => i18n.s().settings_default_ai,
+                SETTINGS_CONTROL_ROW_START + 5 => i18n.s().settings_weixin_direct,
+                SETTINGS_CONTROL_ROW_START + 6 => i18n.s().settings_language,
+                SETTINGS_CONTROL_ROW_START + 7 => i18n.s().settings_restore_tabs,
+                SETTINGS_CONTROL_ROW_START + 8 => i18n.s().settings_distill_suggest,
+                settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_raw_config,
+                settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => i18n.s().settings_restore_defaults,
+                else => "",
+            };
+            const value: []const u8 = if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 9)
+                boolText(shell_integration.isEnabled(allocator, .start_menu))
+            else if (shell_integration.supported and row == SETTINGS_CONTROL_ROW_START + 10)
+                boolText(shell_integration.isEnabled(allocator, .startup))
+            else switch (row) {
+                SETTINGS_FONT_FAMILY_ROW => cfg.@"font-family",
+                SETTINGS_FONT_SIZE_ROW => std.fmt.bufPrint(&font_buf, "-  {d}  +", .{cfg.@"font-size"}) catch "",
+                SETTINGS_THEME_ROW => std.fmt.bufPrint(&theme_buf, "{s}", .{currentThemePresetLabel(cfg)}) catch currentThemePresetLabel(cfg),
+                SETTINGS_CONTROL_ROW_START + 0 => cursorStyleText(cfg.@"cursor-style"),
+                SETTINGS_CONTROL_ROW_START + 1 => boolText(cfg.@"cursor-style-blink"),
+                SETTINGS_CONTROL_ROW_START + 2 => boolText(cfg.@"focus-follows-mouse"),
+                SETTINGS_CONTROL_ROW_START + 3 => shellSettingText(cfg.shell, &shell_buf),
+                SETTINGS_CONTROL_ROW_START + 4 => ai_default_value,
+                SETTINGS_CONTROL_ROW_START + 5 => boolText(cfg.@"weixin-direct-enabled"),
+                SETTINGS_CONTROL_ROW_START + 6 => languageSettingText(cfg.language),
+                SETTINGS_CONTROL_ROW_START + 7 => boolText(cfg.@"restore-tabs-on-startup"),
+                SETTINGS_CONTROL_ROW_START + 8 => boolText(cfg.@"ai-distill-suggest"),
+                settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_value_open,
+                settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => "Enter",
+                else => "",
+            };
+            renderSettingsRow(layout, window_height, row, row_index, title, value, focus == row);
+        }
     }
 
     // Scrollbar indicator when not all rows fit (short windows). The list is
     // scrolled via keyboard/click focus-follow and the mouse wheel.
-    if (layout.visible_rows < rows.len) {
-        const total: f32 = @floatFromInt(rows.len);
+    if (layout.visible_rows < item_count) {
+        const total: f32 = @floatFromInt(item_count);
         const vis: f32 = @floatFromInt(layout.visible_rows);
         const track_h = layout.row_h * vis;
         const track_top_px = layout.row_top_px;
@@ -7148,7 +7261,7 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
         ui_pipeline.fillQuadAlpha(sb_x, track_gl_y, sb_w, track_h, mixColor(bg, fg, 0.25), 0.30);
 
         const thumb_h = @max(24.0, @round(track_h * vis / total));
-        const max_scroll_f: f32 = @floatFromInt(rows.len - layout.visible_rows);
+        const max_scroll_f: f32 = @floatFromInt(item_count - layout.visible_rows);
         const scroll_f: f32 = @floatFromInt(layout.scroll);
         const thumb_offset = if (max_scroll_f > 0) @round((track_h - thumb_h) * (scroll_f / max_scroll_f)) else 0;
         const thumb_gl_y = @round(window_height - (track_top_px + thumb_offset) - thumb_h);
@@ -7160,7 +7273,11 @@ pub fn renderSettingsPage(window_height: f32, top_offset: f32, content_x: f32, c
     const footer_y = @round(window_height - footer_top - footer_h);
     ui_pipeline.fillQuadAlpha(layout.page_x, footer_y, layout.page_w, footer_h, mixColor(bg, fg, 0.030), 0.98);
     ui_pipeline.fillQuadAlpha(layout.page_x, footer_y + footer_h - 1, layout.page_w, 1, border_color, 0.68);
-    renderTitlebarTextLimited(i18n.s().settings_workbench_footer, layout.content_x, rowTextY(footer_y, footer_h), muted_color, layout.content_w);
+    const footer_text = if (picker_open)
+        (if (i18n.lang() == .zh_CN) "↑/↓ 选择  ·  Enter 应用  ·  Esc 返回" else "↑/↓ choose  ·  Enter apply  ·  Esc back")
+    else
+        i18n.s().settings_workbench_footer;
+    renderTitlebarTextLimited(footer_text, layout.content_x, rowTextY(footer_y, footer_h), muted_color, layout.content_w);
 }
 
 /// Mouse-wheel handling for the settings page. The list scrolls by moving the
@@ -7622,6 +7739,7 @@ test "macOS UI smoke: command center opens settings and settings writes config" 
     try std.testing.expect(settingsPageVisible());
 
     executeSettingsAction(.select_appearance);
+    _ = settingsPageHandleKey(.{ .key = .arrow_down });
     _ = settingsPageHandleKey(.{ .key = .arrow_right });
 
     const config_path = try std.fs.path.join(allocator, &.{ config_dir, "config" });

--- a/src/renderer/overlays/settings_page.zig
+++ b/src/renderer/overlays/settings_page.zig
@@ -3,6 +3,7 @@ const input_key = @import("../../input/key.zig");
 const Config = @import("../../config.zig");
 const shell_integration = @import("../../platform/shell_integration.zig");
 const settings_picker = @import("settings_picker.zig");
+const settings_page_layout = @import("settings_page_layout.zig");
 
 pub const SETTINGS_FONT_FAMILY_ROW: usize = 0;
 pub const SETTINGS_FONT_SIZE_ROW: usize = 1;
@@ -105,8 +106,10 @@ pub const State = struct {
     picker: settings_picker.State = .{},
     picker_choices: []const []const u8 = &.{},
     picker_choices_owned: bool = false,
+    picker_allocator: ?std.mem.Allocator = null,
 
     pub fn open(self: *State) void {
+        self.closePicker(null);
         self.visible = true;
         self.selectCategory(.general);
         self.cfg_dirty = true;
@@ -137,7 +140,7 @@ pub const State = struct {
 
     pub fn close(self: *State, allocator: ?std.mem.Allocator) void {
         self.visible = false;
-        self.closePicker(allocator);
+        self.closePicker(null);
         if (self.cfg_loaded) {
             const alloc = allocator orelse return;
             self.cfg_cache.deinit(alloc);
@@ -177,15 +180,18 @@ pub const State = struct {
         return &self.cfg_cache;
     }
 
-    pub fn openPicker(self: *State, kind: settings_picker.Kind, choices: []const []const u8, current: []const u8, owned: bool) void {
+    pub fn openPicker(self: *State, kind: settings_picker.Kind, choices: []const []const u8, current: []const u8, owned: bool, allocator: ?std.mem.Allocator) void {
+        std.debug.assert(!owned or allocator != null);
+        self.closePicker(null);
         self.picker_choices = choices;
         self.picker_choices_owned = owned;
+        self.picker_allocator = if (owned) allocator else null;
         self.picker.open(kind, choices, current);
     }
 
     pub fn closePicker(self: *State, allocator: ?std.mem.Allocator) void {
         if (self.picker_choices_owned) {
-            if (allocator) |alloc| {
+            if (self.picker_allocator orelse allocator) |alloc| {
                 for (self.picker_choices) |choice| alloc.free(choice);
                 alloc.free(self.picker_choices);
             } else return;
@@ -193,6 +199,7 @@ pub const State = struct {
         self.picker.close();
         self.picker_choices = &.{};
         self.picker_choices_owned = false;
+        self.picker_allocator = null;
     }
 
     pub fn pickerOpen(self: *const State) bool {
@@ -266,6 +273,56 @@ pub const State = struct {
         } else if (delta_y < 0) {
             self.moveFocus(1);
         }
+    }
+
+    pub fn hitTest(self: *State, layout: settings_page_layout.Layout, x: f32, y: f32) ?Action {
+        if (layout.categoryAt(x, y)) |index| {
+            return switch (categoryAt(index) orelse return null) {
+                .general => .select_general,
+                .appearance => .select_appearance,
+                .ai => .select_ai,
+                .system => .select_system,
+            };
+        }
+
+        const row_index = layout.rowAt(x, y) orelse return null;
+        if (self.pickerOpen()) {
+            if (!self.selectPickerIndex(row_index)) return null;
+            return .choose_picker_value;
+        }
+        const rows = categoryRows(self.category);
+        if (row_index >= rows.len) return null;
+        const row = rows[row_index];
+        self.focus = row;
+
+        if (row == SETTINGS_FONT_SIZE_ROW) {
+            return switch (layout.fontControlAt(x) orelse return null) {
+                .minus => .font_size_minus,
+                .plus => .font_size_plus,
+            };
+        }
+        if (row == SETTINGS_THEME_ROW) return .cycle_theme;
+        if (row == SETTINGS_FONT_FAMILY_ROW) return .open_font_picker;
+
+        const control_row = row - SETTINGS_CONTROL_ROW_START;
+        if (shell_integration.supported) {
+            if (control_row == 9) return .toggle_start_menu;
+            if (control_row == 10) return .toggle_startup;
+        }
+        return switch (control_row) {
+            0 => .cycle_cursor_style,
+            1 => .toggle_cursor_blink,
+            2 => .toggle_focus_follows_mouse,
+            3 => .open_shell_picker,
+            4 => .cycle_default_ai_profile,
+            5 => .toggle_weixin_direct,
+            6 => .cycle_language,
+            7 => .toggle_restore_tabs,
+            8 => .toggle_distill_suggest,
+            9 + SHELL_INTEGRATION_ROWS => .open_raw_config,
+            10 + SHELL_INTEGRATION_ROWS => .restore_defaults,
+            else => null,
+        };
     }
 
     pub fn firstVisibleRow(self: *const State, visible_rows: usize) usize {
@@ -375,12 +432,47 @@ test "appearance exposes font family before font size" {
 test "settings page choice picker handles navigation selection and cancel" {
     const choices = [_][]const u8{ "bash", "zsh", "fish" };
     var state = State{ .visible = true };
-    state.openPicker(.shell, &choices, "zsh", false);
+    state.openPicker(.shell, &choices, "zsh", false, null);
 
     try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_down }));
     try std.testing.expectEqualStrings("fish", state.pickerValue().?);
     try std.testing.expectEqual(Action.choose_picker_value, state.handleKey(.{ .key = .enter }).?);
     try std.testing.expectEqual(Action.close_picker, state.handleKey(.{ .key = .escape }).?);
+}
+
+test "settings page hit test selects a picker row without AppWindow" {
+    const choices = [_][]const u8{ "bash", "zsh" };
+    var state = State{ .visible = true };
+    state.openPicker(.shell, &choices, "bash", false, null);
+    const layout = settings_page_layout.compute(.{
+        .window_height = 700,
+        .top_offset = 40,
+        .content_x = 0,
+        .content_width = 900,
+        .cell_height = 20,
+        .focus_index = 0,
+        .row_count = choices.len,
+        .category_count = categoryCount(),
+    });
+
+    const action = state.hitTest(layout, layout.content_x + 10, layout.row_top_px + layout.row_h + 1);
+
+    try std.testing.expectEqual(Action.choose_picker_value, action.?);
+    try std.testing.expectEqualStrings("zsh", state.pickerValue().?);
+}
+
+test "settings page reopen releases owned picker choices and resets picker" {
+    var state = State{ .visible = true };
+    const choices = try std.testing.allocator.alloc([]const u8, 2);
+    choices[0] = try std.testing.allocator.dupe(u8, "Fira Code");
+    choices[1] = try std.testing.allocator.dupe(u8, "JetBrains Mono");
+    state.openPicker(.font_family, choices, "Fira Code", true, std.testing.allocator);
+
+    state.open();
+
+    try std.testing.expect(state.visible);
+    try std.testing.expect(!state.pickerOpen());
+    try std.testing.expectEqual(@as(usize, 0), state.pickerCount());
 }
 
 test "settings page deinit frees loaded cache after reload invalidation" {

--- a/src/renderer/overlays/settings_page.zig
+++ b/src/renderer/overlays/settings_page.zig
@@ -2,9 +2,12 @@ const std = @import("std");
 const input_key = @import("../../input/key.zig");
 const Config = @import("../../config.zig");
 const shell_integration = @import("../../platform/shell_integration.zig");
+const settings_picker = @import("settings_picker.zig");
 
-pub const SETTINGS_THEME_ROW: usize = 1;
-pub const SETTINGS_CONTROL_ROW_START: usize = 2;
+pub const SETTINGS_FONT_FAMILY_ROW: usize = 0;
+pub const SETTINGS_FONT_SIZE_ROW: usize = 1;
+pub const SETTINGS_THEME_ROW: usize = 2;
+pub const SETTINGS_CONTROL_ROW_START: usize = 3;
 pub const SHELL_INTEGRATION_ROWS: usize = if (shell_integration.supported) 2 else 0;
 pub const SETTINGS_RAW_CONFIG_ROW: usize = SETTINGS_CONTROL_ROW_START + 9 + SHELL_INTEGRATION_ROWS;
 pub const SETTINGS_RESTORE_DEFAULTS_ROW: usize = SETTINGS_CONTROL_ROW_START + 10 + SHELL_INTEGRATION_ROWS;
@@ -24,7 +27,8 @@ const GENERAL_ROWS = [_]usize{
     SETTINGS_RESTORE_DEFAULTS_ROW,
 };
 const APPEARANCE_ROWS = [_]usize{
-    0, // font size
+    SETTINGS_FONT_FAMILY_ROW,
+    SETTINGS_FONT_SIZE_ROW,
     SETTINGS_THEME_ROW,
     SETTINGS_CONTROL_ROW_START + 0, // cursor style
     SETTINGS_CONTROL_ROW_START + 1, // cursor blink
@@ -64,6 +68,7 @@ pub fn categoryRows(category: Category) []const usize {
 }
 
 pub const Action = enum {
+    open_font_picker,
     font_size_minus,
     font_size_plus,
     cycle_theme,
@@ -71,7 +76,9 @@ pub const Action = enum {
     cycle_cursor_style,
     toggle_cursor_blink,
     toggle_focus_follows_mouse,
-    cycle_shell,
+    open_shell_picker,
+    choose_picker_value,
+    close_picker,
     cycle_default_ai_profile,
     cycle_default_ai_profile_prev,
     toggle_weixin_direct,
@@ -95,6 +102,9 @@ pub const State = struct {
     cfg_dirty: bool = true,
     cfg_loaded: bool = false,
     cfg_cache: Config = .{},
+    picker: settings_picker.State = .{},
+    picker_choices: []const []const u8 = &.{},
+    picker_choices_owned: bool = false,
 
     pub fn open(self: *State) void {
         self.visible = true;
@@ -127,6 +137,7 @@ pub const State = struct {
 
     pub fn close(self: *State, allocator: ?std.mem.Allocator) void {
         self.visible = false;
+        self.closePicker(allocator);
         if (self.cfg_loaded) {
             const alloc = allocator orelse return;
             self.cfg_cache.deinit(alloc);
@@ -137,6 +148,7 @@ pub const State = struct {
     }
 
     pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
+        self.closePicker(allocator);
         if (self.cfg_loaded) self.cfg_cache.deinit(allocator);
         self.cfg_cache = .{};
         self.cfg_loaded = false;
@@ -165,7 +177,67 @@ pub const State = struct {
         return &self.cfg_cache;
     }
 
+    pub fn openPicker(self: *State, kind: settings_picker.Kind, choices: []const []const u8, current: []const u8, owned: bool) void {
+        self.picker_choices = choices;
+        self.picker_choices_owned = owned;
+        self.picker.open(kind, choices, current);
+    }
+
+    pub fn closePicker(self: *State, allocator: ?std.mem.Allocator) void {
+        if (self.picker_choices_owned) {
+            if (allocator) |alloc| {
+                for (self.picker_choices) |choice| alloc.free(choice);
+                alloc.free(self.picker_choices);
+            } else return;
+        }
+        self.picker.close();
+        self.picker_choices = &.{};
+        self.picker_choices_owned = false;
+    }
+
+    pub fn pickerOpen(self: *const State) bool {
+        return self.picker.kind != null;
+    }
+
+    pub fn pickerKind(self: *const State) ?settings_picker.Kind {
+        return self.picker.kind;
+    }
+
+    pub fn pickerCount(self: *const State) usize {
+        return if (self.pickerOpen()) self.picker_choices.len else 0;
+    }
+
+    pub fn pickerValue(self: *const State) ?[]const u8 {
+        return self.picker.selectedValue(self.picker_choices);
+    }
+
+    pub fn pickerValueAt(self: *const State, index: usize) ?[]const u8 {
+        if (!self.pickerOpen() or index >= self.picker_choices.len) return null;
+        return self.picker_choices[index];
+    }
+
+    pub fn selectPickerIndex(self: *State, index: usize) bool {
+        if (!self.pickerOpen() or index >= self.picker_choices.len) return false;
+        self.picker.selected = index;
+        return true;
+    }
+
     pub fn handleKey(self: *State, ev: input_key.KeyEvent) ?Action {
+        if (self.pickerOpen()) {
+            return switch (ev.key) {
+                .escape, .arrow_left => .close_picker,
+                .arrow_down, .tab => blk: {
+                    self.picker.move(1, self.picker_choices.len);
+                    break :blk null;
+                },
+                .arrow_up => blk: {
+                    self.picker.move(-1, self.picker_choices.len);
+                    break :blk null;
+                },
+                .enter, .arrow_right => .choose_picker_value,
+                else => null,
+            };
+        }
         switch (ev.key) {
             .escape => return null,
             .arrow_down, .tab => {
@@ -185,6 +257,10 @@ pub const State = struct {
 
     pub fn handleScroll(self: *State, delta_y: f64) void {
         if (!self.visible) return;
+        if (self.pickerOpen()) {
+            if (delta_y > 0) self.picker.move(-1, self.picker_choices.len) else if (delta_y < 0) self.picker.move(1, self.picker_choices.len);
+            return;
+        }
         if (delta_y > 0) {
             self.moveFocus(-1);
         } else if (delta_y < 0) {
@@ -206,12 +282,13 @@ pub const State = struct {
             if (self.focus == SETTINGS_CONTROL_ROW_START + 10) return .toggle_startup;
         }
         return switch (self.focus) {
-            0 => .font_size_plus,
+            SETTINGS_FONT_FAMILY_ROW => .open_font_picker,
+            SETTINGS_FONT_SIZE_ROW => .font_size_plus,
             SETTINGS_THEME_ROW => .cycle_theme,
             SETTINGS_CONTROL_ROW_START + 0 => .cycle_cursor_style,
             SETTINGS_CONTROL_ROW_START + 1 => .toggle_cursor_blink,
             SETTINGS_CONTROL_ROW_START + 2 => .toggle_focus_follows_mouse,
-            SETTINGS_CONTROL_ROW_START + 3 => .cycle_shell,
+            SETTINGS_CONTROL_ROW_START + 3 => .open_shell_picker,
             SETTINGS_CONTROL_ROW_START + 4 => .cycle_default_ai_profile,
             SETTINGS_CONTROL_ROW_START + 5 => .toggle_weixin_direct,
             SETTINGS_CONTROL_ROW_START + 6 => .cycle_language,
@@ -225,7 +302,7 @@ pub const State = struct {
 
     pub fn focusLeftAction(self: *const State) ?Action {
         return switch (self.focus) {
-            0 => .font_size_minus,
+            SETTINGS_FONT_SIZE_ROW => .font_size_minus,
             SETTINGS_THEME_ROW => .cycle_theme_prev,
             SETTINGS_CONTROL_ROW_START + 4 => .cycle_default_ai_profile_prev,
             else => null,
@@ -234,7 +311,7 @@ pub const State = struct {
 
     pub fn focusRightAction(self: *const State) ?Action {
         return switch (self.focus) {
-            0 => .font_size_plus,
+            SETTINGS_FONT_SIZE_ROW => .font_size_plus,
             SETTINGS_THEME_ROW => .cycle_theme,
             else => self.focusPrimaryAction(),
         };
@@ -261,6 +338,8 @@ test "settings page key navigation wraps within the selected category" {
     try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_down }));
     try std.testing.expectEqual(APPEARANCE_ROWS[0], state.focus);
 
+    try std.testing.expectEqual(Action.open_font_picker, state.handleKey(.{ .key = .enter }).?);
+    try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_down }));
     try std.testing.expectEqual(Action.font_size_plus, state.handleKey(.{ .key = .enter }).?);
     try std.testing.expectEqual(Action.font_size_minus, state.handleKey(.{ .key = .arrow_left }).?);
     try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .escape }));
@@ -285,6 +364,23 @@ test "settings page category selection scopes visible rows" {
 
     try std.testing.expectEqual(Category.ai, state.category);
     try std.testing.expectEqual(@as(usize, 1), scroll);
+}
+
+test "appearance exposes font family before font size" {
+    const rows = categoryRows(.appearance);
+    try std.testing.expectEqual(SETTINGS_FONT_FAMILY_ROW, rows[0]);
+    try std.testing.expectEqual(SETTINGS_FONT_SIZE_ROW, rows[1]);
+}
+
+test "settings page choice picker handles navigation selection and cancel" {
+    const choices = [_][]const u8{ "bash", "zsh", "fish" };
+    var state = State{ .visible = true };
+    state.openPicker(.shell, &choices, "zsh", false);
+
+    try std.testing.expectEqual(@as(?Action, null), state.handleKey(.{ .key = .arrow_down }));
+    try std.testing.expectEqualStrings("fish", state.pickerValue().?);
+    try std.testing.expectEqual(Action.choose_picker_value, state.handleKey(.{ .key = .enter }).?);
+    try std.testing.expectEqual(Action.close_picker, state.handleKey(.{ .key = .escape }).?);
 }
 
 test "settings page deinit frees loaded cache after reload invalidation" {

--- a/src/renderer/overlays/settings_picker.zig
+++ b/src/renderer/overlays/settings_picker.zig
@@ -1,0 +1,58 @@
+//! Pure selection state for Settings choice lists (fonts and shells).
+const std = @import("std");
+
+pub const Kind = enum { font_family, shell };
+
+pub const State = struct {
+    kind: ?Kind = null,
+    selected: usize = 0,
+
+    pub fn open(self: *State, kind: Kind, choices: []const []const u8, current: []const u8) void {
+        self.kind = kind;
+        self.selected = 0;
+        for (choices, 0..) |choice, index| {
+            if (std.ascii.eqlIgnoreCase(choice, current)) {
+                self.selected = index;
+                break;
+            }
+        }
+    }
+
+    pub fn move(self: *State, delta: isize, count: usize) void {
+        if (count == 0) return;
+        const current: isize = @intCast(@min(self.selected, count - 1));
+        self.selected = @intCast(@mod(current + delta, @as(isize, @intCast(count))));
+    }
+
+    pub fn selectedValue(self: *const State, choices: []const []const u8) ?[]const u8 {
+        if (self.kind == null or self.selected >= choices.len) return null;
+        return choices[self.selected];
+    }
+
+    pub fn close(self: *State) void {
+        self.kind = null;
+        self.selected = 0;
+    }
+};
+
+test "settings picker opens on the current value and returns the selected choice" {
+    const choices = [_][]const u8{ "bash", "zsh", "fish" };
+    var picker = State{};
+
+    picker.open(.shell, &choices, "zsh");
+    try std.testing.expectEqual(@as(usize, 1), picker.selected);
+    picker.move(1, choices.len);
+    try std.testing.expectEqualStrings("fish", picker.selectedValue(&choices).?);
+}
+
+test "settings picker wraps and close clears the active choice list" {
+    const choices = [_][]const u8{ "JetBrains Mono", "Menlo" };
+    var picker = State{};
+
+    picker.open(.font_family, &choices, "JetBrains Mono");
+    picker.move(-1, choices.len);
+    try std.testing.expectEqual(@as(usize, 1), picker.selected);
+    picker.close();
+    try std.testing.expect(picker.kind == null);
+    try std.testing.expect(picker.selectedValue(&choices) == null);
+}

--- a/src/renderer/overlays/startup_shortcuts.zig
+++ b/src/renderer/overlays/startup_shortcuts.zig
@@ -71,7 +71,7 @@ const STARTUP_SHORTCUT_ENTRIES = [_]StartupShortcut{
     .{ .keys = "Ctrl+A / Ctrl+C in AI", .keys_macos = "Cmd+A / Cmd+C in AI", .action = "Select / copy chat", .action_zh = "选择 / 复制对话" },
     .{ .keys = "Right-click selection", .action = "Copy selection", .action_zh = "复制选区" },
     .{ .keys = "Ctrl+Shift+V", .kind = .action, .first = .paste_image, .action = "Paste image", .action_zh = "粘贴图片" },
-    .{ .keys = "Ctrl+,", .kind = .action, .first = .open_config, .action = "Open config", .action_zh = "打开配置" },
+    .{ .keys = "Ctrl+,", .kind = .action, .first = .open_settings, .action = "Settings", .action_zh = "设置" },
     .{ .keys = "Ctrl++ / Ctrl+-", .kind = .pair, .first = .font_size_increase, .second = .font_size_decrease, .action = "Font size", .action_zh = "字号" },
     .{ .keys = "Alt+Enter", .kind = .action, .first = .toggle_maximize, .action = "Maximize / restore", .action_zh = "最大化 / 还原" },
 };

--- a/src/renderer/settings_page_renderer.zig
+++ b/src/renderer/settings_page_renderer.zig
@@ -1,0 +1,279 @@
+//! Feature-owned renderer for the Settings workbench.
+//!
+//! Integration code prepares a small view model; this module owns Settings
+//! presentation and never reaches back into AppWindow or configuration I/O.
+
+const std = @import("std");
+const i18n = @import("../i18n.zig");
+const settings_page = @import("overlays/settings_page.zig");
+const settings_page_layout = @import("overlays/settings_page_layout.zig");
+const ui_patterns = @import("ui_patterns.zig");
+
+pub const DrawContext = struct {
+    bg: [3]f32,
+    fg: [3]f32,
+    accent: [3]f32,
+    cell_h: f32,
+    fillQuadAlpha: *const fn (f32, f32, f32, f32, [3]f32, f32) void,
+    roundedQuadAlpha: *const fn (f32, f32, f32, f32, f32, [3]f32, f32) void,
+    renderTextLimited: *const fn ([]const u8, f32, f32, [3]f32, f32) f32,
+    measureText: *const fn ([]const u8) f32,
+};
+
+pub const Row = struct {
+    id: usize,
+    value: []const u8,
+};
+
+pub const View = struct {
+    state: *const settings_page.State,
+    rows: []const Row,
+    picker_current: []const u8 = "",
+    default_shell_label: []const u8 = "",
+};
+
+pub fn render(draw: DrawContext, view: View, layout: settings_page_layout.Layout, window_height: f32) void {
+    const state = view.state;
+    const picker_open = state.pickerOpen();
+    const page_y = @round(window_height - layout.page_top_px - layout.page_h);
+    const border = mixColor(draw.bg, draw.fg, 0.16);
+    const muted = mixColor(draw.bg, draw.fg, 0.58);
+
+    draw.fillQuadAlpha(layout.page_x, page_y, layout.page_w, layout.page_h, mixColor(draw.bg, draw.fg, 0.012), 1.0);
+    draw.fillQuadAlpha(layout.page_x, page_y, layout.nav_w, layout.page_h, mixColor(draw.bg, draw.fg, 0.025), 0.96);
+    draw.fillQuadAlpha(layout.page_x + layout.nav_w - 1, page_y, 1, layout.page_h, border, 0.72);
+
+    _ = draw.renderTextLimited(i18n.s().settings_title, layout.page_x + 24, textYFromTop(draw, window_height, layout.nav_title_top_px), mixColor(draw.fg, draw.accent, 0.10), layout.nav_w - 48);
+    _ = draw.renderTextLimited(if (i18n.lang() == .zh_CN) "偏好设置" else "PREFERENCES", layout.page_x + 24, textYFromTop(draw, window_height, layout.nav_label_top_px), muted, layout.nav_w - 48);
+
+    for (0..settings_page.categoryCount()) |idx| {
+        const category = settings_page.categoryAt(idx) orelse continue;
+        const item_top = layout.nav_item_top_px + layout.nav_item_h * @as(f32, @floatFromInt(idx));
+        const item_y = @round(window_height - item_top - layout.nav_item_h);
+        const selected = category == state.category;
+        if (selected) draw.fillQuadAlpha(layout.page_x + 14, item_y + 10, 3, layout.nav_item_h - 20, draw.accent, 0.84);
+        _ = draw.renderTextLimited(categoryLabel(category), layout.page_x + 28, rowTextY(draw, item_y, layout.nav_item_h), if (selected) mixColor(draw.fg, draw.accent, 0.16) else mixColor(draw.bg, draw.fg, 0.76), layout.nav_w - 48);
+    }
+
+    const page_title = if (state.pickerKind()) |kind| switch (kind) {
+        .font_family => if (i18n.lang() == .zh_CN) "选择字体" else "Choose font family",
+        .shell => if (i18n.lang() == .zh_CN) "选择默认 Shell" else "Choose default shell",
+    } else categoryLabel(state.category);
+    const subtitle = if (picker_open)
+        (if (i18n.lang() == .zh_CN) "用方向键选择，按 Enter 应用，按 Esc 返回" else "Use arrows to choose, Enter to apply, Esc to go back")
+    else
+        categoryDescription(state.category);
+    _ = draw.renderTextLimited(page_title, layout.content_x, textYFromTop(draw, window_height, layout.page_top_px + 28), mixColor(draw.fg, draw.accent, 0.10), layout.content_w);
+    _ = draw.renderTextLimited(subtitle, layout.content_x, textYFromTop(draw, window_height, layout.page_top_px + 28 + lineHeight(draw)), muted, layout.content_w);
+    draw.fillQuadAlpha(layout.content_x, @round(window_height - layout.row_top_px), layout.content_w, 1, border, 0.52);
+
+    if (picker_open) {
+        for (0..state.pickerCount()) |row_index| {
+            const value = state.pickerValueAt(row_index) orelse continue;
+            const label = if (state.pickerKind().? == .shell and value.len == 0) view.default_shell_label else value;
+            renderPickerRow(draw, layout, window_height, row_index, label, state.picker.selected == row_index, std.ascii.eqlIgnoreCase(value, view.picker_current));
+        }
+    } else {
+        for (view.rows, 0..) |row, row_index| {
+            renderRow(draw, state.category, layout, window_height, row, row_index, state.focus == row.id);
+        }
+    }
+
+    const item_count = if (picker_open) state.pickerCount() else view.rows.len;
+    renderScrollbar(draw, layout, window_height, item_count);
+    renderFooter(draw, layout, window_height, picker_open, muted, border);
+}
+
+fn renderRow(draw: DrawContext, category: settings_page.Category, layout: settings_page_layout.Layout, window_height: f32, row: Row, row_index: usize, selected: bool) void {
+    const visible = layout.visibleRow(window_height, row_index) orelse return;
+    const x = layout.content_x;
+    const w = layout.content_w;
+    const title_x = x + 20;
+    const right_edge = x + w - 18;
+    const title_y = textYFromTop(draw, window_height, visible.top_px + 10);
+    const detail_y = textYFromTop(draw, window_height, visible.top_px + 10 + lineHeight(draw));
+    var title_max_w = w - 40;
+
+    if (selected) draw.fillQuadAlpha(x + 2, visible.gl_y + 8, 3, layout.row_h - 16, draw.accent, 0.82);
+    if (row.value.len > 0) {
+        const kind = controlKind(row.id);
+        const max_value_w: f32 = switch (kind) {
+            .toggle => 96,
+            .adjuster => 152,
+            .choice => 360,
+            .action => 180,
+        };
+        const min_value_w: f32 = switch (kind) {
+            .toggle => 76,
+            .adjuster => 118,
+            .choice => 132,
+            .action => 96,
+        };
+        const trailing_w: f32 = switch (kind) {
+            .choice, .action => 26,
+            .adjuster, .toggle => 12,
+        };
+        const value_w = if (kind == .toggle) 46.0 else @min(max_value_w, @max(min_value_w, draw.measureText(row.value) + 24 + trailing_w));
+        const value_x = @round(right_edge - value_w);
+        const control_h = if (kind == .toggle) 24.0 else @round(@max(32.0, draw.cell_h + 10.0));
+        const pill_y = visible.gl_y + @round((layout.row_h - control_h) / 2);
+        const is_on = std.mem.eql(u8, row.value, i18n.s().settings_value_on);
+        if (kind == .toggle) {
+            draw.roundedQuadAlpha(value_x, pill_y, value_w, control_h, control_h / 2, if (is_on) mixColor(draw.bg, draw.accent, 0.40) else mixColor(draw.bg, draw.fg, 0.18), 0.96);
+            const knob_d = control_h - 6;
+            const knob_x = if (is_on) value_x + value_w - knob_d - 3 else value_x + 3;
+            draw.roundedQuadAlpha(knob_x, pill_y + 3, knob_d, knob_d, knob_d / 2, if (is_on) draw.accent else mixColor(draw.bg, draw.fg, 0.42), 0.96);
+        } else {
+            _ = draw.renderTextLimited(row.value, value_x, rowTextY(draw, pill_y, control_h), if (selected) draw.accent else mixColor(draw.bg, draw.fg, 0.82), value_w - trailing_w);
+            if (kind == .choice or kind == .action) _ = draw.renderTextLimited(">", value_x + value_w - 12, rowTextY(draw, pill_y, control_h), mixColor(draw.bg, draw.fg, 0.60), 12);
+        }
+        title_max_w = @max(1.0, value_x - title_x - 18);
+    }
+
+    if (visible.visible_index > 0) draw.fillQuadAlpha(x + 18, visible.gl_y + layout.row_h - 1, w - 36, 1, mixColor(draw.bg, draw.fg, 0.14), 0.62);
+    _ = draw.renderTextLimited(rowTitle(row.id), title_x, title_y, if (selected) mixColor(draw.fg, draw.accent, 0.16) else draw.fg, title_max_w);
+    _ = draw.renderTextLimited(rowDescription(category, row.id), title_x, detail_y, mixColor(draw.bg, draw.fg, 0.56), title_max_w);
+}
+
+fn renderPickerRow(draw: DrawContext, layout: settings_page_layout.Layout, window_height: f32, row_index: usize, label: []const u8, selected: bool, current: bool) void {
+    const visible = layout.visibleRow(window_height, row_index) orelse return;
+    if (selected) {
+        draw.fillQuadAlpha(layout.content_x + 2, visible.gl_y + 8, 3, layout.row_h - 16, draw.accent, 0.82);
+        draw.fillQuadAlpha(layout.content_x + 8, visible.gl_y + 6, layout.content_w - 16, layout.row_h - 12, mixColor(draw.bg, draw.accent, 0.08), 0.72);
+    }
+    if (visible.visible_index > 0) draw.fillQuadAlpha(layout.content_x + 18, visible.gl_y + layout.row_h - 1, layout.content_w - 36, 1, mixColor(draw.bg, draw.fg, 0.14), 0.62);
+    const text_y = rowTextY(draw, visible.gl_y, layout.row_h);
+    _ = draw.renderTextLimited(label, layout.content_x + 20, text_y, if (selected) mixColor(draw.fg, draw.accent, 0.16) else draw.fg, layout.content_w - 170);
+    if (current) _ = draw.renderTextLimited(if (i18n.lang() == .zh_CN) "当前" else "Current", layout.content_x + layout.content_w - 100, text_y, draw.accent, 82);
+}
+
+fn renderScrollbar(draw: DrawContext, layout: settings_page_layout.Layout, window_height: f32, item_count: usize) void {
+    if (layout.visible_rows >= item_count) return;
+    const total: f32 = @floatFromInt(item_count);
+    const vis: f32 = @floatFromInt(layout.visible_rows);
+    const track_h = layout.row_h * vis;
+    const sb_x = layout.content_x + layout.content_w - 10;
+    draw.fillQuadAlpha(sb_x, @round(window_height - layout.row_top_px - track_h), 3, track_h, mixColor(draw.bg, draw.fg, 0.25), 0.30);
+    const thumb_h = @max(24.0, @round(track_h * vis / total));
+    const max_scroll: f32 = @floatFromInt(item_count - layout.visible_rows);
+    const offset = if (max_scroll > 0) @round((track_h - thumb_h) * (@as(f32, @floatFromInt(layout.scroll)) / max_scroll)) else 0;
+    draw.fillQuadAlpha(sb_x, @round(window_height - (layout.row_top_px + offset) - thumb_h), 3, thumb_h, draw.accent, 0.55);
+}
+
+fn renderFooter(draw: DrawContext, layout: settings_page_layout.Layout, window_height: f32, picker_open: bool, muted: [3]f32, border: [3]f32) void {
+    const footer_h = ui_patterns.workbenchFooterHeight(draw.cell_h);
+    const footer_top = ui_patterns.workbenchFooterTop(window_height, layout.page_top_px, footer_h);
+    const footer_y = @round(window_height - footer_top - footer_h);
+    draw.fillQuadAlpha(layout.page_x, footer_y, layout.page_w, footer_h, mixColor(draw.bg, draw.fg, 0.030), 0.98);
+    draw.fillQuadAlpha(layout.page_x, footer_y + footer_h - 1, layout.page_w, 1, border, 0.68);
+    const text = if (picker_open)
+        (if (i18n.lang() == .zh_CN) "↑/↓ 选择  ·  Enter 应用  ·  Esc 返回" else "↑/↓ choose  ·  Enter apply  ·  Esc back")
+    else
+        i18n.s().settings_workbench_footer;
+    _ = draw.renderTextLimited(text, layout.content_x, rowTextY(draw, footer_y, footer_h), muted, layout.content_w);
+}
+
+const ControlKind = enum { adjuster, toggle, choice, action };
+
+fn controlKind(row: usize) ControlKind {
+    if (settings_page.SHELL_INTEGRATION_ROWS > 0 and (row == settings_page.SETTINGS_CONTROL_ROW_START + 9 or row == settings_page.SETTINGS_CONTROL_ROW_START + 10)) return .toggle;
+    return switch (row) {
+        settings_page.SETTINGS_FONT_SIZE_ROW => .adjuster,
+        settings_page.SETTINGS_FONT_FAMILY_ROW, settings_page.SETTINGS_THEME_ROW, settings_page.SETTINGS_CONTROL_ROW_START + 0, settings_page.SETTINGS_CONTROL_ROW_START + 3, settings_page.SETTINGS_CONTROL_ROW_START + 4, settings_page.SETTINGS_CONTROL_ROW_START + 6 => .choice,
+        settings_page.SETTINGS_CONTROL_ROW_START + 1, settings_page.SETTINGS_CONTROL_ROW_START + 2, settings_page.SETTINGS_CONTROL_ROW_START + 5, settings_page.SETTINGS_CONTROL_ROW_START + 7, settings_page.SETTINGS_CONTROL_ROW_START + 8 => .toggle,
+        else => .action,
+    };
+}
+
+fn categoryLabel(category: settings_page.Category) []const u8 {
+    return switch (i18n.lang()) {
+        .en => switch (category) {
+            .general => "General",
+            .appearance => "Appearance",
+            .ai => "AI & Integrations",
+            .system => "System",
+        },
+        .zh_CN => switch (category) {
+            .general => "常规",
+            .appearance => "外观",
+            .ai => "AI 与集成",
+            .system => "系统",
+        },
+    };
+}
+
+fn categoryDescription(category: settings_page.Category) []const u8 {
+    return switch (i18n.lang()) {
+        .en => switch (category) {
+            .general => "Startup, language, and configuration",
+            .appearance => "Typography, theme, and cursor behavior",
+            .ai => "Profiles and assistant integrations",
+            .system => "Desktop integration and startup behavior",
+        },
+        .zh_CN => switch (category) {
+            .general => "启动、语言与配置管理",
+            .appearance => "字体、主题与光标行为",
+            .ai => "配置文件与智能助手集成",
+            .system => "桌面集成与启动方式",
+        },
+    };
+}
+
+fn rowTitle(row: usize) []const u8 {
+    if (settings_page.SHELL_INTEGRATION_ROWS > 0 and row == settings_page.SETTINGS_CONTROL_ROW_START + 9) return i18n.s().settings_start_menu;
+    if (settings_page.SHELL_INTEGRATION_ROWS > 0 and row == settings_page.SETTINGS_CONTROL_ROW_START + 10) return i18n.s().settings_startup;
+    return switch (row) {
+        settings_page.SETTINGS_FONT_FAMILY_ROW => if (i18n.lang() == .zh_CN) "字体" else "Font family",
+        settings_page.SETTINGS_FONT_SIZE_ROW => i18n.s().settings_font_size,
+        settings_page.SETTINGS_THEME_ROW => i18n.s().settings_theme,
+        settings_page.SETTINGS_CONTROL_ROW_START + 0 => i18n.s().settings_cursor_style,
+        settings_page.SETTINGS_CONTROL_ROW_START + 1 => i18n.s().settings_cursor_blink,
+        settings_page.SETTINGS_CONTROL_ROW_START + 2 => i18n.s().settings_focus_follows_mouse,
+        settings_page.SETTINGS_CONTROL_ROW_START + 3 => i18n.s().settings_shell,
+        settings_page.SETTINGS_CONTROL_ROW_START + 4 => i18n.s().settings_default_ai,
+        settings_page.SETTINGS_CONTROL_ROW_START + 5 => i18n.s().settings_weixin_direct,
+        settings_page.SETTINGS_CONTROL_ROW_START + 6 => i18n.s().settings_language,
+        settings_page.SETTINGS_CONTROL_ROW_START + 7 => i18n.s().settings_restore_tabs,
+        settings_page.SETTINGS_CONTROL_ROW_START + 8 => i18n.s().settings_distill_suggest,
+        settings_page.SETTINGS_RAW_CONFIG_ROW => i18n.s().settings_raw_config,
+        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => i18n.s().settings_restore_defaults,
+        else => "",
+    };
+}
+
+fn rowDescription(_: settings_page.Category, row: usize) []const u8 {
+    const zh = i18n.lang() == .zh_CN;
+    if (settings_page.SHELL_INTEGRATION_ROWS > 0 and row == settings_page.SETTINGS_CONTROL_ROW_START + 9) return if (zh) "在 Windows 开始菜单中显示 WispTerm" else "Show WispTerm in the Windows Start menu";
+    if (settings_page.SHELL_INTEGRATION_ROWS > 0 and row == settings_page.SETTINGS_CONTROL_ROW_START + 10) return if (zh) "登录系统后自动启动 WispTerm" else "Launch WispTerm when you sign in";
+    return switch (row) {
+        settings_page.SETTINGS_FONT_FAMILY_ROW => if (zh) "从系统已安装字体中选择终端字体" else "Choose from fonts installed on this system",
+        settings_page.SETTINGS_FONT_SIZE_ROW => if (zh) "调整终端内容的显示字号" else "Adjust the terminal text size",
+        settings_page.SETTINGS_THEME_ROW => if (zh) "选择终端和应用界面的配色主题" else "Choose the terminal and app color theme",
+        settings_page.SETTINGS_CONTROL_ROW_START + 0 => if (zh) "选择终端光标的形状" else "Choose the terminal cursor shape",
+        settings_page.SETTINGS_CONTROL_ROW_START + 1 => if (zh) "控制光标是否闪烁" else "Control whether the cursor blinks",
+        settings_page.SETTINGS_CONTROL_ROW_START + 2 => if (zh) "鼠标移动时自动切换面板焦点" else "Move panel focus with the pointer",
+        settings_page.SETTINGS_CONTROL_ROW_START + 3 => if (zh) "设置新标签页使用的默认 Shell" else "Set the default shell for new tabs",
+        settings_page.SETTINGS_CONTROL_ROW_START + 4 => if (zh) "选择新建 AI 会话使用的配置" else "Choose the profile for new AI sessions",
+        settings_page.SETTINGS_CONTROL_ROW_START + 5 => if (zh) "允许微信消息直接进入当前会话" else "Allow WeChat messages into the active session",
+        settings_page.SETTINGS_CONTROL_ROW_START + 6 => if (zh) "选择 WispTerm 的界面语言" else "Choose the WispTerm interface language",
+        settings_page.SETTINGS_CONTROL_ROW_START + 7 => if (zh) "启动时恢复上次打开的标签页" else "Restore previously open tabs at launch",
+        settings_page.SETTINGS_CONTROL_ROW_START + 8 => if (zh) "在合适时建议将工作流沉淀为技能" else "Suggest reusable skills from completed work",
+        settings_page.SETTINGS_RAW_CONFIG_ROW => if (zh) "在编辑器中打开完整配置文件" else "Open the complete config file in your editor",
+        settings_page.SETTINGS_RESTORE_DEFAULTS_ROW => if (zh) "移除自定义设置并恢复默认值" else "Remove custom settings and restore defaults",
+        else => "",
+    };
+}
+
+fn lineHeight(draw: DrawContext) f32 {
+    return @round(@max(24.0, draw.cell_h + 8.0));
+}
+fn textYFromTop(draw: DrawContext, window_height: f32, top: f32) f32 {
+    return @round(window_height - top - draw.cell_h);
+}
+fn rowTextY(draw: DrawContext, y: f32, h: f32) f32 {
+    return @round(y + (h - draw.cell_h) / 2);
+}
+
+fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
+    return .{ a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t };
+}

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,13 +19,13 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Ratchet ceilings for watched files (AppWindow 45, input 81, overlays 8,
+// Ratchet ceilings for watched files (AppWindow 45, input 81, overlays 0,
 // assistant/conversation/session.zig 0). Lower a ceiling only when direct
 // writes are removed.
 const monoliths = [_]Frozen{
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 45 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
-    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 8 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 0 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },
 };
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -199,6 +199,7 @@ test {
     _ = @import("renderer/overlays/startup_shortcuts_layout.zig");
     _ = @import("renderer/overlays/settings_page_layout.zig");
     _ = @import("renderer/overlays/settings_page.zig");
+    _ = @import("renderer/overlays/settings_picker.zig");
     _ = @import("memory_center/session.zig");
     _ = @import("renderer/memory_center_renderer.zig");
     _ = @import("renderer/overlays/toasts.zig");

--- a/src/test_macos_menu.zig
+++ b/src/test_macos_menu.zig
@@ -142,13 +142,13 @@ test "menu_macos: View > Toggle Tab Sidebar carries toggle_sidebar and ⌘⇧B" 
     );
 }
 
-test "menu_macos: WispTerm > Settings carries open_config and ⌘," {
+test "menu_macos: WispTerm > Settings carries open_settings and ⌘," {
     if (builtin.os.tag != .macos) return error.SkipZigTest;
     installFreshMenu();
     const wispterm_idx = try requireSubmenuTitled("About WispTerm");
     const item_idx = try findItemIndex(wispterm_idx, "Settings…");
     try std.testing.expectEqual(
-        @as(i32, @intCast(@intFromEnum(keybind.Action.open_config))),
+        @as(i32, @intCast(@intFromEnum(keybind.Action.open_settings))),
         menu_macos.wispterm_macos_menu_item_action_for_test(wispterm_idx, item_idx),
     );
     const key_ptr = menu_macos.wispterm_macos_menu_item_key_equivalent_for_test(wispterm_idx, item_idx);
@@ -156,6 +156,23 @@ test "menu_macos: WispTerm > Settings carries open_config and ⌘," {
     try std.testing.expectEqual(
         menu_macos.ModCmd,
         menu_macos.wispterm_macos_menu_item_modifier_for_test(wispterm_idx, item_idx),
+    );
+}
+
+test "menu_macos: File > Close Tab uses the standard ⌘W shortcut" {
+    if (builtin.os.tag != .macos) return error.SkipZigTest;
+    installFreshMenu();
+    const file_idx = try requireSubmenuTitled("New Tab");
+    const item_idx = try findItemIndex(file_idx, "Close Tab");
+    try std.testing.expectEqual(
+        @as(i32, @intCast(@intFromEnum(keybind.Action.close_panel_or_tab))),
+        menu_macos.wispterm_macos_menu_item_action_for_test(file_idx, item_idx),
+    );
+    const key_ptr = menu_macos.wispterm_macos_menu_item_key_equivalent_for_test(file_idx, item_idx);
+    try std.testing.expectEqualStrings("w", std.mem.span(key_ptr.?));
+    try std.testing.expectEqual(
+        menu_macos.ModCmd,
+        menu_macos.wispterm_macos_menu_item_modifier_for_test(file_idx, item_idx),
     );
 }
 


### PR DESCRIPTION
## What changed

- route the default Settings shortcut and macOS Settings menu item to the existing visual Settings workbench while keeping raw config editing available from the command center and Settings page
- add a system font-family picker with keyboard, mouse, scrolling, current-value indication, and reset-to-default support
- replace shell cycling with an explicit platform-aware shell picker that includes bash and zsh on POSIX systems
- make an empty `shell` setting follow the current OS account login shell instead of forcing zsh on macOS; explicit shell configuration still wins
- use the standard macOS `Cmd+W` shortcut for the existing guarded close-panel/tab/window flow while preserving `Ctrl+Shift+W` on Windows and Linux
- update user documentation and shortcut references

## Why

Common terminal settings were technically available through the config file, but editing raw values was difficult to discover and error-prone for less experienced users. Shell startup also used a platform default rather than the user's configured login shell, which forced zsh for macOS users who use bash.

The visual Settings workbench already existed in WispTerm. This change completes and exposes that existing design instead of introducing a separate settings system.

## User impact

- `Cmd+,` opens visual Settings on macOS; advanced users can still open the raw config
- installed fonts and supported shells are selected from explicit lists
- choosing `System default` shows and launches the detected login shell, for example `/bin/bash`
- macOS users can close the focused panel, tab, or window with the native `Cmd+W` convention and retain the existing confirmation safeguards

## Validation

- `zig build test`
- `zig build test-macos-menu`
- `zig build test-macos-ui`
- `zig build macos-app -Dtarget=aarch64-macos`
- local manual verification on macOS
- `git diff --check`
