### PR TITLE
release: v1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ English | [简体中文](README.zh-CN.md)
 ## Versions
 
 The desktop app version is the repository root version in `build.zig.zon`
-(currently `1.37.0`) and is what `wispterm --version`, release notes, desktop
+(currently `1.38.0`) and is what `wispterm --version`, release notes, desktop
 packages, and the command center `Version` entry use.
 
 The WispTerm Remote web console/relay under `remote/` has an independent npm/web
@@ -292,7 +292,7 @@ MIT
 
 ## Citation
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.37.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.38.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 Copyable acknowledgment template:
@@ -302,6 +302,6 @@ We used WispTerm as part of our computational environment for life sciences data
 analysis, remote computing workflows, reproducible command-line processing, and
 the organization of related literature and analysis code.
 
-Xu, Z.-G. (2026). WispTerm (Version 1.37.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.38.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@
 
 ## 版本
 
-桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.37.0`），也是
+桌面应用版本来自仓库根目录的 `build.zig.zon`（当前为 `1.38.0`），也是
 `wispterm --version`、release notes、桌面发布包和命令中心 `Version` 条目使用的版本。
 
 `remote/` 下的 WispTerm Remote 网页控制台/中继有独立的 npm/web 版本（当前为
@@ -278,7 +278,7 @@ MIT
 
 ## 引用
 
-Xu, Z.-G. (2026). *WispTerm* (Version 1.37.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). *WispTerm* (Version 1.38.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 
 可直接复制的致谢模板：
@@ -287,6 +287,6 @@ https://doi.org/10.5281/zenodo.20660541
 我们在生命科学数据分析中使用 WispTerm 作为计算环境的一部分，用于远程计算流程、
 可重复的命令行处理，以及相关文献与分析代码的整理。
 
-Xu, Z.-G. (2026). WispTerm (Version 1.37.0) [Computer software]. Zenodo.
+Xu, Z.-G. (2026). WispTerm (Version 1.38.0) [Computer software]. Zenodo.
 https://doi.org/10.5281/zenodo.20660541
 ```

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wispterm,
-    .version = "1.37.0",
+    .version = "1.38.0",
     .fingerprint = 0x2db6e9e774428a6f,
     .minimum_zig_version = "0.15.2",
 

--- a/release-notes/v1.38.0.md
+++ b/release-notes/v1.38.0.md
@@ -1,0 +1,103 @@
+# WispTerm v1.38.0
+
+> Browse saved Copilot conversations in a dedicated workbench, toggle split
+> orientation, and keep Codex-style Alt+arrow shortcuts working in full-screen
+> TUIs. This release also adds Explorer “Open in WispTerm”, SSH latency in the
+> titlebar, and better Markdown tables. No configuration migration is required.
+
+## Added
+
+- **Conversation Center (#630).** The Copilot History picker stays for quick
+  resume. **Open Center** / **对话中心** (or Ctrl+Enter / Cmd+Enter) opens a
+  Memory Center-style tab to filter by source and calendar day, search, preview
+  transcripts, resume, and delete. Resume focuses an already-open session
+  instead of duplicating it. The command center also has a **Conversation
+  Center** action.
+- **Toggle split layout (#629).** Ctrl+Shift+L (Cmd+Shift+L on macOS) flips the
+  focused pane’s parent split between left-right and top-bottom. Nested pairs
+  rotate without reshaping siblings. A single pane does not consume the chord.
+- **Explorer “Open in WispTerm” (#628).** On Windows 11, folders and folder
+  backgrounds can open WispTerm at that working directory from the native
+  Explorer menu. Portable bundles include add/remove scripts. Enabling the menu
+  on end-user PCs requires a trusted signed identity package; unsigned bundles
+  still run as a terminal.
+- **SSH latency readout (#627).** Command center **Toggle SSH Latency** shows
+  the active WispTerm-managed SSH host’s ICMP round-trip time in the titlebar,
+  probing every five seconds. The switch is off by default and scoped to the
+  window. ICMP-blocked hosts and ProxyJump routes report unavailable.
+
+## Improved
+
+- **Markdown tables in AI Chat and Copilot (#625).** Table cells wrap, column
+  widths follow content, alignment is honored, and selection/copy match the
+  rendered geometry. Copy buttons sit in a band above the header.
+
+## Fixed
+
+- **Alt+arrows in full-screen TUIs (#629).** Spatial panel-focus chords
+  (Alt+arrows / Opt+arrows) are passed through while the focused surface is on
+  the alternate screen, so Codex `Alt+Up`, Claude Code, and vim keep those
+  keys even when another pane sits in that direction. Cycle
+  (`Ctrl+Shift+[ ]`) and numeric panel focus stay host-owned.
+
+## Compatibility
+
+- This is a desktop-only release; WispTerm Remote web console versions are
+  unchanged. Linux AppImage remains experimental.
+- Windows Explorer context-menu installation still requires a signed identity
+  package. Unsigned portable zips do not enable the menu on normal user PCs.
+
+## Performance baseline
+
+- The Windows x86_64 CPU terminal-stream baseline is attached to the GitHub
+  release as `benchmark-windows-v1.38.0.md`, collected with
+  `wispterm-bench --case terminal-stream --duration 1000` in ReleaseFast mode.
+  It measures parser throughput, not GPU rendering or input latency.
+
+---
+
+# WispTerm v1.38.0（中文）
+
+> 本次发布新增对话中心工作台、分屏方向切换，并让全屏 TUI 能使用 Alt+方向键。
+> 同时加入资源管理器“在 WispTerm 中打开”、SSH 延迟显示，以及更好的 Markdown
+> 表格。无需手动迁移配置。
+
+## 新增
+
+- **对话中心（#630）。** 副驾历史选择器仍用于快速 resume。点 **对话中心** /
+  **Open Center**（或 Ctrl+Enter / Cmd+Enter）打开类似记忆中心的标签页，可按
+  来源和日期筛选、搜索、预览记录、继续或删除。Resume 会切到已打开的会话，
+  不会复制一份。命令中心也提供 **对话中心** 动作。
+- **切换分屏方向（#629）。** Ctrl+Shift+L（macOS 为 Cmd+Shift+L）把当前焦点
+  所在分屏在左右和上下之间翻转。嵌套分屏只转这一组。单面板时不占用该快捷键。
+- **资源管理器“在 WispTerm 中打开”（#628）。** Windows 11 可从文件夹或文件夹
+  空白处用系统菜单在该目录打开 WispTerm。便携包附带添加/移除脚本。最终用户
+  电脑启用菜单需要受信任的签名身份包；未签名包仍可作为终端使用。
+- **SSH 延迟显示（#627）。** 命令中心 **切换 SSH 延迟显示** 会在标题栏显示
+  当前 WispTerm 托管 SSH 主机的 ICMP 往返时延，每 5 秒探测一次。默认关闭，
+  作用范围为当前窗口。ICMP 被拦或 ProxyJump 路由显示不可用。
+
+## 改进
+
+- **AI Chat / Copilot 的 Markdown 表格（#625）。** 单元格自动换行，列宽随内容
+  调整，对齐生效，选区和复制与显示几何一致。复制按钮放在表头上方。
+
+## 修复
+
+- **全屏 TUI 中的 Alt+方向键（#629）。** 当前终端处于备用屏幕时，Alt+方向键
+  （macOS 为 Opt+方向键）交给程序，Codex 的 `Alt+Up`、Claude Code、vim 在
+  旁边还有分屏时也能用。循环切换（Ctrl+Shift+[ ]）和数字聚焦面板仍由
+  WispTerm 处理。
+
+## 兼容性
+
+- 本次仅发布桌面应用，WispTerm Remote 网页控制台版本不变。Linux AppImage
+  仍为实验性构建。
+- Windows 资源管理器菜单安装仍需要签名身份包。未签名便携包不会在普通用户
+  电脑上启用该菜单。
+
+## 性能基线
+
+- GitHub Release 附带 `benchmark-windows-v1.38.0.md`，记录 Windows x86_64 上
+  ReleaseFast 构建运行 `wispterm-bench --case terminal-stream --duration 1000`
+  的结果。该基线衡量终端解析吞吐量，不代表 GPU 渲染或输入延迟。

--- a/src/benchmark/report.zig
+++ b/src/benchmark/report.zig
@@ -201,7 +201,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
         .{ .name = "terminal-stream", .unit = .throughput, .value = 56.2, .samples = 900, .duration_ms = 1000 },
     };
     const r: Report = .{
-        .app_version = "1.37.0",
+        .app_version = "1.38.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,
@@ -212,7 +212,7 @@ test "report: JSON includes shared scalars and omits null gpu/window" {
     };
     const json = try formatJson(allocator, r);
     defer allocator.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.37.0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"app_version\":\"1.38.0\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"logical_cores\":8") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"backend\":\"opengl\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\"runner\":\"cli\"") != null);
@@ -228,7 +228,7 @@ test "report: JSON includes gpu/window when filled and latency percentiles" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.37.0",
+        .app_version = "1.38.0",
         .os = "macos",
         .cpu_arch = "aarch64",
         .logical_cores = 10,
@@ -253,7 +253,7 @@ test "report: Markdown renders header, env, and scenario table" {
         .{ .name = "scroll_flood", .unit = .latency_ns, .value = 1_000_000, .p50_ns = 900_000, .p95_ns = 1_800_000, .max_ns = 3_000_000, .samples = 600, .duration_ms = 10_000 },
     };
     const r: Report = .{
-        .app_version = "1.37.0",
+        .app_version = "1.38.0",
         .os = "windows",
         .cpu_arch = "x86_64",
         .logical_cores = 8,

--- a/src/renderer/overlays/update_prompt_model.zig
+++ b/src/renderer/overlays/update_prompt_model.zig
@@ -25,7 +25,7 @@ pub fn updatePromptActionForResult(result: update_check.CheckResult) UpdatePromp
 
 test "overlays: downloaded maps to install_update on macOS only" {
     const expected: UpdatePromptAction = if (builtin.os.tag == .macos) .install_update else .none;
-    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.37.0" }));
+    try std.testing.expectEqual(expected, updatePromptActionForResult(.{ .state = .downloaded, .latest_version = "v1.38.0" }));
 }
 
 test "overlays: update prompt action selection prefers downloadable asset" {

--- a/src/test_main_behavior.zig
+++ b/src/test_main_behavior.zig
@@ -7,7 +7,7 @@ const keybind = @import("keybind.zig");
 const command_dispatch = @import("input/command_dispatch.zig");
 
 test "app version metadata is exposed for CLI and command center" {
-    const expected_version = "1.37.0";
+    const expected_version = "1.38.0";
     try std.testing.expectEqualStrings("WispTerm", app_metadata.name);
     try std.testing.expectEqualStrings(expected_version, app_metadata.version);
     try std.testing.expect(std.mem.indexOf(u8, app_metadata.release_notes, "# WispTerm v" ++ expected_version) != null);


### PR DESCRIPTION
Prepare desktop **v1.38.0** from the five PRs merged since v1.37.0 (#625, #627–#630): Conversation Center, split-layout toggle with TUI Alt+arrow passthrough, Explorer “Open in WispTerm”, SSH latency readout, and Markdown table wrapping/selection.

Synchronize `build.zig.zon`, matching version tests, both READMEs, and bilingual release notes. WispTerm Remote versions are unchanged.

After merge, tag `v1.38.0` on the merge commit so the Windows/macOS/Linux/wisptermctl release workflows publish assets.

## Test plan

- [x] `zig build test`
- [ ] CI: Linux fast tests, macOS ARM full tests, Windows smoke
- [ ] After merge: tag `v1.38.0` and confirm GitHub Release body uses `release-notes/v1.38.0.md`
- [ ] Attach Windows `wispterm-bench --case terminal-stream --duration 1000` as `benchmark-windows-v1.38.0.md`