### PR TITLE
fix(copilot): close empty prompt queue and hit-test Full/Auto/Ask

### DIFF
--- a/src/assistant/conversation/layout.zig
+++ b/src/assistant/conversation/layout.zig
@@ -181,6 +181,46 @@ pub fn permissionChipX(x: f32, w: f32, line_pad_x: f32, status_slot_w: f32, chip
     return x + w - line_pad_x - status_slot_w - chip_gap - chip_w;
 }
 
+/// Left-aligned title plus a hint string in a popup header, never overlapping.
+/// If both cannot fit on one row (with `gap` between them), `stacked` is true
+/// and both occupy the full inner width on separate rows.
+pub const PopupHeaderSplit = struct {
+    title_x: f32,
+    title_w: f32,
+    hint_x: f32,
+    hint_w: f32,
+    stacked: bool,
+};
+
+pub fn popupHeaderSplit(
+    popup_x: f32,
+    popup_w: f32,
+    pad_x: f32,
+    title_w: f32,
+    min_hint_w: f32,
+    gap: f32,
+) PopupHeaderSplit {
+    const title_x = popup_x + pad_x;
+    const inner_w = @max(0.0, popup_w - pad_x * 2);
+    if (title_w + gap + min_hint_w <= inner_w) {
+        const hint_x = title_x + title_w + gap;
+        return .{
+            .title_x = title_x,
+            .title_w = title_w,
+            .hint_x = hint_x,
+            .hint_w = @max(min_hint_w, popup_x + popup_w - pad_x - hint_x),
+            .stacked = false,
+        };
+    }
+    return .{
+        .title_x = title_x,
+        .title_w = inner_w,
+        .hint_x = title_x,
+        .hint_w = inner_w,
+        .stacked = true,
+    };
+}
+
 pub fn stopButtonRect(
     x: f32,
     w: f32,
@@ -434,6 +474,34 @@ test "copyButtonRectForBlock anchors to block top-right" {
 test "permissionChipX" {
     const px = permissionChipX(0, 1000, 18, 280, 12, 104); // w - line_pad - status - gap - chip
     try std.testing.expectApproxEqAbs(@as(f32, 586), px, 0.001);
+}
+
+test "compact copilot chip is to the right of the wide-tab chip" {
+    // Default copilot sidebar is 480px. Wide-tab layout reserves ~22% for
+    // status text; compact only reserves the 36px status-dot trailing pad.
+    // A click on the right half of the compact chip (the underlined Full /
+    // Auto / Ask label) must not land in the wide-tab hit box — that miss is
+    // why the copilot sidebar chip used to ignore clicks.
+    const compact = permissionChipX(0, 480, 18, 36, 12, 104);
+    const status_reserve = @min(@as(f32, 280), @max(@as(f32, 72), 480.0 * 0.22));
+    const wide = permissionChipX(0, 480, 18, status_reserve, 12, 104);
+    try std.testing.expect(compact > wide);
+    const click_x = compact + 52;
+    try std.testing.expect(click_x > wide + 104);
+}
+
+test "popupHeaderSplit keeps title and hints from overlapping on a wide popup" {
+    const s = popupHeaderSplit(0, 800, 14, 160, 80, 16);
+    try std.testing.expect(!s.stacked);
+    try std.testing.expect(s.hint_x >= s.title_x + s.title_w);
+    try std.testing.expectApproxEqAbs(@as(f32, 14 + 160 + 16), s.hint_x, 0.001);
+}
+
+test "popupHeaderSplit stacks on a narrow sidebar popup" {
+    const s = popupHeaderSplit(0, 280, 14, 176, 80, 16);
+    try std.testing.expect(s.stacked);
+    try std.testing.expectApproxEqAbs(s.title_x, s.hint_x, 0.001);
+    try std.testing.expectApproxEqAbs(s.title_w, s.hint_w, 0.001);
 }
 
 test "stopButtonRect centers in header_h" {

--- a/src/assistant/conversation/session.zig
+++ b/src/assistant/conversation/session.zig
@@ -2094,20 +2094,9 @@ pub const Session = struct {
         if (self.queue_open) {
             // 队列面板打开时优先截获按键（仿 rewind 选择器）：↑↓ 选择、
             // Alt+↑/↓ 重排、Delete/Backspace 删除、Enter 取回 composer 编辑、
-            // Esc 及其它键关闭。
-            self.mutex.lock();
-            switch (ev.key) {
-                .arrow_up => if (ev.alt) session_queue.moveQueuedPromptLocked(self, -1) else session_queue.moveQueueSelectionLocked(self, -1),
-                .arrow_down => if (ev.alt) session_queue.moveQueuedPromptLocked(self, 1) else session_queue.moveQueueSelectionLocked(self, 1),
-                .delete, .backspace => session_queue.removeSelectedQueuedPromptLocked(self),
-                .enter => {
-                    session_queue.recallSelectedQueuedPromptLocked(self);
-                    self.queue_open = false;
-                },
-                else => self.queue_open = false,
-            }
-            self.mutex.unlock();
-            return;
+            // Esc 关闭。空面板或 composer 已有新文本时 Enter 不吞掉，落到
+            // 下面的 submit 路径（busy 时再次入队）。
+            if (session_queue.handlePanelKey(self, ev)) return;
         }
 
         if (ev.ctrl and !ev.alt and ev.key == .key_a) {

--- a/src/assistant/conversation/session_queue.zig
+++ b/src/assistant/conversation/session_queue.zig
@@ -13,6 +13,7 @@ const prompt_queue = @import("prompt_queue.zig");
 const chatops_reply = @import("../../chatops/reply.zig");
 const ai_chat_protocol = @import("protocol.zig");
 const ai_chat_types = @import("types.zig");
+const input_key = @import("../../input/key.zig");
 
 const Session = session_mod.Session;
 const OwnedReplyContext = ai_chat_types.OwnedReplyContext;
@@ -92,6 +93,7 @@ pub fn drainPromptQueue(self: *Session) bool {
     self.pending_reply_context = entry.reply_context;
     entry.reply_context = null;
     if (self.queue_selected > 0) self.queue_selected -= 1;
+    closePanelIfEmptyLocked(self);
     self.mutex.unlock();
 
     self.submit();
@@ -132,7 +134,44 @@ pub fn clearPromptQueue(self: *Session) usize {
     const n = self.prompt_queue.len();
     self.prompt_queue.clear();
     self.queue_selected = 0;
+    self.queue_open = false;
     return n;
+}
+
+fn closePanelIfEmptyLocked(self: *Session) void {
+    if (self.prompt_queue.len() == 0) self.queue_open = false;
+}
+
+/// Queue-panel key dispatch. Returns true if the key was consumed. An empty
+/// panel closes without swallowing Enter (so a following submit still fires);
+/// Escape and other keys still close and consume so they cannot stop an
+/// in-flight request or arm rewind. Enter with composer text dismisses the
+/// panel and falls through so the new prompt is submitted (and re-queued if
+/// the request is still inflight) instead of recalling the selected entry.
+pub fn handlePanelKey(self: *Session, ev: input_key.KeyEvent) bool {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    if (!self.queue_open) return false;
+    if (self.prompt_queue.len() == 0) {
+        self.queue_open = false;
+        return ev.key != .enter;
+    }
+    switch (ev.key) {
+        .arrow_up => if (ev.alt) moveQueuedPromptLocked(self, -1) else moveQueueSelectionLocked(self, -1),
+        .arrow_down => if (ev.alt) moveQueuedPromptLocked(self, 1) else moveQueueSelectionLocked(self, 1),
+        .delete, .backspace => removeSelectedQueuedPromptLocked(self),
+        .enter => {
+            if (std.mem.trim(u8, self.input(), " \t\r\n").len == 0) {
+                recallSelectedQueuedPromptLocked(self);
+                self.queue_open = false;
+                return true;
+            }
+            self.queue_open = false;
+            return false;
+        },
+        else => self.queue_open = false,
+    }
+    return true;
 }
 
 /// 在 [0, len) 内移动面板选中项，到边界停住（不回绕）。假定 mutex 已持有。
@@ -167,6 +206,7 @@ pub fn removeSelectedQueuedPromptLocked(self: *Session) void {
     _ = self.prompt_queue.remove(sel);
     const remain = self.prompt_queue.len();
     self.queue_selected = if (remain == 0) 0 else @min(sel, remain - 1);
+    closePanelIfEmptyLocked(self);
 }
 
 /// 把选中条目取回 composer 编辑：出队，文本/图片/回复上下文回到输入区。
@@ -406,4 +446,117 @@ test "prompt queue: drain replays the head through the normal submit path" {
     try std.testing.expectEqualStrings("first", session.input());
     try std.testing.expectEqual(@as(usize, 0), session.messages.items.len);
     try std.testing.expect(!session.request_inflight);
+}
+
+test "prompt queue: drain closes the panel after the last entry is sent" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "");
+    defer session.deinit();
+
+    session.mutex.lock();
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "only", false, null));
+    session.queue_open = true;
+    session.mutex.unlock();
+
+    try std.testing.expect(session.drainPromptQueue());
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 0), session.prompt_queue.len());
+    try std.testing.expect(!session.queue_open);
+}
+
+test "prompt queue: drain keeps the panel open while entries remain" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "");
+    defer session.deinit();
+
+    session.mutex.lock();
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "first", false, null));
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "second", false, null));
+    session.queue_open = true;
+    session.mutex.unlock();
+
+    try std.testing.expect(session.drainPromptQueue());
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expectEqual(@as(usize, 1), session.prompt_queue.len());
+    try std.testing.expect(session.queue_open);
+}
+
+test "prompt queue: removing the last entry closes the panel" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "key");
+    defer session.deinit();
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "only", false, null));
+    session.queue_open = true;
+    session.queue_selected = 0;
+    removeSelectedQueuedPromptLocked(session);
+    try std.testing.expectEqual(@as(usize, 0), session.prompt_queue.len());
+    try std.testing.expect(!session.queue_open);
+}
+
+test "prompt queue: empty panel lets Enter fall through" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "key");
+    defer session.deinit();
+
+    session.queue_open = true;
+    try std.testing.expect(!handlePanelKey(session, .{ .key = .enter }));
+    try std.testing.expect(!session.queue_open);
+}
+
+test "prompt queue: empty panel still consumes Escape" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "key");
+    defer session.deinit();
+
+    session.queue_open = true;
+    try std.testing.expect(handlePanelKey(session, .{ .key = .escape }));
+    try std.testing.expect(!session.queue_open);
+}
+
+test "prompt queue: Enter with composer text dismisses instead of recalling" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "key");
+    defer session.deinit();
+
+    session.mutex.lock();
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "queued", false, null));
+    session.setInputTextLocked("new prompt");
+    session.queue_open = true;
+    session.mutex.unlock();
+
+    try std.testing.expect(!handlePanelKey(session, .{ .key = .enter }));
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expect(!session.queue_open);
+    try std.testing.expectEqual(@as(usize, 1), session.prompt_queue.len());
+    try std.testing.expectEqualStrings("queued", session.prompt_queue.entries.items[0].text);
+    try std.testing.expectEqualStrings("new prompt", session.input());
+}
+
+test "prompt queue: Enter with empty composer recalls the selected entry" {
+    const allocator = std.testing.allocator;
+    const session = try testSession(allocator, "key");
+    defer session.deinit();
+
+    session.mutex.lock();
+    try std.testing.expect(enqueueQueuedPromptLocked(session, "edit me", false, null));
+    session.queue_open = true;
+    session.queue_selected = 0;
+    session.mutex.unlock();
+
+    try std.testing.expect(handlePanelKey(session, .{ .key = .enter }));
+
+    session.mutex.lock();
+    defer session.mutex.unlock();
+    try std.testing.expect(!session.queue_open);
+    try std.testing.expectEqual(@as(usize, 0), session.prompt_queue.len());
+    try std.testing.expectEqualStrings("edit me", session.input());
 }

--- a/src/input.zig
+++ b/src/input.zig
@@ -5981,6 +5981,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             @floatCast(titlebarHeight()),
                             chat_x,
                             chat_w,
+                            true, // copilot sidebar: compact header layout
                         )) {
                             overlays.openSwitchModelPicker(chat);
                             requestInputRepaint();
@@ -5993,6 +5994,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                             @floatCast(titlebarHeight()),
                             chat_x,
                             chat_w,
+                            true, // copilot sidebar: chip sits next to the status dot
                         )) {
                             toggleAiAgentPermission();
                             return;
@@ -6119,6 +6121,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     @floatCast(titlebarHeight()),
                     AppWindow.leftPanelsWidth(),
                     @as(f32, @floatFromInt(fb.width)) - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidthForWindow(fb.width),
+                    false, // full tab
                 )) {
                     overlays.openSwitchModelPicker(chat);
                     requestInputRepaint();
@@ -6131,6 +6134,7 @@ fn handleMouseButton(ev: platform_input.MouseButtonEvent) void {
                     @floatCast(titlebarHeight()),
                     AppWindow.leftPanelsWidth(),
                     @as(f32, @floatFromInt(fb.width)) - AppWindow.leftPanelsWidth() - AppWindow.rightPanelsWidthForWindow(fb.width),
+                    false, // full tab: chip uses the status-text reserve
                 )) {
                     toggleAiAgentPermission();
                     return;

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -35,6 +35,7 @@ pub const INPUT_MAX_H: f32 = composer_layout.input_max_h;
 pub const INPUT_FIELD_PAD_TOP: f32 = composer_layout.Field.pad_top;
 const PERMISSION_CHIP_W: f32 = 104;
 const PERMISSION_CHIP_H: f32 = 24;
+const PERMISSION_CHIP_GAP: f32 = 12;
 const STATUS_SLOT_W: f32 = 280;
 // Wide panels (a full AI-chat tab) show the status as text plus an "Esc Stop"
 // button while a request runs.
@@ -212,10 +213,7 @@ pub fn render(
     // handful of pixels for both the model and the Agent label. Anchor the
     // chip beside the dot in compact mode and give the model the reclaimed
     // header width.
-    const chip_x = if (compact)
-        x + w - LINE_PAD_X - COMPACT_STATUS_TRAILING_RESERVE - 12 - PERMISSION_CHIP_W
-    else
-        permissionChipX(x, w);
+    const chip_x = headerPermissionChipX(x, w, compact);
     const mode_text = if (session.agent_enabled) "Agent" else "Chat";
     const mode_slot_w = @max(MODE_SLOT_W, titlebarTextWidth(mode_text) + 20);
     const mode_x = @max(x + LINE_PAD_X, chip_x - mode_slot_w - 8);
@@ -679,11 +677,12 @@ pub fn permissionChipHitTest(
     titlebar_offset: f32,
     chat_x: f32,
     chat_w: f32,
+    compact: bool,
 ) bool {
     _ = window_width;
     const x = @round(chat_x);
     const w = @round(@max(1.0, chat_w));
-    const chip_x = permissionChipX(x, w);
+    const chip_x = headerPermissionChipX(x, w, compact);
     return pointInRect(@floatCast(xpos), @floatCast(ypos), .{
         .x = chip_x,
         .top_px = titlebar_offset + 12,
@@ -695,8 +694,8 @@ pub fn permissionChipHitTest(
 /// Bounding box of the header model label (top-left of the panel), or null when
 /// the label is hidden because the panel is too narrow (mirrors the render-time
 /// `model_limit > 24` guard in `render`).
-fn modelLabelRect(session: *ai_chat.Session, x: f32, w: f32, titlebar_offset: f32) ?Rect {
-    const chip_x = permissionChipX(x, w);
+fn modelLabelRect(session: *ai_chat.Session, x: f32, w: f32, titlebar_offset: f32, compact: bool) ?Rect {
+    const chip_x = headerPermissionChipX(x, w, compact);
     const mode_x = @max(x + LINE_PAD_X, chip_x - MODE_SLOT_W - 8);
     const model_x = x + LINE_PAD_X;
     const model_limit = mode_x - model_x - 12;
@@ -713,11 +712,12 @@ pub fn modelLabelHitTest(
     titlebar_offset: f32,
     chat_x: f32,
     chat_w: f32,
+    compact: bool,
 ) bool {
     _ = window_width;
     const x = @round(chat_x);
     const w = @round(@max(1.0, chat_w));
-    const rect = modelLabelRect(session, x, w, titlebar_offset) orelse return false;
+    const rect = modelLabelRect(session, x, w, titlebar_offset, compact) orelse return false;
     return pointInRect(@floatCast(xpos), @floatCast(ypos), rect);
 }
 
@@ -1366,7 +1366,21 @@ fn permissionChipX(x: f32, w: f32) f32 {
     // so the right-anchored [mode][chip] cluster can't collapse onto the
     // left-aligned model label. On wide tabs this matches the old ~280 reserve.
     const status_reserve = @min(STATUS_SLOT_W, @max(72.0, w * 0.22));
-    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, status_reserve, 12, PERMISSION_CHIP_W);
+    return ai_chat_layout.permissionChipX(x, w, LINE_PAD_X, status_reserve, PERMISSION_CHIP_GAP, PERMISSION_CHIP_W);
+}
+
+fn headerPermissionChipX(x: f32, w: f32, compact: bool) f32 {
+    if (compact) {
+        return ai_chat_layout.permissionChipX(
+            x,
+            w,
+            LINE_PAD_X,
+            COMPACT_STATUS_TRAILING_RESERVE,
+            PERMISSION_CHIP_GAP,
+            PERMISSION_CHIP_W,
+        );
+    }
+    return permissionChipX(x, w);
 }
 
 // Clickable square centered on the status dot. When a request is in flight the
@@ -1422,7 +1436,7 @@ fn statusActionRect(x: f32, w: f32, titlebar_offset: f32, text: []const u8, comp
     // the LEFT of the status dot. Either way it is clamped to the space right of
     // the permission chip so it can't overlap the chip/dot on a narrow panel.
     const right = if (compact) statusDotRect(x, w, titlebar_offset).x - 8 else x + w - LINE_PAD_X;
-    const avail = @max(1.0, right - (permissionChipX(x, w) + PERMISSION_CHIP_W + 12));
+    const avail = @max(1.0, right - (headerPermissionChipX(x, w, compact) + PERMISSION_CHIP_W + 12));
     const status_w = @min(@min(measureText(text), STATUS_SLOT_W), avail);
     return .{
         .x = right - status_w,
@@ -1468,8 +1482,20 @@ fn renderPromptQueuePanel(session: *ai_chat.Session, layout: InputLayout) void {
     const popup_w = @min(layout.field_w, SUGGESTION_MAX_W);
     const popup_x = layout.field_x;
     const popup_y = layout.field_y + layout.field_h + SUGGESTION_GAP;
-    const header_h = @max(SUGGESTION_ROW_H + 2, font.g_titlebar_cell_height + REWIND_HEADER_EXTRA);
+    const header_row_h = @max(SUGGESTION_ROW_H + 2, font.g_titlebar_cell_height + REWIND_HEADER_EXTRA);
     const row_h = @max(SUGGESTION_ROW_H + 8, font.g_titlebar_cell_height + REWIND_ROW_EXTRA);
+    var title_buf: [40]u8 = undefined;
+    const title = std.fmt.bufPrint(&title_buf, "Queued Prompts ({d})", .{total}) catch "Queued Prompts";
+    const hints = "Enter edit  Del  Alt+Up/Dn  Esc";
+    const split = ai_chat_layout.popupHeaderSplit(
+        popup_x,
+        popup_w,
+        REWIND_PAD_X,
+        titlebarTextWidth(title),
+        80,
+        16,
+    );
+    const header_h = header_row_h * if (split.stacked) @as(f32, 2) else 1;
     // At least one row so an empty queue still shows its empty-state line.
     const visible = @min(@max(total, 1), QUEUE_MAX_ROWS);
     const popup_h = REWIND_PAD_Y * 2 + header_h + row_h * @as(f32, @floatFromInt(visible));
@@ -1484,23 +1510,23 @@ fn renderPromptQueuePanel(session: *ai_chat.Session, layout: InputLayout) void {
 
     const top = popup_y + popup_h - REWIND_PAD_Y;
 
-    const title_row_y = top - header_h;
-    const title_text_y = title_row_y + @round((header_h - font.g_titlebar_cell_height) / 2);
-    var title_buf: [40]u8 = undefined;
-    const title = std.fmt.bufPrint(&title_buf, "Queued Prompts ({d})", .{total}) catch "Queued Prompts";
+    const title_row_y = top - header_row_h;
+    const title_text_y = title_row_y + @round((header_row_h - font.g_titlebar_cell_height) / 2);
     _ = titlebar.renderTextLimited(
         title,
-        popup_x + REWIND_PAD_X,
+        split.title_x,
         title_text_y,
         mixColor(fg, accent, 0.16),
-        popup_w - REWIND_PAD_X * 2,
+        split.title_w,
     );
+    const hint_row_y = if (split.stacked) top - header_row_h * 2 else title_row_y;
+    const hint_text_y = hint_row_y + @round((header_row_h - font.g_titlebar_cell_height) / 2);
     _ = titlebar.renderTextLimited(
-        "Enter edit  Del remove  Alt+Up/Dn move  Esc close",
-        popup_x + REWIND_PAD_X + 176,
-        title_text_y,
+        hints,
+        split.hint_x,
+        hint_text_y,
         mixColor(bg, fg, 0.52),
-        @max(24.0, popup_w - REWIND_PAD_X * 2 - 176),
+        split.hint_w,
     );
 
     if (total == 0) {

--- a/src/test_fast.zig
+++ b/src/test_fast.zig
@@ -72,6 +72,21 @@ test "assistant conversation input routing owns keyboard target lookup" {
     try std.testing.expect(std.mem.indexOf(u8, input_source, "assistant_conversation.current(aiCopilotFocused())") != null);
 }
 
+test "copilot permission chip hit-test uses compact geometry" {
+    const renderer = @embedFile("renderer/assistant/conversation.zig");
+    const fn_start = std.mem.indexOf(u8, renderer, "pub fn permissionChipHitTest(") orelse return error.MissingPermissionChipHitTest;
+    const fn_body = renderer[fn_start .. fn_start + 600];
+    try std.testing.expect(std.mem.indexOf(u8, fn_body, "compact: bool") != null);
+    try std.testing.expect(std.mem.indexOf(u8, fn_body, "headerPermissionChipX(x, w, compact)") != null);
+
+    const input_source = @embedFile("input.zig");
+    const copilot = std.mem.indexOf(u8, input_source, "true, // copilot sidebar: chip sits next to the status dot") orelse
+        return error.MissingCopilotCompactChip;
+    const tab = std.mem.indexOf(u8, input_source, "false, // full tab: chip uses the status-text reserve") orelse
+        return error.MissingTabWideChip;
+    try std.testing.expect(copilot < tab);
+}
+
 test "remote file ssh helpers include short keepalive options" {
     const remote_file_source = @embedFile("platform/remote_file.zig");
     try std.testing.expect(std.mem.indexOf(u8, remote_file_source, "\"ServerAliveInterval=5\"") != null);


### PR DESCRIPTION
## Summary

Fixes two Copilot sidebar issues:

1. **Prompt queue overlay stuck after send.** Submitting while a request is inflight auto-opens the queue panel. After the last queued prompt is drained, the overlay stayed open at `Queued Prompts (0)` / `No queued prompts` and covered the transcript. The header title also overlapped the key hints because hints started at a hardcoded 176px offset.

2. **Full / Auto / Ask not clickable.** Compact sidebar render places the permission chip next to the status dot, but hit-testing still used the wide-tab chip X (which reserves a status-text slot). On the default 480px sidebar, a click on the underlined label missed the hit box.

## Changes

- Close the queue panel when drain/remove/clear empties it.
- Empty-panel Enter falls through to submit instead of being swallowed; Enter with composer text submits instead of recalling the queued entry.
- Measure title width and stack hints onto a second row when the popup is too narrow.
- Share `headerPermissionChipX` between compact render and click hit-testing; pass `compact=true` on the copilot path.

## Test plan

- [x] `zig test src/assistant/conversation/layout.zig` (chip geometry + header split)
- [x] `zig build test` (fast suite, including the compact chip source-scan)
- [ ] In the copilot sidebar, click **Full / Auto / Ask** and confirm it cycles
- [ ] While a reply is in flight, submit another prompt: overlay shows the queued item
- [ ] After the queued prompt is sent, the overlay closes (no empty `Queued Prompts (0)` covering the transcript)
- [ ] On a narrow sidebar, the queue header title and key hints do not overlap