### PR TITLE
fix(ssh): stop spoofing Ghostty terminal identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Structural debt is frozen mechanically by source-scanning ratchet tests (the sam
 | Guard | Freezes | Today's ceiling | Escape hatch |
 |---|---|---|---|
 | `file_size_guard` | lines in any `src/**/*.zig` | < **10,000** (also `zig build check-sizes`) | split by responsibility; never raise the limit |
-| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow **66**, input **49**, overlays **33**, assistant/conversation/session **16** | put new state in a state struct (`appwindow/state.zig`, …) |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow **66**, input **49**, overlays **32**, assistant/conversation/session **16** | put new state in a state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | **17** | import the real module directly, not via `AppWindow.X` |
 | `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow **45**, input **81**, overlays **10**, assistant/conversation/session **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
 

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -447,7 +447,7 @@ gate — you must first remove one, or use the pattern the guard names.
 | Guard | Freezes | Today's ceiling | Escape hatch |
 |---|---|---|---|
 | `file_size_guard` | lines in any `src/**/*.zig` (whole tree, future files too) | < 10,000 | split by responsibility; never raise the limit |
-| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow 66, input 49, overlays 33, assistant/conversation/session 16 | new state → an explicit state struct (`appwindow/state.zig`, …) |
+| `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow 66, input 49, overlays 32, assistant/conversation/session 16 | new state → an explicit state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | 17 | import the real module directly, not via `AppWindow.X` |
 | `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow 45, input 81, overlays 10, assistant/conversation/session 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
 

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -814,6 +814,7 @@ test "platform pty command builds shell command lines for AI History resume" {
     try std.testing.expect(std.mem.indexOf(u8, ssh_command, "ssh") != null);
     try std.testing.expect(std.mem.indexOf(u8, ssh_command, "user@example.test") != null);
     try std.testing.expect(std.mem.indexOf(u8, ssh_command, "codex resume abc") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ssh_command, "TERM_PROGRAM") == null);
 }
 
 test "platform pty command selects backend by target OS" {

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -224,10 +224,9 @@ fn appendAscii(buf: []u8, pos: *usize, text: []const u8) bool {
     return true;
 }
 
-/// Escape `value` for a POSIX single-quoted context WITHOUT writing the
-/// surrounding quotes, so callers can splice an unquoted literal (e.g. an env
-/// prefix) into the same quoted run.
-fn appendPosixSingleQuotedInner(buf: []u8, pos: *usize, value: []const u8) bool {
+/// Append `value` as one POSIX single-quoted argument.
+fn appendPosixSingleQuotedArg(buf: []u8, pos: *usize, value: []const u8) bool {
+    if (!appendAscii(buf, pos, "'")) return false;
     for (value) |ch| {
         if (ch == '\'') {
             if (!appendAscii(buf, pos, "'\\''")) return false;
@@ -237,12 +236,6 @@ fn appendPosixSingleQuotedInner(buf: []u8, pos: *usize, value: []const u8) bool 
             pos.* += 1;
         }
     }
-    return true;
-}
-
-fn appendPosixSingleQuotedArg(buf: []u8, pos: *usize, value: []const u8) bool {
-    if (!appendAscii(buf, pos, "'")) return false;
-    if (!appendPosixSingleQuotedInner(buf, pos, value)) return false;
     return appendAscii(buf, pos, "'");
 }
 
@@ -271,20 +264,14 @@ pub fn scpExecutableName() []const u8 {
 }
 
 pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 {
-    return buildSshCommandLine(buf, options, true);
+    return buildSshCommandLine(buf, options);
 }
 
 pub fn sshControlCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 {
-    // tmux -CC control mode: leave the remote command byte-for-byte so nothing
-    // perturbs the control-protocol handshake (no env injection here).
-    return buildSshCommandLine(buf, options, false);
+    return buildSshCommandLine(buf, options);
 }
 
-/// Prepended to an interactive SSH remote command so the remote shell exports a
-/// TERM_PROGRAM that TUIs recognize as Kitty-keyboard-capable (#302).
-const ssh_remote_env_prefix = "export TERM_PROGRAM=ghostty; ";
-
-fn buildSshCommandLine(buf: []u8, options: SshCommandOptions, export_term_program: bool) ?[]const u8 {
+fn buildSshCommandLine(buf: []u8, options: SshCommandOptions) ?[]const u8 {
     var pos: usize = 0;
     // ServerAlive*: 30s probes keep NAT/firewall state alive (kernel TCP
     // keepalive defaults to 2h, far past middlebox idle timeouts); CountMax=20
@@ -313,20 +300,10 @@ fn buildSshCommandLine(buf: []u8, options: SshCommandOptions, export_term_progra
     if (!appendAscii(buf, &pos, options.host)) return null;
     if (options.remote_command.len > 0) {
         if (!appendAscii(buf, &pos, " ")) return null;
-        if (export_term_program) {
-            // Export TERM_PROGRAM on the remote so full-screen TUIs (Claude Code,
-            // Codex) enable the Kitty keyboard protocol there too — otherwise
-            // Shift+Enter can't be told from Enter. ssh forwards TERM but not
-            // TERM_PROGRAM (it's not in the default SendEnv/AcceptEnv set), so we
-            // bake it into the remote command rather than relying on -o SetEnv,
-            // which the remote sshd would silently drop. Spliced inside the single
-            // quotes since the prefix itself is quote-free. See pty_posix.zig.
-            if (!appendAscii(buf, &pos, "'" ++ ssh_remote_env_prefix)) return null;
-            if (!appendPosixSingleQuotedInner(buf, &pos, options.remote_command)) return null;
-            if (!appendAscii(buf, &pos, "'")) return null;
-        } else {
-            if (!appendPosixSingleQuotedArg(buf, &pos, options.remote_command)) return null;
-        }
+        // Preserve the caller's command byte-for-byte. In particular, do not
+        // forge TERM_PROGRAM: remote TUIs use it as a capability promise and
+        // may enter terminal-specific protocols WispTerm does not implement.
+        if (!appendPosixSingleQuotedArg(buf, &pos, options.remote_command)) return null;
     }
     return buf[0..pos];
 }
@@ -366,14 +343,11 @@ test "unsupported backend builds SSH interactive command lines with ProxyJump" {
     );
 }
 
-test "unsupported backend exports TERM_PROGRAM into the SSH remote command (#302)" {
+test "unsupported backend does not inject terminal identity into SSH remote commands (#579)" {
     var buf: [512]u8 = undefined;
 
-    // A remote command gains the env prefix so the remote Claude Code/Codex sees
-    // a Kitty-capable TERM_PROGRAM (ssh doesn't forward the local one). The
-    // original command stays intact inside the same single-quoted argument.
     try std.testing.expectEqualStrings(
-        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test 'export TERM_PROGRAM=ghostty; cd '\\''/srv/p'\\'' && claude'",
+        "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test 'cd '\\''/srv/p'\\'' && claude'",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",
@@ -381,7 +355,6 @@ test "unsupported backend exports TERM_PROGRAM into the SSH remote command (#302
         }).?,
     );
 
-    // No remote command (plain interactive login shell) is left untouched.
     try std.testing.expectEqualStrings(
         "ssh -tt -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test",
         sshInteractiveCommand(&buf, .{ .user = "user", .host = "example.test" }).?,

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -258,10 +258,11 @@ fn appendAscii(buf: []u8, pos: *usize, text: []const u8) bool {
     return true;
 }
 
-/// Escape `arg` for a double-quoted Windows command-line argument WITHOUT the
-/// surrounding quotes, so callers can splice an unquoted literal (e.g. an env
-/// prefix) into the same quoted run.
-fn appendCommandLineQuotedInner(buf: []u8, pos: *usize, arg: []const u8) bool {
+/// Append `arg` as one double-quoted Windows command-line argument.
+fn appendCommandLineQuotedArg(buf: []u8, pos: *usize, arg: []const u8) bool {
+    if (pos.* >= buf.len) return false;
+    buf[pos.*] = '"';
+    pos.* += 1;
     for (arg) |ch| {
         if (ch == '"') {
             if (!appendAscii(buf, pos, "\\\"")) return false;
@@ -271,25 +272,11 @@ fn appendCommandLineQuotedInner(buf: []u8, pos: *usize, arg: []const u8) bool {
             pos.* += 1;
         }
     }
-    return true;
-}
-
-fn appendCommandLineQuotedArg(buf: []u8, pos: *usize, arg: []const u8) bool {
-    if (pos.* >= buf.len) return false;
-    buf[pos.*] = '"';
-    pos.* += 1;
-    if (!appendCommandLineQuotedInner(buf, pos, arg)) return false;
     if (pos.* >= buf.len) return false;
     buf[pos.*] = '"';
     pos.* += 1;
     return true;
 }
-
-/// Prepended to an interactive SSH remote command so the remote shell exports a
-/// TERM_PROGRAM that TUIs recognize as Kitty-keyboard-capable (#302). The remote
-/// is a POSIX host, so `export …;` is the right syntax regardless of the local
-/// Windows client.
-const ssh_remote_env_prefix = "export TERM_PROGRAM=ghostty; ";
 
 threadlocal var g_wsl_available_cached: bool = false;
 threadlocal var g_wsl_available_value: bool = false;
@@ -394,14 +381,11 @@ pub fn sshInteractiveCommand(buf: []u8, options: SshCommandOptions) ?[]const u8 
     if (!appendAscii(buf, &pos, "@")) return null;
     if (!appendAscii(buf, &pos, options.host)) return null;
     if (options.remote_command.len > 0) {
-        // Export TERM_PROGRAM on the remote so full-screen TUIs (Claude Code,
-        // Codex) enable the Kitty keyboard protocol there too. ssh forwards TERM
-        // but not TERM_PROGRAM, so we bake it into the remote command. Spliced
-        // inside the double quotes since the prefix is quote-free. tmux -CC
-        // control transport below is deliberately left untouched.
-        if (!appendAscii(buf, &pos, " \"" ++ ssh_remote_env_prefix)) return null;
-        if (!appendCommandLineQuotedInner(buf, &pos, options.remote_command)) return null;
-        if (!appendAscii(buf, &pos, "\"")) return null;
+        // Preserve the caller's command byte-for-byte. In particular, do not
+        // forge TERM_PROGRAM: remote TUIs use it as a capability promise and
+        // may enter terminal-specific protocols WispTerm does not implement.
+        if (!appendAscii(buf, &pos, " ")) return null;
+        if (!appendCommandLineQuotedArg(buf, &pos, options.remote_command)) return null;
     }
     return buf[0..pos];
 }
@@ -801,10 +785,8 @@ test "windows pty command builds SSH interactive command lines" {
         }).?,
     );
 
-    // An interactive remote command gains the TERM_PROGRAM export so remote
-    // Claude Code/Codex enable the Kitty keyboard protocol (#302).
     try std.testing.expectEqualStrings(
-        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test \"export TERM_PROGRAM=ghostty; cd /srv && claude\"",
+        "cmd.exe /c ssh.exe -tt -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=20 user@example.test \"cd /srv && claude\"",
         sshInteractiveCommand(&buf, .{
             .user = "user",
             .host = "example.test",

--- a/src/renderer/overlays.zig
+++ b/src/renderer/overlays.zig
@@ -223,10 +223,6 @@ const DebugLineRect = struct {
 
 threadlocal var g_remote_key_copy_rect: ?DebugLineRect = null;
 threadlocal var g_remote_key_copied_until_ms: i64 = 0;
-// Once the user has copied the active session key (via overlay click or the
-// command palette), the floating key overlay is dismissed for that key.
-// Stored as a digest so fixed keys can be shorter or longer than 32 bytes.
-threadlocal var g_remote_key_dismissed_digest: ?[32]u8 = null;
 
 pub const TransferCancelConfirmAction = overlay_keys.TransferCancelConfirmAction;
 
@@ -4185,19 +4181,10 @@ pub fn connectProfileByName(name: []const u8) bool {
 }
 
 fn connectSshProfileReturningSurface(idx: usize) ?*Surface {
-    // Launch the remote login shell explicitly so the SSH command builder's
-    // `export TERM_PROGRAM=ghostty;` prefix actually lands on the remote — ssh
-    // forwards TERM but not TERM_PROGRAM, so a bare interactive `ssh host`
-    // leaves remote Claude Code/Codex unable to enable the Kitty keyboard
-    // protocol (Shift+Enter). This is equivalent to the default interactive
-    // login shell, just with the env exported first (#302).
-    return connectSshProfileReturningSurfaceWithCommand(idx, ssh_interactive_login_shell);
+    // Let OpenSSH start the account's configured login shell. A synthetic
+    // remote command must not be used to forge terminal identity (#579).
+    return connectSshProfileReturningSurfaceWithCommand(idx, "");
 }
-
-/// Re-exec the remote login shell for an interactive SSH profile connection.
-/// Combined with the command builder's TERM_PROGRAM export prefix this yields
-/// `ssh -tt host 'export TERM_PROGRAM=ghostty; exec ${SHELL:-/bin/sh} -l'`.
-const ssh_interactive_login_shell = "exec ${SHELL:-/bin/sh} -l";
 
 fn connectSshProfileReturningSurfaceWithCommand(idx: usize, remote_command: []const u8) ?*Surface {
     if (idx >= sshState().profile_count) return null;
@@ -9056,11 +9043,11 @@ pub fn activateUpdatePrompt() void {
 pub fn remoteKeyOverlayDismiss(key: []const u8) void {
     var digest: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(key, &digest, .{});
-    g_remote_key_dismissed_digest = digest;
+    overlayState().remote_key_dismissed_digest = digest;
 }
 
 fn isRemoteKeyDismissed(key: []const u8) bool {
-    const dismissed = g_remote_key_dismissed_digest orelse return false;
+    const dismissed = overlayState().remote_key_dismissed_digest orelse return false;
     var digest: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(key, &digest, .{});
     return std.mem.eql(u8, dismissed[0..], digest[0..]);

--- a/src/renderer/overlays/state.zig
+++ b/src/renderer/overlays/state.zig
@@ -54,6 +54,8 @@ pub const OverlayState = struct {
     btw: btw_conversation.State = .{},
     whats_new: WhatsNewState = .{},
     snippets: SnippetState = .{},
+    // Dismiss the floating key overlay only for the key the user copied.
+    remote_key_dismissed_digest: ?[32]u8 = null,
 
     pub fn deinit(self: *OverlayState, allocator: std.mem.Allocator) void {
         self.btw.close();
@@ -78,6 +80,7 @@ test "overlay state aggregates migrated overlay groups" {
     state.command_palette.openWithMode(.commands);
     state.mcp.beginAdd();
     state.mcp.setFormField(.name, "srv");
+    state.remote_key_dismissed_digest = [_]u8{7} ** 32;
 
     try std.testing.expect(state.settings.visible);
     try std.testing.expectEqualStrings("Copied", state.toasts.copy.text().?);
@@ -87,6 +90,7 @@ test "overlay state aggregates migrated overlay groups" {
     try std.testing.expectEqual(@as(usize, 2), state.session.ai_history_source_selected);
     try std.testing.expect(state.command_palette.visible);
     try std.testing.expectEqualStrings("srv", state.mcp.formField(.name));
+    try std.testing.expectEqual(@as(u8, 7), state.remote_key_dismissed_digest.?[0]);
 }
 
 test "overlay state deinit releases settings cache" {

--- a/src/source_guards/global_state_guard.zig
+++ b/src/source_guards/global_state_guard.zig
@@ -27,7 +27,7 @@ const monoliths = [_]Frozen{
     // `/btw` adoption passes grouped input, conversation, and overlay state.
     .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 66 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 48 },
-    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 33 },
+    .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 32 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 16 },
 };
 


### PR DESCRIPTION
## Summary

- stop injecting the false `TERM_PROGRAM=ghostty` identity into interactive SSH remote commands on Windows and POSIX
- let saved SSH profiles use OpenSSH's normal login-shell path instead of a synthetic remote command
- keep explicit remote commands unchanged and add regression coverage that rejects `TERM_PROGRAM` injection
- move the remote-key dismissal digest into `OverlayState` and tighten the overlays global-state ratchet from 33 to 32

## Root cause

The earlier #302 workaround advertised WispTerm SSH sessions as Ghostty so some remote tools would enable the Kitty keyboard protocol. Grok 0.2.111 treats that identity as a capability promise and enters Ghostty-specific terminal paths that WispTerm does not fully implement, producing the blank/hung TUI reported in #579.

This removes the forged identity. Terminal compatibility should be negotiated from WispTerm's real capabilities or explicit WispTerm recognition, not by claiming to be another emulator.

Compatibility note: remote Claude Code/Codex versions that hard-code `ghostty` in their terminal allowlist may no longer auto-enable Kitty extended keyboard handling. That follow-up should use WispTerm's real identity/capability negotiation rather than restoring the false Ghostty identity.

## Verification

- `zig build test` — passed
- `zig build` — passed
- `zig build test-full` — compiled and exercised the changed Windows/app paths; the current WSL runner finished with 15,189 passed, 323 skipped, and 9 failures, all repetitions of two unrelated existing `memory_digest.store/cursors` missing-file tests failing on UNC/WSL paths with `BadPathName`
- `git diff --check` — passed

Fixes #579
