### PR TITLE
feat(windows): make native D3D11 the default

### DIFF
--- a/.github/workflows/docs-downloads-r2-sync.yml
+++ b/.github/workflows/docs-downloads-r2-sync.yml
@@ -51,6 +51,7 @@ jobs:
 
           upload_first 'wispterm-windows-portable-[0-9v]*.zip' 'wispterm-windows-portable.zip' 'application/zip'
           upload_first 'wispterm-windows-portable-compat-[0-9v]*.zip' 'wispterm-windows-portable-compat.zip' 'application/zip'
+          upload_first 'wispterm-windows-portable-opengl-[0-9v]*.zip' 'wispterm-windows-portable-opengl.zip' 'application/zip'
           upload_first 'wispterm-macos-aarch64-[0-9v]*.dmg' 'wispterm-macos-aarch64.dmg' 'application/x-apple-diskimage'
           upload_first 'wispterm-macos-x86_64-[0-9v]*.dmg' 'wispterm-macos-x86_64.dmg' 'application/x-apple-diskimage'
           upload_first 'WispTerm-*-x86_64.AppImage' 'wispterm-linux-x86_64.AppImage' 'application/octet-stream'

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -88,9 +88,9 @@ jobs:
           $portableCompatConPty = "zig-out\dist\portable-compat\conpty.dll"
           $portableCompatConsoleHost = "zig-out\dist\portable-compat\OpenConsole.exe"
           $portableCompatPluginSkills = "zig-out\dist\portable-compat\plugins\skills"
-          $portableNativeD3D11Exe = "zig-out\dist\portable-native-d3d11\wispterm.exe"
-          $portableNativeD3D11Version = "zig-out\dist\portable-native-d3d11\version.txt"
-          $portableNativeD3D11PluginSkills = "zig-out\dist\portable-native-d3d11\plugins\skills"
+          $portableOpenGLExe = "zig-out\dist\portable-opengl\wispterm.exe"
+          $portableOpenGLVersion = "zig-out\dist\portable-opengl\version.txt"
+          $portableOpenGLPluginSkills = "zig-out\dist\portable-opengl\plugins\skills"
           $skillFiles = @(
             "plugins\skills\inspect-computer-config\SKILL.md",
             "plugins\skills\inspect-computer-config\scripts\inspect_computer_config.py"
@@ -132,19 +132,19 @@ jobs:
             throw "Portable compat plugin skills directory not found: $portableCompatPluginSkills"
           }
 
-          if (!(Test-Path $portableNativeD3D11Exe)) {
-            throw "Portable native D3D11 executable not found: $portableNativeD3D11Exe"
+          if (!(Test-Path $portableOpenGLExe)) {
+            throw "Portable OpenGL fallback executable not found: $portableOpenGLExe"
           }
 
-          if (!(Test-Path $portableNativeD3D11Version)) {
-            throw "Portable native D3D11 version file not found: $portableNativeD3D11Version"
+          if (!(Test-Path $portableOpenGLVersion)) {
+            throw "Portable OpenGL fallback version file not found: $portableOpenGLVersion"
           }
 
-          if (!(Test-Path $portableNativeD3D11PluginSkills -PathType Container)) {
-            throw "Portable native D3D11 plugin skills directory not found: $portableNativeD3D11PluginSkills"
+          if (!(Test-Path $portableOpenGLPluginSkills -PathType Container)) {
+            throw "Portable OpenGL fallback plugin skills directory not found: $portableOpenGLPluginSkills"
           }
 
-          foreach ($distDir in @("zig-out\dist\portable", "zig-out\dist\portable-compat", "zig-out\dist\portable-native-d3d11")) {
+          foreach ($distDir in @("zig-out\dist\portable", "zig-out\dist\portable-compat", "zig-out\dist\portable-opengl")) {
             foreach ($skillFile in $skillFiles) {
               $path = Join-Path $distDir $skillFile
               if (!(Test-Path $path)) {
@@ -169,7 +169,7 @@ jobs:
           $tag = "${{ github.ref_name }}"
           $portableAsset = "wispterm-windows-portable-$tag.zip"
           $portableCompatAsset = "wispterm-windows-portable-compat-$tag.zip"
-          $portableNativeD3D11Asset = "wispterm-windows-portable-native-d3d11-$tag.zip"
+          $portableOpenGLAsset = "wispterm-windows-portable-opengl-$tag.zip"
           $debugAsset = "wispterm-windows-debug-$tag.zip"
 
           if (Test-Path $portableAsset) {
@@ -178,14 +178,14 @@ jobs:
           if (Test-Path $portableCompatAsset) {
             Remove-Item $portableCompatAsset -Force
           }
-          if (Test-Path $portableNativeD3D11Asset) {
-            Remove-Item $portableNativeD3D11Asset -Force
+          if (Test-Path $portableOpenGLAsset) {
+            Remove-Item $portableOpenGLAsset -Force
           }
           if (Test-Path $debugAsset) { Remove-Item $debugAsset -Force }
 
           Compress-Archive -Path zig-out\dist\portable\* -DestinationPath $portableAsset -Force
           Compress-Archive -Path zig-out\dist\portable-compat\* -DestinationPath $portableCompatAsset -Force
-          Compress-Archive -Path zig-out\dist\portable-native-d3d11\* -DestinationPath $portableNativeD3D11Asset -Force
+          Compress-Archive -Path zig-out\dist\portable-opengl\* -DestinationPath $portableOpenGLAsset -Force
           Compress-Archive -Path zig-out\dist\portable-debug\* -DestinationPath $debugAsset -Force
 
       - name: Upload portable artifact
@@ -202,11 +202,11 @@ jobs:
           path: wispterm-windows-portable-compat-${{ github.ref_name }}.zip
           if-no-files-found: error
 
-      - name: Upload portable native D3D11 artifact
+      - name: Upload portable OpenGL fallback artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wispterm-windows-portable-native-d3d11-${{ github.ref_name }}
-          path: wispterm-windows-portable-native-d3d11-${{ github.ref_name }}.zip
+          name: wispterm-windows-portable-opengl-${{ github.ref_name }}
+          path: wispterm-windows-portable-opengl-${{ github.ref_name }}.zip
           if-no-files-found: error
 
       - name: Upload diagnostic artifact
@@ -224,7 +224,7 @@ jobs:
           $tag = "${{ github.ref_name }}"
           $portableAsset = "wispterm-windows-portable-$tag.zip"
           $portableCompatAsset = "wispterm-windows-portable-compat-$tag.zip"
-          $portableNativeD3D11Asset = "wispterm-windows-portable-native-d3d11-$tag.zip"
+          $portableOpenGLAsset = "wispterm-windows-portable-opengl-$tag.zip"
           $debugAsset = "wispterm-windows-debug-$tag.zip"
 
           if (!(Test-Path $portableAsset)) {
@@ -233,8 +233,8 @@ jobs:
           if (!(Test-Path $portableCompatAsset)) {
             throw "Portable compat release asset not found: $portableCompatAsset"
           }
-          if (!(Test-Path $portableNativeD3D11Asset)) {
-            throw "Portable native D3D11 release asset not found: $portableNativeD3D11Asset"
+          if (!(Test-Path $portableOpenGLAsset)) {
+            throw "Portable OpenGL fallback release asset not found: $portableOpenGLAsset"
           }
           if (!(Test-Path $debugAsset)) {
             throw "Diagnostic release asset not found: $debugAsset"
@@ -242,14 +242,14 @@ jobs:
 
           gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
           if ($LASTEXITCODE -eq 0) {
-            gh release upload $tag $portableAsset $portableCompatAsset $portableNativeD3D11Asset $debugAsset --repo $env:GITHUB_REPOSITORY --clobber
+            gh release upload $tag $portableAsset $portableCompatAsset $portableOpenGLAsset $debugAsset --repo $env:GITHUB_REPOSITORY --clobber
           } else {
             $assetNotes = @(
               "Windows assets included in this release:",
               "",
-              "- Portable: default OpenGL zip archive containing wispterm.exe",
-              "- Portable compat: OpenGL zip archive for older Windows 10 machines - bundles WebView2Loader.dll for the embedded browser plus a modern ConPTY (conpty.dll + OpenConsole.exe) so TUI apps like Codex and Claude Code get mouse scrolling and scrollbars",
-              "- Portable native D3D11: feedback zip archive using the Windows native D3D11 renderer; use the default Portable asset if you hit rendering issues",
+              "- Portable: default native Direct3D 11 zip archive containing wispterm.exe",
+              "- Portable compat: native Direct3D 11 zip archive for older Windows 10 machines - bundles WebView2Loader.dll for the embedded browser plus a modern ConPTY (conpty.dll + OpenConsole.exe) so TUI apps like Codex and Claude Code get mouse scrolling and scrollbars",
+              "- Portable OpenGL fallback: compatibility zip archive for systems where the native D3D11 renderer cannot start or render correctly",
               "- Diagnostic (debug): console build with on-disk logging + crash reports for troubleshooting (ReleaseSafe). See docs/windows-debug-build.md.",
               "",
               "Portable builds can add or remove WispTerm from Windows Search and enable or disable startup from Settings."
@@ -267,7 +267,7 @@ jobs:
               $notes = $assetNotes
             }
 
-            gh release create $tag $portableAsset $portableCompatAsset $portableNativeD3D11Asset $debugAsset `
+            gh release create $tag $portableAsset $portableCompatAsset $portableOpenGLAsset $debugAsset `
               --repo $env:GITHUB_REPOSITORY `
               --verify-tag `
               --generate-notes `

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-WispTerm is a terminal emulator written in Zig, shipping desktop builds for Windows and macOS, plus an experimental Linux AppImage. It uses [libghostty-vt](https://github.com/ghostty-org/ghostty) (Ghostty's VT parser and terminal state machine) for terminal emulation, with its own rendering pipeline (OpenGL/Metal + FreeType, plus DirectWrite/CoreText/fontconfig for font discovery by platform).
+WispTerm is a terminal emulator written in Zig, shipping desktop builds for Windows and macOS, plus an experimental Linux AppImage. It uses [libghostty-vt](https://github.com/ghostty-org/ghostty) (Ghostty's VT parser and terminal state machine) for terminal emulation, with its own rendering pipeline (D3D11/Metal/OpenGL + FreeType, plus DirectWrite/CoreText/fontconfig for font discovery by platform).
 
 Windows is the **primary and default development target** (`x86_64-windows-gnu`), and day-to-day development happens on Windows in PowerShell. Platform-specific code lives behind narrow interfaces in `src/platform/` (per-platform implementations plus `_unsupported`/`_posix` stubs) so macOS and Linux can share the terminal core. macOS is an active supported desktop build that is still stabilizing; Linux is experimental. See `ROADMAP.md` for future work and `KNOWN_ISSUES.md` for current platform limitations.
 
@@ -109,7 +109,7 @@ This repository must remain safe to check out and develop on Windows. Before fin
 
 ```
 src/                         # Desktop terminal application
-├── main.zig                 # Entry point, GLFW window, OpenGL setup, main loop
+├── main.zig                 # Entry point and main loop
 ├── App.zig                  # Application-level state, config reload, remote client lifecycle
 ├── AppWindow.zig            # Window-level tabs, splits, rendering and input routing
 ├── Surface.zig              # Per-terminal surface state and PTY integration
@@ -148,7 +148,7 @@ src/                         # Desktop terminal application
 │                            #   plus source-scan guards (dirty/overlay effect)
 ├── apprt/                   # Win32/windowing support code
 ├── font/                    # Font manager, atlas, embedded fallback, sprite glyphs
-├── renderer/                # OpenGL renderer, cell renderer, overlays, titlebar, panels
+├── renderer/                # GPU backends, cell renderer, overlays, titlebar, panels
 ├── source_guards/           # Cross-cutting architecture ratchets: file-size backstop
 │                            #   + global-state / import-hub / side-effect freezes
 ├── ssh/                     # SSH/SCP descriptors, profile store, prompts, tunnels,

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -27,13 +27,12 @@ console release unless the release explicitly includes `remote/`.
 
 ## Windows
 
-- The native D3D11 renderer on `windows-native-render` is still opt-in and is
-  not the Windows `auto` default. Phase VI is blocked until the evidence and
-  rollback checklist in
-  [windows-native-d3d11-default-gate.md](docs/windows-native-d3d11-default-gate.md)
-  is satisfied.
-- D3D11 fallback is next-launch/future-auto policy only. The app does not switch
-  from D3D11 to OpenGL inside the same running process.
+- Starting with v1.34.0, the native D3D11 renderer is the Windows `auto`
+  default. The separately published `portable-opengl` package is the renderer
+  fallback.
+- The app does not switch from D3D11 to OpenGL inside the same running process.
+  A D3D11 startup/rendering failure requires restarting with the separately
+  built OpenGL package.
 - D3D11 Phase V environment matrix gaps are accepted known issues where the
   current operators do not have matching machines or sessions available. These
   accepted gaps are not passing test evidence, and should be replaced with

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ English | [简体中文](README.zh-CN.md)
 ## Versions
 
 The desktop app version is the repository root version in `build.zig.zon`
-(currently `1.33.1`) and is what `wispterm --version`, release notes, desktop
+(currently `1.34.0`) and is what `wispterm --version`, release notes, desktop
 packages, and the command center `Version` entry use.
 
 The WispTerm Remote web console/relay under `remote/` has an independent npm/web
@@ -270,7 +270,7 @@ MIT
 
 ## Citation
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.33.1) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.34.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 Copyable acknowledgment template:
@@ -280,6 +280,6 @@ We used WispTerm as part of our computational environment for life sciences data
 analysis, remote computing workflows, reproducible command-line processing, and
 the organization of related literature and analysis code.
 
-Xu, Z.-G. (2026). WispTerm (Version 1.33.1) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.34.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@
 
 ## 版本
 
-桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.33.1`），也是
+桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.34.0`），也是
 `wispterm --version`、release notes、桌面发布包和命令中心 `Version` 条目使用的版本。
 
 `remote/` 下的 WispTerm Remote 网页控制台/中继有独立的 npm/web 版本（当前为
@@ -263,7 +263,7 @@ MIT
 
 ## 引用
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.33.1) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.34.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 可直接复制的致谢模板：
@@ -272,6 +272,6 @@ https://doi.org/10.5281/zenodo.20660541
 我们在生命科学数据分析中使用 WispTerm 作为计算环境的一部分，用于远程计算流程、
 可重复的命令行处理，以及相关文献与分析代码的整理。
 
-Xu, Z.-G. (2026). WispTerm (Version 1.33.1) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.34.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,11 +50,10 @@ feel first-class rather than just compile:
 
 ## Renderer And GPU Work
 
-- Make Windows a native GPU target by adding a real Direct3D 11 backend behind
-  the existing renderer backend abstraction. The long-term target matrix is
-  Windows = D3D11/DXGI, macOS = Metal, Linux = OpenGL, with the current
-  OpenGL + DXGI flip-present path retained as the Windows fallback during the
-  migration. See [docs/windows-native-d3d11-roadmap.md](docs/windows-native-d3d11-roadmap.md).
+- Continue hardening the native Direct3D 11 default on Windows. The target
+  matrix is Windows = D3D11/DXGI, macOS = Metal, Linux = OpenGL, with a
+  separately published OpenGL Windows package retained as the compatibility
+  fallback. See [docs/windows-native-d3d11-roadmap.md](docs/windows-native-d3d11-roadmap.md).
 - Finish the custom-shader path on Metal by adding a GLSL-to-MSL translation
   layer and then wiring FBO render-target switching where it has a working
   consumer.

--- a/build.zig
+++ b/build.zig
@@ -287,8 +287,14 @@ fn defaultEmitSharedCompileChecks(features: PlatformFeatures) bool {
 
 fn resolveGpuBackendBuildOption(raw: ?[]const u8, os_tag: std.Target.Os.Tag) []const u8 {
     const value = raw orelse "auto";
-    if (std.mem.eql(u8, value, "auto") or
-        std.mem.eql(u8, value, "opengl") or
+    if (std.mem.eql(u8, value, "auto")) {
+        return switch (os_tag) {
+            .macos, .ios => "metal",
+            .windows => "d3d11",
+            else => "opengl",
+        };
+    }
+    if (std.mem.eql(u8, value, "opengl") or
         std.mem.eql(u8, value, "metal"))
     {
         return value;
@@ -298,6 +304,15 @@ fn resolveGpuBackendBuildOption(raw: ?[]const u8, os_tag: std.Target.Os.Tag) []c
         return value;
     }
     @panic("-Dgpu-backend must be one of: auto, opengl, metal, d3d11");
+}
+
+test "GPU backend build option resolves platform defaults and explicit overrides" {
+    try std.testing.expectEqualStrings("d3d11", resolveGpuBackendBuildOption(null, .windows));
+    try std.testing.expectEqualStrings("d3d11", resolveGpuBackendBuildOption("auto", .windows));
+    try std.testing.expectEqualStrings("metal", resolveGpuBackendBuildOption("auto", .macos));
+    try std.testing.expectEqualStrings("opengl", resolveGpuBackendBuildOption("auto", .linux));
+    try std.testing.expectEqualStrings("opengl", resolveGpuBackendBuildOption("opengl", .windows));
+    try std.testing.expectEqualStrings("d3d11", resolveGpuBackendBuildOption("d3d11", .windows));
 }
 
 test "default development target remains x86_64 windows gnu" {
@@ -1300,7 +1315,7 @@ fn createAppModuleWithRootAndTestShard(
     // OpenGL backend (Windows + Linux): the glad loader needs its include path
     // and C source compiled in. macOS uses Metal and skips this; the native
     // D3D11 flavor never touches GL, so it skips glad and opengl32 entirely.
-    const links_opengl = !std.mem.eql(u8, gpu_backend, "d3d11");
+    const links_opengl = std.mem.eql(u8, gpu_backend, "opengl");
     if (links_opengl and (target.result.os.tag == .windows or target.result.os.tag == .linux)) {
         app_mod.addIncludePath(b.path("vendor/glad/include"));
         app_mod.addCSourceFile(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wispterm,
-    .version = "1.33.1",
+    .version = "1.34.0",
     .fingerprint = 0x2db6e9e774428a6f,
     .minimum_zig_version = "0.15.2",
 

--- a/debug/test-d3d11-normal-session.ps1
+++ b/debug/test-d3d11-normal-session.ps1
@@ -1408,7 +1408,7 @@ try {
     $hasD3D11RecreateSucceeded = $diagText -match "gpu-backend=d3d11 recovery recreate attempt attempted=true succeeded=true"
     $hasD3D11ResourceRestore = $diagText -match "gpu-backend=d3d11 resource recreate restored"
     $hasD3D11FallbackMarkerSmoke = $diagText -match "d3d11-fallback-marker-smoke .*readback_ok=true.*readback_matches=true.*explicit_d3d11_ignored=true.*current_auto_default_unchanged=true.*future_auto_opengl_marker=true.*automatic_fallback=false.*default_unchanged=true"
-    $hasD3D11AutoDryRunSmoke = $diagText -match "d3d11-auto-dry-run-smoke .*current_auto_opengl=true.*future_auto_d3d11=true.*future_auto_marker_opengl=true.*explicit_d3d11_ignored_marker=true.*explicit_opengl=true.*stale_marker_ignored=true.*automatic_fallback=false.*default_unchanged=true"
+    $hasD3D11AutoDryRunSmoke = $diagText -match "d3d11-auto-dry-run-smoke .*current_auto_d3d11=true.*future_auto_d3d11=true.*future_auto_marker_opengl=true.*explicit_d3d11_ignored_marker=true.*explicit_opengl=true.*stale_marker_ignored=true.*automatic_fallback=false.*default_unchanged=true"
     $hasUiProbe = $diagText -match "d3d11-ui-smoke probe .* ok=true"
     $hasOffscreen = $diagText -match "d3d11-offscreen-smoke round-trip active"
     $d3d11ResizeEventCount = [regex]::Matches($diagText, "gpu-backend=d3d11 resized swapchain to").Count

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,9 +63,9 @@ unsupported stubs only for missing capabilities). A new host implements a
   keycodes). IME composition goes through `setImeCaret` / `imePreeditText`.
 - **Rendering surface** — `swapBuffers`, `framebufferSize`, `clientSize`. The
   GPU backend is selected behind the renderer and wired to this surface. The
-  long-term target matrix is Direct3D 11/DXGI on Windows, Metal on macOS, and
-  OpenGL on Linux; today Windows still uses OpenGL for drawing with a DXGI/D3D11
-  flip-model presenter as the default present path.
+  target matrix is Direct3D 11/DXGI on Windows, Metal on macOS, and OpenGL on
+  Linux. Windows defaults to native D3D11 and publishes a separate OpenGL
+  compatibility package.
 - **Window state** — DPI/content scale (`dpi`, `effectiveDpi`,
   `consumeDpiChanged`), geometry (`clientRect`, `windowRect`,
   `nearestMonitorWorkArea`, `setOuterFrame`), and chrome state (fullscreen,

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -212,8 +212,8 @@ and **E** (Windows D3D11). **B** and **C** run in parallel with **A**.
 *Verifiable on Windows; OpenGL keeps working behind the new interface.*
 
 > **Status (A1+A2 landed).** `src/renderer/gpu/gpu.zig` (comptime backend
-> resolver) and `gpu/backend.zig` (`Backend{opengl,metal}`, `default→metal` on
-> Darwin) exist. OpenGL is the first backend under `gpu/opengl/`
+> resolver) and `gpu/backend.zig` (`Backend{opengl,metal,d3d11}`, with D3D11 on
+> Windows, Metal on Darwin, and OpenGL elsewhere) exist. OpenGL is under `gpu/opengl/`
 > (`c.zig`, `Context.zig`, `api.zig`, `gl_init.zig`, `shaders.zig`); the GL
 > table + context load moved out of `AppWindow.zig`, which no longer `@cImport`s
 > `glad`. Consumers reach the table via `AppWindow.gpu.glTable()` (a transition
@@ -314,8 +314,8 @@ Windows-default toolchain.*
 - **D5** Packaging: `.app` bundle / `.dmg` + updater story.
 
 ### Phase E — Windows native D3D11 renderer
-*Gated on Phase A. Windows remains shippable through the existing OpenGL +
-DXGI-present fallback while this lands incrementally.*
+*Landed and selected by default on Windows; the separately built OpenGL path
+remains the compatibility fallback.*
 
 The long-term Windows goal is a true Direct3D 11 renderer, not just the current
 DXGI flip-model presenter for OpenGL frames. The focused roadmap is
@@ -339,8 +339,8 @@ DXGI flip-model presenter for OpenGL frames. The focused roadmap is
 - **E6** Harden for Windows driver reality: device removal/reset, RDP, VMs,
   hybrid GPUs, weak iGPUs, high-DPI monitor moves, rapid resize, and automatic
   fallback to OpenGL + DXGI present.
-- **E7** Switch Windows `auto` backend to D3D11 only after feature parity and at
-  least one compatibility release cycle with the OpenGL fallback intact.
+- **E7** Keep Windows `auto` on D3D11 and retain the OpenGL fallback package
+  while native-driver coverage continues to broaden.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -83,9 +83,9 @@ frozen ceilings are in [`../AGENTS.md`](../AGENTS.md) and
 
 WispTerm's main terminal UI is intentionally custom drawn instead of composed
 from raw Win32 controls. The terminal surface, tabs, splits, overlays,
-background image, shader effects, and theme colors all share one OpenGL
-rendering pipeline, so they can stay visually consistent and behave like one
-terminal canvas.
+background image, shader effects, and theme colors all share one GPU rendering
+pipeline (D3D11 on Windows, Metal on macOS, OpenGL on Linux), so
+they can stay visually consistent and behave like one terminal canvas.
 
 Classic Win32 controls such as `SCROLLBAR` provide native behavior, but they do
 not blend well with WispTerm's dark theme, transparency, background images, and
@@ -360,18 +360,18 @@ survives with nonblank frames, D3D11 resize diagnostics, and no present/resize
 failure lines. It is Phase V reliability evidence only; it does not change the
 Windows default backend or fallback policy.
 
-The Phase VI default migration gate is documented in
+The completed Phase VI default migration gate is documented in
 [windows-native-d3d11-default-gate.md](windows-native-d3d11-default-gate.md).
 Use it as the checklist for collecting evidence, recording matrix gaps, and
-keeping the eventual Windows `auto` default change small and revertible.
+keeping the Windows `auto` default change small and revertible.
 
 D3D11 fallback is a next-launch policy while the renderer backend remains a
 comptime selection. Do not implement same-process D3D11-to-OpenGL switching
 without first changing the backend architecture. The `d3d11-fallback` state-file
 marker is separate from the older OpenGL+DXGI present `d3d-bringup` fuse,
-scoped by app version and adapter identity, and currently feeds only tests and
-future-auto dry-run decisions. Explicit `d3d11` must ignore a matching marker
-except for diagnostics; current Windows `auto` still resolves to OpenGL.
+scoped by app version and adapter identity, and currently feeds only diagnostic
+selector tests. Explicit `d3d11` must ignore a matching marker except for
+diagnostics; current Windows `auto` resolves to D3D11.
 
 To exercise the marker path without changing selection, run:
 
@@ -383,7 +383,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 This sets `WISPTERM_D3D11_FALLBACK_MARKER_SMOKE=1`, writes a synthetic
 version+adapter-scoped `d3d11-fallback` marker into the smoke profile's isolated
 state file, verifies explicit `d3d11` still wins with a warning-class decision,
-verifies current Windows `auto` remains OpenGL, and verifies a future-auto
+verifies current Windows `auto` remains D3D11, and verifies the marker-aware
 dry-run would select OpenGL from the marker. It does not enable live failure
 writes or automatic fallback.
 
@@ -396,17 +396,17 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-se
 ```
 
 This sets `WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE=1` and verifies diagnostics for
-current Windows `auto` staying OpenGL, future Windows `auto` selecting D3D11
-when eligible, future-auto selecting OpenGL from a matching marker, explicit
+current Windows `auto` selecting D3D11, the marker-aware policy selecting D3D11
+when eligible and OpenGL from a matching marker, explicit
 `d3d11` ignoring a matching marker with warning semantics, explicit `opengl`
 remaining OpenGL, and stale markers being ignored. It does not change the
 Windows default backend, write a fallback marker, or trigger automatic fallback.
 
 To prove the Windows OpenGL fallback path still runs the same normal-session UI
-subset on the native-render branch, build the default backend and run:
+subset, build it explicitly and run:
 
 ```powershell
-zig build
+zig build -Dgpu-backend=opengl
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl
 ```
 
@@ -531,9 +531,9 @@ OpenSSH error so regressions can be diagnosed without guessing.
 
 WispTerm supports three portable Windows packages:
 
-- `portable` - default OpenGL portable build, run directly without installation
-- `portable-compat` - OpenGL portable build for older Windows 10 machines: `WebView2Loader.dll` for the embedded browser plus a bundled modern ConPTY (`conpty.dll` + `OpenConsole.exe`) so TUI apps like Codex get mouse scrolling and scrollbars on old inbox conhosts
-- `portable-native-d3d11` - Windows native D3D11 feedback build; use the default `portable` package if it shows rendering issues
+- `portable` - default native D3D11 build, run directly without installation
+- `portable-compat` - native D3D11 build for older Windows 10 machines: `WebView2Loader.dll` for the embedded browser plus a bundled modern ConPTY (`conpty.dll` + `OpenConsole.exe`) so TUI apps like Codex get mouse scrolling and scrollbars on old inbox conhosts
+- `portable-opengl` - renderer fallback for systems where native D3D11 cannot start or render correctly
 
 Build the artifacts with:
 
@@ -553,9 +553,9 @@ zig-out\dist\portable-compat\conpty.dll
 zig-out\dist\portable-compat\OpenConsole.exe
 zig-out\dist\portable-compat\version.txt
 zig-out\dist\portable-compat\plugins\...
-zig-out\dist\portable-native-d3d11\wispterm.exe
-zig-out\dist\portable-native-d3d11\version.txt
-zig-out\dist\portable-native-d3d11\plugins\...
+zig-out\dist\portable-opengl\wispterm.exe
+zig-out\dist\portable-opengl\version.txt
+zig-out\dist\portable-opengl\plugins\...
 ```
 
 The portable app can add or remove its native Start menu shortcut and enable or
@@ -597,7 +597,7 @@ Several GitHub Actions workflows publish release assets whenever a tag matching
 
 - `wispterm-windows-portable-vX.Y.Z.zip`
 - `wispterm-windows-portable-compat-vX.Y.Z.zip`
-- `wispterm-windows-portable-native-d3d11-vX.Y.Z.zip`
+- `wispterm-windows-portable-opengl-vX.Y.Z.zip`
 - `wispterm-windows-debug-vX.Y.Z.zip`
 
 When WispTerm detects a newer release on Windows, it downloads the matching
@@ -607,10 +607,9 @@ your existing install to update.
 WispTerm does not build or publish a Windows installer. Use the default portable
 zip release asset; the `portable-compat` zip when using the embedded browser panel
 or on older Windows 10 machines (its bundled ConPTY restores TUI mouse support);
-or the `portable-native-d3d11` zip when intentionally testing the Windows native
-D3D11 renderer. If the native D3D11 package shows a black window, crash, missing
-UI, resize failure, RDP issue, or multi-monitor/DPI issue, switch back to the
-default portable package and include diagnostics in the bug report. The bundled
+or the `portable-opengl` zip when the default native D3D11 renderer shows a
+black window, crash, missing UI, resize failure, RDP issue, or multi-monitor/DPI
+issue. Include diagnostics in the bug report. The bundled
 ConPTY is preferred automatically when its files sit next to `wispterm.exe`; set
 `windows-conpty = system` in the config to force the OS inbox ConPTY.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -88,12 +88,12 @@ right-click-action = copy-or-paste
 These shortcuts operate on the local system clipboard. tmux's own copy-mode
 buffer remains separate unless tmux is configured to synchronize it.
 
-## Why Is WispTerm Laggy or Black on a Low-Spec PC (Weak Integrated GPU)?
+## Why Is the OpenGL Fallback Laggy or Black on a Low-Spec PC?
 
-On Windows, WispTerm presents frames through a DXGI flip-model swapchain by
-default. On machines with a weak integrated GPU — typically Win11
-thin-and-light laptops — that path can be noticeably slow (v1.18.0), and
-v1.19.0 could even leave the window black.
+This section applies to the separately published OpenGL fallback package. Its
+OpenGL renderer normally presents frames through a DXGI flip-model swapchain.
+On machines with a weak integrated GPU, that path can be noticeably slow or
+leave the window black.
 
 Since v1.19.1 WispTerm detects a sustained-slow or broken present path on its
 own: the first launch after upgrading may still feel slow once, and from the
@@ -104,13 +104,13 @@ at any time, set `wispterm-d3d-present = false`.
 
 ## What Should I Do If the First Launch Opens a Black Window?
 
-On weak integrated-GPU machines, the first launch after installing or upgrading
-can still hit the DXGI bring-up path before WispTerm has learned that the
-machine needs the GDI fallback. Close all WispTerm windows and start it again;
-the next launch should use the recorded fallback path.
+Starting with v1.34.0, first close all WispTerm windows and replace the default
+package with `wispterm-windows-portable-opengl-*.zip`. Renderer backends are
+fixed at build time, so the running native D3D11 binary cannot switch itself to
+OpenGL.
 
-If it still opens black, disable the DXGI presenter manually. Create or edit
-`%APPDATA%\wispterm\config` and add:
+If the OpenGL fallback also opens black, disable its DXGI presenter. Create or
+edit `%APPDATA%\wispterm\config` and add:
 
 ```conf
 wispterm-d3d-present = false
@@ -126,19 +126,19 @@ Add-Content -Path "$env:APPDATA\wispterm\config" -Value "wispterm-d3d-present = 
 
 ## Which Windows Package Should I Download?
 
-Use `wispterm-windows-portable-*.zip` by default. It uses the OpenGL renderer
-and is the recommended Windows package.
+Use `wispterm-windows-portable-*.zip` by default. Starting with v1.34.0 it uses
+the native Direct3D 11 renderer and is the recommended Windows package.
 
 Use `wispterm-windows-portable-compat-*.zip` on older Windows 10 machines or
 when you want the embedded browser loader and bundled modern ConPTY next to the
 exe.
 
-Use `wispterm-windows-portable-native-d3d11-*.zip` only when you want to test
-the Windows native D3D11 renderer and send feedback. If it opens a black window,
-crashes, misses UI, fails resize, or behaves badly over RDP, VM, hybrid GPU, or
-mixed-DPI monitor setups, switch back to the default OpenGL package. Include a
+Use `wispterm-windows-portable-opengl-*.zip` as the renderer fallback. Choose it
+if the default build opens a black window, crashes, misses UI, fails resize, or
+behaves badly over RDP, VM, hybrid GPU, or mixed-DPI monitor setups. Include a
 diagnostic report plus GPU/driver, Windows version, RDP/VM status, hybrid-GPU
-status, and monitor/DPI topology when reporting the issue.
+status, and monitor/DPI topology when reporting the issue. The OpenGL package
+tracks its own OpenGL release asset during in-app updates.
 
 ## Why Does WispTerm Remote Mirror the Local Terminal Size on Phones?
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -179,14 +179,20 @@ nothing to commit, working tree clean
           <div class="install-card">
             <span class="badge">Windows · Recommended</span>
             <h3>Portable</h3>
-            <p>Single executable — download the zip, extract, and run <code>wispterm.exe</code>.</p>
+            <p>Native Direct3D 11 renderer — download the zip, extract, and run <code>wispterm.exe</code>.</p>
             <a class="cta primary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable.zip" target="_blank" rel="noopener">Download zip →</a>
           </div>
           <div class="install-card">
             <span class="badge">Windows · Compatibility</span>
             <h3>Portable compat</h3>
-            <p>OpenGL build with <code>WebView2Loader.dll</code> and a bundled modern ConPTY for older Windows 10 machines.</p>
+            <p>Native Direct3D 11 build with <code>WebView2Loader.dll</code> and a bundled modern ConPTY for older Windows 10 machines.</p>
             <a class="cta primary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable-compat.zip" target="_blank" rel="noopener">Download zip →</a>
+          </div>
+          <div class="install-card">
+            <span class="badge">Windows · Renderer fallback</span>
+            <h3>Portable OpenGL</h3>
+            <p>Use this fallback if the recommended native D3D11 build opens black, crashes, or renders incorrectly.</p>
+            <a class="cta secondary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable-opengl.zip" target="_blank" rel="noopener">Download fallback →</a>
           </div>
           <div class="install-card">
             <span class="badge">macOS · Beta</span>
@@ -349,7 +355,7 @@ __wispterm_report_cwd</code></pre>
           </div>
           <div class="feature">
             <h3>First launch opens a black window?</h3>
-            <p>On weak integrated-GPU machines, close all WispTerm windows and start it again; the next launch should use the recorded GDI fallback. If it still opens black, add <code>wispterm-d3d-present = false</code> to <code>%APPDATA%\wispterm\config</code> and reopen WispTerm.</p>
+            <p>Close all WispTerm windows and use the Portable OpenGL fallback package. Renderer backends are fixed at build time, so the native D3D11 executable cannot switch itself to OpenGL.</p>
           </div>
           <div class="feature">
             <h3>Can I switch AI models without starting over?</h3>

--- a/docs/src/worker.js
+++ b/docs/src/worker.js
@@ -3,6 +3,7 @@ export const ONLINE_TTL_MS = 2 * 60 * 1000;
 const LATEST_DOWNLOADS = new Set([
   "wispterm-windows-portable.zip",
   "wispterm-windows-portable-compat.zip",
+  "wispterm-windows-portable-opengl.zip",
   "wispterm-macos-aarch64.dmg",
   "wispterm-macos-x86_64.dmg",
   "wispterm-linux-x86_64.AppImage",

--- a/docs/test/worker.test.js
+++ b/docs/test/worker.test.js
@@ -41,6 +41,10 @@ test("latestDownloadKey maps public latest download URLs to R2 keys", () => {
     "latest/wispterm-windows-portable.zip",
   );
   assert.equal(
+    latestDownloadKey("/downloads/latest/wispterm-windows-portable-opengl.zip"),
+    "latest/wispterm-windows-portable-opengl.zip",
+  );
+  assert.equal(
     latestDownloadKey("/downloads/latest/wispterm-linux-x86_64.AppImage"),
     "latest/wispterm-linux-x86_64.AppImage",
   );

--- a/docs/windows-native-d3d11-default-gate.md
+++ b/docs/windows-native-d3d11-default-gate.md
@@ -1,19 +1,18 @@
 # Windows Native D3D11 Default Migration Gate
 
-This document is the Phase V closeout gate for making the Windows native D3D11
-renderer eligible for a later Phase VI default migration. It is deliberately not
-a release announcement and not a default change. Windows `auto` remains OpenGL
-until a separate, small, easily revertible Phase VI PR changes that behavior.
+This document records the Phase V closeout gate and the Phase VI migration
+constraints. Phase VI ships in v1.34.0: Windows `auto` and the normal portable
+packages now use native D3D11, while OpenGL remains a separately built and
+published fallback.
 
 ## Current Boundary
 
-- Explicit `d3d11` is the only way to run the native D3D11 backend today.
-- Windows `auto` still resolves to OpenGL.
-- The OpenGL + DXGI present path remains the compatibility fallback.
-- D3D11 fallback is next-launch/future-auto policy; there is no same-process
-  D3D11-to-OpenGL renderer switch.
-- A matching `d3d11-fallback` marker may influence future-auto dry-run
-  decisions, but it must not silently override explicit `d3d11`.
+- Windows `auto` resolves to D3D11.
+- Explicit `-Dgpu-backend=opengl` builds the compatibility fallback.
+- Releases publish the fallback as `wispterm-windows-portable-opengl-*.zip`.
+- There is no same-process D3D11-to-OpenGL renderer switch.
+- The version+adapter-scoped `d3d11-fallback` marker remains diagnostic policy;
+  it does not override the compile-time backend selected in a published binary.
 
 ## Ghostty Comparison
 
@@ -36,9 +35,9 @@ unavailable environment is missing evidence, not a passing result.
 | D3D11 normal session | `debug/test-d3d11-normal-session.ps1` passes after `zig build -Dgpu-backend=d3d11`. |
 | Device recreate success | `-RecreateSmoke` records exactly one successful recreate/restore path. |
 | Device recreate failure | `-RecreateFailureSmoke` escalates exactly once to a fallback candidate and writes a marker. |
-| Fallback marker policy | `-FallbackMarkerSmoke` proves explicit D3D11 still wins, current auto stays OpenGL, and future-auto would select OpenGL from a matching marker. |
+| Fallback marker policy | `-FallbackMarkerSmoke` proves explicit D3D11 still wins, current auto stays D3D11, and the marker-aware policy would select OpenGL from a matching marker. |
 | Future-auto dry-run | `-AutoDryRunSmoke` proves current auto, future eligible D3D11, matching-marker OpenGL, explicit D3D11, explicit OpenGL, and stale-marker selector outcomes. |
-| OpenGL fallback | `zig build` plus `-Backend opengl` proves the compatibility renderer still runs the normal-session UI subset. |
+| OpenGL fallback | `zig build -Dgpu-backend=opengl` plus `-Backend opengl` proves the compatibility renderer still runs the normal-session UI subset. |
 | Rapid resize | `-RapidResizeSmoke` proves nonblank frames, resize diagnostics, and no resize/present failures. |
 | Window state | `-WindowStateSmoke` proves maximize, restore, minimize, and restore-from-minimize. |
 | Fullscreen startup | `-FullscreenStartupSmoke` proves config startup fullscreen, Alt+Enter exit, and restored baseline size. |
@@ -69,7 +68,7 @@ that records the result. The ledger format lives in
 | Multi-monitor same DPI | Resize/window evidence remains nonblank after monitor moves when available. |
 | Multi-monitor mixed DPI | DPI facts are recorded; failures are classified and documented. |
 
-## Phase VI Entry Conditions
+## Phase VI Entry Conditions (completed for v1.34.0)
 
 Phase VI may start only when all of these are true:
 
@@ -81,8 +80,8 @@ Phase VI may start only when all of these are true:
 4. OpenGL fallback still passes its normal-session smoke on the same branch.
 5. The future-auto dry-run explains each selector outcome: D3D11 eligible,
    OpenGL from marker, OpenGL from explicit selection, and stale marker ignored.
-6. The Phase VI default migration is a separate PR that only changes selector
-   policy and documentation needed for that policy.
+6. The Phase VI default migration is a separate PR limited to selector,
+   packaging/updater policy, tests, and documentation needed for that policy.
 7. Reverting the Phase VI PR restores Windows `auto` to OpenGL without reverting
    the native renderer implementation.
 
@@ -119,7 +118,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-environme
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\summarize-d3d11-environment-matrix.ps1
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\audit-d3d11-default-gate.ps1
 
-zig build
+zig build -Dgpu-backend=opengl
 powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-d3d11-normal-session.ps1 -Backend opengl
 
 zig build check-sizes
@@ -145,7 +144,7 @@ the generated matrix table.
 
 ## Rollback Rule
 
-If D3D11 becomes the Windows `auto` default and a post-merge regression appears,
-the first rollback should revert only the Phase VI selector/default PR. Do not
-revert the Phase I-V renderer implementation unless the bug is proven to live
-outside the selector/default policy.
+If a post-merge D3D11-default regression appears, first direct affected users to
+the OpenGL fallback package. If the default itself must be rolled back, revert
+only the Phase VI selector/packaging PR; do not revert the Phase I-V renderer
+implementation unless the bug is proven to live outside default policy.

--- a/docs/windows-native-d3d11-environment-matrix.md
+++ b/docs/windows-native-d3d11-environment-matrix.md
@@ -3,7 +3,7 @@
 This is the Phase V evidence ledger for Windows native D3D11 environment
 coverage. It records evidence requirements and the JSON fields emitted by
 `debug/test-d3d11-environment-smoke.ps1`; it is not a default migration plan.
-Windows `auto` remains OpenGL until the separate Phase VI gate is satisfied.
+Phase VI shipped in v1.34.0, so Windows `auto` now resolves to D3D11.
 
 ## Boundary
 

--- a/docs/windows-native-d3d11-roadmap.md
+++ b/docs/windows-native-d3d11-roadmap.md
@@ -16,13 +16,20 @@ WispTerm's target GPU matrix is:
 | Linux | OpenGL | Default experimental Linux renderer |
 | Windows fallback | OpenGL + DXGI flip-present | Compatibility path during and after migration |
 
-Current Windows builds already use a DXGI/D3D11 flip-model presenter when
-`wispterm-d3d-present = true`, but the terminal content is still drawn by the
-OpenGL renderer and then copied into the DXGI swapchain. This roadmap changes
-that into a real `d3d11` backend that draws cells, glyphs, emoji, UI, images,
-and render targets directly with Direct3D 11.
+Starting with v1.34.0, normal Windows builds use the real `d3d11` backend to
+draw cells, glyphs, emoji, UI, images, and render targets directly with
+Direct3D 11. The separately built OpenGL package retains the older
+OpenGL-to-DXGI compatibility path.
 
-## Current Branch Status
+## Current Status
+
+Phase VI is complete in v1.34.0: Windows `auto` selects D3D11, the default and
+compat portable packages are native D3D11 builds, and
+`wispterm-windows-portable-opengl-*.zip` is the published renderer fallback.
+Backend selection remains compile-time, so fallback requires restarting with
+the OpenGL package rather than switching in-process.
+
+### Historical Phase IV/V Branch Record
 
 On the `windows-native-render` integration branch, the opt-in D3D11 backend is a
 real native renderer path, not merely OpenGL frames presented through DXGI. The
@@ -172,10 +179,9 @@ marker in the isolated smoke profile and verify marker persistence plus the
 explicit/current-auto/future-auto decision surface without triggering automatic
 fallback.
 
-Add `-AutoDryRunSmoke` to the normal-session smoke to verify the future-auto
-selector explanation surface without writing a marker. It must prove current
-Windows `auto` still selects OpenGL, future Windows `auto` would select D3D11
-when eligible, a matching marker would make future-auto select OpenGL, explicit
+Add `-AutoDryRunSmoke` to the normal-session smoke to verify the selector
+explanation surface without writing a marker. It must prove current Windows
+`auto` selects D3D11, the marker-aware branch selects OpenGL when applicable, explicit
 `d3d11` ignores the marker with warning semantics, explicit `opengl` remains
 OpenGL, and stale markers are ignored.
 
@@ -282,21 +288,21 @@ Windows implementation is WispTerm-specific.
    assistant UI, image preview, and background rendering should build geometry
    and issue backend-neutral draw calls.
 5. **Fallback is part of the design.** If the D3D11 backend fails bring-up,
-   loses its device, or hits a known-bad environment, Windows can fall back to
-   the current OpenGL + DXGI present path for that launch.
+   loses its device, or hits a known-bad environment, users can restart with
+   the separately published OpenGL + DXGI compatibility package.
 
-## Phase 0: Current Windows Present Baseline
+## Phase 0: Historical Windows Present Baseline
 
 Status: mostly done.
 
-The current Windows host creates an OpenGL context and, by default, presents via
+The original Windows host created an OpenGL context and presented via
 `src/apprt/win32_dx_present.zig`: OpenGL renders into FBO 0, WGL/DX interop
 copies into a shared D3D11 texture, and DXGI presents a flip-model swapchain.
 This solved several GDI `SwapBuffers` resize, DPI, and black-region issues while
 preserving the existing renderer.
 
-Keep this path working while D3D11 is developed. It is the fallback and the
-regression oracle for visual parity.
+This path remains the separately built fallback and regression oracle for
+visual parity.
 
 Deliverables:
 
@@ -431,8 +437,8 @@ Exit criteria:
 
 ## Phase 6: Default Migration
 
-Only switch the Windows default after D3D11 has feature parity and fallback
-coverage.
+**Status: complete in v1.34.0.** Windows defaults to D3D11 and the OpenGL
+fallback remains separately published.
 
 Deliverables:
 

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -179,14 +179,20 @@
           <div class="install-card">
             <span class="badge">Windows · 推荐</span>
             <h3>便携版</h3>
-            <p>单可执行文件——下载 zip，解压后直接运行 <code>wispterm.exe</code>。</p>
+            <p>使用原生 Direct3D 11 渲染器——下载 zip，解压后直接运行 <code>wispterm.exe</code>。</p>
             <a class="cta primary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable.zip" target="_blank" rel="noopener">下载 zip →</a>
           </div>
           <div class="install-card">
             <span class="badge">Windows · 兼容包</span>
             <h3>便携兼容版</h3>
-            <p>OpenGL 构建，额外捆绑 <code>WebView2Loader.dll</code> 和现代 ConPTY，面向旧版 Windows 10。</p>
+            <p>原生 Direct3D 11 构建，额外捆绑 <code>WebView2Loader.dll</code> 和现代 ConPTY，面向旧版 Windows 10。</p>
             <a class="cta primary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable-compat.zip" target="_blank" rel="noopener">下载 zip →</a>
+          </div>
+          <div class="install-card">
+            <span class="badge">Windows · 渲染兜底</span>
+            <h3>OpenGL 便携版</h3>
+            <p>如果推荐的原生 D3D11 构建出现黑屏、崩溃或显示异常，请改用此兜底包。</p>
+            <a class="cta secondary small" href="https://github.com/xuzhougeng/wispterm/releases/latest" data-cloudflare-download="/downloads/latest/wispterm-windows-portable-opengl.zip" target="_blank" rel="noopener">下载兜底包 →</a>
           </div>
           <div class="install-card">
             <span class="badge">macOS · Beta</span>
@@ -349,7 +355,7 @@ __wispterm_report_cwd</code></pre>
           </div>
           <div class="feature">
             <h3>第一次启动黑屏怎么办？</h3>
-            <p>弱核显机器上，先关闭所有 WispTerm 窗口并重新打开；下一次启动通常会使用已记录的 GDI 回退路径。如果仍然黑屏，请在 <code>%APPDATA%\wispterm\config</code> 中加入 <code>wispterm-d3d-present = false</code>，然后重新打开 WispTerm。</p>
+            <p>关闭所有 WispTerm 窗口，改用 OpenGL 便携兜底包。渲染器在构建时确定，原生 D3D11 可执行文件无法自行切换到 OpenGL。</p>
           </div>
           <div class="feature">
             <h3>可以不中断会话切换 AI 模型吗？</h3>

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -5,7 +5,7 @@ param(
     [string]$ConPtyVersion = '1.24.260512001',
     [switch]$SkipBuild,
     [switch]$SkipCompatBundle,
-    [switch]$SkipNativeD3D11Bundle,
+    [switch]$SkipOpenGLBundle,
     [switch]$DebugConsole,
     [string]$Optimize = 'ReleaseFast'
 )
@@ -184,20 +184,20 @@ if ($DebugConsole) {
     exit 0
 }
 
-$nativeD3D11InstallDir = Join-Path $repoRoot 'zig-out-native-d3d11'
+$openGLInstallDir = Join-Path $repoRoot 'zig-out-opengl'
 
 if (-not $SkipBuild) {
     Push-Location $repoRoot
     try {
-        & zig build -Doptimize=ReleaseFast -Dgpu-backend=opengl
+        & zig build -Doptimize=ReleaseFast
         if ($LASTEXITCODE -ne 0) {
-            throw 'zig build -Doptimize=ReleaseFast -Dgpu-backend=opengl failed.'
+            throw 'zig build -Doptimize=ReleaseFast failed.'
         }
-        if (-not $SkipNativeD3D11Bundle) {
-            Remove-Item -Path $nativeD3D11InstallDir -Recurse -Force -ErrorAction SilentlyContinue
-            & zig build -Doptimize=ReleaseFast -Dgpu-backend=d3d11 -p $nativeD3D11InstallDir
+        if (-not $SkipOpenGLBundle) {
+            Remove-Item -Path $openGLInstallDir -Recurse -Force -ErrorAction SilentlyContinue
+            & zig build -Doptimize=ReleaseFast -Dgpu-backend=opengl -p $openGLInstallDir
             if ($LASTEXITCODE -ne 0) {
-                throw 'zig build -Doptimize=ReleaseFast -Dgpu-backend=d3d11 failed.'
+                throw 'zig build -Doptimize=ReleaseFast -Dgpu-backend=opengl failed.'
             }
         }
     } finally {
@@ -209,14 +209,14 @@ $binaryPath = Join-Path $repoRoot 'zig-out\bin\wispterm.exe'
 if (-not (Test-Path $binaryPath)) {
     throw "Expected release binary was not found: $binaryPath"
 }
-$nativeD3D11BinaryPath = Join-Path $nativeD3D11InstallDir 'bin\wispterm.exe'
-if (-not $SkipNativeD3D11Bundle -and -not (Test-Path $nativeD3D11BinaryPath)) {
-    throw "Expected native D3D11 release binary was not found: $nativeD3D11BinaryPath"
+$openGLBinaryPath = Join-Path $openGLInstallDir 'bin\wispterm.exe'
+if (-not $SkipOpenGLBundle -and -not (Test-Path $openGLBinaryPath)) {
+    throw "Expected OpenGL fallback release binary was not found: $openGLBinaryPath"
 }
 
 $portableDir = Join-Path $resolvedOutputDir 'portable'
 $portableCompatDir = Join-Path $resolvedOutputDir 'portable-compat'
-$portableNativeD3D11Dir = Join-Path $resolvedOutputDir 'portable-native-d3d11'
+$portableOpenGLDir = Join-Path $resolvedOutputDir 'portable-opengl'
 $webView2LoaderPath = $null
 $conPtyPair = $null
 
@@ -225,20 +225,20 @@ if (-not $SkipCompatBundle) {
     $conPtyPair = Get-ConPtyPair -RepoRoot $repoRoot -Version $ConPtyVersion
 }
 
-Remove-Item -Path $portableDir, $portableCompatDir, $portableNativeD3D11Dir, (Join-Path $resolvedOutputDir 'installer') -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path $portableDir, $portableCompatDir, $portableOpenGLDir, (Join-Path $resolvedOutputDir 'installer') -Recurse -Force -ErrorAction SilentlyContinue
 
 Copy-PortablePayload -BinaryPath $binaryPath -TargetDir $portableDir -ReleaseVersion $releaseVersion
 if ($webView2LoaderPath) {
     Copy-PortablePayload -BinaryPath $binaryPath -TargetDir $portableCompatDir -ReleaseVersion $releaseVersion -WebView2LoaderPath $webView2LoaderPath -ConPtyPair $conPtyPair
 }
-if (-not $SkipNativeD3D11Bundle) {
-    Copy-PortablePayload -BinaryPath $nativeD3D11BinaryPath -TargetDir $portableNativeD3D11Dir -ReleaseVersion $releaseVersion
+if (-not $SkipOpenGLBundle) {
+    Copy-PortablePayload -BinaryPath $openGLBinaryPath -TargetDir $portableOpenGLDir -ReleaseVersion $releaseVersion
 }
 
 Write-Host "Portable build: $(Join-Path $portableDir 'wispterm.exe')"
 if ($webView2LoaderPath) {
     Write-Host "Portable compat build: $(Join-Path $portableCompatDir 'wispterm.exe')"
 }
-if (-not $SkipNativeD3D11Bundle) {
-    Write-Host "Portable native D3D11 build: $(Join-Path $portableNativeD3D11Dir 'wispterm.exe')"
+if (-not $SkipOpenGLBundle) {
+    Write-Host "Portable OpenGL fallback build: $(Join-Path $portableOpenGLDir 'wispterm.exe')"
 }

--- a/release-notes/v1.34.0.md
+++ b/release-notes/v1.34.0.md
@@ -1,0 +1,59 @@
+# WispTerm v1.34.0
+
+## Changed
+
+- **Native D3D11 is now the Windows default.** The normal portable and compat
+  packages use the native Direct3D 11 renderer. OpenGL remains available as the
+  separate `wispterm-windows-portable-opengl-*.zip` fallback and keeps following
+  OpenGL assets during in-app updates.
+- **Visual settings and shell defaults (#573).** Improved the Settings visual
+  controls and made new-session shell defaults clearer and more consistent.
+
+## Fixed
+
+- **SSH terminal identity (#579).** SSH sessions no longer spoof Ghostty through
+  `TERM_PROGRAM`, avoiding provider-specific failures such as Grok CLI rejecting
+  WispTerm as an unsupported terminal.
+- **Architecture-aware updates (#575).** macOS now selects the release DMG that
+  matches the running Apple Silicon or Intel architecture.
+- **Linux AppImage updates (#577).** Linux now matches the published x86_64
+  AppImage asset name correctly.
+- **Clipboard documentation (#576, #578).** English and Chinese documentation
+  now agree on tmux selection, image paste, and text-paste fallback behavior.
+
+## Known limitations
+
+- Renderer selection is fixed when the executable is built. If native D3D11
+  cannot start or render correctly, close WispTerm and use the OpenGL fallback
+  package; there is no same-process renderer switch.
+- Custom post-processing shaders remain OpenGL-only.
+
+---
+
+# WispTerm v1.34.0（中文）
+
+## 变更
+
+- **Windows 默认切换为原生 D3D11。** 普通便携包与兼容包现在使用原生
+  Direct3D 11 渲染器。OpenGL 继续作为独立的
+  `wispterm-windows-portable-opengl-*.zip` 兜底包发布，应用内更新也会持续匹配
+  OpenGL 资产。
+- **视觉设置与 Shell 默认值（#573）。** 改进 Settings 中的视觉设置控件，并让新建
+  会话时的 Shell 默认值更清晰、一致。
+
+## 修复
+
+- **SSH 终端身份（#579）。** SSH 会话不再通过 `TERM_PROGRAM` 冒充 Ghostty，避免
+  Grok CLI 等工具因错误识别终端而拒绝运行。
+- **按架构匹配更新（#575）。** macOS 现在会根据 Apple Silicon 或 Intel 运行架构
+  选择对应的 DMG。
+- **Linux AppImage 更新（#577）。** Linux 现在能正确匹配已发布的 x86_64
+  AppImage 资产名。
+- **剪贴板文档（#576、#578）。** 中英文文档现在对 tmux 选区、图片粘贴和文本粘贴
+  回退行为的描述保持一致。
+
+## 已知限制
+
+- 渲染器在构建可执行文件时确定。如果原生 D3D11 无法启动或显示异常，请关闭
+  WispTerm 后改用 OpenGL 兜底包；当前不支持在同一进程内切换渲染器。
+- 自定义后处理着色器仍仅支持 OpenGL。

--- a/src/benchmark/report.zig
+++ b/src/benchmark/report.zig
@@ -201,7 +201,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
         .{ .name = "terminal-stream", .unit = .throughput, .value = 56.2, .samples = 900, .duration_ms = 1000 },
     };
     const r: Report = .{
-        .app_version = "1.33.1",
+        .app_version = "1.34.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,
@@ -212,7 +212,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
     };
     const json = try formatJson(allocator, r);
     defer allocator.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.33.1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.34.0\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"logical_cores\":8") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"backend\":\"opengl\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"runner\":\"cli\"") != null);
@@ -228,7 +228,7 @@ test "report: JSON includes gpu/window when filled and latency percentiles" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.33.1",
+        .app_version = "1.34.0",
         .os = "macos",
         .cpu_arch = "aarch64",
         .logical_cores = 10,
@@ -253,7 +253,7 @@ test "report: Markdown renders header, env, and scenario table" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.33.1",
+        .app_version = "1.34.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,

--- a/src/platform/update_package.zig
+++ b/src/platform/update_package.zig
@@ -30,8 +30,13 @@ const impl = switch (backendForOs(builtin.os.tag)) {
     .unsupported => @import("update_package_unsupported.zig"),
 };
 
-fn runtimeFlavor(webview_enabled: bool, has_compat_payload: bool) release_package.Flavor {
+fn runtimeFlavor(
+    gpu_backend: []const u8,
+    webview_enabled: bool,
+    has_compat_payload: bool,
+) release_package.Flavor {
     _ = webview_enabled;
+    if (std.mem.eql(u8, gpu_backend, "opengl")) return .opengl;
     if (has_compat_payload) return .compat;
     return .baseline;
 }
@@ -81,23 +86,32 @@ pub fn defaultPackage() release_package.Package {
 
 pub fn runtimePackageForOs(
     os_tag: std.Target.Os.Tag,
+    gpu_backend: []const u8,
     webview_enabled: bool,
     has_compat_payload: bool,
 ) release_package.Package {
     return switch (backendForOs(os_tag)) {
-        .windows => release_package.Package.init(.windows, runtimeFlavor(webview_enabled, has_compat_payload)),
+        .windows => release_package.Package.init(.windows, runtimeFlavor(gpu_backend, webview_enabled, has_compat_payload)),
         .linux => defaultPackageForOs(os_tag),
         .macos => defaultPackageForOs(os_tag),
         .unsupported => defaultPackageForOs(os_tag),
     };
 }
 
-pub fn runtimePackage(webview_enabled: bool, has_compat_payload: bool) release_package.Package {
-    return runtimePackageForOs(builtin.os.tag, webview_enabled, has_compat_payload);
+pub fn runtimePackage(
+    gpu_backend: []const u8,
+    webview_enabled: bool,
+    has_compat_payload: bool,
+) release_package.Package {
+    return runtimePackageForOs(builtin.os.tag, gpu_backend, webview_enabled, has_compat_payload);
 }
 
-pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
-    return impl.currentPackage(allocator, webview_enabled);
+pub fn currentPackage(
+    allocator: std.mem.Allocator,
+    webview_enabled: bool,
+    gpu_backend: []const u8,
+) !release_package.Package {
+    return impl.currentPackage(allocator, webview_enabled, gpu_backend);
 }
 
 test "platform update package selects backend by target OS" {
@@ -114,10 +128,12 @@ test "platform update package maps non-Windows targets to non-Windows packages" 
 }
 
 test "platform update package maps Windows runtime payloads after no-WebView retirement" {
-    try std.testing.expectEqual(release_package.Flavor.baseline, runtimeFlavor(false, false));
-    try std.testing.expectEqual(release_package.Flavor.compat, runtimeFlavor(false, true));
-    try std.testing.expectEqual(release_package.Flavor.compat, runtimeFlavor(true, true));
-    try std.testing.expectEqual(release_package.Flavor.baseline, runtimeFlavor(true, false));
+    try std.testing.expectEqual(release_package.Flavor.baseline, runtimeFlavor("d3d11", false, false));
+    try std.testing.expectEqual(release_package.Flavor.compat, runtimeFlavor("d3d11", false, true));
+    try std.testing.expectEqual(release_package.Flavor.compat, runtimeFlavor("d3d11", true, true));
+    try std.testing.expectEqual(release_package.Flavor.baseline, runtimeFlavor("d3d11", true, false));
+    try std.testing.expectEqual(release_package.Flavor.opengl, runtimeFlavor("opengl", true, false));
+    try std.testing.expectEqual(release_package.Flavor.opengl, runtimeFlavor("opengl", true, true));
     try std.testing.expect(release_package.Package.init(.windows, .compat).requiresEmbeddedBrowserPayload());
 }
 
@@ -128,6 +144,9 @@ test "platform update package builds Windows portable asset names" {
 
     const compat = try assetNameForScenario("v0.28.0", .compat, &buf);
     try std.testing.expectEqualStrings("wispterm-windows-portable-compat-v0.28.0.zip", compat);
+
+    const opengl = try assetNameForScenario("v0.28.0", .opengl, &buf);
+    try std.testing.expectEqualStrings("wispterm-windows-portable-opengl-v0.28.0.zip", opengl);
 }
 
 test "platform update package matches exact target asset names only" {
@@ -140,6 +159,16 @@ test "platform update package matches exact target asset names only" {
         "wispterm-windows-portable-v0.28.0.zip",
         "v0.28.0",
         packageForScenario(.compat),
+    ));
+    try std.testing.expect(matchesAssetName(
+        "wispterm-windows-portable-opengl-v0.28.0.zip",
+        "v0.28.0",
+        packageForScenario(.opengl),
+    ));
+    try std.testing.expect(!matchesAssetName(
+        "wispterm-windows-portable-v0.28.0.zip",
+        "v0.28.0",
+        packageForScenario(.opengl),
     ));
 }
 

--- a/src/platform/update_package_linux.zig
+++ b/src/platform/update_package_linux.zig
@@ -14,9 +14,14 @@ fn versionFromTag(tag_name: []const u8) []const u8 {
     return tag_name;
 }
 
-pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
+pub fn currentPackage(
+    allocator: std.mem.Allocator,
+    webview_enabled: bool,
+    gpu_backend: []const u8,
+) !release_package.Package {
     _ = allocator;
     _ = webview_enabled;
+    _ = gpu_backend;
     if (architectureLabel(builtin.cpu.arch) == null) return error.UnsupportedLinuxArchitecture;
     return .{ .platform = .linux };
 }

--- a/src/platform/update_package_macos.zig
+++ b/src/platform/update_package_macos.zig
@@ -10,9 +10,14 @@ fn architectureLabel(arch: std.Target.Cpu.Arch) ?[]const u8 {
     };
 }
 
-pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
+pub fn currentPackage(
+    allocator: std.mem.Allocator,
+    webview_enabled: bool,
+    gpu_backend: []const u8,
+) !release_package.Package {
     _ = allocator;
     _ = webview_enabled;
+    _ = gpu_backend;
     if (architectureLabel(builtin.cpu.arch) == null) return error.UnsupportedMacosArchitecture;
     return .{ .platform = .macos };
 }
@@ -48,7 +53,10 @@ fn matchesAssetNameForArch(
 }
 
 test "macOS update package reports the native platform package" {
-    try std.testing.expectEqual(release_package.Platform.macos, (try currentPackage(std.testing.allocator, false)).platform);
+    try std.testing.expectEqual(
+        release_package.Platform.macos,
+        (try currentPackage(std.testing.allocator, false, "metal")).platform,
+    );
 }
 
 test "macOS update package builds architecture-qualified asset names" {

--- a/src/platform/update_package_unsupported.zig
+++ b/src/platform/update_package_unsupported.zig
@@ -2,9 +2,14 @@ const std = @import("std");
 const builtin = @import("builtin");
 const release_package = @import("../release_package.zig");
 
-pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
+pub fn currentPackage(
+    allocator: std.mem.Allocator,
+    webview_enabled: bool,
+    gpu_backend: []const u8,
+) !release_package.Package {
     _ = allocator;
     _ = webview_enabled;
+    _ = gpu_backend;
     return defaultPackageForOs(builtin.os.tag);
 }
 

--- a/src/platform/update_package_windows.zig
+++ b/src/platform/update_package_windows.zig
@@ -9,17 +9,22 @@ const AssetNameParts = struct {
     suffix: []const u8,
 };
 
-pub fn currentPackage(allocator: std.mem.Allocator, webview_enabled: bool) !release_package.Package {
+pub fn currentPackage(
+    allocator: std.mem.Allocator,
+    webview_enabled: bool,
+    gpu_backend: []const u8,
+) !release_package.Package {
     const exe_path = try std.fs.selfExePathAlloc(allocator);
     defer allocator.free(exe_path);
-    const exe_dir = std.fs.path.dirname(exe_path) orelse return release_package.Package.init(.windows, .baseline);
+    const exe_dir = std.fs.path.dirname(exe_path) orelse
+        return release_package.Package.init(.windows, runtimeFlavor(gpu_backend, webview_enabled, false));
     // Either payload marks a compat install: webview2-flavor installs from
     // before the compat package existed carry only the embedded-browser
     // loader, and their next auto-update migrates them onto the compat asset
     // (a superset that adds the bundled console host).
     const has_compat_payload = payloadExists(allocator, exe_dir, embeddedBrowserPayloadPath()) or
         payloadExists(allocator, exe_dir, bundled_console_host_payload_path);
-    return release_package.Package.init(.windows, runtimeFlavor(webview_enabled, has_compat_payload));
+    return release_package.Package.init(.windows, runtimeFlavor(gpu_backend, webview_enabled, has_compat_payload));
 }
 
 fn payloadExists(allocator: std.mem.Allocator, exe_dir: []const u8, name: []const u8) bool {
@@ -39,6 +44,10 @@ fn assetNameParts(package: release_package.Package) ?AssetNameParts {
         },
         .compat => .{
             .prefix = "wispterm-windows-portable-compat-",
+            .suffix = ".zip",
+        },
+        .opengl => .{
+            .prefix = "wispterm-windows-portable-opengl-",
             .suffix = ".zip",
         },
     };
@@ -61,8 +70,13 @@ pub fn embeddedBrowserPayloadPath() []const u8 {
     return embedded_browser_payload_path;
 }
 
-fn runtimeFlavor(webview_enabled: bool, has_compat_payload: bool) release_package.Flavor {
+fn runtimeFlavor(
+    gpu_backend: []const u8,
+    webview_enabled: bool,
+    has_compat_payload: bool,
+) release_package.Flavor {
     _ = webview_enabled;
+    if (std.mem.eql(u8, gpu_backend, "opengl")) return .opengl;
     if (has_compat_payload) return .compat;
     return .baseline;
 }

--- a/src/release_package.zig
+++ b/src/release_package.zig
@@ -12,6 +12,8 @@ pub const Flavor = enum {
     /// Full-featured package for older Windows machines: ships the embedded
     /// browser loader plus a modern bundled console host.
     compat,
+    /// Windows fallback package that keeps the OpenGL renderer across updates.
+    opengl,
 };
 
 pub const Package = struct {
@@ -33,5 +35,6 @@ pub const Package = struct {
 test "release package exposes embedded browser payload requirement" {
     try std.testing.expect(Package.init(.windows, .compat).requiresEmbeddedBrowserPayload());
     try std.testing.expect(!Package.init(.windows, .baseline).requiresEmbeddedBrowserPayload());
+    try std.testing.expect(!Package.init(.windows, .opengl).requiresEmbeddedBrowserPayload());
     try std.testing.expect(!(Package{ .platform = .linux }).requiresEmbeddedBrowserPayload());
 }

--- a/src/renderer/d3d11_auto_dry_run_smoke.zig
+++ b/src/renderer/d3d11_auto_dry_run_smoke.zig
@@ -1,8 +1,7 @@
-//! Opt-in D3D11 future-auto selector dry-run smoke.
+//! Opt-in D3D11 selector and fallback-policy dry-run smoke.
 //!
 //! Enable with `WISPTERM_D3D11_AUTO_DRY_RUN_SMOKE=1`. This logs selector
-//! decisions for the current Windows auto default and the future Windows auto
-//! policy without changing the active backend or writing fallback markers.
+//! decisions without changing the active backend or writing fallback markers.
 
 const std = @import("std");
 const build_options = @import("build_options");
@@ -19,7 +18,7 @@ threadlocal var enabled_cache = false;
 threadlocal var fired = false;
 
 const SmokeDecision = struct {
-    current_auto_opengl: bool,
+    current_auto_d3d11: bool,
     future_auto_d3d11: bool,
     future_auto_marker_opengl: bool,
     explicit_d3d11_ignored_marker: bool,
@@ -59,7 +58,7 @@ fn evaluateDecisions(version: []const u8, adapter_id: []const u8, marker_text: [
     const stale_marker = fallback_marker.decide(.windows, "auto", stale_marker_text, version, adapter_id, .future_windows_auto);
 
     return .{
-        .current_auto_opengl = current_auto.backend == Backend.opengl and
+        .current_auto_d3d11 = current_auto.backend == Backend.d3d11 and
             current_auto.effect == .current_auto_default_unchanged,
         .future_auto_d3d11 = future_auto.backend == Backend.d3d11 and
             future_auto.effect == .future_auto_d3d11,
@@ -109,10 +108,10 @@ pub fn maybeRun() void {
 
     const decision = evaluateDecisions(build_options.app_version, adapter_id, marker, stale_marker);
     render_diagnostics.log(
-        "d3d11-auto-dry-run-smoke adapter={s} current_auto_opengl={} future_auto_d3d11={} future_auto_marker_opengl={} explicit_d3d11_ignored_marker={} explicit_opengl={} stale_marker_ignored={} automatic_fallback=false default_unchanged=true",
+        "d3d11-auto-dry-run-smoke adapter={s} current_auto_d3d11={} future_auto_d3d11={} future_auto_marker_opengl={} explicit_d3d11_ignored_marker={} explicit_opengl={} stale_marker_ignored={} automatic_fallback=false default_unchanged=true",
         .{
             adapter_id,
-            decision.current_auto_opengl,
+            decision.current_auto_d3d11,
             decision.future_auto_d3d11,
             decision.future_auto_marker_opengl,
             decision.explicit_d3d11_ignored_marker,
@@ -155,7 +154,7 @@ test "D3D11 auto dry-run smoke validates selector decisions" {
     );
 
     const decision = evaluateDecisions("1.20.0", "adapter-a", marker, stale_marker);
-    try std.testing.expect(decision.current_auto_opengl);
+    try std.testing.expect(decision.current_auto_d3d11);
     try std.testing.expect(decision.future_auto_d3d11);
     try std.testing.expect(decision.future_auto_marker_opengl);
     try std.testing.expect(decision.explicit_d3d11_ignored_marker);

--- a/src/renderer/d3d11_fallback_marker_smoke.zig
+++ b/src/renderer/d3d11_fallback_marker_smoke.zig
@@ -2,8 +2,7 @@
 //!
 //! Enable with `WISPTERM_D3D11_FALLBACK_MARKER_SMOKE=1`. This writes a
 //! synthetic next-launch fallback marker into the isolated state file used by
-//! the smoke harness, then verifies the current/future selector decisions. It
-//! does not change the current Windows `auto` default and does not trigger
+//! the smoke harness, then verifies the selector decisions. It does not trigger
 //! automatic fallback.
 
 const std = @import("std");
@@ -82,7 +81,7 @@ fn evaluateDecisions(marker_text: []const u8, version: []const u8, adapter_id: [
         .explicit_d3d11_ignored = explicit_d3d11.backend == .d3d11 and
             explicit_d3d11.effect == .explicit_d3d11_ignores_marker and
             explicit_d3d11.warning,
-        .current_auto_default_unchanged = current_auto.backend == Backend.opengl and
+        .current_auto_default_unchanged = current_auto.backend == Backend.d3d11 and
             current_auto.effect == .current_auto_default_unchanged,
         .future_auto_opengl_marker = future_auto.backend == Backend.opengl and
             future_auto.effect == .future_auto_opengl_marker,

--- a/src/renderer/gpu/backend.zig
+++ b/src/renderer/gpu/backend.zig
@@ -1,6 +1,6 @@
 //! GPU backend selection. Mirrors Ghostty's `src/renderer/backend.zig`:
-//! a `Backend` enum with `default(os_tag)` that returns `.metal` on Darwin,
-//! `.opengl` elsewhere. Windows-native D3D11 is opt-in during Phase II.
+//! a `Backend` enum with `default(os_tag)` that keeps the platform choice thin:
+//! Metal on Darwin, D3D11 on Windows, and OpenGL elsewhere.
 //! Selection is comptime (see `gpu.zig`).
 
 const std = @import("std");
@@ -10,12 +10,11 @@ pub const Backend = enum {
     metal,
     d3d11,
 
-    /// The default backend for a target OS. macOS/iOS are Metal-only
-    /// (Apple deprecated OpenGL at 4.1); everything else uses OpenGL while
-    /// the D3D11 backend is experimental.
+    /// The default backend for a target OS.
     pub fn default(os_tag: std.Target.Os.Tag) Backend {
         return switch (os_tag) {
             .macos, .ios => .metal,
+            .windows => .d3d11,
             else => .opengl,
         };
     }
@@ -35,15 +34,15 @@ pub const Backend = enum {
     }
 };
 
-test "Backend.default maps Darwin to metal, others to opengl while d3d11 is opt-in" {
+test "Backend.default maps each desktop family to its native default" {
     try std.testing.expectEqual(Backend.metal, Backend.default(.macos));
     try std.testing.expectEqual(Backend.metal, Backend.default(.ios));
-    try std.testing.expectEqual(Backend.opengl, Backend.default(.windows));
+    try std.testing.expectEqual(Backend.d3d11, Backend.default(.windows));
     try std.testing.expectEqual(Backend.opengl, Backend.default(.linux));
 }
 
-test "Backend.resolve honors explicit d3d11 without changing auto defaults" {
-    try std.testing.expectEqual(Backend.opengl, Backend.resolve(.windows, "auto"));
+test "Backend.resolve honors auto and explicit overrides" {
+    try std.testing.expectEqual(Backend.d3d11, Backend.resolve(.windows, "auto"));
     try std.testing.expectEqual(Backend.metal, Backend.resolve(.macos, "auto"));
     try std.testing.expectEqual(Backend.d3d11, Backend.resolve(.windows, "d3d11"));
     try std.testing.expectEqual(Backend.opengl, Backend.resolve(.windows, "opengl"));

--- a/src/renderer/gpu/d3d11/fallback_marker.zig
+++ b/src/renderer/gpu/d3d11/fallback_marker.zig
@@ -2,8 +2,8 @@
 //!
 //! WispTerm resolves the active renderer backend at comptime, Ghostty-style, so
 //! D3D11 cannot safely switch to OpenGL in-process. This module defines the
-//! state-file marker and dry-run selection rules used by later Phase V/VI work;
-//! it does not change the current Windows `auto` default or trigger fallback.
+//! state-file marker and dry-run selection rules. It never switches renderer
+//! backends in-process.
 
 const std = @import("std");
 const Backend = @import("../backend.zig").Backend;
@@ -256,7 +256,7 @@ test "D3D11 fallback policy keeps current Windows auto default unchanged" {
     const text = try format(&buf, .blocked, "1.20.0", "adapter-a", .device_lost);
     const decision = decide(.windows, "auto", text, "1.20.0", "adapter-a", .current_default);
 
-    try std.testing.expectEqual(Backend.opengl, decision.backend);
+    try std.testing.expectEqual(Backend.d3d11, decision.backend);
     try std.testing.expectEqual(MarkerEffect.current_auto_default_unchanged, decision.effect);
     try std.testing.expect(!decision.warning);
 }

--- a/src/renderer/overlays/update_prompt_model.zig
+++ b/src/renderer/overlays/update_prompt_model.zig
@@ -25,7 +25,7 @@ pub fn updatePromptActionForResult(result: update_check.CheckResult) UpdatePromp
 
 test "overlays: downloaded maps to install_update on macOS only" {
     const expected: UpdatePromptAction = if (builtin.os.tag == .macos) .install_update else .none;
-    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.33.1" }));
+    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.34.0" }));
 }
 
 test "overlays: update prompt action selection prefers downloadable asset" {

--- a/src/test_main_behavior.zig
+++ b/src/test_main_behavior.zig
@@ -7,7 +7,7 @@ const keybind = @import("keybind.zig");
 const command_dispatch = @import("input/command_dispatch.zig");
 
 test "app version metadata is exposed for CLI and command center" {
-    const expected_version = "1.33.1";
+    const expected_version = "1.34.0";
     try std.testing.expectEqualStrings("WispTerm", app_metadata.name);
     try std.testing.expectEqualStrings(expected_version, app_metadata.version);
     try std.testing.expect(std.mem.indexOf(u8, app_metadata.release_notes, "# WispTerm v" ++ expected_version) != null);

--- a/src/update_check.zig
+++ b/src/update_check.zig
@@ -432,10 +432,13 @@ test "update_check: selects supported Windows portable assets" {
     const tag_name = "v0.28.0";
     var portable_name_buf: [asset_name_buffer_len]u8 = undefined;
     var compat_name_buf: [asset_name_buffer_len]u8 = undefined;
+    var opengl_name_buf: [asset_name_buffer_len]u8 = undefined;
     const portable_package = platform_update_package.packageForScenario(.baseline);
     const compat_package = platform_update_package.packageForScenario(.compat);
+    const opengl_package = platform_update_package.packageForScenario(.opengl);
     const portable_name = try platform_update_package.assetName(tag_name, portable_package, &portable_name_buf);
     const compat_name = try platform_update_package.assetName(tag_name, compat_package, &compat_name_buf);
+    const opengl_name = try platform_update_package.assetName(tag_name, opengl_package, &opengl_name_buf);
 
     const json = try std.fmt.allocPrint(std.testing.allocator,
         \\{{
@@ -445,7 +448,8 @@ test "update_check: selects supported Windows portable assets" {
         \\  "prerelease":false,
         \\  "assets":[
         \\    {{"name":"{s}","browser_download_url":"https://example.test/portable.zip","size":11}},
-        \\    {{"name":"{s}","browser_download_url":"https://example.test/compat.zip","size":22}}
+        \\    {{"name":"{s}","browser_download_url":"https://example.test/compat.zip","size":22}},
+        \\    {{"name":"{s}","browser_download_url":"https://example.test/opengl.zip","size":33}}
         \\  ]
         \\}}
     , .{
@@ -453,6 +457,7 @@ test "update_check: selects supported Windows portable assets" {
         tag_name,
         portable_name,
         compat_name,
+        opengl_name,
     });
     defer std.testing.allocator.free(json);
 
@@ -468,6 +473,11 @@ test "update_check: selects supported Windows portable assets" {
     try std.testing.expectEqualStrings(compat_name, compat.name);
     try std.testing.expectEqualStrings("https://example.test/compat.zip", compat.download_url);
     try std.testing.expectEqual(@as(u64, 22), compat.size);
+
+    const opengl = selectReleaseAsset(release, opengl_package) orelse return error.ExpectedAsset;
+    try std.testing.expectEqualStrings(opengl_name, opengl.name);
+    try std.testing.expectEqualStrings("https://example.test/opengl.zip", opengl.download_url);
+    try std.testing.expectEqual(@as(u64, 33), opengl.size);
 }
 
 test "update_check: selects macOS DMG asset for macOS package" {

--- a/src/update_install.zig
+++ b/src/update_install.zig
@@ -5,15 +5,27 @@ const platform_update_package = @import("platform/update_package.zig");
 const update_check = @import("update_check.zig");
 
 pub fn runtimePackage(webview_enabled: bool, has_embedded_browser_payload: bool) update_check.ReleasePackage {
-    return platform_update_package.runtimePackage(webview_enabled, has_embedded_browser_payload);
+    return platform_update_package.runtimePackage(
+        build_options.gpu_backend,
+        webview_enabled,
+        has_embedded_browser_payload,
+    );
 }
 
 pub fn defaultPackage() update_check.ReleasePackage {
-    return platform_update_package.defaultPackage();
+    return platform_update_package.runtimePackage(
+        build_options.gpu_backend,
+        build_options.webview,
+        false,
+    );
 }
 
 pub fn currentPackage(allocator: std.mem.Allocator) !update_check.ReleasePackage {
-    return platform_update_package.currentPackage(allocator, build_options.webview);
+    return platform_update_package.currentPackage(
+        allocator,
+        build_options.webview,
+        build_options.gpu_backend,
+    );
 }
 
 /// Absolute path the release asset is saved to: the user's Downloads folder


### PR DESCRIPTION
## Summary

- make native D3D11 the Windows `auto` backend and stop linking OpenGL in the default build
- publish the normal and compat packages with D3D11, plus a separate OpenGL fallback package
- preserve the installed renderer flavor during in-app updates
- prepare desktop v1.34.0 release notes and synchronized version surfaces

## Ghostty comparison

Ghostty keeps backend selection in a thin `Backend.default` selector (WebGL for WebAssembly, Metal on Darwin, OpenGL elsewhere). WispTerm keeps that same thin boundary and adds the Windows-specific `.d3d11` choice; no renderer rewrite or new runtime abstraction is part of this migration.

## Phase V evidence and matrix

- native renderer merge: `5a3f325db7813a4ce77db304dcefce7b293e2dae`
- accepted-gap record: `d380d99b08a311ef51d65327af58ebf9cdb486ca`
- Phase VI implementation: `7594564ecb8704d06d8ecb3c4ec6e7349179eccf` on `feat/windows-native-default-v1.34.0`
- recorded environment classes: `local-physical`, `multi-monitor-mixed-dpi`
- accepted, not-passing gaps: `rdp`, `virtual-machine`, `hybrid-gpu`, `weak-integrated-gpu`, `single-monitor`, `multi-monitor-same-dpi`

## Fallback behavior

Renderer selection remains compile-time. There is no same-process D3D11-to-OpenGL switch. The version+adapter-scoped `d3d11-fallback` marker remains diagnostic policy: explicit D3D11 ignores a matching marker with a warning, while the marker-aware dry-run demonstrates the OpenGL decision. Published users fall back by restarting with `wispterm-windows-portable-opengl-*.zip`.

Force either build explicitly:

```powershell
zig build -Dgpu-backend=opengl
zig build -Dgpu-backend=d3d11
```

Inspect the marker:

```powershell
Select-String -Path "$env:APPDATA\wispterm\state" -Pattern "^d3d11-fallback\s*="
```

Clear only that marker:

```powershell
$path = "$env:APPDATA\wispterm\state"
(Get-Content $path) | Where-Object { $_ -notmatch "^d3d11-fallback\s*=" } | Set-Content -Encoding ascii $path
```

## Verification

- `zig test build.zig` — 29 passed
- `zig build check-sizes` — passed
- `zig build test --summary all` — 2371 passed, 1 skipped
- `zig test src/update_check.zig` — 32 passed
- `npm test` under `docs/` — passed
- default `zig build -Doptimize=ReleaseFast` — passed; artifact reports `d3d11` and does not link `OPENGL32.dll`
- explicit OpenGL ReleaseFast build — passed; artifact reports `opengl` and links `OPENGL32.dll`
- Windows checkout safety — 0 invalid names, 0 case-fold collisions, 0 symlinks, max path 90
- local WSL/Wine `test-full` compiled all shards; runtime summary was 15,267 passed / 323 skipped / 9 failed because the same pre-existing `memory_digest` store/cursor tests reject WSL UNC temp paths with `BadPathName`. Native macOS full CI and Windows smoke CI remain the merge gates.

## Rollback

Direct affected users to the OpenGL fallback asset first. To restore OpenGL as Windows `auto`, revert only this PR merge:

```bash
git revert -m 1 <phase-vi-merge-commit>
```

The Phase I-V native renderer implementation does not need to be reverted.
