### PR TITLE
Polish titlebar chrome icons (gear/help cluster)

### DIFF
--- a/src/platform/font_backend.zig
+++ b/src/platform/font_backend.zig
@@ -42,6 +42,10 @@ pub const TitlebarIcon = enum {
     maximize,
     minimize,
     restore,
+    menu,
+    settings,
+    help,
+    copilot,
 };
 
 pub fn discoveryDisplayName() []const u8 {
@@ -111,6 +115,10 @@ test "platform font backend owns titlebar icon glyph mapping" {
     try std.testing.expect(titlebarIconGlyph(.maximize) != 0);
     try std.testing.expect(titlebarIconGlyph(.restore) != 0);
     try std.testing.expect(titlebarIconGlyph(.maximize) != titlebarIconGlyph(.restore));
+    try std.testing.expect(titlebarIconGlyph(.menu) != 0);
+    try std.testing.expect(titlebarIconGlyph(.settings) != 0);
+    try std.testing.expect(titlebarIconGlyph(.help) != 0);
+    try std.testing.expect(titlebarIconGlyph(.copilot) != 0);
 }
 
 test "platform font backend selects backend by target OS" {

--- a/src/platform/font_backend_linux.zig
+++ b/src/platform/font_backend_linux.zig
@@ -27,6 +27,10 @@ pub fn titlebarIconGlyph(icon: anytype) u32 {
         .maximize => 0x25A1,
         .minimize => '-',
         .restore => 0x25A3,
+        .menu => '=',
+        .settings => '*',
+        .help => '?',
+        .copilot => '@',
     };
 }
 

--- a/src/platform/font_backend_macos.zig
+++ b/src/platform/font_backend_macos.zig
@@ -27,6 +27,10 @@ pub fn titlebarIconGlyph(icon: anytype) u32 {
         .maximize => 0x25A1,
         .minimize => '-',
         .restore => 0x25A3,
+        .menu => '=',
+        .settings => '*',
+        .help => '?',
+        .copilot => '@',
     };
 }
 

--- a/src/platform/font_backend_unsupported.zig
+++ b/src/platform/font_backend_unsupported.zig
@@ -211,6 +211,10 @@ pub fn titlebarIconGlyph(icon: anytype) u32 {
         .maximize => 0x25A1,
         .minimize => '-',
         .restore => 0x25A3,
+        .menu => '=',
+        .settings => '*',
+        .help => '?',
+        .copilot => '@',
     };
 }
 

--- a/src/platform/font_backend_windows.zig
+++ b/src/platform/font_backend_windows.zig
@@ -36,6 +36,10 @@ pub fn titlebarIconGlyph(icon: anytype) u32 {
         .maximize => 0xE922,
         .minimize => 0xE921,
         .restore => 0xE923,
+        .menu => 0xE700,
+        .settings => 0xE713,
+        .help => 0xE897,
+        .copilot => 0xE8F2,
     };
 }
 

--- a/src/renderer/chrome_icons.zig
+++ b/src/renderer/chrome_icons.zig
@@ -1,0 +1,242 @@
+//! Axis-aligned chrome icon geometry for the app-drawn titlebar.
+//!
+//! Linux (and Windows when Segoe MDL2 is missing) paints these quads instead
+//! of an icon font. Hit-test and layout widths stay in `titlebar_layout`; this
+//! module only decides what is drawn inside those rects.
+
+const std = @import("std");
+
+pub const Quad = struct {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+};
+
+pub const Kind = enum {
+    menu,
+    add,
+    close,
+    settings,
+    help,
+    copilot,
+    minimize,
+    maximize,
+    restore,
+};
+
+pub const max_quads: usize = 64;
+
+const stroke: f32 = 1.75;
+
+fn glyphSize(w: f32, h: f32) f32 {
+    _ = h;
+    // Width-only: titlebar height is often 34px while the hit target stays 46px
+    // wide. Scaling by min(w,h) made the gear look undersized next to the old
+    // fixed 12px fallbacks.
+    return @min(12.0, w * 0.28);
+}
+
+fn append(out: []Quad, i: *usize, q: Quad) void {
+    if (i.* >= out.len) return;
+    if (q.w <= 0 or q.h <= 0) return;
+    out[i.*] = q;
+    i.* += 1;
+}
+
+fn appendLine(out: []Quad, i: *usize, x0: f32, y0: f32, x1: f32, y1: f32, t: f32) void {
+    const dx = x1 - x0;
+    const dy = y1 - y0;
+    const len = @sqrt(dx * dx + dy * dy);
+    if (len < 0.01) return;
+    const steps = @max(2, @as(usize, @intFromFloat(@ceil(len / (t * 0.55)))));
+    const last = steps - 1;
+    var s: usize = 0;
+    while (s < steps) : (s += 1) {
+        const frac = @as(f32, @floatFromInt(s)) / @as(f32, @floatFromInt(last));
+        const px = x0 + dx * frac;
+        const py = y0 + dy * frac;
+        append(out, i, .{ .x = px - t / 2, .y = py - t / 2, .w = t, .h = t });
+    }
+}
+
+fn appendHBar(out: []Quad, i: *usize, cx: f32, cy: f32, width: f32, t: f32) void {
+    append(out, i, .{ .x = cx - width / 2, .y = cy - t / 2, .w = width, .h = t });
+}
+
+fn appendVBar(out: []Quad, i: *usize, cx: f32, cy: f32, height: f32, t: f32) void {
+    append(out, i, .{ .x = cx - t / 2, .y = cy - height / 2, .w = t, .h = height });
+}
+
+fn appendRectStroke(out: []Quad, i: *usize, x: f32, y: f32, w: f32, h: f32, t: f32) void {
+    append(out, i, .{ .x = x, .y = y + h - t, .w = w, .h = t }); // top (GL y-up)
+    append(out, i, .{ .x = x, .y = y, .w = w, .h = t }); // bottom
+    append(out, i, .{ .x = x, .y = y, .w = t, .h = h }); // left
+    append(out, i, .{ .x = x + w - t, .y = y, .w = t, .h = h }); // right
+}
+
+fn appendOctagonRing(out: []Quad, i: *usize, cx: f32, cy: f32, r: f32, t: f32) void {
+    const cut = r * 0.42;
+    const inner = r - t;
+    // Cardinal sides.
+    append(out, i, .{ .x = cx - r + cut, .y = cy + inner, .w = (r - cut) * 2, .h = t });
+    append(out, i, .{ .x = cx - r + cut, .y = cy - r, .w = (r - cut) * 2, .h = t });
+    append(out, i, .{ .x = cx - r, .y = cy - r + cut, .w = t, .h = (r - cut) * 2 });
+    append(out, i, .{ .x = cx + inner, .y = cy - r + cut, .w = t, .h = (r - cut) * 2 });
+    // Diagonal corners as short bars.
+    appendLine(out, i, cx - r + cut, cy + r, cx - r, cy + r - cut, t);
+    appendLine(out, i, cx + r - cut, cy + r, cx + r, cy + r - cut, t);
+    appendLine(out, i, cx - r + cut, cy - r, cx - r, cy - r + cut, t);
+    appendLine(out, i, cx + r - cut, cy - r, cx + r, cy - r + cut, t);
+}
+
+fn fillMenu(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const width = g + 2.0;
+    const gap = 3.5;
+    appendHBar(out, i, cx, cy + gap, width, stroke);
+    appendHBar(out, i, cx, cy, width, stroke);
+    appendHBar(out, i, cx, cy - gap, width, stroke);
+}
+
+fn fillAdd(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    appendHBar(out, i, cx, cy, g, stroke);
+    appendVBar(out, i, cx, cy, g, stroke);
+}
+
+fn fillClose(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const arm = g * 0.42;
+    appendLine(out, i, cx - arm, cy - arm, cx + arm, cy + arm, stroke);
+    appendLine(out, i, cx - arm, cy + arm, cx + arm, cy - arm, stroke);
+}
+
+fn fillSettings(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const r = g * 0.38;
+    appendOctagonRing(out, i, cx, cy, r, stroke);
+    const tooth = g * 0.22;
+    const hub = r + 0.15;
+    appendVBar(out, i, cx, cy + hub + tooth / 2, tooth, stroke);
+    appendVBar(out, i, cx, cy - hub - tooth / 2, tooth, stroke);
+    appendHBar(out, i, cx + hub + tooth / 2, cy, tooth, stroke);
+    appendHBar(out, i, cx - hub - tooth / 2, cy, tooth, stroke);
+    const diag = (hub + tooth * 0.35) * 0.72;
+    appendLine(out, i, cx + diag, cy + diag, cx + diag + 1.6, cy + diag + 1.6, stroke);
+    appendLine(out, i, cx - diag, cy + diag, cx - diag - 1.6, cy + diag + 1.6, stroke);
+    appendLine(out, i, cx + diag, cy - diag, cx + diag + 1.6, cy - diag - 1.6, stroke);
+    appendLine(out, i, cx - diag, cy - diag, cx - diag - 1.6, cy - diag - 1.6, stroke);
+}
+
+fn fillHelp(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    appendOctagonRing(out, i, cx, cy, g * 0.52, stroke);
+    // Question mark, optically centered in the ring.
+    const q = g * 0.22;
+    appendHBar(out, i, cx + 0.2, cy + q * 1.15, q * 1.35, stroke);
+    appendVBar(out, i, cx + q * 0.72, cy + q * 0.55, q * 1.15, stroke);
+    appendHBar(out, i, cx + 0.15, cy + q * 0.05, q * 0.7, stroke);
+    append(out, i, .{ .x = cx - 0.85, .y = cy - q * 1.15, .w = 1.7, .h = 1.7 });
+}
+
+fn fillCopilot(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const bw = g + 3.0;
+    const bh = g * 0.78;
+    const rad = 2.0;
+    const bx = cx - bw / 2;
+    const by = cy - bh / 2 + 0.6;
+    // Sides inset by the corner radius so the outline reads rounded.
+    append(out, i, .{ .x = bx + rad, .y = by + bh - stroke, .w = bw - rad * 2, .h = stroke });
+    append(out, i, .{ .x = bx + rad, .y = by, .w = bw - rad * 2, .h = stroke });
+    append(out, i, .{ .x = bx, .y = by + rad, .w = stroke, .h = bh - rad * 2 });
+    append(out, i, .{ .x = bx + bw - stroke, .y = by + rad, .w = stroke, .h = bh - rad * 2 });
+    // Corner caps.
+    append(out, i, .{ .x = bx, .y = by + bh - rad, .w = stroke, .h = rad - 0.2 });
+    append(out, i, .{ .x = bx, .y = by + bh - stroke, .w = rad, .h = stroke });
+    append(out, i, .{ .x = bx + bw - rad, .y = by + bh - stroke, .w = rad, .h = stroke });
+    append(out, i, .{ .x = bx + bw - stroke, .y = by + bh - rad, .w = stroke, .h = rad - 0.2 });
+    append(out, i, .{ .x = bx, .y = by, .w = rad, .h = stroke });
+    append(out, i, .{ .x = bx, .y = by, .w = stroke, .h = rad });
+    append(out, i, .{ .x = bx + bw - rad, .y = by, .w = rad, .h = stroke });
+    append(out, i, .{ .x = bx + bw - stroke, .y = by, .w = stroke, .h = rad });
+    // Tail (bottom-left), matching the wisp / speech-bubble mark.
+    append(out, i, .{ .x = bx + 2.0, .y = by - 2.4, .w = stroke, .h = 2.6 });
+    append(out, i, .{ .x = bx + 2.0, .y = by - 2.4, .w = 3.2, .h = stroke });
+}
+
+fn fillMinimize(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    appendHBar(out, i, cx, cy, g, stroke);
+}
+
+fn fillMaximize(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const s = g * 0.86;
+    appendRectStroke(out, i, cx - s / 2, cy - s / 2, s, s, stroke);
+}
+
+fn fillRestore(out: []Quad, i: *usize, cx: f32, cy: f32, g: f32) void {
+    const s = g * 0.68;
+    const off = 2.6;
+    // Back square: top + right only.
+    append(out, i, .{ .x = cx - s / 2 + off, .y = cy + s / 2 + off - stroke, .w = s, .h = stroke });
+    append(out, i, .{ .x = cx + s / 2 + off - stroke, .y = cy - s / 2 + off, .w = stroke, .h = s });
+    // Front square: full stroke.
+    appendRectStroke(out, i, cx - s / 2 - off * 0.35, cy - s / 2 - off * 0.15, s, s, stroke);
+}
+
+/// Write icon quads for `kind` into `out`. Returns the number of quads written.
+pub fn fill(out: []Quad, kind: Kind, x: f32, y: f32, w: f32, h: f32) usize {
+    var i: usize = 0;
+    if (w <= 0 or h <= 0 or out.len == 0) return 0;
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+    const g = glyphSize(w, h);
+    switch (kind) {
+        .menu => fillMenu(out, &i, cx, cy, g),
+        .add => fillAdd(out, &i, cx, cy, g),
+        .close => fillClose(out, &i, cx, cy, g),
+        .settings => fillSettings(out, &i, cx, cy, g),
+        .help => fillHelp(out, &i, cx, cy, g),
+        .copilot => fillCopilot(out, &i, cx, cy, g),
+        .minimize => fillMinimize(out, &i, cx, cy, g),
+        .maximize => fillMaximize(out, &i, cx, cy, g),
+        .restore => fillRestore(out, &i, cx, cy, g),
+    }
+    return i;
+}
+
+fn quadsInsideRect(kind: Kind, x: f32, y: f32, w: f32, h: f32) !void {
+    var buf: [max_quads]Quad = undefined;
+    const n = fill(&buf, kind, x, y, w, h);
+    try std.testing.expect(n > 0);
+    try std.testing.expect(n <= max_quads);
+    const pad: f32 = 2.0;
+    for (buf[0..n]) |q| {
+        try std.testing.expect(q.x + 0.01 >= x - pad);
+        try std.testing.expect(q.y + 0.01 >= y - pad);
+        try std.testing.expect(q.x + q.w <= x + w + pad + 0.01);
+        try std.testing.expect(q.y + q.h <= y + h + pad + 0.01);
+    }
+}
+
+test "chrome icons stay inside the button rect" {
+    const kinds = std.meta.tags(Kind);
+    for (kinds) |kind| {
+        try quadsInsideRect(kind, 100, 200, 46, 34);
+        try quadsInsideRect(kind, 0, 0, 46, 46);
+    }
+}
+
+test "chrome icons collapse on a zero-width caption slot" {
+    var buf: [max_quads]Quad = undefined;
+    try std.testing.expectEqual(@as(usize, 0), fill(&buf, .close, 0, 0, 0, 34));
+}
+
+test "chrome icons share one optical size in a 46px titlebar button" {
+    try std.testing.expectEqual(@as(f32, 12), glyphSize(46, 34));
+    try std.testing.expectEqual(@as(f32, 12), glyphSize(46, 46));
+    try std.testing.expectEqual(@as(f32, 0), glyphSize(0, 34));
+}
+
+test "caption restore is not the same quad set as maximize" {
+    var max_buf: [max_quads]Quad = undefined;
+    var rest_buf: [max_quads]Quad = undefined;
+    const max_n = fill(&max_buf, .maximize, 0, 0, 46, 34);
+    const rest_n = fill(&rest_buf, .restore, 0, 0, 46, 34);
+    try std.testing.expect(rest_n > max_n);
+}

--- a/src/renderer/titlebar.zig
+++ b/src/renderer/titlebar.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const titlebar_layout = @import("titlebar_layout.zig");
+const chrome_icons = @import("chrome_icons.zig");
 const AppWindow = @import("../AppWindow.zig");
 const ui_pipeline = AppWindow.ui_pipeline;
 const font = AppWindow.font;
@@ -273,60 +274,22 @@ pub fn renderTextLimited(text: []const u8, x: f32, y: f32, color: [3]f32, max_w:
     return cursor_x;
 }
 
-fn renderFallbackMenuIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const line_w: f32 = 14;
-    const line_h: f32 = 1.5;
-    ui_pipeline.fillQuad(cx - line_w / 2, cy - 5, line_w, line_h, color);
-    ui_pipeline.fillQuad(cx - line_w / 2, cy, line_w, line_h, color);
-    ui_pipeline.fillQuad(cx - line_w / 2, cy + 5, line_w, line_h, color);
-}
-
-fn renderFallbackGearIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const stroke: f32 = 2;
-    const ring: f32 = 12;
-    const tooth: f32 = 4;
-
-    ui_pipeline.fillQuad(cx - ring / 2, cy - ring / 2, ring, stroke, color);
-    ui_pipeline.fillQuad(cx - ring / 2, cy + ring / 2 - stroke, ring, stroke, color);
-    ui_pipeline.fillQuad(cx - ring / 2, cy - ring / 2, stroke, ring, color);
-    ui_pipeline.fillQuad(cx + ring / 2 - stroke, cy - ring / 2, stroke, ring, color);
-
-    ui_pipeline.fillQuad(cx - stroke / 2, cy - ring / 2 - tooth, stroke, tooth, color);
-    ui_pipeline.fillQuad(cx - stroke / 2, cy + ring / 2, stroke, tooth, color);
-    ui_pipeline.fillQuad(cx - ring / 2 - tooth, cy - stroke / 2, tooth, stroke, color);
-    ui_pipeline.fillQuad(cx + ring / 2, cy - stroke / 2, tooth, stroke, color);
-}
-
-fn renderFallbackHelpIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    const ch: u32 = '?';
-    if (font.g_titlebar_cell_width > 0) {
-        const gw = titlebarGlyphAdvance(ch);
-        const gh = font.g_titlebar_cell_height;
-        const tx = x + (w - gw) / 2;
-        const ty = y + (h - gh) / 2;
-        renderTitlebarChar(ch, tx, ty, color);
+fn renderChromeIcon(kind: chrome_icons.Kind, x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    var buf: [chrome_icons.max_quads]chrome_icons.Quad = undefined;
+    const n = chrome_icons.fill(&buf, kind, x, y, w, h);
+    for (buf[0..n]) |q| {
+        ui_pipeline.fillQuad(q.x, q.y, q.w, q.h, color);
     }
 }
 
-/// A minimal speech-bubble icon (outline body + a small tail), matching the
-/// stroked style of the help/gear fallbacks. Vector so it is font-independent.
-fn renderFallbackCopilotIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const stroke: f32 = 2;
-    const bw: f32 = 16;
-    const bh: f32 = 11;
-    const bx = cx - bw / 2;
-    const by = cy - bh / 2 + 1;
-    ui_pipeline.fillQuad(bx, by, bw, stroke, color); // top
-    ui_pipeline.fillQuad(bx, by + bh - stroke, bw, stroke, color); // bottom
-    ui_pipeline.fillQuad(bx, by, stroke, bh, color); // left
-    ui_pipeline.fillQuad(bx + bw - stroke, by, stroke, bh, color); // right
-    ui_pipeline.fillQuad(bx + 3, by - 3, stroke, 3, color); // tail
+fn renderTitlebarIcon(icon: font_backend.TitlebarIcon, kind: chrome_icons.Kind, x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
+    if (font.icon_face != null) {
+        if (font.loadIconGlyph(font_backend.titlebarIconGlyph(icon))) |ch| {
+            renderIconGlyph(ch, x, y, w, h, color, 1.0);
+            return;
+        }
+    }
+    renderChromeIcon(kind, x, y, w, h, color);
 }
 
 fn renderPlusIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
@@ -337,12 +300,7 @@ fn renderPlusIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
         }
     }
 
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const arm: f32 = 5;
-    const t: f32 = 1.25;
-    ui_pipeline.fillQuad(cx - arm, cy - t / 2, arm * 2, t, color);
-    ui_pipeline.fillQuad(cx - t / 2, cy - arm, t, arm * 2, color);
+    renderChromeIcon(.add, x, y, w, h, color);
 }
 
 pub fn renderCloseIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
@@ -353,17 +311,7 @@ pub fn renderCloseIcon(x: f32, y: f32, w: f32, h: f32, color: [3]f32) void {
         }
     }
 
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const arm: f32 = 4;
-    const t: f32 = 1;
-    const steps: usize = 20;
-    for (0..steps) |si| {
-        const frac = @as(f32, @floatFromInt(si)) / @as(f32, @floatFromInt(steps - 1));
-        const px = cx - arm + frac * arm * 2;
-        ui_pipeline.fillQuad(px - t / 2, (cy + arm - frac * arm * 2) - t / 2, t, t, color);
-        ui_pipeline.fillQuad(px - t / 2, (cy - arm + frac * arm * 2) - t / 2, t, t, color);
-    }
+    renderChromeIcon(.close, x, y, w, h, color);
 }
 
 /// Render a titlebar glyph at 1:1 atlas size (no scaling).
@@ -503,15 +451,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
         if (toggle_hovered) {
             ui_pipeline.fillQuad(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, hover_bg);
         }
-        if (font.icon_face != null) {
-            if (font.loadIconGlyph(0xE700)) |ch| {
-                renderIconGlyph(ch, toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color, 1.0);
-            } else {
-                renderFallbackMenuIcon(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
-            }
-        } else {
-            renderFallbackMenuIcon(toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
-        }
+        renderTitlebarIcon(.menu, .menu, toggle_x, layout.top_y, TITLEBAR_TOGGLE_W, titlebar_h, icon_color);
 
         const top_hovered: window_backend.CaptionButton = if (AppWindow.g_window) |w| window_backend.hoveredCaptionButton(w) else .none;
 
@@ -521,15 +461,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
             if (config_hovered) {
                 ui_pipeline.fillQuad(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, hover_bg);
             }
-            if (font.icon_face != null) {
-                if (font.loadIconGlyph(0xE713)) |ch| {
-                    renderIconGlyph(ch, config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color, 1.0);
-                } else {
-                    renderFallbackGearIcon(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
-                }
-            } else {
-                renderFallbackGearIcon(config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
-            }
+            renderTitlebarIcon(.settings, .settings, config_x, layout.top_y, TITLEBAR_CONFIG_W, titlebar_h, icon_color);
         }
 
         const help_x = layout.help_x;
@@ -538,15 +470,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
             if (help_hovered) {
                 ui_pipeline.fillQuad(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, hover_bg);
             }
-            if (font.icon_face != null) {
-                if (font.loadIconGlyph(0xEDA7)) |ch| {
-                    renderIconGlyph(ch, help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color, 1.0);
-                } else {
-                    renderFallbackHelpIcon(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color);
-                }
-            } else {
-                renderFallbackHelpIcon(help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color);
-            }
+            renderTitlebarIcon(.help, .help, help_x, layout.top_y, TITLEBAR_HELP_W, titlebar_h, icon_color);
         }
 
         const copilot_x = layout.copilot_x;
@@ -563,7 +487,7 @@ pub fn renderTitlebar(window_width: f32, window_height: f32, titlebar_h: f32) vo
                 blend(bg, AppWindow.g_theme.cursor_color, 0.85) // active
             else
                 icon_color;
-            renderFallbackCopilotIcon(copilot_x, layout.top_y, TITLEBAR_COPILOT_W, titlebar_h, copilot_tint);
+            renderTitlebarIcon(.copilot, .copilot, copilot_x, layout.top_y, TITLEBAR_COPILOT_W, titlebar_h, copilot_tint);
         }
 
         if (tab.activeTab()) |active_tab| {
@@ -1326,54 +1250,13 @@ pub fn renderCaptionButton(button: titlebar_layout.CaptionButtonVisual) void {
         }
     }
 
-    // Fallback: quad-based icons
-    const cx = rect.x + rect.w / 2;
-    const cy = rect.y + rect.h / 2;
-
-    switch (button.icon) {
-        .close => {
-            const size: f32 = 5;
-            const steps: usize = 32;
-            const t: f32 = 1.5;
-            for (0..steps) |i| {
-                const frac = @as(f32, @floatFromInt(i)) / @as(f32, @floatFromInt(steps - 1));
-                const px = cx - size + frac * size * 2;
-                const py1 = cy + size - frac * size * 2;
-                ui_pipeline.fillQuad(px - t / 2, py1 - t / 2, t, t, icon_color);
-                const py2 = cy - size + frac * size * 2;
-                ui_pipeline.fillQuad(px - t / 2, py2 - t / 2, t, t, icon_color);
-            }
-        },
-        .maximize => {
-            const size: f32 = 5;
-            const t: f32 = 1;
-            ui_pipeline.fillQuad(cx - size, cy + size - t, size * 2, t, icon_color); // top
-            ui_pipeline.fillQuad(cx - size, cy - size, size * 2, t, icon_color); // bottom
-            ui_pipeline.fillQuad(cx - size, cy - size, t, size * 2, icon_color); // left
-            ui_pipeline.fillQuad(cx + size - t, cy - size, t, size * 2, icon_color); // right
-        },
-        .restore => {
-            const size: f32 = 4.5;
-            const t: f32 = 1;
-            const offset: f32 = 3;
-            const back_x = cx - size + offset;
-            const back_y = cy - size + offset;
-            ui_pipeline.fillQuad(back_x, back_y + size * 2 - t, size * 2, t, icon_color);
-            ui_pipeline.fillQuad(back_x + size * 2 - t, back_y, t, size * 2, icon_color);
-
-            const front_x = cx - size - offset / 2;
-            const front_y = cy - size - offset / 2;
-            ui_pipeline.fillQuad(front_x, front_y + size * 2 - t, size * 2, t, icon_color);
-            ui_pipeline.fillQuad(front_x, front_y, size * 2, t, icon_color);
-            ui_pipeline.fillQuad(front_x, front_y, t, size * 2, icon_color);
-            ui_pipeline.fillQuad(front_x + size * 2 - t, front_y, t, size * 2, icon_color);
-        },
-        .minimize => {
-            const size: f32 = 5;
-            const t: f32 = 1;
-            ui_pipeline.fillQuad(cx - size, cy - t / 2, size * 2, t, icon_color);
-        },
-    }
+    const kind: chrome_icons.Kind = switch (button.icon) {
+        .close => .close,
+        .maximize => .maximize,
+        .restore => .restore,
+        .minimize => .minimize,
+    };
+    renderChromeIcon(kind, rect.x, rect.y, rect.w, rect.h, icon_color);
 }
 
 /// Render placeholder content for tabs that don't have a terminal yet.

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -408,6 +408,7 @@ test {
     _ = @import("benchmark/scenarios.zig");
     _ = @import("renderer/cell_geometry.zig");
     _ = @import("renderer/titlebar_layout.zig");
+    _ = @import("renderer/chrome_icons.zig");
     _ = @import("assistant/conversation/layout.zig");
     _ = @import("assistant/conversation/types.zig");
     _ = @import("assistant/conversation/identity.zig");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Visual-only refresh of the **in-app titlebar chrome**, not the WispTerm product mark.

`assets/wispterm.png`, `assets/wispterm.ico`, `assets/wispterm.icns`, and the docs favicon are **untouched**.

## Why

On Linux (and Windows when Segoe MDL2 is missing) the titlebar paints its own icons with `fillQuad`. The settings gear was a square with four teeth, help was a raw `?` from the titlebar font, and the rest of the cluster (hamburger, plus, close, caption min/max/restore) used 1px debug-style primitives. They did not share a stroke or optical size, so the gear/help group looked like placeholders.

Ghostty does not have this problem: GTK builds use Adwaita symbolic icons, and Windows uses native caption glyphs. WispTerm’s SDL/Linux titlebar is app-drawn, so the fallbacks have to carry the same weight as Segoe MDL2 on Windows.

## What changed

- New `src/renderer/chrome_icons.zig`: one 1.75px stroke set, 12px optical size, centered in the existing 46px hit targets.
- Settings: octagon ring + 8 teeth (reads as a gear, not a box).
- Help: circled question mark instead of a lone `?`.
- Same stroke used for hamburger, plus, close, copilot bubble, and caption min/max/restore/close.
- Windows still prefers Segoe MDL2 (`E713` settings, `E897` help, `E700` menu, `E8F2` chat). Fallbacks only paint when that face is missing.
- `titlebar_layout` widths and hit-test math are unchanged. No input, shortcut, or drag changes.

## Before / after

| Control | Before | After |
|---|---|---|
| Settings | Square frame + 4 teeth | Octagon cog, same 12px size as neighbors |
| Help | Titlebar-font `?` | Circled `?` in the same stroke |
| Hamburger / + / X / captions | Thin unmatched quads | Shared stroke, optically centered |
| App icon / `.ico` / `.icns` | — | **not changed** |

## Tests

- `zig fmt` on touched Zig
- `zig test src/renderer/chrome_icons.zig`
- `zig build test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940d09ee-969c-4bf6-bd1f-6e3b6d97df0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940d09ee-969c-4bf6-bd1f-6e3b6d97df0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

