### PR TITLE
ci: deploy docs worker on changes

### DIFF
--- a/.github/workflows/docs-cloudflare-deploy.yml
+++ b/.github/workflows/docs-cloudflare-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy docs to Cloudflare
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-cloudflare-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-cloudflare-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: docs
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build Cloudflare docs
+        run: npm run build:cloudflare
+
+      - name: Deploy Worker
+        run: npx --yes wrangler@4.88.0 deploy --config wrangler.toml


### PR DESCRIPTION
## Summary

- deploy the Cloudflare docs Worker whenever `docs/**` changes land on `main`
- keep a manual dispatch path for release recovery
- use the existing repository Cloudflare credentials and pinned Wrangler version

## Why

v1.34.0 added a stable OpenGL fallback download route and synced the corresponding R2 object, but the production Worker still had the previous route allowlist. This workflow keeps Worker routing and checked-in docs changes synchronized.

## Validation

- `npm test` (docs)
- `npm run build:cloudflare`
- `npx --yes wrangler@4.88.0 deploy --config wrangler.toml --dry-run`
- YAML parse check