### PR TITLE
Fix OSC color sequences becoming titles and leftover PTY zombies

### DIFF
--- a/src/Command.zig
+++ b/src/Command.zig
@@ -18,8 +18,16 @@ pub fn start(self: *Command, pty: *Pty, command: platform_command.CommandLine, c
     return pty.startCommand(&self.impl, command, cwd);
 }
 
-pub fn wait(self: *const Command, block: bool) !?Exit {
+pub fn wait(self: *Command, block: bool) !?Exit {
     return self.impl.wait(block);
+}
+
+/// After PTY EOF/EIO the child is usually already a zombie, but a single
+/// WNOHANG can lose that race and leave a defunct pid under the emulator.
+/// Retry until reaped or `timeout_ms` elapses. Does not block forever so a
+/// process that closed the slave and kept running cannot hang the reader.
+pub fn waitUntilReaped(self: *Command, timeout_ms: u64) ?Exit {
+    return self.impl.waitUntilReaped(timeout_ms);
 }
 
 pub fn deinit(self: *Command) void {
@@ -47,7 +55,11 @@ test "Command delegates lifecycle API to platform implementation" {
 
     const wait_info = @typeInfo(@TypeOf(wait)).@"fn";
     try std.testing.expectEqual(@as(usize, 2), wait_info.params.len);
-    try std.testing.expect(wait_info.params[0].type.? == *const Command);
+    try std.testing.expect(wait_info.params[0].type.? == *Command);
+
+    const reap_info = @typeInfo(@TypeOf(waitUntilReaped)).@"fn";
+    try std.testing.expectEqual(@as(usize, 2), reap_info.params.len);
+    try std.testing.expect(reap_info.params[0].type.? == *Command);
 
     const deinit_info = @typeInfo(@TypeOf(deinit)).@"fn";
     try std.testing.expectEqual(@as(usize, 1), deinit_info.params.len);

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -28,6 +28,7 @@ const surface_registry = @import("surface_registry.zig");
 const platform_process = @import("platform/process.zig");
 const ssh_connection_mod = @import("ssh/connection.zig");
 const clipboard_osc52 = @import("clipboard_osc52.zig");
+const osc_title = @import("osc_title.zig");
 
 const Surface = @This();
 const io_log = std.log.scoped(.surface_io);
@@ -87,9 +88,6 @@ pub const IoState = union(enum) {
     exited: ExitInfo,
     failed: IoFailure,
 };
-
-/// OSC parser state machine — handles sequences split across PTY reads.
-const OscParseState = enum { ground, esc, osc_num, osc_semi, osc_title };
 
 const ImageOscParseState = enum {
     ground,
@@ -381,11 +379,7 @@ window_title_len: usize = 0,
 /// Set via double-click on tab or keyboard shortcut. Clear by setting len to 0.
 title_override: [256]u8 = undefined,
 title_override_len: usize = 0,
-osc_state: OscParseState = .ground,
-osc_is_title: bool = false,
-osc_num: u8 = 0,
-osc_buf: [512]u8 = undefined,
-osc_buf_len: usize = 0,
+title_osc: osc_title.Scanner = .{},
 osc7_title: [256]u8 = undefined,
 osc7_title_len: usize = 0,
 got_osc7_this_batch: bool = false,
@@ -563,10 +557,7 @@ fn finishInit(
     // Init OSC state
     surface.window_title_len = 0;
     surface.title_override_len = 0;
-    surface.osc_state = .ground;
-    surface.osc_is_title = false;
-    surface.osc_num = 0;
-    surface.osc_buf_len = 0;
+    surface.title_osc = .{};
     surface.osc7_title_len = 0;
     surface.got_osc7_this_batch = false;
     surface.wispterm_image_osc_state = .ground;
@@ -1772,62 +1763,11 @@ fn handleWispTermImageOsc(self: *Surface) void {
 /// Scan PTY output for OSC 0/1/2/7 title sequences.
 /// Handles sequences split across multiple reads via state machine.
 pub fn scanForOscTitle(self: *Surface, data: []const u8) void {
-    for (data) |byte| {
-        switch (self.osc_state) {
-            .ground => {
-                if (byte == 0x1b) {
-                    self.osc_state = .esc;
-                }
-            },
-            .esc => {
-                if (byte == ']') {
-                    self.osc_state = .osc_num;
-                    self.osc_is_title = false;
-                } else {
-                    self.osc_state = .ground;
-                }
-            },
-            .osc_num => {
-                if (byte == '0' or byte == '1' or byte == '2' or byte == '7') {
-                    self.osc_is_title = true;
-                    self.osc_num = byte;
-                    self.osc_state = .osc_semi;
-                } else if (byte >= '0' and byte <= '9') {
-                    self.osc_is_title = false;
-                    self.osc_num = byte;
-                    self.osc_state = .osc_semi;
-                } else {
-                    self.osc_state = .ground;
-                }
-            },
-            .osc_semi => {
-                if (byte == ';') {
-                    if (self.osc_is_title) {
-                        self.osc_buf_len = 0;
-                        self.osc_state = .osc_title;
-                    } else {
-                        self.osc_state = .ground;
-                    }
-                } else if (byte >= '0' and byte <= '9') {
-                    // Multi-digit OSC number, stay in osc_semi
-                } else {
-                    self.osc_state = .ground;
-                }
-            },
-            .osc_title => {
-                if (byte == 0x07) {
-                    self.updateTitle(self.osc_buf[0..self.osc_buf_len], self.osc_num);
-                    self.osc_state = .ground;
-                } else if (byte == 0x1b) {
-                    self.updateTitle(self.osc_buf[0..self.osc_buf_len], self.osc_num);
-                    self.osc_state = .esc;
-                } else if (self.osc_buf_len < self.osc_buf.len) {
-                    self.osc_buf[self.osc_buf_len] = byte;
-                    self.osc_buf_len += 1;
-                }
-            },
-        }
-    }
+    self.title_osc.feed(data, self, onTitleOscEvent);
+}
+
+fn onTitleOscEvent(self: *Surface, event: osc_title.Event) void {
+    self.updateTitle(event.text, event.code);
 }
 
 /// Update the surface title from an OSC sequence.
@@ -1838,7 +1778,7 @@ fn updateTitle(self: *Surface, title: []const u8, osc_num: u8) void {
     if (title.len == 0) return;
     if (!std.unicode.utf8ValidateSlice(title)) return;
 
-    if (osc_num == '7') {
+    if (osc_num == 7) {
         // OSC 7: file://host/path — extract the path
         self.got_osc7_this_batch = true;
         const prefix = "file://";

--- a/src/osc_title.zig
+++ b/src/osc_title.zig
@@ -1,0 +1,201 @@
+//! OSC 0/1/2 window-title and OSC 7 cwd scanner.
+//!
+//! Ghostty parses the *complete* OSC command number before dispatching
+//! (`ghostty/src/terminal/osc.zig`: OSC 0/2 → `change_window_title`,
+//! OSC 10–19 / 104 / 110–119 → color/palette). WispTerm used to treat the
+//! first digit 0/1/2/7 as a title command, so multi-digit color sequences
+//! such as OSC 10/11 (`#eeeeee`, `#fab283`) became the tab/window title.
+
+const std = @import("std");
+
+pub const Event = struct {
+    /// 0/1/2 = window/icon title, 7 = OSC 7 cwd.
+    code: u8,
+    text: []const u8,
+};
+
+pub fn isTitleOrCwdOsc(code: u16) bool {
+    return code == 0 or code == 1 or code == 2 or code == 7;
+}
+
+pub const Scanner = struct {
+    const State = enum { ground, esc, osc_num, osc_payload };
+
+    state: State = .ground,
+    code: u16 = 0,
+    buf: [512]u8 = undefined,
+    buf_len: usize = 0,
+
+    pub fn feed(
+        self: *Scanner,
+        data: []const u8,
+        ctx: anytype,
+        comptime on_event: fn (@TypeOf(ctx), Event) void,
+    ) void {
+        for (data) |byte| {
+            if (self.step(byte)) |event| on_event(ctx, event);
+        }
+    }
+
+    fn step(self: *Scanner, byte: u8) ?Event {
+        switch (self.state) {
+            .ground => {
+                if (byte == 0x1b) self.state = .esc;
+            },
+            .esc => {
+                if (byte == ']') {
+                    self.state = .osc_num;
+                    self.code = 0;
+                } else {
+                    self.state = .ground;
+                }
+            },
+            .osc_num => {
+                if (byte >= '0' and byte <= '9') {
+                    const next: u32 = @as(u32, self.code) * 10 + (byte - '0');
+                    if (next > 9999) {
+                        self.state = .ground;
+                    } else {
+                        self.code = @intCast(next);
+                    }
+                } else if (byte == ';') {
+                    if (isTitleOrCwdOsc(self.code)) {
+                        self.buf_len = 0;
+                        self.state = .osc_payload;
+                    } else {
+                        self.state = .ground;
+                    }
+                } else {
+                    self.state = .ground;
+                }
+            },
+            .osc_payload => {
+                if (byte == 0x07) {
+                    const event = self.payloadEvent();
+                    self.state = .ground;
+                    return event;
+                } else if (byte == 0x1b) {
+                    const event = self.payloadEvent();
+                    self.state = .esc;
+                    return event;
+                } else if (self.buf_len < self.buf.len) {
+                    self.buf[self.buf_len] = byte;
+                    self.buf_len += 1;
+                }
+            },
+        }
+        return null;
+    }
+
+    fn payloadEvent(self: *const Scanner) Event {
+        return .{
+            .code = @intCast(self.code),
+            .text = self.buf[0..self.buf_len],
+        };
+    }
+};
+
+const Collect = struct {
+    title: [256]u8 = undefined,
+    title_len: usize = 0,
+    last_code: u8 = 255,
+    events: usize = 0,
+
+    fn onEvent(self: *Collect, event: Event) void {
+        const n = @min(event.text.len, self.title.len);
+        @memcpy(self.title[0..n], event.text[0..n]);
+        self.title_len = n;
+        self.last_code = event.code;
+        self.events += 1;
+    }
+
+    fn text(self: *const Collect) []const u8 {
+        return self.title[0..self.title_len];
+    }
+};
+
+fn scan(data: []const u8) Collect {
+    var scanner: Scanner = .{};
+    var out: Collect = .{};
+    scanner.feed(data, &out, Collect.onEvent);
+    return out;
+}
+
+test "OSC 0/2 set the window title including Unicode" {
+    const osc0 = scan("\x1b]0;Capabilities\x07");
+    try std.testing.expectEqual(@as(u8, 0), osc0.last_code);
+    try std.testing.expectEqualStrings("Capabilities", osc0.text());
+
+    const osc2 = scan("\x1b]2;π - box\x07");
+    try std.testing.expectEqual(@as(u8, 2), osc2.last_code);
+    try std.testing.expectEqualStrings("π - box", osc2.text());
+}
+
+test "OSC 10/11 color sequences are not titles" {
+    const fg = scan("\x1b]10;#eeeeee\x07");
+    try std.testing.expectEqual(@as(usize, 0), fg.events);
+
+    const bg = scan("\x1b]11;#fab283\x07");
+    try std.testing.expectEqual(@as(usize, 0), bg.events);
+
+    const query = scan("\x1b]11;?\x07");
+    try std.testing.expectEqual(@as(usize, 0), query.events);
+
+    const rgb = scan("\x1b]10;rgb:ee/ee/ee\x07");
+    try std.testing.expectEqual(@as(usize, 0), rgb.events);
+}
+
+test "OSC 4/104 palette sequences are not titles" {
+    try std.testing.expectEqual(@as(usize, 0), scan("\x1b]4;0;#eeeeee\x07").events);
+    try std.testing.expectEqual(@as(usize, 0), scan("\x1b]104;0\x07").events);
+}
+
+test "a real OSC 0 title still wins after a color sequence" {
+    var scanner: Scanner = .{};
+    var out: Collect = .{};
+    scanner.feed("\x1b]11;#eeeeee\x07\x1b]0;π - box\x07", &out, Collect.onEvent);
+    try std.testing.expectEqual(@as(usize, 1), out.events);
+    try std.testing.expectEqualStrings("π - box", out.text());
+}
+
+test "color OSC after a title does not overwrite it" {
+    var scanner: Scanner = .{};
+    var out: Collect = .{};
+    scanner.feed("\x1b]0;grok\x07\x1b]11;#fab283\x07", &out, Collect.onEvent);
+    try std.testing.expectEqual(@as(usize, 1), out.events);
+    try std.testing.expectEqualStrings("grok", out.text());
+}
+
+test "title sequences split across reads keep state" {
+    var scanner: Scanner = .{};
+    var out: Collect = .{};
+    scanner.feed("\x1b]0;hel", &out, Collect.onEvent);
+    try std.testing.expectEqual(@as(usize, 0), out.events);
+    scanner.feed("lo\x07", &out, Collect.onEvent);
+    try std.testing.expectEqualStrings("hello", out.text());
+}
+
+test "ST-terminated OSC 2 is accepted" {
+    const got = scan("\x1b]2;wispterm\x1b\\");
+    try std.testing.expectEqual(@as(u8, 2), got.last_code);
+    try std.testing.expectEqualStrings("wispterm", got.text());
+}
+
+test "OSC 7 is reported as cwd, not ignored" {
+    const got = scan("\x1b]7;file://host/home/box\x07");
+    try std.testing.expectEqual(@as(u8, 7), got.last_code);
+    try std.testing.expectEqualStrings("file://host/home/box", got.text());
+}
+
+test "isTitleOrCwdOsc matches Ghostty's title/cwd numbers only" {
+    try std.testing.expect(isTitleOrCwdOsc(0));
+    try std.testing.expect(isTitleOrCwdOsc(1));
+    try std.testing.expect(isTitleOrCwdOsc(2));
+    try std.testing.expect(isTitleOrCwdOsc(7));
+    try std.testing.expect(!isTitleOrCwdOsc(4));
+    try std.testing.expect(!isTitleOrCwdOsc(10));
+    try std.testing.expect(!isTitleOrCwdOsc(11));
+    try std.testing.expect(!isTitleOrCwdOsc(12));
+    try std.testing.expect(!isTitleOrCwdOsc(104));
+    try std.testing.expect(!isTitleOrCwdOsc(777));
+}

--- a/src/platform/pty_command.zig
+++ b/src/platform/pty_command.zig
@@ -505,8 +505,12 @@ test "platform pty command exposes command lifecycle API" {
 
     const wait_info = @typeInfo(@TypeOf(CommandType.wait)).@"fn";
     try std.testing.expectEqual(@as(usize, 2), wait_info.params.len);
-    try std.testing.expect(wait_info.params[0].type.? == *const CommandType);
+    try std.testing.expect(wait_info.params[0].type.? == *CommandType);
     try std.testing.expect(wait_info.params[1].type.? == bool);
+
+    const reap_info = @typeInfo(@TypeOf(CommandType.waitUntilReaped)).@"fn";
+    try std.testing.expectEqual(@as(usize, 2), reap_info.params.len);
+    try std.testing.expect(reap_info.params[0].type.? == *CommandType);
 
     const deinit_info = @typeInfo(@TypeOf(CommandType.deinit)).@"fn";
     try std.testing.expectEqual(@as(usize, 1), deinit_info.params.len);

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -409,7 +409,9 @@ test "unsupported backend uses UTF-8 native command and cwd storage" {
 test "Command.wait reaps an exited child so it does not stay defunct" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-    var child = std.process.Child.init(&.{"/bin/true"}, std.testing.allocator);
+    // `/bin/sh -c` matches the other POSIX spawn tests in this file. A bare
+    // `/bin/true` exited 1 on macOS ARM CI, which is not the reap invariant.
+    var child = std.process.Child.init(&.{ "/bin/sh", "-c", "exit 42" }, std.testing.allocator);
     child.stdin_behavior = .Ignore;
     child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Ignore;
@@ -418,7 +420,7 @@ test "Command.wait reaps an exited child so it does not stay defunct" {
     var cmd = Command{ .pid = child.id };
     defer cmd.deinit();
     const exit = cmd.waitUntilReaped(500) orelse return error.NotReaped;
-    try std.testing.expectEqual(Command.Exit{ .exited = 0 }, exit);
+    try std.testing.expectEqual(Command.Exit{ .exited = 42 }, exit);
     try std.testing.expectEqual(@as(std.c.pid_t, -1), cmd.pid);
     try std.testing.expectEqual(process_shared.WaitResult.no_child, process_shared.reapChild(child.id, 0));
 }

--- a/src/platform/pty_command_unsupported.zig
+++ b/src/platform/pty_command_unsupported.zig
@@ -118,7 +118,7 @@ pub const Command = struct {
     /// child" (not yet spawned, or already reaped).
     pid: std.c.pid_t = -1,
 
-    pub fn wait(self: *const Command, block: bool) !?Exit {
+    pub fn wait(self: *Command, block: bool) !?Exit {
         if (self.pid <= 0) return null;
         // POSIX-only: guarded so this file still compiles under a Windows
         // target build (it is selected only for non-windows hosts).
@@ -127,9 +127,33 @@ pub const Command = struct {
         const options: u32 = if (block) 0 else process_shared.WNOHANG;
         switch (process_shared.reapChild(self.pid, options)) {
             .still_running => return null,
-            .no_child => return null,
-            .reaped => |code| return Exit{ .exited = code },
-            .reaped_unknown => return .unknown,
+            .no_child => {
+                self.pid = -1;
+                return null;
+            },
+            .reaped => |code| {
+                self.pid = -1;
+                return Exit{ .exited = code };
+            },
+            .reaped_unknown => {
+                self.pid = -1;
+                return .unknown;
+            },
+        }
+    }
+
+    /// Retry a non-blocking wait until the child is reaped or `timeout_ms`
+    /// elapses. Used after PTY EOF/EIO so a single WNOHANG race cannot leave
+    /// a defunct child under the emulator.
+    pub fn waitUntilReaped(self: *Command, timeout_ms: u64) ?Exit {
+        if (self.pid <= 0) return null;
+        const start_ms = std.time.milliTimestamp();
+        while (true) {
+            const result = self.wait(false) catch return null;
+            if (result) |exit| return exit;
+            if (self.pid <= 0) return null;
+            if (std.time.milliTimestamp() - start_ms >= @as(i64, @intCast(timeout_ms))) return null;
+            std.Thread.sleep(5 * std.time.ns_per_ms);
         }
     }
 
@@ -380,6 +404,45 @@ test "unsupported backend uses UTF-8 native command and cwd storage" {
     defer freeCwd(std.testing.allocator, cwd);
     var utf8: [32]u8 = undefined;
     try std.testing.expectEqualStrings("/tmp", cwdToUtf8(&utf8, cwdFromOwned(cwd)).?);
+}
+
+test "Command.wait reaps an exited child so it does not stay defunct" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var child = std.process.Child.init(&.{"/bin/true"}, std.testing.allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    try child.spawn();
+
+    var cmd = Command{ .pid = child.id };
+    defer cmd.deinit();
+    const exit = cmd.waitUntilReaped(500) orelse return error.NotReaped;
+    try std.testing.expectEqual(Command.Exit{ .exited = 0 }, exit);
+    try std.testing.expectEqual(@as(std.c.pid_t, -1), cmd.pid);
+    try std.testing.expectEqual(process_shared.WaitResult.no_child, process_shared.reapChild(child.id, 0));
+}
+
+test "waitUntilReaped catches a child that exits after the first WNOHANG" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    var child = std.process.Child.init(&.{ "/bin/sh", "-c", "sleep 0.05" }, std.testing.allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    try child.spawn();
+
+    var cmd = Command{ .pid = child.id };
+    defer cmd.deinit();
+    const first = try cmd.wait(false);
+    if (first) |exit| {
+        try std.testing.expectEqual(Command.Exit{ .exited = 0 }, exit);
+    } else {
+        const exit = cmd.waitUntilReaped(500) orelse return error.NotReaped;
+        try std.testing.expectEqual(Command.Exit{ .exited = 0 }, exit);
+    }
+    try std.testing.expectEqual(@as(std.c.pid_t, -1), cmd.pid);
+    try std.testing.expectEqual(process_shared.WaitResult.no_child, process_shared.reapChild(child.id, 0));
 }
 
 test "Command.kill sends SIGHUP and the child is reaped as signaled" {

--- a/src/platform/pty_command_windows.zig
+++ b/src/platform/pty_command_windows.zig
@@ -616,7 +616,7 @@ pub const Command = struct {
         self.attr_list_size = attr_size;
     }
 
-    pub fn wait(self: *const Command, block: bool) !?Exit {
+    pub fn wait(self: *Command, block: bool) !?Exit {
         if (self.process == INVALID_HANDLE_VALUE) return null;
 
         const timeout: DWORD = if (block) infinite else 0;
@@ -629,6 +629,18 @@ pub const Command = struct {
         if (GetExitCodeProcess(self.process, &exit_code) == 0) return error.GetExitCodeFailed;
 
         return Exit{ .exited = exit_code };
+    }
+
+    pub fn waitUntilReaped(self: *Command, timeout_ms: u64) ?Exit {
+        if (self.process == INVALID_HANDLE_VALUE) return null;
+        const start_ms = std.time.milliTimestamp();
+        while (true) {
+            const result = self.wait(false) catch return null;
+            if (result) |exit| return exit;
+            if (self.process == INVALID_HANDLE_VALUE) return null;
+            if (std.time.milliTimestamp() - start_ms >= @as(i64, @intCast(timeout_ms))) return null;
+            std.Thread.sleep(5 * std.time.ns_per_ms);
+        }
     }
 
     pub fn deinit(self: *Command) void {

--- a/src/termio/ReadThread.zig
+++ b/src/termio/ReadThread.zig
@@ -20,6 +20,11 @@ const read_coalesce = @import("read_coalesce.zig");
 /// accept arbitrary buffer sizes.
 const READ_BUF_SIZE = 64 * 1024;
 
+/// After PTY EOF/EIO, retry waitpid this long so a single WNOHANG cannot
+/// leave a defunct child. Short enough that a process which closed the
+/// slave and kept running cannot hang the reader thread.
+const CHILD_REAP_TIMEOUT_MS: u64 = 250;
+
 pub fn threadMain(surface: *Surface) void {
     defer surface.markStopped();
 
@@ -38,7 +43,7 @@ pub fn threadMain(surface: *Surface) void {
         };
         if (bytes_read == 0) {
             if (!surface.exited.load(.acquire)) {
-                surface.markExited(.eof, surface.pollExitStatus());
+                surface.markExited(.eof, surface.command.waitUntilReaped(CHILD_REAP_TIMEOUT_MS));
             }
             return;
         }
@@ -99,7 +104,7 @@ fn drainResizeOutput(
 
         if (bytes_read == 0) {
             if (!surface.exited.load(.acquire)) {
-                surface.markExited(.eof, surface.pollExitStatus());
+                surface.markExited(.eof, surface.command.waitUntilReaped(CHILD_REAP_TIMEOUT_MS));
             }
             return;
         }
@@ -149,7 +154,7 @@ fn drainAvailableOutput(
         };
         if (bytes_read == 0) {
             if (!surface.exited.load(.acquire)) {
-                surface.markExited(.eof, surface.pollExitStatus());
+                surface.markExited(.eof, surface.command.waitUntilReaped(CHILD_REAP_TIMEOUT_MS));
             }
             return;
         }
@@ -212,7 +217,7 @@ fn handleReadError(surface: *Surface, err: anyerror) ReadErrorAction {
     if (surface.exited.load(.acquire)) return .stop;
 
     if (err == error.BrokenPipe) {
-        surface.markExited(.broken_pipe, surface.pollExitStatus());
+        surface.markExited(.broken_pipe, surface.command.waitUntilReaped(CHILD_REAP_TIMEOUT_MS));
         return .stop;
     }
 

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -460,6 +460,8 @@ test {
     _ = @import("html/server_model.zig");
     // Platform-aware agent prompt: pure string constants, no heavy deps.
     _ = @import("platform/agent_prompt.zig");
+    // OSC 0/1/2/7 title scanner: must ignore OSC 10/11 color payloads.
+    _ = @import("osc_title.zig");
     // Pure login-shell argv logic (macOS bash/.bashrc fix). OS-agnostic, so it
     // runs here on the native host rather than in the POSIX-only exec path.
     _ = @import("platform/login_shell.zig");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two Linux TUI bugs (OpenCode / Codex / Claude / pi). Both are shared parser/PTY-lifecycle issues, not Linux-only backends.

## Bug 1 — OSC color sequences became the window/tab title

**Cause:** WispTerm’s title scanner (`scanForOscTitle`) treated the *first digit* of an OSC number as the command. `0`/`1`/`2`/`7` marked the sequence as a title, and extra digits (the `0` in OSC 10, the `1` in OSC 11, the `04` in OSC 104) were ignored. OpenCode’s OSC 10/11 color payloads (`#eeeeee`, `#fab283`) were therefore stored as the tab title.

**Ghostty:** [`src/terminal/osc.zig`](https://github.com/ghostty-org/ghostty/blob/main/src/terminal/osc.zig) parses the *complete* OSC number, then dispatches: OSC 0/2 → `change_window_title`, OSC 7 → `report_pwd`, OSC 10–19 / 104 / 110–119 → `color_operation`. WispTerm now does the same classification in `src/osc_title.zig` (ghostty-vt still owns VT color state; this scanner only decides what may become a tab title).

**Fix:** Accumulate the full OSC number; only exact 0/1/2/7 update the title/cwd. Real OSC 0/2 titles, including Unicode (`π - box`), still work.

## Bug 2 — spawned command children left as zombies

**Cause:** On PTY EOF/EIO the reader called a single `waitpid(WNOHANG)`. That can lose the race: the slave is already closed (banner shows “Process exited”) but the child is not yet waitable. The reader then stops, the tab stays open for reconnect, and nobody `waitpid`s again until surface teardown — so `[codex] <defunct>` / `[opencode] <defunct>` linger under `wispterm-main`.

`surface_snapshots.zig` already documented this race for exit *codes*; the IO path never retried the reap.

**Fix:** After PTY close, `waitUntilReaped` retries non-blocking wait for 250ms and clears the tracked pid. Direct child only — no `waitpid(-1)`, so shell tabs and other helper processes are untouched. Reconnect banner unchanged.

Leftover *running* grandchildren (e.g. a `node` worker that ignored SIGHUP) are reparented by the kernel and are out of scope; this change only reaps the tracked PTY child.

## Test plan

- [x] `zig fmt --check` on touched files
- [x] `zig build test` (fast suite): new `src/osc_title.zig` cases (OSC 0/2 Unicode, OSC 10/11/4/104 ignored, split reads, ST terminator) and POSIX `Command.wait` / `waitUntilReaped` reap tests (child is gone; second `waitpid` is `ECHILD`)
- [ ] Existing Linux e2e `test_osc_title_sets_surface_title` and macOS original still apply (OSC 0 probe unchanged)
- [ ] Manual: `wisptermctl spawn -- opencode` (or Codex/pi) → title is not a hex color; after quit, no `<defunct>` child under the WispTerm process; Enter reconnect still works; a normal shell tab is unaffected

Windows `Command.wait` signature is `*Command` to match POSIX (needed to clear pid after reap). Wait semantics on Windows are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc87e33-638f-4dca-87bb-e1c859af64d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc87e33-638f-4dca-87bb-e1c859af64d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

