### PR TITLE
fix(macos): unblock Cmd+Q deadlock when joining window threads

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -1268,19 +1268,19 @@ test "app: macOS window-thread join pumps the main queue (issue 611)" {
     const source = @embedFile("App.zig");
     const join_fn = "fn joinAllWindowThreads";
     const join_at = std.mem.indexOf(u8, source, join_fn) orelse return error.MissingJoin;
-    const body = source[join_at .. @min(source.len, join_at + 1500)];
+    const body = source[join_at..@min(source.len, join_at + 1500)];
     try std.testing.expect(std.mem.indexOf(u8, body, "live_window_threads") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "pumpWhileLive") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "pumpAppEvents") != null);
 
     const spawn_fn = "pub fn requestNewWindow(self: *App,";
     const spawn_at = std.mem.indexOf(u8, source, spawn_fn) orelse return error.MissingSpawn;
-    const spawn_body = source[spawn_at .. @min(source.len, spawn_at + 2500)];
+    const spawn_body = source[spawn_at..@min(source.len, spawn_at + 2500)];
     try std.testing.expect(std.mem.indexOf(u8, spawn_body, "live_window_threads.fetchAdd") != null);
 
     const thread_fn = "fn windowThreadMain";
     const thread_at = std.mem.indexOf(u8, source, thread_fn) orelse return error.MissingThreadMain;
-    const thread_body = source[thread_at .. @min(source.len, thread_at + 400)];
+    const thread_body = source[thread_at..@min(source.len, thread_at + 400)];
     try std.testing.expect(std.mem.indexOf(u8, thread_body, "live_window_threads.fetchSub") != null);
 }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -159,6 +159,10 @@ startup_update_check_started: bool,
 windows: std.ArrayListUnmanaged(*AppWindow),
 mutex: std.Thread.Mutex,
 window_threads: std.ArrayListUnmanaged(std.Thread),
+/// Spawned window threads that have not yet returned from `windowThreadMain`.
+/// Counted independently of `window_threads` so a failed `append` that detaches
+/// the handle still waits for the worker to finish teardown.
+live_window_threads: std.atomic.Value(usize) = .init(0),
 
 // Position for next spawned window (cascading)
 next_window_x: ?i32 = null,
@@ -1062,7 +1066,11 @@ pub fn requestNewWindow(self: *App, parent_handle: ?window_backend.NativeHandle,
 
     self.mutex.unlock();
 
+    // Increment before spawn so the worker cannot finish and decrement first
+    // (that would wrap the counter). Roll back if spawn itself fails.
+    _ = self.live_window_threads.fetchAdd(1, .monotonic);
     const thread = std.Thread.spawn(.{}, windowThreadMain, .{self}) catch |err| {
+        _ = self.live_window_threads.fetchSub(1, .monotonic);
         std.debug.print("Failed to spawn window thread: {}\n", .{err});
         return;
     };
@@ -1093,6 +1101,8 @@ pub fn requestNewWindowWithRecipe(self: *App, parent_handle: ?window_backend.Nat
 
 /// Thread entry point for spawned windows.
 fn windowThreadMain(app: *App) void {
+    defer _ = app.live_window_threads.fetchSub(1, .acq_rel);
+
     // Initialize the native UI thread apartment for platform backends.
     const com_apartment = platform_com.initUiThread();
     defer com_apartment.deinit();
@@ -1135,6 +1145,16 @@ fn windowThreadMain(app: *App) void {
 
 /// Wait for all spawned window threads to finish.
 fn joinAllWindowThreads(self: *App) void {
+    // On macOS the main thread owns the GCD main queue. Worker windows destroy
+    // NSWindow (and WKWebView) via dispatch_sync onto that queue, so a blocking
+    // Thread.join() here starves teardown and deadlocks for ~30s (issue #611).
+    // Ghostty does not hit this: its AppKit host closes windows on the main
+    // thread already. Keep pumping until every worker has left windowThreadMain.
+    if (comptime builtin.os.tag == .macos) {
+        const thread_join = @import("appwindow/thread_join.zig");
+        thread_join.pumpWhileLive(&self.live_window_threads, window_backend.pumpAppEvents, 0.05);
+    }
+
     // Take ownership of the thread list
     self.mutex.lock();
     const threads = self.window_threads.toOwnedSlice(self.allocator) catch {
@@ -1242,6 +1262,26 @@ pub fn deinit(self: *App) void {
 
     self.windows.deinit(self.allocator);
     self.window_threads.deinit(self.allocator);
+}
+
+test "app: macOS window-thread join pumps the main queue (issue 611)" {
+    const source = @embedFile("App.zig");
+    const join_fn = "fn joinAllWindowThreads";
+    const join_at = std.mem.indexOf(u8, source, join_fn) orelse return error.MissingJoin;
+    const body = source[join_at .. @min(source.len, join_at + 1500)];
+    try std.testing.expect(std.mem.indexOf(u8, body, "live_window_threads") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "pumpWhileLive") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "pumpAppEvents") != null);
+
+    const spawn_fn = "pub fn requestNewWindow(self: *App,";
+    const spawn_at = std.mem.indexOf(u8, source, spawn_fn) orelse return error.MissingSpawn;
+    const spawn_body = source[spawn_at .. @min(source.len, spawn_at + 2500)];
+    try std.testing.expect(std.mem.indexOf(u8, spawn_body, "live_window_threads.fetchAdd") != null);
+
+    const thread_fn = "fn windowThreadMain";
+    const thread_at = std.mem.indexOf(u8, source, thread_fn) orelse return error.MissingThreadMain;
+    const thread_body = source[thread_at .. @min(source.len, thread_at + 400)];
+    try std.testing.expect(std.mem.indexOf(u8, thread_body, "live_window_threads.fetchSub") != null);
 }
 
 test "app: updateConfig refreshes configured shell command" {

--- a/src/appwindow/thread_join.zig
+++ b/src/appwindow/thread_join.zig
@@ -1,0 +1,89 @@
+//! Join helper that keeps draining a main-thread event queue.
+//!
+//! WispTerm runs extra windows on worker threads. On macOS those workers tear
+//! down NSWindow via `dispatch_sync` onto the main GCD queue. Ghostty does not
+//! have this deadlock: its macOS host is a native AppKit app, so window close
+//! and `applicationShouldTerminate` already run on the main thread
+//! (`macos/Sources/App/AppDelegate.swift`). A blocking `Thread.join()` on
+//! WispTerm's main thread starves that queue and deadlocks (GitHub issue #611).
+//! Pump until the live worker count reaches 0, then join (joins are then instant).
+
+const std = @import("std");
+
+pub const PumpFn = *const fn (timeout_seconds: f64) void;
+
+/// Invoke `pump` until `live` reaches 0. `pump_timeout_seconds` must be > 0
+/// so the macOS AppKit pump actually runs the GCD main queue (a 0s
+/// `distantPast` drain never does).
+pub fn pumpWhileLive(
+    live: *const std.atomic.Value(usize),
+    pump: PumpFn,
+    pump_timeout_seconds: f64,
+) void {
+    while (live.load(.acquire) > 0) {
+        pump(pump_timeout_seconds);
+    }
+}
+
+test "pumpWhileLive is a no-op when live is already 0" {
+    const Holder = struct {
+        var pumps: std.atomic.Value(u32) = .init(0);
+        fn pump(_: f64) void {
+            _ = pumps.fetchAdd(1, .monotonic);
+        }
+    };
+    Holder.pumps.store(0, .release);
+    var live = std.atomic.Value(usize).init(0);
+    pumpWhileLive(&live, Holder.pump, 0.01);
+    try std.testing.expectEqual(@as(u32, 0), Holder.pumps.load(.acquire));
+}
+
+test "pumpWhileLive keeps pumping until a worker waiting on the pump drops live" {
+    // Mirrors issue #611: the worker cannot finish teardown until the main
+    // thread pumps. Blocking join without a pump would hang this test.
+    const Holder = struct {
+        var pumped: std.atomic.Value(bool) = .init(false);
+        fn pump(_: f64) void {
+            pumped.store(true, .release);
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+        }
+    };
+    Holder.pumped.store(false, .release);
+
+    var live = std.atomic.Value(usize).init(1);
+    const Worker = struct {
+        live: *std.atomic.Value(usize),
+        fn run(self: *@This()) void {
+            while (!Holder.pumped.load(.acquire)) {
+                std.Thread.yield() catch {};
+            }
+            _ = self.live.fetchSub(1, .acq_rel);
+        }
+    };
+    var worker = Worker{ .live = &live };
+    const thread = try std.Thread.spawn(.{}, Worker.run, .{&worker});
+
+    var done = std.atomic.Value(bool).init(false);
+    const Runner = struct {
+        live: *std.atomic.Value(usize),
+        done: *std.atomic.Value(bool),
+        fn run(self: *@This()) void {
+            pumpWhileLive(self.live, Holder.pump, 0.01);
+            self.done.store(true, .release);
+        }
+    };
+    var runner_ctx = Runner{ .live = &live, .done = &done };
+    const runner = try std.Thread.spawn(.{}, Runner.run, .{&runner_ctx});
+
+    var timer = try std.time.Timer.start();
+    const timeout_ns: u64 = 2 * std.time.ns_per_s;
+    while (!done.load(.acquire)) {
+        if (timer.read() > timeout_ns) return error.JoinDeadlock;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+
+    runner.join();
+    thread.join();
+    try std.testing.expectEqual(@as(usize, 0), live.load(.acquire));
+    try std.testing.expect(Holder.pumped.load(.acquire));
+}

--- a/src/platform/window_macos_bridge.m
+++ b/src/platform/window_macos_bridge.m
@@ -277,6 +277,10 @@ static int32_t wispterm_macos_round_double(double value) {
 // dispatch_sync self-deadlock; otherwise wait for the main run loop to drain
 // the block (the main thread idles in -nextEventMatchingMask: which keeps the
 // main queue running).
+//
+// Callers on the Zig main thread MUST keep pumping that queue while any
+// worker may still be in a run_on_main wait. A blocking Thread.join() on
+// the main thread during quit is issue #611.
 static void wispterm_macos_run_on_main(dispatch_block_t block) {
     if ([NSThread isMainThread]) {
         block();
@@ -1116,6 +1120,9 @@ void *wispterm_macos_window_create(
 }
 
 void wispterm_macos_window_destroy(void *handle) {
+    // Off-main this dispatch_sync's onto the GCD main queue. App.joinAllWindowThreads
+    // must keep pumping that queue until workers finish; otherwise quit deadlocks
+    // (GitHub issue #611).
     WispTermMacWindowState *state = wispterm_macos_state(handle);
     if (state == NULL) return;
     wispterm_macos_run_on_main(^{

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -19,6 +19,15 @@ const build_options = @import("build_options");
 const std = @import("std");
 const app_metadata = @import("app_metadata.zig");
 
+test "App joinAllWindowThreads pumps the macOS main queue (issue 611)" {
+    const source = @embedFile("App.zig");
+    const join_at = std.mem.indexOf(u8, source, "fn joinAllWindowThreads") orelse return error.MissingJoin;
+    const body = source[join_at..@min(source.len, join_at + 1500)];
+    try std.testing.expect(std.mem.indexOf(u8, body, "live_window_threads") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "pumpWhileLive") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "pumpAppEvents") != null);
+}
+
 test "input ssh download surfaces missing connection and helper probe failures" {
     const input_source = @embedFile("input.zig");
     try std.testing.expect(std.mem.indexOf(u8, input_source, "\"SSH connection unavailable\"") != null);
@@ -286,6 +295,7 @@ test {
     _ = @import("appwindow/state.zig");
     _ = @import("appwindow/state_guard.zig");
     _ = @import("appwindow/p3_1_guard.zig");
+    _ = @import("appwindow/thread_join.zig");
     _ = @import("ssh/scp.zig");
     _ = @import("surface_registry.zig");
     _ = @import("ctl/protocol.zig");


### PR DESCRIPTION
Fixes #611.

## Problem

Quitting WispTerm 1.35.4 on Apple Silicon hangs for ~28–30s with a beachball. Hang reports show a two-thread deadlock:

- **Main thread:** `App.run` → `joinAllWindowThreads` → `pthread_join`
- **Window thread:** `AppWindow.runMainLoop` → `wispterm_macos_window_destroy` → `dispatch_sync` onto the GCD main queue

Extra windows (Dock reopen after closing the first window, or new-window) run on worker threads. AppKit requires `NSWindow` / `WKWebView` teardown on the main thread, so those workers `dispatch_sync` back to main. `macIdleUntilQuit` already pumps that queue, but **`joinAllWindowThreads` did not**. After Cmd+Q the idle loop returns and a blocking join starves GCD.

Force-quitting during the hang kills in-flight AI agent work, which matches the report that tasks die halfway through.

Ghostty does not hit this: its macOS host is a native AppKit app, so window close and `applicationShouldTerminate` already run on the main thread (`macos/Sources/App/AppDelegate.swift`). WispTerm’s per-window Zig threads are the extra seam.

## Fix

- Count live spawned window threads independently of the join-handle list.
- On macOS, `joinAllWindowThreads` pumps `pumpAppEvents` until that count reaches 0, then joins (joins are then instant).
- Document the invariant next to `wispterm_macos_run_on_main` / `window_destroy`.

## Tests

- `src/appwindow/thread_join.zig`: worker cannot finish until the join helper pumps (the #611 shape).
- Source-scan tests in `test_fast.zig` and `App.zig` lock the join path to `pumpWhileLive` + `pumpAppEvents`.

`zig build test` passes. This host cannot exercise a real Cmd+Q beachball (Linux); please verify on Apple Silicon: extra window or Dock-reopen window → Cmd+Q should exit immediately.