### PR TITLE
fix(windows): focus WispTerm when a task-complete toast is clicked

### DIFF
--- a/src/AppWindow.zig
+++ b/src/AppWindow.zig
@@ -6563,6 +6563,7 @@ fn onPlatformMessage(msg: window_backend.MessageId, wParam: window_backend.WordP
         toggleQuakeVisibility();
         return 1;
     }
+    if (platform_notifications.handleCallback(msg, wParam, lParam)) return 1;
 
     const decoded = thread_message.decode(msg, lParam) orelse return null;
     const agent_host = agentRequestHost();
@@ -7318,6 +7319,9 @@ fn ensureNotifAuthRequested(native_toast: bool) void {
 /// Z-terminate title/body (truncating to the notification limits) and show a
 /// native toast. Caller has already routed via `notif_mod.decideRoute`.
 fn showToastZ(title: []const u8, body: []const u8) void {
+    if (g_window) |win| {
+        platform_notifications.bindWindow(window_backend.nativeHandle(win));
+    }
     var title_z: [notif_mod.max_title + 1]u8 = undefined;
     var body_z: [notif_mod.max_body + 1]u8 = undefined;
     const t = title[0..@min(title.len, notif_mod.max_title)];

--- a/src/platform/notifications.zig
+++ b/src/platform/notifications.zig
@@ -61,10 +61,27 @@ pub fn requestAttention(handle: NativeHandle) void {
     impl.requestAttention(handle);
 }
 
+/// Remember the window a later toast click should present. No-op where the
+/// backend has no click-to-focus path.
+pub fn bindWindow(handle: NativeHandle) void {
+    impl.bindWindow(handle);
+}
+
 /// Post a native desktop notification (Windows tray balloon / macOS toast /
 /// Linux notify-send). No-op where unsupported.
 pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
     impl.showDesktopNotification(title, body);
+}
+
+/// Consume a tray/toast click posted to the window's WndProc. Returns true
+/// when the message was a notification click (the backend presents the
+/// bound window). Always false on platforms without a tray callback.
+pub fn handleCallback(
+    msg: platform_window.MessageId,
+    wparam: platform_window.WordParam,
+    lparam: platform_window.LongParam,
+) bool {
+    return impl.handleCallback(msg, wparam, lparam);
 }
 
 /// Release any process-wide notification resources (Windows removes its tray
@@ -103,6 +120,15 @@ test "notifications exposes bell and attention API shape" {
     const show_info = @typeInfo(@TypeOf(showDesktopNotification)).@"fn";
     try std.testing.expectEqual(@as(usize, 2), show_info.params.len);
     try std.testing.expect(show_info.return_type.? == void);
+
+    const bind_info = @typeInfo(@TypeOf(bindWindow)).@"fn";
+    try std.testing.expectEqual(@as(usize, 1), bind_info.params.len);
+    try std.testing.expect(bind_info.params[0].type.? == NativeHandle);
+    try std.testing.expect(bind_info.return_type.? == void);
+
+    const click_info = @typeInfo(@TypeOf(handleCallback)).@"fn";
+    try std.testing.expectEqual(@as(usize, 3), click_info.params.len);
+    try std.testing.expect(click_info.return_type.? == bool);
 
     const status_info = @typeInfo(@TypeOf(notificationAuthStatus)).@"fn";
     try std.testing.expectEqual(@as(usize, 0), status_info.params.len);

--- a/src/platform/notifications_linux.zig
+++ b/src/platform/notifications_linux.zig
@@ -14,6 +14,10 @@ const NativeHandle = platform_window.NativeHandle;
 /// The terminal bell is already handled by the pty/VT layer writing '\x07'.
 pub fn bell() void {}
 
+pub fn bindWindow(handle: NativeHandle) void {
+    _ = handle;
+}
+
 /// Flash the taskbar/window-decoration entry until the window is focused.
 pub fn requestAttention(handle: NativeHandle) void {
     const win: *c.SDL_Window = @ptrCast(handle);
@@ -39,6 +43,17 @@ pub fn notificationAuthStatus() u8 {
 
 /// No authorization request needed on Linux.
 pub fn requestNotificationAuth() void {}
+
+pub fn handleCallback(
+    msg: platform_window.MessageId,
+    wparam: platform_window.WordParam,
+    lparam: platform_window.LongParam,
+) bool {
+    _ = msg;
+    _ = wparam;
+    _ = lparam;
+    return false;
+}
 
 /// notify-send spawns leave nothing to tear down.
 pub fn cleanup() void {}

--- a/src/platform/notifications_macos.zig
+++ b/src/platform/notifications_macos.zig
@@ -10,6 +10,10 @@ pub fn bell() void {
     wispterm_macos_notification_bell();
 }
 
+pub fn bindWindow(handle: platform_window.NativeHandle) void {
+    _ = handle;
+}
+
 pub fn requestAttention(handle: platform_window.NativeHandle) void {
     wispterm_macos_notification_request_attention(handle);
 }
@@ -25,6 +29,18 @@ pub fn notificationAuthStatus() u8 {
 
 pub fn requestNotificationAuth() void {
     wispterm_macos_notif_request_auth();
+}
+
+/// macOS click-to-focus is handled by UNUserNotificationCenter, not a tray callback.
+pub fn handleCallback(
+    msg: platform_window.MessageId,
+    wparam: platform_window.WordParam,
+    lparam: platform_window.LongParam,
+) bool {
+    _ = msg;
+    _ = wparam;
+    _ = lparam;
+    return false;
 }
 
 /// macOS notifications need no process-level teardown.

--- a/src/platform/notifications_unsupported.zig
+++ b/src/platform/notifications_unsupported.zig
@@ -5,6 +5,10 @@ const platform_window = @import("window.zig");
 
 pub fn bell() void {}
 
+pub fn bindWindow(handle: platform_window.NativeHandle) void {
+    _ = handle;
+}
+
 pub fn requestAttention(handle: platform_window.NativeHandle) void {
     _ = handle;
 }
@@ -19,5 +23,16 @@ pub fn notificationAuthStatus() u8 {
 }
 
 pub fn requestNotificationAuth() void {}
+
+pub fn handleCallback(
+    msg: platform_window.MessageId,
+    wparam: platform_window.WordParam,
+    lparam: platform_window.LongParam,
+) bool {
+    _ = msg;
+    _ = wparam;
+    _ = lparam;
+    return false;
+}
 
 pub fn cleanup() void {}

--- a/src/platform/notifications_windows.zig
+++ b/src/platform/notifications_windows.zig
@@ -3,10 +3,17 @@
 //! via a `Shell_NotifyIcon` tray balloon. On Windows 10 1607+ the shell
 //! automatically surfaces tray balloons as toast notifications, so this gives
 //! native toasts with plain `extern "shell32"` calls — no AppUserModelID,
-//! COM, or WinRT required. Clicking the balloon foregrounds the main window.
+//! COM, or WinRT required.
+//!
+//! Clicking the toast must present the WispTerm window (Ghostty's GTK path
+//! does the same via `app.present-surface`). The icon is registered against
+//! the real window when we have one so the shell can activate it; the
+//! VERSION_4 callback is decoded by `notify_tray_callback.zig` (wParam is
+//! the mouse point, not the icon id).
 
 const std = @import("std");
 const platform_window = @import("window.zig");
+const tray_callback = @import("notify_tray_callback.zig");
 
 const NativeHandle = platform_window.NativeHandle;
 const windows = std.os.windows;
@@ -54,10 +61,24 @@ extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: INT) callconv(.winapi) BOOL;
 extern "user32" fn IsIconic(hWnd: HWND) callconv(.winapi) BOOL;
 extern "user32" fn IsWindowVisible(hWnd: HWND) callconv(.winapi) BOOL;
 extern "user32" fn SetForegroundWindow(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn BringWindowToTop(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn SetWindowPos(
+    hWnd: HWND,
+    hWndInsertAfter: ?HWND,
+    X: INT,
+    Y: INT,
+    cx: INT,
+    cy: INT,
+    uFlags: UINT,
+) callconv(.winapi) BOOL;
+extern "user32" fn AttachThreadInput(idAttach: DWORD, idAttachTo: DWORD, fAttach: BOOL) callconv(.winapi) BOOL;
+extern "user32" fn SwitchToThisWindow(hWnd: HWND, fAltTab: BOOL) callconv(.winapi) void;
+extern "user32" fn IsWindow(hWnd: HWND) callconv(.winapi) BOOL;
 extern "user32" fn EnumWindows(lpEnumFunc: WNDENUMPROC, lParam: LPARAM) callconv(.winapi) BOOL;
 extern "user32" fn GetWindowThreadProcessId(hWnd: HWND, lpdwProcessId: ?*DWORD) callconv(.winapi) DWORD;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const WCHAR) callconv(.winapi) ?HINSTANCE;
 extern "kernel32" fn GetCurrentProcessId() callconv(.winapi) DWORD;
+extern "kernel32" fn GetCurrentThreadId() callconv(.winapi) DWORD;
 extern "shell32" fn Shell_NotifyIconW(dwMessage: DWORD, lpData: *NOTIFYICONDATAW) callconv(.winapi) BOOL;
 
 const WNDENUMPROC = *const fn (HWND, LPARAM) callconv(.winapi) BOOL;
@@ -119,10 +140,8 @@ const FLASHW_TIMERNOFG: DWORD = 12; // Flash until window comes to foreground
 const MB_OK: UINT = 0x00000000; // Default system sound
 
 // Tray icon / balloon plumbing.
-const WM_USER: UINT = 0x0400;
-const WM_APP: UINT = 0x8000;
-const TRAY_CALLBACK_MSG: UINT = WM_APP + 0x4E; // 'N' for notification
-const TRAY_ICON_ID: UINT = 1;
+const TRAY_CALLBACK_MSG: UINT = tray_callback.tray_callback_msg;
+const TRAY_ICON_ID: UINT = tray_callback.tray_icon_id;
 const NIM_ADD: DWORD = 0;
 const NIM_MODIFY: DWORD = 1;
 const NIM_DELETE: DWORD = 2;
@@ -133,24 +152,34 @@ const NIF_TIP: UINT = 0x4;
 const NIF_INFO: UINT = 0x10;
 const NIIF_INFO: DWORD = 0x1;
 const NOTIFYICON_VERSION_4: UINT = 4;
-const NIN_BALLOONUSERCLICK: UINT = WM_USER + 5;
-const HWND_MESSAGE: HWND = @ptrFromInt(@as(usize, @bitCast(@as(isize, -3))));
+const HWND_TOP: ?HWND = null;
+const HWND_TOPMOST: HWND = @ptrFromInt(@as(usize, @bitCast(@as(isize, -1))));
+const HWND_NOTOPMOST: HWND = @ptrFromInt(@as(usize, @bitCast(@as(isize, -2))));
+const SWP_NOSIZE: UINT = 0x0001;
+const SWP_NOMOVE: UINT = 0x0002;
+const SWP_SHOWWINDOW: UINT = 0x0040;
+const SW_SHOW: INT = 5;
 const SW_RESTORE: INT = 9;
 const IMAGE_ICON: UINT = 1;
 const LR_SHARED: UINT = 0x8000;
 const IDI_APPLICATION: usize = 32512;
+const WS_POPUP: DWORD = 0x80000000;
+const WS_EX_TOOLWINDOW: DWORD = 0x00000080;
+const WM_ACTIVATE: UINT = 0x0006;
 /// Embedded application icon resource ID (see assets/wispterm.rc and
 /// apprt/win32.zig, which loads the same ID for the window icon).
 const APP_ICON_RESOURCE_ID: usize = 1;
 
-/// All tray-toast state lives here: whether NIM_ADD succeeded, the
-/// message-only window receiving tray callbacks, the cached main-window
-/// handle used to foreground the app on balloon click, and the icon handle.
+/// All tray-toast state lives here: whether NIM_ADD succeeded, the HWND
+/// registered with the icon (the real window when known, otherwise a hidden
+/// popup so the shell can still activate us), whether we own that HWND, the
+/// cached main-window handle, and the icon handle.
 const TrayState = struct {
     mutex: std.Thread.Mutex = .{},
     icon_added: bool = false,
     class_registered: bool = false,
-    msg_hwnd: ?HWND = null,
+    callback_hwnd: ?HWND = null,
+    owns_callback_hwnd: bool = false,
     main_hwnd: ?HWND = null,
     icon: ?HICON = null,
 };
@@ -161,12 +190,14 @@ pub fn bell() void {
     _ = MessageBeep(MB_OK);
 }
 
-pub fn requestAttention(handle: NativeHandle) void {
-    // Cache the window handle so a balloon click can foreground it even when
-    // no other path handed us a window handle.
+pub fn bindWindow(handle: NativeHandle) void {
     tray.mutex.lock();
     tray.main_hwnd = handle;
     tray.mutex.unlock();
+}
+
+pub fn requestAttention(handle: NativeHandle) void {
+    bindWindow(handle);
 
     // Only flash if the window is not already the foreground window.
     if (GetForegroundWindow() == handle) return;
@@ -207,10 +238,32 @@ fn copyUtf16Truncated(dest: []WCHAR, src: []const u8) void {
     dest[out] = 0;
 }
 
-/// Lazily create the message-only window and register the tray icon.
-/// Caller must hold tray.mutex.
-fn ensureTrayLocked() bool {
-    if (tray.icon_added) return true;
+/// HWND the shell should activate / send balloon clicks to. Prefer the real
+/// window so a toast click can present it; fall back to a hidden popup (not
+/// a message-only window — those cannot be activated on Windows 10/11).
+fn resolveCallbackHwndLocked() ?HWND {
+    if (validWindow(tray.main_hwnd)) |hwnd| return hwnd;
+    if (findMainWindowSkipping(fallbackSkipLocked())) |hwnd| {
+        tray.main_hwnd = hwnd;
+        return hwnd;
+    }
+    return ensureFallbackWindowLocked();
+}
+
+fn fallbackSkipLocked() ?HWND {
+    return if (tray.owns_callback_hwnd) tray.callback_hwnd else null;
+}
+
+fn validWindow(handle: ?HWND) ?HWND {
+    const hwnd = handle orelse return null;
+    if (IsWindow(hwnd) == 0) return null;
+    return hwnd;
+}
+
+fn ensureFallbackWindowLocked() ?HWND {
+    if (validWindow(tray.callback_hwnd)) |hwnd| {
+        if (tray.owns_callback_hwnd) return hwnd;
+    }
 
     const hInstance = GetModuleHandleW(null);
     const tray_class = std.unicode.utf8ToUtf16LeStringLiteral("WispTermTrayCallback");
@@ -226,30 +279,41 @@ fn ensureTrayLocked() bool {
         tray.class_registered = true;
     }
 
-    if (tray.msg_hwnd == null) {
-        tray.msg_hwnd = CreateWindowExW(
-            0,
-            tray_class,
-            std.unicode.utf8ToUtf16LeStringLiteral(""),
-            0,
-            0,
-            0,
-            0,
-            0,
-            HWND_MESSAGE,
-            null,
-            hInstance,
-            null,
-        ) orelse return false;
-    }
+    const hwnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW,
+        tray_class,
+        std.unicode.utf8ToUtf16LeStringLiteral(""),
+        WS_POPUP,
+        0,
+        0,
+        0,
+        0,
+        null,
+        null,
+        hInstance,
+        null,
+    ) orelse return null;
+    tray.callback_hwnd = hwnd;
+    tray.owns_callback_hwnd = true;
+    return hwnd;
+}
 
+/// Lazily register the tray icon against the best available HWND.
+/// Caller must hold tray.mutex.
+fn ensureTrayLocked() bool {
+    if (tray.icon_added) return true;
+
+    const callback_hwnd = resolveCallbackHwndLocked() orelse return false;
+    tray.callback_hwnd = callback_hwnd;
+
+    const hInstance = GetModuleHandleW(null);
     const icon = LoadImageW(hInstance, APP_ICON_RESOURCE_ID, IMAGE_ICON, 0, 0, LR_SHARED) orelse
         LoadIconW(null, IDI_APPLICATION) orelse return false;
     tray.icon = icon;
 
     var data = std.mem.zeroes(NOTIFYICONDATAW);
     data.cbSize = @sizeOf(NOTIFYICONDATAW);
-    data.hWnd = tray.msg_hwnd.?;
+    data.hWnd = callback_hwnd;
     data.uID = TRAY_ICON_ID;
     data.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
     data.uCallbackMessage = TRAY_CALLBACK_MSG;
@@ -257,7 +321,7 @@ fn ensureTrayLocked() bool {
     copyUtf16Truncated(&data.szTip, "WispTerm");
     if (Shell_NotifyIconW(NIM_ADD, &data) == 0) return false;
 
-    // Version 4: balloon clicks arrive as NIN_BALLOONUSERCLICK.
+    // Version 4: balloon clicks arrive as NIN_BALLOONUSERCLICK in LOWORD(lParam).
     data.uVersion = NOTIFYICON_VERSION_4;
     _ = Shell_NotifyIconW(NIM_SETVERSION, &data);
 
@@ -265,30 +329,82 @@ fn ensureTrayLocked() bool {
     return true;
 }
 
-/// Tray callback receiver (runs on the thread that created the message-only
-/// window, which pumps messages as part of the normal render loop).
+/// Fallback-window WndProc (used only when no real window is bound yet).
 fn trayWndProc(hwnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT {
-    if (msg == TRAY_CALLBACK_MSG and wParam == TRAY_ICON_ID) {
-        // With NOTIFYICON_VERSION_4 the event code is in LOWORD(lParam).
-        const event: UINT = @as(u16, @truncate(@as(u64, @bitCast(lParam))));
-        if (event == NIN_BALLOONUSERCLICK) {
-            tray.mutex.lock();
-            const cached = tray.main_hwnd;
-            tray.mutex.unlock();
-            if (cached orelse findMainWindow()) |main_hwnd| {
-                if (IsIconic(main_hwnd) != 0) _ = ShowWindow(main_hwnd, SW_RESTORE);
-                _ = SetForegroundWindow(main_hwnd);
-            }
-            return 0;
-        }
+    if (handleCallback(msg, wParam, lParam)) return 0;
+    // The shell may activate this hidden popup on toast click instead of
+    // (or in addition to) posting NIN_BALLOONUSERCLICK.
+    if (msg == WM_ACTIVATE and wParam != 0) {
+        presentMainWindow();
+        return 0;
     }
     return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
+/// Called from the main window WndProc (and the fallback popup). True when
+/// the message is a tray/toast click that we consumed.
+pub fn handleCallback(msg: UINT, wParam: WPARAM, lParam: LPARAM) bool {
+    if (tray_callback.decode(msg, wParam, lParam) == null) return false;
+    presentMainWindow();
+    return true;
+}
+
+fn presentMainWindow() void {
+    tray.mutex.lock();
+    const cached = tray.main_hwnd;
+    const skip = fallbackSkipLocked();
+    tray.mutex.unlock();
+    if (validWindow(cached) orelse findMainWindowSkipping(skip)) |main_hwnd| {
+        forceForegroundWindow(main_hwnd);
+    }
+}
+
+/// Restore / show / steal focus. Toast clicks arrive from explorer /
+/// ShellExperienceHost, so a bare `SetForegroundWindow` is usually denied
+/// by the foreground lock; attach to the current foreground thread and
+/// briefly go topmost if that is still not enough.
+fn forceForegroundWindow(hwnd: HWND) void {
+    if (IsIconic(hwnd) != 0) {
+        _ = ShowWindow(hwnd, SW_RESTORE);
+    } else if (IsWindowVisible(hwnd) == 0) {
+        _ = ShowWindow(hwnd, SW_SHOW);
+    }
+
+    if (GetForegroundWindow() == hwnd) return;
+
+    const this_thread = GetCurrentThreadId();
+    var attached = false;
+    var fg_thread: DWORD = 0;
+    if (GetForegroundWindow()) |fg_hwnd| {
+        fg_thread = GetWindowThreadProcessId(fg_hwnd, null);
+        if (fg_thread != 0 and fg_thread != this_thread) {
+            attached = AttachThreadInput(fg_thread, this_thread, 1) != 0;
+        }
+    }
+
+    _ = BringWindowToTop(hwnd);
+    _ = SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+    _ = SetForegroundWindow(hwnd);
+
+    if (attached) {
+        _ = AttachThreadInput(fg_thread, this_thread, 0);
+    }
+
+    if (GetForegroundWindow() != hwnd) {
+        _ = SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        _ = SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+        _ = SetForegroundWindow(hwnd);
+    }
+    if (GetForegroundWindow() != hwnd) {
+        SwitchToThisWindow(hwnd, 1);
+    }
+}
+
 /// Fallback main-window lookup: first visible top-level window owned by this
-/// process (the message-only tray window is not top-level and never matches).
+/// process (the hidden tray popup is never shown and does not match).
 const FindCtx = struct {
     pid: DWORD,
+    skip: ?HWND = null,
     hwnd: ?HWND = null,
 };
 
@@ -297,14 +413,20 @@ fn enumWindowsProc(hwnd: HWND, lParam: LPARAM) callconv(.winapi) BOOL {
     var pid: DWORD = 0;
     _ = GetWindowThreadProcessId(hwnd, &pid);
     if (pid == ctx.pid and IsWindowVisible(hwnd) != 0) {
+        if (ctx.skip) |skip| {
+            if (hwnd == skip) return 1;
+        }
         ctx.hwnd = hwnd;
         return 0; // stop enumerating
     }
     return 1;
 }
 
-fn findMainWindow() ?HWND {
-    var ctx = FindCtx{ .pid = GetCurrentProcessId() };
+fn findMainWindowSkipping(skip: ?HWND) ?HWND {
+    var ctx = FindCtx{
+        .pid = GetCurrentProcessId(),
+        .skip = skip,
+    };
     _ = EnumWindows(enumWindowsProc, @bitCast(@as(isize, @intCast(@intFromPtr(&ctx)))));
     return ctx.hwnd;
 }
@@ -320,8 +442,7 @@ pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
         // The callback window may have lived on a window thread that has
         // since exited (the system destroys it with the thread), leaving a
         // stale HWND. Drop the dead state and rebuild the tray icon once.
-        tray.icon_added = false;
-        tray.msg_hwnd = null;
+        dropTrayRegistrationLocked();
         if (ensureTrayLocked() and sendBalloonLocked(title, body)) {
             std.log.debug("toast: tray balloon sent after tray rebuild, title={s}", .{title});
         } else {
@@ -337,7 +458,7 @@ pub fn showDesktopNotification(title: [:0]const u8, body: [:0]const u8) void {
 fn sendBalloonLocked(title: [:0]const u8, body: [:0]const u8) bool {
     var data = std.mem.zeroes(NOTIFYICONDATAW);
     data.cbSize = @sizeOf(NOTIFYICONDATAW);
-    data.hWnd = tray.msg_hwnd.?;
+    data.hWnd = tray.callback_hwnd.?;
     data.uID = TRAY_ICON_ID;
     data.uFlags = NIF_INFO;
     copyUtf16Truncated(&data.szInfoTitle, title);
@@ -354,25 +475,31 @@ pub fn notificationAuthStatus() u8 {
 
 pub fn requestNotificationAuth() void {}
 
-/// Remove the tray icon and destroy the callback window. Called once from the
-/// app shutdown path; safe to call when nothing was ever initialized.
+fn dropTrayRegistrationLocked() void {
+    if (tray.icon_added) {
+        if (tray.callback_hwnd) |hwnd| {
+            var data = std.mem.zeroes(NOTIFYICONDATAW);
+            data.cbSize = @sizeOf(NOTIFYICONDATAW);
+            data.hWnd = hwnd;
+            data.uID = TRAY_ICON_ID;
+            _ = Shell_NotifyIconW(NIM_DELETE, &data);
+        }
+        tray.icon_added = false;
+    }
+    if (tray.owns_callback_hwnd) {
+        if (tray.callback_hwnd) |hwnd| {
+            _ = DestroyWindow(hwnd);
+        }
+        tray.owns_callback_hwnd = false;
+    }
+    tray.callback_hwnd = null;
+}
+
+/// Remove the tray icon and destroy any fallback callback window. Called once
+/// from the app shutdown path; safe to call when nothing was ever initialized.
 pub fn cleanup() void {
     tray.mutex.lock();
     defer tray.mutex.unlock();
-    if (tray.icon_added) {
-        var data = std.mem.zeroes(NOTIFYICONDATAW);
-        data.cbSize = @sizeOf(NOTIFYICONDATAW);
-        data.hWnd = tray.msg_hwnd.?;
-        data.uID = TRAY_ICON_ID;
-        _ = Shell_NotifyIconW(NIM_DELETE, &data);
-        tray.icon_added = false;
-    }
-    // The message window may have been created on a window thread that has
-    // already exited (the system destroys it with the thread); a cross-thread
-    // DestroyWindow simply fails and is ignored.
-    if (tray.msg_hwnd) |hwnd| {
-        _ = DestroyWindow(hwnd);
-        tray.msg_hwnd = null;
-    }
+    dropTrayRegistrationLocked();
     tray.main_hwnd = null;
 }

--- a/src/platform/notify_tray_callback.zig
+++ b/src/platform/notify_tray_callback.zig
@@ -1,0 +1,83 @@
+//! Decode `Shell_NotifyIcon` callback messages.
+//!
+//! With `NOTIFYICON_VERSION_4` the shell packs the event in `LOWORD(lParam)`
+//! and the icon id in `HIWORD(lParam)`. `wParam` is the mouse coordinate, not
+//! the icon id (that was the pre-v4 layout). The decoder is integer-only so
+//! it can be unit-tested on every host. Ghostty's GTK notifications set
+//! `app.present-surface` as the default action so a click presents the app;
+//! this is the Windows equivalent of recognizing that click.
+
+const std = @import("std");
+
+pub const tray_callback_msg: u32 = 0x8000 + 0x4E; // WM_APP + 'N'
+pub const tray_icon_id: u32 = 1;
+
+const wm_user: u32 = 0x0400;
+pub const nin_select: u32 = wm_user + 0;
+pub const nin_keyselect: u32 = wm_user + 1;
+pub const nin_balloon_user_click: u32 = wm_user + 5;
+pub const wm_lbuttonup: u32 = 0x0202;
+
+pub const Click = enum { balloon, icon };
+
+/// `wparam`/`lparam` match the Win32 `WPARAM`/`LPARAM` integer widths.
+pub fn decode(msg: u32, wparam: usize, lparam: isize) ?Click {
+    if (msg != tray_callback_msg) return null;
+    _ = wparam;
+    const raw: u64 = @bitCast(@as(i64, lparam));
+    const event: u32 = @as(u16, @truncate(raw));
+    return switch (event) {
+        nin_balloon_user_click => .balloon,
+        nin_select, nin_keyselect, wm_lbuttonup => .icon,
+        else => null,
+    };
+}
+
+fn packLParam(lo: u16, hi: u16) isize {
+    const packed_val: u32 = @as(u32, lo) | (@as(u32, hi) << 16);
+    return @intCast(packed_val);
+}
+
+test "VERSION_4 balloon click is in LOWORD(lParam); wParam is coordinates" {
+    const wparam: usize = 0x00C8_0064; // y=200, x=100 — never equals the icon id
+    const lparam = packLParam(nin_balloon_user_click, tray_icon_id);
+    try std.testing.expectEqual(Click.balloon, decode(tray_callback_msg, wparam, lparam).?);
+    try std.testing.expect(wparam != tray_icon_id);
+}
+
+test "pre-v4 balloon click still decodes (event in lParam, icon id in wParam)" {
+    try std.testing.expectEqual(
+        Click.balloon,
+        decode(tray_callback_msg, tray_icon_id, nin_balloon_user_click).?,
+    );
+}
+
+test "tray icon select and left-click also count as activation" {
+    try std.testing.expectEqual(
+        Click.icon,
+        decode(tray_callback_msg, 0, packLParam(nin_select, tray_icon_id)).?,
+    );
+    try std.testing.expectEqual(
+        Click.icon,
+        decode(tray_callback_msg, 0, packLParam(nin_keyselect, tray_icon_id)).?,
+    );
+    try std.testing.expectEqual(
+        Click.icon,
+        decode(tray_callback_msg, 0, packLParam(wm_lbuttonup, tray_icon_id)).?,
+    );
+}
+
+test "unrelated messages and balloon timeout are ignored" {
+    const nin_balloon_timeout: u32 = wm_user + 4;
+    try std.testing.expectEqual(@as(?Click, null), decode(0x0010, 0, 0));
+    try std.testing.expectEqual(
+        @as(?Click, null),
+        decode(tray_callback_msg, 0, packLParam(nin_balloon_timeout, tray_icon_id)),
+    );
+}
+
+test "windows toast handler uses the VERSION_4 decoder, not wParam as icon id" {
+    const source = @embedFile("notifications_windows.zig");
+    try std.testing.expect(std.mem.indexOf(u8, source, "wParam == TRAY_ICON_ID") == null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "tray_callback.decode") != null);
+}

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -393,6 +393,7 @@ test {
     _ = @import("render_diagnostics.zig");
     _ = @import("diag_log.zig");
     _ = @import("notification.zig");
+    _ = @import("platform/notify_tray_callback.zig");
     _ = @import("clipboard_osc52.zig");
     _ = @import("renderer/gpu/backend.zig");
     // Performance benchmark core (pure modules). cli.zig is excluded here


### PR DESCRIPTION
## Summary

Clicking a task-complete desktop toast on Windows did not focus WispTerm (#597).

`NOTIFYICON_VERSION_4` delivers balloon/toast clicks with the event in `LOWORD(lParam)` and mouse coordinates in `wParam`. The handler still treated `wParam` as the tray icon id (the pre-v4 layout), so clicks were dropped. The icon was also registered on a message-only window, which Windows 10/11 cannot activate.

This change:

- decodes VERSION_4 tray callbacks correctly
- registers the tray icon against the real WispTerm window
- restores/shows the window and force-foregrounds it on click (Ghostty GTK uses `app.present-surface` for the same present-on-click contract)
- binds the window before showing a toast and routes the callback through the main `WndProc`

## Testing

- `zig test src/platform/notify_tray_callback.zig`
- `zig build test`
- `zig build` (`x86_64-windows-gnu`)
- `zig build test-full` compiled cleanly; remaining failures are pre-existing WSL path issues in memory-digest/recipe tests

Closes #597