### PR TITLE
fix: match macOS update assets by architecture

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -13,7 +13,7 @@ plans belong in [ROADMAP.md](ROADMAP.md); completed changes belong in
 | Terminal host | Win32/ConPTY | AppKit/PTY | SDL3/POSIX PTY, experimental |
 | Embedded browser panel | WebView2 | WKWebView | Disabled |
 | WispTerm Remote transport | WinHTTP WebSocket | NSURLSession WebSocket | Not implemented |
-| Auto-update package matching | Windows portable zip flavors | Generic DMG matcher; release-asset naming needs review | Not implemented |
+| Auto-update package matching | Windows portable zip flavors | Architecture-specific DMG matching | Not implemented |
 
 ## Version Surfaces
 
@@ -73,10 +73,6 @@ tested passes.
 - Remote transport uses a native `NSURLSessionWebSocketTask` bridge and is
   compiled/tested on macOS, but full relay interoperability still needs live
   relay smoke coverage before removing the "stabilizing" qualifier.
-- The macOS update checker currently matches a generic `wispterm-macos-{tag}.dmg`
-  name while release workflows publish arch-qualified DMG assets. Align the
-  matcher before relying on in-app macOS update downloads.
-
 ## Linux
 
 - Embedded browser panel is disabled. `url-open-mode = embedded` falls back to

--- a/src/platform/update_package.zig
+++ b/src/platform/update_package.zig
@@ -139,8 +139,14 @@ test "platform update package matches exact target asset names only" {
 test "platform update package builds macOS DMG asset names" {
     var buf: [128]u8 = undefined;
     const name = try assetName("v1.28.0", .{ .platform = .macos }, &buf);
-    try std.testing.expectEqualStrings("wispterm-macos-v1.28.0.dmg", name);
-    try std.testing.expect(matchesAssetName("wispterm-macos-v1.28.0.dmg", "v1.28.0", .{ .platform = .macos }));
+    const expected = switch (builtin.cpu.arch) {
+        .aarch64 => "wispterm-macos-aarch64-v1.28.0.dmg",
+        .x86_64 => "wispterm-macos-x86_64-v1.28.0.dmg",
+        else => return error.SkipZigTest,
+    };
+    try std.testing.expectEqualStrings(expected, name);
+    try std.testing.expect(matchesAssetName(expected, "v1.28.0", .{ .platform = .macos }));
+    try std.testing.expect(!matchesAssetName("wispterm-macos-v1.28.0.dmg", "v1.28.0", .{ .platform = .macos }));
     try std.testing.expect(!matchesAssetName("wispterm-macos-v1.28.0.zip", "v1.28.0", .{ .platform = .macos }));
 }
 

--- a/src/platform/update_package_macos.zig
+++ b/src/platform/update_package_macos.zig
@@ -1,33 +1,107 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const release_package = @import("../release_package.zig");
 
-fn assetNameParts(package: release_package.Package) ?struct { prefix: []const u8, suffix: []const u8 } {
-    if (package.platform != .macos) return null;
-    return .{
-        .prefix = "wispterm-macos-",
-        .suffix = ".dmg",
+fn architectureLabel(arch: std.Target.Cpu.Arch) ?[]const u8 {
+    return switch (arch) {
+        .aarch64 => "aarch64",
+        .x86_64 => "x86_64",
+        else => null,
     };
 }
 
 pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
     _ = allocator;
     _ = webview_enabled;
+    if (architectureLabel(builtin.cpu.arch) == null) return error.UnsupportedMacosArchitecture;
     return .{ .platform = .macos };
 }
 
 pub fn assetName(tag_name: []const u8, package: release_package.Package, buf: []u8) ![]const u8 {
-    const parts = assetNameParts(package) orelse return error.UnsupportedReleasePackage;
-    return std.fmt.bufPrint(buf, "{s}{s}{s}", .{ parts.prefix, tag_name, parts.suffix });
+    return assetNameForArch(tag_name, package, builtin.cpu.arch, buf);
 }
 
 pub fn matchesAssetName(name: []const u8, tag_name: []const u8, package: release_package.Package) bool {
-    const parts = assetNameParts(package) orelse return false;
-    return name.len == parts.prefix.len + tag_name.len + parts.suffix.len and
-        std.mem.startsWith(u8, name, parts.prefix) and
-        std.mem.endsWith(u8, name, parts.suffix) and
-        std.mem.eql(u8, name[parts.prefix.len .. parts.prefix.len + tag_name.len], tag_name);
+    return matchesAssetNameForArch(name, tag_name, package, builtin.cpu.arch);
+}
+
+fn assetNameForArch(
+    tag_name: []const u8,
+    package: release_package.Package,
+    arch: std.Target.Cpu.Arch,
+    buf: []u8,
+) ![]const u8 {
+    if (package.platform != .macos) return error.UnsupportedReleasePackage;
+    const arch_label = architectureLabel(arch) orelse return error.UnsupportedMacosArchitecture;
+    return std.fmt.bufPrint(buf, "wispterm-macos-{s}-{s}.dmg", .{ arch_label, tag_name });
+}
+
+fn matchesAssetNameForArch(
+    name: []const u8,
+    tag_name: []const u8,
+    package: release_package.Package,
+    arch: std.Target.Cpu.Arch,
+) bool {
+    var expected_buf: [128]u8 = undefined;
+    const expected = assetNameForArch(tag_name, package, arch, &expected_buf) catch return false;
+    return std.mem.eql(u8, name, expected);
 }
 
 test "macOS update package reports the native platform package" {
     try std.testing.expectEqual(release_package.Platform.macos, (try currentPackage(std.testing.allocator, false)).platform);
+}
+
+test "macOS update package builds architecture-qualified asset names" {
+    const package = release_package.Package{ .platform = .macos };
+    var buf: [128]u8 = undefined;
+
+    const arm = try assetNameForArch("v1.33.1", package, .aarch64, &buf);
+    try std.testing.expectEqualStrings("wispterm-macos-aarch64-v1.33.1.dmg", arm);
+
+    const intel = try assetNameForArch("v1.33.1", package, .x86_64, &buf);
+    try std.testing.expectEqualStrings("wispterm-macos-x86_64-v1.33.1.dmg", intel);
+}
+
+test "macOS update package matches only the requested architecture" {
+    const package = release_package.Package{ .platform = .macos };
+
+    try std.testing.expect(matchesAssetNameForArch(
+        "wispterm-macos-aarch64-v1.33.1.dmg",
+        "v1.33.1",
+        package,
+        .aarch64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "wispterm-macos-x86_64-v1.33.1.dmg",
+        "v1.33.1",
+        package,
+        .aarch64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "wispterm-macos-v1.33.1.dmg",
+        "v1.33.1",
+        package,
+        .aarch64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "wispterm-macos-aarch64-v1.33.1.zip",
+        "v1.33.1",
+        package,
+        .aarch64,
+    ));
+}
+
+test "macOS update package rejects unsupported release architectures" {
+    const package = release_package.Package{ .platform = .macos };
+    var buf: [128]u8 = undefined;
+    try std.testing.expectError(
+        error.UnsupportedMacosArchitecture,
+        assetNameForArch("v1.33.1", package, .riscv64, &buf),
+    );
+    try std.testing.expect(!matchesAssetNameForArch(
+        "wispterm-macos-riscv64-v1.33.1.dmg",
+        "v1.33.1",
+        package,
+        .riscv64,
+    ));
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -457,6 +457,9 @@ test {
     _ = @import("platform/login_shell.zig");
     // Pure OS/2 weight → fontconfig FC_WEIGHT_* mapping; std-only, no fontconfig dep.
     _ = @import("platform/font_weight_fc.zig");
+    // Pure macOS release-asset naming: both supported architectures are tested
+    // on every native host without pulling in App/AppWindow or platform APIs.
+    _ = @import("platform/update_package_macos.zig");
     // Generic POSIX SSH/WSL command builder: asserts native (non-Windows)
     // command-line shapes, so it runs here rather than in test-full's Windows
     // cross-compile path. (The Windows backend stays in test-full.)

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const platform_update_package = @import("platform/update_package.zig");
 const release_package = @import("release_package.zig");
 
@@ -471,27 +472,32 @@ test "update_check: selects supported Windows portable assets" {
 
 test "update_check: selects macOS DMG asset for macOS package" {
     const package = ReleasePackage{ .platform = .macos };
-    var asset_name_buf: [asset_name_buffer_len]u8 = undefined;
-    const asset_name = try platform_update_package.assetName("v1.28.0", package, &asset_name_buf);
-
-    const release = ReleaseInfo{
-        .tag_name = "v1.28.0",
-        .html_url = "https://github.com/xuzhougeng/wispterm/releases/tag/v1.28.0",
-        .draft = false,
-        .prerelease = false,
-        .assets = &.{
-            .{
-                .name = asset_name,
-                .download_url = "https://example.test/wispterm-macos-v1.28.0.dmg",
-                .size = 1234,
-            },
+    const expected_name, const expected_url = switch (builtin.cpu.arch) {
+        .aarch64 => .{
+            "wispterm-macos-aarch64-v1.28.0.dmg",
+            "https://example.test/wispterm-macos-aarch64-v1.28.0.dmg",
         },
-        .owned = false,
+        .x86_64 => .{
+            "wispterm-macos-x86_64-v1.28.0.dmg",
+            "https://example.test/wispterm-macos-x86_64-v1.28.0.dmg",
+        },
+        else => return error.SkipZigTest,
     };
+
+    const json =
+        \\{"tag_name":"v1.28.0","html_url":"https://github.com/xuzhougeng/wispterm/releases/tag/v1.28.0","draft":false,"prerelease":false,"assets":[
+        \\  {"name":"wispterm-macos-v1.28.0.dmg","browser_download_url":"https://example.test/wispterm-macos-v1.28.0.dmg","size":1000},
+        \\  {"name":"wispterm-macos-aarch64-v1.28.0.dmg","browser_download_url":"https://example.test/wispterm-macos-aarch64-v1.28.0.dmg","size":2000},
+        \\  {"name":"wispterm-macos-x86_64-v1.28.0.dmg","browser_download_url":"https://example.test/wispterm-macos-x86_64-v1.28.0.dmg","size":3000}
+        \\]}
+    ;
+    const release = try parseLatestRelease(std.testing.allocator, json);
+    defer release.deinit(std.testing.allocator);
 
     const result = evaluateReleaseForPackage("1.27.0", release, package);
     try std.testing.expectEqual(State.update_available, result.state);
-    try std.testing.expectEqualStrings("wispterm-macos-v1.28.0.dmg", result.asset_name);
+    try std.testing.expectEqualStrings(expected_name, result.asset_name);
+    try std.testing.expectEqualStrings(expected_url, result.asset_download_url);
 }
 
 test "update_check: update result includes selected asset fields" {


### PR DESCRIPTION
## What changed

- match macOS updater assets using the running binary's architecture
- select `wispterm-macos-aarch64-{tag}.dmg` on Apple Silicon and `wispterm-macos-x86_64-{tag}.dmg` on Intel
- reject the legacy generic DMG name, the opposite architecture, unsupported architectures, and non-DMG assets
- exercise the matcher in the fast suite and cover full GitHub Release JSON asset selection
- update `KNOWN_ISSUES.md` now that the published asset names and updater matcher agree

## Why

The updater expected `wispterm-macos-{tag}.dmg`, while the release workflows publish architecture-qualified DMGs. As a result, a newer release could be detected but no downloadable macOS asset would be selected.

## User impact

The in-app updater now selects the DMG built for the user's Mac architecture instead of failing to find the generic asset or risking a cross-architecture match.

## Validation

- `zig fmt --check build.zig src`
- `zig build test`
- `zig build test-full -Dtarget=native`
- `zig build check-sizes`
- `zig build macos-app -Dtarget=aarch64-macos`
- `zig build macos-app -Dtarget=x86_64-macos`
- `git diff --check`
- verified the generated names against the assets published in release `v1.33.1`
