### PR TITLE
release: v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ English | [简体中文](README.zh-CN.md)
 ## Versions
 
 The desktop app version is the repository root version in `build.zig.zon`
-(currently `1.36.0`) and is what `wispterm --version`, release notes, desktop
+(currently `1.37.0`) and is what `wispterm --version`, release notes, desktop
 packages, and the command center `Version` entry use.
 
 The WispTerm Remote web console/relay under `remote/` has an independent npm/web
@@ -275,7 +275,7 @@ MIT
 
 ## Citation
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.36.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.37.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 Copyable acknowledgment template:
@@ -285,6 +285,6 @@ We used WispTerm as part of our computational environment for life sciences data
 analysis, remote computing workflows, reproducible command-line processing, and
 the organization of related literature and analysis code.
 
-Xu, Z.-G. (2026). WispTerm (Version 1.36.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.37.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@
 
 ## 版本
 
-桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.36.0`），也是
+桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.37.0`），也是
 `wispterm --version`、release notes、桌面发布包和命令中心 `Version` 条目使用的版本。
 
 `remote/` 下的 WispTerm Remote 网页控制台/中继有独立的 npm/web 版本（当前为
@@ -267,7 +267,7 @@ MIT
 
 ## 引用
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.36.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.37.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 可直接复制的致谢模板：
@@ -276,6 +276,6 @@ https://doi.org/10.5281/zenodo.20660541
 我们在生命科学数据分析中使用 WispTerm 作为计算环境的一部分，用于远程计算流程、
 可重复的命令行处理，以及相关文献与分析代码的整理。
 
-Xu, Z.-G. (2026). WispTerm (Version 1.36.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.37.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wispterm,
-    .version = "1.36.0",
+    .version = "1.37.0",
     .fingerprint = 0x2db6e9e774428a6f,
     .minimum_zig_version = "0.15.2",
 

--- a/release-notes/v1.37.0.md
+++ b/release-notes/v1.37.0.md
@@ -1,0 +1,95 @@
+# WispTerm v1.37.0
+
+> Configure memory sources independently for each server, collect Kimi and
+> Grok Build history, and preview JPEG images. This release also improves SSH
+> profile selection and Settings layout. No manual configuration migration is
+> required.
+
+## Added
+
+- **Memory sources by location and tool (#619, #620).** Memory Center now has
+  a Sources page with checkboxes for the local machine, WSL, and individual
+  saved SSH servers. Each location has its own Codex, Claude Code, Kimi, and
+  Grok Build selection; WispTerm history is available locally. For example,
+  one server can collect only Claude Code while another collects only Codex.
+  Turning off a location pauses its collection and preserves its tool choices.
+- **Kimi and Grok Build memory collection (#619).** Local and remote session
+  histories can contribute to manual and scheduled memory digests. Session
+  titles, project paths, and message times are preserved, and incremental
+  collection handles newly appended conversation text. Kimi and Grok Build
+  are opt-in: enable them on the Sources page.
+
+## Improved
+
+- **Port-forwarding SSH profile picker (#617).** New and edit rule forms show
+  saved SSH profiles in a list, highlight the current selection, and display
+  its position. Use Left/Right or Space on the Profile field to change it.
+
+## Fixed
+
+- **JPEG preview (#621).** `.jpg` and `.jpeg` files now display in the preview
+  panel instead of showing "Image preview failed". The shared decoder also
+  enables JPEG background images, while PNG support remains available.
+- **Settings font controls on resize (#616, #618).** The font-size minus,
+  value, and plus controls stay visible and their click targets match the
+  rendered layout, including wide windows and Retina scaling.
+
+## Compatibility
+
+- Existing memory source choices are retained. Previous shared tool choices
+  are applied to each location and saved as independent selections on edit.
+  Disabling a source keeps its existing summaries and excludes it from future
+  collection and historical backfill.
+- This is a desktop-only release; WispTerm Remote web console versions are
+  unchanged. Linux AppImage remains experimental.
+
+## Performance baseline
+
+- The Windows x86_64 CPU terminal-stream baseline is attached to the GitHub
+  release as `benchmark-windows-v1.37.0.md`, collected with
+  `wispterm-bench --case terminal-stream --duration 1000` in ReleaseFast mode.
+  It measures parser throughput, not GPU rendering or input latency.
+
+---
+
+# WispTerm v1.37.0（中文）
+
+> 本次发布支持按服务器独立配置记忆来源，接入 Kimi 和 Grok Build 历史采集，
+> 修复 JPEG 预览，并改进端口转发的 SSH 配置选择和设置页布局。无需手动迁移配置。
+
+## 新增
+
+- **按位置和工具配置记忆来源（#619、#620）。** 记忆中心新增“来源配置”页面，
+  可通过复选框选择本机、WSL 和单台已保存的 SSH 服务器。每个位置分别选择
+  Codex、Claude Code、Kimi 和 Grok Build；WispTerm 自身历史仅在本机提供。
+  例如，CPU 服务器只采集 Claude Code，GPU 服务器只采集 Codex。关闭整个位置
+  会暂停采集，并保留其下的工具选择。
+- **Kimi 与 Grok Build 记忆采集（#619）。** 支持从本机及远端会话历史生成手动
+  或定时记忆摘要，保留会话标题、项目路径和消息时间，并增量采集续写的对话文本。
+  Kimi 和 Grok Build 默认不勾选，可在“来源配置”中按需开启。
+
+## 改进
+
+- **端口转发的 SSH 配置列表（#617）。** 新建或编辑规则时直接显示已保存的 SSH
+  配置，突出显示当前选中项及其序号。聚焦 Profile 字段后，可用左右方向键或空格
+  切换配置。
+
+## 修复
+
+- **JPEG 图片预览（#621）。** `.jpg`、`.jpeg` 可以在预览面板中显示，不再出现
+  “Image preview failed”。共用的解码器也支持 JPEG 背景图片，PNG 预览继续可用。
+- **设置页字体控件缩放（#616、#618）。** 调整窗口大小时，字号减号、数值和加号
+  保持可见，点击区域与实际显示位置一致，覆盖宽窗口及 Retina 缩放场景。
+
+## 兼容性
+
+- 保留现有记忆来源设置。旧版统一的工具选择会沿用到各位置，编辑后保存为独立
+  配置。关闭来源不会删除已有摘要，后续采集和历史补摘要会跳过该来源。
+- 本次仅发布桌面应用，WispTerm Remote 网页控制台版本不变。Linux AppImage
+  仍为实验性构建。
+
+## 性能基线
+
+- GitHub Release 附带 `benchmark-windows-v1.37.0.md`，记录 Windows x86_64 上
+  ReleaseFast 构建运行 `wispterm-bench --case terminal-stream --duration 1000`
+  的结果。该基线衡量终端解析吞吐量，不代表 GPU 渲染或输入延迟。

--- a/src/benchmark/report.zig
+++ b/src/benchmark/report.zig
@@ -201,7 +201,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
         .{ .name = "terminal-stream", .unit = .throughput, .value = 56.2, .samples = 900, .duration_ms = 1000 },
     };
     const r: Report = .{
-        .app_version = "1.36.0",
+        .app_version = "1.37.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,
@@ -212,7 +212,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
     };
     const json = try formatJson(allocator, r);
     defer allocator.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.36.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.37.0\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"logical_cores\":8") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"backend\":\"opengl\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"runner\":\"cli\"") != null);
@@ -228,7 +228,7 @@ test "report: JSON includes gpu/window when filled and latency percentiles" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.36.0",
+        .app_version = "1.37.0",
         .os = "macos",
         .cpu_arch = "aarch64",
         .logical_cores = 10,
@@ -253,7 +253,7 @@ test "report: Markdown renders header, env, and scenario table" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.36.0",
+        .app_version = "1.37.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,

--- a/src/renderer/overlays/update_prompt_model.zig
+++ b/src/renderer/overlays/update_prompt_model.zig
@@ -25,7 +25,7 @@ pub fn updatePromptActionForResult(result: update_check.CheckResult) UpdatePromp
 
 test "overlays: downloaded maps to install_update on macOS only" {
     const expected: UpdatePromptAction = if (builtin.os.tag == .macos) .install_update else .none;
-    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.36.0" }));
+    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.37.0" }));
 }
 
 test "overlays: update prompt action selection prefers downloadable asset" {

--- a/src/test_main_behavior.zig
+++ b/src/test_main_behavior.zig
@@ -7,7 +7,7 @@ const keybind = @import("keybind.zig");
 const command_dispatch = @import("input/command_dispatch.zig");
 
 test "app version metadata is exposed for CLI and command center" {
-    const expected_version = "1.36.0";
+    const expected_version = "1.37.0";
     try std.testing.expectEqualStrings("WispTerm", app_metadata.name);
     try std.testing.expectEqualStrings(expected_version, app_metadata.version);
     try std.testing.expect(std.mem.indexOf(u8, app_metadata.release_notes, "# WispTerm v" ++ expected_version) != null);


### PR DESCRIPTION
Prepare desktop v1.37.0 from the five PRs merged since v1.36.0 (#617–#621): per-server memory source settings, Kimi/Grok Build collection, the port-forwarding SSH profile list, Settings font control layout, and JPEG previews.

Synchronize the desktop manifest, matching version tests, and both READMEs; add English and Chinese release notes. WispTerm Remote versions are unchanged.

Validation:

- Required CI passed: Linux fast tests, macOS ARM full tests, and Windows smoke. Remote checks skipped as expected for this desktop-only release.
- Windows ReleaseFast app and benchmark build: 29/29 build steps passed.
- Verified `wispterm.exe --version`, portable `version.txt`, and the packaged executable all identify v1.37.0.
- Windows x86_64 terminal-stream benchmark: 56.62 MB/s, 906 iterations in 1,000 ms. Markdown/JSON reports are prepared as release attachments.
- Formatting, diff checks, and Windows checkout safety passed (no name/case collisions or symlinks).
- Local WSL→Windows full suite: 15,973 passed, 333 skipped, 13 failures across shards in the same three existing `/nonexistent/...` path tests (memory summary store, cursors, recipe store). The native macOS full CI suite passed.
