### PR TITLE
Add Linux companion e2e tests and fix the Linux driver

### DIFF
--- a/tests/macos_e2e/README.md
+++ b/tests/macos_e2e/README.md
@@ -80,7 +80,7 @@ python3 -m pytest tests/macos_e2e -m "not e2e"
 - `test_smoke.py` — 控制通道 echo 往返(启动 + 配置 + 控制服务 + shell + get-text),跨平台
 - `test_linux.py` — Linux-only:首启无冻结(#599 回归),隔离 HOME;另有 config-dir / cmd→ctrl 单测
 - `test_linux_companion.py` — Linux 伴侣用例:click-to-PTY、legacy 键编码、Ctrl+V 粘贴、窗口缩放→`stty size`、Shift+Enter CSI-u、键盘分屏/新标签、`wisptermctl spawn`、OSC 标题。不依赖 Quartz/AX/osascript
-- `test_linux_mcp_discovery.py` — Linux 伴侣:启动时读 `~/.config/wispterm/mcp.json` 并完成 MCP discovery
+- `test_linux_mcp_discovery.py` — Linux 伴侣:带 `~/.config/wispterm/mcp.json` 仍能启动,且**不会**在启动时 spawn MCP server(discovery 推迟到 panel Test / `mcp_activate`;macOS 原用例的 launch handshake 断言已过时,保持不动)
 - `test_menu.py` — Edit > Copy 菜单状态读取(osascript→AX,真实),macOS-only(Linux 无 AX,不移植)
 - `test_quartz_input.py` — Quartz modifier flags 单测,macOS-only
 - `test_keybinds.py` — 真实键盘入 PTY(跨平台);`test_cmd_c_copies_selection` 仍 xfail(无 select-all)

--- a/tests/macos_e2e/README.md
+++ b/tests/macos_e2e/README.md
@@ -23,6 +23,13 @@ make test-linux-e2e
 会先按 `x86_64-linux-gnu` 构建 `wispterm` + `wisptermctl`,确保 `pytest` 在位(缺则
 `pip install --user pytest`),再用 `python3 -m pytest tests/macos_e2e`。
 
+可用环境变量指向预构建产物,跳过默认 `zig-out` 路径:
+
+```bash
+WISPTERM_E2E_BINARY=/path/to/wispterm WISPTERM_E2E_CTL=/path/to/wisptermctl \
+  python3 -m pytest tests/macos_e2e -v
+```
+
 只跑无需 GUI 的纯逻辑单测:
 
 ```bash
@@ -49,27 +56,35 @@ python3 -m pytest tests/macos_e2e -m "not e2e"
 - **libsdl3** + **fontconfig**(运行时依赖):通常由包管理器提供,例如 Ubuntu/Debian 的
   `libsdl3-0` / `libfontconfig1`。
 - **xdotool**(可选):真实键盘/鼠标路径需要它。控制通道测试(如 `test_smoke.py` 的
-  echo 往返)在其缺失时也能跑;依赖真实输入的测试会 skip。安装:`sudo apt install xdotool`。
+  echo 往返、`wisptermctl spawn`、OSC 标题、MCP discovery)在其缺失时也能跑;
+  `test_linux_companion.py` 里的键编码/粘贴/分屏/标签/点击/缩放会 skip。
+  安装:`sudo apt install xdotool`。
 - **xclip**(可选):剪贴板读取需要它。`sudo apt install xclip`。
 - **scrot**(可选):失败时截屏诊断需要它。`sudo apt install scrot`。
 
 ## 隔离
 
 每次 session 用临时 `HOME`,在其中写 `config`(开启 `agent-control-enabled`、
-关闭 `auto-update-check`)。所有 `wisptermctl` 调用带同一 `HOME`,只连测试实例,
-**不影响你正在用的开发实例**。
+关闭 `auto-update-check`)。Linux 写入 `$HOME/.config/wispterm`(与
+`src/platform/dirs.zig` `configDirFromXdgOrHome` 一致;同时钉死
+`XDG_CONFIG_HOME=$HOME/.config`,避免宿主机 XDG 泄漏)。所有 `wisptermctl`
+调用带同一 `HOME` + XDG,只连测试实例,**不影响你正在用的开发实例**。
 
 ## 结构
 
 - `driver/base.py` — 跨平台抽象接口(用例只依赖它)
 - `driver/macos.py` — MacDriver:`open` 隔离启动 + CGEvent(键鼠,真实路径)+ osascript(菜单/AX)
   + wisptermctl(`send_text`/`get_text`,控制通道)
-- `driver/linux.py` — LinuxDriver:隔离启动 + xdotool(键鼠,可选)+ wisptermctl(`send_text`/`get_text`,控制通道)
+- `driver/linux.py` — LinuxDriver:隔离启动 + xdotool(键鼠,可选)+ wisptermctl(`send_text`/`get_text`/`spawn`,控制通道)。harness 的 `cmd` 在 Linux 上映射为 Ctrl(与 `keybind.zig` 默认一致)
 - 纯逻辑模块(`panes`/`keycodes`/`wait`/`osascript` 构造/`ctl` 装配)有单元测试,无需 GUI
 - `test_smoke.py` — 控制通道 echo 往返(启动 + 配置 + 控制服务 + shell + get-text),跨平台
-- `test_linux.py` — Linux-only:首启无冻结(#599 回归),隔离 HOME
-- `test_menu.py` — `Edit ▸ Copy` 菜单状态读取(osascript→AX,真实),macOS-only
-- `test_keybinds.py` — 真实 Cmd+C 复制,**当前 `skip`**(见下方已知限制),macOS-only
+- `test_linux.py` — Linux-only:首启无冻结(#599 回归),隔离 HOME;另有 config-dir / cmd→ctrl 单测
+- `test_linux_companion.py` — Linux 伴侣用例:click-to-PTY、legacy 键编码、Ctrl+V 粘贴、窗口缩放→`stty size`、Shift+Enter CSI-u、键盘分屏/新标签、`wisptermctl spawn`、OSC 标题。不依赖 Quartz/AX/osascript
+- `test_linux_mcp_discovery.py` — Linux 伴侣:启动时读 `~/.config/wispterm/mcp.json` 并完成 MCP discovery
+- `test_menu.py` — Edit > Copy 菜单状态读取(osascript→AX,真实),macOS-only(Linux 无 AX,不移植)
+- `test_quartz_input.py` — Quartz modifier flags 单测,macOS-only
+- `test_keybinds.py` — 真实键盘入 PTY(跨平台);`test_cmd_c_copies_selection` 仍 xfail(无 select-all)
+- `test_copilot_history.py` / `test_mcp_panel.py` — 模块级导入 MacDriver/Quartz,Linux 收集阶段忽略
 
 ## 已知限制(见 issue #279)
 

--- a/tests/macos_e2e/conftest.py
+++ b/tests/macos_e2e/conftest.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import sys
+
 import pytest
 
 
@@ -7,19 +11,21 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "linux_only: test that only applies to the Linux backend")
 
 
-# Platform markers for test filtering
-import sys
-
 macos_only = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only behavior")
 linux_only = pytest.mark.skipif(sys.platform != "linux", reason="Linux-only behavior")
 
-import os
+# These modules import MacDriver → Quartz at collection time. Skip the files on
+# non-macOS rather than erroring out of the Linux run.
+collect_ignore = []
+if sys.platform != "darwin":
+    collect_ignore.extend(["test_copilot_history.py", "test_mcp_panel.py"])
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-# macOS uses .app bundle; Linux uses plain binary
+# macOS uses .app bundle; Linux uses plain binary. Env overrides let CI/dev
+# point at a prebuilt pair without rebuilding via `make test-linux-e2e`.
 APP_BUNDLE = os.path.join(REPO_ROOT, "zig-out", "bin", "WispTerm.app")
-LINUX_BINARY = os.path.join(REPO_ROOT, "zig-out", "bin", "wispterm")
-CTL_BINARY = os.path.join(REPO_ROOT, "zig-out", "bin", "wisptermctl")
+LINUX_BINARY = os.environ.get("WISPTERM_E2E_BINARY") or os.path.join(REPO_ROOT, "zig-out", "bin", "wispterm")
+CTL_BINARY = os.environ.get("WISPTERM_E2E_CTL") or os.path.join(REPO_ROOT, "zig-out", "bin", "wisptermctl")
 
 
 def _pyobjc_available() -> bool:
@@ -98,6 +104,18 @@ def require_linux_gui():
         pytest.skip(f"missing {LINUX_BINARY}; run `make test-linux-e2e` (builds it first)")
     if not os.path.exists(CTL_BINARY):
         pytest.skip(f"missing {CTL_BINARY}; run `make test-linux-e2e` (builds it first)")
+
+
+def require_xdotool():
+    """Skip unless xdotool can inject real key/mouse events."""
+    if not shutil.which("xdotool"):
+        pytest.skip("xdotool not installed; real-input Linux E2E skipped")
+
+
+def require_xclip():
+    """Skip unless xclip can read/write the clipboard."""
+    if not shutil.which("xclip"):
+        pytest.skip("xclip not installed; clipboard Linux E2E skipped")
 
 
 @pytest.fixture(scope="session")

--- a/tests/macos_e2e/driver/ctl.py
+++ b/tests/macos_e2e/driver/ctl.py
@@ -13,9 +13,17 @@ class Ctl:
         self.home = home
         self.binary = binary
 
-    def _run(self, args, timeout: float = 10.0) -> str:
+    def _env(self) -> dict:
         env = dict(os.environ)
         env["HOME"] = self.home
+        # Match LinuxDriver isolation: wisptermctl reads the same XDG config dir
+        # the app writes (src/platform/dirs.zig configDirFromXdgOrHome). Harmless
+        # on macOS, where dirs.zig uses ~/Library/Application Support.
+        env["XDG_CONFIG_HOME"] = os.path.join(self.home, ".config")
+        return env
+
+    def _run(self, args, timeout: float = 10.0) -> str:
+        env = self._env()
         proc = subprocess.run(
             [self.binary, *args],
             capture_output=True, text=True, env=env, timeout=timeout,
@@ -43,6 +51,15 @@ class Ctl:
         # bypassing the OS input path (see issue #279). `data` may contain a
         # literal newline to submit a command.
         self._run(["send-text", "-t", pane, data])
+
+    def spawn(self, *command: str, cwd: str = None) -> None:
+        """Open a new tab. Empty command → the configured default shell."""
+        args = ["spawn"]
+        if cwd:
+            args += ["--cwd", cwd]
+        if command:
+            args += ["--", *command]
+        self._run(args)
 
     def wait_for(self, pane: str, pattern: str, timeout: float = 5.0,
                  interval: float = 0.2, clock=wait._RealClock) -> None:

--- a/tests/macos_e2e/driver/linux.py
+++ b/tests/macos_e2e/driver/linux.py
@@ -4,7 +4,6 @@ control-channel-only mode when xdotool is missing (same pattern as macOS #279).
 """
 import os
 import shutil
-import signal
 import subprocess
 import tempfile
 import time
@@ -25,6 +24,27 @@ _CONFIG = (
 )
 
 
+def config_dir_for_home(home: str) -> str:
+    """Config dir the Linux app actually reads: ~/.config/wispterm.
+
+    Must match ``src/platform/dirs.zig`` ``configDirFromXdgOrHome`` (not
+    XDG_DATA_HOME / ~/.local/share). The isolated launch sets XDG_CONFIG_HOME
+    to ``{home}/.config`` so a host XDG_CONFIG_HOME cannot leak in.
+    """
+    return os.path.join(home, ".config", "wispterm")
+
+
+def map_linux_mods(mods):
+    """Map harness modifier names to xdotool keysyms.
+
+    Shared tests pass ``cmd`` for the primary chord (Cmd+Shift+P on macOS).
+    Linux defaults keep Ctrl (``src/keybind.zig``), so ``cmd`` → ``ctrl`` here
+    only. Pass ``super`` when Super is actually required.
+    """
+    mod_map = {"cmd": "ctrl", "ctrl": "ctrl", "shift": "shift", "alt": "alt", "super": "super"}
+    return [mod_map.get(m.lower(), m) for m in mods]
+
+
 class LinuxDriver:
     def __init__(self, binary: str, ctl_binary: str):
         # binary: .../zig-out/bin/wispterm ; ctl_binary: .../zig-out/bin/wisptermctl
@@ -38,7 +58,18 @@ class LinuxDriver:
 
     # ---- lifecycle ----
     def _config_dir(self) -> str:
-        return os.path.join(self.home, ".local", "share", "wispterm")
+        return config_dir_for_home(self.home)
+
+    def _isolated_env(self) -> dict:
+        env = dict(os.environ)
+        env["HOME"] = self.home
+        # Pin XDG so the app and wisptermctl agree with _config_dir(), even when
+        # the host session exports XDG_CONFIG_HOME / XDG_DATA_HOME.
+        env["XDG_CONFIG_HOME"] = os.path.join(self.home, ".config")
+        env["XDG_DATA_HOME"] = os.path.join(self.home, ".local", "share")
+        env["XDG_STATE_HOME"] = os.path.join(self.home, ".local", "state")
+        env["XDG_CACHE_HOME"] = os.path.join(self.home, ".cache")
+        return env
 
     def launch(self, *, cols: int = 80, rows: int = 24) -> None:
         cfg_dir = self._config_dir()
@@ -54,12 +85,12 @@ class LinuxDriver:
         with open(os.path.join(cfg_dir, "state"), "w") as f:
             f.write("ai-setup-prompted = 1\n")
 
-        env = dict(os.environ)
-        env["HOME"] = self.home
         # DISPLAY is inherited from the test process; if unset, the skip
         # machinery in conftest has already excluded this run.
-
-        self.proc = subprocess.Popen([self.binary], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.proc = subprocess.Popen(
+            [self.binary], env=self._isolated_env(),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
 
         # control server publishes its discovery file inside our isolated HOME
         disc = os.path.join(cfg_dir, "agent-control.json")
@@ -130,12 +161,15 @@ class LinuxDriver:
             "down": "Down",
             "left": "Left",
             "right": "Right",
+            "equal": "equal",
+            "plus": "plus",
+            "minus": "minus",
         }
         keysym = keysym_map.get(key_name.lower(), key_name)
         # xdotool modifier syntax: key --clearmodifiers ctrl+shift+p
+        # Harness "cmd" maps to Ctrl on Linux (see map_linux_mods).
         if mods:
-            mod_map = {"cmd": "super", "ctrl": "ctrl", "shift": "shift", "alt": "alt"}
-            mods_str = "+".join(mod_map.get(m.lower(), m) for m in mods)
+            mods_str = "+".join(map_linux_mods(mods))
             keysym = f"{mods_str}+{keysym}"
         subprocess.run([self._xdotool, "key", "--clearmodifiers", keysym], check=False)
         time.sleep(self._KEY_GAP)
@@ -180,9 +214,62 @@ class LinuxDriver:
         for _ in range(count):
             subprocess.run([self._xdotool, "click", "1"], check=False)
 
+    def _window_id(self) -> str:
+        """xdotool id of the test instance's WispTerm window."""
+        if not self._xdotool or not self.proc:
+            raise RuntimeError("xdotool unavailable; window geometry skipped in this run")
+        out = subprocess.run(
+            [self._xdotool, "search", "--onlyvisible", "--pid", str(self.proc.pid), "--name", "WispTerm"],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+        ids = out.stdout.split()
+        if not ids:
+            # --onlyvisible can miss a just-mapped window; retry without it.
+            out = subprocess.run(
+                [self._xdotool, "search", "--pid", str(self.proc.pid), "--name", "WispTerm"],
+                capture_output=True, text=True, timeout=3, check=False,
+            )
+            ids = out.stdout.split()
+        if not ids:
+            raise RuntimeError("WispTerm window id not found")
+        return ids[-1]
+
+    def window_rect(self):
+        """(x, y, w, h) of the test window in screen pixels (xdotool space)."""
+        wid = self._window_id()
+        out = subprocess.run(
+            [self._xdotool, "getwindowgeometry", "--shell", wid],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+        vals = {}
+        for line in out.stdout.splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                try:
+                    vals[k] = int(v)
+                except ValueError:
+                    continue
+        try:
+            return vals["X"], vals["Y"], vals["WIDTH"], vals["HEIGHT"]
+        except KeyError:
+            raise RuntimeError(f"xdotool getwindowgeometry failed: {out.stdout!r} {out.stderr!r}")
+
+    def window_size(self):
+        """Current (w, h) in screen pixels."""
+        _, _, w, h = self.window_rect()
+        return w, h
+
+    def set_window_size(self, w: int, h: int) -> None:
+        """Resize via xdotool (non-AX). Used to drive PTY stty-size changes."""
+        wid = self._window_id()
+        subprocess.run(
+            [self._xdotool, "windowsize", wid, str(w), str(h)],
+            capture_output=True, timeout=3, check=False,
+        )
+
     # ---- menu / window ----
-    # Linux does not expose a stable menu/window API analogous to macOS AX, so
-    # these are stubs. Tests that rely on them should be marked @macos_only.
+    # Linux has no AX menu API. menu_* stay NotImplemented; window geometry is
+    # driveable via xdotool (window_rect / set_window_size).
     def menu_click(self, *path: str) -> None:
         raise NotImplementedError("menu automation not implemented on Linux")
 

--- a/tests/macos_e2e/test_ctl.py
+++ b/tests/macos_e2e/test_ctl.py
@@ -26,3 +26,26 @@ def test_wait_for_times_out(monkeypatch):
     monkeypatch.setattr(c, "get_text", lambda pane, recent=None: "nope")
     with pytest.raises(WaitTimeout):
         c.wait_for("pane1", "hello", timeout=2, interval=1, clock=_FakeClock())
+
+
+def test_spawn_bare_is_plain_shell_tab(monkeypatch):
+    c = Ctl(home="/tmp/x", binary="/bin/false")
+    seen = []
+    monkeypatch.setattr(c, "_run", lambda args, timeout=10.0: seen.append(args) or "")
+    c.spawn()
+    assert seen == [["spawn"]]
+
+
+def test_spawn_cwd_and_command(monkeypatch):
+    c = Ctl(home="/tmp/x", binary="/bin/false")
+    seen = []
+    monkeypatch.setattr(c, "_run", lambda args, timeout=10.0: seen.append(args) or "")
+    c.spawn("bash", "-lc", "true", cwd="/work")
+    assert seen == [["spawn", "--cwd", "/work", "--", "bash", "-lc", "true"]]
+
+
+def test_ctl_env_pins_xdg_config_under_home():
+    c = Ctl(home="/tmp/iso-home", binary="/bin/false")
+    env = c._env()
+    assert env["HOME"] == "/tmp/iso-home"
+    assert env["XDG_CONFIG_HOME"] == "/tmp/iso-home/.config"

--- a/tests/macos_e2e/test_linux.py
+++ b/tests/macos_e2e/test_linux.py
@@ -2,7 +2,20 @@
 test_ctl.py, test_panes.py, etc. These tests are Linux-only assertions.
 """
 import pytest
+
 from tests.macos_e2e.conftest import linux_only
+from tests.macos_e2e.driver.linux import config_dir_for_home, map_linux_mods
+
+
+def test_config_dir_is_xdg_config_not_data_home():
+    # src/platform/dirs.zig configDirFromXdgOrHome → ~/.config/wispterm
+    assert config_dir_for_home("/tmp/iso") == "/tmp/iso/.config/wispterm"
+
+
+def test_harness_cmd_maps_to_ctrl():
+    assert map_linux_mods(("cmd", "shift")) == ["ctrl", "shift"]
+    assert map_linux_mods(("ctrl",)) == ["ctrl"]
+    assert map_linux_mods(("super",)) == ["super"]
 
 
 @pytest.mark.e2e

--- a/tests/macos_e2e/test_linux_companion.py
+++ b/tests/macos_e2e/test_linux_companion.py
@@ -1,0 +1,370 @@
+"""Linux companions for portable E2E cases the macOS originals skip as harness gaps.
+
+macOS files stay intact (AX/Quartz/osascript). These drive the same behaviors
+through LinuxDriver + wisptermctl. Edit-menu AX and Quartz modifier-flag tests
+have no Linux equivalent and stay skipped.
+"""
+import os
+import re
+import subprocess
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.conftest import (
+    LINUX_BINARY,
+    CTL_BINARY,
+    linux_only,
+    require_linux_gui,
+    require_xclip,
+    require_xdotool,
+)
+from tests.macos_e2e.driver import wait
+from tests.macos_e2e.driver.linux import LinuxDriver
+
+_PY = sys.executable
+
+# ---- shared helpers -------------------------------------------------------
+
+def _need_xdotool():
+    require_xdotool()
+
+
+def _tab_count(app) -> int:
+    return len(app.ctl.panes().get("tabs", []))
+
+
+def _active_surface_count(app) -> int:
+    panes = app.ctl.panes()
+    tabs = panes.get("tabs", [])
+    active = panes.get("activeTab", 0)
+    tab = next((t for t in tabs if t.get("index") == active and t.get("surfaces")), None)
+    if tab is None:
+        tab = next((t for t in tabs if t.get("surfaces")), None)
+    return len(tab.get("surfaces", [])) if tab else 0
+
+
+def _wait_count(read, n: int, label: str, timeout: float = 6.0):
+    box = {}
+
+    def check():
+        box["last"] = read()
+        return True if box["last"] == n else None
+
+    try:
+        wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"expected {n} {label}, last saw {box.get('last')}")
+
+
+def _wait_overlay(app, value: str, timeout: float = 4.0):
+    box = {}
+
+    def check():
+        box["last"] = app.ui_state().get("activeOverlay")
+        return True if box["last"] == value else None
+
+    try:
+        wait.wait_until(check, timeout=timeout, interval=0.15)
+    except wait.TimeoutError:
+        raise AssertionError(f"expected overlay {value!r}, last saw {box.get('last')!r}")
+
+
+def _pty_size(app, pane: str, tag: str):
+    app.send_text("\x03", pane)
+    time.sleep(0.2)
+    app.send_text(f"echo W''SZ{tag} $(stty size)\n", pane)
+    pat = re.compile(rf"WSZ{tag} (\d+) (\d+)")
+
+    def check():
+        m = pat.search(app.get_text(pane))
+        return (int(m.group(1)), int(m.group(2))) if m else None
+
+    return wait.wait_until(check, timeout=8, interval=0.2)
+
+
+def _focused_title(app, pane: str) -> str:
+    for tab in app.ctl.panes().get("tabs", []):
+        for s in tab.get("surfaces", []):
+            if s.get("id") == pane:
+                return s.get("title", "")
+    return ""
+
+
+# ---- 1. click-to-PTY ------------------------------------------------------
+
+_MOUSE_PROBE = r'''
+import os, sys, termios, tty, select
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(1, b"\x1b[?1000h\x1b[?1006h")
+    os.write(1, b"MOUSEREADY\r\n")
+    r, _, _ = select.select([fd], [], [], 10)
+    data = os.read(fd, 64) if r else b""
+finally:
+    os.write(1, b"\x1b[?1006l\x1b[?1000l")
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+os.write(1, b"MOUSE=" + data.hex().encode() + b"\r\n")
+'''
+_SGR_PREFIX = b"\x1b[<".hex()
+
+
+@pytest.mark.e2e
+@linux_only
+def test_left_click_reaches_pty_as_mouse_report(app, pane):
+    _need_xdotool()
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.send_text("\x03", pane)
+
+    probe_path = os.path.join(app.home, "mouse_probe.py")
+    with open(probe_path, "w") as f:
+        f.write(_MOUSE_PROBE)
+
+    app.send_text(f"{_PY} {probe_path}\n", pane)
+    app.wait_for(pane, "MOUSEREADY", timeout=15)
+
+    x, y, w, h = app.window_rect()
+    app.click(x + w // 2, y + int(h * 0.6))
+    app.wait_for(pane, f"MOUSE={_SGR_PREFIX}", timeout=15)
+
+
+# ---- 2–6. legacy key encoding --------------------------------------------
+
+_KEY_PROBE = r'''
+import os, sys, termios, tty, select
+tok = (sys.argv[1] if len(sys.argv) > 1 else "X").encode()
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+
+def read(timeout):
+    r, _, _ = select.select([fd], [], [], timeout)
+    return os.read(fd, 64) if r else b""
+
+try:
+    tty.setraw(fd)
+    os.write(1, b"\x1b[<u")
+    os.write(1, b"READY:" + tok + b"\r\n")
+    keybytes = read(10)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+os.write(1, b"KB:" + tok + b"=" + keybytes.hex().encode() + b"\r\n")
+'''
+
+_KEY_CASES = [
+    ("plain_enter", ("return",), b"\r"),
+    ("shift_enter_legacy", ("return", "shift"), b"\r"),
+    ("ctrl_c", ("c", "ctrl"), b"\x03"),
+    ("tab", ("tab",), b"\t"),
+    ("escape", ("escape",), b"\x1b"),
+]
+
+
+@pytest.mark.e2e
+@linux_only
+@pytest.mark.parametrize("token,keyargs,expected", _KEY_CASES, ids=[c[0] for c in _KEY_CASES])
+def test_legacy_key_encoding_reaches_pty(app, pane, token, keyargs, expected):
+    _need_xdotool()
+    app.ensure_keyboard_ready(pane)
+
+    probe_path = os.path.join(app.home, "key_encoding_probe.py")
+    with open(probe_path, "w") as f:
+        f.write(_KEY_PROBE)
+
+    app.send_text("\x03", pane)
+    app.send_text(f"{_PY} {probe_path} {token}\n", pane)
+    app.wait_for(pane, f"READY:{token}", timeout=15)
+    app.key(*keyargs)
+    app.wait_for(pane, f"KB:{token}={expected.hex()}", timeout=15)
+
+
+# ---- 9. Ctrl+V paste ------------------------------------------------------
+
+_PASTE_MARKER = "WISPTERM_LINUX_PASTE_42"
+
+
+@pytest.mark.e2e
+@linux_only
+def test_ctrl_v_pastes_clipboard_into_pty(app, pane):
+    _need_xdotool()
+    require_xclip()
+    subprocess.run(
+        ["xclip", "-selection", "clipboard"],
+        input=_PASTE_MARKER, text=True, check=True,
+    )
+
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.send_text("\x03", pane)
+    time.sleep(0.3)
+
+    # Shared harness spelling: cmd → Ctrl on Linux (Ctrl+V paste).
+    app.key("v", "cmd")
+    try:
+        app.wait_for(pane, _PASTE_MARKER, timeout=8)
+    finally:
+        app.send_text("\x03", pane)
+
+
+# ---- 11. window resize → stty size ----------------------------------------
+
+@pytest.mark.e2e
+@linux_only
+def test_window_resize_propagates_to_pty(app, pane):
+    _need_xdotool()
+    w0, h0 = app.window_size()
+    before = _pty_size(app, pane, "A")
+    try:
+        app.set_window_size(max(w0 - 160, 400), max(h0 - 120, 300))
+        time.sleep(0.5)
+        after = _pty_size(app, pane, "B")
+        assert after != before, f"PTY size unchanged after window resize: {before} -> {after}"
+    finally:
+        app.set_window_size(w0, h0)
+
+
+# ---- 12. Shift+Enter CSI-u ------------------------------------------------
+
+_KITTY_PROBE = r'''
+import os, sys, termios, tty, select
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+
+def read(timeout):
+    r, _, _ = select.select([fd], [], [], timeout)
+    return os.read(fd, 64) if r else b""
+
+try:
+    tty.setraw(fd)
+    os.write(1, b"\x1b[?u")
+    qresp = read(5)
+    os.write(1, b"\x1b[>1u")
+    os.write(1, b"KITTYREADY\r\n")
+    keybytes = read(10)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    os.write(1, b"\x1b[<u")
+os.write(1, b"QRESP=" + qresp.hex().encode()
+         + b" KEYBYTES=" + keybytes.hex().encode() + b"\r\n")
+'''
+_SHIFT_ENTER = b"\x1b[13;2u".hex()
+_QUERY_REPLY_PREFIX = b"\x1b[?".hex()
+
+
+@pytest.mark.e2e
+@linux_only
+def test_shift_enter_sends_kitty_csi_u(app, pane):
+    _need_xdotool()
+    app.ensure_keyboard_ready(pane)
+
+    probe_path = os.path.join(app.home, "kitty_shift_enter_probe.py")
+    with open(probe_path, "w") as f:
+        f.write(_KITTY_PROBE)
+
+    app.send_text("\x03", pane)
+    app.send_text(f"{_PY} {probe_path}\n", pane)
+    app.wait_for(pane, "KITTYREADY", timeout=15)
+    app.key("return", "shift")
+    app.wait_for(pane, f"KEYBYTES={_SHIFT_ENTER}", timeout=15)
+
+    screen = app.get_text(pane)
+    assert f"QRESP={_QUERY_REPLY_PREFIX}" in screen, (
+        f"terminal did not answer the Kitty keyboard query; screen:\n{screen}"
+    )
+
+
+# ---- 13. split via keyboard -----------------------------------------------
+
+@pytest.mark.e2e
+@linux_only
+def test_split_adds_surface_to_active_tab(app, pane):
+    _need_xdotool()
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.key("escape")
+    base = _active_surface_count(app)
+
+    # Ctrl+Shift+= → split_right (harness cmd → ctrl).
+    app.key("equal", "cmd", "shift")
+    _wait_count(lambda: _active_surface_count(app), base + 1, "surfaces")
+
+    app.key("w", "cmd", "shift")
+    time.sleep(0.3)
+    app.key("return")
+    _wait_count(lambda: _active_surface_count(app), base, "surfaces")
+
+
+# ---- 14. new tab / close via keyboard + ctl spawn -------------------------
+
+@pytest.mark.e2e
+@linux_only
+def test_new_tab_and_close_via_keyboard(app, pane):
+    _need_xdotool()
+    app.focus()
+    app.ensure_keyboard_ready(pane)
+    app.key("escape")
+    _wait_overlay(app, "none")
+    base = _tab_count(app)
+
+    # Ctrl+Shift+T → session launcher; Enter → new terminal tab.
+    app.key("t", "cmd", "shift")
+    _wait_overlay(app, "session_launcher")
+    app.key("return")
+    _wait_count(lambda: _tab_count(app), base + 1, "tabs")
+
+    app.key("w", "cmd", "shift")
+    time.sleep(0.3)
+    app.key("return")
+    _wait_count(lambda: _tab_count(app), base, "tabs")
+
+
+@pytest.mark.e2e
+@linux_only
+def test_spawn_opens_new_default_shell_tab():
+    """ctl-only new-tab: `wisptermctl spawn` with an empty command."""
+    require_linux_gui()
+    driver = LinuxDriver(binary=LINUX_BINARY, ctl_binary=CTL_BINARY)
+    driver.launch()
+    try:
+        base = _tab_count(driver)
+        driver.ctl.spawn()
+        _wait_count(lambda: _tab_count(driver), base + 1, "tabs")
+    finally:
+        driver.quit()
+
+
+# ---- 15. OSC title --------------------------------------------------------
+
+_TITLE_MARKER = "WISPTERM_LINUX_E2E_TITLE"
+_TITLE_SCRIPT = (
+    "import sys, time\n"
+    f'sys.stdout.write("\\x1b]0;{_TITLE_MARKER}\\x07")\n'
+    "sys.stdout.flush()\n"
+    "time.sleep(4)\n"
+)
+
+
+@pytest.mark.e2e
+@linux_only
+def test_osc_title_sets_surface_title(app, pane):
+    script_path = os.path.join(app.home, "osc_title_probe.py")
+    with open(script_path, "w") as f:
+        f.write(_TITLE_SCRIPT)
+
+    app.send_text("\x03", pane)
+    time.sleep(0.3)
+    app.send_text(f"{_PY} {script_path}\n", pane)
+
+    box = {}
+
+    def check():
+        box["last"] = _focused_title(app, pane)
+        return True if _TITLE_MARKER in box["last"] else None
+
+    try:
+        wait.wait_until(check, timeout=8.0, interval=0.2)
+    except wait.TimeoutError:
+        raise AssertionError(f"OSC title not reflected in panes; last title={box.get('last')!r}")

--- a/tests/macos_e2e/test_linux_mcp_discovery.py
+++ b/tests/macos_e2e/test_linux_mcp_discovery.py
@@ -1,8 +1,14 @@
-"""Linux companion of test_mcp_discovery: startup MCP handshake against ~/.config/wispterm.
+"""Linux companion of test_mcp_discovery: mcp.json must not spawn a server at launch.
 
-The macOS original hardcodes APP_BUNDLE + ~/Library/Application Support/wispterm.
-This launches the Linux binary with the same isolated-HOME / XDG config the
-driver uses, and asserts initialize + tools/list reached a fake stdio server.
+Current main (see src/main.zig) builds the MCP catalog from mcp.json + the disk
+cache but does **not** spawn servers at startup — discovery is deferred to the
+panel Test probe / first mcp_activate. The macOS original still asserts
+initialize + tools/list at launch; that is stale. This companion keeps the
+macOS file intact and asserts the Linux behavior that matches the app today:
+
+- isolated launch with ~/.config/wispterm/mcp.json still starts (agent-control
+  published, panes visible)
+- the configured stdio server process is never spawned
 """
 import json
 import os
@@ -14,9 +20,13 @@ import pytest
 from tests.macos_e2e.conftest import CTL_BINARY, LINUX_BINARY, linux_only, require_linux_gui
 from tests.macos_e2e.driver.linux import LinuxDriver
 
+# Writes "spawned" the instant the process starts, before any JSON-RPC. That
+# distinguishes "server never launched" from "launched but handshake incomplete".
 _FAKE_MCP_SERVER = '''
 import sys, json
 record_path = sys.argv[1]
+with open(record_path, "a") as f:
+    f.write("spawned\\n")
 
 def rec(method):
     with open(record_path, "a") as f:
@@ -48,9 +58,15 @@ for line in sys.stdin:
 '''
 
 
+def _recorded(path: str) -> list:
+    if not os.path.exists(path):
+        return []
+    return open(path).read().split()
+
+
 @pytest.mark.e2e
 @linux_only
-def test_mcp_servers_discovered_at_startup():
+def test_mcp_json_does_not_spawn_server_at_startup():
     require_linux_gui()
     driver = LinuxDriver(binary=LINUX_BINARY, ctl_binary=CTL_BINARY)
     try:
@@ -69,16 +85,21 @@ def test_mcp_servers_discovered_at_startup():
 
         driver.launch()
 
-        methods = []
-        deadline = time.monotonic() + 20
-        while time.monotonic() < deadline:
-            if os.path.exists(record_path):
-                methods = open(record_path).read().split()
-                if "initialize" in methods and "tools/list" in methods:
-                    break
-            time.sleep(0.3)
+        # launch() already blocked on agent-control.json + a live pane.
+        disc = os.path.join(cfg_dir, "agent-control.json")
+        assert os.path.exists(disc), "agent-control discovery file missing after launch with mcp.json"
+        panes = driver.ctl.panes()
+        assert panes.get("tabs"), "isolated launch with mcp.json published no tabs"
 
-        assert "initialize" in methods, f"app never sent initialize to the MCP server; recorded {methods}"
-        assert "tools/list" in methods, f"app never sent tools/list to the MCP server; recorded {methods}"
+        # Give a slow async spawn a moment; startup discovery used to be
+        # synchronous and would have written "spawned" before launch() returned.
+        time.sleep(2.0)
+        methods = _recorded(record_path)
+        assert "spawned" not in methods, (
+            "MCP server was spawned at startup; main.zig defers discovery to "
+            f"the panel Test probe / mcp_activate. recorded {methods}"
+        )
+        assert "initialize" not in methods
+        assert "tools/list" not in methods
     finally:
         driver.quit()

--- a/tests/macos_e2e/test_linux_mcp_discovery.py
+++ b/tests/macos_e2e/test_linux_mcp_discovery.py
@@ -1,0 +1,84 @@
+"""Linux companion of test_mcp_discovery: startup MCP handshake against ~/.config/wispterm.
+
+The macOS original hardcodes APP_BUNDLE + ~/Library/Application Support/wispterm.
+This launches the Linux binary with the same isolated-HOME / XDG config the
+driver uses, and asserts initialize + tools/list reached a fake stdio server.
+"""
+import json
+import os
+import sys
+import time
+
+import pytest
+
+from tests.macos_e2e.conftest import CTL_BINARY, LINUX_BINARY, linux_only, require_linux_gui
+from tests.macos_e2e.driver.linux import LinuxDriver
+
+_FAKE_MCP_SERVER = '''
+import sys, json
+record_path = sys.argv[1]
+
+def rec(method):
+    with open(record_path, "a") as f:
+        f.write(method + "\\n")
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        msg = json.loads(line)
+    except Exception:
+        continue
+    method, mid = msg.get("method"), msg.get("id")
+    rec(method or "?")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": "2025-06-18", "capabilities": {"tools": {}},
+            "serverInfo": {"name": "e2e-fake", "version": "1"}}})
+    elif method == "tools/list":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"tools": [
+            {"name": "e2e_probe", "description": "probe", "inputSchema": {"type": "object"}}]}})
+    elif mid is not None:
+        send({"jsonrpc": "2.0", "id": mid, "error": {"code": -32601, "message": "nope"}})
+'''
+
+
+@pytest.mark.e2e
+@linux_only
+def test_mcp_servers_discovered_at_startup():
+    require_linux_gui()
+    driver = LinuxDriver(binary=LINUX_BINARY, ctl_binary=CTL_BINARY)
+    try:
+        cfg_dir = driver._config_dir()
+        os.makedirs(cfg_dir, exist_ok=True)
+
+        server_path = os.path.join(driver.home, "fake_mcp_server.py")
+        record_path = os.path.join(driver.home, "mcp_requests.log")
+        with open(server_path, "w") as f:
+            f.write(_FAKE_MCP_SERVER)
+        with open(os.path.join(cfg_dir, "mcp.json"), "w") as f:
+            json.dump(
+                {"mcpServers": {"e2e": {"command": sys.executable, "args": [server_path, record_path]}}},
+                f,
+            )
+
+        driver.launch()
+
+        methods = []
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if os.path.exists(record_path):
+                methods = open(record_path).read().split()
+                if "initialize" in methods and "tools/list" in methods:
+                    break
+            time.sleep(0.3)
+
+        assert "initialize" in methods, f"app never sent initialize to the MCP server; recorded {methods}"
+        assert "tools/list" in methods, f"app never sent tools/list to the MCP server; recorded {methods}"
+    finally:
+        driver.quit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`make test-linux-e2e` already runs `tests/macos_e2e` on Linux, but most portable cases skipped as “macOS-only E2E harness” because the Linux driver wrote config to the wrong directory, mapped `cmd` to Super, and had no non-AX hooks. Those are harness gaps, not unsupported product behavior.

Local Linux run against current main binary (`/home/box/.local/bin/wispterm-main`, DISPLAY=:5) after these driver fixes: command palette, key encodings, Shift+Enter CSI-u, tabs, split, spawn, and OSC title all passed. The one fail was the stale MCP-at-startup assertion (folded in below).

## Driver fixes (`tests/macos_e2e/driver/linux.py`, `ctl.py`)

- **Config dir (confirmed):** write isolated config/state/discovery to `$HOME/.config/wispterm`, matching `src/platform/dirs.zig` `configDirFromXdgOrHome`. Pin `XDG_CONFIG_HOME=$HOME/.config` on both the app and `wisptermctl`. (Previously wrote `~/.local/share/wispterm`.)
- **cmd → ctrl (confirmed):** harness `cmd` maps to Ctrl on Linux only. Shared `test_command_palette_overlay_state_is_observable` now PASSES (Ctrl+Shift+P).
- **Hooks:** xdotool `window_rect` / `set_window_size` for click-to-PTY and resize→`stty size`; `wisptermctl spawn` on the ctl wrapper.

## Companion tests (macOS originals untouched)

New `@linux_only` files, no Quartz / ApplicationServices / osascript:

- `test_linux_companion.py` — click-to-PTY, five legacy key encodings, Ctrl+V paste (skips only if `xclip` is missing), window resize→PTY, Shift+Enter CSI-u, keyboard split, keyboard new-tab/close, `wisptermctl spawn`, OSC title
- `test_linux_mcp_discovery.py` — isolated launch with `~/.config/wispterm/mcp.json` still starts (agent-control published) and does **not** spawn the stdio server. `src/main.zig` defers discovery to the panel Test probe / first `mcp_activate`; the macOS original’s “initialize + tools/list at launch” assertion is stale and is left intact.

Still skipped (no non-AX/Quartz path): Edit ▸ Copy menu, Quartz modifier flags. `test_cmd_c_copies_selection` stays xfail (no select-all). `test_copilot_history.py` / `test_mcp_panel.py` are `collect_ignore`d on non-macOS.

## Other

- `WISPTERM_E2E_BINARY` / `WISPTERM_E2E_CTL` env overrides in conftest
- README notes Linux companion coverage

## How to run

```bash
make test-linux-e2e
# or, with a prebuilt pair:
WISPTERM_E2E_BINARY=/path/to/wispterm WISPTERM_E2E_CTL=/path/to/wisptermctl \
  python3 -m pytest tests/macos_e2e -v
```

Does not change `make test-macos-e2e` paths or macOS test files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d339fd0-346b-4d13-bc48-a9b52240b314?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d339fd0-346b-4d13-bc48-a9b52240b314&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

