### PR TITLE
feat(windows): add native Explorer context menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,36 @@ jobs:
       # sockets) reached release. This guards it where it actually bit.
       - name: Agent-control socket round-trip
         run: zig build test-ctl
+
+  windows-shell-integration:
+    name: Windows Explorer integration
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+      - name: Build COM extension and test driver
+        run: zig build shell-extension-test
+      - name: Sign and test identity registration on disposable runner
+        shell: pwsh
+        run: |
+          $cert = New-SelfSignedCertificate -Type Custom -Subject 'CN=WispTerm CI Test' `
+            -KeyUsage DigitalSignature -HashAlgorithm SHA256 -KeyAlgorithm RSA -KeyLength 2048 `
+            -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddDays(2) `
+            -TextExtension @('2.5.29.37={text}1.3.6.1.5.5.7.3.3','2.5.29.19={text}')
+          $cerPath = Join-Path $env:RUNNER_TEMP 'wispterm-shell-test.cer'
+          try {
+            Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
+            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\CurrentUser\TrustedPeople | Out-Null
+            $env:WISPTERM_WINDOWS_SIGN_THUMBPRINT = $cert.Thumbprint
+            powershell.exe -NoProfile -ExecutionPolicy Bypass -File debug\test-shell-integration.ps1 -RegisterPackage
+            if ($LASTEXITCODE -ne 0) { throw 'Explorer integration tests failed.' }
+          } finally {
+            Remove-Item "Cert:\CurrentUser\TrustedPeople\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+            Remove-Item "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+            Remove-Item $cerPath -ErrorAction SilentlyContinue
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,15 @@ jobs:
         with:
           version: 0.15.2
       - name: Build COM extension and test driver
-        run: zig build shell-extension-test
+        shell: pwsh
+        run: |
+          # This DLL has no terminal dependencies. Compile it directly so the
+          # integration test does not fetch Ghostty's unrelated build graph.
+          New-Item -ItemType Directory -Force zig-out\bin | Out-Null
+          zig c++ -std=c++17 -DUNICODE -D_UNICODE -shared src/platform/explorer/shell_extension.cpp -lole32 -lshell32 -lshlwapi -luuid -o zig-out/bin/wispterm-shell-extension.dll
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          zig c++ -std=c++17 -DUNICODE -D_UNICODE src/platform/explorer/shell_extension_test.cpp -lole32 -lshell32 -lshlwapi -luuid -o zig-out/bin/wispterm-shell-extension-test.exe
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Sign and test identity registration on disposable runner
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
           zig c++ -std=c++17 -DUNICODE -D_UNICODE src/platform/explorer/shell_extension_test.cpp -lole32 -lshell32 -lshlwapi -luuid -o zig-out/bin/wispterm-shell-extension-test.exe
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Sign and test identity registration on disposable runner
+        timeout-minutes: 8
         shell: pwsh
         run: |
           $cert = New-SelfSignedCertificate -Type Custom -Subject 'CN=WispTerm CI Test' `
@@ -197,15 +198,18 @@ jobs:
           try {
             Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
             # AppX deployment and Authenticode use different trust policies.
-            # These stores belong only to this disposable CI VM.
+            # These stores belong only to this disposable CI VM. Machine
+            # stores avoid CurrentUser Root's interactive trust confirmation.
+            Write-Host 'Preparing disposable VM certificate trust'
             Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null
-            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
+            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
             $env:WISPTERM_WINDOWS_SIGN_THUMBPRINT = $cert.Thumbprint
+            Write-Host 'Building and testing signed identity registration'
             powershell.exe -NoProfile -ExecutionPolicy Bypass -File debug\test-shell-integration.ps1 -RegisterPackage
             if ($LASTEXITCODE -ne 0) { throw 'Explorer integration tests failed.' }
           } finally {
             Remove-Item "Cert:\LocalMachine\TrustedPeople\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
-            Remove-Item "Cert:\CurrentUser\Root\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+            Remove-Item "Cert:\LocalMachine\Root\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
             Remove-Item "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
             Remove-Item $cerPath -ErrorAction SilentlyContinue
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,16 @@ jobs:
           $cerPath = Join-Path $env:RUNNER_TEMP 'wispterm-shell-test.cer'
           try {
             Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
-            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\CurrentUser\TrustedPeople | Out-Null
+            # AppX deployment and Authenticode use different trust policies.
+            # These stores belong only to this disposable CI VM.
+            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null
+            Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
             $env:WISPTERM_WINDOWS_SIGN_THUMBPRINT = $cert.Thumbprint
             powershell.exe -NoProfile -ExecutionPolicy Bypass -File debug\test-shell-integration.ps1 -RegisterPackage
             if ($LASTEXITCODE -ne 0) { throw 'Explorer integration tests failed.' }
           } finally {
-            Remove-Item "Cert:\CurrentUser\TrustedPeople\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+            Remove-Item "Cert:\LocalMachine\TrustedPeople\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+            Remove-Item "Cert:\CurrentUser\Root\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
             Remove-Item "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
             Remove-Item $cerPath -ErrorAction SilentlyContinue
           }

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -42,6 +42,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-zig-0.15.2-
 
+      - name: Configure optional Windows identity-package signing
+        shell: pwsh
+        env:
+          SIGNING_PFX: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
+          SIGNING_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PFX_PASSWORD }}
+        run: |
+          if (!$env:SIGNING_PFX) {
+            Write-Warning 'Windows signing is not configured. Context menu identity packages will be unsigned and cannot be enabled on end-user PCs.'
+            exit 0
+          }
+          $pfx = Join-Path $env:RUNNER_TEMP 'wispterm-signing.pfx'
+          try {
+            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:SIGNING_PFX))
+            $password = ConvertTo-SecureString $env:SIGNING_PASSWORD -AsPlainText -Force
+            $certs = @(Import-PfxCertificate -FilePath $pfx -Password $password -CertStoreLocation Cert:\CurrentUser\My | Where-Object HasPrivateKey)
+            if ($certs.Count -ne 1) { throw 'Expected one Windows signing certificate with a private key.' }
+            $cert = $certs[0]
+            "WISPTERM_WINDOWS_SIGN_THUMBPRINT=$($cert.Thumbprint)" | Out-File $env:GITHUB_ENV -Append
+          } finally { Remove-Item $pfx -Force -ErrorAction SilentlyContinue }
+
       - name: Fetch dependencies and build release
         shell: pwsh
         run: |
@@ -97,7 +117,13 @@ jobs:
           )
           $replaceFiles = @(
             "Replace-WispTerm.cmd",
-            "replace-install.ps1"
+            "replace-install.ps1",
+            "Add-Context-Menu.cmd",
+            "Remove-Context-Menu.cmd",
+            "context-menu.ps1",
+            "Uninstall-WispTerm.cmd",
+            "uninstall.ps1",
+            "shell-integration\identity.json"
           )
 
           if (!(Test-Path $portableExe)) {
@@ -282,4 +308,12 @@ jobs:
               --verify-tag `
               --generate-notes `
               --notes $notes
+          }
+
+      - name: Remove imported Windows signing identity
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:WISPTERM_WINDOWS_SIGN_THUMBPRINT) {
+            Remove-Item "Cert:\CurrentUser\My\$env:WISPTERM_WINDOWS_SIGN_THUMBPRINT" -ErrorAction SilentlyContinue
           }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Options:
 
 Configuration file details are in [Configuration](docs/configuration.md).
 
+Windows builds include an optional **Open in WispTerm** Explorer context menu for folders and folder backgrounds. Enable it with `Add-Context-Menu.cmd` from a trusted signed bundle; use `Remove-Context-Menu.cmd` to remove it. See [Windows context menu setup](docs/windows-context-menu.md) for signing requirements and installation details.
+
 ## Keyboard shortcuts
 
 Default app-level chords are defined in [`src/keybind.zig`](src/keybind.zig) and can be remapped with repeated `keybind = ...` lines in the config file. Some modal/editor-local keys are still handled by the focused overlay first (command center navigation, session launcher editing, AI Chat input, and similar).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,6 +123,8 @@ wispterm [options]
 
 配置文件细节见[配置](docs/configuration.md)。
 
+Windows 版本支持可选的 **在 WispTerm 中打开** 文件夹右键菜单（含文件夹空白区域）。在附带受信任签名身份包的发行版中运行 `Add-Context-Menu.cmd` 启用，运行 `Remove-Context-Menu.cmd` 移除。签名要求和安装说明见 [Windows 右键菜单](docs/windows-context-menu.md)。
+
 ## 键盘快捷键
 
 应用级默认组合键定义在 [`src/keybind.zig`](src/keybind.zig)，可在配置文件中用重复的

--- a/build.zig
+++ b/build.zig
@@ -674,6 +674,36 @@ pub fn build(b: *std.Build) void {
             });
             askpass_exe.subsystem = .Windows;
             b.installArtifact(askpass_exe);
+
+            const shell_mod = b.createModule(.{
+                .target = target,
+                .optimize = optimize,
+                .link_libc = true,
+                .link_libcpp = true,
+            });
+            shell_mod.addCSourceFile(.{
+                .file = b.path("src/platform/explorer/shell_extension.cpp"),
+                .flags = &.{ "-std=c++17", "-DUNICODE", "-D_UNICODE" },
+            });
+            for ([_][]const u8{ "ole32", "shell32", "shlwapi", "uuid" }) |lib| shell_mod.linkSystemLibrary(lib, .{});
+            const shell_extension = b.addLibrary(.{
+                .name = "wispterm-shell-extension",
+                .linkage = .dynamic,
+                .root_module = shell_mod,
+            });
+            b.installArtifact(shell_extension);
+            const shell_step = b.step("shell-extension", "Build the Explorer context menu DLL");
+            shell_step.dependOn(&b.addInstallArtifact(shell_extension, .{}).step);
+            const shell_test_mod = b.createModule(.{ .target = target, .optimize = optimize, .link_libc = true, .link_libcpp = true });
+            shell_test_mod.addCSourceFile(.{
+                .file = b.path("src/platform/explorer/shell_extension_test.cpp"),
+                .flags = &.{ "-std=c++17", "-DUNICODE", "-D_UNICODE" },
+            });
+            for ([_][]const u8{ "ole32", "shell32", "shlwapi", "uuid" }) |lib| shell_test_mod.linkSystemLibrary(lib, .{});
+            const shell_test = b.addExecutable(.{ .name = "wispterm-shell-extension-test", .root_module = shell_test_mod });
+            const shell_test_step = b.step("shell-extension-test", "Build the native Explorer COM test driver (run debug/test-shell-integration.ps1)");
+            shell_test_step.dependOn(&b.addInstallArtifact(shell_extension, .{}).step);
+            shell_test_step.dependOn(&b.addInstallArtifact(shell_test, .{}).step);
         }
 
         // Standalone CLI client for the agent terminal control API. Lean: it

--- a/debug/test-shell-integration.ps1
+++ b/debug/test-shell-integration.ps1
@@ -12,6 +12,7 @@ $second = Join-Path $scratch 'relocated install'
 New-Item -ItemType Directory -Force $install | Out-Null
 try {
     Copy-Item -LiteralPath $test -Destination (Join-Path $install 'wispterm.exe')
+    Copy-Item -LiteralPath $test -Destination (Join-Path $install 'shell-test-client.exe')
     & (Join-Path $repo 'packaging\windows\shell-integration\build-package.ps1') -TargetDir $install -ExtensionPath $dll -TimestampUrl ""
     $metadata = Get-Content -Raw (Join-Path $install 'shell-integration\identity.json') | ConvertFrom-Json
     [xml]$manifest = Get-Content -Raw (Join-Path $install $metadata.Manifest)
@@ -46,8 +47,12 @@ try {
         if (!(& $menu -Action Status).Enabled) { throw 'Registration status was not enabled.' }
         Push-Location $scratch
         try {
-            & (Join-Path $install 'wispterm.exe') --registered
-            if ($LASTEXITCODE -ne 0) { throw ('Packaged COM activation/launch tests failed; exit=0x{0:X8}' -f ($LASTEXITCODE -band 0xffffffffL)) }
+            & (Join-Path $install 'shell-test-client.exe') --registered
+            if ($LASTEXITCODE -ne 0) {
+                $testExit = $LASTEXITCODE
+                Get-Content (Join-Path $scratch 'shell-test-failure.log') -ErrorAction SilentlyContinue
+                throw ('Packaged COM activation/launch tests failed; exit=0x{0:X8}' -f ($testExit -band 0xffffffffL))
+            }
         } finally { Pop-Location }
         Copy-Item -LiteralPath $install -Destination $second -Recurse
         $secondMenu = Join-Path $second 'context-menu.ps1'
@@ -56,7 +61,7 @@ try {
         if (!(& $secondMenu -Action Status).Enabled) { throw 'Removing an old copy removed the active registration.' }
         Push-Location $scratch
         try {
-            & (Join-Path $second 'wispterm.exe') --registered
+            & (Join-Path $second 'shell-test-client.exe') --registered
             if ($LASTEXITCODE -ne 0) { throw 'Relocated packaged COM activation failed.' }
         } finally { Pop-Location }
         & $secondMenu -Action Remove

--- a/debug/test-shell-integration.ps1
+++ b/debug/test-shell-integration.ps1
@@ -1,0 +1,76 @@
+param([switch]$RegisterPackage)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$test = Join-Path $repo 'zig-out\bin\wispterm-shell-extension-test.exe'
+$dll = Join-Path $repo 'zig-out\bin\wispterm-shell-extension.dll'
+if (!(Test-Path $test) -or !(Test-Path $dll)) { throw 'Run zig build shell-extension-test first.' }
+# C: working directories avoid WSL UNC semantics in the Windows test runner.
+$scratch = Join-Path ([IO.Path]::GetTempPath()) ('WispTermShellTest-' + [guid]::NewGuid().ToString('N'))
+$install = Join-Path $scratch 'install space'
+$second = Join-Path $scratch 'relocated install'
+New-Item -ItemType Directory -Force $install | Out-Null
+try {
+    Copy-Item -LiteralPath $test -Destination (Join-Path $install 'wispterm.exe')
+    & (Join-Path $repo 'packaging\windows\shell-integration\build-package.ps1') -TargetDir $install -ExtensionPath $dll -TimestampUrl ""
+    $metadata = Get-Content -Raw (Join-Path $install 'shell-integration\identity.json') | ConvertFrom-Json
+    [xml]$manifest = Get-Content -Raw (Join-Path $install $metadata.Manifest)
+    $ns = New-Object Xml.XmlNamespaceManager $manifest.NameTable
+    $ns.AddNamespace('com','http://schemas.microsoft.com/appx/manifest/com/windows10')
+    $class = $manifest.SelectSingleNode('//com:Class',$ns)
+    $packagedDll = Join-Path $install $class.Path
+    Push-Location $scratch
+    try {
+        & (Join-Path $install 'wispterm.exe') $packagedDll
+        if ($LASTEXITCODE -ne 0) { throw 'Direct COM/launch tests failed.' }
+    } finally { Pop-Location }
+    $menu = Join-Path $install 'context-menu.ps1'
+    $before = & $menu -Action Status
+    & $menu -Action Refresh # Must not opt a fresh installation into registration.
+    $after = & $menu -Action Status
+    if ($before.Enabled -ne $after.Enabled) { throw 'Refresh enabled an unregistered installation.' }
+    if (!$RegisterPackage -and !(Get-AuthenticodeSignature (Join-Path $install $metadata.Package)).Status.Equals('Valid')) {
+        $rejected = $false
+        try { & $menu -Action Install } catch { $rejected = $true }
+        if (!$rejected -or (& $menu -Action Status).Enabled) { throw 'Untrusted package was not rejected before registration.' }
+        Write-Host 'PASS: unsigned package refused without changing registration'
+    }
+    if ($RegisterPackage) {
+        if (@(Get-AppxPackage -Name WispTerm.ContextMenu).Count -or (Test-Path 'HKCU:\Software\WispTerm\ContextMenu')) {
+            throw 'Registration tests require a clean/disposable Windows user profile.'
+        }
+        # Uses an already trusted signing certificate; this script neither
+        # creates certificates nor enables Developer Mode.
+        & $menu -Action Install
+        & $menu -Action Install # idempotence
+        if (!(& $menu -Action Status).Enabled) { throw 'Registration status was not enabled.' }
+        Push-Location $scratch
+        try {
+            & (Join-Path $install 'wispterm.exe') --registered
+            if ($LASTEXITCODE -ne 0) { throw 'Packaged COM activation/launch tests failed.' }
+        } finally { Pop-Location }
+        Copy-Item -LiteralPath $install -Destination $second -Recurse
+        $secondMenu = Join-Path $second 'context-menu.ps1'
+        & $secondMenu -Action Install
+        & $menu -Action Remove # An old copy must not unregister the active copy.
+        if (!(& $secondMenu -Action Status).Enabled) { throw 'Removing an old copy removed the active registration.' }
+        Push-Location $scratch
+        try {
+            & (Join-Path $second 'wispterm.exe') --registered
+            if ($LASTEXITCODE -ne 0) { throw 'Relocated packaged COM activation failed.' }
+        } finally { Pop-Location }
+        & $secondMenu -Action Remove
+        & $secondMenu -Action Remove # removal is idempotent
+        if (@(Get-AppxPackage -Name WispTerm.ContextMenu).Count) { throw 'Package remained registered after removal.' }
+        Write-Host 'PASS: signed identity registration, packaged activation, relocation, ownership and removal'
+    }
+} finally {
+    if ($RegisterPackage) {
+        foreach ($root in @($second,$install)) {
+            $menu = Join-Path $root 'context-menu.ps1'
+            if (Test-Path $menu) { & $menu -Action Remove }
+        }
+    }
+    try { Remove-Item -LiteralPath $scratch -Recurse -Force }
+    catch { Write-Warning "A COM surrogate still holds test files; cleanup directory: $scratch" }
+}

--- a/debug/test-shell-integration.ps1
+++ b/debug/test-shell-integration.ps1
@@ -29,7 +29,7 @@ try {
     & $menu -Action Refresh # Must not opt a fresh installation into registration.
     $after = & $menu -Action Status
     if ($before.Enabled -ne $after.Enabled) { throw 'Refresh enabled an unregistered installation.' }
-    if (!$RegisterPackage -and !(Get-AuthenticodeSignature (Join-Path $install $metadata.Package)).Status.Equals('Valid')) {
+    if (!$RegisterPackage -and ((Get-AuthenticodeSignature (Join-Path $install $metadata.Package)).Status -ne 'Valid')) {
         $rejected = $false
         try { & $menu -Action Install } catch { $rejected = $true }
         if (!$rejected -or (& $menu -Action Status).Enabled) { throw 'Untrusted package was not rejected before registration.' }

--- a/debug/test-shell-integration.ps1
+++ b/debug/test-shell-integration.ps1
@@ -47,7 +47,7 @@ try {
         Push-Location $scratch
         try {
             & (Join-Path $install 'wispterm.exe') --registered
-            if ($LASTEXITCODE -ne 0) { throw 'Packaged COM activation/launch tests failed.' }
+            if ($LASTEXITCODE -ne 0) { throw ('Packaged COM activation/launch tests failed; exit=0x{0:X8}' -f ($LASTEXITCODE -band 0xffffffffL)) }
         } finally { Pop-Location }
         Copy-Item -LiteralPath $install -Destination $second -Recurse
         $secondMenu = Join-Path $second 'context-menu.ps1'

--- a/docs/windows-context-menu.md
+++ b/docs/windows-context-menu.md
@@ -1,0 +1,120 @@
+# Windows Explorer context menu
+
+WispTerm can add **Open in WispTerm** / **在 WispTerm 中打开** to the
+Windows 11 context menu for a single filesystem folder or the background of an
+open folder. The command opens a new WispTerm window with that directory via
+`--working-directory`; explicit directory launches skip session restore. Drive
+roots work through the background menu after opening the drive. Files, virtual
+folders, archives, and multiple selections are not offered this command.
+
+The integration supports x64 Windows 10 2004 and later. Windows 11 uses its
+modern context menu; Windows 10 uses its classic menu. This is an independent
+WispTerm command, not a replacement for Windows Terminal's entry.
+
+## Enable and remove
+
+Extract the entire Windows zip to a stable local installation directory. A
+**trusted signed identity package** is required for normal installation. The
+ordinary unsigned desktop executable alone cannot register this modern menu.
+Unsigned developer bundles contain the integration payload but their
+`Add-Context-Menu.cmd` reports that a signed release is required.
+
+- Run `Add-Context-Menu.cmd` to enable the menu for the current Windows user.
+- Run `Remove-Context-Menu.cmd` to remove it.
+- To inspect registration, run `powershell -NoProfile -File .\context-menu.ps1 -Action Status`.
+- `Replace-WispTerm.cmd` refreshes registration if that installation already
+  owns it. To opt in during first installation, run
+  `powershell -NoProfile -File .\replace-install.ps1 -EnableContextMenu`.
+- `Uninstall-WispTerm.cmd` unregisters the menu before removing application
+  payloads, preserving user configuration, plugins and unrelated files.
+
+Close that WispTerm installation before changing an existing registration;
+registration scripts do not terminate terminal sessions. Reopen Explorer after
+registration. If Windows caches the previous menu, sign out and back in. The
+scripts do not restart Explorer, elevate, import certificates, or enable
+Developer Mode.
+
+When moving a portable installation, run `Add-Context-Menu.cmd` from the new
+location. This rebinds the current user's registration. Running the removal
+script from an old copy does not remove the new copy's menu. Unregister before
+manually deleting the active installation directory.
+
+## Packaging and signing
+
+`zig build` builds the standalone `wispterm-shell-extension.dll` alongside the
+Windows desktop app. `zig build shell-extension` builds only that DLL.
+`packaging/windows/package.ps1` packages it with every Windows bundle.
+
+The Windows SDK's `MakeAppx.exe` and `mt.exe` are needed for packaging;
+`SignTool.exe` is also needed when signing. The scripts discover the x64 SDK
+tools automatically. The identity package version comes from `build.zig.zon`,
+using `major.minor.patch.0`, independently of a descriptive zip filename.
+
+To sign, install the release signing certificate, including its private key,
+in the build account's `Cert:\CurrentUser\My` store and set
+`WISPTERM_WINDOWS_SIGN_THUMBPRINT` to its thumbprint. The package publisher and
+the embedded executable identity are generated from that certificate's subject.
+The identity package is timestamped when signed. Without a signing certificate,
+packaging produces an explicitly unsigned developer identity package; it does
+not create or trust a self-signed certificate automatically.
+
+The release workflow accepts optional `WINDOWS_SIGNING_PFX_BASE64` and
+`WINDOWS_SIGNING_PFX_PASSWORD` repository secrets. It imports the certificate only
+on the release runner and removes it afterward. Configure these before shipping
+an end-user-enabled context menu. No Windows release certificate is checked in.
+
+Each package registers `IExplorerCommand` using `windows.comServer` and
+`windows.fileExplorerContextMenus`. A sparse identity package points to the
+existing EXE installation through `Add-AppxPackage -ExternalLocation`, preserving
+the portable distribution. Extension DLLs and their MSIX/manifest are stored in
+immutable version/content directories so updates don't overwrite Explorer's
+loaded DLL. The installer retains prior directories for registration rollback;
+uninstall removes them after unregistration, with a notice if Windows still
+holds a file open. A failed re-registration attempts to restore the previous
+package and retains its ownership record.
+
+## Verification
+
+```powershell
+zig build shell-extension-test
+powershell -NoProfile -ExecutionPolicy Bypass -File .\debug\test-shell-integration.ps1
+```
+
+This builds an unsigned test identity package and tests the DLL through actual
+COM interfaces, including folder/background selection, object lifetime,
+non-folder and multi-selection rejection, direct process creation, Unicode and
+space-containing paths, and Windows argv quoting (UNC and trailing root slash).
+It uses a small launch recorder in an isolated temporary directory and does not
+register a package or modify certificate trust.
+
+For full registration tests on a disposable Windows account, configure an
+already trusted signing certificate as above and add `-RegisterPackage`. These
+checks install and activate packaged COM, test idempotence and relocation, and
+remove the package afterward. CI performs this on its disposable runner with a
+short-lived test certificate; test certificates are never distributed.
+
+For loose-manifest debugging on a machine where **you have explicitly enabled
+Developer Mode**, run `context-menu.ps1 -Action Install -Development` from a
+packaged developer installation. Remove it with the normal removal script.
+This is a development path, not an end-user installation method.
+
+Also verify Explorer visually on Windows 11: folder right-click, folder
+background, drive-root background, Chinese and English display languages,
+correct initial shell directory, and disappearance after removal. COM tests
+exercise the actual registered command but do not assert Explorer's visual
+placement.
+
+## Reference design
+
+Ghostty keeps directory-opening integration in the OS host: its
+[Dolphin service](https://github.com/ghostty-org/ghostty/blob/main/dist/linux/ghostty_dolphin.desktop)
+passes `--working-directory`, and its
+[macOS services](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Services/ServiceProvider.swift)
+pass the selected directory to window/tab creation. WispTerm uses that same
+boundary. Its Windows adapter follows
+[Windows Terminal's OpenTerminalHere](https://github.com/microsoft/terminal/blob/main/src/cascadia/ShellExtension/OpenTerminalHere.cpp)
+for selection/site folder resolution and direct `CreateProcessW` launch.
+
+See Microsoft's [Explorer extension documentation](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/integrate-packaged-app-with-file-explorer)
+and [external-location identity packaging documentation](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/grant-identity-to-nonpackaged-apps)
+for the registration, manifest and signing requirements.

--- a/docs/windows-context-menu.md
+++ b/docs/windows-context-menu.md
@@ -66,7 +66,9 @@ an end-user-enabled context menu. No Windows release certificate is checked in.
 Each package registers `IExplorerCommand` using `windows.comServer` and
 `windows.fileExplorerContextMenus`. A sparse identity package points to the
 existing EXE installation through `Add-AppxPackage -ExternalLocation`, preserving
-the portable distribution. Extension DLLs and their MSIX/manifest are stored in
+the portable distribution. The identity explicitly disables registry/AppData
+write virtualization so the terminal continues using its existing user configuration and state paths.
+Extension DLLs and their MSIX/manifest are stored in
 immutable version/content directories so updates don't overwrite Explorer's
 loaded DLL. The installer retains prior directories for registration rollback;
 uninstall removes them after unregistration, with a notice if Windows still

--- a/packaging/windows/Uninstall-WispTerm.cmd
+++ b/packaging/windows/Uninstall-WispTerm.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0uninstall.ps1"
+if errorlevel 1 pause

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -161,6 +161,11 @@ function Copy-PortablePayload {
     if (-not (Test-Path $replacePs1)) { throw "Replace script was not found: $replacePs1" }
     Copy-Item -Path $replaceCmd -Destination (Join-Path $TargetDir 'Replace-WispTerm.cmd') -Force
     Copy-Item -Path $replacePs1 -Destination (Join-Path $TargetDir 'replace-install.ps1') -Force
+
+    $extension = Join-Path (Split-Path -Parent $BinaryPath) 'wispterm-shell-extension.dll'
+    & (Join-Path $PSScriptRoot 'shell-integration\build-package.ps1') -TargetDir $TargetDir -ExtensionPath $extension
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'uninstall.ps1') -Destination $TargetDir -Force
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot 'Uninstall-WispTerm.cmd') -Destination $TargetDir -Force
 }
 
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))

--- a/packaging/windows/replace-install.ps1
+++ b/packaging/windows/replace-install.ps1
@@ -2,6 +2,8 @@
 # this script. Double-click Replace-WispTerm.cmd; do not run the exe from
 # inside the zip (Explorer would extract only that one file).
 
+param([switch]$EnableContextMenu)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -126,6 +128,11 @@ $destDir = [System.IO.Path]::GetFullPath($destDir)
 $destExe = Join-Path $destDir 'wispterm.exe'
 
 if ($destDir -eq $sourceDirFull) {
+    $menuScript = Join-Path $destDir 'context-menu.ps1'
+    if (Test-Path -LiteralPath $menuScript) {
+        $menuAction = if ($EnableContextMenu) { 'Install' } else { 'Refresh' }
+        & $menuScript -Action $menuAction -InstallDir $destDir
+    }
     Write-Host (T 'This folder is already the install. Starting WispTerm.' '当前文件夹就是安装目录，正在启动 WispTerm。')
     Start-Process -FilePath $destExe -WorkingDirectory $destDir
     exit 0
@@ -151,11 +158,26 @@ $payloads = @(
     'OpenConsole.exe'
     'Replace-WispTerm.cmd'
     'replace-install.ps1'
+    'context-menu.ps1'
+    'Add-Context-Menu.cmd'
+    'Remove-Context-Menu.cmd'
+    'uninstall.ps1'
+    'Uninstall-WispTerm.cmd'
 )
 foreach ($name in $payloads) {
     $src = Join-Path $sourceDir $name
     if (Test-Path -LiteralPath $src) {
         Copy-LockedFile $src (Join-Path $destDir $name)
+    }
+}
+
+$sourceIntegration = Join-Path $sourceDir 'shell-integration'
+if (Test-Path -LiteralPath $sourceIntegration) {
+    # Retain previous immutable extension/package directories for rollback.
+    # Explorer can keep its old DLL loaded until it releases the COM server.
+    Get-ChildItem -LiteralPath $sourceIntegration -Recurse -File | ForEach-Object {
+        $relative = $_.FullName.Substring($sourceDir.Length).TrimStart('\')
+        Copy-LockedFile $_.FullName (Join-Path $destDir $relative)
     }
 }
 
@@ -167,5 +189,10 @@ if (Test-Path -LiteralPath $srcPlugins) {
 }
 
 Write-StartMenuShortcut $destExe $destDir
+$menuScript = Join-Path $destDir 'context-menu.ps1'
+if (Test-Path -LiteralPath $menuScript) {
+    $menuAction = if ($EnableContextMenu) { 'Install' } else { 'Refresh' }
+    & $menuScript -Action $menuAction -InstallDir $destDir
+}
 Start-Process -FilePath $destExe -WorkingDirectory $destDir
 Write-Host (T 'Done. WispTerm is starting.' '完成，正在启动 WispTerm。')

--- a/packaging/windows/shell-integration/Add-Context-Menu.cmd
+++ b/packaging/windows/shell-integration/Add-Context-Menu.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0context-menu.ps1" -Action Install
+if errorlevel 1 pause

--- a/packaging/windows/shell-integration/AppxManifest.xml
+++ b/packaging/windows/shell-integration/AppxManifest.xml
@@ -4,15 +4,18 @@
  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
  xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
  xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+ xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
  xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
- IgnorableNamespaces="uap uap10 desktop4 desktop5 com rescap">
+ IgnorableNamespaces="uap uap10 desktop4 desktop5 desktop6 com rescap">
  <Identity Name="WispTerm.ContextMenu" Publisher="@PUBLISHER@" Version="@VERSION@" ProcessorArchitecture="x64" />
  <Properties>
   <DisplayName>WispTerm</DisplayName>
   <PublisherDisplayName>WispTerm</PublisherDisplayName>
   <Logo>shell-integration\Assets\StoreLogo.png</Logo>
   <uap10:AllowExternalContent>true</uap10:AllowExternalContent>
+  <desktop6:RegistryWriteVirtualization>disabled</desktop6:RegistryWriteVirtualization>
+  <desktop6:FileSystemWriteVirtualization>disabled</desktop6:FileSystemWriteVirtualization>
  </Properties>
  <Resources><Resource Language="en-us" /><Resource Language="zh-cn" /></Resources>
  <Dependencies><TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" /></Dependencies>

--- a/packaging/windows/shell-integration/AppxManifest.xml
+++ b/packaging/windows/shell-integration/AppxManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+ xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+ xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+ xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+ xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+ xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+ xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+ IgnorableNamespaces="uap uap10 desktop4 desktop5 com rescap">
+ <Identity Name="WispTerm.ContextMenu" Publisher="@PUBLISHER@" Version="@VERSION@" ProcessorArchitecture="x64" />
+ <Properties>
+  <DisplayName>WispTerm</DisplayName>
+  <PublisherDisplayName>WispTerm</PublisherDisplayName>
+  <Logo>shell-integration\Assets\StoreLogo.png</Logo>
+  <uap10:AllowExternalContent>true</uap10:AllowExternalContent>
+ </Properties>
+ <Resources><Resource Language="en-us" /><Resource Language="zh-cn" /></Resources>
+ <Dependencies><TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" /></Dependencies>
+ <Applications>
+  <Application Id="WispTerm" Executable="wispterm.exe" uap10:RuntimeBehavior="win32App" uap10:TrustLevel="mediumIL">
+   <uap:VisualElements AppListEntry="none" DisplayName="WispTerm" Description="Open a folder in WispTerm"
+    BackgroundColor="transparent" Square150x150Logo="shell-integration\Assets\Square150x150Logo.png"
+    Square44x44Logo="shell-integration\Assets\Square44x44Logo.png" />
+   <Extensions>
+    <com:Extension Category="windows.comServer">
+     <com:ComServer><com:SurrogateServer DisplayName="WispTerm Explorer integration">
+      <com:Class Id="22FE0F26-8C15-4BC6-A6F7-3C88F4E20A71" Path="@EXTENSION_PATH@" ThreadingModel="STA" />
+     </com:SurrogateServer></com:ComServer>
+    </com:Extension>
+    <desktop4:Extension Category="windows.fileExplorerContextMenus">
+     <desktop4:FileExplorerContextMenus>
+      <desktop5:ItemType Type="Directory"><desktop5:Verb Id="OpenWispTerm" Clsid="22FE0F26-8C15-4BC6-A6F7-3C88F4E20A71" /></desktop5:ItemType>
+      <desktop5:ItemType Type="Directory\Background"><desktop5:Verb Id="OpenWispTerm" Clsid="22FE0F26-8C15-4BC6-A6F7-3C88F4E20A71" /></desktop5:ItemType>
+     </desktop4:FileExplorerContextMenus>
+    </desktop4:Extension>
+   </Extensions>
+  </Application>
+ </Applications>
+ <Capabilities><rescap:Capability Name="runFullTrust" /><rescap:Capability Name="unvirtualizedResources" /></Capabilities>
+</Package>

--- a/packaging/windows/shell-integration/Remove-Context-Menu.cmd
+++ b/packaging/windows/shell-integration/Remove-Context-Menu.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0context-menu.ps1" -Action Remove
+if errorlevel 1 pause

--- a/packaging/windows/shell-integration/build-package.ps1
+++ b/packaging/windows/shell-integration/build-package.ps1
@@ -98,8 +98,19 @@ $appManifest = Join-Path $integration 'wispterm.manifest'
 </assembly>
 "@, $utf8)
 $mt = Find-SdkTool 'mt.exe'
-& $mt -nologo -manifest $appManifest "-outputresource:$exe;#1"
-if ($LASTEXITCODE -ne 0) { throw 'Embedding package identity in wispterm.exe failed.' }
+# mt.exe mishandles UNC manifest paths (including WSL checkouts). Give it
+# short native paths and copy back only after successful resource editing.
+$resourceStage = Join-Path ([IO.Path]::GetTempPath()) ('WispTermResources-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force $resourceStage | Out-Null
+try {
+    $localExe = Join-Path $resourceStage 'wispterm.exe'
+    $localManifest = Join-Path $resourceStage 'wispterm.manifest'
+    Copy-Item -LiteralPath $exe -Destination $localExe
+    Copy-Item -LiteralPath $appManifest -Destination $localManifest
+    & $mt -nologo -manifest $localManifest "-outputresource:$localExe;#1"
+    if ($LASTEXITCODE -ne 0) { throw 'Embedding package identity in wispterm.exe failed.' }
+    Copy-Item -LiteralPath $localExe -Destination $exe -Force
+} finally { Remove-Item -LiteralPath $resourceStage -Recurse -Force }
 if ($certificate) {
     $signTool = Find-SdkTool 'signtool.exe'
     $signArgs = @('sign','/fd','SHA256','/sha1',$certificate.Thumbprint)

--- a/packaging/windows/shell-integration/build-package.ps1
+++ b/packaging/windows/shell-integration/build-package.ps1
@@ -1,0 +1,119 @@
+param(
+    [Parameter(Mandatory = $true)][string]$TargetDir,
+    [Parameter(Mandatory = $true)][string]$ExtensionPath,
+    [string]$SigningCertificateThumbprint = $env:WISPTERM_WINDOWS_SIGN_THUMBPRINT,
+    [string]$TimestampUrl = 'http://timestamp.digicert.com'
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-SdkTool([string]$Name) {
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($command) { return $command.Source }
+    $sdk = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin'
+    $tool = Get-ChildItem -Path (Join-Path $sdk "*\x64\$Name") -ErrorAction SilentlyContinue |
+        Sort-Object FullName -Descending | Select-Object -First 1
+    if (!$tool) { throw "Windows SDK tool $Name was not found. Install the Windows SDK packaging tools." }
+    return $tool.FullName
+}
+
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
+$target = [IO.Path]::GetFullPath($TargetDir)
+$exe = Join-Path $target 'wispterm.exe'
+if (!(Test-Path -LiteralPath $exe)) { throw "Missing desktop executable: $exe" }
+if (!(Test-Path -LiteralPath $ExtensionPath)) { throw "Missing Explorer extension: $ExtensionPath" }
+$pe = [IO.File]::ReadAllBytes($ExtensionPath)
+if ($pe.Length -lt 64) { throw 'Invalid Explorer DLL.' }
+$peOffset = [BitConverter]::ToInt32($pe, 60)
+if ($peOffset -lt 0 -or $peOffset + 6 -gt $pe.Length -or [BitConverter]::ToUInt32($pe, $peOffset) -ne 0x4550 -or [BitConverter]::ToUInt16($pe, $peOffset + 4) -ne 0x8664) {
+    throw 'Explorer identity packaging requires an x64 DLL.'
+}
+$versionText = Get-Content -Raw (Join-Path $repoRoot 'build.zig.zon')
+if ($versionText -notmatch '\.version\s*=\s*"(\d+)\.(\d+)\.(\d+)"') { throw 'Cannot read desktop version from build.zig.zon.' }
+$version = "$($Matches[1]).$($Matches[2]).$($Matches[3]).0"
+foreach ($part in $version.Split('.')) { if ([int]$part -gt 65535) { throw 'Desktop version exceeds MSIX version range.' } }
+$publisher = 'CN=WispTerm'
+$certificate = $null
+if ($SigningCertificateThumbprint) {
+    $certificate = Get-Item -LiteralPath "Cert:\CurrentUser\My\$SigningCertificateThumbprint"
+    if (!$certificate.HasPrivateKey) { throw 'Signing certificate has no private key.' }
+    $publisher = $certificate.Subject
+}
+$integration = Join-Path $target 'shell-integration'
+New-Item -ItemType Directory -Force $integration | Out-Null
+$dllHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $ExtensionPath).Hash.Substring(0,16).ToLowerInvariant()
+$templateHash = (Get-FileHash -Algorithm SHA256 (Join-Path $PSScriptRoot 'AppxManifest.xml')).Hash
+$sha = [Security.Cryptography.SHA256]::Create()
+try { $hash = ([BitConverter]::ToString($sha.ComputeHash([Text.Encoding]::UTF8.GetBytes("$dllHash|$templateHash|$publisher")))).Replace('-','').Substring(0,16).ToLowerInvariant() } finally { $sha.Dispose() }
+$payloadRelative = "shell-integration\$version-$hash"
+$extensionRelative = "$payloadRelative\wispterm-shell-extension.dll"
+$extensionDest = Join-Path $target $extensionRelative
+New-Item -ItemType Directory -Force (Split-Path -Parent $extensionDest) | Out-Null
+Copy-Item -LiteralPath $ExtensionPath -Destination $extensionDest -Force
+
+# Resize the existing application artwork into the MSIX resource sizes.
+Add-Type -AssemblyName System.Drawing
+$assets = Join-Path $integration 'Assets'
+New-Item -ItemType Directory -Force $assets | Out-Null
+$image = [Drawing.Image]::FromFile((Join-Path $repoRoot 'assets\wispterm.png'))
+try {
+    foreach ($entry in @(@('StoreLogo',50), @('Square44x44Logo',44), @('Square150x150Logo',150))) {
+        $bitmap = New-Object Drawing.Bitmap ([int]$entry[1]), ([int]$entry[1])
+        $graphics = [Drawing.Graphics]::FromImage($bitmap)
+        try {
+            $graphics.InterpolationMode = [Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+            $graphics.DrawImage($image, 0, 0, [int]$entry[1], [int]$entry[1])
+            $bitmap.Save((Join-Path $assets "$($entry[0]).png"), [Drawing.Imaging.ImageFormat]::Png)
+        } finally { $graphics.Dispose(); $bitmap.Dispose() }
+    }
+} finally { $image.Dispose() }
+
+$escapedPublisher = [Security.SecurityElement]::Escape($publisher)
+$manifest = (Get-Content -Raw (Join-Path $PSScriptRoot 'AppxManifest.xml')).
+    Replace('@PUBLISHER@', $escapedPublisher).Replace('@VERSION@', $version).Replace('@EXTENSION_PATH@', $extensionRelative)
+$utf8 = New-Object Text.UTF8Encoding $false
+# Keep a loose manifest for explicit developer registration; never silently
+# enable Developer Mode or trust a certificate on the user's machine.
+$payloadDir = Split-Path -Parent $extensionDest
+$manifestPath = Join-Path $payloadDir 'AppxManifest.xml'
+[IO.File]::WriteAllText($manifestPath, $manifest, $utf8)
+$staging = Join-Path $integration 'package-staging'
+New-Item -ItemType Directory -Force $staging | Out-Null
+try {
+    [IO.File]::WriteAllText((Join-Path $staging 'AppxManifest.xml'), $manifest, $utf8)
+    $makeAppx = Find-SdkTool 'makeappx.exe'
+    $msix = Join-Path $payloadDir 'WispTerm.ContextMenu.msix'
+    & $makeAppx pack /o /nv /d $staging /p $msix
+    if ($LASTEXITCODE -ne 0) { throw 'MakeAppx failed.' }
+} finally { Remove-Item -LiteralPath $staging -Recurse -Force }
+
+# Embed the matching identity in the COPIED desktop exe. Dev builds and the
+# source binary are untouched; existing icon resources are preserved by mt.
+$appManifest = Join-Path $integration 'wispterm.manifest'
+[IO.File]::WriteAllText($appManifest, @"
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+ <assemblyIdentity version="1.0.0.0" name="WispTerm" />
+ <msix xmlns="urn:schemas-microsoft-com:msix.v1" publisher="$escapedPublisher" packageName="WispTerm.ContextMenu" applicationId="WispTerm" />
+</assembly>
+"@, $utf8)
+$mt = Find-SdkTool 'mt.exe'
+& $mt -nologo -manifest $appManifest "-outputresource:$exe;#1"
+if ($LASTEXITCODE -ne 0) { throw 'Embedding package identity in wispterm.exe failed.' }
+if ($certificate) {
+    $signTool = Find-SdkTool 'signtool.exe'
+    $signArgs = @('sign','/fd','SHA256','/sha1',$certificate.Thumbprint)
+    if ($TimestampUrl) { $signArgs += @('/tr',$TimestampUrl,'/td','SHA256') }
+    & $signTool @signArgs $msix
+    if ($LASTEXITCODE -ne 0) { throw 'Signing the context menu identity package failed.' }
+} else {
+    Write-Warning 'Context menu package is unsigned. Add-Context-Menu.cmd requires a trusted signed package. See docs/windows-context-menu.md for developer testing and release signing.'
+}
+foreach ($name in @('context-menu.ps1', 'Add-Context-Menu.cmd', 'Remove-Context-Menu.cmd')) {
+    Copy-Item -LiteralPath (Join-Path $PSScriptRoot $name) -Destination (Join-Path $target $name) -Force
+}
+
+[IO.File]::WriteAllText((Join-Path $integration 'identity.json'), (@{
+    Manifest = "$payloadRelative\AppxManifest.xml"
+    Package = "$payloadRelative\WispTerm.ContextMenu.msix"
+} | ConvertTo-Json), $utf8)

--- a/packaging/windows/shell-integration/context-menu.ps1
+++ b/packaging/windows/shell-integration/context-menu.ps1
@@ -1,0 +1,134 @@
+﻿param(
+    [ValidateSet('Install','Remove','Status','Refresh')][string]$Action = 'Status',
+    [string]$InstallDir = $PSScriptRoot,
+    [switch]$Development
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$packageName = 'WispTerm.ContextMenu'
+$stateKey = 'HKCU:\Software\WispTerm\ContextMenu'
+$root = [IO.Path]::GetFullPath($InstallDir).TrimEnd('\')
+$zh = (Get-UICulture).Name.StartsWith('zh')
+function T([string]$English, [string]$Chinese) { if ($zh) { return $Chinese }; return $English }
+function Read-State {
+    if (Test-Path -LiteralPath $stateKey) { return Get-ItemProperty -LiteralPath $stateKey }
+    return $null
+}
+function Resolve-Payload([string]$Relative) {
+    $path = [IO.Path]::GetFullPath((Join-Path $root $Relative))
+    if (!$path.StartsWith($root + '\', [StringComparison]::OrdinalIgnoreCase)) { throw 'Invalid context-menu payload path.' }
+    if (!(Test-Path -LiteralPath $path -PathType Leaf)) { throw "Missing context-menu payload: $path" }
+    return $path
+}
+function Assert-NotRunning([string]$Directory) {
+    $exe = Join-Path $Directory 'wispterm.exe'
+    $running = @(Get-Process -Name wispterm -ErrorAction SilentlyContinue | Where-Object {
+        try { $_.Path -eq $exe } catch { $false }
+    })
+    if ($running.Count) { throw (T 'Close the registered WispTerm installation before changing its context menu. Sessions have not been terminated.' '请先关闭已注册的 WispTerm，再更改右键菜单。当前会话未被终止。') }
+}
+function Write-State($Values) {
+    New-Item -Path $stateKey -Force | Out-Null
+    foreach ($name in @('InstallDir','PackagePath','ManifestPath','PackageFullName','Development')) {
+        $type = if ($name -eq 'Development') { 'DWord' } else { 'String' }
+        New-ItemProperty -LiteralPath $stateKey -Name $name -Value $Values.$name -PropertyType $type -Force | Out-Null
+    }
+}
+function Register-Payload([string]$PackagePath, [string]$ManifestPath, [string]$ExternalLocation, [bool]$Dev) {
+    if ($Dev) {
+        Add-AppxPackage -Register $ManifestPath -ExternalLocation $ExternalLocation -ErrorAction Stop
+    } else {
+        Add-AppxPackage -Path $PackagePath -ExternalLocation $ExternalLocation -ErrorAction Stop
+    }
+}
+function Notify-Shell {
+    if (!('WispTermShellNotify' -as [type])) {
+        Add-Type 'using System; using System.Runtime.InteropServices; public static class WispTermShellNotify { [DllImport("shell32.dll")] public static extern void SHChangeNotify(uint e, uint f, IntPtr a, IntPtr b); }'
+    }
+    [WispTermShellNotify]::SHChangeNotify(0x08000000, 0, [IntPtr]::Zero, [IntPtr]::Zero)
+}
+
+$state = Read-State
+$owned = $state -and $state.InstallDir -eq $root
+$packages = @(Get-AppxPackage -Name $packageName -ErrorAction Stop)
+if ($Action -eq 'Status') {
+    [pscustomobject]@{
+        Enabled = [bool]($owned -and (@($packages | ForEach-Object { $_.PackageFullName }) -contains $state.PackageFullName))
+        RegisteredInstallDir = if ($state) { $state.InstallDir } else { '' }
+        Package = if ($packages.Count) { $packages[0].PackageFullName } else { '' }
+    }
+    return
+}
+if ($Action -eq 'Remove') {
+    # Removing an older portable copy must not unregister a newer installation.
+    if ($owned) {
+        Assert-NotRunning $root
+        foreach ($package in $packages) {
+            if ($package.PackageFullName -eq $state.PackageFullName) { Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop }
+        }
+        Remove-Item -LiteralPath $stateKey -Force
+        Notify-Shell
+    }
+    Write-Host (T 'WispTerm context menu removed for this installation.' '已移除此安装目录的 WispTerm 右键菜单。')
+    return
+}
+if ($Action -eq 'Refresh' -and (!$owned -or !(@($packages | ForEach-Object { $_.PackageFullName }) -contains $state.PackageFullName))) { return }
+if ([Environment]::OSVersion.Version.Build -lt 19041) { throw (T 'The context menu requires Windows 10 2004 or later.' '右键菜单需要 Windows 10 2004 或更新版本。') }
+if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64') { throw 'Use x64 PowerShell on an x64 Windows installation for this extension.' }
+$metadata = Get-Content -Raw (Resolve-Payload 'shell-integration\identity.json') | ConvertFrom-Json
+$manifestPath = Resolve-Payload $metadata.Manifest
+$packagePath = Resolve-Payload $metadata.Package
+[xml]$manifest = Get-Content -Raw $manifestPath
+$identity = $manifest.Package.Identity
+if ($identity.Name -ne $packageName) { throw 'Unexpected context-menu package name.' }
+$null = Resolve-Payload 'wispterm.exe'
+$dev = [bool]$Development
+if ($Action -eq 'Refresh' -and $state) { $dev = [bool]$state.Development }
+if ($dev) {
+    $unlocked = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -ErrorAction SilentlyContinue
+    if (!$unlocked -or !($unlocked.PSObject.Properties.Name -contains 'AllowDevelopmentWithoutDevLicense') -or $unlocked.AllowDevelopmentWithoutDevLicense -ne 1) {
+        throw 'Developer Mode is not enabled. Enable it explicitly in Windows Settings for loose-manifest testing, or use a trusted signed package.'
+    }
+} else {
+    $signature = Get-AuthenticodeSignature -LiteralPath $packagePath
+    if ($signature.Status -ne 'Valid') {
+        throw (T "Context menu package signature is not trusted ($($signature.Status)). Install a release with a trusted signed identity package. No certificates were imported." "右键菜单身份包的签名不受信任（$($signature.Status)）。请使用附带受信任签名身份包的版本；本脚本未导入任何证书。")
+    }
+}
+# Refuse to replace a registration we cannot roll back or attribute to WispTerm.
+foreach ($package in $packages) {
+    if (!$state -or $package.PackageFullName -ne $state.PackageFullName) { throw 'An unmanaged WispTerm context-menu package is registered. Remove it explicitly before registering this installation.' }
+    if ($package.Publisher -ne $identity.Publisher) { throw 'Publisher changed. Remove the previous context menu before installing the new publisher.' }
+}
+if ($packages.Count -gt 1) { throw 'Multiple WispTerm context-menu packages are registered.' }
+$previous = if ($packages.Count) { $packages[0] } else { $null }
+# Preserve an existing equal-version registration only if it points at these
+# immutable payloads. New builds at the same app version still get re-registered.
+if ($previous -and $owned -and $state.PackagePath -eq $packagePath -and [bool]$state.Development -eq $dev) {
+    Write-Host (T 'WispTerm context menu is already enabled.' 'WispTerm 右键菜单已启用。')
+    return
+}
+if ($previous) { Assert-NotRunning $state.InstallDir; Remove-AppxPackage -Package $previous.PackageFullName -ErrorAction Stop }
+try {
+    Register-Payload $packagePath $manifestPath $root $dev
+    $installed = @(Get-AppxPackage -Name $packageName | Where-Object { $_.Publisher -eq $identity.Publisher })
+    if ($installed.Count -ne 1) { throw 'Package registration did not produce exactly one matching package.' }
+    Write-State @{
+        InstallDir = $root; PackagePath = $packagePath; ManifestPath = $manifestPath
+        PackageFullName = $installed[0].PackageFullName; Development = [int]$dev
+    }
+} catch {
+    $failure = $_
+    # Undo any partially successful new registration before restoring the old.
+    Get-AppxPackage -Name $packageName | Where-Object { $_.Publisher -eq $identity.Publisher } |
+        ForEach-Object { Remove-AppxPackage -Package $_.PackageFullName -ErrorAction Continue }
+    if ($previous) {
+        try { Register-Payload $state.PackagePath $state.ManifestPath $state.InstallDir ([bool]$state.Development) }
+        catch { Write-Warning "Previous context menu could not be restored: $_" }
+    }
+    if ($state) { Write-State $state }
+    elseif (Test-Path -LiteralPath $stateKey) { Remove-Item -LiteralPath $stateKey -Force }
+    throw $failure
+}
+Notify-Shell
+Write-Host (T 'WispTerm context menu enabled. Reopen File Explorer; if its menu is cached, sign out and back in.' '已启用 WispTerm 右键菜单。请重新打开资源管理器；若菜单仍有缓存，请注销后重新登录。')

--- a/packaging/windows/shell-integration/context-menu.ps1
+++ b/packaging/windows/shell-integration/context-menu.ps1
@@ -92,7 +92,7 @@ if ($dev) {
 } else {
     $signature = Get-AuthenticodeSignature -LiteralPath $packagePath
     if ($signature.Status -ne 'Valid') {
-        throw (T "Context menu package signature is not trusted ($($signature.Status)). Install a release with a trusted signed identity package. No certificates were imported." "右键菜单身份包的签名不受信任（$($signature.Status)）。请使用附带受信任签名身份包的版本；本脚本未导入任何证书。")
+        throw (T "Context menu package signature is not trusted ($($signature.Status): $($signature.StatusMessage)). Install a release with a trusted signed identity package. No certificates were imported." "右键菜单身份包的签名不受信任（$($signature.Status)）。请使用附带受信任签名身份包的版本；本脚本未导入任何证书。")
     }
 }
 # Refuse to replace a registration we cannot roll back or attribute to WispTerm.

--- a/packaging/windows/uninstall.ps1
+++ b/packaging/windows/uninstall.ps1
@@ -1,0 +1,29 @@
+# Unregister shell integration before removing its external files. User config
+# and additional user-created files in a portable directory are preserved.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$root = [IO.Path]::GetFullPath($PSScriptRoot)
+$exe = Join-Path $root 'wispterm.exe'
+$menu = Join-Path $root 'context-menu.ps1'
+if (Test-Path -LiteralPath $menu) { & $menu -Action Remove -InstallDir $root }
+# Do not terminate sessions or remove an unrelated copy's shortcuts.
+$running = @(Get-Process -Name wispterm -ErrorAction SilentlyContinue | Where-Object {
+    try { $_.Path -eq $exe } catch { $false }
+})
+if ($running.Count) { throw 'Close this WispTerm installation before uninstalling it. Your sessions have not been terminated.' }
+$shell = New-Object -ComObject WScript.Shell
+foreach ($folder in @('Microsoft\Windows\Start Menu\Programs','Microsoft\Windows\Start Menu\Programs\Startup')) {
+    $link = Join-Path $env:APPDATA "$folder\WispTerm.lnk"
+    if ((Test-Path -LiteralPath $link) -and $shell.CreateShortcut($link).TargetPath -eq $exe) { Remove-Item -LiteralPath $link -Force }
+}
+foreach ($name in @('wispterm.exe','wispterm-ssh-askpass.exe','version.txt','WebView2Loader.dll','conpty.dll','OpenConsole.exe',
+                   'Replace-WispTerm.cmd','replace-install.ps1','Add-Context-Menu.cmd','Remove-Context-Menu.cmd','context-menu.ps1')) {
+    $path = Join-Path $root $name
+    if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Force }
+}
+$integration = Join-Path $root 'shell-integration'
+if (Test-Path -LiteralPath $integration) {
+    try { Remove-Item -LiteralPath $integration -Recurse -Force }
+    catch { Write-Warning 'The menu is unregistered, but Explorer still holds an extension file. Sign out and back in, then remove the remaining shell-integration folder.' }
+}
+Write-Host 'WispTerm uninstalled. Your configuration, plugins, and other files are preserved.'

--- a/src/platform/explorer/command_line.h
+++ b/src/platform/explorer/command_line.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+
+namespace wispterm {
+// Windows argv quoting, including the doubled trailing slash in a drive root.
+// Launch directly with CreateProcessW: directory names never become shell code.
+inline std::wstring quoteArgument(const std::wstring& value) {
+    std::wstring out = L"\"";
+    size_t slashes = 0;
+    for (wchar_t ch : value) {
+        if (ch == L'\\') { ++slashes; continue; }
+        out.append(slashes * (ch == L'"' ? 2 : 1), L'\\');
+        slashes = 0;
+        if (ch == L'"') out.push_back(L'\\');
+        out.push_back(ch);
+    }
+    out.append(slashes * 2, L'\\');
+    out.push_back(L'"');
+    return out;
+}
+inline std::wstring launchCommand(const std::wstring& exe, const std::wstring& directory) {
+    return quoteArgument(exe) + L" --working-directory " + quoteArgument(directory);
+}
+}

--- a/src/platform/explorer/shell_extension.cpp
+++ b/src/platform/explorer/shell_extension.cpp
@@ -1,0 +1,233 @@
+// Explorer integration is a separate COM DLL; it never loads the terminal core.
+// Like Ghostty's directory services and Windows Terminal's OpenTerminalHere,
+// this adapter passes a filesystem directory to the existing launch API.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <shlwapi.h>
+#include <servprov.h>
+#include <new>
+#include <string>
+#include "command_line.h"
+
+// Keep in sync with packaging/windows/shell-integration/AppxManifest.xml.
+static const CLSID commandId = {0x22fe0f26,0x8c15,0x4bc6,{0xa6,0xf7,0x3c,0x88,0xf4,0xe2,0x0a,0x71}};
+static HMODULE module;
+static LONG objects = 0;
+static LONG locks = 0;
+
+template<class T> struct ComPtr {
+    T* p = nullptr;
+    ~ComPtr() { if (p) p->Release(); }
+    T* operator->() const { return p; }
+    T** put() { return &p; }
+};
+struct ShellString {
+    PWSTR p = nullptr;
+    ~ShellString() { CoTaskMemFree(p); }
+};
+
+// The DLL is stored in <install>/shell-integration/<version-hash>/.
+static HRESULT executablePath(std::wstring& out) {
+    std::wstring path(32768, L'\0');
+    DWORD n = GetModuleFileNameW(module, path.data(), static_cast<DWORD>(path.size()));
+    if (!n) return HRESULT_FROM_WIN32(GetLastError());
+    if (n >= path.size()) return HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
+    path.resize(n);
+    for (int i = 0; i < 3; ++i) {
+        auto slash = path.find_last_of(L"\\/");
+        if (slash == std::wstring::npos) return E_UNEXPECTED;
+        path.resize(slash);
+    }
+    out = path + L"\\wispterm.exe";
+    return S_OK;
+}
+
+class Command final : public IExplorerCommand, public IObjectWithSite {
+    LONG refs = 1;
+    IUnknown* site = nullptr;
+public:
+    Command() { InterlockedIncrement(&objects); }
+    ~Command() { if (site) site->Release(); InterlockedDecrement(&objects); }
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        if (IsEqualIID(iid, IID_IUnknown) || IsEqualIID(iid, IID_IExplorerCommand))
+            *out = static_cast<IExplorerCommand*>(this);
+        else if (IsEqualIID(iid, IID_IObjectWithSite)) *out = static_cast<IObjectWithSite*>(this);
+        else return E_NOINTERFACE;
+        AddRef();
+        return S_OK;
+    }
+    ULONG STDMETHODCALLTYPE AddRef() override { return InterlockedIncrement(&refs); }
+    ULONG STDMETHODCALLTYPE Release() override {
+        LONG n = InterlockedDecrement(&refs);
+        if (!n) delete this;
+        return n;
+    }
+    HRESULT STDMETHODCALLTYPE SetSite(IUnknown* value) override {
+        if (value) value->AddRef();
+        if (site) site->Release();
+        site = value;
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE GetSite(REFIID iid, void** out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        return site ? site->QueryInterface(iid, out) : E_FAIL;
+    }
+    HRESULT location(IShellItemArray* selection, IShellItem** out) {
+        *out = nullptr;
+        if (selection) {
+            DWORD count = 0;
+            HRESULT hr = selection->GetCount(&count);
+            if (FAILED(hr)) return hr;
+            if (count > 1) return E_INVALIDARG;
+            if (count == 1) return selection->GetItemAt(0, out);
+        }
+        // Explorer's background menu has no selected item. Its site exposes
+        // the current folder through SID_SFolderView, including UNC folders.
+        if (!site) return E_FAIL;
+        ComPtr<IServiceProvider> services;
+        HRESULT hr = site->QueryInterface(IID_IServiceProvider, reinterpret_cast<void**>(services.put()));
+        if (FAILED(hr)) return hr;
+        ComPtr<IFolderView> view;
+        hr = services->QueryService(SID_SFolderView, IID_IFolderView, reinterpret_cast<void**>(view.put()));
+        if (FAILED(hr)) return hr;
+        return view->GetFolder(IID_IShellItem, reinterpret_cast<void**>(out));
+    }
+    HRESULT STDMETHODCALLTYPE GetTitle(IShellItemArray*, LPWSTR* out) override {
+        if (!out) return E_POINTER;
+        return SHStrDupW(PRIMARYLANGID(GetUserDefaultUILanguage()) == LANG_CHINESE
+            ? L"在 WispTerm 中打开" : L"Open in WispTerm", out);
+    }
+    HRESULT STDMETHODCALLTYPE GetIcon(IShellItemArray*, LPWSTR* out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        try {
+            std::wstring exe;
+            HRESULT hr = executablePath(exe);
+            if (FAILED(hr)) return hr;
+            return SHStrDupW((exe + L",-1").c_str(), out);
+        } catch (const std::bad_alloc&) { return E_OUTOFMEMORY; }
+          catch (...) { return E_FAIL; }
+    }
+    HRESULT STDMETHODCALLTYPE GetToolTip(IShellItemArray*, LPWSTR* out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        return E_NOTIMPL;
+    }
+    HRESULT STDMETHODCALLTYPE GetCanonicalName(GUID* out) override {
+        if (!out) return E_POINTER;
+        *out = commandId;
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE GetState(IShellItemArray* selection, BOOL, EXPCMDSTATE* out) override {
+        if (!out) return E_POINTER;
+        *out = ECS_HIDDEN;
+        ComPtr<IShellItem> item;
+        if (FAILED(location(selection, item.put())) || !item.p) return S_OK;
+        SFGAOF attrs = 0;
+        const SFGAOF required = SFGAO_FILESYSTEM | SFGAO_FOLDER;
+        // Attribute-only check: never spawn, probe disks, or load WispTerm
+        // while Explorer is constructing a context menu.
+        if (SUCCEEDED(item->GetAttributes(required | SFGAO_STREAM, &attrs)) &&
+            (attrs & required) == required && !(attrs & SFGAO_STREAM)) *out = ECS_ENABLED;
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE Invoke(IShellItemArray* selection, IBindCtx*) override {
+        try {
+            EXPCMDSTATE state;
+            HRESULT hr = GetState(selection, FALSE, &state);
+            if (FAILED(hr)) return hr;
+            if (state != ECS_ENABLED) return E_INVALIDARG;
+            ComPtr<IShellItem> item;
+            hr = location(selection, item.put());
+            if (FAILED(hr)) return hr;
+            ShellString folder;
+            hr = item->GetDisplayName(SIGDN_FILESYSPATH, &folder.p);
+            if (FAILED(hr)) return hr;
+            std::wstring exe;
+            hr = executablePath(exe);
+            if (FAILED(hr)) return hr;
+            std::wstring args = wispterm::launchCommand(exe, folder.p);
+            STARTUPINFOW si{};
+            si.cb = sizeof(si);
+            si.dwFlags = STARTF_USESHOWWINDOW;
+            si.wShowWindow = SW_SHOWNORMAL;
+            PROCESS_INFORMATION pi{};
+            if (!CreateProcessW(exe.c_str(), args.data(), nullptr, nullptr, FALSE,
+                                CREATE_UNICODE_ENVIRONMENT, nullptr, folder.p, &si, &pi))
+                return HRESULT_FROM_WIN32(GetLastError());
+            CloseHandle(pi.hThread);
+            CloseHandle(pi.hProcess);
+            return S_OK;
+        } catch (const std::bad_alloc&) { return E_OUTOFMEMORY; }
+          catch (...) { return E_FAIL; }
+    }
+    HRESULT STDMETHODCALLTYPE GetFlags(EXPCMDFLAGS* out) override {
+        if (!out) return E_POINTER;
+        *out = ECF_DEFAULT;
+        return S_OK;
+    }
+    HRESULT STDMETHODCALLTYPE EnumSubCommands(IEnumExplorerCommand** out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        return E_NOTIMPL;
+    }
+};
+
+class Factory final : public IClassFactory {
+    LONG refs = 1;
+public:
+    Factory() { InterlockedIncrement(&objects); }
+    ~Factory() { InterlockedDecrement(&objects); }
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        if (!IsEqualIID(iid, IID_IUnknown) && !IsEqualIID(iid, IID_IClassFactory)) return E_NOINTERFACE;
+        *out = static_cast<IClassFactory*>(this);
+        AddRef();
+        return S_OK;
+    }
+    ULONG STDMETHODCALLTYPE AddRef() override { return InterlockedIncrement(&refs); }
+    ULONG STDMETHODCALLTYPE Release() override {
+        LONG n = InterlockedDecrement(&refs);
+        if (!n) delete this;
+        return n;
+    }
+    HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown* outer, REFIID iid, void** out) override {
+        if (!out) return E_POINTER;
+        *out = nullptr;
+        if (outer) return CLASS_E_NOAGGREGATION;
+        auto command = new (std::nothrow) Command;
+        if (!command) return E_OUTOFMEMORY;
+        HRESULT hr = command->QueryInterface(iid, out);
+        command->Release();
+        return hr;
+    }
+    HRESULT STDMETHODCALLTYPE LockServer(BOOL lock) override {
+        if (lock) InterlockedIncrement(&locks); else InterlockedDecrement(&locks);
+        return S_OK;
+    }
+};
+
+extern "C" __declspec(dllexport) HRESULT WINAPI DllGetClassObject(REFCLSID clsid, REFIID iid, void** out) {
+    if (!out) return E_POINTER;
+    *out = nullptr;
+    if (!IsEqualCLSID(clsid, commandId)) return CLASS_E_CLASSNOTAVAILABLE;
+    auto factory = new (std::nothrow) Factory;
+    if (!factory) return E_OUTOFMEMORY;
+    HRESULT hr = factory->QueryInterface(iid, out);
+    factory->Release();
+    return hr;
+}
+extern "C" __declspec(dllexport) HRESULT WINAPI DllCanUnloadNow() {
+    return InterlockedCompareExchange(&objects, 0, 0) == 0 &&
+           InterlockedCompareExchange(&locks, 0, 0) == 0 ? S_OK : S_FALSE;
+}
+extern "C" BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID) {
+    if (reason == DLL_PROCESS_ATTACH) module = instance;
+    return TRUE;
+}

--- a/src/platform/explorer/shell_extension_test.cpp
+++ b/src/platform/explorer/shell_extension_test.cpp
@@ -9,10 +9,15 @@
 #include <servprov.h>
 #include <string>
 #include <iostream>
+#include <cstdio>
 #include "command_line.h"
 
-#define CHECK(value) do { if (!(value)) { std::cerr << "FAILED line " << __LINE__ << ": " #value "\n"; return 1; } } while (0)
-#define OK(call) do { HRESULT result=(call); if(FAILED(result)) { std::cerr << "FAILED line " << __LINE__ << " HRESULT=0x" << std::hex << static_cast<unsigned long>(result) << ": " #call "\n"; return 1; } } while(0)
+static void failure(int line, const char* expression, unsigned long hr=0) {
+    FILE* file=fopen("shell-test-failure.log","a");
+    if(file){fprintf(file,"line %d: %s HRESULT=0x%08lx\n",line,expression,hr);fclose(file);}
+}
+#define CHECK(value) do { if (!(value)) { std::cerr << "FAILED line " << __LINE__ << ": " #value "\n"; failure(__LINE__,#value); return 1; } } while (0)
+#define OK(call) do { HRESULT result=(call); if(FAILED(result)) { std::cerr << "FAILED line " << __LINE__ << " HRESULT=0x" << std::hex << static_cast<unsigned long>(result) << ": " #call "\n"; failure(__LINE__,#call,static_cast<unsigned long>(result)); return 1; } } while(0)
 template<class T> struct Ptr { T* p=nullptr; ~Ptr(){if(p)p->Release();} T* operator->(){return p;} T** put(){return &p;} };
 static std::wstring cwd() { std::wstring s(32768,L'\0'); s.resize(GetCurrentDirectoryW(static_cast<DWORD>(s.size()),s.data())); return s; }
 static int record(const wchar_t* dir) {
@@ -84,6 +89,7 @@ static int run(const wchar_t* source) {
     }
     PWSTR text=nullptr; OK(command->GetTitle(nullptr,&text));CHECK(text && *text);CoTaskMemFree(text);
     OK(command->GetIcon(nullptr,&text));std::wstring ownExe(32768,L'\0');ownExe.resize(GetModuleFileNameW(nullptr,ownExe.data(),static_cast<DWORD>(ownExe.size())));
+    ownExe.resize(ownExe.find_last_of(L"\\/"));ownExe+=L"\\wispterm.exe";
     CHECK(_wcsicmp(text,(ownExe+L",-1").c_str())==0);CoTaskMemFree(text);
     EXPCMDSTATE state;OK(command->GetState(nullptr,FALSE,&state));CHECK(state==ECS_HIDDEN);
     GUID canonical;OK(command->GetCanonicalName(&canonical));CHECK(canonical==clsid);

--- a/src/platform/explorer/shell_extension_test.cpp
+++ b/src/platform/explorer/shell_extension_test.cpp
@@ -12,7 +12,7 @@
 #include "command_line.h"
 
 #define CHECK(value) do { if (!(value)) { std::cerr << "FAILED line " << __LINE__ << ": " #value "\n"; return 1; } } while (0)
-#define OK(call) CHECK(SUCCEEDED(call))
+#define OK(call) do { HRESULT result=(call); if(FAILED(result)) { std::cerr << "FAILED line " << __LINE__ << " HRESULT=0x" << std::hex << static_cast<unsigned long>(result) << ": " #call "\n"; return 1; } } while(0)
 template<class T> struct Ptr { T* p=nullptr; ~Ptr(){if(p)p->Release();} T* operator->(){return p;} T** put(){return &p;} };
 static std::wstring cwd() { std::wstring s(32768,L'\0'); s.resize(GetCurrentDirectoryW(static_cast<DWORD>(s.size()),s.data())); return s; }
 static int record(const wchar_t* dir) {
@@ -127,7 +127,8 @@ static int run(const wchar_t* source) {
 int main() {
     int count=0;LPWSTR* args=CommandLineToArgvW(GetCommandLineW(),&count);
     if(count==3 && std::wstring(args[1])==L"--working-directory")return record(args[2]);
+    std::cerr << "Starting COM test, argc=" << count << "\n";
     if(count!=2)return 2;
-    if(FAILED(CoInitializeEx(nullptr,COINIT_APARTMENTTHREADED)))return 2;
+    OK(CoInitializeEx(nullptr,COINIT_APARTMENTTHREADED));
     int result=run(args[1]);LocalFree(args);CoUninitialize();return result;
 }

--- a/src/platform/explorer/shell_extension_test.cpp
+++ b/src/platform/explorer/shell_extension_test.cpp
@@ -1,0 +1,133 @@
+// Real COM/Win32 integration tests. This exe also acts as a harmless launch
+// recorder when copied to the test installation as wispterm.exe.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <shlwapi.h>
+#include <servprov.h>
+#include <string>
+#include <iostream>
+#include "command_line.h"
+
+#define CHECK(value) do { if (!(value)) { std::cerr << "FAILED line " << __LINE__ << ": " #value "\n"; return 1; } } while (0)
+#define OK(call) CHECK(SUCCEEDED(call))
+template<class T> struct Ptr { T* p=nullptr; ~Ptr(){if(p)p->Release();} T* operator->(){return p;} T** put(){return &p;} };
+static std::wstring cwd() { std::wstring s(32768,L'\0'); s.resize(GetCurrentDirectoryW(static_cast<DWORD>(s.size()),s.data())); return s; }
+static int record(const wchar_t* dir) {
+    std::wstring data = std::wstring(dir) + L"\n" + cwd();
+    HANDLE f = CreateFileW((std::wstring(dir)+L"\\wispterm-shell-launch.txt").c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0, nullptr);
+    if(f==INVALID_HANDLE_VALUE)return 2;
+    DWORD written=0;
+    bool ok=WriteFile(f,data.data(),static_cast<DWORD>(data.size()*sizeof(wchar_t)),&written,nullptr);
+    CloseHandle(f);
+    return ok?0:2;
+}
+static bool waitRecord(const std::wstring& dir) {
+    const auto expected=dir+L"\n"+dir;
+    for(int i=0;i<100;++i) {
+        HANDLE f=CreateFileW((dir+L"\\wispterm-shell-launch.txt").c_str(),GENERIC_READ,FILE_SHARE_READ|FILE_SHARE_WRITE,nullptr,OPEN_EXISTING,0,nullptr);
+        if(f!=INVALID_HANDLE_VALUE) {
+            std::wstring data(32768,L'\0'); DWORD n=0;
+            ReadFile(f,data.data(),static_cast<DWORD>(data.size()*sizeof(wchar_t)),&n,nullptr); CloseHandle(f);
+            data.resize(n/sizeof(wchar_t));
+            if(data==expected)return true;
+        }
+        Sleep(50);
+    }
+    return false;
+}
+class Site final : public IServiceProvider {
+    LONG refs=1; IFolderView* view;
+public:
+    explicit Site(IFolderView* v):view(v){view->AddRef();}
+    ~Site(){view->Release();}
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,void** out) override {
+        *out=nullptr;
+        if(iid!=IID_IUnknown && iid!=IID_IServiceProvider)return E_NOINTERFACE;
+        *out=static_cast<IServiceProvider*>(this);AddRef();return S_OK;
+    }
+    ULONG STDMETHODCALLTYPE AddRef() override {return InterlockedIncrement(&refs);}
+    ULONG STDMETHODCALLTYPE Release() override {LONG n=InterlockedDecrement(&refs);if(!n)delete this;return n;}
+    HRESULT STDMETHODCALLTYPE QueryService(REFGUID service,REFIID iid,void** out) override {
+        *out=nullptr;if(service!=SID_SFolderView)return E_NOINTERFACE;return view->QueryInterface(iid,out);
+    }
+};
+static int run(const wchar_t* source) {
+    for(const auto& arg : {L"C:\\",L"C:\\space & percent %\\",L"\\\\server\\share\\中文",L"C:\\a\"b\\",L""}) {
+        const auto line=wispterm::launchCommand(L"C:\\App Space\\wispterm.exe",arg);
+        int count=0; LPWSTR* parsed=CommandLineToArgvW(line.c_str(),&count);
+        CHECK(parsed && count==3 && std::wstring(parsed[1])==L"--working-directory" && std::wstring(parsed[2])==arg);
+        LocalFree(parsed);
+    }
+    const bool registered=std::wstring(source)==L"--registered";
+    CLSID clsid; OK(CLSIDFromString(L"{22FE0F26-8C15-4BC6-A6F7-3C88F4E20A71}",&clsid));
+    Ptr<IExplorerCommand> command;
+    HMODULE dll=nullptr;
+    using Unload=HRESULT (WINAPI*)();
+    Unload canUnload=nullptr;
+    if(registered) {
+        OK(CoCreateInstance(clsid,nullptr,CLSCTX_LOCAL_SERVER,IID_IExplorerCommand,reinterpret_cast<void**>(command.put())));
+    } else {
+        dll=LoadLibraryW(source);CHECK(dll);
+        auto getClass=reinterpret_cast<HRESULT (WINAPI*)(REFCLSID,REFIID,void**)>(GetProcAddress(dll,"DllGetClassObject"));
+        canUnload=reinterpret_cast<Unload>(GetProcAddress(dll,"DllCanUnloadNow"));
+        CHECK(getClass && canUnload && canUnload()==S_OK);
+        Ptr<IClassFactory> factory;
+        CHECK(getClass(CLSID_NULL,IID_IClassFactory,reinterpret_cast<void**>(factory.put()))==CLASS_E_CLASSNOTAVAILABLE);
+        OK(getClass(clsid,IID_IClassFactory,reinterpret_cast<void**>(factory.put())));
+        CHECK(canUnload()==S_FALSE);
+        CHECK(factory->CreateInstance(factory.p,IID_IExplorerCommand,reinterpret_cast<void**>(command.put()))==CLASS_E_NOAGGREGATION);
+        OK(factory->CreateInstance(nullptr,IID_IExplorerCommand,reinterpret_cast<void**>(command.put())));
+        OK(factory->LockServer(TRUE)); OK(factory->LockServer(FALSE));
+    }
+    PWSTR text=nullptr; OK(command->GetTitle(nullptr,&text));CHECK(text && *text);CoTaskMemFree(text);
+    OK(command->GetIcon(nullptr,&text));std::wstring ownExe(32768,L'\0');ownExe.resize(GetModuleFileNameW(nullptr,ownExe.data(),static_cast<DWORD>(ownExe.size())));
+    CHECK(_wcsicmp(text,(ownExe+L",-1").c_str())==0);CoTaskMemFree(text);
+    EXPCMDSTATE state;OK(command->GetState(nullptr,FALSE,&state));CHECK(state==ECS_HIDDEN);
+    GUID canonical;OK(command->GetCanonicalName(&canonical));CHECK(canonical==clsid);
+    EXPCMDFLAGS flags;OK(command->GetFlags(&flags));CHECK(flags==ECF_DEFAULT);
+    IEnumExplorerCommand* sub=nullptr;CHECK(command->EnumSubCommands(&sub)==E_NOTIMPL && !sub);
+    const auto dir=cwd()+L"\\folder 中文 & % test";
+    CHECK(CreateDirectoryW(dir.c_str(),nullptr) || GetLastError()==ERROR_ALREADY_EXISTS);
+    Ptr<IShellItem> item;OK(SHCreateItemFromParsingName(dir.c_str(),nullptr,IID_IShellItem,reinterpret_cast<void**>(item.put())));
+    Ptr<IShellItemArray> selection;OK(SHCreateShellItemArrayFromShellItem(item.p,IID_IShellItemArray,reinterpret_cast<void**>(selection.put())));
+    OK(command->GetState(selection.p,FALSE,&state));CHECK(state==ECS_ENABLED);
+    DeleteFileW((dir+L"\\wispterm-shell-launch.txt").c_str());
+    OK(command->Invoke(selection.p,nullptr));CHECK(waitRecord(dir));
+
+    // A multi-selection must not silently launch only its first item.
+    PIDLIST_ABSOLUTE id=nullptr;OK(SHGetIDListFromObject(item.p,&id));
+    PCIDLIST_ABSOLUTE ids[]={id,id};Ptr<IShellItemArray> multi;
+    OK(SHCreateShellItemArrayFromIDLists(2,ids,multi.put()));CoTaskMemFree(id);
+    OK(command->GetState(multi.p,FALSE,&state));CHECK(state==ECS_HIDDEN);
+    CHECK(FAILED(command->Invoke(multi.p,nullptr)));
+
+    const auto file=dir+L"\\wispterm-shell-launch.txt";
+    Ptr<IShellItem> fileItem;OK(SHCreateItemFromParsingName(file.c_str(),nullptr,IID_IShellItem,reinterpret_cast<void**>(fileItem.put())));
+    Ptr<IShellItemArray> fileSelection;OK(SHCreateShellItemArrayFromShellItem(fileItem.p,IID_IShellItemArray,reinterpret_cast<void**>(fileSelection.put())));
+    OK(command->GetState(fileSelection.p,FALSE,&state));CHECK(state==ECS_HIDDEN);
+    if(!registered) {
+        // Obtain an actual folder view without creating an Explorer window.
+        Ptr<IShellFolder> folder;OK(item->BindToHandler(nullptr,BHID_SFObject,IID_IShellFolder,reinterpret_cast<void**>(folder.put())));
+        Ptr<IShellView> shellView;OK(folder->CreateViewObject(nullptr,IID_IShellView,reinterpret_cast<void**>(shellView.put())));
+        Ptr<IFolderView> view;OK(shellView->QueryInterface(IID_IFolderView,reinterpret_cast<void**>(view.put())));
+        Ptr<IObjectWithSite> withSite;OK(command->QueryInterface(IID_IObjectWithSite,reinterpret_cast<void**>(withSite.put())));
+        auto site=new Site(view.p);OK(withSite->SetSite(site));site->Release();
+        OK(command->GetState(nullptr,FALSE,&state));CHECK(state==ECS_ENABLED);
+        DeleteFileW(file.c_str());OK(command->Invoke(nullptr,nullptr));CHECK(waitRecord(dir));
+        OK(withSite->SetSite(nullptr));OK(command->GetState(nullptr,FALSE,&state));CHECK(state==ECS_HIDDEN);
+    }
+    command.p->Release();command.p=nullptr;
+    if(canUnload){CHECK(canUnload()==S_OK);FreeLibrary(dll);}
+    std::cout << "PASS: COM activation, folder/background selection, launch argv/cwd, quoting and lifetime\n";
+    return 0;
+}
+int main() {
+    int count=0;LPWSTR* args=CommandLineToArgvW(GetCommandLineW(),&count);
+    if(count==3 && std::wstring(args[1])==L"--working-directory")return record(args[2]);
+    if(count!=2)return 2;
+    if(FAILED(CoInitializeEx(nullptr,COINIT_APARTMENTTHREADED)))return 2;
+    int result=run(args[1]);LocalFree(args);CoUninitialize();return result;
+}


### PR DESCRIPTION
Adds **Open in WispTerm / 在 WispTerm 中打开** for filesystem folders and folder backgrounds using the Windows 11 native Explorer menu. A standalone COM DLL resolves the selected/current folder and launches the existing `--working-directory` entry point, keeping Explorer integration outside the terminal core.

Windows bundles now include a sparse identity package, add/remove menu scripts, registration refresh during replace-install, and an uninstaller that unregisters before deleting payloads. Version/content-specific DLL directories avoid overwriting loaded shell extensions. Registration tracks installation ownership, preserves unrelated copies, refuses untrusted packages before mutation, and attempts rollback on failed replacement.

**Release prerequisite:** no Windows signing certificate is currently configured. Optional release secrets (`WINDOWS_SIGNING_PFX_BASE64`, `WINDOWS_SIGNING_PFX_PASSWORD`) sign the identity package and generate matching EXE identity metadata. Unsigned bundles remain usable as terminals, but normal context-menu installation explicitly requires a trusted signed package. Scripts never import certificates or enable Developer Mode automatically.

Validation:
- Windows Debug build and full portable packaging passed; the packaged desktop executable still reports `WispTerm 1.37.0` after identity resource embedding.
- Real COM tests passed for folder/background selection, actual child argv/cwd, Unicode/spaces, Windows quoting, rejection of files/multiple selections, and object lifetime.
- Windows SDK MakeAppx schema validation and PowerShell 5.1 parsing passed.
- Full Zig suite: all compilation, 2,492 fast tests and unaffected shards passed. Three pre-existing absolute-path cases fail under the WSL UNC working directory (13 failures across five Windows shards); all five affected shards passed from native Windows directories with their fixtures: 13,158 passed, 331 skipped, zero failures.
- Windows Explorer CI passed: temporary trusted signed identity package installation, activation from an unpackaged Explorer-like client, actual child argv/cwd, idempotence, relocation, ownership protection, and removal. Linux fast tests and macOS full tests also passed.
- Explorer visual placement on Windows 11 remains a manual check; CI exercises registered COM activation and launch behavior.
- Format, whitespace, and Windows checkout-safety checks passed.

Ghostty reference: its [Dolphin service](https://github.com/ghostty-org/ghostty/blob/main/dist/linux/ghostty_dolphin.desktop) and [macOS directory services](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Services/ServiceProvider.swift) keep directory-to-window integration in the OS host. Windows selection/site lookup follows [Windows Terminal OpenTerminalHere](https://github.com/microsoft/terminal/blob/main/src/cascadia/ShellExtension/OpenTerminalHere.cpp). Setup and testing are documented in `docs/windows-context-menu.md`.
