### PR TITLE
fix: handle macOS keypad Enter and scheduler lifetime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Structural debt is frozen mechanically by source-scanning ratchet tests (the sam
 | `file_size_guard` | lines in any `src/**/*.zig` | < **10,000** (also `zig build check-sizes`) | split by responsibility; never raise the limit |
 | `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow **66**, input **49**, overlays **32**, assistant/conversation/session **16** | put new state in a state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | **17** | import the real module directly, not via `AppWindow.X` |
-| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow **45**, input **81**, overlays **10**, assistant/conversation/session **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow **44**, input **81**, overlays **10**, assistant/conversation/session **0** | return a `UiEffect`, land it through `AppWindow.applyUiEffect` |
 
 The 10,000-line guard is a **runaway tripwire, not a health metric**: `check-sizes` prevents uncontrolled growth, it does not certify architectural health. A file under it can still be tangled; treat any file over **5,000 lines** as a signal to review responsibility, dependency direction, state ownership, and test boundaries. The boundary ratchets — not the line count — are the primary enforcement mechanism.
 

--- a/docs/decoupling-guide.md
+++ b/docs/decoupling-guide.md
@@ -449,7 +449,7 @@ gate — you must first remove one, or use the pattern the guard names.
 | `file_size_guard` | lines in any `src/**/*.zig` (whole tree, future files too) | < 10,000 | split by responsibility; never raise the limit |
 | `global_state_guard` | top-level `g_*` / `threadlocal` in the watched integration/session files | AppWindow 66, input 49, overlays 32, assistant/conversation/session 16 | new state → an explicit state struct (`appwindow/state.zig`, …) |
 | `import_hub_guard` | `pub const X = @import(...)` re-exports in `AppWindow.zig` | 17 | import the real module directly, not via `AppWindow.X` |
-| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow 45, input 81, overlays 10, assistant/conversation/session 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
+| `side_effect_guard` | direct `g_force_rebuild` / `g_cells_valid` writes in the watched integration/session files | AppWindow 44, input 81, overlays 10, assistant/conversation/session 0 | return a `UiEffect`; land it via `AppWindow.applyUiEffect` |
 
 They run in `zig build test` and — since `test-full` is now a superset of `test`
 — in the pre-merge gate. The file-size backstop is also a standalone command,

--- a/src/App.zig
+++ b/src/App.zig
@@ -11,6 +11,7 @@ const AppWindow = @import("AppWindow.zig");
 const ai_chat = @import("assistant/conversation/session.zig");
 const app_metadata = @import("app_metadata.zig");
 const keybind = @import("keybind.zig");
+const memory_digest_scheduler = @import("memory_digest/scheduler.zig");
 const console_host_policy = @import("platform/console_host_policy.zig");
 const platform_com = @import("platform/com.zig");
 const platform_display = @import("platform/display.zig");
@@ -1153,6 +1154,7 @@ pub fn deinit(self: *App) void {
     self.joinAllWindowThreads();
     self.joinUpdateThread();
     self.joinDownloadThread();
+    memory_digest_scheduler.deinit();
 
     if (self.remote_client) |client| {
         client.destroy();

--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -7714,7 +7714,7 @@ fn runMainLoop(self: *AppWindow) !void {
 
         // Update focus state
         const focused = window_backend.isFocused(win);
-        if (window_focused != focused) g_force_rebuild = true;
+        if (window_focused != focused) applyUiEffect(.{ .needs_rebuild = true });
         window_focused = focused;
 
         const fb = window_backend.framebufferSize(win);
@@ -8162,7 +8162,6 @@ fn runMainLoop(self: *AppWindow) !void {
 
     // Clean up file explorer async state (join background thread, free job)
     file_explorer.deinit();
-    memory_digest_scheduler.deinit();
     weixin_qr_renderer.deinit();
     weixin_qr_panel.deinit();
     feishu_reg_renderer.deinit();

--- a/src/memory_digest/scheduler.zig
+++ b/src/memory_digest/scheduler.zig
@@ -90,6 +90,7 @@ pub const ProgressSnapshot = struct {
 
 var g_settings_arena: std.heap.ArenaAllocator = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 var g_settings: Settings = .{};
+var g_state_mutex: std.Thread.Mutex = .{};
 var g_thread: ?std.Thread = null;
 var g_in_flight: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var g_last_tick_check_ms: i64 = 0;
@@ -100,8 +101,11 @@ var g_progress: ProgressSnapshot = .{};
 var g_progress_ctx: u8 = 0;
 
 /// Loads a copy of `s`, duping the borrowed strings into the module's own
-/// arena. Call on the main thread whenever config is loaded/hot-reloaded.
+/// arena. Config reloads may arrive from any window thread.
 pub fn updateSettings(s: Settings) void {
+    g_state_mutex.lock();
+    defer g_state_mutex.unlock();
+
     g_settings_arena.deinit();
     g_settings_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     const alloc = g_settings_arena.allocator();
@@ -124,6 +128,9 @@ pub fn updateSettings(s: Settings) void {
 /// Main-loop tick. Self-throttles: only actually checks once per
 /// TICK_INTERVAL_MS. Cheap to call every frame.
 pub fn tick(gpa: std.mem.Allocator) void {
+    g_state_mutex.lock();
+    defer g_state_mutex.unlock();
+
     const now_ms = std.time.milliTimestamp();
     if (g_app_started_ms == null) g_app_started_ms = now_ms;
 
@@ -159,6 +166,9 @@ pub fn tick(gpa: std.mem.Allocator) void {
 /// explicit user request, not a scheduled decision). Still respects the
 /// in_flight guard: if a run is already in progress, this is a no-op.
 pub fn runNow(gpa: std.mem.Allocator) void {
+    g_state_mutex.lock();
+    defer g_state_mutex.unlock();
+
     if (g_in_flight.load(.acquire)) {
         std.log.info("memory_digest: runNow skipped, a run is already in progress", .{});
         setProgress(.skipped, true, .{ .detail = "Memory digest already running" });
@@ -216,6 +226,9 @@ fn spawnRun(gpa: std.mem.Allocator, now_ms: i64, tz_offset_seconds: i32, manual:
 /// case is losing the in-progress run's record, not a corrupt one. Proper
 /// LLM-call timeouts are M5.
 pub fn deinit() void {
+    g_state_mutex.lock();
+    defer g_state_mutex.unlock();
+
     g_shutting_down.store(true, .release);
     if (g_thread) |t| {
         if (g_in_flight.load(.acquire)) {
@@ -226,6 +239,12 @@ pub fn deinit() void {
         g_thread = null;
     }
     g_settings_arena.deinit();
+    // ArenaAllocator.deinit does not clear its linked-list head. Leave a fresh
+    // empty value behind so a repeated process teardown cannot walk freed nodes.
+    g_settings_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    g_settings = .{};
+    g_last_tick_check_ms = 0;
+    g_app_started_ms = null;
 }
 
 /// "HH:MM" (H:0-23, M:0-59, 1-2 digit fields) -> minutes since local midnight.
@@ -510,6 +529,30 @@ fn markRanToday(gpa: std.mem.Allocator, now_ms: i64, tz_offset_seconds: i32) voi
 // otherwise identical and already covered by reading the source directly.
 // If this needs real coverage later, test it via test-full's macOS-only
 // app test binary instead of the fast suite.
+
+test "memory_digest_scheduler: settings reload and shutdown can repeat safely" {
+    defer g_shutting_down.store(false, .release);
+
+    updateSettings(.{
+        .enabled = true,
+        .profile_name = "first",
+        .run_after = "01:23",
+    });
+    try std.testing.expectEqualStrings("first", g_settings.profile_name);
+    try std.testing.expectEqualStrings("01:23", g_settings.run_after);
+
+    updateSettings(.{
+        .profile_name = "second",
+        .run_after = "04:56",
+    });
+    try std.testing.expectEqualStrings("second", g_settings.profile_name);
+    try std.testing.expectEqualStrings("04:56", g_settings.run_after);
+
+    deinit();
+    deinit();
+    try std.testing.expectEqualStrings("", g_settings.profile_name);
+    try std.testing.expectEqualStrings("04:00", g_settings.run_after);
+}
 
 test "memory_digest_scheduler: parseRunAfterMinutes accepts HH:MM" {
     try std.testing.expectEqual(@as(?u16, 240), parseRunAfterMinutes("04:00"));

--- a/src/platform/window_backend_macos.zig
+++ b/src/platform/window_backend_macos.zig
@@ -450,6 +450,20 @@ test "macOS backend normalizes control-modified shortcut key codes" {
     try std.testing.expectEqual(@as(usize, 0xBF), wispterm_macos_window_test_map_key_code(44, "/"));
 }
 
+test "macOS backend maps keypad Enter to normal Enter" {
+    // AppKit reports the keypad key as native key code 0x4C and character
+    // NSEnterCharacter (U+0003), not the carriage return produced by Return.
+    const keypad_enter = [_:0]u8{0x03};
+    try std.testing.expectEqual(
+        @as(usize, platform_input.key_enter),
+        wispterm_macos_window_test_map_key_code(0x4C, &keypad_enter),
+    );
+    try std.testing.expectEqual(
+        @as(usize, platform_input.key_enter),
+        wispterm_macos_window_test_map_key_code(0x4C, null),
+    );
+}
+
 test "macOS backend drains text, mouse, wheel, and IME preedit events" {
     const title = std.unicode.utf8ToUtf16LeStringLiteral("WispTerm Input Smoke");
     var window = try Window.init(320, 180, title, null, null, false);

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -646,6 +646,7 @@ static uintptr_t wispterm_macos_map_ansi_key_code(unsigned short key_code) {
 static uintptr_t wispterm_macos_map_key_code(unsigned short key_code, NSString *characters) {
     switch (key_code) {
         case 36: return 0x0D;  // Return
+        case 76: return 0x0D;  // Keypad Enter
         case 48: return 0x09;  // Tab
         case 51: return 0x08;  // Backspace
         case 53: return 0x1B;  // Escape

--- a/src/source_guards/side_effect_guard.zig
+++ b/src/source_guards/side_effect_guard.zig
@@ -19,11 +19,11 @@ const Frozen = struct {
     ceiling: usize,
 };
 
-// Ratchet ceilings for watched files (AppWindow 45, input 81, overlays 0,
+// Ratchet ceilings for watched files (AppWindow 44, input 81, overlays 0,
 // assistant/conversation/session.zig 0). Lower a ceiling only when direct
 // writes are removed.
 const monoliths = [_]Frozen{
-    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 45 },
+    .{ .name = "AppWindow.zig", .source = @embedFile("../AppWindow.zig"), .ceiling = 44 },
     .{ .name = "input.zig", .source = @embedFile("../input.zig"), .ceiling = 81 },
     .{ .name = "renderer/overlays.zig", .source = @embedFile("../renderer/overlays.zig"), .ceiling = 0 },
     .{ .name = "assistant/conversation/session.zig", .source = @embedFile("../assistant/conversation/session.zig"), .ceiling = 0 },


### PR DESCRIPTION
## Summary

- map macOS keypad Enter (`keyCode 0x4C`, `NSEnterCharacter`) to WispTerm's neutral Enter event
- keep the process-wide memory-digest scheduler alive when an individual window closes
- serialize scheduler reload/tick/run/shutdown state across window threads
- reset scheduler-owned arena state after shutdown and add regression coverage
- lower the AppWindow side-effect ratchet from 45 to 44

## Root causes

### #587

AppKit reports the numeric keypad Enter key as native key code `0x4C` and character `U+0003`. The macOS bridge only mapped the normal Return key (`keyCode 36`) to `0x0D`, so keypad Enter fell through as key code `3`. Shared terminal and UI input only recognize `platform_input.key_enter`, so the event was ignored.

### #585

The memory-digest scheduler is a process-wide singleton, but every `AppWindow` called its `deinit` during window teardown. On macOS, closing a window does not terminate the process, and additional windows run on separate threads. Closing/reopening a window or closing one of several windows therefore freed the scheduler settings arena while the process continued. The next config reload called `updateSettings`, whose `ArenaAllocator.deinit` walked the already-freed arena list and crashed. Multiple window config watchers and scheduler ticks could also mutate the singleton concurrently.

The fix moves scheduler shutdown to `App.deinit`, after all window threads have joined, and protects the scheduler control state with a mutex.

## Validation

- `zig build test`
- `zig build`
- `zig build check-sizes`
- `zig fmt --check src/App.zig src/AppWindow.zig src/memory_digest/scheduler.zig src/platform/window_backend_macos.zig src/source_guards/side_effect_guard.zig`
- `git diff --check`

`zig build test-full` compiles successfully, then hits the existing WSL/Windows path failures in the memory-digest missing-file tests (`/nonexistent/...` becomes `BadPathName`). The same failure was reproduced from an unmodified clean `HEAD` tree.

Closes #585
Closes #587
