### PR TITLE
fix: match Linux AppImage update assets

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -13,7 +13,7 @@ plans belong in [ROADMAP.md](ROADMAP.md); completed changes belong in
 | Terminal host | Win32/ConPTY | AppKit/PTY | SDL3/POSIX PTY, experimental |
 | Embedded browser panel | WebView2 | WKWebView | Disabled |
 | WispTerm Remote transport | WinHTTP WebSocket | NSURLSession WebSocket | Not implemented |
-| Auto-update package matching | Windows portable zip flavors | Architecture-specific DMG matching | Not implemented |
+| Auto-update package matching | Windows portable zip flavors | Architecture-specific DMG matching | x86_64 AppImage matching |
 
 ## Version Surfaces
 
@@ -82,7 +82,6 @@ tested passes.
 - Global hotkeys are not implemented, so Quake mode cannot bind a system-wide
   shortcut.
 - Live config reload is not implemented; config changes require restart.
-- Update asset detection does not match Linux AppImage assets yet.
 - Font family enumeration is incomplete; exact `font-family` values can work,
   but picker/autocomplete results may be empty.
 - Off-screen window guards are incomplete.

--- a/src/platform/update_package.zig
+++ b/src/platform/update_package.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const release_package = @import("../release_package.zig");
+const linux_release_asset_backend = @import("update_package_linux.zig");
 const macos_release_asset_backend = @import("update_package_macos.zig");
 const windows_release_asset_backend = @import("update_package_windows.zig");
 
 pub const Backend = enum {
     windows,
+    linux,
     macos,
     unsupported,
 };
@@ -15,6 +17,7 @@ pub const PackageScenario = release_package.Flavor;
 pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
     return switch (os_tag) {
         .windows => .windows,
+        .linux => .linux,
         .macos => .macos,
         else => .unsupported,
     };
@@ -22,6 +25,7 @@ pub fn backendForOs(os_tag: std.Target.Os.Tag) Backend {
 
 const impl = switch (backendForOs(builtin.os.tag)) {
     .windows => @import("update_package_windows.zig"),
+    .linux => @import("update_package_linux.zig"),
     .macos => @import("update_package_macos.zig"),
     .unsupported => @import("update_package_unsupported.zig"),
 };
@@ -47,6 +51,7 @@ pub fn assetNameForScenario(
 pub fn assetName(tag_name: []const u8, package: release_package.Package, buf: []u8) ![]const u8 {
     return switch (package.platform) {
         .windows => windows_release_asset_backend.assetName(tag_name, package, buf),
+        .linux => linux_release_asset_backend.assetName(tag_name, package, buf),
         .macos => macos_release_asset_backend.assetName(tag_name, package, buf),
         else => error.UnsupportedReleasePackage,
     };
@@ -55,6 +60,7 @@ pub fn assetName(tag_name: []const u8, package: release_package.Package, buf: []
 pub fn matchesAssetName(name: []const u8, tag_name: []const u8, package: release_package.Package) bool {
     return switch (package.platform) {
         .windows => windows_release_asset_backend.matchesAssetName(name, tag_name, package),
+        .linux => linux_release_asset_backend.matchesAssetName(name, tag_name, package),
         .macos => macos_release_asset_backend.matchesAssetName(name, tag_name, package),
         else => false,
     };
@@ -80,6 +86,7 @@ pub fn runtimePackageForOs(
 ) release_package.Package {
     return switch (backendForOs(os_tag)) {
         .windows => release_package.Package.init(.windows, runtimeFlavor(webview_enabled, has_compat_payload)),
+        .linux => defaultPackageForOs(os_tag),
         .macos => defaultPackageForOs(os_tag),
         .unsupported => defaultPackageForOs(os_tag),
     };
@@ -95,7 +102,7 @@ pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !rele
 
 test "platform update package selects backend by target OS" {
     try std.testing.expectEqual(Backend.windows, backendForOs(.windows));
-    try std.testing.expectEqual(Backend.unsupported, backendForOs(.linux));
+    try std.testing.expectEqual(Backend.linux, backendForOs(.linux));
     try std.testing.expectEqual(Backend.macos, backendForOs(.macos));
 }
 
@@ -150,13 +157,24 @@ test "platform update package builds macOS DMG asset names" {
     try std.testing.expect(!matchesAssetName("wispterm-macos-v1.28.0.zip", "v1.28.0", .{ .platform = .macos }));
 }
 
+test "platform update package builds Linux AppImage asset names" {
+    if (builtin.cpu.arch != .x86_64) return error.SkipZigTest;
+
+    var buf: [128]u8 = undefined;
+    const package = release_package.Package{ .platform = .linux };
+    const name = try assetName("v1.33.1", package, &buf);
+    try std.testing.expectEqualStrings("WispTerm-1.33.1-x86_64.AppImage", name);
+    try std.testing.expect(matchesAssetName("WispTerm-1.33.1-x86_64.AppImage", "v1.33.1", package));
+    try std.testing.expect(!matchesAssetName("WispTerm-v1.33.1-x86_64.AppImage", "v1.33.1", package));
+}
+
 test "platform update package rejects unsupported platform asset names" {
     var buf: [128]u8 = undefined;
     try std.testing.expectError(error.UnsupportedReleasePackage, assetName("v0.28.0", .{
-        .platform = .linux,
+        .platform = .unsupported,
     }, &buf));
-    try std.testing.expect(!matchesAssetName("wispterm-linux-v0.28.0.tar.gz", "v0.28.0", .{
-        .platform = .linux,
+    try std.testing.expect(!matchesAssetName("wispterm-freebsd-v0.28.0.tar.gz", "v0.28.0", .{
+        .platform = .unsupported,
     }));
 }
 

--- a/src/platform/update_package_linux.zig
+++ b/src/platform/update_package_linux.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const release_package = @import("../release_package.zig");
+
+fn architectureLabel(arch: std.Target.Cpu.Arch) ?[]const u8 {
+    return switch (arch) {
+        .x86_64 => "x86_64",
+        else => null,
+    };
+}
+
+fn versionFromTag(tag_name: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, tag_name, "v")) return tag_name[1..];
+    return tag_name;
+}
+
+pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
+    _ = allocator;
+    _ = webview_enabled;
+    if (architectureLabel(builtin.cpu.arch) == null) return error.UnsupportedLinuxArchitecture;
+    return .{ .platform = .linux };
+}
+
+pub fn assetName(tag_name: []const u8, package: release_package.Package, buf: []u8) ![]const u8 {
+    return assetNameForArch(tag_name, package, builtin.cpu.arch, buf);
+}
+
+pub fn matchesAssetName(name: []const u8, tag_name: []const u8, package: release_package.Package) bool {
+    return matchesAssetNameForArch(name, tag_name, package, builtin.cpu.arch);
+}
+
+fn assetNameForArch(
+    tag_name: []const u8,
+    package: release_package.Package,
+    arch: std.Target.Cpu.Arch,
+    buf: []u8,
+) ![]const u8 {
+    if (package.platform != .linux) return error.UnsupportedReleasePackage;
+    const arch_label = architectureLabel(arch) orelse return error.UnsupportedLinuxArchitecture;
+    return std.fmt.bufPrint(buf, "WispTerm-{s}-{s}.AppImage", .{ versionFromTag(tag_name), arch_label });
+}
+
+fn matchesAssetNameForArch(
+    name: []const u8,
+    tag_name: []const u8,
+    package: release_package.Package,
+    arch: std.Target.Cpu.Arch,
+) bool {
+    var expected_buf: [128]u8 = undefined;
+    const expected = assetNameForArch(tag_name, package, arch, &expected_buf) catch return false;
+    return std.mem.eql(u8, name, expected);
+}
+
+test "Linux update package builds the published x86_64 AppImage name" {
+    const package = release_package.Package{ .platform = .linux };
+    var buf: [128]u8 = undefined;
+    const name = try assetNameForArch("v1.33.1", package, .x86_64, &buf);
+    try std.testing.expectEqualStrings("WispTerm-1.33.1-x86_64.AppImage", name);
+}
+
+test "Linux update package matches only the exact published asset" {
+    const package = release_package.Package{ .platform = .linux };
+    try std.testing.expect(matchesAssetNameForArch(
+        "WispTerm-1.33.1-x86_64.AppImage",
+        "v1.33.1",
+        package,
+        .x86_64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "WispTerm-v1.33.1-x86_64.AppImage",
+        "v1.33.1",
+        package,
+        .x86_64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "wispterm-1.33.1-x86_64.AppImage",
+        "v1.33.1",
+        package,
+        .x86_64,
+    ));
+    try std.testing.expect(!matchesAssetNameForArch(
+        "WispTerm-1.33.1-x86_64.tar.gz",
+        "v1.33.1",
+        package,
+        .x86_64,
+    ));
+}
+
+test "Linux update package rejects architectures without published assets" {
+    const package = release_package.Package{ .platform = .linux };
+    var buf: [128]u8 = undefined;
+    try std.testing.expectError(
+        error.UnsupportedLinuxArchitecture,
+        assetNameForArch("v1.33.1", package, .aarch64, &buf),
+    );
+    try std.testing.expect(!matchesAssetNameForArch(
+        "WispTerm-1.33.1-aarch64.AppImage",
+        "v1.33.1",
+        package,
+        .aarch64,
+    ));
+}

--- a/src/platform/update_package_unsupported.zig
+++ b/src/platform/update_package_unsupported.zig
@@ -11,7 +11,6 @@ pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !rele
 fn defaultPackageForOs(os_tag: std.Target.Os.Tag) release_package.Package {
     return switch (os_tag) {
         .macos => .{ .platform = .macos },
-        .linux => .{ .platform = .linux },
         else => .{ .platform = .unsupported },
     };
 }

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -460,6 +460,8 @@ test {
     // Pure macOS release-asset naming: both supported architectures are tested
     // on every native host without pulling in App/AppWindow or platform APIs.
     _ = @import("platform/update_package_macos.zig");
+    // Pure Linux release-asset naming, including architecture filtering.
+    _ = @import("platform/update_package_linux.zig");
     // Generic POSIX SSH/WSL command builder: asserts native (non-Windows)
     // command-line shapes, so it runs here rather than in test-full's Windows
     // cross-compile path. (The Windows backend stays in test-full.)

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -500,6 +500,34 @@ test "update_check: selects macOS DMG asset for macOS package" {
     try std.testing.expectEqualStrings(expected_url, result.asset_download_url);
 }
 
+test "update_check: selects the published Linux x86_64 AppImage asset" {
+    if (builtin.cpu.arch != .x86_64) return error.SkipZigTest;
+
+    const json =
+        \\{
+        \\  "tag_name":"v1.33.1",
+        \\  "html_url":"https://github.com/xuzhougeng/wispterm/releases/tag/v1.33.1",
+        \\  "draft":false,
+        \\  "prerelease":false,
+        \\  "assets":[
+        \\    {"name":"wispterm-linux-v1.33.1.AppImage","browser_download_url":"https://example.test/generic.AppImage","size":11},
+        \\    {"name":"WispTerm-1.33.1-aarch64.AppImage","browser_download_url":"https://example.test/arm64.AppImage","size":22},
+        \\    {"name":"WispTerm-1.33.1-x86_64.AppImage","browser_download_url":"https://example.test/x86_64.AppImage","size":33}
+        \\  ]
+        \\}
+    ;
+
+    const release = try parseLatestRelease(std.testing.allocator, json);
+    defer release.deinit(std.testing.allocator);
+
+    const package = ReleasePackage{ .platform = .linux };
+    const result = evaluateReleaseForPackage("1.33.0", release, package);
+    try std.testing.expectEqual(State.update_available, result.state);
+    try std.testing.expectEqualStrings("WispTerm-1.33.1-x86_64.AppImage", result.asset_name);
+    try std.testing.expectEqualStrings("https://example.test/x86_64.AppImage", result.asset_download_url);
+    try std.testing.expectEqual(@as(u64, 33), result.asset_size);
+}
+
 test "update_check: update result includes selected asset fields" {
     const package = platform_update_package.packageForScenario(.compat);
     var asset_name_buf: [asset_name_buffer_len]u8 = undefined;


### PR DESCRIPTION
## Summary

- add a Linux update-package backend for the published x86_64 AppImage naming scheme
- route Linux update selection through the new backend and reject architectures without published assets
- add exact-match and release JSON regression coverage, and update the support matrix

## Validation

- `zig fmt --check build.zig src`
- focused native suite: 28 passed, 2 x86_64-only tests skipped
- focused x86_64 macOS suite under Rosetta: 30 passed
- focused x86_64 Linux cross-compile
- `zig build check-sizes`
- `git diff --check`

The full `zig build test` local run was stopped after more than ten minutes of silent first-build compilation; the focused suites above exercise the changed update path, and draft PR CI remains the full gate.