### PR TITLE
fix(preview): enable JPEG decoding alongside PNG

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1246,7 +1246,9 @@ fn createAppModuleWithRootAndTestShard(
         app_mod.addIncludePath(dep.path("src/stb"));
         app_mod.addCSourceFile(.{
             .file = dep.path("src/stb/stb.c"),
-            .flags = &.{},
+            // Ghostty enables PNG for Kitty graphics; WispTerm's preview
+            // panel and background images also use this decoder for JPEG.
+            .flags = &.{"-DSTBI_ONLY_JPEG"},
         });
     }
 
@@ -1439,7 +1441,7 @@ fn createBenchModule(
         bench_mod.addIncludePath(dep.path("src/stb"));
         bench_mod.addCSourceFile(.{
             .file = dep.path("src/stb/stb.c"),
-            .flags = &.{},
+            .flags = &.{"-DSTBI_ONLY_JPEG"},
         });
     }
     return bench_mod;

--- a/src/renderer/markdown_preview_renderer.zig
+++ b/src/renderer/markdown_preview_renderer.zig
@@ -1111,6 +1111,30 @@ fn appendSlice(buf: *[1024]u8, pos: usize, text: []const u8) usize {
     return pos + len;
 }
 
+test "preview decoder loads JPEG and PNG as RGBA" {
+    // The same 2x1 white RGB image encoded as JPEG and PNG. Exercise the
+    // linked decoder: recognizing a .jpg suffix does not enable JPEG in stb.
+    const fixtures = [_][]const u8{
+        "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAIDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+AD//Z",
+        "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAIAAAB7QOjdAAAAD0lEQVR42mP8//8/AwMDAA7/Av8BviLeAAAAAElFTkSuQmCC",
+    };
+    for (fixtures) |encoded| {
+        var source: [512]u8 = undefined;
+        const len = try std.base64.standard.Decoder.calcSizeForSlice(encoded);
+        try std.base64.standard.Decoder.decode(source[0..len], encoded);
+        var width: c_int = 0;
+        var height: c_int = 0;
+        var channels: c_int = 0;
+        const data = c.stbi_load_from_memory(&source, @intCast(len), &width, &height, &channels, 4);
+        try std.testing.expect(data != null);
+        defer c.stbi_image_free(data);
+        try std.testing.expectEqual(@as(c_int, 2), width);
+        try std.testing.expectEqual(@as(c_int, 1), height);
+        try std.testing.expectEqual(@as(c_int, 3), channels);
+        try std.testing.expectEqualSlices(u8, &.{ 255, 255, 255, 255, 255, 255, 255, 255 }, data[0..8]);
+    }
+}
+
 test "countNonBlankLines ignores blank and whitespace-only lines" {
     try std.testing.expectEqual(@as(usize, 3), countNonBlankLines("a,b\n\nc,d\n   \ne,f\n"));
     try std.testing.expectEqual(@as(usize, 1), countNonBlankLines("only"));


### PR DESCRIPTION
Opening a `.jpg` or `.jpeg` in the preview panel shows "Image preview failed" because [Ghostty's bundled stb configuration](https://github.com/ghostty-org/ghostty/blob/4dcb09ada0c0909717d92547623b26eafa50ca8a/src/stb/stb.c) enables only PNG for Kitty graphics. Enable JPEG alongside that existing PNG support in the app and benchmark builds, allowing the shared preview/background decoder to load JPEG images.

Add a regression test that decodes JPEG and PNG fixtures and checks their dimensions, channels, and RGBA pixels.

Validation:

- Windows debug build passed (`zig build -j2`).
- Fast suite passed: 2,485 passed, 1 skipped.
- Decoder regression fails with the old flags and passes with JPEG enabled.
- Visually verified the reported JPEG and a PNG control in a visible Windows preview panel using Win32 automation.
- `zig fmt --check` and `git diff --check` passed.
- Full gate ran and compiled all app shards: 15,963 passed, 333 skipped, 13 failed. The failures are in three existing missing-path tests (`memory_digest.store`, `memory_digest.cursors`, and `recipe.store`), repeated across shards, using `/nonexistent/...` paths from the Windows/WSL checkout.
