### PR TITLE
Improve Markdown table rendering and selection in AI Chat/Copilot

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -218,6 +218,21 @@ demand.
 - `/forget <name>` deletes a memory by its name.
 - Set `ai-memory-enabled = false` in the config to turn the system off.
 
+## Markdown in replies
+
+AI Chat tabs and the Copilot sidebar share the native Markdown renderer. Tables
+have header shading, cell borders, and left/center/right alignment from their
+delimiter row. Long cells wrap within the message width; narrow panels give
+more space to long columns. Tables currently wrap rather than scroll horizontally.
+Escaped pipes (`\|`), Chinese text, emoji, and code-span punctuation are preserved,
+and cells longer than 256 bytes are no longer truncated.
+
+Drag across table text to select and copy it. The table's copy button sits above
+the header and copies the original Markdown; code-block copy buttons retain the
+original code, including indentation. Replies use native text drawing, so model
+HTML and scripts are never executed. This remains a lightweight Markdown subset,
+not a full browser-based GFM renderer.
+
 ## Markdown Export
 
 Use the command center to run `Export Copilot Markdown` for the full transcript,

--- a/src/markdown_text.zig
+++ b/src/markdown_text.zig
@@ -4,7 +4,55 @@
 //! copy all agree. No rendering, no AppWindow, std-only.
 const std = @import("std");
 
-pub const TABLE_MAX_COLS: usize = 8;
+pub const TABLE_MAX_COLS: usize = 32;
+
+pub const TableAlignment = enum { left, center, right };
+
+/// Keep short columns compact and give long cells the remaining wrap width.
+pub fn fitTableWidths(widths: []f32, available: f32, minimum: f32) void {
+    if (widths.len == 0) return;
+    const floor = @min(minimum, available / @as(f32, @floatFromInt(widths.len)));
+    var total: f32 = 0;
+    for (widths) |*width| {
+        width.* = @max(floor, width.*);
+        total += width.*;
+    }
+    if (total <= available) return;
+    var low = floor;
+    var high = total;
+    for (0..32) |_| {
+        const cap = (low + high) / 2;
+        var used: f32 = 0;
+        for (widths) |width| used += @min(width, cap);
+        if (used > available) high = cap else low = cap;
+    }
+    for (widths) |*width| width.* = @min(width.*, low);
+}
+
+pub fn tableAlignment(cell: []const u8) TableAlignment {
+    const value = std.mem.trim(u8, cell, " \t");
+    if (std.mem.endsWith(u8, value, ":")) {
+        return if (std.mem.startsWith(u8, value, ":")) .center else .right;
+    }
+    return .left;
+}
+
+/// Small cells stay on the caller's stack; long paths/content are never cut
+/// at the old 256-byte boundary. The model and renderer use the same bytes.
+pub const CellText = struct {
+    text: []const u8,
+    owned: ?[]u8 = null,
+
+    pub fn init(scratch: []u8, source: []const u8) CellText {
+        if (source.len <= scratch.len) return .{ .text = cleanInline(scratch, source) };
+        const owned = std.heap.page_allocator.alloc(u8, source.len) catch return .{ .text = source };
+        return .{ .text = cleanInline(owned, source), .owned = owned };
+    }
+
+    pub fn deinit(self: CellText) void {
+        if (self.owned) |owned| std.heap.page_allocator.free(owned);
+    }
+};
 
 pub const SourceLine = struct {
     line: []const u8,
@@ -41,7 +89,11 @@ pub fn isMarkdownTableStart(text: []const u8, start: usize) bool {
     if (!looksLikeTableRow(first.line)) return false;
     if (first.next >= text.len) return false;
     const second = nextSourceLine(text, first.next);
-    return isTableSeparatorLine(second.line);
+    if (!isTableSeparatorLine(second.line)) return false;
+    var header: [TABLE_MAX_COLS][]const u8 = undefined;
+    var separator: [TABLE_MAX_COLS][]const u8 = undefined;
+    const count = parseTableRowCells(first.line, &header);
+    return count > 0 and count == parseTableRowCells(second.line, &separator);
 }
 
 pub fn tableBlockEnd(text: []const u8, start: usize) usize {
@@ -52,6 +104,8 @@ pub fn tableBlockEnd(text: []const u8, start: usize) usize {
         const line = nextSourceLine(text, cursor);
         const trimmed = std.mem.trim(u8, line.line, " \t");
         if (trimmed.len == 0 or !looksLikeTableRow(line.line) or isTableSeparatorLine(line.line)) break;
+        var cells: [TABLE_MAX_COLS][]const u8 = undefined;
+        if (parseTableRowCells(line.line, &cells) == 0) break;
         cursor = line.next;
     }
     return cursor;
@@ -61,16 +115,25 @@ pub fn parseTableRowCells(line: []const u8, out: *[TABLE_MAX_COLS][]const u8) us
     var trimmed = std.mem.trim(u8, line, " \t");
     if (trimmed.len == 0) return 0;
     if (trimmed[0] == '|') trimmed = trimmed[1..];
-    if (trimmed.len > 0 and trimmed[trimmed.len - 1] == '|') trimmed = trimmed[0 .. trimmed.len - 1];
+    if (trimmed.len > 0 and trimmed[trimmed.len - 1] == '|' and !isEscaped(trimmed, trimmed.len - 1)) trimmed = trimmed[0 .. trimmed.len - 1];
 
     var count: usize = 0;
-    var parts = std.mem.splitScalar(u8, trimmed, '|');
-    while (parts.next()) |part| {
-        if (count >= TABLE_MAX_COLS) break;
-        out[count] = std.mem.trim(u8, part, " \t");
+    var start: usize = 0;
+    for (0..trimmed.len + 1) |i| {
+        if (i < trimmed.len and (trimmed[i] != '|' or isEscaped(trimmed, i))) continue;
+        // Unsupported oversized tables fall back to text, never lose columns.
+        if (count >= TABLE_MAX_COLS) return 0;
+        out[count] = std.mem.trim(u8, trimmed[start..i], " \t");
         count += 1;
+        start = i + 1;
     }
     return count;
+}
+
+fn isEscaped(text: []const u8, index: usize) bool {
+    var start = index;
+    while (start > 0 and text[start - 1] == '\\') : (start -= 1) {}
+    return (index - start) % 2 == 1;
 }
 
 pub fn looksLikeTableRow(line: []const u8) bool {
@@ -87,16 +150,11 @@ pub fn isTableSeparatorLine(line: []const u8) bool {
     for (cells[0..count]) |cell| {
         const trimmed = std.mem.trim(u8, cell, " \t");
         if (trimmed.len == 0) return false;
-        var dash_count: usize = 0;
-        for (trimmed) |ch| {
-            if (ch == '-') {
-                dash_count += 1;
-                continue;
-            }
-            if (ch == ':') continue;
-            return false;
-        }
-        if (dash_count == 0) return false;
+        var dashes = trimmed;
+        if (dashes[0] == ':') dashes = dashes[1..];
+        if (dashes.len > 0 and dashes[dashes.len - 1] == ':') dashes = dashes[0 .. dashes.len - 1];
+        if (dashes.len == 0) return false;
+        for (dashes) |ch| if (ch != '-') return false;
     }
     return true;
 }
@@ -183,6 +241,30 @@ pub fn cleanInline(buf: []u8, text: []const u8) []const u8 {
     var i: usize = 0;
     while (i < text.len and pos < buf.len) {
         const ch = text[i];
+        if (ch == '\\' and i + 1 < text.len and std.ascii.isPrint(text[i + 1]) and !std.ascii.isAlphanumeric(text[i + 1]) and text[i + 1] != ' ') {
+            buf[pos] = text[i + 1];
+            pos += 1;
+            i += 2;
+            continue;
+        }
+        if (ch == '`') {
+            var run_end = i + 1;
+            while (run_end < text.len and text[run_end] == '`') : (run_end += 1) {}
+            if (std.mem.indexOf(u8, text[run_end..], text[i..run_end])) |close| {
+                var code_i = run_end;
+                while (code_i < run_end + close and pos < buf.len) : (code_i += 1) {
+                    // GFM table pipes are escaped even inside code spans.
+                    if (text[code_i] == '\\' and code_i + 1 < run_end + close and text[code_i + 1] == '|') code_i += 1;
+                    buf[pos] = text[code_i];
+                    pos += 1;
+                }
+                i = run_end + close + (run_end - i);
+                continue;
+            }
+            pos = appendSlice(buf, pos, text[i..run_end]);
+            i = run_end;
+            continue;
+        }
         if (ch == '<') {
             while (i < text.len and text[i] != '>') : (i += 1) {}
             if (i < text.len) i += 1;
@@ -260,10 +342,10 @@ pub const CleanedLine = struct {
 /// line heights); both must be updated together when new constructs are added.
 pub fn cleanedLine(buf: *[1024]u8, raw_line: []const u8, in_code: bool) CleanedLine {
     const trimmed = std.mem.trimLeft(u8, raw_line, " \t");
-    if (trimmed.len == 0) return .{ .style = .blank };
     if (isFence(trimmed)) return .{ .style = .fence, .fence_label = fenceLanguage(trimmed) };
+    if (in_code) return .{ .style = .code, .text = raw_line };
+    if (trimmed.len == 0) return .{ .style = .blank };
     if (isHorizontalRule(trimmed)) return .{ .style = .rule };
-    if (in_code) return .{ .style = .code, .text = cleanPlain(buf, raw_line) };
     if (headingBody(trimmed)) |heading| {
         return .{ .style = .heading, .text = cleanInline(buf, heading.body), .heading_level = @intCast(heading.level) };
     }
@@ -304,7 +386,9 @@ pub fn appendTableBlockDisplay(
         for (0..count) |i| {
             if (i > 0) try out.appendSlice(allocator, " | ");
             var clean_buf: [256]u8 = undefined;
-            try out.appendSlice(allocator, cleanInline(&clean_buf, cells[i]));
+            const cell = CellText.init(&clean_buf, cells[i]);
+            defer cell.deinit();
+            try out.appendSlice(allocator, cell.text);
         }
         try out.append(allocator, '\n');
     }
@@ -349,7 +433,9 @@ fn tableRowDisplayLen(line: []const u8) usize {
     for (0..count) |i| {
         if (i > 0) total += 3; // " | "
         var clean_buf: [256]u8 = undefined;
-        total += cleanInline(&clean_buf, cells[i]).len;
+        const cell = CellText.init(&clean_buf, cells[i]);
+        defer cell.deinit();
+        total += cell.text.len;
     }
     return total;
 }
@@ -451,4 +537,52 @@ test "allocDisplayText plain text is unchanged except trailing newline" {
     const out = try allocDisplayText(testing.allocator, "alpha beta gamma");
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("alpha beta gamma\n", out);
+}
+
+test "GFM tables accept omitted outer pipes and escaped code pipes" {
+    const text = "名称 | 值\n:--- | ---:\n中文😀 | `a\\|b_*<c>`\n";
+    try testing.expect(isMarkdownTableStart(text, 0));
+    const out = try allocDisplayText(testing.allocator, text);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("名称 | 值\n中文😀 | a|b_*<c>\n", out);
+    try testing.expectEqual(out.len, tableBlockDisplayLen(text, 0, text.len));
+    try testing.expectEqual(TableAlignment.center, tableAlignment(":---:"));
+    try testing.expectEqual(TableAlignment.right, tableAlignment("---:"));
+    try testing.expectEqual(TableAlignment.left, tableAlignment(":---"));
+}
+
+test "table recognition rejects mismatched and invalid delimiters" {
+    try testing.expect(!isMarkdownTableStart("a | b\n--- | --- | ---\n", 0));
+    try testing.expect(!isMarkdownTableStart("a | b\n--- | :-:-\n", 0));
+    try testing.expect(!isTableSeparatorLine("| ::--- | --- |"));
+    try testing.expect(!isMarkdownTableStart("a | b\n--- |", 0));
+    var cells: [TABLE_MAX_COLS][]const u8 = undefined;
+    try testing.expectEqual(@as(usize, 2), parseTableRowCells("| a | b\\|", &cells));
+    try testing.expectEqualStrings("b\\|", cells[1]);
+}
+
+test "long UTF-8 table cells are fully copied and offsets agree" {
+    const content = "长路径😀/" ** 100;
+    const text = "| path |\n| --- |\n| `" ++ content ++ "` |\n";
+    const out = try allocDisplayText(testing.allocator, text);
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("path\n" ++ content ++ "\n", out);
+    try testing.expectEqual(out.len, tableBlockDisplayLen(text, 0, text.len));
+    try testing.expectEqual(@as(usize, 5), tableRowDisplayOffsetWithin(text, 0, text.len, 1));
+}
+
+test "column allocation fits narrow panels and preserves compact columns" {
+    var widths = [_]f32{ 32, 900, 80 };
+    fitTableWidths(&widths, 300, 56);
+    try testing.expectApproxEqAbs(@as(f32, 56), widths[0], 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 80), widths[2], 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 300), widths[0] + widths[1] + widths[2], 0.01);
+    fitTableWidths(&widths, 30, 56);
+    for (widths) |width| try testing.expectApproxEqAbs(@as(f32, 10), width, 0.01);
+}
+
+test "fenced code preserves indentation blank lines and rule-looking source" {
+    const out = try allocDisplayText(testing.allocator, "```\n    x = a * b\n\n---\n```\n");
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("\n    x = a * b\n\n---\n\n", out);
 }

--- a/src/renderer/assistant/conversation.zig
+++ b/src/renderer/assistant/conversation.zig
@@ -71,6 +71,8 @@ const DETAIL_RULE_W: f32 = 3;
 const GROUP_HEADER_GAP: f32 = 6;
 const TABLE_CELL_PAD_X: f32 = 10;
 const TABLE_MIN_COL_W: f32 = 56;
+const TABLE_CELL_PAD_Y: f32 = 5;
+const TABLE_TOOLBAR_H: f32 = 32;
 const SUGGESTION_ROW_H: f32 = 28;
 const SUGGESTION_PAD_Y: f32 = 6;
 const SUGGESTION_GAP: f32 = 6;
@@ -1042,7 +1044,7 @@ fn markdownContentHeight(text: []const u8, max_w: f32) f32 {
     while (cursor < text.len) {
         if (!in_code and isMarkdownTableStart(text, cursor)) {
             const end = tableBlockEnd(text, cursor);
-            total += tableBlockHeight(text, cursor, end);
+            total += tableBlockHeight(text, cursor, end, max_w);
             cursor = end;
             continue;
         }
@@ -2026,7 +2028,7 @@ fn renderMarkdownContent(
         if (!in_code and isMarkdownTableStart(text, cursor)) {
             const table_start = cursor;
             const end = tableBlockEnd(text, cursor);
-            current_top += renderTableBlock(text, cursor, end, x, current_top, max_w, window_height, palette);
+            current_top += renderTableBlock(text, cursor, end, x, current_top, max_w, window_height, palette, display_cursor, selection_range);
             display_cursor += md.tableBlockDisplayLen(text, table_start, end);
             cursor = end;
             continue;
@@ -2119,11 +2121,9 @@ fn forEachCopyBlock(
         if (!in_code and isMarkdownTableStart(text, cursor)) {
             const start = cursor;
             const end = tableBlockEnd(text, cursor);
-            var widths: [TABLE_MAX_COLS]f32 = .{0} ** TABLE_MAX_COLS;
-            const col_count = measureTableColumns(text, start, end, max_w, &widths);
-            const table_w = if (col_count == 0) max_w else tableUsedWidth(widths[0..col_count]);
-            emit(ctx, CopyBlock{ .button = blockCopyButtonRect(x, current_top, table_w), .start = start, .end = end });
-            current_top += tableBlockHeight(text, start, end);
+            const table = TableLayout.init(text, start, end, max_w);
+            emit(ctx, CopyBlock{ .button = blockCopyButtonRect(x, current_top, table.width()), .start = start, .end = end });
+            current_top += tableBlockHeight(text, start, end, max_w);
             cursor = end;
             continue;
         }
@@ -2192,11 +2192,9 @@ fn byteOffsetForMarkdownPoint(
         if (!in_code and isMarkdownTableStart(text, cursor)) {
             const start = cursor;
             const end = tableBlockEnd(text, cursor);
-            const block_h = tableBlockHeight(text, cursor, end);
+            const block_h = tableBlockHeight(text, cursor, end, max_w);
             if (py < current_top + block_h) {
-                const row_h = tableRowHeight();
-                const row_index: usize = @intFromFloat(@max(0.0, @floor((py - current_top) / row_h)));
-                return display_cursor + md.tableRowDisplayOffsetWithin(text, start, end, row_index);
+                return display_cursor + tableByteOffsetForPoint(text, start, end, max_w, x, current_top, px, py);
             }
             current_top += block_h;
             display_cursor += md.tableBlockDisplayLen(text, start, end);
@@ -2307,17 +2305,143 @@ fn renderMarkdownFence(label: []const u8, x: f32, top_px: f32, max_w: f32, windo
     }
 }
 
-fn tableBlockHeight(text: []const u8, start: usize, end: usize) f32 {
-    var row_count: usize = 0;
+/// One geometry contract for height, painting, selection and block-copy buttons.
+const TableLayout = struct {
+    widths: [TABLE_MAX_COLS]f32 = .{0} ** TABLE_MAX_COLS,
+    alignments: [TABLE_MAX_COLS]md.TableAlignment = .{.left} ** TABLE_MAX_COLS,
+    count: usize = 0,
+    pad: f32 = TABLE_CELL_PAD_X,
+
+    fn init(text: []const u8, start: usize, end: usize, max_w: f32) TableLayout {
+        var self: TableLayout = .{};
+        var cells: [TABLE_MAX_COLS][]const u8 = undefined;
+        const header = nextSourceLine(text, start);
+        self.count = parseTableRowCells(header.line, &cells);
+        if (self.count == 0) return self;
+        const separator = nextSourceLine(text, header.next);
+        _ = parseTableRowCells(separator.line, &cells);
+        for (0..self.count) |col| self.alignments[col] = md.tableAlignment(cells[col]);
+        var cursor = start;
+        while (cursor < end) {
+            const info = nextSourceLine(text, cursor);
+            cursor = info.next;
+            if (isTableSeparatorLine(info.line)) continue;
+            const count = parseTableRowCells(info.line, &cells);
+            self.count = @max(self.count, count);
+            for (0..count) |col| {
+                var scratch: [256]u8 = undefined;
+                const cell = md.CellText.init(&scratch, cells[col]);
+                defer cell.deinit();
+                self.widths[col] = @max(self.widths[col], measureText(cell.text));
+            }
+        }
+        const n: f32 = @floatFromInt(self.count);
+        self.pad = @min(TABLE_CELL_PAD_X, @max(0, (max_w / n - 16) / 2));
+        const available = @max(n, max_w - n * (self.pad * 2 + 1) - 1);
+        md.fitTableWidths(self.widths[0..self.count], available, TABLE_MIN_COL_W);
+        return self;
+    }
+
+    fn width(self: TableLayout) f32 {
+        var total: f32 = 1;
+        for (self.widths[0..self.count]) |w| total += w + self.pad * 2 + 1;
+        return total;
+    }
+
+    fn rowHeight(self: TableLayout, line: []const u8) f32 {
+        var cells: [TABLE_MAX_COLS][]const u8 = undefined;
+        const count = parseTableRowCells(line, &cells);
+        var height = lineHeight();
+        for (0..@min(count, self.count)) |col| {
+            var scratch: [256]u8 = undefined;
+            const cell = md.CellText.init(&scratch, cells[col]);
+            defer cell.deinit();
+            height = @max(height, plainContentHeight(cell.text, self.widths[col], lineHeight()));
+        }
+        return height + TABLE_CELL_PAD_Y * 2;
+    }
+};
+
+/// UTF-8 wrap boundaries and alignment are shared by draw and hit-test.
+const TableCellLines = struct {
+    text: []const u8,
+    width: f32,
+    alignment: md.TableAlignment,
+    cursor: usize = 0,
+
+    const Line = struct { text: []const u8, offset: usize, inset: f32 };
+
+    fn next(self: *TableCellLines) ?Line {
+        if (self.cursor >= self.text.len) return null;
+        const start = self.cursor;
+        var width: f32 = 0;
+        while (self.cursor < self.text.len) {
+            const item = nextCodepoint(self.text, self.cursor);
+            if (self.cursor > start and width + item.advance > self.width) break;
+            width += item.advance;
+            self.cursor += item.len;
+        }
+        const free = @max(0, self.width - width);
+        return .{ .text = self.text[start..self.cursor], .offset = start, .inset = switch (self.alignment) {
+            .left => 0,
+            .center => free / 2,
+            .right => free,
+        } };
+    }
+};
+
+fn tableBlockHeight(text: []const u8, start: usize, end: usize, max_w: f32) f32 {
+    const table = TableLayout.init(text, start, end, max_w);
+    var total: f32 = TABLE_TOOLBAR_H + 1;
     var cursor = start;
     while (cursor < end) {
         const info = nextSourceLine(text, cursor);
         cursor = info.next;
-        if (isTableSeparatorLine(info.line)) continue;
-        row_count += 1;
+        if (!isTableSeparatorLine(info.line)) total += table.rowHeight(info.line);
     }
-    if (row_count == 0) return tableRowHeight();
-    return @as(f32, @floatFromInt(row_count)) * tableRowHeight() + 1;
+    return total;
+}
+
+fn tableByteOffsetForPoint(text: []const u8, start: usize, end: usize, max_w: f32, x: f32, top: f32, px: f32, py: f32) usize {
+    const table = TableLayout.init(text, start, end, max_w);
+    var cursor = start;
+    var row_top = top + TABLE_TOOLBAR_H;
+    var offset: usize = 0;
+    while (cursor < end) {
+        const info = nextSourceLine(text, cursor);
+        cursor = info.next;
+        if (isTableSeparatorLine(info.line)) continue;
+        const height = table.rowHeight(info.line);
+        var cells: [TABLE_MAX_COLS][]const u8 = undefined;
+        const count = parseTableRowCells(info.line, &cells);
+        var cell_x = x + 1;
+        for (0..count) |col| {
+            if (col > 0) offset += 3;
+            var scratch: [256]u8 = undefined;
+            const cell = md.CellText.init(&scratch, cells[col]);
+            defer cell.deinit();
+            if (col < table.count) {
+                const cell_w = table.widths[col] + table.pad * 2 + 1;
+                if (py < row_top + height and (px < cell_x + cell_w or col + 1 == table.count)) {
+                    var lines = TableCellLines{ .text = cell.text, .width = table.widths[col], .alignment = table.alignments[col] };
+                    var line_top = row_top + TABLE_CELL_PAD_Y;
+                    while (lines.next()) |line| {
+                        if (py < line_top + lineHeight()) return byteOffsetForLineX(line.text, offset + line.offset, cell_x + table.pad + line.inset, px);
+                        line_top += lineHeight();
+                    }
+                    return offset + cell.text.len;
+                }
+                cell_x += cell_w;
+            }
+            offset += cell.text.len;
+        }
+        // A GFM row may omit trailing cells. Clicking that empty area belongs
+        // to this row's end, not the following row's first character.
+        if (py < row_top + height) return offset;
+        offset += 1;
+        row_top += height;
+    }
+    return offset;
 }
 
 fn renderTableBlock(
@@ -2329,104 +2453,67 @@ fn renderTableBlock(
     max_w: f32,
     window_height: f32,
     palette: MarkdownPalette,
+    base_offset: usize,
+    selection_range: ?ai_chat.TextSelectionRange,
 ) f32 {
-    var widths: [TABLE_MAX_COLS]f32 = .{0} ** TABLE_MAX_COLS;
-    const col_count = measureTableColumns(text, start, end, max_w, &widths);
-    if (col_count == 0) return 0;
-
-    const table_w = tableUsedWidth(widths[0..col_count]);
-    const row_h = tableRowHeight();
-    const total_h = tableBlockHeight(text, start, end);
-    const table_y = window_height - top_px - total_h;
-
-    ui_pipeline.fillQuadAlpha(x, table_y, table_w, total_h, palette.table_bg, 0.94);
-    ui_pipeline.fillQuadAlpha(x, table_y, DETAIL_RULE_W, total_h, palette.table_border, 0.85);
-    ui_pipeline.fillQuadAlpha(x, table_y, table_w, 1, palette.table_border, 0.85);
-    ui_pipeline.fillQuadAlpha(x, table_y + total_h - 1, table_w, 1, palette.table_border, 0.85);
-    ui_pipeline.fillQuadAlpha(x + table_w - 1, table_y, 1, total_h, palette.table_border, 0.85);
-
+    const table = TableLayout.init(text, start, end, max_w);
+    if (table.count == 0) return 0;
+    const table_w = table.width();
+    // Give Copy its own band so it never covers the final header cell.
+    renderTopQuad(x, table_w, window_height, top_px, TABLE_TOOLBAR_H, palette.table_bg);
+    var row_top = top_px + TABLE_TOOLBAR_H;
     var cursor = start;
     var row_index: usize = 0;
+    var offset = base_offset;
     while (cursor < end) {
         const info = nextSourceLine(text, cursor);
         cursor = info.next;
         if (isTableSeparatorLine(info.line)) continue;
-
-        var cells: [TABLE_MAX_COLS][]const u8 = .{""} ** TABLE_MAX_COLS;
+        const row_h = table.rowHeight(info.line);
+        var cells: [TABLE_MAX_COLS][]const u8 = undefined;
         const cell_count = parseTableRowCells(info.line, &cells);
-        const row_top = top_px + @as(f32, @floatFromInt(row_index)) * row_h;
-        const row_y = window_height - row_top - row_h;
-        const row_bg = if (row_index == 0)
-            mixColor(palette.table_bg, AppWindow.g_theme.cursor_color, 0.10)
-        else if (row_index % 2 == 0)
-            palette.table_bg
-        else
-            palette.table_alt;
-        ui_pipeline.fillQuadAlpha(x, row_y, table_w, row_h, row_bg, if (row_index == 0) 0.98 else 0.92);
-        ui_pipeline.fillQuadAlpha(x, row_y, table_w, 1, palette.table_border, 0.85);
-
-        var cell_x = x + 1;
-        for (0..col_count) |col| {
-            if (col > 0) ui_pipeline.fillQuadAlpha(cell_x - 1, row_y, 1, row_h, palette.table_border, 0.85);
-            const text_w = widths[col];
-            const cell_w = text_w + TABLE_CELL_PAD_X * 2 + 1;
-            var clean_buf: [256]u8 = undefined;
-            const cell_text = if (col < cell_count) cleanInline(&clean_buf, cells[col]) else "";
-            _ = titlebar.renderTextLimited(
-                cell_text,
-                cell_x + TABLE_CELL_PAD_X,
-                row_y + @round((row_h - font.g_titlebar_cell_height) / 2),
-                if (row_index == 0) palette.strong else palette.normal,
-                text_w,
-            );
-            cell_x += cell_w;
+        const visible = row_top + row_h >= 0 and row_top < window_height;
+        if (visible) {
+            const bg = if (row_index == 0) mixColor(palette.table_bg, AppWindow.g_theme.cursor_color, 0.10) else if (row_index % 2 == 0) palette.table_bg else palette.table_alt;
+            renderTopQuad(x, table_w, window_height, row_top, row_h, bg);
+            renderTopQuad(x, table_w, window_height, row_top, 1, palette.table_border);
+            renderTopQuad(x, 1, window_height, row_top, row_h, palette.table_border);
         }
-
+        var cell_x = x + 1;
+        for (0..table.count) |col| {
+            if (col > 0 and col < cell_count) offset += 3;
+            var scratch: [256]u8 = undefined;
+            const cell = md.CellText.init(&scratch, if (col < cell_count) cells[col] else "");
+            defer cell.deinit();
+            if (visible) {
+                var lines = TableCellLines{ .text = cell.text, .width = table.widths[col], .alignment = table.alignments[col] };
+                var line_top = row_top + TABLE_CELL_PAD_Y;
+                while (lines.next()) |line| {
+                    const text_x = cell_x + table.pad + line.inset;
+                    if (selection_range) |range| renderTextLineSelection(line.text, offset + line.offset, text_x, line_top, lineHeight(), range, window_height, window_height);
+                    renderTextLine(line.text, text_x, line_top, table.widths[col] - line.inset, if (row_index == 0) palette.strong else palette.normal, window_height, window_height);
+                    line_top += lineHeight();
+                }
+            }
+            offset += cell.text.len;
+            cell_x += table.widths[col] + table.pad * 2 + 1;
+            if (visible) renderTopQuad(cell_x - 1, 1, window_height, row_top, row_h, palette.table_border);
+        }
+        // Preserve canonical offsets for malformed rows with extra cells.
+        if (cell_count > table.count) {
+            for (table.count..cell_count) |col| {
+                var scratch: [256]u8 = undefined;
+                const cell = md.CellText.init(&scratch, cells[col]);
+                defer cell.deinit();
+                offset += 3 + cell.text.len;
+            }
+        }
+        offset += 1;
+        row_top += row_h;
         row_index += 1;
     }
-
-    return total_h;
-}
-
-fn measureTableColumns(text: []const u8, start: usize, end: usize, max_w: f32, widths: *[TABLE_MAX_COLS]f32) usize {
-    @memset(widths, 0);
-    var col_count: usize = 0;
-    var cursor = start;
-    while (cursor < end) {
-        const info = nextSourceLine(text, cursor);
-        cursor = info.next;
-        if (isTableSeparatorLine(info.line)) continue;
-
-        var cells: [TABLE_MAX_COLS][]const u8 = .{""} ** TABLE_MAX_COLS;
-        const count = parseTableRowCells(info.line, &cells);
-        col_count = @max(col_count, count);
-        for (0..count) |i| {
-            var clean_buf: [256]u8 = undefined;
-            const cell_text = cleanInline(&clean_buf, cells[i]);
-            widths[i] = @max(widths[i], measureText(cell_text));
-        }
-    }
-    if (col_count == 0) return 0;
-
-    var natural_content_w: f32 = 0;
-    for (0..col_count) |i| {
-        widths[i] = @max(widths[i], TABLE_MIN_COL_W);
-        natural_content_w += widths[i];
-    }
-
-    const chrome = @as(f32, @floatFromInt(col_count)) * (TABLE_CELL_PAD_X * 2 + 1) + 1;
-    if (natural_content_w + chrome > max_w) {
-        const available = @max(24.0, (max_w - chrome) / @as(f32, @floatFromInt(col_count)));
-        for (0..col_count) |i| widths[i] = available;
-    }
-
-    return col_count;
-}
-
-fn tableUsedWidth(widths: []const f32) f32 {
-    var total: f32 = 1;
-    for (widths) |w| total += w + TABLE_CELL_PAD_X * 2 + 1;
-    return total;
+    renderTopQuad(x, table_w, window_height, row_top, 1, palette.table_border);
+    return row_top - top_px + 1;
 }
 
 fn renderWrappedSelection(
@@ -2683,10 +2770,6 @@ fn reasoningLineHeight() f32 {
     return @round(@max(21.0, font.g_titlebar_cell_height + 6.0));
 }
 
-fn tableRowHeight() f32 {
-    return @round(@max(28.0, font.g_titlebar_cell_height + 10.0));
-}
-
 fn blankLineHeight() f32 {
     return @round(@max(12.0, lineHeight() * 0.56));
 }
@@ -2706,4 +2789,51 @@ fn mixColor(a: [3]f32, b: [3]f32, t: f32) [3]f32 {
         a[1] + (b[1] - a[1]) * clamped,
         a[2] + (b[2] - a[2]) * clamped,
     };
+}
+
+test "markdown table wrapping height and selection share cell geometry" {
+    const text = "| Name | Path |\n| :--- | ---: |\n| 中文😀 | `C:/a/very/long/path/to/a/file.txt` |\n";
+    const narrow = TableLayout.init(text, 0, text.len, 220);
+    const wide = TableLayout.init(text, 0, text.len, 900);
+    try std.testing.expect(narrow.width() <= 220.01);
+    try std.testing.expect(wide.width() <= 900.01);
+    try std.testing.expect(tableBlockHeight(text, 0, text.len, 220) >= tableBlockHeight(text, 0, text.len, 900));
+    const header = nextSourceLine(text, 0);
+    const body_top = TABLE_TOOLBAR_H + narrow.rowHeight(header.line);
+    const first_cell_x: f32 = 1 + narrow.pad;
+    const row_offset = md.tableRowDisplayOffsetWithin(text, 0, text.len, 1);
+    try std.testing.expectEqual(row_offset, tableByteOffsetForPoint(text, 0, text.len, 220, 0, 0, first_cell_x, body_top + TABLE_CELL_PAD_Y + 1));
+    const second_cell_x = 1 + narrow.widths[0] + narrow.pad * 2 + 1;
+    const display = try md.allocDisplayText(std.testing.allocator, text);
+    defer std.testing.allocator.free(display);
+    const offset = tableByteOffsetForPoint(text, 0, text.len, 220, 0, 0, second_cell_x, body_top + TABLE_CELL_PAD_Y + 1);
+    try std.testing.expectEqualStrings("C:/", display[offset..][0..3]);
+    try std.testing.expectEqual(display.len, tableByteOffsetForPoint(text, 0, text.len, 220, 0, 0, 0, 10000));
+    var copy_ctx = struct {
+        count: usize = 0,
+        fn check(ctx: *@This(), block: CopyBlock) void {
+            ctx.count += 1;
+            std.debug.assert(block.start == 0 and block.end == text.len);
+            std.debug.assert(block.button.top_px + block.button.h <= TABLE_TOOLBAR_H);
+        }
+    }{};
+    forEachCopyBlock(text, 0, 0, 220, &copy_ctx, @TypeOf(copy_ctx).check);
+    try std.testing.expectEqual(@as(usize, 1), copy_ctx.count);
+    const sparse = "| Name | Path |\n| --- | --- |\n| short\n| next | value |\n";
+    const sparse_table = TableLayout.init(sparse, 0, sparse.len, 220);
+    const sparse_top = TABLE_TOOLBAR_H + sparse_table.rowHeight(nextSourceLine(sparse, 0).line);
+    const sparse_offset = md.tableRowDisplayOffsetWithin(sparse, 0, sparse.len, 1);
+    try std.testing.expectEqual(sparse_offset + "short".len, tableByteOffsetForPoint(sparse, 0, sparse.len, 220, 0, 0, 219, sparse_top + 6));
+}
+
+test "table line wrapping preserves UTF-8 boundaries and right alignment" {
+    var lines = TableCellLines{ .text = "中文😀abc", .width = 30, .alignment = .right };
+    var bytes: usize = 0;
+    while (lines.next()) |line| {
+        try std.testing.expect(std.unicode.utf8ValidateSlice(line.text));
+        try std.testing.expectEqual(bytes, line.offset);
+        try std.testing.expect(line.inset >= 0);
+        bytes += line.text.len;
+    }
+    try std.testing.expectEqual(@as(usize, "中文😀abc".len), bytes);
 }


### PR DESCRIPTION
AI Chat and Copilot tables used fixed-height rows and truncated cell text, making long paths difficult to read and table selection imprecise. This change wraps cells, allocates column widths by content, honors left/center/right alignment, and uses matching geometry for rendering, hit-testing, and selection. Table copy buttons now have a separate band above the header.

The shared Markdown helpers also preserve escaped pipes, inline-code punctuation, long UTF-8 cells, and fenced-code indentation/blank lines. The native text renderer continues to avoid HTML/script execution. Documentation describes the supported subset.

Validation:
- `zig build`: 26/26 steps succeeded.
- `zig build test-full`: 60/60 steps succeeded; 15,777 tests passed and 364 skipped, including new parsing, layout, and selection regressions.
- Real Windows AI Chat window: inspected structured tables, Chinese/emoji, alignment, and selection highlighting. Clipboard contents matched the fixtures exactly for raw table Markdown (330 bytes), fenced code (23 bytes), and selection across cells/rows (132 bytes).
- Copilot uses the same renderer; separate sidebar visual validation was not completed.

This is a focused improvement toward #624. Tables wrap within the message width; horizontal scrolling and a full GFM renderer remain outside this change.
