### PR TITLE
Fix Linux titlebar: exclude interactive buttons from drag region

### DIFF
--- a/src/apprt/sdl.zig
+++ b/src/apprt/sdl.zig
@@ -345,22 +345,39 @@ fn hitTest(
 ) callconv(.c) c.SDL_HitTestResult {
     _ = win;
     const self: *Window = @ptrCast(@alignCast(data orelse return c.SDL_HITTEST_NORMAL));
-    // Exclude the caption-button cluster from the draggable titlebar so clicks
-    // reach the host (which performs minimize/maximize/close) instead of being
-    // swallowed as a window-move.
+    // Exclude all interactive titlebar buttons from the draggable titlebar so clicks
+    // reach the host instead of being swallowed as a window-move. This includes the
+    // toggle/hamburger button at the left, the config/help/copilot buttons before the
+    // caption buttons, and the caption-button cluster (min/max/close) at the right.
     const cap_w: i32 = @intFromFloat(platform_window.caption_button_width);
-    const caption_excl = [_]window_drag_region.Rect{.{
-        .x = self.width - cap_w * 3,
-        .y = 0,
-        .w = cap_w * 3,
-        .h = self.titlebar_height,
-    }};
+    const toggle_w: i32 = 46;
+    const config_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
+    const help_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
+    const copilot_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
+    
+    const caption_start = self.width - cap_w * 3;
+    const config_x = caption_start - config_w;
+    const help_x = config_x - help_w;
+    const copilot_x = help_x - copilot_w;
+    
+    const exclusions = [_]window_drag_region.Rect{
+        // Toggle/hamburger button at left
+        .{ .x = 0, .y = 0, .w = toggle_w, .h = self.titlebar_height },
+        // Copilot button (before help)
+        .{ .x = copilot_x, .y = 0, .w = copilot_w, .h = self.titlebar_height },
+        // Help button (before config)
+        .{ .x = help_x, .y = 0, .w = help_w, .h = self.titlebar_height },
+        // Config/gear button (before caption buttons)
+        .{ .x = config_x, .y = 0, .w = config_w, .h = self.titlebar_height },
+        // Caption buttons (min/max/close)
+        .{ .x = caption_start, .y = 0, .w = cap_w * 3, .h = self.titlebar_height },
+    };
     const hit = window_drag_region.classify(
         self.width,
         self.height,
         area.*.x,
         area.*.y,
-        .{ .titlebar_height = self.titlebar_height, .border = 4, .exclusions = &caption_excl },
+        .{ .titlebar_height = self.titlebar_height, .border = 4, .exclusions = &exclusions },
     );
     return switch (hit) {
         .normal => c.SDL_HITTEST_NORMAL,

--- a/src/apprt/sdl.zig
+++ b/src/apprt/sdl.zig
@@ -354,12 +354,12 @@ fn hitTest(
     const config_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
     const help_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
     const copilot_w: i32 = if (builtin.os.tag == .macos) 0 else 46;
-    
+
     const caption_start = self.width - cap_w * 3;
     const config_x = caption_start - config_w;
     const help_x = config_x - help_w;
     const copilot_x = help_x - copilot_w;
-    
+
     const exclusions = [_]window_drag_region.Rect{
         // Toggle/hamburger button at left
         .{ .x = 0, .y = 0, .w = toggle_w, .h = self.titlebar_height },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Linux SDL hit-testing only excluded the caption buttons (min/max/close) from the draggable titlebar, causing clicks on the hamburger/menu toggle button to incorrectly trigger a window drag operation. This resulted in:
- Clicking the hamburger started a window move instead of opening the menu
- Window jumped far right/down (~+578px/+285px reported), putting controls off-screen
- Window became effectively unmovable via titlebar drag or maximize
- Settings/window controls were unreachable on 1280×800 displays

## Solution

Extended SDL hit-test exclusions to cover all interactive titlebar buttons:
- Toggle/hamburger button (46px at left)
- Copilot button (46px, before help)
- Help button (46px, before config)
- Config/gear button (46px, before caption buttons)
- Caption buttons (3×46px min/max/close at right)

On macOS, config/help/copilot buttons have zero width and are not drawn (native menu bar is used), so their exclusions collapse to zero-width rects that don't affect hit-testing.

## Test Plan

### Manual verification on Linux (Debian 13 XFCE-like, 1280×800)

1. **Hamburger/menu button click** (left titlebar):
   - Single left-click on the hamburger icon
   - ✓ Expected: Opens command center/menu (or does nothing if not implemented), does NOT start window drag
   - ✗ Before: Window enters drag state and jumps off-screen

2. **Titlebar drag** (empty region):
   - Click and drag on empty titlebar area between hamburger and config buttons
   - ✓ Expected: Window moves smoothly following the mouse
   - Note: Titlebar should still be draggable in non-button regions

3. **Config/gear button click** (right titlebar, before caption buttons):
   - Single left-click on settings gear icon
   - ✓ Expected: Opens settings overlay, does NOT start window drag

4. **Help button click** (right titlebar, before config):
   - Single left-click on help/? icon
   - ✓ Expected: Opens help overlay, does NOT start window drag

5. **Window controls remain reachable**:
   - All window controls (help, settings gear, min/max/close) visible on screen
   - ✓ Expected: Controls stay within 1280×800 bounds after any titlebar interaction

6. **Double-click maximize** (empty titlebar region):
   - Double-click on empty titlebar area
   - ✓ Expected: Window maximizes/restores

7. **Caption buttons** (min/max/close):
   - Click each caption button
   - ✓ Expected: Each performs its action (minimize/maximize/close)

### Regression check
- Build succeeds: `zig build`
- Fast tests pass: `zig build test`
- Full tests pass: `zig build test-full`

## Related

- Follows the same exclusion pattern as Windows non-client hit-testing
- Matches button layout from `src/renderer/titlebar.zig` and `src/renderer/titlebar_layout.zig`
- SDL hit-test implementation: `src/apprt/sdl.zig` lines 341-377
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a04fd52-6035-49e0-82d8-2c9ea52005c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a04fd52-6035-49e0-82d8-2c9ea52005c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

