### PR TITLE
Fix Linux keyboard shortcuts: paste, command center, and split panes

### DIFF
--- a/LINUX_SHORTCUT_TEST_PLAN.md
+++ b/LINUX_SHORTCUT_TEST_PLAN.md
@@ -1,0 +1,78 @@
+# Linux Keyboard Shortcut Test Plan
+
+## Issue
+Several documented keyboard shortcuts were non-functional on Linux (Debian 13, XFCE):
+1. Paste: `Ctrl+V` (and `Ctrl+Shift+V`)
+2. Command center: `Ctrl+Shift+P`
+3. Split right/down: `Ctrl+Shift++` / `Ctrl+Shift+-`
+
+## Root Cause
+SDL3 event handler only processed special keys (arrows, F-keys) via scancode lookup. Alphanumeric keys with modifiers returned null from `keyCodeFromScancode()`, so no KeyEvent was created.
+
+## Fix
+- Added `keyCodeFromSdlKeycode()` to map SDL logical keycodes to neutral key codes
+- Updated SDL_EVENT_KEY_DOWN handler to check keycode when scancode fails and modifiers are pressed
+- Preserves existing behavior for text input without modifiers
+
+## Test Procedure
+
+### Prerequisites
+- Linux system with X11 or Wayland
+- WispTerm built from branch `cursor/fix-linux-keyboard-shortcuts-1b5a`
+
+### Build
+```bash
+cd /workspace
+zig build
+```
+
+### Test 1: Paste in Terminal (Ctrl+V)
+1. Open a browser and copy text: `echo hello-user`
+2. Launch WispTerm: `./zig-out/bin/wispterm`
+3. Press `Ctrl+V` in the terminal
+4. **Expected**: Text appears at the prompt
+5. **Verify**: Can also test `Ctrl+Shift+V` (paste image fallback)
+
+### Test 2: Command Center (Ctrl+Shift+P)
+1. With WispTerm open, press `Ctrl+Shift+P`
+2. **Expected**: Command palette/center opens with search field
+3. Type a few characters to verify search works
+4. Press `Escape` to close
+5. **Verify**: Can also test `Ctrl+P` (documented alternate)
+
+### Test 3: Split Panes (Ctrl+Shift++ and Ctrl+Shift+-)
+1. Press `Ctrl+Shift++` (or `Ctrl+Shift+=` depending on keyboard)
+2. **Expected**: New pane appears to the right of current pane
+3. Press `Ctrl+Shift+-`
+4. **Expected**: New pane appears below current pane
+5. **Verify**: Can navigate between panes with `Alt+Arrow` keys
+
+### Test 4: Existing Shortcuts Still Work
+1. Copy text: Select with mouse, press `Ctrl+Shift+C`
+2. **Expected**: Text copied to clipboard, can paste in browser
+3. New tab: `Ctrl+Shift+T`
+4. **Expected**: New tab opens
+5. Settings: `Ctrl+,`
+6. **Expected**: Settings page opens
+
+### Test 5: Normal Typing Unaffected
+1. Type regular text without modifiers: `ls -la`
+2. **Expected**: Characters appear normally
+3. Type with Shift: `HELLO`
+4. **Expected**: Uppercase letters appear
+5. **Verify**: No double input or missing characters
+
+## Regression Checks
+- Arrow keys work: `Up`, `Down`, `Left`, `Right`
+- F5 works (if bound to a function)
+- Tab completion works: type `cd /h` then `Tab`
+- Escape works to close overlays
+- Mouse copy/paste still works
+
+## Known Limitations
+- No changes to Windows or macOS input handling
+- SDL3-specific fix (does not affect other backends)
+- Keyboard layout dependent (QWERTY tested)
+
+## Exit Criteria
+All 5 test procedures pass without errors or unexpected behavior.

--- a/src/apprt/sdl.zig
+++ b/src/apprt/sdl.zig
@@ -514,35 +514,22 @@ fn processEvent(event: c.SDL_Event) void {
             if (g_registry.find(win_id)) |ptr| {
                 const w: *Window = @ptrCast(@alignCast(ptr));
                 const m = keymap.modifiers(@intCast(event.key.mod));
-                
-                // Try scancode first for special keys (arrows, F-keys, etc.)
                 const sc: u32 = @intCast(event.key.scancode);
-                if (keymap.keyCodeFromScancode(sc)) |code| {
+                const code = keymap.keyCodeFromScancode(sc) orelse blk: {
+                    // Printable keys normally arrive via TEXT_INPUT. With a
+                    // shortcut modifier, map the logical keycode (then scancode)
+                    // so Ctrl+V / Ctrl+Shift+P / Ctrl+Shift+= reach keybinds.
+                    if (!(m.ctrl or m.alt or m.super)) break :blk null;
+                    break :blk keymap.shortcutKeyCode(sc, @intCast(event.key.key));
+                };
+                if (code) |key_code| {
                     w.key_events.push(.{
-                        .key_code = code,
+                        .key_code = key_code,
                         .ctrl = m.ctrl,
                         .shift = m.shift,
                         .alt = m.alt,
                         .super = m.super,
                     });
-                } else {
-                    // Scancode didn't map to a special key. If any modifier
-                    // (Ctrl, Alt, Super) is pressed, this is likely a shortcut,
-                    // so try the SDL keycode (logical key) for alphanumerics.
-                    // Without modifiers, let it go to TEXT_INPUT.
-                    const has_shortcut_mod = m.ctrl or m.alt or m.super;
-                    if (has_shortcut_mod) {
-                        const kc: u32 = @intCast(event.key.key);
-                        if (keymap.keyCodeFromSdlKeycode(kc)) |code| {
-                            w.key_events.push(.{
-                                .key_code = code,
-                                .ctrl = m.ctrl,
-                                .shift = m.shift,
-                                .alt = m.alt,
-                                .super = m.super,
-                            });
-                        }
-                    }
                 }
             }
         },

--- a/src/apprt/sdl.zig
+++ b/src/apprt/sdl.zig
@@ -503,14 +503,21 @@ fn processEvent(event: c.SDL_Event) void {
         // ---------------------------------------------------------------
         // Keyboard: key-down → KeyEvent (key-up discarded; no press/release
         //           in neutral layer), text-input → CharEvent.
+        //
+        // SDL3 provides both scancode (hardware position) and keycode (logical
+        // key). Special keys (arrows, F-keys, etc.) use scancode; alphanumeric
+        // keys with modifiers (Ctrl+V, Ctrl+Shift+P, etc.) use keycode so the
+        // keybind system can match them regardless of keyboard layout.
         // ---------------------------------------------------------------
         c.SDL_EVENT_KEY_DOWN => {
             const win_id = event.key.windowID;
             if (g_registry.find(win_id)) |ptr| {
                 const w: *Window = @ptrCast(@alignCast(ptr));
+                const m = keymap.modifiers(@intCast(event.key.mod));
+                
+                // Try scancode first for special keys (arrows, F-keys, etc.)
                 const sc: u32 = @intCast(event.key.scancode);
                 if (keymap.keyCodeFromScancode(sc)) |code| {
-                    const m = keymap.modifiers(@intCast(event.key.mod));
                     w.key_events.push(.{
                         .key_code = code,
                         .ctrl = m.ctrl,
@@ -518,6 +525,24 @@ fn processEvent(event: c.SDL_Event) void {
                         .alt = m.alt,
                         .super = m.super,
                     });
+                } else {
+                    // Scancode didn't map to a special key. If any modifier
+                    // (Ctrl, Alt, Super) is pressed, this is likely a shortcut,
+                    // so try the SDL keycode (logical key) for alphanumerics.
+                    // Without modifiers, let it go to TEXT_INPUT.
+                    const has_shortcut_mod = m.ctrl or m.alt or m.super;
+                    if (has_shortcut_mod) {
+                        const kc: u32 = @intCast(event.key.key);
+                        if (keymap.keyCodeFromSdlKeycode(kc)) |code| {
+                            w.key_events.push(.{
+                                .key_code = code,
+                                .ctrl = m.ctrl,
+                                .shift = m.shift,
+                                .alt = m.alt,
+                                .super = m.super,
+                            });
+                        }
+                    }
                 }
             }
         },

--- a/src/input/sdl_keymap.zig
+++ b/src/input/sdl_keymap.zig
@@ -39,6 +39,34 @@ pub fn keyCodeFromScancode(scancode: u32) ?ev.KeyCode {
     };
 }
 
+/// SDL3 keycode → neutral KeyCode for alphanumeric and punctuation keys.
+/// Returns uppercase letters ('A'-'Z'), digits ('0'-'9'), and common punctuation.
+/// Returns null for keys that should be handled via scancode or text input.
+pub fn keyCodeFromSdlKeycode(keycode: u32) ?ev.KeyCode {
+    // SDL keycodes for lowercase letters are 'a'-'z' (97-122)
+    // SDL keycodes for uppercase letters are 'A'-'Z' (65-90)
+    // Convert lowercase to uppercase for consistency with Windows/macOS keybind system
+    if (keycode >= 'a' and keycode <= 'z') {
+        return keycode - ('a' - 'A');
+    }
+    // Uppercase letters and digits are their ASCII values
+    if ((keycode >= 'A' and keycode <= 'Z') or (keycode >= '0' and keycode <= '9')) {
+        return keycode;
+    }
+    // Common punctuation that may be used in shortcuts
+    // These match the Key constants in keybind.zig
+    return switch (keycode) {
+        '`' => 0xC0, // backquote
+        ',' => 0xBC, // comma
+        '+' => 0xBB, // plus
+        '=' => 0xBB, // equal (same as plus for keybinds)
+        '-' => 0xBD, // minus
+        '[' => 0xDB, // bracket_left
+        ']' => 0xDD, // bracket_right
+        else => null,
+    };
+}
+
 /// SDL3 keymod bitmask (KMOD_*) → neutral modifier flags.
 pub fn modifiers(mod: u16) Mods {
     return .{
@@ -65,4 +93,20 @@ test "modifier bitmask decodes to neutral flags" {
     try std.testing.expect(m.ctrl and m.shift and !m.alt and !m.super);
     const g = modifiers(0x0400); // KMOD_LGUI
     try std.testing.expect(g.super and !g.ctrl);
+}
+
+test "SDL keycode maps alphanumeric keys to uppercase for shortcuts" {
+    // Lowercase letters convert to uppercase
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), keyCodeFromSdlKeycode('v'));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'P'), keyCodeFromSdlKeycode('p'));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'C'), keyCodeFromSdlKeycode('c'));
+    // Uppercase letters pass through
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'A'), keyCodeFromSdlKeycode('A'));
+    // Digits pass through
+    try std.testing.expectEqual(@as(?ev.KeyCode, '1'), keyCodeFromSdlKeycode('1'));
+    try std.testing.expectEqual(@as(?ev.KeyCode, '9'), keyCodeFromSdlKeycode('9'));
+    // Common punctuation used in shortcuts
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('+')); // plus
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('=')); // equal (same as plus)
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBD), keyCodeFromSdlKeycode('-')); // minus
 }

--- a/src/input/sdl_keymap.zig
+++ b/src/input/sdl_keymap.zig
@@ -41,30 +41,43 @@ pub fn keyCodeFromScancode(scancode: u32) ?ev.KeyCode {
 
 /// SDL3 keycode → neutral KeyCode for alphanumeric and punctuation keys.
 /// Returns uppercase letters ('A'-'Z'), digits ('0'-'9'), and common punctuation.
-/// Returns null for keys that should be handled via scancode or text input.
+/// Also accepts Ctrl-letter control codes (0x01-0x1A) that some X11 paths emit.
 pub fn keyCodeFromSdlKeycode(keycode: u32) ?ev.KeyCode {
-    // SDL keycodes for lowercase letters are 'a'-'z' (97-122)
-    // SDL keycodes for uppercase letters are 'A'-'Z' (65-90)
-    // Convert lowercase to uppercase for consistency with Windows/macOS keybind system
-    if (keycode >= 'a' and keycode <= 'z') {
-        return keycode - ('a' - 'A');
-    }
-    // Uppercase letters and digits are their ASCII values
-    if ((keycode >= 'A' and keycode <= 'Z') or (keycode >= '0' and keycode <= '9')) {
-        return keycode;
-    }
-    // Common punctuation that may be used in shortcuts
-    // These match the Key constants in keybind.zig
+    // Some Linux/X11 paths report Ctrl+V as 0x16 rather than 'v'.
+    if (keycode >= 1 and keycode <= 26) return 'A' + (keycode - 1);
+    if (keycode >= 'a' and keycode <= 'z') return keycode - ('a' - 'A');
+    if ((keycode >= 'A' and keycode <= 'Z') or (keycode >= '0' and keycode <= '9')) return keycode;
     return switch (keycode) {
-        '`' => 0xC0, // backquote
-        ',' => 0xBC, // comma
-        '+' => 0xBB, // plus
-        '=' => 0xBB, // equal (same as plus for keybinds)
-        '-' => 0xBD, // minus
+        '`' => 0xC0, // backquote / Key.backquote
+        ',' => 0xBC, // comma / Key.comma
+        '+', '=' => 0xBB, // plus/equal / Key.plus
+        '-' => 0xBD, // minus / Key.minus
         '[' => 0xDB, // bracket_left
         ']' => 0xDD, // bracket_right
         else => null,
     };
+}
+
+/// SDL3 scancode → shortcut KeyCode for letters, digits, and punctuation used
+/// by default keybinds. Used when the logical keycode is 0 / unmapped.
+pub fn keyCodeFromShortcutScancode(scancode: u32) ?ev.KeyCode {
+    return switch (scancode) {
+        4...29 => 'A' + (scancode - 4), // SDL_SCANCODE_A..Z
+        30...38 => '1' + (scancode - 30), // SDL_SCANCODE_1..9
+        39 => '0', // SDL_SCANCODE_0
+        45 => 0xBD, // SDL_SCANCODE_MINUS
+        46 => 0xBB, // SDL_SCANCODE_EQUALS (Key.plus)
+        47 => 0xDB, // SDL_SCANCODE_LEFTBRACKET
+        48 => 0xDD, // SDL_SCANCODE_RIGHTBRACKET
+        53 => 0xC0, // SDL_SCANCODE_GRAVE
+        54 => 0xBC, // SDL_SCANCODE_COMMA
+        else => null,
+    };
+}
+
+/// Layout-aware shortcut key first (keycode), then physical scancode fallback.
+pub fn shortcutKeyCode(scancode: u32, keycode: u32) ?ev.KeyCode {
+    return keyCodeFromSdlKeycode(keycode) orelse keyCodeFromShortcutScancode(scancode);
 }
 
 /// SDL3 keymod bitmask (KMOD_*) → neutral modifier flags.
@@ -96,17 +109,32 @@ test "modifier bitmask decodes to neutral flags" {
 }
 
 test "SDL keycode maps alphanumeric keys to uppercase for shortcuts" {
-    // Lowercase letters convert to uppercase
     try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), keyCodeFromSdlKeycode('v'));
     try std.testing.expectEqual(@as(?ev.KeyCode, 'P'), keyCodeFromSdlKeycode('p'));
     try std.testing.expectEqual(@as(?ev.KeyCode, 'C'), keyCodeFromSdlKeycode('c'));
-    // Uppercase letters pass through
     try std.testing.expectEqual(@as(?ev.KeyCode, 'A'), keyCodeFromSdlKeycode('A'));
-    // Digits pass through
     try std.testing.expectEqual(@as(?ev.KeyCode, '1'), keyCodeFromSdlKeycode('1'));
     try std.testing.expectEqual(@as(?ev.KeyCode, '9'), keyCodeFromSdlKeycode('9'));
-    // Common punctuation used in shortcuts
-    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('+')); // plus
-    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('=')); // equal (same as plus)
-    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBD), keyCodeFromSdlKeycode('-')); // minus
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('+'));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromSdlKeycode('='));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBD), keyCodeFromSdlKeycode('-'));
+    // X11-style Ctrl+letter control codes
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), keyCodeFromSdlKeycode(0x16));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'P'), keyCodeFromSdlKeycode(0x10));
+}
+
+test "shortcut scancodes map letters and plus/minus keys" {
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'A'), keyCodeFromShortcutScancode(4));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), keyCodeFromShortcutScancode(25));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'P'), keyCodeFromShortcutScancode(19));
+    try std.testing.expectEqual(@as(?ev.KeyCode, '1'), keyCodeFromShortcutScancode(30));
+    try std.testing.expectEqual(@as(?ev.KeyCode, '0'), keyCodeFromShortcutScancode(39));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), keyCodeFromShortcutScancode(46));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBD), keyCodeFromShortcutScancode(45));
+}
+
+test "shortcutKeyCode prefers logical keycode then scancode" {
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), shortcutKeyCode(25, 'v'));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 'V'), shortcutKeyCode(25, 0));
+    try std.testing.expectEqual(@as(?ev.KeyCode, 0xBB), shortcutKeyCode(46, '='));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes broken keyboard shortcuts on Linux (Debian 13, XFCE):
- **Paste**: `Ctrl+V` now works in the terminal
- **Command center**: `Ctrl+Shift+P` now opens the command palette
- **Split panes**: `Ctrl+Shift++` / `Ctrl+Shift+=` (split right) and `Ctrl+Shift+-` (split down)

## Root Cause

The SDL3 `KEY_DOWN` handler only mapped special scancodes (arrows, F-keys). Alphanumeric keys with modifiers (`Ctrl+V`, `Ctrl+Shift+P`, `Ctrl+Shift+=`) returned `null` from `keyCodeFromScancode()`, so no `KeyEvent` was queued and the documented keybinds never fired.

## Changes

1. **`src/input/sdl_keymap.zig`**
   - `keyCodeFromSdlKeycode()` maps SDL logical keycodes to the same uppercase / OEM codes Windows uses
   - Accepts X11-style Ctrl-letter control codes (`0x16` → `V`)
   - `keyCodeFromShortcutScancode()` / `shortcutKeyCode()` fall back to physical scancodes when the keycode is 0
   - Unit tests cover paste / palette / plus-minus mappings

2. **`src/apprt/sdl.zig`**
   - With Ctrl/Alt/Super, map keycode then scancode so shortcuts reach `keybind`
   - Unmodified printable keys still go through `TEXT_INPUT` only
   - `zig fmt` clean (this was the previous CI failure)

## Testing

`zig fmt --check build.zig src` and `zig build test` pass locally.

### Linux manual plan

See `LINUX_SHORTCUT_TEST_PLAN.md`.

1. Copy text, then `Ctrl+V` in the terminal — text appears at the prompt
2. `Ctrl+Shift+P` — command center opens
3. `Ctrl+Shift+=` / `Ctrl+Shift++` — pane to the right; `Ctrl+Shift+-` — pane below
4. Regression: `Ctrl+Shift+C` copy, `Ctrl+Shift+T` new tab, normal typing, arrows

## Impact

Linux SDL only. Windows/macOS backends are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1db00d5-79b5-42d3-ae2e-046e89881b5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1db00d5-79b5-42d3-ae2e-046e89881b5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

