### PR TITLE
fix(ci): prepare Wrangler docs config

### DIFF
--- a/.github/workflows/docs-cloudflare-deploy.yml
+++ b/.github/workflows/docs-cloudflare-deploy.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Build Cloudflare docs
         run: npm run build:cloudflare
 
+      - name: Prepare Wrangler config
+        run: cp wrangler.toml.example wrangler.toml
+
       - name: Deploy Worker
         run: npx --yes wrangler@4.88.0 deploy --config wrangler.toml


### PR DESCRIPTION
## Summary

- copy the committed `wrangler.toml.example` to the ignored runtime filename before deploying
- keep the production deploy command aligned with the documented local workflow

## Cause

The first automated deployment built successfully but CI did not have the ignored `docs/wrangler.toml`, so Wrangler exited with `ENOENT`.

## Validation

- the committed example matches the locally dry-run-tested `wrangler.toml`
- `npx --yes wrangler@4.88.0 deploy --config wrangler.toml --dry-run` passed
- `git diff --check`