### PR TITLE
Fix Linux first-launch freeze: SDL event pump in pollEvents

### DIFF
--- a/src/apprt/sdl.zig
+++ b/src/apprt/sdl.zig
@@ -266,6 +266,12 @@ pub const Window = struct {
     // -----------------------------------------------------------------------
 
     pub fn pollEvents(self: *Window) bool {
+        // Non-blocking drain of all pending SDL events. This mirrors the macOS/Windows
+        // behavior where pollEvents actively pumps the platform event queue rather than
+        // being a pure liveness check. Without this, SDL events accumulate unprocessed
+        // until the render gate blocks (rare when overlays are active), causing input
+        // to appear frozen while the loop burns CPU redrawing the same state.
+        pumpAppEvents(0);
         return !self.close_requested;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Debian 13 (Trixie) XFCE, WispTerm v1.33.1 AppImage starts but is completely unusable on first launch:

- **Quick Configure AI overlay appears** but cannot be interacted with
- **No input works**: Escape, arrow keys, clicks, typing - all ignored
- **High CPU usage** (~300% in a busy loop)
- **UI never progresses** - screenshots stay pixel-identical, can't reach a terminal

## Root Cause

On Linux, `Window.pollEvents()` in `src/apprt/sdl.zig` was a pure liveness check:

```zig
pub fn pollEvents(self: *Window) bool {
    return !self.close_requested;
}
```

This differs from macOS/Windows where `pollEvents()` **actively drains** the platform event queue.

The main loop (`AppWindow.zig` line 8023) calls `pollEvents()` every frame:

```zig
running = window_backend.pollEvents(win) and !g_should_close;
```

But it only calls the **blocking** `pumpAppEvents(timeout)` when the render gate decides not to render (lines 8121, 8159). 

When the Quick Configure AI overlay is active:
- `overlays.anyOverlayActive()` returns `true`
- `needs_render` stays `true` (line 8152)
- The blocking pump **never runs**
- SDL events accumulate unprocessed
- Input appears frozen
- The loop burns CPU redrawing the same state

## Solution

Call `pumpAppEvents(0)` inside `pollEvents()` to **non-blocking drain** all pending SDL events every frame, matching macOS/Windows behavior:

```zig
pub fn pollEvents(self: *Window) bool {
    pumpAppEvents(0);  // Non-blocking drain
    return !self.close_requested;
}
```

This ensures keyboard, mouse, and window events are always processed regardless of render-gate state.

## Test Plan

1. **First launch test**:
   - Fresh Linux install or delete `~/.config/wispterm/`, `~/.local/share/wispterm/`
   - Run WispTerm AppImage
   - **Expected**: Quick Configure AI overlay is interactive
     - Arrow keys navigate (Up/Down move focus)
     - Escape closes the overlay
     - Typing in API Key field works
     - Clicks respond
     - Can reach a usable terminal prompt

2. **Skip wizard test**:
   - Press Escape to dismiss the Quick Configure AI overlay
   - **Expected**: Reach a working shell prompt immediately
   - Type a command (e.g., `echo test`)
   - **Expected**: Command runs, no API key required

3. **CPU usage test**:
   - Monitor `top` or `htop` while overlay is visible
   - **Expected**: <10% CPU when idle, not 300%

4. **General input test**:
   - Overlays: Command Palette (Ctrl+P), Settings (Ctrl+,)
   - **Expected**: All overlays respond to keyboard/mouse immediately

## Impact

- **Fixes**: Linux first-launch freeze (showstopper)
- **Improves**: Input responsiveness in all overlay states
- **Risk**: Low - matches existing macOS/Windows pattern, no logic changes
- **Platforms**: Linux only (`src/apprt/sdl.zig` is Linux-specific)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbdf2450-1272-422d-80ed-a45ae02f9fe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbdf2450-1272-422d-80ed-a45ae02f9fe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

